### PR TITLE
Differentiate between permanent and transient storage errors

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai_test.go
@@ -69,7 +69,7 @@ func (suite *EpsAuthTestSuite) TestAuthenticationInformation_UnknownSubscriber()
 	}
 
 	aia, err := suite.AuthenticationInformation(air)
-	suite.EqualError(err, "rpc error: code = Aborted desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
+	suite.EqualError(err, "rpc error: code = NotFound desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
 	suite.checkAIA(aia, protos.ErrorCode_USER_UNKNOWN, 0)
 }
 

--- a/lte/cloud/go/services/eps_authentication/servicers/server.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/server.go
@@ -15,6 +15,9 @@ import (
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/subscriberdb/storage"
 	orc8rprotos "magma/orc8r/cloud/go/protos"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type EPSAuthServer struct {
@@ -37,8 +40,10 @@ func (srv *EPSAuthServer) lookupSubscriber(userName, networkID string) (*lteprot
 	}
 	subscriber, err := srv.Store.GetSubscriberData(lookup)
 	if err != nil {
-		// TODO: Differentiate between permanent and transient storage errors.
-		return nil, fegprotos.ErrorCode_USER_UNKNOWN, err
+		if status.Convert(err).Code() == codes.NotFound {
+			return nil, fegprotos.ErrorCode_USER_UNKNOWN, err
+		}
+		return nil, fegprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE, err
 	}
 	return subscriber, fegprotos.ErrorCode_SUCCESS, nil
 }

--- a/lte/cloud/go/services/eps_authentication/servicers/ul_test.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ul_test.go
@@ -16,43 +16,54 @@ func (suite *EpsAuthTestSuite) TestUpdateLocation_NilRequest() {
 }
 
 func (suite *EpsAuthTestSuite) TestUpdateLocation_EmptyUserName() {
-	air := &protos.UpdateLocationRequest{
+	ulr := &protos.UpdateLocationRequest{
 		VisitedPlmn: []byte{0, 0, 0},
 	}
 
-	_, err := suite.UpdateLocation(air)
+	_, err := suite.UpdateLocation(ulr)
 	suite.EqualError(err, "rpc error: code = InvalidArgument desc = user name was empty")
 }
 
 func (suite *EpsAuthTestSuite) TestUpdateLocation_EmptyPlmm() {
-	air := &protos.UpdateLocationRequest{
+	ulr := &protos.UpdateLocationRequest{
 		UserName: "sub1",
 	}
 
-	_, err := suite.UpdateLocation(air)
+	_, err := suite.UpdateLocation(ulr)
 	suite.EqualError(err, "rpc error: code = InvalidArgument desc = expected Visited PLMN to be 3 bytes, but got 0 bytes")
 }
 
 func (suite *EpsAuthTestSuite) TestUpdateLocation_Success() {
-	air := &protos.UpdateLocationRequest{
+	ulr := &protos.UpdateLocationRequest{
 		UserName:    "sub1",
 		VisitedPlmn: []byte{0, 0, 0},
 	}
 
-	ula, err := suite.UpdateLocation(air)
+	ula, err := suite.UpdateLocation(ulr)
 	suite.NoError(err)
 	suite.checkULA(ula, 7000, 5000)
 }
 
 func (suite *EpsAuthTestSuite) TestUpdateLocation_DefaultProfile() {
-	air := &protos.UpdateLocationRequest{
+	ulr := &protos.UpdateLocationRequest{
 		UserName:    "empty_sub",
 		VisitedPlmn: []byte{0, 0, 0},
 	}
 
-	ula, err := suite.UpdateLocation(air)
+	ula, err := suite.UpdateLocation(ulr)
 	suite.NoError(err)
 	suite.checkULA(ula, 1000, 2000)
+}
+
+func (suite *EpsAuthTestSuite) TestUpdateLocation_UnknownSubscriber() {
+	ulr := &protos.UpdateLocationRequest{
+		UserName:    "sub_unknown",
+		VisitedPlmn: []byte{0, 0, 0},
+	}
+
+	ula, err := suite.UpdateLocation(ulr)
+	suite.EqualError(err, "rpc error: code = NotFound desc = Error fetching subscriber: IMSIsub_unknown, No record for query")
+	suite.Equal(protos.ErrorCode_USER_UNKNOWN, ula.ErrorCode)
 }
 
 func (suite *EpsAuthTestSuite) checkULA(ula *protos.UpdateLocationAnswer, maxUlBitRate, maxDlBitRate uint32) {

--- a/lte/cloud/go/services/subscriberdb/storage/subscriberdb_storage.go
+++ b/lte/cloud/go/services/subscriberdb/storage/subscriberdb_storage.go
@@ -112,6 +112,10 @@ func (s *SubscriberDBStorage) GetSubscriberData(lookup *lteprotos.SubscriberLook
 	if err != nil {
 		errMsg := fmt.Sprintf("Error fetching subscriber: %s, %s", sid, err)
 		glog.Error(errMsg)
+
+		if err == datastore.ErrNotFound {
+			return nil, status.Error(codes.NotFound, errMsg)
+		}
 		return nil, status.Error(codes.Aborted, errMsg)
 	}
 	if err = proto.Unmarshal(value, &subs); err != nil {


### PR DESCRIPTION
Summary:
When the EPS Authentication service fails to lookup a subscriber, then either the subscriber is not in the database, or there was a transient storage error. This changes the `lookupSubscriber` function to differentiate between these two kinds of errors as specified by 3GPP TS 29.272. A transient error indicates to the caller that they can retry the request at a later time whereas a permanent error signals that the request should not be retried.

Also, while adding a unit test, I noticed that in `ul_test.go` there is a typo where the message variable name was `air` instead of `ulr`. I corrected the typo in this change as well.

Differential Revision: D14548337
