### PR TITLE
graphite query handlers

### DIFF
--- a/feg/cloud/go/go.sum
+++ b/feg/cloud/go/go.sum
@@ -24,6 +24,7 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/feg/cloud/go/go.sum
+++ b/feg/cloud/go/go.sum
@@ -24,6 +24,7 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23 h1:D21IyuvjDCshj1/qq+pCNd3VZOAEI9jy6Bi131YlXgI=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -21,6 +21,7 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/feg/gateway/services/eap/client/go.sum
+++ b/feg/gateway/services/eap/client/go.sum
@@ -20,6 +20,7 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/lte/cloud/go/go.sum
+++ b/lte/cloud/go/go.sum
@@ -25,6 +25,7 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/lte/cloud/go/go.sum
+++ b/lte/cloud/go/go.sum
@@ -25,6 +25,7 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23 h1:D21IyuvjDCshj1/qq+pCNd3VZOAEI9jy6Bi131YlXgI=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=

--- a/orc8r/cloud/configs/metricsd.yml
+++ b/orc8r/cloud/configs/metricsd.yml
@@ -12,3 +12,4 @@ prometheusPushgatewayAddress: "http://192.168.80.50:9091"
 
 graphiteAddress: "192.168.80.50"
 graphiteReceivePort: 2003
+graphiteQueryPort: 8080

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
 	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.16.19
+	github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23
 	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142
 	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect

--- a/orc8r/cloud/go/go.sum
+++ b/orc8r/cloud/go/go.sum
@@ -27,6 +27,8 @@ github.com/aws/aws-sdk-go v1.16.19/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8/go.mod h1:Iev9Q3MErcn+w3UOJD/DkEzllvugfdx7bGcMOFhvr/4=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23 h1:D21IyuvjDCshj1/qq+pCNd3VZOAEI9jy6Bi131YlXgI=
+github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/cenk/backoff v2.0.0+incompatible/go.mod h1:7FtoeaSnHoZnmZzz47cM35Y9nSW7tNyaidugnHTaFDE=
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=

--- a/orc8r/cloud/go/obsidian/handlers/handler.go
+++ b/orc8r/cloud/go/obsidian/handlers/handler.go
@@ -55,6 +55,7 @@ const (
 	MAGMA_OPERATORS_URL_PART  = "operators"
 	MAGMA_CHANNELS_URL_PART   = "channels"
 	MAGMA_PROMETHEUS_URL_PART = "prometheus"
+	MAGMA_GRAPHITE_URL_PART   = "graphite"
 	// "/magma"
 	REST_ROOT = URL_SEP + MAGMA_URL_ROOT
 	// "/magma/networks"
@@ -64,7 +65,9 @@ const (
 	// "/magma/channels"
 	CHANNELS_ROOT = REST_ROOT + URL_SEP + MAGMA_CHANNELS_URL_PART
 	// "/magma/network/{network_id}/prometheus
-	PROMETHEUS_ROOT  = REST_ROOT + URL_SEP + "networks" + URL_SEP + ":network_id" + URL_SEP + MAGMA_PROMETHEUS_URL_PART
+	PROMETHEUS_ROOT = REST_ROOT + URL_SEP + "networks" + URL_SEP + ":network_id" + URL_SEP + MAGMA_PROMETHEUS_URL_PART
+	// "/magma/network/{network_id}/graphite
+	GRAPHITE_ROOT    = REST_ROOT + URL_SEP + "networks" + URL_SEP + ":network_id" + URL_SEP + MAGMA_GRAPHITE_URL_PART
 	WILDCARD         = "*"
 	NETWORK_WILDCARD = "N*"
 )

--- a/orc8r/cloud/go/plugin/test.go
+++ b/orc8r/cloud/go/plugin/test.go
@@ -30,6 +30,7 @@ var testMetricsConfigMap = &config.ConfigMap{
 		confignames.PrometheusPushgatewayAddress: "",
 		confignames.GraphiteAddress:              "",
 		confignames.GraphiteReceivePort:          0,
+		confignames.GraphiteQueryPort:            0,
 	},
 }
 

