### PR TITLE
Use TitleCase for consts in the CWAG registry

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -13,7 +13,9 @@ replace (
 
 require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
+	golang.org/x/net v0.0.0-20190110200230-915654e7eabc
 	google.golang.org/grpc v1.17.0
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/orc8r/cloud/go v0.0.0

--- a/cwf/gateway/registry/local_registry.go
+++ b/cwf/gateway/registry/local_registry.go
@@ -18,6 +18,7 @@ const (
 	ModuleName = "cwf"
 
 	TWANSIM = "TWANSIM"
+	UESIM   = "UESIM"
 )
 
 // Add a new service.
@@ -43,4 +44,5 @@ func addLocalService(serviceType string, port int) {
 
 func init() {
 	addLocalService(TWANSIM, 10100)
+	addLocalService(UESIM, 10101)
 }

--- a/cwf/gateway/registry/local_registry.go
+++ b/cwf/gateway/registry/local_registry.go
@@ -17,8 +17,8 @@ import (
 const (
 	ModuleName = "cwf"
 
-	TWANSIM = "TWANSIM"
-	UESIM   = "UESIM"
+	TwanSim = "TWANSIM"
+	UeSim   = "UESIM"
 )
 
 // Add a new service.
@@ -43,6 +43,6 @@ func addLocalService(serviceType string, port int) {
 }
 
 func init() {
-	addLocalService(TWANSIM, 10100)
-	addLocalService(UESIM, 10101)
+	addLocalService(TwanSim, 10100)
+	addLocalService(UeSim, 10101)
 }

--- a/cwf/gateway/services/twansim/main.go
+++ b/cwf/gateway/services/twansim/main.go
@@ -23,9 +23,9 @@ func init() {
 
 func main() {
 	// Create the service
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.TWANSIM)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.TwanSim)
 	if err != nil {
-		glog.Fatalf("Error creating TWANSIM service: %s", err)
+		glog.Fatalf("Error creating TwanSim service: %s", err)
 	}
 
 	// Run the service

--- a/cwf/gateway/services/uesim/main.go
+++ b/cwf/gateway/services/uesim/main.go
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// This starts the user equipment (ue) service.
+package main
+
+import (
+	"magma/cwf/cloud/go/protos"
+	"magma/cwf/gateway/registry"
+	"magma/cwf/gateway/services/uesim/servicers"
+	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/service"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UESIM)
+	if err != nil {
+		glog.Fatalf("Error creating UESIM service: %s", err)
+	}
+
+	store := blobstore.NewMemoryBlobStorageFactory()
+	servicer, err := servicers.NewUESimServer(store)
+	if err != nil {
+		glog.Fatalf("Error creating UE server: %s", err)
+	}
+	protos.RegisterUESimServer(srv.GrpcServer, servicer)
+
+	// Run the service
+	err = srv.Run()
+	if err != nil {
+		glog.Fatalf("Error running UE service: %s", err)
+	}
+}

--- a/cwf/gateway/services/uesim/main.go
+++ b/cwf/gateway/services/uesim/main.go
@@ -20,9 +20,9 @@ import (
 )
 
 func main() {
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UESIM)
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.UeSim)
 	if err != nil {
-		glog.Fatalf("Error creating UESIM service: %s", err)
+		glog.Fatalf("Error creating UeSim service: %s", err)
 	}
 
 	store := blobstore.NewMemoryBlobStorageFactory()

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -1,0 +1,95 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package servicers
+
+import (
+	cwfprotos "magma/cwf/cloud/go/protos"
+	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/protos"
+
+	"github.com/pkg/errors"
+	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	networkIDPlaceholder = "magma"
+	blobTypePlaceholder  = "uesim"
+)
+
+// UESimServer tracks all the UEs being simulated.
+type UESimServer struct {
+	store blobstore.BlobStorageFactory
+}
+
+// NewUESimServer initializes a UESimServer with an empty store map.
+// Output: a new UESimServer
+func NewUESimServer(factory blobstore.BlobStorageFactory) (*UESimServer, error) {
+	return &UESimServer{
+		store: factory,
+	}, nil
+}
+
+// AddUE tries to add this UE to the server.
+// Input: The UE data which will be added.
+func (srv *UESimServer) AddUE(ctx context.Context, ue *cwfprotos.UEConfig) (ret *protos.Void, err error) {
+	ret = &protos.Void{}
+
+	err = validateUEData(ue)
+	if err != nil {
+		err = ConvertStorageErrorToGrpcStatus(err)
+		return
+	}
+	blob, err := ueToBlob(ue)
+	store, err := srv.store.StartTransaction()
+	if err != nil {
+		err = errors.Wrap(err, "Error while starting transaction")
+		err = ConvertStorageErrorToGrpcStatus(err)
+		return
+	}
+	defer func() {
+		switch err {
+		case nil:
+			if commitErr := store.Commit(); commitErr != nil {
+				err = errors.Wrap(err, "Error while committing transaction")
+				err = ConvertStorageErrorToGrpcStatus(err)
+			}
+		default:
+			if rollbackErr := store.Rollback(); rollbackErr != nil {
+				err = errors.Wrap(err, "Error while rolling back transaction")
+				err = ConvertStorageErrorToGrpcStatus(err)
+			}
+		}
+	}()
+
+	err = store.CreateOrUpdate(networkIDPlaceholder, []blobstore.Blob{blob})
+	return
+}
+
+// Converts UE data to a blob for storage.
+func ueToBlob(ue *cwfprotos.UEConfig) (blobstore.Blob, error) {
+	marshaledUE, err := protos.Marshal(ue)
+	if err != nil {
+		return blobstore.Blob{}, err
+	}
+	return blobstore.Blob{
+		Type:  blobTypePlaceholder,
+		Key:   ue.GetImsi(),
+		Value: marshaledUE,
+	}, nil
+}
+
+// ConvertStorageErrorToGrpcStatus converts a UE error into a gRPC status error.
+func ConvertStorageErrorToGrpcStatus(err error) error {
+	if err == nil {
+		return nil
+	}
+	return status.Errorf(codes.Unknown, err.Error())
+}

--- a/cwf/gateway/services/uesim/servicers/uesim_test.go
+++ b/cwf/gateway/services/uesim/servicers/uesim_test.go
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package servicers_test
+
+import (
+	"context"
+	"testing"
+
+	"magma/cwf/cloud/go/protos"
+	"magma/cwf/gateway/services/uesim/servicers"
+	"magma/orc8r/cloud/go/blobstore"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUESimulator_AddUE(t *testing.T) {
+	store := blobstore.NewMemoryBlobStorageFactory()
+
+	server, err := servicers.NewUESimServer(store)
+	assert.NoError(t, err)
+
+	expectedIMSI1 := "1234567890"
+	expectedIMSI2 := "2345678901"
+	ue1 := &protos.UEConfig{Imsi: expectedIMSI1, AuthKey: make([]byte, 32), AuthOpc: make([]byte, 32)}
+	ue2 := &protos.UEConfig{Imsi: expectedIMSI2, AuthKey: make([]byte, 32), AuthOpc: make([]byte, 32)}
+
+	_, err = server.AddUE(context.Background(), ue1)
+	assert.NoError(t, err)
+
+	_, err = server.AddUE(context.Background(), ue2)
+	assert.NoError(t, err)
+}

--- a/cwf/gateway/services/uesim/servicers/validate.go
+++ b/cwf/gateway/services/uesim/servicers/validate.go
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package storage
+package servicers
 
 import (
 	"errors"

--- a/cwf/gateway/services/uesim/servicers/validate_test.go
+++ b/cwf/gateway/services/uesim/servicers/validate_test.go
@@ -6,7 +6,7 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 */
 
-package storage
+package servicers
 
 import (
 	"errors"


### PR DESCRIPTION
Summary: The `const` service names in the cwf gateway registry were all `UPPERCASE`, but have been changed to `TitleCase` to better follow Go `const` conventions.

Reviewed By: xjtian

Differential Revision: D15812566

