### PR TITLE
Add missing AVPs to AIAs and ULAs

### DIFF
--- a/feg/gateway/services/testcore/hss/servicers/ai.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai.go
@@ -80,12 +80,13 @@ func (srv *HomeSubscriberServer) setLteAuthNextSeq(subscriber *lteprotos.Subscri
 // authentication information request (AIR) message. It populates AIA with all of the mandatory fields
 // and adds the authentication vectors.
 func (srv *HomeSubscriberServer) NewSuccessfulAIA(msg *diam.Message, sessionID datatype.UTF8String, vectors []*crypto.EutranVector) *diam.Message {
-	answer := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server)
-	for _, vector := range vectors {
+	answer := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server, diam.TGPP_S6A_APP_ID)
+	for itemNumber, vector := range vectors {
 		answer.NewAVP(avp.AuthenticationInfo, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
 			AVP: []*diam.AVP{
 				diam.NewAVP(avp.EUTRANVector, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
 					AVP: []*diam.AVP{
+						diam.NewAVP(avp.ItemNumber, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(itemNumber)),
 						diam.NewAVP(avp.RAND, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Rand[:])),
 						diam.NewAVP(avp.XRES, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Xres[:])),
 						diam.NewAVP(avp.AUTN, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Autn[:])),

--- a/feg/gateway/services/testcore/hss/servicers/ma.go
+++ b/feg/gateway/services/testcore/hss/servicers/ma.go
@@ -95,7 +95,7 @@ func NewMAA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 // multimedia authentication request (MAR) message. It populates the MAA with all of the mandatory fields
 // and adds the authentication vectors. See 3GPP TS 29.273 table 8.1.2.1.1/5.
 func (srv *HomeSubscriberServer) NewSuccessfulMAA(msg *diam.Message, sessionID datatype.UTF8String, userName datatype.UTF8String, vectors []*crypto.SIPAuthVector) *diam.Message {
-	maa := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server)
+	maa := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server, diam.TGPP_SWX_APP_ID)
 	for itemNumber, vector := range vectors {
 		authenticate := append(vector.Rand[:], vector.Autn[:]...)
 		maa.NewAVP(avp.SIPAuthDataItem, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
@@ -111,13 +111,6 @@ func (srv *HomeSubscriberServer) NewSuccessfulMAA(msg *diam.Message, sessionID d
 	}
 	maa.NewAVP(avp.SIPNumberAuthItems, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(len(vectors)))
 	maa.NewAVP(avp.UserName, avp.Mbit, 0, userName)
-	maa.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(swx.AuthSessionState_NO_STATE_MAINTAINED))
-	maa.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
-		AVP: []*diam.AVP{
-			diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
-			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(diam.TGPP_SWX_APP_ID)),
-		},
-	})
 	return maa
 }
 

--- a/feg/gateway/services/testcore/hss/servicers/message.go
+++ b/feg/gateway/services/testcore/hss/servicers/message.go
@@ -54,9 +54,16 @@ func ConvertAuthErrorToFailureMessage(err error, msg *diam.Message, sessionID da
 
 // ConstructSuccessAnswer returns a message response with a success result code
 // and with the server config AVPs already added.
-func ConstructSuccessAnswer(msg *diam.Message, sessionID datatype.UTF8String, serverCfg *mconfig.DiamServerConfig) *diam.Message {
+func ConstructSuccessAnswer(msg *diam.Message, sessionID datatype.UTF8String, serverCfg *mconfig.DiamServerConfig, authApplicationID uint32) *diam.Message {
 	answer := msg.Answer(diam.Success)
 	AddStandardAnswerAVPS(answer, sessionID, serverCfg, diam.Success)
+	answer.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
+			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(authApplicationID)),
+		},
+	})
+	answer.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(swx.AuthSessionState_NO_STATE_MAINTAINED))
 	return answer
 }
 
@@ -64,13 +71,14 @@ func ConstructSuccessAnswer(msg *diam.Message, sessionID datatype.UTF8String, se
 func AddStandardAnswerAVPS(answer *diam.Message, sessionID datatype.UTF8String, serverCfg *mconfig.DiamServerConfig, resultCode uint32) {
 	// SessionID is required to be the AVP in position 1
 	answer.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, sessionID))
