### PR TITLE
Network Resource Identifier Container decode failure fix

### DIFF
--- a/lte/gateway/c/oai/lib/3gpp/3gpp_24.008.h
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_24.008.h
@@ -50,13 +50,14 @@
 //******************************************************************************
 
 typedef enum common_ie_e {
-  C_MOBILE_STATION_CLASSMARK_2_IEI = 0x11,    /* 0x11 = 17  */
-  C_LOCATION_AREA_IDENTIFICATION_IEI = 0x13,  /* 0x13 = 19 */
-  C_MOBILE_STATION_CLASSMARK_3_IEI = 0x20,    /* 0x20 = 32  */
-  C_MOBILE_IDENTITY_IEI = 0x23,               /* 0x23 = 35 */
-  C_PLMN_LIST_IEI = 0x4A,                     /* 0x4A = 74 */
-  C_CIPHERING_KEY_SEQUENCE_NUMBER_IEI = 0x80, /* 0x80 = 128 */
-  C_MS_NETWORK_FEATURE_SUPPORT_IEI = 0xC0,    /* 0xC- = 192-  */
+  C_MOBILE_STATION_CLASSMARK_2_IEI = 0x11,            /* 0x11 = 17   */
+  C_LOCATION_AREA_IDENTIFICATION_IEI = 0x13,          /* 0x13 = 19   */
+  C_MOBILE_STATION_CLASSMARK_3_IEI = 0x20,            /* 0x20 = 32   */
+  C_MOBILE_IDENTITY_IEI = 0x23,                       /* 0x23 = 35   */
+  C_PLMN_LIST_IEI = 0x4A,                             /* 0x4A = 74   */
+  C_CIPHERING_KEY_SEQUENCE_NUMBER_IEI = 0x80,         /* 0x80 = 128  */
+  C_MS_NETWORK_FEATURE_SUPPORT_IEI = 0xC0,            /* 0xC- = 192- */
+  C_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IEI = 0x10, /* 0x10 = 16   */
 } common_ie_t;
 
 //------------------------------------------------------------------------------
@@ -363,6 +364,27 @@ int encode_ms_network_feature_support_ie(
   const uint32_t len);
 int decode_ms_network_feature_support_ie(
   ms_network_feature_support_t *msnetworkfeaturesupport,
+  const bool iei_present,
+  uint8_t *buffer,
+  const uint32_t len);
+//------------------------------------------------------------------------------
+// 10.5.5.31 Network Resource Identifier Container
+//------------------------------------------------------------------------------
+#define NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IE_TYPE 4
+#define NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IE_MIN_LENGTH 4 //TODO
+#define NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IE_MAX_LENGTH 4
+
+typedef struct network_resource_identifier_container_s {
+  uint8_t byte[32]; //TODO
+} network_resource_identifier_container_t;
+
+int encode_network_resource_identifier_container_ie(
+  network_resource_identifier_container_t *networkresourceidentifiercontainer,
+  const bool iei_present,
+  uint8_t *buffer,
+  const uint32_t len);
+int decode_network_resource_identifier_container_ie(
+  network_resource_identifier_container_t *networkresourceidentifiercontainer,
   const bool iei_present,
   uint8_t *buffer,
   const uint32_t len);

--- a/lte/gateway/c/oai/lib/3gpp/3gpp_24.008_common_ies.c
+++ b/lte/gateway/c/oai/lib/3gpp/3gpp_24.008_common_ies.c
@@ -1124,3 +1124,41 @@ int encode_ms_network_feature_support_ie(
   encoded++;
   return encoded;
 }
+
+//------------------------------------------------------------------------------
+// 10.5.5.31 Network Resource Identifier Container
+//------------------------------------------------------------------------------
+
+int decode_network_resource_identifier_container_ie(
+  network_resource_identifier_container_t *networkresourceidentifiercontainer,
+  const bool iei_present,
+  uint8_t *buffer,
+  const uint32_t len)
+{
+  //AssertFatal(false, "TODO");
+  //Temporary fix so that we decode other IEs
+  int decoded = 0;
+  uint8_t ielen = 0;
+
+  if (iei_present > 0) {
+    CHECK_IEI_DECODER(C_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IEI, *buffer);
+    decoded++;
+  }
+
+  ielen = *(buffer + decoded);
+  decoded++;
+
+  decoded += ielen;
+  return decoded;
+}
+
+//------------------------------------------------------------------------------
+int encode_network_resource_identifier_container_ie(
+  network_resource_identifier_container_t *networkresourceidentifiercontainer,
+  const bool iei_present,
+  uint8_t *buffer,
+  const uint32_t len)
+{
+  //AssertFatal(false, "TODO");
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
@@ -349,6 +349,25 @@ int decode_attach_request(
         attach_request->presencemask |=
           ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_PRESENT;
         break;
+
+      case ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IEI:
+        if (
+          (decoded_result = decode_network_resource_identifier_container_ie(
+             &attach_request->networkresourceidentifiercontainer,
+             true,
+             buffer + decoded,
+             len - decoded)) <= 0) {
+          OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoded_result);
+        }
+
+        decoded += decoded_result;
+        /*
+         * Set corresponding mask to 1 in presencemask
+         */
+        attach_request->presencemask |=
+          ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_PRESENT;
+	break;
+
       default:
         errorCodeDecoder = TLV_UNEXPECTED_IEI;
         {

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.h
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.h
@@ -78,6 +78,7 @@
 #define ATTACH_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_PRESENT    \
   (1 << 12)
 #define ATTACH_REQUEST_MS_NETWORK_FEATURE_SUPPORT_PRESENT (1 << 13)
+#define ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_PRESENT (1 << 14)
 
 typedef enum attach_request_iei_tag {
   ATTACH_REQUEST_OLD_PTMSI_SIGNATURE_IEI = GMM_PTMSI_SIGNATURE_IEI,
@@ -98,7 +99,8 @@ typedef enum attach_request_iei_tag {
   ATTACH_REQUEST_ADDITIONAL_UPDATE_TYPE_IEI = 0xF0, /* 0xF0 = 240 */
   ATTACH_REQUEST_OLD_GUTI_TYPE_IEI = 0xE0,          /* 0xE0 = 224 */
   ATTACH_REQUEST_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI =
-    GMM_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI
+    GMM_VOICE_DOMAIN_PREFERENCE_AND_UE_USAGE_SETTING_IEI,
+  ATTACH_REQUEST_NETWORK_RESOURCE_IDENTIFIER_CONTAINER_IEI = 0x10
 } attach_request_iei;
 
 /*
@@ -135,6 +137,7 @@ typedef struct attach_request_msg_tag {
   voice_domain_preference_and_ue_usage_setting_t
     voicedomainpreferenceandueusagesetting;
   ms_network_feature_support_t msnetworkfeaturesupport;
+  network_resource_identifier_container_t networkresourceidentifiercontainer;
 } attach_request_msg;
 
 int decode_attach_request(


### PR DESCRIPTION
Given a fix for Network Resource Identifier Container decode failure issue (Issue #245 ).
Verified sanity with s1ap-tester.
