### PR TITLE
Change service checking to report enb serial, conform to old format

### DIFF
--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -9,7 +9,8 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 from threading import Thread
 from unittest import mock
-from magma.enodebd.enodeb_status import get_status, get_operational_states
+from magma.enodebd.enodeb_status import get_service_status_old, \
+    get_operational_states
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
 from .rpc_servicer import EnodebdRpcServicer
 from .stats_manager import StatsManager
@@ -52,7 +53,7 @@ def main():
 
     # Register function to get service status
     def get_enodebd_status():
-        return get_status(state_machine_manager)
+        return get_service_status_old(state_machine_manager)
     service.register_get_status_callback(get_enodebd_status)
 
     # Register a callback function for GetOperationalStates service303 function

--- a/lte/gateway/python/magma/enodebd/rpc_servicer.py
+++ b/lte/gateway/python/magma/enodebd/rpc_servicer.py
@@ -9,7 +9,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 import grpc
 from typing import Any
-from magma.enodebd.enodeb_status import get_status, get_single_enb_status
+from magma.enodebd.enodeb_status import get_service_status, get_single_enb_status
 from lte.protos.enodebd_pb2 import GetParameterResponse
 from lte.protos.enodebd_pb2_grpc import EnodebdServicer, \
     add_EnodebdServicer_to_server
@@ -106,7 +106,7 @@ class EnodebdRpcServicer(EnodebdServicer):
         Note: input variable defaults used so this can be either called locally
         or as an RPC.
         """
-        status = dict(get_status(self.state_machine_manager))
+        status = dict(get_service_status(self.state_machine_manager))
         status_message = ServiceStatus()
         status_message.meta.update(status)
         return status_message

--- a/lte/gateway/python/magma/enodebd/tests/enodeb_status_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enodeb_status_tests.py
@@ -1,0 +1,44 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+# pylint: disable=protected-access
+from unittest import TestCase
+from magma.enodebd.enodeb_status import get_service_status_old
+from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
+from magma.enodebd.tests.test_utils.tr069_msg_builder import \
+    Tr069MessageBuilder
+from magma.enodebd.tests.test_utils.enb_acs_builder import \
+    EnodebAcsStateMachineBuilder
+from magma.enodebd.tests.test_utils.spyne_builder import \
+    get_spyne_context_with_ip
+
+
+class EnodebStatusTests(TestCase):
+    def test_get_service_status_old(self):
+        manager = self._get_manager()
+        status = get_service_status_old(manager)
+        self.assertTrue(status['enodeb_connected'] == '0',
+                        'Should report no eNB connected')
+
+        ##### Start session for the first IP #####
+        ctx1 = get_spyne_context_with_ip("192.168.60.145")
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
+                                                    'BaiBS_RTS_3.1.6',
+                                                    '120200002618AGP0001')
+        manager.handle_tr069_message(ctx1, inform_msg)
+        status = get_service_status_old(manager)
+        self.assertTrue(status['enodeb_connected'] == '1',
+                        'Should report an eNB as conencted')
+        self.assertTrue(status['enodeb_serial'] == '120200002618AGP0001',
+                        'eNodeB serial should match the earlier Inform')
+
+    def _get_manager(self) -> StateMachineManager:
+        service = EnodebAcsStateMachineBuilder.build_magma_service()
+        return StateMachineManager(service)

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/spyne_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/spyne_builder.py
@@ -1,0 +1,21 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from unittest import mock
+from spyne.server.wsgi import WsgiMethodContext
+
+
+def get_spyne_context_with_ip(
+    req_ip: str = "192.168.60.145",
+) -> WsgiMethodContext:
+    with mock.patch('spyne.server.wsgi.WsgiApplication') as MockTransport:
+        MockTransport.req_env = {"REMOTE_ADDR": req_ip}
+        with mock.patch('spyne.server.wsgi.WsgiMethodContext') as MockContext:
+            MockContext.transport = MockTransport
+            return MockContext


### PR DESCRIPTION
Summary: Report the old service checkin format from enodebd. This is temporary until controller/NMS-ui endpoints are updated. Also, report the attached eNodeB serial, so later configuration and data migration is easier.

Reviewed By: xjtian

Differential Revision: D15159445