-	answer.NewAVP(avp.ExperimentalResult, avp.Mbit, 0, &diam.GroupedAVP{
-		AVP: []*diam.AVP{
-			diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
-			diam.NewAVP(avp.ExperimentalResultCode, avp.Mbit, 0, datatype.Unsigned32(resultCode)),
-		},
-	})
-
+	if resultCode != diam.Success {
+		answer.NewAVP(avp.ExperimentalResult, avp.Mbit, 0, &diam.GroupedAVP{
+			AVP: []*diam.AVP{
+				diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
+				diam.NewAVP(avp.ExperimentalResultCode, avp.Mbit, 0, datatype.Unsigned32(resultCode)),
+			},
+		})
+	}
 	answer.NewAVP(avp.OriginHost, avp.Mbit, 0, datatype.DiameterIdentity(serverCfg.DestHost))
 	answer.NewAVP(avp.OriginRealm, avp.Mbit, 0, datatype.DiameterIdentity(serverCfg.DestRealm))
 	answer.NewAVP(avp.OriginStateID, avp.Mbit, 0, datatype.Unsigned32(time.Now().Unix()))

--- a/feg/gateway/services/testcore/hss/servicers/sa.go
+++ b/feg/gateway/services/testcore/hss/servicers/sa.go
@@ -65,16 +65,9 @@ func NewSAA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 		return ConstructFailureAnswer(msg, sar.SessionID, srv.Config.Server, uint32(fegprotos.SwxErrorCode_USER_NO_NON_3GPP_SUBSCRIPTION)), err
 	}
 
-	answer := ConstructSuccessAnswer(msg, sar.SessionID, srv.Config.Server)
+	answer := ConstructSuccessAnswer(msg, sar.SessionID, srv.Config.Server, diam.TGPP_SWX_APP_ID)
 	answer.NewAVP(avp.TGPPAAAServerName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, aaaServer)
 	answer.NewAVP(avp.UserName, avp.Mbit, 0, sar.UserName)
-	answer.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(servicers.AuthSessionState_NO_STATE_MAINTAINED))
-	answer.NewAVP(avp.VendorSpecificApplicationID, avp.Mbit, 0, &diam.GroupedAVP{
-		AVP: []*diam.AVP{
-			diam.NewAVP(avp.VendorID, avp.Mbit, 0, datatype.Unsigned32(diameter.Vendor3GPP)),
-			diam.NewAVP(avp.AuthApplicationID, avp.Mbit, 0, datatype.Unsigned32(diam.TGPP_SWX_APP_ID)),
-		},
-	})
 	switch sar.ServerAssignmentType {
 	case servicers.ServerAssignmentType_REGISTRATION:
 		subscriber.State.TgppAaaServerRegistered = true

--- a/feg/gateway/services/testcore/hss/servicers/test/ai_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/ai_test.go
@@ -72,7 +72,6 @@ func TestNewAIA_SuccessfulResponse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "magma;123_1234", aia.SessionID)
 	assert.Equal(t, diam.Success, int(aia.ResultCode))
-	assert.Equal(t, uint32(diam.Success), aia.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), aia.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), aia.OriginRealm)
 	assert.Equal(t, 1, len(aia.AIs))
@@ -266,7 +265,6 @@ func TestNewSuccessfulAIA(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, uint32(diam.Success), aia.ResultCode)
-	assert.Equal(t, uint32(diam.Success), aia.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, air.SessionID, datatype.UTF8String(aia.SessionID))
 	assert.Equal(t, datatype.DiameterIdentity(serverCfg.DestHost), aia.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity(serverCfg.DestRealm), aia.OriginRealm)

--- a/feg/gateway/services/testcore/hss/servicers/test/hss_diameter_integration_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/hss_diameter_integration_test.go
@@ -35,7 +35,6 @@ func TestHomeSubscriberServer_handleAIR(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "magma;123_1234", aia.SessionID)
 		assert.Equal(t, diam.Success, int(aia.ResultCode))
