### PR TITLE
Send empty states instead of error for go service303 function GetOperationalStates

### DIFF
--- a/orc8r/cloud/go/service/service303.go
+++ b/orc8r/cloud/go/service/service303.go
@@ -67,8 +67,8 @@ func (service *Service) ReloadServiceConfig(ctx context.Context, void *protos.Vo
 	return &res, fmt.Errorf("method ReloadServiceConfig  not implemented\n")
 }
 
-// GetOperationalStates not currently implemented for cloud services
+// GetOperationalStates not currently implemented for go services
 func (service *Service) GetOperationalStates(ctx context.Context, void *protos.Void) (*protos.GetOperationalStatesResponse, error) {
 	res := protos.GetOperationalStatesResponse{}
-	return &res, fmt.Errorf("GetOperationalStates not implemented on cloud side")
+	return &res, nil
 }


### PR DESCRIPTION
Summary:
There are a lot of errors popping up in FeG since the GetOperationalStates service303 function is not implemented in go.
I'll change it to send empty states for now so that the error logs are not overwhelming.

Reviewed By: xjtian

Differential Revision: D15456115

