### PR TITLE
Add pre-configured subscribers on startup to testcore HSS

### DIFF
--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -50,4 +50,7 @@ lint:
 build_only:
 	go build ./...
 
+run_local_hss:
+	sudo service magma@hss start
+
 precommit: fmt gen build_only test vet

--- a/feg/gateway/configs/hss.yml
+++ b/feg/gateway/configs/hss.yml
@@ -1,0 +1,17 @@
+---
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# HSS Config
+#
+# ---
+#subscribers:
+#  <imsi>:
+#    <auth_key>: - required (hex string)
+#    <non_3gpp_enabled>: - optional (bool)
+subscribers:

--- a/feg/gateway/services/testcore/hss/main.go
+++ b/feg/gateway/services/testcore/hss/main.go
@@ -10,6 +10,7 @@ LICENSE file in the root directory of this source tree.
 package main
 
 import (
+	"context"
 	"log"
 
 	"magma/feg/cloud/go/protos"
@@ -36,6 +37,18 @@ func main() {
 	}
 	protos.RegisterHSSConfiguratorServer(srv.GrpcServer, servicer)
 
+	subscribers, err := servicers.GetConfiguredSubscribers()
+	if err != nil {
+		glog.Errorf("Could not fetch preconfigured subscribers: %s", err)
+	} else {
+		// Add preconfigured subscribers
+		for _, sub := range subscribers {
+			_, err = servicer.AddSubscriber(context.Background(), sub)
+			if err != nil {
+				glog.Errorf("Error adding subscriber: %s", err)
+			}
+		}
+	}
 	// Start diameter server
 	go func() {
 		glog.V(2).Info("Starting home subscriber server")

--- a/orc8r/cloud/go/service/config/service_config.go
+++ b/orc8r/cloud/go/service/config/service_config.go
@@ -73,6 +73,19 @@ func (cfgMap *ConfigMap) GetIntParam(key string) (int, error) {
 	return param, nil
 }
 
+// GetBoolParam is used to retrieve a bool param from a YML file
+func (cfgMap *ConfigMap) GetBoolParam(key string) (bool, error) {
+	paramIface, ok := cfgMap.RawMap[key]
+	if !ok {
+		return false, fmt.Errorf("Could not find key %s", key)
+	}
+	param, ok := paramIface.(bool)
+	if !ok {
+		return false, fmt.Errorf("Could not convert param to bool for key %s", key)
+	}
+	return param, nil
+}
+
 func getServiceConfigImpl(moduleName string, serviceName, configDir, oldConfigDir, configOverrideDir string) (*ConfigMap, error) {
 	// Filenames should be lower case
 	moduleName = strings.ToLower(moduleName)


### PR DESCRIPTION
Summary:
Recent testing of the HSS has shown a need to be able to configure subscribers in
the test HSS on start-up rather than using the hss_cli. Preconfigured subscribers allow a
repeatable test environment with less variables in play. This diff serves to add subscribers
that are listed in an `hss.yml` file as the HSS service begins running. These subscribers are
given a basic profile.

If the need arises in the future to allow for more configurable options, this can easily be added.
While helpful, the best long term solution would be to stream subscribers from the orc8r, so that
subscribers are stored state, rather than being added on startup.

Reviewed By: vikg-fb

Differential Revision: D14573510
