### PR TITLE
Implement a connection pool for GRPC services

### DIFF
--- a/feg/cloud/go/services/feg_relay/servicers/abort.go
+++ b/feg/cloud/go/services/feg_relay/servicers/abort.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) ServiceAbortRequestUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.ServiceAbort(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/alert.go
+++ b/feg/cloud/go/services/feg_relay/servicers/alert.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) AlertRequestUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.AlertReq(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/cancel_location.go
+++ b/feg/cloud/go/services/feg_relay/servicers/cancel_location.go
@@ -47,7 +47,6 @@ func (srv *FegToGwRelayServer) CancelLocationUnverified(
 		return &fegprotos.CancelLocationAnswer{ErrorCode: 1},
 			fmt.Errorf("unable to get connection to the gateway ID: %s", hwId)
 	}
-	defer conn.Close()
 	client := fegprotos.NewS6AGatewayServiceClient(conn)
 	return client.CancelLocation(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/detach.go
+++ b/feg/cloud/go/services/feg_relay/servicers/detach.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) EPSDetachAckUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.EPSDetachAc(ctx, req)
 }
@@ -58,7 +57,6 @@ func (srv *FegToGwRelayServer) IMSIDetachAckUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.IMSIDetachAc(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/downlink.go
+++ b/feg/cloud/go/services/feg_relay/servicers/downlink.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) DownlinkUnitdataUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.Downlink(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
+++ b/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
@@ -112,9 +112,3 @@ func getAllGWSGSServiceConnCtx(ctx context.Context) ([]*grpc.ClientConn, []conte
 
 	return connList, ctxList, nil
 }
-
-func closeAllConnection(allConn []*grpc.ClientConn) {
-	for _, conn := range allConn {
-		conn.Close()
-	}
-}

--- a/feg/cloud/go/services/feg_relay/servicers/gx_reauth.go
+++ b/feg/cloud/go/services/feg_relay/servicers/gx_reauth.go
@@ -34,6 +34,5 @@ func (srv *FegToGwRelayServer) PolicyReAuth(
 		return &protos.PolicyReAuthAnswer{Result: protos.ReAuthResult_OTHER_FAILURE},
 			fmt.Errorf("unable to get connection to the gateway ID: %s", hwID)
 	}
-	defer conn.Close()
 	return protos.NewSessionProxyResponderClient(conn).PolicyReAuth(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/gy_reauth.go
+++ b/feg/cloud/go/services/feg_relay/servicers/gy_reauth.go
@@ -34,6 +34,5 @@ func (srv *FegToGwRelayServer) ChargingReAuth(
 		return &protos.ChargingReAuthAnswer{Result: protos.ChargingReAuthAnswer_OTHER_FAILURE},
 			fmt.Errorf("unable to get connection to the gateway ID: %s", hwID)
 	}
-	defer conn.Close()
 	return protos.NewSessionProxyResponderClient(conn).ChargingReAuth(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/location.go
+++ b/feg/cloud/go/services/feg_relay/servicers/location.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) LocationUpdateAcceptUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.LocationUpdateAcc(ctx, req)
 }
@@ -58,7 +57,6 @@ func (srv *FegToGwRelayServer) LocationUpdateRejectUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.LocationUpdateRej(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/mmi_info.go
+++ b/feg/cloud/go/services/feg_relay/servicers/mmi_info.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) MMInformationRequestUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.MMInformationReq(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/paging.go
+++ b/feg/cloud/go/services/feg_relay/servicers/paging.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) PagingRequestUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.PagingReq(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/release.go
+++ b/feg/cloud/go/services/feg_relay/servicers/release.go
@@ -34,7 +34,6 @@ func (srv *FegToGwRelayServer) ReleaseRequestUnverified(
 	if err != nil {
 		return &protos.Void{}, err
 	}
-	defer conn.Close()
 	client := fegprotos.NewCSFBGatewayServiceClient(conn)
 	return client.ReleaseReq(ctx, req)
 }

--- a/feg/cloud/go/services/feg_relay/servicers/reset.go
+++ b/feg/cloud/go/services/feg_relay/servicers/reset.go
@@ -92,5 +92,4 @@ func sendReset(hwId string, req *protos.ResetRequest) {
 		diamErrName, _ := protos.ErrorCode_name[int32(ans.ErrorCode)]
 		glog.Errorf("Reset Diameter error %d (%s) for gateway Hw ID: %s.", ans.ErrorCode, diamErrName, hwId)
 	}
-	conn.Close()
 }

--- a/feg/cloud/go/services/feg_relay/servicers/vlr.go
+++ b/feg/cloud/go/services/feg_relay/servicers/vlr.go
@@ -32,7 +32,6 @@ func (srv *FegToGwRelayServer) VLRResetAckUnverified(
 	req *fegprotos.ResetAck,
 ) (*protos.Void, error) {
 	connList, ctxList, err := getAllGWSGSServiceConnCtx(ctx)
-	defer closeAllConnection(connList)
 	if err != nil {
 		return &protos.Void{}, err
 	}
@@ -66,7 +65,6 @@ func (srv *FegToGwRelayServer) VLRResetIndicationUnverified(
 	req *fegprotos.ResetIndication,
 ) (*protos.Void, error) {
 	connList, ctxList, err := getAllGWSGSServiceConnCtx(ctx)
-	defer closeAllConnection(connList)
 	if err != nil {
 		glog.Errorf("Failed to getAllGWSGSServiceConnCtx(ctx): %s", err)
 		return &protos.Void{}, err
@@ -100,7 +98,6 @@ func (srv *FegToGwRelayServer) VLRStatusUnverified(
 	req *fegprotos.Status,
 ) (*protos.Void, error) {
 	connList, ctxList, err := getAllGWSGSServiceConnCtx(ctx)
-	defer closeAllConnection(connList)
 	if err != nil {
 		return &protos.Void{}, err
 	}

--- a/feg/cloud/go/services/health/client_api.go
+++ b/feg/cloud/go/services/health/client_api.go
@@ -20,30 +20,28 @@ import (
 	"magma/orc8r/cloud/go/registry"
 
 	"github.com/golang/glog"
-	"google.golang.org/grpc"
 )
 
 const ServiceName = "HEALTH"
 
 // getHealthClient is a utility function to get an RPC connection to the
 // Health service
-func getHealthClient() (protos.HealthClient, *grpc.ClientConn, error) {
+func getHealthClient() (protos.HealthClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewHealthClient(conn), conn, nil
+	return protos.NewHealthClient(conn), nil
 }
 
 // GetActiveGateway returns the active federated gateway in the network specified by networkID
 func GetActiveGateway(networkID string) (string, error) {
-	client, conn, err := getHealthClient()
+	client, err := getHealthClient()
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
 
 	// Currently, we use networkID as clusterID as we only support one cluster per network
 	clusterState, err := client.GetClusterState(context.Background(), &protos.ClusterStateRequest{
@@ -65,11 +63,10 @@ func GetHealth(networkID string, logicalID string) (*protos.HealthStats, error) 
 	if len(logicalID) == 0 {
 		return nil, fmt.Errorf("Empty logicalId provided")
 	}
-	client, conn, err := getHealthClient()
+	client, err := getHealthClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	gatewayHealthReq := &protos.GatewayStatusRequest{
 		NetworkId: networkID,

--- a/feg/cloud/go/services/health/client_api_test.go
+++ b/feg/cloud/go/services/health/client_api_test.go
@@ -197,7 +197,6 @@ func updateHealth(t *testing.T, req *protos.HealthRequest) (*protos.HealthRespon
 	}
 	conn, err := registry.GetConnection(health.ServiceName)
 	assert.NoError(t, err)
-	defer conn.Close()
 
 	client := protos.NewHealthClient(conn)
 	return client.UpdateHealth(context.Background(), req)

--- a/lte/cloud/go/services/meteringd_records/client_api.go
+++ b/lte/cloud/go/services/meteringd_records/client_api.go
@@ -18,50 +18,47 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const ServiceName = "METERINGD_RECORDS"
 
-// Get a thin RPC client to the stats service.
-func GetMeteringdRecordsClient() (protos.MeteringdRecordsControllerClient, *grpc.ClientConn, error) {
+// GetMeteringdRecordsClient get a thin RPC client to the stats service.
+func GetMeteringdRecordsClient() (protos.MeteringdRecordsControllerClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewMeteringdRecordsControllerClient(conn), conn, err
+	return protos.NewMeteringdRecordsControllerClient(conn), err
 }
 
-// Get a Record from a network
-func GetRecord(networkId string, recordId string) (*protos.FlowRecord, error) {
-	client, conn, err := GetMeteringdRecordsClient()
+// GetRecord get a Record from a network
+func GetRecord(networkID string, recordID string) (*protos.FlowRecord, error) {
+	client, err := GetMeteringdRecordsClient()
 	if err != nil {
 		return &protos.FlowRecord{}, err
 	}
-	defer conn.Close()
 
 	req := &protos.FlowRecordQuery{
-		NetworkId: networkId,
+		NetworkId: networkID,
 		Query: &protos.FlowRecordQuery_RecordId{
-			RecordId: recordId,
+			RecordId: recordID,
 		},
 	}
 	ctx := context.Background()
 	return client.GetRecord(ctx, req)
 }
 
-// List Records for a subscriber
-func ListSubscriberRecords(networkId string, sid string) ([]*protos.FlowRecord, error) {
-	client, conn, err := GetMeteringdRecordsClient()
+// ListSubscriberRecords list Records for a subscriber
+func ListSubscriberRecords(networkID string, sid string) ([]*protos.FlowRecord, error) {
+	client, err := GetMeteringdRecordsClient()
 	if err != nil {
 		return []*protos.FlowRecord{}, err
 	}
-	defer conn.Close()
 
 	req := &protos.FlowRecordQuery{
-		NetworkId: networkId,
+		NetworkId: networkID,
 		Query: &protos.FlowRecordQuery_SubscriberId{
 			SubscriberId: sid,
 		},

--- a/lte/cloud/go/services/meteringd_records/client_test.go
+++ b/lte/cloud/go/services/meteringd_records/client_test.go
@@ -37,11 +37,10 @@ const (
 // NOTE: This endpoint exists for testing ONLY
 // Real clients will use gRPC directly
 func UpdateFlowsTest(csn string, tbl *protos.FlowTable) error {
-	client, conn, err := meteringd_records.GetMeteringdRecordsClient()
+	client, err := meteringd_records.GetMeteringdRecordsClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	// Hack in the identity context
 	ctx := metadata.NewOutgoingContext(

--- a/lte/cloud/go/services/meteringd_records/obsidian/handlers/meteringd_records_test.go
+++ b/lte/cloud/go/services/meteringd_records/obsidian/handlers/meteringd_records_test.go
@@ -37,11 +37,10 @@ import (
 // NOTE: This endpoint exists for testing ONLY
 // Real clients will use gRPC directly
 func UpdateFlowsTest(csn string, tbl *protos.FlowTable) error {
-	client, conn, err := meteringd_records.GetMeteringdRecordsClient()
+	client, err := meteringd_records.GetMeteringdRecordsClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	// Hack in the identity context
 	ctx := metadata.NewOutgoingContext(

--- a/lte/cloud/go/services/subscriberdb/client_api.go
+++ b/lte/cloud/go/services/subscriberdb/client_api.go
@@ -20,32 +20,30 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const ServiceName = "SUBSCRIBERDB"
 
 // Utility function to get a RPC connection to the subscriberdb service
 func getSubscriberdbClient() (
-	lteprotos.SubscriberDBControllerClient, *grpc.ClientConn, error) {
+	lteprotos.SubscriberDBControllerClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		glog.Errorf("Subscriberdb client initialization error: %s", err)
-		return nil, nil, fmt.Errorf(
+		return nil, fmt.Errorf(
 			"Subscriberdb client initialization error: %s", err)
 	}
-	return lteprotos.NewSubscriberDBControllerClient(conn), conn, err
+	return lteprotos.NewSubscriberDBControllerClient(conn), err
 }
 
-// Add a new subscriber.
+// AddSubscriber add a new subscriber.
 // The subscriber must not be existing already.
 func AddSubscriber(networkId string, sd *lteprotos.SubscriberData) error {
 	sd.NetworkId = &protos.NetworkID{Id: networkId}
-	client, conn, err := getSubscriberdbClient()
+	client, err := getSubscriberdbClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	if _, err = client.AddSubscriber(context.Background(), sd); err != nil {
 		glog.Errorf("[Network: %s] AddSubscriber error: %s", networkId, err)
@@ -54,14 +52,13 @@ func AddSubscriber(networkId string, sd *lteprotos.SubscriberData) error {
 	return nil
 }
 
-// Get the subscriber data.
+// GetSubscriber get the subscriber data.
 func GetSubscriber(networkId string, subscriberId string) (
 	*lteprotos.SubscriberData, error) {
-	client, conn, err := getSubscriberdbClient()
+	client, err := getSubscriberdbClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	lookup := &lteprotos.SubscriberLookup{
 		NetworkId: &protos.NetworkID{Id: networkId},
@@ -75,14 +72,13 @@ func GetSubscriber(networkId string, subscriberId string) (
 	return data, nil
 }
 
-// Update the subscriber info.
+// UpdateSubscriber update the subscriber info.
 func UpdateSubscriber(networkId string, sd *lteprotos.SubscriberData) error {
 	sd.NetworkId = &protos.NetworkID{Id: networkId}
-	client, conn, err := getSubscriberdbClient()
+	client, err := getSubscriberdbClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	if _, err = client.UpdateSubscriber(context.Background(), sd); err != nil {
 		glog.Errorf("[Network: %s] UpdateSubscriber error: %s", networkId, err)
@@ -91,13 +87,12 @@ func UpdateSubscriber(networkId string, sd *lteprotos.SubscriberData) error {
 	return nil
 }
 
-// Delete the subscriber.
+// DeleteSubscriber delete the subscriber.
 func DeleteSubscriber(networkId string, subscriberId string) error {
-	client, conn, err := getSubscriberdbClient()
+	client, err := getSubscriberdbClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	lookup := &lteprotos.SubscriberLookup{
 		NetworkId: &protos.NetworkID{Id: networkId},
@@ -110,14 +105,13 @@ func DeleteSubscriber(networkId string, subscriberId string) error {
 	return nil
 }
 
-// List all existing subscribers.
+// ListSubscribers list all existing subscribers.
 // Returns an array of subscriber ids.
 func ListSubscribers(networkId string) ([]string, error) {
-	client, conn, err := getSubscriberdbClient()
+	client, err := getSubscriberdbClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	subs, err := client.ListSubscribers(
 		context.Background(),
@@ -134,12 +128,12 @@ func ListSubscribers(networkId string) ([]string, error) {
 	return ret, nil
 }
 
+// GetAllSubscriberData returns all subscribers' data.
 func GetAllSubscriberData(networkId string) ([]*lteprotos.SubscriberData, error) {
-	client, conn, err := getSubscriberdbClient()
+	client, err := getSubscriberdbClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	response, err := client.GetAllSubscriberData(context.Background(), &protos.NetworkID{Id: networkId})
 	if err != nil {

--- a/orc8r/cloud/go/service/client/client_api.go
+++ b/orc8r/cloud/go/service/client/client_api.go
@@ -15,63 +15,57 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
-func getClient(service string) (protos.Service303Client, *grpc.ClientConn, error) {
+func getClient(service string) (protos.Service303Client, error) {
 	conn, err := registry.GetConnection(service)
 	if err != nil {
 		initErr := errors.NewInitError(err, "SERVICE303")
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewService303Client(conn), conn, nil
+	return protos.NewService303Client(conn), nil
 }
 
 func Service303GetServiceInfo(service string) (*protos.ServiceInfo, error) {
-	client, conn, err := getClient(service)
+	client, err := getClient(service)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	return client.GetServiceInfo(context.Background(), new(protos.Void))
 }
 
 func Service303GetMetrics(service string) (*protos.MetricsContainer, error) {
-	client, conn, err := getClient(service)
+	client, err := getClient(service)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	return client.GetMetrics(context.Background(), new(protos.Void))
 }
 
 func Service303StopService(service string) error {
-	client, conn, err := getClient(service)
+	client, err := getClient(service)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.StopService(context.Background(), new(protos.Void))
 	return err
 }
 
 func Service303SetLogLevel(service string, in *protos.LogLevelMessage) error {
-	client, conn, err := getClient(service)
+	client, err := getClient(service)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.SetLogLevel(context.Background(), in)
 	return err
 }
 
 func Service303SetLogVerbosity(service string, in *protos.LogVerbosity) error {
-	client, conn, err := getClient(service)
+	client, err := getClient(service)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.SetLogVerbosity(context.Background(), in)
 	return err
 }

--- a/orc8r/cloud/go/service/service_test.go
+++ b/orc8r/cloud/go/service/service_test.go
@@ -44,7 +44,6 @@ func TestServiceRun(t *testing.T) {
 	conn, err := registry.GetConnection(checkind.ServiceName)
 	assert.NoError(t, err, "err in getting connection to service")
 	client := protos.NewService303Client(conn)
-	defer conn.Close()
 
 	actualServiceInfo, err := client.GetServiceInfo(context.Background(), new(protos.Void))
 

--- a/orc8r/cloud/go/services/checkind/client_api.go
+++ b/orc8r/cloud/go/services/checkind/client_api.go
@@ -16,30 +16,28 @@ import (
 	"magma/orc8r/cloud/go/registry"
 
 	"github.com/golang/glog"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 const ServiceName = "CHECKIND"
 
-func getCheckindClient() (protos.CheckindClient, *grpc.ClientConn, error) {
+func getCheckindClient() (protos.CheckindClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewCheckindClient(conn), conn, err
+	return protos.NewCheckindClient(conn), err
 }
 
 // GetStatus returns the gateway status for the gateway with logicalID in the network specified by networkID
 func GetStatus(networkID string, logicalID string) (*protos.GatewayStatus, error) {
-	client, conn, err := getCheckindClient()
+	client, err := getCheckindClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	ret, err := client.GetStatus(context.Background(), &protos.GatewayStatusRequest{
 		NetworkId: networkID,
@@ -58,11 +56,10 @@ func GetStatus(networkID string, logicalID string) (*protos.GatewayStatus, error
 // DeleteGatewayStatus removes the gateway status record from the gateway's network table
 // NOTE: the record will be created again after next successful gateway checkin
 func DeleteGatewayStatus(networkID string, logicalID string) error {
-	client, conn, err := getCheckindClient()
+	client, err := getCheckindClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.DeleteGatewayStatus(context.Background(), &protos.GatewayStatusRequest{
 		NetworkId: networkID,
 		LogicalId: logicalID,
@@ -73,11 +70,10 @@ func DeleteGatewayStatus(networkID string, logicalID string) error {
 // DeleteNetwork deletes the network's status table. All gateway statuses must
 // be deleted prior to removal.
 func DeleteNetwork(networkID string) error {
-	client, conn, err := getCheckindClient()
+	client, err := getCheckindClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.DeleteNetwork(context.Background(), &protos.NetworkID{Id: networkID})
 	return err
 }
@@ -85,10 +81,9 @@ func DeleteNetwork(networkID string) error {
 // List returns a list of all logical gateway IDs for the given network which
 // have been stored in the service DB
 func List(networkID string) (*protos.IDList, error) {
-	client, conn, err := getCheckindClient()
+	client, err := getCheckindClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	return client.List(context.Background(), &protos.NetworkID{Id: networkID})
 }

--- a/orc8r/cloud/go/services/checkind/client_api_test.go
+++ b/orc8r/cloud/go/services/checkind/client_api_test.go
@@ -104,7 +104,6 @@ func registerGateways(t *testing.T) {
 func insertStatuses(t *testing.T) map[string]*protos.CheckinRequest {
 	conn, err := registry.GetConnection(checkind.ServiceName)
 	assert.NoError(t, err)
-	defer conn.Close()
 	client := protos.NewCheckindClient(conn)
 	checkinRequest1 := test_utils.GetCheckinRequestProtoFixture(gw1HardwareID)
 	_, err = client.Checkin(context.Background(), checkinRequest1)

--- a/orc8r/cloud/go/services/config/client_api.go
+++ b/orc8r/cloud/go/services/config/client_api.go
@@ -30,7 +30,6 @@ import (
 	"magma/orc8r/cloud/go/storage"
 
 	"github.com/golang/glog"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -40,23 +39,22 @@ const (
 	SerdeDomain = "config_manager"
 )
 
-func getConfigServiceClient() (protos.ConfigServiceClient, *grpc.ClientConn, error) {
+func getConfigServiceClient() (protos.ConfigServiceClient, error) {
 	conn, err := service_registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewConfigServiceClient(conn), conn, err
+	return protos.NewConfigServiceClient(conn), err
 }
 
 // Retrieve a specific config.
 func GetConfig(networkId string, configType string, key string) (interface{}, error) {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	req := &protos.GetOrDeleteConfigRequest{NetworkId: networkId, Type: configType, Key: key}
 	val, err := client.GetConfig(context.Background(), req)
@@ -68,11 +66,10 @@ func GetConfig(networkId string, configType string, key string) (interface{}, er
 
 // Fetch all configs matching a type.
 func GetConfigsByType(networkId string, configType string) (map[storage.TypeAndKey]interface{}, error) {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	req := &protos.GetOrDeleteConfigsRequest{
 		NetworkId: networkId,
@@ -87,11 +84,10 @@ func GetConfigsByType(networkId string, configType string) (map[storage.TypeAndK
 
 // Fetch all configs matching a key.
 func GetConfigsByKey(networkId string, key string) (map[storage.TypeAndKey]interface{}, error) {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	req := &protos.GetOrDeleteConfigsRequest{
 		NetworkId: networkId,
@@ -106,11 +102,10 @@ func GetConfigsByKey(networkId string, key string) (map[storage.TypeAndKey]inter
 
 // List all configuration keys for a specific type.
 func ListKeysForType(networkId string, configType string) ([]string, error) {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	req := &protos.ListKeysForTypeRequest{NetworkId: networkId, Type: configType}
 	keys, err := client.ListKeysForType(context.Background(), req)
@@ -126,11 +121,10 @@ func ListKeysForType(networkId string, configType string) ([]string, error) {
 // Create a new config. This will error out if there is an existing config
 // with the same type and key.
 func CreateConfig(networkId string, configType string, key string, value interface{}) error {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	marshaledValue, err := serde.Serialize(SerdeDomain, configType, value)
 	if err != nil {
@@ -145,11 +139,10 @@ func CreateConfig(networkId string, configType string, key string, value interfa
 // Update an existing config. This will error out if there is no existing
 // config with a matching type and key.
 func UpdateConfig(networkId string, configType string, key string, updatedValue interface{}) error {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	marshaledValue, err := serde.Serialize(SerdeDomain, configType, updatedValue)
 	if err != nil {
@@ -164,11 +157,10 @@ func UpdateConfig(networkId string, configType string, key string, updatedValue 
 // Delete an existing config. This will error out if there is no existing
 // config with a matching type and key.
 func DeleteConfig(networkId string, configType string, key string) error {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.GetOrDeleteConfigRequest{NetworkId: networkId, Type: configType, Key: key}
 	_, err = client.DeleteConfig(context.Background(), req)
@@ -177,11 +169,10 @@ func DeleteConfig(networkId string, configType string, key string) error {
 
 // Delete all configs matching a type
 func DeleteConfigsByType(networkId string, configType string) error {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.GetOrDeleteConfigsRequest{
 		NetworkId: networkId,
@@ -193,11 +184,10 @@ func DeleteConfigsByType(networkId string, configType string) error {
 
 // Delete all configs matching a key
 func DeleteConfigsByKey(networkId string, key string) error {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.GetOrDeleteConfigsRequest{
 		NetworkId: networkId,
@@ -210,11 +200,10 @@ func DeleteConfigsByKey(networkId string, key string) error {
 
 // Delete all the configs for all entities in a network
 func DeleteAllNetworkConfigs(networkId string) error {
-	client, conn, err := getConfigServiceClient()
+	client, err := getConfigServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.NetworkIdRequest{NetworkId: networkId}
 	_, err = client.DeleteAllConfigsForNetwork(context.Background(), req)

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -16,36 +16,33 @@ import (
 	"magma/orc8r/cloud/go/services/device/protos"
 
 	"github.com/golang/glog"
-	"google.golang.org/grpc"
 )
 
-func getDeviceClient() (protos.DeviceClient, *grpc.ClientConn, error) {
+func getDeviceClient() (protos.DeviceClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewDeviceClient(conn), conn, err
+	return protos.NewDeviceClient(conn), err
 }
 
 func RegisterDevices(networkID string, entities []*protos.PhysicalEntity) error {
-	client, conn, err := getDeviceClient()
+	client, err := getDeviceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	req := &protos.RegisterDevicesRequest{NetworkID: networkID, Entities: entities}
 	_, err = client.RegisterDevices(context.Background(), req)
 	return err
 }
 
 func DeleteDevices(networkID string, deviceIDs []*protos.DeviceID) error {
-	client, conn, err := getDeviceClient()
+	client, err := getDeviceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.DeleteDevicesRequest{NetworkID: networkID, DeviceIDs: deviceIDs}
 	_, err = client.DeleteDevices(context.Background(), req)
@@ -53,11 +50,10 @@ func DeleteDevices(networkID string, deviceIDs []*protos.DeviceID) error {
 }
 
 func GetDeviceInfo(networkID string, deviceIDs []*protos.DeviceID) (map[string]*protos.PhysicalEntity, error) {
-	client, conn, err := getDeviceClient()
+	client, err := getDeviceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	req := &protos.GetDeviceInfoRequest{NetworkID: networkID, DeviceIDs: deviceIDs}
 	res, err := client.GetDeviceInfo(context.Background(), req)
 	if err != nil {

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -17,20 +17,19 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const ServiceName = "DIRECTORYD"
 
 // Get a thin RPC client to the directory service.
-func GetDirectorydClient() (protos.DirectoryServiceClient, *grpc.ClientConn, error) {
+func GetDirectorydClient() (protos.DirectoryServiceClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewDirectoryServiceClient(conn), conn, err
+	return protos.NewDirectoryServiceClient(conn), err
 }
 
 func GetHardwareIdByIMSI(imsi string) (string, error) {
@@ -42,11 +41,10 @@ func GetHostNameByIMSI(hwId string) (string, error) {
 }
 
 func getLocation(tableId protos.TableID, recordId string) (string, error) {
-	client, conn, err := GetDirectorydClient()
+	client, err := GetDirectorydClient()
 	if err != nil {
 		return "", err
 	}
-	defer conn.Close()
 
 	req := &protos.GetLocationRequest{
 		Table: tableId,
@@ -69,11 +67,10 @@ func UpdateHostNameByHwId(hwId string, hostName string) error {
 }
 
 func updateLocation(tableId protos.TableID, recordId string, location string) error {
-	client, conn, err := GetDirectorydClient()
+	client, err := GetDirectorydClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.UpdateDirectoryLocationRequest{
 		Table:  tableId,
@@ -94,11 +91,10 @@ func DeleteHostNameByIMSI(hwId string) error {
 }
 
 func deleteLocation(tableId protos.TableID, recordId string) error {
-	client, conn, err := GetDirectorydClient()
+	client, err := GetDirectorydClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &protos.DeleteLocationRequest{
 		Table: tableId,

--- a/orc8r/cloud/go/services/dispatcher/gw_client_apis/service303/gw_service303_client_api.go
+++ b/orc8r/cloud/go/services/dispatcher/gw_client_apis/service303/gw_service303_client_api.go
@@ -17,64 +17,58 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
-func getGWClient(service gateway_registry.GwServiceType, hwId string) (protos.Service303Client, *grpc.ClientConn, context.Context, error) {
+func getGWClient(service gateway_registry.GwServiceType, hwId string) (protos.Service303Client, context.Context, error) {
 	conn, ctx, err := gateway_registry.GetGatewayConnection(service, hwId)
 	if err != nil {
 		errMsg := fmt.Sprintf("service303 gwClient initialization error: %s", err)
 		glog.Error(errMsg)
-		return nil, nil, nil, errors.New(errMsg)
+		return nil, nil, errors.New(errMsg)
 	}
-	return protos.NewService303Client(conn), conn, ctx, nil
+	return protos.NewService303Client(conn), ctx, nil
 
 }
 
 func GWService303GetServiceInfo(service gateway_registry.GwServiceType, hwId string) (*protos.ServiceInfo, error) {
-	client, conn, ctx, err := getGWClient(service, hwId)
+	client, ctx, err := getGWClient(service, hwId)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	return client.GetServiceInfo(ctx, new(protos.Void))
 }
 
 func GWService303GetMetrics(service gateway_registry.GwServiceType, hwId string) (*protos.MetricsContainer, error) {
-	client, conn, ctx, err := getGWClient(service, hwId)
+	client, ctx, err := getGWClient(service, hwId)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 	return client.GetMetrics(ctx, new(protos.Void))
 }
 
 func GWService303StopService(service gateway_registry.GwServiceType, hwId string) error {
-	client, conn, ctx, err := getGWClient(service, hwId)
+	client, ctx, err := getGWClient(service, hwId)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.StopService(ctx, new(protos.Void))
 	return err
 }
 
 func GWService303SetLogLevel(service gateway_registry.GwServiceType, hwId string, in *protos.LogLevelMessage) error {
-	client, conn, ctx, err := getGWClient(service, hwId)
+	client, ctx, err := getGWClient(service, hwId)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.SetLogLevel(ctx, in)
 	return err
 }
 
 func GWService303SetLogVerbosity(service gateway_registry.GwServiceType, hwId string, in *protos.LogVerbosity) error {
-	client, conn, ctx, err := getGWClient(service, hwId)
+	client, ctx, err := getGWClient(service, hwId)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.SetLogVerbosity(ctx, in)
 	return err
 }

--- a/orc8r/cloud/go/services/logger/client_api.go
+++ b/orc8r/cloud/go/services/logger/client_api.go
@@ -17,21 +17,20 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const ServiceName = "LOGGER"
 
 // getLoggerClient is a utility function to get a RPC connection to the
 // loggingService service
-func getLoggerClient() (protos.LoggingServiceClient, *grpc.ClientConn, error) {
+func getLoggerClient() (protos.LoggingServiceClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewLoggingServiceClient(conn), conn, err
+	return protos.NewLoggingServiceClient(conn), err
 
 }
 
@@ -44,11 +43,10 @@ func shouldLog(samplingRate float64) bool {
 // User call this directly to log //
 ////////////////////////////////////
 func LogEntriesToDest(entries []*protos.LogEntry, destination protos.LoggerDestination, samplingRate float64) error {
-	lg, conn, err := getLoggerClient()
+	lg, err := getLoggerClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	if !shouldLog(samplingRate) {
 		return nil
 	}

--- a/orc8r/cloud/go/services/magmad/gateway_api.go
+++ b/orc8r/cloud/go/services/magmad/gateway_api.go
@@ -17,49 +17,45 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
-func getGWMagmadClient(networkId string, gatewayId string) (protos.MagmadClient, *grpc.ClientConn, context.Context, error) {
+func getGWMagmadClient(networkId string, gatewayId string) (protos.MagmadClient, context.Context, error) {
 	gwRecord, err := FindGatewayRecord(networkId, gatewayId)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 	conn, ctx, err := gateway_registry.GetGatewayConnection(gateway_registry.GwMagmad, gwRecord.HwId.Id)
 	if err != nil {
 		errMsg := fmt.Sprintf("gateway magmad client initialization error: %s", err)
 		glog.Errorf(errMsg, err)
-		return nil, nil, nil, errors.New(errMsg)
+		return nil, nil, errors.New(errMsg)
 	}
-	return protos.NewMagmadClient(conn), conn, ctx, nil
+	return protos.NewMagmadClient(conn), ctx, nil
 }
 
 func GatewayReboot(networkId string, gatewayId string) error {
-	client, conn, ctx, err := getGWMagmadClient(networkId, gatewayId)
+	client, ctx, err := getGWMagmadClient(networkId, gatewayId)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.Reboot(ctx, new(protos.Void))
 	return err
 }
 
 func GatewayRestartServices(networkId string, gatewayId string, services []string) error {
-	client, conn, ctx, err := getGWMagmadClient(networkId, gatewayId)
+	client, ctx, err := getGWMagmadClient(networkId, gatewayId)
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.RestartServices(ctx, &protos.RestartServicesRequest{Services: services})
 	return err
 }
 
 func GatewayPing(networkId string, gatewayId string, packets int32, hosts []string) (*protos.NetworkTestResponse, error) {
-	client, conn, ctx, err := getGWMagmadClient(networkId, gatewayId)
+	client, ctx, err := getGWMagmadClient(networkId, gatewayId)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	var pingParams []*protos.PingParams
 	for _, host := range hosts {
@@ -69,25 +65,24 @@ func GatewayPing(networkId string, gatewayId string, packets int32, hosts []stri
 }
 
 func GatewayGenericCommand(networkId string, gatewayId string, params *protos.GenericCommandParams) (*protos.GenericCommandResponse, error) {
-	client, conn, ctx, err := getGWMagmadClient(networkId, gatewayId)
+	client, ctx, err := getGWMagmadClient(networkId, gatewayId)
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	return client.GenericCommand(ctx, params)
 }
 
-func TailGatewayLogs(networkId string, gatewayId string, service string) (protos.Magmad_TailLogsClient, *grpc.ClientConn, error) {
-	client, conn, ctx, err := getGWMagmadClient(networkId, gatewayId)
+func TailGatewayLogs(networkId string, gatewayId string, service string) (protos.Magmad_TailLogsClient, error) {
+	client, ctx, err := getGWMagmadClient(networkId, gatewayId)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	stream, err := client.TailLogs(ctx, &protos.TailLogsRequest{Service: service})
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	return stream, conn, nil
+	return stream, nil
 }

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers.go
@@ -309,15 +309,13 @@ func tailGatewayLogs(c echo.Context) error {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
 
-	stream, conn, err := magmad.TailGatewayLogs(networkId, gatewayId, request.Service)
+	stream, err := magmad.TailGatewayLogs(networkId, gatewayId, request.Service)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
-	defer conn.Close()
 
 	go func() {
 		<-c.Request().Context().Done()
-		conn.Close()
 	}()
 	// https://echo.labstack.com/cookbook/streaming-response
 	c.Response().Header().Set(echo.HeaderContentType, echo.MIMETextPlainCharsetUTF8)

--- a/orc8r/cloud/go/services/state/tests/state_test.go
+++ b/orc8r/cloud/go/services/state/tests/state_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -133,22 +132,21 @@ func (*Serde) Deserialize(message []byte) (interface{}, error) {
 	return res, err
 }
 
-func getClient() (protos.StateServiceClient, *grpc.ClientConn, error) {
+func getClient() (protos.StateServiceClient, error) {
 	conn, err := registry.GetConnection(state.ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, state.ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return protos.NewStateServiceClient(conn), conn, err
+	return protos.NewStateServiceClient(conn), err
 }
 
 func reportStates(ctx context.Context, bundles ...stateBundle) error {
-	client, conn, err := getClient()
+	client, err := getClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 	_, err = client.ReportStates(ctx, makeReportStatesRequest(bundles))
 	return err
 }

--- a/orc8r/cloud/go/services/streamer/mconfig/provider_test.go
+++ b/orc8r/cloud/go/services/streamer/mconfig/provider_test.go
@@ -121,7 +121,6 @@ func TestMconfigStreamer(t *testing.T) {
 	// Assert value
 	updateBatch, err := streamerClient.Recv()
 	assert.NoError(t, err)
-	conn.Close()
 	assert.Equal(t, 1, len(updateBatch.Updates))
 	assert.Equal(t, gwId1, updateBatch.GetUpdates()[0].GetKey())
 	assert.Equal(t, expectedMarshaled, updateBatch.GetUpdates()[0].GetValue(), expectedMarshaled)

--- a/orc8r/cloud/go/services/streamer/servicers/streamer_test.go
+++ b/orc8r/cloud/go/services/streamer/servicers/streamer_test.go
@@ -41,7 +41,6 @@ func (m *mockStreamProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([
 func TestStreamingServer_GetUpdates(t *testing.T) {
 	streamer_test_init.StartTestService(t)
 	conn, err := registry.GetConnection(streamer.ServiceName)
-	defer conn.Close()
 	assert.NoError(t, err)
 	grpcClient := protos.NewStreamerClient(conn)
 

--- a/orc8r/cloud/go/services/upgrade/client_api.go
+++ b/orc8r/cloud/go/services/upgrade/client_api.go
@@ -16,19 +16,18 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
-	"google.golang.org/grpc"
 )
 
 const ServiceName = "UPGRADE"
 
-func getUpgradeServiceClient() (upgrade_protos.UpgradeServiceClient, *grpc.ClientConn, error) {
+func getUpgradeServiceClient() (upgrade_protos.UpgradeServiceClient, error) {
 	conn, err := registry.GetConnection(ServiceName)
 	if err != nil {
 		initErr := errors.NewInitError(err, ServiceName)
 		glog.Error(initErr)
-		return nil, nil, initErr
+		return nil, initErr
 	}
-	return upgrade_protos.NewUpgradeServiceClient(conn), conn, err
+	return upgrade_protos.NewUpgradeServiceClient(conn), err
 }
 
 // A channel in this context is a way to partition released packages
@@ -39,11 +38,10 @@ func getUpgradeServiceClient() (upgrade_protos.UpgradeServiceClient, *grpc.Clien
 
 // Create a new global release channel.
 func CreateReleaseChannel(channelName string, channel *upgrade_protos.ReleaseChannel) error {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.CreateOrUpdateReleaseChannelRequest{
 		ChannelName: channelName,
@@ -54,11 +52,10 @@ func CreateReleaseChannel(channelName string, channel *upgrade_protos.ReleaseCha
 }
 
 func GetReleaseChannel(channel string) (*upgrade_protos.ReleaseChannel, error) {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.GetReleaseChannelRequest{ChannelName: channel}
 	res, err := client.GetReleaseChannel(context.Background(), req)
@@ -69,11 +66,10 @@ func GetReleaseChannel(channel string) (*upgrade_protos.ReleaseChannel, error) {
 }
 
 func ListReleaseChannels() ([]string, error) {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return nil, err
 	}
-	defer conn.Close()
 
 	req := &protos.Void{}
 	res, err := client.ListReleaseChannels(context.Background(), req)
@@ -84,11 +80,10 @@ func ListReleaseChannels() ([]string, error) {
 }
 
 func UpdateReleaseChannel(channelName string, updatedChannel *upgrade_protos.ReleaseChannel) error {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.CreateOrUpdateReleaseChannelRequest{
 		ChannelName: channelName,
@@ -99,11 +94,10 @@ func UpdateReleaseChannel(channelName string, updatedChannel *upgrade_protos.Rel
 }
 
 func DeleteReleaseChannel(channel string) error {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.DeleteReleaseChannelRequest{ChannelName: channel}
 	_, err = client.DeleteReleaseChannel(context.Background(), req)
@@ -120,11 +114,10 @@ func DeleteReleaseChannel(channel string) error {
 // If any non-existent tiers are provided in the filter parameter, an
 // error will be returned.
 func GetTiers(networkId string, tierFilter []string) (map[string]*upgrade_protos.TierInfo, error) {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return map[string]*upgrade_protos.TierInfo{}, err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.GetTiersRequest{NetworkId: networkId, TierFilter: tierFilter}
 	res, err := client.GetTiers(context.Background(), req)
@@ -135,11 +128,10 @@ func GetTiers(networkId string, tierFilter []string) (map[string]*upgrade_protos
 }
 
 func CreateTier(networkId string, tierId string, tierInfo *upgrade_protos.TierInfo) error {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.CreateTierRequest{
 		NetworkId: networkId,
@@ -151,11 +143,10 @@ func CreateTier(networkId string, tierId string, tierInfo *upgrade_protos.TierIn
 }
 
 func UpdateTier(networkId string, tierId string, tierInfo *upgrade_protos.TierInfo) error {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.UpdateTierRequest{
 		NetworkId:   networkId,
@@ -167,11 +158,10 @@ func UpdateTier(networkId string, tierId string, tierInfo *upgrade_protos.TierIn
 }
 
 func DeleteTier(networkId string, tierId string) error {
-	client, conn, err := getUpgradeServiceClient()
+	client, err := getUpgradeServiceClient()
 	if err != nil {
 		return err
 	}
-	defer conn.Close()
 
 	req := &upgrade_protos.DeleteTierRequest{
 		NetworkId:      networkId,

--- a/orc8r/cloud/go/tools/gateway_cli/tail_logs.go
+++ b/orc8r/cloud/go/tools/gateway_cli/tail_logs.go
@@ -37,19 +37,17 @@ func tailLogsCmd(cmd *cobra.Command, args []string) {
 	if len(args) == 1 {
 		service = args[0]
 	}
-	stream, conn, err := magmad.TailGatewayLogs(networkId, gatewayId, service)
+	stream, err := magmad.TailGatewayLogs(networkId, gatewayId, service)
 	if err != nil {
 		glog.Error(err)
 		os.Exit(1)
 	}
-	defer conn.Close()
 
 	// https://stackoverflow.com/q/11268943
 	term := make(chan os.Signal, 1)
 	signal.Notify(term, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-term
-		conn.Close()
 	}()
 	for {
 		line, err := stream.Recv()


### PR DESCRIPTION
Summary: modify magma registry to reuse grpc connection instead of create&release for each request.

Reviewed By: xjtian

Differential Revision: D15364141

