### PR TITLE
GetObjectParameters explicitly count PLMNs

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -524,14 +524,22 @@ class WaitGetObjectParametersState(EnodebAcsState):
                     param_value_struct.Value.Data
         logging.debug('Received object parameters: %s', str(path_to_val))
 
-        # TODO: This might a string for some strange reason, investigate why
-        # Get the names of parameters belonging to numbered objects
-        num_plmns = \
-            int(self.acs.device_cfg.get_parameter(ParameterName.NUM_PLMNS))
-        for i in range(1, num_plmns + 1):
-            obj_name = ParameterName.PLMN_N % i
-            obj_to_params = self.acs.data_model.get_numbered_param_names()
+        # Number of PLMN objects reported can be incorrect. Let's count them
+        num_plmns = 0
+        obj_to_params = self.acs.data_model.get_numbered_param_names()
+        while True:
+            obj_name = ParameterName.PLMN_N % (num_plmns + 1)
+            if obj_name not in obj_to_params or len(obj_to_params[obj_name]) == 0:
+                logging.warning("eNB has PLMN %s but not defined in model",
+                    obj_name)
+                break
             param_name_list = obj_to_params[obj_name]
+            obj_path = self.acs.data_model.get_parameter(param_name_list[0]).path
+            if obj_path not in path_to_val:
+                break
+            if not self.acs.device_cfg.has_object(obj_name):
+                self.acs.device_cfg.add_object(obj_name)
+            num_plmns += 1
             for name in param_name_list:
                 path = self.acs.data_model.get_parameter(name).path
                 value = path_to_val[path]
@@ -539,6 +547,13 @@ class WaitGetObjectParametersState(EnodebAcsState):
                     self.acs.data_model.transform_for_magma(name, value)
                 self.acs.device_cfg.set_parameter_for_object(name, magma_val,
                                                              obj_name)
+        num_plmns_reported = \
+                int(self.acs.device_cfg.get_parameter(ParameterName.NUM_PLMNS))
+        if num_plmns != num_plmns_reported:
+            logging.warning("eNB reported %d PLMNs but found %d",
+                    num_plmns_reported, num_plmns)
+            self.acs.device_cfg.set_parameter(ParameterName.NUM_PLMNS,
+                                              num_plmns)
 
         # Now we can have the desired state
         if self.acs.desired_cfg is None:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -517,9 +517,11 @@ class WaitGetObjectParametersState(EnodebAcsState):
             return AcsReadMsgResult(False, None)
 
         path_to_val = {}
-        for param_value_struct in message.ParameterList.ParameterValueStruct:
-            path_to_val[param_value_struct.Name] = \
-                param_value_struct.Value.Data
+        if hasattr(message.ParameterList, 'ParameterValueStruct') and \
+                message.ParameterList.ParameterValueStruct is not None:
+            for param_value_struct in message.ParameterList.ParameterValueStruct:
+                path_to_val[param_value_struct.Name] = \
+                    param_value_struct.Value.Data
         logging.debug('Received object parameters: %s', str(path_to_val))
 
         # TODO: This might a string for some strange reason, investigate why

