### PR TITLE
Update logging in tail_logs and sync RPC client

### DIFF
--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -218,7 +218,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
             exec_list = ['sudo', 'journalctl', '-fu',
                          'magma@{}'.format(request.service)]
 
-        logging.info("Tailing logs")
+        logging.debug('Tailing logs')
         log_queue = queue.Queue()
 
         async def enqueue_log_lines():
@@ -237,7 +237,7 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
                     except asyncio.TimeoutError:
                         pass
             finally:
-                logging.info("Terminating log stream")
+                logging.debug('Terminating log stream')
                 os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
 
         self._loop.create_task(enqueue_log_lines())

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -94,7 +94,6 @@ class SyncRPCClient(threading.Thread):
             try:
                 resp = self._response_queue.get(block=True,
                                                 timeout=self._response_timeout)
-                logging.debug("[SyncRPC] Sending response")
                 yield resp
             except queue.Empty:
                 # response_queue is empty, send heartbeat
@@ -121,8 +120,8 @@ class SyncRPCClient(threading.Thread):
                 self.forward_request(req)
         except grpc.RpcError as err:
             # server end closed connection; retry rpc connection.
-            raise Exception("Error when retrieving request: [%s] %s"
-                            % (err.code(), err.details()))
+            raise Exception("Error when retrieving request: [{}] {}".format(
+                err.code(), err.details()))
 
     def forward_request(self, request):
         if request.heartBeat:


### PR DESCRIPTION
Summary:
- Changed log statements in tail_logs servicer to debug
- Removed debug log statement after getting response from Sync RPC response queue because it causes tail_logs to infinitely place that log statement on the queue
- Updated an exception to use `.format` instead of `%` operator

Reviewed By: vikg-fb

Differential Revision: D14835581
