### PR TITLE
Fix docker build after docker SRC_ROOT change

### DIFF
--- a/orc8r/cloud/docker/proxy/Dockerfile
+++ b/orc8r/cloud/docker/proxy/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 # Add the magma apt repo
 RUN apt-get update && \
     apt-get install -y apt-utils software-properties-common apt-transport-https
-COPY magma/orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
+COPY src/magma/orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ xenial main"
 
@@ -20,16 +20,16 @@ RUN pip3 install PyYAML jinja2
 
 # Copy the scripts and configs from the context
 COPY configs /etc/magma/configs
-COPY magma/orc8r/cloud/deploy/roles/proxy/templates /etc/magma/templates
-COPY magma/orc8r/cloud/deploy/files/envdir /var/opt/magma/envdir
-COPY magma/orc8r/cloud/deploy/roles/proxy/files/magma_headers.rb /etc/nghttpx/magma_headers.rb
-COPY magma/orc8r/cloud/deploy/roles/proxy/files/run_nghttpx.py /usr/local/bin/run_nghttpx.py
-COPY magma/orc8r/cloud/scripts/create_test_proxy_certs /usr/local/bin/create_test_proxy_certs
+COPY src/magma/orc8r/cloud/deploy/roles/proxy/templates /etc/magma/templates
+COPY src/magma/orc8r/cloud/deploy/files/envdir /var/opt/magma/envdir
+COPY src/magma/orc8r/cloud/deploy/roles/proxy/files/magma_headers.rb /etc/nghttpx/magma_headers.rb
+COPY src/magma/orc8r/cloud/deploy/roles/proxy/files/run_nghttpx.py /usr/local/bin/run_nghttpx.py
+COPY src/magma/orc8r/cloud/scripts/create_test_proxy_certs /usr/local/bin/create_test_proxy_certs
 
 # Override the dev environments to suit Docker
 # TODO: Remove this step after removing vagrant
 RUN echo "controller" > /var/opt/magma/envdir/PROXY_BACKENDS
 
 # Copy the supervisor configs
-COPY magma/orc8r/cloud/deploy/roles/proxy/files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY src/magma/orc8r/cloud/deploy/roles/proxy/files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 CMD ["/usr/bin/supervisord"]


### PR DESCRIPTION
Summary:
Made a couple of changes to the Dockerfiles for orc8r to build successfully.

Proxy: Changing the file paths in proxy/Dockerfile from magma/* to src/magma/* to adapt to the changes from D14883420.
Controller: One of the commands seemed to be missing a ';'. ./build.py built fine after adding the semicolon.

Reviewed By: rpraveen, sciencemanx

Differential Revision: D14978561

