### PR TITLE
Implement pipelined app to add subscriber flows using UE MAC addr

### DIFF
--- a/cwf/gateway/configs/gateway.mconfig
+++ b/cwf/gateway/configs/gateway.mconfig
@@ -14,19 +14,20 @@
       "package_version": "0.0.0-0",
       "dynamic_services": []
     },
-    "metricsd": {
-      "@type": "type.googleapis.com/magma.mconfig.MetricsD",
-      "logLevel": "INFO"
-    },
     "pipelined": {
       "@type": "type.googleapis.com/magma.mconfig.PipelineD",
       "logLevel": "INFO",
       "ueIpBlock": "192.168.128.0/24",
       "natEnabled": true,
-      "relayEnabled": false,
+      "relayEnabled": true,
       "apps": [],
       "services": [
       ]
+    },
+    "sessiond": {
+      "@type": "type.googleapis.com/magma.mconfig.SessionD",
+      "logLevel": "INFO",
+      "relayEnabled": true
     }
   }
 }

--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -59,7 +59,6 @@ metricsd:
   # A string in the form path.to.module.fn_name
   # @see magma.magmad.metrics_collector.example_metrics_postprocessor
   post_processing_fn: magma.magmad.metrics_collector.do_nothing_metrics_postprocessor
-
   # List of services for metricsd to poll
   services:
     - magmad

