### PR TITLE
alert receivers

### DIFF
--- a/feg/cloud/go/go.sum
+++ b/feg/cloud/go/go.sum
@@ -222,6 +222,7 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/lte/cloud/go/go.sum
+++ b/lte/cloud/go/go.sum
@@ -224,6 +224,7 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/orc8r/cloud/deploy/roles/prometheus/templates/alertconfig_server.service
+++ b/orc8r/cloud/deploy/roles/prometheus/templates/alertconfig_server.service
@@ -3,7 +3,7 @@ Description=Magma alertconfig server service
 
 [Service]
 Type=simple
-ExecStart="{{ alertconfig_binary_dir }}/alerting" -port={{ alertconfig_server_port }} -rules-dir={{ alert_rules_dir }}
+ExecStart="{{ alertconfig_binary_dir }}/alerting" -port={{ alertconfig_server_port }} -rules-dir={{ alert_rules_dir }} -alertmanager-conf={{ alertmanager_subdir }}/alertmanager.yml
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=alertconfig server

--- a/orc8r/cloud/go/go.sum
+++ b/orc8r/cloud/go/go.sum
@@ -235,6 +235,7 @@ github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/oklog v0.0.0-20170918173356-f857583a70c3/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=

--- a/orc8r/cloud/go/services/metricsd/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/handlers/handlers.go
@@ -66,6 +66,8 @@ func GetObsidianHandlers(configMap *config.ConfigMap) []handlers.Handler {
 		handlers.Handler{Path: promH.AlertConfigURL, Methods: handlers.DELETE, HandlerFunc: promH.GetDeleteAlertRuleHandler(alertConfigWebServerURL)},
 
 		handlers.Handler{Path: firingAlertURL, Methods: handlers.GET, HandlerFunc: promH.GetViewFiringAlertHandler(alertmanagerURL)},
+		handlers.Handler{Path: promH.AlertReceiverConfigURL, Methods: handlers.POST, HandlerFunc: promH.GetConfigureAlertReceiverHandler(alertConfigWebServerURL)},
+		handlers.Handler{Path: promH.AlertReceiverConfigURL, Methods: handlers.GET, HandlerFunc: promH.GetRetrieveAlertReceiverHandler(alertConfigWebServerURL)},
 	)
 
 	return ret

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule.go
@@ -34,14 +34,14 @@ func (f *File) Rules() []rulefmt.Rule {
 	return f.RuleGroups[0].Rules
 }
 
-// GetRule returns the specific rule by name, nil if it doesn't exist in the file
+// GetRule returns the specific rule by name
 func (f *File) GetRule(rulename string) (*rulefmt.Rule, error) {
 	for _, rule := range f.RuleGroups[0].Rules {
 		if rule.Alert == rulename {
 			return &rule, nil
 		}
 	}
-	return &rulefmt.Rule{}, fmt.Errorf("could not find rule: %s", rulename)
+	return nil, fmt.Errorf("could not find rule: %s", rulename)
 }
 
 // AddRule appends a new rule to the list of rules in this file
@@ -71,6 +71,7 @@ func SecureRule(rule *rulefmt.Rule, networkID string) error {
 		return err
 	}
 	rule.Expr = restrictedExpression
