### PR TITLE
Add metrics to health service for FeG alerts

### DIFF
--- a/feg/cloud/go/go.mod
+++ b/feg/cloud/go/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/go-openapi/validate v0.18.0
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.2.0
+	github.com/prometheus/client_golang v0.9.2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 	google.golang.org/grpc v1.17.0

--- a/feg/cloud/go/services/health/metrics/metrics.go
+++ b/feg/cloud/go/services/health/metrics/metrics.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+package metrics
+
+import (
+	"magma/feg/cloud/go/protos"
+
+	"github.com/golang/glog"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	ActiveGatewayChanged = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "active_gateway_changed_total",
+			Help: "increases everytime the active gateway for a network is updated",
+		},
+		[]string{"networkId"},
+	)
+	TotalGatewayCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gateway_total_count",
+			Help: "Total number of gateways that are in the network"},
+		[]string{"networkId"},
+	)
+	HealthyGatewayCount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "gateway_health_count",
+			Help: "Number of gateways that are healthy in the network"},
+		[]string{"networkId"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(ActiveGatewayChanged, TotalGatewayCount, HealthyGatewayCount)
+}
+
+// SetHealthyGatewayMetric takes the current health of both active and standby gateways
+// in a network and sets the prometheus gauge metric for number of healthy gateways accordingly.
+// Note: Prometheus gauge metric Set's are done with the atomic operation StoreUint64
+func SetHealthyGatewayMetric(networkID string, gwHealth1, gwHealth2 protos.HealthStatus_HealthState) {
+	if gwHealth1 == protos.HealthStatus_HEALTHY && gwHealth2 == protos.HealthStatus_HEALTHY {
+		HealthyGatewayCount.WithLabelValues(networkID).Set(2)
+	} else if gwHealth1 == protos.HealthStatus_UNHEALTHY && gwHealth2 == protos.HealthStatus_HEALTHY {
+		HealthyGatewayCount.WithLabelValues(networkID).Set(1)
+	} else if gwHealth1 == protos.HealthStatus_HEALTHY && gwHealth2 == protos.HealthStatus_UNHEALTHY {
+		HealthyGatewayCount.WithLabelValues(networkID).Set(1)
+	} else {
+		glog.Infof("Both gateways are unhealthy in network: %s", networkID)
+		HealthyGatewayCount.WithLabelValues(networkID).Set(0)
+	}
+}

--- a/feg/cloud/go/services/health/reporter/network_health_reporter.go
+++ b/feg/cloud/go/services/health/reporter/network_health_reporter.go
@@ -1,0 +1,77 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package reporter
+
+import (
+	"time"
+
+	"magma/feg/cloud/go/protos"
+	fegcfg "magma/feg/cloud/go/services/controller/config"
+	"magma/feg/cloud/go/services/health/metrics"
+	"magma/feg/cloud/go/services/health/servicers"
+	"magma/feg/cloud/go/services/health/storage"
+	orc8rcfg "magma/orc8r/cloud/go/services/config"
+	"magma/orc8r/cloud/go/services/magmad"
+
+	"github.com/golang/glog"
+)
+
+type NetworkHealthStatusReporter struct {
+	Store storage.HealthStorage
+}
+
+func NewNetworkHealthStatusReporter(store storage.HealthStorage) (*NetworkHealthStatusReporter, error) {
+	return &NetworkHealthStatusReporter{Store: store}, nil
+}
+
+func (reporter *NetworkHealthStatusReporter) ReportHealthStatus(dur time.Duration) {
+	for _ = range time.Tick(dur) {
+		err := reporter.reportHealthStatus()
+		if err != nil {
+			glog.Errorf("err in reportHealthStatus: %v\n", err)
+		}
+	}
+}
+
+func (reporter *NetworkHealthStatusReporter) reportHealthStatus() error {
+	networks, err := magmad.ListNetworks()
+	if err != nil {
+		return err
+	}
+	for _, nw := range networks {
+		// Consider a FeG network to be only those that have FeG Network configs defined
+		config, err := orc8rcfg.GetConfig(nw, fegcfg.FegNetworkType, nw)
+		if err != nil || config == nil {
+			continue
+		}
+		gateways, err := magmad.ListGateways(nw)
+		if err != nil {
+			glog.Errorf("error getting gateways for network %v: %v\n", nw, err)
+			continue
+		}
+		healthyGateways := 0
+		for _, gw := range gateways {
+			healthStatus, err := reporter.Store.GetHealth(nw, gw)
+			if err != nil {
+				glog.V(2).Infof("error getting health for network %s, gateway %s: %v\n", nw, gw, err)
+				continue
+			}
+			status, _, err := servicers.AnalyzeHealthStats(healthStatus, nw)
+			if err != nil {
+				glog.V(2).Infof("error analyzing health stats for network %s, gateway %s: %v", nw, gw, err)
+			}
+			if status == protos.HealthStatus_HEALTHY {
+				healthyGateways++
+			}
+		}
+		metrics.TotalGatewayCount.WithLabelValues(nw).Set(float64(len(gateways)))
+		metrics.HealthyGatewayCount.WithLabelValues(nw).Set(float64(healthyGateways))
+	}
+	return nil
+}


### PR DESCRIPTION
Summary:
Currently there aren't any metrics for if an active gateway changes or all Federated Gateways in a network are unhealthy.
This diff adds the necessary metrics and sets them appropriately in the FeG's health service. These metrics will give us more insight
into how the health service is operating for upcoming FeG testing and deployments.

Reviewed By: xjtian

Differential Revision: D14460875
