### PR TITLE
Make StatsManager into an observer of the state machine

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -29,17 +29,15 @@ from magma.enodebd.state_machines.enb_acs_states import EnodebAcsState, \
     BaicellsSendRebootState, WaitRebootResponseState, WaitInformMRebootState, \
     CheckOptionalParamsState, WaitEmptyMessageState, ErrorState, \
     EndSessionState, BaicellsRemWaitState
-from magma.enodebd.stats_manager import StatsManager
 
 
 class BaicellsHandler(BasicEnodebAcsStateMachine):
     def __init__(
         self,
         service: MagmaService,
-        stats_mgr: StatsManager,
     ) -> None:
         self._state_map = {}
-        super().__init__(service, stats_mgr)
+        super().__init__(service)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -29,17 +29,15 @@ from magma.enodebd.state_machines.enb_acs_states import \
     WaitRebootResponseState, WaitInformMRebootState, EnodebAcsState, \
     CheckOptionalParamsState, WaitEmptyMessageState, ErrorState, \
     EndSessionState, BaicellsRemWaitState, BaicellsSendRebootState
-from magma.enodebd.stats_manager import StatsManager
 
 
 class BaicellsOldHandler(BasicEnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ) -> None:
         self._state_map = {}
-        super().__init__(service, stats_mgr)
+        super().__init__(service)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -34,17 +34,15 @@ from magma.enodebd.state_machines.enb_acs_states import WaitInformState, \
 from magma.enodebd.state_machines.acs_state_utils import \
      get_all_objects_to_delete, get_all_objects_to_add
 from magma.enodebd.tr069 import models
-from magma.enodebd.stats_manager import StatsManager
 
 
 class CaviumHandler(BasicEnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ) -> None:
         self._state_map = {}
