### PR TITLE
Use constant instead of hard coded string in gw magmad client

### DIFF
--- a/orc8r/cloud/go/services/magmad/gateway_api.go
+++ b/orc8r/cloud/go/services/magmad/gateway_api.go
@@ -25,7 +25,7 @@ func getGWMagmadClient(networkId string, gatewayId string) (protos.MagmadClient,
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	conn, ctx, err := gateway_registry.GetGatewayConnection("magmad", gwRecord.HwId.Id)
+	conn, ctx, err := gateway_registry.GetGatewayConnection(gateway_registry.GWMAGMAD, gwRecord.HwId.Id)
 	if err != nil {
 		errMsg := fmt.Sprintf("gateway magmad client initialization error: %s", err)
 		glog.Errorf(errMsg, err)


### PR DESCRIPTION
Summary: `getGWMagmadClient` now uses the constant defined in `gateway_registry` when getting the connection instead of a hardcoded string.

Reviewed By: vikg-fb

Differential Revision: D14408188
