### PR TITLE
Improve logging for eNB -> MME connection

### DIFF
--- a/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
+++ b/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
@@ -8,22 +8,34 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import textwrap
+from typing import Optional
+from magma.enodebd.exceptions import ConfigurationError
+
 
 DUPLEX_MAP = {
     '01': 'TDDMode',
     '02': 'FDDMode'
 }
 
+BANDWIDTH_RBS_TO_MHZ_MAP = {
+    'n6': 1.4,
+    'n15': 3,
+    'n25': 5,
+    'n50': 10,
+    'n75': 15,
+    'n100': 20,
+}
 
-def duplex_mode(value):
+
+def duplex_mode(value: str) -> Optional[str]:
     return DUPLEX_MAP.get(value)
 
 
-def band_capability(value):
+def band_capability(value: str) -> str:
     return ','.join([str(int(b, 16)) for b in textwrap.wrap(value, 2)])
 
 
-def gps_tr181(value):
+def gps_tr181(value: str) -> str:
     """Convert GPS value (lat or lng) to float
 
     Per TR-181 specification, coordinates are returned in degrees,
@@ -37,3 +49,21 @@ def gps_tr181(value):
     if value.isnumeric():
         return str(float(value) / 1e6)
     return value
+
+
+def bandwidth(bandwidth_rbs: str) -> float:
+    """
+
+    Map bandwidth in number of RBs to MHz
+    TODO: TR-196 spec says this should be '6' rather than 'n6', but
+    BaiCells eNodeB uses 'n6'. Need to resolve this.
+
+    Args:
+        bandwidth_rbs (str): Bandwidth in number of RBs
+    Returns:
+        str: Bandwidth in MHz
+    """
+    if bandwidth_rbs not in BANDWIDTH_RBS_TO_MHZ_MAP:
+        raise ConfigurationError('Unknown bandwidth_rbs (%s)' %
+                                 str(bandwidth_rbs))
+    return BANDWIDTH_RBS_TO_MHZ_MAP[bandwidth_rbs]

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -210,6 +210,9 @@ class BaicellsTrDataModel(DataModel):
         ParameterName.UL_BANDWIDTH: transform_for_enb.bandwidth
     }
     TRANSFORMS_FOR_MAGMA = {
+        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
+        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
+        # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181
     }

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -50,7 +50,10 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
             'delete_objs': DeleteObjectsState(self, when_add='add_objs', when_skip='set_params'),
             'add_objs': AddObjectsState(self, when_done='set_params'),
             'set_params': SetParameterValuesState(self, when_done='wait_set_params'),
-            'wait_set_params': WaitSetParameterValuesState(self, when_done='reboot'),
+            'wait_set_params': WaitSetParameterValuesState(self, when_done='check_get_params'),
+            'check_get_params': GetParametersState(self, when_done='check_wait_get_params', request_all_params=True),
+            'check_wait_get_params': WaitGetParametersState(self, when_done='get_transient_params'),
+            # The state below are only entered with manual user intervention.
             'reboot': SendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
             'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_empty_after_reboot', when_timeout='disconnected'),

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -8,6 +8,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 from typing import Optional, Callable, Any, Dict, List, Type
+from magma.common.service import MagmaService
 from magma.enodebd.data_models.data_model import TrParam, DataModel
 from magma.enodebd.data_models.data_model_parameters import ParameterName, \
     TrParameterType
@@ -20,25 +21,34 @@ from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.state_machines.enb_acs_impl import \
     BasicEnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_states import EnodebAcsState, \
-    BaicellsDisconnectedState, SendGetTransientParametersState, \
+    WaitInformState, SendGetTransientParametersState, \
     WaitGetTransientParametersState, GetParametersState, \
     WaitGetParametersState, GetObjectParametersState, \
     WaitGetObjectParametersState, DeleteObjectsState, AddObjectsState, \
     SetParameterValuesState, WaitSetParameterValuesState, SendRebootState, \
-    WaitRebootResponseState, WaitInformMRebootState, UnexpectedInformState, \
+    WaitRebootResponseState, WaitInformMRebootState, \
     CheckOptionalParamsState, WaitEmptyMessageState, ErrorState
+from magma.enodebd.stats_manager import StatsManager
 
 
 class BaicellsHandler(BasicEnodebAcsStateMachine):
+    def __init__(
+        self,
+        service: MagmaService,
+        stats_mgr: StatsManager,
+    ) -> None:
+        self._state_map = {}
+        super().__init__(service, stats_mgr)
+
     def reboot_asap(self) -> None:
         self.transition('reboot')
 
     def is_enodeb_connected(self) -> bool:
-        return not isinstance(self.state, BaicellsDisconnectedState)
+        return not isinstance(self.state, WaitInformState)
 
     def _init_state_map(self) -> None:
         self._state_map = {
-            'disconnected': BaicellsDisconnectedState(self, when_done='wait_empty'),
+            'wait_inform': WaitInformState(self, when_done='wait_empty'),
             'wait_empty': WaitEmptyMessageState(self, when_done='check_optional_params'),
             'check_optional_params': CheckOptionalParamsState(self, when_done='get_transient_params'),
             'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
@@ -56,11 +66,10 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
             # The state below are only entered with manual user intervention.
             'reboot': SendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
-            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_empty_after_reboot', when_timeout='disconnected'),
+            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_empty_after_reboot', when_timeout='wait_inform'),
             'wait_empty_after_reboot': WaitEmptyMessageState(self, when_done='get_transient_params'),
             # The states below are entered when an unexpected message type is
             # received
-            'unexpected_inform': UnexpectedInformState(self, when_done='wait_empty'),
             'unexpected_fault': ErrorState(self),
         }
 
@@ -82,11 +91,7 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
 
     @property
     def disconnected_state_name(self) -> str:
-        return 'disconnected'
-
-    @property
-    def unexpected_inform_state_name(self) -> str:
-        return 'unexpected_inform'
+        return 'wait_inform'
 
     @property
     def unexpected_fault_state_name(self) -> str:

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -51,7 +51,10 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
             'delete_objs': DeleteObjectsState(self, when_add='add_objs', when_skip='set_params'),
             'add_objs': AddObjectsState(self, when_done='set_params'),
             'set_params': SetParameterValuesState(self, when_done='wait_set_params'),
-            'wait_set_params': WaitSetParameterValuesState(self, when_done='reboot'),
+            'wait_set_params': WaitSetParameterValuesState(self, when_done='check_get_params'),
+            'check_get_params': GetParametersState(self, when_done='check_wait_get_params', request_all_params=True),
+            'check_wait_get_params': WaitGetParametersState(self, when_done='get_transient_params'),
+            # The state below are only entered with manual user intervention.
             'reboot': SendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
             'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_empty_after_reboot', when_timeout='disconnected'),

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -225,6 +225,9 @@ class BaicellsTrOldDataModel(DataModel):
         ParameterName.CELL_RESERVED: transform_for_enb.invert_cell_reserved,
     }
     TRANSFORMS_FOR_MAGMA = {
+        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
+        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
+        # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181
     }

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -402,6 +402,7 @@ class BaicellsQAFBTrDataModel(DataModel):
 
     TRANSFORMS_FOR_ENB[ParameterName.ADMIN_STATE] = transform_for_enb.admin_state
     TRANSFORMS_FOR_MAGMA = {
+        # We don't set these parameters
         ParameterName.BAND_CAPABILITY: transform_for_magma.band_capability,
         ParameterName.DUPLEX_MODE_CAPABILITY: transform_for_magma.duplex_mode
     }

--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -9,6 +9,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 import logging
 from typing import Optional, Any, Callable, Dict, List, Type
+from magma.common.service import MagmaService
 from magma.enodebd.data_models.data_model import TrParam, DataModel
 from magma.enodebd.data_models.data_model_parameters import ParameterName, \
     TrParameterType
@@ -29,25 +30,34 @@ from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_impl import \
     BasicEnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_states import \
-    BaicellsDisconnectedState, SendGetTransientParametersState, \
+    WaitInformState, SendGetTransientParametersState, \
     GetParametersState, WaitGetParametersState, DeleteObjectsState, \
     AddObjectsState, SetParameterValuesState, WaitSetParameterValuesState, \
     SendRebootState, WaitRebootResponseState, WaitInformMRebootState, \
     EnodebAcsState, AcsMsgAndTransition, AcsReadMsgResult, \
-    UnexpectedInformState, WaitEmptyMessageState, ErrorState
+    WaitEmptyMessageState, ErrorState
 from magma.enodebd.tr069 import models
+from magma.enodebd.stats_manager import StatsManager
 
 
 class BaicellsQAFBHandler(BasicEnodebAcsStateMachine):
+    def __init__(
+            self,
+            service: MagmaService,
+            stats_mgr: StatsManager,
+    ) -> None:
+        self._state_map = {}
+        super().__init__(service, stats_mgr)
+
     def reboot_asap(self) -> None:
         self.transition('reboot')
 
     def is_enodeb_connected(self) -> bool:
-        return not isinstance(self.state, BaicellsDisconnectedState)
+        return not isinstance(self.state, WaitInformState)
 
     def _init_state_map(self) -> None:
         self._state_map = {
-            'disconnected': BaicellsDisconnectedState(self, when_done='wait_empty'),
+            'wait_inform': WaitInformState(self, when_done='wait_empty'),
             'wait_empty': WaitEmptyMessageState(self, when_done='get_transient_params'),
             'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
             'wait_get_transient_params': BaicellsQafbWaitGetTransientParametersState(self, when_get='get_params', when_get_obj_params='get_obj_params', when_delete='delete_objs', when_add='add_objs', when_set='set_params', when_skip='get_transient_params'),
@@ -63,10 +73,9 @@ class BaicellsQAFBHandler(BasicEnodebAcsStateMachine):
             # The state below are only entered with manual user intervention.
             'reboot': SendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
-            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='get_transient_params', when_timeout='disconnected'),
+            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='get_transient_params', when_timeout='wait_inform'),
             # The states below are entered when an unexpected message type is
             # received
-            'unexpected_inform': UnexpectedInformState(self, when_done='get_transient_params'),
             'unexpected_fault': ErrorState(self),
         }
 
@@ -88,11 +97,7 @@ class BaicellsQAFBHandler(BasicEnodebAcsStateMachine):
 
     @property
     def disconnected_state_name(self) -> str:
-        return 'disconnected'
-
-    @property
-    def unexpected_inform_state_name(self) -> str:
-        return 'unexpected_inform'
+        return 'wait_inform'
 
     @property
     def unexpected_fault_state_name(self) -> str:

--- a/lte/gateway/python/magma/enodebd/devices/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/cavium.py
@@ -259,6 +259,9 @@ class CaviumTrDataModel(DataModel):
         ParameterName.UL_BANDWIDTH: transform_for_enb.bandwidth
     }
     TRANSFORMS_FOR_MAGMA = {
+        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
+        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
+        # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181
     }

--- a/lte/gateway/python/magma/enodebd/devices/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/devices/tests/baicells_tests.py
@@ -99,6 +99,22 @@ class BaicellsHandlerTests(TestCase):
         resp = acs_state_machine.handle_tr069_message(req)
         self.assertTrue(isinstance(resp, models.GetParameterValues),
                         'State machine should be requesting param values')
+
+        # If a different eNB is suddenly plugged in, or the same eNB sends a
+        # new Inform, enodebd should be able to handle it.
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = self._get_inform()
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+        # Send an empty http request to kick off the rest of provisioning
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # Expect a request for an optional parameter, three times
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
         return
 
     def _get_mconfig(self) -> mconfigs_pb2.EnodebD:

--- a/lte/gateway/python/magma/enodebd/devices/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/devices/tests/baicells_tests.py
@@ -79,33 +79,26 @@ class BaicellsHandlerTests(TestCase):
         req.Status = 0
         resp = acs_state_machine.handle_tr069_message(req)
 
-        # SM should be attempting to reboot the Baicells device
-        self.assertTrue(isinstance(resp, models.Reboot),
-                        'State machine should be rebooting the eNB')
-        req = self._get_reboot_response()
-        resp = acs_state_machine.handle_tr069_message(req)
-
-        # SM should be trying to end the session with a dummy message
-        self.assertTrue(isinstance(resp, models.DummyInput))
-        req = self._get_reboot_inform()
-        resp = acs_state_machine.handle_tr069_message(req)
-
-        # SM should have responded to an Inform message with an Inform response
-        self.assertTrue(isinstance(resp, models.InformResponse))
-        req = models.DummyInput()
-        resp = acs_state_machine.handle_tr069_message(req)
-
-        # And now the SM has finished provisioning, and should only request
-        # the transient, read-only parameters
+        # Expect a request for read-only params
         self.assertTrue(isinstance(resp, models.GetParameterValues),
-                        'State machine should be requesting read-only params')
+                        'State machine should be requesting param values')
+        req = self._get_read_only_param_values_response()
 
-        # The eNodeB will send an Inform after ~10 minutes anyways, even
-        # during a provisioning session
-        req = self._get_inform()
+        # Send back some typical values
+        # And then SM should continue polling the read-only params
         resp = acs_state_machine.handle_tr069_message(req)
-        self.assertTrue(isinstance(resp, models.InformResponse),
-                        'State machine should handle unexpected Inform msgs')
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
+
+        # Expect a request for read-only params
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req = self._get_read_only_param_values_response()
+
+        # Send back some typical values
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param values')
         return
 
     def _get_mconfig(self) -> mconfigs_pb2.EnodebD:

--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -137,11 +137,14 @@ def get_all_objects_to_delete(
 def get_params_to_get(
     device_cfg: EnodebConfiguration,
     data_model: DataModel,
+    request_all_params: bool = False,
 ) -> List[ParameterName]:
     """
     Returns the names of params not belonging to objects that are added/removed
     """
     desired_names = data_model.get_present_params()
+    if request_all_params:
+        return desired_names
     known_names = device_cfg.get_parameter_names()
     names = list(set(desired_names) - set(known_names))
     return names

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -443,10 +443,18 @@ class GetParametersState(EnodebAcsState):
     Get the value of most parameters of the eNB that are defined in the data
     model. Object parameters are excluded.
     """
-    def __init__(self, acs: EnodebAcsStateMachine, when_done: str):
+    def __init__(
+        self,
+        acs: EnodebAcsStateMachine,
+        when_done: str,
+        request_all_params: bool = False,
+    ):
         super().__init__()
         self.acs = acs
         self.done_transition = when_done
+        # Set to True if we want to request values of all parameters, even if
+        # the ACS state machine already has recorded values of them.
+        self.request_all_params = request_all_params
 
     def read_msg(self, message: Any) -> AcsReadMsgResult:
         """
@@ -469,7 +477,8 @@ class GetParametersState(EnodebAcsState):
         """
 
         # Get the names of regular parameters
-        names = get_params_to_get(self.acs.device_cfg, self.acs.data_model)
+        names = get_params_to_get(self.acs.device_cfg, self.acs.data_model,
+                                  self.request_all_params)
 
         # Generate the request
         request = models.GetParameterValues()


### PR DESCRIPTION
Summary: Magma service 'enodebd' runs _check_mme_connection() every 15 seconds. This revision changes the logging message output from this method for increased clarity. Now, enodebd will report when it believes the eNB has connected/disconnected from MME, and also give more clear information about its reboot policy.

Reviewed By: rpraveen

Differential Revision: D14362443
