### PR TITLE
Add missing AVPs to multimedia authentication answers

### DIFF
--- a/feg/gateway/services/swx_proxy/servicers/swx_definitions.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_definitions.go
@@ -31,6 +31,10 @@ const (
 
 	// 3GPP 29.273 8.2.3.4
 	Non3GPPIPAccess_ENABLED = 0
+
+	// Value of AVP auth-session-state indicating that no state is maintained
+	// between calls.
+	AuthSessionState_NO_STATE_MAINTAINED = 1
 )
 
 // 3GPP 29.273 8.2.2.1 - Multimedia Authentication Request

--- a/feg/gateway/services/testcore/hss/servicers/test/ma_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/ma_test.go
@@ -276,6 +276,7 @@ func testNewMAASuccessfulResponse(t *testing.T, server *hss.HomeSubscriberServer
 	assert.Equal(t, uint32(diam.Success), maa.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), maa.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), maa.OriginRealm)
+	assert.Equal(t, int32(definitions.AuthSessionState_NO_STATE_MAINTAINED), maa.AuthSessionState)
 	checkSIPAuthVectors(t, maa, 1)
 
 	subscriber, err := server.GetSubscriberData(context.Background(), &lteprotos.SubscriberID{Id: "sub1"})


### PR DESCRIPTION
Summary:
This change adds AVPs that a real HSS would send in a multimedia authentication answer (MAA) to the HSS lite. That way, the HSS lite behaves more similarly to a real HSS and is a more effective testing component.

The following AVPs were added to MAAs:
* User name
* Auth session state
* Vendor specific application id
* SIP item number

Differential Revision: D14510141
