### PR TITLE
Fix concurrency issue with swx cache

### DIFF
--- a/feg/gateway/services/swx_proxy/cache/swx_cache.go
+++ b/feg/gateway/services/swx_proxy/cache/swx_cache.go
@@ -105,6 +105,8 @@ func (swxCache *Impl) Get(imsi string) *protos.AuthenticationAnswer {
 // Put adds ans vectors into the cache after extracting the first vector from the list, which it returns back to
 // the caller in the returned AuthenticationAnswer
 func (swxCache *Impl) Put(ans *protos.AuthenticationAnswer) *protos.AuthenticationAnswer {
+	swxCache.mu.Lock()
+	defer swxCache.mu.Unlock()
 	if ans == nil || len(ans.UserName) == 0 {
 		return ans
 	}


### PR DESCRIPTION
Summary:
Recent unit tests have been failing due to a race condition with concurrent read and writes of a map.
This diff fixes that failure by ensuring that the cache's Put method locks the mutex before writing to the map

Differential Revision: D14964285