+	rule.Labels[exporters.NetworkLabelNetwork] = networkID
 	return nil
 }
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/receiver_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/receiver_handlers.go
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers"
+
+	"github.com/labstack/echo"
+)
+
+const (
+	alertmanagerReloadPath = "/-/reload"
+)
+
+// GetReceiverPostHandler returns a handler function that creates a new
+// receiver and then reloads alertmanager
+func GetReceiverPostHandler(client *receivers.Client, alertmanagerURL string) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		receiver, err := decodeReceiverPostResponse(c)
+		if err != nil {
+			return c.String(http.StatusInternalServerError, fmt.Sprintf("%s", err))
+		}
+		err = client.CreateReceiver(&receiver, getNetworkID(c))
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+
+		err = reloadAlertmanager(alertmanagerURL)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+		return c.NoContent(http.StatusOK)
+	}
+}
+
+// GetGetReceiversHandler returns a handler function to retrieve receivers for
+// a network
+func GetGetReceiversHandler(client *receivers.Client) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		networkID := getNetworkID(c)
+		recs, err := client.GetReceivers(networkID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		}
+		return c.JSON(http.StatusOK, recs)
+	}
+}
+
+func decodeReceiverPostResponse(c echo.Context) (receivers.Receiver, error) {
+	body, err := ioutil.ReadAll(c.Request().Body)
+	if err != nil {
+		return receivers.Receiver{}, fmt.Errorf("error reading request body: %v", err)
+	}
+	receiver := receivers.Receiver{}
+	err = json.Unmarshal(body, &receiver)
+	if err != nil {
+		return receivers.Receiver{}, fmt.Errorf("error unmarshalling payload: %v", err)
+	}
+	return receiver, nil
+}
+
+func reloadAlertmanager(url string) error {
+	resp, err := http.Post(fmt.Sprintf("http://%s%s", url, alertmanagerReloadPath), "text/plain", &bytes.Buffer{})
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("code: %d error reloading alertmanager: %v", resp.StatusCode, err)
+	}
+	return nil
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/client.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/client.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package receivers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v2"
+)
+
+// Client provides methods to create and read receiver configurations
+type Client struct {
+	configPath string
+	sync.RWMutex
+}
+
+func NewClient(configPath string) *Client {
+	return &Client{
+		configPath: configPath,
+	}
+}
+
+// CreateReceiver writes a new receiver to the config file with the networkID
+// prepended to the name so multiple networks can be supported
+func (c *Client) CreateReceiver(rec *Receiver, networkID string) error {
+	c.Lock()
+	defer c.Unlock()
+	conf, err := c.readConfigFile()
+	if err != nil {
+		return err
+	}
+
+	rec.Secure(networkID)
+	conf.Receivers = append(conf.Receivers, rec)
+	err = conf.Validate()
+	if err != nil {
+		return err
+	}
+	return c.writeConfigFile(conf)
+}
+
+// GetReceivers returns the receiver configs for the given networkID
+func (c *Client) GetReceivers(networkID string) ([]Receiver, error) {
+	c.RLock()
+	defer c.RUnlock()
+	conf, err := c.readConfigFile()
+	if err != nil {
+		return []Receiver{}, nil
+	}
+
+	recs := make([]Receiver, 0)
+	for _, rec := range conf.Receivers {
+		if strings.HasPrefix(rec.Name, receiverNetworkPrefix(networkID)) {
+			rec.Unsecure(networkID)
+			recs = append(recs, *rec)
+		}
+	}
+	return recs, nil
+}
+
+func (c *Client) readConfigFile() (*Config, error) {
+	configFile := Config{}
+	file, err := ioutil.ReadFile(c.configPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading config files: %v", err)
+	}
+	err = yaml.Unmarshal(file, &configFile)
+	return &configFile, err
+}
+
+func (c *Client) writeConfigFile(conf *Config) error {
+	yamlFile, err := yaml.Marshal(conf)
+	err = ioutil.WriteFile(c.configPath, yamlFile, 0660)
+	if err != nil {
+		return fmt.Errorf("error writing config file: %v\n", yamlFile)
+	}
+	return nil
+}
+
+func receiverNetworkPrefix(networkID string) string {
+	return strings.Replace(networkID, "_", "", -1) + "_"
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/receiver.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/receiver.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package receivers
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/prometheus/alertmanager/config"
+)
+
+// Config uses a custom receiver struct to avoid scrubbing of 'secrets' during
+// marshaling
+type Config struct {
+	Global       *config.GlobalConfig  `yaml:"global,omitempty" json:"global,omitempty"`
+	Route        *config.Route         `yaml:"route,omitempty" json:"route,omitempty"`
+	InhibitRules []*config.InhibitRule `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
+	Receivers    []*Receiver           `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	Templates    []string              `yaml:"templates" json:"templates"`
+}
+
+// GetReceiver returns the receiver config with the given name
+func (c *Config) GetReceiver(name string) *Receiver {
+	for _, rec := range c.Receivers {
+		if rec.Name == name {
+			return rec
+		}
+	}
+	return nil
+}
+
+// Validate makes sure that the config is properly formed. Have to do this here
+// since alertmanager only does validation during Unmarshaling
+func (c *Config) Validate() error {
+	receiverNames := map[string]struct{}{}
+
+	for _, rcv := range c.Receivers {
+		if _, ok := receiverNames[rcv.Name]; ok {
+			return fmt.Errorf("notification config name %s is not unique", rcv.Name)
+		}
+		for _, sc := range rcv.SlackConfigs {
+			err := validateURL(sc.APIURL)
+			if err != nil {
+				return err
+			}
+		}
+		receiverNames[rcv.Name] = struct{}{}
+	}
+	if c.Route == nil {
+		return fmt.Errorf("no route provided")
+	}
+	if len(c.Route.Receiver) == 0 {
+		return fmt.Errorf("root route must specify a default receiver")
+	}
+	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 {
+		return fmt.Errorf("root route must not have any matchers")
+	}
+
+	// check that all receivers used in routing tree are defined
+	return checkReceiver(c.Route, receiverNames)
+}
+
+func validateURL(url string) error {
+	if !strings.HasPrefix(url, "http") {
+		return fmt.Errorf("invalid url: %s", url)
+	}
+	return nil
+}
+
+// checkReceiver returns an error if a node in the routing tree
+// references a receiver not in the given map.
+func checkReceiver(r *config.Route, receivers map[string]struct{}) error {
+	for _, sr := range r.Routes {
+		if err := checkReceiver(sr, receivers); err != nil {
+			return err
+		}
+	}
+	if r.Receiver == "" {
+		return nil
+	}
+	if _, ok := receivers[r.Receiver]; !ok {
+		return fmt.Errorf("undefined receiver %q used in route", r.Receiver)
+	}
+	return nil
+}
+
+// Receiver uses custom notifier configs to allow for marshaling of secrets.
+type Receiver struct {
+	Name string `yaml:"name" json:"name"`
+
+	SlackConfigs []*SlackConfig `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+}
+
+// Secure replaces the receiver's name with a networkID prefix
+func (r *Receiver) Secure(networkID string) {
+	r.Name = secureReceiverName(r.Name, networkID)
+}
+
+// Unsecure removes the networkID prefix from the receiver name
+func (r *Receiver) Unsecure(networkID string) {
+	r.Name = unsecureReceiverName(r.Name, networkID)
+}
+
+func secureReceiverName(name, networkID string) string {
+	return receiverNetworkPrefix(networkID) + name
+}
+
+func unsecureReceiverName(name, networkID string) string {
+	if strings.HasPrefix(name, receiverNetworkPrefix(networkID)) {
+		return name[len(receiverNetworkPrefix(networkID)):]
+	}
+	return name
+}
+
+// SlackConfig uses string instead of SecretURL for the APIURL field so that it
+// is marshaled as is instead of being obscured which is how alertmanager handles
+// secrets
+type SlackConfig struct {
+	APIURL   string `yaml:"api_url" json:"api_url"`
+	Channel  string `yaml:"channel" json:"channel"`
+	Username string `yaml:"username" json:"username"`
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/receiver_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/receiver_test.go
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package receivers
+
+import (
+	"testing"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	sampleRoute = config.Route{
+		Receiver: "testReceiver",
+	}
+	sampleReceiver = Receiver{
+		Name: "testReceiver",
+	}
+)
+
+func TestConfig_Validate(t *testing.T) {
+	defaultGlobalConf := config.DefaultGlobalConfig()
+	validConfig := Config{
+		Route:     &sampleRoute,
+		Receivers: []*Receiver{&sampleReceiver},
+		Global:    &defaultGlobalConf,
+	}
+
+	err := validConfig.Validate()
+	assert.NoError(t, err)
+
+	invalidConfig := Config{
+		Route:     &sampleRoute,
+		Receivers: []*Receiver{},
+		Global:    &defaultGlobalConf,
+	}
+
+	err = invalidConfig.Validate()
+	assert.Error(t, err)
+
+	invalidSlackReceiver := Receiver{
+		Name: "invalidSlack",
+		SlackConfigs: []*SlackConfig{
+			{
+				APIURL: "invalidURL",
+			},
+		},
+	}
+
+	invalidSlackConfig := Config{
+		Route: &config.Route{
+			Receiver: "invalidSlack",
+		},
+		Receivers: []*Receiver{&invalidSlackReceiver},
+		Global:    &defaultGlobalConf,
+	}
+	err = invalidSlackConfig.Validate()
+	assert.Error(t, err)
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/server.go
@@ -6,34 +6,45 @@ import (
 
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers"
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
 )
 
 const (
-	defaultPort          = "9093"
-	defaultPrometheusURL = "localhost:9090"
-	rootPath             = "/:network_id"
+	defaultPort                   = "9093"
+	defaultPrometheusURL          = "localhost:9090"
+	defaultAlertmanagerURL        = "localhost:9092"
+	defaultAlertmanagerConfigPath = "./alertmanager.yml"
+
+	rootPath     = "/:network_id"
+	alertPath    = rootPath + "/alert"
+	receiverPath = rootPath + "/receiver"
 )
 
 func main() {
 	port := flag.String("port", defaultPort, fmt.Sprintf("Port to listen for requests. Default is %s", defaultPort))
 	rulesDir := flag.String("rules-dir", ".", "Directory to write rules files. Default is '.'")
 	prometheusURL := flag.String("prometheusURL", "localhost:9090", fmt.Sprintf("URL of the prometheus instance that is reading these rules. Default is %s", defaultPrometheusURL))
+	alertmanagerConfPath := flag.String("alertmanager-conf", "./alertmanager.yml", fmt.Sprintf("Path to alertmanager configuration file. Default is %s", defaultAlertmanagerConfigPath))
+	alertmanagerURL := flag.String("alertmanagerURL", "localhost:9092", fmt.Sprintf("URL of the alertmanager instance that is being used. Default is %s", defaultAlertmanagerURL))
 	flag.Parse()
 
-	client, err := alert.NewClient(*rulesDir)
+	e := echo.New()
+
+	alertClient, err := alert.NewClient(*rulesDir)
 	if err != nil {
 		glog.Errorf("error creating alert client: %v", err)
 		return
 	}
+	e.POST(alertPath, handlers.GetPostHandler(alertClient, *prometheusURL))
+	e.GET(alertPath, handlers.GetGetHandler(alertClient))
+	e.DELETE(alertPath, handlers.GetDeleteHandler(alertClient, *prometheusURL))
 
-	e := echo.New()
-
-	e.POST(rootPath, handlers.GetPostHandler(client, *prometheusURL))
-	e.GET(rootPath, handlers.GetGetHandler(client))
-	e.DELETE(rootPath, handlers.GetDeleteHandler(client, *prometheusURL))
+	receiverClient := receivers.NewClient(*alertmanagerConfPath)
+	e.POST(receiverPath, handlers.GetReceiverPostHandler(receiverClient, *alertmanagerURL))
+	e.GET(receiverPath, handlers.GetGetReceiversHandler(receiverClient))
 
 	glog.Infof("Alertconfig server listening on Port: %s\n", *port)
 	e.Logger.Fatal(e.Start(fmt.Sprintf(":%s", *port)))

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -26,8 +26,11 @@ import (
 
 const (
 	alertConfigPart     = "alert_config"
-	AlertConfigURL      = handlers.PROMETHEUS_ROOT + handlers.URL_SEP + alertConfigPart
+	alertReceiverPart   = "alert_receiver"
 	AlertNameQueryParam = "alert_name"
+
+	AlertConfigURL         = handlers.PROMETHEUS_ROOT + handlers.URL_SEP + alertConfigPart
+	AlertReceiverConfigURL = handlers.PROMETHEUS_ROOT + handlers.URL_SEP + alertReceiverPart
 )
 
 func GetConfigurePrometheusAlertHandler(webServerURL string) func(c echo.Context) error {
@@ -89,14 +92,14 @@ func configurePrometheusAlert(c echo.Context, url, networkID string) error {
 		return handlers.HttpError(fmt.Errorf("Invalid rule: %v\n", errs), http.StatusBadRequest)
 	}
 
-	err = sendConfigToPrometheusServer(rule, url)
+	err = sendConfig(rule, url)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 	return c.JSON(http.StatusCreated, rule.Alert)
 }
 
-func sendConfigToPrometheusServer(payload rulefmt.Rule, url string) error {
+func sendConfig(payload interface{}, url string) error {
 	requestBody, err := json.Marshal(payload)
 	if err != nil {
 		return err

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers.go
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers"
+
+	"github.com/labstack/echo"
+)
+
+func GetConfigureAlertReceiverHandler(webServerURL string) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		networkID, nerr := handlers.GetNetworkId(c)
+		if nerr != nil {
+			return nerr
+		}
+		url := makeNetworkReceiverPath(webServerURL, networkID)
+		return configureAlertReceiver(c, url)
+	}
+}
+
+func GetRetrieveAlertReceiverHandler(webServerURL string) func(c echo.Context) error {
+	return func(c echo.Context) error {
+		networkID, nerr := handlers.GetNetworkId(c)
+		if nerr != nil {
+			return nerr
+		}
+		url := makeNetworkReceiverPath(webServerURL, networkID)
+		return retrieveAlertReceivers(c, url)
+	}
+}
+
+func configureAlertReceiver(c echo.Context, url string) error {
+	receiver, err := buildReceiverFromContext(c)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+
+	err = sendConfig(receiver, url)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+func retrieveAlertReceivers(c echo.Context, url string) error {
+	client := &http.Client{}
+	resp, err := client.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return handlers.HttpError(fmt.Errorf("alert server responded with error"), resp.StatusCode)
+	}
+	var recs []receivers.Receiver
+	err = json.NewDecoder(resp.Body).Decode(&recs)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, fmt.Errorf("error decoding server response %v", err))
+	}
+	return c.JSON(http.StatusOK, recs)
+}
+
+func buildReceiverFromContext(c echo.Context) (receivers.Receiver, error) {
+	wrapper := receivers.Receiver{}
+	err := json.NewDecoder(c.Request().Body).Decode(&wrapper)
+	if err != nil {
+		return receivers.Receiver{}, err
+	}
+	return wrapper, nil
+}
+
+func makeNetworkReceiverPath(webServerURL, networkID string) string {
+	return webServerURL + "/" + networkID + "/receiver"
+}

--- a/orc8r/cloud/go/services/metricsd/swagger/swagger.yml
+++ b/orc8r/cloud/go/services/metricsd/swagger/swagger.yml
@@ -178,7 +178,39 @@ paths:
           description: Deleted
         default:
           $ref: './swagger-common.yml#/responses/UnexpectedError'
-
+  /networks/{network_id}/prometheus/alert_receiver:
+    post:
+      summary: Create new alert receiver
+      tags:
+        - Metrics
+      parameters:
+        - $ref: './swagger-common.yml#/parameters/network_id'
+        - in: body
+          name: receiver_config
+          description: Alert receiver that is to be added
+          required: true
+          schema:
+            $ref: '#/definitions/alert_receiver_config'
+      responses:
+        '201':
+          description: Created
+        default:
+          $ref: './swagger-common.yml#/responses/UnexpectedError'
+    get:
+      summary: Retrive alert receivers
+      tags:
+        - Metrics
+      parameters:
+        - $ref: './swagger-common.yml#/parameters/network_id'
+      responses:
+        '200':
+          description: List of alert receivers
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/alert_receiver_config'
+        default:
+          $ref: './swagger-common.yml#/responses/UnexpectedError'
 
 definitions:
   graphite_return_object:


### PR DESCRIPTION
Summary:
Implements the basic functionality for alert receivers (services that alerts are sent to).
* Only implement slack receiver for now, since it's the easiest to set up and use. Additional receivers will be simple to add.
* Multi-tenancy support is provided by attaching the networkID to each receiver name, so receivers can then be retrieved per network.
* Have to use a custom struct for the receivers, since alertmanager's structs obscure "secrets" such as API urls when marshaling

Reviewed By: xjtian

Differential Revision: D15404813

