### PR TITLE
change Wifi Gateway Configs read logic to read meshID from associations

### DIFF
--- a/orc8r/cloud/go/services/configurator/client_test.go
+++ b/orc8r/cloud/go/services/configurator/client_test.go
@@ -149,7 +149,7 @@ func TestConfiguratorService(t *testing.T) {
 	assert.Equal(t, "foobar", entities[0].Name)
 	assert.Equal(t, "fooboo", entities[1].Name)
 
-	// Update, Load
+	// Update, Load add an association from foobar to fooboo
 	newPhysID := "4321"
 	entityUpdateCriteria := configurator.EntityUpdateCriteria{
 		Type:              entityID1.Type,
@@ -175,6 +175,7 @@ func TestConfiguratorService(t *testing.T) {
 	assert.Equal(t, 1, len(entities[0].Associations))
 	assert.Equal(t, entityID2.Type, entities[0].Associations[0].Type)
 	assert.Equal(t, entityID2.Key, entities[0].Associations[0].Key)
+	assert.Equal(t, entityID1.Key, entities[1].ParentAssociations[0].Key)
 
 	// Delete, Load
 	err = configurator.DeleteEntities(networkID1, []storage.TypeAndKey{entityID2})

--- a/orc8r/cloud/go/services/configurator/types.go
+++ b/orc8r/cloud/go/services/configurator/types.go
@@ -179,7 +179,7 @@ func (ent NetworkEntity) fromStorageProto(protoEnt *storage.NetworkEntity) (Netw
 	ent.PhysicalID = protoEnt.PhysicalID
 	ent.GraphID = protoEnt.GraphID
 	ent.Associations = entIDsToTKs(protoEnt.Associations)
-	ent.ParentAssociations = entIDsToTKs(protoEnt.Associations)
+	ent.ParentAssociations = entIDsToTKs(protoEnt.ParentAssociations)
 	ent.Version = protoEnt.Version
 
 	if !funk.IsEmpty(protoEnt.Config) {


### PR DESCRIPTION
Summary:
change wifi gateway association read logic to look at magmad gateway entity's parent association.
Also fix bug in storage <-> proto entity conversion to properly propagate parent associations.

Differential Revision: D16112368

