### PR TITLE
Turned on disable_known_hosts fab option.

### DIFF
--- a/lte/gateway/fabfile.py
+++ b/lte/gateway/fabfile.py
@@ -47,7 +47,9 @@ DEFAULT_PROXY = "$MAGMA_ROOT/lte/gateway/configs/control_proxy.yml"
 
 # Look for keys as specified in our ~/.ssh/config
 env.use_ssh_config = True
-
+# Disable ssh known hosts to resolve key errors
+# with multiple vagrant boxes in use.
+env.disable_known_hosts = True
 
 def dev():
     env.debug_mode = True


### PR DESCRIPTION
# Turn on Fabric disable_known_hosts option

Effectively turns off StrictHostKeyChecking.

Vagrant guests share the same address on a linux host and StrictHostKeyChecking will fail if running more than one vagrant box.

```
➜  gateway git:(master) ✗ fab dev package:git
...
fabric.exceptions.NetworkError: Host key for 127.0.0.1 did not match pre-existing key! Server's key was changed recently, or possible man-in-the-middle attack.
```

