### PR TITLE
Use ServerStream instead of Stream in orc8r identity.go

### DIFF
--- a/orc8r/cloud/go/identity/identity.go
+++ b/orc8r/cloud/go/identity/identity.go
@@ -77,7 +77,7 @@ func IsGateway(id *protos.Identity) bool {
 
 //GetStreamGatewayId returns a valid, non nil Gateway identity based on the
 //stream's metadata CTX or error if no GW Identity can be found/verified
-func GetStreamGatewayId(stream grpc.Stream) (*protos.Identity_Gateway, error) {
+func GetStreamGatewayId(stream grpc.ServerStream) (*protos.Identity_Gateway, error) {
 	ctx := stream.Context()
 	if ctx == nil {
 		msg := "Missing Stream Context"


### PR DESCRIPTION
Summary: Use `grpc.ServerStream` instead of `grpc.Stream` in `identity.go`, since `grpc.Stream` is deprecated. The function is used in two instances, both of which are server streams.

Reviewed By: rpraveen

Differential Revision: D14446666
