### PR TITLE
Stop services before test_python

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -80,7 +80,7 @@ format_oai:
 	find $(GATEWAY_C_DIR)/oai \( -iname "*.c" -o -iname "*.cpp" -o -iname "*.h" \) -exec \
 	clang-format --style=file -i {} \;
 
-test_python:
+test_python: stop
 	make -C $(MAGMA_ROOT)/lte/gateway/python test_all
 
 test_oai: build_common


### PR DESCRIPTION
Summary: `make test_python` in `lte/gateway` fails if services are currently running, so run `stop` before `test_python`.

Differential Revision: D14568049