-		assert.Equal(t, uint32(diam.Success), aia.ExperimentalResult.ExperimentalResultCode)
 		assert.Equal(t, datatype.DiameterIdentity("magma.com"), aia.OriginHost)
 		assert.Equal(t, datatype.DiameterIdentity("magma.com"), aia.OriginRealm)
 	}
@@ -54,7 +53,6 @@ func TestHomeSubscriberServer_handleULA(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "magma;123_1234", ula.SessionID)
 		assert.Equal(t, diam.Success, int(ula.ResultCode))
-		assert.Equal(t, uint32(diam.Success), ula.ExperimentalResult.ExperimentalResultCode)
 		assert.Equal(t, datatype.DiameterIdentity("magma.com"), ula.OriginHost)
 		assert.Equal(t, datatype.DiameterIdentity("magma.com"), ula.OriginRealm)
 	}
@@ -73,7 +71,6 @@ func TestHomeSubscriberServer_handleMAR(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "magma;123_1234", maa.SessionID)
 		assert.Equal(t, diam.Success, int(maa.ResultCode))
-		assert.Equal(t, uint32(diam.Success), maa.ExperimentalResult.ExperimentalResultCode)
 		assert.Equal(t, datatype.DiameterIdentity("magma.com"), maa.OriginHost)
 		assert.Equal(t, datatype.DiameterIdentity("magma.com"), maa.OriginRealm)
 		checkSIPAuthVectors(t, maa, 1)

