### PR TITLE
Include scripts which are missing in the setup.py of orc8r

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -36,6 +36,7 @@ setup(
         'scripts/generate_dnsd_config.py',
         'scripts/generate_lighttpd_config.py',
         'scripts/generate_nghttpx_config.py',
+        'scripts/generate_service_config.py',
         'scripts/magma_conditional_service.py',
         'scripts/magma_get_config.py',
         'scripts/magmad_cli.py',


### PR DESCRIPTION
Summary: Two Python scripts under orc8r is not included in the `setup.py` so they are missed in the magma Debian package. Installing magma with this incomplete Debian package causes Python import error.

Differential Revision: D14292897
