### PR TITLE
Fix load service mconfig key error

### DIFF
--- a/orc8r/gateway/python/magma/configuration/mconfig_managers.py
+++ b/orc8r/gateway/python/magma/configuration/mconfig_managers.py
@@ -161,7 +161,7 @@ class MconfigManagerImpl(MconfigManager[GatewayConfigs]):
         cfg_file_name = self._get_mconfig_file_path()
         with open(cfg_file_name, 'r') as f:
             json_mconfig = json.load(f)
-            service_configs = json_mconfig["configsByKey"]
+            service_configs = json_mconfig["configs_by_key"]
         if service_name not in service_configs:
             raise LoadConfigError(
                 "Service ({}) missing in mconfig".format(service_name),


### PR DESCRIPTION
Summary: mconfigs were loaded from json with the key 'configsByKey' which should have been 'configs_by_key'

Differential Revision: D15698062

