### PR TITLE
Using s1ap-tester from Magma package repo

### DIFF
--- a/lte/gateway/deploy/magma_test.yml
+++ b/lte/gateway/deploy/magma_test.yml
@@ -12,6 +12,7 @@
     - role: apt_cache
       vars:
         distribution: "stretch"
+    - role: pkgrepo
     - role: python_dev
     - role: dev_common
       vars:

--- a/lte/gateway/deploy/roles/magma_test/files/install_s1_tester.sh
+++ b/lte/gateway/deploy/roles/magma_test/files/install_s1_tester.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+#install the package from repo
+sudo apt-get install s1aptester
+
+# create symlinks to the libs
+ln -sf "/usr/local/lib/s1sim/libtfw.so" "$S1AP_ROOT/bin/libtfw.so"
+ln -sf "/usr/local/lib/s1sim/libtrfgen.so" "$S1AP_ROOT/bin/libtrfgen.so"
+ln -sf "/usr/local/lib/s1sim/libiperf.so" "$S1AP_ROOT/bin/libiperf.so"
+ln -sf "/usr/local/lib/s1sim/libiperf.so.0" "$S1AP_ROOT/bin/libiperf.so.0"
+
+# create symlinks to the headers
+ln -sf "/usr/local/include/s1sim/fw_api_int.h" "$S1AP_ROOT/bin/fw_api_int.h"
+ln -sf "/usr/local/include/s1sim/fw_api_int.x" "$S1AP_ROOT/bin/fw_api_int.x"
+ln -sf "/usr/local/include/s1sim/trfgen.x" "$S1AP_ROOT/bin/trfgen.x"

--- a/lte/gateway/deploy/roles/magma_test/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma_test/tasks/main.yml
@@ -41,32 +41,8 @@
     - build_s1_tester.sh
   when: full_provision
 
-- name: Check out s1aptester code
-  shell: "{{ test_scripts }}/clone_s1_tester.sh"
-  args:
-    executable: /bin/bash
-  environment:
-    S1AP_SRC: "{{ s1aptester_src }}"
-    TIP_REPO: "{{ tip_repo }}"
-  when: full_provision
-
-- name: Disable S1SIM logging
-  replace:
-    path: "{{ s1aptester_src }}/TestCntlrApp/build/fw.mak"
-    regexp: '\-DLTE_UE_NAS_SEC'
-    replace: ''
-  when: full_provision
-
-# Used for non-git-checkout s1aptester building
-#- name: Unpack and clean s1aptester build if git checkout fails
-#  shell: "cd {{ s1aptester_src }}/{{ item }}/build && make clean -s"
-#  with_items:
-#    - TestCntlrApp
-#    - TestCntlrStub
-#    - Trfgen
-
-- name: Build s1aptester code
-  shell: "{{ test_scripts }}/build_s1_tester.sh -s"
+- name: Install s1aptester code
+  shell: "{{ test_scripts }}/install_s1_tester.sh"
   args:
     executable: /bin/bash
   environment:


### PR DESCRIPTION
Summary:
For open source, the s1aptester is available as a package on Magma repo. While
provisioning test VM, the s1ap-tester needs to be installed from the package
repo.

Reviewed By: themarwhal

Differential Revision: D14280677
