### PR TITLE
Fix FeG mconfig init refresh error

### DIFF
--- a/feg/gateway/mconfig/impl.go
+++ b/feg/gateway/mconfig/impl.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/protos"
+	_ "magma/orc8r/cloud/go/protos/mconfig"
 )
 
 var localConfig atomic.Value // always *mconfig.GatewayConfigs, never should be nil


### PR DESCRIPTION
Summary:
Currently, when the mconfig init function is called for the Federated Gateway, there's an error
that the mconfig for a given service is not found. This stems from the ocr8r mconfig protos not having
been registered before the mconfig init() function is run. This produces an error such as `magma.mconfig.ControlProxy` not found.

This diff adds the orc8r mconfig protos to the import list to ensure that these message types are known before the function triggers.
Since the protos don't have to be used, they are prefixed with `_`

Reviewed By: vikg-fb

Differential Revision: D14236492
