### PR TITLE
Add REST api calls for test controller in orc8r

### DIFF
--- a/orc8r/cloud/docker/controller/apidocs/swagger-common.yml
+++ b/orc8r/cloud/docker/controller/apidocs/swagger-common.yml
@@ -25,6 +25,8 @@ tags:
     description: Provision and manage gateways
   - name: Operators
     description: Access Control Operations and Participants
+  - name: TestController
+    description: Controller for CI Test & Upgrade Services
 
 paths:
   /foo:

--- a/orc8r/cloud/go/services/configurator/obsidian/handlers/config_handlers.go
+++ b/orc8r/cloud/go/services/configurator/obsidian/handlers/config_handlers.go
@@ -28,7 +28,7 @@ func instantiateUnderlyingModel(serde serde.Serde) interface{} {
 
 // GetCRUDNetworkConfigHandlers returns 4 Handlers which implement CRUD for
 // a network config.
-// Path should look like '/magma/configurator/networks/:network_id/configs/{config_type}'
+// Path should look like '.../networks/:network_id/{config_type}'
 // Serde is used to serialize/deserialize the config stored
 func GetCRUDNetworkConfigHandlers(path string, serde serde.Serde) []handlers.Handler {
 	return []handlers.Handler{


### PR DESCRIPTION
Summary: Create a test controller service that will allow for CI on the orc8r cloud. This commit creates a skeleton for the REST API calls for the controller and adds handlers for the api endpoints. It outlines functionality for automatic cloud upgrades based on a given package repo and target upgrade tier.

Differential Revision: D15719883

