### PR TITLE
GetParameterValuesResponse ParameterValueStruct can be empty

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/acs_state_utils.py
@@ -70,16 +70,21 @@ def process_inform_message(
 
         # Check the OUI and version number to see if the data model matches
         path_list = list(param_values_by_path.keys())
-        device_oui = _get_param_value_from_path_suffix(
-            'DeviceInfo.ManufacturerOUI',
-            path_list,
-            param_values_by_path,
-        )
         sw_version = _get_param_value_from_path_suffix(
             'DeviceInfo.SoftwareVersion',
             path_list,
             param_values_by_path,
         )
+        # Check DeviceId struct for OUI first
+        if hasattr(inform, 'DeviceId') and \
+                hasattr(inform.DeviceId, 'OUI'):
+            device_oui = inform.DeviceId.OUI
+        else:
+            device_oui = _get_param_value_from_path_suffix(
+                'DeviceInfo.ManufacturerOUI',
+                path_list,
+                param_values_by_path,
+            )
         logging.info('OUI: %s, Software: %s', device_oui, sw_version)
         correct_device_name = get_device_name(device_oui, sw_version)
         if device_name is not correct_device_name:
@@ -116,7 +121,6 @@ def are_tr069_params_equal(param_a: Any, param_b: Any, type_: str) -> bool:
     if cmp_a.lower() in ['true', 'false']:
         cmp_a, cmp_b = map(lambda s: s.lower(), (cmp_a, cmp_b))
     return cmp_a == cmp_b
-
 
 def get_all_objects_to_add(
     desired_cfg: EnodebConfiguration,

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -288,14 +288,14 @@ class SendGetTransientParametersState(EnodebAcsState):
     def get_msg(self) -> AcsMsgAndTransition:
         request = models.GetParameterValues()
         request.ParameterNames = models.ParameterNames()
-        request.ParameterNames.arrayType = \
-            'xsd:string[%d]' % len(self.PARAMETERS)
         request.ParameterNames.string = []
         for name in self.PARAMETERS:
             # Not all data models have these parameters
             if self.acs.data_model.is_parameter_present(name):
                 path = self.acs.data_model.get_parameter(name).path
                 request.ParameterNames.string.append(path)
+        request.ParameterNames.arrayType = \
+            'xsd:string[%d]' % len(request.ParameterNames.string)
 
         return AcsMsgAndTransition(request, self.done_transition)
 

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -517,9 +517,11 @@ class WaitGetObjectParametersState(EnodebAcsState):
             return AcsReadMsgResult(False, None)
 
         path_to_val = {}
-        for param_value_struct in message.ParameterList.ParameterValueStruct:
-            path_to_val[param_value_struct.Name] = \
-                param_value_struct.Value.Data
+        if hasattr(message.ParameterList, 'ParameterValueStruct') and \
+                message.ParameterList.ParameterValueStruct is not None:
+            for param_value_struct in message.ParameterList.ParameterValueStruct:
+                path_to_val[param_value_struct.Name] = \
+                    param_value_struct.Value.Data
         logging.debug('Received object parameters: %s', str(path_to_val))
 
         # TODO: This might a string for some strange reason, investigate why


### PR DESCRIPTION
Summary: If we are trying to get parameters that don't exist, the ParameterValueStruct can be missing. Add a null check

Reviewed By: andreilee

Differential Revision: D14598356