--- a/feg/gateway/services/testcore/hss/servicers/test/hss_s6a_proxy_integration_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/hss_s6a_proxy_integration_test.go
@@ -30,7 +30,7 @@ func TestAIR_Successful(t *testing.T) {
 
 	aia, err := s6aProxy.AuthenticationInformation(context.Background(), air)
 	assert.NoError(t, err)
-	assert.Equal(t, protos.ErrorCode_SUCCESS, aia.ErrorCode)
+	assert.Equal(t, protos.ErrorCode_UNDEFINED, aia.ErrorCode)
 
 	assert.Equal(t, 1, len(aia.EutranVectors))
 	vector := aia.EutranVectors[0]
@@ -63,7 +63,7 @@ func TestULR_Successful(t *testing.T) {
 
 	ula, err := s6aProxy.UpdateLocation(context.Background(), ulr)
 	assert.NoError(t, err)
-	assert.Equal(t, protos.ErrorCode_SUCCESS, ula.ErrorCode)
+	assert.Equal(t, protos.ErrorCode_UNDEFINED, ula.ErrorCode)
 	assert.Equal(t, uint32(defaultMaxUlBitRate), ula.GetTotalAmbr().GetMaxBandwidthUl())
 	assert.Equal(t, uint32(defaultMaxDlBitRate), ula.GetTotalAmbr().GetMaxBandwidthDl())
 	assert.Equal(t, []byte("12345"), ula.Msisdn)

--- a/feg/gateway/services/testcore/hss/servicers/test/ma_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/ma_test.go
@@ -273,7 +273,6 @@ func testNewMAASuccessfulResponse(t *testing.T, server *hss.HomeSubscriberServer
 	assert.NoError(t, err)
 	assert.Equal(t, "magma;123_1234", maa.SessionID)
 	assert.Equal(t, diam.Success, int(maa.ResultCode))
-	assert.Equal(t, uint32(diam.Success), maa.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), maa.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), maa.OriginRealm)
 	assert.Equal(t, int32(definitions.AuthSessionState_NO_STATE_MAINTAINED), maa.AuthSessionState)

--- a/feg/gateway/services/testcore/hss/servicers/test/message_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/message_test.go
@@ -54,16 +54,16 @@ func TestConstructSuccessAnswer(t *testing.T) {
 		DestHost:  "magma_host",
 		DestRealm: "magma_realm",
 	}
-	response := servicers.ConstructSuccessAnswer(msg, datatype.UTF8String("magma"), serverCfg)
+	response := servicers.ConstructSuccessAnswer(msg, datatype.UTF8String("magma"), serverCfg, diam.TGPP_S6A_APP_ID)
 
 	var aia definitions.AIA
 	err := response.Unmarshal(&aia)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(diam.Success), aia.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, uint32(diam.Success), aia.ResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma_host"), aia.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity("magma_realm"), aia.OriginRealm)
 	assert.Equal(t, "magma", aia.SessionID)
+	assert.Equal(t, int32(1), aia.AuthSessionState)
 }
 
 func TestAddStandardAnswerAVPS(t *testing.T) {
@@ -77,7 +77,6 @@ func TestAddStandardAnswerAVPS(t *testing.T) {
 	var aia definitions.AIA
 	err := msg.Unmarshal(&aia)
 	assert.NoError(t, err)
-	assert.Equal(t, uint32(diam.Success), aia.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma_host"), aia.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity("magma_realm"), aia.OriginRealm)
 	assert.Equal(t, "magma", aia.SessionID)

--- a/feg/gateway/services/testcore/hss/servicers/test/sa_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/sa_test.go
@@ -156,7 +156,6 @@ func createSARExtended(userName string, serverAssignmentType int, originHost str
 func checkSAASuccess(t *testing.T, response *diam.Message) {
 	saa := testUnmarshalSAA(t, response)
 	assert.Equal(t, diam.Success, int(saa.ResultCode))
-	assert.Equal(t, uint32(diam.Success), saa.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), saa.AAAServerName)
 	assert.Equal(t, datatype.UTF8String("sub1"), saa.UserName)
 	assert.Equal(t, int32(definitions.AuthSessionState_NO_STATE_MAINTAINED), saa.AuthSessionState)

--- a/feg/gateway/services/testcore/hss/servicers/test/ul_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/test/ul_test.go
@@ -63,7 +63,6 @@ func TestNewULA_SuccessfulResponse(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "magma;123_1234", ula.SessionID)
 	assert.Equal(t, diam.Success, int(ula.ResultCode))
-	assert.Equal(t, uint32(diam.Success), ula.ExperimentalResult.ExperimentalResultCode)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), ula.OriginHost)
 	assert.Equal(t, datatype.DiameterIdentity("magma.com"), ula.OriginRealm)
 }

--- a/feg/gateway/services/testcore/hss/servicers/ul.go
+++ b/feg/gateway/services/testcore/hss/servicers/ul.go
@@ -83,7 +83,7 @@ func NewULA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 // update location request (ULR) message. It populates the ULA with all of the mandatory fields
 // and adds the subscriber profile information.
 func (srv *HomeSubscriberServer) NewSuccessfulULA(msg *diam.Message, sessionID datatype.UTF8String, profile *mconfig.HSSConfig_SubscriptionProfile) *diam.Message {
-	ula := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server)
+	ula := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server, diam.TGPP_S6A_APP_ID)
 	ula.NewAVP(avp.ULAFlags, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(ulaFlags))
 	ula.NewAVP(avp.SubscriptionData, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
 		AVP: []*diam.AVP{
@@ -99,7 +99,7 @@ func (srv *HomeSubscriberServer) NewSuccessfulULA(msg *diam.Message, sessionID d
 						AVP: []*diam.AVP{
 							diam.NewAVP(avp.ContextIdentifier, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(apnContextIdentifier)),
 							diam.NewAVP(avp.PDNType, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(protos.UpdateLocationAnswer_APNConfiguration_IPV4)),
-							diam.NewAVP(avp.ServiceSelection, avp.Mbit, diameter.Vendor3GPP, datatype.UTF8String(apnServiceSelection)),
+							diam.NewAVP(avp.ServiceSelection, avp.Mbit, 0, datatype.UTF8String(apnServiceSelection)),
 							diam.NewAVP(avp.EPSSubscribedQoSProfile, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
 								AVP: []*diam.AVP{
 									diam.NewAVP(avp.QoSClassIdentifier, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(apnQoSClassIdentifier)),


### PR DESCRIPTION
Summary:
This change adds AVPs to the HSS lite that a real HSS would send in authentication information answers (AIAs) and update location answers (ULAs). That way, the HSS lite behaves more similarly to a real HSS and is a more effective testing component.

The following AVPs were added:
* Auth session state
* Vendor specific application id
* E-UTRAN vector item number

Also, the experimental result AVP is no longer added on success.

Differential Revision: D14544002
