### PR TITLE
Use sql builder for all DDL statements in service storage layers

### DIFF
--- a/feg/cloud/go/go.sum
+++ b/feg/cloud/go/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/Azure/azure-sdk-for-go v0.0.0-20161028183111-bd73d950fa44/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Masterminds/squirrel v1.1.0 h1:baP1qLdoQCeTw3ifCdOq2dkYc6vGcmRdaociKLbEJXs=
-github.com/Masterminds/squirrel v1.1.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73 h1:+cRmVBz3H/U19fwW85uY+vS+EweAj7cPdhlP4b7vrE4=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -115,6 +113,7 @@ github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0 h1:PVXYcP1GkTl+XIAJnyJxOmK6CSG5Q1UcvoCvNO++5Kg=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
+github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -369,6 +368,7 @@ golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190118193359-16909d206f00/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.0.0-20180506000402-20530fd5d65a/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v0.0.0-20170522224838-a2f4131514e5/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/cloud v0.0.0-20160622021550-0a83eba2cadb/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20170531203552-aa2eb687b4d3/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/lte/cloud/go/go.sum
+++ b/lte/cloud/go/go.sum
@@ -2,8 +2,6 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/Azure/azure-sdk-for-go v0.0.0-20161028183111-bd73d950fa44/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Masterminds/squirrel v1.1.0 h1:baP1qLdoQCeTw3ifCdOq2dkYc6vGcmRdaociKLbEJXs=
-github.com/Masterminds/squirrel v1.1.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73 h1:+cRmVBz3H/U19fwW85uY+vS+EweAj7cPdhlP4b7vrE4=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
@@ -116,6 +114,7 @@ github.com/go-openapi/swag v0.18.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/
 github.com/go-openapi/validate v0.17.2/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
 github.com/go-openapi/validate v0.18.0 h1:PVXYcP1GkTl+XIAJnyJxOmK6CSG5Q1UcvoCvNO++5Kg=
 github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+MYsct2VUrAJ4=
+github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx+opk=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -371,6 +370,7 @@ golang.org/x/tools v0.0.0-20181112210238-4b1f3b6b1646/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190118193359-16909d206f00/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/api v0.0.0-20180506000402-20530fd5d65a/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/appengine v0.0.0-20170522224838-a2f4131514e5/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
+google.golang.org/appengine v1.1.0 h1:igQkv0AAhEIvTEpD5LIpAfav2eeVO9HBTjvKHVJPRSs=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/cloud v0.0.0-20160622021550-0a83eba2cadb/go.mod h1:0H1ncTHf11KCFhTc/+EFRbzSCOZx+VUbRMk55Yv5MYk=
 google.golang.org/genproto v0.0.0-20170531203552-aa2eb687b4d3/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0 // indirect
 	github.com/labstack/echo v0.0.0-20181123063414-c54d9e8eed6c
 	github.com/labstack/gommon v0.2.8 // indirect
+	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0
 	github.com/lib/pq v1.0.0
 	github.com/marpaia/graphite-golang v0.0.0-20171231172105-134b9af18cf3
 	github.com/mattn/go-sqlite3 v1.10.0

--- a/orc8r/cloud/go/go.sum
+++ b/orc8r/cloud/go/go.sum
@@ -3,8 +3,6 @@ github.com/Azure/azure-sdk-for-go v0.0.0-20161028183111-bd73d950fa44/go.mod h1:9
 github.com/Azure/go-autorest v10.8.1+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/Masterminds/squirrel v1.1.0 h1:baP1qLdoQCeTw3ifCdOq2dkYc6vGcmRdaociKLbEJXs=
-github.com/Masterminds/squirrel v1.1.0/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73 h1:+cRmVBz3H/U19fwW85uY+vS+EweAj7cPdhlP4b7vrE4=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=

--- a/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_network_helpers.go
@@ -107,11 +107,13 @@ func getNetworkIDsNotFound(networksByID map[string]*Network, queriedIDs []string
 }
 
 func (store *sqlConfiguratorStorage) doesNetworkExist(id string) (bool, error) {
-	query := fmt.Sprintf("SELECT count(1) FROM %s WHERE id = $1", networksTable)
-	row := store.tx.QueryRow(query, id)
-
 	var count int
-	err := row.Scan(&count)
+	err := store.builder.Select("COUNT(1)").
+		From(networksTable).
+		Where(sq.Eq{"id": id}).
+		RunWith(store.tx).
+		QueryRow().
+		Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("error checking if network id %s exists: %s", id, err)
 	}

--- a/orc8r/cloud/go/services/configurator/storage/sql_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_test.go
@@ -197,7 +197,7 @@ func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
 
 	idOnly := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_networks`).
 				WithArgs("n1").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
@@ -212,7 +212,7 @@ func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
 
 	allMetadata := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_networks`).
 				WithArgs("n2").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
