### PR TITLE
Add UE MAC flow when creating CWF session

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -395,6 +395,17 @@ bool LocalEnforcer::init_session_credit(
   }
   session_map_[imsi] = std::unique_ptr<SessionState>(session_state);
 
+  if (session_state->is_radius_cwf_session()) {
+    MLOG(MDEBUG) << "Adding UE MAC flow for subscriber " << imsi;
+    SubscriberID sid;
+    sid.set_id(imsi);
+    bool add_ue_mac_flow_success = pipelined_client_->add_ue_mac_flow(
+      sid, session_state->get_mac_addr());
+    if (!add_ue_mac_flow_success) {
+      MLOG(MERROR) << "Failed to add UE MAC flow for subscriber " << imsi;
+    }
+  }
+
   auto ip_addr = session_state->get_subscriber_ip_addr();
 
   RulesToProcess rules_to_activate;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -128,6 +128,9 @@ void LocalSessionManagerHandlerImpl::create_carrier_wifi_session(
   cfg.apn = request->apn();
   cfg.imei = request->imei();
   cfg.msisdn = request->msisdn();
+  cfg.rat_type = RATType::TGPP_WLAN;
+  cfg.mac_addr = request->hardware_addr();
+  cfg.radius_session_id = request->radius_session_id();
 
   auto imsi = request->sid().id();
   auto sid = id_gen_.gen_session_id(imsi);
@@ -150,7 +153,8 @@ void LocalSessionManagerHandlerImpl::create_lte_session(
                               .imei = request->imei(),
                               .plmn_id = request->plmn_id(),
                               .imsi_plmn_id = request->imsi_plmn_id(),
-                              .user_location = request->user_location()};
+                              .user_location = request->user_location(),
+                              .rat_type = RATType::TGPP_LTE};
   send_create_session(
     copy_session_info2create_req(request, sid),
     imsi, sid, cfg, response_callback);

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -13,6 +13,7 @@
 
 #include <lte/protos/policydb.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
+#include <lte/protos/subscriberdb.pb.h>
 
 #include "GRPCReceiver.h"
 
@@ -53,6 +54,14 @@ class PipelinedClient {
     const std::string &ip_addr,
     const std::vector<std::string> &static_rules,
     const std::vector<PolicyRule> &dynamic_rules) = 0;
+
+  /**
+   * Send the MAC address of UE and the subscriberID
+   * for pipelined to add a flow for the subscriber by matching the MAC
+   */
+  virtual bool add_ue_mac_flow(
+    const SubscriberID &sid,
+    const std::string &mac_addr) = 0;
 };
 
 /**
@@ -92,6 +101,10 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
     const std::vector<std::string> &static_rules,
     const std::vector<PolicyRule> &dynamic_rules);
 
+  bool add_ue_mac_flow(
+    const SubscriberID &sid,
+    const std::string &mac_addr);
+
  private:
   static const uint32_t RESPONSE_TIMEOUT = 6; // seconds
   std::unique_ptr<Pipelined::Stub> stub_;
@@ -104,6 +117,10 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   void activate_flows_rpc(
     const ActivateFlowsRequest &request,
     std::function<void(Status, ActivateFlowsResult)> callback);
+
+  void add_ue_mac_flow_rpc(
+    const UEMacFlowRequest &request,
+    std::function<void(Status, FlowResponse)> callback);
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -228,4 +228,14 @@ std::string SessionState::get_subscriber_ip_addr()
   return config_.ue_ipv4;
 }
 
+std::string SessionState::get_mac_addr()
+{
+  return config_.mac_addr;
+}
+
+bool SessionState::is_radius_cwf_session()
+{
+  return (config_.rat_type == RATType::TGPP_WLAN);
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -33,6 +33,9 @@ class SessionState {
     std::string plmn_id;
     std::string imsi_plmn_id;
     std::string user_location;
+    RATType rat_type;
+    std::string mac_addr; // MAC Address for WLAN
+    std::string radius_session_id;
   };
 
  public:
@@ -115,6 +118,10 @@ class SessionState {
   std::string get_session_id();
 
   std::string get_subscriber_ip_addr();
+
+  std::string get_mac_addr();
+
+  bool is_radius_cwf_session();
 
  private:
   /**

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -66,6 +66,7 @@ class MockPipelinedClient : public PipelinedClient {
       .WillByDefault(Return(true));
     ON_CALL(*this, activate_flows_for_rules(_, _, _, _))
       .WillByDefault(Return(true));
+    ON_CALL(*this, add_ue_mac_flow(_, _)).WillByDefault(Return(true));
   }
 
   MOCK_METHOD1(deactivate_all_flows, bool(const std::string &imsi));
@@ -82,6 +83,11 @@ class MockPipelinedClient : public PipelinedClient {
       const std::string &ip_addr,
       const std::vector<std::string> &static_rules,
       const std::vector<PolicyRule> &dynamic_rules));
+  MOCK_METHOD2(
+    add_ue_mac_flow,
+    bool(
+      const SubscriberID &sid,
+      const std::string &mac_addr));
 };
 
 /**

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -132,6 +132,38 @@ TEST_F(LocalEnforcerTest, test_init_session_credit)
 
   EXPECT_CALL(
     *pipelined_client,
+    add_ue_mac_flow(
+      testing::_, testing::_))
+    .Times(1)
+    .WillOnce(testing::Return(true));
+
+  EXPECT_CALL(
+    *pipelined_client,
+    activate_flows_for_rules(
+      testing::_, testing::_, CheckCount(0), CheckCount(0)))
+    .Times(1)
+    .WillOnce(testing::Return(true));
+
+  SessionState::Config test_cwf_cfg;
+  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+  test_cwf_cfg.mac_addr = "00:00:00:00:00:00";
+
+  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+
+  EXPECT_EQ(
+    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 1024);
+}
+
+TEST_F(LocalEnforcerTest, test_init_cwf_session_credit)
+{
+  insert_static_rule(1, "", "rule1");
+
+  CreateSessionResponse response;
+  auto credits = response.mutable_credits();
+  create_credit_update_response("IMSI1", 1, 1024, credits->Add());
+
+  EXPECT_CALL(
+    *pipelined_client,
     activate_flows_for_rules(
       testing::_, testing::_, CheckCount(0), CheckCount(0)))
     .Times(1)


### PR DESCRIPTION
Summary:
**Summary**
When a CWF session is created, session manager need to make rpc to `pipelined` to add UE MAC flow before activating rules.

**Implementation**
1. Store RAT type and MAC address as additional information for CWF session
2. Implement pipelined client function for adding UE MAC flow
3. Call the client function when creating CWF session

**What is affected**
When creating a CWF session, session manager makes rpc to `pipelined` to add UE MAC flow before activating rules.
Creation of LTE session should not be affected.

Differential Revision: D15904138

