### PR TITLE
Migrate magmad gateway REST handlers to use configurator

### DIFF
--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -8,8 +8,10 @@ LICENSE file in the root directory of this source tree.
 
 package orc8r
 
-const ModuleName string = "orc8r"
-
-const MagmadGatewayType = "magmad_gateway"
-
-const UpgradeTierEntityType = "upgrade_tier"
+const (
+	ModuleName            string = "orc8r"
+	MagmadGatewayType            = "magmad_gateway"
+	MagmadNetworkType            = "magmad_network"
+	UpgradeTierEntityType        = "upgrade_tier"
+	NetworkFeaturesConfig        = "orc8r_features"
+)

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -48,10 +48,6 @@ import (
 	"magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 )
 
-const (
-	NetworkFeaturesConfig = "orc8r_features"
-)
-
 // BaseOrchestratorPlugin is the OrchestratorPlugin for the orc8r module
 type BaseOrchestratorPlugin struct{}
 
@@ -78,7 +74,7 @@ func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 
 		// Config manager serdes
 		configurator.NewNetworkConfigSerde(dnsdconfig.DnsdNetworkType, &models2.NetworkDNSConfig{}),
-		configurator.NewNetworkConfigSerde(NetworkFeaturesConfig, &models3.NetworkFeatures{}),
+		configurator.NewNetworkConfigSerde(orc8r.NetworkFeaturesConfig, &models3.NetworkFeatures{}),
 
 		configurator.NewNetworkEntityConfigSerde(orc8r.MagmadGatewayType, &models3.MagmadGatewayConfig{}),
 		configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{}),

--- a/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/storage"
 
@@ -19,11 +20,16 @@ import (
 )
 
 // Gateway is a special type of network entity. Since magmad supports multiple
