### PR TITLE
ServiceLogErrorReporter _run() function should be async

### DIFF
--- a/orc8r/gateway/python/magma/common/log_counter.py
+++ b/orc8r/gateway/python/magma/common/log_counter.py
@@ -31,6 +31,6 @@ class ServiceLogErrorReporter(Job):
         self._service_config = service_config
         self._handler = handler
 
-    def _run(self):
+    async def _run(self):
         error_count = self._handler.pop_error_count()
         SERVICE_ERRORS.inc(error_count)


### PR DESCRIPTION
Summary:
This was causing an error:

```
Jun 13 16:07:24 magma-dev mobilityd[4430]: ERROR:root:Exception from _run: 'ERROR'
Jun 13 16:07:34 magma-dev mobilityd[4430]: ERROR:root:Exception from _run: object NoneType can't be used in 'await' expression
```

Fixing this just requires making _run into an async function

Reviewed By: sciencemanx

Differential Revision: D15819760