--- a/orc8r/cloud/go/services/metricsd/confignames/const.go
+++ b/orc8r/cloud/go/services/metricsd/confignames/const.go
@@ -16,4 +16,5 @@ const (
 
 	GraphiteAddress     = "graphiteAddress"
 	GraphiteReceivePort = "graphiteReceivePort"
+	GraphiteQueryPort   = "graphiteQueryPort"
 )

--- a/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite.go
@@ -27,8 +27,8 @@ import (
 const (
 	exportInterval = time.Second * 30
 
-	networkTagName = "networkID"
-	gatewayTagName = "gatewayID"
+	NetworkTagName = "networkID"
+	GatewayTagName = "gatewayID"
 	defaultNetwork = "defaultNetwork"
 	defaultGateway = "defaultGateway"
 )
@@ -182,19 +182,19 @@ func makeGraphiteName(metric *dto.Metric, ctx exporters.MetricsContext) string {
 		gatewayID = defaultGateway
 	}
 
-	tags := make(tagSet)
-	tags.insert(networkTagName, networkID)
-	tags.insert(gatewayTagName, gatewayID)
+	tags := make(TagSet)
+	tags.Insert(NetworkTagName, networkID)
+	tags.Insert(GatewayTagName, gatewayID)
 
 	for _, labelPair := range labels {
-		tags.insert(labelPair.GetName(), labelPair.GetValue())
+		tags.Insert(labelPair.GetName(), labelPair.GetValue())
 	}
 	return name + tags.String()
 }
 
-type tagSet map[string]string
+type TagSet map[string]string
 
