### PR TITLE
Adjust carbon conf settings

### DIFF
--- a/orc8r/cloud/deploy/roles/third_party/graphite/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/defaults/main.yml
@@ -44,9 +44,9 @@ graphite_cache_log_updates: false
 graphite_cache_log_creates: false
 graphite_cache_enable_manhole: false
 graphite_cache_max_cache_size: inf
-graphite_cache_max_creates_per_minute: 100
-graphite_cache_max_updates_per_second: 500
-graphite_cache_max_updates_per_second_on_shutdown: 1000
+graphite_cache_max_creates_per_minute: 1000
+graphite_cache_max_updates_per_second: 2000
+graphite_cache_max_updates_per_second_on_shutdown: 5000
 graphite_cache_min_timestamp_resolution: 1
 graphite_cache_pickle_receiver_port: 0
 graphite_cache_graphite_url: false  # Set to http://my-graphite-url:port


### PR DESCRIPTION
Summary:
The machines can handle much more than the default settings and we need to update some for better performance.
* creates_per_minute: Lets carbon create more .wsp files at a time so it won't take ~16 hours to create all the metric files
* max_updates_per_second: We weren't getting enough updates per second to update all the metrics

Reviewed By: tcirstea

Differential Revision: D14966525

