### PR TITLE
Replace all instances of errors.New(fmt.Sprintf()) with fmt.Errorf()

### DIFF
--- a/orc8r/cloud/go/obsidian/handlers/handler.go
+++ b/orc8r/cloud/go/obsidian/handlers/handler.go
@@ -86,7 +86,7 @@ var echoHandlerInitializers = map[HttpMethod]echoHandlerInitializer{
 func register(registry handlerRegistry, path string, handler echo.HandlerFunc) error {
 	_, registered := registry[path]
 	if registered {
-		return errors.New(fmt.Sprintf("HandlerFunc[s] already registered for path: %q", path))
+		return fmt.Errorf("HandlerFunc[s] already registered for path: %q", path)
 	}
 	registry[path] = handler
 	return nil
@@ -97,7 +97,7 @@ func register(registry handlerRegistry, path string, handler echo.HandlerFunc) e
 // server, see AttachAll below
 func Register(handler Handler) error {
 	if (handler.Methods & ^ALL) != 0 {
-		return errors.New(fmt.Sprintf("Invalid handler method[s]: %b", handler.Methods))
+		return fmt.Errorf("Invalid handler method[s]: %b", handler.Methods)
 	}
 
 	if len(handler.Path) == 0 {

--- a/orc8r/cloud/go/services/dispatcher/broker/memstore/request_queue.go
+++ b/orc8r/cloud/go/services/dispatcher/broker/memstore/request_queue.go
@@ -87,12 +87,12 @@ func (queues *requestQueueImpl) Enqueue(gwReq *protos.SyncRPCRequest) error {
 	defer queues.RUnlock()
 	reqQueue, ok := queues.reqQueueByGwId[gwId]
 	if !ok {
-		return errors.New(fmt.Sprintf("Queue does not exist for gwId %v\n", gwId))
+		return fmt.Errorf("Queue does not exist for gwId %v\n", gwId)
 	}
 	select {
 	case reqQueue <- gwReq:
 		return nil
 	case <-time.After(time.Second):
-		return errors.New(fmt.Sprintf("Failed to enqueue %v because queue for gwId %v is full\n", gwReq, gwId))
+		return fmt.Errorf("Failed to enqueue %v because queue for gwId %v is full\n", gwReq, gwId)
 	}
 }

--- a/orc8r/cloud/go/services/dispatcher/broker/memstore/response_table.go
+++ b/orc8r/cloud/go/services/dispatcher/broker/memstore/response_table.go
@@ -65,7 +65,7 @@ func (table *ResponseTableImpl) SendResponse(resp *protos.SyncRPCResponse) error
 			return errors.New("sendResponse timed out as respChan is not being actively waited on")
 		}
 	} else {
-		return errors.New(fmt.Sprintf("No response channel found for reqId %v\n", resp.ReqId))
+		return fmt.Errorf("No response channel found for reqId %v\n", resp.ReqId)
 	}
 }
 

--- a/orc8r/cloud/go/services/dispatcher/httpserver/http_server.go
+++ b/orc8r/cloud/go/services/dispatcher/httpserver/http_server.go
@@ -16,7 +16,6 @@ LICENSE file in the root directory of this source tree.
 package httpserver
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -206,11 +205,11 @@ func getHttpStatusFromGatewayResponse(gwRespStatus string) (int, error) {
 	httpStatus, err := strconv.Atoi(gwRespStatus)
 	if err != nil {
 		return DEFAULT_HTTP_RESPONSE_STATUS,
-			errors.New(fmt.Sprintf("cannot parse status of gatewayResponse: %v\n", err))
+			fmt.Errorf("cannot parse status of gatewayResponse: %v\n", err)
 	}
 	// invalid status code, defaults to 200
 	if statusText := http.StatusText(httpStatus); len(statusText) == 0 {
-		return DEFAULT_HTTP_RESPONSE_STATUS, errors.New(fmt.Sprintf("Unrecognized httpStatus: %v\n", httpStatus))
+		return DEFAULT_HTTP_RESPONSE_STATUS, fmt.Errorf("Unrecognized httpStatus: %v\n", httpStatus)
 	}
 	return httpStatus, nil
 }

--- a/orc8r/cloud/go/services/logger/exporters/scribe.go
+++ b/orc8r/cloud/go/services/logger/exporters/scribe.go
@@ -10,7 +10,6 @@ package exporters
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -100,7 +99,7 @@ func (e *ScribeExporter) write(client HttpClient, logEntries []*ScribeLogEntry) 
 	if resp.StatusCode != 200 {
 		errMsg, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
-		err = errors.New(fmt.Sprintf("Scribe status code %d: %s", resp.StatusCode, errMsg))
+		err = fmt.Errorf("Scribe status code %d: %s", resp.StatusCode, errMsg)
 	}
 	return err
 }

--- a/orc8r/cloud/go/services/logger/exporters/scribe_entry_utils.go
+++ b/orc8r/cloud/go/services/logger/exporters/scribe_entry_utils.go
@@ -10,7 +10,6 @@ package exporters
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	"magma/orc8r/cloud/go/protos"
@@ -38,7 +37,7 @@ func ConvertToScribeLogEntries(entries []*protos.LogEntry) ([]*ScribeLogEntry, e
 	scribeEntries := []*ScribeLogEntry{}
 	for _, entry := range entries {
 		if entry.Time == 0 {
-			return nil, errors.New(fmt.Sprintf("ScribeLogEntry %v doesn't have time field set", entry))
+			return nil, fmt.Errorf("ScribeLogEntry %v doesn't have time field set", entry)
 		}
 		scribeMsg := ScribeLogMessage{}
 		// if any of the following fields are nil, they will be omitted when scribeMsg is marshalled into json.

--- a/orc8r/cloud/go/services/logger/servicers/logging_service.go
+++ b/orc8r/cloud/go/services/logger/servicers/logging_service.go
@@ -39,7 +39,7 @@ func (srv *LoggingService) Log(ctx context.Context, request *protos.LogRequest) 
 	exporter, ok := srv.exporters[request.Destination]
 	if !ok {
 		return new(protos.Void),
-			errors.New(fmt.Sprintf("LoggerDestination %v not supported", request.Destination))
+			fmt.Errorf("LoggerDestination %v not supported", request.Destination)
 	}
 	err := exporter.Submit(request.Entries)
 	return new(protos.Void), err


### PR DESCRIPTION
Summary: Cleanup all instances of `errors.New(fmt.Sprintf())` by replacing them with `fmt.Errorf()`, as they are identical under the hood.

Reviewed By: vikg-fb

Differential Revision: D14434525
