### PR TITLE
(1/3) Integrate enb acs manager: StatsManager changed to use eNodeB ACS Manager

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -29,17 +29,15 @@ from magma.enodebd.state_machines.enb_acs_states import EnodebAcsState, \
     BaicellsSendRebootState, WaitRebootResponseState, WaitInformMRebootState, \
     CheckOptionalParamsState, WaitEmptyMessageState, ErrorState, \
     EndSessionState, BaicellsRemWaitState
-from magma.enodebd.stats_manager import StatsManager
 
 
 class BaicellsHandler(BasicEnodebAcsStateMachine):
     def __init__(
         self,
         service: MagmaService,
-        stats_mgr: StatsManager,
     ) -> None:
         self._state_map = {}
-        super().__init__(service, stats_mgr)
+        super().__init__(service)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -29,17 +29,15 @@ from magma.enodebd.state_machines.enb_acs_states import \
     WaitRebootResponseState, WaitInformMRebootState, EnodebAcsState, \
     CheckOptionalParamsState, WaitEmptyMessageState, ErrorState, \
     EndSessionState, BaicellsRemWaitState, BaicellsSendRebootState
-from magma.enodebd.stats_manager import StatsManager
 
 
 class BaicellsOldHandler(BasicEnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ) -> None:
         self._state_map = {}
-        super().__init__(service, stats_mgr)
+        super().__init__(service)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -34,17 +34,15 @@ from magma.enodebd.state_machines.enb_acs_states import WaitInformState, \
 from magma.enodebd.state_machines.acs_state_utils import \
      get_all_objects_to_delete, get_all_objects_to_add
 from magma.enodebd.tr069 import models
-from magma.enodebd.stats_manager import StatsManager
 
 
 class CaviumHandler(BasicEnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ) -> None:
         self._state_map = {}
