### PR TITLE
Change PCI for Baicells to a non-invasive parameter

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -141,7 +141,7 @@ class BaicellsTrDataModel(DataModel):
         ParameterName.EARFCNDL: TrParam(FAPSERVICE_PATH + 'X_BAICELLS_COM_LTE.EARFCNDLInUse', True, TrParameterType.INT, False),
         ParameterName.EARFCNUL: TrParam(FAPSERVICE_PATH + 'X_BAICELLS_COM_LTE.EARFCNULInUse', True, TrParameterType.INT, False),
         ParameterName.BAND: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.FreqBandIndicator', True, TrParameterType.INT, False),
-        ParameterName.PCI: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.PhyCellID', True, TrParameterType.INT, False),
+        ParameterName.PCI: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.PhyCellID', False, TrParameterType.INT, False),
         ParameterName.DL_BANDWIDTH: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.DLBandwidth', True, TrParameterType.STRING, False),
         ParameterName.UL_BANDWIDTH: TrParam(FAPSERVICE_PATH + 'CellConfig.LTE.RAN.RF.ULBandwidth', True, TrParameterType.STRING, False),
         ParameterName.SUBFRAME_ASSIGNMENT: TrParam(


### PR DESCRIPTION
Summary: The PCI value gets reset on reboot of the Baicells eNB. Changing the the parameter to be marked as 'non-invasive' will keep enodebd from rebooting the eNB when the PCI value is changed.

Reviewed By: fishlinghu

Differential Revision: D15370466

