### PR TITLE
Add latency metrics for Swx Proxy

### DIFF
--- a/feg/gateway/services/swx_proxy/metrics/metrics.go
+++ b/feg/gateway/services/swx_proxy/metrics/metrics.go
@@ -59,10 +59,38 @@ var (
 		Name: "unauthorized_auth_requests_total",
 		Help: "Total number of authentication requests for un-authorized users",
 	})
+
+	// Latency Metrics
+	MARLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "mar_latency",
+		Help:       "Latency of MAR Diameter requests (seconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	SARLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "sar_latency",
+		Help:       "Latency of SAR Diameter requests (seconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	AuthLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "auth_latency",
+		Help:       "Latency of Authenticate GRPC requests (seconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	RegisterLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "register_latency",
+		Help:       "Latency of Register GRPC requests (seconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	DeregisterLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "deregister_latency",
+		Help:       "Latency of Deregister GRPC requests (seconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
 )
 
 func init() {
 	prometheus.MustRegister(MARRequests, MARSendFailures, SARRequests,
 		SARSendFailures, SwxTimeouts, SwxUnparseableMsg, SwxInvalidSessions,
-		SwxResultCodes, SwxExperimentalResultCodes, UnauthorizedAuthAttempts)
+		SwxResultCodes, SwxExperimentalResultCodes, UnauthorizedAuthAttempts,
+		MARLatency, SARLatency, AuthLatency, RegisterLatency, DeregisterLatency)
 }

--- a/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
@@ -16,6 +16,7 @@ import (
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/services/swx_proxy/cache"
+	"magma/feg/gateway/services/swx_proxy/metrics"
 
 	"github.com/fiorix/go-diameter/diam"
 	"github.com/fiorix/go-diameter/diam/avp"
@@ -135,7 +136,12 @@ func (s *swxProxy) Authenticate(
 	ctx context.Context,
 	req *protos.AuthenticationRequest,
 ) (*protos.AuthenticationAnswer, error) {
-	return s.AuthenticateImpl(req)
+	authStartTime := time.Now()
+	res, err := s.AuthenticateImpl(req)
+	if err == nil {
+		metrics.AuthLatency.Observe(time.Since(authStartTime).Seconds())
+	}
+	return res, err
 }
 
 // Register sends SAR (code 301) over diameter connection,
@@ -144,7 +150,12 @@ func (s *swxProxy) Register(
 	ctx context.Context,
 	req *protos.RegistrationRequest,
 ) (*protos.RegistrationAnswer, error) {
-	return s.RegisterImpl(req, ServerAssignmentType_REGISTRATION)
+	registerStartTime := time.Now()
+	res, err := s.RegisterImpl(req, ServerAssignmentType_REGISTRATION)
+	if err == nil {
+		metrics.RegisterLatency.Observe(time.Since(registerStartTime).Seconds())
+	}
+	return res, err
 }
 
 // Deregister sends SAR (code 301) over diameter connection,
@@ -153,7 +164,12 @@ func (s *swxProxy) Deregister(
 	ctx context.Context,
 	req *protos.RegistrationRequest,
 ) (*protos.RegistrationAnswer, error) {
-	return s.RegisterImpl(req, ServerAssignnmentType_USER_DEREGISTRATION)
+	deregisterStartTime := time.Now()
+	res, err := s.RegisterImpl(req, ServerAssignnmentType_USER_DEREGISTRATION)
+	if err == nil {
+		metrics.DeregisterLatency.Observe(time.Since(deregisterStartTime).Seconds())
+	}
+	return res, err
 }
 
 func (s *swxProxy) genSID() string {


### PR DESCRIPTION
Summary:
This diff serves to add latency metrics for SWx requests.
These metrics are split between the actual diameter requests that
are sent to the HSS and the entire GRPC requests which include
between 0 - 2 diameter requests depending on configuration and
caching.

Reviewed By: fishlinghu

Differential Revision: D15361536

