### PR TITLE
Create a new magma service : 'configurator'

### DIFF
--- a/orc8r/cloud/configs/configurator.yml
+++ b/orc8r/cloud/configs/configurator.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) 2019-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -87,3 +87,8 @@ services:
     host: "localhost"
     port: 9106
     proxy_type: "clientcert"
+
+  configurator:
+    host: "localhost"
+    port: 9108
+    proxy_type: "clientcert"

--- a/orc8r/cloud/deploy/files/docker/docker-compose.controller.yml
+++ b/orc8r/cloud/deploy/files/docker/docker-compose.controller.yml
@@ -16,7 +16,7 @@ services:
       - /var/opt/magma/envdir:/var/opt/magma/envdir
     ports:
       - "8080:8080"
-      - "9079-9106:9079-9106"
+      - "9079-9108:9079-9108"
     ulimits:
       nofile:
         soft: 65536

--- a/orc8r/cloud/docker/controller/supervisord.conf
+++ b/orc8r/cloud/docker/controller/supervisord.conf
@@ -200,6 +200,13 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart=true
 
+[program:configurator]
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/configurator -logtostderr=true -v=0
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+autorestart=true
+
 [program:dev_setup]
 command=/usr/local/bin/create_test_controller_certs
 startsecs=0

--- a/orc8r/cloud/go/defs.mk
+++ b/orc8r/cloud/go/defs.mk
@@ -4,4 +4,4 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 #
-$(MODULE)_SERVICE_NAMES := accessd checkind metricsd streamer upgrade certifier bootstrapper magmad logger dispatcher config state device
+$(MODULE)_SERVICE_NAMES := accessd checkind metricsd streamer upgrade certifier bootstrapper magmad logger dispatcher config state device configurator

--- a/orc8r/cloud/go/services/configurator/configurator/main.go
+++ b/orc8r/cloud/go/services/configurator/configurator/main.go
@@ -1,0 +1,60 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+/*
+Configurator is a dedicated Magma Cloud service which maintains configurations
+and meta data for the network and network entity structures.
+*/
+
+package main
+
+import (
+	"database/sql"
+
+	"magma/orc8r/cloud/go/datastore"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/service"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/configurator/protos"
+	"magma/orc8r/cloud/go/services/configurator/servicers"
+	"magma/orc8r/cloud/go/services/configurator/storage"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	// Create the service
+	srv, err := service.NewOrchestratorService(orc8r.ModuleName, configurator.ServiceName)
+	if err != nil {
+		glog.Fatalf("Error creating service: %s", err)
+	}
+	db, err := sql.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
+	if err != nil {
+		glog.Fatalf("Failed to connect to database: %s", err)
+	}
+
+	factory := storage.NewSQLConfiguratorStorageFactory(db, &storage.DefaultIDGenerator{})
+	err = factory.InitializeServiceStorage()
+
+	nbServicer, err := servicers.NewNorthboundConfiguratorServicer(factory)
+	if err != nil {
+		glog.Fatalf("Failed to instantiate the device servicer: %v", nbServicer)
+	}
+	protos.RegisterNorthboundConfiguratorServer(srv.GrpcServer, nbServicer)
+
+	sbServicer, err := servicers.NewSouthboundConfiguratorServicer(factory)
+	if err != nil {
+		glog.Fatalf("Failed to instantiate the device servicer: %v", sbServicer)
+	}
+	protos.RegisterSouthboundConfiguratorServer(srv.GrpcServer, sbServicer)
+
+	err = srv.Run()
+	if err != nil {
+		glog.Fatalf("Failed to start configurator service: %v", err)
+	}
+}

--- a/orc8r/cloud/go/services/configurator/doc.go
+++ b/orc8r/cloud/go/services/configurator/doc.go
@@ -9,3 +9,8 @@
 // Package configurator contains the Configurator service which manages
 // configuration of and relationships between logical network entities.
 package configurator
+
+const (
+	// ServiceName is the name of this service
+	ServiceName = "CONFIGURATOR"
+)

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -59,7 +59,7 @@ The following table list the configurable parameters of the orchestrator chart a
 | `controller.service.port` | Controller web service external port. | `8080` |
 | `controller.service.targetPort` | Controller web service internal port. | `8080` |
 | `controller.service.portStart` | Controller service port range start. | `9079` |
-| `controller.service.portEnd` | Controller service inclusive port range end. | `9104` |
+| `controller.service.portEnd` | Controller service inclusive port range end. | `9108` |
 | `controller.image.repository` | Repository for orchestrator controller image. | `nil` |
 | `controller.image.tag` | Tag for orchestrator controller image. | `latest` |
 | `controller.image.pullPolicy` | Pull policy for orchestrator controller image. | `IfNotPresent` |

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -81,7 +81,7 @@ controller:
     targetPort: 8080
     # port range exposed by controller
     portStart: 9079
-    portEnd: 9104
+    portEnd: 9108
 
   # proxy image
   image:


### PR DESCRIPTION
Summary: Add a main file and register servicers to make configurator a running service on the cloud.

Reviewed By: xjtian

Differential Revision: D15349419

