### PR TITLE
Suppress PingReceived KeyError in proxy client

### DIFF
--- a/orc8r/gateway/python/magma/magmad/tests/proxy_client_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/proxy_client_tests.py
@@ -23,6 +23,7 @@ class MockClient(object):
         self._expected_headers = headers
         self._expected_trailers = trailers
         self._expected_req = expected_req
+        self._event_handlers = {}
 
     async def start_request(self, headers):
         return 3


### PR DESCRIPTION
Summary:
Log gets spammed with this error in the proxy client:
```
Mar 27 23:39:33 magma-dev magmad[9142]: ERROR:asyncio:Exception in callback _SelectorSocketTransport._read_ready()
Mar 27 23:39:33 magma-dev magmad[9142]: handle: <Handle _SelectorSocketTransport._read_ready()>
Mar 27 23:39:33 magma-dev magmad[9142]: Traceback (most recent call last):
Mar 27 23:39:33 magma-dev magmad[9142]:   File "/usr/lib/python3.5/asyncio/events.py", line 126, in _run
Mar 27 23:39:33 magma-dev magmad[9142]:     self._callback(*self._args)
Mar 27 23:39:33 magma-dev magmad[9142]:   File "/usr/lib/python3.5/asyncio/selector_events.py", line 730, in _read_ready
Mar 27 23:39:33 magma-dev magmad[9142]:     self._protocol.data_received(data)
Mar 27 23:39:33 magma-dev magmad[9142]:   File "/home/vagrant/build/python/lib/python3.5/site-packages/aioh2/protocol.py", line 259, in data_received
Mar 27 23:39:33 magma-dev magmad[9142]:     self._event_received(event)
Mar 27 23:39:33 magma-dev magmad[9142]:   File "/home/vagrant/build/python/lib/python3.5/site-packages/aioh2/protocol.py", line 268, in _event_received
Mar 27 23:39:33 magma-dev magmad[9142]:     self._event_handlers[type(event)](event)
Mar 27 23:39:33 magma-dev magmad[9142]: KeyError: <class 'h2.events.PingReceived'>
```
Set event handler for `PingReceived` to do nothing so the log doesn't get spammed.

Differential Revision: D14658966
