### PR TITLE
Updates to gateway configs update entity associations

### DIFF
--- a/lte/cloud/go/services/cellular/config/mconfig_builder_test.go
+++ b/lte/cloud/go/services/cellular/config/mconfig_builder_test.go
@@ -37,13 +37,13 @@ func TestCellularBuilder_Build(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]proto.Message{}, actual)
 
-	err = config.CreateConfig("network", lte.CellularNetworkType, "network", test_utils.NewDefaultTDDNetworkConfig())
+	err = config.CreateConfig("network", lte.CellularNetworkType, "network", test_utils.NewDefaultProtosTDDNetworkConfig())
 	assert.NoError(t, err)
 	err = config.CreateConfig("network", orc8r.DnsdNetworkType, "network", &dnsd_protos.NetworkDNSConfig{EnableCaching: false, LocalTTL: 0})
 	assert.NoError(t, err)
-	err = config.CreateConfig("network", lte.CellularEnodebType, "enb1", test_utils.NewDefaultEnodebConfig())
+	err = config.CreateConfig("network", lte.CellularEnodebType, "enb1", test_utils.NewDefaultProtosEnodebConfig())
 	assert.NoError(t, err)
-	err = config.CreateConfig("network", lte.CellularGatewayType, "gw1", test_utils.NewDefaultGatewayConfig())
+	err = config.CreateConfig("network", lte.CellularGatewayType, "gw1", test_utils.NewDefaultProtosGatewayConfig())
 	assert.NoError(t, err)
 
 	actual, err = builder.Build("network", "gw1")
@@ -139,9 +139,9 @@ func TestCellularBuilder_Build_NullDnsdConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]proto.Message{}, actual)
 
-	err = config.CreateConfig("network", lte.CellularNetworkType, "network", test_utils.NewDefaultTDDNetworkConfig())
+	err = config.CreateConfig("network", lte.CellularNetworkType, "network", test_utils.NewDefaultProtosTDDNetworkConfig())
 	assert.NoError(t, err)
-	err = config.CreateConfig("network", lte.CellularGatewayType, "gw1", test_utils.NewDefaultGatewayConfig())
+	err = config.CreateConfig("network", lte.CellularGatewayType, "gw1", test_utils.NewDefaultProtosGatewayConfig())
 	assert.NoError(t, err)
 
 	actual, err = builder.Build("network", "gw1")

--- a/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers.go
+++ b/lte/cloud/go/services/cellular/obsidian/handlers/cellular_handlers.go
@@ -19,8 +19,11 @@ import (
 	"magma/lte/cloud/go/services/cellular/obsidian/models"
 	"magma/lte/cloud/go/services/cellular/utils"
 	"magma/orc8r/cloud/go/obsidian/handlers"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/config/obsidian"
+	"magma/orc8r/cloud/go/services/configurator"
 	magmad_handlers "magma/orc8r/cloud/go/services/magmad/obsidian/handlers"
+	"magma/orc8r/cloud/go/storage"
 
 	"github.com/labstack/echo"
 )
