### PR TITLE
Delete network configs when deleting networks

### DIFF
--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -396,8 +396,13 @@ func (store *sqlConfiguratorStorage) UpdateNetworks(updates []NetworkUpdateCrite
 		}
 	}
 
-	// Then delete all networks requested for deletion
-	_, err := store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
+	_, err := store.builder.Delete(networkConfigTable).Where(sq.Eq{nwcIDCol: networksToDelete}).
+		RunWith(store.tx).
+		Exec()
+	if err != nil {
+		return errors.Wrap(err, "failed to delete configs associated with networks")
+	}
+	_, err = store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
 		RunWith(store.tx).
 		Exec()
 	if err != nil {

--- a/orc8r/cloud/go/services/configurator/storage/sql_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_test.go
@@ -355,6 +355,7 @@ func TestSqlConfiguratorStorage_UpdateNetworks(t *testing.T) {
 			upsertStmt.ExpectExec().WithArgs("n4", "foo", []byte("bar"), []byte("bar")).WillReturnResult(mockResult)
 			m.ExpectExec("DELETE FROM cfg_network_configs").WithArgs("n4", "hello", "n4", "world").WillReturnResult(mockResult)
 
+			m.ExpectExec("DELETE FROM cfg_network_configs").WithArgs("n1").WillReturnResult(mockResult)
 			m.ExpectExec("DELETE FROM cfg_networks").WithArgs("n1").WillReturnResult(mockResult)
 		},
 		run: runFactory(


### PR DESCRIPTION
Summary: When a network is deleted, all its configs should be deleted as well.

Reviewed By: andreilee

Differential Revision: D15925360

