### PR TITLE
Remove prometheus from default exporter and ansible roles

### DIFF
--- a/orc8r/cloud/configs/metricsd.yml
+++ b/orc8r/cloud/configs/metricsd.yml
@@ -6,7 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-profile: "default"
+profile: "exportall"
 prometheusAddress: "http://192.168.80.50:9090"
 prometheusPushgatewayAddress: "http://192.168.80.50:9091"
 

--- a/orc8r/cloud/deploy/metrics.dev.yml
+++ b/orc8r/cloud/deploy/metrics.dev.yml
@@ -42,5 +42,4 @@
     full_provision: true
 
   roles:
-    - { role: prometheus }
     - { role: 'third_party/graphite', vars: {graphite_cache_graphite_url: 'http://127.0.0.1:8080'}}

--- a/orc8r/cloud/deploy/metrics.yml
+++ b/orc8r/cloud/deploy/metrics.yml
@@ -12,5 +12,4 @@
   become: yes
 
   roles:
-    - { role: prometheus }
     - { role: graphite, vars: {graphite_cache_graphite_url: 'http://127.0.0.1:8080'}}


### PR DESCRIPTION
Summary: Removes prometheus role from metrics ansible tasks. Since we are no longer using prometheus as the main metrics database it makes no sense to install it by default. It can still be installed by adding the role back to the metrics.yml file and will work just as before.

Differential Revision: D14976407

