### PR TITLE
Include enodebd directory that is missing in setup.py

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -25,6 +25,7 @@ setup(
         'magma.enodebd',
         'magma.enodebd.data_models',
         'magma.enodebd.device_config',
+        'magma.enodebd.devices',
         'magma.enodebd.state_machines',
         'magma.enodebd.tr069',
         'magma.mobilityd',


### PR DESCRIPTION
Summary: The `devices` directory under enodebd is not included in the `setup.py` so it is missed in the magma Debian package.

Differential Revision: D14275292
