### PR TITLE
Add back device class to eNB config

### DIFF
--- a/lte/cloud/go/services/cellular/obsidian/models/network_enodeb_configs_swaggergen.go
+++ b/lte/cloud/go/services/cellular/obsidian/models/network_enodeb_configs_swaggergen.go
@@ -27,6 +27,10 @@ type NetworkEnodebConfigs struct {
 	// Maximum: 2.68435455e+08
 	CellID uint32 `json:"cell_id,omitempty"`
 
+	// device class
+	// Enum: [Baicells Nova-233 G2 OD FDD Baicells Nova-243 OD TDD Baicells ID TDD/FDD NuRAN Cavium OC-LTE]
+	DeviceClass string `json:"device_class,omitempty"`
+
 	// earfcndl
 	// Maximum: 65535
 	Earfcndl uint32 `json:"earfcndl,omitempty"`
@@ -60,6 +64,10 @@ func (m *NetworkEnodebConfigs) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateCellID(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateDeviceClass(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -130,6 +138,55 @@ func (m *NetworkEnodebConfigs) validateCellID(formats strfmt.Registry) error {
 	}
 
 	if err := validate.MaximumInt("cell_id", "body", int64(m.CellID), 2.68435455e+08, false); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var networkEnodebConfigsTypeDeviceClassPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["Baicells Nova-233 G2 OD FDD","Baicells Nova-243 OD TDD","Baicells ID TDD/FDD","NuRAN Cavium OC-LTE"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		networkEnodebConfigsTypeDeviceClassPropEnum = append(networkEnodebConfigsTypeDeviceClassPropEnum, v)
+	}
+}
+
+const (
+
+	// NetworkEnodebConfigsDeviceClassBaicellsNova233G2ODFDD captures enum value "Baicells Nova-233 G2 OD FDD"
+	NetworkEnodebConfigsDeviceClassBaicellsNova233G2ODFDD string = "Baicells Nova-233 G2 OD FDD"
+
+	// NetworkEnodebConfigsDeviceClassBaicellsNova243ODTDD captures enum value "Baicells Nova-243 OD TDD"
+	NetworkEnodebConfigsDeviceClassBaicellsNova243ODTDD string = "Baicells Nova-243 OD TDD"
+
+	// NetworkEnodebConfigsDeviceClassBaicellsIDTDDFDD captures enum value "Baicells ID TDD/FDD"
+	NetworkEnodebConfigsDeviceClassBaicellsIDTDDFDD string = "Baicells ID TDD/FDD"
+
+	// NetworkEnodebConfigsDeviceClassNuRANCaviumOCLTE captures enum value "NuRAN Cavium OC-LTE"
+	NetworkEnodebConfigsDeviceClassNuRANCaviumOCLTE string = "NuRAN Cavium OC-LTE"
+)
+
+// prop value enum
+func (m *NetworkEnodebConfigs) validateDeviceClassEnum(path, location string, value string) error {
+	if err := validate.Enum(path, location, value, networkEnodebConfigsTypeDeviceClassPropEnum); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *NetworkEnodebConfigs) validateDeviceClass(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.DeviceClass) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateDeviceClassEnum("device_class", "body", m.DeviceClass); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/cellular/protos/proto_validation.go
+++ b/lte/cloud/go/services/cellular/protos/proto_validation.go
@@ -195,6 +195,16 @@ func ValidateEnodebConfig(config *CellularEnodebConfig) error {
 	if config.Tac < 0 || config.Tac > 65535 {
 		return errors.New("TAC must be within 0-65535")
 	}
+	switch config.DeviceClass {
+	case
+		"Baicells Nova-233 G2 OD FDD",
+		"Baicells Nova-243 OD TDD",
+		"Baicells ID TDD/FDD",
+		"NuRAN Cavium OC-LTE":
+		break
+	default:
+		return errors.New("Invalid eNodeB device class")
+	}
 	switch config.BandwidthMhz {
 	case
 		3,

--- a/lte/cloud/go/services/cellular/protos/proto_validation_test.go
+++ b/lte/cloud/go/services/cellular/protos/proto_validation_test.go
@@ -274,6 +274,11 @@ func TestValidateEnodebConfig(t *testing.T) {
 	assert.Error(t, err)
 
 	config = test_utils.NewDefaultEnodebConfig()
+	config.DeviceClass = "Some unsupported device"
+	err = protos.ValidateEnodebConfig(config)
+	assert.Error(t, err)
+
+	config = test_utils.NewDefaultEnodebConfig()
 	config.CellId = 268435456
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)

--- a/lte/cloud/go/services/cellular/swagger/swagger.yml
+++ b/lte/cloud/go/services/cellular/swagger/swagger.yml
@@ -262,6 +262,14 @@ definitions:
       transmit_enabled:
         type: boolean
         example: true
+      device_class:
+        type: string
+        example: 'Baicells ID TDD/FDD'
+        enum:
+        - 'Baicells Nova-233 G2 OD FDD'
+        - 'Baicells Nova-243 OD TDD'
+        - 'Baicells ID TDD/FDD'
+        - 'NuRAN Cavium OC-LTE'
   network_cellular_configs:
     description: Cellular configuration for a network
     type: object

--- a/lte/cloud/go/services/cellular/test_utils/defaults.go
+++ b/lte/cloud/go/services/cellular/test_utils/defaults.go
@@ -127,5 +127,6 @@ func NewDefaultEnodebConfig() *protos.CellularEnodebConfig {
 		Tac:                    15000,
 		BandwidthMhz:           3,
 		TransmitEnabled:        true,
+		DeviceClass:            "Baicells ID TDD/FDD",
 	}
 }


### PR DESCRIPTION
Summary: Device class is needed for eNB devices that are not configured through TR-069 interface. Currently we are not supporting non-tr069 devices, but we will in the future.

Reviewed By: fishlinghu

Differential Revision: D15283220

