### PR TITLE
Fix enodebd sending non-empty http responses when it should send an empty response

### DIFF
--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -126,22 +126,17 @@ class AutoConfigServer(ServiceBase):
         else:
             logging.debug('Sending TR069 message.')
 
-        # Set return message name
-        ctx.descriptor.out_message.Attributes.sub_name = req.__class__.__name__
-
         # Set header
         ctx.out_header = models.ID(mustUnderstand='1')
         ctx.out_header.Data = 'null'
 
-        req_out = cls._generate_acs_to_cpe_request_copy(req)
-        return req_out
-
-    @staticmethod
-    def _generate_empty_acs_to_cpe_request(ctx):
-        """ Generate 'empty' request to CPE using dummy message and empty
-            message name """
-        ctx.descriptor.out_message.Attributes.sub_name = 'EmptyHttp'
-        return models.AcsToCpeRequests()
+        # Set return message name
+        if isinstance(req, models.DummyInput):
+            # Generate 'empty' request to CPE using empty message name
+            ctx.descriptor.out_message.Attributes.sub_name = 'EmptyHttp'
+            return models.AcsToCpeRequests()
+        ctx.descriptor.out_message.Attributes.sub_name = req.__class__.__name__
+        return cls._generate_acs_to_cpe_request_copy(req)
 
     @staticmethod
     def _generate_acs_to_cpe_request_copy(request):


### PR DESCRIPTION
Summary: Examining a pcap from enodebd, it was discovered that where we expected an empty http response from ACS to CPE, enodebd was instead sending an XML. This fix changes rpc_methods.py so that our placeholder object representing an empty http response will actually cause enodebd to respond with an empty http response.

Reviewed By: fishlinghu

Differential Revision: D14317173
