### PR TITLE
Gateway Config update should update tier association

### DIFF
--- a/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
@@ -14,6 +14,8 @@ import (
 	"magma/orc8r/cloud/go/obsidian/handlers"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	upgrade_models "magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
 
 	"github.com/labstack/echo"
@@ -22,12 +24,13 @@ import (
 // Gateway is a special type of network entity. Since magmad supports multiple
 // config types per gateway, each config is modeled as an entity with an
 // association to the gateway entity. If the configType is "magmad_gateway" the
-// config will simply be stored inside the gateway entity
+// config will simply be stored inside the gateway entity with an association
+// to the corresponding tier entity.
 
 func configuratorCreateGatewayConfig(c echo.Context, networkID string, configType string, configKey string, iConfig interface{}) error {
 	// If the type is magmad_gateway add the config to the gw entity
 	if configType == orc8r.MagmadGatewayType {
-		return configuratorCreateEntityConfig(c, networkID, configType, configKey, iConfig)
+		return configuratorCreateMagmadGatewayConfig(c, networkID, configKey, iConfig)
 	}
 
 	config, nerr := GetConfigAndValidate(c, iConfig)
@@ -60,10 +63,18 @@ func configuratorCreateGatewayConfig(c echo.Context, networkID string, configTyp
 	return c.JSON(http.StatusCreated, configKey)
 }
 
-func configuratorDeleteGatewayConfig(c echo.Context, networkID string, configType string, configKey string) error {
-	// If the type is magmad_gateway remove config from the gateway entity
+func configuratorUpdateGatewayConfig(c echo.Context, networkID string, configType string, configKey string, iConfig interface{}) error {
 	if configType == orc8r.MagmadGatewayType {
-		return configuratorDeleteEntityConfig(c, networkID, configType, configKey)
+		return configuratorUpdateMagmadGatewayConfig(c, networkID, configKey, iConfig)
+	}
+
+	// if the config is not for magmad_gateway, this is the same as entity config update
+	return configuratorUpdateEntityConfig(c, networkID, configType, configKey, iConfig)
+}
+
+func configuratorDeleteGatewayConfig(c echo.Context, networkID string, configType string, configKey string) error {
+	if configType == orc8r.MagmadGatewayType {
+		return configuratorDeleteMagmadGatewayConfig(c, networkID, configKey)
 	}
 
 	err := configurator.DeleteEntity(networkID, configType, configKey)
@@ -71,4 +82,109 @@ func configuratorDeleteGatewayConfig(c echo.Context, networkID string, configTyp
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 	return c.NoContent(http.StatusOK)
+}
+
+func configuratorCreateMagmadGatewayConfig(c echo.Context, networkID string, gatewayID string, iConfig interface{}) error {
+	iRequestedConfig, nerr := GetConfigAndValidate(c, iConfig)
+	if nerr != nil {
+		return nerr
+	}
+	requestedConfig := iRequestedConfig.(*models.MagmadGatewayConfig)
+
+	nerr = createTierEntityIfDoesNotExist(networkID, requestedConfig.Tier)
+	if nerr != nil {
+		return nerr
+	}
+
+	update := configurator.EntityUpdateCriteria{
+		Type:              orc8r.MagmadGatewayType,
+		Key:               gatewayID,
+		NewConfig:         requestedConfig,
+		AssociationsToAdd: []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: requestedConfig.Tier}},
+	}
+
+	_, err := configurator.UpdateEntity(networkID, update)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusCreated, gatewayID)
+}
+
+func configuratorUpdateMagmadGatewayConfig(c echo.Context, networkID string, gatewayID string, iConfig interface{}) error {
+	iRequestedConfig, nerr := GetConfigAndValidate(c, iConfig)
+	if nerr != nil {
+		return nerr
+	}
+	requestedConfig := iRequestedConfig.(*models.MagmadGatewayConfig)
+
+	// fetch previous update tier to compute association change
+	iCurrentConfig, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	currentConfig := iCurrentConfig.(*models.MagmadGatewayConfig)
+
+	var associationsToAdd, associationsToDelete []storage.TypeAndKey
+	if currentConfig.Tier != requestedConfig.Tier {
+		nerr = createTierEntityIfDoesNotExist(networkID, requestedConfig.Tier)
+		if nerr != nil {
+			return nerr
+		}
+		associationsToAdd = []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: requestedConfig.Tier}}
+		associationsToDelete = []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: currentConfig.Tier}}
+	}
+
+	update := configurator.EntityUpdateCriteria{
+		Type:                 orc8r.MagmadGatewayType,
+		Key:                  gatewayID,
+		NewConfig:            requestedConfig,
+		AssociationsToAdd:    associationsToAdd,
+		AssociationsToDelete: associationsToDelete,
+	}
+
+	_, err = configurator.UpdateEntity(networkID, update)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+func configuratorDeleteMagmadGatewayConfig(c echo.Context, networkID, gatewayID string) error {
+	iCurrentConfig, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	currentConfig := iCurrentConfig.(*models.MagmadGatewayConfig)
+
+	update := configurator.EntityUpdateCriteria{
+		DeleteConfig:         true,
+		AssociationsToDelete: []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: currentConfig.Tier}},
+	}
+	_, err = configurator.UpdateEntity(networkID, update)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusOK)
+}
+
+func createTierEntityIfDoesNotExist(networkID, tierID string) error {
+	exists, err := configurator.DoesEntityExist(networkID, orc8r.UpgradeTierEntityType, tierID)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	if exists {
+		return nil
+	}
+	entity := configurator.NetworkEntity{
+		Type: orc8r.UpgradeTierEntityType,
+		Key:  tierID,
+		Config: &upgrade_models.Tier{
+			ID: tierID,
+		},
+	}
+	_, err = configurator.CreateEntity(networkID, entity)
+	if err != nil {
+		return handlers.HttpError(err, http.StatusInternalServerError)
+	}
+	return nil
 }