-func (s tagSet) insert(name, value string) {
+func (s TagSet) Insert(name, value string) {
 	if _, ok := s[name]; !ok {
 		s[name] = value
 	}
@@ -202,7 +202,7 @@ func (s tagSet) insert(name, value string) {
 
 // String prints the tagSet sorted by key in a format that can be appended to
 // a graphite metric name
-func (s tagSet) String() string {
+func (s TagSet) String() string {
 	var sortedKeys []string
 
 	for key := range s {

--- a/orc8r/cloud/go/services/metricsd/graphite/handlers/graphite_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/handlers/graphite_handlers.go
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/metricsd/graphite/exporters"
+	"magma/orc8r/cloud/go/services/metricsd/graphite/third_party/api"
+	"magma/orc8r/cloud/go/services/metricsd/obsidian/utils"
+
+	"github.com/labstack/echo"
+)
+
+const (
+	queryPart = "query"
+
+	QueryURL = handlers.GRAPHITE_ROOT + handlers.URL_SEP + queryPart
+	Protocol = "http"
+
+	// matches graphite metric name. Alphanumeric plus '.' and '_'
+	metricNameRegexString = `[a-zA-Z_\.\+\*\d]+`
+)
+
+var (
+	tagRegexString = fmt.Sprintf(",%s=%s", metricNameRegexString, metricNameRegexString)
+	// regex to match an list of tags
+	tagListRegex = regexp.MustCompile(fmt.Sprintf("(%s)+", tagRegexString))
+	//regex to match a metric name followed by an optional list of tags
+	basicQueryRegex = regexp.MustCompile(fmt.Sprintf("^(%s)(%s)*$", metricNameRegexString, tagRegexString))
+)
+
+func GetQueryHandler(gc *api.Client) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		return graphiteQuery(c, gc)
+	}
+}
+
+func graphiteQuery(c echo.Context, gc *api.Client) error {
+	startTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeStart), nil)
+	if err != nil {
+		return handlers.HttpError(fmt.Errorf("unable to parse %s parameter: %v", utils.ParamRangeEnd, err), http.StatusBadRequest)
+	}
+
+	defaultTime := time.Now()
+	endTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeEnd), &defaultTime)
+	if err != nil {
+		return handlers.HttpError(fmt.Errorf("unable to parse %s parameter: %v", utils.ParamRangeEnd, err), http.StatusBadRequest)
+	}
+
+	preparedQuery, err := prepareQuery(c)
+	if err != nil {
+		return handlers.HttpError(fmt.Errorf("unable to prepare query: %v", err))
+	}
+
+	renderRequest := api.RenderRequest{
+		From:    startTime,
+		Until:   endTime,
+		Targets: []string{preparedQuery},
+	}
+
+	res, err := gc.QueryRender(renderRequest)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusOK, wrapGraphiteResult(res))
+}
+
+func wrapGraphiteResult(res []api.Series) GraphiteResultStruct {
+	return GraphiteResultStruct{Status: utils.StatusSuccess, Result: res}
+}
+
+func prepareQuery(c echo.Context) (string, error) {
+	networkID, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return "", nerr
+	}
+
+	query := c.QueryParam(utils.ParamQuery)
+	if ok := validateQuery(query); !ok {
+		return "", fmt.Errorf("invalid query: %s", query)
+	}
+
+	tags := parseTagsFromQuery(query)
+	tags.Insert(exporters.NetworkTagName, networkID)
+
+	metricName := extractMetricNameFromQuery(query)
+
+	request := buildTaggedQuery(metricName, tags)
+	return request, nil
+}
+
+func extractMetricNameFromQuery(query string) string {
+	firstTagIndex := strings.Index(query, ",")
+	if firstTagIndex != -1 {
+		return query[:firstTagIndex]
+	}
+	return query
+}
+
+func buildTaggedQuery(metricName string, tags exporters.TagSet) string {
+	nameSelector := fmt.Sprintf("'name=~^%s$'", metricName)
+	var keys []string
+	for key := range tags {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var query strings.Builder
+	query.WriteString(nameSelector)
+	for _, key := range keys {
+		query.WriteString(fmt.Sprintf(",'%s=%s'", key, tags[key]))
+	}
+	return fmt.Sprintf("%s(%s)", "seriesByTag", query.String())
+}
+
+// GraphiteResultStruct carries the result and status
+type GraphiteResultStruct struct {
+	Status string       `json:"status"`
+	Result []api.Series `json:"result"`
+}
+
+func validateQuery(query string) bool {
+	// matches <metric_name>[,tag1=val1]*
+	return basicQueryRegex.MatchString(query)
+}
+
+func parseTagsFromQuery(query string) exporters.TagSet {
+	tags := make(exporters.TagSet)
+	tagString := tagListRegex.FindString(query)
+	if tagString == "" {
+		return tags
+	}
+
+	tagsList := strings.Split(tagString, ",")[1:]
+	for _, tag := range tagsList {
+		equalsIndex := strings.Index(tag, "=")
+		key := tag[:equalsIndex]
+		val := tag[equalsIndex+1:]
+		tags.Insert(key, val)
+	}
+	return tags
+}

--- a/orc8r/cloud/go/services/metricsd/graphite/handlers/graphite_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/handlers/graphite_handlers_test.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"testing"
+
+	"magma/orc8r/cloud/go/services/metricsd/graphite/exporters"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateQuery(t *testing.T) {
+	goodQueries := []string{"metric_name", "metric.name", "metric_name,tag1=val1,tag2=val2"}
+	for _, query := range goodQueries {
+		assert.True(t, validateQuery(query))
+	}
+	badQueries := []string{"bad$name", "function(metric_name)", "metric;badtags", "metric;delimiter=bad"}
+	for _, query := range badQueries {
+		assert.False(t, validateQuery(query))
+	}
+}
+
+func TestParseTagsFromQuery(t *testing.T) {
+	query := "metric,tag1=val1"
+	tags := parseTagsFromQuery(query)
+	assert.Equal(t, 1, len(tags))
+	assert.Equal(t, tags.String(), ";tag1=val1")
+
+	query = "metric,tag1=val1,tag2=val2"
+	tags = parseTagsFromQuery(query)
+	assert.Equal(t, 2, len(tags))
+	assert.Equal(t, tags.String(), ";tag1=val1;tag2=val2")
+
+	query = "metric_name"
+	tags = parseTagsFromQuery(query)
+	assert.Equal(t, exporters.TagSet{}, tags)
+}
+
+func TestBuildSeriesByTagQuery(t *testing.T) {
+	tags := make(exporters.TagSet)
+
+	name := "metric_name"
+	query := buildTaggedQuery(name, tags)
+	assert.Equal(t, "seriesByTag('name=~^metric_name$')", query)
+
+	tags.Insert("tag1", "val1")
+	query = buildTaggedQuery(name, tags)
+	assert.Equal(t, "seriesByTag('name=~^metric_name$','tag1=val1')", query)
+
+	tags.Insert("tag2", "val2")
+	query = buildTaggedQuery(name, tags)
+	assert.Equal(t, "seriesByTag('name=~^metric_name$','tag1=val1','tag2=val2')", query)
+}

--- a/orc8r/cloud/go/services/metricsd/graphite/third_party/api/LICENSE
+++ b/orc8r/cloud/go/services/metricsd/graphite/third_party/api/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Lev Orekhov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/orc8r/cloud/go/services/metricsd/graphite/third_party/api/client.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/third_party/api/client.go
@@ -1,0 +1,74 @@
+// Package graphite provides client to graphite-web-api (http://graphite-api.readthedocs.io/en/latest/api.html).
+package api
+
+import (
+	"errors"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+)
+
+var WrongUrlError = errors.New("Wrong url")
+
+// RequestError is special error, which not only implements an error interface,
+// but also provides access to `Query` field, containing original query which
+// cause an error.
+type RequestError struct {
+	Query string
+	Type  string
+}
+
+func (e RequestError) Error() string {
+	return e.Type
+}
+
+// Client is client to `graphite web api` (http://graphite-api.readthedocs.io/en/latest/api.html).
+// You can either instantiate it manually by providing `url` and `client` or use a `NewFromString` shortcut.
+type Client struct {
+	Url    url.URL
+	Client *http.Client
+}
+
+// NewFromString is a convenient function for constructing `graphite.Client` from url string.
+// For example 'https://my-graphite.tld'. NewFromString could return either `graphite.Client`
+// instance or `WrongUrlError` error.
+func NewFromString(urlString string) (*Client, error) {
+	url, err := url.Parse(urlString)
+	if err != nil {
+		return nil, WrongUrlError
+	}
+	return &Client{*url, &http.Client{}}, nil
+}
+
+func (c *Client) makeRequest(q qsGenerator) ([]byte, error) {
+	empty := []byte{}
+	response, err := c.Client.Get(c.queryAsString(q))
+	if err != nil {
+		return empty, c.createError(q, "Request error")
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return empty, c.createError(q, "Wrong status code")
+	}
+
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		return empty, c.createError(q, "Can't read response body")
+	}
+	return body, nil
+}
+
+func (c *Client) createError(r qsGenerator, t string) error {
+	return RequestError{
+		Type:  t,
+		Query: c.queryAsString(r),
+	}
+}
+
+func (c *Client) queryAsString(r qsGenerator) string {
+	return c.Url.String() + r.toQueryString()
+}
+
+type qsGenerator interface {
+	toQueryString() string
+}

