### PR TITLE
Allow options when creating orchestrator service

### DIFF
--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -40,6 +40,18 @@ const (
 var printGrpcPayload bool
 var currentlyRunningServices = make(map[string]*Service)
 
+var defaultKeepaliveParams = keepalive.ServerParameters{
+	MaxConnectionIdle:     2 * time.Minute,
+	MaxConnectionAge:      10 * time.Minute,
+	MaxConnectionAgeGrace: 5 * time.Minute,
+	// first ping will be sent after 2*Time from server to client
+	// Note nghttpx proxy has a backend-read-timeout defaults to 1m so we
+	// want to send a ping within 1m to keep the connection alive
+	// https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--backend-read-timeout
+	Time:    20 * time.Second,
+	Timeout: 10 * time.Second,
+}
+
 func init() {
 	flag.BoolVar(&printGrpcPayload, PrintGrpcPayloadFlag, false, "Enable GRPC Payload Printout")
 }
@@ -74,17 +86,23 @@ type Service struct {
 // perform identity checks, (e.g. federation), use NewServiceWithOptions.
 func NewOrchestratorService(moduleName string, serviceName string) (*Service, error) {
 	plugin.LoadAllPluginsFatalOnError(&plugin.DefaultOrchestratorPluginLoader{})
-	return newOrchestratorService(moduleName, serviceName)
+	return NewServiceWithOptions(moduleName, serviceName, grpc.UnaryInterceptor(unary.MiddlewareHandler))
 }
 
-func newOrchestratorService(moduleType string, serviceName string) (*Service, error) {
-	return NewServiceWithOptions(moduleType, serviceName, grpc.UnaryInterceptor(unary.MiddlewareHandler))
+// NewOrchestratorServiceWithOptions returns a new GRPC orchestrator service
+// implementing service303 with the specified grpc server options. This service
+// will implement a middleware interceptor to perform identity check.
+func NewOrchestratorServiceWithOptions(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
+	plugin.LoadAllPluginsFatalOnError(&plugin.DefaultOrchestratorPluginLoader{})
+	serverOptions = append(serverOptions, grpc.UnaryInterceptor(unary.MiddlewareHandler))
+	return NewServiceWithOptions(moduleName, serviceName, serverOptions...)
 }
 
 // NewServiceWithOptions returns a new GRPC orchestrator service implementing
 // service303 with the specified grpc server options. This will not instantiate
 // the service with the identity checking middleware.
-// This function will also load all orchestrater plugins to populate registries
+//
+// This function will also load all orchestrator plugins to populate registries
 // which the service may use. Errors during plugin loading will result in a
 // fatal. It also will load the config specified by [service name].yml. Since
 // not all services have configs, it will only log in case it does not exist
@@ -100,7 +118,7 @@ func NewServiceWithOptions(moduleName string, serviceName string, serverOptions 
 	}
 
 	// Check if service was started with print-grpc-payload flag or MAGMA_PRINT_GRPC_PAYLOAD env is set
-	if ev := strings.ToLower(os.Getenv(PrintGrpcPayloadEnv)); printGrpcPayload || isThruthy(ev) {
+	if ev := strings.ToLower(os.Getenv(PrintGrpcPayloadEnv)); printGrpcPayload || isTruthy(ev) {
 		ls := logCodec{encoding.GetCodec(grpc_proto.Name)}
 		if ls.protoCodec != nil {
 			glog.Errorf("Adding Debug Codec for service %s", serviceName)
@@ -110,23 +128,12 @@ func NewServiceWithOptions(moduleName string, serviceName string, serverOptions 
 
 	// Use keepalive options to proactively reinit http2 connections and
 	// mitigate flow control issues
-	keepaliveParams := keepalive.ServerParameters{
-		MaxConnectionIdle:     2 * time.Minute,
-		MaxConnectionAge:      10 * time.Minute,
-		MaxConnectionAgeGrace: 5 * time.Minute,
-		// first ping will be sent after 2*Time from server to client
-		// Note nghttpx proxy has a backend-read-timeout defaults to 1m so we
-		// want to send a ping within 1m to keep the connection alive
-		// https://nghttp2.org/documentation/nghttpx.1.html#cmdoption-nghttpx--backend-read-timeout
-		Time:    20 * time.Second,
-		Timeout: 10 * time.Second,
-	}
-
-	opts := []grpc.ServerOption{grpc.KeepaliveParams(keepaliveParams)}
-	opts = append(opts, serverOptions...)
+	opts := []grpc.ServerOption{grpc.KeepaliveParams(defaultKeepaliveParams)}
+	opts = append(opts, serverOptions...) // keepalive is prepended so serverOptions can override if requested
 
 	grpcServer := grpc.NewServer(opts...)
-	service := Service{Type: serviceName,
+	service := Service{
+		Type:          serviceName,
 		GrpcServer:    grpcServer,
 		Version:       "0.0.0",
 		State:         protos.ServiceInfo_STARTING,
@@ -168,7 +175,12 @@ func (service *Service) RunTest(lis net.Listener) error {
 	return service.GrpcServer.Serve(lis)
 }
 
-func isThruthy(value string) bool {
+// GetDefaultKeepaliveParameters returns the default keepalive server parameters.
+func GetDefaultKeepaliveParameters() keepalive.ServerParameters {
+	return defaultKeepaliveParams
+}
+
+func isTruthy(value string) bool {
 	if len(value) == 0 {
 		return false
 	}

--- a/orc8r/cloud/go/service/test.go
+++ b/orc8r/cloud/go/service/test.go
@@ -10,6 +10,10 @@ package service
 
 import (
 	"testing"
+
+	"magma/orc8r/cloud/go/service/middleware/unary"
+
+	"google.golang.org/grpc"
 )
 
 // NewTestOrchestratorService returns a new GRPC orchestrator service without
@@ -19,5 +23,5 @@ func NewTestOrchestratorService(t *testing.T, moduleName string, serviceType str
 	if t == nil {
 		panic("Nice try, but *testing.T must be non-nil. NewTestOrchestratorService can only be used in a test context.")
 	}
-	return newOrchestratorService(moduleName, serviceType)
+	return NewServiceWithOptions(moduleName, serviceType, grpc.UnaryInterceptor(unary.MiddlewareHandler))
 }

--- a/orc8r/cloud/go/services/dispatcher/dispatcher/main.go
+++ b/orc8r/cloud/go/services/dispatcher/dispatcher/main.go
@@ -23,13 +23,23 @@ import (
 	"magma/orc8r/cloud/go/services/dispatcher/servicers"
 
 	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 const HTTP_SERVER_PORT = 9080
 
 func main() {
+	// Set MaxConnectionAge to infinity so Sync RPC stream doesn't restart
+	var keepaliveParams = service.GetDefaultKeepaliveParameters()
+	keepaliveParams.MaxConnectionAge = 0
+	keepaliveParams.MaxConnectionAgeGrace = 0
+
 	// Create the service
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, dispatcher.ServiceName)
+	srv, err := service.NewOrchestratorServiceWithOptions(
+		orc8r.ModuleName,
+		dispatcher.ServiceName,
+		grpc.KeepaliveParams(keepaliveParams),
+	)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}


### PR DESCRIPTION
Summary:
- Added a new function `NewOrchestratorServiceWithOptions` that both allows options and implements a middleware interceptor
- Updated dispatcher to use `NewOrchestratorServiceWithOptions` with keepalive `MaxConnectionAge` set to 0 so the stream doesn't close

Differential Revision: D14803370
