### PR TITLE
Make graphite attempt to reconnect after error submitting metric

### DIFF
--- a/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite.go
@@ -144,6 +144,7 @@ func (e *GraphiteExporter) Export() error {
 	for _, metric := range e.registeredMetrics {
 		err := metric.Export(e)
 		if err != nil {
+			e.connected = false
 			return err
 		}
 	}


### PR DESCRIPTION
Summary: If the carbon daemon is stopped on the metrics instance, the connection will be closed and metricsd would need to be restarted to get the connection again. This just tells the exporter that the connection is closed once an error occurs. Then on the next export it will try to reconnect before exporting.

Reviewed By: tcirstea

Differential Revision: D14966796

