### PR TITLE
Ignore closed TCP connection from eNodeB

### DIFF
--- a/lte/gateway/python/magma/enodebd/tr069/server.py
+++ b/lte/gateway/python/magma/enodebd/tr069/server.py
@@ -48,7 +48,19 @@ class tr069_WSGIRequestHandler(WSGIRequestHandler):
         )
         handler.http_version = "1.1"
         handler.request_handler = self  # backpointer for logging
-        handler.run(self.server.get_app())
+
+        # eNodeB will sometimes close connection to enodebd.
+        # The cause of this is unknown, but we can safely ignore the
+        # closed connection, and continue as normal otherwise.
+        #
+        # While this throws a BrokenPipe exception in wsgi server,
+        # it also causes an AttributeError to be raised because of a
+        # bug in the wsgi server.
+        # https://bugs.python.org/issue27682
+        try:
+            handler.run(self.server.get_app())
+        except BrokenPipeError:
+            self.log_error("eNodeB has unexpectedly closed the TCP connection.")
 
     def handle(self):
         self.protocol_version = "HTTP/1.1"


### PR DESCRIPTION
Summary:
Sometimes the following stacktrace is observed:

```
Apr 14 22:27:56 magma enodebd[741]: Traceback (most recent call last):
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 138, in run
Apr 14 22:27:56 magma enodebd[741]:     self.finish_response()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 180, in finish_response
Apr 14 22:27:56 magma enodebd[741]:     self.write(data)
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 274, in write
Apr 14 22:27:56 magma enodebd[741]:     self.send_headers()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 332, in send_headers
Apr 14 22:27:56 magma enodebd[741]:     self.send_preamble()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 255, in send_preamble
Apr 14 22:27:56 magma enodebd[741]:     ('Date: %s\r\n' % format_date_time(time.time())).encode('iso-8859-1')
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 453, in _write
Apr 14 22:27:56 magma enodebd[741]:     result = self.stdout.write(data)
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/socket.py", line 594, in write
Apr 14 22:27:56 magma enodebd[741]:     return self._sock.send(b)
Apr 14 22:27:56 magma enodebd[741]: BrokenPipeError: [Errno 32] Broken pipe
Apr 14 22:27:56 magma enodebd[741]: During handling of the above exception, another exception occurred:
Apr 14 22:27:56 magma enodebd[741]: Traceback (most recent call last):
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 141, in run
Apr 14 22:27:56 magma enodebd[741]:     self.handle_error()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 368, in handle_error
Apr 14 22:27:56 magma enodebd[741]:     self.finish_response()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 180, in finish_response
Apr 14 22:27:56 magma enodebd[741]:     self.write(data)
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 274, in write
Apr 14 22:27:56 magma enodebd[741]:     self.send_headers()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 331, in send_headers
Apr 14 22:27:56 magma enodebd[741]:     if not self.origin_server or self.client_is_modern():
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 344, in client_is_modern
Apr 14 22:27:56 magma enodebd[741]:     return self.environ['SERVER_PROTOCOL'].upper() != 'HTTP/0.9'
Apr 14 22:27:56 magma enodebd[741]: TypeError: 'NoneType' object is not subscriptable
Apr 14 22:27:56 magma enodebd[741]: During handling of the above exception, another exception occurred:
Apr 14 22:27:56 magma enodebd[741]: Traceback (most recent call last):
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/socketserver.py", line 313, in _handle_request_noblock
Apr 14 22:27:56 magma enodebd[741]:     self.process_request(request, client_address)
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/socketserver.py", line 341, in process_request
Apr 14 22:27:56 magma enodebd[741]:     self.finish_request(request, client_address)
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/socketserver.py", line 354, in finish_request
Apr 14 22:27:56 magma enodebd[741]:     self.RequestHandlerClass(request, client_address, self)
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/socketserver.py", line 681, in __init__
Apr 14 22:27:56 magma enodebd[741]:     self.handle()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/tr069/server.py", line 59, in handle
Apr 14 22:27:56 magma enodebd[741]:     self.handle_single()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/tr069/server.py", line 51, in handle_single
Apr 14 22:27:56 magma enodebd[741]:     handler.run(self.server.get_app())
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 144, in run
Apr 14 22:27:56 magma enodebd[741]:     self.close()
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/simple_server.py", line 36, in close
Apr 14 22:27:56 magma enodebd[741]:     self.status.split(' ',1)[0], self.bytes_sent
Apr 14 22:27:56 magma enodebd[741]: AttributeError: 'NoneType' object has no attribute 'split'
Apr 14 22:27:56 magma enodebd[741]: Traceback (most recent call last):
Apr 14 22:27:56 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 138, in run
Apr 14 22:27:56 magma enodebd[741]:     self.finish_response()
Apr 14 22:27:57 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 180, in finish_response
Apr 14 22:27:57 magma enodebd[741]:     self.write(data)
Apr 14 22:27:57 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 274, in write
Apr 14 22:27:57 magma enodebd[741]:     self.send_headers()
Apr 14 22:27:57 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 332, in send_headers
Apr 14 22:27:57 magma enodebd[741]:     self.send_preamble()
Apr 14 22:27:57 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 255, in send_preamble
Apr 14 22:27:57 magma enodebd[741]:     ('Date: %s\r\n' % format_date_time(time.time())).encode('iso-8859-1')
Apr 14 22:27:57 magma enodebd[741]:   File "/usr/lib/python3.5/wsgiref/handlers.py", line 453, in _write
Apr 14 22:27:57 magma enodebd[741]:     result = self.stdout.write(data)
Apr 14 22:27:57 magma enodebd[741]:   File "/usr/lib/python3.5/socket.py", line 594, in write
Apr 14 22:27:57 magma enodebd[741]:     return self._sock.send(b)
Apr 14 22:27:57 magma enodebd[741]: BrokenPipeError: [Errno 32] Broken pipe
```

Looking at https://bugs.python.org/issue27682

The stacktrace matches well, and there's a comment:
> This error is a protocol error.  It is the analog to WSAECONNRESET.
ECONNRESET occurs when the local host receives a RST packet from the peer, usually because the peer closed the connection.
WSAECONNABORT occurs when the local tcp layer decides that the connection is dead, (it may have sent RST to the peer itself).  This can occur for various reasons.  Often because the client has cone away, closed the connection or other things.  It is best to treat WSACONNRESET as WSACONNABORT, i.e., there was a TCP protocol error and the transaction (http request) probably wasn't completed completely by both parties.

Because of this, there's reason to suspect that the eNodeB may occasionally close a TCP connection prematurely, and that we need to handle this.
This revision ignores dropped TCP connections, and enodebd will continue running as usual. The dropped TCP connection will be logged though, in case we discover later that there is a way to avoid it.

Reviewed By: xjtian

Differential Revision: D14944680