--- a/orc8r/cloud/go/services/metricsd/graphite/third_party/api/metrics.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/third_party/api/metrics.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+)
+
+// FindMetricRequest is struct describing request to /metrics/find api.
+type FindMetricRequest struct {
+	From      time.Time
+	Until     time.Time
+	Query     string
+	Wildcards bool
+}
+
+func (r FindMetricRequest) toQueryString() string {
+	values := url.Values{
+		"format": []string{"treejson"},
+	}
+	if !r.From.IsZero() {
+		values.Set("from", strconv.FormatInt(r.From.Unix(), 10))
+	}
+	if !r.Until.IsZero() {
+		values.Set("until", strconv.FormatInt(r.Until.Unix(), 10))
+	}
+	if r.Query != "" {
+		values.Set("query", r.Query)
+	}
+	if r.Wildcards {
+		values.Set("wildcards", strconv.Itoa(1))
+	}
+	qs := values.Encode()
+	return "/metrics/find?" + qs
+}
+
+type Metric struct {
+	Id            string
+	Text          string
+	Expandable    int
+	Leaf          int
+	AllowChildren int
+}
+
+// FindMetrics perform request to /metrics/find API: http://graphite-api.readthedocs.io/en/latest/api.html#metrics-find
+// It returns slice of Metric if all is OK or RequestError if things goes wrong.
+func (c *Client) FindMetrics(r FindMetricRequest) ([]Metric, error) {
+	empty := []Metric{}
+	data, err := c.makeRequest(r)
+	if err != nil {
+		return empty, err
+	}
+
+	metrics, err := unmarshallMetrics(data)
+	if err != nil {
+		return empty, c.createError(r, "Can't unmarshall response")
+	}
+	return metrics, nil
+}
+
+func unmarshallMetrics(data []byte) ([]Metric, error) {
+	var metrics []Metric
+	err := json.Unmarshal(data, &metrics)
+	return metrics, err
+}
+
+type ExpandMetricRequest struct {
+	Query       string
+	GroupByExpr bool
+	LeavesOnly  bool
+}
+
+func (r ExpandMetricRequest) toQueryString() string {
+	values := url.Values{}
+	if r.Query != "" {
+		values.Set("query", r.Query)
+	}
+	if r.GroupByExpr {
+		values.Set("groupByExpr", strconv.Itoa(1))
+	}
+	if r.LeavesOnly {
+		values.Set("leavesOnly", strconv.Itoa(1))
+	}
+	qs := values.Encode()
+	return "/metrics/expand?" + qs
+}
+
+// Results is a list of metric ids.
+type ExpandResult struct {
+	Results []string
+}
+
+// FindMetrics perform request to /metrics/expand API: http://graphite-api.readthedocs.io/en/latest/api.html#metrics-expand
+// It returns slice of Metric if all is OK or RequestError if things goes wrong.
+func (c *Client) ExpandMetrics(r ExpandMetricRequest) (ExpandResult, error) {
+	result := ExpandResult{}
+	data, err := c.makeRequest(r)
+	if err != nil {
+		return result, err
+	}
+
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		return result, c.createError(r, "Cant unmarshall response")
+	}
+	return result, nil
+}

