### PR TITLE
Migrate cellular config REST handlers to use configurator

### DIFF
--- a/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers.go
+++ b/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers.go
@@ -51,6 +51,13 @@ func GetObsidianHandlers() []handlers.Handler {
 				}
 				return defaultUpdateHandler.HandlerFunc(cc)
 			},
+			MigratedHandlerFunc: func(c echo.Context) error {
+				cc, err := getNetworkConfigFromRequest(c)
+				if err != nil {
+					return err
+				}
+				return defaultUpdateHandler.MigratedHandlerFunc(cc)
+			},
 		},
 		obsidian.GetReadConfigHandler(EnodebConfigPath, config.CellularEnodebType, getEnodebId, &models.NetworkEnodebConfigs{}),
 		obsidian.GetCreateConfigHandler(EnodebConfigPath, config.CellularEnodebType, getEnodebId, &models.NetworkEnodebConfigs{}),

--- a/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers_legacy_test.go
+++ b/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers_legacy_test.go
@@ -22,17 +22,14 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/protos"
-	"magma/orc8r/cloud/go/services/configurator"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
-	"magma/orc8r/cloud/go/services/magmad"
-	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetNetworkConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestGetNetworkConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -72,8 +69,8 @@ func TestGetNetworkConfigs(t *testing.T) {
 	// for now
 }
 
-func TestSetTDDNetworkConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetTDDNetworkConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -81,8 +78,8 @@ func TestSetTDDNetworkConfigs(t *testing.T) {
 	testSetNetworkConfigs(t, test_utils.NewDefaultTDDNetworkConfig(), test_utils.NewDefaultTDDNetworkConfig())
 }
 
-func TestSetFDDNetworkConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetFDDNetworkConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -90,8 +87,8 @@ func TestSetFDDNetworkConfigs(t *testing.T) {
 	testSetNetworkConfigs(t, test_utils.NewDefaultFDDNetworkConfig(), test_utils.NewDefaultFDDNetworkConfig())
 }
 
-func TestSetOldTddNetworkConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetOldTddNetworkConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -99,8 +96,8 @@ func TestSetOldTddNetworkConfigs(t *testing.T) {
 	testSetNetworkConfigs(t, test_utils.OldTDDNetworkConfig(), test_utils.NewDefaultTDDNetworkConfig())
 }
 
-func TestSetOldFddNetworkConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetOldFddNetworkConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -108,8 +105,8 @@ func TestSetOldFddNetworkConfigs(t *testing.T) {
 	testSetNetworkConfigs(t, test_utils.OldFDDNetworkConfig(), test_utils.NewDefaultFDDNetworkConfig())
 }
 
-func TestSetBadNetworkConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetBadNetworkConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -201,8 +198,8 @@ func TestSetBadNetworkConfigs(t *testing.T) {
 	assert.Equal(t, 400, status)
 }
 
-func TestSetBadOldConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetBadOldConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -234,8 +231,8 @@ func TestSetBadOldConfigs(t *testing.T) {
 	assert.Equal(t, 400, status)
 }
 
-func TestGetGatewayConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestGetGatewayConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -276,8 +273,8 @@ func TestGetGatewayConfigs(t *testing.T) {
 	// for now
 }
 