--- a/lte/gateway/python/magma/enodebd/tests/cavium_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/cavium_tests.py
@@ -1,0 +1,140 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+# pylint: disable=protected-access
+from unittest import TestCase
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.data_models.data_model_parameters import ParameterName
+from magma.enodebd.tr069 import models
+from magma.enodebd.tests.test_utils.tr069_msg_builder import \
+    Tr069MessageBuilder
+from magma.enodebd.tests.test_utils.enb_acs_builder import \
+    EnodebAcsStateMachineBuilder
+
+
+class CaviumHandlerTests(TestCase):
+    def test_count_plmns_less(self) -> None:
+        """
+        Tests the Cavium provisioning up to GetObjectParameters.
+
+        In particular tests when the eNB reports NUM_PLMNS less
+        than actually listed. The eNB says there are no PLMNs
+        defined when actually there are two.
+
+        Verifies that the number of PLMNs is correctly accounted.
+        """
+        acs_state_machine = \
+            EnodebAcsStateMachineBuilder \
+                .build_acs_state_machine(EnodebDeviceName.CAVIUM)
+
+        # Send an Inform message
+        inform_msg = Tr069MessageBuilder.get_inform('000FB7',
+                                                    'OC-LTE',
+                                                    '120200002618AGP0003',
+                                                    ['1 BOOT'])
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+        # Send an empty http request to kick off the rest of provisioning
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                'State machine should be requesting param values: %s' % resp)
+
+        # Transient config response and request for parameter values
+        req = Tr069MessageBuilder.get_read_only_param_values_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                'State machine should be requesting param values: %s' % resp)
+
+        # Send back typical values for the regular parameters
+        req = Tr069MessageBuilder.get_cavium_param_values_response(num_plmns=0)
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # SM will be requesting object parameter values
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting object param vals')
+
+        # Send back some object parameters with TWO plmns
+        req = Tr069MessageBuilder.get_cavium_object_param_values_response(
+                num_plmns=2)
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # In this scenario, the ACS and thus state machine will not need
+        # to delete or add objects to the eNB configuration.
+        # SM should then just be attempting to set parameter values
+        self.assertTrue(isinstance(resp, models.SetParameterValues),
+                        'State machine should be setting param values')
+
+        # Number of PLMNs should reflect object count
+        num_plmns_cur = \
+                acs_state_machine \
+                .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
+        self.assertEqual(num_plmns_cur, 2)
+
+    def test_count_plmns_more_defined(self) -> None:
+        """
+        Tests the Cavium provisioning up to GetObjectParameters.
+
+        In particular tests when the eNB has more PLMNs than is
+        currently defined in our data model (NUM_PLMNS_IN_CONFIG)
+        """
+        acs_state_machine = \
+            EnodebAcsStateMachineBuilder \
+                .build_acs_state_machine(EnodebDeviceName.CAVIUM)
+
+        # Send an Inform message
+        inform_msg = Tr069MessageBuilder.get_inform('000FB7',
+                                                    'OC-LTE',
+                                                    '120200002618AGP0003',
+                                                    ['1 BOOT'])
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+        # Send an empty http request to kick off the rest of provisioning
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                'State machine should be requesting param values: %s' % resp)
+
+        # Transient config response and request for parameter values
+        req = Tr069MessageBuilder.get_read_only_param_values_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                'State machine should be requesting param values: %s' % resp)
+
+        # Send back regular parameters, and some absurd number of PLMNS
+        req = Tr069MessageBuilder.get_cavium_param_values_response(
+                num_plmns=100)
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # SM will be requesting object parameter values
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting object param vals')
+
+        # Send back some object parameters with an absurd number of PLMNs
+        req = Tr069MessageBuilder.get_cavium_object_param_values_response(
+                num_plmns=100)
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # In this scenario, the ACS and thus state machine will not need
+        # to delete or add objects to the eNB configuration.
+        # SM should then just be attempting to set parameter values
+        self.assertTrue(isinstance(resp, models.SetParameterValues),
+                        'State machine should be setting param values')
+
+        # Number of PLMNs should reflect data model
+        num_plmns_cur = \
+                acs_state_machine \
+                .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
+        self.assertEqual(num_plmns_cur, 6)

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/config_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/config_builder.py
@@ -19,18 +19,19 @@ class EnodebConfigBuilder:
     ) -> mconfigs_pb2.EnodebD:
         mconfig = mconfigs_pb2.EnodebD()
         mconfig.bandwidth_mhz = 20
-        mconfig.special_subframe_pattern = 7
         # This earfcndl is actually unused, remove later
         mconfig.earfcndl = 44490
         mconfig.log_level = 1
         mconfig.plmnid_list = "00101"
         mconfig.pci = 260
         mconfig.allow_enodeb_transmit = False
-        mconfig.subframe_assignment = 2
         mconfig.tac = 1
         if device is EnodebDeviceName.BAICELLS_QAFB:
             # fdd config
             mconfig.fdd_config.earfcndl = 9211
+        elif device is EnodebDeviceName.CAVIUM:
+            # fdd config
+            mconfig.fdd_config.earfcndl = 2405
         else:
             # tdd config
             mconfig.tdd_config.earfcndl = 39150

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-from typing import Any, List
+from typing import Any, List, Optional
 from magma.enodebd.tr069 import models
 
 
@@ -61,8 +61,10 @@ class Tr069MessageBuilder:
         oui: str = '48BF74',
         sw_version: str = 'BaiBS_RTS_3.1.6',
         enb_serial: str = '120200002618AGP0003',
-        event_codes: List[str] = [],
+        event_codes: Optional[List[str]] = None,
     ) -> models.Inform:
+        if event_codes is None:
+            event_codes = []
         msg = models.Inform()
 
         # DeviceId
