### PR TITLE
Multiplex magmad network writes into configurator

### DIFF
--- a/lte/cloud/go/services/meteringd_records/obsidian/handlers/meteringd_records_test.go
+++ b/lte/cloud/go/services/meteringd_records/obsidian/handlers/meteringd_records_test.go
@@ -26,6 +26,7 @@ import (
 	"magma/orc8r/cloud/go/pluginimpl"
 	orcprotos "magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/service/middleware/unary/test_utils"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,7 @@ func TestMeteringdRecords(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
 	sdb_test_init.StartTestService(t)
 	meteringd_records_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/base_name_handler_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/base_name_handler_test.go
@@ -20,12 +20,14 @@ import (
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 )
 
 func TestBaseNames(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configurator_test_init.StartTestService(t)
 	magmad_test_init.StartTestService(t)
 	policydb_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policydb_handler_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policydb_handler_test.go
@@ -20,12 +20,14 @@ import (
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 )
 
 func TestPolicyRules(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configurator_test_init.StartTestService(t)
 	magmad_test_init.StartTestService(t)
 	policydb_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/subscriberdb_handler_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/subscriberdb_handler_test.go
@@ -20,6 +20,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 )
 
@@ -30,6 +31,7 @@ func TestSubscriberd(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
 	sdb_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
 
 	restPort := tests.StartObsidian(t)
 

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -65,6 +65,17 @@ func DeleteNetworks(networkIDs []string) error {
 	return err
 }
 
+func NetworkExists(networkID string) (bool, error) {
+	loaded, _, err := LoadNetworks([]string{networkID}, true, false)
+	if err != nil {
+		return false, err
+	}
+	if _, ok := loaded[networkID]; !ok {
+		return false, nil
+	}
+	return true, nil
+}
+
 // LoadNetworks loads networks specified by networks according to criteria specified and
 // returns the result
 func LoadNetworks(networks []string, loadMetadata bool, loadConfigs bool) (map[string]*protos.Network, []string, error) {

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
@@ -18,6 +18,8 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
 	"magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
@@ -28,6 +30,8 @@ import (
 func TestMagmad(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	device_test_init.StartTestService(t)
 	config_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
 

--- a/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_test.go
@@ -17,6 +17,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 	upgrade_test_init "magma/orc8r/cloud/go/services/upgrade/test_init"
 
@@ -131,6 +132,7 @@ func TestTiers(t *testing.T) {
 	magmad_test_init.StartTestService(t)
 	upgrade_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
+	configurator_test_init.StartTestService(t)
 	netUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
 
 	registerNetworkTestCase := tests.Testcase{


### PR DESCRIPTION
Summary:
Add logic for multiplexing network related magmad writes into configurator. The multiplex happens on the obsidian handlers level so that it is easier to turn off the magmad writes later on.
For network creation, the http post operation will fail if the multiplex fails.
For network update, if the network already does not exist, it will just create a new network using the information passed into the handler.

Reviewed By: xjtian

Differential Revision: D15520750

