### PR TITLE
Update CWAG and Pipelined to install OVS from Jfrog Debian repo

### DIFF
--- a/cwf/gateway/deploy/cwag.yml
+++ b/cwf/gateway/deploy/cwag.yml
@@ -8,5 +8,8 @@
   hosts: localhost
   become: yes
   roles:
+    - role: pkgrepo
+      vars:
+        distribution: "bionic"
     - role: ovs
     - role: cwag

--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -12,6 +12,10 @@
     - user: vagrant
     - full_provision: true
   roles:
+    - role: apt_cache
+    - role: pkgrepo
+      vars:
+        distribution: "bionic"
     - role: ovs
     - role: golang
     - role: cwag

--- a/cwf/gateway/deploy/roles/ovs/files/magma-preferences
+++ b/cwf/gateway/deploy/roles/ovs/files/magma-preferences
@@ -1,0 +1,3 @@
+Package: *
+Pin: origin magma.jfrog.io
+Pin-Priority: 900

--- a/cwf/gateway/deploy/roles/ovs/tasks/main.yml
+++ b/cwf/gateway/deploy/roles/ovs/tasks/main.yml
@@ -4,10 +4,8 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
-- name: Get OVS v2.8.1 Tarball
-  get_url:
-    url: 'https://www.openvswitch.org/releases/openvswitch-2.8.1.tar.gz'
-    dest: /tmp
+- name: Copy preferences file for Magma's pkg repo
+  copy: src=magma-preferences dest=/etc/apt/preferences.d/magma-preferences
 
 - name: Install OVS Dependencies for Ubuntu
   package:
@@ -32,35 +30,13 @@
     - build-essential
     - fakeroot
 
-- name: Creates OVS unarchive directory
-  file:
-    path: /tmp/ovs
-    state: directory
-
-- name: Unarchive OVS tarball
-  unarchive:
-    src: /tmp/openvswitch-2.8.1.tar.gz
-    dest: /tmp/ovs/
-    remote_src: yes
-  become: true
-
-- name: Build OVS debian packages
-  command: fakeroot ./debian/rules binary
-  args:
-    chdir: /tmp/ovs/openvswitch-2.8.1
-  environment:
-    DEB_BUILD_OPTIONS: 'parallel=8 nocheck'
-  become: true
-
-- name: Install OVS debian packages
-  apt:
-    deb: "{{ item }}"
+- name: Install OVS v2.8.1 from Magma's pkgrepo
+  apt: pkg={{ item }} state=present update_cache=yes
   with_items:
-    - "/tmp/ovs/libopenvswitch_2.8.1-1_amd64.deb"
-    - "/tmp/ovs/openvswitch-common_2.8.1-1_amd64.deb"
-    - "/tmp/ovs/openvswitch-switch_2.8.1-1_amd64.deb"
-    - "/tmp/ovs/python-openvswitch_2.8.1-1_all.deb"
-  become: true
+    - libopenvswitch
+    - openvswitch-common
+    - openvswitch-switch
+    - python-openvswitch
 
 - name: Start OVS
   service:

--- a/lte/gateway/docker/c/Dockerfile
+++ b/lte/gateway/docker/c/Dockerfile
@@ -55,6 +55,7 @@ ENV XDG_CACHE_HOME $MAGMA_ROOT/.cache
 
 # Copy proto files
 COPY feg/protos $MAGMA_ROOT/feg/protos
+COPY feg/gateway/services/aaa/protos $MAGMA_ROOT/feg/gateway/services/aaa/protos
 COPY lte/protos $MAGMA_ROOT/lte/protos
 COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
 COPY protos $MAGMA_ROOT/protos

--- a/lte/gateway/docker/python/Dockerfile
+++ b/lte/gateway/docker/python/Dockerfile
@@ -1,43 +1,10 @@
 # -----------------------------------------------------------------------------
