### PR TITLE
Add default values to mconfig for attachedEnodebTacs

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -19,7 +19,8 @@
       "nonEpsServiceControl": 0,
       "csfbMcc": "001",
       "csfbMnc": "01",
-      "lac": 1
+      "lac": 1,
+      "attachedEnodebTacs": []
     },
     "enodebd": {
       "@type": "type.googleapis.com/magma.mconfig.EnodebD",

--- a/lte/gateway/configs/gateway.streamed.mconfig
+++ b/lte/gateway/configs/gateway.streamed.mconfig
@@ -21,7 +21,8 @@
         "nonEpsServiceControl": 0,
         "csfbMcc": "001",
         "csfbMnc": "01",
-        "lac": 1
+        "lac": 1,
+        "attachedEnodebTacs": []
       },
       "enodebd": {
         "@type": "type.googleapis.com/magma.mconfig.EnodebD",


### PR DESCRIPTION
Summary:
Finding that after initial provision of Magma LTE AGW, there is the following error:

```
Jun 20 16:42:34 ip-192-168-61-230 systemd[1]: Starting Magma OAI MME service...
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]: ERROR:root:Error retrieving config for mme, key not found: use_stateless
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]: Traceback (most recent call last):
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:   File "/usr/local/bin/generate_oai_config.py", line 161, in <module>
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:     main()
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:   File "/usr/local/bin/generate_oai_config.py", line 152, in main
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:     context = _get_context()
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:   File "/usr/local/bin/generate_oai_config.py", line 136, in _get_context
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:     context["attached_enodeb_tacs"] = _get_attached_enodeb_tacs()
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:   File "/usr/local/bin/generate_oai_config.py", line 113, in _get_attached_enodeb_tacs
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]:     attached_enodeb_tacs = mme_config["attachedEnodebTacs"]
Jun 20 16:42:35 ip-192-168-61-230 mme[12993]: KeyError: 'attachedEnodebTacs'
```

This revision fixes the error by adding the field to default gateway.mconfig

Reviewed By: ssanadhya

Differential Revision: D15926127

