### PR TITLE
Add AAAClient for communicating with AAA service

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "AAAClient.h"
+#include "ServiceRegistrySingleton.h"
+#include "magma_logging.h"
+
+using grpc::Status;
+
+namespace { // anonymous
+
+aaa::terminate_session_request create_deactivate_req(
+  const std::string &radius_session_id,
+  const std::string &imsi)
+{
+  aaa::terminate_session_request req;
+  req.set_radius_session_id(radius_session_id);
+  req.set_imsi(imsi);
+  return req;
+}
+
+} // namespace
+
+namespace aaa {
+
+AsyncAAAClient::AsyncAAAClient(
+  std::shared_ptr<grpc::Channel> channel):
+  stub_(accounting::NewStub(channel))
+{
+}
+
+AsyncAAAClient::AsyncAAAClient():
+  AsyncAAAClient(magma::ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+    "aaa",
+    magma::ServiceRegistrySingleton::LOCAL))
+{
+}
+
+bool AsyncAAAClient::terminate_session(
+  const std::string &radius_session_id,
+  const std::string &imsi)
+{
+  auto req = create_deactivate_req(radius_session_id, imsi);
+  terminate_session_rpc(req, [radius_session_id, imsi](
+    Status status, acct_resp resp) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not add terminate session. Radius ID:"
+                   << radius_session_id << ", IMSI: " << imsi
+                   << ", Error: " << status.error_message();
+    }
+  });
+  return true;
+}
+
+void AsyncAAAClient::terminate_session_rpc(
+  const terminate_session_request &request,
+  std::function<void(Status, acct_resp)> callback)
+{
+  auto local_resp = new magma::AsyncLocalResponse<acct_resp>(
+    std::move(callback), RESPONSE_TIMEOUT);
+  local_resp->set_response_reader(std::move(stub_->Asyncterminate_session(
+    local_resp->get_context(), request, &queue_)));
+}
+
+} // namespace aaa

--- a/lte/gateway/c/session_manager/AAAClient.h
+++ b/lte/gateway/c/session_manager/AAAClient.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "GRPCReceiver.h"
+
+#include <feg/gateway/services/aaa/protos/accounting.grpc.pb.h>
+
+using grpc::Status;
+
+namespace aaa {
+using namespace protos;
+
+/**
+ * AAAClient is the base class for interacting with AAA service
+ */
+class AAAClient {
+ public:
+  virtual bool terminate_session(
+    const std::string &radius_session_id,
+    const std::string &imsi) = 0;
+};
+
+/**
+ * AsyncAAAClient implements AAAClient and sends call
+ * asynchronously to AAA service.
+ */
+class AsyncAAAClient : public magma::GRPCReceiver, public AAAClient {
+ public:
+  AsyncAAAClient();
+
+  AsyncAAAClient(std::shared_ptr<grpc::Channel> aaa_channel);
+
+  bool terminate_session(
+    const std::string &radius_session_id,
+    const std::string &imsi);
+
+ private:
+  static const uint32_t RESPONSE_TIMEOUT = 6; // seconds
+  std::unique_ptr<accounting::Stub> stub_;
+
+ private:
+  void terminate_session_rpc(
+    const terminate_session_request &request,
+    std::function<void(Status, acct_resp)> callback);
+};
+
+} // namespace aaa

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -53,6 +53,10 @@ set(SMGR_GRPC_PROTOS session_manager pipelined pgw)
 generate_grpc_protos("${SMGR_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${LTE_PROTO_DIR} ${LTE_CPP_OUT_DIR})
 
+set(SMGR_CWF_GRPC_PROTOS accounting)
+generate_grpc_protos("${SMGR_CWF_GRPC_PROTOS}" "${PROTO_SRCS}"
+  "${PROTO_HDRS}" ${CWF_PROTO_DIR} ${CWF_CPP_OUT_DIR})
+
 message("Proto_srcs are ${PROTO_SRCS}")
 
 link_directories(
@@ -64,6 +68,8 @@ link_directories(
   ${MAGMA_LIB_DIR}/service_registry)
 
 add_library(SESSION_MANAGER
+    AAAClient.cpp
+    AAAClient.h
     SessionManagerServer.cpp
     SessionManagerServer.h
     LocalSessionManagerHandler.cpp

--- a/orc8r/gateway/c/common/CMakeProtoMacros.txt
+++ b/orc8r/gateway/c/common/CMakeProtoMacros.txt
@@ -71,6 +71,25 @@ macro(generate_cpp_protos PROTO_NAME_LIST PROTO_SRCS PROTO_HDRS IN_DIR OUT_DIR)
   endforeach()
 endmacro()
 
+macro(generate_cwf_grpc_protos PROTO_NAME_LIST PROTO_SRCS PROTO_HDRS IN_DIR OUT_DIR)
+  foreach(PROTO_NAME ${PROTO_NAME_LIST})
+    list(APPEND PROTO_SRCS ${OUT_DIR}/${PROTO_NAME}.grpc.pb.cc)
+    list(APPEND PROTO_HDRS ${OUT_DIR}/${PROTO_NAME}.grpc.pb.h)
+
+    add_custom_command(
+      OUTPUT "${OUT_DIR}/${PROTO_NAME}.grpc.pb.cc"
+           "${OUT_DIR}/${PROTO_NAME}.grpc.pb.h"
+      COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+      ARGS -I ${CWF_PROTO_DIR} --proto_path=${IN_DIR}
+          --grpc_out=${OUT_DIR}
+          --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_PATH}/grpc_cpp_plugin
+          ${IN_DIR}/${PROTO_NAME}.proto
+          DEPENDS ${IN_DIR}/${PROTO_NAME}.proto ${PROTOBUF_PROTOC_EXECUTABLE}
+          COMMENT "Running GRPC protobuf compiler on ${IN_DIR}/${PROTO_NAME}.proto"
+      VERBATIM )
+  endforeach()
+endmacro()
+
 macro(generate_grpc_protos PROTO_NAME_LIST PROTO_SRCS PROTO_HDRS IN_DIR OUT_DIR)
   foreach(PROTO_NAME ${PROTO_NAME_LIST})
     list(APPEND PROTO_SRCS ${OUT_DIR}/${PROTO_NAME}.grpc.pb.cc)


### PR DESCRIPTION
Summary:
**Summary**
Similar to PipelinedClient and PgwClient, this AAAClient is used by sessiond to communicate with AAA service. Currently we only plan to support session termination initiated from sessiond.

**Implementation**
1. Generate C++ codes from `accounting.proto`
2. Call the generated RPC functions from AAAClient's functions

**What is affected**
Nothing is affected since this class is not used by anyone.

Differential Revision: D16064319

