### PR TITLE
Make ODS sample submission lock only once

### DIFF
--- a/orc8r/cloud/go/services/metricsd/exporters/exporter.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/exporter.go
@@ -20,12 +20,19 @@ import (
 	prometheus_proto "github.com/prometheus/client_model/go"
 )
 
+// Exporter exports metrics received by the metricsd servicer to a datasink.
 type Exporter interface {
 	// This method has to be thread-safe
-	// Submit submits a metric to Exporter
-	Submit(family *dto.MetricFamily, context MetricsContext) error
+	// Submit submits metrics to the exporter
+	Submit(metrics []MetricAndContext) error
 
 	Start()
+}
+
+// MetricAndContext wraps a metric family and metric context
+type MetricAndContext struct {
+	Family  *dto.MetricFamily
+	Context MetricsContext
 }
 
 // MetricsContext provides information to the exporter about where this metric

--- a/orc8r/cloud/go/services/metricsd/exporters/promo_test.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/promo_test.go
@@ -53,7 +53,7 @@ func testSubmitPrometheusType(t *testing.T, metricType dto.MetricType, config ex
 		Name:  makeStringPointer(exporters.SERVICE_LABEL_NAME),
 		Value: makeStringPointer("testService"),
 	}
-	family := makeTestMetricFamily(metricType, []*dto.LabelPair{&serviceLabelPair})
+	family := makeTestMetricFamily(metricType, 1, []*dto.LabelPair{&serviceLabelPair})
 	context := exporters.MetricsContext{
 		NetworkID:         "nID",
 		GatewayID:         "gID",
@@ -63,7 +63,7 @@ func testSubmitPrometheusType(t *testing.T, metricType dto.MetricType, config ex
 
 	registry.On("Register", mock.Anything).Return(nil)
 	// Registering a new metric should not throw error
-	err := exporter.Submit(family, context)
+	err := exporter.Submit([]exporters.MetricAndContext{{Family: family, Context: context}})
 	assert.NoError(t, err)
 	registry.AssertCalled(t, "Register", mock.Anything)
 
@@ -86,7 +86,7 @@ func testSubmitPrometheusType(t *testing.T, metricType dto.MetricType, config ex
 	registry.Calls = []mock.Call{}
 
 	// Updating existing metric should not throw error
-	err = exporter.Submit(family, context)
+	err = exporter.Submit([]exporters.MetricAndContext{{Family: family, Context: context}})
 	assert.NoError(t, err)
 	// Register() should not have been called, should have updated instead
 	registry.AssertNotCalled(t, "Register", mock.Anything)

--- a/orc8r/cloud/go/services/metricsd/exporters/sample.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/sample.go
@@ -34,8 +34,9 @@ func NewSample(
 	value string,
 	timestampMs int64,
 	labels []*dto.LabelPair,
-	entity string) *Sample {
-	return &Sample{
+	entity string,
+) Sample {
+	return Sample{
 		name:        name,
 		value:       value,
 		timestampMs: timestampMs,


### PR DESCRIPTION
Summary:
- Previous implementation ODS export would acquire and release the lock for the queue once for every sample being submitted
- This could get us into a situation where many goroutines from gateway RPC calls are trying to submit metrics and high-frequency lock contention results in a round-robin between the different goroutines, keeping each goroutine and its local data alive for a long time.
- This can result in a sort of cascading failure as more goroutines pile up and lock contention increases, increasing memory pressure and ultimately bricking the controller
- Convert all submitted metrics to samples and only acquire the lock once for each call to Submit to mediate this scenario

Differential Revision: D14766179
