### PR TITLE
Remove Baicells bandwidth transform from RBs to MHz

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -210,8 +210,7 @@ class BaicellsTrDataModel(DataModel):
         ParameterName.UL_BANDWIDTH: transform_for_enb.bandwidth
     }
     TRANSFORMS_FOR_MAGMA = {
-        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
-        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
+        # For DL_BANDWIDTH and UL_BANDWIDTH, we read in values as MHz, not RBs
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -225,8 +225,6 @@ class BaicellsTrOldDataModel(DataModel):
         ParameterName.CELL_RESERVED: transform_for_enb.invert_cell_reserved,
     }
     TRANSFORMS_FOR_MAGMA = {
-        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
-        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -364,8 +364,6 @@ class CaviumTrDataModel(DataModel):
         ParameterName.UL_BANDWIDTH: transform_for_enb.bandwidth
     }
     TRANSFORMS_FOR_MAGMA = {
-        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
-        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181

--- a/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
@@ -451,6 +451,9 @@ class BaicellsHandlerTests(TestCase):
         acs_state_machine = \
             EnodebAcsStateMachineBuilder\
             .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+        # Since the test utils pretend the eNB is set to 20MHz, we force this
+        # to 10 MHz, so the state machine sets this value.
+        acs_state_machine.mconfig.bandwidth_mhz = 10
 
         # Send an Inform message, wait for an InformResponse
         inform_msg = Tr069MessageBuilder.get_inform('48BF74',

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
@@ -268,7 +268,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.DLBandwidth',
             val_type='string',
-            data='n100',
+            data='20',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator',
@@ -288,7 +288,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.ULBandwidth',
             val_type='string',
-            data='n100',
+            data='20',
         ))
         # MME IP
         param_val_list.append(cls.get_parameter_value_struct(
@@ -392,7 +392,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.DLBandwidth',
             val_type='string',
-            data='n100',
+            data='20',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator',
@@ -412,7 +412,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.ULBandwidth',
             val_type='string',
-            data='n100',
+            data='20',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.X_BAICELLS_COM_LTE.EARFCNDLInUse',
@@ -536,7 +536,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='InternetGatewayDevice.Services.FAPService.1.CellConfig.LTE.RAN.RF.DLBandwidth',
             val_type='string',
-            data='n100',
+            data='20',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='InternetGatewayDevice.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator',
@@ -556,7 +556,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='InternetGatewayDevice.Services.FAPService.1.CellConfig.LTE.RAN.RF.ULBandwidth',
             val_type='string',
-            data='n100',
+            data='20',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='InternetGatewayDevice.Services.FAPService.1.X_BAICELLS_COM_LTE.EARFCNDLInUse',

--- a/lte/gateway/python/magma/enodebd/tests/transform_for_enb_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/transform_for_enb_tests.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+# pylint: disable=protected-access
+from unittest import TestCase
+from magma.enodebd.data_models.transform_for_enb import bandwidth
+
+
+class TransformForMagmaTests(TestCase):
+    def test_bandwidth(self) -> None:
+        inp = 1.4
+        out = bandwidth(inp)
+        expected = 'n6'
+        self.assertEqual(out, expected, 'Should work with a float')
+
+        inp = 20
+        out = bandwidth(inp)
+        expected = 'n100'
+        self.assertEqual(out, expected, 'Should work with an int')
+
+        inp = 10
+        out = bandwidth(inp)
+        expected = 'n50'
+        self.assertEqual(out, expected, 'Should work with int 10')


### PR DESCRIPTION
Summary:
While we set the DL and UL bandwidth on Baicells devices as RBs, we read in the values as MHz. This revision changes the read from RBs to MHz.

```
May 08 17:18:11 debiansb enodebd[9648]: ERROR:spyne.application.server:Unknown bandwidth_rbs (10)
May 08 17:18:11 debiansb enodebd[9648]: Traceback (most recent call last):
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/spyne/application.py", line 151, in process_request
May 08 17:18:11 debiansb enodebd[9648]:     ctx.out_object = self.call_wrapper(ctx)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/spyne/application.py", line 235, in call_wrapper
May 08 17:18:11 debiansb enodebd[9648]:     retval = ctx.descriptor.service_class.call_wrapper(ctx)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/spyne/service.py", line 209, in call_wrapper
May 08 17:18:11 debiansb enodebd[9648]:     return ctx.function(ctx, *args)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/tr069/rpc_methods.py", line 226, in set_parameter_values_response
May 08 17:18:11 debiansb enodebd[9648]:     return AutoConfigServer._handle_tr069_message(ctx, response)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/tr069/rpc_methods.py", line 116, in _handle_tr069_message
May 08 17:18:11 debiansb enodebd[9648]:     req = cls.state_machine().handle_tr069_message(message)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 86, in handle_tr069_message
May 08 17:18:11 debiansb enodebd[9648]:     self._read_tr069_msg(message)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 141, in _read_tr069_msg
May 08 17:18:11 debiansb enodebd[9648]:     msg_handled, next_state = self.state.read_msg(message)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_states.py", line 835, in read_msg
May 08 17:18:11 debiansb enodebd[9648]:     self._mark_as_configured()
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_states.py", line 862, in _mark_as_configured
May 08 17:18:11 debiansb enodebd[9648]:     magma_val = self.acs.data_model.transform_for_magma(name, val)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/data_models/data_model.py", line 117, in transform_for_magma
May 08 17:18:11 debiansb enodebd[9648]:     return transform_function(enb_value)
May 08 17:18:11 debiansb enodebd[9648]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/data_models/transform_for_magma.py", line 69, in bandwidth
May 08 17:18:11 debiansb enodebd[9648]:     str(bandwidth_rbs))
May 08 17:18:11 debiansb enodebd[9648]: magma.enodebd.exceptions.ConfigurationError: Unknown bandwidth_rbs (10)
```

Reviewed By: xjtian

Differential Revision: D15268101

