### PR TITLE
Sort gateway config's array field generated from iterating through map

### DIFF
--- a/lte/cloud/go/services/cellular/config/mconfig_builder.go
+++ b/lte/cloud/go/services/cellular/config/mconfig_builder.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"log"
 	"reflect"
+	"sort"
 
 	"magma/lte/cloud/go/protos/mconfig"
 	cellular_protos "magma/lte/cloud/go/services/cellular/protos"
@@ -193,6 +194,7 @@ func getEnodebTacs(enbConfigsBySerial map[string]*mconfig.EnodebD_EnodebConfig) 
 		enbTacs[i] = enbConfig.Tac
 		i += 1
 	}
+	sort.Slice(enbTacs, func(i, j int) bool { return enbTacs[i] < enbTacs[j] })
 	return enbTacs
 }
 


### PR DESCRIPTION
Summary: Since Go will iterate through maps in random order, this was causing AGW magmad service to believe that the gateway config had changed, and would then restart the MME service.

Reviewed By: themarwhal

Differential Revision: D15973133

