### PR TITLE
Allow user to specify network address for SGs interface

### DIFF
--- a/feg/gateway/services/csfb/servicers/sctp_connection.go
+++ b/feg/gateway/services/csfb/servicers/sctp_connection.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/golang/glog"
 	"github.com/ishidawataru/sctp"
 )
 
@@ -39,6 +40,7 @@ func NewSCTPClientConnection(vlrIP string, vlrPort int) (*SCTPClientConnection, 
 }
 
 func (conn *SCTPClientConnection) EstablishConn() error {
+	glog.V(2).Infof("Establishing SCTP connection with %s", conn.vlrSCTPAddr)
 	sendConn, err := sctp.DialSCTP(
 		"sctp",
 		nil,
@@ -47,12 +49,14 @@ func (conn *SCTPClientConnection) EstablishConn() error {
 	if err != nil {
 		return err
 	}
+	glog.V(2).Info("SCTP connection with VLR established")
 	conn.sendConn = sendConn
 
 	return nil
 }
 
 func (conn *SCTPClientConnection) CloseConn() error {
+	glog.V(2).Info("Closing SCTP connection with VLR")
 	if conn.sendConn == nil {
 		return errors.New("connection to VLR not established")
 	}
@@ -62,11 +66,13 @@ func (conn *SCTPClientConnection) CloseConn() error {
 	if err != nil {
 		return err
 	}
+	glog.V(2).Info("SCTP connection with VLR closed successfully")
 
 	return nil
 }
 
 func (conn *SCTPClientConnection) Send(message []byte) error {
+	glog.V(2).Info("Sending message to VLR through SCTP")
 	if conn.sendConn == nil {
 		return errors.New("connection to VLR not established")
 	}
@@ -83,6 +89,7 @@ func (conn *SCTPClientConnection) Send(message []byte) error {
 	if err != nil {
 		return err
 	}
+	glog.V(2).Info("Message sent successfully to VLR")
 
 	return nil
 }

--- a/feg/gateway/services/csfb/servicers/test/csfb_sctp_integration_test.go
+++ b/feg/gateway/services/csfb/servicers/test/csfb_sctp_integration_test.go
@@ -62,10 +62,11 @@ func TestCsfbServer_EPSDetach_Integration(t *testing.T) {
 	}()
 
 	// wait for initialization of mock listener
-	vlrConn, err := servicers.NewSCTPClientConnection(
+	vlrSCTPAddr := servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		<-port,
 	)
+	vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 	assert.NoError(t, err)
 	err = vlrConn.EstablishConn()
 	defer vlrConn.CloseConn()

--- a/feg/gateway/services/csfb/servicers/test/sctp_connection_test.go
+++ b/feg/gateway/services/csfb/servicers/test/sctp_connection_test.go
@@ -43,10 +43,11 @@ func TestSend(t *testing.T) {
 	}()
 
 	// Send message to the mocked server
-	vlrConn, err := servicers.NewSCTPClientConnection(
+	vlrSCTPAddr := servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		port,
 	)
+	vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 	assert.NoError(t, err)
 
 	err = vlrConn.EstablishConn()
@@ -87,10 +88,11 @@ func TestReceive(t *testing.T) {
 	}()
 
 	// Receive message from the mocked server
-	vlrConn, err := servicers.NewSCTPClientConnection(
+	vlrSCTPAddr := servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		port,
 	)
+	vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 	assert.NoError(t, err)
 
 	err = vlrConn.EstablishConn()
@@ -118,10 +120,11 @@ func TestServerReceiveAndReply(t *testing.T) {
 	// Client sends and receives message
 	clientReadyToReceive := make(chan bool)
 	go func() {
-		vlrConn, err := servicers.NewSCTPClientConnection(
+		vlrSCTPAddr := servicers.ConstructSCTPAddr(
 			servicers.DefaultVLRIPAddress,
 			portNumber,
 		)
+		vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 		assert.NoError(t, err)
 
 		err = vlrConn.EstablishConn()

--- a/feg/gateway/services/csfb/test_init/test_service_init.go
+++ b/feg/gateway/services/csfb/test_init/test_service_init.go
@@ -46,7 +46,7 @@ func GetConnToTestFedGWServiceServer(t *testing.T, connectionInterface servicers
 }
 
 func GetMockVLRListenerAndPort(t *testing.T) (*sctp.SCTPListener, int) {
-	ln, err := sctp.ListenSCTP("sctp", servicers.ParseAddr(
+	ln, err := sctp.ListenSCTP("sctp", servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		0,
 	))


### PR DESCRIPTION
Summary:
**Summary**
Allow user to specify the IP/port to be used to establish the SCTP connection with MSC/VLR. This is a required feature because MSC/VLR or routers might only allow traffic coming from specific address.

**Implementation**
1. Get the address from environment variable

**What is affected**
1. Some CSFB unit tests that establish SCTP connection are updated and should still pass.
2. User can now specify address to use in `/var/opt/magma/envdir/`. If a wrong address is specified there, CSFB service would not be able to establish SCTP connection with the MSC/VLR

Differential Revision: D15126332

