### PR TITLE
Test for Out-Of-Order UE Context Release and Service Request

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/out_of_order_service_req.py
+++ b/lte/gateway/python/integ_tests/s1aptests/out_of_order_service_req.py
@@ -1,0 +1,133 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+
+import unittest
+
+import s1ap_types
+import s1ap_wrapper
+import time
+import gpp_types
+
+
+class TestAttachDelayUeContextRelComplete(unittest.TestCase):
+
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_delay_ue_ctxt_rel_cmp(self):
+        """ Attach, Delay Ue context release complete """
+        # Ground work.
+        self._s1ap_wrapper.configUEDevice(1)
+        req = self._s1ap_wrapper.ue_req
+
+        # Trigger Attach Request
+        attach_req = s1ap_types.ueAttachRequest_t()
+        sec_ctxt = s1ap_types.TFW_CREATE_NEW_SECURITY_CONTEXT
+        id_type = s1ap_types.TFW_MID_TYPE_IMSI
+        eps_type = s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH
+        attach_req.ue_Id = req.ue_id
+        attach_req.mIdType = id_type
+        attach_req.epsAttachType = eps_type
+        attach_req.useOldSecCtxt = sec_ctxt
+
+        print("********Triggering Attach Request ")
+
+        self._s1ap_wrapper._s1_util.issue_cmd(s1ap_types.tfwCmd.
+                                              UE_ATTACH_REQUEST,
+                                              attach_req)
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(response,
+                        s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value)
+
+        # Trigger Authentication Response
+        auth_res = s1ap_types.ueAuthResp_t()
+        auth_res.ue_Id = req.ue_id
+        sqnRecvd = s1ap_types.ueSqnRcvd_t()
+        sqnRecvd.pres = 0
+        auth_res.sqnRcvd = sqnRecvd
+        self._s1ap_wrapper._s1_util.issue_cmd(s1ap_types.tfwCmd.UE_AUTH_RESP,
+                                              auth_res)
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(response,
+                        s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value)
+
+        # Trigger Security Mode Complete
+        sec_mode_complete = s1ap_types.ueSecModeComplete_t()
+        sec_mode_complete.ue_Id = req.ue_id
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete)
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(response, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value)
+
+        delay_ue_ctxt_rel_cmp = s1ap_types.UeDelayUeCtxtRelCmp()
+        delay_ue_ctxt_rel_cmp.ue_Id = req.ue_id
+        delay_ue_ctxt_rel_cmp.flag = 1
+        delay_ue_ctxt_rel_cmp.tmrVal = 2000
+
+        print("*** Setting Delay for Ue context release complete ***")
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SET_DELAY_UE_CTXT_REL_CMP,
+            delay_ue_ctxt_rel_cmp)
+
+        # Trigger Attach Complete
+        attach_complete = s1ap_types.ueAttachComplete_t()
+        attach_complete.ue_Id = req.ue_id
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE,
+            attach_complete)
+        time.sleep(0.5)
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(response, s1ap_types.tfwCmd.UE_EMM_INFORMATION.value)
+
+        time.sleep(0.5)
+        print("*** Sending UE context release request ",
+              "for UE id ***", req.ue_id)
+
+        # Send UE context release request to move UE to idle mode
+        uectxtrel_req = s1ap_types.ueCntxtRelReq_t()
+        uectxtrel_req.ue_Id = req.ue_id
+        uectxtrel_req.cause.causeVal = (gpp_types.
+                                        CauseRadioNetwork.
+                                        RELEASE_DUE_TO_EUTRAN_GENERATED_REASON.
+                                        value)
+
+        self._s1ap_wrapper.s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, uectxtrel_req)
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+
+        # self.assertEqual(
+        #    response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+
+        # Trigger Service Request
+        print("************************* Sending Service request for UE id ",
+              req.ue_id)
+        # Send Service Request to reconnect UE
+        service_req = s1ap_types.ueserviceReq_t()
+        service_req.ue_Id = req.ue_id
+        service_req.ueMtmsi = s1ap_types.ueMtmsi_t()
+        service_req.ueMtmsi.pres = False
+        service_req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
+
+        print("********Triggering Service Request ")
+        self._s1ap_wrapper.s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, service_req)
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        # self.assertEqual(response.msg_type,
+        #                   s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value)
+        time.sleep(10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
As reported in https://github.com/facebookincubator/magma/issues/96, the MME
crashes when a service request is received for a UE before the UE context release
complete message is received. This change adds a test to simulate this scenario
with S1ap-tester

Differential Revision: D14695200
