### PR TITLE
Make grpc call to AAA when terminating session in enforcer

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -22,3 +22,6 @@ usage_reporting_threshold: 0.8
 # terminating the session. This should be at least twice the poll interval of
 # pipelined
 session_force_termination_timeout_ms: 5000
+
+# Set to true to enable sessiond support of carrier wifi
+support_carrier_wifi: true

--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "AAAClient.h"
+#include "ServiceRegistrySingleton.h"
+#include "magma_logging.h"
+
+using grpc::Status;
+
+namespace { // anonymous
+
+aaa::terminate_session_request create_deactivate_req(
+  const std::string &radius_session_id,
+  const std::string &imsi)
+{
+  aaa::terminate_session_request req;
+  req.set_radius_session_id(radius_session_id);
+  req.set_imsi(imsi);
+  return req;
+}
+
+} // namespace
+
+namespace aaa {
+
+AsyncAAAClient::AsyncAAAClient(
+  std::shared_ptr<grpc::Channel> channel):
+  stub_(accounting::NewStub(channel))
+{
+}
+
+AsyncAAAClient::AsyncAAAClient():
+  AsyncAAAClient(magma::ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+    "aaa",
+    magma::ServiceRegistrySingleton::LOCAL))
+{
+}
+
+bool AsyncAAAClient::terminate_session(
+  const std::string &radius_session_id,
+  const std::string &imsi)
+{
+  auto req = create_deactivate_req(radius_session_id, imsi);
+  terminate_session_rpc(req, [radius_session_id, imsi](
+    Status status, acct_resp resp) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not add terminate session. Radius ID:"
+                   << radius_session_id << ", IMSI: " << imsi
+                   << ", Error: " << status.error_message();
+    }
+  });
+  return true;
+}
+
+void AsyncAAAClient::terminate_session_rpc(
+  const terminate_session_request &request,
+  std::function<void(Status, acct_resp)> callback)
+{
+  auto local_resp = new magma::AsyncLocalResponse<acct_resp>(
+    std::move(callback), RESPONSE_TIMEOUT);
+  local_resp->set_response_reader(std::move(stub_->Asyncterminate_session(
+    local_resp->get_context(), request, &queue_)));
+}
+
+} // namespace aaa

