### PR TITLE
Read OUI from DeviceID struct

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -70,16 +70,21 @@ def process_inform_message(
 
         # Check the OUI and version number to see if the data model matches
         path_list = list(param_values_by_path.keys())
-        device_oui = _get_param_value_from_path_suffix(
-            'DeviceInfo.ManufacturerOUI',
-            path_list,
-            param_values_by_path,
-        )
         sw_version = _get_param_value_from_path_suffix(
             'DeviceInfo.SoftwareVersion',
             path_list,
             param_values_by_path,
         )
+        # Check DeviceId struct for OUI first
+        if hasattr(inform, 'DeviceId') and \
+                hasattr(inform.DeviceId, 'OUI'):
+            device_oui = inform.DeviceId.OUI
+        else:
+            device_oui = _get_param_value_from_path_suffix(
+                'DeviceInfo.ManufacturerOUI',
+                path_list,
+                param_values_by_path,
+            )
         logging.info('OUI: %s, Software: %s', device_oui, sw_version)
         correct_device_name = get_device_name(device_oui, sw_version)
         if device_name is not correct_device_name:
@@ -116,7 +121,6 @@ def are_tr069_params_equal(param_a: Any, param_b: Any, type_: str) -> bool:
     if cmp_a.lower() in ['true', 'false']:
         cmp_a, cmp_b = map(lambda s: s.lower(), (cmp_a, cmp_b))
     return cmp_a == cmp_b
-
 
 def get_all_objects_to_add(
     desired_cfg: EnodebConfiguration,


### PR DESCRIPTION
Summary:
in some implementations, OUI is actually in the DeviceID struct, eg. in Cavium

```
<?xml version="1.0" encoding="UTF-8"?>
<SOAP-ENV:Envelope xmlns:SOAP-ENV="http://schemas.xmlsoap.org/soap/envelope/" xmlns:SOAP-ENC="http://schemas.xmlsoap.org/soap/encoding/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="h
ttp://www.w3.org/2001/XMLSchema" xmlns:cwmp="urn:dslforum-org:cwmp-1-0">
  <SOAP-ENV:Header>
    <cwmp:ID SOAP-ENV:mustUnderstand="1">CPE_3286</cwmp:ID>
  </SOAP-ENV:Header>
  <SOAP-ENV:Body SOAP-ENV:encodingStyle="http://schemas.xmlsoap.org/soap/encoding/">
    <cwmp:Inform>
      <DeviceId>
        <Manufacturer>NuRAN Wireless</Manufacturer>
        <OUI>000FB7</OUI>
        <ProductClass>Cavium eNB</ProductClass>
        <SerialNumber>10.102.81.61</SerialNumber>
      </DeviceId>
      <Event xsi:type="SOAP-ENC:Array" SOAP-ENC:arrayType="cwmp:EventStruct[1]">
        <EventStruct>
          <EventCode>2 PERIODIC</EventCode>
          <CommandKey></CommandKey>
        </EventStruct>
      </Event>
      <MaxEnvelopes>1</MaxEnvelopes>
      <CurrentTime>1970-01-09T23:03:44.067132+00:00</CurrentTime>
      <RetryCount>0</RetryCount>
      <ParameterList xsi:type="SOAP-ENC:Array" SOAP-ENC:arrayType="cwmp:ParameterValueStruct[9]">
        <ParameterValueStruct>
          <Name>Device.DeviceInfo.HardwareVersion</Name>
          <Value xsi:type="xsd:string">1.0</Value>
        </ParameterValueStruct>
        ...
      </ParameterList>
    </cwmp:Inform>
  </SOAP-ENV:Body>
</SOAP-ENV:Envelope>
```

Reviewed By: andreilee, xjtian

Differential Revision: D14526182
