### PR TITLE
Fix for MME crash during ESM Information timer exp handling

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Detach.c
@@ -158,7 +158,8 @@ void _clear_emm_ctxt(emm_context_t *emm_context)
       ->mme_ue_s1ap_id;
 
   nas_delete_all_emm_procedures(emm_context);
-
+  //Stop T3489 timer
+  free_esm_context_content(&emm_context->esm_ctx);
   esm_sap_t esm_sap = {0};
   /*
    * Release ESM PDN and bearer context

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_as.c
@@ -1521,6 +1521,12 @@ static int _emm_as_data_req(
         LOG_NAS_EMM,
         "Set nas_msg.header.sequence_number -> %u\n",
         nas_msg.header.sequence_number);
+    } else {
+      OAILOG_ERROR(
+        LOG_NAS_EMM,
+        "Security context is NULL for UE -> %d\n",
+        msg->ue_id);
+      OAILOG_FUNC_RETURN(LOG_NAS_EMM,RETURNerror);
     }
 
     if (!is_encoded) {


### PR DESCRIPTION
Fix for MME crash during ESM Information timer exp handling.
Verified sanity on S1 SIM.Executed combined_attach_01 TC from SGS test suite and authentication_information_01 TC from S6a test suite on TeraVM setup