### PR TITLE
Include mconfigs.proto from both feg and gateway

### DIFF
--- a/feg/gateway/mconfig/impl.go
+++ b/feg/gateway/mconfig/impl.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	_ "magma/feg/cloud/go/protos/mconfig"
+	_ "magma/lte/cloud/go/protos/mconfig"
 	"magma/orc8r/cloud/go/protos"
 	_ "magma/orc8r/cloud/go/protos/mconfig"
 )


### PR DESCRIPTION
Summary:
**Summary**
FeG was not able to parse `gateway.mconfig` containing lte and feg service, but MME configs is required for constructing some CSFB related messages.

**Implementation**
Import `"magma/feg/cloud/go/protos/mconfig"` and `"magma/lte/cloud/go/protos/mconfig"`

**Result**
FeG is now able to parse `gateway.mconfig` containing messages from `mconfigs.proto` of lte and feg

Differential Revision: D14532382
