### PR TITLE
Implement network-related configurator storage methods for SQL

### DIFF
--- a/feg/cloud/go/go.sum
+++ b/feg/cloud/go/go.sum
@@ -10,7 +10,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
-github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
@@ -52,7 +51,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elastic/gosigar v0.9.0/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
-github.com/fiorix/go-diameter v3.0.2+incompatible/go.mod h1:GgNrDCADT8o3k8zV1UsI473j8CFdLGY9ikZYDNEeYU8=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/raven-go v0.1.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -275,6 +273,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
 github.com/toqueteos/webbrowser v1.1.0/go.mod h1:Hqqqmzj8AHn+VlZyVjaRWY20i25hoOZGAABCcg2el4A=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -259,6 +259,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
 github.com/toqueteos/webbrowser v1.1.0/go.mod h1:Hqqqmzj8AHn+VlZyVjaRWY20i25hoOZGAABCcg2el4A=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/feg/gateway/services/eap/client/go.sum
+++ b/feg/gateway/services/eap/client/go.sum
@@ -243,6 +243,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
 github.com/toqueteos/webbrowser v1.1.0/go.mod h1:Hqqqmzj8AHn+VlZyVjaRWY20i25hoOZGAABCcg2el4A=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -13,7 +13,6 @@ replace (
 
 require (
 	github.com/aws/aws-sdk-go v1.16.19
-	github.com/fiorix/go-diameter v3.0.2+incompatible
 	github.com/go-openapi/errors v0.18.0
 	github.com/go-openapi/strfmt v0.18.0
 	github.com/go-openapi/swag v0.18.0

--- a/lte/cloud/go/go.sum
+++ b/lte/cloud/go/go.sum
@@ -10,7 +10,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
-github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
@@ -53,8 +52,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elastic/gosigar v0.9.0/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyCIo22xvs=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=
-github.com/fiorix/go-diameter v3.0.2+incompatible h1:PLk2NkqMYILlEdeiz0hJVB3xcuuL+Gc9iCaEgjfbs5w=
-github.com/fiorix/go-diameter v3.0.2+incompatible/go.mod h1:GgNrDCADT8o3k8zV1UsI473j8CFdLGY9ikZYDNEeYU8=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/raven-go v0.1.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
@@ -278,6 +275,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
 github.com/toqueteos/webbrowser v1.1.0/go.mod h1:Hqqqmzj8AHn+VlZyVjaRWY20i25hoOZGAABCcg2el4A=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -8,11 +8,9 @@ module magma/orc8r/cloud/go
 
 require (
 	github.com/BurntSushi/toml v0.3.1 // indirect
-	github.com/VividCortex/gohistogram v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.16.19
 	github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23
 	github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142
-	github.com/go-kit/kit v0.8.0
 	github.com/go-logfmt/logfmt v0.4.0 // indirect
 	github.com/go-openapi/analysis v0.18.0 // indirect
 	github.com/go-openapi/errors v0.18.0
@@ -35,7 +33,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/labstack/echo v0.0.0-20181123063414-c54d9e8eed6c
-	github.com/labstack/gommon v0.2.8
+	github.com/labstack/gommon v0.2.8 // indirect
 	github.com/lib/pq v1.0.0
 	github.com/marpaia/graphite-golang v0.0.0-20171231172105-134b9af18cf3
 	github.com/mattn/go-sqlite3 v1.10.0
@@ -49,6 +47,7 @@ require (
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1 // indirect
 	github.com/stretchr/testify v1.3.0
+	github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de
 	github.com/toqueteos/webbrowser v1.1.0 // indirect
 	github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
@@ -56,7 +55,7 @@ require (
 	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 	golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4 // indirect
 	golang.org/x/sys v0.0.0-20190115152922-a457fd036447 // indirect
-	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c
+	google.golang.org/genproto v0.0.0-20190111180523-db91494dd46c // indirect
 	google.golang.org/grpc v1.17.0
 	gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0
 	gopkg.in/yaml.v2 v2.2.2

--- a/orc8r/cloud/go/go.sum
+++ b/orc8r/cloud/go/go.sum
@@ -11,8 +11,6 @@ github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
-github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
-github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
@@ -295,6 +293,8 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de h1:rkbKsxnGd0LdRk7ma+r0IR1H7KxVpNqaHl5BlmKc0Lo=
+github.com/thoas/go-funk v0.0.0-20190407194523-c43409e2d5de/go.mod h1:mlR+dHGb+4YgXkf13rkQTuzrneeHANxOm6+ZnEV9HsA=
 github.com/toqueteos/webbrowser v1.1.0 h1:Prj1okiysRgHPoe3B1bOIVxcv+UuSt525BDQmR5W0x0=
 github.com/toqueteos/webbrowser v1.1.0/go.mod h1:Hqqqmzj8AHn+VlZyVjaRWY20i25hoOZGAABCcg2el4A=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -1,0 +1,283 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+
+	"magma/orc8r/cloud/go/sql_utils"
+	"magma/orc8r/cloud/go/storage"
+
+	"github.com/golang/glog"
+	"github.com/thoas/go-funk"
+)
+
+const (
+	networksTable      = "cfg_networks"
+	networkConfigTable = "cfg_network_configs"
+)
+
+// NewSQLConfiguratorStorageFactory returns a ConfiguratorStorageFactory
+// implementation backed by a SQL database.
+func NewSQLConfiguratorStorageFactory(db *sql.DB) ConfiguratorStorageFactory {
+	return &sqlConfiguratorStorageFactory{db}
+}
+
+type sqlConfiguratorStorageFactory struct {
+	db *sql.DB
+}
+
+func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error) {
+	tx, err := fact.db.BeginTx(context.Background(), &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+	})
+	if err != nil {
+		return
+	}
+
+	defer func() {
+		if err == nil {
+			err = tx.Commit()
+		} else {
+			rollbackErr := tx.Rollback()
+			if rollbackErr != nil {
+				err = fmt.Errorf("%s; rollback error: %s", err, rollbackErr)
+			}
+		}
+	}()
+
+	networksTableExec := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s
+		(
+			id text PRIMARY KEY,
+			name text,
+			description text,
+			version INTEGER NOT NULL DEFAULT 0
+		)
+	`, networksTable)
+
+	networksConfigTableExec := fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s
+		(
+			network_id text REFERENCES %s (id) ON DELETE CASCADE,
+			type text NOT NULL,
+			value bytea,
+
+			PRIMARY KEY (network_id, type)
+		)
+	`, networkConfigTable, networksTable)
+
+	// Named return value for err so we can automatically decide to
+	// commit/rollback
+	tablesToCreate := []string{
+		networksTableExec,
+		networksConfigTableExec,
+	}
+	for _, execQuery := range tablesToCreate {
+		_, err = tx.Exec(execQuery)
+		if err != nil {
+			return
+		}
+	}
+
+	// Create internal network(s)
+	_, err = tx.Exec(
+		fmt.Sprintf("INSERT INTO %s (id, name, description) VALUES ($1, $2, $3) ON CONFLICT (id) DO NOTHING", networksTable),
+		InternalNetworkID, internalNetworkName, internalNetworkDescription,
+	)
+	if err != nil {
+		err = fmt.Errorf("error creating internal networks: %s", err)
+		return
+	}
+
+	return
+}
+
+func (fact *sqlConfiguratorStorageFactory) StartTransaction(ctx context.Context, opts *TxOptions) (ConfiguratorStorage, error) {
+	tx, err := fact.db.BeginTx(ctx, getSqlOpts(opts))
+	if err != nil {
+		return nil, err
+	}
+	return &sqlConfiguratorStorage{tx: tx}, nil
+}
+
+func getSqlOpts(opts *TxOptions) *sql.TxOptions {
+	if opts == nil {
+		return nil
+	}
+	return &sql.TxOptions{ReadOnly: opts.ReadOnly}
+}
+
+type sqlConfiguratorStorage struct {
+	tx *sql.Tx
+}
+
+func (store *sqlConfiguratorStorage) Commit() error {
+	return store.tx.Commit()
+}
+
+func (store *sqlConfiguratorStorage) Rollback() error {
+	return store.tx.Rollback()
+}
+
+func (store *sqlConfiguratorStorage) LoadNetworks(ids []string, loadCriteria NetworkLoadCriteria) (NetworkLoadResult, error) {
+	emptyRet := NetworkLoadResult{NetworkIDsNotFound: []string{}, Networks: []Network{}}
+	if len(ids) == 0 {
+		return emptyRet, nil
+	}
+
+	query, err := getNetworkQuery(ids, loadCriteria)
+	if err != nil {
+		return emptyRet, err
+	}
+	queryArgs := make([]interface{}, 0, len(ids))
+	funk.ConvertSlice(ids, &queryArgs)
+
+	rows, err := store.tx.Query(query, queryArgs...)
+	if err != nil {
+		return emptyRet, fmt.Errorf("error querying for networks: %s", err)
+	}
+	defer func() {
+		err := rows.Close()
+		if err != nil {
+			glog.Warningf("error while closing *Rows object in LoadNetworks: %s", err)
+		}
+	}()
+
+	// Pointer values because we're modifying .Config in-place
+	loadedNetworksByID := map[string]*Network{}
+	for rows.Next() {
+		nwResult, err := scanNextNetworkRow(rows, loadCriteria)
+		if err != nil {
+			return emptyRet, err
+		}
+
+		existingNetwork, wasLoaded := loadedNetworksByID[nwResult.ID]
+		if wasLoaded {
+			for k, v := range nwResult.Configs {
+				existingNetwork.Configs[k] = v
+			}
+		} else {
+			loadedNetworksByID[nwResult.ID] = &nwResult
+		}
+	}
+
+	// Sort map keys so we return deterministically
+	loadedNetworkIDs := funk.Keys(loadedNetworksByID).([]string)
+	sort.Strings(loadedNetworkIDs)
+
+	ret := NetworkLoadResult{
+		NetworkIDsNotFound: getNetworkIDsNotFound(loadedNetworksByID, ids),
+		Networks:           make([]Network, 0, len(loadedNetworksByID)),
+	}
+	for _, nid := range loadedNetworkIDs {
+		ret.Networks = append(ret.Networks, *loadedNetworksByID[nid])
+	}
+	return ret, nil
+}
+
+func (store *sqlConfiguratorStorage) CreateNetwork(network Network) (Network, error) {
+	exists, err := store.doesNetworkExist(network.ID)
+	if err != nil {
+		return network, err
+	}
+	if exists {
+		return network, fmt.Errorf("a network with ID %s already exists", network.ID)
+	}
+
+	// Insert the network, then insert its configs
+	exec := fmt.Sprintf("INSERT INTO %s (id, name, description) VALUES ($1, $2, $3)", networksTable)
+	_, err = store.tx.Exec(exec, network.ID, network.Name, network.Description)
+	if err != nil {
+		return network, fmt.Errorf("error inserting network: %s", err)
+	}
+
+	if funk.IsEmpty(network.Configs) {
+		return network, nil
+	}
+
+	configExec := fmt.Sprintf("INSERT INTO %s (network_id, type, value) VALUES ($1, $2, $3)", networkConfigTable)
+	configInsertStatement, err := store.tx.Prepare(configExec)
+	if err != nil {
+		return network, fmt.Errorf("error preparing network configuration insert: %s", err)
+	}
+	defer sql_utils.GetCloseStatementsDeferFunc([]*sql.Stmt{configInsertStatement}, "CreateNetwork")()
+
+	// Sort config keys for deterministic behavior
+	configKeys := funk.Keys(network.Configs).([]string)
+	sort.Strings(configKeys)
+	for _, configKey := range configKeys {
+		_, err := configInsertStatement.Exec(network.ID, configKey, network.Configs[configKey])
+		if err != nil {
+			return network, fmt.Errorf("error inserting config %s: %s", configKey, err)
+		}
+	}
+
+	return network, nil
+}
+
+func (store *sqlConfiguratorStorage) UpdateNetworks(updates []NetworkUpdateCriteria) (FailedOperations, error) {
+	failures := FailedOperations{}
+	if err := validateNetworkUpdates(updates); err != nil {
+		return failures, err
+	}
+
+	// Prepare statements
+	deleteExec := fmt.Sprintf("DELETE FROM %s WHERE id = $1", networksTable)
+	upsertConfigExec := fmt.Sprintf(`
+		INSERT INTO %s (network_id, type, value) VALUES ($1, $2, $3)
+		ON CONFLICT (network_id, type) DO UPDATE SET value = $4
+	`, networkConfigTable)
+	deleteConfigExec := fmt.Sprintf("DELETE FROM %s WHERE (network_id, type) = ($1, $2)", networkConfigTable)
+	statements, err := sql_utils.PrepareStatements(store.tx, []string{deleteExec, upsertConfigExec, deleteConfigExec})
+	if err != nil {
+		return failures, err
+	}
+	defer sql_utils.GetCloseStatementsDeferFunc(statements, "UpdateNetworks")()
+
+	deleteStmt, upsertConfigStmt, deleteConfigStmt := statements[0], statements[1], statements[2]
+	for _, update := range updates {
+		if update.DeleteNetwork {
+			_, err := deleteStmt.Exec(update.ID)
+			if err != nil {
+				failures[update.ID] = fmt.Errorf("error deleting network %s: %s", update.ID, err)
+			}
+		} else {
+			err := store.updateNetwork(update, upsertConfigStmt, deleteConfigStmt)
+			if err != nil {
+				failures[update.ID] = err
+			}
+		}
+	}
+
+	if funk.IsEmpty(failures) {
+		return failures, nil
+	}
+	return failures, errors.New("some errors were encountered, see return value for details")
+}
+
+func (store *sqlConfiguratorStorage) LoadEntities(ids []storage.TypeAndKey, loadCriteria EntityLoadCriteria) (EntityLoadResult, error) {
+	panic("implement me")
+}
+
+func (store *sqlConfiguratorStorage) CreateEntities(entities []NetworkEntity) (EntityCreationResult, error) {
+	panic("implement me")
+}
+
+func (store *sqlConfiguratorStorage) UpdateEntities(updates []EntityUpdateCriteria) (FailedOperations, error) {
+	panic("implement me")
+}
+
+func (store *sqlConfiguratorStorage) LoadGraphForEntity(entityID storage.TypeAndKey, loadCriteria EntityLoadCriteria) (EntityGraph, error) {
+	panic("implement me")
+}

--- a/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package storage_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"magma/orc8r/cloud/go/services/configurator/storage"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSqlConfiguratorStorage_Integration(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("Could not initialize sqlite DB: %s", err)
+	}
+	factory := storage.NewSQLConfiguratorStorageFactory(db)
+	err = factory.InitializeServiceStorage()
+	assert.NoError(t, err)
+
+	// Check the contract for an empty datastore
+	store, err := factory.StartTransaction(context.Background(), nil)
+	assert.NoError(t, err)
+
+	loadNetworksActual, err := store.LoadNetworks([]string{"n1", "n2"}, storage.FullNetworkLoadCriteria)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		storage.NetworkLoadResult{
+			Networks:           []storage.Network{},
+			NetworkIDsNotFound: []string{"n1", "n2"},
+		},
+		loadNetworksActual,
+	)
+	err = store.Commit()
+	assert.NoError(t, err)
+
+	// Create networks, read them back
+	store, err = factory.StartTransaction(context.Background(), nil)
+	assert.NoError(t, err)
+
+	expectedn1 := storage.Network{ID: "n1", Name: "Network 1", Description: "foo", Configs: map[string][]byte{"hello": []byte("world"), "goodbye": []byte("alsoworld")}}
+	actualNetwork, err := store.CreateNetwork(expectedn1)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedn1, actualNetwork)
+
+	expectedn2 := storage.Network{ID: "n2"}
+	actualNetwork, err = store.CreateNetwork(expectedn2)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedn2, actualNetwork)
+	expectedn2.Configs = map[string][]byte{}
+
+	err = store.Commit()
+	assert.NoError(t, err)
+
+	store, err = factory.StartTransaction(context.Background(), nil)
+	assert.NoError(t, err)
+	loadNetworksActual, err = store.LoadNetworks([]string{"n1", "n2", "n3"}, storage.FullNetworkLoadCriteria)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		storage.NetworkLoadResult{
+			Networks:           []storage.Network{expectedn1, expectedn2},
+			NetworkIDsNotFound: []string{"n3"},
+		},
+		loadNetworksActual,
+	)
+	err = store.Commit()
+	assert.NoError(t, err)
+
+	// Update networks, read them back
+	store, err = factory.StartTransaction(context.Background(), nil)
+	assert.NoError(t, err)
+	_, err = store.CreateNetwork(storage.Network{ID: "n3"})
+	assert.NoError(t, err)
+
+	newNames := []string{"New Network 1"}
+	newDescs := []string{"New Network 1 description"}
+	updates := []storage.NetworkUpdateCriteria{
+		{ID: "n1", NewName: &newNames[0], NewDescription: &newDescs[0], ConfigsToDelete: []string{"goodbye"}, ConfigsToAddOrUpdate: map[string][]byte{"foo": []byte("bar")}},
+		{ID: "n2", ConfigsToDelete: []string{"dne"}, ConfigsToAddOrUpdate: map[string][]byte{"baz": []byte("quz")}},
+		{ID: "n3", DeleteNetwork: true},
+		{ID: "n4", DeleteNetwork: true},
+	}
+
+	expectedn1.Name, expectedn1.Description = newNames[0], newDescs[0]
+	delete(expectedn1.Configs, "goodbye")
+	expectedn1.Configs["foo"] = []byte("bar")
+	expectedn1.Version = 1
+	expectedn2.Configs = map[string][]byte{"baz": []byte("quz")}
+	expectedn2.Version = 1
+
+	failures, err := store.UpdateNetworks(updates)
+	assert.NoError(t, err)
+	assert.Equal(t, storage.FailedOperations{}, failures)
+	assert.NoError(t, store.Commit())
+
+	store, err = factory.StartTransaction(context.Background(), &storage.TxOptions{ReadOnly: true})
+	assert.NoError(t, err)
+	loadNetworksActual, err = store.LoadNetworks([]string{"n1", "n2", "n3"}, storage.FullNetworkLoadCriteria)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		storage.NetworkLoadResult{
+			Networks:           []storage.Network{expectedn1, expectedn2},
+			NetworkIDsNotFound: []string{"n3"},
+		},
+		loadNetworksActual,
+	)
+	assert.NoError(t, store.Commit())
+}

