### PR TITLE
Multiplex magmad gateway write into device and configurator

### DIFF
--- a/lte/cloud/go/services/meteringd_records/obsidian/handlers/meteringd_records_test.go
+++ b/lte/cloud/go/services/meteringd_records/obsidian/handlers/meteringd_records_test.go
@@ -27,6 +27,7 @@ import (
 	orcprotos "magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/service/middleware/unary/test_utils"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
@@ -58,6 +59,7 @@ func TestMeteringdRecords(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
+	device_test_init.StartTestService(t)
 	sdb_test_init.StartTestService(t)
 	meteringd_records_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)

--- a/orc8r/cloud/go/services/configurator/doc.go
+++ b/orc8r/cloud/go/services/configurator/doc.go
@@ -15,4 +15,6 @@ const (
 	ServiceName = "CONFIGURATOR"
 	// SerdeDomain is the name of this service's serde domain
 	SerdeDomain = "configurator"
+
+	GatewayEntityType = "gateway"
 )

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -12,7 +12,9 @@ import (
 	"context"
 
 	"magma/orc8r/cloud/go/errors"
+	magma_errors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/registry"
+	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/device/protos"
 
 	"github.com/golang/glog"
@@ -28,12 +30,25 @@ func getDeviceClient() (protos.DeviceClient, error) {
 	return protos.NewDeviceClient(conn), err
 }
 
-func RegisterDevices(networkID string, entities []*protos.PhysicalEntity) error {
+func CreateOrUpdate(networkID, deviceType, deviceKey string, info interface{}) error {
 	client, err := getDeviceClient()
 	if err != nil {
 		return err
 	}
-	req := &protos.RegisterDevicesRequest{NetworkID: networkID, Entities: entities}
+
+	serializedInfo, err := serde.Serialize(SerdeDomain, deviceType, info)
+	if err != nil {
+		return err
+	}
+	entity := &protos.PhysicalEntity{
+		DeviceID: deviceKey,
+		Type:     deviceType,
+		Info:     serializedInfo,
+	}
+	req := &protos.RegisterDevicesRequest{
+		NetworkID: networkID,
+		Entities:  []*protos.PhysicalEntity{entity},
+	}
 	_, err = client.RegisterDevices(context.Background(), req)
 	return err
 }
@@ -49,15 +64,28 @@ func DeleteDevices(networkID string, deviceIDs []*protos.DeviceID) error {
 	return err
 }
 
-func GetDeviceInfo(networkID string, deviceIDs []*protos.DeviceID) (map[string]*protos.PhysicalEntity, error) {
+func GetDevice(networkID, deviceType, deviceKey string) (interface{}, error) {
 	client, err := getDeviceClient()
 	if err != nil {
 		return nil, err
 	}
-	req := &protos.GetDeviceInfoRequest{NetworkID: networkID, DeviceIDs: deviceIDs}
+	deviceID := &protos.DeviceID{Type: deviceType, DeviceID: deviceKey}
+	req := &protos.GetDeviceInfoRequest{NetworkID: networkID, DeviceIDs: []*protos.DeviceID{deviceID}}
 	res, err := client.GetDeviceInfo(context.Background(), req)
 	if err != nil {
 		return nil, err
 	}
-	return res.DeviceMap, nil
+	device, ok := res.DeviceMap[deviceKey]
+	if !ok {
+		return nil, magma_errors.ErrNotFound
+	}
+	return serde.Deserialize(SerdeDomain, deviceType, device.Info)
+}
+
+func DoesDeviceExist(networkID, deviceType, deviceID string) bool {
+	_, err := GetDevice(networkID, deviceType, deviceID)
+	if err != nil {
+		return false
+	}
+	return true
 }

--- a/orc8r/cloud/go/services/device/client_test.go
+++ b/orc8r/cloud/go/services/device/client_test.go
@@ -26,19 +26,10 @@ const (
 	networkID = "network1"
 )
 
-type idAndEntity struct {
-	id     *protos.DeviceID
-	entity *protos.PhysicalEntity
-}
-
-func makeIDAndEntity(deviceID string, typeVal string, value []byte) idAndEntity {
-	id := protos.DeviceID{DeviceID: deviceID, Type: typeVal}
-	entity := protos.PhysicalEntity{
-		DeviceID: deviceID,
-		Type:     typeVal,
-		Info:     value,
-	}
-	return idAndEntity{id: &id, entity: &entity}
+type idAndInfo struct {
+	deviceKey  string
+	deviceType string
+	info       interface{}
 }
 
 func TestDeviceService(t *testing.T) {
@@ -47,70 +38,57 @@ func TestDeviceService(t *testing.T) {
 	assert.NoError(t, err)
 	test_init.StartTestService(t)
 
-	serialized1, err := testSerde.Serialize(1)
-	serialized2, err := testSerde.Serialize(2)
-	bundle1 := makeIDAndEntity("device1", typeVal, serialized1)
-	bundle2 := makeIDAndEntity("device2", typeVal, serialized2)
+	bundle1 := idAndInfo{deviceKey: "device1", deviceType: typeVal, info: 1}
+	bundle2 := idAndInfo{deviceKey: "device2", deviceType: typeVal, info: 2}
 	// Entities that should fail to register
-	unregisteredSerdeBundle := makeIDAndEntity("device2", "unregistered", serialized2)
-	unserializableBundle := makeIDAndEntity("device3", typeVal, []byte("(*_*)"))
+	unregisteredSerdeBundle := idAndInfo{deviceKey: "device2", deviceType: "unregistered", info: 2}
+	unserializableBundle := idAndInfo{deviceKey: "device2", deviceType: typeVal, info: "(*.*)"}
 
 	// Check contract for empty network
-	assertDevicesNotRegistered(t, bundle1.id, bundle2.id)
+	assertDevicesNotRegistered(t, bundle1, bundle2)
 
 	// Check contract for empty requests
-	registerDevicesAssertError(t, networkID)
-	registerDevicesAssertError(t, "", bundle1.entity)
+	registerDevicesAssertError(t, "", bundle1)
 
 	// Registering ill formatted device values should fail
-	registerDevicesAssertError(t, networkID, unregisteredSerdeBundle.entity)
-	registerDevicesAssertError(t, networkID, unserializableBundle.entity)
+	registerDevicesAssertError(t, networkID, unregisteredSerdeBundle)
+	registerDevicesAssertError(t, networkID, unserializableBundle)
 
 	// Register and retrieve devices
-	registerDevicesAssertNoError(t, networkID, bundle1.entity, bundle2.entity)
+	registerDevicesAssertNoError(t, networkID, bundle1)
+	registerDevicesAssertNoError(t, networkID, bundle2)
 	assertDevicesAreRegistered(t, bundle1, bundle2)
 
 	// Test deletion
-	err = device.DeleteDevices(networkID, []*protos.DeviceID{bundle1.id})
+	err = device.DeleteDevices(networkID, []*protos.DeviceID{{DeviceID: bundle1.deviceKey, Type: bundle1.deviceType}})
 	assert.NoError(t, err)
-	assertDevicesNotRegistered(t, bundle1.id)
+	assertDevicesNotRegistered(t, bundle1)
 	assertDevicesAreRegistered(t, bundle2)
 }
 
-func assertDevicesAreRegistered(t *testing.T, bundles ...idAndEntity) {
-	deviceIDs := []*protos.DeviceID{}
+func assertDevicesAreRegistered(t *testing.T, bundles ...idAndInfo) {
 	for _, bundle := range bundles {
-		deviceIDs = append(deviceIDs, bundle.id)
+		actualInfo, err := device.GetDevice(networkID, bundle.deviceType, bundle.deviceKey)
+		assert.NoError(t, err)
+		assert.Equal(t, bundle.info, actualInfo)
 	}
-
-	deviceMap, err := device.GetDeviceInfo(networkID, deviceIDs)
-	assert.NoError(t, err)
-	assertDevicesInEntityMap(t, deviceMap, bundles)
 }
 
-func assertDevicesNotRegistered(t *testing.T, deviceIDs ...*protos.DeviceID) {
-	deviceMap, err := device.GetDeviceInfo(networkID, deviceIDs)
-	assert.NoError(t, err)
-	assert.Equal(t, 0, len(deviceMap))
+func assertDevicesNotRegistered(t *testing.T, bundles ...idAndInfo) {
+	for _, bundle := range bundles {
+		_, err := device.GetDevice(networkID, bundle.deviceType, bundle.deviceKey)
+		assert.Error(t, err)
+	}
 }
 
-func registerDevicesAssertNoError(t *testing.T, networkID string, entities ...*protos.PhysicalEntity) {
-	err := device.RegisterDevices(networkID, entities)
+func registerDevicesAssertNoError(t *testing.T, networkID string, bundle idAndInfo) {
+	err := device.CreateOrUpdate(networkID, bundle.deviceType, bundle.deviceKey, bundle.info)
 	assert.NoError(t, err)
 }
 
-func registerDevicesAssertError(t *testing.T, networkID string, entities ...*protos.PhysicalEntity) {
-	err := device.RegisterDevices(networkID, entities)
+func registerDevicesAssertError(t *testing.T, networkID string, bundle idAndInfo) {
+	err := device.CreateOrUpdate(networkID, bundle.deviceType, bundle.deviceKey, bundle.info)
 	assert.Error(t, err)
-}
-
-func assertDevicesInEntityMap(t *testing.T, deviceMap map[string]*protos.PhysicalEntity, bundles []idAndEntity) {
-	for _, bundle := range bundles {
-		entity := deviceMap[bundle.id.DeviceID]
-		assert.NotNil(t, entity)
-		assert.Equal(t, bundle.entity.Info, entity.Info)
-	}
-	assert.Equal(t, len(bundles), len(deviceMap))
 }
 
 type Serde struct {

--- a/orc8r/cloud/go/services/device/doc.go
+++ b/orc8r/cloud/go/services/device/doc.go
@@ -13,10 +13,14 @@ package device
 
 // SerdeDomain is the domain for all Serde implementations for the device
 // service
-const SerdeDomain = "device"
+const (
+	SerdeDomain = "device"
 
-// ServiceName is the name of this service
-const ServiceName = "DEVICE"
+	// ServiceName is the name of this service
+	ServiceName = "DEVICE"
 
-// DBTableName is the name of the sql table used for this service
-const DBTableName = "device"
+	// DBTableName is the name of the sql table used for this service
+	DBTableName = "device"
+
+	GatewayInfoType = "access_gateway_record"
+)

--- a/orc8r/cloud/go/services/device/servicers/device.go
+++ b/orc8r/cloud/go/services/device/servicers/device.go
@@ -27,6 +27,7 @@ func NewDeviceServicer(factory blobstore.BlobStorageFactory) (protos.DeviceServe
 	}
 	return &deviceServicer{factory: factory}, nil
 }
+
 func (srv *deviceServicer) RegisterDevices(ctx context.Context, req *protos.RegisterDevicesRequest) (*commonProtos.Void, error) {
 	void := &commonProtos.Void{}
 	if err := ValidateRegisterDevicesRequest(req); err != nil {

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
@@ -131,7 +131,7 @@ func updateNetwork(c echo.Context) error {
 }
 
 func multiplexUpdateNetworkIntoConfigurator(networkID string, record *magmad_models.NetworkRecord) error {
-	exists, err := configurator.NetworkExists(networkID)
+	exists, err := configurator.DoesNetworkExist(networkID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Summary:
Add logic for multiplexing gateway related magmad writes into configurator.
The multiplex happens on the obsidian handlers level so that it is easier to turn off the magmad writes later on.
Since configurator/device DBs and magmad DBs are not yet synched up, if a gateway is not already registered in configurator/device when update is called, it will fetch the necessary information (physicalID) from magmad and create a gateway with the update patched on.

Reviewed By: xjtian

Differential Revision: D15520701

