### PR TITLE
Add package upgrade functionality to test controller service (#998)

### DIFF
--- a/orc8r/cloud/docker/controller/supervisord.conf
+++ b/orc8r/cloud/docker/controller/supervisord.conf
@@ -207,6 +207,14 @@ stdout_logfile_maxbytes=0
 redirect_stderr=true
 autorestart=true
 
+[program:testcontroller]
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/testcontroller -logtostderr=true -v=0
+autorestart=true
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled = true
+stderr_events_enabled = true
+
 [program:dev_setup]
 command=/usr/local/bin/create_test_controller_certs
 startsecs=0


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/998

D15719883 added api handlers for the test controller service. This adds package upgrade functionality: every 15 minutes, the  most recent magma package version is pulled from the package repo. If the current magma version is not up-to-date, the upgrader service is used to upgrade magma, allowing for better CI.

Differential Revision: D15870785