--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -24,6 +24,7 @@ log_level: INFO
 # the same order as the list. Cloud managed services will be initialized
 # after these static services.
 static_services: [
+  'ue_mac',
   'arpd',
   'access_control',
   'ryu_rest_service',

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -15,6 +15,3 @@
     - role: ovs
     - role: golang
     - role: cwag
-
-
-

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - /var/run/openvswitch:/var/run/openvswitch
     command: >
       sh -c "set bridge br0 protocols=protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true &&
-        /usr/bin/ovs-vsctl set-controller br0 tcp:127.0.0.1:6633 tcp:127.0.0.1:6654 &&
+        /usr/bin/ovs-vsctl set-controller br0 tcp:127.0.0.1:6633 &&
         python3 -m magma.pipelined.main"
 
   sessiond:

--- a/lte/gateway/python/magma/pipelined/app/ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/app/ue_mac.py
@@ -1,0 +1,94 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+from collections import namedtuple
+
+from .base import MagmaController
+from magma.pipelined.imsi import encode_imsi
+from magma.pipelined.openflow import flows
+from magma.pipelined.openflow.magma_match import MagmaMatch
+from magma.pipelined.openflow.registers import IMSI_REG
+
+
+class UEMacAddressController(MagmaController):
+    """
+    UE MAC Address Controller
+
+    This controller controls table 0 which is the first table every packet
+    touches. It matches on UE MAC address and sets IMSI metadata
+    """
+
+    APP_NAME = "ue_mac"
+    UEMacConfig = namedtuple(
+        'UEMacConfig',
+        ['gre_tunnel_port'],
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(UEMacAddressController, self).__init__(*args, **kwargs)
+        self.config = self._get_config(kwargs['config'])
+        self._datapath = None
+
+    def _get_config(self, config_dict):
+        return self.UEMacConfig(
+            # TODO: rename port number to a tunneling protocol agnostic name
+            gre_tunnel_port=config_dict['ovs_gtp_port_number'],
+        )
+
+    def initialize_on_connect(self, datapath):
+        flows.delete_all_flows_from_table(datapath,
+                                          self._service_manager.get_table_num(
+                                              self.APP_NAME))
+        self._datapath = datapath
+
+    def cleanup_on_disconnect(self, datapath):
+        flows.delete_all_flows_from_table(datapath,
+                                          self._service_manager.get_table_num(
+                                              self.APP_NAME))
+
+    def add_ue_mac_flow(self, sid, mac_addr):
+        uplink_match = MagmaMatch(in_port=self.config.gre_tunnel_port,
+                                  eth_src=mac_addr)
+        self._add_resubmit_flow(sid, uplink_match)
+
+        downlink_match = MagmaMatch(in_port=self._datapath.ofproto.OFPP_LOCAL,
+                                    eth_dst=mac_addr)
+        self._add_resubmit_flow(sid, downlink_match)
+
+    def delete_ue_mac_flow(self, sid, mac_addr):
+        uplink_match = MagmaMatch(in_port=self.config.gre_tunnel_port,
+                                  eth_src=mac_addr)
+        self._delete_resubmit_flow(sid, uplink_match)
+
+        downlink_match = MagmaMatch(in_port=self._datapath.ofproto.OFPP_LOCAL,
+                                    eth_dst=mac_addr)
+        self._delete_resubmit_flow(sid, downlink_match)
+
+    def _add_resubmit_flow(self, sid, match):
+        parser = self._datapath.ofproto_parser
+        tbl_num = self._service_manager.get_table_num(self.APP_NAME)
+        next_table = self._service_manager.get_next_table_num(self.APP_NAME)
+
+        # Add IMSI metadata
+        actions = [
+            parser.NXActionRegLoad2(dst=IMSI_REG, value=encode_imsi(sid))]
+
+        flows.add_resubmit_next_service_flow(self._datapath, tbl_num, match,
+                                             actions=actions,
+                                             priority=flows.DEFAULT_PRIORITY,
+                                             resubmit_table=next_table)
+
+    def _delete_resubmit_flow(self, sid, match):
+        parser = self._datapath.ofproto_parser
+        tbl_num = self._service_manager.get_table_num(self.APP_NAME)
+
+        # Add IMSI metadata
+        actions = [
+            parser.NXActionRegLoad2(dst=IMSI_REG, value=encode_imsi(sid))]
+
+        flows.delete_flow(self._datapath, tbl_num, match, actions=actions)

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -77,6 +77,7 @@ def main():
         manager.applications.get('EnforcementController', None),
         manager.applications.get('EnforcementStatsController', None),
         manager.applications.get('DPIController', None),
+        manager.applications.get('UEMacAddressController', None),
         service_manager)
     pipelined_srv.add_to_server(service.rpc_server)
 

--- a/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
@@ -77,6 +77,9 @@ class PipelinedController(Enum):
     Subscriber = Controller(
         'magma.pipelined.app.subscriber', 'subscriber'
     )
+    UEMac = Controller(
+        'magma.pipelined.app.ue_mac', 'ue_mac'
+    )
 
 
 def assert_pipelined_not_running():

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -334,7 +334,7 @@ def get_meter_stats(controller: MeterStatsController) \
     return stats
 
 
-def create_service_manager(services=list):
+def create_service_manager(services: List[int], include_ue_mac=False):
     """
     Creates a service manager from the given list of services.
     Args:
@@ -345,8 +345,12 @@ def create_service_manager(services=list):
     mconfig = PipelineD(relay_enabled=True, services=services)
     magma_service = MagicMock()
     magma_service.mconfig = mconfig
+
+    static_services = (['ue_mac', 'arpd', 'access_control']
+                       if include_ue_mac
+                       else ['arpd', 'access_control'])
     magma_service.config = {
-        'static_services': ['arpd', 'access_control']
+        'static_services': static_services
     }
     return ServiceManager(magma_service)
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_add_two_subscribers.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_add_two_subscribers.snapshot
@@ -1,0 +1,4 @@
+ cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768,dl_src=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768,dl_src=5e:cc:cc:aa:aa:fe actions=set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ue_mac(main_table), n_packets=1, n_bytes=14, priority=10,in_port=LOCAL,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ue_mac(main_table), n_packets=1, n_bytes=14, priority=10,in_port=LOCAL,dl_dst=5e:cc:cc:aa:aa:fe actions=set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_delete_one_subscriber.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_delete_one_subscriber.snapshot
@@ -1,0 +1,2 @@
+ cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768,dl_src=5e:cc:cc:aa:aa:fe actions=set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ue_mac(main_table), n_packets=2, n_bytes=28, priority=10,in_port=LOCAL,dl_dst=5e:cc:cc:aa:aa:fe actions=set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_mac.py
@@ -1,0 +1,189 @@
+"""
+Copyright (c) 2019-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import warnings
+from concurrent.futures import Future
+
+from magma.pipelined.app.ue_mac import UEMacAddressController
+from magma.pipelined.tests.app.packet_builder import EtherPacketBuilder
+from magma.pipelined.tests.app.packet_injector import ScapyPacketInjector
+from magma.pipelined.tests.app.start_pipelined import (
+    TestSetup,
+    PipelinedController,
+)
+from magma.pipelined.openflow.magma_match import MagmaMatch
+from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery \
+    as FlowQuery
+from magma.pipelined.bridge_util import BridgeTools
+from magma.pipelined.tests.pipelined_test_util import (
+    start_ryu_app_thread,
+    stop_ryu_app_thread,
+    create_service_manager,
+    wait_after_send,
+    FlowVerifier,
+    FlowTest,
+    SnapshotVerifier,
+)
+
+
+class UEMacAddressTest(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    UE_MAC_1 = '5e:cc:cc:b1:49:4b'
+    UE_MAC_2 = '5e:cc:cc:aa:aa:fe'
+    BRIDGE_IP = '192.168.130.1'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UEMacAddressTest, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([], include_ue_mac=True)
+        cls._tbl_num = cls.service_manager.get_table_num(
+            UEMacAddressController.APP_NAME)
+        ue_mac_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.UEMac,
+                  PipelinedController.Testing],
+            references={
+                PipelinedController.UEMac:
+                    ue_mac_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.ue_mac_controller = ue_mac_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+
+    def test_add_two_subscribers(self):
+        """
+           Add UE MAC flows for two subscribers
+        """
+        imsi_1 = 'IMSI010000000088888'
+        imsi_2 = 'IMSI010000000099999'
+        other_mac = '5e:cc:cc:b1:aa:aa'
+
+        # Add subscriber with UE MAC address """
+        self.ue_mac_controller.add_ue_mac_flow(imsi_1, self.UE_MAC_1)
+        self.ue_mac_controller.add_ue_mac_flow(imsi_2, self.UE_MAC_2)
+
+        # Create a set of packets
+        pkt_sender = ScapyPacketInjector(self.BRIDGE)
+
+        # Only send downlink as the pkt_sender sends pkts from in_port=LOCAL
+        downlink_packet1 = EtherPacketBuilder() \
+            .set_ether_layer(self.UE_MAC_1, other_mac) \
+            .build()
+        downlink_packet2 = EtherPacketBuilder() \
+            .set_ether_layer(self.UE_MAC_2, other_mac) \
+            .build()
+
+        # Check if these flows were added (queries should return flows)
+        flow_queries = [
+            FlowQuery(self._tbl_num, self.testing_controller,
+                      match=MagmaMatch(eth_dst=self.UE_MAC_1)),
+            FlowQuery(self._tbl_num, self.testing_controller,
+                      match=MagmaMatch(eth_dst=self.UE_MAC_2))
+        ]
+
+        # =========================== Verification ===========================
+        # Verify 4 flows installed and 2 total pkts matched (one for each UE)
+        flow_verifier = FlowVerifier(
+            [FlowTest(FlowQuery(self._tbl_num, self.testing_controller), 2, 4)]
+            + [FlowTest(query, 1, 1) for query in flow_queries],
+            lambda: wait_after_send(self.testing_controller))
+
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager)
+
+        with flow_verifier, snapshot_verifier:
+            pkt_sender.send(downlink_packet1)
+            pkt_sender.send(downlink_packet2)
+
+        flow_verifier.verify()
+
+    def test_delete_one_subscriber(self):
+        """
+            Delete one of the existing subscribers
+        """
+
+        imsi_1 = 'IMSI010000000088888'
+        other_mac = '5e:cc:cc:b1:aa:aa'
+
+        # Delete subscriber with UE MAC_1 address
+        self.ue_mac_controller.delete_ue_mac_flow(imsi_1, self.UE_MAC_1)
+
+        # Create a set of packets
+        pkt_sender = ScapyPacketInjector(self.BRIDGE)
+
+        # Only send downlink as the pkt_sender sends pkts from in_port=LOCAL
+        removed_ue_packet = EtherPacketBuilder() \
+            .set_ether_layer(self.UE_MAC_1, other_mac) \
+            .build()
+        remaining_ue_packet = EtherPacketBuilder() \
+            .set_ether_layer(self.UE_MAC_2, other_mac) \
+            .build()
+
+        # Ensure the first query doesn't match anything
+        # And the second query still does
+        flow_queries = [
+            FlowQuery(self._tbl_num, self.testing_controller,
+                      match=MagmaMatch(eth_dst=self.UE_MAC_1)),
+            FlowQuery(self._tbl_num, self.testing_controller,
+                      match=MagmaMatch(eth_dst=self.UE_MAC_2))
+        ]
+
+        # =========================== Verification ===========================
+        # Verify 2 flows installed and 1 total pkt matched
+        flow_verifier = FlowVerifier(
+            [
+                FlowTest(FlowQuery(self._tbl_num, self.testing_controller), 1,
+                         2),
+                FlowTest(flow_queries[0], 0, 0),
+                FlowTest(flow_queries[1], 1, 1),
+            ], lambda: wait_after_send(self.testing_controller))
+
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager)
+
+        with flow_verifier, snapshot_verifier:
+            pkt_sender.send(removed_ue_packet)
+            pkt_sender.send(remaining_ue_packet)
+
+        flow_verifier.verify()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -28,6 +28,7 @@ from lte.protos.pipelined_pb2 import (
     ActivateFlowsRequest,
     DeactivateFlowsRequest,
     RuleModResult,
+    UEMacFlowRequest,
 )
 from lte.protos.pipelined_pb2_grpc import PipelinedStub
 from lte.protos.policydb_pb2 import FlowMatch, FlowDescription, PolicyRule
