### PR TITLE
Migrate Wifi Gateway Config to fit configurator association model

### DIFF
--- a/orc8r/cloud/go/services/config/obsidian/configurator_entity_handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_entity_handlers.go
@@ -22,7 +22,7 @@ import (
 // This set of CRUD handlers are meant for entities that only have one config
 // per entity.
 func configuratorCreateEntityConfig(c echo.Context, networkID string, entityType string, entityKey string, iConfig interface{}) error {
-	config, nerr := getConfigAndValidate(c, iConfig)
+	config, nerr := GetConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
 	}
@@ -48,7 +48,7 @@ func configuratorGetEntityConfig(c echo.Context, networkID string, entityType st
 }
 
 func configuratorUpdateEntityConfig(c echo.Context, networkID string, entityType string, entityKey string, iConfig interface{}) error {
-	config, nerr := getConfigAndValidate(c, iConfig)
+	config, nerr := GetConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
 	}

--- a/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
@@ -30,7 +30,7 @@ func configuratorCreateGatewayConfig(c echo.Context, networkID string, configTyp
 		return configuratorCreateEntityConfig(c, networkID, configType, configKey, iConfig)
 	}
 
-	config, nerr := getConfigAndValidate(c, iConfig)
+	config, nerr := GetConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
 	}

--- a/orc8r/cloud/go/services/config/obsidian/configurator_network_handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_network_handlers.go
@@ -39,7 +39,7 @@ func getConfigTypeForConfigurator(configType string) ConfigType {
 // Networks
 
 func configuratorCreateNetworkConfig(c echo.Context, networkID string, configType string, iConfig interface{}) error {
-	config, nerr := getConfigAndValidate(c, iConfig)
+	config, nerr := GetConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
 	}
@@ -62,7 +62,7 @@ func configuratorGetNetworkConfig(c echo.Context, networkID string, configType s
 }
 
 func configuratorUpdateNetworkConfig(c echo.Context, networkID string, configType string, iConfig interface{}) error {
-	config, nerr := getConfigAndValidate(c, iConfig)
+	config, nerr := GetConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
 	}
@@ -81,7 +81,7 @@ func configuratorDeleteNetworkConfig(c echo.Context, networkID string, configTyp
 	return c.NoContent(http.StatusOK)
 }
 
-func getConfigAndValidate(c echo.Context, iConfig interface{}) (ConvertibleUserModel, error) {
+func GetConfigAndValidate(c echo.Context, iConfig interface{}) (ConvertibleUserModel, error) {
 	cfgInstance := reflect.New(reflect.TypeOf(iConfig).Elem()).Interface().(ConvertibleUserModel)
 	if err := c.Bind(cfgInstance); err != nil {
 		return nil, handlers.HttpError(err, http.StatusBadRequest)

--- a/orc8r/cloud/go/services/configurator/test_utils/utils.go
+++ b/orc8r/cloud/go/services/configurator/test_utils/utils.go
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package test_utils
+
+import (
+	"testing"
+
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/services/configurator"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func RegisterNetwork(t *testing.T, networkID string, networkName string) {
+	err := configurator.CreateNetwork(
+		configurator.Network{
+			ID:   networkID,
+			Name: networkName,
+		})
+	assert.NoError(t, err)
+}
+
+func RegisterGateway(t *testing.T, networkID string, gatewayID string) {
+	gw := configurator.NetworkEntity{
+		Key:  gatewayID,
+		Type: orc8r.MagmadGatewayType,
+	}
+	_, err := configurator.CreateEntity(networkID, gw)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Summary:
Since mesh and wifi gateway configs have a bidirectional dependency, this diff modifies the wifi gateway config logic to support this.
Each mesh has associations to gateways that it has and each gateway config has a meshID field that represents which mesh network the gateway is part of. So any time the gateway config is modified, the change should be reflected in the mesh entity associations field.

This feature can be turned on by the USE_NEW_HANDLERS env variable. Tests are duplicated to test both versions.

Reviewed By: xjtian

Differential Revision: D15972648