--- a/orc8r/cloud/go/services/metricsd/graphite/third_party/api/render.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/third_party/api/render.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/buger/jsonparser"
+)
+
+// RenderRequest is struct, describing request to graphite `/render/` api.
+// No fields are required. If field has zero value it'll be just skipped in request.
+// RenderRequest.Targets are slice of strings, were every entry is a path identifying one or several metrics,
+// optionally with functions acting on those metrics.
+//
+// Warning. While wildcards could be used in Targets one should use them with caution, as
+// using of the simple target like "main.cluster.*.cpu.*" could result in hundreds of series
+// with megabytes of data inside.
+type RenderRequest struct {
+	From          time.Time
+	Until         time.Time
+	MaxDataPoints int
+	Targets       []string
+}
+
+func (r RenderRequest) toQueryString() string {
+	values := url.Values{
+		"format": []string{"json"},
+		"target": r.Targets,
+	}
+	if !r.From.IsZero() {
+		values.Set("from", strconv.FormatInt(r.From.Unix(), 10))
+	}
+	if !r.Until.IsZero() {
+		values.Set("until", strconv.FormatInt(r.Until.Unix(), 10))
+	}
+	if r.MaxDataPoints != 0 {
+		values.Set("maxDataPoints", strconv.Itoa(r.MaxDataPoints))
+	}
+	qs := values.Encode()
+	return "/render/?" + qs
+}
+
+// QueryRender performs query to graphite `/render/` api. Normally it should return `[]graphite.Series`,
+// but if things go wrong it will return `graphite.RequestError` error.
+func (c *Client) QueryRender(r RenderRequest) ([]Series, error) {
+	empty := []Series{}
+	data, err := c.makeRequest(r)
+	if err != nil {
+		return empty, err
+	}
+
+	metrics, err := unmarshallSeries(data)
+	if err != nil {
+		return empty, c.createError(r, "Can't unmarshall response")
+	}
+	return metrics, nil
+}
+
+// Series describes time series data for given target.
+type Series struct {
+	Target     string            `json:"target"`
+	Datapoints []DataPoint       `json:"datapoints"`
+	Tags       map[string]string `json:"tags"`
+}
+
+// DataPoint describes concrete point of time series.
+type DataPoint []string
+
+func unmarshallSeries(data []byte) ([]Series, error) {
+	empty, result := []Series{}, []Series{}
+	if len(data) == 0 {
+		return empty, nil
+	}
+	var ie error = nil
+	_, err := jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		if err != nil {
+			return
+		}
+
+		datapoints, e := unmarshallDatapoints(value)
+		if e != nil {
+			ie = e
+			return
+		}
+
+		target, e := jsonparser.GetString(value, "target")
+		if e != nil {
+			ie = e
+			return
+		}
+
+		tags := unmarshallTags(value)
+
+		result = append(result, Series{Target: target, Datapoints: datapoints, Tags: tags})
+	})
+
+	if err != nil {
+		return empty, err
+	}
+	if ie != nil {
+		return empty, ie
+	}
+	return result, nil
+}
+
+func unmarshallDatapoints(data []byte) ([]DataPoint, error) {
+	empty, result := []DataPoint{}, []DataPoint{}
+	rawData, _, _, err := jsonparser.Get(data, "datapoints")
+	if err != nil {
+		return empty, err
+	}
+
+	_, err = jsonparser.ArrayEach(rawData, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		if err != nil {
+			return
+		}
+		datapoint, e := unmarshallDatapoint(value)
+		if e != nil {
+			err = e
+			return
+		}
+		result = append(result, datapoint)
+	})
+	if err != nil {
+		return empty, err
+	}
+	return result, nil
+}
+
+func unmarshallTags(data []byte) map[string]string {
+	tags := make(map[string]string)
+	rawData, _, _, err := jsonparser.Get(data, "tags")
+	if err != nil {
+		return tags
+	}
+
+	err = jsonparser.ObjectEach(rawData, func(key, value []byte, dataType jsonparser.ValueType, offset int) error {
+		if err != nil {
+			return err
+		}
+		tags[string(key)] = string(value)
+		return nil
+	})
+	return tags
+}
+
+func unmarshallDatapoint(data []byte) (DataPoint, error) {
+	empty, result := DataPoint{}, make(DataPoint, 2)
+	var err error = nil
+	position := 0
+	_, err = jsonparser.ArrayEach(data, func(value []byte, dataType jsonparser.ValueType, offset int, err error) {
+		if err != nil {
+			return
+		}
+		if position == 0 {
+			if dataType == jsonparser.Null {
+				result[1] = "null"
+			} else {
+				result[1] = string(value)
+			}
+		} else {
+			result[0] = string(value)
+		}
+		position++
+	})
+	if err != nil {
+		return empty, err
+	}
+	return result, nil
+}

