### PR TITLE
Adjust MME name encoding approach according to hcore requirement

### DIFF
--- a/feg/gateway/services/csfb/servicers/encode/ie/encoder.go
+++ b/feg/gateway/services/csfb/servicers/encode/ie/encoder.go
@@ -84,19 +84,11 @@ func EncodeMMEName(mmeName string) ([]byte, error) {
 	encodedMMEName := constructMessage(
 		decode.IEIMMEName,
 		lengthIndicator,
-		[]byte(mmeName),
+		[]byte(mmeName[1:]),
 	)
 
-	// replace dots with length labels
-	charCounter := 0
-	for idx := len(encodedMMEName) - 1; idx > 1; idx-- {
-		if encodedMMEName[idx] == byte('.') {
-			encodedMMEName[idx] = byte(charCounter)
-			charCounter = 0
-		} else {
-			charCounter++
-		}
-	}
+	// H-core MSC needs a 0x00 at the end of MME name
+	encodedMMEName = append(encodedMMEName, byte(0x00))
 
 	return encodedMMEName, nil
 }

--- a/feg/gateway/services/csfb/servicers/encode/ie/encoder_test.go
+++ b/feg/gateway/services/csfb/servicers/encode/ie/encoder_test.go
@@ -55,23 +55,15 @@ func TestEncodeMMEName(t *testing.T) {
 	encodedMMEName, err := ie.EncodeMMEName(mmeName)
 	assert.NoError(t, err)
 
-	encodedMMEName2, err := ie.EncodeFixedLengthIE(
+	expectedEncodedMMEName, err := ie.EncodeFixedLengthIE(
 		decode.IEIMMEName,
 		decode.IELengthMMEName,
-		[]byte(mmeName),
+		[]byte("mmec01.mmegi0001.mme.EPC.mnc001.mcc001.3gppnetwork.org "),
 	)
+	// replace the ending space with 0x00
+	expectedEncodedMMEName[len(expectedEncodedMMEName)-1] = byte(0x00)
 
-	// replace dots with length labels
-	encodedMMEName2[2] = byte(0x06)
-	encodedMMEName2[9] = byte(0x09)
-	encodedMMEName2[19] = byte(0x03)
-	encodedMMEName2[23] = byte(0x03)
-	encodedMMEName2[27] = byte(0x06)
-	encodedMMEName2[34] = byte(0x06)
-	encodedMMEName2[41] = byte(0x0b)
-	encodedMMEName2[53] = byte(0x03)
-
-	assert.Equal(t, encodedMMEName, encodedMMEName2)
+	assert.Equal(t, expectedEncodedMMEName, encodedMMEName)
 }
 
 func TestEncodeFixedLengthIE(t *testing.T) {

--- a/feg/gateway/services/csfb/servicers/sctp_connection.go
+++ b/feg/gateway/services/csfb/servicers/sctp_connection.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"unsafe"
 
+	"github.com/golang/glog"
 	"github.com/ishidawataru/sctp"
 )
 
@@ -39,6 +40,7 @@ func NewSCTPClientConnection(vlrIP string, vlrPort int) (*SCTPClientConnection, 
 }
 
 func (conn *SCTPClientConnection) EstablishConn() error {
+	glog.V(2).Infof("Establishing SCTP connection with %s", conn.vlrSCTPAddr)
 	sendConn, err := sctp.DialSCTP(
 		"sctp",
 		nil,
@@ -47,12 +49,14 @@ func (conn *SCTPClientConnection) EstablishConn() error {
 	if err != nil {
 		return err
 	}
+	glog.V(2).Info("SCTP connection with VLR established")
 	conn.sendConn = sendConn
 
 	return nil
 }
 
 func (conn *SCTPClientConnection) CloseConn() error {
+	glog.V(2).Info("Closing SCTP connection with VLR")
 	if conn.sendConn == nil {
 		return errors.New("connection to VLR not established")
 	}
@@ -62,11 +66,13 @@ func (conn *SCTPClientConnection) CloseConn() error {
 	if err != nil {
 		return err
 	}
+	glog.V(2).Info("SCTP connection with VLR closed successfully")
 
 	return nil
 }
 
 func (conn *SCTPClientConnection) Send(message []byte) error {
+	glog.V(2).Info("Sending message to VLR through SCTP")
 	if conn.sendConn == nil {
 		return errors.New("connection to VLR not established")
 	}
@@ -83,6 +89,7 @@ func (conn *SCTPClientConnection) Send(message []byte) error {
 	if err != nil {
 		return err
 	}
+	glog.V(2).Info("Message sent successfully to VLR")
 
 	return nil
 }

--- a/feg/gateway/services/csfb/servicers/test/csfb_sctp_integration_test.go
+++ b/feg/gateway/services/csfb/servicers/test/csfb_sctp_integration_test.go
@@ -62,10 +62,11 @@ func TestCsfbServer_EPSDetach_Integration(t *testing.T) {
 	}()
 
 	// wait for initialization of mock listener
-	vlrConn, err := servicers.NewSCTPClientConnection(
+	vlrSCTPAddr := servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		<-port,
 	)
+	vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 	assert.NoError(t, err)
 	err = vlrConn.EstablishConn()
 	defer vlrConn.CloseConn()

--- a/feg/gateway/services/csfb/servicers/test/sctp_connection_test.go
+++ b/feg/gateway/services/csfb/servicers/test/sctp_connection_test.go
@@ -43,10 +43,11 @@ func TestSend(t *testing.T) {
 	}()
 
 	// Send message to the mocked server
-	vlrConn, err := servicers.NewSCTPClientConnection(
+	vlrSCTPAddr := servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		port,
 	)
+	vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 	assert.NoError(t, err)
 
 	err = vlrConn.EstablishConn()
@@ -87,10 +88,11 @@ func TestReceive(t *testing.T) {
 	}()
 
 	// Receive message from the mocked server
-	vlrConn, err := servicers.NewSCTPClientConnection(
+	vlrSCTPAddr := servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		port,
 	)
+	vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 	assert.NoError(t, err)
 
 	err = vlrConn.EstablishConn()
@@ -118,10 +120,11 @@ func TestServerReceiveAndReply(t *testing.T) {
 	// Client sends and receives message
 	clientReadyToReceive := make(chan bool)
 	go func() {
-		vlrConn, err := servicers.NewSCTPClientConnection(
+		vlrSCTPAddr := servicers.ConstructSCTPAddr(
 			servicers.DefaultVLRIPAddress,
 			portNumber,
 		)
+		vlrConn, err := servicers.NewSCTPClientConnection(vlrSCTPAddr, nil)
 		assert.NoError(t, err)
 
 		err = vlrConn.EstablishConn()

--- a/feg/gateway/services/csfb/test_init/test_service_init.go
+++ b/feg/gateway/services/csfb/test_init/test_service_init.go
@@ -46,7 +46,7 @@ func GetConnToTestFedGWServiceServer(t *testing.T, connectionInterface servicers
 }
 
 func GetMockVLRListenerAndPort(t *testing.T) (*sctp.SCTPListener, int) {
-	ln, err := sctp.ListenSCTP("sctp", servicers.ParseAddr(
+	ln, err := sctp.ListenSCTP("sctp", servicers.ConstructSCTPAddr(
 		servicers.DefaultVLRIPAddress,
 		0,
 	))


### PR DESCRIPTION
Summary:
**Summary**
H-core MSC uses a MME name format that is different from the format used by TeraVM.
TeraVM does not want the `.` in MME name while H-core MSC needs the `.`.
Also, H-core MSC needs `0x00` as the ending character.
In the future, we plan to construct MME name completely in FeG instead of getting the information from Access Gateway.

**Implementation**
- Change the MME name encoding function in FeG

**What is affected**
TeraVM combine attach will fail.
We need to try to modify the test to use this new format for MME name.

Differential Revision: D15246634

