### PR TITLE
Fix bug preventing metrics from reporting regularly

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -141,7 +141,7 @@ class BaicellsTrDataModel(DataModel):
         ParameterName.EARFCNDL: TrParam(FAPSERVICE_PATH + 'X_BAICELLS_COM_LTE.EARFCNDLInUse', True, TrParameterType.INT, False),
         ParameterName.EARFCNUL: TrParam(FAPSERVICE_PATH + 'X_BAICELLS_COM_LTE.EARFCNULInUse', True, TrParameterType.INT, False),
         ParameterName.BAND: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.FreqBandIndicator', True, TrParameterType.INT, False),
-        ParameterName.PCI: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.PhyCellID', True, TrParameterType.INT, False),
+        ParameterName.PCI: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.PhyCellID', False, TrParameterType.INT, False),
         ParameterName.DL_BANDWIDTH: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.DLBandwidth', True, TrParameterType.STRING, False),
         ParameterName.UL_BANDWIDTH: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.ULBandwidth', True, TrParameterType.STRING, False),
         ParameterName.SUBFRAME_ASSIGNMENT: TrParam(

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_impl.py
@@ -164,11 +164,11 @@ class BasicEnodebAcsStateMachine(EnodebAcsStateMachine):
         been disconnected.
         """
         if isinstance(message, models.Inform):
-            logging.warning('ACS in (%s) state. Received an Inform message',
+            logging.debug('ACS in (%s) state. Received an Inform message',
                           self.state.state_description())
             self._reset_state_machine(self.service)
         elif isinstance(message, models.Fault):
-            logging.warning('ACS in (%s) state. Received a Fault <%s>',
+            logging.debug('ACS in (%s) state. Received a Fault <%s>',
                           self.state.state_description(), message.FaultString)
             self.transition(self.unexpected_fault_state_name)
         else:

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -90,7 +90,7 @@ class StatsManager:
         self._check_rf_tx()
         self.mme_timeout_handler = self.loop.call_later(
             self.CHECK_RF_TX_PERIOD,
-            self._check_rf_tx,
+            self._periodic_check_rf_tx,
         )
 
     def _check_rf_tx(self) -> None:


### PR DESCRIPTION
Summary: enodebd is not reporting metrics regularly, leading to incorrect signals.

Reviewed By: fishlinghu

Differential Revision: D15370464

