### PR TITLE
Move docker magmad.yml to default feg configs

### DIFF
--- a/feg/gateway/Vagrantfile
+++ b/feg/gateway/Vagrantfile
@@ -28,7 +28,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     feg.ssh.insert_key = true
 
     config.vm.provider "virtualbox" do |v|
-      v.customize ['modifyvm', :id, '--natnet1', '10.0.5.0/24']
       v.linked_clone = true
       v.memory = 1536
       v.cpus = 2

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -1,4 +1,11 @@
 ---
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
 log_level: INFO
 # List of services for magmad to control
 magma_services:
@@ -20,7 +27,7 @@ non_service303_services:
 
 # Init system to use to control services
 # Supported systems include: [systemd, runit, docker]
-init_system: systemd
+init_system: docker
 
 # bootstrap_manager config
 bootstrap_config:
@@ -31,7 +38,7 @@ bootstrap_config:
 enable_config_streamer: True
 enable_upgrade_manager: False
 enable_network_monitor: False
-enable_systemd_tailer: True
+enable_systemd_tailer: False
 enable_sync_rpc: True
 
 systemd_tailer_poll_interval: 30 # seconds
@@ -61,4 +68,3 @@ metricsd:
     - eap_aka
     - aaa_server
     - csfb
-

--- a/feg/gateway/configs/magmad_legacy.yml
+++ b/feg/gateway/configs/magmad_legacy.yml
@@ -6,10 +6,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-# This config override will be moved to /feg/gateway/configs once Docker
-# officially replaces the vagrant/systemd workflow. For now, this config
-# will override the existing one at feg/gateway/configs.
-
 log_level: INFO
 # List of services for magmad to control
 magma_services:
@@ -31,7 +27,7 @@ non_service303_services:
 
 # Init system to use to control services
 # Supported systems include: [systemd, runit, docker]
-init_system: docker
+init_system: systemd
 
 # bootstrap_manager config
 bootstrap_config:
@@ -42,7 +38,7 @@ bootstrap_config:
 enable_config_streamer: True
 enable_upgrade_manager: False
 enable_network_monitor: False
-enable_systemd_tailer: False
+enable_systemd_tailer: True
 enable_sync_rpc: True
 
 systemd_tailer_poll_interval: 30 # seconds
@@ -72,3 +68,4 @@ metricsd:
     - eap_aka
     - aaa_server
     - csfb
+

--- a/feg/gateway/deploy/feg.dev.yml
+++ b/feg/gateway/deploy/feg.dev.yml
@@ -18,4 +18,5 @@
     - role: feg_dev
       vars:
         user: "{{ ansible_user }}"
+        config_dir: "feg/gateway/configs"
     - role: feg_services

--- a/feg/gateway/deploy/roles/feg_dev/tasks/main.yml
+++ b/feg/gateway/deploy/roles/feg_dev/tasks/main.yml
@@ -52,6 +52,13 @@
     owner: "{{ user }}"
   when: full_provision
 
+- name: Create configs dir
+  file:
+    path: /var/opt/magma/configs
+    state: directory
+    owner: "{{ user }}"
+  when: full_provision
+
 #################################
 # Copy service files for mock cores
 #################################
@@ -83,4 +90,11 @@
 - name: Add the service entries into /etc/hosts from service_registry.yml
   lineinfile: dest=/etc/hosts regexp='.*{{ item }}$' line='127.0.0.1 {{ item }}' state=present
   with_items: "{{ service_registry.services }}"
+  when: full_provision
+
+- name: Copy magmad_legacy.yml to config override directory
+  copy:
+    src: "{{ magma_root }}/{{ config_dir }}/magmad_legacy.yml"
+    dest: /var/opt/magma/configs/magmad.yml
+    remote_src: yes
   when: full_provision

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -109,8 +109,6 @@ COPY --from=base /var/opt/magma/bin /var/opt/magma/bin
 
 # Copy the configs.
 COPY feg/gateway/configs /etc/magma
-# Add docker config overrides
-COPY feg/gateway/docker/configs /etc/magma
 
 # Create empty envdir directory
 RUN mkdir -p /var/opt/magma/envdir

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -74,8 +74,6 @@ COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/
 
 # Copy the configs.
 COPY feg/gateway/configs /etc/magma
-# Add docker config overrides
-COPY feg/gateway/docker/configs /etc/magma
 
 COPY orc8r/gateway/configs/templates /etc/magma/templates
 COPY orc8r/cloud/docker/proxy/magma_headers.rb /etc/nghttpx/magma_headers.rb


### PR DESCRIPTION
Summary:
Previously, we had a seperate directory for docker specific configs. This
is a bit risky given that they're not likely to be known and will go un-updated. This
diff moves these to the default configs directory at `magma/feg/gateway/configs`
and symlinks any legacy configs to ensure a Vagrant dev env still works.

Note: the NAT vagrantfile config is removed to ensure that FeG VM can still
connect to the orc8r. This was currently broken.

Reviewed By: emakeev

Differential Revision: D16043692

