### PR TITLE
Retry travis job to run services and display service status on failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ matrix:
         - travis_retry travis_retry travis_wait make -C ${MAGMA_ROOT}/orc8r/cloud download
         - make -C ${MAGMA_ROOT}/orc8r/cloud travis_run
         - /bin/sleep 20
-        - make -C ${MAGMA_ROOT}/orc8r/cloud check
+        - travis_retry make -C ${MAGMA_ROOT}/orc8r/cloud check
 
     - language: go
       name: FeG precommit

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -168,7 +168,7 @@ restart: restart_proxy restart_services # Restart proxies & all magma services
 CHECK_LIST = $(foreach srv, $(SERVICES), $(srv)_check) obsidian_check
 check: $(CHECK_LIST)
 $(CHECK_LIST): %_check:
-	sudo systemctl is-active magma@$*
+	sudo systemctl is-active magma@$* || (sudo service magma@$* status && sleep 5)
 
 list:  # List all commands
 	@echo -e "\nAvailable commands:\n"


### PR DESCRIPTION
Summary:
- travis_retry the make run
- Show systemd service status for any services which aren't active

Differential Revision: D14562275
