### PR TITLE
Transition to error state for un-set parameters

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -758,11 +758,10 @@ class WaitSetParameterValuesState(EnodebAcsState):
                     logging.error('SetParameterValuesFault Param: %s, '
                                   'Code: %s, String: %s', fault.ParameterName,
                                   fault.FaultCode, fault.FaultString)
-            raise Tr069Error(
-                'Received Fault in response to SetParameterValues '
-                '(faultstring = %s)' % message.FaultString)
-        else:
-            return AcsReadMsgResult(False, None)
+                logging.error('Received Fault in response to '
+                              'SetParameterValues (faultstring = %s)',
+                              message.FaultString)
+        return AcsReadMsgResult(False, None)
 
     def _mark_as_configured(self) -> None:
         """


### PR DESCRIPTION
Summary: State machines handling an eNB device should transition to an ErrorState if an unhandled TR-069 Fault message is received. This adds the behavior to the state handling SetParameterValues

Reviewed By: fishlinghu

Differential Revision: D14566515
