### PR TITLE
Accept bandwidth from eNB as either MHz or RBs

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -215,7 +215,8 @@ class BaicellsTrDataModel(DataModel):
         ParameterName.UL_BANDWIDTH: transform_for_enb.bandwidth
     }
     TRANSFORMS_FOR_MAGMA = {
-        # For DL_BANDWIDTH and UL_BANDWIDTH, we read in values as MHz, not RBs
+        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
+        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -230,6 +230,8 @@ class BaicellsTrOldDataModel(DataModel):
         ParameterName.CELL_RESERVED: transform_for_enb.invert_cell_reserved,
     }
     TRANSFORMS_FOR_MAGMA = {
+        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
+        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181

--- a/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
+++ b/lte/gateway/python/magma/enodebd/devices/experimental/cavium.py
@@ -365,6 +365,8 @@ class CaviumTrDataModel(DataModel):
         ParameterName.UL_BANDWIDTH: transform_for_enb.bandwidth
     }
     TRANSFORMS_FOR_MAGMA = {
+        ParameterName.DL_BANDWIDTH: transform_for_magma.bandwidth,
+        ParameterName.UL_BANDWIDTH: transform_for_magma.bandwidth,
         # We don't set GPS, so we don't need transform for enb
         ParameterName.GPS_LAT: transform_for_magma.gps_tr181,
         ParameterName.GPS_LONG: transform_for_magma.gps_tr181

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
@@ -288,7 +288,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.ULBandwidth',
             val_type='string',
-            data='20',
+            data='n100',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.Common.CellIdentity',
@@ -397,7 +397,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.DLBandwidth',
             val_type='string',
-            data='20',
+            data='n100',
         ))
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.RF.FreqBandIndicator',

--- a/lte/gateway/python/magma/enodebd/tests/transform_for_magma_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/transform_for_magma_tests.py
@@ -9,7 +9,8 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 # pylint: disable=protected-access
 from unittest import TestCase
-from magma.enodebd.data_models.transform_for_magma import gps_tr181
+from magma.enodebd.data_models.transform_for_magma import gps_tr181, bandwidth
+from magma.enodebd.exceptions import ConfigurationError
 
 
 class TransformForMagmaTests(TestCase):
@@ -29,3 +30,22 @@ class TransformForMagmaTests(TestCase):
         out = gps_tr181(inp)
         expected = '0.0'
         self.assertEqual(out, expected, 'Should leave zero as zero')
+
+    def test_bandwidth(self) -> None:
+        inp = 'n6'
+        out = bandwidth(inp)
+        expected = 1.4
+        self.assertEqual(out, expected, 'Should convert RBs')
+
+        inp = 1.4
+        out = bandwidth(inp)
+        expected = 1.4
+        self.assertEqual(out, expected, 'Should accept MHz')
+
+        with self.assertRaises(ConfigurationError):
+            inp = 'asdf'
+            bandwidth(inp)
+
+        with self.assertRaises(ConfigurationError):
+            inp = 1234
+            bandwidth(inp)


### PR DESCRIPTION
Summary: Various eNodeB devices will report their DL and UL bandwidth in different formats. For now, accept both, until it's known specifically which devices support which formats.

Reviewed By: xjtian

Differential Revision: D15288899