-        super().__init__(service, stats_mgr)
+        super().__init__(service)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -154,7 +154,7 @@ def _parse_param_as_bool(
     """
     try:
         param = enodeb.get_parameter(param_name)
-        pval = param.lower().strip()
+        pval = str(param).lower().strip()
         if pval in {'true', '1'}:
             return '1'
         elif pval in {'false', '0'}:

--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -31,7 +31,7 @@ def main():
     # We incorrectly assume that we are dealing with a Baicells device here.
     # When this assumption is invalidated (after the device reports its
     # make and model, then we recreate a new handler to use
-    acs_state_machine = BaicellsHandler(service, stats_mgr)
+    acs_state_machine = BaicellsHandler(service)
     state_machine_pointer = StateMachinePointer(acs_state_machine)
 
     # Start TR-069 thread

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
@@ -18,7 +18,6 @@ from magma.enodebd.device_config.enodeb_configuration import \
     EnodebConfiguration
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.state_machines.acs_state_utils import are_tr069_params_equal
-from magma.enodebd.stats_manager import StatsManager
 
 
 class EnodebAcsStateMachine(ABC):
@@ -38,7 +37,6 @@ class EnodebAcsStateMachine(ABC):
 
     def __init__(self) -> None:
         self._service = None
-        self._stats_manager = None
         self._desired_cfg = None
         self._device_cfg = None
         self._data_model = None
@@ -122,14 +120,6 @@ class EnodebAcsStateMachine(ABC):
     @property
     def service_config(self) -> Any:
         return self._service.config
-
-    @property
-    def stats_manager(self) -> StatsManager:
-        return self._stats_manager
-
-    @stats_manager.setter
-    def stats_manager(self, val: StatsManager) -> None:
-        self._stats_manager = val
 
     @property
     def desired_cfg(self) -> EnodebConfiguration:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -13,14 +13,13 @@ from typing import Any, Dict
 from abc import abstractmethod
 from magma.common.service import MagmaService
 from magma.enodebd import metrics
+from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.device_config.enodeb_configuration import \
     EnodebConfiguration
-from magma.enodebd.enodeb_status import get_enodeb_status
 from magma.enodebd.exceptions import ConfigurationError
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_states import EnodebAcsState
 from magma.enodebd.state_machines.timer import StateMachineTimer
-from magma.enodebd.stats_manager import StatsManager
 from magma.enodebd.tr069 import models
 from magma.enodebd.tr069.models import Tr069ComplexModel
 
@@ -54,14 +53,13 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ) -> None:
         super().__init__()
         self.state = None
         self.timeout_handler = None
         self.mme_timeout_handler = None
         self.mme_timer = None
-        self._start_state_machine(service, stats_mgr)
+        self._start_state_machine(service)
 
     def get_state(self) -> str:
         if self.state is None:
@@ -107,7 +105,6 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
             self.mme_timeout_handler.cancel()
             self.timeout_handler.cancel()
         self._service = None
-        self._stats_manager = None
         self._desired_cfg = None
         self._device_cfg = None
         self._data_model = None
@@ -119,10 +116,8 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def _start_state_machine(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ):
         self.service = service
-        self.stats_manager = stats_mgr
         self.data_model = self.data_model_class()
         # The current known device config has few known parameters
         # The desired configuration depends on what the current configuration
@@ -138,10 +133,9 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def _reset_state_machine(
         self,
         service: MagmaService,
-        stats_mgr: StatsManager,
     ):
         self.stop_state_machine()
-        self._start_state_machine(service, stats_mgr)
+        self._start_state_machine(service)
 
     def _read_tr069_msg(self, message: Any) -> None:
         """ Process incoming message and maybe transition state """
@@ -171,7 +165,7 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         if isinstance(message, models.Inform):
             logging.debug('ACS in (%s) state. Received an Inform message',
                           self.state.state_description())
-            self._reset_state_machine(self.service, self.stats_manager)
+            self._reset_state_machine(self.service)
         elif isinstance(message, models.Fault):
             logging.debug('ACS in (%s) state. Received a Fault <%s>',
                           self.state.state_description(), message.FaultString)
@@ -209,14 +203,18 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         This method checks the last polled MME connection status, and if
         eNodeB should be connected to MME but it isn't.
         """
-        status = get_enodeb_status(self)
+        if self.device_cfg.has_parameter(ParameterName.MME_STATUS) and \
+                self.device_cfg.get_parameter(ParameterName.MME_STATUS):
+            is_mme_connected = 1
+        else:
+            is_mme_connected = 0
 
         # True if we would expect MME to be connected, but it isn't
         is_mme_unexpectedly_dc = \
             self.is_enodeb_connected() \
             and self.is_enodeb_configured() \
             and self.mconfig.allow_enodeb_transmit \
-            and not status['mme_connected'] == '1'
+            and not is_mme_connected
 
         if is_mme_unexpectedly_dc:
             logging.warning('eNodeB is connected to AGw, is configured, '

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -8,17 +8,44 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import pkg_resources
-from unittest import TestCase
+from unittest import TestCase, mock
 from xml.etree import ElementTree
-
 from magma.enodebd import metrics
+from magma.enodebd.data_models.data_model_parameters import ParameterName
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.state_machines.enb_acs_pointer import StateMachinePointer
 from magma.enodebd.stats_manager import StatsManager
+from magma.enodebd.tests.test_utils.enb_acs_builder import \
+    EnodebAcsStateMachineBuilder
 
 
 class StatsManagerTest(TestCase):
     """
     Tests for eNodeB statistics manager
     """
+    def setUp(self) -> None:
+        handler = EnodebAcsStateMachineBuilder\
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+        state_machine_pointer = StateMachinePointer
+        state_machine_pointer.state_machine = handler
+        self.mgr = StatsManager(state_machine_pointer)
+        self.is_clear_stats_called = False
+
+    def tearDown(self):
+        self.mgr = None
+
+    def test_check_rf_tx(self):
+        """ Check that stats are cleared when transmit is disabled on eNB """
+        handler = EnodebAcsStateMachineBuilder \
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+        handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, True)
+        with mock.patch('magma.enodebd.stats_manager.StatsManager'
+                        '._clear_stats') as func:
+            self.mgr._check_rf_tx_for_handler(handler)
+            func.assert_not_called()
+            handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, False)
+            self.mgr._check_rf_tx_for_handler(handler)
+            func.assert_any_call()
 
     def test_parse_stats(self):
         """ Test that example statistics from eNodeB can be parsed, and metrics
@@ -28,9 +55,7 @@ class StatsManagerTest(TestCase):
                                                         'pm_file_example.xml')
 
         root = ElementTree.fromstring(pm_file_example)
-
-        mgr = StatsManager()
-        mgr.parse_pm_xml(root)
+        self.mgr._parse_pm_xml(root)
 
         # Check that metrics were correctly populated
         # See '<V i="5">123</V>' in pm_file_example

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
@@ -13,7 +13,6 @@ from magma.common.service import MagmaService
 from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
-from magma.enodebd.stats_manager import StatsManager
 from magma.enodebd.tests.test_utils.config_builder import EnodebConfigBuilder
 
 
@@ -24,10 +23,9 @@ class EnodebAcsStateMachineBuilder:
         device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
     ) -> EnodebAcsStateMachine:
         # Build the state_machine
-        stats_mgr = StatsManager()
         service = cls.build_magma_service(device)
         handler_class = get_device_handler_from_name(device)
-        acs_state_machine = handler_class(service, stats_mgr)
+        acs_state_machine = handler_class(service)
         return acs_state_machine
 
     @classmethod


### PR DESCRIPTION
Summary:
This revision reverses the relationship between the state machine and StatsManager.

Instead of the state machine (henceforth called the 'handler') being responsible for clearing stats on the StatsManager whenever the eNodeB stops transmitting, the StatsManager will keep a reference to the handler.

The StatsManager will indirectly observe the state of the eNodeB through the handler. When it detects that that the eNodeB has stopped transmitting, then stats will be cleared.

This change is useful for two reasons:
1) This reorganizes dependencies into a stricter hierarchy, and avoids circular dependencies later on.
2) The StatsManager and the handler/state-machine have a better separation of responsibility.

Reviewed By: ssanadhya

Differential Revision: D14663225

