### PR TITLE
Change checkind obsidian handler to read from state service

### DIFF
--- a/orc8r/cloud/go/services/checkind/obsidian/handlers/checkindh_test.go
+++ b/orc8r/cloud/go/services/checkind/obsidian/handlers/checkindh_test.go
@@ -17,16 +17,15 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/protos"
-	"magma/orc8r/cloud/go/registry"
-	"magma/orc8r/cloud/go/services/checkind"
 	checkindTestInit "magma/orc8r/cloud/go/services/checkind/test_init"
 	"magma/orc8r/cloud/go/services/checkind/test_utils"
 	"magma/orc8r/cloud/go/services/magmad"
 	magmadProtos "magma/orc8r/cloud/go/services/magmad/protos"
 	magmadTestInit "magma/orc8r/cloud/go/services/magmad/test_init"
+	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
+	stateTestUtils "magma/orc8r/cloud/go/services/state/test_utils"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/net/context"
 )
 
 const testAgHwId = "Test-AGW-Hw-Id"
@@ -37,193 +36,50 @@ func TestCheckind(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmadTestInit.StartTestService(t)
 	checkindTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
 	restPort := tests.StartObsidian(t)
 
 	// create a test network with a single GW
-	testNetworkId, err := magmad.RegisterNetwork(
+	testNetworkID, err := magmad.RegisterNetwork(
 		&magmadProtos.MagmadNetworkRecord{Name: "Test Network 1"},
 		"checkind_obsidian_test_network")
 	assert.NoError(t, err)
 
-	t.Logf("New Registered Network: %s", testNetworkId)
+	t.Logf("New Registered Network: %s", testNetworkID)
 
-	hwId := protos.AccessGatewayID{Id: testAgHwId}
-	logicalId, err := magmad.RegisterGateway(testNetworkId, &magmadProtos.AccessGatewayRecord{HwId: &hwId, Name: "Test GW Name"})
+	hwID := protos.AccessGatewayID{Id: testAgHwId}
+	logicalID, err := magmad.RegisterGateway(testNetworkID, &magmadProtos.AccessGatewayRecord{HwId: &hwID, Name: "Test GW Name"})
 	assert.NoError(t, err)
-	assert.NotEqual(t, logicalId, "")
+	assert.NotEqual(t, logicalID, "")
 
-	conn, err := registry.GetConnection(checkind.ServiceName)
-	assert.NoError(t, err)
+	ctx := stateTestUtils.GetContextWithCertificate(t, testAgHwId)
+	// put one checkin state into state service
+	checkinRequest := test_utils.GetCheckinRequestProtoFixture(testAgHwId)
+	stateTestUtils.ReportCheckin(t, ctx, checkinRequest)
 
-	magmaCheckindClient := protos.NewCheckindClient(conn)
+	getGWStatusNoError(t, restPort, testNetworkID, logicalID)
+	getGWStatusNotFoundError(t, restPort, testNetworkID)
 
-	// Test GW updating old status
-	request := &protos.CheckinRequest{
-		GatewayId:       testAgHwId,
-		MagmaPkgVersion: "1.2.3",
-		KernelVersion:   "4.9.0-6-amd64",
-		Status: &protos.ServiceStatus{
-			Meta: map[string]string{
-				"hello": "world",
-			},
-		},
-		SystemStatus: &protos.SystemStatus{
-			Time:       1495484735606,
-			CpuUser:    31498,
-			CpuSystem:  8361,
-			CpuIdle:    1869111,
-			MemTotal:   1016084,
-			MemUsed:    54416,
-			MemFree:    412772,
-			UptimeSecs: 1234,
-		},
-	}
-	resp, err := magmaCheckindClient.Checkin(context.Background(), request)
-	assert.NoError(t, err)
-	assert.Equal(t, resp.Action, protos.CheckinResponse_NONE)
+	magmad.ForceRemoveNetwork(testNetworkID)
+}
 
-	// Get GW status from the checkin above via REST API
-	testUrlRoot := fmt.Sprintf(
-		"http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
-	getOldAGStatusTestCase := tests.Testcase{
-		Name:   "Get Old AG Status",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/%s/status",
-			testUrlRoot, testNetworkId, logicalId),
-		Payload: "",
-		Expected: fmt.Sprintf(`
-			{
-			   "checkin_time":%d,
-			   "hardware_id":"Test-AGW-Hw-Id",
-			   "kernel_version":"4.9.0-6-amd64",
-			   "meta":{
-				  "hello":"world"
-			   },
-			   "platform_info":{
-				  "kernel_version":"4.9.0-6-amd64",
-				  "packages":[
-					 {
-						"name":"magma",
-						"version":"1.2.3"
-					 }
-				  ]
-			   },
-			   "system_status":{
-				  "cpu_idle":1869111,
-				  "cpu_system":8361,
-				  "cpu_user":31498,
-				  "mem_free":412772,
-				  "mem_total":1016084,
-				  "mem_used":54416,
-				  "time":1495484735606,
-				  "uptime_secs":1234
-			   },
-			   "version":"1.2.3"
-			}`, resp.Time),
-	}
-	tests.RunTest(t, getOldAGStatusTestCase)
+func getURL(restPort int, networkID string, logicalID string) string {
+	url := fmt.Sprintf(
+		"http://localhost:%d%s/networks/%s/gateways/%s/status",
+		restPort,
+		handlers.REST_ROOT,
+		networkID,
+		logicalID,
+	)
+	return url
+}
 
-	// Test GW updating status
-	request = test_utils.GetCheckinRequestProtoFixture(testAgHwId)
-	resp, err = magmaCheckindClient.Checkin(context.Background(), request)
-	assert.NoError(t, err)
-	assert.Equal(t, resp.Action, protos.CheckinResponse_NONE)
+func getGWStatusNoError(t *testing.T, restPort int, networkID string, logicalID string) {
+	url := getURL(restPort, networkID, logicalID)
+	stateTestUtils.GetGWStatusViaHTTPNoError(t, url, networkID, logicalID)
+}
 
-	// Get GW status from the checkin above via REST API
-	getAGStatusTestCase := tests.Testcase{
-		Name:   "Get AG Status",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/%s/status",
-			testUrlRoot, testNetworkId, logicalId),
-		Payload: "",
-		Expected: fmt.Sprintf(`
-			{
-			   "checkin_time":%d,
-			   "hardware_id":"Test-AGW-Hw-Id",
-			   "kernel_version":"42",
-			   "kernel_versions_installed":[
-				  "42",
-				  "43"
-			   ],
-			   "machine_info":{
-				  "cpu_info":{
-					 "architecture":"x86_64",
-					 "core_count":4,
-					 "model_name":"Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz",
-					 "threads_per_core":1
-				  },
-				  "network_info":{
-					 "network_interfaces":[
-						{
-						   "ip_addresses":[
-							  "10.10.10.1"
-						   ],
-						   "ipv6_addresses":[
-							  "fe80::a00:27ff:fe1e:8332"
-						   ],
-						   "mac_address":"08:00:27:1e:8a:32",
-						   "network_interface_id":"gtp_br0",
-						   "status":"UP"
-						}
-					 ],
-					 "routing_table":[
-						{
-						   "destination_ip":"0.0.0.0",
-						   "gateway_ip":"10.10.10.1",
-						   "genmask":"255.255.255.0",
-						   "network_interface_id":"eth0"
-						}
-					 ]
-				  }
-			   },
-			   "meta":{
-				  "hello":"world"
-			   },
-			   "platform_info":{
-				  "config_info":{
-					 "mconfig_created_at":1552968732
-				  },
-				  "kernel_version":"42",
-				  "kernel_versions_installed":[
-					 "42",
-					 "43"
-				  ],
-				  "packages":[
-					 {
-						"name":"magma",
-						"version":"0.0.0.0"
-					 }
-				  ],
-				  "vpn_ip":"facebook.com"
-			   },
-			   "system_status":{
-				  "cpu_idle":1869111,
-				  "cpu_system":8361,
-				  "cpu_user":31498,
-				  "disk_partitions":[
-					 {
-						"device":"/dev/sda1",
-						"free":3,
-						"mount_point":"/",
-						"total":1,
-						"used":2
-					 }
-				  ],
-				  "mem_free":412772,
-				  "mem_total":1016084,
-				  "mem_used":54416,
-				  "swap_free":412771,
-				  "swap_total":1016081,
-				  "swap_used":54415,
-				  "time":1495484735606,
-				  "uptime_secs":1234
-			   },
-			   "version":"0.0.0.0",
-			   "vpn_ip":"facebook.com"
-			}`, resp.Time),
-	}
-	tests.RunTest(t, getAGStatusTestCase)
-
-	err = magmad.ForceRemoveNetwork(testNetworkId)
-	assert.NoError(t, err)
+func getGWStatusNotFoundError(t *testing.T, restPort int, networkID string) {
+	url := getURL(restPort, networkID, "should-not-exist")
+	stateTestUtils.GetGWStatusExpectNotFound(t, url)
 }


### PR DESCRIPTION
Summary:
Checkind REST GET API handler now reads from state service storage, instead of the checkind service.
The implementation is extremely similar to the state service handler to get gateway status, since it is essentially doing the same thing.
One difference is that since the checkind REST API queries the gateway by its logical gateway id and the states are stored by physical ID, an extra query to magmad is made to translate the ID.

Reviewed By: xjtian

Differential Revision: D15174507

