### PR TITLE
Add missing Vendor-Specific-Application-ID AVP to MAR and SAR messages

### DIFF
--- a/feg/gateway/services/swx_proxy/servicers/auth.go
+++ b/feg/gateway/services/swx_proxy/servicers/auth.go
@@ -125,6 +125,12 @@ func (s *swxProxy) createMAR(sid string, req *protos.AuthenticationRequest) (*di
 
 	msg := diameter.NewProxiableRequest(diam.MultimediaAuthentication, diam.TGPP_SWX_APP_ID, dict.Default)
 	msg.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String(sid))
+	msg.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(diam.TGPP_SWX_APP_ID)),
+			diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
+		},
+	})
 	msg.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Host))
 	msg.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Realm))
 	msg.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(req.GetUserName()))

--- a/feg/gateway/services/swx_proxy/servicers/register.go
+++ b/feg/gateway/services/swx_proxy/servicers/register.go
@@ -92,8 +92,15 @@ func (s *swxProxy) sendSAR(userName string, serverAssignmentType uint32) (*SAA, 
 func (s *swxProxy) createSAR(sid, userName string, saType uint32) *diam.Message {
 	msg := diameter.NewProxiableRequest(diam.ServerAssignment, diam.TGPP_SWX_APP_ID, dict.Default)
 	msg.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String(sid))
+	msg.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(diam.TGPP_SWX_APP_ID)),
+			diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
+		},
+	})
 	msg.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Host))
 	msg.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(s.config.ClientCfg.Realm))
+
 	msg.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(userName))
 	msg.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(1))
 	msg.NewAVP(avp.ServerAssignmentType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Enumerated(saType))

--- a/feg/gateway/services/swx_proxy/servicers/swx_definitions.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_definitions.go
@@ -35,14 +35,15 @@ const (
 
 // 3GPP 29.273 8.2.2.1 - Multimedia Authentication Request
 type MAR struct {
-	SessionID        datatype.UTF8String       `avp:"Session-Id"`
-	OriginHost       datatype.DiameterIdentity `avp:"Origin-Host"`
-	OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
-	AuthSessionState datatype.UTF8String       `avp:"Auth-Session-State"`
-	UserName         string                    `avp:"User-Name"`
-	RATType          datatype.Enumerated       `avp:"RAT-Type"`
-	AuthData         SIPAuthDataItem           `avp:"SIP-Auth-Data-Item"`
-	NumberAuthItems  uint32                    `avp:"SIP-Number-Auth-Items"`
+	SessionID           datatype.UTF8String         `avp:"Session-Id"`
+	VendorSpecificAppId VendorSpecificApplicationId `avp:"Vendor-Specific-Application-Id"`
+	OriginHost          datatype.DiameterIdentity   `avp:"Origin-Host"`
+	OriginRealm         datatype.DiameterIdentity   `avp:"Origin-Realm"`
+	AuthSessionState    datatype.UTF8String         `avp:"Auth-Session-State"`
+	UserName            string                      `avp:"User-Name"`
+	RATType             datatype.Enumerated         `avp:"RAT-Type"`
+	AuthData            SIPAuthDataItem             `avp:"SIP-Auth-Data-Item"`
+	NumberAuthItems     uint32                      `avp:"SIP-Number-Auth-Items"`
 }
 
 // 3GPP 29.273 8.2.2.1 - Multimedia Authentication Answer
@@ -56,6 +57,13 @@ type MAA struct {
 	SIPAuthDataItems   []SIPAuthDataItem         `avp:"SIP-Auth-Data-Item"`
 	SIPNumberAuthItems uint32                    `avp:"SIP-Number-Auth-Items"`
 	AAAServerName      datatype.DiameterIdentity `avp:"TGPP-AAA-Server-Name"`
+}
+
+// VendorSpecificApplicationId
+type VendorSpecificApplicationId struct {
+	VendorId          uint32 `avp:"Vendor-Id"`
+	AuthApplicationId uint32 `avp:"Auth-Application-Id"`
+	AcctApplicationId uint32 `avp:"Acct-Application-Id"`
 }
 
 type ExperimentalResult struct {
@@ -73,12 +81,13 @@ type SIPAuthDataItem struct {
 
 // 3GPP 29.273 8.2.2.3 - Server Assignment Request
 type SAR struct {
-	SessionID            datatype.UTF8String       `avp:"Session-Id"`
-	OriginHost           datatype.DiameterIdentity `avp:"Origin-Host"`
-	OriginRealm          datatype.DiameterIdentity `avp:"Origin-Realm"`
-	AuthSessionState     datatype.Unsigned32       `avp:"Auth-Session-State"`
-	UserName             datatype.UTF8String       `avp:"User-Name"`
-	ServerAssignmentType datatype.Enumerated       `avp:"Server-Assignment-Type"`
+	SessionID            datatype.UTF8String         `avp:"Session-Id"`
+	VendorSpecificAppId  VendorSpecificApplicationId `avp:"Vendor-Specific-Application-Id"`
+	OriginHost           datatype.DiameterIdentity   `avp:"Origin-Host"`
+	OriginRealm          datatype.DiameterIdentity   `avp:"Origin-Realm"`
+	AuthSessionState     datatype.Unsigned32         `avp:"Auth-Session-State"`
+	UserName             datatype.UTF8String         `avp:"User-Name"`
+	ServerAssignmentType datatype.Enumerated         `avp:"Server-Assignment-Type"`
 }
 
 // 3GPP 29.273 8.2.2.3 - Server Assignment Answer


### PR DESCRIPTION
Summary:
In initial testing, it was found that the existing swx_proxy service does not
add the Vendor-Specific-Application-ID AVP to the MAR and SAR diameter messages. These
AVPs are required in the messages. This diff fixes this error by adding the AVP to the
functions that create these messages.

Reviewed By: vikg-fb

Differential Revision: D14380279
