### PR TITLE
Add port mapping support in FeG docker-compose

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -38,4 +38,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       ansible.verbose = 'v'
     end
   end
+
+  config.vm.define :cwag_test, primary: true do |cwag_test|
+    cwag_test.vm.box = "generic/ubuntu1804"
+    cwag_test.vm.hostname = "cwag-test"
+    cwag_test.vm.network "private_network", ip: "192.168.70.102", nic_type: "82540EM"
+    cwag_test.vm.network "private_network", ip: "192.168.132.11", nic_type: "82540EM"
+    cwag_test.ssh.password = "vagrant"
+    cwag_test.ssh.insert_key = true
+
+    cwag_test.vm.provider "virtualbox" do |vb|
+      vb.name = "cwag-test"
+      vb.linked_clone = true
+      vb.customize ["modifyvm", :id, "--memory", "4096"]
+      vb.customize ["modifyvm", :id, "--cpus", "4"]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+    end
+  end
 end

--- a/cwf/gateway/deploy/cwag.yml
+++ b/cwf/gateway/deploy/cwag.yml
@@ -1,0 +1,12 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+---
+- name: Set up Carrier WiFi Access Gateway for production
+  hosts: localhost
+  become: yes
+  roles:
+    - role: ovs
+    - role: cwag

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -15,3 +15,20 @@
     - role: ovs
     - role: golang
     - role: cwag
+
+  tasks:
+    - # Only run installation for docker
+      - include_role:
+          name: docker
+          tasks_from: install
+
+      - name: Create snowflake file
+        copy:
+          content: ""
+          dest: /etc/snowflake
+
+      # Required by some go libraries
+      - name: Install bzr dependency
+        apt:
+          name: bzr
+          state: present

--- a/cwf/gateway/deploy/roles/cwag/files/create_gre_tunnel.sh
+++ b/cwf/gateway/deploy/roles/cwag/files/create_gre_tunnel.sh
@@ -7,8 +7,8 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-ovs-vsctl add-br br0
+ovs-vsctl --may-exist add-br br0
 sysctl net.ipv4.ip_forward=1
 iptables -t mangle -A FORWARD -i br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
 iptables -t mangle -A FORWARD -o br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
-ovs-vsctl add-port br0 gre0 -- set interface gre0 type=gre ofport_request=32768 options:remote_ip=flow options:key=flow
+ovs-vsctl --may-exist add-port br0 gre0 -- set interface gre0 type=gre ofport_request=32768 options:remote_ip=flow options:key=flow

--- a/cwf/gateway/deploy/roles/cwag/tasks/main.yml
+++ b/cwf/gateway/deploy/roles/cwag/tasks/main.yml
@@ -4,22 +4,6 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-# Only run installation for docker
-- include_role:
-    name: docker
-    tasks_from: install
-
-- name: Create snowflake file
-  copy:
-    content: ""
-    dest: /etc/snowflake
-
-# Required by some go libraries
-- name: Install bzr dependency
-  apt:
-    name: bzr
-    state: present
-
 - name: Create OVS bridge br0 and GRE tunnel gre0
   become: true
   script: create_gre_tunnel.sh

--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -9,12 +9,12 @@ COMPOSE_PROJECT_NAME=cwf
 DOCKER_REGISTRY=cwf_
 IMAGE_VERSION=latest
 
-BUILD_CONTEXT=../../..
+BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
 
-ROOTCA_PATH=../../../.cache/test_certs/rootCA.pem
-CONTROL_PROXY_PATH=../configs/control_proxy.yml
-CONFIGS_TEMPLATES_PATH=../../../orc8r/gateway/configs/templates
+ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
+CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml
+CONFIGS_TEMPLATES_PATH=/etc/magma/templates
 
 CERTS_VOLUME=/var/opt/magma/certs
 CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
-CONFIGS_DEFAULT_VOLUME=../configs
+CONFIGS_DEFAULT_VOLUME=/etc/magma

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -13,8 +13,8 @@ x-standard-volumes: &volumes_anchor
   - ${CERTS_VOLUME}:/var/opt/magma/certs
   - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
   - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
   - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
-  - ../../../orc8r/gateway/configs/templates:/etc/magma/templates
   - /etc/snowflake:/etc/snowflake
 
 x-generic-service: &service
@@ -50,15 +50,15 @@ services:
     <<: *pyservice
     container_name: magmad
     build:
-      context: ../../../ # TODO: Move feg/gateway/docker/python to magma/orc8r/gateway/docker
+      context: ${BUILD_CONTEXT} # TODO: Move feg/gateway/docker/python to magma/orc8r/gateway/docker
       dockerfile: feg/gateway/docker/python/Dockerfile
     volumes:
       - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
       - ${CERTS_VOLUME}:/var/opt/magma/certs
       - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
       - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+      - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
       - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
-      - ../../../orc8r/gateway/configs/templates:/etc/magma/templates
       - /etc/snowflake:/etc/snowflake
       - /var/run/docker.sock:/var/run/docker.sock
     command: python3 -m magma.magmad.main
@@ -67,15 +67,15 @@ services:
     <<: *ltepyservice
     container_name: pipelined
     build:
-      context: ../../../
+      context: ${BUILD_CONTEXT}
       dockerfile: lte/gateway/docker/python/Dockerfile
     volumes:
       - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
       - ${CERTS_VOLUME}:/var/opt/magma/certs
       - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
       - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+      - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
       - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
