### PR TITLE
Enable traffic tests in S1AP tester

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -30,9 +30,9 @@ s1aptests/test_attach_ipv4v6_pdn_type.py \
 s1aptests/test_service_info.py \
 s1aptests/test_attach_detach_with_ovs.py \
 s1aptests/test_resync.py \
-s1aptests/test_standalone_pdn_conn_req.py
-#s1aptests/test_attach_ul_udp_data.py \
-#s1aptests/test_attach_ul_tcp_data.py \
+s1aptests/test_standalone_pdn_conn_req.py \
+s1aptests/test_attach_ul_udp_data.py \
+s1aptests/test_attach_ul_tcp_data.py
 
 # TODO Disabled because MME wont run without UEs in HSS
 #s1aptests/test_attach_missing_imsi.py \


### PR DESCRIPTION
Summary: Traffic tests were disabled as they were failing on CI. The suspect diff is D13884172 and the tests were also failing locally. D14301148 fixes the bug and the tests are passing locally. This diff enables these tests again so we can see if they still fail on CI.

Differential Revision: D14315192