@@ -189,6 +191,130 @@ class Tr069MessageBuilder:
         msg.ParameterList = models.ParameterValueList()
         msg.ParameterList.ParameterValueStruct = param_val_list
         return msg
+
+    @classmethod
+    def get_cavium_param_values_response(
+        cls,
+        admin_state: bool = False,
+        earfcndl: int = 2405,
+        num_plmns: int = 0,
+    ) -> models.GetParameterValuesResponse:
+        msg = models.GetParameterValuesResponse()
+        param_val_list = []
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.DLBandwidth',
+            val_type='string',
+            data='n100',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator',
+            val_type='string',
+            data='5',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.ManagementServer.PeriodicInformInterval',
+            val_type='int',
+            data='5',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.CellRestriction.CellReservedForOperatorUse',
+            val_type='boolean',
+            data='false',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.ULBandwidth',
+            val_type='string',
+            data='n100',
+        ))
+        # MME IP
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.FAPControl.LTE.Gateway.S1SigLinkServerList',
+            val_type='string',
+            data='"192.168.60.142"',
+        ))
+        # perf mgmt enable
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.PerfMgmt.Config.1.Enable',
+            val_type='boolean',
+            data='true'
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.CellRestriction.CellBarred',
+            val_type='boolean',
+            data='false'
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.PerfMgmt.Config.1.PeriodicUploadInterval',
+            val_type='int',
+            data='600'
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.FAPControl.LTE.AdminState',
+            val_type='boolean',
+            data=admin_state,
+        ))
+        # Perf mgmt upload url
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.PerfMgmt.Config.1.URL',
+            val_type='string',
+            data='http://192.168.60.142:8081/'
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.EPC.TAC',
+            val_type='int',
+            data='1',
+        ))
+        # PCI
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.PhyCellID',
+            val_type='int',
+            data='260',
+        ))
+        # MME port
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.FAPControl.LTE.Gateway.S1SigLinkPort',
+            val_type='int',
+            data='36412',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.IPsec.Enable',
+            val_type='boolean',
+            data='false',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.EARFCNDL',
+            val_type='int',
+            data='2405',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.EARFCNUL',
+            val_type='int',
+            data='20405',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.Capabilities.LTE.DuplexMode',
+            val_type='string',
+            data='FDDMode',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.Capabilities.LTE.BandsSupported',
+            val_type='string',
+            data='5',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.ManagementServer.PeriodicInformEnable',
+            val_type='int',
+            data='5',
+        ))
+        param_val_list.append(cls.get_parameter_value_struct(
+            name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNListNumberOfEntries',
+            val_type='int',
+            data=str(num_plmns),
+        ))
+        msg.ParameterList = models.ParameterValueList()
+        msg.ParameterList.ParameterValueStruct = param_val_list
+        return msg
+
 
     @classmethod
     def get_regular_param_values_response(
@@ -475,6 +601,39 @@ class Tr069MessageBuilder:
         msg.ParameterList = models.ParameterValueList()
         msg.ParameterList.ParameterValueStruct = param_val_list
         return msg
+
+    @classmethod
+    def get_cavium_object_param_values_response(
+            cls,
+            num_plmns: int,
+    ) -> models.GetParameterValuesResponse:
+        msg = models.GetParameterValuesResponse()
+        param_val_list = []
+        for i in range(1, num_plmns+1):
+            param_val_list.append(cls.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.%d.IsPrimary' % i,
+                val_type='boolean',
+                data='true',
+            ))
+            param_val_list.append(cls.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.%d.CellReservedForOperatorUse' % i,
+                val_type='boolean',
+                data='false',
+            ))
+            param_val_list.append(cls.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.%d.PLMNID' % i,
+                val_type='string',
+                data='00101',
+            ))
+            param_val_list.append(cls.get_parameter_value_struct(
+                name='Device.Services.FAPService.1.CellConfig.LTE.EPC.PLMNList.%d.Enable' % i,
+                val_type='boolean',
+                data='true',
+            ))
+        msg.ParameterList = models.ParameterValueList()
+        msg.ParameterList.ParameterValueStruct = param_val_list
+        return msg
+
 
     @classmethod
     def get_object_param_values_response(


### PR DESCRIPTION
Summary: The enodeB can incorrectly report the number of associated PLMNs. Manually counts the PLMN objects and reports any discrepancies

Reviewed By: andreilee

Differential Revision: D14598509
