### PR TITLE
Fix service manager integration tests

### DIFF
--- a/orc8r/gateway/python/magma/magmad/service_manager.py
+++ b/orc8r/gateway/python/magma/magmad/service_manager.py
@@ -296,7 +296,7 @@ class ServiceManager(object):
         def parse_status(self, status):
             """Transforms status returned by init system into a ServiceState"""
             statuses = self._statuses
-            std_out_formatted = status.strip()
+            std_out_formatted = status.strip().decode()
             if std_out_formatted in statuses:
                 return statuses[std_out_formatted]
             else:

--- a/orc8r/gateway/python/magma/magmad/tests/magma@dummy_service.service
+++ b/orc8r/gateway/python/magma/magmad/tests/magma@dummy_service.service
@@ -9,10 +9,10 @@ Description=Dummy service for unit testing
 
 [Service]
 Type=simple
-ExecStart=/home/$USER/build/python/bin/python3 /home/$USER/magma/orc8r/gateway/magmad/tests/dummy_service.py
-ExecStop=
-ExecReload=
+EnvironmentFile=/etc/environment
+ExecStart=/usr/bin/env python3 -m magma.magmad.tests.dummy_service
 StandardOutput=syslog
 StandardError=syslog
+SyslogIdentifier=dummy_service
 
 [Install]


### PR DESCRIPTION
Summary: The magmad service_manager integration tests were out of date and failed on the current service_manager implementation. This change updates the tests so that they pass.

Reviewed By: themarwhal

Differential Revision: D14686112