@@ -36,7 +39,14 @@ const (
 // GetObsidianHandlers returns all obsidian handlers for the cellular service
 func GetObsidianHandlers() []handlers.Handler {
 	defaultUpdateHandler := obsidian.GetUpdateNetworkConfigHandler(NetworkConfigPath, lte.CellularNetworkType, &models.NetworkCellularConfigs{})
-	ret := []handlers.Handler{
+	createGatewayConfigHandler := obsidian.GetCreateGatewayConfigHandler(GatewayConfigPath, lte.CellularGatewayType, &models.GatewayCellularConfigs{})
+	updateGatewayConfigHandler := obsidian.GetUpdateGatewayConfigHandler(GatewayConfigPath, lte.CellularGatewayType, &models.GatewayCellularConfigs{})
+
+	// override create and update migrated handler func
+	createGatewayConfigHandler.MigratedHandlerFunc = createGatewayConfig
+	updateGatewayConfigHandler.MigratedHandlerFunc = updateGatewayConfig
+
+	return []handlers.Handler{
 		obsidian.GetReadNetworkConfigHandler(NetworkConfigPath, lte.CellularNetworkType, &models.NetworkCellularConfigs{}),
 		obsidian.GetCreateNetworkConfigHandler(NetworkConfigPath, lte.CellularNetworkType, &models.NetworkCellularConfigs{}),
 		obsidian.GetDeleteNetworkConfigHandler(NetworkConfigPath, lte.CellularNetworkType),
@@ -65,9 +75,12 @@ func GetObsidianHandlers() []handlers.Handler {
 		obsidian.GetDeleteConfigHandler(EnodebConfigPath, lte.CellularEnodebType, getEnodebId),
 		// List all eNodeB devices for a network
 		obsidian.GetReadAllKeysConfigHandler(EnodebListPath, lte.CellularEnodebType),
+		// Cellular gateway configs
+		obsidian.GetReadGatewayConfigHandler(GatewayConfigPath, lte.CellularGatewayType, &models.GatewayCellularConfigs{}),
+		obsidian.GetDeleteGatewayConfigHandler(GatewayConfigPath, lte.CellularGatewayType),
+		createGatewayConfigHandler,
+		updateGatewayConfigHandler,
 	}
-	ret = append(ret, obsidian.GetCRUDGatewayConfigHandlers(GatewayConfigPath, lte.CellularGatewayType, &models.GatewayCellularConfigs{})...)
-	return ret
 }
 
 func getEnodebId(c echo.Context) (string, *echo.HTTPError) {
@@ -138,4 +151,96 @@ func setAppropriateNetworkSubConfig(band *utils.LTEBand, config *models.NetworkC
 	default:
 		return nil, fmt.Errorf("Invalid LTE band mode supplied")
 	}
+}
+
+func createGatewayConfig(c echo.Context) error {
+	networkID, gatewayID, nerr := getIDs(c)
+	if nerr != nil {
+		return nerr
+	}
+	iConfig, nerr := obsidian.GetConfigAndValidate(c, &models.GatewayCellularConfigs{})
+	if nerr != nil {
+		return nerr
+	}
+	config := iConfig.(*models.GatewayCellularConfigs)
+
+	associationsToAdd := getEnodebTKs(config.AttachedEnodebSerials)
+
+	_, err := configurator.CreateEntity(networkID, configurator.NetworkEntity{
+		Type:         lte.CellularGatewayType,
+		Key:          gatewayID,
+		Config:       config,
+		Associations: associationsToAdd,
+	})
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+
+	_, err = configurator.UpdateEntity(networkID, configurator.EntityUpdateCriteria{
+		Type:              orc8r.MagmadGatewayType,
+		Key:               gatewayID,
+		AssociationsToSet: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: gatewayID}},
+	})
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusCreated, gatewayID)
+}
+
+func updateGatewayConfig(c echo.Context) error {
+	networkID, gatewayID, nerr := getIDs(c)
+	if nerr != nil {
+		return nerr
+	}
+	iConfig, nerr := obsidian.GetConfigAndValidate(c, &models.GatewayCellularConfigs{})
+	if nerr != nil {
+		return nerr
+	}
+	config := iConfig.(*models.GatewayCellularConfigs)
+
+	associationsToDelete := []storage.TypeAndKey{}
+	associationsToSet := getEnodebTKs(config.AttachedEnodebSerials)
+
+	if len(config.AttachedEnodebSerials) == 0 {
+		// due to the way protobuf serialize/deserializes,
+		// associationsToSet = [] does not delete all associations, so here we
+		// look up the entity's association to pass in as associationsToDelete.
+		entity, err := configurator.LoadEntity(networkID, lte.CellularGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
+		if err != nil {
+			return handlers.HttpError(err, http.StatusInternalServerError)
+		}
+		associationsToDelete = entity.Associations
+	}
+
+	_, err := configurator.UpdateEntity(networkID, configurator.EntityUpdateCriteria{
+		Type:                 lte.CellularGatewayType,
+		Key:                  gatewayID,
+		NewConfig:            config,
+		AssociationsToSet:    associationsToSet,
+		AssociationsToDelete: associationsToDelete,
+	})
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+func getEnodebTKs(enodbSerials []string) []storage.TypeAndKey {
+	enodebTKs := []storage.TypeAndKey{}
+	for _, enodebSerial := range enodbSerials {
+		enodebTKs = append(enodebTKs, storage.TypeAndKey{Key: enodebSerial, Type: lte.CellularEnodebType})
+	}
+	return enodebTKs
+}
+
+func getIDs(c echo.Context) (string, string, error) {
+	networkID, err := handlers.GetNetworkId(c)
+	if err != nil {
+		return "", "", err
+	}
+	gatewayID, err := handlers.GetLogicalGwId(c)
+	if err != nil {
+		return "", "", err
+	}
+	return networkID, gatewayID, nil
 }

--- a/lte/cloud/go/services/cellular/obsidian/models/validation.go
+++ b/lte/cloud/go/services/cellular/obsidian/models/validation.go
@@ -57,7 +57,6 @@ func (m *GatewayEpcConfigs) validateGatewayEPCConfig() error {
 }
 
 func (m *NetworkCellularConfigs) ValidateNetworkConfig() error {
-	glog.Errorf("verifying network config : %v %v %s", m.Ran, m.Epc, m.FegNetworkID)
 	if m == nil {
 		return errors.New("Network config is nil")
 	}

--- a/lte/cloud/go/services/cellular/protos/proto_validation_test.go
+++ b/lte/cloud/go/services/cellular/protos/proto_validation_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestValidateGatewayConfig(t *testing.T) {
-	config := test_utils.NewDefaultGatewayConfig()
+	config := test_utils.NewDefaultProtosGatewayConfig()
 	err := protos.ValidateGatewayConfig(config)
 	assert.NoError(t, err)
 
@@ -27,7 +27,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 	err = protos.ValidateGatewayConfig(config)
 	assert.Error(t, err, "Gateway EPC config is nil")
 
-	config = test_utils.NewDefaultGatewayConfig()
+	config = test_utils.NewDefaultProtosGatewayConfig()
 	config.Ran = nil
 	err = protos.ValidateGatewayConfig(config)
 	assert.Error(t, err, "Gateway RAN config is nil")
@@ -36,7 +36,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 	assert.Error(t, err, "Gateway config is nil")
 
 	// IP block parsing
-	config = test_utils.NewDefaultGatewayConfig()
+	config = test_utils.NewDefaultProtosGatewayConfig()
 	config.Epc.IpBlock = "20.20.20.0/24"
 	assert.NoError(t, protos.ValidateGatewayConfig(config))
 	config.Epc.IpBlock = "12345"
@@ -44,7 +44,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 }
 
 func TestValidateNetworkConfig(t *testing.T) {
-	config := test_utils.NewDefaultTDDNetworkConfig()
+	config := test_utils.NewDefaultProtosTDDNetworkConfig()
 	err := protos.ValidateNetworkConfig(config)
 	assert.NoError(t, err)
 
@@ -97,7 +97,7 @@ func TestValidateNetworkConfig(t *testing.T) {
 }
 
 func TestValidateNetworkRANConfig(t *testing.T) {
-	config := test_utils.NewDefaultTDDNetworkConfig()
+	config := test_utils.NewDefaultProtosTDDNetworkConfig()
 	tddConf := &protos.NetworkRANConfig_TDDConfig{
 		Earfcndl:               43950,
 		SubframeAssignment:     2,
@@ -144,7 +144,7 @@ func TestValidateNetworkRANConfig(t *testing.T) {
 }
 
 func TestValidateNetworkTDDRANConfig(t *testing.T) {
-	config := test_utils.NewDefaultTDDNetworkConfig()
+	config := test_utils.NewDefaultProtosTDDNetworkConfig()
 
 	positiveTestCases := []struct {
 		earfcndl int32
@@ -184,7 +184,7 @@ func TestValidateNetworkTDDRANConfig(t *testing.T) {
 }
 
 func TestValidateNetworkFDDRANConfig(t *testing.T) {
-	config := test_utils.NewDefaultTDDNetworkConfig()
+	config := test_utils.NewDefaultProtosTDDNetworkConfig()
 
 	positiveTestCases := []struct {
 		earfcndl int32
@@ -226,7 +226,7 @@ func TestValidateNetworkFDDRANConfig(t *testing.T) {
 }
 
 func TestValidateSubProfile(t *testing.T) {
-	config := test_utils.NewDefaultTDDNetworkConfig()
+	config := test_utils.NewDefaultProtosTDDNetworkConfig()
 	config.Epc.SubProfiles = make(
 		map[string]*protos.NetworkEPCConfig_SubscriptionProfile)
 	config.Epc.SubProfiles["test"] = &protos.NetworkEPCConfig_SubscriptionProfile{
@@ -249,46 +249,46 @@ func TestValidateSubProfile(t *testing.T) {
 }
 
 func TestValidateEnodebConfig(t *testing.T) {
-	config := test_utils.NewDefaultEnodebConfig()
+	config := test_utils.NewDefaultProtosEnodebConfig()
 	err := protos.ValidateEnodebConfig(config)
 	assert.NoError(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.Earfcndl = -1
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.SubframeAssignment = 7
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.SpecialSubframePattern = 10
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.Pci = 505
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.DeviceClass = "Some unsupported device"
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.CellId = 268435456
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.Tac = 65536
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)
 
-	config = test_utils.NewDefaultEnodebConfig()
+	config = test_utils.NewDefaultProtosEnodebConfig()
 	config.BandwidthMhz = 0
 	err = protos.ValidateEnodebConfig(config)
 	assert.Error(t, err)

--- a/lte/cloud/go/services/cellular/test_utils/defaults_protos.go
+++ b/lte/cloud/go/services/cellular/test_utils/defaults_protos.go
@@ -1,31 +1,31 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- * All rights reserved.
- *
- * This source code is licensed under the BSD-style license found in the
- * LICENSE file in the root directory of this source tree.
- */
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
 
 package test_utils
 
 import (
-	"magma/lte/cloud/go/services/cellular/obsidian/models"
+	"magma/lte/cloud/go/services/cellular/protos"
 )
 
-func NewDefaultTDDNetworkConfig() *models.NetworkCellularConfigs {
-	return &models.NetworkCellularConfigs{
-		Ran: &models.NetworkRanConfigs{
+func NewDefaultProtosTDDNetworkConfig() *protos.CellularNetworkConfig {
+	return &protos.CellularNetworkConfig{
+		Ran: &protos.NetworkRANConfig{
 			BandwidthMhz:           20,
 			Earfcndl:               44590,
 			SubframeAssignment:     2,
 			SpecialSubframePattern: 7,
-			TddConfig: &models.NetworkRanConfigsTddConfig{
+			TddConfig: &protos.NetworkRANConfig_TDDConfig{
 				Earfcndl:               44590,
 				SubframeAssignment:     2,
 				SpecialSubframePattern: 7,
 			},
 		},
-		Epc: &models.NetworkEpcConfigs{
+		Epc: &protos.NetworkEPCConfig{
 			Mcc: "001",
 			Mnc: "01",
 			Tac: 1,
@@ -37,17 +37,17 @@ func NewDefaultTDDNetworkConfig() *models.NetworkCellularConfigs {
 	}
 }
 
-func NewDefaultFDDNetworkConfig() *models.NetworkCellularConfigs {
-	return &models.NetworkCellularConfigs{
-		Ran: &models.NetworkRanConfigs{
+func NewDefaultProtosFDDNetworkConfig() *protos.CellularNetworkConfig {
+	return &protos.CellularNetworkConfig{
+		Ran: &protos.NetworkRANConfig{
 			BandwidthMhz: 20,
 			Earfcndl:     1,
-			FddConfig: &models.NetworkRanConfigsFddConfig{
+			FddConfig: &protos.NetworkRANConfig_FDDConfig{
 				Earfcndl: 1,
 				Earfcnul: 18001,
 			},
 		},
-		Epc: &models.NetworkEpcConfigs{
+		Epc: &protos.NetworkEPCConfig{
 			Mcc: "001",
 			Mnc: "01",
 			Tac: 1,
@@ -59,15 +59,15 @@ func NewDefaultFDDNetworkConfig() *models.NetworkCellularConfigs {
 	}
 }
 
-func OldTDDNetworkConfig() *models.NetworkCellularConfigs {
-	return &models.NetworkCellularConfigs{
-		Ran: &models.NetworkRanConfigs{
+func OldProtosTDDNetworkConfig() *protos.CellularNetworkConfig {
+	return &protos.CellularNetworkConfig{
+		Ran: &protos.NetworkRANConfig{
 			BandwidthMhz:           20,
 			Earfcndl:               44590,
 			SubframeAssignment:     2,
 			SpecialSubframePattern: 7,
 		},
-		Epc: &models.NetworkEpcConfigs{
+		Epc: &protos.NetworkEPCConfig{
 			Mcc: "001",
 			Mnc: "01",
 			Tac: 1,
@@ -78,13 +78,13 @@ func OldTDDNetworkConfig() *models.NetworkCellularConfigs {
 	}
 }
 
-func OldFDDNetworkConfig() *models.NetworkCellularConfigs {
-	return &models.NetworkCellularConfigs{
-		Ran: &models.NetworkRanConfigs{
+func OldProtosFDDNetworkConfig() *protos.CellularNetworkConfig {
+	return &protos.CellularNetworkConfig{
+		Ran: &protos.NetworkRANConfig{
 			BandwidthMhz: 20,
 			Earfcndl:     1,
 		},
-		Epc: &models.NetworkEpcConfigs{
+		Epc: &protos.NetworkEPCConfig{
 			Mcc: "001",
 			Mnc: "01",
 			Tac: 1,
@@ -95,35 +95,35 @@ func OldFDDNetworkConfig() *models.NetworkCellularConfigs {
 	}
 }
 
-func NewDefaultGatewayConfig() *models.GatewayCellularConfigs {
-	return &models.GatewayCellularConfigs{
+func NewDefaultProtosGatewayConfig() *protos.CellularGatewayConfig {
+	return &protos.CellularGatewayConfig{
 		AttachedEnodebSerials: []string{"enb1"},
-		Ran: &models.GatewayRanConfigs{
+		Ran: &protos.GatewayRANConfig{
 			Pci:             260,
 			TransmitEnabled: true,
 		},
-		Epc: &models.GatewayEpcConfigs{
+		Epc: &protos.GatewayEPCConfig{
 			NatEnabled: true,
-			IPBlock:    "192.168.128.0/24",
+			IpBlock:    "192.168.128.0/24",
 		},
-		NonEpsService: &models.GatewayNonEpsServiceConfigs{
+		NonEpsService: &protos.GatewayNonEPSConfig{
 			CsfbMcc:              "",
 			CsfbMnc:              "",
 			Lac:                  1,
-			CsfbRat:              0, //2G
-			Arfcn2g:              []uint32{},
-			NonEpsServiceControl: 0, //CONTROL_OFF
+			CsfbRat:              protos.GatewayNonEPSConfig_CSFBRAT_2G,
+			Arfcn_2G:             []int32(""),
+			NonEpsServiceControl: protos.GatewayNonEPSConfig_NON_EPS_SERVICE_CONTROL_OFF,
 		},
 	}
 }
 
-func NewDefaultEnodebConfig() *models.NetworkEnodebConfigs {
-	return &models.NetworkEnodebConfigs{
+func NewDefaultProtosEnodebConfig() *protos.CellularEnodebConfig {
+	return &protos.CellularEnodebConfig{
 		Earfcndl:               39150,
 		SubframeAssignment:     2,
 		SpecialSubframePattern: 7,
 		Pci:                    260,
-		CellID:                 138777000,
+		CellId:                 138777000,
 		Tac:                    15000,
 		BandwidthMhz:           20,
 		TransmitEnabled:        true,


### PR DESCRIPTION
Summary:
LTE gateway entities are now associated to enodeb device entities.
Any time an lte gateway config is updated, the change in `AttachedEnodebSerials` is propagated to the entities' associations.

Also added new tests to test the migrated func, and added some default configs in swagger models.

Differential Revision: D16006927

