### PR TITLE
detach type is SWITCHOFF while test case is waiting for UE CONTEXT RE…

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
@@ -67,7 +67,7 @@ class TestEnbCompleteReset(unittest.TestCase):
         for ue in ue_ids:
             print("************************* Calling detach for UE id ", ue)
             self._s1ap_wrapper.s1_util.detach(
-                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True)
+                ue, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
detach type is SWITCHOFF while test case is waiting for UE CONTEXT RELEASE COMMAND from MME. Fixed the issue by changing the detach type NORMAL instead SWITCHOFF.
executed complete reset test case and sanity from S1SIM.