### PR TITLE
Update graphite-web database to MySQL

### DIFF
--- a/orc8r/cloud/deploy/roles/third_party/graphite/defaults/main.yml
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/defaults/main.yml
@@ -17,6 +17,11 @@ graphite_admin_last_login: "2014-07-21T10:11:17.464"
 graphite_admin_username: admin
 graphite_admin_password: admin
 
+graphite_db_name: graphitedb
+graphite_mysql_user: graphite_user
+graphite_mysql_password: graphitepass
+mysql_root_pass: mypassword
+
 graphite_service_carbon_open_files_limit: 4096
 
 graphite_storage_schemas_default_retentions: "1m:14d,15m:180d,1h:2y"

--- a/orc8r/cloud/deploy/roles/third_party/graphite/handlers/main.yml
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/handlers/main.yml
@@ -11,3 +11,6 @@
 - name: restart uwsgi
   service: name=uwsgi state=restarted
   when: graphite_enable_uwsgi
+
+- name: Restart MySQL
+  service: name=mysql state=restarted

--- a/orc8r/cloud/deploy/roles/third_party/graphite/tasks/main.yml
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/tasks/main.yml
@@ -22,6 +22,9 @@
   environment:
     PYTHONPATH: "{{ graphite_install_path }}/lib:{{ graphite_install_path }}/webapp"
 
+- name: Install MySQL
+  include: mysql.yml
+
 - name: Setup graphite with pip
   pip:
     name: "graphite-web=={{ graphite_version }}"

--- a/orc8r/cloud/deploy/roles/third_party/graphite/tasks/mysql.yml
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/tasks/mysql.yml
@@ -1,0 +1,46 @@
+---
+- name: Install the MySQL packages
+  apt: name={{ item }} state=installed update_cache=yes
+  with_items:
+    - mysql-server
+    - mysql-client
+    - python-mysqldb
+    - libmysqlclient-dev
+
+- name: Copy the root credentials as .my.cnf file
+  template: src=root.cnf.j2 dest=~/.my.cnf mode=0600
+
+- name: Update MySQL root password for all root accounts
+  mysql_user: name=root host={{ item }} password={{ mysql_root_pass }} state=present
+  with_items:
+    - "{{ ansible_hostname }}"
+    - 127.0.0.1
+    - ::1
+    - localhost
+
+- name: Create graphite database
+  mysql_db:
+    name: "{{ graphite_db_name }}"
+    state: present
+
+- name: Grant access to graphite_user
+  mysql_user:
+    name: "{{ graphite_mysql_user }}"
+    host: "{{ item }}"
+    password: "{{ graphite_mysql_password }}"
+    priv: '{{ graphite_db_name }}.*:ALL,GRANT'
+    state: present
+  with_items:
+    - '%'
+    - 'localhost'
+
+- name: Ensure Anonymous user(s) are not in the database
+  mysql_user: name='' host={{ item }} state=absent
+  with_items:
+    - localhost
+    - "{{ ansible_hostname }}"
+
+- name: Remove the test database
+  mysql_db: name=test state=absent
+  notify:
+    - Restart MySQL

--- a/orc8r/cloud/deploy/roles/third_party/graphite/templates/local_settings.py.j2
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/templates/local_settings.py.j2
@@ -147,16 +147,16 @@ WHISPER_DIR = '/data/graphite/storage/whisper'
 # The default is 'django.db.backends.sqlite3' with file 'graphite.db'
 # located in STORAGE_DIR
 #
-#DATABASES = {
-#    'default': {
-#        'NAME': '/opt/graphite/storage/graphite.db',
-#        'ENGINE': 'django.db.backends.sqlite3',
-#        'USER': '',
-#        'PASSWORD': '',
-#        'HOST': '',
-#        'PORT': ''
-#    }
-#}
+DATABASES = {
+    'default': {
+        'NAME': 'graphitedb',
+        'ENGINE': 'django.db.backends.mysql',
+        'USER': '{{ graphite_mysql_user }}',
+        'PASSWORD': '{{ graphite_mysql_password }}',
+        'HOST': 'localhost',
+        'PORT': '3306'
+    }
+}
 #
 
 

--- a/orc8r/cloud/deploy/roles/third_party/graphite/templates/root.cnf.j2
+++ b/orc8r/cloud/deploy/roles/third_party/graphite/templates/root.cnf.j2
@@ -1,0 +1,3 @@
+[client]
+user=root
+password={{ mysql_root_pass }}


### PR DESCRIPTION
Summary: The default setup for graphite-web uses SQLite as the database for tags. This works for staging scale, but on prod we have too many metrics and the database is locked constantly, making it impossible to query.

Reviewed By: tcirstea

Differential Revision: D14966466

