### PR TITLE
GetRPCMethods model

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_qafb.py
@@ -35,7 +35,7 @@ from magma.enodebd.state_machines.enb_acs_states import \
     AddObjectsState, SetParameterValuesState, WaitSetParameterValuesState, \
     WaitRebootResponseState, WaitInformMRebootState, EnodebAcsState, \
     AcsMsgAndTransition, AcsReadMsgResult, WaitEmptyMessageState, ErrorState, \
-    EndSessionState, BaicellsSendRebootState
+    EndSessionState, BaicellsSendRebootState, GetRPCMethodsState
 from magma.enodebd.tr069 import models
 from magma.enodebd.stats_manager import StatsManager
 
@@ -57,7 +57,8 @@ class BaicellsQAFBHandler(BasicEnodebAcsStateMachine):
 
     def _init_state_map(self) -> None:
         self._state_map = {
-            'wait_inform': WaitInformState(self, when_done='wait_empty'),
+            'wait_inform': WaitInformState(self, when_done='get_rpc_methods'),
+            'get_rpc_methods': GetRPCMethodsState(self, when_done='wait_empty', when_skip='get_transient_params'),
             'wait_empty': WaitEmptyMessageState(self, when_done='get_transient_params'),
             'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
             'wait_get_transient_params': BaicellsQafbWaitGetTransientParametersState(self, when_get='get_params', when_get_obj_params='get_obj_params', when_delete='delete_objs', when_add='add_objs', when_set='set_params', when_skip='end_session'),

--- a/lte/gateway/python/magma/enodebd/devices/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/cavium.py
@@ -29,7 +29,8 @@ from magma.enodebd.state_machines.enb_acs_states import WaitInformState, \
     AddObjectsState, SetParameterValuesNotAdminState, \
     WaitSetParameterValuesState, SendRebootState, WaitRebootResponseState, \
     WaitInformMRebootState, EnodebAcsState, AcsMsgAndTransition, \
-    AcsReadMsgResult, WaitEmptyMessageState, ErrorState, EndSessionState
+    AcsReadMsgResult, WaitEmptyMessageState, ErrorState, EndSessionState, \
+    GetRPCMethodsState
 from magma.enodebd.tr069 import models
 from magma.enodebd.stats_manager import StatsManager
 
@@ -51,7 +52,8 @@ class CaviumHandler(BasicEnodebAcsStateMachine):
 
     def _init_state_map(self) -> None:
         self._state_map = {
-            'wait_inform': WaitInformState(self, when_done='wait_empty'),
+            'wait_inform': WaitInformState(self, when_done='get_rpc_methods'),
+            'get_rpc_methods': GetRPCMethodsState(self, when_done='wait_empty', when_skip='get_transient_params'),
             'wait_empty': WaitEmptyMessageState(self, when_done='get_transient_params'),
             'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
             'wait_get_transient_params': WaitGetTransientParametersState(self, when_get='get_params', when_get_obj_params='get_obj_params', when_delete='delete_objs', when_add='add_objs', when_set='set_params', when_skip='end_session'),

--- a/lte/gateway/python/magma/enodebd/tr069/models.py
+++ b/lte/gateway/python/magma/enodebd/tr069/models.py
@@ -91,7 +91,7 @@ class Fault(Tr069ComplexModel):
 
 class MethodList(Tr069ComplexModel):
     _type_info = odict()
-    _type_info["MethodList"] = String(max_length=64, max_occurs='unbounded')
+    _type_info["string"] = String(max_length=64, max_occurs='unbounded')
     _type_info["arrayType"] = XmlAttribute(String, ns=SOAP_ENC)
 
 
@@ -360,8 +360,19 @@ class TransferCompleteResponse(Tr069ComplexModel):
     _type_info["DummyField"] = UnsignedInteger
 
 
-# Miscellaneous
+class GetRPCMethods(Tr069ComplexModel):
+    _type_info = odict()
+    _type_info["DummyField"] = UnsignedInteger
 
+
+class GetRPCMethodsResponse(Tr069ComplexModel):
+    _type_info = odict()
+    _type_info["MethodList"] = MethodList
+
+
+#
+# Miscellaneous
+#
 
 class ParameterListUnion(Tr069ComplexModel):
     """ Union of structures that get instantiated as 'ParameterList' in ACS->CPE

--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -165,15 +165,18 @@ class AutoConfigServer(ServiceBase):
 
     # CPE->ACS RPC calls
 
-    @rpc(_returns=Iterable(String),
-         _operation_name="GetRPCMethods")
-    def get_rpc_methods(ctx):
+    @rpc(models.GetRPCMethods,
+         _returns=models.GetRPCMethodsResponse,
+         _body_style="bare",
+         _operation_name="GetRPCMethods",
+         _out_message_name="GetRPCMethodsResponse")
+    def get_rpc_methods(ctx, request):
         """ GetRPCMethods RPC call is terminated here. No need to pass to higher
             layer """
         fill_response_header(ctx)
+        resp = AutoConfigServer._handle_tr069_message(ctx, request)
+        return resp
 
-        for rpc_method in RPC_METHODS:
-            yield '%s' % rpc_method
 
     @rpc(models.Inform,
          _returns=models.InformResponse,


### PR DESCRIPTION
Summary:
The current GetRPCMethod handler sends a malformed response to the Cavium, failing to correctly form the MethodList.
Adds the full response model as well as corresponding state. This state can be used to track when we have a reboot since GetRPCMethods only occurs after Inform message after a reboot/loss of eNB state.

Reviewed By: andreilee

Differential Revision: D14599889