-# Builder image to generate OVS debian packages and Magma proto files
+# Builder image for Magma proto files
 # -----------------------------------------------------------------------------
 FROM ubuntu:xenial AS builder
 
-# Add the magma apt repo
-RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https
-COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
-RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ xenial main"
-
 # Install the runtime deps from apt.
-RUN apt-get -y update && apt-get -y install curl make virtualenv zip tar
-
-# TODO: Fetch necessary OVS debian packages from pkgrepo
-# Fetch OVS v2.8.1 tarball
-RUN curl -Lfs https://www.openvswitch.org/releases/openvswitch-2.8.1.tar.gz | tar xvz
-
-# Install OVS dependencies for building
-RUN apt-get -y update && apt-get -y install \
-  graphviz \
-  autoconf \
-  automake \
-  bzip2 \
-  debhelper \
-  dh-autoreconf \
-  libssl-dev \
-  libtool \
-  openssl \
-  procps \
-  python-all \
-  python-twisted-conch \
-  python-zopeinterface \
-  python-six \
-  build-essential \
-  fakeroot
-
-# Build OVS v2.8.1 debian packages
-RUN cd openvswitch-2.8.1 && DEB_BUILD_OPTIONS='parallel=8 nocheck' fakeroot debian/rules binary
+RUN apt-get -y update && apt-get -y install curl make virtualenv zip
 
 # Install protobuf compiler.
 RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
@@ -71,6 +38,7 @@ FROM ubuntu:xenial AS lte_gateway_python
 RUN apt-get update && \
     apt-get install -y apt-utils software-properties-common apt-transport-https
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
+COPY cwf/gateway/deploy/roles/ovs/files/magma-preferences /etc/apt/preferences.d/
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ xenial main"
 
@@ -94,18 +62,15 @@ RUN apt-get -y update && apt-get -y install \
   python3-pip \
   redis-server
 
-# Copy OVS debian packages from builder
-COPY --from=builder libopenvswitch_2.8.1-1_amd64.deb /tmp/ovs/
-COPY --from=builder openvswitch-common_2.8.1-1_amd64.deb /tmp/ovs/
-COPY --from=builder openvswitch-switch_2.8.1-1_amd64.deb /tmp/ovs/
-COPY --from=builder python-openvswitch_2.8.1-1_all.deb /tmp/ovs/
+# Install OVS via Magma bionic pkg repo
+RUN apt-key add /tmp/jfrog.pub && \
+    apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ bionic main"
 
-# Install OVS debian packages
-RUN apt-get -y install \
-  /tmp/ovs/libopenvswitch_2.8.1-1_amd64.deb \
-  /tmp/ovs/openvswitch-common_2.8.1-1_amd64.deb \
-  /tmp/ovs/openvswitch-switch_2.8.1-1_amd64.deb \
-  /tmp/ovs/python-openvswitch_2.8.1-1_all.deb
+RUN apt-get -y update && apt-get -y install \
+  libopenvswitch \
+  openvswitch-common \
+  openvswitch-switch \
+  python-openvswitch
 
 # Install orc8r python (magma.common required for lte python)
 COPY orc8r/gateway/python /tmp/orc8r

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -81,7 +81,7 @@ if [ "$GW_TYPE" == "$CWAG" ]; then
   apt-add-repository -y ppa:ansible/ansible
   apt-get update -y
   apt-get -y install ansible
-  ansible-playbook "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/deploy/cwag.yml -i "localhost," -c local -v
+  ANSIBLE_CONFIG="$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/ansible.cfg ansible-playbook "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/deploy/cwag.yml -i "localhost," -c local -v
 fi
 
 if [ "$GW_TYPE" == "$FEG" ]; then


### PR DESCRIPTION
Summary:
This diff serves to no longer build OVS v2.8.1 for the
Carrier WiFi Access Gateway from source, but rather installs
the .debs from Magma's pkg repo. This diff helps fix an
installation error that was occuring from a compilation
error happening with more recent Ubuntu 18.04 versions.

Differential Revision: D16087562