--- a/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package storage
+
+import (
+	"bytes"
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"text/template"
+
+	"magma/orc8r/cloud/go/sql_utils"
+
+	"github.com/thoas/go-funk"
+)
+
+type networkQueryArgs struct {
+	Fields, TableName, JoinQuery, IdList string
+}
+
+func getNetworkQuery(ids []string, criteria NetworkLoadCriteria) (string, error) {
+	// SELECT cfg_networks.id, cfg_networks.name, cfg_networks.description cfg_network_configs.type, cfg_network_configs.value
+	// FROM cfg_networks
+	// [[ LEFT JOIN cfg_network_configs ON cfg_networks.id = cfg_network_configs.network_id ]]
+	// WHERE cfg_networks.id IN (id list)
+	queryTemplate := template.Must(template.New("nw_query").Parse(
+		"SELECT {{.Fields}} FROM {{.TableName}} " +
+			"{{.JoinQuery}} " +
+			"WHERE {{.TableName}}.id IN {{.IdList}}",
+	))
+	args := getNetworkQueryArgs(ids, criteria)
+
+	buf := new(bytes.Buffer)
+	err := queryTemplate.Execute(buf, args)
+	if err != nil {
+		return "", fmt.Errorf("failed to format network query: %s", err)
+	}
+	return buf.String(), nil
+}
+
+func getNetworkQueryArgs(ids []string, criteria NetworkLoadCriteria) networkQueryArgs {
+	ret := networkQueryArgs{
+		TableName: networksTable,
+		Fields:    fmt.Sprintf("%s.id", networksTable),
+		IdList:    sql_utils.GetPlaceholderArgList(1, len(ids)),
+	}
+
+	if criteria.LoadMetadata {
+		ret.Fields += fmt.Sprintf(", %s.name, %s.description", networksTable, networksTable)
+	}
+
+	if criteria.LoadConfigs {
+		ret.Fields += fmt.Sprintf(", %s.type, %s.value", networkConfigTable, networkConfigTable)
+		ret.JoinQuery = fmt.Sprintf("LEFT JOIN %s ON %s.network_id = %s.id", networkConfigTable, networkConfigTable, networksTable)
+	}
+
+	ret.Fields += fmt.Sprintf(", %s.version", networksTable)
+
+	return ret
+}
+
+func scanNextNetworkRow(rows *sql.Rows, criteria NetworkLoadCriteria) (Network, error) {
+	var id string
+	var name, description sql.NullString
+	var cfgType sql.NullString
+	var cfgValue []byte
+	var version uint64
+
+	scanArgs := []interface{}{
+		&id,
+	}
+	if criteria.LoadMetadata {
+		scanArgs = append(scanArgs, &name, &description)
+	}
+	if criteria.LoadConfigs {
+		scanArgs = append(scanArgs, &cfgType, &cfgValue)
+	}
+	scanArgs = append(scanArgs, &version)
+
+	err := rows.Scan(scanArgs...)
+	if err != nil {
+		return Network{}, fmt.Errorf("error while scanning network row: %s", err)
+	}
+
+	ret := Network{ID: id, Name: nullStringToValue(name), Description: nullStringToValue(description), Configs: map[string][]byte{}, Version: version}
+	if criteria.LoadConfigs && cfgType.Valid {
+		ret.Configs[cfgType.String] = cfgValue
+	}
+	return ret, nil
+}
+
+func getNetworkIDsNotFound(networksByID map[string]*Network, queriedIDs []string) []string {
+	ret := []string{}
+	for _, id := range queriedIDs {
+		if _, ok := networksByID[id]; !ok {
+			ret = append(ret, id)
+		}
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+func (store *sqlConfiguratorStorage) doesNetworkExist(id string) (bool, error) {
+	query := fmt.Sprintf("SELECT count(1) FROM %s WHERE id = $1", networksTable)
+	row := store.tx.QueryRow(query, id)
+
+	var count int
+	err := row.Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("error checking if network id %s exists: %s", id, err)
+	}
+
+	return count > 0, nil
+}
+
+func validateNetworkUpdates(updates []NetworkUpdateCriteria) error {
+	updatesByID := funk.ToMap(updates, "ID").(map[string]NetworkUpdateCriteria)
+	if len(updatesByID) < len(updates) {
+		return errors.New("multiple updates for a single network are not allowed")
+	}
+	return nil
+}
+
+func (store *sqlConfiguratorStorage) updateNetwork(update NetworkUpdateCriteria, upsertConfigStmt *sql.Stmt, deleteConfigStmt *sql.Stmt) error {
+	updNetworkQuery, updNetworkArgs, err := getNetworkUpdateExec(update)
+	if err != nil {
+		return err
+	}
+
+	_, err = store.tx.Exec(updNetworkQuery, updNetworkArgs...)
+	if err != nil {
+		return fmt.Errorf("error updating network %s: %s", update.ID, err)
+	}
+
+	// Sort config keys for deterministic behavior
+	configUpdateTypes := funk.Keys(update.ConfigsToAddOrUpdate).([]string)
+	sort.Strings(configUpdateTypes)
+	for _, configType := range configUpdateTypes {
+		configValue := update.ConfigsToAddOrUpdate[configType]
+		_, err := upsertConfigStmt.Exec(update.ID, configType, configValue, configValue)
+		if err != nil {
+			return fmt.Errorf("error updating config %s on network %s: %s", configType, update.ID, err)
+		}
+	}
+	for _, configType := range update.ConfigsToDelete {
+		_, err := deleteConfigStmt.Exec(update.ID, configType)
+		if err != nil {
+			return fmt.Errorf("error deleting config %s on network %s: %s", configType, update.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func getNetworkUpdateExec(update NetworkUpdateCriteria) (string, []interface{}, error) {
+	// UPDATE cfg_networks SET (name, description, version) = ($1, $2, cfg_networks.version + 1) WHERE id = $3
+	networkExecTemplate := template.Must(template.New("nw_upd_exec").Parse(
+		"UPDATE {{.TableName}} SET {{.Fields}} = {{.FieldsPlaceholder}} " +
+			"WHERE {{.TableName}}.id = {{.IDPlaceholder}}",
+	))
+	templateArgs := getNetworkExecTemplateArgs(update)
+
+	buf := new(bytes.Buffer)
+	err := networkExecTemplate.Execute(buf, templateArgs)
+	if err != nil {
+		return "", []interface{}{}, fmt.Errorf("failed to format network update query: %s", err)
+	}
+	return buf.String(), getNetworkExecQueryArgs(update), nil
+}
+
+type networkExecTemplateArgs struct {
+	TableName, Fields, FieldsPlaceholder, IDPlaceholder string
+}
+
+func getNetworkExecTemplateArgs(update NetworkUpdateCriteria) networkExecTemplateArgs {
+	ret := networkExecTemplateArgs{
+		TableName: networksTable,
+	}
+
+	fields := []string{}
+	if update.NewName != nil {
+		fields = append(fields, "name")
+	}
+	if update.NewDescription != nil {
+		fields = append(fields, "description")
+	}
+	fields = append(fields, "version")
+
+	ret.Fields = fmt.Sprintf("(%s)", strings.Join(fields, ", "))
+	ret.FieldsPlaceholder = sql_utils.GetPlaceholderArgListWithSuffix(
+		1,
+		len(fields)-1,
+		fmt.Sprintf("%s.version + 1", networksTable),
+	)
+	ret.IDPlaceholder = fmt.Sprintf("$%d", len(fields)+1)
+
+	return ret
+}
+
+func getNetworkExecQueryArgs(update NetworkUpdateCriteria) []interface{} {
+	ret := []interface{}{}
+	if update.NewName != nil {
+		ret = append(ret, stringPtrToVal(update.NewName))
+	}
+	if update.NewDescription != nil {
+		ret = append(ret, stringPtrToVal(update.NewDescription))
+	}
+	ret = append(ret, update.ID)
+	return ret
+}
+
+func stringPtrToVal(in *string) interface{} {
+	if *in == "" {
+		return nil
+	}
+	return *in
+}
+
+func nullStringToValue(in sql.NullString) string {
+	if in.Valid {
+		return in.String
+	}
+	return ""
+}

--- a/orc8r/cloud/go/services/configurator/storage/sql_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_test.go
@@ -1,0 +1,505 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package storage_test
+
+import (
+	"context"
+	"errors"
+	"log"
+	"testing"
+
+	"magma/orc8r/cloud/go/services/configurator/storage"
+
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+var mockResult = sqlmock.NewResult(1, 1)
+
+func TestSqlConfiguratorStorage_LoadNetworks(t *testing.T) {
+	runFactory := func(ids []string, loadCriteria storage.NetworkLoadCriteria) func(store storage.ConfiguratorStorage) (interface{}, error) {
+		return func(store storage.ConfiguratorStorage) (interface{}, error) {
+			return store.LoadNetworks(ids, loadCriteria)
+		}
+	}
+
+	idsOnly := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery("SELECT cfg_networks.id, cfg_networks.version FROM cfg_networks").
+				WillReturnRows(
+					sqlmock.NewRows([]string{"id", "version"}).
+						AddRow("hello", 1).
+						AddRow("world", 2),
+				)
+		},
+		run: runFactory([]string{"hello", "world"}, storage.NetworkLoadCriteria{}),
+
+		expectedResult: storage.NetworkLoadResult{
+			NetworkIDsNotFound: []string{},
+			Networks: []storage.Network{
+				{ID: "hello", Configs: map[string][]byte{}, Version: 1},
+				{ID: "world", Configs: map[string][]byte{}, Version: 2},
+			},
+		},
+	}
+
+	metadataLoad := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery("SELECT cfg_networks.id, cfg_networks.name, cfg_networks.description, cfg_networks.version FROM cfg_networks").
+				WillReturnRows(
+					sqlmock.NewRows([]string{"id", "name", "description", "version"}).
+						AddRow("hello", "Hello", "Hello network", 1).
+						AddRow("world", "World", "World network", 2),
+				)
+		},
+		run: runFactory([]string{"hello", "world"}, storage.NetworkLoadCriteria{LoadMetadata: true}),
+
+		expectedResult: storage.NetworkLoadResult{
+			NetworkIDsNotFound: []string{},
+			Networks: []storage.Network{
+				{
+					ID:          "hello",
+					Name:        "Hello",
+					Description: "Hello network",
+					Configs:     map[string][]byte{},
+					Version:     1,
+				},
+				{
+					ID:          "world",
+					Name:        "World",
+					Description: "World network",
+					Configs:     map[string][]byte{},
+					Version:     2,
+				},
+			},
+		},
+	}
+
+	// 1 network has 2 configs, 1 has no configs
+	idsAndConfigs := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery("SELECT cfg_networks.id, cfg_network_configs.type, cfg_network_configs.value, cfg_networks.version FROM cfg_networks").
+				WillReturnRows(
+					sqlmock.NewRows([]string{"id", "type", "value", "version"}).
+						AddRow("hello", "foo", []byte("foo"), 1).
+						AddRow("hello", "bar", []byte("bar"), 1).
+						AddRow("world", nil, nil, 3),
+				)
+		},
+		run: runFactory([]string{"hello", "world", "foobar"}, storage.NetworkLoadCriteria{LoadConfigs: true}),
+
+		expectedResult: storage.NetworkLoadResult{
+			NetworkIDsNotFound: []string{"foobar"},
+			Networks: []storage.Network{
+				{
+					ID: "hello",
+					Configs: map[string][]byte{
+						"foo": []byte("foo"),
+						"bar": []byte("bar"),
+					},
+					Version: 1,
+				},
+				{
+					ID:      "world",
+					Configs: map[string][]byte{},
+					Version: 3,
+				},
+			},
+		},
+	}
+
+	// Same setup as above, plus 1 network not found
+	fullLoad := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery("SELECT cfg_networks.id, cfg_networks.name, cfg_networks.description, cfg_network_configs.type, cfg_network_configs.value, cfg_networks.version FROM cfg_networks").
+				WillReturnRows(
+					sqlmock.NewRows([]string{"id", "name", "description", "type", "value", "version"}).
+						AddRow("hello", "Hello", "Hello network", "foo", []byte("foo"), 1).
+						AddRow("hello", "Hello", "Hello network", "bar", []byte("bar"), 1).
+						AddRow("world", "World", "World network", nil, nil, 2),
+				)
+		},
+		run: runFactory([]string{"hello", "world", "foobar"}, storage.NetworkLoadCriteria{LoadMetadata: true, LoadConfigs: true}),
+
+		expectedResult: storage.NetworkLoadResult{
+			NetworkIDsNotFound: []string{"foobar"},
+			Networks: []storage.Network{
+				{
+					ID:          "hello",
+					Name:        "Hello",
+					Description: "Hello network",
+					Configs: map[string][]byte{
+						"foo": []byte("foo"),
+						"bar": []byte("bar"),
+					},
+					Version: 1,
+				},
+				{
+					ID:          "world",
+					Name:        "World",
+					Description: "World network",
+					Configs:     map[string][]byte{},
+					Version:     2,
+				},
+			},
+		},
+	}
+
+	noneFound := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery("SELECT cfg_networks.id, cfg_networks.version FROM cfg_networks").
+				WillReturnRows(sqlmock.NewRows([]string{"id", "version"}))
+		},
+		run: runFactory([]string{"hello", "world"}, storage.NetworkLoadCriteria{}),
+
+		expectedResult: storage.NetworkLoadResult{
+			NetworkIDsNotFound: []string{"hello", "world"},
+			Networks:           []storage.Network{},
+		},
+	}
+
+	queryError := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery("SELECT cfg_networks.id, cfg_networks.version FROM cfg_networks").
+				WillReturnError(errors.New("mock query error"))
+		},
+		run: runFactory([]string{"hello", "world"}, storage.NetworkLoadCriteria{}),
+
+		expectedError: errors.New("error querying for networks: mock query error"),
+	}
+
+	runCase(t, idsOnly)
+	runCase(t, metadataLoad)
+	runCase(t, idsAndConfigs)
+	runCase(t, fullLoad)
+	runCase(t, noneFound)
+	runCase(t, queryError)
+}
+
+func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
+	runFactory := func(network storage.Network) func(store storage.ConfiguratorStorage) (interface{}, error) {
+		return func(store storage.ConfiguratorStorage) (interface{}, error) {
+			return store.CreateNetwork(network)
+		}
+	}
+
+	idOnly := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+				WithArgs("n1").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+			m.ExpectExec("INSERT INTO cfg_networks").
+				WithArgs("n1", "", "").
+				WillReturnResult(mockResult)
+		},
+		run: runFactory(storage.Network{ID: "n1"}),
+
+		expectedResult: storage.Network{ID: "n1"},
+	}
+
+	allMetadata := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+				WithArgs("n2").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+			m.ExpectExec("INSERT INTO cfg_networks").
+				WithArgs("n2", "hello", "world").
+				WillReturnResult(mockResult)
+		},
+		run: runFactory(storage.Network{ID: "n2", Name: "hello", Description: "world"}),
+
+		expectedResult: storage.Network{ID: "n2", Name: "hello", Description: "world"},
+	}
+
+	everythingNw := storage.Network{
+		ID:          "n3",
+		Name:        "hello",
+		Description: "world",
+		Configs: map[string][]byte{
+			"foo": []byte("bar"),
+			"baz": []byte("quz"),
+		},
+	}
+	everything := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+				WithArgs("n3").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+			m.ExpectExec("INSERT INTO cfg_networks").
+				WithArgs("n3", "hello", "world").
+				WillReturnResult(mockResult)
+
+			configStmt := m.ExpectPrepare("INSERT INTO cfg_network_configs")
+			configStmt.ExpectExec().WithArgs("n3", "baz", []byte("quz")).WillReturnResult(mockResult)
+			configStmt.ExpectExec().WithArgs("n3", "foo", []byte("bar")).WillReturnResult(mockResult)
+			configStmt.WillBeClosed()
+		},
+		run: runFactory(everythingNw),
+
+		expectedResult: everythingNw,
+	}
+
+	networkTableError := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+				WithArgs("n4").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+			m.ExpectExec("INSERT INTO cfg_networks").
+				WithArgs("n4", "", "").
+				WillReturnError(errors.New("mock exec error"))
+		},
+		run: runFactory(storage.Network{ID: "n4"}),
+
+		expectedResult: storage.Network{ID: "n4"},
+		expectedError:  errors.New("error inserting network: mock exec error"),
+	}
+
+	configTableErrNw := storage.Network{
+		ID: "n5",
+		Configs: map[string][]byte{
+			"foo": []byte("bar"),
+			"baz": []byte("quz"),
+		},
+	}
+	configTableError := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+				WithArgs("n5").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
+
+			m.ExpectExec("INSERT INTO cfg_networks").
+				WithArgs("n5", "", "").
+				WillReturnResult(mockResult)
+
+			configStmt := m.ExpectPrepare("INSERT INTO cfg_network_configs")
+			configStmt.ExpectExec().WithArgs("n5", "baz", []byte("quz")).
+				WillReturnError(errors.New("mock exec error"))
+			configStmt.WillBeClosed()
+		},
+		run: runFactory(configTableErrNw),
+
+		expectedResult: configTableErrNw,
+		expectedError:  errors.New("error inserting config baz: mock exec error"),
+	}
+
+	networkExists := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+				WithArgs("n5").
+				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+		},
+		run: runFactory(storage.Network{ID: "n5"}),
+
+		expectedResult: storage.Network{ID: "n5"},
+		expectedError:  errors.New("a network with ID n5 already exists"),
+	}
+
+	runCase(t, idOnly)
+	runCase(t, allMetadata)
+	runCase(t, everything)
+	runCase(t, networkTableError)
+	runCase(t, configTableError)
+	runCase(t, networkExists)
+}
+
+func TestSqlConfiguratorStorage_UpdateNetworks(t *testing.T) {
+	runFactory := func(updates []storage.NetworkUpdateCriteria) func(store storage.ConfiguratorStorage) (interface{}, error) {
+		return func(store storage.ConfiguratorStorage) (interface{}, error) {
+			return store.UpdateNetworks(updates)
+		}
+	}
+
+	// Delete 1 network (n1)
+	// Update only metadata of another (n2)
+	// Update and delete configs of another (n3)
+	// Fill out all fields of the update criteria (n4)
+	names := []string{"should be ignored", "name2", "name4"}
+	descs := []string{"should be ignored", "desc2", ""}
+	happyPath := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			deleteStmt := m.ExpectPrepare("DELETE FROM cfg_networks")
+			upsertStmt := m.ExpectPrepare("INSERT INTO cfg_network_configs")
+			deleteConfigStmt := m.ExpectPrepare("DELETE FROM cfg_network_configs")
+
+			deleteStmt.ExpectExec().WithArgs("n1").WillReturnResult(mockResult)
+
+			m.ExpectExec("UPDATE cfg_networks").WithArgs(names[1], descs[1], "n2").WillReturnResult(mockResult)
+
+			m.ExpectExec("UPDATE cfg_networks").WithArgs("n3").WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n3", "baz", []byte("quz"), []byte("quz")).WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n3", "foo", []byte("bar"), []byte("bar")).WillReturnResult(mockResult)
+			deleteConfigStmt.ExpectExec().WithArgs("n3", "hello").WillReturnResult(mockResult)
+			deleteConfigStmt.ExpectExec().WithArgs("n3", "world").WillReturnResult(mockResult)
+
+			m.ExpectExec("UPDATE cfg_networks").WithArgs(names[2], nil, "n4").WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n4", "baz", []byte("quz"), []byte("quz")).WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n4", "foo", []byte("bar"), []byte("bar")).WillReturnResult(mockResult)
+			deleteConfigStmt.ExpectExec().WithArgs("n4", "hello").WillReturnResult(mockResult)
+			deleteConfigStmt.ExpectExec().WithArgs("n4", "world").WillReturnResult(mockResult)
+
+			deleteStmt.WillBeClosed()
+			upsertStmt.WillBeClosed()
+			deleteConfigStmt.WillBeClosed()
+		},
+		run: runFactory(
+			[]storage.NetworkUpdateCriteria{
+				{ID: "n1", DeleteNetwork: true, NewName: &names[0], NewDescription: &descs[0]},
+				{ID: "n2", NewName: &names[1], NewDescription: &descs[1]},
+				{
+					ID:              "n3",
+					ConfigsToDelete: []string{"hello", "world"},
+					ConfigsToAddOrUpdate: map[string][]byte{
+						"foo": []byte("bar"),
+						"baz": []byte("quz"),
+					},
+				},
+				{
+					ID:              "n4",
+					NewName:         &names[2],
+					NewDescription:  &descs[2],
+					ConfigsToDelete: []string{"hello", "world"},
+					ConfigsToAddOrUpdate: map[string][]byte{
+						"foo": []byte("bar"),
+						"baz": []byte("quz"),
+					},
+				},
+			},
+		),
+
+		expectedResult: storage.FailedOperations{},
+	}
+
+	// Error in 1 network should not block other networks (try with 3 networks/2 errors)
+	errorCase := &testCase{
+		setup: func(m sqlmock.Sqlmock) {
+			deleteStmt := m.ExpectPrepare("DELETE FROM cfg_networks")
+			upsertStmt := m.ExpectPrepare("INSERT INTO cfg_network_configs")
+			deleteConfigStmt := m.ExpectPrepare("DELETE FROM cfg_network_configs")
+
+			deleteStmt.ExpectExec().WithArgs("n1").WillReturnError(errors.New("n1 delete error"))
+
+			m.ExpectExec("UPDATE cfg_networks").WithArgs(names[1], descs[1], "n2").WillReturnError(errors.New("n2 update error"))
+
+			m.ExpectExec("UPDATE cfg_networks").WithArgs("n3").WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n3", "baz", []byte("quz"), []byte("quz")).WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n3", "foo", []byte("bar"), []byte("bar")).WillReturnError(errors.New("n3foo update error"))
+
+			m.ExpectExec("UPDATE cfg_networks").WithArgs(names[2], nil, "n4").WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n4", "baz", []byte("quz"), []byte("quz")).WillReturnResult(mockResult)
+			upsertStmt.ExpectExec().WithArgs("n4", "foo", []byte("bar"), []byte("bar")).WillReturnResult(mockResult)
+			deleteConfigStmt.ExpectExec().WithArgs("n4", "hello").WillReturnResult(mockResult)
+			deleteConfigStmt.ExpectExec().WithArgs("n4", "world").WillReturnResult(mockResult)
+
+			deleteStmt.WillBeClosed()
+			upsertStmt.WillBeClosed()
+			deleteConfigStmt.WillBeClosed()
+		},
+		run: runFactory(
+			[]storage.NetworkUpdateCriteria{
+				{ID: "n1", DeleteNetwork: true},
+				{ID: "n2", NewName: &names[1], NewDescription: &descs[1]},
+				{
+					ID:              "n3",
+					ConfigsToDelete: []string{"hello", "world"},
+					ConfigsToAddOrUpdate: map[string][]byte{
+						"foo": []byte("bar"),
+						"baz": []byte("quz"),
+					},
+				},
+				{
+					ID:              "n4",
+					NewName:         &names[2],
+					NewDescription:  &descs[2],
+					ConfigsToDelete: []string{"hello", "world"},
+					ConfigsToAddOrUpdate: map[string][]byte{
+						"foo": []byte("bar"),
+						"baz": []byte("quz"),
+					},
+				},
+			},
+		),
+
+		expectedResult: storage.FailedOperations{
+			"n1": errors.New("error deleting network n1: n1 delete error"),
+			"n2": errors.New("error updating network n2: n2 update error"),
+			"n3": errors.New("error updating config foo on network n3: n3foo update error"),
+		},
+		expectedError: errors.New("some errors were encountered, see return value for details"),
+	}
+
+	validationFailure := &testCase{
+		setup: func(m sqlmock.Sqlmock) {},
+
+		run: runFactory(
+			[]storage.NetworkUpdateCriteria{
+				{ID: "n1", DeleteNetwork: true},
+				{ID: "n1", NewName: &names[1]},
+			},
+		),
+
+		expectedError: errors.New("multiple updates for a single network are not allowed"),
+	}
+
+	runCase(t, happyPath)
+	runCase(t, errorCase)
+	runCase(t, validationFailure)
+}
+
+type testCase struct {
+	// setup mock expectations. Transaction start is expected on the mock
+	// generically
+	setup func(m sqlmock.Sqlmock)
+
+	// run the test case
+	run func(store storage.ConfiguratorStorage) (interface{}, error)
+
+	expectedError      error
+	matchErrorInstance bool
+	expectedResult     interface{}
+}
+
+func runCase(t *testing.T, test *testCase) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error opening stub DB conn: %s", err)
+	}
+	defer func() {
+		err = db.Close()
+		if err != nil {
+			log.Printf("error closing stub DB: %s", err)
+		}
+	}()
+
+	mock.ExpectBegin()
+	test.setup(mock)
+
+	factory := storage.NewSQLConfiguratorStorageFactory(db)
+	store, err := factory.StartTransaction(context.Background(), nil)
+	assert.NoError(t, err)
+	actual, err := test.run(store)
+
+	if test.expectedError != nil {
+		if test.matchErrorInstance {
+			assert.True(t, err == test.expectedError)
+		}
+		assert.EqualError(t, err, test.expectedError.Error())
+	} else {
+		assert.NoError(t, err)
+	}
+
+	if test.expectedResult != nil {
+		assert.Equal(t, test.expectedResult, actual)
+	}
+
+	assert.NoError(t, mock.ExpectationsWereMet())
+}

