### PR TITLE
Migrate magmad network REST handlers to use configurator

### DIFF
--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -8,8 +8,10 @@ LICENSE file in the root directory of this source tree.
 
 package orc8r
 
-const ModuleName string = "orc8r"
-
-const MagmadGatewayType = "magmad_gateway"
-
-const UpgradeTierEntityType = "upgrade_tier"
+const (
+	ModuleName            string = "orc8r"
+	MagmadGatewayType            = "magmad_gateway"
+	MagmadNetworkType            = "magmad_network"
+	UpgradeTierEntityType        = "upgrade_tier"
+	NetworkFeaturesConfig        = "orc8r_features"
+)

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -48,10 +48,6 @@ import (
 	"magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 )
 
-const (
-	NetworkFeaturesConfig = "orc8r_features"
-)
-
 // BaseOrchestratorPlugin is the OrchestratorPlugin for the orc8r module
 type BaseOrchestratorPlugin struct{}
 
@@ -78,7 +74,7 @@ func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 
 		// Config manager serdes
 		configurator.NewNetworkConfigSerde(dnsdconfig.DnsdNetworkType, &models2.NetworkDNSConfig{}),
-		configurator.NewNetworkConfigSerde(NetworkFeaturesConfig, &models3.NetworkFeatures{}),
+		configurator.NewNetworkConfigSerde(orc8r.NetworkFeaturesConfig, &models3.NetworkFeatures{}),
 
 		configurator.NewNetworkEntityConfigSerde(orc8r.MagmadGatewayType, &models3.MagmadGatewayConfig{}),
 		configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{}),

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -103,13 +103,26 @@ func UpdateNetworks(updates []NetworkUpdateCriteria) error {
 	return err
 }
 
-// DeleteNetwork deletes the network specified by networkID
+// DeleteNetworks deletes the network specified by networkID
 func DeleteNetworks(networkIDs []string) error {
 	client, err := getNBConfiguratorClient()
 	if err != nil {
 		return err
 	}
 	_, err = client.DeleteNetworks(context.Background(), &protos.DeleteNetworksRequest{NetworkIDs: networkIDs})
+	return err
+}
+
+// DeleteNetwork deletes a network.
+func DeleteNetwork(networkID string) error {
+	client, err := getNBConfiguratorClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.DeleteNetworks(
+		context.Background(),
+		&protos.DeleteNetworksRequest{NetworkIDs: []string{networkID}},
+	)
 	return err
 }
 
@@ -153,6 +166,17 @@ func LoadNetworks(networks []string, loadMetadata bool, loadConfigs bool) ([]Net
 		ret[i] = retNet
 	}
 	return ret, result.NetworkIDsNotFound, nil
+}
+
+func LoadNetwork(networkID string, loadMetadata bool, loadConfigs bool) (Network, error) {
+	networks, _, err := LoadNetworks([]string{networkID}, loadMetadata, loadConfigs)
+	if err != nil {
+		return Network{}, err
+	}
+	if len(networks) == 0 {
+		return Network{}, merrors.ErrNotFound
+	}
+	return networks[0], nil
 }
 
 func UpdateNetworkConfig(networkID, configType string, config interface{}) error {

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -396,8 +396,13 @@ func (store *sqlConfiguratorStorage) UpdateNetworks(updates []NetworkUpdateCrite
 		}
 	}
 
