### PR TITLE
Properly handle cloud names and labels in metricsd servicer

### DIFF
--- a/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite_internal_test.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite_internal_test.go
@@ -14,7 +14,7 @@ import (
 
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/metricsd/exporters"
-	"magma/orc8r/cloud/go/services/metricsd/test_common"
+	tc "magma/orc8r/cloud/go/services/metricsd/test_common"
 
 	dto "github.com/prometheus/client_model/go"
 
@@ -22,42 +22,38 @@ import (
 )
 
 const (
-	testFamilyName       = "testFamily"
-	testNetwork          = "test_network"
-	testGateway          = "test_gateway"
-	testMetricLabelName  = "metricLabelName"
-	testMetricLabelValue = "metricLabelValue"
-
-	gIDName = "gatewayID"
-	nIDName = "networkID"
-)
-
-var (
-	testLabelPair = &dto.LabelPair{
-		Name:  test_common.MakeStringPointer(testMetricLabelName),
-		Value: test_common.MakeStringPointer(testMetricLabelValue),
-	}
+	testFamilyName = "testFamily"
+	testNetwork    = "test_network"
+	testGateway    = "test_gateway"
 )
 
 func TestMakeGraphiteName(t *testing.T) {
-	expectedName := fmt.Sprintf("%s;%s=%s;%s=%s", testFamilyName, gIDName, "defaultGateway", nIDName, "defaultNetwork")
+	expectedName := fmt.Sprintf("%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, defaultGateway, NetworkTagName, defaultNetwork)
 	testMakeGraphiteNameHelper(t, "", "", testFamilyName, []*dto.LabelPair{}, expectedName)
 
-	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s;%s=%s", testFamilyName, gIDName, testGateway, testMetricLabelName, testMetricLabelValue, nIDName, testNetwork)
-	testMakeGraphiteNameHelper(t, testNetwork, testGateway, testFamilyName, []*dto.LabelPair{testLabelPair}, expectedName)
+	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, testGateway, tc.SimpleLabelName, tc.SimpleLabelValue, NetworkTagName, testNetwork)
+	testMakeGraphiteNameHelper(t, testNetwork, testGateway, testFamilyName, tc.SimpleLabels, expectedName)
 
-	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s;%s=%s", testFamilyName, gIDName, "defaultGateway", testMetricLabelName, testMetricLabelValue, nIDName, testNetwork)
-	testMakeGraphiteNameHelper(t, testNetwork, "", testFamilyName, []*dto.LabelPair{testLabelPair}, expectedName)
+	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, defaultGateway, tc.SimpleLabelName, tc.SimpleLabelValue, NetworkTagName, testNetwork)
+	testMakeGraphiteNameHelper(t, testNetwork, "", testFamilyName, tc.SimpleLabels, expectedName)
 
-	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s;%s=%s", testFamilyName, gIDName, "defaultGateway", testMetricLabelName, testMetricLabelValue, nIDName, "defaultNetwork")
-	testMakeGraphiteNameHelper(t, "", "", testFamilyName, []*dto.LabelPair{testLabelPair}, expectedName)
+	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, defaultGateway, tc.SimpleLabelName, tc.SimpleLabelValue, NetworkTagName, defaultNetwork)
+	testMakeGraphiteNameHelper(t, "", "", testFamilyName, tc.SimpleLabels, expectedName)
+
+	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, tc.TestGateway, NetworkTagName, tc.TestNetwork)
+	testMakeGraphiteNameHelper(t, tc.TestNetwork, tc.TestGateway, testFamilyName, tc.NetworkLabels, expectedName)
+
+	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, defaultGateway, NetworkTagName, defaultNetwork)
+	testMakeGraphiteNameHelper(t, "", "", testFamilyName, tc.GatewayLabels, expectedName)
+
+	expectedName = fmt.Sprintf("%s;%s=%s;%s=%s", testFamilyName, GatewayTagName, tc.TestGateway, NetworkTagName, tc.TestNetwork)
+	testMakeGraphiteNameHelper(t, tc.TestNetwork, tc.TestGateway, testFamilyName, tc.NetworkAndGatewayLabels, expectedName)
 }
 
 func testMakeGraphiteNameHelper(t *testing.T, networkID, gatewayID, familyName string, labels []*dto.LabelPair, expectedName string) {
-	metric := test_common.MakePromoGauge(100)
+	metric := tc.MakePromoGauge(100)
 	metric.Label = labels
-	family := test_common.MakeTestMetricFamily(dto.MetricType_GAUGE, 1, []*dto.LabelPair{})
-	family.Name = &familyName
+	family := tc.MakeTestMetricFamily(dto.MetricType_GAUGE, familyName, 1, []*dto.LabelPair{})
 	ctx := exporters.MetricsContext{
 		MetricName:  protos.GetDecodedName(family),
 		NetworkID:   networkID,

--- a/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite_test.go
+++ b/orc8r/cloud/go/services/metricsd/graphite/exporters/graphite_test.go
@@ -42,7 +42,7 @@ func testSubmitGraphiteType(t *testing.T, metricType dto.MetricType) {
 		Name:  test_common.MakeStringPointer(mxd_exp.SERVICE_LABEL_NAME),
 		Value: test_common.MakeStringPointer("testService"),
 	}
-	family := test_common.MakeTestMetricFamily(metricType, 1, []*dto.LabelPair{&serviceLabelPair})
+	family := test_common.MakeTestMetricFamily(metricType, "testName", 1, []*dto.LabelPair{&serviceLabelPair})
 	context := mxd_exp.MetricsContext{
 		NetworkID:         "nID",
 		GatewayID:         "gID",

--- a/orc8r/cloud/go/services/metricsd/prometheus/exporters/promo_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/exporters/promo_test.go
@@ -55,7 +55,7 @@ func testSubmitPrometheusType(t *testing.T, metricType dto.MetricType, config ex
 		Name:  test_common.MakeStringPointer(mxd_exp.SERVICE_LABEL_NAME),
 		Value: test_common.MakeStringPointer("testService"),
 	}
-	family := test_common.MakeTestMetricFamily(metricType, 1, []*dto.LabelPair{&serviceLabelPair})
+	family := test_common.MakeTestMetricFamily(metricType, "testName", 1, []*dto.LabelPair{&serviceLabelPair})
 	context := mxd_exp.MetricsContext{
 		NetworkID:         "nID",
 		GatewayID:         "gID",

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_internal_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_internal_test.go
@@ -9,21 +9,33 @@
 package servicers
 
 import (
+	"fmt"
 	"testing"
+
+	"magma/orc8r/cloud/go/services/metricsd/exporters"
+	tc "magma/orc8r/cloud/go/services/metricsd/test_common"
+
+	dto "github.com/prometheus/client_model/go"
 
 	"github.com/stretchr/testify/assert"
 )
 
 const (
-	testCloudName   = "gateway_checkin_status_gatewayId_idfaceb00cfaceb00cface6031973e8372_networkId_mesh_tobias_dogfooding"
+	testCloudNetwork = "mesh_tobias_dogfooding"
+	testCloudGateway = "idfaceb00cfaceb00cface6031973e8372"
+
 	testRegularName = "regular_metric_name"
 	testNoGatewayID = "no_gwID_networkId=test_network"
 )
 
+var (
+	testCloudName = fmt.Sprintf("gateway_checkin_status_gatewayId_%s_networkId_%s", testCloudGateway, testCloudNetwork)
+)
+
 func TestParseCloudMetricName(t *testing.T) {
 	networkID, gatewayID := unpackCloudMetricName(testCloudName)
-	assert.Equal(t, "mesh_tobias_dogfooding", networkID)
-	assert.Equal(t, "idfaceb00cfaceb00cface6031973e8372", gatewayID)
+	assert.Equal(t, testCloudNetwork, networkID)
+	assert.Equal(t, testCloudGateway, gatewayID)
 
 	networkID, gatewayID = unpackCloudMetricName(testRegularName)
 	assert.Equal(t, "", networkID)
@@ -45,4 +57,46 @@ func TestRemoveCloudMetricLabels(t *testing.T) {
 	expectedName = "no_gwID"
 	strippedName = removeCloudMetricLabels(testNoGatewayID)
 	assert.Equal(t, expectedName, strippedName)
+}
+
+type networkAndGatewayTestCase struct {
+	metricLabels    []*dto.LabelPair
+	familyName      string
+	expectedNetwork string
+	expectedGateway string
+}
+
+func (c networkAndGatewayTestCase) runTest(t *testing.T) {
+	family := tc.MakeTestMetricFamily(dto.MetricType_GAUGE, c.familyName, 1, c.metricLabels)
+	networkID, gatewayID := determineCloudNetworkAndGatewayID(family, tc.DefaultGateway)
+	assert.Equal(t, c.expectedNetwork, networkID)
+	assert.Equal(t, c.expectedGateway, gatewayID)
+}
+
+func makeNetworkAndGatewayTestCase(labels []*dto.LabelPair, name, expectedNetwork, expectedGateway string) networkAndGatewayTestCase {
+	return networkAndGatewayTestCase{
+		metricLabels:    labels,
+		familyName:      name,
+		expectedNetwork: expectedNetwork,
+		expectedGateway: expectedGateway,
+	}
+}
+
+func TestDetermineCloudNetworkAndGatewayID(t *testing.T) {
+	testCases := []networkAndGatewayTestCase{
+		// Use labels when none in metric name
+		makeNetworkAndGatewayTestCase(tc.SimpleLabels, testRegularName, exporters.CloudMetricID, tc.DefaultGateway),
+		makeNetworkAndGatewayTestCase(tc.GatewayLabels, testRegularName, exporters.CloudMetricID, tc.TestGateway),
+		makeNetworkAndGatewayTestCase(tc.NetworkLabels, testRegularName, tc.TestNetwork, tc.DefaultGateway),
+		makeNetworkAndGatewayTestCase(tc.NetworkAndGatewayLabels, testRegularName, tc.TestNetwork, tc.TestGateway),
+
+		// Use metric name instead of labels
+		makeNetworkAndGatewayTestCase(tc.SimpleLabels, testCloudName, testCloudNetwork, testCloudGateway),
+		makeNetworkAndGatewayTestCase(tc.GatewayLabels, testCloudName, testCloudNetwork, testCloudGateway),
+		makeNetworkAndGatewayTestCase(tc.NetworkLabels, testCloudName, testCloudNetwork, testCloudGateway),
+		makeNetworkAndGatewayTestCase(tc.NetworkAndGatewayLabels, testCloudName, testCloudNetwork, testCloudGateway),
+	}
+	for _, c := range testCases {
+		c.runTest(t)
+	}
 }

--- a/orc8r/cloud/go/services/metricsd/test_common/utils.go
+++ b/orc8r/cloud/go/services/metricsd/test_common/utils.go
@@ -13,7 +13,41 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
-func MakeTestMetricFamily(metricType dto.MetricType, count int, labels []*dto.LabelPair) *dto.MetricFamily {
+const (
+	TestNetwork = "testNetwork"
+	TestGateway = "testGateway"
+
+	SimpleLabelName  = "name"
+	SimpleLabelValue = "value"
+
+	DefaultGateway = "defaultGateway"
+)
+
+var (
+	SimpleLabelPair = dto.LabelPair{
+		Name:  MakeStringPointer(SimpleLabelName),
+		Value: MakeStringPointer(SimpleLabelValue),
+	}
+	TagLabelPair = dto.LabelPair{
+		Name:  MakeStringPointer("tags"),
+		Value: MakeStringPointer("Tag1,Tag2"),
+	}
+	NetworkLabelPair = dto.LabelPair{
+		Name:  MakeStringPointer("networkId"),
+		Value: MakeStringPointer(TestNetwork),
+	}
+	GatewayLabelPair = dto.LabelPair{
+		Name:  MakeStringPointer("gatewayId"),
+		Value: MakeStringPointer(TestGateway),
+	}
+
+	SimpleLabels            = []*dto.LabelPair{&SimpleLabelPair}
+	GatewayLabels           = []*dto.LabelPair{&GatewayLabelPair}
+	NetworkLabels           = []*dto.LabelPair{&NetworkLabelPair}
+	NetworkAndGatewayLabels = []*dto.LabelPair{&NetworkLabelPair, &GatewayLabelPair}
+)
+
+func MakeTestMetricFamily(metricType dto.MetricType, name string, count int, labels []*dto.LabelPair) *dto.MetricFamily {
 	var testMetric dto.Metric
 	switch metricType {
 	case dto.MetricType_COUNTER:
@@ -32,7 +66,7 @@ func MakeTestMetricFamily(metricType dto.MetricType, count int, labels []*dto.La
 		metrics = append(metrics, &testMetric)
 	}
 	return &dto.MetricFamily{
-		Name:   MakeStringPointer("testFamily"),
+		Name:   MakeStringPointer(name),
 		Help:   MakeStringPointer("testFamilyHelp"),
 		Type:   MakeMetricTypePointer(metricType),
 		Metric: metrics,


### PR DESCRIPTION
Summary:
The MetricsContext object is supposed to hold all the relevant information about a metric. However, with cloud metrics there was ambiguity about the actual networkID and gatewayID due to the different ways that a cloud metric could be named/labeled. This diff makes the context the "source of truth" so exporters do not have to deal with figuring out IDs.

* Parse the network and gateway IDs out of metrics in this order:
  * Inside the metric name: e.g. `metric_name_gatewayId_<gateway>_networkId_<network>`
  * From the labels of the metric
  * Default values `networkID: "cloud"`, `gatewayID: <hostname>`
* Refactor a lot of the testing code to reuse constants
* Add more complete unit tests to servicer, graphite
* Drop `networkId` and `gatewayId` labels in the graphite exporter since those will be parsed into the context

Differential Revision: D14944924

