### PR TITLE
Activate and deactivate flows in one atomic function

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -170,6 +170,9 @@ class EnforcementStatsController(PolicyMixin, MagmaController):
         Returns flow add messages used for rule matching.
         """
         version = self._session_rule_version_mapper.get_version(imsi, rule_id)
+        self.logger.debug(
+            'Installing flow for %s with rule num %s (version %s)', imsi,
+            rule_num, version)
         inbound_rule_match = _generate_rule_match(imsi, rule_num, version,
                                                   Direction.IN)
         outbound_rule_match = _generate_rule_match(imsi, rule_num, version,

--- a/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/subscriber.py
@@ -164,15 +164,13 @@ class RyuDirectSubscriberContext(SubscriberContext):
             self._ec.activate_rules(imsi=self.cfg.imsi,
                                     ip_addr=self.cfg.ip,
                                     static_rule_ids=self._static_rule_names,
-                                    dynamic_rules=self._dynamic_rules,
-                                    fut=Future())
+                                    dynamic_rules=self._dynamic_rules)
             if self._esc:
                 self._esc.activate_rules(
                     imsi=self.cfg.imsi,
                     ip_addr=self.cfg.ip,
                     static_rule_ids=self._static_rule_names,
-                    dynamic_rules=self._dynamic_rules,
-                    fut=Future())
+                    dynamic_rules=self._dynamic_rules)
         hub.joinall([hub.spawn(activate_flows)])
 
     def _deactivate_subscriber_rules(self):

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
@@ -525,16 +525,10 @@ class EnforcementStatsTest(unittest.TestCase):
             self.service_manager.session_rule_version_mapper. \
                 update_version(imsi, 'rule1')
             self.enforcement_controller.deactivate_rules(imsi, [policy.id])
-            enf_future = Future()
-            es_future = Future()
             self.enforcement_controller.activate_rules(imsi, sub_ip,
-                                                       [policy.id], [],
-                                                       enf_future)
+                                                       [policy.id], [])
             self.enforcement_stats_controller.activate_rules(imsi, sub_ip,
-                                                             [policy.id], [],
-                                                             es_future)
-            enf_future.result()
-            es_future.result()
+                                                             [policy.id], [])
             pkt_sender.send(packet)
 
         verifier.verify()


### PR DESCRIPTION
Summary:
During TerraVM testing, a race condition with flow activation and deactivation was discovered in Pipelined due to the new rule versioning system. This bug happens because version update, enforcement flow activation, and enforcement_stats flow activation are scheduled separately in the run loop. It is possible for the version to be updated again by another rpc call, before the flow is activated in the apps.

Example:
rpc call to activate flow (update version to 1) --> rpc call to deactivate flow (update version to 2) --> flow install by enforcement apps (flow installed with version = 2)

This diff fixes the issue by refactoring all rule activation/deactivation logic into one atomic function, which is scheduled in the run loop. For activation, the function will perform version update and flow activation for each app without scheduling them in the run loop.

Differential Revision: D14564504
