### PR TITLE
Modify defs.mk to not attempt running unit tests in non-existent folder

### DIFF
--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -10,7 +10,6 @@ PROTO_LIST:=orc8r_protos lte_protos feg_protos
 # Path to the test files
 TESTS=magma/tests \
       magma/enodebd/tests \
-      magma/enodebd/device_config/tests \
       magma/mobilityd/tests \
       magma/pipelined/openflow/tests \
       magma/pkt_tester/tests \


### PR DESCRIPTION
Summary: **magma/enodebd/device_config/tests** does not exist anymore. This revision removes the reference to this folder from defs.mk.

Reviewed By: ssanadhya

Differential Revision: D14628182
