### PR TITLE
Implementation of revalidation timer for RAR

### DIFF
--- a/lte/gateway/c/session_manager/CloudReporter.cpp
+++ b/lte/gateway/c/session_manager/CloudReporter.cpp
@@ -31,7 +31,7 @@ void AsyncEvbResponse<ResponseType>::handle_response()
   });
 }
 
-SessionCloudReporter::SessionCloudReporter(
+SessionCloudReporterImpl::SessionCloudReporterImpl(
   folly::EventBase *base,
   std::shared_ptr<grpc::Channel> channel):
   base_(base),
@@ -39,7 +39,7 @@ SessionCloudReporter::SessionCloudReporter(
 {
 }
 
-void SessionCloudReporter::report_updates(
+void SessionCloudReporterImpl::report_updates(
   const UpdateSessionRequest &request,
   std::function<void(grpc::Status, UpdateSessionResponse)> callback)
 {
@@ -49,7 +49,7 @@ void SessionCloudReporter::report_updates(
     cloud_response->get_context(), request, &queue_)));
 }
 
-void SessionCloudReporter::report_create_session(
+void SessionCloudReporterImpl::report_create_session(
   const CreateSessionRequest &request,
   std::function<void(grpc::Status, CreateSessionResponse)> callback)
 {
@@ -59,7 +59,7 @@ void SessionCloudReporter::report_create_session(
     cloud_response->get_context(), request, &queue_)));
 }
 