-func TestSetGatewayConfigs(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestSetGatewayConfigsLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
@@ -357,118 +354,4 @@ func TestSetGatewayConfigs(t *testing.T) {
 	status, _, err := obsidian_test.RunTest(t, setConfigTestCase)
 	assert.Equal(t, 400, status)
 
-}
-
-func testSetNetworkConfigs(t *testing.T, config *cellular_protos.CellularNetworkConfig, expectedConfig *cellular_protos.CellularNetworkConfig) {
-	restPort := obsidian_test.StartObsidian(t)
-	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
-
-	networkId := registerNetwork(t, "Test Network 1", "cellular_obsidian_test_network")
-
-	// Happy path
-	swaggerConfig := &models.NetworkCellularConfigs{}
-	protos.FillIn(config, swaggerConfig)
-	marshaledCfg, err := swaggerConfig.MarshalBinary()
-	assert.NoError(t, err)
-	swaggerConfigString := string(marshaledCfg)
-
-	createConfigTestCase := obsidian_test.Testcase{
-		Name:     "Create Cellular Network Config",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/configs/cellular", testUrlRoot, networkId),
-		Payload:  swaggerConfigString,
-		Expected: fmt.Sprintf(`"%s"`, networkId),
-	}
-	obsidian_test.RunTest(t, createConfigTestCase)
-
-	config.Epc.Mcc = "123"
-	config.Epc.SubProfiles = make(
-		map[string]*cellular_protos.NetworkEPCConfig_SubscriptionProfile)
-	config.Epc.SubProfiles["test"] =
-		&cellular_protos.NetworkEPCConfig_SubscriptionProfile{
-			MaxUlBitRate: 100, MaxDlBitRate: 200,
-		}
-	config.Ran.BandwidthMhz = 15
-
-	expectedConfig.Epc.Mcc = "123"
-	expectedConfig.Epc.SubProfiles = make(
-		map[string]*cellular_protos.NetworkEPCConfig_SubscriptionProfile)
-	expectedConfig.Epc.SubProfiles["test"] =
-		&cellular_protos.NetworkEPCConfig_SubscriptionProfile{
-			MaxUlBitRate: 100, MaxDlBitRate: 200,
-		}
-	expectedConfig.Ran.BandwidthMhz = 15
-
-	swaggerConfig = &models.NetworkCellularConfigs{}
-	protos.FillIn(config, swaggerConfig)
-	swaggerConfig.Epc.NetworkServices = []string{"metering", "dpi", "policy_enforcement"}
-
-	expectedSwaggerConfig := &models.NetworkCellularConfigs{}
-	protos.FillIn(expectedConfig, expectedSwaggerConfig)
-	expectedSwaggerConfig.Epc.NetworkServices = []string{"metering", "dpi", "policy_enforcement"}
-
-	marshaledCfg, err = swaggerConfig.MarshalBinary()
-	assert.NoError(t, err)
-	swaggerConfigString = string(marshaledCfg)
-
-	exMarshaledCfg, err := expectedSwaggerConfig.MarshalBinary()
-	assert.NoError(t, err)
-	exSwaggerConfigString := string(exMarshaledCfg)
-
-	setConfigTestCase := obsidian_test.Testcase{
-		Name:     "Set Cellular Network Config",
-		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s/configs/cellular", testUrlRoot, networkId),
-		Payload:  swaggerConfigString,
-		Expected: "",
-	}
-	obsidian_test.RunTest(t, setConfigTestCase)
-	getConfigTestCase := obsidian_test.Testcase{
-		Name:     "Get Updated Cellular Network Config",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/configs/cellular", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: exSwaggerConfigString,
-	}
-	obsidian_test.RunTest(t, getConfigTestCase)
-}
-
-func registerNetwork(t *testing.T, networkName string, networkID string) string {
-	useNewHandler := os.Getenv(handlers.UseNewHandlersEnv)
-	if useNewHandler == "1" {
-		err := configurator.CreateNetwork(
-			configurator.Network{
-				Name: networkName,
-				ID:   networkID,
-			},
-		)
-		assert.NoError(t, err)
-		return networkID
-	} else {
-		networkId, err := magmad.RegisterNetwork(
-			&magmad_protos.MagmadNetworkRecord{Name: networkName},
-			networkID)
-		assert.NoError(t, err)
-		return networkId
-	}
-}
-
-func registerGateway(t *testing.T, networkId string, gatewayId string) string {
-	useNewHandler := os.Getenv(handlers.UseNewHandlersEnv)
-	if useNewHandler == "1" {
-		_, err := configurator.CreateEntity(networkId, configurator.NetworkEntity{
-			Key:        gatewayId,
-			Type:       "magmad_gateway",
-			PhysicalID: gatewayId,
-		})
-		assert.NoError(t, err)
-		return gatewayId
-	} else {
-		gatewayRecord := &magmad_protos.AccessGatewayRecord{
-			HwId: &protos.AccessGatewayID{Id: gatewayId},
-		}
-		registeredId, err := magmad.RegisterGateway(networkId, gatewayRecord)
-		assert.NoError(t, err)
-		return registeredId
-	}
 }

--- a/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers_test.go
+++ b/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers_test.go
@@ -129,7 +129,7 @@ func TestSetBadNetworkConfigs(t *testing.T) {
 		Method:                   "PUT",
 		Url:                      fmt.Sprintf("%s/%s/configs/cellular", testUrlRoot, networkId),
 		Payload:                  swaggerConfigString,
-		Expected:                 `{"message":"Error converting config model: Only one of TDD or FDD configs can be set"}`,
+		Expected:                 `{"message":"Invalid config: Only one of TDD or FDD configs can be set"}`,
 		Expect_http_error_status: true,
 	}
 	status, _, err := obsidian_test.RunTest(t, setConfigTestCase)
@@ -219,7 +219,7 @@ func TestSetBadOldConfigs(t *testing.T) {
 		Method:                   "POST",
 		Url:                      fmt.Sprintf("%s/%s/configs/cellular", testUrlRoot, networkId),
 		Payload:                  swaggerConfigString,
-		Expected:                 `{"message":"Error converting config model: Invalid EARFCNDL: no matching band"}`,
+		Expected:                 `{"message":"Invalid config: Invalid EARFCNDL: no matching band"}`,
 		Expect_http_error_status: true,
 	}
 	status, _, err := obsidian_test.RunTest(t, setConfigTestCase)
@@ -341,7 +341,7 @@ func TestSetGatewayConfigs(t *testing.T) {
 		Method:                   "PUT",
 		Url:                      fmt.Sprintf("%s/%s/gateways/%s/configs/cellular", testUrlRoot, networkId, gatewayId),
 		Payload:                  swaggerConfigString,
-		Expected:                 `{"message":"Error converting config model: Gateway RAN config is nil"}`,
+		Expected:                 `{"message":"Invalid config: Gateway RAN config is nil"}`,
 		Expect_http_error_status: true,
 	}
 	status, _, err := obsidian_test.RunTest(t, setConfigTestCase)

--- a/lte/cloud/go/services/cellular/obsidian/models/config_conversion.go
+++ b/lte/cloud/go/services/cellular/obsidian/models/config_conversion.go
@@ -28,7 +28,10 @@ func init() {
 }
 
 func (m *NetworkCellularConfigs) ValidateModel() error {
-	return m.Validate(formatsRegistry)
+	if err := m.Validate(formatsRegistry); err != nil {
+		return err
+	}
+	return m.ValidateNetworkConfig()
 }
 
 func (m *NetworkCellularConfigs) ToServiceModel() (interface{}, error) {
@@ -36,9 +39,6 @@ func (m *NetworkCellularConfigs) ToServiceModel() (interface{}, error) {
 	protos.FillIn(m, magmadConfig)
 	magmadConfig.FegNetworkId = m.FegNetworkID
 	if err := m.networkServicesToServiceModel(magmadConfig); err != nil {
-		return nil, err
-	}
-	if err := cellularprotos.ValidateNetworkConfig(magmadConfig); err != nil {
 		return nil, err
 	}
 	magmadConfig.Epc.RelayEnabled = m.Epc.RelayEnabled
@@ -87,15 +87,15 @@ func (m *NetworkCellularConfigs) networkServicesFromServiceModel(magmadConfig *c
 }
 
 func (m *GatewayCellularConfigs) ValidateModel() error {
-	return m.Validate(formatsRegistry)
+	if err := m.Validate(formatsRegistry); err != nil {
+		return err
+	}
+	return m.ValidateGatewayConfig()
 }
 
 func (m *GatewayCellularConfigs) ToServiceModel() (interface{}, error) {
 	magmadConfig := &cellularprotos.CellularGatewayConfig{}
 	protos.FillIn(m, magmadConfig)
-	if err := cellularprotos.ValidateGatewayConfig(magmadConfig); err != nil {
-		return nil, err
-	}
 	return magmadConfig, nil
 }
 
@@ -105,15 +105,12 @@ func (m *GatewayCellularConfigs) FromServiceModel(magmadModel interface{}) error
 }
 
 func (m *NetworkEnodebConfigs) ValidateModel() error {
-	return nil
+	return m.ValidateEnodebConfig()
 }
 
 func (m *NetworkEnodebConfigs) ToServiceModel() (interface{}, error) {
 	magmadConfig := &cellularprotos.CellularEnodebConfig{}
 	protos.FillIn(m, magmadConfig)
-	if err := cellularprotos.ValidateEnodebConfig(magmadConfig); err != nil {
-		return nil, err
-	}
 	return magmadConfig, nil
 }
 

--- a/lte/cloud/go/services/cellular/obsidian/models/validation.go
+++ b/lte/cloud/go/services/cellular/obsidian/models/validation.go
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package models
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"regexp"
+
+	"magma/lte/cloud/go/services/cellular/utils"
+
+	"github.com/golang/glog"
+)
+
+var mccRe = regexp.MustCompile("^[0-9]{3}$")
+var mncRe = regexp.MustCompile("^[0-9]{2,3}$")
+
+func (m *GatewayCellularConfigs) ValidateGatewayConfig() error {
+	if m == nil {
+		return errors.New("Gateway config is nil")
+	}
+	if err := m.Ran.validateGatewayRANConfig(); err != nil {
+		glog.Errorf("error : %v", err)
+		return err
+	}
+	if err := m.Epc.validateGatewayEPCConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *GatewayRanConfigs) validateGatewayRANConfig() error {
+	if m == nil {
+		return errors.New("Gateway RAN config is nil")
+	}
+	return nil
+}
+
+func (m *GatewayEpcConfigs) validateGatewayEPCConfig() error {
+	if m == nil {
+		return errors.New("Gateway EPC config is nil")
+	}
+	if m.IPBlock != "" {
+		_, _, err := net.ParseCIDR(m.IPBlock)
+		if err != nil {
+			return fmt.Errorf("Invalid IP block: %s", err)
+		}
+	}
+	return nil
+}
+
+func (m *NetworkCellularConfigs) ValidateNetworkConfig() error {
+	glog.Errorf("verifying network config : %v %v %s", m.Ran, m.Epc, m.FegNetworkID)
+	if m == nil {
+		return errors.New("Network config is nil")
+	}
+	if err := m.Ran.validateNetworkRANConfig(); err != nil {
+		return err
+	}
+	if err := m.Epc.validateNetworkEPCConfig(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *NetworkRanConfigs) validateNetworkRANConfig() error {
+	if m == nil {
+		return errors.New("Network RAN config is nil")
+	}
+
+	// TODO: after data migration and corresponding update to partner portal,
+	// we can enforce that exactly one is always set (i.e. none set is invalid)
+	fddConfigSet := m.FddConfig != nil
+	tddConfigSet := m.TddConfig != nil
+	if fddConfigSet && tddConfigSet {
+		return errors.New("Only one of TDD or FDD configs can be set")
+	}
+
+	earfcnDl := getEarfcnDl(m)
+	band, err := utils.GetBand(earfcnDl)
+	if err != nil {
+		return err
+	}
+
+	if err := validateFDDConfig(earfcnDl, band, m.FddConfig); err != nil {
+		return err
+	}
+	if err := validateTDDConfig(band, m.TddConfig); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *NetworkEpcConfigs) validateNetworkEPCConfig() error {
+	if m == nil {
+		return errors.New("Network EPC config is nil")
+	}
+	if !mccRe.MatchString(m.Mcc) {
+		return errors.New("MCC must be in the form of a 3-digit number (leading 0's are allowed).")
+	}
+	if !mncRe.MatchString(m.Mnc) {
+		return errors.New("MNC must be in the form of a 2- or 3-digit number (leading 0's are allowed).")
+	}
+	tac := m.Tac
+	if tac < 1 || tac > 65535 {
+		return errors.New("TAC must be between 1 and 65535 inclusive")
+	}
+
+	if len(m.LteAuthOp) < 15 || len(m.LteAuthOp) > 16 {
+		return errors.New("Auth OP must be between 15 and 16 bytes")
+	}
+	for name, profile := range m.SubProfiles {
+		if name == "" {
+			return errors.New("Profile name should be non-empty")
+		}
+		if profile.MaxDlBitRate == 0 || profile.MaxUlBitRate == 0 {
+			return errors.New("Bit rate should be greater than 0")
+		}
+	}
+	return nil
+}
+
+func getEarfcnDl(config *NetworkRanConfigs) int32 {
+	if config.FddConfig != nil {
+		return int32(config.FddConfig.Earfcndl)
+	} else if config.TddConfig != nil {
+		return int32(config.TddConfig.Earfcndl)
+	} else {
+		// TODO: after migration, nix this else
+		return int32(config.Earfcndl)
+	}
+}
+
+func validateFDDConfig(earfcnDl int32, band *utils.LTEBand, fddConfig *NetworkRanConfigsFddConfig) error {
+	if fddConfig == nil {
+		return nil
+	}
+
+	if band.Mode != utils.FDDMode {
+		return fmt.Errorf("Not a FDD Band: %d", band.ID)
+	}
+	earfcnUl := fddConfig.Earfcnul
+	// Provide default EARFCNUL if not set
+	if earfcnUl == 0 {
+		fddConfig.Earfcnul = uint32(earfcnDl - band.StartEarfcnDl + band.StartEarfcnUl)
+		earfcnUl = fddConfig.Earfcnul
+	}
+	if !band.EarfcnULInRange(int32(earfcnUl)) {
+		return fmt.Errorf("EARFCNUL=%d invalid for Band %d (%d, %d)",
+			earfcnUl,
+			band.ID,
+			band.StartEarfcnUl,
+			band.StartEarfcnUl+band.CountEarfcn)
+	}
+	return nil
+}
+
+func validateTDDConfig(band *utils.LTEBand, tddConfig *NetworkRanConfigsTddConfig) error {
+	if tddConfig == nil {
+		return nil
+	}
+
+	if band.Mode != utils.TDDMode {
+		return fmt.Errorf("Not a TDD Band: %d", band.ID)
+	}
+	return nil
+}
+
+func (config *NetworkEnodebConfigs) ValidateEnodebConfig() error {
+	if config == nil {
+		return errors.New("Gateway config is nil")
+	}
+	if config.Earfcndl < 0 || config.Earfcndl > 65535 {
+		return errors.New("EARFCNDL must be within 0-65535")
+	}
+	if config.SubframeAssignment < 0 || config.SubframeAssignment > 6 {
+		return errors.New("Subframe assignment must be within 0-6")
+	}
+	if config.SpecialSubframePattern < 0 || config.SpecialSubframePattern > 9 {
+		return errors.New("Special subframe pattern must be within 0-9")
+	}
+	if config.Pci < 0 || config.Pci > 504 {
+		return errors.New("PCI must be within 0-504")
+	}
+	if config.CellID < 0 || config.CellID > 268435455 {
+		return errors.New("Cell ID must be within 0-268435455")
+	}
+	if config.Tac < 0 || config.Tac > 65535 {
+		return errors.New("TAC must be within 0-65535")
+	}
+	switch config.DeviceClass {
+	case
+		"Baicells Nova-233 G2 OD FDD",
+		"Baicells Nova-243 OD TDD",
+		"Baicells ID TDD/FDD",
+		"NuRAN Cavium OC-LTE":
+		break
+	default:
+		return errors.New("Invalid eNodeB device class")
+	}
+	switch config.BandwidthMhz {
+	case
+		3,
+		5,
+		10,
+		15,
+		20:
+		break
+	default:
+		return errors.New("Invalid eNodeB bandwidth option")
+	}
+	return nil
+}

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rules.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rules.go
@@ -93,7 +93,7 @@ func updateRule(c echo.Context) error {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
 
-	err := configurator.UpdateEntityConfig(networkID, policydb.PolicyRuleEntityType, ruleID, rule)
+	err := configurator.CreateOrUpdateEntityConfig(networkID, policydb.PolicyRuleEntityType, ruleID, rule)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -137,7 +137,7 @@ func updateSubscriber(c echo.Context) error {
 		subscriberID = string(sub.ID)
 	}
 
-	err := configurator.UpdateEntityConfig(networkID, lte.SubscriberEntityType, subscriberID, sub)
+	err := configurator.CreateOrUpdateEntityConfig(networkID, lte.SubscriberEntityType, subscriberID, sub)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}

--- a/orc8r/cloud/go/services/config/obsidian/configurator_entity_handlers_test.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_entity_handlers_test.go
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package obsidian_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/config/obsidian"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/configurator/test_init"
+
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func commonSetupEntities(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
+	err := serde.RegisterSerdes(
+		configurator.NewNetworkEntityConfigSerde("cfg_entity", &configType{}),
+		configurator.NewNetworkEntityConfigSerde("err_entity", &errValidateType{}),
+	)
+	assert.NoError(t, err)
+	test_init.StartTestService(t)
+	err = configurator.CreateNetwork(configurator.Network{ID: "network1"})
+	assert.NoError(t, err)
+}
+
+func TestConfiguratorGetEntityConfig(t *testing.T) {
+	commonSetupEntities(t)
+	testGetEntityConfig(t, "cfg_entity")
+}
+
+func TestConfiguratorCreateEntityConfig(t *testing.T) {
+	commonSetupEntities(t)
+
+	e := echo.New()
+
+	// Happy path
+	post := `{"Foo": "foo", "Bar": "bar"}`
+	req := httptest.NewRequest(echo.POST, "/", strings.NewReader(post))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	_, err := configurator.CreateEntity("network1", configurator.NetworkEntity{
+		Type: "cfg_entity",
+		Key:  "key",
+	})
+	assert.NoError(t, err)
+
+	handler := obsidian.GetCreateConfigHandler("google.com", "cfg_entity", mockKeyGetter, &configType{})
+	err = handler.MigratedHandlerFunc(c)
+	assert.NoError(t, err)
+	actual, err := configurator.LoadEntity("network1", "cfg_entity", "key", configurator.EntityLoadCriteria{LoadConfig: true})
+	assert.NoError(t, err)
+	assert.Equal(t, &configType{Foo: "foo", Bar: "bar"}, actual.Config)
+
+	// Validation error
+	post = `{"Msg": "hello"}`
+	req = httptest.NewRequest(echo.POST, "/", strings.NewReader(post))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c = e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	handler = obsidian.GetCreateConfigHandler("google.com", "err_gateway", mockKeyGetter, &errValidateType{})
+	err = handler.MigratedHandlerFunc(c)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
+	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+
+	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
+}
+
+func TestConfiguratorUpdateEntityConfig(t *testing.T) {
+	commonSetupEntities(t)
+	testEntityUpdate(t, "cfg_entity", "err_entity")
+}
+
+func TestConfiguratorDeleteEntityConfig(t *testing.T) {
+	commonSetupEntities(t)
+	_, err := configurator.CreateEntity("network1", configurator.NetworkEntity{
+		Type:   "cfg_entity",
+		Key:    "key",
+		Config: &configType{Foo: "foo"},
+	})
+	assert.NoError(t, err)
+
+	e := echo.New()
+
+	// Happy path
+	req := httptest.NewRequest(echo.DELETE, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	handler := obsidian.GetDeleteConfigHandler("google.com", "cfg_entity", mockKeyGetter)
+	err = handler.MigratedHandlerFunc(c)
+	assert.NoError(t, err)
+
+	// Double delete - should be no error
+	err = handler.MigratedHandlerFunc(c)
+	assert.NoError(t, err)
+
+	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
+}
+
+func testEntityUpdate(t *testing.T, succConfigType string, errConfigType string) {
+	e := echo.New()
+	// Happy path - create a config with the PUT
+	post := `{"Foo": "foo", "Bar": "bar"}`
+	req := httptest.NewRequest(echo.PUT, "/", strings.NewReader(post))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	_, err := configurator.CreateEntity("network1", configurator.NetworkEntity{
+		Type:   succConfigType,
+		Key:    "key",
+		Config: &configType{Foo: "foo", Bar: "bar"},
+	})
+	assert.NoError(t, err)
+
+	// Happy path - update a config with the PUT
+	handler := obsidian.GetUpdateConfigHandler("google.com", succConfigType, mockKeyGetter, &configType{})
+	post = `{"Foo": "foo2", "Bar": "bar2"}`
+	req = httptest.NewRequest(echo.PUT, "/", strings.NewReader(post))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec = httptest.NewRecorder()
+	c = e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	err = handler.MigratedHandlerFunc(c)
+	assert.NoError(t, err)
+	assert.NoError(t, err)
+	actual, err := configurator.LoadEntity("network1", succConfigType, "key", configurator.EntityLoadCriteria{LoadConfig: true})
+	assert.NoError(t, err)
+	assert.Equal(t, &configType{Foo: "foo2", Bar: "bar2"}, actual.Config)
+
+	// Validation error
+	post = `{"Msg": "hello"}`
+	req = httptest.NewRequest(echo.POST, "/", strings.NewReader(post))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c = e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	handler = obsidian.GetUpdateConfigHandler("google.com", errConfigType, mockKeyGetter, &errValidateType{})
+	err = handler.MigratedHandlerFunc(c)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
+	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+
+	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
+}
+
+func testGetEntityConfig(t *testing.T, succConfigType string) {
+	e := echo.New()
+	req := httptest.NewRequest(echo.GET, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.SetParamNames("network_id")
+	c.SetParamValues("network1")
+
+	handler := obsidian.GetReadConfigHandler("google.com", succConfigType, mockKeyGetter, &configType{})
+
+	// 404
+	err := handler.MigratedHandlerFunc(c)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusNotFound, err.(*echo.HTTPError).Code)
+
+	// Happy path
+	expected := &configType{Foo: "foo", Bar: "bar"}
+	_, err = configurator.CreateEntity("network1", configurator.NetworkEntity{
+		Type:   succConfigType,
+		Key:    "key",
+		Config: expected,
+	})
+	assert.NoError(t, err)
+	err = handler.MigratedHandlerFunc(c)
+	assert.NoError(t, err)
+
+	actual := &configType{}
+	assert.Equal(t, http.StatusOK, rec.Code)
+	err = json.Unmarshal(rec.Body.Bytes(), actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+
+	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
+}

--- a/orc8r/cloud/go/services/config/obsidian/configurator_entity_handlers_test.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_entity_handlers_test.go
@@ -83,7 +83,7 @@ func TestConfiguratorCreateEntityConfig(t *testing.T) {
 	err = handler.MigratedHandlerFunc(c)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
-	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+	assert.Equal(t, "Invalid config: hello", err.(*echo.HTTPError).Message)
 
 	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
 }
@@ -169,7 +169,7 @@ func testEntityUpdate(t *testing.T, succConfigType string, errConfigType string)
 	err = handler.MigratedHandlerFunc(c)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
-	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+	assert.Equal(t, "Invalid config: hello", err.(*echo.HTTPError).Message)
 
 	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
 }

--- a/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers_test.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers_test.go
@@ -84,7 +84,7 @@ func TestConfiguratorCreateGatewayConfig(t *testing.T) {
 	err = handler.MigratedHandlerFunc(c)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
-	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+	assert.Equal(t, "Invalid config: hello", err.(*echo.HTTPError).Message)
 
 	serde.UnregisterSerdesForDomain(t, configurator.NetworkEntitySerdeDomain)
 }

--- a/orc8r/cloud/go/services/config/obsidian/configurator_network_handlers_test.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_network_handlers_test.go
@@ -105,7 +105,7 @@ func TestConfiguratorCreateNetworkConfig(t *testing.T) {
 	err = handler.MigratedHandlerFunc(c)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
-	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+	assert.Equal(t, "Invalid config: hello", err.(*echo.HTTPError).Message)
 
 	serde.UnregisterSerdesForDomain(t, configurator.NetworkConfigSerdeDomain)
 }
@@ -158,7 +158,7 @@ func TestConfiguratorUpdateNetworkConfig(t *testing.T) {
 	err = handler.MigratedHandlerFunc(c)
 	assert.Error(t, err)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
-	assert.Equal(t, "hello", err.(*echo.HTTPError).Message)
+	assert.Equal(t, "Invalid config: hello", err.(*echo.HTTPError).Message)
 
 	serde.UnregisterSerdesForDomain(t, configurator.NetworkConfigSerdeDomain)
 }

--- a/orc8r/cloud/go/services/config/obsidian/handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/handlers.go
@@ -139,6 +139,13 @@ func GetReadAllKeysConfigHandler(
 			}
 			return handleGetAllKeys(c, networkID, configType)
 		},
+		MigratedHandlerFunc: func(c echo.Context) error {
+			networkID, nerr := handlers.GetNetworkId(c)
+			if nerr != nil {
+				return nerr
+			}
+			return configuratorGetAllKeys(c, networkID, configType)
+		},
 	}
 }
 

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -275,7 +275,7 @@ func UpdateInternalEntity(update EntityUpdateCriteria) (NetworkEntity, error) {
 	return UpdateEntity(storage.InternalNetworkID, update)
 }
 
