### PR TITLE
Should not try to query for optional parameters after already knowing

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -66,7 +66,11 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
             'end_session': EndSessionState(self),
             'reboot': BaicellsSendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
-            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_rem', when_timeout='wait_inform'),
+            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_rem_post_reboot', when_timeout='wait_inform_post_reboot'),
+            # After rebooting, we don't need to query optional params again.
+            'wait_inform_post_reboot': WaitInformState(self, when_done='wait_empty_post_reboot', when_boot='wait_rem_post_reboot'),
+            'wait_rem_post_reboot': BaicellsRemWaitState(self, when_done='wait_inform_post_reboot'),
+            'wait_empty_post_reboot': WaitEmptyMessageState(self, when_done='get_transient_params'),
             # The states below are entered when an unexpected message type is
             # received
             'unexpected_fault': ErrorState(self),

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -66,7 +66,11 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
             'end_session': EndSessionState(self),
             'reboot': BaicellsSendRebootState(self, when_done='wait_reboot'),
             'wait_reboot': WaitRebootResponseState(self, when_done='wait_post_reboot_inform'),
-            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_rem', when_timeout='wait_inform'),
+            'wait_post_reboot_inform': WaitInformMRebootState(self, when_done='wait_rem_post_reboot', when_timeout='wait_inform_post_reboot'),
+            # After rebooting, we don't need to query optional params again.
+            'wait_inform_post_reboot': WaitInformState(self, when_done='wait_empty_post_reboot', when_boot='wait_rem_post_reboot'),
+            'wait_rem_post_reboot': BaicellsRemWaitState(self, when_done='wait_inform_post_reboot'),
+            'wait_empty_post_reboot': WaitEmptyMessageState(self, when_done='get_transient_params'),
             # The states below are entered when an unexpected message type is
             # received
             'unexpected_fault': ErrorState(self),

--- a/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
@@ -359,3 +359,23 @@ class BaicellsOldHandlerTests(TestCase):
                         'After receiving a post-reboot Inform, enodebd '
                         'should end TR-069 sessions for 10 minutes to wait '
                         'for REM process to finish.')
+
+        # Pretend that we have waited, and now we are in normal operation again
+        acs_state_machine.transition('wait_inform_post_reboot')
+        req = \
+            Tr069MessageBuilder.get_inform('48BF74',
+                                           'BaiStation_V100R001C00B110SPC002',
+                                           '120200002618AGP0003',
+                                           ['2 PERIODIC'])
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'After receiving a post-reboot Inform, enodebd '
+                        'should end TR-069 sessions for 10 minutes to wait '
+                        'for REM process to finish.')
+
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'enodebd should be requesting params')
+        self.assertTrue(len(resp.ParameterNames.string) > 1,
+                        'Should be requesting transient params.')

--- a/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
@@ -536,3 +536,21 @@ class BaicellsHandlerTests(TestCase):
                         'After receiving a post-reboot Inform, enodebd '
                         'should end TR-069 sessions for 10 minutes to wait '
                         'for REM process to finish.')
+
+        # Pretend that we have waited, and now we are in normal operation again
+        acs_state_machine.transition('wait_inform_post_reboot')
+        req = Tr069MessageBuilder.get_inform('48BF74', 'BaiBS_RTS_3.1.6',
+                                             '120200002618AGP0003',
+                                             ['2 PERIODIC'])
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'After receiving a post-reboot Inform, enodebd '
+                        'should end TR-069 sessions for 10 minutes to wait '
+                        'for REM process to finish.')
+
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'enodebd should be requesting params')
+        self.assertTrue(len(resp.ParameterNames.string) > 1,
+                        'Should be requesting transient params.')


### PR DESCRIPTION
Summary: After rebooting the eNB, the state machine should not attempt to query for optional parameters again, because their existence is known.

Reviewed By: xjtian

Differential Revision: D15271988

