### PR TITLE
Update spyne version from 2.12.14 to 2.12.16

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -69,7 +69,7 @@ setup(
         # lxml required by spyne.
         'lxml==4.2.1',
         'ryu==4.13',
-        'spyne==2.12.14',
+        'spyne==2.12.16',
         'scapy==2.4.2',
         'flask>=1.0.2',
         'aiodns>=1.1.1',


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/magma/issues/18

Build fails using dependency Spyne 2.12.14, but succeeds with 2.12.16
Updating spyne version

Reviewed By: vikg-fb

Differential Revision: D14286582