-func UpdateEntityConfig(networkID string, entityType string, entityKey string, config interface{}) error {
+func CreateOrUpdateEntityConfig(networkID string, entityType string, entityKey string, config interface{}) error {
 	updateCriteria := EntityUpdateCriteria{
 		Key:       entityKey,
 		Type:      entityType,
@@ -383,6 +383,14 @@ func LoadEntity(networkID string, entityType string, entityKey string, criteria 
 		return ret, merrors.ErrNotFound
 	}
 	return loaded[0], nil
+}
+
+func LoadEntityConfig(networkID, entityType, entityKey string) (interface{}, error) {
+	entity, err := LoadEntity(networkID, entityType, entityKey, EntityLoadCriteria{LoadConfig: true})
+	if err != nil {
+		return nil, err
+	}
+	return entity.Config, nil
 }
 
 // LoadEntities loads entities specified by the parameters.


### PR DESCRIPTION
Summary:
The cellular configs API now supports the migration to configurator.  If "USE_NEW_HANDLERS" is set to 1, cellular configs will be backed by configurator, not configs.

I have duplicated the tests so that both versions are tested. The original tests are moved to cellular_handlers_legacy_test.go.

I've also modified the config type switch logic to look at the last index for the 'gateway' or 'network' keyword, not the second.

Reviewed By: xjtian

Differential Revision: D15907944

