### PR TITLE
Migrate Mesh and Mesh config REST handlers to use configurator

### DIFF
--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -9,14 +9,14 @@ LICENSE file in the root directory of this source tree.
 package orc8r
 
 const (
-	ModuleName            string = "orc8r"
+	ModuleName string = "orc8r"
 
-	MagmadNetworkType            = "magmad_network"
-	NetworkFeaturesConfig        = "orc8r_features"
+	MagmadNetworkType     = "magmad_network"
+	NetworkFeaturesConfig = "orc8r_features"
 
-	MagmadGatewayType            = "magmad_gateway"
+	MagmadGatewayType = "magmad_gateway"
 
-	UpgradeTierEntityType        = "upgrade_tier"
+	UpgradeTierEntityType = "upgrade_tier"
 
-    DnsdNetworkType = "dnsd_network"
+	DnsdNetworkType = "dnsd_network"
 )


### PR DESCRIPTION
Summary:
the rest API for mesh now has the migration implemented, so that if "USE_NEW_HANDLERS" is set to 1, it will use configurator instead of mesh.

The current REST API handlers being used have moved to mesh_handler_legacy.go in the same folder. The newly implemented handlers are in mesh_handler.go

I've also duplicated the mesh_handler tests to test both "USE_NEW_HANDLERS=1" and "USE_NEW_HANDLERS=0" case. (In mesh_handler_test.go and mesh_handler_legacy_test.go respectively)

The wifi module now has a orc8r/const.go file with all configurator related constants defined.

Reviewed By: xjtian

Differential Revision: D15901003