--- a/lte/gateway/c/session_manager/AAAClient.h
+++ b/lte/gateway/c/session_manager/AAAClient.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "GRPCReceiver.h"
+
+#include <feg/gateway/services/aaa/protos/accounting.grpc.pb.h>
+
+using grpc::Status;
+
+namespace aaa {
+using namespace protos;
+
+/**
+ * AAAClient is the base class for interacting with AAA service
+ */
+class AAAClient {
+ public:
+  virtual bool terminate_session(
+    const std::string &radius_session_id,
+    const std::string &imsi) = 0;
+};
+
+/**
+ * AsyncAAAClient implements AAAClient and sends call
+ * asynchronously to AAA service.
+ */
+class AsyncAAAClient : public magma::GRPCReceiver, public AAAClient {
+ public:
+  AsyncAAAClient();
+
+  AsyncAAAClient(std::shared_ptr<grpc::Channel> aaa_channel);
+
+  bool terminate_session(
+    const std::string &radius_session_id,
+    const std::string &imsi);
+
+ private:
+  static const uint32_t RESPONSE_TIMEOUT = 6; // seconds
+  std::unique_ptr<accounting::Stub> stub_;
+
+ private:
+  void terminate_session_rpc(
+    const terminate_session_request &request,
+    std::function<void(Status, acct_resp)> callback);
+};
+
+} // namespace aaa

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -53,6 +53,10 @@ set(SMGR_GRPC_PROTOS session_manager pipelined pgw)
 generate_grpc_protos("${SMGR_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 
+set(SMGR_CWF_GRPC_PROTOS accounting)
+generate_grpc_protos("${SMGR_CWF_GRPC_PROTOS}" "${PROTO_SRCS}"
+  "${PROTO_HDRS}" ${CWF_PROTO_DIR} ${CWF_CPP_OUT_DIR})
+
 message("Proto_srcs are ${PROTO_SRCS}")
 
 link_directories(
@@ -64,6 +68,8 @@ link_directories(
   ${MAGMA_LIB_DIR}/service_registry)
 
 add_library(SESSION_MANAGER
+    AAAClient.cpp
+    AAAClient.h
     SessionManagerServer.cpp
     SessionManagerServer.h
     LocalSessionManagerHandler.cpp

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -11,9 +11,10 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 #include <folly/io/async/EventBaseManager.h>
 
+#include "AAAClient.h"
 #include "CloudReporter.h"
-#include "RuleStore.h"
 #include "PipelinedClient.h"
+#include "RuleStore.h"
 #include "SessionState.h"
 
 namespace magma {
@@ -35,6 +36,7 @@ class LocalEnforcer {
     std::shared_ptr<SessionCloudReporter> reporter,
     std::shared_ptr<StaticRuleStore> rule_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
+    std::shared_ptr<aaa::AAAClient> aaa_client,
     long session_force_termination_timeout_ms);
 
   void attachEventBase(folly::EventBase *evb);
@@ -131,6 +133,7 @@ class LocalEnforcer {
   std::shared_ptr<SessionCloudReporter> reporter_;
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
+  std::shared_ptr<aaa::AAAClient> aaa_client_;
   std::unordered_map<std::string, std::unique_ptr<SessionState>> session_map_;
   folly::EventBase *evb_;
   long session_force_termination_timeout_ms_;
@@ -227,6 +230,9 @@ class LocalEnforcer {
     const google::protobuf::Timestamp &revalidation_time);
 
   void check_usage_for_reporting();
+
+  void execute_actions(
+    const std::vector<std::unique_ptr<ServiceAction>> &actions);
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -248,4 +248,9 @@ void SessionCredit::reauth()
   reauth_state_ = REAUTH_REQUIRED;
 }
 
+bool SessionCredit::no_more_grant()
+{
+  return is_final_;
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -139,6 +139,11 @@ class SessionCredit {
   void reauth();
 
   /**
+   * Returns true when there will be no more quora granted
+   */
+  bool no_more_grant();
+
+  /**
    * A threshold represented as a ratio for triggering usage update before
    * an user completely used up the quota
    * Session manager will send usage update when

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -238,4 +238,9 @@ bool SessionState::is_radius_cwf_session()
   return (config_.rat_type == RATType::TGPP_WLAN);
 }
 
+std::string SessionState::get_radius_session_id()
+{
+  return config_.radius_session_id;
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -121,6 +121,8 @@ class SessionState {
 
   std::string get_mac_addr();
 
+  std::string get_radius_session_id();
+
   bool is_radius_cwf_session();
 
  private:

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -178,4 +178,18 @@ class MockSessionCloudReporter : public SessionCloudReporter {
 
 };
 
+class MockAAAClient : public aaa::AAAClient {
+ public:
+  MockAAAClient()
+  {
+    ON_CALL(*this, terminate_session(_, _)).WillByDefault(Return(true));
+  }
+
+  MOCK_METHOD2(
+    terminate_session,
+    bool(
+      const std::string &radius_session_id,
+      const std::string &imsi));
+};
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -51,7 +51,7 @@ class SessiondTest : public ::testing::Test {
 
     reporter = std::make_shared<SessionCloudReporterImpl>(evb, test_channel);
     monitor = std::make_shared<LocalEnforcer>(
-      reporter, rule_store, pipelined_client, 0);
+      reporter, rule_store, pipelined_client, nullptr, 0);
 
     local_service =
       std::make_shared<service303::MagmaService>("sessiond", "1.0");

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -22,3 +22,6 @@ usage_reporting_threshold: 0.8
 # terminating the session. This should be at least twice the poll interval of
 # pipelined
 session_force_termination_timeout_ms: 5000
+
+# Set to true to enable sessiond support of carrier wifi
+support_carrier_wifi: false

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -21,3 +21,6 @@ usage_reporting_threshold: 0.8
 # terminating the session. This should be at least twice the poll interval of
 # pipelined
 session_force_termination_timeout_ms: 5000
+
+# Set to true to enable sessiond support of carrier wifi
+support_carrier_wifi: false

--- a/orc8r/gateway/c/common/CMakeProtoMacros.txt
+++ b/orc8r/gateway/c/common/CMakeProtoMacros.txt
@@ -71,6 +71,25 @@ macro(generate_cpp_protos PROTO_NAME_LIST PROTO_SRCS PROTO_HDRS IN_DIR OUT_DIR)
   endforeach()
 endmacro()
 
+macro(generate_cwf_grpc_protos PROTO_NAME_LIST PROTO_SRCS PROTO_HDRS IN_DIR OUT_DIR)
+  foreach(PROTO_NAME ${PROTO_NAME_LIST})
+    list(APPEND PROTO_SRCS ${OUT_DIR}/${PROTO_NAME}.grpc.pb.cc)
+    list(APPEND PROTO_HDRS ${OUT_DIR}/${PROTO_NAME}.grpc.pb.h)
+
+    add_custom_command(
+      OUTPUT "${OUT_DIR}/${PROTO_NAME}.grpc.pb.cc"
+           "${OUT_DIR}/${PROTO_NAME}.grpc.pb.h"
+      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+      ARGS -I ${CWF_PROTO_DIR} --proto_path=${IN_DIR}
+          --grpc_out=${OUT_DIR}
+          --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_PATH}/grpc_cpp_plugin
+          ${IN_DIR}/${PROTO_NAME}.proto
+          DEPENDS ${IN_DIR}/${PROTO_NAME}.proto ${PROTOBUF_PROTOC_EXECUTABLE}
+          COMMENT "Running GRPC protobuf compiler on ${IN_DIR}/${PROTO_NAME}.proto"
+      VERBATIM )
+  endforeach()
+endmacro()
+
 macro(generate_grpc_protos PROTO_NAME_LIST PROTO_SRCS PROTO_HDRS IN_DIR OUT_DIR)
   foreach(PROTO_NAME ${PROTO_NAME_LIST})
     list(APPEND PROTO_SRCS ${OUT_DIR}/${PROTO_NAME}.grpc.pb.cc)


### PR DESCRIPTION
Summary:
**Summary**
After a session received last update and exhausted the quota, sessiond should make a GRPC call to AAA service to terminate the session.

**Implementation**
When terminating service, sessiond also check if the session is a CWF session. If so, use `AAAClient` to send session termination to the AAA service.

**What is affected**
LTE session should not be affected.
CWF session should be terminated when running out of quota without more grant.

Differential Revision: D16079998

