### PR TITLE
Stopping NAS timers when EMM context is cleaned

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/nas/nas_procedures.c
@@ -432,15 +432,18 @@ static void nas_delete_common_procedures(struct emm_context_s *emm_context)
         case EMM_COMM_PROC_AUTH: {
           nas_emm_auth_proc_t *auth_info_proc =
             (nas_emm_auth_proc_t *) p1->proc;
+          nas_stop_T3460(auth_info_proc->ue_id, &auth_info_proc->T3460, NULL);
           if (auth_info_proc->unchecked_imsi) {
             free_wrapper((void **) &auth_info_proc->unchecked_imsi);
           }
         } break;
         case EMM_COMM_PROC_SMC: {
-          //nas_emm_smc_proc_t *smc_proc = (nas_emm_smc_proc_t *)(*proc);
+          nas_emm_smc_proc_t *smc_proc = (nas_emm_smc_proc_t *)(p1->proc);
+          nas_stop_T3460( smc_proc->ue_id, &smc_proc->T3460, NULL);
         } break;
         case EMM_COMM_PROC_IDENT: {
-          //nas_emm_ident_proc_t *ident_proc = (nas_emm_ident_proc_t *)(*proc);
+          nas_emm_ident_proc_t *ident_proc = (nas_emm_ident_proc_t *)(p1->proc);
+          nas_stop_T3470(ident_proc->ue_id, &ident_proc->T3470, NULL);
         } break;
         case EMM_COMM_PROC_INFO: break;
         default:;


### PR DESCRIPTION
Summary:
The ongoing NAS timers for Authentication request, Security Mode Command and Identity
request are not stopped when EMM context is cleared, leading to
heap-use-after-free error when the timer actually expires. This change stops
these timers when NAS common procedures are being deleted.

Reviewed By: sciencemanx

Differential Revision: D14784170