-// config types per gateway, each config if modeled as an entity with an
-// association to the gateway entity. This assumes that the configType passed
-// in is different from the entity type of the gateway.
+// config types per gateway, each config is modeled as an entity with an
+// association to the gateway entity. If the configType is "magmad_gateway" the
+// config will simply be stored inside the gateway entity
 
 func configuratorCreateGatewayConfig(c echo.Context, networkID string, configType string, configKey string, iConfig interface{}) error {
+	// If the type is magmad_gateway add the config to the gw entity
+	if configType == orc8r.MagmadGatewayType {
+		return configuratorCreateEntityConfig(c, networkID, configType, configKey, iConfig)
+	}
+
 	config, nerr := getConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
@@ -44,7 +50,7 @@ func configuratorCreateGatewayConfig(c echo.Context, networkID string, configTyp
 
 	_, err = configurator.UpdateEntity(networkID, configurator.EntityUpdateCriteria{
 		// hardcoded type to prevent import cycle
-		Type:              "magmad_gateway",
+		Type:              orc8r.MagmadGatewayType,
 		Key:               configKey,
 		AssociationsToAdd: []storage.TypeAndKey{{Type: configType, Key: configKey}},
 	})
@@ -55,6 +61,11 @@ func configuratorCreateGatewayConfig(c echo.Context, networkID string, configTyp
 }
 
 func configuratorDeleteGatewayConfig(c echo.Context, networkID string, configType string, configKey string) error {
+	// If the type is magmad_gateway remove config from the gateway entity
+	if configType == orc8r.MagmadGatewayType {
+		return configuratorDeleteEntityConfig(c, networkID, configType, configKey)
+	}
+
 	err := configurator.DeleteEntity(networkID, configType, configKey)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -103,13 +103,26 @@ func UpdateNetworks(updates []NetworkUpdateCriteria) error {
 	return err
 }
 
-// DeleteNetwork deletes the network specified by networkID
+// DeleteNetworks deletes the network specified by networkID
 func DeleteNetworks(networkIDs []string) error {
 	client, err := getNBConfiguratorClient()
 	if err != nil {
 		return err
 	}
 	_, err = client.DeleteNetworks(context.Background(), &protos.DeleteNetworksRequest{NetworkIDs: networkIDs})
+	return err
+}
+
+// DeleteNetwork deletes a network.
+func DeleteNetwork(networkID string) error {
+	client, err := getNBConfiguratorClient()
+	if err != nil {
+		return err
+	}
+	_, err = client.DeleteNetworks(
+		context.Background(),
+		&protos.DeleteNetworksRequest{NetworkIDs: []string{networkID}},
+	)
 	return err
 }
 
@@ -153,6 +166,17 @@ func LoadNetworks(networks []string, loadMetadata bool, loadConfigs bool) ([]Net
 		ret[i] = retNet
 	}
 	return ret, result.NetworkIDsNotFound, nil
+}
+
+func LoadNetwork(networkID string, loadMetadata bool, loadConfigs bool) (Network, error) {
+	networks, _, err := LoadNetworks([]string{networkID}, loadMetadata, loadConfigs)
+	if err != nil {
+		return Network{}, err
+	}
+	if len(networks) == 0 {
+		return Network{}, merrors.ErrNotFound
+	}
+	return networks[0], nil
 }
 
 func UpdateNetworkConfig(networkID, configType string, config interface{}) error {

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -396,8 +396,13 @@ func (store *sqlConfiguratorStorage) UpdateNetworks(updates []NetworkUpdateCrite
 		}
 	}
 
-	// Then delete all networks requested for deletion
-	_, err := store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
+	_, err := store.builder.Delete(networkConfigTable).Where(sq.Eq{nwcIDCol: networksToDelete}).
+		RunWith(store.tx).
+		Exec()
+	if err != nil {
+		return errors.Wrap(err, "failed to delete configs associated with networks")
+	}
+	_, err = store.builder.Delete(networksTable).Where(sq.Eq{nwIDCol: networksToDelete}).
 		RunWith(store.tx).
 		Exec()
 	if err != nil {

--- a/orc8r/cloud/go/services/configurator/storage/sql_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_test.go
@@ -355,6 +355,7 @@ func TestSqlConfiguratorStorage_UpdateNetworks(t *testing.T) {
 			upsertStmt.ExpectExec().WithArgs("n4", "foo", []byte("bar"), []byte("bar")).WillReturnResult(mockResult)
 			m.ExpectExec("DELETE FROM cfg_network_configs").WithArgs("n4", "hello", "n4", "world").WillReturnResult(mockResult)
 
+			m.ExpectExec("DELETE FROM cfg_network_configs").WithArgs("n1").WillReturnResult(mockResult)
 			m.ExpectExec("DELETE FROM cfg_networks").WithArgs("n1").WillReturnResult(mockResult)
 		},
 		run: runFactory(

--- a/orc8r/cloud/go/services/magmad/config/managers.go
+++ b/orc8r/cloud/go/services/magmad/config/managers.go
@@ -18,10 +18,6 @@ import (
 	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
 )
 
-const (
-	MagmadNetworkType = "magmad_network"
-)
-
 // To be deprecated! Config service DB tables have been seeded with magmad
 // network configs that were migrated from legacy magmad network configs,
 // so this will stick around for a bit. We can delete this after deleting
@@ -34,7 +30,7 @@ func (*MagmadNetworkConfigManager) GetDomain() string {
 }
 
 func (*MagmadNetworkConfigManager) GetType() string {
-	return MagmadNetworkType
+	return orc8r.MagmadNetworkType
 }
 
 func (*MagmadNetworkConfigManager) Serialize(config interface{}) ([]byte, error) {

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers.go
@@ -17,18 +17,16 @@ import (
 
 	"magma/orc8r/cloud/go/datastore"
 	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/configurator"
-	configurator_utils "magma/orc8r/cloud/go/services/configurator/obsidian/handler_utils"
 	"magma/orc8r/cloud/go/services/device"
 	deviceprotos "magma/orc8r/cloud/go/services/device/protos"
 	"magma/orc8r/cloud/go/services/magmad"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory"
 	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
-	magmadprotos "magma/orc8r/cloud/go/services/magmad/protos"
 	"magma/orc8r/cloud/go/storage"
 
-	"github.com/golang/glog"
 	"github.com/labstack/echo"
 )
 
@@ -45,7 +43,7 @@ const (
 	TailGatewayLogs       = CommandRoot + "/tail_logs"
 )
 
-func getListGatewaysHandler(factory view_factory.FullGatewayViewFactory) func(echo.Context) error {
+func getListGateways(factory view_factory.FullGatewayViewFactory) func(echo.Context) error {
 	return func(c echo.Context) error {
 		fields := c.QueryParam("view")
 		if fields == "full" {
@@ -56,183 +54,133 @@ func getListGatewaysHandler(factory view_factory.FullGatewayViewFactory) func(ec
 }
 
 func listGateways(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-	gatewayIds, err := magmad.ListGateways(networkId)
+	gatewayIDs, err := configurator.ListEntityKeys(networkID, orc8r.MagmadGatewayType)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 
 	// Return a deterministic ordering of IDs
-	sort.Strings(gatewayIds)
-	return c.JSON(http.StatusOK, gatewayIds)
+	sort.Strings(gatewayIDs)
+	return c.JSON(http.StatusOK, gatewayIDs)
 }
 
-func registerGateway(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+func createGateway(c echo.Context) error {
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-	swaggerRecord := &magmad_models.AccessGatewayRecord{}
-	if err := c.Bind(swaggerRecord); err != nil {
+	record := &magmad_models.AccessGatewayRecord{}
+	if err := c.Bind(record); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerRecord.Verify(); err != nil {
+	if err := record.Verify(); err != nil {
 		return handlers.HttpError(
 			fmt.Errorf("Invalid Gateway Record, Error: %s", err),
 			http.StatusBadRequest)
 	}
-	record, err := swaggerRecord.ToMconfig()
-	if err != nil {
-		return handlers.HttpError(err, http.StatusUnsupportedMediaType)
-	}
 
-	var gatewayId string
-	requestedId := c.QueryParam("requested_id")
-	if len(requestedId) > 0 {
+	gatewayID := c.QueryParam("requested_id")
+	if len(gatewayID) > 0 {
 		r, _ := regexp.Compile("^[a-zA-Z_][0-9a-zA-Z_-]+$")
-		if !r.MatchString(requestedId) {
+		if !r.MatchString(gatewayID) {
 			return handlers.HttpError(
 				fmt.Errorf("Gateway ID '%s' is not allowed. Gateway ID can only contain "+
-					"alphanumeric characters and underscore, and should start with a letter or underscore.", requestedId),
+					"alphanumeric characters and underscore, and should start with a letter or underscore.", gatewayID),
 				http.StatusBadRequest,
 			)
 		}
-		gatewayId, err = magmad.RegisterGatewayWithId(networkId, record, requestedId)
 	} else {
-		gatewayId, err = magmad.RegisterGateway(networkId, record)
+		gatewayID = record.HwID.ID
 	}
 
+	if device.DoesDeviceExist(networkID, device.GatewayInfoType, record.HwID.ID) {
+		return fmt.Errorf("Hwid is already registered %s", record.HwID.ID)
+	}
+	// write into device
+	err := device.CreateOrUpdate(networkID, device.GatewayInfoType, record.HwID.ID, record)
 	if err != nil {
-		return handlers.HttpError(err, http.StatusConflict)
-	}
-
-	err = multiplexGatewayCreateIntoDeviceAndConfigurator(networkId, gatewayId, swaggerRecord)
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex write into configurator/device %v", err), http.StatusInternalServerError)
-	}
-
-	return c.JSON(http.StatusCreated, gatewayId)
-}
-
-func multiplexGatewayCreateIntoDeviceAndConfigurator(networkID, gatewayID string, gwRecord *magmad_models.AccessGatewayRecord) error {
-	err := configurator_utils.CreateNetworkIfNotExists(networkID)
-	if err != nil {
-		return err
-	}
-
-	if device.DoesDeviceExist(networkID, device.GatewayInfoType, gwRecord.HwID.ID) {
-		return fmt.Errorf("Hwid is already registered %s", gwRecord.HwID.ID)
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 	// write into configurator
 	gwEntity := configurator.NetworkEntity{
-		Name:       gwRecord.Name,
-		Type:       configurator.GatewayEntityType,
+		Name:       record.Name,
+		Type:       orc8r.MagmadGatewayType,
 		Key:        gatewayID,
-		PhysicalID: gwRecord.HwID.ID,
+		PhysicalID: record.HwID.ID,
 	}
-	_, err = configurator.CreateEntities(networkID, []configurator.NetworkEntity{gwEntity})
+	_, err = configurator.CreateEntity(networkID, gwEntity)
 	if err != nil {
-		return err
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 
-	// write into device
-	return device.CreateOrUpdate(networkID, device.GatewayInfoType, gwRecord.HwID.ID, gwRecord)
+	return c.JSON(http.StatusCreated, gatewayID)
 }
 
 func getGateway(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-	lid, gerr := handlers.GetLogicalGwId(c)
-	if gerr != nil {
-		return gerr
-	}
-	swaggerRecord, err := getSwaggerGWRecordFromMagmad(networkId, lid)
-	if err != nil {
-		return err
+	gatewayID, nerr := handlers.GetLogicalGwId(c)
+	if nerr != nil {
+		return nerr
 	}
 
-	return c.JSON(http.StatusOK, swaggerRecord)
-}
+	record := &magmad_models.AccessGatewayRecord{}
 
-func getSwaggerGWRecordFromMagmad(networkID, logicalID string) (*magmad_models.AccessGatewayRecord, error) {
-	record, err := magmad.FindGatewayRecord(networkID, logicalID)
+	gatewayEntity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadMetadata: true})
 	if err != nil {
-		return nil, handlers.HttpError(err, http.StatusNotFound)
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
-	swaggerRecord := magmad_models.AccessGatewayRecord{}
-	err = swaggerRecord.FromMconfig(record)
+	deviceEntity, err := device.GetDevice(networkID, device.GatewayInfoType, gatewayEntity.PhysicalID)
 	if err != nil {
-		return nil, handlers.HttpError(err, http.StatusUnsupportedMediaType)
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
-	return &swaggerRecord, nil
+	record.HwID = &magmad_models.HwGatewayID{ID: gatewayEntity.PhysicalID}
+	record.Name = gatewayEntity.Name
+	record.Key = deviceEntity.(*magmad_models.AccessGatewayRecord).Key
+
+	return c.JSON(http.StatusOK, record)
 }
 
 func updateGateway(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-	lid, gerr := handlers.GetLogicalGwId(c)
+	gatewayID, gerr := handlers.GetLogicalGwId(c)
 	if gerr != nil {
 		return gerr
 	}
 
-	swaggerRecord := magmad_models.MutableGatewayRecord{}
-	if berr := c.Bind(&swaggerRecord); berr != nil {
+	record := magmad_models.MutableGatewayRecord{}
+	if berr := c.Bind(&record); berr != nil {
 		return handlers.HttpError(berr, http.StatusBadRequest)
 	}
-	if err := swaggerRecord.Verify(); err != nil {
+	if err := record.Verify(); err != nil {
 		return handlers.HttpError(
 			fmt.Errorf("Invalid Gateway Record, Error: %s", err),
 			http.StatusBadRequest)
 	}
-	record := magmadprotos.AccessGatewayRecord{}
-	berr := swaggerRecord.ToMconfig(&record)
-	if berr != nil {
-		return handlers.HttpError(berr, http.StatusUnsupportedMediaType)
-	}
-	err := magmad.UpdateGatewayRecord(networkId, lid, &record)
-	if err != nil {
-		return handlers.HttpError(err, http.StatusConflict)
-	}
 
-	err = multiplexGatewayUpdateIntoDeviceAndConfigurator(networkId, lid, &swaggerRecord)
+	err := updateChallengeKey(networkID, gatewayID, record.Key)
 	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex update into configurator/device %v", err), http.StatusInternalServerError)
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	err = updateGatewayName(networkID, gatewayID, record.Name)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 
 	return c.NoContent(http.StatusOK)
 }
 
-func multiplexGatewayUpdateIntoDeviceAndConfigurator(networkID, gatewayID string, updateRecord *magmad_models.MutableGatewayRecord) error {
-	entityExists, err := configurator.DoesEntityExist(networkID, configurator.GatewayEntityType, gatewayID)
-	if err != nil {
-		return err
-	}
-	if !entityExists {
-		// fetch the existing gw record from magmad to get the HWID since it is needed for the device service
-		storedRecord, err := getSwaggerGWRecordFromMagmad(networkID, gatewayID)
-		if err != nil {
-			return err
-		}
-		storedRecord.Name = updateRecord.Name
-		storedRecord.Key = updateRecord.Key
-		return multiplexGatewayCreateIntoDeviceAndConfigurator(networkID, gatewayID, storedRecord)
-	}
-	err = updateChallengeKey(networkID, gatewayID, updateRecord.Key)
-	if err != nil {
-		return err
-	}
-	return updateGatewayName(networkID, gatewayID, updateRecord.Name)
-}
-
 func updateChallengeKey(networkID, gatewayID string, challengeKey *magmad_models.ChallengeKey) error {
-	deviceID, err := configurator.GetPhysicalIDOfEntity(networkID, configurator.GatewayEntityType, gatewayID)
+	deviceID, err := configurator.GetPhysicalIDOfEntity(networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
 		return err
 	}
@@ -251,7 +199,7 @@ func updateChallengeKey(networkID, gatewayID string, challengeKey *magmad_models
 func updateGatewayName(networkID, gatewayID, name string) error {
 	updateRequest := configurator.EntityUpdateCriteria{
 		Key:     gatewayID,
-		Type:    configurator.GatewayEntityType,
+		Type:    orc8r.MagmadGatewayType,
 		NewName: &name,
 	}
 	_, err := configurator.UpdateEntities(networkID, []configurator.EntityUpdateCriteria{updateRequest})
@@ -259,39 +207,29 @@ func updateGatewayName(networkID, gatewayID, name string) error {
 }
 
 func deleteGateway(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-	lid, gerr := handlers.GetLogicalGwId(c)
+	gatewayID, gerr := handlers.GetLogicalGwId(c)
 	if gerr != nil {
 		return gerr
 	}
 
-	err := magmad.RemoveGateway(networkId, lid)
+	physicalID, err := configurator.GetPhysicalIDOfEntity(networkID, orc8r.MagmadGatewayType, gatewayID)
 	if err != nil {
-		return handlers.HttpError(err, http.StatusNotFound)
-	}
-
-	err = multiplexGatewayDeleteIntoDeviceAndConfigurator(networkId, lid)
-	if err != nil {
-		glog.Errorf("Failed to multiplex delete into configurator/device %v", err)
-	}
-
-	return c.NoContent(http.StatusNoContent)
-}
-
-func multiplexGatewayDeleteIntoDeviceAndConfigurator(networkID, gatewayID string) error {
-	physicalID, err := configurator.GetPhysicalIDOfEntity(networkID, configurator.GatewayEntityType, gatewayID)
-	if err != nil {
-		return err
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 	err = device.DeleteDevices(networkID, []*deviceprotos.DeviceID{{DeviceID: physicalID, Type: device.GatewayInfoType}})
 	if err != nil {
-		return err
+		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
-	return configurator.DeleteEntities(networkID, []storage.TypeAndKey{{Key: gatewayID, Type: configurator.GatewayEntityType}})
+	err = configurator.DeleteEntities(networkID, []storage.TypeAndKey{{Key: gatewayID, Type: orc8r.MagmadGatewayType}})
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
 
+	return c.NoContent(http.StatusNoContent)
 }
 
 func rebootGateway(c echo.Context) error {

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers_legacy.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers_legacy.go
@@ -1,0 +1,171 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/magmad"
+	"magma/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory"
+	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	magmadprotos "magma/orc8r/cloud/go/services/magmad/protos"
+
+	"github.com/labstack/echo"
+)
+
+func getListGatewaysHandler(factory view_factory.FullGatewayViewFactory) func(echo.Context) error {
+	return func(c echo.Context) error {
+		fields := c.QueryParam("view")
+		if fields == "full" {
+			return ListFullGatewayViews(c, factory)
+		}
+		return listGatewaysHandler(c)
+	}
+}
+
+func listGatewaysHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+	gatewayIds, err := magmad.ListGateways(networkId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+
+	// Return a deterministic ordering of IDs
+	sort.Strings(gatewayIds)
+	return c.JSON(http.StatusOK, gatewayIds)
+}
+
+func createGatewayHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+	swaggerRecord := &magmad_models.AccessGatewayRecord{}
+	if err := c.Bind(swaggerRecord); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	if err := swaggerRecord.Verify(); err != nil {
+		return handlers.HttpError(
+			fmt.Errorf("Invalid Gateway Record, Error: %s", err),
+			http.StatusBadRequest)
+	}
+	record, err := swaggerRecord.ToMconfig()
+	if err != nil {
+		return handlers.HttpError(err, http.StatusUnsupportedMediaType)
+	}
+
+	var gatewayId string
+	requestedId := c.QueryParam("requested_id")
+	if len(requestedId) > 0 {
+		r, _ := regexp.Compile("^[a-zA-Z_][0-9a-zA-Z_-]+$")
+		if !r.MatchString(requestedId) {
+			return handlers.HttpError(
+				fmt.Errorf("Gateway ID '%s' is not allowed. Gateway ID can only contain "+
+					"alphanumeric characters and underscore, and should start with a letter or underscore.", requestedId),
+				http.StatusBadRequest,
+			)
+		}
+		gatewayId, err = magmad.RegisterGatewayWithId(networkId, record, requestedId)
+	} else {
+		gatewayId, err = magmad.RegisterGateway(networkId, record)
+	}
+
+	if err != nil {
+		return handlers.HttpError(err, http.StatusConflict)
+	}
+
+	return c.JSON(http.StatusCreated, gatewayId)
+}
+
+func getGatewayHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+	lid, gerr := handlers.GetLogicalGwId(c)
+	if gerr != nil {
+		return gerr
+	}
+	swaggerRecord, err := getSwaggerGWRecordFromMagmad(networkId, lid)
+	if err != nil {
+		return err
+	}
+
+	return c.JSON(http.StatusOK, swaggerRecord)
+}
+
+func updateGatewayHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+	lid, gerr := handlers.GetLogicalGwId(c)
+	if gerr != nil {
+		return gerr
+	}
+
+	swaggerRecord := magmad_models.MutableGatewayRecord{}
+	if berr := c.Bind(&swaggerRecord); berr != nil {
+		return handlers.HttpError(berr, http.StatusBadRequest)
+	}
+	if err := swaggerRecord.Verify(); err != nil {
+		return handlers.HttpError(
+			fmt.Errorf("Invalid Gateway Record, Error: %s", err),
+			http.StatusBadRequest)
+	}
+	record := magmadprotos.AccessGatewayRecord{}
+	berr := swaggerRecord.ToMconfig(&record)
+	if berr != nil {
+		return handlers.HttpError(berr, http.StatusUnsupportedMediaType)
+	}
+	err := magmad.UpdateGatewayRecord(networkId, lid, &record)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusConflict)
+	}
+
+	return c.NoContent(http.StatusOK)
+}
+
+func deleteGatewayHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+	lid, gerr := handlers.GetLogicalGwId(c)
+	if gerr != nil {
+		return gerr
+	}
+
+	err := magmad.RemoveGateway(networkId, lid)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusNotFound)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}
+
+func getSwaggerGWRecordFromMagmad(networkID, logicalID string) (*magmad_models.AccessGatewayRecord, error) {
+	record, err := magmad.FindGatewayRecord(networkID, logicalID)
+	if err != nil {
+		return nil, handlers.HttpError(err, http.StatusNotFound)
+	}
+	swaggerRecord := magmad_models.AccessGatewayRecord{}
+	err = swaggerRecord.FromMconfig(record)
+	if err != nil {
+		return nil, handlers.HttpError(err, http.StatusUnsupportedMediaType)
+	}
+	return &swaggerRecord, nil
+}

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/gateways_full_legacy_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/gateways_full_legacy_test.go
@@ -1,10 +1,10 @@
 /*
-Copyright (c) Facebook, Inc. and its affiliates.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package handlers_test
 
@@ -24,11 +24,10 @@ import (
 
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
-func TestGetViewsForNetwork(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestGetViewsForNetworkLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	// Set up test
 	mockStore := &mocks.FullGatewayViewFactory{}
 	config.TLS = false
@@ -68,8 +67,8 @@ func TestGetViewsForNetwork(t *testing.T) {
 	mockStore.AssertNumberOfCalls(t, "GetGatewayViewsForNetwork", 1)
 }
 
-func TestGetViewsForNetworkEmptyResponse(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestGetViewsForNetworkEmptyResponseLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	mockStore := &mocks.FullGatewayViewFactory{}
 	config.TLS = false
 
@@ -95,51 +94,12 @@ func TestGetViewsForNetworkEmptyResponse(t *testing.T) {
 	mockStore.AssertNumberOfCalls(t, "GetGatewayViewsForNetwork", 1)
 }
 
-func TestGetGatewayViews_QueryType1(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestGetGatewayViews_QueryType1Legacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	testGetGatewayViews(t, "gateway_ids=gw0,gw1,badgw")
 }
 
-func TestGetGatewayViews_QueryType2(t *testing.T) {
-	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
+func TestGetGatewayViews_QueryType2Legacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
 	testGetGatewayViews(t, "gateway_ids[0]=gw0&gateway_ids[1]=gw1&gateway_ids[2]=badgw")
-}
-
-func testGetGatewayViews(t *testing.T, queryString string) {
-	mockStore := &mocks.FullGatewayViewFactory{}
-	config.TLS = false
-
-	networkID := "net1"
-	gatewayIDs := []string{"gw0", "gw1", "badgw"}
-	gatewayStates := map[string]*view_factory.GatewayState{
-		"gw0": {GatewayID: "gw0"},
-		"gw1": {GatewayID: "gw1"},
-	}
-	modelStates := []*models.GatewayStateType{
-		{GatewayID: "gw0"},
-		{GatewayID: "gw1"},
-	}
-
-	mockStore.On("GetGatewayViews", networkID, mock.MatchedBy(func(input []string) bool {
-		return assert.ElementsMatch(t, gatewayIDs, input)
-	})).Return(gatewayStates, nil)
-
-	e := echo.New()
-	req := httptest.NewRequest(echo.GET, "/", nil)
-	req.URL.RawQuery = queryString
-	rec := httptest.NewRecorder()
-	c := e.NewContext(req, rec)
-	c.SetParamNames("network_id")
-	c.SetParamValues(networkID)
-
-	err := magmadh.ListFullGatewayViews(c, mockStore)
-	assert.NoError(t, err)
-	assert.Equal(t, http.StatusOK, rec.Code)
-
-	var actualModelStates []*models.GatewayStateType
-	err = json.Unmarshal(rec.Body.Bytes(), &actualModelStates)
-	assert.NoError(t, err)
-	assert.Equal(t, 2, len(actualModelStates))
-	assert.ElementsMatch(t, modelStates, actualModelStates)
-	mockStore.AssertNumberOfCalls(t, "GetGatewayViews", 1)
 }

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/handlers.go
@@ -27,11 +27,13 @@ func GetObsidianHandlers() []handlers.Handler {
 		{Path: ManageNetwork, Methods: handlers.DELETE, HandlerFunc: deleteNetworkHandler, MigratedHandlerFunc: deleteNetwork},
 
 		// Gateway
-		{Path: RegisterAG, Methods: handlers.GET, HandlerFunc: getListGatewaysHandler(&view_factory.FullGatewayViewFactoryImpl{})},
-		{Path: RegisterAG, Methods: handlers.POST, HandlerFunc: registerGateway},
-		{Path: ManageAG, Methods: handlers.GET, HandlerFunc: getGateway},
-		{Path: ManageAG, Methods: handlers.PUT, HandlerFunc: updateGateway},
-		{Path: ManageAG, Methods: handlers.DELETE, HandlerFunc: deleteGateway},
+		{Path: RegisterAG, Methods: handlers.GET,
+			HandlerFunc:         getListGatewaysHandler(&view_factory.FullGatewayViewFactoryImpl{}),
+			MigratedHandlerFunc: getListGateways(&view_factory.FullGatewayViewFactoryImpl{})},
+		{Path: RegisterAG, Methods: handlers.POST, HandlerFunc: createGatewayHandler, MigratedHandlerFunc: createGateway},
+		{Path: ManageAG, Methods: handlers.GET, HandlerFunc: getGatewayHandler, MigratedHandlerFunc: getGateway},
+		{Path: ManageAG, Methods: handlers.PUT, HandlerFunc: updateGatewayHandler, MigratedHandlerFunc: updateGateway},
+		{Path: ManageAG, Methods: handlers.DELETE, HandlerFunc: deleteGatewayHandler, MigratedHandlerFunc: deleteGateway},
 
 		// Gateway Commands
 		{Path: RebootGateway, Methods: handlers.POST, HandlerFunc: rebootGateway},

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/handlers.go
@@ -20,11 +20,11 @@ import (
 func GetObsidianHandlers() []handlers.Handler {
 	return []handlers.Handler{
 		// Network
-		{Path: ListNetworks, Methods: handlers.GET, HandlerFunc: listNetworks},
-		{Path: RegisterNetwork, Methods: handlers.POST, HandlerFunc: registerNetwork},
-		{Path: ManageNetwork, Methods: handlers.GET, HandlerFunc: getNetwork},
-		{Path: ManageNetwork, Methods: handlers.PUT, HandlerFunc: updateNetwork},
-		{Path: ManageNetwork, Methods: handlers.DELETE, HandlerFunc: deleteNetwork},
+		{Path: ListNetworks, Methods: handlers.GET, HandlerFunc: listNetworksHandler, MigratedHandlerFunc: listNetworks},
+		{Path: RegisterNetwork, Methods: handlers.POST, HandlerFunc: registerNetworkHandler, MigratedHandlerFunc: registerNetwork},
+		{Path: ManageNetwork, Methods: handlers.GET, HandlerFunc: getNetworkHandler, MigratedHandlerFunc: getNetwork},
+		{Path: ManageNetwork, Methods: handlers.PUT, HandlerFunc: updateNetworkHandler, MigratedHandlerFunc: updateNetwork},
+		{Path: ManageNetwork, Methods: handlers.DELETE, HandlerFunc: deleteNetworkHandler, MigratedHandlerFunc: deleteNetwork},
 
 		// Gateway
 		{Path: RegisterAG, Methods: handlers.GET, HandlerFunc: getListGatewaysHandler(&view_factory.FullGatewayViewFactoryImpl{})},

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_legacy_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_legacy_test.go
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
+	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMagmadLegacy(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "0")
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	magmad_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	device_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
+	restPort := tests.StartObsidian(t)
+
+	testUrlRoot := fmt.Sprintf(
+		"http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
+
+	// Test List Networks
+	listCloudsTestCase := tests.Testcase{
+		Name:     "List Networks",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: `[]`,
+	}
+	tests.RunTest(t, listCloudsTestCase)
+
+	// Test Register Network with requestedId
+	registerNetworkWithIdTestCase := tests.Testcase{
+		Name:                      "Register Network with Requested Id",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obsidian_test_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+		Expected:                  `"magmad_obsidian_test_network"`,
+	}
+	tests.RunTest(t, registerNetworkWithIdTestCase)
+
+	// Test Removal Of Empty Network
+	removeNetworkTestCase := tests.Testcase{
+		Name:     "Remove Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, "magmad_obsidian_test_network"),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Register Network with invalid requestedId
+	registerNetworkWithInvalidIdTestCase := tests.Testcase{
+		Name:                      "Register Network with Invalid Requested Id",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=00*my_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerNetworkWithInvalidIdTestCase)
+
+	// Register network with uppercase requestedId
+	registerNetworkWithInvalidIdTestCase = tests.Testcase{
+		Name:                      "Register Network with Invalid Requested Id",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=Magmad_obsidian_test_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerNetworkWithInvalidIdTestCase)
+
+	// Test Register Network
+	registerNetworkTestCase := tests.Testcase{
+		Name:                      "Register Network",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obsidian_test_network", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+	}
+	_, networkId, _ := tests.RunTest(t, registerNetworkTestCase)
+
+	json.Unmarshal([]byte(networkId), &networkId)
+
+	// Test Register AG with invalid requestedId
+	registerAGWithInvalidIdTestCase := tests.Testcase{
+		Name:   "Register AG with Invalid Requested Id",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, "*00_bad_ag"),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId12345"}, "name": "Test AG Name", "key": {"key_type": "ECHO"}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGWithInvalidIdTestCase)
+
+	// Test Register AG with requestedId
+	requestedAGId := "my_gateway-1"
+	registerAGWithIdTestCase := tests.Testcase{
+		Name:   "Register AG with Requested Id",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, requestedAGId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId00001"}, "name": "Test AG Name",  "key": {"key_type": "ECHO"}}`,
+		Expected: fmt.Sprintf(`"%s"`, requestedAGId),
+	}
+	tests.RunTest(t, registerAGWithIdTestCase)
+
+	// Test Register AG
+	registerAGTestCase := tests.Testcase{
+		Name:     "Register AG",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId00002"}, "name": "Test AG Name", "key": {"key_type": "SOFTWARE_ECDSA_SHA256", "key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC"}}`,
+		Expected: `"TestAGHwId00002"`,
+	}
+	tests.RunTest(t, registerAGTestCase)
+
+	// Test Register without key
+	registerAGTestCaseNoKey := tests.Testcase{
+		Name:                      "Register AG without Key",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseNoKey)
+
+	// Test Register without key content
+	registerAGTestCaseNoKeyContent := tests.Testcase{
+		Name:                      "Register AG with Key but no Key Content",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256"}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseNoKeyContent)
+
+	// Test Register with wrong key content
+	registerAGTestCaseWrongKeyContent := tests.Testcase{
+		Name:                      "Register AG with Key but Wrong Key Content",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256", "key":"AAAAAAAAAAAAAAAAAAAAAA=="}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseWrongKeyContent)
+
+	// Test Getting AG record
+	getAGRecordTestCase := tests.Testcase{
+		Name:   "Get AG Record With Specified Name",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/%s",
+			testUrlRoot, networkId, requestedAGId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00001"},"key":{"key_type":"ECHO"},"name":"Test AG Name"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	getAGRecordTestCase = tests.Testcase{
+		Name:     "Get AG Record With Default Name",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00002"},"key":{"key":"MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC","key_type":"SOFTWARE_ECDSA_SHA256"},"name":"Test AG Name"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	// Test Updating AG record
+	setAGRecordTestCase := tests.Testcase{
+		Name:     "Update AG Record Name",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  `{"name": "SoDoSoPaTown Tower", "key": {"key_type": "ECHO"}}`,
+		Expected: "",
+	}
+	tests.RunTest(t, setAGRecordTestCase)
+
+	// Test Getting AG record 2
+	getAGRecordTestCase = tests.Testcase{
+		Name:     "Get AG Record With Modified Name",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00002"}, "key": {"key_type": "ECHO"}, "name": "SoDoSoPaTown Tower"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	// Test Listing All Registered AGs
+	listAGsTestCase := tests.Testcase{
+		Name:                      "List Registered AGs",
+		Method:                    "GET",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   "",
+		Expected:                  "",
+		Skip_payload_verification: true,
+	}
+	_, r, _ := tests.RunTest(t, listAGsTestCase)
+
+	exp1 := fmt.Sprintf(`["TestAGHwId00002","%s"]`, requestedAGId)
+	exp2 := fmt.Sprintf(`["%s","TestAGHwId00002"]`, requestedAGId)
+
+	if r != exp1 && r != exp2 {
+		t.Fatalf("***** %s test failed, received: %s\n***** Expected: %s or %s",
+			listAGsTestCase.Name, r, exp1, exp2)
+	}
+
+	// Test Removal Of Non Empty Network
+	removeNetworkTestCase = tests.Testcase{
+		Name:                      "Remove Non Empty Network",
+		Method:                    "DELETE",
+		Url:                       fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:                   "",
+		Expected:                  "",
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Forced Removal
+	removeNetworkTestCase = tests.Testcase{
+		Name:     "Force Remove Non Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s?mode=force", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Register Network
+	registerNetworkTestCase = tests.Testcase{
+		Name:                      "Register Network 2",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obisidian_test_network2", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+	}
+	_, networkId, _ = tests.RunTest(t, registerNetworkTestCase)
+
+	json.Unmarshal([]byte(networkId), &networkId)
+
+	// Test Register AG
+	registerAGTestCase = tests.Testcase{
+		Name:     "Register AG 2",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId12345"}, "key": {"key_type": "ECHO"}}`,
+		Expected: `"TestAGHwId12345"`,
+	}
+	tests.RunTest(t, registerAGTestCase)
+
+	// Test Listing All Registered AGs
+	listAGsTestCase = tests.Testcase{
+		Name:     "List Registered AGs 2",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `["TestAGHwId12345"]`,
+	}
+	tests.RunTest(t, listAGsTestCase)
+
+	expCfg := &models.MagmadGatewayConfig{}
+	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
+	assert.NoError(t, err)
+	marshaledCfg, err := expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr := string(marshaledCfg)
+
+	// Test Getting AG Configs
+	createAGConfigTestCase := tests.Testcase{
+		Name:     "Create AG Configs",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs", testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: `"TestAGHwId12345"`,
+	}
+	tests.RunTest(t, createAGConfigTestCase)
+
+	getAGConfigTestCase := tests.Testcase{
+		Name:   "Get AG Configs",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getAGConfigTestCase)
+
+	expCfg.Tier = "changed"
+	marshaledCfg, err = expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	// Test Setting (Updating) AG Configs
+	setAGConfigTestCase := tests.Testcase{
+		Name:   "Set AG Configs",
+		Method: "PUT",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: "",
+	}
+	tests.RunTest(t, setAGConfigTestCase)
+
+	// Test Getting AG Configs After Config Update
+	getAGConfigTestCase2 := tests.Testcase{
+		Name:   "Get AG Configs 2",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getAGConfigTestCase2)
+
+	// Update network wide property
+	//
+	// Get Current Network Record
+	networkCfg := &models.NetworkRecord{Name: "This Is A Test Network Name"}
+	marshaledCfg, err = networkCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	getNetworkRecordTestCase := tests.Testcase{
+		Name:     "Get Network Record",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getNetworkRecordTestCase)
+
+	networkCfg.Name = "Updated Network Name"
+	marshaledCfg, err = networkCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	updateNetworkRecordTestCase := tests.Testcase{
+		Name:     "Update Network Record",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: "",
+	}
+	tests.RunTest(t, updateNetworkRecordTestCase)
+
+	getNetworkRecordTestCase2 := tests.Testcase{
+		Name:     "Get Network Record after Update",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getNetworkRecordTestCase2)
+
+	// Test AG Unregister
+	setAGUnregisterTestCase := tests.Testcase{
+		Name:   "Unregister AG",
+		Method: "DELETE",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, setAGUnregisterTestCase)
+
+	// Test Listing All Registered AGs after Removal Of AG
+	listAGsTestCase2 := tests.Testcase{
+		Name:     "List Registered AGs",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `[]`, // should return an empty array
+	}
+	tests.RunTest(t, listAGsTestCase2)
+
+	// Test List Networks
+	listNetworksTestCase := tests.Testcase{
+		Name:     "List Networks",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: fmt.Sprintf(`["%s"]`, networkId),
+	}
+	tests.RunTest(t, listNetworksTestCase)
+
+	// Test Removal Of Empty Network
+	removeNetworkTestCase = tests.Testcase{
+		Name:     "Remove Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test List Networks
+	listNetworksTestCase = tests.Testcase{
+		Name:     "List Networks Post Delete",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: "[]",
+	}
+	tests.RunTest(t, listNetworksTestCase)
+}

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
@@ -21,8 +21,11 @@ import (
 	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
+	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
 	"magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestMagmad(t *testing.T) {
@@ -101,6 +104,319 @@ func TestMagmad(t *testing.T) {
 	_, networkId, _ := tests.RunTest(t, registerNetworkTestCase)
 
 	json.Unmarshal([]byte(networkId), &networkId)
+
+	// Test Register AG with invalid requestedId
+	registerAGWithInvalidIdTestCase := tests.Testcase{
+		Name:   "Register AG with Invalid Requested Id",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, "*00_bad_ag"),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId12345"}, "name": "Test AG Name", "key": {"key_type": "ECHO"}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGWithInvalidIdTestCase)
+
+	// Test Register AG with requestedId
+	requestedAGId := "my_gateway-1"
+	registerAGWithIdTestCase := tests.Testcase{
+		Name:   "Register AG with Requested Id",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, requestedAGId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId00001"}, "name": "Test AG Name",  "key": {"key_type": "ECHO"}}`,
+		Expected: fmt.Sprintf(`"%s"`, requestedAGId),
+	}
+	tests.RunTest(t, registerAGWithIdTestCase)
+
+	// Test Register AG
+	registerAGTestCase := tests.Testcase{
+		Name:     "Register AG",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId00002"}, "name": "Test AG Name", "key": {"key_type": "SOFTWARE_ECDSA_SHA256", "key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC"}}`,
+		Expected: `"TestAGHwId00002"`,
+	}
+	tests.RunTest(t, registerAGTestCase)
+
+	// Test Register without key
+	registerAGTestCaseNoKey := tests.Testcase{
+		Name:                      "Register AG without Key",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseNoKey)
+
+	// Test Register without key content
+	registerAGTestCaseNoKeyContent := tests.Testcase{
+		Name:                      "Register AG with Key but no Key Content",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256"}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseNoKeyContent)
+
+	// Test Register with wrong key content
+	registerAGTestCaseWrongKeyContent := tests.Testcase{
+		Name:                      "Register AG with Key but Wrong Key Content",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256", "key":"AAAAAAAAAAAAAAAAAAAAAA=="}}`,
+		Skip_payload_verification: true,
+		Expect_http_error_status:  true,
+	}
+	tests.RunTest(t, registerAGTestCaseWrongKeyContent)
+
+	// Test Getting AG record
+	getAGRecordTestCase := tests.Testcase{
+		Name:   "Get AG Record With Specified Name",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/%s",
+			testUrlRoot, networkId, requestedAGId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00001"},"key":{"key_type":"ECHO"},"name":"Test AG Name"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	getAGRecordTestCase = tests.Testcase{
+		Name:     "Get AG Record With Default Name",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00002"},"key":{"key":"MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC","key_type":"SOFTWARE_ECDSA_SHA256"},"name":"Test AG Name"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	// Test Updating AG record
+	setAGRecordTestCase := tests.Testcase{
+		Name:     "Update AG Record Name",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  `{"name": "SoDoSoPaTown Tower", "key": {"key_type": "ECHO"}}`,
+		Expected: "",
+	}
+	tests.RunTest(t, setAGRecordTestCase)
+
+	// Test Getting AG record 2
+	getAGRecordTestCase = tests.Testcase{
+		Name:     "Get AG Record With Modified Name",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"hw_id":{"id":"TestAGHwId00002"}, "key": {"key_type": "ECHO"}, "name": "SoDoSoPaTown Tower"}`,
+	}
+	tests.RunTest(t, getAGRecordTestCase)
+
+	// Test Listing All Registered AGs
+	listAGsTestCase := tests.Testcase{
+		Name:                      "List Registered AGs",
+		Method:                    "GET",
+		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:                   "",
+		Expected:                  "",
+		Skip_payload_verification: true,
+	}
+	_, r, _ := tests.RunTest(t, listAGsTestCase)
+
+	exp1 := fmt.Sprintf(`["TestAGHwId00002","%s"]`, requestedAGId)
+	exp2 := fmt.Sprintf(`["%s","TestAGHwId00002"]`, requestedAGId)
+
+	if r != exp1 && r != exp2 {
+		t.Fatalf("***** %s test failed, received: %s\n***** Expected: %s or %s",
+			listAGsTestCase.Name, r, exp1, exp2)
+	}
+
+	// Test Forced Removal
+	removeNetworkTestCase = tests.Testcase{
+		Name:     "Force Remove Non Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s?mode=force", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test Register Network
+	registerNetworkTestCase = tests.Testcase{
+		Name:                      "Register Network 2",
+		Method:                    "POST",
+		Url:                       fmt.Sprintf("%s?requested_id=magmad_obisidian_test_network2", testUrlRoot),
+		Payload:                   `{"name":"This Is A Test Network Name"}`,
+		Skip_payload_verification: true,
+	}
+	_, networkId, _ = tests.RunTest(t, registerNetworkTestCase)
+
+	json.Unmarshal([]byte(networkId), &networkId)
+
+	// Test Register AG
+	registerAGTestCase = tests.Testcase{
+		Name:     "Register AG 2",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  `{"hw_id":{"id":"TestAGHwId12345"}, "key": {"key_type": "ECHO"}}`,
+		Expected: `"TestAGHwId12345"`,
+	}
+	tests.RunTest(t, registerAGTestCase)
+
+	// Test Listing All Registered AGs
+	listAGsTestCase = tests.Testcase{
+		Name:     "List Registered AGs 2",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `["TestAGHwId12345"]`,
+	}
+	tests.RunTest(t, listAGsTestCase)
+
+	expCfg := &models.MagmadGatewayConfig{}
+	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
+	assert.NoError(t, err)
+	marshaledCfg, err := expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr := string(marshaledCfg)
+
+	// Test Getting AG Configs
+	createAGConfigTestCase := tests.Testcase{
+		Name:     "Create AG Configs",
+		Method:   "POST",
+		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs", testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: `"TestAGHwId12345"`,
+	}
+	tests.RunTest(t, createAGConfigTestCase)
+
+	getAGConfigTestCase := tests.Testcase{
+		Name:   "Get AG Configs",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getAGConfigTestCase)
+
+	expCfg.Tier = "changed"
+	marshaledCfg, err = expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	// Test Setting (Updating) AG Configs
+	setAGConfigTestCase := tests.Testcase{
+		Name:   "Set AG Configs",
+		Method: "PUT",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: "",
+	}
+	tests.RunTest(t, setAGConfigTestCase)
+
+	// Test Getting AG Configs After Config Update
+	getAGConfigTestCase2 := tests.Testcase{
+		Name:   "Get AG Configs 2",
+		Method: "GET",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getAGConfigTestCase2)
+
+	// Update network wide property
+	//
+	// Get Current Network Record
+	networkCfg := &models.NetworkRecord{Name: "This Is A Test Network Name"}
+	marshaledCfg, err = networkCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	getNetworkRecordTestCase := tests.Testcase{
+		Name:     "Get Network Record",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getNetworkRecordTestCase)
+
+	networkCfg.Name = "Updated Network Name"
+	marshaledCfg, err = networkCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+
+	updateNetworkRecordTestCase := tests.Testcase{
+		Name:     "Update Network Record",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  expectedCfgStr,
+		Expected: "",
+	}
+	tests.RunTest(t, updateNetworkRecordTestCase)
+
+	getNetworkRecordTestCase2 := tests.Testcase{
+		Name:     "Get Network Record after Update",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expectedCfgStr,
+	}
+	tests.RunTest(t, getNetworkRecordTestCase2)
+
+	// Test AG Unregister
+	setAGUnregisterTestCase := tests.Testcase{
+		Name:   "Unregister AG",
+		Method: "DELETE",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345",
+			testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, setAGUnregisterTestCase)
+
+	// Test Listing All Registered AGs after Removal Of AG
+	listAGsTestCase2 := tests.Testcase{
+		Name:     "List Registered AGs",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `[]`, // should return an empty array
+	}
+	tests.RunTest(t, listAGsTestCase2)
+
+	// Test List Networks
+	listNetworksTestCase := tests.Testcase{
+		Name:     "List Networks",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: fmt.Sprintf(`["%s"]`, networkId),
+	}
+	tests.RunTest(t, listNetworksTestCase)
+
+	// Test Removal Of Empty Network
+	removeNetworkTestCase = tests.Testcase{
+		Name:     "Remove Empty Network",
+		Method:   "DELETE",
+		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, removeNetworkTestCase)
+
+	// Test List Networks
+	listNetworksTestCase = tests.Testcase{
+		Name:     "List Networks Post Delete",
+		Method:   "GET",
+		Url:      testUrlRoot,
+		Payload:  "",
+		Expected: "[]",
+	}
+	tests.RunTest(t, listNetworksTestCase)
 }
 
 // Default gateway config struct. Please DO NOT MODIFY this struct in-place

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
@@ -1,16 +1,17 @@
 /*
-Copyright (c) Facebook, Inc. and its affiliates.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package handlers_test
 
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
@@ -20,14 +21,12 @@ import (
 	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
-	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
 	"magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMagmad(t *testing.T) {
+	_ = os.Setenv(handlers.UseNewHandlersEnv, "1")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
@@ -102,331 +101,6 @@ func TestMagmad(t *testing.T) {
 	_, networkId, _ := tests.RunTest(t, registerNetworkTestCase)
 
 	json.Unmarshal([]byte(networkId), &networkId)
-
-	// Test Register AG with invalid requestedId
-	registerAGWithInvalidIdTestCase := tests.Testcase{
-		Name:   "Register AG with Invalid Requested Id",
-		Method: "POST",
-		Url: fmt.Sprintf(
-			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, "*00_bad_ag"),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId12345"}, "name": "Test AG Name", "key": {"key_type": "ECHO"}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGWithInvalidIdTestCase)
-
-	// Test Register AG with requestedId
-	requestedAGId := "my_gateway-1"
-	registerAGWithIdTestCase := tests.Testcase{
-		Name:   "Register AG with Requested Id",
-		Method: "POST",
-		Url: fmt.Sprintf(
-			"%s/%s/gateways?requested_id=%s", testUrlRoot, networkId, requestedAGId),
-		Payload:  `{"hw_id":{"id":"TestAGHwId00001"}, "name": "Test AG Name",  "key": {"key_type": "ECHO"}}`,
-		Expected: fmt.Sprintf(`"%s"`, requestedAGId),
-	}
-	tests.RunTest(t, registerAGWithIdTestCase)
-
-	// Test Register AG
-	registerAGTestCase := tests.Testcase{
-		Name:     "Register AG",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  `{"hw_id":{"id":"TestAGHwId00002"}, "name": "Test AG Name", "key": {"key_type": "SOFTWARE_ECDSA_SHA256", "key": "MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC"}}`,
-		Expected: `"TestAGHwId00002"`,
-	}
-	tests.RunTest(t, registerAGTestCase)
-
-	// Test Register without key
-	registerAGTestCaseNoKey := tests.Testcase{
-		Name:                      "Register AG without Key",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGTestCaseNoKey)
-
-	// Test Register without key content
-	registerAGTestCaseNoKeyContent := tests.Testcase{
-		Name:                      "Register AG with Key but no Key Content",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256"}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGTestCaseNoKeyContent)
-
-	// Test Register with wrong key content
-	registerAGTestCaseWrongKeyContent := tests.Testcase{
-		Name:                      "Register AG with Key but Wrong Key Content",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   `{"hw_id":{"id":"TestAGHwId00003"}, "name": "Test AG Name", "key": {"key_type":  "SOFTWARE_ECDSA_SHA256", "key":"AAAAAAAAAAAAAAAAAAAAAA=="}}`,
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, registerAGTestCaseWrongKeyContent)
-
-	// Test Getting AG record
-	getAGRecordTestCase := tests.Testcase{
-		Name:   "Get AG Record With Specified Name",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/%s",
-			testUrlRoot, networkId, requestedAGId),
-		Payload:  "",
-		Expected: `{"hw_id":{"id":"TestAGHwId00001"},"key":{"key_type":"ECHO"},"name":"Test AG Name"}`,
-	}
-	tests.RunTest(t, getAGRecordTestCase)
-
-	getAGRecordTestCase = tests.Testcase{
-		Name:     "Get AG Record With Default Name",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `{"hw_id":{"id":"TestAGHwId00002"},"key":{"key":"MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+Lckvw/eeV8CemEOWpX30/5XhTHKx/mm6T9MpQWuIM8sOKforNm5UPbZrdOTPEBAtGwJB6Uk9crjCIveFe+sN0zw705L94Giza4ny/6ASBcctCm2JJxFccVsocJIraSC","key_type":"SOFTWARE_ECDSA_SHA256"},"name":"Test AG Name"}`,
-	}
-	tests.RunTest(t, getAGRecordTestCase)
-
-	// Test Updating AG record
-	setAGRecordTestCase := tests.Testcase{
-		Name:     "Update AG Record Name",
-		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
-		Payload:  `{"name": "SoDoSoPaTown Tower", "key": {"key_type": "ECHO"}}`,
-		Expected: "",
-	}
-	tests.RunTest(t, setAGRecordTestCase)
-
-	// Test Getting AG record 2
-	getAGRecordTestCase = tests.Testcase{
-		Name:     "Get AG Record With Modified Name",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId00002", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `{"hw_id":{"id":"TestAGHwId00002"}, "key": {"key_type": "ECHO"}, "name": "SoDoSoPaTown Tower"}`,
-	}
-	tests.RunTest(t, getAGRecordTestCase)
-
-	// Test Listing All Registered AGs
-	listAGsTestCase := tests.Testcase{
-		Name:                      "List Registered AGs",
-		Method:                    "GET",
-		Url:                       fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:                   "",
-		Expected:                  "",
-		Skip_payload_verification: true,
-	}
-	_, r, _ := tests.RunTest(t, listAGsTestCase)
-
-	exp1 := fmt.Sprintf(`["TestAGHwId00002","%s"]`, requestedAGId)
-	exp2 := fmt.Sprintf(`["%s","TestAGHwId00002"]`, requestedAGId)
-
-	if r != exp1 && r != exp2 {
-		t.Fatalf("***** %s test failed, received: %s\n***** Expected: %s or %s",
-			listAGsTestCase.Name, r, exp1, exp2)
-	}
-
-	// Test Removal Of Non Empty Network
-	removeNetworkTestCase = tests.Testcase{
-		Name:                      "Remove Non Empty Network",
-		Method:                    "DELETE",
-		Url:                       fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:                   "",
-		Expected:                  "",
-		Skip_payload_verification: true,
-		Expect_http_error_status:  true,
-	}
-	tests.RunTest(t, removeNetworkTestCase)
-
-	// Test Forced Removal
-	removeNetworkTestCase = tests.Testcase{
-		Name:     "Force Remove Non Empty Network",
-		Method:   "DELETE",
-		Url:      fmt.Sprintf("%s/%s?mode=force", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: "",
-	}
-	tests.RunTest(t, removeNetworkTestCase)
-
-	// Test Register Network
-	registerNetworkTestCase = tests.Testcase{
-		Name:                      "Register Network 2",
-		Method:                    "POST",
-		Url:                       fmt.Sprintf("%s?requested_id=magmad_obisidian_test_network2", testUrlRoot),
-		Payload:                   `{"name":"This Is A Test Network Name"}`,
-		Skip_payload_verification: true,
-	}
-	_, networkId, _ = tests.RunTest(t, registerNetworkTestCase)
-
-	json.Unmarshal([]byte(networkId), &networkId)
-
-	// Test Register AG
-	registerAGTestCase = tests.Testcase{
-		Name:     "Register AG 2",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  `{"hw_id":{"id":"TestAGHwId12345"}, "key": {"key_type": "ECHO"}}`,
-		Expected: `"TestAGHwId12345"`,
-	}
-	tests.RunTest(t, registerAGTestCase)
-
-	// Test Listing All Registered AGs
-	listAGsTestCase = tests.Testcase{
-		Name:     "List Registered AGs 2",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `["TestAGHwId12345"]`,
-	}
-	tests.RunTest(t, listAGsTestCase)
-
-	expCfg := &models.MagmadGatewayConfig{}
-	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
-	assert.NoError(t, err)
-	marshaledCfg, err := expCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr := string(marshaledCfg)
-
-	// Test Getting AG Configs
-	createAGConfigTestCase := tests.Testcase{
-		Name:     "Create AG Configs",
-		Method:   "POST",
-		Url:      fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs", testUrlRoot, networkId),
-		Payload:  expectedCfgStr,
-		Expected: `"TestAGHwId12345"`,
-	}
-	tests.RunTest(t, createAGConfigTestCase)
-
-	getAGConfigTestCase := tests.Testcase{
-		Name:   "Get AG Configs",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
-			testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getAGConfigTestCase)
-
-	expCfg.Tier = "changed"
-	marshaledCfg, err = expCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr = string(marshaledCfg)
-
-	// Test Setting (Updating) AG Configs
-	setAGConfigTestCase := tests.Testcase{
-		Name:   "Set AG Configs",
-		Method: "PUT",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
-			testUrlRoot, networkId),
-		Payload:  expectedCfgStr,
-		Expected: "",
-	}
-	tests.RunTest(t, setAGConfigTestCase)
-
-	// Test Getting AG Configs After Config Update
-	getAGConfigTestCase2 := tests.Testcase{
-		Name:   "Get AG Configs 2",
-		Method: "GET",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
-			testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getAGConfigTestCase2)
-
-	// Update network wide property
-	//
-	// Get Current Network Record
-	networkCfg := &models.NetworkRecord{Name: "This Is A Test Network Name"}
-	marshaledCfg, err = networkCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr = string(marshaledCfg)
-
-	getNetworkRecordTestCase := tests.Testcase{
-		Name:     "Get Network Record",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getNetworkRecordTestCase)
-
-	networkCfg.Name = "Updated Network Name"
-	marshaledCfg, err = networkCfg.MarshalBinary()
-	assert.NoError(t, err)
-	expectedCfgStr = string(marshaledCfg)
-
-	updateNetworkRecordTestCase := tests.Testcase{
-		Name:     "Update Network Record",
-		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  expectedCfgStr,
-		Expected: "",
-	}
-	tests.RunTest(t, updateNetworkRecordTestCase)
-
-	getNetworkRecordTestCase2 := tests.Testcase{
-		Name:     "Get Network Record after Update",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: expectedCfgStr,
-	}
-	tests.RunTest(t, getNetworkRecordTestCase2)
-
-	// Test AG Unregister
-	setAGUnregisterTestCase := tests.Testcase{
-		Name:   "Unregister AG",
-		Method: "DELETE",
-		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345",
-			testUrlRoot, networkId),
-		Payload:  "",
-		Expected: "",
-	}
-	tests.RunTest(t, setAGUnregisterTestCase)
-
-	// Test Listing All Registered AGs after Removal Of AG
-	listAGsTestCase2 := tests.Testcase{
-		Name:     "List Registered AGs",
-		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: `[]`, // should return an empty array
-	}
-	tests.RunTest(t, listAGsTestCase2)
-
-	// Test List Networks
-	listNetworksTestCase := tests.Testcase{
-		Name:     "List Networks",
-		Method:   "GET",
-		Url:      testUrlRoot,
-		Payload:  "",
-		Expected: fmt.Sprintf(`["%s"]`, networkId),
-	}
-	tests.RunTest(t, listNetworksTestCase)
-
-	// Test Removal Of Empty Network
-	removeNetworkTestCase = tests.Testcase{
-		Name:     "Remove Empty Network",
-		Method:   "DELETE",
-		Url:      fmt.Sprintf("%s/%s", testUrlRoot, networkId),
-		Payload:  "",
-		Expected: "",
-	}
-	tests.RunTest(t, removeNetworkTestCase)
-
-	// Test List Networks
-	listNetworksTestCase = tests.Testcase{
-		Name:     "List Networks Post Delete",
-		Method:   "GET",
-		Url:      testUrlRoot,
-		Payload:  "",
-		Expected: "[]",
-	}
-	tests.RunTest(t, listNetworksTestCase)
 }
 
 // Default gateway config struct. Please DO NOT MODIFY this struct in-place

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
@@ -9,14 +9,12 @@ LICENSE file in the root directory of this source tree.
 package handlers
 
 import (
-	"fmt"
 	"net/http"
-	"strings"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorh "magma/orc8r/cloud/go/services/configurator/obsidian/handlers"
-	"magma/orc8r/cloud/go/services/magmad"
 	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
 
 	"github.com/labstack/echo"
@@ -36,11 +34,14 @@ func listNetworks(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	networks, err := magmad.ListNetworks()
+	networks, err := configurator.ListNetworkIDs()
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
-
+	//magmad expects [] not null for the empty case
+	if networks == nil {
+		networks = []string{}
+	}
 	return c.JSON(http.StatusOK, networks)
 }
 
@@ -52,124 +53,92 @@ func registerNetwork(c echo.Context) error {
 	}
 
 	// Bind network record from swagger
-	swaggerRecord := &magmad_models.NetworkRecord{}
-	err := c.Bind(&swaggerRecord)
+	record := &magmad_models.NetworkRecord{}
+	err := c.Bind(&record)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerRecord.ValidateModel(); err != nil {
+	if err := record.ValidateModel(); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	magmadRecord := swaggerRecord.ToProto()
 
-	var networkId string
-	requestedId := c.QueryParam("requested_id")
-	err = configuratorh.VerifyNetworkIDFormat(requestedId)
+	requestedID := c.QueryParam("requested_id")
+	err = configuratorh.VerifyNetworkIDFormat(requestedID)
 	if err != nil {
 		return err
 	}
-	networkId, err = magmad.RegisterNetwork(magmadRecord, requestedId)
-	if err != nil {
-		return handlers.HttpError(err, http.StatusConflict)
-	}
 
-	_, err = multiplexCreateNetworkIntoConfigurator(networkId, swaggerRecord)
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex into configurator: %v", err), http.StatusInternalServerError)
-	}
-
-	return c.JSON(http.StatusCreated, networkId)
-}
-
-func multiplexCreateNetworkIntoConfigurator(requestedID string, swaggerRecord *magmad_models.NetworkRecord) (string, error) {
 	network := configurator.Network{
-		Name: swaggerRecord.Name,
+		Name: record.Name,
 		ID:   requestedID,
+		Configs: map[string]interface{}{
+			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
+		},
 	}
-	createdNetworks, err := configurator.CreateNetworks([]configurator.Network{network})
+
+	err = configurator.CreateNetwork(network)
 	if err != nil {
-		return "", err
+		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	return createdNetworks[0].ID, nil
+	return c.JSON(http.StatusCreated, requestedID)
 }
 
 func getNetwork(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
-
-	record, err := magmad.GetNetwork(networkId)
+	network, err := configurator.LoadNetwork(networkID, true, false)
 	if err != nil {
-		return handlers.HttpError(err, http.StatusInternalServerError)
+		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	swaggerRecord := magmad_models.NetworkRecordFromProto(record)
-	return c.JSON(http.StatusOK, &swaggerRecord)
+
+	networkFeatures := &magmad_models.NetworkFeatures{}
+	features, ok := network.Configs[orc8r.NetworkFeaturesConfig]
+	if ok {
+		networkFeatures = features.(*magmad_models.NetworkFeatures)
+	}
+
+	record := magmad_models.NetworkRecord{
+		Name:     network.Name,
+		Features: networkFeatures.Features,
+	}
+	return c.JSON(http.StatusOK, &record)
 }
 
 func updateNetwork(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
 
-	swaggerRecord := &magmad_models.NetworkRecord{}
-	if err := c.Bind(&swaggerRecord); err != nil {
+	record := &magmad_models.NetworkRecord{}
+	if err := c.Bind(&record); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerRecord.ValidateModel(); err != nil {
+	if err := record.ValidateModel(); err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
 
-	err := multiplexUpdateNetworkIntoConfigurator(networkId, swaggerRecord)
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex into configurator: %v", err), http.StatusInternalServerError)
-	}
-
-	return magmad.UpdateNetwork(networkId, swaggerRecord.ToProto())
-}
-
-func multiplexUpdateNetworkIntoConfigurator(networkID string, record *magmad_models.NetworkRecord) error {
-	exists, err := configurator.DoesNetworkExist(networkID)
-	if err != nil {
-		return err
-	}
-	if !exists {
-		_, err := multiplexCreateNetworkIntoConfigurator(networkID, record)
-		return err
-	}
 	updateCriteria := configurator.NetworkUpdateCriteria{
 		ID:      networkID,
 		NewName: &record.Name,
+		ConfigsToAddOrUpdate: map[string]interface{}{
+			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
+		},
 	}
 	return configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
 }
 
 func deleteNetwork(c echo.Context) error {
-	networkId, nerr := handlers.GetNetworkId(c)
+	networkID, nerr := handlers.GetNetworkId(c)
 	if nerr != nil {
 		return nerr
 	}
 
-	force := c.QueryParam("mode")
-	var err error
-	if strings.ToUpper(force) == "FORCE" {
-		err = magmad.ForceRemoveNetwork(networkId)
-	} else {
-		err = magmad.RemoveNetwork(networkId)
-	}
-
+	err := configurator.DeleteNetwork(networkID)
 	if err != nil {
-		status := http.StatusInternalServerError
-		// TODO: conversion based on grpc code
-		return handlers.HttpError(err, status)
+		return handlers.HttpError(err, http.StatusBadRequest)
 	}
-
-	// multiplex delete network into configurator
-	err = configurator.DeleteNetworks([]string{networkId})
-	if err != nil {
-		return handlers.HttpError(fmt.Errorf("Failed to multiplex into configurator: %v", err), http.StatusInternalServerError)
-	}
-
 	return c.NoContent(http.StatusNoContent)
 }

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers_legacy.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers_legacy.go
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"net/http"
+	"strings"
+
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	configuratorh "magma/orc8r/cloud/go/services/configurator/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/magmad"
+	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
+
+	"github.com/labstack/echo"
+)
+
+func listNetworksHandler(c echo.Context) error {
+	// Check for wildcard network access
+	nerr := handlers.CheckNetworkAccess(c, handlers.NETWORK_WILDCARD)
+	if nerr != nil {
+		return nerr
+	}
+	networks, err := magmad.ListNetworks()
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+
+	return c.JSON(http.StatusOK, networks)
+}
+
+func registerNetworkHandler(c echo.Context) error {
+	// Check for wildcard network access
+	nerr := handlers.CheckNetworkAccess(c, handlers.NETWORK_WILDCARD)
+	if nerr != nil {
+		return nerr
+	}
+
+	// Bind network record from swagger
+	swaggerRecord := &magmad_models.NetworkRecord{}
+	err := c.Bind(&swaggerRecord)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	if err := swaggerRecord.ValidateModel(); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	magmadRecord := swaggerRecord.ToProto()
+
+	var networkId string
+	requestedId := c.QueryParam("requested_id")
+	err = configuratorh.VerifyNetworkIDFormat(requestedId)
+	if err != nil {
+		return err
+	}
+	networkId, err = magmad.RegisterNetwork(magmadRecord, requestedId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusConflict)
+	}
+
+	return c.JSON(http.StatusCreated, networkId)
+}
+
+func getNetworkHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	record, err := magmad.GetNetwork(networkId)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	swaggerRecord := magmad_models.NetworkRecordFromProto(record)
+	return c.JSON(http.StatusOK, &swaggerRecord)
+}
+
+func updateNetworkHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	swaggerRecord := &magmad_models.NetworkRecord{}
+	if err := c.Bind(&swaggerRecord); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+	if err := swaggerRecord.ValidateModel(); err != nil {
+		return handlers.HttpError(err, http.StatusBadRequest)
+	}
+
+	return magmad.UpdateNetwork(networkId, swaggerRecord.ToProto())
+}
+
+func deleteNetworkHandler(c echo.Context) error {
+	networkId, nerr := handlers.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	force := c.QueryParam("mode")
+	var err error
+	if strings.ToUpper(force) == "FORCE" {
+		err = magmad.ForceRemoveNetwork(networkId)
+	} else {
+		err = magmad.RemoveNetwork(networkId)
+	}
+
+	if err != nil {
+		status := http.StatusInternalServerError
+		// TODO: conversion based on grpc code
+		return handlers.HttpError(err, status)
+	}
+
+	return c.NoContent(http.StatusNoContent)
+}


### PR DESCRIPTION
Summary: Magmad Gateway REST API handlers are migrated to use the configurator. Gateway_handlers use both configurator and device to keep track gateway records and configs. Old handlers and tests are moved to <file_name>_legacy.go

Reviewed By: xjtian

Differential Revision: D15930484

