### PR TITLE
Add tests for ReloadServiceConfig in MagmaService

### DIFF
--- a/orc8r/gateway/c/common/service303/MagmaService.cpp
+++ b/orc8r/gateway/c/common/service303/MagmaService.cpp
@@ -33,6 +33,7 @@ using grpc::InsecureServerCredentials;
 using grpc::Server;
 using magma::orc8r::Service303;
 using magma::orc8r::ServiceInfo;
+using magma::orc8r::ReloadConfigResponse;
 using magma::orc8r::Void;
 using magma::service303::MetricsSingleton;
 using magma::service303::MagmaService;
@@ -126,6 +127,14 @@ Status MagmaService::SetLogLevel(
   // log level FATAL is minimum verbosity and maximum level
   auto verbosity = LogLevel::FATAL - request->level();
   set_verbosity(verbosity);
+  return Status::OK;
+}
+
+Status MagmaService::ReloadServiceConfig(
+    ServerContext *context,
+    const Void *request,
+    ReloadConfigResponse *response) {
+  response->set_result(ReloadConfigResponse::RELOAD_UNSUPPORTED);
   return Status::OK;
 }
 

--- a/orc8r/gateway/c/common/service303/MagmaService.h
+++ b/orc8r/gateway/c/common/service303/MagmaService.h
@@ -27,6 +27,7 @@ namespace magma { namespace service303 {
 
 using ServiceInfoMeta = std::map<std::string,std::string>;
 using ServiceInfoCallback = std::function<ServiceInfoMeta()>;
+using ConfigReloadCallback = std::function<bool()>;
 
 /**
  * MagmaService provides the framework for all Magma services.
@@ -73,6 +74,16 @@ class MagmaService final : public Service303::Service {
      * Unsets the callback to generate the meta field for service info
      */
     void ClearServiceInfoCallback();
+
+    /**
+     * Sets the callback to request a config reload from a service
+     */
+    void SetConfigReloadCallback(ConfigReloadCallback callback);
+
+    /**
+     * Unsets the callback to request a config reload from a service
+     */
+    void ClearConfigReloadCallback();
 
     /*
     * Returns the service info (name, version, state, etc.)
@@ -179,6 +190,7 @@ class MagmaService final : public Service303::Service {
     std::unique_ptr<Server> server_;
     grpc::ServerBuilder builder_;
     ServiceInfoCallback service_info_callback_;
+    ConfigReloadCallback config_reload_callback_;
 };
 
 }} // namespace magma::service303

--- a/orc8r/gateway/c/common/service303/MagmaService.h
+++ b/orc8r/gateway/c/common/service303/MagmaService.h
@@ -128,6 +128,19 @@ class MagmaService final : public Service303::Service {
          Void* response) override;
 
     /*
+     * Handles request to reload the service config file
+     *
+     * @param context: the grpc Server context
+     * @param request: Void
+     * @param response (out): reload config result (SUCCESS/FAILURE/UNSUPPORTED)
+     * @return grpc Status instance
+     */
+    Status ReloadServiceConfig(
+        ServerContext *context,
+        const Void *request,
+        ReloadConfigResponse *response) override;
+
+    /*
      * Simple setter function to set the new application health
      *
      * @param newState: the new application health you want to set

--- a/orc8r/gateway/c/common/test/test_magma_service.cpp
+++ b/orc8r/gateway/c/common/test/test_magma_service.cpp
@@ -70,7 +70,40 @@ TEST(test_magma_service, test_GetServiceInfo_with_callback) {
   magma_service.ClearServiceInfoCallback();
   magma_service.GetServiceInfo(nullptr, nullptr, &response);
   EXPECT_TRUE(response.status().meta().empty());
+}
 
+bool reload_succeeded() {
+  return true;
+}
+
+bool reload_failed() {
+  return false;
+}
+
+TEST(test_magma_service, test_ReloadServiceConfig) {
+  MagmaService magma_service(MAGMA_SERIVCE_NAME, MAGMA_SERVICE_VERSION);
+  ReloadConfigResponse response;
+
+  magma_service.ReloadServiceConfig(nullptr, nullptr, &response);
+  EXPECT_EQ(response.result(), ReloadConfigResponse::RELOAD_UNSUPPORTED);
+
+  response.Clear();
+
+  magma_service.SetConfigReloadCallback(reload_succeeded);
+  magma_service.ReloadServiceConfig(nullptr, nullptr, &response);
+  EXPECT_EQ(response.result(), ReloadConfigResponse::RELOAD_SUCCESS);
+
+  response.Clear();
+
+  magma_service.SetConfigReloadCallback(reload_failed);
+  magma_service.ReloadServiceConfig(nullptr, nullptr, &response);
+  EXPECT_EQ(response.result(), ReloadConfigResponse::RELOAD_FAILURE);
+
+  response.Clear();
+
+  magma_service.ClearConfigReloadCallback();
+  magma_service.ReloadServiceConfig(nullptr, nullptr, &response);
+  EXPECT_EQ(response.result(), ReloadConfigResponse::RELOAD_UNSUPPORTED);
 }
 
 int main(int argc, char **argv) {

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -19,9 +19,11 @@ import os
 import pkg_resources
 from orc8r.protos.common_pb2 import LogLevel, Void
 from orc8r.protos.metricsd_pb2 import MetricsContainer
-from orc8r.protos.service303_pb2 import ServiceInfo
-from orc8r.protos.service303_pb2_grpc import Service303Servicer, \
-    add_Service303Servicer_to_server
+from orc8r.protos.service303_pb2 import ServiceInfo, ReloadConfigResponse
+from orc8r.protos.service303_pb2_grpc import (
+    Service303Servicer,
+    add_Service303Servicer_to_server,
+)
 
 from magma.configuration.exceptions import LoadConfigError
 from magma.configuration.mconfig_managers import get_mconfig_manager
@@ -299,3 +301,10 @@ class MagmaService(Service303Servicer):
 
     def SetLogVerbosity(self, request, context):
         pass  # Not Implemented
+
+    def ReloadServiceConfig(self, request, context):
+        """
+        Handles request to reload the service config file
+        """
+        res = ReloadConfigResponse.RELOAD_UNSUPPORTED
+        return ReloadConfigResponse(result=res)

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -43,6 +43,7 @@ class MagmaService(Service303Servicer):
         self._name = name
         self._port = 0
         self._get_status_callback = None
+        self._reload_config_callback = None
 
         # Init logging before doing anything
         logging.basicConfig(
@@ -182,6 +183,11 @@ class MagmaService(Service303Servicer):
             Must return a map(string, string)"""
         self._get_status_callback = get_status_callback
 
+    def register_reload_config_callback(self, reload_config_callback):
+        """ Register function for reloading config file.
+            Must return boolean whether the reload succeeded"""
+        self._reload_config_callback = reload_config_callback
+
     def _stop(self, reason):
         """
         Stops the service gracefully
@@ -306,5 +312,11 @@ class MagmaService(Service303Servicer):
         """
         Handles request to reload the service config file
         """
-        res = ReloadConfigResponse.RELOAD_UNSUPPORTED
+        if self._reload_config_callback:
+            if self._reload_config_callback():
+                res = ReloadConfigResponse.RELOAD_SUCCESS
+            else:
+                res = ReloadConfigResponse.RELOAD_FAILURE
+        else:
+            res = ReloadConfigResponse.RELOAD_UNSUPPORTED
         return ReloadConfigResponse(result=res)

--- a/orc8r/protos/service303.proto
+++ b/orc8r/protos/service303.proto
@@ -74,6 +74,16 @@ message LogVerbosity {
   int32 verbosity = 1;
 }
 
+message ReloadConfigResponse {
+  enum ReloadConfigResult {
+    RELOAD_UNKNOWN = 0;
+    RELOAD_SUCCESS = 1;
+    RELOAD_FAILURE = 2;
+    RELOAD_UNSUPPORTED = 3;
+  }
+  ReloadConfigResult result = 1;
+}
+
 
 // --------------------------------------------------------------------------
 // Service303 interface definition.
@@ -102,4 +112,7 @@ service Service303 {
 
   // Set logging verbosity The larger, the more verbose. default 0
   rpc SetLogVerbosity (LogVerbosity) returns (Void) {}
+
+  // Requests service reloads config files loaded on startup (<servicename>.yml)
+  rpc ReloadServiceConfig (Void) returns (ReloadConfigResponse) {}
 }


### PR DESCRIPTION
Summary:
Ian is working on a command line tool to adjust service configurations
without requiring a service restart. To support this we need a way for
each service to accept these requests.

This diff adds unit tests for ReloadServiceConfig in MagmaService.cpp.
Specifically, it tests that by default MagmaService::ReloadServiceConfig
returns an unsupported result code. Then, sets the callback to a
succeeding and failing config change and tests that it receives the
correct return codes (success/failure). Finally, the callback is cleared
and we check that it again returns an unsupported result code.

Differential Revision: D14482020
