### PR TITLE
Add LoadAllEntitiesInNetwork to configurator client_api for future usages (get all gateways in a network etc.)

### DIFF
--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -141,3 +141,25 @@ func LoadEntities(networkID string, typeFilter *string, keyFilter *string, ids [
 	}
 	return resp.Entities, resp.NotFound, err
 }
+
+func LoadAllEntitiesInNetwork(networkID string, typeVal string, criteria *protos.EntityLoadCriteria) ([]*protos.NetworkEntity, error) {
+	client, err := getNBConfiguratorClient()
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.LoadEntities(
+		context.Background(),
+		&protos.LoadEntitiesRequest{
+			NetworkID:  networkID,
+			TypeFilter: protos.GetStringWrapper(&typeVal),
+			KeyFilter:  nil,
+			EntityIDs:  nil,
+			Criteria:   criteria,
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return resp.Entities, err
+}


### PR DESCRIPTION
Summary: Add LoadAllEntitiesInNetwork since it'll be useful when implementing gateway/entities api endpoints. (Listing all entities of a certain type in a network, etc)

Reviewed By: xjtian

Differential Revision: D15415663