--- a/orc8r/cloud/go/services/config/obsidian/handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/handlers.go
@@ -370,7 +370,13 @@ func GetUpdateConfigHandler(
 			switch getConfigTypeForConfigurator(configType) {
 			case Network:
 				return configuratorUpdateNetworkConfig(c, networkId, configType, userModel)
-			case Gateway, Entity:
+			case Gateway:
+				configKey, err := configKeyGetter(c)
+				if err != nil {
+					return err
+				}
+				return configuratorUpdateGatewayConfig(c, networkId, configType, configKey, userModel)
+			case Entity:
 				configKey, err := configKeyGetter(c)
 				if err != nil {
 					return err

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_legacy_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_legacy_test.go
@@ -20,9 +20,9 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
-	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	"magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
@@ -32,7 +32,6 @@ func TestMagmadLegacy(t *testing.T) {
 	_ = os.Setenv(orc8r.UseConfiguratorEnv, "0")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	magmad_test_init.StartTestService(t)
-	configurator_test_init.StartTestService(t)
 	device_test_init.StartTestService(t)
 	config_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
@@ -286,7 +285,7 @@ func TestMagmadLegacy(t *testing.T) {
 	tests.RunTest(t, listAGsTestCase)
 
 	expCfg := &models.MagmadGatewayConfig{}
-	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
+	err := expCfg.FromServiceModel(newDefaultProtosGatewayConfig())
 	assert.NoError(t, err)
 	marshaledCfg, err := expCfg.MarshalBinary()
 	assert.NoError(t, err)
@@ -429,4 +428,16 @@ func TestMagmadLegacy(t *testing.T) {
 		Expected: "[]",
 	}
 	tests.RunTest(t, listNetworksTestCase)
+}
+
+// Default gateway config struct. Please DO NOT MODIFY this struct in-place
+func newDefaultProtosGatewayConfig() *protos.MagmadGatewayConfig {
+	return &protos.MagmadGatewayConfig{
+		AutoupgradeEnabled:      true,
+		AutoupgradePollInterval: 300,
+		CheckinInterval:         60,
+		CheckinTimeout:          10,
+		Tier:                    "default",
+		DynamicServices:         []string{},
+	}
 }

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
@@ -19,11 +19,10 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
-	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
+	"magma/orc8r/cloud/go/services/configurator"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
-	"magma/orc8r/cloud/go/services/magmad/protos"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
@@ -35,7 +34,6 @@ func TestMagmad(t *testing.T) {
 	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 	device_test_init.StartTestService(t)
-	config_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
 
 	testUrlRoot := fmt.Sprintf(
@@ -274,12 +272,15 @@ func TestMagmad(t *testing.T) {
 	}
 	tests.RunTest(t, listAGsTestCase)
 
-	expCfg := &models.MagmadGatewayConfig{}
-	err := expCfg.FromServiceModel(newDefaultGatewayConfig())
-	assert.NoError(t, err)
+	expCfg := newDefaultGatewayConfig()
 	marshaledCfg, err := expCfg.MarshalBinary()
 	assert.NoError(t, err)
 	expectedCfgStr := string(marshaledCfg)
+	_, err = configurator.CreateEntity(networkId, configurator.NetworkEntity{
+		Type: orc8r.UpgradeTierEntityType,
+		Key:  "default",
+	})
+	assert.NoError(t, err)
 
 	// Test Getting AG Configs
 	createAGConfigTestCase := tests.Testcase{
@@ -301,14 +302,35 @@ func TestMagmad(t *testing.T) {
 	}
 	tests.RunTest(t, getAGConfigTestCase)
 
+	// assert the gateway now has an association to tier entity
+	entity, err := configurator.LoadEntity(networkId, orc8r.MagmadGatewayType, "TestAGHwId12345", configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "default", entity.Associations[0].Key)
+
+	// empty tier should not be accepted
+	expCfg.Tier = ""
+	marshaledCfg, err = expCfg.MarshalBinary()
+	assert.NoError(t, err)
+	expectedCfgStr = string(marshaledCfg)
+	setAGConfigTestCase := tests.Testcase{
+		Name:   "Set AG Configs With Empty Tier",
+		Method: "PUT",
+		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
+			testUrlRoot, networkId),
+		Payload:                  expectedCfgStr,
+		Expected:                 `{"message":"Invalid config: Tier ID must be specified"}`,
+		Expect_http_error_status: true,
+	}
+	tests.RunTest(t, setAGConfigTestCase)
+
 	expCfg.Tier = "changed"
 	marshaledCfg, err = expCfg.MarshalBinary()
 	assert.NoError(t, err)
 	expectedCfgStr = string(marshaledCfg)
 
-	// Test Setting (Updating) AG Configs
-	setAGConfigTestCase := tests.Testcase{
-		Name:   "Set AG Configs",
+	// Test Setting (Updating) AG Configs With An Unregistered Tier
+	setAGConfigTestCase = tests.Testcase{
+		Name:   "Set AG Configs With Unregistered Tier",
 		Method: "PUT",
 		Url: fmt.Sprintf("%s/%s/gateways/TestAGHwId12345/configs",
 			testUrlRoot, networkId),
@@ -316,6 +338,12 @@ func TestMagmad(t *testing.T) {
 		Expected: "",
 	}
 	tests.RunTest(t, setAGConfigTestCase)
+
+	// assert the gateway's tier association has changed
+	entity, err = configurator.LoadEntity(networkId, orc8r.MagmadGatewayType, "TestAGHwId12345", configurator.EntityLoadCriteria{LoadAssocsFromThis: true, LoadConfig: true})
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(entity.Associations))
+	assert.Equal(t, "changed", entity.Associations[0].Key)
 
 	// Test Getting AG Configs After Config Update
 	getAGConfigTestCase2 := tests.Testcase{
@@ -327,6 +355,15 @@ func TestMagmad(t *testing.T) {
 		Expected: expectedCfgStr,
 	}
 	tests.RunTest(t, getAGConfigTestCase2)
+
+	getRegisteredTier := tests.Testcase{
+		Name:     "Get 'challenge' Tier",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/tiers/changed", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: `{"id":"changed","images":null}`,
+	}
+	tests.RunTest(t, getRegisteredTier)
 
 	// Update network wide property
 	//
@@ -421,8 +458,8 @@ func TestMagmad(t *testing.T) {
 }
 
 // Default gateway config struct. Please DO NOT MODIFY this struct in-place
-func newDefaultGatewayConfig() *protos.MagmadGatewayConfig {
-	return &protos.MagmadGatewayConfig{
+func newDefaultGatewayConfig() *models.MagmadGatewayConfig {
+	return &models.MagmadGatewayConfig{
 		AutoupgradeEnabled:      true,
 		AutoupgradePollInterval: 300,
 		CheckinInterval:         60,

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
@@ -127,7 +127,8 @@ func updateNetwork(c echo.Context) error {
 			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
 		},
 	}
-	return configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
+	configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
+	return c.NoContent(http.StatusNoContent)
 }
 
 func deleteNetwork(c echo.Context) error {

--- a/orc8r/cloud/go/services/magmad/obsidian/models/config_conversion.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/models/config_conversion.go
@@ -26,6 +26,9 @@ var formatsRegistry = strfmt.NewFormats()
 // Config conversion for magmad
 
 func (m *MagmadGatewayConfig) ValidateModel() error {
+	if err := m.ValidateGatewayConfig(); err != nil {
+		return err
+	}
 	return m.Validate(formatsRegistry)
 }
 
@@ -65,6 +68,9 @@ func (m *NetworkRecord) ToProto() *magmadprotos.MagmadNetworkRecord {
 }
 
 func (m *NetworkRecord) ValidateModel() error {
+	if err := m.ValidateNetworkRecord(); err != nil {
+		return err
+	}
 	return m.Validate(formatsRegistry)
 }
 

--- a/orc8r/cloud/go/services/magmad/obsidian/models/validation.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/models/validation.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package models
+
+import "errors"
+
+func (m *MagmadGatewayConfig) ValidateGatewayConfig() error {
+	if m == nil {
+		return errors.New("Gateway m is nil")
+	}
+	if m.Tier == "" {
+		return errors.New("Tier ID must be specified")
+	}
+	return nil
+}
+
+func (m *NetworkRecord) ValidateNetworkRecord() error {
+	if m == nil {
+		return errors.New("Network m is nil")
+	}
+	if m.Name == "" {
+		return errors.New("Network name must be specified")
+	}
+	return nil
+}


### PR DESCRIPTION
Summary: Magmad Gateway Config specifies which tier the gateway is on, so it should also manage an association to the corresponding upgrade tier entity.

Reviewed By: xjtian

Differential Revision: D16053603

