### PR TITLE
Remove auto-reboot of eNB devices after configuration

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -50,7 +50,10 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
             'delete_objs': DeleteObjectsState(self, when_add='add_objs', when_skip='set_params'),
             'add_objs': AddObjectsState(self, when_done='set_params'),
             'set_params': SetParameterValuesState(self, when_done='wait_set_params'),
-            'wait_set_params': WaitSetParameterValuesState(self, when_done='reboot'),
+            'wait_set_params': WaitSetParameterValuesState(self, when_done='check_get_params'),
+            'check_get_params': GetParametersState(self, when_done='check_wait_get_params', request_all_params=True),
+            'check_wait_get_params': WaitGetParametersState(self, when_done='get_transient_params'),
+            # The state below are only entered with manual user intervention.
             'reboot': SendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
             'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_empty_after_reboot', when_timeout='disconnected'),

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -51,7 +51,10 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
             'delete_objs': DeleteObjectsState(self, when_add='add_objs', when_skip='set_params'),
             'add_objs': AddObjectsState(self, when_done='set_params'),
             'set_params': SetParameterValuesState(self, when_done='wait_set_params'),
-            'wait_set_params': WaitSetParameterValuesState(self, when_done='reboot'),
+            'wait_set_params': WaitSetParameterValuesState(self, when_done='check_get_params'),
+            'check_get_params': GetParametersState(self, when_done='check_wait_get_params', request_all_params=True),
+            'check_wait_get_params': WaitGetParametersState(self, when_done='get_transient_params'),
+            # The state below are only entered with manual user intervention.
             'reboot': SendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
             'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_empty_after_reboot', when_timeout='disconnected'),

--- a/lte/gateway/python/magma/enodebd/devices/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/devices/tests/baicells_tests.py
@@ -79,33 +79,26 @@ class BaicellsHandlerTests(TestCase):
         req.Status = 0
         resp = acs_state_machine.handle_tr069_message(req)
 
-        # SM should be attempting to reboot the Baicells device
-        self.assertTrue(isinstance(resp, models.Reboot),
-                        'State machine should be rebooting the eNB')
-        req = self._get_reboot_response()
-        resp = acs_state_machine.handle_tr069_message(req)
-
-        # SM should be trying to end the session with a dummy message
-        self.assertTrue(isinstance(resp, models.DummyInput))
-        req = self._get_reboot_inform()
-        resp = acs_state_machine.handle_tr069_message(req)
-
-        # SM should have responded to an Inform message with an Inform response
-        self.assertTrue(isinstance(resp, models.InformResponse))
-        req = models.DummyInput()
-        resp = acs_state_machine.handle_tr069_message(req)
-
-        # And now the SM has finished provisioning, and should only request
-        # the transient, read-only parameters
+        # Expect a request for read-only params
         self.assertTrue(isinstance(resp, models.GetParameterValues),
-                        'State machine should be requesting read-only params')
+                        'State machine should be requesting param values')
+        req = self._get_read_only_param_values_response()
 
-        # The eNodeB will send an Inform after ~10 minutes anyways, even
-        # during a provisioning session
-        req = self._get_inform()
+        # Send back some typical values
+        # And then SM should continue polling the read-only params
         resp = acs_state_machine.handle_tr069_message(req)
-        self.assertTrue(isinstance(resp, models.InformResponse),
-                        'State machine should handle unexpected Inform msgs')
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
+
+        # Expect a request for read-only params
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req = self._get_read_only_param_values_response()
+
+        # Send back some typical values
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
         return
 
     def _get_mconfig(self) -> mconfigs_pb2.EnodebD:

--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -137,11 +137,14 @@ def get_all_objects_to_delete(
 def get_params_to_get(
     device_cfg: EnodebConfiguration,
     data_model: DataModel,
+    request_all_params: bool = False,
 ) -> List[ParameterName]:
     """
     Returns the names of params not belonging to objects that are added/removed
     """
     desired_names = data_model.get_present_params()
+    if request_all_params:
+        return desired_names
     known_names = device_cfg.get_parameter_names()
     names = list(set(desired_names) - set(known_names))
     return names

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -443,10 +443,18 @@ class GetParametersState(EnodebAcsState):
     Get the value of most parameters of the eNB that are defined in the data
     model. Object parameters are excluded.
     """
-    def __init__(self, acs: EnodebAcsStateMachine, when_done: str):
+    def __init__(
+        self,
+        acs: EnodebAcsStateMachine,
+        when_done: str,
+        request_all_params: bool = False,
+    ):
         super().__init__()
         self.acs = acs
         self.done_transition = when_done
+        # Set to True if we want to request values of all parameters, even if
+        # the ACS state machine already has recorded values of them.
+        self.request_all_params = request_all_params
 
     def read_msg(self, message: Any) -> AcsReadMsgResult:
         """
@@ -469,7 +477,8 @@ class GetParametersState(EnodebAcsState):
         """
 
         # Get the names of regular parameters
-        names = get_params_to_get(self.acs.device_cfg, self.acs.data_model)
+        names = get_params_to_get(self.acs.device_cfg, self.acs.data_model,
+                                  self.request_all_params)
 
         # Generate the request
         request = models.GetParameterValues()


### PR DESCRIPTION
Summary: Reboot should not be done to eNB devices. If reboot is required, devices will do so themselves. Reboot has prevented the proper configuration of eNB from taking effect. This revision removes auto-reboot from enodebd service.

Reviewed By: fishlinghu

Differential Revision: D14376676
