### PR TITLE
Properly delete all enforcement_stats flows on subscriber detach

### DIFF
--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -159,9 +159,14 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details('Service not enabled!')
             return None
-        for rule_id in request.rule_ids:
+        if request.rule_ids:
+            for rule_id in request.rule_ids:
+                self._service_manager.session_rule_version_mapper \
+                    .update_version(request.sid.id, rule_id)
+        else:
+            # If no rule ids are given, all flows are deactivated
             self._service_manager.session_rule_version_mapper.update_version(
-                request.sid.id, rule_id)
+                request.sid.id)
         self._loop.call_soon_threadsafe(
             self._enforcer_app.deactivate_rules,
             request.sid.id, request.rule_ids)

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -70,7 +70,7 @@ def activate_flows(client, args):
 def deactivate_flows(client, args):
     request = DeactivateFlowsRequest(
         sid=SIDUtils.to_pb(args.imsi),
-        rule_ids=args.rule_ids.split(','))
+        rule_ids=args.rule_ids.split(',') if args.rule_ids else [])
     client.DeactivateFlows(request)
 
 
@@ -147,8 +147,7 @@ def create_enforcement_parser(apps):
 
     subcmd = subparsers.add_parser('deactivate_flows', help='Deactivate flows')
     subcmd.add_argument('--imsi', help='Subscriber ID', default='IMSI12345')
-    subcmd.add_argument('--rule_ids',
-                        help='Comma separated rule ids', default='rule1,rule2')
+    subcmd.add_argument('--rule_ids', help='Comma separated rule ids')
     subcmd.set_defaults(func=deactivate_flows)
 
     subcmd = subparsers.add_parser('activate_dynamic_rule',


### PR DESCRIPTION
Summary:
Currently, the `deactivate_flow` rpc endpoint deleted enforcement_stats flows for a given subscriber + ruld_ids combination by incrementing the current version of these flows, which schedules a deletion. However, it did not handle the other use case of deleting all flows for a subscriber if rule_ids is empty. As a result, these enforcement_stats flows are not deleted, and enforcement_stats continues reporting stats to sessiond, resulting in errors in sessiond's side.

This diff adds a check in the rpc servicer for empty rule_ids. If it is empty, then the version of all flows for the subscriber will be incremented so they will be deleted.

`pipelined_cli` is also updated to test this case. When --rule_ids is not specified, an empty list will be sent to delete all flows, rather than a default list of rules.

Differential Revision: D14459830
