### PR TITLE
Fix enodebd state type mismatch between cloud and agw

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -326,7 +326,7 @@ def get_operational_states(
     for serial_id in state_machine_manager.get_connected_serial_id_list():
         enb_state = get_single_enb_status(serial_id, state_machine_manager)
         state = State(
-            type="enodebd",
+            type="enodeb",
             deviceID=serial_id,
             value=MessageToJson(enb_state).encode('utf-8')
         )


### PR DESCRIPTION
Summary:
controller staging was spewing out "[ERROR /magma.orc8r.StateService/ReportStates]: No Serde found for type enodebd".
This was because the type name in serde defined was 'enodeb' where as the states sent in the AGW were tagged as type 'enodebd'.

Reviewed By: ssanadhya

Differential Revision: D15878258

