### PR TITLE
Validate auth key and opc length

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/models/lte_subscription_swaggergen.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/lte_subscription_swaggergen.go
@@ -24,10 +24,14 @@ type LteSubscription struct {
 
 	// auth key
 	// Required: true
+	// Max Length: 16
+	// Min Length: 16
 	// Format: byte
 	AuthKey *strfmt.Base64 `json:"auth_key"`
 
 	// auth opc
+	// Max Length: 16
+	// Min Length: 16
 	// Format: byte
 	AuthOpc *strfmt.Base64 `json:"auth_opc,omitempty"`
 
@@ -108,6 +112,14 @@ func (m *LteSubscription) validateAuthKey(formats strfmt.Registry) error {
 		return err
 	}
 
+	if err := validate.MinLength("auth_key", "body", string(*m.AuthKey), 16); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("auth_key", "body", string(*m.AuthKey), 16); err != nil {
+		return err
+	}
+
 	// Format "byte" (base64 string) is already validated when unmarshalled
 
 	return nil
@@ -117,6 +129,14 @@ func (m *LteSubscription) validateAuthOpc(formats strfmt.Registry) error {
 
 	if swag.IsZero(m.AuthOpc) { // not required
 		return nil
+	}
+
+	if err := validate.MinLength("auth_opc", "body", string(*m.AuthOpc), 16); err != nil {
+		return err
+	}
+
+	if err := validate.MaxLength("auth_opc", "body", string(*m.AuthOpc), 16); err != nil {
+		return err
 	}
 
 	// Format "byte" (base64 string) is already validated when unmarshalled

--- a/lte/cloud/go/services/subscriberdb/swagger/swagger.yml
+++ b/lte/cloud/go/services/subscriberdb/swagger/swagger.yml
@@ -121,11 +121,15 @@ definitions:
       auth_key:
         type: string
         format: byte
+        minLength: 16
+        maxLength: 16
         x-nullable: true
         example: "AAAAAAAAAAAAAAAAAAAAAA=="
       auth_opc:
         type: string
         format: byte
+        minLength: 16
+        maxLength: 16
         x-nullable: true
         example: 'AAECAwQFBgcICQoLDA0ODw=='
   subscriber:


### PR DESCRIPTION
Summary: This is a fix for issue #59. The backend was not validating the length of the auth key and opc. This allowed invalid keys to get to SubscriberDB running in the gateway. This change adds validation so that invalid subscriber data cannot be added to the database using NMS.

Differential Revision: D14430821
