### PR TITLE
Checkin_manager now uses asyncio not callback model

### DIFF
--- a/orc8r/gateway/python/magma/common/rpc_utils.py
+++ b/orc8r/gateway/python/magma/common/rpc_utils.py
@@ -6,7 +6,9 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
+# pylint: disable=broad-except
 
+import asyncio
 import grpc
 from orc8r.protos import common_pb2
 
@@ -71,3 +73,32 @@ def cloud_grpc_wrapper(func):
             print("Error! [%s] %s" % (err.code(), err.details()))
             exit(1)
     return wrapper
+
+
+def _grpc_async_wrapper(f, gf):
+    try:
+        f.set_result(gf.result())
+    except Exception as e:
+        f.set_exception(e)
+
+
+def grpc_async_wrapper(gf, loop=None):
+    """
+    Wraps a GRPC result in a future that can be yielded by asyncio
+
+    Usage:
+
+    async def my_fn(param):
+        result =
+            await grpc_async_wrapper(stub.function_name.future(param, timeout))
+
+    Code taken and modified from:
+        https://github.com/grpc/grpc/wiki/Integration-with-tornado-(python)
+    """
+    f = asyncio.Future()
+    if loop is None:
+        loop = asyncio.get_event_loop()
+    gf.add_done_callback(
+        lambda _: loop.call_soon_threadsafe(_grpc_async_wrapper, f, gf)
+    )
+    return f

--- a/orc8r/gateway/python/magma/magmad/checkin_manager.py
+++ b/orc8r/gateway/python/magma/magmad/checkin_manager.py
@@ -6,11 +6,13 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
+# pylint: disable=broad-except
 
 import logging
 import platform
 import sys
 import time
+import asyncio
 
 import grpc
 import psutil
@@ -19,6 +21,7 @@ from orc8r.protos.magmad_pb2 import CheckinRequest, SystemStatus
 from orc8r.protos.magmad_pb2_grpc import CheckindStub
 
 from magma.common.misc_utils import get_ip_from_if
+from magma.common.rpc_utils import grpc_async_wrapper
 from magma.common.sdwatchdog import SDWatchdogTask
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.kernel_check.kernel_versions import get_kernel_versions_async
@@ -36,6 +39,8 @@ class CheckinManager(SDWatchdogTask):
         self._loop = service.loop
         self._service = service
         self._service_poller = service_poller
+
+        self.delay = max(5, service.mconfig.checkin_interval)
 
         # Number of consecutive failed checkins before we check for an outdated
         # cert
@@ -56,8 +61,9 @@ class CheckinManager(SDWatchdogTask):
         self._kernel_version = platform.uname().release
 
         self._kernel_versions_installed = []
+        self._periodically_check_kernel_versions = False
         if service.config.get('enable_kernel_version_checking', False):
-            self._periodic_check_kernel_versions()
+            self._periodically_check_kernel_versions = True
 
         # set initial checkin timeout to "large" since no checkins occur until
         #   bootstrap succeeds.
@@ -66,10 +72,75 @@ class CheckinManager(SDWatchdogTask):
         #   will recheck alive status
         self.SetSDWatchdogAlive()
 
+        # Start try_checkin loop
+        self._task = asyncio.ensure_future(self._run(), loop=self._loop)
+
+    def try_checkin(self):
+        """
+        Attempt to check in. Continue to schedule future checkins
+
+        Uses self.num_skipped_checkins to track skipped checkins
+        """
+        mconfig = self._service.mconfig
+        config = self._service.config
+
+        # specifies number of checkin iterations that can have an empty/missing
+        #   service meta before checking in anyway.
+        # If 0, then never check in if missing.
+        #  Use safe default to make "forever" explicit.
+        # (check config early so config is validated)
+        max_skipped_checkins = int(config.get("max_skipped_checkins", 3))
+
+        try:
+            # gather information required to determine checkin
+            service_statusmeta = self._gather_service_statusmeta()
+
+            # use necessary information to determine can_checkin
+            can_checkin = self._can_checkin(service_statusmeta)
+
+            if can_checkin:
+                # we can checkin! Continue on below to actually _checkin()
+                # clear fail count
+                self.num_skipped_checkins = 0
+            else:
+                # we should only not checkin up to a specified limit, at
+                #  which time we checkin anyway
+                if 0 < max_skipped_checkins < self.num_skipped_checkins:
+                    logging.warning(
+                        "Number of skipped checkins exceeds %d "
+                        "(cfg: max_skipped_checkins). Checking in anyway.",
+                        max_skipped_checkins)
+                    # intentionally don't reset num_skipped_checkins here
+                else:
+                    self.num_skipped_checkins += 1
+                    return
+
+            asyncio.ensure_future(
+                self._checkin(service_statusmeta),
+                loop=self._loop
+            )
+
+        finally:
+            # always schedule the next checkin, don't allow interval < 5 sec
+            self.delay = max(5, mconfig.checkin_interval)
+
+            # flag to ensure the loop is still running, successfully or not
+            self.SetSDWatchdogAlive()
+            # reset checkin timeout to config plus buffer
+            self.SetSDWatchdogTimeout(self.delay * 2)
+
     def set_failure_cb(self, checkin_failure_cb):
         self._checkin_failure_cb = checkin_failure_cb
 
