### PR TITLE
Change ServiceRegistry to read in 'proxy_aliases' fields from service_registry.yml files

### DIFF
--- a/orc8r/cloud/go/registry/registry.go
+++ b/orc8r/cloud/go/registry/registry.go
@@ -23,9 +23,10 @@ import (
 // ServiceLocation is an entry for the service registry which identifies a
 // service by name and the host:port that it is running on.
 type ServiceLocation struct {
-	Name string
-	Host string
-	Port int
+	Name         string
+	Host         string
+	Port         int
+	ProxyAliases map[string]int
 }
 
 const (
@@ -76,6 +77,18 @@ func GetServiceAddress(service string) (string, error) {
 		return "", fmt.Errorf("Service %s is not available", service)
 	}
 	return fmt.Sprintf("%s:%d", location.Host, location.Port), nil
+}
+
+// GetServiceProxyAliases Returns the proxy_aliases, if any, of the service.
+// The service needs to be added to the registry before this.
+func GetServiceProxyAliases(service string) (map[string]int, error) {
+	registry.RLock()
+	defer registry.RUnlock()
+	location, ok := registry.serviceLocations[string(service)]
+	if !ok {
+		return nil, fmt.Errorf("Service %s not registered", service)
+	}
+	return location.ProxyAliases, nil
 }
 
 // Returns the listening port for the RPC service.

--- a/orc8r/cloud/go/service/serviceregistry/service_registry.go
+++ b/orc8r/cloud/go/service/serviceregistry/service_registry.go
@@ -14,53 +14,83 @@ import (
 
 	"magma/orc8r/cloud/go/registry"
 	"magma/orc8r/cloud/go/service/config"
+
+	"github.com/golang/glog"
 )
 
 const (
 	serviceRegistryFilename = "service_registry"
 )
 
+type rawMapType = map[interface{}]interface{}
+
 // LoadServiceRegistryConfig reads service registry config file from /etc/magma/configs/{moduleName} or override config
 func LoadServiceRegistryConfig(moduleName string) ([]registry.ServiceLocation, error) {
 	config, err := config.GetServiceConfig(moduleName, serviceRegistryFilename)
 	if err != nil {
+		// file does not exist
 		return nil, err
 	}
-
-	return convertToServiceLocations(config)
+	rawMap, err := getRawMap(config)
+	if err != nil {
+		// file is empty
+		return nil, err
+	}
+	locations, err := convertToServiceLocations(rawMap, len(config.RawMap))
+	if err != nil {
+		glog.Fatalf("Failed to load in service registry for %s: %v", moduleName, err)
+	}
+	return locations, nil
 }
 
-func convertToServiceLocations(serviceRegistry *config.ConfigMap) ([]registry.ServiceLocation, error) {
-	services := serviceRegistry.RawMap["services"]
-	rawMap, ok := services.(map[interface{}]interface{})
-	if !ok {
-		return nil, fmt.Errorf("Unable to convert map %v", rawMap)
+func getProxyAliases(rawMap map[interface{}]interface{}) map[string]int {
+	proxyAliases := map[string]int{}
+	if val, ok := rawMap["proxy_aliases"]; ok {
+		rawMap, _ := val.(rawMapType)
+		for k, v := range rawMap {
+			proxyName, _ := k.(string)
+			portMap, _ := v.(rawMapType)
+			port, _ := portMap["port"].(int)
+			proxyAliases[proxyName] = port
+		}
 	}
+	return proxyAliases
+}
 
-	serviceLocations := make([]registry.ServiceLocation, len(serviceRegistry.RawMap))
+func getRawMap(serviceRegistry *config.ConfigMap) (map[interface{}]interface{}, error) {
+	services, ok := serviceRegistry.RawMap["services"]
+	if !ok {
+		return nil, fmt.Errorf("The field:services does not exist")
+	}
+	rawMap, ok := services.(rawMapType)
+	if !ok {
+		return nil, fmt.Errorf("Unable to convert serviceRegistry to map")
+	}
+	return rawMap, nil
+}
+
+func convertToServiceLocations(rawMap rawMapType, len int) ([]registry.ServiceLocation, error) {
+	serviceLocations := make([]registry.ServiceLocation, len)
 	for k, v := range rawMap {
 		name, ok := k.(string)
 		if !ok {
-			return nil, fmt.Errorf("Unable convert key:%v to string", k)
+			return nil, fmt.Errorf("The name of the service is not a string: %v", k)
 		}
-
-		rawMap, ok := v.(map[interface{}]interface{})
+		rawMap, ok := v.(rawMapType)
 		if !ok {
-			return nil, fmt.Errorf("Unable to convert map %v", rawMap)
+			return nil, fmt.Errorf("The value associated with key:%v is not a map: %v", k, v)
 		}
 		configMap := &config.ConfigMap{RawMap: rawMap}
-
 		host, err := configMap.GetStringParam("host")
 		if err != nil {
 			return nil, err
 		}
-
 		port, err := configMap.GetIntParam("port")
 		if err != nil {
 			return nil, err
 		}
-
-		serviceLocations = append(serviceLocations, registry.ServiceLocation{Name: strings.ToUpper(name), Host: host, Port: port})
+		proxyAliases := getProxyAliases(rawMap)
+		serviceLocations = append(serviceLocations, registry.ServiceLocation{Name: strings.ToUpper(name), Host: host, Port: port, ProxyAliases: proxyAliases})
 	}
 	return serviceLocations, nil
 }


### PR DESCRIPTION
Summary:
Currently there are multiple lists of services, when the service_registry YAML files should be the only place and everything else should point to the registry. My goal is to get rid of `magma/orc8r/cloud/deploy/files/envdir/CONTROLLER_SERVICES`, which currently lists controller services.
This is step one in trying to achieve this goal. Right now, not all of the fields in service_registry.yml files are being loaded into the corresponding struct in Go.

ServiceRegistry now reads in the field proxy_aliases which was added back in D14176660, so these can be used to specify different proxy ports.

Differential Revision: D14428141
