### PR TITLE
Add sleep 5 to check target so travis will wait between retries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ matrix:
         - travis_retry travis_retry travis_wait make -C ${MAGMA_ROOT}/orc8r/cloud download
         - make -C ${MAGMA_ROOT}/orc8r/cloud travis_run
         - /bin/sleep 20
-        - make -C ${MAGMA_ROOT}/orc8r/cloud check
+        - travis_retry make -C ${MAGMA_ROOT}/orc8r/cloud check
 
     - language: go
       name: FeG precommit

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -168,7 +168,7 @@ restart: restart_proxy restart_services # Restart proxies & all magma services
 CHECK_LIST = $(foreach srv, $(SERVICES), $(srv)_check) obsidian_check
 check: $(CHECK_LIST)
 $(CHECK_LIST): %_check:
-	sudo systemctl is-active magma@$*
+	sudo systemctl is-active magma@$* || (sudo service magma@$* status && sleep 5)
 
 list:  # List all commands
 	@echo -e "\nAvailable commands:\n"

--- a/orc8r/cloud/Makefile
+++ b/orc8r/cloud/Makefile
@@ -166,9 +166,11 @@ restart: restart_proxy restart_services # Restart proxies & all magma services
 
 # Check if all magma services are healthy
 CHECK_LIST = $(foreach srv, $(SERVICES), $(srv)_check) obsidian_check
-check: $(CHECK_LIST)
+check: check_sleep $(CHECK_LIST)
+check_sleep:
+	sleep 5
 $(CHECK_LIST): %_check:
-	sudo systemctl is-active magma@$* || (sudo service magma@$* status && sleep 5)
+	sudo systemctl is-active magma@$* || (sudo journalctl -u magma@$* -n 20 --no-pager && false)
 
 list:  # List all commands
 	@echo -e "\nAvailable commands:\n"


### PR DESCRIPTION
Summary:
- Add a sleep 5 to check so if check fails because services are initializing, travis_retry will wait before retrying
- Use journalctl with set number of lines in service checks

Reviewed By: vikg-fb

Differential Revision: D14562402
