### PR TITLE
Add the service's loop as a parameter to get_kernel_versions_async

### DIFF
--- a/orc8r/gateway/python/magma/magmad/checkin_manager.py
+++ b/orc8r/gateway/python/magma/magmad/checkin_manager.py
@@ -323,7 +323,7 @@ class CheckinManager(SDWatchdogTask):
 
     async def _check_kernel_versions(self):
         try:
-            result = await get_kernel_versions_async()
+            result = await get_kernel_versions_async(loop=self._loop)
             result = list(result)[0].kernel_versions_installed
             self._kernel_versions_installed = result
         except Exception as e:


### PR DESCRIPTION
Summary:
In checkin_manager, get_kernel_versions_async is called. The function can take in an event loop to run in.
I don't think this was a bug since there is only one loop, but this way it's more explicit.

Reviewed By: vikg-fb

Differential Revision: D14934707