@@ -156,6 +157,38 @@ def create_enforcement_parser(apps):
     subcmd.set_defaults(func=get_policy_usage)
 
 
+# -------------
+# UE MAC APP
+# -------------
+
+@grpc_wrapper
+def add_ue_mac_flow(client, args):
+    request = UEMacFlowRequest(
+        sid=SIDUtils.to_pb(args.imsi),
+        mac_addr=args.mac
+    )
+    res = client.AddUEMacFlow(request)
+    if res is None:
+        print("Error associating MAC to IMSI")
+
+
+def create_ue_mac_parser(apps):
+    """
+    Creates the argparse subparser for the MAC App
+    """
+    app = apps.add_parser('ue_mac')
+    subparsers = app.add_subparsers(title='subcommands', dest='cmd')
+
+    # Add subcommands
+    subcmd = subparsers.add_parser('add_ue_mac_flow',
+                                   help='Add flow to match UE MAC \
+                                   with a subscriber')
+    subcmd.add_argument('--imsi', help='Subscriber ID', default='IMSI12345')
+    subcmd.add_argument('--mac', help='UE MAC address',
+                        default='5e:cc:cc:b1:49:ff')
+    subcmd.set_defaults(func=add_ue_mac_flow)
+
+
 # --------------------------
 # Debugging
 # --------------------------
@@ -267,6 +300,7 @@ def create_parser():
     apps = parser.add_subparsers(title='apps', dest='cmd')
     create_metering_parser(apps)
     create_enforcement_parser(apps)
+    create_ue_mac_parser(apps)
     create_debug_parser(apps)
     return parser
 


### PR DESCRIPTION
Summary:
This diff implements a pipelined app `ue_mac` to match packets based on
UE MAC address. This app controls table 0 and is necessary as the EPC app which
controls Table 0 for the LTE AGW is not present in the Carrier WiFi solution.

The app supports both adding and deleting flows based on MAC addr, but for now an
RPC only exists for the addition of a subscriber/mac addr. If necessary, an RPC can
easily be added to support deletion.

Differential Revision: D15873258

