### PR TITLE
Migrate network config validation to be done in swagger not protobuf

### DIFF
--- a/orc8r/cloud/go/services/dnsd/obsidian/models/config_conversion.go
+++ b/orc8r/cloud/go/services/dnsd/obsidian/models/config_conversion.go
@@ -22,6 +22,9 @@ import (
 var formatsRegistry strfmt.Registry = strfmt.NewFormats()
 
 func (m *NetworkDNSConfig) ValidateModel() error {
+	if err := m.ValidateNetworkConfig(); err != nil {
+		return err
+	}
 	return m.Validate(formatsRegistry)
 }
 

--- a/orc8r/cloud/go/services/dnsd/obsidian/models/validation.go
+++ b/orc8r/cloud/go/services/dnsd/obsidian/models/validation.go
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package models
+
+import (
+	"errors"
+
+	"magma/orc8r/cloud/go/services/dnsd/protos"
+)
+
+func (m *NetworkDNSConfig) ValidateNetworkConfig() error {
+	if m == nil {
+		return errors.New("NetworkDNSconfig is nil.")
+	}
+	if err := validateNetworkDNSRecordsConfig(m.Records); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateNetworkDNSRecordsConfig(records []*NetworkDNSConfigRecordsItems0) error {
+	if records == nil {
+		return nil
+	}
+
+	for _, item := range records {
+		if err := validateNetworkDNSConfigRecordsItems(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNetworkDNSConfigRecordsItems(config *NetworkDNSConfigRecordsItems0) error {
+	if config == nil {
+		return errors.New("NetworkDNSconfig Records Item is nil.")
+	}
+
+	if err := protos.ValidateNetworkDNSConfigARecord(config.ARecord); err != nil {
+		return err
+	}
+	if err := protos.ValidateNetworkDNSConfigAaaaRecord(config.AaaaRecord); err != nil {
+		return err
+	}
+
+	if err := protos.ValidateNetworkDNSConfigDomain(config.Domain); err != nil {
+		return err
+	}
+
+	if err := protos.ValidateNetworkDNSConfigCname(config.CnameRecord); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/orc8r/cloud/go/services/dnsd/protos/proto_validation.go
+++ b/orc8r/cloud/go/services/dnsd/protos/proto_validation.go
@@ -43,25 +43,25 @@ func validateNetworkDNSConfigRecordsItems(config *NetworkDNSConfigRecordsItems) 
 		return errors.New("NetworkDNSconfig Records Item is nil.")
 	}
 
-	if err := validateNetworkDNSConfigARecord(config.GetARecord()); err != nil {
+	if err := ValidateNetworkDNSConfigARecord(config.GetARecord()); err != nil {
 		return err
 	}
-	if err := validateNetworkDNSConfigAaaaRecord(config.GetAaaaRecord()); err != nil {
-		return err
-	}
-
-	if err := validateNetworkDNSConfigDomain(config.GetDomain()); err != nil {
+	if err := ValidateNetworkDNSConfigAaaaRecord(config.GetAaaaRecord()); err != nil {
 		return err
 	}
 
-	if err := validateNetworkDNSConfigCname(config.GetCnameRecord()); err != nil {
+	if err := ValidateNetworkDNSConfigDomain(config.GetDomain()); err != nil {
+		return err
+	}
+
+	if err := ValidateNetworkDNSConfigCname(config.GetCnameRecord()); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func validateNetworkDNSConfigARecord(ARecord []string) error {
+func ValidateNetworkDNSConfigARecord(ARecord []string) error {
 	if ARecord == nil {
 		return nil
 	}
@@ -73,7 +73,7 @@ func validateNetworkDNSConfigARecord(ARecord []string) error {
 	return nil
 }
 
-func validateNetworkDNSConfigAaaaRecord(AaaaRecord []string) error {
+func ValidateNetworkDNSConfigAaaaRecord(AaaaRecord []string) error {
 	if AaaaRecord == nil {
 		return nil
 	}
@@ -85,7 +85,7 @@ func validateNetworkDNSConfigAaaaRecord(AaaaRecord []string) error {
 	return nil
 }
 
-func validateNetworkDNSConfigDomain(domain string) error {
+func ValidateNetworkDNSConfigDomain(domain string) error {
 	// TODO: Figure out how to validate a string is a domain
 	if domain == "" {
 		return errors.New("Domain cannot be empty string.")
@@ -93,12 +93,12 @@ func validateNetworkDNSConfigDomain(domain string) error {
 	return nil
 }
 
-func validateNetworkDNSConfigCname(CnameRecord []string) error {
+func ValidateNetworkDNSConfigCname(CnameRecord []string) error {
 	if CnameRecord == nil {
 		return nil
 	}
 	for _, record := range CnameRecord {
-		if err := validateNetworkDNSConfigDomain(record); err != nil {
+		if err := ValidateNetworkDNSConfigDomain(record); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Summary: Perform config validation in terms of swagger models.

Reviewed By: xjtian

Differential Revision: D16061429