--- a/orc8r/cloud/go/services/metricsd/graphite/third_party/api/render_test.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/third_party/api/render_test.go
@@ -1,0 +1,162 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var testUnmarshallMetricsCases = []struct {
+	Json   string
+	Result []Series
+	Err    error
+}{
+	{
+		Json:   "",
+		Result: []Series{},
+		Err:    nil,
+	},
+	{
+		Json: "[{\"target\": \"main\", \"datapoints\": [[1.0, 1468339853], [1.0, 1468339854], [null, 1468339855]]}]",
+		Result: []Series{
+			{
+				Target: "main",
+				Datapoints: []DataPoint{
+					{"1468339853", "1.0"},
+					{"1468339854", "1.0"},
+					{"1468339855", "null"},
+				},
+				Tags: make(map[string]string),
+			},
+		},
+		Err: nil,
+	},
+}
+
+func TestUnmarshallMetrics(t *testing.T) {
+	for _, tc := range testUnmarshallMetricsCases {
+		res, err := unmarshallSeries([]byte(tc.Json))
+		if !reflect.DeepEqual(res, tc.Result) {
+			t.Errorf("Result is %+v, \n expected %+v", res, tc.Result)
+		}
+
+		if err != tc.Err {
+			t.Errorf("E %+v", err)
+		}
+	}
+}
+
+func TestNewClientFromString(t *testing.T) {
+	urlString := "http://domain.tld/path"
+	client, _ := NewFromString(urlString)
+	testRequest := RenderRequest{}
+	shouldUrl := urlString + testRequest.toQueryString()
+	if shouldUrl != client.queryAsString(testRequest) {
+		t.Errorf("Resulting URL is %v, \n but should be %v", client.queryAsString(testRequest), shouldUrl)
+	}
+}
+
+func TestGraphiteRequest_ToQueryString(t *testing.T) {
+	testCases := []struct {
+		Request RenderRequest
+		Result  string
+	}{
+		{
+			Request: RenderRequest{},
+			Result:  "/render/?format=json",
+		},
+		{
+			Request: RenderRequest{Targets: []string{"foo", "bar"}},
+			Result:  "/render/?format=json&target=foo&target=bar",
+		},
+		{
+			Request: RenderRequest{From: time.Unix(1468339853, 0), Until: time.Unix(1468339853, 0)},
+			Result:  "/render/?format=json&from=1468339853&until=1468339853",
+		},
+		{
+			Request: RenderRequest{MaxDataPoints: 10},
+			Result:  "/render/?format=json&maxDataPoints=10",
+		},
+	}
+	for _, tc := range testCases {
+		res := tc.Request.toQueryString()
+		if res != tc.Result {
+			t.Errorf("Result should be \"%v\", but \"%v\" received", tc.Result, res)
+		}
+	}
+}
+
+func makeTest(t *testing.T, request RenderRequest, expectedQuery, result string, series []Series) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		parsedQuery, _ := url.ParseQuery(expectedQuery)
+		if !reflect.DeepEqual(r.URL.Query(), parsedQuery) {
+			t.Errorf("Expected query is %+v but %+v got", parsedQuery, r.URL.Query())
+		}
+		if r.URL.Path != "/render/" {
+			t.Errorf("Path should be `/render/` but %s found", r.URL.Path)
+		}
+		fmt.Fprintln(w, result)
+	}))
+	defer ts.Close()
+	client, _ := NewFromString(ts.URL)
+	res, _ := client.QueryRender(request)
+	if !reflect.DeepEqual(res, series) {
+		t.Errorf("Expected series %+v, but %+v got", series, res)
+	}
+}
+
+var queryTestCases = []struct {
+	Request       RenderRequest
+	ExpectedQuery string
+	Result        string
+	Series        []Series
+}{
+	{
+		Request:       RenderRequest{Targets: []string{"main1", "main2"}},
+		ExpectedQuery: "format=json&target=main1&target=main2",
+		Result:        "[{\"target\": \"main\", \"datapoints\": [[1.0, 1468339853], [1.0, 1468339854], [null, 1468339855]]}]",
+		Series: []Series{
+			{
+				Target: "main",
+				Datapoints: []DataPoint{
+					{"1468339853", "1.0"},
+					{"1468339854", "1.0"},
+					{"1468339855", "null"},
+				},
+				Tags: make(map[string]string),
+			},
+		},
+	},
+	{
+		Request:       RenderRequest{From: time.Unix(1468339853, 0), Until: time.Unix(1468339854, 0)},
+		ExpectedQuery: "format=json&from=1468339853&until=1468339854",
+		Result:        "[{\"target\": \"main\", \"datapoints\": [[1.0, 1468339853], [1.0, 1468339854], [null, 1468339855]]}]",
+		Series: []Series{
+			{
+				Target: "main",
+				Datapoints: []DataPoint{
+					{"1468339853", "1.0"},
+					{"1468339854", "1.0"},
+					{"1468339855", "null"},
+				},
+				Tags: make(map[string]string),
+			},
+		},
+	},
+	{
+		Request:       RenderRequest{MaxDataPoints: 1},
+		ExpectedQuery: "format=json&maxDataPoints=1",
+		Result:        "[]",
+		Series:        []Series{},
+	},
+}
+
+func TestGraphiteClient_Query(t *testing.T) {
+	for _, tc := range queryTestCases {
+		makeTest(t, tc.Request, tc.ExpectedQuery, tc.Result, tc.Series)
+	}
+}