--- a/orc8r/cloud/go/services/configurator/storage/storage.go
+++ b/orc8r/cloud/go/services/configurator/storage/storage.go
@@ -105,11 +105,16 @@ type Network struct {
 	// configuration value. The type value will point to the Serde
 	// implementation which can deserialize the associated value.
 	Configs map[string][]byte
+
+	Version uint64
 }
 
 // InternalNetworkID is the ID of the network under which all non-tenant
 // entities are organized under.
 const InternalNetworkID = "network_magma_internal"
+
+const internalNetworkName = "Internal Magma Network"
+const internalNetworkDescription = "Internal network to hold non-network entities"
 
 // NetworkLoadCriteria specifies how much of a network to load
 type NetworkLoadCriteria struct {
@@ -118,6 +123,9 @@ type NetworkLoadCriteria struct {
 
 	LoadConfigs bool
 }
+
+// FullNetworkLoadCriteria is a utility variable to specify a full network load
+var FullNetworkLoadCriteria = NetworkLoadCriteria{LoadMetadata: true, LoadConfigs: true}
 
 type NetworkLoadResult struct {
 	Networks           []Network
@@ -134,6 +142,9 @@ type NetworkUpdateCriteria struct {
 	// Set DeleteNetwork to true to delete the network
 	DeleteNetwork bool
 
+	// Set NewName or NewDescription to nil to indicate that no update is
+	// desired. To clear the value of name or description, set these fields to
+	// a pointer to an empty string.
 	NewName        *string
 	NewDescription *string
 

--- a/orc8r/cloud/go/sql_utils/query.go
+++ b/orc8r/cloud/go/sql_utils/query.go
@@ -13,9 +13,22 @@ import (
 	"strings"
 )
 
-// GetPlaceholderArgList returns a string "($1, $2, ..., $numArgs)" for use
-// in a SELECT ... IN query or INSERT query.
+// GetPlaceholderArgList returns a string
+// "(${startIdx}, ${startIdx+1}, ..., ${startIdx+numArgs-1})"
 func GetPlaceholderArgList(startIdx int, numArgs int) string {
+	return GetPlaceholderArgListWithSuffix(startIdx, numArgs, "")
+}
+
+// GetPlaceholderArgListWithSuffix returns a string
+// "(${startIdx}, ${startIdx+1}, ..., ${startIdx+numArgs-1}, {suffix})"
+//
+// The suffix argument is typically used for a field that's being updated
+// in-place in an UPDATE query.
+func GetPlaceholderArgListWithSuffix(startIdx int, numArgs int, suffix string) string {
+	if numArgs == 0 {
+		return fmt.Sprintf("(%s)", suffix)
+	}
+
 	retBuilder := strings.Builder{}
 	retBuilder.WriteString("(")
 
@@ -25,6 +38,11 @@ func GetPlaceholderArgList(startIdx int, numArgs int) string {
 		if i < endIdx-1 {
 			retBuilder.WriteString(", ")
 		}
+	}
+
+	if suffix != "" {
+		retBuilder.WriteString(", ")
+		retBuilder.WriteString(suffix)
 	}
 	retBuilder.WriteString(")")
 	return retBuilder.String()

--- a/orc8r/cloud/go/sql_utils/query_test.go
+++ b/orc8r/cloud/go/sql_utils/query_test.go
@@ -16,23 +16,34 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPlaceholderArgList(t *testing.T) {
+func TestGetPlaceholderArgListWithSuffix(t *testing.T) {
 	testCases := []struct {
 		startIdx int
 		numArgs  int
+		suffix   string
 		expected string
 	}{
-		{1, 3, "($1, $2, $3)"},
-		{1, 1, "($1)"},
-		{1, 0, "()"},
-		{5, 3, "($5, $6, $7)"},
-		{5, 1, "($5)"},
-		{5, 0, "()"},
+		{1, 3, "hello", "($1, $2, $3, hello)"},
+		{1, 3, "", "($1, $2, $3)"},
+		{1, 1, "world", "($1, world)"},
+		{1, 1, "", "($1)"},
+		{1, 0, "", "()"},
+		{1, 0, "foo", "(foo)"},
+		{5, 3, "bar", "($5, $6, $7, bar)"},
+		{5, 3, "", "($5, $6, $7)"},
+		{5, 1, "baz", "($5, baz)"},
+		{5, 1, "", "($5)"},
+		{5, 0, "qux", "(qux)"},
+		{5, 0, "", "()"},
 	}
 
 	for _, testCase := range testCases {
-		actual := sql_utils.GetPlaceholderArgList(testCase.startIdx, testCase.numArgs)
+		actual := sql_utils.GetPlaceholderArgListWithSuffix(testCase.startIdx, testCase.numArgs, testCase.suffix)
 		assert.Equal(t, testCase.expected, actual)
+
+		if testCase.suffix == "" {
+			assert.Equal(t, actual, sql_utils.GetPlaceholderArgList(testCase.startIdx, testCase.numArgs))
+		}
 	}
 }
 

--- a/orc8r/cloud/go/sql_utils/tx.go
+++ b/orc8r/cloud/go/sql_utils/tx.go
@@ -8,7 +8,12 @@ LICENSE file in the root directory of this source tree.
 
 package sql_utils
 
-import "database/sql"
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/golang/glog"
+)
 
 // ExecInTx executes a callback inside a sql transaction on the provided DB.
 // The transaction is rolled back if any error is encountered.
@@ -28,7 +33,9 @@ func ExecInTx(
 		case nil:
 			err = tx.Commit()
 		default:
-			tx.Rollback()
+			if rollbackErr := tx.Rollback(); rollbackErr != nil {
+				err = fmt.Errorf("%s; tx rollback error: %s", err, rollbackErr)
+			}
 		}
 	}()
 
@@ -39,4 +46,40 @@ func ExecInTx(
 
 	ret, err = txFn(tx)
 	return
+}
+
+// PrepareStatements prepares a list of SQL query strings and returns the
+// *sql.Stmt statements in the order that the query strings were provided.
+// Responsibility is on the caller to close the statements.
+func PrepareStatements(tx *sql.Tx, stmtStrings []string) ([]*sql.Stmt, error) {
+	ret := make([]*sql.Stmt, 0, len(stmtStrings))
+	for _, stmtStr := range stmtStrings {
+		stmt, err := tx.Prepare(stmtStr)
+		if err != nil {
+			return nil, fmt.Errorf("error preparing DB statement: %s", err)
+		}
+		ret = append(ret, stmt)
+	}
+	return ret, nil
+}
+
+// GetCloseStatementsDeferFunc returns a function which closes all provided
+// sql statements to defer. Any error encountered while closing a statement
+// will be logged.
+// The callsite argument will be included in the log message for context.
+//
+// IMPORTANT: don't forget to call the returned func() in the defer clause.
+// In other words, this should be used like:
+// 		defer GetCloseStatementsDeferFunc(stmts, "foo")()
+// If you forget the last set of parens, your statements will NOT close.
+func GetCloseStatementsDeferFunc(stmts []*sql.Stmt, callsite string) func() {
+	return func() {
+		for _, stmt := range stmts {
+			if stmt != nil {
+				if err := stmt.Close(); err != nil {
+					glog.Errorf("error closing statement in %s: %s", callsite, err)
+				}
+			}
+		}
+	}
 }


### PR DESCRIPTION
Summary: - Add SQL implementations (postgres-flavored) of network-related methods of the configurator storage interface

Differential Revision: D14936859

