### PR TITLE
Mock get_ip_from_if to work in travis environment

### DIFF
--- a/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
@@ -8,13 +8,15 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase
+from unittest import TestCase, mock
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.tr069 import models
 from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
+from magma.enodebd.tests.test_utils.mock_functions import \
+    mock_get_ip_from_if, GET_IP_FROM_IF_PATH
 
 
 class BaicellsOldHandlerTests(TestCase):
@@ -123,7 +125,8 @@ class BaicellsOldHandlerTests(TestCase):
                         'State machine should end TR-069 session after '
                         'receiving a RebootResponse')
 
-    def test_provision_without_invasive_changes(self) -> None:
+    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
+    def test_provision_without_invasive_changes(self, _mock_func) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration
@@ -239,7 +242,8 @@ class BaicellsOldHandlerTests(TestCase):
         self.assertTrue(isinstance(resp, models.GetParameterValues),
                         'State machine should be requesting param values')
 
-    def test_reboot_after_invasive_changes(self) -> None:
+    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
+    def test_reboot_after_invasive_changes(self, _mock_func) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration

--- a/lte/gateway/python/magma/enodebd/tests/baicells_qafb_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_qafb_tests.py
@@ -8,13 +8,15 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase
+from unittest import TestCase, mock
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.tr069 import models
 from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
+from magma.enodebd.tests.test_utils.mock_functions import \
+    mock_get_ip_from_if, GET_IP_FROM_IF_PATH
 
 
 class BaicellsQAFBHandlerTests(TestCase):
@@ -97,7 +99,9 @@ class BaicellsQAFBHandlerTests(TestCase):
         self.assertTrue(isinstance(resp, models.DummyInput),
                         'State machine should end TR-069 session after '
                         'receiving a RebootResponse')
-    def test_provision(self) -> None:
+
+    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
+    def test_provision(self, _mock_func) -> None:
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
                 .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)

--- a/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
@@ -8,13 +8,15 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase
+from unittest import TestCase, mock
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.tr069 import models
 from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
+from magma.enodebd.tests.test_utils.mock_functions import \
+    mock_get_ip_from_if, GET_IP_FROM_IF_PATH
 
 
 class BaicellsHandlerTests(TestCase):
@@ -121,7 +123,8 @@ class BaicellsHandlerTests(TestCase):
                         'State machine should end TR-069 session after '
                         'receiving a RebootResponse')
 
-    def test_provision_without_invasive_changes(self) -> None:
+    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
+    def test_provision_without_invasive_changes(self, _mock_func) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration
@@ -221,7 +224,8 @@ class BaicellsHandlerTests(TestCase):
         self.assertTrue(isinstance(resp, models.GetParameterValues),
                         'State machine should be requesting param values')
 
-    def test_reboot_after_invasive_changes(self) -> None:
+    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
+    def test_reboot_after_invasive_changes(self, _mock_func) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/mock_functions.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/mock_functions.py
@@ -1,0 +1,21 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from typing import Any
+
+
+GET_IP_FROM_IF_PATH = \
+    'magma.enodebd.device_config.configuration_init.get_ip_from_if'
+
+
+def mock_get_ip_from_if(
+    _iface_name: str,
+    _preference: Any = None,
+) -> str:
+    return '192.168.60.142'


### PR DESCRIPTION
Summary: Function get_ip_from_if was being called with an invalid value when running on Travis. This revision mocks the function out during unit testing so tests pass in all environments.

Reviewed By: sciencemanx

Differential Revision: D14646661
