### PR TITLE
Change default cell identity from 0 to 138777000

### DIFF
--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -25,6 +25,9 @@ from magma.enodebd.lte_utils import DuplexMode, \
 
 # LTE constants
 DEFAULT_S1_PORT = 36412
+# This is a known working value for supported eNB devices.
+# Cell Identity is a 28 bit number, but not all values are supported.
+DEFAULT_CELL_IDENTITY = 138777000
 
 
 SingleEnodebConfig = namedtuple('SingleEnodebConfig',
@@ -126,7 +129,7 @@ def _get_enb_config(
         allow_enodeb_transmit = mconfig.allow_enodeb_transmit
         tac = mconfig.tac
         bandwidth_mhz = mconfig.bandwidth_mhz
-        cell_id = 0
+        cell_id = DEFAULT_CELL_IDENTITY
         if mconfig.tdd_config is not None and str(mconfig.tdd_config) != '':
             earfcndl = mconfig.tdd_config.earfcndl
             subframe_assignment = mconfig.tdd_config.subframe_assignment

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/tr069_msg_builder.py
@@ -293,7 +293,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.Common.CellIdentity',
             val_type='int',
-            data='0',
+            data='138777000',
         ))
         # MME IP
         param_val_list.append(cls.get_parameter_value_struct(
@@ -432,7 +432,7 @@ class Tr069MessageBuilder:
         param_val_list.append(cls.get_parameter_value_struct(
             name='Device.Services.FAPService.1.CellConfig.LTE.RAN.Common.CellIdentity',
             val_type='int',
-            data='0',
+            data='138777000',
         ))
         # MME IP
         param_val_list.append(cls.get_parameter_value_struct(


### PR DESCRIPTION
Summary: In theory any 28 bit number should work for an eNodeB Cell Identity. In practice we find that certain values don't work, so this revision switches the default value to something that was found to be working.

Reviewed By: xjtian

Differential Revision: D15811051