--- a/orc8r/cloud/go/services/metricsd/obsidian/utils/utils.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/utils/utils.go
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+const (
+	ParamQuery      = "query"
+	ParamRangeStart = "start"
+	ParamRangeEnd   = "end"
+	ParamStepWidth  = "step"
+	ParamTime       = "time"
+
+	StatusSuccess = "success"
+)
+
+func ParseTime(timeString string, defaultTime *time.Time) (time.Time, error) {
+	if timeString == "" {
+		if defaultTime != nil {
+			return *defaultTime, nil
+		}
+		return time.Time{}, fmt.Errorf("time parameter not provided")
+	}
+	time, err := parseUnixTime(timeString)
+	if err == nil {
+		return time, nil
+	}
+	return parseRFCTime(timeString)
+}
+
+func parseUnixTime(timeString string) (time.Time, error) {
+	timeNum, err := strconv.ParseFloat(timeString, 64)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Unix(int64(timeNum), 0), nil
+}
+
+func parseRFCTime(timeString string) (time.Time, error) {
+	return time.Parse(time.RFC3339, timeString)
+}
+
+func ParseDuration(durationString, defaultDuration string) (time.Duration, error) {
+	if durationString == "" {
+		durationString = defaultDuration
+	}
+	return time.ParseDuration(durationString)
+}

