### PR TITLE
Stop incrementing IND when generating auth vectors

### DIFF
--- a/feg/gateway/services/testcore/hss/servicers/hss.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss.go
@@ -33,8 +33,7 @@ type HomeSubscriberServer struct {
 	Milenage *crypto.MilenageCipher
 
 	// authSqnInd is an index used in the array scheme described by 3GPP TS 33.102 Appendix C.1.2 and C.2.2.
-	// SQN consists of two parts (SQN = SEQ||IND). This value is incremented every
-	// time a batch of authentication vectors is generated (see Appendix C.3.4).
+	// SQN consists of two parts (SQN = SEQ||IND).
 	AuthSqnInd uint64
 }
 

--- a/feg/gateway/services/testcore/hss/servicers/ma.go
+++ b/feg/gateway/services/testcore/hss/servicers/ma.go
@@ -117,12 +117,11 @@ func (srv *HomeSubscriberServer) GenerateSIPAuthVector(subscriber *lteprotos.Sub
 	if err != nil {
 		return nil, err
 	}
-	ind := srv.AuthSqnInd // Store IND before incrementing
 	err = srv.IncreaseSQN(subscriber)
 	if err != nil {
 		return nil, err
 	}
-	sqn := SeqToSqn(subscriber.State.LteAuthNextSeq, ind)
+	sqn := SeqToSqn(subscriber.State.LteAuthNextSeq, srv.AuthSqnInd)
 	vector, err := srv.Milenage.GenerateSIPAuthVector(lte.AuthKey, opc, sqn)
 	if err != nil {
 		return vector, NewAuthRejectedError(err.Error())

--- a/feg/gateway/services/testcore/hss/servicers/test/ai_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/ai_test.go
@@ -443,7 +443,6 @@ func TestSetNextLteAuthSqnAfterResync(t *testing.T) {
 
 	err = server.SetNextLteAuthSqnAfterResync(subscriber, servicers.SeqToSqn(1<<30-1, 3))
 	assert.NoError(t, err)
-	assert.Equal(t, uint64(3), server.AuthSqnInd)
 	assert.Equal(t, uint64(1<<30), subscriber.State.LteAuthNextSeq)
 }
 
@@ -465,7 +464,6 @@ func TestSetNextLteAuthSeq(t *testing.T) {
 
 func TestIncrementSQN(t *testing.T) {
 	server := newTestHomeSubscriberServer(t)
-	server.AuthSqnInd = 31
 
 	id := &lteprotos.SubscriberID{Id: "sub1"}
 	subscriber, err := server.GetSubscriberData(context.Background(), id)
@@ -477,7 +475,6 @@ func TestIncrementSQN(t *testing.T) {
 	err = server.IncreaseSQN(subscriber)
 	assert.NoError(t, err)
 	assert.Equal(t, uint64(51), subscriber.State.LteAuthNextSeq)
-	assert.Equal(t, uint64(0), server.AuthSqnInd)
 
 	subscriber, err = server.GetSubscriberData(context.Background(), id)
 	assert.NoError(t, err)


### PR DESCRIPTION
Summary: Per 3GPP TS 33.102 Appendix C3.4, if a new request comes from the same serving node as the previous request (which will always be the case since we use a FeG), then the index value used for the new request should be the same as the previous request. So, instead of allocating the value cyclically within its range, it should instead be kept as a constant.

Differential Revision: D14226835
