### PR TITLE
Migrate Upgrade Tier REST handlers to use configurator

### DIFF
--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -77,8 +77,8 @@ func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 		configurator.NewNetworkConfigSerde(NetworkFeaturesConfig, &models3.NetworkFeatures{}),
 
 		configurator.NewNetworkEntityConfigSerde(magmadconfig.MagmadGatewayType, &models3.MagmadGatewayConfig{}),
-		configurator.NewNetworkEntityConfigSerde(upgrade.ReleaseChannelType, &models.ReleaseChannel{}),
-		configurator.NewNetworkEntityConfigSerde(upgrade.NetworkTierType, &models.Tier{}),
+		configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{}),
+		configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeTierEntityType, &models.Tier{}),
 
 		// Legacy config manager serdes
 		&magmadconfig.MagmadGatewayConfigManager{},

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -221,10 +221,10 @@ func CreateEntities(networkID string, entities []NetworkEntity) ([]NetworkEntity
 	return ret, err
 }
 
-// CreateInternalEntity is a loose wrapper around CreateEntities to create an
+// CreateInternalEntity is a loose wrapper around CreateEntity to create an
 // entity in the internal network structure
-func CreateInternalEntities(entities []NetworkEntity) ([]NetworkEntity, error) {
-	return CreateEntities(storage.InternalNetworkID, entities)
+func CreateInternalEntity(entity NetworkEntity) (NetworkEntity, error) {
+	return CreateEntity(storage.InternalNetworkID, entity)
 }
 
 func UpdateEntity(networkID string, update EntityUpdateCriteria) (NetworkEntity, error) {
@@ -269,10 +269,10 @@ func UpdateEntities(networkID string, updates []EntityUpdateCriteria) (map[strin
 	return ret, err
 }
 
-// UpdateInternalEntity is a loose wrapper around UpdateEntities to update an
+// UpdateInternalEntity is a loose wrapper around UpdateEntity to update an
 // entity in the internal network structure
-func UpdateInternalEntity(updates []EntityUpdateCriteria) (map[string]NetworkEntity, error) {
-	return UpdateEntities(storage.InternalNetworkID, updates)
+func UpdateInternalEntity(update EntityUpdateCriteria) (NetworkEntity, error) {
+	return UpdateEntity(storage.InternalNetworkID, update)
 }
 
 func UpdateEntityConfig(networkID string, entityType string, entityKey string, config interface{}) error {
@@ -317,8 +317,8 @@ func DeleteEntities(networkID string, ids []storage2.TypeAndKey) error {
 
 // DeleteInternalEntity is a loose wrapper around DeleteEntities to delete an
 // entity in the internal network structure
-func DeleteInternalEntities(ids []storage2.TypeAndKey) error {
-	return DeleteEntities(storage.InternalNetworkID, ids)
+func DeleteInternalEntity(entityType, entityKey string) error {
+	return DeleteEntity(storage.InternalNetworkID, entityType, entityKey)
 }
 
 // GetPhysicalIDOfEntity gets the physicalID associated with the entity
@@ -361,6 +361,11 @@ func ListEntityKeys(networkID string, entityType string) ([]string, error) {
 	}
 
 	return funk.Map(resp.Entities, func(ent *storage.NetworkEntity) string { return ent.Key }).([]string), nil
+}
+
+// ListInternalEntityKeys calls ListEntityKeys with the internal networkID
+func ListInternalEntityKeys(entityType string) ([]string, error) {
+	return ListEntityKeys(storage.InternalNetworkID, entityType)
 }
 
 func LoadEntity(networkID string, entityType string, entityKey string, criteria EntityLoadCriteria) (NetworkEntity, error) {
@@ -420,6 +425,11 @@ func LoadEntities(
 	return ret, entIDsToTKs(resp.EntitiesNotFound), nil
 }
 
+// LoadInternalEntity calls LoadEntity with the internal networkID
+func LoadInternalEntity(entityType string, entityKey string, criteria EntityLoadCriteria) (NetworkEntity, error) {
+	return LoadEntity(storage.InternalNetworkID, entityType, entityKey, criteria)
+}
+
 // DoesEntityExist returns a boolean that indicated whether the entity specified
 // exists in the network
 func DoesEntityExist(networkID, entityType, entityKey string) (bool, error) {
@@ -437,6 +447,11 @@ func DoesEntityExist(networkID, entityType, entityKey string) (bool, error) {
 		return false, nil
 	}
 	return true, nil
+}
+
+// DoesInternalEntityExist calls DoesEntityExist with the internal networkID
+func DoesInternalEntityExist(entityType, entityKey string) (bool, error) {
+	return DoesEntityExist(storage.InternalNetworkID, entityType, entityKey)
 }
 
 // LoadAllEntitiesInNetwork fetches all entities of specified type in a network

--- a/orc8r/cloud/go/services/upgrade/client_api.go
+++ b/orc8r/cloud/go/services/upgrade/client_api.go
@@ -21,9 +21,9 @@ import (
 const (
 	ServiceName = "UPGRADE"
 	// type used in configurator to identify network entities that are related to release channels
-	ReleaseChannelType = "upgrade_release_channel"
+	UpgradeReleaseChannelEntityType = "upgrade_release_channel"
 	// type used in configurator to identify network entities that are related to network tier
-	NetworkTierType = "network_tier"
+	UpgradeTierEntityType = "upgrade_tier"
 )
 
 func getUpgradeServiceClient() (upgrade_protos.UpgradeServiceClient, error) {

--- a/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_legacy.go
+++ b/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_legacy.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package handlers
+
+import (
+	"errors"
+	"net/http"
+	"sort"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	upgrade_client "magma/orc8r/cloud/go/services/upgrade"
+	"magma/orc8r/cloud/go/services/upgrade/obsidian/models"
+	"magma/orc8r/cloud/go/services/upgrade/protos"
+
+	"github.com/labstack/echo"
+)
+
+// List all release channels by ID
+func listReleaseChannelsHandler(c echo.Context) error {
+	channels, err := upgrade_client.ListReleaseChannels()
+	if err != nil {
+		return handlers.HttpError(err)
+	}
+	// Return a deterministic ordering of channels
+	sort.Strings(channels)
+	return c.JSON(http.StatusOK, channels)
+}
+
+func getReleaseChannelsHandler(c echo.Context) error {
+	channelId := c.Param("channel_id")
+	if channelId == "" {
+		return noChannelIdError()
+	}
+
+	channel, err := upgrade_client.GetReleaseChannel(channelId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusNotFound)
+	}
+
+	swaggerChannel := models.ReleaseChannel{}
+	swaggerChannel.Name = channelId
+	swaggerChannel.SupportedVersions = channel.GetSupportedVersions()
+	return c.JSON(http.StatusOK, swaggerChannel)
+}
+
+func createReleaseChannelHandler(c echo.Context) error {
+	restChannel := new(models.ReleaseChannel)
+	if err := c.Bind(restChannel); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+
+	// Construct proto model and persist
+	channelProto := &protos.ReleaseChannel{
+		SupportedVersions: restChannel.SupportedVersions,
+	}
+	err := upgrade_client.CreateReleaseChannel(restChannel.Name, channelProto)
+	if err != nil {
+		return handlers.HttpError(err)
+	}
+
+	// Return the ID of the created channel
+	return c.JSON(http.StatusCreated, restChannel.Name)
+}
+
+func updateReleaseChannelHandler(c echo.Context) error {
+	channelId := c.Param("channel_id")
+	if channelId == "" {
+		return noChannelIdError()
+	}
+	restChannel := new(models.ReleaseChannel)
+	if err := c.Bind(restChannel); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+
+	// Release channel name is immutable
+	// This could change if release channels are keyed by UUID in their tables
+	if restChannel.Name != channelId {
+		return handlers.HttpError(
+			errors.New("Release channel name cannot be modified"),
+			http.StatusBadRequest)
+	}
+	updatedChannelProto := &protos.ReleaseChannel{
+		SupportedVersions: restChannel.SupportedVersions,
+	}
+
+	err := upgrade_client.UpdateReleaseChannel(channelId, updatedChannelProto)
+	if err != nil {
+		return handlers.HttpError(err)
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+func deleteReleaseChannelHandler(c echo.Context) error {
+	channelId := c.Param("channel_id")
+	if channelId == "" {
+		return noChannelIdError()
+	}
+
+	err := upgrade_client.DeleteReleaseChannel(channelId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusNoContent)
+}

--- a/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_test.go
@@ -11,6 +11,7 @@ package handlers_test
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
@@ -27,10 +28,117 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Obsidian integration test for release channel API endpoints
-func TestReleaseChannels(t *testing.T) {
+// Obsidian integration test for release channel migrated API endpoints backed by configurator
+func TestMigratedReleaseChannels(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	configurator.NewNetworkEntityConfigSerde(upgrade.ReleaseChannelType, &models.ReleaseChannel{})
+	configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{})
+	magmad_test_init.StartTestService(t)
+	upgrade_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	restPort := tests.StartObsidian(t)
+	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/channels", restPort, handlers.REST_ROOT)
+
+	// List channels when none exist
+	listChannelsTestCase := tests.Testcase{
+		Name:     "List Release Channels",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: "null",
+	}
+	tests.RunTest(t, listChannelsTestCase)
+
+	// Create 2 release channels
+	createChannelTestCase := tests.Testcase{
+		Name:                      "Create Release Channel",
+		Method:                    "POST",
+		Url:                       testUrlRoot,
+		Payload:                   `{"name": "stable", "supported_versions": ["1.0.0-0", "1.1.0-0"]}`,
+		Skip_payload_verification: true,
+	}
+	_, channelId, _ := tests.RunTest(t, createChannelTestCase)
+	json.Unmarshal([]byte(channelId), &channelId)
+	assert.Equal(t, "stable", channelId)
+
+	createChannelTestCase.Payload = `{
+		"name": "beta",
+		"supported_versions": ["1.2.0-0"]
+	}`
+	_, channelId, _ = tests.RunTest(t, createChannelTestCase)
+	json.Unmarshal([]byte(channelId), &channelId)
+	assert.Equal(t, "beta", channelId)
+
+	listChannelsTestCase.Expected = `["beta", "stable"]`
+	tests.RunTest(t, listChannelsTestCase)
+
+	// Get release channel
+	getChannelTestCase := tests.Testcase{
+		Name:     "Get Release Channel",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, "stable"),
+		Payload:  "",
+		Expected: `{"name": "stable", "supported_versions": ["1.0.0-0", "1.1.0-0"]}`,
+	}
+	tests.RunTest(t, getChannelTestCase)
+
+	// Update release channel
+	updateChannelTestCase := tests.Testcase{
+		Name:     "Update Release Channel",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, "stable"),
+		Payload:  `{"name": "stable", "supported_versions": ["1.3.0-0"]}`,
+		Expected: "",
+	}
+	tests.RunTest(t, updateChannelTestCase)
+	getChannelTestCase.Expected = `{"name": "stable", "supported_versions": ["1.3.0-0"]}`
+	tests.RunTest(t, getChannelTestCase)
+
+	// Delete release channel
+	deleteChannelTestCase := tests.Testcase{
+		Name:     "Delete Release Channel",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, "beta"),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, deleteChannelTestCase)
+	listChannelsTestCase.Expected = `["stable"]`
+	tests.RunTest(t, listChannelsTestCase)
+
+	// Some error cases
+
+	// Get nonexistent release channel should 404
+	status, _, err := tests.SendHttpRequest(
+		"GET",
+		fmt.Sprintf("%s/%s", testUrlRoot, "beta"),
+		"")
+	assert.NoError(t, err)
+	assert.Equal(t, 404, status)
+
+	// Update name of release channel should 400
+	status, _, err = tests.SendHttpRequest(
+		"PUT",
+		fmt.Sprintf("%s/%s", testUrlRoot, "stable"),
+		`{"name": "prod2", "supported_versions": ["1.4.0-0"]}`)
+	assert.NoError(t, err)
+	assert.Equal(t, 400, status)
+	tests.RunTest(t, getChannelTestCase)
+
+	// Delete nonexistent release channel should 500
+	status, _, err = tests.SendHttpRequest(
+		"DELETE",
+		fmt.Sprintf("%s/%s", testUrlRoot, "beta"),
+		"")
+	assert.NoError(t, err)
+	assert.Equal(t, 500, status)
+}
+
+// Obsidian integration test for release channel legacy API endpoints
+func TestLegacyReleaseChannels(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{})
 	magmad_test_init.StartTestService(t)
 	upgrade_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
@@ -134,7 +242,7 @@ func TestReleaseChannels(t *testing.T) {
 
 func TestTiers(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	configurator.NewNetworkEntityConfigSerde(upgrade.NetworkTierType, &models.Tier{})
+	configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeTierEntityType, &models.Tier{})
 	magmad_test_init.StartTestService(t)
 	upgrade_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)


### PR DESCRIPTION
Summary: Removing the multiplex write functions, and moving them into the MigrateHandler class, so that it can be used based on an env var. (UseNewHandlersEnv = "USE_NEW_HANDLERS")

Reviewed By: xjtian

Differential Revision: D15868575