--- a/orc8r/cloud/go/services/metricsd/obsidian/utils/utils_test.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/utils/utils_test.go
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package utils_test
+
+import (
+	"testing"
+	"time"
+
+	"magma/orc8r/cloud/go/services/metricsd/obsidian/utils"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseTime(t *testing.T) {
+	exampleUnixTimeString := "1547751342"
+	exampleUnixFloatString := "1547751342.23"
+	exampleUnixTime := time.Unix(1547751342, 0)
+
+	exampleRFCTimeString := "2018-07-01T20:10:30.781Z"
+	exampleBadRFCTimeString := "2018-07-01T20:10.781Z"
+	exampleRFCTime, err := time.Parse(time.RFC3339, "2018-07-01T20:10:30.781Z")
+
+	defaultTime := time.Time{}
+
+	time, err := utils.ParseTime(exampleUnixTimeString, &defaultTime)
+	assert.NoError(t, err)
+	assert.Equal(t, exampleUnixTime, time)
+
+	time, err = utils.ParseTime(exampleUnixFloatString, &defaultTime)
+	assert.NoError(t, err)
+	assert.Equal(t, exampleUnixTime, time)
+
+	time, err = utils.ParseTime(exampleRFCTimeString, &defaultTime)
+	assert.NoError(t, err)
+	assert.Equal(t, exampleRFCTime, time)
+
+	time, err = utils.ParseTime(exampleBadRFCTimeString, &defaultTime)
+	assert.Error(t, err)
+
+	time, err = utils.ParseTime("", &defaultTime)
+	assert.NoError(t, err)
+	assert.Equal(t, time, defaultTime)
+
+	time, err = utils.ParseTime("", nil)
+	assert.Error(t, err)
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
@@ -11,7 +11,6 @@ package handlers
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
 
@@ -25,38 +24,4 @@ func TestPreprocessQuery(t *testing.T) {
 	assert.NoError(t, err)
 	expectedQuery := fmt.Sprintf("%s{%s=\"%s\"}", testQuery, exporters.NetworkLabelInstance, networkID)
 	assert.Equal(t, expectedQuery, preprocessedQuery)
-}
-
-func TestParseTime(t *testing.T) {
-	exampleUnixTimeString := "1547751342"
-	exampleUnixFloatString := "1547751342.23"
-	exampleUnixTime := time.Unix(1547751342, 0)
-
-	exampleRFCTimeString := "2018-07-01T20:10:30.781Z"
-	exampleBadRFCTimeString := "2018-07-01T20:10.781Z"
-	exampleRFCTime, err := time.Parse(time.RFC3339, "2018-07-01T20:10:30.781Z")
-
-	defaultTime := time.Time{}
-
-	time, err := parseTime(exampleUnixTimeString, &defaultTime)
-	assert.NoError(t, err)
-	assert.Equal(t, exampleUnixTime, time)
-
-	time, err = parseTime(exampleUnixFloatString, &defaultTime)
-	assert.NoError(t, err)
-	assert.Equal(t, exampleUnixTime, time)
-
-	time, err = parseTime(exampleRFCTimeString, &defaultTime)
-	assert.NoError(t, err)
-	assert.Equal(t, exampleRFCTime, time)
-
-	time, err = parseTime(exampleBadRFCTimeString, &defaultTime)
-	assert.Error(t, err)
-
-	time, err = parseTime("", &defaultTime)
-	assert.NoError(t, err)
-	assert.Equal(t, time, defaultTime)
-
-	time, err = parseTime("", nil)
-	assert.Error(t, err)
 }


### PR DESCRIPTION
Summary:
Implements the GET handler for graphite query requests. This will allow the switch from prometheus to graphite as metrics will be received in the database and are now accessible to users. Basic multi-tenant support is in place by validating networkID and wrapping the query in a function that restricts by this tag.
Also moves common functionality between prometheus and graphite handlers into own util package.

Differential Revision: D14876647
