### PR TITLE
Move swx proxy cache unit test to same folder as cache

### DIFF
--- a/feg/gateway/services/swx_proxy/cache/swx_cache_test.go
+++ b/feg/gateway/services/swx_proxy/cache/swx_cache_test.go
@@ -5,7 +5,7 @@ All rights reserved.
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 */
-package test
+package cache_test
 
 import (
 	"context"


### PR DESCRIPTION
Summary:
The recent addition of the swx_proxy's cache put it's unit test in a seperate directory.
To remain consistent with the style of the FeG and golang in general, this diff moves the unit
test to the same directory that the cache is defined in, renaming the package to `cache_test`.

Reviewed By: vikg-fb

Differential Revision: D14968815

