### PR TITLE
Convert all prometheus metrics to gauges

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package exporters
+
+import (
+	"fmt"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+const (
+	bucketPostfix = "_bucket"
+	countPostfix  = "_count"
+	sumPostfix    = "_sum"
+
+	histogramBucketLabelName = "le"
+	summaryQuantileLabelName = "quantile"
+)
+
+var (
+	gaugeType = dto.MetricType_GAUGE
+)
+
+func convertFamilyToGauges(baseFamily *dto.MetricFamily) []*dto.MetricFamily {
+	gaugeFamilies := make([]*dto.MetricFamily, 0)
+	switch *baseFamily.Type {
+	case dto.MetricType_GAUGE:
+		gaugeFamilies = append(gaugeFamilies, baseFamily)
+	case dto.MetricType_COUNTER:
+		gaugeFamilies = append(gaugeFamilies, counterToGauge(baseFamily))
+	case dto.MetricType_HISTOGRAM:
+		gaugeFamilies = append(gaugeFamilies, histogramToGauges(baseFamily)...)
+	case dto.MetricType_SUMMARY:
+		gaugeFamilies = append(gaugeFamilies, summaryToGauges(baseFamily)...)
+	}
+	return gaugeFamilies
+}
+
+// counterToGauge takes a counter and converts it to a guage with the
+// same value
+func counterToGauge(family *dto.MetricFamily) *dto.MetricFamily {
+	counterFamily := dto.MetricFamily{
+		Name: makeStringPointer(family.GetName()),
+		Type: &gaugeType,
+	}
+	for _, metric := range family.Metric {
+		if metric.Counter == nil {
+			continue
+		}
+		counterValue := float64(*metric.Counter.Value)
+		counterMetric := dto.Metric{
+			Label: metric.Label,
+			Gauge: &dto.Gauge{
+				Value: &counterValue,
+			},
+		}
+		counterFamily.Metric = append(counterFamily.Metric, &counterMetric)
+	}
+	return &counterFamily
+}
+
+// histogramToGauges converts a histogram into 3 families of gauges, one for the
+// buckets, sum, and count each.
+func histogramToGauges(family *dto.MetricFamily) []*dto.MetricFamily {
+	baseName := family.GetName()
+	bucketFamily := dto.MetricFamily{
+		Name: makeStringPointer(baseName + bucketPostfix),
+		Type: &gaugeType,
+	}
+	sumFamily := dto.MetricFamily{
+		Name: makeStringPointer(baseName + sumPostfix),
+		Type: &gaugeType,
+	}
+	countFamily := dto.MetricFamily{
+		Name: makeStringPointer(baseName + countPostfix),
+		Type: &gaugeType,
+	}
+
+	for _, metric := range family.Metric {
+		if metric.Histogram == nil {
+			continue
+		}
+		sumValue := float64(*metric.Histogram.SampleSum)
+		sumMetric := dto.Metric{
+			Label: metric.Label,
+			Gauge: &dto.Gauge{
+				Value: &sumValue,
+			},
+		}
+		sumFamily.Metric = append(sumFamily.Metric, &sumMetric)
+		countValue := float64(*metric.Histogram.SampleCount)
+		countMetric := dto.Metric{
+			Label: metric.Label,
+			Gauge: &dto.Gauge{
+				Value: &countValue,
+			},
+		}
+		countFamily.Metric = append(countFamily.Metric, &countMetric)
+		for _, bucket := range metric.Histogram.Bucket {
+			bucketValue := float64(*bucket.CumulativeCount)
+			bucketMetric := dto.Metric{
+				Label: append(metric.Label, &dto.LabelPair{
+					Name:  makeStringPointer(histogramBucketLabelName),
+					Value: makeStringPointer(fmt.Sprintf("%g", bucket.GetUpperBound())),
+				}),
+				Gauge: &dto.Gauge{
+					Value: &bucketValue,
+				},
+			}
+			bucketFamily.Metric = append(bucketFamily.Metric, &bucketMetric)
+		}
+	}
+	return []*dto.MetricFamily{&bucketFamily, &sumFamily, &countFamily}
+}
+
+// summaryToGauges converts a summary to 3 gauge families, one for the quantiles,
+// sum, and count each
+func summaryToGauges(family *dto.MetricFamily) []*dto.MetricFamily {
+	baseName := family.GetName()
+	quantFamily := dto.MetricFamily{
+		Name: makeStringPointer(baseName),
+		Type: &gaugeType,
+	}
+	sumFamily := dto.MetricFamily{
+		Name: makeStringPointer(baseName + sumPostfix),
+		Type: &gaugeType,
+	}
+	countFamily := dto.MetricFamily{
+		Name: makeStringPointer(baseName + countPostfix),
+		Type: &gaugeType,
+	}
+
+	for _, metric := range family.Metric {
+		if metric.Summary == nil {
+			continue
+		}
+		sumValue := float64(*metric.Summary.SampleSum)
+		sumMetric := dto.Metric{
+			Label: metric.Label,
+			Gauge: &dto.Gauge{
+				Value: &sumValue,
+			},
+		}
+		sumFamily.Metric = append(sumFamily.Metric, &sumMetric)
+
+		countValue := float64(*metric.Summary.SampleCount)
+		countMetric := dto.Metric{
+			Label: metric.Label,
+			Gauge: &dto.Gauge{
+				Value: &countValue,
+			},
+		}
+		countFamily.Metric = append(countFamily.Metric, &countMetric)
+
+		for _, quant := range metric.Summary.Quantile {
+			quantValue := *quant.Value
+			quantMetric := dto.Metric{
+				Label: append(metric.Label, &dto.LabelPair{
+					Name:  makeStringPointer(summaryQuantileLabelName),
+					Value: makeStringPointer(fmt.Sprintf("%g", *quant.Quantile)),
+				}),
+				Gauge: &dto.Gauge{
+					Value: &quantValue,
+				},
+			}
+			quantFamily.Metric = append(quantFamily.Metric, &quantMetric)
+		}
+	}
+	return []*dto.MetricFamily{&quantFamily, &sumFamily, &countFamily}
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter_test.go
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package exporters
+
+import (
+	"testing"
+
+	tests "magma/orc8r/cloud/go/services/metricsd/test_common"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCounterToGauge(t *testing.T) {
+	originalFamily := tests.MakeTestMetricFamily(dto.MetricType_COUNTER, 2, sampleLabels)
+	convertedGauge := counterToGauge(originalFamily)
+	assert.Equal(t, dto.MetricType_GAUGE, *convertedGauge.Type)
+	assert.Equal(t, tests.CounterMetricName, convertedGauge.GetName())
+}
+
+func TestHistogramToGauge(t *testing.T) {
+	originalFamily := tests.MakeTestMetricFamily(dto.MetricType_HISTOGRAM, 1, sampleLabels)
+	convertedFams := histogramToGauges(originalFamily)
+	assert.Equal(t, 3, len(convertedFams))
+	for _, family := range convertedFams {
+		assert.Equal(t, dto.MetricType_GAUGE, *family.Type)
+		name := family.GetName()
+		for _, metric := range family.Metric {
+			if name == (tests.HistogramMetricName + bucketPostfix) {
+				assert.True(t, hasLabelName(metric.Label, histogramBucketLabelName))
+			} else if name == (tests.HistogramMetricName + sumPostfix) {
+				assert.False(t, hasLabelName(metric.Label, histogramBucketLabelName))
+			} else if name == (tests.HistogramMetricName + countPostfix) {
+				assert.False(t, hasLabelName(metric.Label, histogramBucketLabelName))
+			} else {
+				// Unexpected family name
+				t.Fail()
+			}
+		}
+	}
+}
+
+func TestSummaryToGauge(t *testing.T) {
+	originalFamily := tests.MakeTestMetricFamily(dto.MetricType_SUMMARY, 1, sampleLabels)
+	convertedFams := summaryToGauges(originalFamily)
+	assert.Equal(t, 3, len(convertedFams))
+	for _, family := range convertedFams {
+		assert.Equal(t, dto.MetricType_GAUGE, *family.Type)
+		name := family.GetName()
+		for _, metric := range family.Metric {
+			if name == tests.SummaryMetricName {
+				assert.True(t, hasLabelName(metric.Label, summaryQuantileLabelName))
+			} else if name == (tests.SummaryMetricName + sumPostfix) {
+				assert.False(t, hasLabelName(metric.Label, summaryQuantileLabelName))
+			} else if name == (tests.SummaryMetricName + countPostfix) {
+				assert.False(t, hasLabelName(metric.Label, summaryQuantileLabelName))
+			} else {
+				// Unexpected family name
+				t.Fail()
+			}
+		}
+
+	}
+}

--- a/orc8r/cloud/go/services/metricsd/test_common/utils.go
+++ b/orc8r/cloud/go/services/metricsd/test_common/utils.go
@@ -13,17 +13,29 @@ import (
 	dto "github.com/prometheus/client_model/go"
 )
 
+const (
+	GaugeMetricName     = "testGauge"
+	CounterMetricName   = "testCounter"
+	HistogramMetricName = "testHistogram"
+	SummaryMetricName   = "testSummary"
+)
+
 func MakeTestMetricFamily(metricType dto.MetricType, count int, labels []*dto.LabelPair) *dto.MetricFamily {
 	var testMetric dto.Metric
+	var familyName string
 	switch metricType {
 	case dto.MetricType_COUNTER:
 		testMetric = MakePromoCounter(0)
+		familyName = CounterMetricName
 	case dto.MetricType_SUMMARY:
 		testMetric = MakePromoSummary(map[float64]float64{0.1: 0.01}, []float64{})
+		familyName = SummaryMetricName
 	case dto.MetricType_HISTOGRAM:
 		testMetric = MakePromoHistogram([]float64{1, 5, 10}, []float64{})
+		familyName = HistogramMetricName
 	default:
 		testMetric = MakePromoGauge(0)
+		familyName = GaugeMetricName
 	}
 
 	testMetric.Label = labels
@@ -32,7 +44,7 @@ func MakeTestMetricFamily(metricType dto.MetricType, count int, labels []*dto.La
 		metrics = append(metrics, &testMetric)
 	}
 	return &dto.MetricFamily{
-		Name:   MakeStringPointer("testFamily"),
+		Name:   MakeStringPointer(familyName),
 		Help:   MakeStringPointer("testFamilyHelp"),
 		Type:   MakeMetricTypePointer(metricType),
 		Metric: metrics,
@@ -41,7 +53,7 @@ func MakeTestMetricFamily(metricType dto.MetricType, count int, labels []*dto.La
 
 func MakePromoGauge(value float64) dto.Metric {
 	var metric dto.Metric
-	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: "testGauge", Help: "testGaugeHelp"})
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: GaugeMetricName, Help: "testGaugeHelp"})
 	gauge.Set(value)
 	gauge.Write(&metric)
 	return metric
@@ -49,7 +61,7 @@ func MakePromoGauge(value float64) dto.Metric {
 
 func MakePromoCounter(value float64) dto.Metric {
 	var metric dto.Metric
-	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: "testCounter", Help: "testCounterHelp"})
+	counter := prometheus.NewCounter(prometheus.CounterOpts{Name: CounterMetricName, Help: "testCounterHelp"})
 	counter.Add(value)
 	counter.Write(&metric)
 	return metric
@@ -59,7 +71,7 @@ func MakePromoSummary(objectives map[float64]float64, observations []float64) dt
 	var metric dto.Metric
 	summary := prometheus.NewSummary(
 		prometheus.SummaryOpts{
-			Name:       "testSummary",
+			Name:       SummaryMetricName,
 			Help:       "testSummaryHelp",
 			Objectives: objectives,
 		},
@@ -75,7 +87,7 @@ func MakePromoHistogram(buckets []float64, observations []float64) dto.Metric {
 	var metric dto.Metric
 	histogram := prometheus.NewHistogram(
 		prometheus.HistogramOpts{
-			Name:    "testHistogram",
+			Name:    HistogramMetricName,
 			Help:    "testHistogramHelp",
 			Buckets: buckets,
 		},


### PR DESCRIPTION
Summary:
This is another issue that prometheus causes that we have to work around to make it work for our case. The following situation would cause a scrape to fail:
* NetworkA provides metric `metricA` as type `GAUGE`
* NetworkB provides metric `metricA` as type `COUNTER`
* This is possible since we can't expect different networks to follow identical metric naming/type protocols
* If these both made it into the final scrape text exposition, the scrape would fail since there are identical metrics of different types
* To solve this, we simply convert all metrics into gauges before prometheus does it internally
  * A gauge is a gauge, and a counter just switches types
  * A histogram is converted into 3 gauge families `<basename>_bucket`, `<basename>_sum`, `<basename>_count`, where `{le=xxx}` labels are added to the buckets
  * A summary is converted into 3 gauge families `<basename>`, `<basename>_sum`, `<basename>_count`, where `{quantile=xxx}` labels are added to the basename metric
* Since all conversions are well-defined, we lose no functionality in the end since prometheus would have done exactly this internally.
* Metrics from different networks are still segmented using a networkID label

Differential Revision: D15454037

