### PR TITLE
Add docker init system

### DIFF
--- a/example/gateway/configs/magmad.yml
+++ b/example/gateway/configs/magmad.yml
@@ -10,7 +10,7 @@ non_service303_services:
   - control_proxy
 
 # Init system to use to control services
-# Supported systems include: [systemd, runit]
+# Supported systems include: [systemd, runit, docker]
 init_system: systemd
 
 # bootstrap_manager config

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -20,7 +20,7 @@ non_service303_services:
   - redis
 
 # Init system to use to control services
-# Supported systems include: [systemd, runit]
+# Supported systems include: [systemd, runit, docker]
 init_system: systemd
 
 # bootstrap_manager config

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -44,7 +44,7 @@ skip_checkin_if_missing_meta_services: []
 # max_skipped_checkins: 3
 
 # Init system to use to control services
-# Supported systems include: [systemd, runit]
+# Supported systems include: [systemd, runit, docker]
 init_system: systemd
 
 # bootstrap_manager config

--- a/orc8r/gateway/python/magma/magmad/tests/Dockerfile
+++ b/orc8r/gateway/python/magma/magmad/tests/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3
+COPY dummy_service.py /dummy_service.py
+CMD python3 /dummy_service.py

--- a/orc8r/gateway/python/magma/magmad/tests/docker-compose.yml
+++ b/orc8r/gateway/python/magma/magmad/tests/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "2.0"
+
+services:
+  dummy_service:
+    container_name: dummy_service
+    build:
+      dockerfile: Dockerfile
+      context: .
+
+  dummy1:
+    container_name: dummy1
+    build:
+      dockerfile: Dockerfile
+      context: .
+
+  dummy2:
+    container_name: dummy2
+    build:
+      dockerfile: Dockerfile
+      context: .

--- a/orc8r/gateway/python/magma/magmad/tests/service_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/service_manager_tests.py
@@ -249,3 +249,96 @@ class ServiceManagerRunitTest(TestCase):
         )
         self.assertEqual(mgr._service_control['redirectd'].status(),
                          ServiceState.Inactive)
+
+
+class ServiceManagerDockerTest(TestCase):
+    """
+    Tests for the service manager class using the docker init system, and the
+    service control sub-class. Can be run as integration tests by setting
+    environment variable MAGMA_INTEGRATION_TEST=1.
+    Must run docker-compose up -d in this directory for integration tests
+    to pass.
+    """
+
+    def setUp(self):
+        """
+        Run before each test
+        """
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        #  Only patch if this is a unit test. Otherwise create dummy mock so
+        #  code that affects the mock can run.
+        self.subprocess_mock = MagicMock(return_value='')
+        if not os.environ.get('MAGMA_INTEGRATION_TEST'):
+            subprocess.check_output = self.subprocess_mock
+
+        #  Ensure test process is stopped
+        self.dummy_service = ServiceManager.ServiceControl(
+            name='dummy_service',
+            init_system_spec=ServiceManager.DockerInitSystem
+        )
+        try:
+            self._loop.run_until_complete(self.dummy_service.stop_process())
+        except FileNotFoundError:
+            pass
+
+    def tearDown(self):
+        """
+        Run after each test
+        """
+        #  Ensure test process is stopped
+        try:
+            self._loop.run_until_complete(self.dummy_service.stop_process())
+        except FileNotFoundError:
+            pass
+        self._loop.close()
+
+    def test_process_start_stop(self):
+        """
+        Test that process can be started and stopped
+        """
+        self.subprocess_mock.return_value = b'[{"State": {"Status": "exited"}}]'
+        self.assertEqual(self.dummy_service.status(), ServiceState.Inactive)
+
+        self.subprocess_mock.return_value = b'[{"State": {"Status": "running"}}]'
+        try:
+            self._loop.run_until_complete(self.dummy_service.start_process())
+        except FileNotFoundError:
+            pass
+        time.sleep(1)  # Make sure that process doesnt immediately die
+        self.assertEqual(self.dummy_service.status(), ServiceState.Active)
+
+        self.subprocess_mock.return_value = b'[{"State": {"Status": "exited"}}]'
+        try:
+            self._loop.run_until_complete(self.dummy_service.stop_process())
+        except FileNotFoundError:
+            pass
+        self.assertEqual(self.dummy_service.status(), ServiceState.Inactive)
+
+    def test_service_manager_start_stop(self):
+        """
+        This test exercises the ServiceManager functions, but doesn't really
+        verify functionality beyond the tests above
+        """
+        mgr = ServiceManager(['dummy1', 'dummy2'], init_system='docker',
+                             service_poller=MagicMock())
+
+        try:
+            self._loop.run_until_complete(mgr.start_services())
+        except FileNotFoundError:
+            pass
+        self.subprocess_mock.return_value = b'[{"State": {"Status": "running"}}]'
+        self.assertEqual(mgr._service_control['dummy1'].status(),
+                         ServiceState.Active)
+        self.assertEqual(mgr._service_control['dummy2'].status(),
+                         ServiceState.Active)
+
+        try:
+            self._loop.run_until_complete(mgr.stop_services())
+        except FileNotFoundError:
+            pass
+        self.subprocess_mock.return_value = b'[{"State": {"Status": "exited"}}]'
+        self.assertEqual(mgr._service_control['dummy1'].status(),
+                         ServiceState.Inactive)
+        self.assertEqual(mgr._service_control['dummy2'].status(),
+                         ServiceState.Inactive)


### PR DESCRIPTION
Summary: This change adds an option to use docker as an init system as an alternative to systemd and runit. This requires docker to be installed, and if running in a container, the docker socket should be mounted. This new init system will be used to dockerize the FeG and run one container per service. Then, docker will be used to manage the services instead of systemd.

Differential Revision: D14687148