-      - ../../../orc8r/gateway/configs/templates:/etc/magma/templates
       - /etc/snowflake:/etc/snowflake
       - /var/run/openvswitch:/var/run/openvswitch
     command: >
@@ -87,6 +87,6 @@ services:
     <<: *ltecservice
     container_name: sessiond
     build:
-      context: ../../../
+      context: ${BUILD_CONTEXT}
       dockerfile: lte/gateway/docker/c/Dockerfile
     command: /usr/local/bin/sessiond

--- a/feg/gateway/docker/.env
+++ b/feg/gateway/docker/.env
@@ -16,3 +16,21 @@ SNOWFLAKE_PATH=../../../.cache/feg/snowflake
 
 CERTS_VOLUME=gwcerts
 CONFIGS_VOLUME=gwconfigs
+
+# This section is unnecessary if using host networking
+# Docker-compose for Mac doesn't yet support SCTP mapping
+S6A_LOCAL_PORT=3868
+S6A_HOST_PORT=3869
+S6A_NETWORK=tcp
+
+SWX_LOCAL_PORT=3868
+SWX_HOST_PORT=3868
+SWX_NETWORK=tcp
+
+GX_LOCAL_PORT=3907
+GX_HOST_PORT=0
+GX_NETWORK=tcp
+
+GY_LOCAL_PORT=3906
+GY_HOST_PORT=0
+GY_NETWORK=tcp

--- a/feg/gateway/docker/.prod_env
+++ b/feg/gateway/docker/.prod_env
@@ -16,3 +16,20 @@ SNOWFLAKE_PATH=/etc/snowflake
 
 CERTS_VOLUME=/var/opt/magma/certs
 CONFIGS_VOLUME=/var/opt/magma/configs
+
++# This section is unnecessary if using host networking
++S6A_LOCAL_PORT=3868
++S6A_HOST_PORT=3869
++S6A_NETWORK=sctp
++
++SWX_LOCAL_PORT=3868
++SWX_HOST_PORT=3868
++SWX_NETWORK=sctp
++
++GX_LOCAL_PORT=3907
++GX_HOST_PORT=0
++GX_NETWORK=tcp
++
++GY_LOCAL_PORT=3906
++GY_HOST_PORT=0
++GY_NETWORK=tcp

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -72,16 +72,34 @@ services:
   session_proxy:
     <<: *goservice
     container_name: session_proxy
+    ports:
+      - "${GX_HOST_PORT}:${GX_LOCAL_PORT}/${GX_NETWORK}"
+      - "${GY_HOST_PORT}:${GY_LOCAL_PORT}/${GY_NETWORK}"
+    environment:
+      GX_NETWORK: ${GX_NETWORK}
+      GX_LOCAL_ADDR: :${GX_LOCAL_PORT}
+      GY_NETWORK: ${GY_NETWORK}
+      GY_LOCAL_ADDR: :${GY_LOCAL_PORT}
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
 
   swx_proxy:
     <<: *goservice
     container_name: swx_proxy
+    ports:
+      - "${SWX_HOST_PORT}:${SWX_LOCAL_PORT}/${SWX_NETWORK}"
+    environment:
+      SWX_NETWORK: ${SWX_NETWORK}
+      SWX_LOCAL_ADDR: :${SWX_LOCAL_PORT}
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
 
   s6a_proxy:
     <<: *goservice
     container_name: s6a_proxy
+    ports:
+      - "${S6A_HOST_PORT}:${S6A_LOCAL_PORT}/${S6A_NETWORK}"
+    environment:
+      S6A_NETWORK: ${S6A_NETWORK}
+      S6A_LOCAL_ADDR: :${S6A_LOCAL_PORT}
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
 
   control_proxy:

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -15,6 +15,12 @@ CWAG="cwag"
 FEG="feg"
 INSTALL_DIR="/tmp/magmagw_install"
 
+# TODO: Update docker-compose to stable version
+
+# Using RC as opposed to stable (1.24.0) due to
+# SCTP port mapping support
+DOCKER_COMPOSE_VERSION=1.25.0-rc1
+
 DIR="."
 echo "Setting working directory as: $DIR"
 cd "$DIR"
@@ -76,8 +82,13 @@ if [ "$GW_TYPE" == "$CWAG" ]; then
   apt-get update -y
   apt-get -y install ansible
   ansible-playbook "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/deploy/cwag.yml -i "localhost," -c local -v
-else
+fi
+
+if [ "$GW_TYPE" == "$FEG" ]; then
   MODULE_DIR="$GW_TYPE"
+
+  # Load kernel module necessary for docker SCTP support
+  sudo modprobe nf_conntrack_proto_sctp
 fi
 
 cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose.yml .
@@ -100,7 +111,7 @@ sudo apt-get update
 sudo apt-get install -y docker-ce docker-ce-cli containerd.io
 
 # Install Docker-Compose
-sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+sudo curl -L "https://github.com/docker/compose/releases/download/"$DOCKER_COMPOSE_VERSION"/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
 sudo chmod +x /usr/local/bin/docker-compose
 
 # Create snowflake to be mounted into containers


### PR DESCRIPTION
Summary:
The FeG's recent switch to bind networking
requires appropriate port mappings set up to allow
connections to core components. By setting these
elements as env vars, we ensure that these
parameters serve as a single source of configuration,
since we use environment overrides over mconfig when set.
Mconfig will continue to be used for all other parameters.

Reviewed By: emakeev

Differential Revision: D15927666