-void SessionCloudReporter::report_terminate_session(
+void SessionCloudReporterImpl::report_terminate_session(
   const SessionTerminateRequest &request,
   std::function<void(grpc::Status, SessionTerminateResponse)> callback)
 {

--- a/lte/gateway/c/session_manager/CloudReporter.h
+++ b/lte/gateway/c/session_manager/CloudReporter.h
@@ -38,29 +38,44 @@ class AsyncEvbResponse : public AsyncGRPCResponse<ResponseType> {
   folly::EventBase *base_;
 };
 
-class SessionCloudReporter : public GRPCReceiver {
+class SessionCloudReporter : public GRPCReceiver{
  public:
-  SessionCloudReporter(
-    folly::EventBase *base,
-    std::shared_ptr<grpc::Channel> channel);
-
   /**
    * Proxy an UpdateSessionRequest gRPC call to the cloud
    */
-  void report_updates(
+  virtual void report_updates(
     const UpdateSessionRequest &request,
-    std::function<void(grpc::Status, UpdateSessionResponse)> callback);
+    std::function<void(grpc::Status, UpdateSessionResponse)> callback) = 0;
 
   /**
    * Proxy a CreateSessionRequest gRPC call to the cloud
    */
-  void report_create_session(
+  virtual void report_create_session(
     const CreateSessionRequest &request,
-    std::function<void(grpc::Status, CreateSessionResponse)> callback);
+    std::function<void(grpc::Status, CreateSessionResponse)> callback) = 0;
 
   /**
    * Proxy a SessionTerminateRequest gRPC call to the cloud
    */
+  virtual void report_terminate_session(
+    const SessionTerminateRequest &request,
+    std::function<void(grpc::Status, SessionTerminateResponse)> callback) = 0;
+};
+
+class SessionCloudReporterImpl : public SessionCloudReporter {
+ public:
+  SessionCloudReporterImpl(
+    folly::EventBase *base,
+    std::shared_ptr<grpc::Channel> channel);
+
+  void report_updates(
+    const UpdateSessionRequest &request,
+    std::function<void(grpc::Status, UpdateSessionResponse)> callback);
+
+  void report_create_session(
+    const CreateSessionRequest &request,
+    std::function<void(grpc::Status, CreateSessionResponse)> callback);
+
   void report_terminate_session(
     const SessionTerminateRequest &request,
     std::function<void(grpc::Status, SessionTerminateResponse)> callback);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -14,8 +14,10 @@
 #include <google/protobuf/repeated_field.h>
 #include <google/protobuf/timestamp.pb.h>
 #include <google/protobuf/util/time_util.h>
+#include <grpcpp/channel.h>
 
 #include "LocalEnforcer.h"
+#include "ServiceRegistrySingleton.h"
 #include "magma_logging.h"
 
 namespace {
@@ -47,20 +49,14 @@ static void mark_rule_failures(
   PolicyReAuthAnswer &answer_out);
 
 LocalEnforcer::LocalEnforcer(
+  std::shared_ptr<SessionCloudReporter> reporter,
   std::shared_ptr<StaticRuleStore> rule_store,
   std::shared_ptr<PipelinedClient> pipelined_client,
   long session_force_termination_timeout_ms):
+  reporter_(reporter),
   rule_store_(rule_store),
   pipelined_client_(pipelined_client),
   session_force_termination_timeout_ms_(session_force_termination_timeout_ms)
-{
-}
-
-LocalEnforcer::LocalEnforcer():
-  LocalEnforcer(
-    std::make_shared<StaticRuleStore>(),
-    std::make_shared<AsyncPipelinedClient>(),
-    0)
 {
 }
 
@@ -627,6 +623,10 @@ void LocalEnforcer::get_rules_from_policy_reauth_request(
   RulesToProcess *rules_to_deactivate)
 {
   MLOG(MDEBUG) << "Processing policy reauth for subscriber " << request.imsi();
+  if (revalidation_required(request.event_triggers())) {
+    schedule_revalidation(request.revalidation_time());
+  }
+
   for (const auto &rule_id : request.rules_to_remove()) {
     // Try to remove as dynamic rule first
     PolicyRule dy_rule;
@@ -681,6 +681,54 @@ void LocalEnforcer::get_rules_from_policy_reauth_request(
       rules_to_deactivate->dynamic_rules.push_back(dynamic_rule.policy_rule());
     }
   }
+}
+
+bool LocalEnforcer::revalidation_required(
+  const google::protobuf::RepeatedField<int> &event_triggers)
+{
+  auto it = std::find(
+    event_triggers.begin(), event_triggers.end(), REVALIDATION_TIMEOUT);
+  return it != event_triggers.end();
+}
+
+void LocalEnforcer::schedule_revalidation(
+  const google::protobuf::Timestamp &revalidation_time)
+{
+  auto delta = time_difference_from_now(revalidation_time);
+  evb_->runInEventBaseThread([=] {
+    evb_->timer().scheduleTimeoutFn(
+      std::move([=] {
+        MLOG(MDEBUG) << "Revalidation timeout!";
+        check_usage_for_reporting();
+      }),
+      delta);
+  });
+}
+
+void LocalEnforcer::check_usage_for_reporting()
+{
+  auto request = collect_updates();
+  if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
+    return; // nothing to report
+  }
+  MLOG(MDEBUG) << "Sending " << request.updates_size()
+               << " charging updates and " << request.usage_monitors_size()
+               << " monitor updates to OCS and PCRF";
+
+  // report to cloud
+  (*reporter_).report_updates(
+    request, [this, request](Status status, UpdateSessionResponse response) {
+      if (!status.ok()) {
+        reset_updates(request);
+        MLOG(MERROR) << "Update of size " << request.updates_size()
+                     << " to OCS failed entirely: " << status.error_message();
+      } else {
+        MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
+        update_session_credit(response);
+        // Check if we need to report more updates
+        check_usage_for_reporting();
+      }
+    });
 }
 
 static void mark_rule_failures(

--- a/lte/gateway/c/session_manager/PgwClient.h
+++ b/lte/gateway/c/session_manager/PgwClient.h
@@ -15,7 +15,6 @@
 
 #include "GRPCReceiver.h"
 
-using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace magma {

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -12,7 +12,6 @@
 #include "ServiceRegistrySingleton.h"
 #include "magma_logging.h"
 
-using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace { // anonymous

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -16,7 +16,6 @@
 
 #include "GRPCReceiver.h"
 
-using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace magma {

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -11,7 +11,6 @@
 #include "RuleStore.h"
 #include "ServiceRegistrySingleton.h"
 
-using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace magma {

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -16,7 +16,6 @@
 
 #include "GRPCReceiver.h"
 
-using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace magma {

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -104,4 +104,38 @@ void create_monitor_update_response(
   response->set_sid(imsi);
 }
 
+void create_policy_reauth_request(
+  const std::string &session_id,
+  const std::string &imsi,
+  const std::vector<std::string> &rules_to_remove,
+  const std::vector<StaticRuleInstall> &rules_to_install,
+  const std::vector<DynamicRuleInstall> &dynamic_rules_to_install,
+  const std::vector<EventTrigger> &event_triggers,
+  const uint64_t revalidation_time_unix_ts,
+  const std::vector<UsageMonitoringCredit> &usage_monitoring_credits,
+  PolicyReAuthRequest *request)
+{
+  request->set_session_id(session_id);
+  request->set_imsi(imsi);
+  for (const auto &rule_id : rules_to_remove) {
+    request->add_rules_to_remove(rule_id);
+  }
+  auto req_rules_to_install = request->mutable_rules_to_install();
+  for (const auto &static_rule_to_install : rules_to_install) {
+    req_rules_to_install->Add()->CopyFrom(static_rule_to_install);
+  }
+  auto req_dynamic_rules_to_install = request->mutable_dynamic_rules_to_install();
+  for (const auto &dynamic_rule_to_install : dynamic_rules_to_install) {
+    req_dynamic_rules_to_install->Add()->CopyFrom(dynamic_rule_to_install);
+  }
+  for (const auto &event_trigger : event_triggers) {
+    request->add_event_triggers(event_trigger);
+  }
+  request->mutable_revalidation_time()->set_seconds(revalidation_time_unix_ts);
+  auto req_credits = request->mutable_usage_monitoring_credits();
+  for (const auto &credit : usage_monitoring_credits) {
+    req_credits->Add()->CopyFrom(credit);
+  }
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -56,4 +56,15 @@ void create_usage_update(
   CreditUsage::UpdateType type,
   CreditUsageUpdate *update);
 
+void create_policy_reauth_request(
+  const std::string &session_id,
+  const std::string &imsi,
+  const std::vector<std::string> &rules_to_remove,
+  const std::vector<StaticRuleInstall> &rules_to_install,
+  const std::vector<DynamicRuleInstall> &dynamic_rules_to_install,
+  const std::vector<EventTrigger> &event_triggers,
+  const uint64_t revalidation_time_unix_ts,
+  const std::vector<UsageMonitoringCredit> &usage_monitoring_credits,
+  PolicyReAuthRequest *request);
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -16,6 +16,9 @@
 #include <lte/protos/pipelined.grpc.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
 
+#include <folly/io/async/EventBase.h>
+
+#include "CloudReporter.h"
 #include "LocalSessionManagerHandler.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
@@ -145,6 +148,28 @@ class MockSessionHandler final : public LocalSessionManagerHandler {
       grpc::ServerContext *,
       const SubscriberID *,
       std::function<void(Status, LocalEndSessionResponse)>));
+};
+
+class MockSessionCloudReporter : public SessionCloudReporter {
+  public:
+    MOCK_METHOD2(
+      report_updates,
+      void(
+        const UpdateSessionRequest &,
+        std::function<void(grpc::Status, UpdateSessionResponse)>));
+
+    MOCK_METHOD2(
+      report_create_session,
+      void(
+        const CreateSessionRequest &,
+        std::function<void(Status, CreateSessionResponse)>));
+
+    MOCK_METHOD2(
+      report_terminate_session,
+      void(
+        const SessionTerminateRequest &,
+        std::function<void(Status, SessionTerminateResponse)>));
+
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
@@ -38,7 +38,7 @@ class CloudReporterTest : public ::testing::Test {
     mock_cloud = std::make_shared<MockCentralController>();
     magma_service->AddServiceToServer(mock_cloud.get());
 
-    reporter = std::make_shared<SessionCloudReporter>(&evb, channel);
+    reporter = std::make_shared<SessionCloudReporterImpl>(&evb, channel);
 
     std::thread reporter_thread([&]() {
       std::cout << "Started reporter thread\n";

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -49,8 +49,9 @@ class SessiondTest : public ::testing::Test {
     insert_static_rule(rule_store, 1, "rule2");
     insert_static_rule(rule_store, 2, "rule3");
 
-    monitor = std::make_shared<LocalEnforcer>(rule_store, pipelined_client, 0);
-    reporter = std::make_shared<SessionCloudReporter>(evb, test_channel);
+    reporter = std::make_shared<SessionCloudReporterImpl>(evb, test_channel);
+    monitor = std::make_shared<LocalEnforcer>(
+      reporter, rule_store, pipelined_client, 0);
 
     local_service =
       std::make_shared<service303::MagmaService>("sessiond", "1.0");
@@ -134,7 +135,7 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<MockCentralController> controller_mock;
   std::shared_ptr<MockPipelined> pipelined_mock;
   std::shared_ptr<LocalEnforcer> monitor;
-  std::shared_ptr<SessionCloudReporter> reporter;
+  std::shared_ptr<SessionCloudReporterImpl> reporter;
   std::shared_ptr<LocalSessionManagerAsyncService> session_manager;
   std::shared_ptr<SessionProxyResponderAsyncService> proxy_responder;
   std::shared_ptr<service303::MagmaService> local_service;


### PR DESCRIPTION
Summary:
**Summary**
`session_proxy` in FeG might send `EventTriggers` and `RevalidationTime` to `sessiond` in the GW through RAR and CCU-A, but the `sessiond` does not have the implementation to trigger a CCU-R when the timer expires. This diff takes the information related to revalidation timer in RAR and implement the logic to trigger a CCU-R. There will be another diff doing the similar thing using CCU-A.

Some `using google::protobuf::RepeatedPtrField;` are removed as I noticed they are not needed.

**Implementation**
1. Get revalidation time from RAR message when `RevalidationTimeout` is one of the `EventTriggers`.
2. Schedule a rpc call to send CCU-R to `session_proxy` using EventBase.

**What is affected**
1. `sessiond` will send a CCU-R when revalidation timer it receives from RAR expires.

Differential Revision: D15707762

