### PR TITLE
Sleep before checking if services are active

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ matrix:
       script:
         - travis_retry travis_retry travis_wait make -C ${MAGMA_ROOT}/orc8r/cloud download
         - make -C ${MAGMA_ROOT}/orc8r/cloud travis_run
+        - /bin/sleep 20
         - make -C ${MAGMA_ROOT}/orc8r/cloud check
 
     - language: go


### PR DESCRIPTION
Summary: Travis has failed many times because a service has been in the `activating` state instead of `active`. Waiting for 20 seconds before checking if the services are active should make this test less flaky (this will give the services more time to start).

Differential Revision: D14552016
