### PR TITLE
Implement AuthenticationInformation function

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/ai.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai.go
@@ -9,22 +9,129 @@ LICENSE file in the root directory of this source tree.
 package servicers
 
 import (
+	"errors"
+	"fmt"
+
+	fegprotos "magma/feg/cloud/go/protos"
+	lteprotos "magma/lte/cloud/go/protos"
+	"magma/lte/cloud/go/services/eps_authentication/crypto"
+
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-
-	"magma/feg/cloud/go/protos"
 )
 
-func (srv *EPSAuthServer) AuthenticationInformation(ctx context.Context, air *protos.AuthenticationInformationRequest) (*protos.AuthenticationInformationAnswer, error) {
+func (srv *EPSAuthServer) AuthenticationInformation(ctx context.Context, air *fegprotos.AuthenticationInformationRequest) (*fegprotos.AuthenticationInformationAnswer, error) {
+	if err := validateAIR(air); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, err.Error())
+	}
+
 	networkID, err := getNetworkID(ctx)
 	if err != nil {
 		return nil, err
 	}
-	_, err = getConfig(networkID)
+	config, err := getConfig(networkID)
 	if err != nil {
 		return nil, err
 	}
+	subscriber, errorCode, err := srv.lookupSubscriber(air.UserName, networkID)
+	if err != nil {
+		return &fegprotos.AuthenticationInformationAnswer{ErrorCode: errorCode}, err
+	}
 
-	return nil, status.Errorf(codes.Unimplemented, "authentication information not implemented")
+	lteAuthNextSeq, err := ResyncLteAuthSeq(subscriber, air.ResyncInfo, config.LteAuthOp)
+	if err != nil {
+		return convertAuthErrorToAuthenticationAnswer(err)
+	}
+	if err = srv.setLteAuthNextSeq(subscriber, lteAuthNextSeq); err != nil {
+		return &fegprotos.AuthenticationInformationAnswer{ErrorCode: fegprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE}, err
+	}
+
+	milenage, err := crypto.NewMilenageCipher(config.LteAuthAmf)
+	if err != nil {
+		return &fegprotos.AuthenticationInformationAnswer{ErrorCode: fegprotos.ErrorCode_AUTHORIZATION_REJECTED},
+			status.Errorf(codes.FailedPrecondition, "Could not create milenage cipher: %s", err.Error())
+	}
+
+	vectors, lteAuthNextSeq, err := GenerateLteAuthVectors(
+		air.NumRequestedEutranVectors,
+		milenage,
+		subscriber,
+		air.VisitedPlmn,
+		config.LteAuthOp,
+		0,
+	)
+	if err != nil {
+		return convertAuthErrorToAuthenticationAnswer(err)
+	}
+	if err = srv.setLteAuthNextSeq(subscriber, lteAuthNextSeq); err != nil {
+		return &fegprotos.AuthenticationInformationAnswer{ErrorCode: fegprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE}, err
+	}
+
+	return &fegprotos.AuthenticationInformationAnswer{
+		ErrorCode:     fegprotos.ErrorCode_SUCCESS,
+		EutranVectors: convertEutranVectorsToProto(vectors),
+	}, nil
+}
+
+// validateAIR returns an error iff the AIR is invalid.
+func validateAIR(air *fegprotos.AuthenticationInformationRequest) error {
+	if air == nil {
+		return errors.New("received a nil AuthenticationInformationRequest")
+	}
+	if len(air.UserName) == 0 {
+		return errors.New("user name was empty")
+	}
+	if len(air.VisitedPlmn) != crypto.ExpectedPlmnBytes {
+		return fmt.Errorf("expected Visited PLMN to be %v bytes, but got %v bytes", crypto.ExpectedPlmnBytes, len(air.VisitedPlmn))
+	}
+	if air.NumRequestedEutranVectors == 0 {
+		return errors.New("0 E-UTRAN vectors were requested")
+	}
+	return nil
+}
+
+// convertAuthErrorToAuthenticationAnswer converts an auth error to a result which can be returned by AuthenticationInformation.
+func convertAuthErrorToAuthenticationAnswer(err error) (*fegprotos.AuthenticationInformationAnswer, error) {
+	var errorCode fegprotos.ErrorCode
+	var grpcErr error
+
+	switch err.(type) {
+	case AuthRejectedError:
+		errorCode = fegprotos.ErrorCode_AUTHORIZATION_REJECTED
+		grpcErr = status.Errorf(codes.Unauthenticated, err.Error())
+	case AuthDataUnavailableError:
+		errorCode = fegprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE
+		grpcErr = status.Errorf(codes.Unavailable, err.Error())
+	default:
+		errorCode = fegprotos.ErrorCode_UNDEFINED
+		grpcErr = status.Errorf(codes.Unknown, err.Error())
+	}
+
+	answer := &fegprotos.AuthenticationInformationAnswer{ErrorCode: errorCode}
+	return answer, grpcErr
+}
+
+// setLteAuthNextSeq sets the subscriber's LteAuthNextSeq field in the database.
+func (srv *EPSAuthServer) setLteAuthNextSeq(subscriber *lteprotos.SubscriberData, lteAuthNextSeq uint64) error {
+	if subscriber.GetState() == nil {
+		return NewAuthDataUnavailableError("subscriber state was nil")
+	}
+	subscriber.State.LteAuthNextSeq = lteAuthNextSeq
+	_, err := srv.Store.UpdateSubscriber(subscriber)
+	return err
+}
+
+// convertEutranVectorsToProto serialized a list of E-UTRAN vectors to proto.
+func convertEutranVectorsToProto(vectors []*crypto.EutranVector) []*fegprotos.AuthenticationInformationAnswer_EUTRANVector {
+	result := make([]*fegprotos.AuthenticationInformationAnswer_EUTRANVector, len(vectors))
+	for i, vector := range vectors {
+		result[i] = &fegprotos.AuthenticationInformationAnswer_EUTRANVector{
+			Rand:  vector.Rand[:],
+			Xres:  vector.Xres[:],
+			Autn:  vector.Autn[:],
+			Kasme: vector.Kasme[:],
+		}
+	}
+	return result
 }

