### PR TITLE
NoneType check for mme_timeout_handler

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -102,15 +102,16 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         """ Clean up anything the state machine is tracking or doing """
         self.state.exit()
         if self.timeout_handler is not None:
-            self.mme_timeout_handler.cancel()
             self.timeout_handler.cancel()
+            self.timeout_handler = None
+        if self.mme_timeout_handler is not None:
+            self.mme_timeout_handler.cancel()
+            self.mme_timeout_handler = None
         self._service = None
         self._desired_cfg = None
         self._device_cfg = None
         self._data_model = None
 
-        self.timeout_handler = None
-        self.mme_timeout_handler = None
         self.mme_timer = None
 
     def _start_state_machine(
@@ -163,11 +164,11 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         been disconnected.
         """
         if isinstance(message, models.Inform):
-            logging.debug('ACS in (%s) state. Received an Inform message',
+            logging.warning('ACS in (%s) state. Received an Inform message',
                           self.state.state_description())
             self._reset_state_machine(self.service)
         elif isinstance(message, models.Fault):
-            logging.debug('ACS in (%s) state. Received a Fault <%s>',
+            logging.warning('ACS in (%s) state. Received a Fault <%s>',
                           self.state.state_description(), message.FaultString)
             self.transition(self.unexpected_fault_state_name)
         else:


### PR DESCRIPTION
Summary:
Error logs seen:
```
May  8 18:15:03 magma control_proxy[1614]: 2019-05-08T18:15:03.261Z [127.0.0.1 -> meteringd_records-controller.magma.etagecom.io,8443] "POST /magma.lte.MeteringdRecordsController/UpdateFlows HTTP/2" 200 5bytes 0.178s
May  8 18:15:06 magma enodebd[31150]: ERROR:spyne.application.server:'NoneType' object has no attribute 'cancel'
May  8 18:15:06 magma enodebd[31150]: Traceback (most recent call last):
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/spyne/application.py", line 151, in process_request
May  8 18:15:06 magma enodebd[31150]:     ctx.out_object = self.call_wrapper(ctx)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/spyne/application.py", line 235, in call_wrapper
May  8 18:15:06 magma enodebd[31150]:     retval = ctx.descriptor.service_class.call_wrapper(ctx)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/spyne/service.py", line 209, in call_wrapper
May  8 18:15:06 magma enodebd[31150]:     return ctx.function(ctx, *args)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/tr069/rpc_methods.py", line 191, in inform
May  8 18:15:06 magma enodebd[31150]:     resp = AutoConfigServer._handle_tr069_message(ctx, request)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/tr069/rpc_methods.py", line 116, in _handle_tr069_message
May  8 18:15:06 magma enodebd[31150]:     req = cls.state_machine().handle_tr069_message(message)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 86, in handle_tr069_message
May  8 18:15:06 magma enodebd[31150]:     self._read_tr069_msg(message)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 143, in _read_tr069_msg
May  8 18:15:06 magma enodebd[31150]:     self._transition_for_unexpected_msg(message)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 166, in _transition_for_unexpected_msg
May  8 18:15:06 magma enodebd[31150]:     self._reset_state_machine(self.service, self.stats_manager)
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 135, in _reset_state_machine
May  8 18:15:06 magma enodebd[31150]:     self.stop_state_machine()
May  8 18:15:06 magma enodebd[31150]:   File "/usr/local/lib/python3.5/dist-packages/magma/enodebd/state_machines/enb_acs_impl.py", line 99, in stop_state_machine
May  8 18:15:06 magma enodebd[31150]:     self.mme_timeout_handler.cancel()
May  8 18:15:06 magma enodebd[31150]: AttributeError: 'NoneType' object has no attribute 'cancel'
```

Don't know what sort of code path caused this, but the NoneType check should prevent this.

Reviewed By: rpraveen

Differential Revision: D15267173

