### PR TITLE
Remove serde parameter from CRUD functions in configurator service

### DIFF
--- a/orc8r/cloud/go/serde/registry.go
+++ b/orc8r/cloud/go/serde/registry.go
@@ -95,6 +95,17 @@ func Deserialize(domain string, typeVal string, data []byte) (interface{}, error
 	return subregistry.deserialize(typeVal, data)
 }
 
+func GetSerdeByDomainAndType(domain string, typeVal string) (interface{}, error) {
+	registry.RLock()
+	defer registry.RUnlock()
+
+	subregistry, ok := registry.serdeRegistriesByDomain[domain]
+	if !ok {
+		return nil, fmt.Errorf("No serdes registered for domain %s", domain)
+	}
+	return subregistry.deserialize(typeVal, nil)
+}
+
 func getSerdesByDomain(serdesToGroup []Serde) map[string][]Serde {
 	ret := map[string][]Serde{}
 	for _, s := range serdesToGroup {

--- a/orc8r/cloud/go/services/configurator/obsidian/handlers/config_handlers.go
+++ b/orc8r/cloud/go/services/configurator/obsidian/handlers/config_handlers.go
@@ -20,21 +20,21 @@ import (
 	"github.com/labstack/echo"
 )
 
-func instantiateUnderlyingModel(serde serde.Serde) interface{} {
-	model, _ := serde.Deserialize(nil)
-	modelType := reflect.TypeOf(model)
-	return reflect.New(modelType).Elem()
+func getSerdeModelFromRegistry(configType string) interface{} {
+	model, _ := serde.GetSerdeByDomainAndType(configurator.NetworkConfigSerdeDomain, configType)
+	modelType := reflect.TypeOf(model).Elem()
+	return reflect.New(modelType).Interface().(serde.BinaryConvertible)
 }
 
 // GetCRUDNetworkConfigHandlers returns 4 Handlers which implement CRUD for
 // a network config.
 // Path should look like '.../networks/:network_id/{config_type}'
 // Serde is used to serialize/deserialize the config stored
-func GetCRUDNetworkConfigHandlers(path string, serde serde.Serde) []handlers.Handler {
+func GetCRUDNetworkConfigHandlers(path string) []handlers.Handler {
 	return []handlers.Handler{
-		GetCreateNetworkConfigHandler(path, serde),
+		GetCreateNetworkConfigHandler(path),
 		GetReadNetworkConfigHandler(path),
-		GetUpdateNetworkConfigHandler(path, serde),
+		GetUpdateNetworkConfigHandler(path),
 		GetDeleteNetworkConfigHandler(path),
 	}
 }
@@ -66,22 +66,22 @@ func GetReadNetworkConfigHandler(path string) handlers.Handler {
 	}
 }
 
-func GetCreateNetworkConfigHandler(path string, serde serde.Serde) handlers.Handler {
+func GetCreateNetworkConfigHandler(path string) handlers.Handler {
 	return handlers.Handler{
 		Path:    path,
 		Methods: handlers.POST,
 		HandlerFunc: func(c echo.Context) error {
-			return createOrUpdateNetworkConfig(c, path, serde)
+			return createOrUpdateNetworkConfig(c, path)
 		},
 	}
 }
 
-func GetUpdateNetworkConfigHandler(path string, serde serde.Serde) handlers.Handler {
+func GetUpdateNetworkConfigHandler(path string) handlers.Handler {
 	return handlers.Handler{
 		Path:    path,
 		Methods: handlers.PUT,
 		HandlerFunc: func(c echo.Context) error {
-			return createOrUpdateNetworkConfig(c, path, serde)
+			return createOrUpdateNetworkConfig(c, path)
 		},
 	}
 }
@@ -104,12 +104,12 @@ func GetDeleteNetworkConfigHandler(path string) handlers.Handler {
 	}
 }
 
-func createOrUpdateNetworkConfig(c echo.Context, path string, serde serde.Serde) error {
+func createOrUpdateNetworkConfig(c echo.Context, path string) error {
 	networkID, configType, nerr := getNetworkIDAndConfigType(c, path)
 	if nerr != nil {
 		return nerr
 	}
-	config, err := getConfigFromContext(c, serde)
+	config, err := getConfigFromContext(c, configType)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusBadRequest)
 	}
@@ -125,8 +125,8 @@ func createOrUpdateNetworkConfig(c echo.Context, path string, serde serde.Serde)
 	return c.JSON(http.StatusOK, "Created Config")
 }
 
-func getConfigFromContext(c echo.Context, serde serde.Serde) (interface{}, error) {
-	model := instantiateUnderlyingModel(serde)
+func getConfigFromContext(c echo.Context, configType string) (interface{}, error) {
+	model := getSerdeModelFromRegistry(configType)
 	err := c.Bind(&model)
 	if err != nil {
 		return nil, handlers.HttpError(err, http.StatusBadRequest)


### PR DESCRIPTION
Summary: Removed the serde parameter from CRUD handlers for network configs in the configurator API. Now, the configurator pulls the serde from the serde registry via the config type string and the network config domain.

Differential Revision: D16022247

