### PR TITLE
Add missing repository of magmad in setup.py

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -24,6 +24,7 @@ setup(
         'magma.common.redis',
         'magma.configuration',
         'magma.magmad',
+        'magma.magmad.generic_command',
         'magma.magmad.kernel_check',
         'magma.magmad.logging',
         'magma.magmad.network_check',


### PR DESCRIPTION
Summary: A directory of magmad was missing in `setup.py` so the Debian magma package was broken.

Reviewed By: alexanderclin

Differential Revision: D14544269