@@ -236,7 +236,7 @@ func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
 	}
 	everything := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_networks`).
 				WithArgs("n3").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
@@ -258,7 +258,7 @@ func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
 
 	networkTableError := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_networks`).
 				WithArgs("n4").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
@@ -281,7 +281,7 @@ func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
 	}
 	configTableError := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_networks`).
 				WithArgs("n5").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(0))
 
@@ -304,7 +304,7 @@ func TestSqlConfiguratorStorage_CreateNetwork(t *testing.T) {
 
 	networkExists := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_networks`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_networks`).
 				WithArgs("n5").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 		},
@@ -754,12 +754,11 @@ func TestSqlConfiguratorStorage_CreateEntity(t *testing.T) {
 	// basic fields
 	basicCase := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_entities`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_entities`).
 				WithArgs("network", "foo", "bar").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}))
 
-			insertStmt := m.ExpectPrepare("INSERT INTO cfg_entities").WillBeClosed()
-			insertStmt.ExpectExec().
+			m.ExpectExec("INSERT INTO cfg_entities").
 				WithArgs("1", "network", "foo", "bar", "2", "foobar", "foobar ent", nil, nil).
 				WillReturnResult(mockResult)
 		},
@@ -790,12 +789,11 @@ func TestSqlConfiguratorStorage_CreateEntity(t *testing.T) {
 	// with permissions
 	withPerms := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_entities`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_entities`).
 				WithArgs("network", "foo", "bar").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}))
 
-			insertStmt := m.ExpectPrepare("INSERT INTO cfg_entities").WillBeClosed()
-			insertStmt.ExpectExec().
+			m.ExpectExec("INSERT INTO cfg_entities").
 				WithArgs("1", "network", "foo", "bar", "2", "foobar", "foobar ent", nil, nil).
 				WillReturnResult(mockResult)
 
@@ -828,12 +826,11 @@ func TestSqlConfiguratorStorage_CreateEntity(t *testing.T) {
 	// merge 2 graphs together
 	mergeGraphs := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_entities`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_entities`).
 				WithArgs("network", "foo", "bar").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}))
 
-			insertStmt := m.ExpectPrepare("INSERT INTO cfg_entities").WillBeClosed()
-			insertStmt.ExpectExec().
+			m.ExpectExec("INSERT INTO cfg_entities").
 				WithArgs("1", "network", "foo", "bar", "2", "foobar", "foobar ent", nil, nil).
 				WillReturnResult(mockResult)
 
@@ -879,7 +876,7 @@ func TestSqlConfiguratorStorage_CreateEntity(t *testing.T) {
 	// already exists
 	alreadyExists := &testCase{
 		setup: func(m sqlmock.Sqlmock) {
-			m.ExpectQuery(`SELECT count\(1\) FROM cfg_entities`).
+			m.ExpectQuery(`SELECT COUNT\(1\) FROM cfg_entities`).
 				WithArgs("network", "foo", "bar").
 				WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
 		},
@@ -1587,26 +1584,29 @@ func expectEdgeQueries(m sqlmock.Sqlmock, assocs []storage2.TypeAndKey, edgeLoad
 
 // [(from_pk, to_pk)]
 func expectEdgeInsertions(m sqlmock.Sqlmock, newEdges [][2]string) {
-	edgeStmt := m.ExpectPrepare("INSERT INTO cfg_assocs").WillBeClosed()
+	args := make([]driver.Value, 0, len(newEdges)*2)
 	for _, edge := range newEdges {
-		edgeStmt.ExpectExec().WithArgs(edge[0], edge[1]).WillReturnResult(mockResult)
+		args = append(args, edge[0], edge[1])
 	}
+	m.ExpectExec("INSERT INTO cfg_assocs").WithArgs(args...).WillReturnResult(mockResult)
 }
 
 func expectEdgeDeletions(m sqlmock.Sqlmock, edges [][2]string) {
-	edgeStmt := m.ExpectPrepare("DELETE FROM cfg_assocs").WillBeClosed()
+	args := make([]driver.Value, 0, len(edges)*2)
 	for _, edge := range edges {
-		edgeStmt.ExpectExec().WithArgs(edge[0], edge[1]).WillReturnResult(mockResult)
+		args = append(args, edge[0], edge[1])
 	}
+	m.ExpectExec("DELETE FROM cfg_assocs").WithArgs(args...).WillReturnResult(mockResult)
 }
 
 func expectPermissionCreation(m sqlmock.Sqlmock, entPk string, startId int, perms ...storage.ACL) {
-	aclStmt := m.ExpectPrepare("INSERT INTO cfg_acls").WillBeClosed()
+	args := make([]driver.Value, 0, len(perms)*6)
 	for _, perm := range perms {
 		exp := getExpectedACLInsert(entPk, &startId, perm)
-		aclStmt.ExpectExec().WithArgs(exp.id, exp.entPk, exp.scope, exp.perm, exp.aclType, exp.filter).WillReturnResult(mockResult)
+		args = append(args, exp.id, exp.entPk, exp.scope, exp.perm, exp.aclType, exp.filter)
 		startId++
 	}
+	m.ExpectExec("INSERT INTO cfg_acls").WillReturnResult(mockResult)
 }
 
 func expectPermissionUpdates(m sqlmock.Sqlmock, entPk string, perms ...storage.ACL) {

--- a/orc8r/cloud/go/sql_utils/builder.go
+++ b/orc8r/cloud/go/sql_utils/builder.go
@@ -256,10 +256,10 @@ func (mib mysqlInsertBuilder) Select(sb squirrel.SelectBuilder) InsertBuilder {
 	return mysqlInsertBuilder{newDelegate}
 }
 
-func ClearStatementCacheLogOnError(cache *squirrel.StmtCache) {
+func ClearStatementCacheLogOnError(cache *squirrel.StmtCache, callsite string) {
 	err := cache.Clear()
 	if err != nil {
-		glog.Errorf("error clearing statement cache in UpdateNetworks: %s", err)
+		glog.Errorf("error clearing statement cache in %s: %s", callsite, err)
 	}
 }
 

--- a/orc8r/cloud/go/sql_utils/table.go
+++ b/orc8r/cloud/go/sql_utils/table.go
@@ -1,0 +1,320 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package sql_utils
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/lann/builder"
+	"github.com/pkg/errors"
+	"github.com/thoas/go-funk"
+)
+
+func init() {
+	builder.Register(ColumnBuilder{}, createColumnData{})
+	builder.Register(CreateTableBuilder{}, createTableData{})
+}
+
+/*
+Because we are only supporting psql and mysql right now and the only difference
+between those dialects for table creation is the names of column types, we can
+use concrete types for the CREATE TABLE builder and column builder.
+
+The parameterized difference between the dialects is stored as a mapping of
+column type to name inside the data structure for each builder.
+*/
+
+var postgresColumnTypeMap = map[ColumnType]string{
+	ColumnTypeText: "TEXT",
+	ColumnTypeInt:  "INTEGER",
+	// BYTEA is effectively limited to 1GB
+	ColumnTypeBytes: "BYTEA",
+}
+
+var mysqlColumnTypeMap = map[ColumnType]string{
+	ColumnTypeText: "TEXT",
+	ColumnTypeInt:  "INT",
+	// LONGBLOB stores up to 4GB and the cost is a flat extra 2 bytes of
+	// storage over BLOB, which is limited to 64KB
+	ColumnTypeBytes: "LONGBLOB",
+}
+
+// ColumnOnDeleteOption is an enum type to specify ON DELETE behavior for
+// foreign keys
+type ColumnOnDeleteOption uint8
+
+const (
+	ColumnOnDeleteCascade ColumnOnDeleteOption = iota
+	// Fill in other behaviors as needed
+)
+
+// ColumnType is an enum type to specify table column types
+type ColumnType uint8
+
+const (
+	ColumnTypeText ColumnType = iota
+	ColumnTypeInt
+	ColumnTypeBytes
+	// Fill in other types as needed
+)
+
+// CreateTableBuilder is a builder for DDL table creation statements.
+// This builder is immutable and all operations will return a new instance
+// with the requested fields set.
+type CreateTableBuilder builder.Builder
+
+// Name sets the name of the table to be created
+func (b CreateTableBuilder) Name(name string) CreateTableBuilder {
+	return builder.Set(b, "Name", name).(CreateTableBuilder)
+}
+
+// IfNotExists sets the table creation to run only if the table does not
+// already exist
+func (b CreateTableBuilder) IfNotExists() CreateTableBuilder {
+	return builder.Set(b, "IfNotExists", true).(CreateTableBuilder)
+}
+
+// PrimaryKey specifies columns to create a primary key on
+// Note that the column builder also has a PrimaryKey. We do not cross-validate
+// primary key constraints, so avoid specifying PKs in multiple places.
+func (b CreateTableBuilder) PrimaryKey(columns ...string) CreateTableBuilder {
+	return builder.Set(b, "PrimaryKey", columns).(CreateTableBuilder)
+}
+
+// Unique adds a unique constraint on a set of columns.
+func (b CreateTableBuilder) Unique(columns ...string) CreateTableBuilder {
+	return builder.Append(b, "Unique", columns).(CreateTableBuilder)
+}
+
+// RunWith sets the runner for the statement.
+func (b CreateTableBuilder) RunWith(runner squirrel.BaseRunner) CreateTableBuilder {
+	return builder.Set(b, "RunWith", runner).(CreateTableBuilder)
+}
+
+// StartColumn returns a ColumnBuilder to build a column for the table. The
+// returned ColumnBuilder will have a reference back to this CreateTableBuilder
+// which will be returned when EndColumn() is called so you can chain column
+// creation into table creation.
+func (b CreateTableBuilder) StartColumn(name string) ColumnBuilder {
+	val, _ := builder.Get(b, "ColumnTypeNames")
+	return ColumnBuilder(builder.EmptyBuilder).
+		parentBuilder(&b).
+		columnTypeNames(val.(map[ColumnType]string)).
+		Name(name)
+}
+
+// Exec runs the statement using the set runner.
+func (b CreateTableBuilder) Exec() (sql.Result, error) {
+	d := builder.GetStruct(b).(createTableData)
+	return d.Exec()
+}
+
+// ToSql returns the SQL string and arguments for the statement.
+func (b CreateTableBuilder) ToSql() (string, []interface{}, error) {
+	d := builder.GetStruct(b).(createTableData)
+	return d.ToSql()
+}
+
+// unexported internal function for multi-dialect support
+func (b CreateTableBuilder) columnTypeNames(m map[ColumnType]string) CreateTableBuilder {
+	return builder.Set(b, "ColumnTypeNames", m).(CreateTableBuilder)
+}
+
+// ColumnBuilder is a builder for columns within a table creation statement
+// This builder is immutable and all methods will return a new instance of the
+// builder with the requested fields set.
+type ColumnBuilder builder.Builder
+
+// Name sets the name of the column.
+func (b ColumnBuilder) Name(name string) ColumnBuilder {
+	return builder.Set(b, "Name", name).(ColumnBuilder)
+}
+
+// Type sets the type of the column.
+func (b ColumnBuilder) Type(columnType ColumnType) ColumnBuilder {
+	return builder.Set(b, "Type", &columnType).(ColumnBuilder)
+}
+
+// NotNull marks the column as not nullable.
+func (b ColumnBuilder) NotNull() ColumnBuilder {
+	return builder.Set(b, "NotNull", true).(ColumnBuilder)
+}
+
+// Default sets the default value for the column. This value is not escaped so
+// SQL expressions are valid.
+func (b ColumnBuilder) Default(value interface{}) ColumnBuilder {
+	return builder.Set(b, "Default", value).(ColumnBuilder)
+}
+
+// PrimaryKey marks the column as a PK for the table.
+func (b ColumnBuilder) PrimaryKey() ColumnBuilder {
+	return builder.Set(b, "PrimaryKey", true).(ColumnBuilder)
+}
+
+// References marks the column as a foreign key to the specified table and
+// foreign column.
+func (b ColumnBuilder) References(table string, column string) ColumnBuilder {
+	return builder.Set(b, "References", &[2]string{table, column}).(ColumnBuilder)
+}
+
+// OnDelete sets the deletion behavior for a foreign key column.
+func (b ColumnBuilder) OnDelete(onDelete ColumnOnDeleteOption) ColumnBuilder {
+	return builder.Set(b, "OnDelete", &onDelete).(ColumnBuilder)
+}
+
+// EndColumn returns the parent CreateTableBuilder to continue building the
+// table creation statement.
+func (b ColumnBuilder) EndColumn() CreateTableBuilder {
+	pb, _ := builder.Get(b, "ParentBuilder")
+	return builder.Append(*(pb.(*CreateTableBuilder)), "Columns", &b).(CreateTableBuilder)
+}
+
+// ToSql returns the column creation as a SQL string.
+func (b ColumnBuilder) ToSql() (string, error) {
+	d := builder.GetStruct(b).(createColumnData)
+	return d.ToSql()
+}
+
+// unexported internal methods for multi-dialect support
+
+func (b ColumnBuilder) parentBuilder(pb *CreateTableBuilder) ColumnBuilder {
+	return builder.Set(b, "ParentBuilder", pb).(ColumnBuilder)
+}
+
+func (b ColumnBuilder) columnTypeNames(m map[ColumnType]string) ColumnBuilder {
+	return builder.Set(b, "ColumnTypeNames", m).(ColumnBuilder)
+}
+
+type createTableData struct {
+	RunWith squirrel.BaseRunner
+	// this should be set by the statement builder entry point
+	ColumnTypeNames map[ColumnType]string
+
+	Name        string
+	IfNotExists bool
+	Columns     []*ColumnBuilder
+
+	// Constraints
+	PrimaryKey []string
+	Unique     [][]string
+}
+
+func (d createTableData) Exec() (sql.Result, error) {
+	if d.RunWith == nil {
+		return nil, squirrel.RunnerNotSet
+	}
+	return squirrel.ExecWith(d.RunWith, d)
+}
+
+func (d createTableData) ToSql() (string, []interface{}, error) {
+	if funk.IsEmpty(d.Name) {
+		return "", nil, errors.New("table name must be specified")
+	}
+	if funk.IsEmpty(d.Columns) {
+		return "", nil, errors.New("table must specify at least one column")
+	}
+	if funk.IsEmpty(d.ColumnTypeNames) {
+		return "", nil, errors.New("column type-name mapping is empty")
+	}
+
+	sb := strings.Builder{}
+	sb.WriteString("CREATE TABLE ")
+	if d.IfNotExists {
+		sb.WriteString("IF NOT EXISTS ")
+	}
+	sb.WriteString(d.Name)
+	sb.WriteString(" (\n")
+
+	colSqls := make([]string, 0, len(d.Columns))
+	for i, col := range d.Columns {
+		colSql, err := col.ToSql()
+		if err != nil {
+			return "", nil, errors.Wrapf(err, "could not sqlize column at position %d", i)
+		}
+		colSqls = append(colSqls, colSql)
+	}
+	sb.WriteString(strings.Join(colSqls, ",\n"))
+
+	if !funk.IsEmpty(d.PrimaryKey) {
+		sb.WriteString(",\n")
+		sb.WriteString(fmt.Sprintf("PRIMARY KEY (%s)", strings.Join(d.PrimaryKey, ", ")))
+	}
+	for _, uniqConstr := range d.Unique {
+		sb.WriteString(",\n")
+		sb.WriteString(fmt.Sprintf("UNIQUE (%s)", strings.Join(uniqConstr, ", ")))
+	}
+	sb.WriteString("\n)")
+	return sb.String(), []interface{}{}, nil
+}
+
+type createColumnData struct {
+	// These should be set by the table builder when it spawns a column builder
+	ParentBuilder   *CreateTableBuilder
+	ColumnTypeNames map[ColumnType]string
+
+	Name    string
+	Type    *ColumnType
+	NotNull bool
+	Default interface{}
+
+	// Foreign key options
+	References *[2]string
+	OnDelete   *ColumnOnDeleteOption
+
+	PrimaryKey bool
+}
+
+func (d createColumnData) ToSql() (string, error) {
+	if funk.IsEmpty(d.Name) {
+		return "", errors.New("column name must be specified")
+	}
+	if d.Type == nil {
+		return "", errors.New("column type must be specified")
+	}
+	if _, typeOk := d.ColumnTypeNames[*d.Type]; !typeOk {
+		return "", errors.Errorf("column type %v not recognized", *d.Type)
+	}
+	if d.References != nil && (len(d.References[0]) == 0 || len(d.References[1]) == 0) {
+		return "", errors.Errorf("reference table name and column of foreign key must not be empty")
+	}
+	if d.OnDelete != nil && d.References == nil {
+		return "", errors.Errorf("cannot specify an ON DELETE without a REFERENCES")
+	}
+
+	sb := strings.Builder{}
+	sb.WriteString(d.Name)
+	sb.WriteString(" ")
+	sb.WriteString(d.ColumnTypeNames[*d.Type])
+
+	if d.PrimaryKey {
+		sb.WriteString(" PRIMARY KEY")
+	}
+
+	if d.NotNull {
+		sb.WriteString(" NOT NULL")
+	}
+	if d.Default != nil {
+		sb.WriteString(fmt.Sprintf(" DEFAULT %v", d.Default))
+	}
+	if d.References != nil {
+		sb.WriteString(fmt.Sprintf(" REFERENCES %s (%s)", d.References[0], d.References[1]))
+	}
+	if d.OnDelete != nil {
+		switch *d.OnDelete {
+		case ColumnOnDeleteCascade:
+			sb.WriteString(" ON DELETE CASCADE")
+		default:
+			return "", errors.Errorf("unrecognized on delete option %v", *d.OnDelete)
+		}
+	}
+	return sb.String(), nil
+}

--- a/orc8r/cloud/go/sql_utils/table.go
+++ b/orc8r/cloud/go/sql_utils/table.go
@@ -39,6 +39,7 @@ var postgresColumnTypeMap = map[ColumnType]string{
 	ColumnTypeInt:  "INTEGER",
 	// BYTEA is effectively limited to 1GB
 	ColumnTypeBytes: "BYTEA",
+	ColumnTypeBool:  "BOOLEAN",
 }
 
 var mysqlColumnTypeMap = map[ColumnType]string{
@@ -47,6 +48,7 @@ var mysqlColumnTypeMap = map[ColumnType]string{
 	// LONGBLOB stores up to 4GB and the cost is a flat extra 2 bytes of
 	// storage over BLOB, which is limited to 64KB
 	ColumnTypeBytes: "LONGBLOB",
+	ColumnTypeBool:  "BOOLEAN",
 }
 
 // ColumnOnDeleteOption is an enum type to specify ON DELETE behavior for
@@ -65,6 +67,7 @@ const (
 	ColumnTypeText ColumnType = iota
 	ColumnTypeInt
 	ColumnTypeBytes
+	ColumnTypeBool
 	// Fill in other types as needed
 )
 
@@ -105,11 +108,11 @@ func (b CreateTableBuilder) RunWith(runner squirrel.BaseRunner) CreateTableBuild
 	return builder.Set(b, "RunWith", runner).(CreateTableBuilder)
 }
 
-// StartColumn returns a ColumnBuilder to build a column for the table. The
-// returned ColumnBuilder will have a reference back to this CreateTableBuilder
-// which will be returned when EndColumn() is called so you can chain column
-// creation into table creation.
-func (b CreateTableBuilder) StartColumn(name string) ColumnBuilder {
+// Column returns a ColumnBuilder to build a column for the table. The returned
+// ColumnBuilder will have a reference back to this CreateTableBuilder which
+// will be returned when EndColumn() is called so you can chain column creation
+// into table creation.
+func (b CreateTableBuilder) Column(name string) ColumnBuilder {
 	val, _ := builder.Get(b, "ColumnTypeNames")
 	return ColumnBuilder(builder.EmptyBuilder).
 		parentBuilder(&b).

--- a/orc8r/cloud/go/sql_utils/table_test.go
+++ b/orc8r/cloud/go/sql_utils/table_test.go
@@ -255,6 +255,27 @@ func TestCreateTableBuilder_Exec(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestCreateIndexBuilder_ToSql(t *testing.T) {
+	actual, _, err := CreateIndexBuilder(builder.EmptyBuilder).
+		Name("foo").
+		IfNotExists().
+		On("foobar").
+		Columns("bar", "baz").
+		ToSql()
+	assert.NoError(t, err)
+	expected := "CREATE INDEX IF NOT EXISTS foo ON foobar (bar, baz)"
+	assert.Equal(t, expected, actual)
+
+	actual, _, err = CreateIndexBuilder(builder.EmptyBuilder).
+		Name("foo").
+		On("foobar").
+		Columns("bar").
+		ToSql()
+	assert.NoError(t, err)
+	expected = "CREATE INDEX foo ON foobar (bar)"
+	assert.Equal(t, expected, actual)
+}
+
 func columnBuilder(mapping map[ColumnType]string) ColumnBuilder {
 	return ColumnBuilder(builder.EmptyBuilder).columnTypeNames(mapping)
 }

--- a/orc8r/cloud/go/sql_utils/table_test.go
+++ b/orc8r/cloud/go/sql_utils/table_test.go
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package sql_utils
+
+import (
+	"log"
+	"testing"
+
+	"github.com/lann/builder"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+)
+
+func TestColumnBuilder_ToSql(t *testing.T) {
+	// psql
+
+	actual, err := columnBuilder(postgresColumnTypeMap).
+		Name("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		References("foo", "bar").
+		Default("\"hello world\"").
+		NotNull().
+		OnDelete(ColumnOnDeleteCascade).
+		ToSql()
+	assert.NoError(t, err)
+	expected := "pk TEXT PRIMARY KEY NOT NULL DEFAULT \"hello world\" REFERENCES foo (bar) ON DELETE CASCADE"
+	assert.Equal(t, expected, actual)
+
+	actual, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes).
+		ToSql()
+	assert.NoError(t, err)
+	expected = "foo BYTEA"
+	assert.Equal(t, expected, actual)
+
+	actual, err = columnBuilder(postgresColumnTypeMap).
+		Name("version").
+		Type(ColumnTypeInt).
+		NotNull().
+		Default(0).
+		ToSql()
+	assert.NoError(t, err)
+	expected = "version INTEGER NOT NULL DEFAULT 0"
+	assert.Equal(t, expected, actual)
+
+	// mysql
+	actual, err = columnBuilder(mysqlColumnTypeMap).
+		Name("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		References("foo", "bar").
+		Default("\"hello world\"").
+		NotNull().
+		OnDelete(ColumnOnDeleteCascade).
+		ToSql()
+	assert.NoError(t, err)
+	expected = "pk TEXT PRIMARY KEY NOT NULL DEFAULT \"hello world\" REFERENCES foo (bar) ON DELETE CASCADE"
+	assert.Equal(t, expected, actual)
+
+	actual, err = columnBuilder(mysqlColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes).
+		ToSql()
+	assert.NoError(t, err)
+	expected = "foo LONGBLOB"
+	assert.Equal(t, expected, actual)
+
+	actual, err = columnBuilder(mysqlColumnTypeMap).
+		Name("version").
+		Type(ColumnTypeInt).
+		NotNull().
+		Default(0).
+		ToSql()
+	assert.NoError(t, err)
+	expected = "version INT NOT NULL DEFAULT 0"
+	assert.Equal(t, expected, actual)
+}
+
+func TestColumnBuilder_ToSql_Errors(t *testing.T) {
+	_, err := columnBuilder(postgresColumnTypeMap).
+		Type(ColumnTypeBytes).
+		ToSql()
+	assert.EqualError(t, err, "column name must be specified")
+
+	_, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		ToSql()
+	assert.EqualError(t, err, "column type must be specified")
+
+	_, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes + 100).
+		ToSql()
+	assert.EqualError(t, err, "column type 102 not recognized")
+
+	_, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes).
+		References("", "bar").
+		ToSql()
+	assert.EqualError(t, err, "reference table name and column of foreign key must not be empty")
+
+	_, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes).
+		References("bar", "").
+		ToSql()
+	assert.EqualError(t, err, "reference table name and column of foreign key must not be empty")
+
+	_, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes).
+		OnDelete(ColumnOnDeleteCascade).
+		ToSql()
+	assert.EqualError(t, err, "cannot specify an ON DELETE without a REFERENCES")
+
+	_, err = columnBuilder(postgresColumnTypeMap).
+		Name("foo").
+		Type(ColumnTypeBytes).
+		References("bar", "baz").
+		OnDelete(ColumnOnDeleteCascade + 100).
+		ToSql()
+	assert.EqualError(t, err, "unrecognized on delete option 100")
+}
+
+func TestCreateTableBuilder_ToSql(t *testing.T) {
+	// psql
+	// we allow setting primary key constraint on a column and at the table
+	// level even though it would be rejected by the engine
+	actual, _, err := tableBuilder(postgresColumnTypeMap).
+		Name("foobar").
+		IfNotExists().
+		StartColumn("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		EndColumn().
+		StartColumn("foo").
+		Type(ColumnTypeBytes).
+		NotNull().
+		References("barbaz", "bites").
+		OnDelete(ColumnOnDeleteCascade).
+		EndColumn().
+		StartColumn("bar").
+		Type(ColumnTypeInt).
+		Default(42).
+		EndColumn().
+		PrimaryKey("pk", "foo").
+		Unique("foo", "bar").
+		ToSql()
+	assert.NoError(t, err)
+	expected := "CREATE TABLE IF NOT EXISTS foobar (\n" +
+		"pk TEXT PRIMARY KEY,\n" +
+		"foo BYTEA NOT NULL REFERENCES barbaz (bites) ON DELETE CASCADE,\n" +
+		"bar INTEGER DEFAULT 42,\n" +
+		"PRIMARY KEY (pk, foo),\n" +
+		"UNIQUE (foo, bar)\n" +
+		")"
+	assert.Equal(t, expected, actual)
+
+	actual, _, err = tableBuilder(postgresColumnTypeMap).
+		Name("foobar").
+		StartColumn("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		EndColumn().
+		ToSql()
+	assert.NoError(t, err)
+	expected = "CREATE TABLE foobar (\n" +
+		"pk TEXT PRIMARY KEY\n" +
+		")"
+	assert.Equal(t, expected, actual)
+
+	// mysql
+	actual, _, err = tableBuilder(mysqlColumnTypeMap).
+		Name("foobar").
+		IfNotExists().
+		StartColumn("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		EndColumn().
+		StartColumn("foo").
+		Type(ColumnTypeBytes).
+		NotNull().
+		References("barbaz", "bites").
+		OnDelete(ColumnOnDeleteCascade).
+		EndColumn().
+		StartColumn("bar").
+		Type(ColumnTypeInt).
+		Default(42).
+		EndColumn().
+		PrimaryKey("pk", "foo").
+		Unique("foo", "bar").
+		ToSql()
+	assert.NoError(t, err)
+	expected = "CREATE TABLE IF NOT EXISTS foobar (\n" +
+		"pk TEXT PRIMARY KEY,\n" +
+		"foo LONGBLOB NOT NULL REFERENCES barbaz (bites) ON DELETE CASCADE,\n" +
+		"bar INT DEFAULT 42,\n" +
+		"PRIMARY KEY (pk, foo),\n" +
+		"UNIQUE (foo, bar)\n" +
+		")"
+	assert.Equal(t, expected, actual)
+
+	actual, _, err = tableBuilder(mysqlColumnTypeMap).
+		Name("foobar").
+		StartColumn("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		EndColumn().
+		ToSql()
+	assert.NoError(t, err)
+	expected = "CREATE TABLE foobar (\n" +
+		"pk TEXT PRIMARY KEY\n" +
+		")"
+	assert.Equal(t, expected, actual)
+}
+
+func TestCreateTableBuilder_Exec(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error oppening stub DB conn: %s", err)
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			log.Printf("error closing stub DB: %s", err)
+		}
+	}()
+
+	mock.ExpectBegin()
+	mock.ExpectExec(
+		"CREATE TABLE IF NOT EXISTS foobar \\(\n" +
+			"pk TEXT PRIMARY KEY\n" +
+			"\\)",
+	).WillReturnResult(sqlmock.NewResult(1, 1))
+
+	tx, err := db.Begin()
+	assert.NoError(t, err)
+
+	_, err = NewPostgresStatementBuilder().CreateTable("foobar").
+		IfNotExists().
+		StartColumn("pk").
+		Type(ColumnTypeText).
+		PrimaryKey().
+		EndColumn().
+		RunWith(tx).
+		Exec()
+	assert.NoError(t, err)
+}
+
+func columnBuilder(mapping map[ColumnType]string) ColumnBuilder {
+	return ColumnBuilder(builder.EmptyBuilder).columnTypeNames(mapping)
+}
+
+func tableBuilder(mapping map[ColumnType]string) CreateTableBuilder {
+	return CreateTableBuilder(builder.EmptyBuilder).columnTypeNames(mapping)
+}

--- a/orc8r/cloud/go/sql_utils/table_test.go
+++ b/orc8r/cloud/go/sql_utils/table_test.go
@@ -138,17 +138,17 @@ func TestCreateTableBuilder_ToSql(t *testing.T) {
 	actual, _, err := tableBuilder(postgresColumnTypeMap).
 		Name("foobar").
 		IfNotExists().
-		StartColumn("pk").
+		Column("pk").
 		Type(ColumnTypeText).
 		PrimaryKey().
 		EndColumn().
-		StartColumn("foo").
+		Column("foo").
 		Type(ColumnTypeBytes).
 		NotNull().
 		References("barbaz", "bites").
 		OnDelete(ColumnOnDeleteCascade).
 		EndColumn().
-		StartColumn("bar").
+		Column("bar").
 		Type(ColumnTypeInt).
 		Default(42).
 		EndColumn().
@@ -167,7 +167,7 @@ func TestCreateTableBuilder_ToSql(t *testing.T) {
 
 	actual, _, err = tableBuilder(postgresColumnTypeMap).
 		Name("foobar").
-		StartColumn("pk").
+		Column("pk").
 		Type(ColumnTypeText).
 		PrimaryKey().
 		EndColumn().
@@ -182,17 +182,17 @@ func TestCreateTableBuilder_ToSql(t *testing.T) {
 	actual, _, err = tableBuilder(mysqlColumnTypeMap).
 		Name("foobar").
 		IfNotExists().
-		StartColumn("pk").
+		Column("pk").
 		Type(ColumnTypeText).
 		PrimaryKey().
 		EndColumn().
-		StartColumn("foo").
+		Column("foo").
 		Type(ColumnTypeBytes).
 		NotNull().
 		References("barbaz", "bites").
 		OnDelete(ColumnOnDeleteCascade).
 		EndColumn().
-		StartColumn("bar").
+		Column("bar").
 		Type(ColumnTypeInt).
 		Default(42).
 		EndColumn().
@@ -211,7 +211,7 @@ func TestCreateTableBuilder_ToSql(t *testing.T) {
 
 	actual, _, err = tableBuilder(mysqlColumnTypeMap).
 		Name("foobar").
-		StartColumn("pk").
+		Column("pk").
 		Type(ColumnTypeText).
 		PrimaryKey().
 		EndColumn().
@@ -246,7 +246,7 @@ func TestCreateTableBuilder_Exec(t *testing.T) {
 
 	_, err = NewPostgresStatementBuilder().CreateTable("foobar").
 		IfNotExists().
-		StartColumn("pk").
+		Column("pk").
 		Type(ColumnTypeText).
 		PrimaryKey().
 		EndColumn().


### PR DESCRIPTION
Summary:
- Replace all CREATE TABLE and CREATE INDEX hand-rolled sql with builders
- Will probably need some changes in the builder layer after testing against mariaDB but for now this gets everything working on postgres using builders all around

Differential Revision: D15554291