--- a/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
@@ -1,0 +1,168 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package servicers
+
+import (
+	"magma/feg/cloud/go/protos"
+	"magma/lte/cloud/go/services/eps_authentication/crypto"
+
+	"golang.org/x/net/context"
+)
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_NilRequest() {
+	_, err := suite.AuthenticationInformation(nil)
+	suite.EqualError(err, "rpc error: code = InvalidArgument desc = received a nil AuthenticationInformationRequest")
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_EmptyUserName() {
+	air := &protos.AuthenticationInformationRequest{
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 1,
+	}
+
+	_, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = InvalidArgument desc = user name was empty")
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_EmptyPlmm() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub1",
+		NumRequestedEutranVectors: 1,
+	}
+
+	_, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = InvalidArgument desc = expected Visited PLMN to be 3 bytes, but got 0 bytes")
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_0RequestedVectors() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:    "sub1",
+		VisitedPlmn: []byte{0, 0, 0},
+	}
+
+	_, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = InvalidArgument desc = 0 E-UTRAN vectors were requested")
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_UnknownGateway() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub1",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 1,
+	}
+
+	_, err := suite.Server.AuthenticationInformation(context.Background(), air)
+	suite.EqualError(err, "rpc error: code = PermissionDenied desc = Missing Gateway Identity")
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_UnknownSubscriber() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub_unknown",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 1,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = Aborted desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
+	suite.checkAIA(aia, protos.ErrorCode_USER_UNKNOWN, 0)
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_MissingAuthKey() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "missing_auth_key",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 1,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = Unauthenticated desc = Authentication rejected: incorrect key size. Expected 16 bytes, but got 0 bytes")
+	suite.checkAIA(aia, protos.ErrorCode_AUTHORIZATION_REJECTED, 0)
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_MissingSubscriberState() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "empty_sub",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 1,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = Unavailable desc = Authentication data unavailable: subscriber state is nil")
+	suite.checkAIA(aia, protos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE, 0)
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_Success() {
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub1",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 3,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.NoError(err)
+	suite.checkAIA(aia, protos.ErrorCode_SUCCESS, 3)
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_InvalidResyncInfo() {
+	resyncInfo := make([]byte, 10)
+	resyncInfo[5] = 1
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub1",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 3,
+		ResyncInfo:                resyncInfo,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = Unauthenticated desc = Authentication rejected: resync info incorrect length. expected 30 bytes, but got 10 bytes")
+	suite.checkAIA(aia, protos.ErrorCode_AUTHORIZATION_REJECTED, 0)
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_InvalidResyncMacS() {
+	resyncInfo := make([]byte, 30)
+	macS := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	copy(resyncInfo[22:], macS)
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub1",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 3,
+		ResyncInfo:                resyncInfo,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.EqualError(err, "rpc error: code = Unauthenticated desc = Authentication rejected: Invalid resync authentication code")
+	suite.checkAIA(aia, protos.ErrorCode_AUTHORIZATION_REJECTED, 0)
+}
+
+func (suite *EpsAuthTestSuite) TestAuthenticationInformation_ResyncSuccess() {
+	resyncInfo := make([]byte, 30)
+	macS := []byte{47, 223, 5, 242, 77, 209, 76, 218}
+	copy(resyncInfo[22:], macS)
+	air := &protos.AuthenticationInformationRequest{
+		UserName:                  "sub1",
+		VisitedPlmn:               []byte{0, 0, 0},
+		NumRequestedEutranVectors: 3,
+		ResyncInfo:                resyncInfo,
+	}
+
+	aia, err := suite.AuthenticationInformation(air)
+	suite.NoError(err)
+	suite.checkAIA(aia, protos.ErrorCode_SUCCESS, 3)
+}
+
+func (suite *EpsAuthTestSuite) checkAIA(aia *protos.AuthenticationInformationAnswer, errorCode protos.ErrorCode, numVectors int) {
+	suite.Equal(errorCode, aia.ErrorCode)
+	suite.Equal(numVectors, len(aia.EutranVectors))
+	for _, vector := range aia.EutranVectors {
+		suite.Equal(crypto.RandChallengeBytes, len(vector.Rand))
+		suite.Equal(crypto.XresBytes, len(vector.Xres))
+		suite.Equal(crypto.AutnBytes, len(vector.Autn))
+		suite.Equal(crypto.KasmeBytes, len(vector.Kasme))
+	}
+}

--- a/lte/cloud/go/services/eps_authentication/servicers/eps_auth_suite_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/eps_auth_suite_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package servicers
+
+import (
+	"testing"
+
+	fegprotos "magma/feg/cloud/go/protos"
+	cellular "magma/lte/cloud/go/services/cellular/config"
+	cellular_protos "magma/lte/cloud/go/services/cellular/protos"
+	utils "magma/lte/cloud/go/services/eps_authentication/servicers/test_utils"
+	"magma/lte/cloud/go/services/subscriberdb/storage"
+	orc8rprotos "magma/orc8r/cloud/go/protos"
+	"magma/orc8r/cloud/go/services/config"
+	"magma/orc8r/cloud/go/services/config/registry"
+	"magma/orc8r/cloud/go/services/config/test_init"
+	"magma/orc8r/cloud/go/test_utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"golang.org/x/net/context"
+)
+
+// EpsAuthTestSuite is a test suite that will setup a test EPS auth server
+// and config service pre-populated with a cellular config.
+type EpsAuthTestSuite struct {
+	suite.Suite
+	Server *EPSAuthServer
+}
+
+func (suite *EpsAuthTestSuite) AuthenticationInformation(air *fegprotos.AuthenticationInformationRequest) (*fegprotos.AuthenticationInformationAnswer, error) {
+	return suite.Server.AuthenticationInformation(getTestContext(), air)
+}
+
+func (suite *EpsAuthTestSuite) UpdateLocation(ulr *fegprotos.UpdateLocationRequest) (*fegprotos.UpdateLocationAnswer, error) {
+	return suite.Server.UpdateLocation(getTestContext(), ulr)
+}
+
+func (suite *EpsAuthTestSuite) PurgeUE(purge *fegprotos.PurgeUERequest) (*fegprotos.PurgeUEAnswer, error) {
+	return suite.Server.PurgeUE(getTestContext(), purge)
+}
+
+func (suite *EpsAuthTestSuite) SetupTest() {
+	store, err := storage.NewSubscriberDBStorage(test_utils.NewMockDatastore())
+	suite.NoError(err)
+
+	for _, subscriber := range utils.GetTestSubscribers() {
+		_, err := store.AddSubscriber(subscriber)
+		suite.NoError(err)
+	}
+
+	server, err := NewEPSAuthServer(store)
+	suite.NoError(err)
+	suite.Server = server
+}
+
+func TestEpsAuthSuite(t *testing.T) {
+	test_init.StartTestService(t)
+	err := registry.RegisterConfigManager(&cellular.CellularNetworkConfigManager{})
+	assert.NoError(t, err)
+
+	configProto := &cellular_protos.CellularNetworkConfig{
+		Ran: &cellular_protos.NetworkRANConfig{},
+		Epc: &cellular_protos.NetworkEPCConfig{
+			Mcc:        "123",
+			Mnc:        "123",
+			Tac:        1,
+			LteAuthOp:  []byte("\xcd\xc2\x02\xd5\x12> \xf6+mgj\xc7,\xb3\x18"),
+			LteAuthAmf: []byte("\x80\x00"),
+			SubProfiles: map[string]*cellular_protos.NetworkEPCConfig_SubscriptionProfile{
+				"default": &cellular_protos.NetworkEPCConfig_SubscriptionProfile{
+					MaxUlBitRate: 1000,
+					MaxDlBitRate: 2000,
+				},
+				"test_profile": &cellular_protos.NetworkEPCConfig_SubscriptionProfile{
+					MaxUlBitRate: 7000,
+					MaxDlBitRate: 5000,
+				},
+			},
+		},
+	}
+	err = config.CreateConfig("test", cellular.CellularNetworkType, "test", configProto)
+	assert.NoError(t, err)
+
+	testSuite := &EpsAuthTestSuite{}
+	suite.Run(t, testSuite)
+}
+
+func getTestContext() context.Context {
+	return orc8rprotos.NewGatewayIdentity("test", "test", "test").NewContextWithIdentity(context.Background())
+}

--- a/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
@@ -10,6 +10,7 @@ package test_utils
 
 import (
 	"magma/lte/cloud/go/protos"
+	orc8rprotos "magma/orc8r/cloud/go/protos"
 )
 
 const (
@@ -24,7 +25,8 @@ func GetTestSubscribers() []*protos.SubscriberData {
 	subs := make([]*protos.SubscriberData, 0)
 
 	sub := &protos.SubscriberData{
-		Sid: &protos.SubscriberID{Id: "sub1"},
+		Sid:       &protos.SubscriberID{Id: "sub1"},
+		NetworkId: &orc8rprotos.NetworkID{Id: "test"},
 		Lte: &protos.LTESubscription{
 			State:    protos.LTESubscription_ACTIVE,
 			AuthAlgo: protos.LTESubscription_MILENAGE,
@@ -64,12 +66,14 @@ func GetTestSubscribers() []*protos.SubscriberData {
 	subs = append(subs, sub)
 
 	sub = &protos.SubscriberData{
-		Sid: &protos.SubscriberID{Id: "empty_sub"},
+		Sid:       &protos.SubscriberID{Id: "empty_sub"},
+		NetworkId: &orc8rprotos.NetworkID{Id: "test"},
 	}
 	subs = append(subs, sub)
 
 	sub = &protos.SubscriberData{
-		Sid: &protos.SubscriberID{Id: "missing_auth_key"},
+		Sid:       &protos.SubscriberID{Id: "missing_auth_key"},
+		NetworkId: &orc8rprotos.NetworkID{Id: "test"},
 		Lte: &protos.LTESubscription{
 			State:    protos.LTESubscription_ACTIVE,
 			AuthAlgo: protos.LTESubscription_MILENAGE,


### PR DESCRIPTION
Summary: Implement the AuthenticationInformation gRPC function in the EPS Authentication service. This function will be invoked by the mme to generate E-UTRAN authentication vectors or to perform re-sync requests for the sequence numbers. See 3GPP TS 29.272.

Differential Revision: D14380762
