### PR TITLE
Remove unused import lint failure

### DIFF
--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -10,8 +10,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 import logging
 from typing import Any
 from spyne.decorator import rpc
-from spyne.model.complex import Iterable, ComplexModelBase
-from spyne.model.primitive import String
+from spyne.model.complex import ComplexModelBase
 from spyne.service import ServiceBase
 from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName


### PR DESCRIPTION
Summary:
```
[admin@192.168.61.193:22] out: AssertionError: PyLint found errors:
[admin@192.168.61.193:22] out: ************* Module enodebd.tr069.rpc_methods
[admin@192.168.61.193:22] out: W0611: 13, 0: Unused Iterable imported from spyne.model.complex (unused-import)
[admin@192.168.61.193:22] out: W0611: 14, 0: Unused String imported from spyne.model.primitive (unused-import)
```

Reviewed By: andreilee

Differential Revision: D14948053