### PR TITLE
Add remote FeG connection for swx_proxy

### DIFF
--- a/feg/gateway/fabfile.py
+++ b/feg/gateway/fabfile.py
@@ -17,7 +17,7 @@ from fab.hosts import split_hoststring # NOQA
 from fab.vagrant import setup_env_vagrant  # NOQA
 
 AWS = 'aws --region eu-west-1'
-
+DEFAULT_CERT = "$MAGMA_ROOT/.cache/test_certs/rootCA.pem"
 
 def register_feg_vm():
     """ Provisions the feg vm with the cloud vm """
@@ -114,3 +114,13 @@ def package(feg_host=None, vcs="hg", force=False):
     _package_go(target)
     _package_scripts(target)
     return _push_archive_to_s3(vcs, target)
+
+
+def connect_gateway_to_cloud(control_proxy_setting_path=None, cert_path=DEFAULT_CERT):
+    """
+    Setup the feg gateway VM to connect to the cloud
+    Path to control_proxy.yml and rootCA.pem could be specified to use
+    non-default control proxy setting and certificates
+    """
+    setup_env_vagrant("feg")
+    dev_utils.connect_gateway_to_cloud(control_proxy_setting_path, cert_path)

--- a/feg/gateway/services/swx_proxy/client_api_test.go
+++ b/feg/gateway/services/swx_proxy/client_api_test.go
@@ -87,10 +87,10 @@ func standardSwxProxyTest(t *testing.T) {
 
 	// Test client error handling
 	authRes, err = swx_proxy.Authenticate(nil)
-	assert.EqualError(t, err, "Invalid AuthenticationRequest provided")
+	assert.EqualError(t, err, "Invalid AuthenticationRequest provided: request is nil")
 	assert.Nil(t, authRes)
 
 	regRes, err = swx_proxy.Register(nil)
-	assert.EqualError(t, err, "Invalid RegistrationRequest provided")
+	assert.EqualError(t, err, "Invalid RegistrationRequest provided: request is nil")
 	assert.Nil(t, regRes)
 }

--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -102,22 +102,7 @@ def connect_gateway_to_cloud(control_proxy_setting_path=None, cert_path=DEFAULT_
     non-default control proxy setting and certificates
     """
     setup_env_vagrant()
-    # Add the override for the production endpoints
-    run("sudo rm -rf /var/opt/magma/configs")
-    run("sudo mkdir /var/opt/magma/configs")
-    if control_proxy_setting_path is not None:
-        run("sudo cp " + control_proxy_setting_path
-            + " /var/opt/magma/configs/control_proxy.yml")
-
-    # Copy certs which will be used by the bootstrapper
-    run("sudo rm -rf /var/opt/magma/certs")
-    run("sudo mkdir /var/opt/magma/certs")
-    run("sudo cp " + cert_path + " /var/opt/magma/certs/")
-
-    # Restart the bootstrapper in the gateway to use the new certs
-    run("sudo systemctl stop magma@*")
-    run("sudo systemctl restart magma@magmad")
-
+    dev_utils.connect_gateway_to_cloud(control_proxy_setting_path, cert_path)
 
 def _set_service_config_var(service, var_name, value):
     """ Sets variable in config file by value """


### PR DESCRIPTION
Summary:
This diff serves to add the ability to connect a federated gateway VM to different cloud instances. This serves
to allow the local feg vm to be tested against a running cloud instance. Additionally, a remote client is added to
the swx_proxy service to allow for the use case of the eap service and swx_proxy service running on different machines.

Reviewed By: fishlinghu

Differential Revision: D14536789
