### PR TITLE
Using default MME should not be an error

### DIFF
--- a/feg/gateway/mconfig/impl.go
+++ b/feg/gateway/mconfig/impl.go
@@ -21,6 +21,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	_ "magma/feg/cloud/go/protos/mconfig"
+	_ "magma/lte/cloud/go/protos/mconfig"
 	"magma/orc8r/cloud/go/protos"
 	_ "magma/orc8r/cloud/go/protos/mconfig"
 )

--- a/feg/gateway/services/csfb/servicers/config.go
+++ b/feg/gateway/services/csfb/servicers/config.go
@@ -37,7 +37,7 @@ func ConstructMMEName() (string, error) {
 			err,
 			DefaultMMEName,
 		)
-		return DefaultMMEName, err
+		return DefaultMMEName, nil
 	}
 
 	mnc := mmeConfig.GetCsfbMnc()


### PR DESCRIPTION
Summary:
**Summary**
When MME name could not be constructed using `gateway.mconfig`, an error is returned.
Actually, the CSFB service could use the default MME name and proceed.

**Implementation**
Instead of returning error, return `nil` when using default MME name.

**Result**
The CSFB service should be able to use the default MME name when the MME name could not be constructed from `gateway.mconfig` .

Differential Revision: D14532494
