### PR TITLE
Negative gps coordinates are stored correctly

### DIFF
--- a/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
+++ b/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
@@ -46,9 +46,10 @@ def gps_tr181(value: str) -> str:
     Returns:
         str: GPS value (latitude/longitude) in degrees
     """
-    if value.isnumeric():
+    try:
         return str(float(value) / 1e6)
-    return value
+    except ValueError:
+        return value
 
 
 def bandwidth(bandwidth_rbs: str) -> float:

--- a/lte/gateway/python/magma/enodebd/tests/transform_for_magma_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/transform_for_magma_tests.py
@@ -1,0 +1,31 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+# pylint: disable=protected-access
+from unittest import TestCase
+from magma.enodebd.data_models.transform_for_magma import gps_tr181
+
+
+class TransformForMagmaTests(TestCase):
+    def test_gps_tr181(self) -> None:
+        # Negative longitude
+        inp = '-122150583'
+        out = gps_tr181(inp)
+        expected = '-122.150583'
+        self.assertEqual(out, expected, 'Should convert negative longitude')
+
+        inp = '122150583'
+        out = gps_tr181(inp)
+        expected = '122.150583'
+        self.assertEqual(out, expected, 'Should convert positive longitude')
+
+        inp = '0'
+        out = gps_tr181(inp)
+        expected = '0.0'
+        self.assertEqual(out, expected, 'Should leave zero as zero')


### PR DESCRIPTION
Summary: When processing GPS coordinates from Baicells eNB, they are returned as integer values instead of float values. This revision fixes a bug that would cause negative values to not be converted correctly.

Reviewed By: sciencemanx

Differential Revision: D14651562