-        super().__init__(service, stats_mgr)
+        super().__init__(service)
 
     def reboot_asap(self) -> None:
         self.transition('reboot')

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -154,7 +154,7 @@ def _parse_param_as_bool(
     """
     try:
         param = enodeb.get_parameter(param_name)
-        pval = param.lower().strip()
+        pval = str(param).lower().strip()
         if pval in {'true', '1'}:
             return '1'
         elif pval in {'false', '0'}:

--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -31,7 +31,7 @@ def main():
     # We incorrectly assume that we are dealing with a Baicells device here.
     # When this assumption is invalidated (after the device reports its
     # make and model, then we recreate a new handler to use
-    acs_state_machine = BaicellsHandler(service, stats_mgr)
+    acs_state_machine = BaicellsHandler(service)
     state_machine_pointer = StateMachinePointer(acs_state_machine)
 
     # Start TR-069 thread

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs.py
@@ -18,7 +18,6 @@ from magma.enodebd.device_config.enodeb_configuration import \
     EnodebConfiguration
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.state_machines.acs_state_utils import are_tr069_params_equal
-from magma.enodebd.stats_manager import StatsManager
 
 
 class EnodebAcsStateMachine(ABC):
@@ -38,7 +37,6 @@ class EnodebAcsStateMachine(ABC):
 
     def __init__(self) -> None:
         self._service = None
-        self._stats_manager = None
         self._desired_cfg = None
         self._device_cfg = None
         self._data_model = None
@@ -122,14 +120,6 @@ class EnodebAcsStateMachine(ABC):
     @property
     def service_config(self) -> Any:
         return self._service.config
-
-    @property
-    def stats_manager(self) -> StatsManager:
-        return self._stats_manager
-
-    @stats_manager.setter
-    def stats_manager(self, val: StatsManager) -> None:
-        self._stats_manager = val
 
     @property
     def desired_cfg(self) -> EnodebConfiguration:

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -13,14 +13,13 @@ from typing import Any, Dict
 from abc import abstractmethod
 from magma.common.service import MagmaService
 from magma.enodebd import metrics
+from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.device_config.enodeb_configuration import \
     EnodebConfiguration
-from magma.enodebd.enodeb_status import get_enodeb_status
 from magma.enodebd.exceptions import ConfigurationError
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_states import EnodebAcsState
 from magma.enodebd.state_machines.timer import StateMachineTimer
-from magma.enodebd.stats_manager import StatsManager
 from magma.enodebd.tr069 import models
 from magma.enodebd.tr069.models import Tr069ComplexModel
 
@@ -54,14 +53,13 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def __init__(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ) -> None:
         super().__init__()
         self.state = None
         self.timeout_handler = None
         self.mme_timeout_handler = None
         self.mme_timer = None
-        self._start_state_machine(service, stats_mgr)
+        self._start_state_machine(service)
 
     def get_state(self) -> str:
         if self.state is None:
@@ -107,7 +105,6 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
             self.mme_timeout_handler.cancel()
             self.timeout_handler.cancel()
         self._service = None
-        self._stats_manager = None
         self._desired_cfg = None
         self._device_cfg = None
         self._data_model = None
@@ -119,10 +116,8 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def _start_state_machine(
             self,
             service: MagmaService,
-            stats_mgr: StatsManager,
     ):
         self.service = service
-        self.stats_manager = stats_mgr
         self.data_model = self.data_model_class()
         # The current known device config has few known parameters
         # The desired configuration depends on what the current configuration
@@ -138,10 +133,9 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
     def _reset_state_machine(
         self,
         service: MagmaService,
-        stats_mgr: StatsManager,
     ):
         self.stop_state_machine()
-        self._start_state_machine(service, stats_mgr)
+        self._start_state_machine(service)
 
     def _read_tr069_msg(self, message: Any) -> None:
         """ Process incoming message and maybe transition state """
@@ -171,7 +165,7 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         if isinstance(message, models.Inform):
             logging.debug('ACS in (%s) state. Received an Inform message',
                           self.state.state_description())
-            self._reset_state_machine(self.service, self.stats_manager)
+            self._reset_state_machine(self.service)
         elif isinstance(message, models.Fault):
             logging.debug('ACS in (%s) state. Received a Fault <%s>',
                           self.state.state_description(), message.FaultString)
@@ -209,14 +203,18 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         This method checks the last polled MME connection status, and if
         eNodeB should be connected to MME but it isn't.
         """
-        status = get_enodeb_status(self)
+        if self.device_cfg.has_parameter(ParameterName.MME_STATUS) and \
+                self.device_cfg.get_parameter(ParameterName.MME_STATUS):
+            is_mme_connected = 1
+        else:
+            is_mme_connected = 0
 
         # True if we would expect MME to be connected, but it isn't
         is_mme_unexpectedly_dc = \
             self.is_enodeb_connected() \
             and self.is_enodeb_configured() \
             and self.mconfig.allow_enodeb_transmit \
-            and not status['mme_connected'] == '1'
+            and not is_mme_connected
 
         if is_mme_unexpectedly_dc:
             logging.warning('eNodeB is connected to AGw, is configured, '

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
@@ -1,0 +1,207 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import logging
+from typing import Any, Optional, List
+from magma.common.service import MagmaService
+from magma.enodebd.devices.device_map import get_device_handler_from_name
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
+from magma.enodebd.state_machines.acs_state_utils import \
+    get_device_name_from_inform
+from magma.enodebd.tr069 import models
+from spyne import ComplexModelBase
+from spyne.server.wsgi import WsgiMethodContext
+
+
+class StateMachineManager:
+    """
+    Delegates tr069 message handling to a dedicated state machine for the
+    device.
+    """
+    def __init__(
+        self,
+        service: MagmaService,
+    ):
+        self._ip_serial_mapping = IpToSerialMapping()
+        self._service = service
+        self._state_machine_by_ip = {}
+
+    def handle_tr069_message(
+        self,
+        ctx: WsgiMethodContext,
+        tr069_message: ComplexModelBase,
+    ) -> Any:
+        """ Delegate message handling to the appropriate eNB state machine """
+        client_ip = self._get_client_ip(ctx)
+        if isinstance(tr069_message, models.Inform):
+            self._update_device_mapping(client_ip, tr069_message)
+        handler = self._get_handler(client_ip)
+
+        if handler is None:
+            logging.warning('Received non-Inform tr069 msg from unknown eNB. '
+                            'Ending session with empty HTTP response.')
+            return models.DummyInput()
+
+        return handler.handle_tr069_message(tr069_message)
+
+    def get_handler_by_ip(self, client_ip: str) -> EnodebAcsStateMachine:
+        return self._state_machine_by_ip[client_ip]
+
+    def get_handler_by_serial(self, enb_serial: str) -> EnodebAcsStateMachine:
+        client_ip = self._ip_serial_mapping.get_ip(enb_serial)
+        return self._state_machine_by_ip[client_ip]
+
+    def get_connected_serial_id_list(self) -> List[str]:
+        return self._ip_serial_mapping.get_serial_list()
+
+    def get_ip_of_serial(self, enb_serial: str) -> str:
+        return self._ip_serial_mapping.get_ip(enb_serial)
+
+    def _get_handler(
+        self,
+        client_ip: str,
+    ) -> EnodebAcsStateMachine:
+        return self._state_machine_by_ip[client_ip]
+
+    def _update_device_mapping(
+        self,
+        client_ip: str,
+        inform: models.Inform,
+    ) -> None:
+        """
+        When receiving an Inform message, we can figure out what device we
+        are talking to. We can also see if the IP has changed, and the
+        StateMachineManager must track this so that subsequent tr069
+        messages can be handled correctly.
+        """
+        enb_serial = self._parse_msg_for_serial(inform)
+        self._associate_serial_to_ip(client_ip, enb_serial)
+        handler = self._get_handler(client_ip)
+        if handler is None:
+            device_name = get_device_name_from_inform(inform)
+            handler = self._build_handler(device_name)
+            self._state_machine_by_ip[client_ip] = handler
+
+    def _associate_serial_to_ip(
+        self,
+        client_ip: str,
+        enb_serial: str,
+    ) -> None:
+        """
+        If a device/IP combination changes, then the StateMachineManager
+        must detect this, and update its mapping of what serial/IP corresponds
+        to which handler.
+        """
+        if enb_serial is None:
+            # TR-069 message did not contain an eNodeB serial ID.
+            logging.error('Cannot associate null eNB serial to a an IP')
+            pass
+        elif self._ip_serial_mapping.has_ip(client_ip):
+            # Same IP, different eNB connected
+            prev_serial = self._ip_serial_mapping.get_serial(client_ip)
+            if enb_serial != prev_serial:
+                logging.info('eNodeB change on IP <%s>, from %s to %s',
+                             client_ip, prev_serial, enb_serial)
+                self._ip_serial_mapping.set_ip_and_serial(client_ip, enb_serial)
+                self._state_machine_by_ip[client_ip] = None
+        elif self._ip_serial_mapping.has_serial(enb_serial):
+            # Same eNB, different IP
+            prev_ip = self._ip_serial_mapping.get_ip(enb_serial)
+            if client_ip != prev_ip:
+                logging.info('eNodeB <%s> changed IP from %s to %s',
+                             enb_serial, prev_ip, client_ip)
+                self._ip_serial_mapping.set_ip_and_serial(client_ip, enb_serial)
+                handler = self._state_machine_by_ip[prev_ip]
+                self._state_machine_by_ip[client_ip] = handler
+                del self._state_machine_by_ip[prev_ip]
+        else:
+            # TR069 message is coming from a different IP, and a different
+            # serial ID. No need to change mapping
+            handler = None
+            self._ip_serial_mapping.set_ip_and_serial(client_ip, enb_serial)
+            self._state_machine_by_ip[client_ip] = handler
+
+    def _parse_msg_for_serial(
+        self,
+        tr069_message: models.Inform,
+    ) -> Optional[str]:
+        """ Return the eNodeB serial ID if it's found in the message """
+        if not isinstance(tr069_message, models.Inform):
+            return
+        if not hasattr(tr069_message, 'ParameterList') or \
+                not hasattr(tr069_message.ParameterList, 'ParameterValueStruct'):
+            return None
+
+        # Parse the parameters
+        param_values_by_path = {}
+        for param_value in tr069_message.ParameterList.ParameterValueStruct:
+            path = param_value.Name
+            value = param_value.Value.Data
+            param_values_by_path[path] = value
+
+        enb_serial = param_values_by_path['Device.DeviceInfo.SerialNumber']
+        return enb_serial
+
+    def _get_client_ip(self, ctx: WsgiMethodContext) -> str:
+        return ctx.transport.req_env.get("REMOTE_ADDR", "unknown")
+
+    def _build_handler(
+        self,
+        device_name: EnodebDeviceName,
+    ) -> EnodebAcsStateMachine:
+        """
+        Create a new state machine based on the device type
+        """
+        device_handler_class = get_device_handler_from_name(device_name)
+        acs_state_machine = device_handler_class(self._service)
+        return acs_state_machine
+
+
+class IpToSerialMapping:
+    """ Bidirectional map between <eNodeB IP> and <eNodeB serial ID> """
+    def __init__(self) -> None:
+        self.ip_by_enb_serial = {}
+        self.enb_serial_by_ip = {}
+
+    def del_ip(self, ip: str) -> None:
+        if ip not in self.enb_serial_by_ip:
+            raise KeyError('Cannot delete missing IP')
+        serial = self.enb_serial_by_ip[ip]
+        del self.enb_serial_by_ip[ip]
+        del self.ip_by_enb_serial[serial]
+
+    def del_serial(self, serial: str) -> None:
+        if serial not in self.ip_by_enb_serial:
+            raise KeyError('Cannot delete missing eNodeB serial ID')
+        ip = self.ip_by_enb_serial[serial]
+        del self.ip_by_enb_serial[serial]
+        del self.enb_serial_by_ip[ip]
+
+    def set_ip_and_serial(self, ip: str, serial: str) -> None:
+        self.ip_by_enb_serial[serial] = ip
+        self.enb_serial_by_ip[ip] = serial
+
+    def get_ip(self, serial: str) -> str:
+        return self.ip_by_enb_serial[serial]
+
+    def get_serial(self, ip: str) -> str:
+        return self.enb_serial_by_ip[ip]
+
+    def has_ip(self, ip: str) -> bool:
+        return ip in self.enb_serial_by_ip
+
+    def has_serial(self, serial: str) -> bool:
+        return serial in self.ip_by_enb_serial
+
+    def get_serial_list(self) -> List[str]:
+        return list(self.ip_by_enb_serial.keys())
+
+    def get_ip_list(self) -> List[str]:
+        return list(self.enb_serial_by_ip.keys())

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -116,8 +116,8 @@ class WaitInformState(EnodebAcsState):
         """
         if not isinstance(message, models.Inform):
             return AcsReadMsgResult(False, None)
-        process_inform_message(message, self.acs.device_name,
-                               self.acs.data_model, self.acs.device_cfg)
+        process_inform_message(message, self.acs.data_model,
+                               self.acs.device_cfg)
         if does_inform_have_event(message, '1 BOOT'):
             return AcsReadMsgResult(True, self.boot_transition)
         return AcsReadMsgResult(True, None)
@@ -200,8 +200,8 @@ class BaicellsRemWaitState(EnodebAcsState):
     def read_msg(self, message: Any) -> AcsReadMsgResult:
         if not isinstance(message, models.Inform):
             return AcsReadMsgResult(False, None)
-        process_inform_message(message, self.acs.device_name,
-                               self.acs.data_model, self.acs.device_cfg)
+        process_inform_message(message, self.acs.data_model,
+                               self.acs.device_cfg)
         return AcsReadMsgResult(True, None)
 
     def get_msg(self) -> AcsMsgAndTransition:
@@ -899,8 +899,8 @@ class BaicellsSendRebootState(EnodebAcsState):
             return AcsReadMsgResult(False, None)
         elif isinstance(message, models.Inform):
             self.prev_msg_was_inform = True
-            process_inform_message(message, self.acs.device_name,
-                                   self.acs.data_model, self.acs.device_cfg)
+            process_inform_message(message, self.acs.data_model,
+                                   self.acs.device_cfg)
             return AcsReadMsgResult(True, None)
         self.prev_msg_was_inform = False
         return AcsReadMsgResult(True, None)
@@ -939,8 +939,8 @@ class SendRebootState(EnodebAcsState):
             return AcsReadMsgResult(False, None)
         elif isinstance(message, models.Inform):
             self.prev_msg_was_inform = True
-            process_inform_message(message, self.acs.device_name,
-                                   self.acs.data_model, self.acs.device_cfg)
+            process_inform_message(message, self.acs.data_model,
+                                   self.acs.device_cfg)
             return AcsReadMsgResult(True, None)
         self.prev_msg_was_inform = False
         return AcsReadMsgResult(True, None)
@@ -1030,8 +1030,8 @@ class WaitInformMRebootState(EnodebAcsState):
         if not does_inform_have_event(message, self.INFORM_EVENT_CODE):
             raise Tr069Error('Did not receive M Reboot event code in '
                              'Inform')
-        process_inform_message(message, self.acs.device_name,
-                               self.acs.data_model, self.acs.device_cfg)
+        process_inform_message(message, self.acs.data_model,
+                               self.acs.device_cfg)
         return AcsReadMsgResult(True, self.done_transition)
 
     @classmethod

--- a/lte/gateway/python/magma/enodebd/tests/enb_acs_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enb_acs_manager_tests.py
@@ -1,0 +1,184 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+# pylint: disable=protected-access
+from unittest import TestCase, mock
+from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
+from magma.enodebd.tr069 import models
+from spyne.server.wsgi import WsgiMethodContext
+from magma.enodebd.tests.test_utils.enb_acs_builder import \
+    EnodebAcsStateMachineBuilder
+from magma.enodebd.tests.test_utils.tr069_msg_builder import \
+    Tr069MessageBuilder
+
+
+class StateMachineManagerTests(TestCase):
+    def test_handle_one_ip(self):
+        manager = self._get_manager()
+
+        # Send in an Inform message, and we should get an InformResponse
+        ctx = self._get_spyne_context_with_ip()
+        inform = Tr069MessageBuilder.get_inform()
+        req = manager.handle_tr069_message(ctx, inform)
+        self.assertTrue(isinstance(req, models.InformResponse),
+                        'State machine handler should reply with an '
+                        'InformResponse')
+
+    def test_handle_two_ips(self):
+        manager = self._get_manager()
+        ctx1 = self._get_spyne_context_with_ip("192.168.60.145")
+        ctx2 = self._get_spyne_context_with_ip("192.168.60.99")
+
+        ##### Start session for the first IP #####
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0001')
+        resp1 = manager.handle_tr069_message(ctx1, inform_msg)
+        self.assertTrue(isinstance(resp1, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+        # Send an empty http request to kick off the rest of provisioning
+        req1 = models.DummyInput()
+        resp1 = manager.handle_tr069_message(ctx1, req1)
+
+        # Expect a request for an optional parameter, three times
+        self.assertTrue(isinstance(resp1, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req1 = Tr069MessageBuilder.get_fault()
+        resp1 = manager.handle_tr069_message(ctx1, req1)
+        self.assertTrue(isinstance(resp1, models.GetParameterValues),
+                        'State machine should be requesting param values')
+
+        ##### Start session for the second IP #####
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0002')
+        resp2 = manager.handle_tr069_message(ctx2, inform_msg)
+        self.assertTrue(isinstance(resp2, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+        ##### Continue session for the first IP #####
+        req1 = Tr069MessageBuilder.get_fault()
+        resp1 = manager.handle_tr069_message(ctx1, req1)
+        self.assertTrue(isinstance(resp1, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req1 = Tr069MessageBuilder.get_fault()
+        resp1 = manager.handle_tr069_message(ctx1, req1)
+        # Expect a request for read-only params
+        self.assertTrue(isinstance(resp1, models.GetParameterValues),
+                        'State machine should be requesting param values')
+
+        ##### Continue session for the second IP #####
+        # Send an empty http request to kick off the rest of provisioning
+        req2 = models.DummyInput()
+        resp2 = manager.handle_tr069_message(ctx2, req2)
+        # Expect a request for an optional parameter, three times
+        self.assertTrue(isinstance(resp2, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req2 = Tr069MessageBuilder.get_fault()
+        resp2 = manager.handle_tr069_message(ctx2, req2)
+        self.assertTrue(isinstance(resp2, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req2 = Tr069MessageBuilder.get_fault()
+        resp2 = manager.handle_tr069_message(ctx2, req2)
+        self.assertTrue(isinstance(resp2, models.GetParameterValues),
+                        'State machine should be requesting param values')
+        req2 = Tr069MessageBuilder.get_fault()
+        resp2 = manager.handle_tr069_message(ctx2, req2)
+        # Expect a request for read-only params
+        self.assertTrue(isinstance(resp2, models.GetParameterValues),
+                        'State machine should be requesting param values')
+
+    def test_ip_change(self) -> None:
+        manager = self._get_manager()
+
+        # Send an Inform
+        ip1 = "192.168.60.145"
+        ctx1 = self._get_spyne_context_with_ip(ip1)
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0003')
+        resp1 = manager.handle_tr069_message(ctx1, inform_msg)
+        self.assertTrue(isinstance(resp1, models.InformResponse),
+                        'Should respond with an InformResponse')
+        handler1 = manager.get_handler_by_ip(ip1)
+
+        # Send an Inform from the same serial, but different IP
+        ip2 = "192.168.60.99"
+        ctx2 = self._get_spyne_context_with_ip(ip2)
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0003')
+        resp2 = manager.handle_tr069_message(ctx2, inform_msg)
+        self.assertTrue(isinstance(resp2, models.InformResponse),
+                        'Should respond with an InformResponse')
+        handler2 = manager.get_handler_by_ip(ip2)
+
+        # Now check that the serial is associated with the second ip
+        self.assertTrue((handler1 is handler2),
+                        'After an IP switch, the manager should have moved '
+                        'the handler to a new IP')
+
+    def test_serial_change(self) -> None:
+        manager = self._get_manager()
+        ip = "192.168.60.145"
+
+        # Send an Inform
+        ctx1 = self._get_spyne_context_with_ip(ip)
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0001')
+        resp1 = manager.handle_tr069_message(ctx1, inform_msg)
+        self.assertTrue(isinstance(resp1, models.InformResponse),
+                        'Should respond with an InformResponse')
+        handler1 = manager.get_handler_by_ip(ip)
+
+        # Send an Inform from the same serial, but different IP
+        ctx2 = self._get_spyne_context_with_ip(ip)
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0002')
+        resp2 = manager.handle_tr069_message(ctx2, inform_msg)
+        self.assertTrue(isinstance(resp2, models.InformResponse),
+                        'Should respond with an InformResponse')
+        handler2 = manager.get_handler_by_ip(ip)
+
+        # Now check that the serial is associated with the second ip
+        self.assertTrue((handler1 is not handler2),
+                        'After an IP switch, the manager should have moved '
+                        'the handler to a new IP')
+
+    def test_inform_from_baicells_qafb(self) -> None:
+        manager = self._get_manager()
+        ip = "192.168.60.145"
+
+        # Send an Inform
+        ctx1 = self._get_spyne_context_with_ip(ip)
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_QAFB_v1234',
+                                                    '120200002618AGP0001')
+        resp1 = manager.handle_tr069_message(ctx1, inform_msg)
+        self.assertTrue(isinstance(resp1, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+    def _get_manager(self) -> StateMachineManager:
+        service = EnodebAcsStateMachineBuilder.build_magma_service()
+        return StateMachineManager(service)
+
+    def _get_spyne_context_with_ip(
+        self,
+        req_ip: str = "192.168.60.145",
+    ) -> WsgiMethodContext:
+        with mock.patch('spyne.server.wsgi.WsgiApplication') as MockTransport:
+            MockTransport.req_env = {"REMOTE_ADDR": req_ip}
+            with mock.patch('spyne.server.wsgi.WsgiMethodContext') as MockContext:
+                MockContext.transport = MockTransport
+                return MockContext

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -13,10 +13,13 @@ from xml.etree import ElementTree
 from magma.enodebd import metrics
 from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.devices.device_utils import EnodebDeviceName
-from magma.enodebd.state_machines.enb_acs_pointer import StateMachinePointer
 from magma.enodebd.stats_manager import StatsManager
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
+from magma.enodebd.state_machines.enb_acs_manager import \
+    StateMachineManager
+from magma.enodebd.tests.test_utils.config_builder import \
+    EnodebConfigBuilder
 
 
 class StatsManagerTest(TestCase):
@@ -24,11 +27,9 @@ class StatsManagerTest(TestCase):
     Tests for eNodeB statistics manager
     """
     def setUp(self) -> None:
-        handler = EnodebAcsStateMachineBuilder\
-            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
-        state_machine_pointer = StateMachinePointer
-        state_machine_pointer.state_machine = handler
-        self.mgr = StatsManager(state_machine_pointer)
+        service = EnodebConfigBuilder.get_service_config()
+        self.enb_acs_manager = StateMachineManager(service)
+        self.mgr = StatsManager(self.enb_acs_manager)
         self.is_clear_stats_called = False
 
     def tearDown(self):
@@ -36,7 +37,7 @@ class StatsManagerTest(TestCase):
 
     def test_check_rf_tx(self):
         """ Check that stats are cleared when transmit is disabled on eNB """
-        handler = EnodebAcsStateMachineBuilder \
+        handler = EnodebAcsStateMachineBuilder\
             .build_acs_state_machine(EnodebDeviceName.BAICELLS)
         handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, True)
         with mock.patch('magma.enodebd.stats_manager.StatsManager'

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -8,17 +8,44 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import pkg_resources
-from unittest import TestCase
+from unittest import TestCase, mock
 from xml.etree import ElementTree
-
 from magma.enodebd import metrics
+from magma.enodebd.data_models.data_model_parameters import ParameterName
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.state_machines.enb_acs_pointer import StateMachinePointer
 from magma.enodebd.stats_manager import StatsManager
+from magma.enodebd.tests.test_utils.enb_acs_builder import \
+    EnodebAcsStateMachineBuilder
 
 
 class StatsManagerTest(TestCase):
     """
     Tests for eNodeB statistics manager
     """
+    def setUp(self) -> None:
+        handler = EnodebAcsStateMachineBuilder\
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+        state_machine_pointer = StateMachinePointer
+        state_machine_pointer.state_machine = handler
+        self.mgr = StatsManager(state_machine_pointer)
+        self.is_clear_stats_called = False
+
+    def tearDown(self):
+        self.mgr = None
+
+    def test_check_rf_tx(self):
+        """ Check that stats are cleared when transmit is disabled on eNB """
+        handler = EnodebAcsStateMachineBuilder \
+            .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+        handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, True)
+        with mock.patch('magma.enodebd.stats_manager.StatsManager'
+                        '._clear_stats') as func:
+            self.mgr._check_rf_tx_for_handler(handler)
+            func.assert_not_called()
+            handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, False)
+            self.mgr._check_rf_tx_for_handler(handler)
+            func.assert_any_call()
 
     def test_parse_stats(self):
         """ Test that example statistics from eNodeB can be parsed, and metrics
@@ -28,9 +55,7 @@ class StatsManagerTest(TestCase):
                                                         'pm_file_example.xml')
 
         root = ElementTree.fromstring(pm_file_example)
-
-        mgr = StatsManager()
-        mgr.parse_pm_xml(root)
+        self.mgr._parse_pm_xml(root)
 
         # Check that metrics were correctly populated
         # See '<V i="5">123</V>' in pm_file_example

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
@@ -14,9 +14,18 @@ from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.tests.test_utils.config_builder import EnodebConfigBuilder
+from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
 
 
 class EnodebAcsStateMachineBuilder:
+    @classmethod
+    def build_acs_manager(
+        cls,
+        device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
+    ) -> StateMachineManager:
+        service = cls.build_magma_service(device)
+        return StateMachineManager(service)
+
     @classmethod
     def build_acs_state_machine(
         cls,

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enb_acs_builder.py
@@ -13,7 +13,6 @@ from magma.common.service import MagmaService
 from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
-from magma.enodebd.stats_manager import StatsManager
 from magma.enodebd.tests.test_utils.config_builder import EnodebConfigBuilder
 
 
@@ -24,10 +23,9 @@ class EnodebAcsStateMachineBuilder:
         device: EnodebDeviceName = EnodebDeviceName.BAICELLS,
     ) -> EnodebAcsStateMachine:
         # Build the state_machine
-        stats_mgr = StatsManager()
         service = cls.build_magma_service(device)
         handler_class = get_device_handler_from_name(device)
-        acs_state_machine = handler_class(service, stats_mgr)
+        acs_state_machine = handler_class(service)
         return acs_state_machine
 
     @classmethod

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
@@ -103,6 +103,11 @@ class Tr069MessageBuilder:
             data=sw_version,
         ))
         val_list.append(cls.get_parameter_value_struct(
+            name='Device.DeviceInfo.SerialNumber',
+            val_type='string',
+            data=enb_serial,
+        ))
+        val_list.append(cls.get_parameter_value_struct(
             name='Device.ManagementServer.ConnectionRequestURL',
             val_type='string',
             data='http://192.168.60.248:7547/25dbc91d31276f0cb03391160531ecae',

--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -8,18 +8,16 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import logging
-from typing import Any
-
+from spyne.decorator import rpc
+from spyne.model.complex import ComplexModelBase
+from spyne.server.wsgi import WsgiMethodContext
+from spyne.service import ServiceBase
 from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.exceptions import Tr069Error, \
     IncorrectDeviceHandlerError
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_pointer import StateMachinePointer
-from spyne.decorator import rpc
-from spyne.model.complex import ComplexModelBase, Iterable  # pylint: disable=unused-import
-from spyne.model.primitive import String  # pylint: disable=unused-import
-from spyne.service import ServiceBase
 
 from . import models
 
@@ -101,7 +99,11 @@ class AutoConfigServer(ServiceBase):
         return acs_state_machine
 
     @classmethod
-    def _handle_tr069_message(cls, ctx: Any, message: ComplexModelBase) -> Any:
+    def _handle_tr069_message(
+        cls,
+        ctx: WsgiMethodContext,
+        message: ComplexModelBase,
+    ) -> ComplexModelBase:
         if not cls.state_machine():
             raise Tr069Error('ACS not given eNB state machine')
 

--- a/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
+++ b/lte/gateway/python/magma/enodebd/tr069/rpc_methods.py
@@ -12,8 +12,7 @@ from typing import Any
 
 from magma.enodebd.devices.device_map import get_device_handler_from_name
 from magma.enodebd.devices.device_utils import EnodebDeviceName
-from magma.enodebd.exceptions import Tr069Error
-from magma.enodebd.state_machines.acs_state_utils import \
+from magma.enodebd.exceptions import Tr069Error, \
     IncorrectDeviceHandlerError
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_pointer import StateMachinePointer


### PR DESCRIPTION
Summary: StatsManager will have a reference to the eNodeB ACS Manager, and regularly check the device configurations to track stats. Prior to this change, StatsManager would have a reference to a single eNodeB handler/state-machine, but since support is being added to have multiple eNB configured per gateway, this change is necessary.

Reviewed By: xjtian

Differential Revision: D14709619

