### PR TITLE
Implement GetOperationalStates callback for enodebd

### DIFF
--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -12,6 +12,7 @@ import (
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/services/cellular/config"
 	cellularh "magma/lte/cloud/go/services/cellular/obsidian/handlers"
+	"magma/lte/cloud/go/services/cellular/state"
 	meteringdh "magma/lte/cloud/go/services/meteringd_records/obsidian/handlers"
 	policydbh "magma/lte/cloud/go/services/policydb/obsidian/handlers"
 	policydbstreamer "magma/lte/cloud/go/services/policydb/streamer"
@@ -48,6 +49,7 @@ func (*LteOrchestratorPlugin) GetSerdes() []serde.Serde {
 		&config.CellularNetworkConfigManager{},
 		&config.CellularGatewayConfigManager{},
 		&config.CellularEnodebConfigManager{},
+		&state.EnodebStateSerde{},
 	}
 }
 

--- a/lte/cloud/go/services/cellular/state/serdes.go
+++ b/lte/cloud/go/services/cellular/state/serdes.go
@@ -1,0 +1,42 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package state
+
+import (
+	"encoding/json"
+
+	"magma/lte/cloud/go/protos"
+	"magma/orc8r/cloud/go/services/state"
+)
+
+const (
+	enodebStateType = "enodebd"
+)
+
+// EnodebStateSerde is used to serialize/deserialize enodeb operational states
+type EnodebStateSerde struct {
+}
+
+func (*EnodebStateSerde) GetDomain() string {
+	return state.SerdeDomain
+}
+
+func (*EnodebStateSerde) GetType() string {
+	return enodebStateType
+}
+
+func (*EnodebStateSerde) Serialize(in interface{}) ([]byte, error) {
+	return json.Marshal(in)
+}
+
+func (*EnodebStateSerde) Deserialize(message []byte) (interface{}, error) {
+	res := protos.SingleEnodebStatus{}
+	err := json.Unmarshal(message, &res)
+	return res, err
+}

--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -9,13 +9,15 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 from threading import Thread
 from unittest import mock
-from magma.enodebd.enodeb_status import get_status
+from magma.enodebd.enodeb_status import get_status, get_operational_states
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
 from .rpc_servicer import EnodebdRpcServicer
 from .stats_manager import StatsManager
 from .tr069.server import tr069_server
 from .enodebd_iptables_rules import set_enodebd_iptables_rule
 from magma.common.service import MagmaService
+from orc8r.protos.service303_pb2 import State
+from typing import List
 
 
 def get_context(ip: str):
@@ -52,6 +54,11 @@ def main():
     def get_enodebd_status():
         return get_status(state_machine_manager)
     service.register_get_status_callback(get_enodebd_status)
+
+    # Register a callback function for GetOperationalStates service303 function
+    def get_enodeb_operational_states() -> List[State]:
+        return get_operational_states(state_machine_manager)
+    service.register_operational_states_callback(get_enodeb_operational_states)
 
     # Set eNodeBD iptables rules due to exposing public IP to eNodeB
     service.loop.create_task(set_enodebd_iptables_rule())


### PR DESCRIPTION
Summary:
Per-enodeb operational states (`SingleEnodebStatus`) are now reported to the cloud state service.
A callback function `get_enodeb_operational_states` collects operating information about all enodebs connected to the enodebd and encodes them into a list of States.
The state service will use EnodebStateSerde to deserialize the states.

Differential Revision: D15064644