-	// Then delete all networks requested for deletion
-	_, err := store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
+	_, err := store.builder.Delete(networkConfigTable).Where(sq.Eq{nwcIDCol: networksToDelete}).
+		RunWith(store.tx).
+		Exec()
+	if err != nil {
+		return errors.Wrap(err, "failed to delete configs associated with networks")
+	}
+	_, err = store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
 		RunWith(store.tx).
 		Exec()
 	if err != nil {

--- a/orc8r/cloud/go/services/configurator/storage/sql_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_test.go
@@ -355,6 +355,7 @@ func TestSqlConfiguratorStorage_UpdateNetworks(t *testing.T) {
 			upsertStmt.ExpectExec().WithArgs("n4", "foo", []byte("bar"), []byte("bar")).WillReturnResult(mockResult)
 			m.ExpectExec("DELETE FROM cfg_network_configs").WithArgs("n4", "hello", "n4", "world").WillReturnResult(mockResult)
 
+			m.ExpectExec("DELETE FROM cfg_network_configs").WithArgs("n1").WillReturnResult(mockResult)
 			m.ExpectExec("DELETE FROM cfg_networks").WithArgs("n1").WillReturnResult(mockResult)
 		},
 		run: runFactory(

--- a/orc8r/cloud/go/services/magmad/config/managers.go
+++ b/orc8r/cloud/go/services/magmad/config/managers.go
@@ -18,10 +18,6 @@ import (
 	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
 )
 
-const (
-	MagmadNetworkType = "magmad_network"
-)
-
 // To be deprecated! Config service DB tables have been seeded with magmad
 // network configs that were migrated from legacy magmad network configs,
 // so this will stick around for a bit. We can delete this after deleting
@@ -34,7 +30,7 @@ func (*MagmadNetworkConfigManager) GetDomain() string {
 }
 
 func (*MagmadNetworkConfigManager) GetType() string {
-	return MagmadNetworkType
+	return orc8r.MagmadNetworkType
 }
 
 func (*MagmadNetworkConfigManager) Serialize(config interface{}) ([]byte, error) {

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/handlers.go
@@ -20,11 +20,11 @@ import (
 func GetObsidianHandlers() []handlers.Handler {
 	return []handlers.Handler{
 		// Network
-		{Path: ListNetworks, Methods: handlers.GET, HandlerFunc: listNetworks},
-		{Path: RegisterNetwork, Methods: handlers.POST, HandlerFunc: registerNetwork},
-		{Path: ManageNetwork, Methods: handlers.GET, HandlerFunc: getNetwork},
-		{Path: ManageNetwork, Methods: handlers.PUT, HandlerFunc: updateNetwork},
-		{Path: ManageNetwork, Methods: handlers.DELETE, HandlerFunc: deleteNetwork},
+		{Path: ListNetworks, Methods: handlers.GET, HandlerFunc: listNetworksHandler, MigratedHandlerFunc: listNetworks},
+		{Path: RegisterNetwork, Methods: handlers.POST, HandlerFunc: registerNetworkHandler, MigratedHandlerFunc: registerNetwork},
+		{Path: ManageNetwork, Methods: handlers.GET, HandlerFunc: getNetworkHandler, MigratedHandlerFunc: getNetwork},
+		{Path: ManageNetwork, Methods: handlers.PUT, HandlerFunc: updateNetworkHandler, MigratedHandlerFunc: updateNetwork},
+		{Path: ManageNetwork, Methods: handlers.DELETE, HandlerFunc: deleteNetworkHandler, MigratedHandlerFunc: deleteNetwork},
 
 		// Gateway
 		{Path: RegisterAG, Methods: handlers.GET, HandlerFunc: getListGatewaysHandler(&view_factory.FullGatewayViewFactoryImpl{})},

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_legacy_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_legacy_test.go
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
+	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMagmadLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	magmad_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	device_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
+	restPort := tests.StartObsidian(t)
+
+	testUrlRoot := fmt.Sprintf(
+		"http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
+
+	// Test List Networks
+	listCloudsTestCase := tests.Testcase{
+		Name:     "List Networks",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: `[]`,
+	}
+	tests.RunTest(t, listCloudsTestCase)
+
+	// Test Register Network with requestedId
+	registerNetworkWithIdTestCase := tests.Testcase{
+		Name:                      "Register Network with Requested Id",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obsidian_test_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+		Expected:                  `"magmad_obsidian_test_network"`,
+	}
+	tests.RunTest(t, registerNetworkWithIdTestCase)
+
+	// Test Removal Of Empty Network
+	removeNetworkTestCase := tests.Testcase{
+		Name:     "Remove Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, "magmad_obsidian_test_network"),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Register Network with invalid requestedId
+	registerNetworkWithInvalidIdTestCase := tests.Testcase{
+		Name:                      "Register Network with Invalid Requested Id",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=00*my_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerNetworkWithInvalidIdTestCase)
+
+	// Register network with uppercase requestedId
+	registerNetworkWithInvalidIdTestCase = tests.Testcase{
+		Name:                      "Register Network with Invalid Requested Id",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=Magmad_obsidian_test_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerNetworkWithInvalidIdTestCase)
+
+	// Test Register Network
+	registerNetworkTestCase := tests.Testcase{
+		Name:                      "Register Network",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obsidian_test_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+	}
+	_, networkId, _ := tests.RunTest(t, registerNetworkTestCase)
+
+	json.Unmarshal([]byte(networkId), &networkId)
+
+	// Test Register AG with invalid requestedId
+	registerAGWithInvalidIdTestCase := tests.Testcase{
+		Name:   "Register AG with Invalid Requested Id",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, "*00_bad_ag"),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId12345"}, "name": "Test AG Name", "key": {"key_type": "ECHO"}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGWithInvalidIdTestCase)
+
+	// Test Register AG with requestedId
+	requestedAGId := "my_gateway-1"
+	registerAGWithIdTestCase := tests.Testcase{
+		Name:   "Register AG with Requested Id",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, requestedAGId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId00001"}, "name": "Test AG Name",  "key": {"key_type": "ECHO"}}`,
+		Expected: fmt.Sprintf(`"%s"`, requestedAGId),
+	}
+	tests.RunTest(t, registerAGWithIdTestCase)
+
+	// Test Register AG
+	registerAGTestCase := tests.Testcase{
+		Name:     "Register AG",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId00002"}, "name": "Test AG Name", "key": {"key_type": "SOFTWARE_ECDSA_SHA256", "key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC"}}`,
+		Expected: `"TestAGHwId00002"`,
+	}
+	tests.RunTest(t, registerAGTestCase)
+
+	// Test Register without key
+	registerAGTestCaseNoKey := tests.Testcase{
+		Name:                      "Register AG without Key",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseNoKey)
+
+	// Test Register without key content
+	registerAGTestCaseNoKeyContent := tests.Testcase{
+		Name:                      "Register AG with Key but no Key Content",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256"}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseNoKeyContent)
+
+	// Test Register with wrong key content
+	registerAGTestCaseWrongKeyContent := tests.Testcase{
+		Name:                      "Register AG with Key but Wrong Key Content",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256", "key":"AAAAAAAAAAAAAAAAAAAAAA=="}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseWrongKeyContent)
+
+	// Test Getting AG record
+	getAGRecordTestCase := tests.Testcase{
+		Name:   "Get AG Record With Specified Name",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/%s",
+			testUrlRoot, networkId, requestedAGId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00001"},"key":{"key_type":"ECHO"},"name":"Test AG Name"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	getAGRecordTestCase = tests.Testcase{
+		Name:     "Get AG Record With Default Name",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00002"},"key":{"key":"MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC","key_type":"SOFTWARE_ECDSA_SHA256"},"name":"Test AG Name"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	// Test Updating AG record
+	setAGRecordTestCase := tests.Testcase{
+		Name:     "Update AG Record Name",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  `{"name": "SoDoSoPaTown Tower", "key": {"key_type": "ECHO"}}`,
+		Expected: "",
+	}
+	tests.RunTest(t, setAGRecordTestCase)
+
+	// Test Getting AG record 2
+	getAGRecordTestCase = tests.Testcase{
+		Name:     "Get AG Record With Modified Name",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00002"}, "key": {"key_type": "ECHO"}, "name": "SoDoSoPaTown Tower"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	// Test Listing All Registered AGs
+	listAGsTestCase := tests.Testcase{
+		Name:                      "List Registered AGs",
+		Method:                    "GET",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   "",
+		Expected:                  "",
+		Skip_payload_verification: true,
+	}
+	_, r, _ := tests.RunTest(t, listAGsTestCase)
+
+	exp1 := fmt.Sprintf(`["TestAGHwId00002","%s"]`, requestedAGId)
+	exp2 := fmt.Sprintf(`["%s","TestAGHwId00002"]`, requestedAGId)
+
+	if r != exp1 && r != exp2 {
+		t.Fatalf("***** %s test failed, received: %s\n***** Expected: %s or %s",
+			listAGsTestCase.Name, r, exp1, exp2)
+	}
+
+	// Test Removal Of Non Empty Network
+	removeNetworkTestCase = tests.Testcase{
+		Name:                      "Remove Non Empty Network",
+		Method:                    "DELETE",
+		Url:                       fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:                   "",
+		Expected:                  "",
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Forced Removal
+	removeNetworkTestCase = tests.Testcase{
+		Name:     "Force Remove Non Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s?mode=force", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Register Network
+	registerNetworkTestCase = tests.Testcase{
+		Name:                      "Register Network 2",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obisidian_test_network2", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+	}
+	_, networkId, _ = tests.RunTest(t, registerNetworkTestCase)
+
+	json.Unmarshal([]byte(networkId), &networkId)
+
+	// Test Register AG
+	registerAGTestCase = tests.Testcase{
+		Name:     "Register AG 2",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId12345"}, "key": {"key_type": "ECHO"}}`,
+		Expected: `"TestAGHwId12345"`,
+	}
+	tests.RunTest(t, registerAGTestCase)
+
+	// Test Listing All Registered AGs
+	listAGsTestCase = tests.Testcase{
+		Name:     "List Registered AGs 2",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `["TestAGHwId12345"]`,
+	}
+	tests.RunTest(t, listAGsTestCase)
+
+	expCfg := &models.MagmadGatewayConfig{}
+	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
+	assert.NoError(t, err)
+	marshaledCfg, err := expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr := string(marshaledCfg)
+
+	// Test Getting AG Configs
+	createAGConfigTestCase := tests.Testcase{
+		Name:     "Create AG Configs",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs", testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: `"TestAGHwId12345"`,
+	}
+	tests.RunTest(t, createAGConfigTestCase)
+
+	getAGConfigTestCase := tests.Testcase{
+		Name:   "Get AG Configs",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getAGConfigTestCase)
+
+	expCfg.Tier = "changed"
+	marshaledCfg, err = expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	// Test Setting (Updating) AG Configs
+	setAGConfigTestCase := tests.Testcase{
+		Name:   "Set AG Configs",
+		Method: "PUT",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: "",
+	}
+	tests.RunTest(t, setAGConfigTestCase)
+
+	// Test Getting AG Configs After Config Update
+	getAGConfigTestCase2 := tests.Testcase{
+		Name:   "Get AG Configs 2",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getAGConfigTestCase2)
+
+	// Update network wide property
+	//
+	// Get Current Network Record
+	networkCfg := &models.NetworkRecord{Name: "This Is A Test Network Name"}
+	marshaledCfg, err = networkCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	getNetworkRecordTestCase := tests.Testcase{
+		Name:     "Get Network Record",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getNetworkRecordTestCase)
+
+	networkCfg.Name = "Updated Network Name"
+	marshaledCfg, err = networkCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	updateNetworkRecordTestCase := tests.Testcase{
+		Name:     "Update Network Record",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: "",
+	}
+	tests.RunTest(t, updateNetworkRecordTestCase)
+
+	getNetworkRecordTestCase2 := tests.Testcase{
+		Name:     "Get Network Record after Update",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getNetworkRecordTestCase2)
+
+	// Test AG Unregister
+	setAGUnregisterTestCase := tests.Testcase{
+		Name:   "Unregister AG",
+		Method: "DELETE",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, setAGUnregisterTestCase)
+
+	// Test Listing All Registered AGs after Removal Of AG
+	listAGsTestCase2 := tests.Testcase{
+		Name:     "List Registered AGs",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `[]`, // should return an empty array
+	}
+	tests.RunTest(t, listAGsTestCase2)
+
+	// Test List Networks
+	listNetworksTestCase := tests.Testcase{
+		Name:     "List Networks",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: fmt.Sprintf(`["%s"]`, networkId),
+	}
+	tests.RunTest(t, listNetworksTestCase)
+
+	// Test Removal Of Empty Network
+	removeNetworkTestCase = tests.Testcase{
+		Name:     "Remove Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test List Networks
+	listNetworksTestCase = tests.Testcase{
+		Name:     "List Networks Post Delete",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: "[]",
+	}
+	tests.RunTest(t, listNetworksTestCase)
+}

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
@@ -1,16 +1,17 @@
 /*
-Copyright (c) Facebook, Inc. and its affiliates.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package handlers_test
 
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
@@ -20,14 +21,12 @@ import (
 	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
-	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
 	"magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMagmad(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
@@ -102,331 +101,6 @@ func TestMagmad(t *testing.T) {
 	_, networkId, _ := tests.RunTest(t, registerNetworkTestCase)
 
 	json.Unmarshal([]byte(networkId), &networkId)
-
-	// Test Register AG with invalid requestedId
-	registerAGWithInvalidIdTestCase := tests.Testcase{
-		Name:   "Register AG with Invalid Requested Id",
-		Method: "POST",
-		Url: fmt.Sprintf(
-			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, "*00_bad_ag"),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId12345"}, "name": "Test AG Name", "key": {"key_type": "ECHO"}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGWithInvalidIdTestCase)
-
-	// Test Register AG with requestedId
-	requestedAGId := "my_gateway-1"
-	registerAGWithIdTestCase := tests.Testcase{
-		Name:   "Register AG with Requested Id",
-		Method: "POST",
-		Url: fmt.Sprintf(
-			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, requestedAGId),
-		Payload:  `{"hw_id":{"id":"TestAGHwId00001"}, "name": "Test AG Name",  "key": {"key_type": "ECHO"}}`,
-		Expected: fmt.Sprintf(`"%s"`, requestedAGId),
-	}
-	tests.RunTest(t, registerAGWithIdTestCase)
-
-	// Test Register AG
-	registerAGTestCase := tests.Testcase{
-		Name:     "Register AG",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  `{"hw_id":{"id":"TestAGHwId00002"}, "name": "Test AG Name", "key": {"key_type": "SOFTWARE_ECDSA_SHA256", "key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC"}}`,
-		Expected: `"TestAGHwId00002"`,
-	}
-	tests.RunTest(t, registerAGTestCase)
-
-	// Test Register without key
-	registerAGTestCaseNoKey := tests.Testcase{
-		Name:                      "Register AG without Key",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGTestCaseNoKey)
-
-	// Test Register without key content
-	registerAGTestCaseNoKeyContent := tests.Testcase{
-		Name:                      "Register AG with Key but no Key Content",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256"}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGTestCaseNoKeyContent)
-
-	// Test Register with wrong key content
-	registerAGTestCaseWrongKeyContent := tests.Testcase{
-		Name:                      "Register AG with Key but Wrong Key Content",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256", "key":"AAAAAAAAAAAAAAAAAAAAAA=="}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGTestCaseWrongKeyContent)
-
-	// Test Getting AG record
-	getAGRecordTestCase := tests.Testcase{
-		Name:   "Get AG Record With Specified Name",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/%s",
-			testUrlRoot, networkId, requestedAGId),
-		Payload:  "",
-		Expected: `{"hw_id":{"id":"TestAGHwId00001"},"key":{"key_type":"ECHO"},"name":"Test AG Name"}`,
-	}
-	tests.RunTest(t, getAGRecordTestCase)
-
-	getAGRecordTestCase = tests.Testcase{
-		Name:     "Get AG Record With Default Name",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `{"hw_id":{"id":"TestAGHwId00002"},"key":{"key":"MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC","key_type":"SOFTWARE_ECDSA_SHA256"},"name":"Test AG Name"}`,
-	}
-	tests.RunTest(t, getAGRecordTestCase)
-
-	// Test Updating AG record
-	setAGRecordTestCase := tests.Testcase{
-		Name:     "Update AG Record Name",
-		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
-		Payload:  `{"name": "SoDoSoPaTown Tower", "key": {"key_type": "ECHO"}}`,
-		Expected: "",
-	}
-	tests.RunTest(t, setAGRecordTestCase)
-
-	// Test Getting AG record 2
-	getAGRecordTestCase = tests.Testcase{
-		Name:     "Get AG Record With Modified Name",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `{"hw_id":{"id":"TestAGHwId00002"}, "key": {"key_type": "ECHO"}, "name": "SoDoSoPaTown Tower"}`,
-	}
-	tests.RunTest(t, getAGRecordTestCase)
-
-	// Test Listing All Registered AGs
-	listAGsTestCase := tests.Testcase{
-		Name:                      "List Registered AGs",
-		Method:                    "GET",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   "",
-		Expected:                  "",
-		Skip_payload_verification: true,
-	}
-	_, r, _ := tests.RunTest(t, listAGsTestCase)
-
-	exp1 := fmt.Sprintf(`["TestAGHwId00002","%s"]`, requestedAGId)
-	exp2 := fmt.Sprintf(`["%s","TestAGHwId00002"]`, requestedAGId)
-
-	if r != exp1 && r != exp2 {
-		t.Fatalf("***** %s test failed, received: %s\n***** Expected: %s or %s",
-			listAGsTestCase.Name, r, exp1, exp2)
-	}
-
-	// Test Removal Of Non Empty Network
-	removeNetworkTestCase = tests.Testcase{
-		Name:                      "Remove Non Empty Network",
-		Method:                    "DELETE",
-		Url:                       fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:                   "",
-		Expected:                  "",
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, removeNetworkTestCase)
-
-	// Test Forced Removal
-	removeNetworkTestCase = tests.Testcase{
-		Name:     "Force Remove Non Empty Network",
-		Method:   "DELETE",
-		Url:      fmt.Sprintf("%s/%s?mode=force", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: "",
-	}
-	tests.RunTest(t, removeNetworkTestCase)
-
-	// Test Register Network
-	registerNetworkTestCase = tests.Testcase{
-		Name:                      "Register Network 2",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s?requested_id=magmad_obisidian_test_network2", testUrlRoot),
-		Payload:                   `{"name":"This Is A Test Network Name"}`,
-		Skip_payload_verification: true,
-	}
-	_, networkId, _ = tests.RunTest(t, registerNetworkTestCase)
-
-	json.Unmarshal([]byte(networkId), &networkId)
-
-	// Test Register AG
-	registerAGTestCase = tests.Testcase{
-		Name:     "Register AG 2",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  `{"hw_id":{"id":"TestAGHwId12345"}, "key": {"key_type": "ECHO"}}`,
-		Expected: `"TestAGHwId12345"`,
-	}
-	tests.RunTest(t, registerAGTestCase)
-
-	// Test Listing All Registered AGs
-	listAGsTestCase = tests.Testcase{
-		Name:     "List Registered AGs 2",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `["TestAGHwId12345"]`,
-	}
-	tests.RunTest(t, listAGsTestCase)
-
-	expCfg := &models.MagmadGatewayConfig{}
-	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
-	assert.NoError(t, err)
-	marshaledCfg, err := expCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr := string(marshaledCfg)
-
-	// Test Getting AG Configs
-	createAGConfigTestCase := tests.Testcase{
-		Name:     "Create AG Configs",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs", testUrlRoot, networkId),
-		Payload:  expectedCfgStr,
-		Expected: `"TestAGHwId12345"`,
-	}
-	tests.RunTest(t, createAGConfigTestCase)
-
-	getAGConfigTestCase := tests.Testcase{
-		Name:   "Get AG Configs",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
-			testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getAGConfigTestCase)
-
-	expCfg.Tier = "changed"
-	marshaledCfg, err = expCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr = string(marshaledCfg)
-
-	// Test Setting (Updating) AG Configs
-	setAGConfigTestCase := tests.Testcase{
-		Name:   "Set AG Configs",
-		Method: "PUT",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
-			testUrlRoot, networkId),
-		Payload:  expectedCfgStr,
-		Expected: "",
-	}
-	tests.RunTest(t, setAGConfigTestCase)
-
-	// Test Getting AG Configs After Config Update
-	getAGConfigTestCase2 := tests.Testcase{
-		Name:   "Get AG Configs 2",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
-			testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getAGConfigTestCase2)
-
-	// Update network wide property
-	//
-	// Get Current Network Record
-	networkCfg := &models.NetworkRecord{Name: "This Is A Test Network Name"}
-	marshaledCfg, err = networkCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr = string(marshaledCfg)
-
-	getNetworkRecordTestCase := tests.Testcase{
-		Name:     "Get Network Record",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getNetworkRecordTestCase)
-
-	networkCfg.Name = "Updated Network Name"
-	marshaledCfg, err = networkCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr = string(marshaledCfg)
-
-	updateNetworkRecordTestCase := tests.Testcase{
-		Name:     "Update Network Record",
-		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  expectedCfgStr,
-		Expected: "",
-	}
-	tests.RunTest(t, updateNetworkRecordTestCase)
-
-	getNetworkRecordTestCase2 := tests.Testcase{
-		Name:     "Get Network Record after Update",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getNetworkRecordTestCase2)
-
-	// Test AG Unregister
-	setAGUnregisterTestCase := tests.Testcase{
-		Name:   "Unregister AG",
-		Method: "DELETE",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345",
-			testUrlRoot, networkId),
-		Payload:  "",
-		Expected: "",
-	}
-	tests.RunTest(t, setAGUnregisterTestCase)
-
-	// Test Listing All Registered AGs after Removal Of AG
-	listAGsTestCase2 := tests.Testcase{
-		Name:     "List Registered AGs",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `[]`, // should return an empty array
-	}
-	tests.RunTest(t, listAGsTestCase2)
-
-	// Test List Networks
-	listNetworksTestCase := tests.Testcase{
-		Name:     "List Networks",
-		Method:   "GET",
-		Url:      testUrlRoot,
-		Payload:  "",
-		Expected: fmt.Sprintf(`["%s"]`, networkId),
-	}
-	tests.RunTest(t, listNetworksTestCase)
-
-	// Test Removal Of Empty Network
-	removeNetworkTestCase = tests.Testcase{
-		Name:     "Remove Empty Network",
-		Method:   "DELETE",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: "",
-	}
-	tests.RunTest(t, removeNetworkTestCase)
-
-	// Test List Networks
-	listNetworksTestCase = tests.Testcase{
-		Name:     "List Networks Post Delete",
-		Method:   "GET",
-		Url:      testUrlRoot,
-		Payload:  "",
-		Expected: "[]",
-	}
-	tests.RunTest(t, listNetworksTestCase)
 }
 
 // Default gateway config struct. Please DO NOT MODIFY this struct in-place

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
@@ -9,14 +9,12 @@ LICENSE file in the root directory of this source tree.
 package handlers
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorh "magma/orc8r/cloud/go/services/configurator/obsidian/handlers"
-	"magma/orc8r/cloud/go/services/magmad"
 	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
 
 	"github.com/labstack/echo"
@@ -36,11 +34,14 @@ func listNetworks(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	networks, err := magmad.ListNetworks()
+	networks, err := configurator.ListNetworkIDs()
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
-
+	//magmad expects [] not null for the empty case
+	if networks == nil {
+		networks = []string{}
+	}
 	return c.JSON(http.StatusOK, networks)
 }
 
@@ -52,124 +53,92 @@ func registerNetwork(c echo.Context) error {
 	}
 
 	// Bind network record from swagger
-	swaggerRecord := &magmad_models.NetworkRecord{}
-	err := c.Bind(&swaggerRecord)
+	record := &magmad_models.NetworkRecord{}
+	err := c.Bind(&record)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerRecord.ValidateModel(); err != nil {
+	if err := record.ValidateModel(); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	magmadRecord := swaggerRecord.ToProto()
 
-	var networkId string
-	requestedId := c.QueryParam("requested_id")
-	err = configuratorh.VerifyNetworkIDFormat(requestedId)
+	requestedID := c.QueryParam("requested_id")
+	err = configuratorh.VerifyNetworkIDFormat(requestedID)
 	if err != nil {
 		return err
 	}
-	networkId, err = magmad.RegisterNetwork(magmadRecord, requestedId)
-	if err != nil {
-		return handlers.HttpError(err, http.StatusConflict)
-	}
 
-	_, err = multiplexCreateNetworkIntoConfigurator(networkId, swaggerRecord)
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex into configurator: %v", err), http.StatusInternalServerError)
-	}
-
-	return c.JSON(http.StatusCreated, networkId)
-}
-
-func multiplexCreateNetworkIntoConfigurator(requestedID string, swaggerRecord *magmad_models.NetworkRecord) (string, error) {
 	network := configurator.Network{
-		Name: swaggerRecord.Name,
+		Name: record.Name,
 		ID:   requestedID,
+		Configs: map[string]interface{}{
+			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
+		},
 	}
-	createdNetworks, err := configurator.CreateNetworks([]configurator.Network{network})
+
+	err = configurator.CreateNetwork(network)
 	if err != nil {
-		return "", err
+		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	return createdNetworks[0].ID, nil
+	return c.JSON(http.StatusCreated, requestedID)
 }
 
 func getNetwork(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-
-	record, err := magmad.GetNetwork(networkId)
+	network, err := configurator.LoadNetwork(networkID, true, false)
 	if err != nil {
-		return handlers.HttpError(err, http.StatusInternalServerError)
+		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	swaggerRecord := magmad_models.NetworkRecordFromProto(record)
-	return c.JSON(http.StatusOK, &swaggerRecord)
+
+	networkFeatures := &magmad_models.NetworkFeatures{}
+	features, ok := network.Configs[orc8r.NetworkFeaturesConfig]
+	if ok {
+		networkFeatures = features.(*magmad_models.NetworkFeatures)
+	}
+
+	record := magmad_models.NetworkRecord{
+		Name:     network.Name,
+		Features: networkFeatures.Features,
+	}
+	return c.JSON(http.StatusOK, &record)
 }
 
 func updateNetwork(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
 
-	swaggerRecord := &magmad_models.NetworkRecord{}
-	if err := c.Bind(&swaggerRecord); err != nil {
+	record := &magmad_models.NetworkRecord{}
+	if err := c.Bind(&record); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerRecord.ValidateModel(); err != nil {
+	if err := record.ValidateModel(); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
 
-	err := multiplexUpdateNetworkIntoConfigurator(networkId, swaggerRecord)
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex into configurator: %v", err), http.StatusInternalServerError)
-	}
-
-	return magmad.UpdateNetwork(networkId, swaggerRecord.ToProto())
-}
-
-func multiplexUpdateNetworkIntoConfigurator(networkID string, record *magmad_models.NetworkRecord) error {
-	exists, err := configurator.DoesNetworkExist(networkID)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		_, err := multiplexCreateNetworkIntoConfigurator(networkID, record)
-		return err
-	}
 	updateCriteria := configurator.NetworkUpdateCriteria{
 		ID:      networkID,
 		NewName: &record.Name,
+		ConfigsToAddOrUpdate: map[string]interface{}{
+			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
+		},
 	}
 	return configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
 }
 
 func deleteNetwork(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
 
-	force := c.QueryParam("mode")
-	var err error
-	if strings.ToUpper(force) == "FORCE" {
-		err = magmad.ForceRemoveNetwork(networkId)
-	} else {
-		err = magmad.RemoveNetwork(networkId)
-	}
-
+	err := configurator.DeleteNetwork(networkID)
 	if err != nil {
-		status := http.StatusInternalServerError
-		// TODO: conversion based on grpc code
-		return handlers.HttpError(err, status)
+		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-
-	// multiplex delete network into configurator
-	err = configurator.DeleteNetworks([]string{networkId})
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex into configurator: %v", err), http.StatusInternalServerError)
-	}
-
 	return c.NoContent(http.StatusNoContent)
 }

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers_legacy.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers_legacy.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	configuratorh "magma/orc8r/cloud/go/services/configurator/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/magmad"
+	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
+
+	"github.com/labstack/echo"
+)
+
+func listNetworksHandler(c echo.Context) error {
+	// Check for wildcard network access
+	nerr := handlers.CheckNetworkAccess(c, handlers.NETWORK_WILDCARD)
+	if nerr != nil {
+		return nerr
+	}
+	networks, err := magmad.ListNetworks()
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+
+	return c.JSON(http.StatusOK, networks)
+}
+
+func registerNetworkHandler(c echo.Context) error {
+	// Check for wildcard network access
+	nerr := handlers.CheckNetworkAccess(c, handlers.NETWORK_WILDCARD)
+	if nerr != nil {
+		return nerr
+	}
+
+	// Bind network record from swagger
+	swaggerRecord := &magmad_models.NetworkRecord{}
+	err := c.Bind(&swaggerRecord)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	if err := swaggerRecord.ValidateModel(); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	magmadRecord := swaggerRecord.ToProto()
+
+	var networkId string
+	requestedId := c.QueryParam("requested_id")
+	err = configuratorh.VerifyNetworkIDFormat(requestedId)
+	if err != nil {
+		return err
+	}
+	networkId, err = magmad.RegisterNetwork(magmadRecord, requestedId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusConflict)
+	}
+
+	return c.JSON(http.StatusCreated, networkId)
+}
+
+func getNetworkHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	record, err := magmad.GetNetwork(networkId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	swaggerRecord := magmad_models.NetworkRecordFromProto(record)
+	return c.JSON(http.StatusOK, &swaggerRecord)
+}
+
+func updateNetworkHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	swaggerRecord := &magmad_models.NetworkRecord{}
+	if err := c.Bind(&swaggerRecord); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	if err := swaggerRecord.ValidateModel(); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+
+	return magmad.UpdateNetwork(networkId, swaggerRecord.ToProto())
+}
+
+func deleteNetworkHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	force := c.QueryParam("mode")
+	var err error
+	if strings.ToUpper(force) == "FORCE" {
+		err = magmad.ForceRemoveNetwork(networkId)
+	} else {
+		err = magmad.RemoveNetwork(networkId)
+	}
+
+	if err != nil {
+		status := http.StatusInternalServerError
+		// TODO: conversion based on grpc code
+		return handlers.HttpError(err, status)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}


### PR DESCRIPTION
Summary:
Added a new configurator client_api DeleteNetwork that has the force boolean flag, which mimics the magmad DeleteNetwork behavior.

All magmad handler tests are moved to magmadh_legacy_test.go. And the tests for the new handlers are in magmadh_test.go.

NetworkFeatures is stored as a network config under config type "orc8r_features"

Reviewed By: xjtian

Differential Revision: D15926161

