### PR TITLE
Handle serial number form Qualcomm eNB correctly

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
@@ -146,7 +146,12 @@ class StateMachineManager:
             value = param_value.Value.Data
             param_values_by_path[path] = value
 
-        enb_serial = param_values_by_path['Device.DeviceInfo.SerialNumber']
+        if 'Device.DeviceInfo.SerialNumber' in param_values_by_path:
+            enb_serial = param_values_by_path['Device.DeviceInfo.SerialNumber']
+        else:
+            param_path = 'InternetGatewayDevice.DeviceInfo.SerialNumber'
+            enb_serial = param_values_by_path[param_path]
+
         return enb_serial
 
     def _get_client_ip(self, ctx: WsgiMethodContext) -> str:

--- a/lte/gateway/python/magma/enodebd/tests/enb_acs_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enb_acs_manager_tests.py
@@ -163,9 +163,9 @@ class StateMachineManagerTests(TestCase):
 
         # Send an Inform
         ctx1 = get_spyne_context_with_ip(ip)
-        inform_msg = Tr069MessageBuilder.get_inform('48BF74',
-                                                    'BaiBS_QAFB_v1234',
-                                                    '120200002618AGP0001')
+        inform_msg = Tr069MessageBuilder.get_qafb_inform('48BF74',
+                                                         'BaiBS_QAFB_v1234',
+                                                         '120200002618AGP0001')
         resp1 = manager.handle_tr069_message(ctx1, inform_msg)
         self.assertTrue(isinstance(resp1, models.InformResponse),
                         'Should respond with an InformResponse')


### PR DESCRIPTION
Summary: The path for the serial number for Baicells Nova 233 OD FDD eNodeB is different from the other units we support.

Reviewed By: fishlinghu

Differential Revision: D15571196