-    def _checkin(self, service_statusmeta):
+    async def _run(self):
+        while True:
+            mconfig = self._service.mconfig
+            self.try_checkin()
+            if self._periodically_check_kernel_versions:
+                await self._check_kernel_versions()
+            await asyncio.sleep(max(mconfig.checkin_interval, 5))
+
+    async def _checkin(self, service_statusmeta):
         """
         if previous checkin is successful, create a new channel
         (to make sure the channel does't become stale). Otherwise,
@@ -109,57 +180,39 @@ class CheckinManager(SDWatchdogTask):
         for statusmeta in service_statusmeta.values():
             request.status.meta.update(statusmeta)
 
-        future = self._checkin_client.Checkin.future(
-            request, mconfig.checkin_timeout,
-        )
-        future.add_done_callback(
-            lambda f: self._loop.call_soon_threadsafe(self._checkin_done, f),
-        )
+        try:
+            await grpc_async_wrapper(
+                self._checkin_client.Checkin.future(
+                    request, mconfig.checkin_timeout,
+                ),
+                self._loop)
+            self._checkin_done()
+        except grpc.RpcError as err:
+            self._checkin_error(err)
 
-    def _checkin_done(self, future):
-        err = future.exception()
-        if err:
-            logging.error("Checkin Error! [%s] %s", err.code(), err.details())
-            CHECKIN_STATUS.set(0)
-            self.num_failed_checkins += 1
-            if self.num_failed_checkins == self.CHECKIN_FAIL_THRESHOLD:
-                logging.info('Checkin failure threshold met, remediating...')
-                if self._checkin_failure_cb is not None:
-                    self._checkin_failure_cb(err.code())
-            self._try_reuse_checkin_client(err.code())
-        else:
-            CHECKIN_STATUS.set(1)
-            self._checkin_client = None
-            self.num_failed_checkins = 0
-            logging.info("Checkin Successful!")
+    def _checkin_error(self, err):
+        logging.error("Checkin Error! [%s] %s", err.code(), err.details())
+        CHECKIN_STATUS.set(0)
+        self.num_failed_checkins += 1
+        if self.num_failed_checkins == self.CHECKIN_FAIL_THRESHOLD:
+            logging.info('Checkin failure threshold met, remediating...')
+            if self._checkin_failure_cb is not None:
+                self._checkin_failure_cb(err.code())
+        self._try_reuse_checkin_client(err.code())
 
-    def _periodic_check_kernel_versions(self):
-        mconfig = self._service.mconfig
-        self._check_kernel_versions()
-        self._loop.call_later(
-            max(mconfig.checkin_interval, 5),
-            self._periodic_check_kernel_versions
-        )
+    def _checkin_done(self):
+        CHECKIN_STATUS.set(1)
+        self._checkin_client = None
+        self.num_failed_checkins = 0
+        logging.info("Checkin Successful!")
 
-    def _check_kernel_versions(self):
-        get_kernel_versions_future = self._loop.create_task(
-            get_kernel_versions_async()
-        )
-        get_kernel_versions_future.add_done_callback(
-            lambda future:
-            self._loop.call_soon(self._get_kernel_versions_done, future)
-        )
-
-    def _get_kernel_versions_done(self, future):
-        err = future.exception()
-        if err:
-            logging.error(
-                "Error getting kernel versions! %s",
-                str(err))
-        else:
-            result = list(future.result())[0].kernel_versions_installed
+    async def _check_kernel_versions(self):
+        try:
+            result = await get_kernel_versions_async()
+            result = list(result)[0].kernel_versions_installed
             self._kernel_versions_installed = result
-
+        except Exception as e:
+            logging.error("Error getting kernel versions! %s", e)
 
     def _try_reuse_checkin_client(self, err_code):
         """
@@ -221,55 +274,3 @@ class CheckinManager(SDWatchdogTask):
                 ", ".join(required_meta - got_meta))
 
         return can_checkin
-
-    def try_checkin(self):
-        """
-        Attempt to check in. Continue to schedule future checkins
-
-        Uses self.num_skipped_checkins to track skipped checkins
-        """
-        mconfig = self._service.mconfig
-        config = self._service.config
-
-        # specifies number of checkin iterations that can have an empty/missing
-        #   service meta before checking in anyway.
-        # If 0, then never check in if missing.
-        #  Use safe default to make "forever" explicit.
-        # (check config early so config is validated)
-        max_skipped_checkins = int(config.get("max_skipped_checkins", 3))
-
-        try:
-            # gather information required to determine checkin
-            service_statusmeta = self._gather_service_statusmeta()
-
-            # use necessary information to determine can_checkin
-            can_checkin = self._can_checkin(service_statusmeta)
-
-            if can_checkin:
-                # we can checkin! Continue on below to actually _checkin()
-                # clear fail count
-                self.num_skipped_checkins = 0
-            else:
-                # we should only not checkin up to a specified limit, at
-                #  which time we checkin anyway
-                if 0 < max_skipped_checkins < self.num_skipped_checkins:
-                    logging.warning(
-                        "Number of skipped checkins exceeds %d "
-                        "(cfg: max_skipped_checkins). Checking in anyway.",
-                        max_skipped_checkins)
-                    # intentionally don't reset num_skipped_checkins here
-                else:
-                    self.num_skipped_checkins += 1
-                    return
-
-            self._checkin(service_statusmeta)
-
-        finally:
-            # always schedule the next checkin, don't allow interval < 5 sec
-            checkin_interval = max(5, mconfig.checkin_interval)
-            self._loop.call_later(checkin_interval, self.try_checkin)
-
-            # flag to ensure the loop is still running, successfully or not
-            self.SetSDWatchdogAlive()
-            # reset checkin timeout to config plus buffer
-            self.SetSDWatchdogTimeout(checkin_interval * 2)


### PR DESCRIPTION
Summary: Converting checkin_manager.py so that it uses await and futures instead of relying on callbacks. This will later make it easier to use the loop based Job interface, defined in common/job.py.

Reviewed By: xjtian

Differential Revision: D14215189
