### PR TITLE
Create Dockerfile and docker-compose files to containerize magmad as a Docker container

### DIFF
--- a/orc8r/gateway/configs/control_proxy.yml
+++ b/orc8r/gateway/configs/control_proxy.yml
@@ -1,0 +1,34 @@
+---
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# nghttpx config will be generated here and used
+nghttpx_config_location: /var/tmp/nghttpx.conf
+
+# Location for certs
+rootca_cert: /var/opt/magma/certs/rootCA.pem
+gateway_cert: /var/opt/magma/certs/gateway.crt
+gateway_key: /var/opt/magma/certs/gateway.key
+
+# Listening port of the proxy for local services. The port would be closed
+# for the rest of the world.
+local_port: 8443
+
+# Cloud address for reaching out to the cloud.
+cloud_address: controller.magma.test
+cloud_port: 9443
+
+bootstrap_address: bootstrapper-controller.magma.test
+bootstrap_port: 9444
+
+# Option to use nghttpx for proxying. If disabled, the individual
+# services would establish the TLS connections themselves.
+proxy_cloud_connections: True
+
+# Allows http_proxy usage if the environment variable is present
+allow_http_proxy: True

--- a/orc8r/gateway/configs/gateway.mconfig
+++ b/orc8r/gateway/configs/gateway.mconfig
@@ -1,0 +1,18 @@
+{
+  "configs_by_key": {
+    "control_proxy": {
+      "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
+      "logLevel": "INFO"
+    },
+    "magmad": {
+      "@type": "type.googleapis.com/magma.mconfig.MagmaD",
+      "logLevel": "INFO",
+      "checkinInterval": 60,
+      "checkinTimeout": 10,
+      "autoupgradeEnabled": false,
+      "autoupgradePollInterval": 300,
+      "package_version": "0.0.0-0",
+      "dynamic_services": []
+    }
+  }
+}

--- a/orc8r/gateway/configs/magmad.yml
+++ b/orc8r/gateway/configs/magmad.yml
@@ -1,0 +1,71 @@
+---
+log_level: INFO
+
+# List of services for magmad to control
+magma_services:
+  - control_proxy
+
+# List of services that don't provide service303 interface
+non_service303_services:
+  - control_proxy
+
+# list of services that are required to have meta before checking in
+# (meta = data gathered via MagmaService.register_get_status_callback())
+# skip limit specified by config 'max_skipped_checkins'
+skip_checkin_if_missing_meta_services: []
+
+# default = 3, use 0 for "infinity"
+# max_skipped_checkins: 3
+
+# Init system to use to control services
+# Supported systems include: [systemd, runit, docker]
+init_system: docker
+
+# bootstrap_manager config
+bootstrap_config:
+  # location of the challenge key
+  challenge_key: /var/opt/magma/certs/gw_challenge.key
+
+# Flags indicating the magmad features to be enabled
+enable_config_streamer: False
+enable_upgrade_manager: False
+enable_network_monitor: False
+enable_systemd_tailer: False
+enable_sync_rpc: False
+enable_kernel_version_checking: False
+
+systemd_tailer_poll_interval: 30 # seconds
+
+network_monitor_config:
+  # How long to sleep between statistic collections
+  sampling_period: 60
+
+  # ping stats config
+  ping_config:
+    hosts:
+      - 8.8.8.8
+    num_packets: 1
+    timeout_secs: 20
+
+upgrader_factory:
+  # Module where the UpgraderFactory implementation is located
+  module: magma.magmad.upgrade.magma_upgrader
+  # Name of the UpgraderFactory implementation
+  class: MagmaUpgraderFactory
+mconfig_modules:
+  - orc8r.protos.mconfig.mconfigs_pb2
+
+metricsd:
+  log_level: INFO
+  collect_interval: 60 # How frequently to collect metrics samples in seconds
+  sync_interval: 60 # How frequently to sync to cloud in seconds
+  grpc_timeout: 30 # Timeout in seconds
+  queue_length: 1000 # Number of failed samples to enqueue for resend
+
+  # An optional function  to mutate metrics before they are sent to the cloud
+  # A string in the form path.to.module.fn_name
+  # @see magma.magmad.metrics_collector.example_metrics_postprocessor
+  post_processing_fn: magma.magmad.metrics_collector.do_nothing_metrics_postprocessor
+  # List of services for metricsd to poll
+  services:
+    - magmad

--- a/orc8r/gateway/configs/service_registry.yml
+++ b/orc8r/gateway/configs/service_registry.yml
@@ -1,0 +1,13 @@
+---
+services:
+  # NOTE: do NOT include dash(-) in your service name. Use underscore instead.
+  # Example service name that contains dash: hello-world-blah
+  # As we use "-" in nghttpx config to connect service name and hostname,
+  # "-" is used as a delimiter in dispatcher to parse out service names.
+
+  magmad:
+    ip_address: 127.0.0.1
+    port: 50052
+  control_proxy:
+    ip_address: 127.0.0.1
+    port: 50053

--- a/orc8r/gateway/docker/.env
+++ b/orc8r/gateway/docker/.env
@@ -1,0 +1,18 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+COMPOSE_PROJECT_NAME=magmad
+DOCKER_REGISTRY=magmad_
+IMAGE_VERSION=latest
+BUILD_CONTEXT=../../../
+
+ROOTCA_PATH=../../../.cache/test_certs/rootCA.pem
+CONTROL_PROXY_PATH=../configs/control_proxy.yml
+SNOWFLAKE_PATH=../../../.cache/orc8r/gateway/snowflake
+
+CERTS_VOLUME=gwcerts
+CONFIGS_VOLUME=gwconfigs

--- a/orc8r/gateway/docker/.prod_env
+++ b/orc8r/gateway/docker/.prod_env
@@ -1,0 +1,18 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+COMPOSE_PROJECT_NAME=magmad
+DOCKER_REGISTRY=magmad_
+IMAGE_VERSION=latest
+BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
+
+ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
+CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml
+SNOWFLAKE_PATH=/etc/snowflake
+
+CERTS_VOLUME=/var/opt/magma/certs
+CONFIGS_VOLUME=/var/opt/magma/configs

--- a/orc8r/gateway/docker/Dockerfile
+++ b/orc8r/gateway/docker/Dockerfile
@@ -1,5 +1,4 @@
-# -----------------------------------------------------------------------------
-# Builder image for Magma proto files
+# Builder image to generate proto files
 # -----------------------------------------------------------------------------
 FROM ubuntu:xenial AS builder
 
@@ -20,7 +19,6 @@ ENV PYTHON_BUILD /build/python
 ENV PIP_CACHE_HOME ~/.pipcache
 
 # Generate python proto bindings.
-COPY feg/protos $MAGMA_ROOT/feg/protos
 COPY lte/gateway/python/defs.mk $MAGMA_ROOT/lte/gateway/python/defs.mk
 COPY lte/gateway/python/Makefile $MAGMA_ROOT/lte/gateway/python/Makefile
 COPY lte/protos $MAGMA_ROOT/lte/protos
@@ -30,9 +28,9 @@ COPY protos $MAGMA_ROOT/protos
 RUN make -C $MAGMA_ROOT/lte/gateway/python protos
 
 # -----------------------------------------------------------------------------
-# Dev/Production image
+# Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:xenial AS lte_gateway_python
+FROM ubuntu:xenial AS gateway_python
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -58,33 +56,24 @@ RUN apt-get -y update && apt-get -y install \
   openssl \
   pkg-config \
   python-cffi \
-  python3-aioeventlet \
   python3-pip \
   redis-server
 
-# Install OVS via Magma bionic pkg repo
-RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ bionic main"
+RUN curl -sSL https://get.docker.com/ > /tmp/get_docker.sh && \
+    sh /tmp/get_docker.sh && \
+    rm /tmp/get_docker.sh
 
-RUN apt-get -y update && apt-get -y install \
-  libopenvswitch \
-  openvswitch-common \
-  openvswitch-switch \
-  python-openvswitch
-
-# Install orc8r python (magma.common required for lte python)
+# Install python code.
 COPY orc8r/gateway/python /tmp/orc8r
 RUN pip3 install /tmp/orc8r
-
-# Install lte python
-COPY lte/gateway/python /tmp/lte
-RUN pip3 install /tmp/lte
 
 # Copy the build artifacts.
 COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/
 
 # Copy the configs.
-COPY lte/gateway/configs /etc/magma
+COPY orc8r/gateway/configs /etc/magma
+
 COPY orc8r/gateway/configs/templates /etc/magma/templates
 COPY orc8r/cloud/docker/proxy/magma_headers.rb /etc/nghttpx/magma_headers.rb
+
 RUN mkdir -p /var/opt/magma/configs

--- a/orc8r/gateway/docker/docker-compose.override.yml
+++ b/orc8r/gateway/docker/docker-compose.override.yml
@@ -1,0 +1,15 @@
+version: "3.7"
+
+services:
+  magmad:
+    build:
+      context: ${BUILD_CONTEXT}
+      dockerfile: orc8r/gateway/docker/Dockerfile
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
+
+  control_proxy:
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1

--- a/orc8r/gateway/docker/docker-compose.yml
+++ b/orc8r/gateway/docker/docker-compose.yml
@@ -1,0 +1,51 @@
+version: "3.7"
+
+# Standard logging for each service
+x-logging: &logging_anchor
+  driver: "json-file"
+  options:
+    max-size: "10mb"
+    max-file: "10"
+
+# Standard volumes plus the snowflake
+x-snowflake-volumes: &snowflake_volumes
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_VOLUME}:/var/opt/magma/configs
+  - ${SNOWFLAKE_PATH}:/etc/snowflake
+
+# Use generic python anchor to avoid repetition for python services
+x-pyservice: &pyservice
+  image: ${DOCKER_REGISTRY}gateway_python:${IMAGE_VERSION}
+  volumes: *snowflake_volumes
+  logging: *logging_anchor
+  restart: always
+  network_mode: host
+
+services:
+  magmad:
+    <<: *pyservice
+    container_name: magmad
+    volumes:
+      - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+      - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+      - ${CERTS_VOLUME}:/var/opt/magma/certs
+      - ${CONFIGS_VOLUME}:/var/opt/magma/configs
+      - ${SNOWFLAKE_PATH}:/etc/snowflake
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: python3 -m magma.magmad.main
+
+  control_proxy:
+    <<: *pyservice
+    container_name: control_proxy
+    volumes: *snowflake_volumes
+    environment:
+      DOCKER_NETWORK_MODE: 1
+    command: >
+      /bin/bash -c "/usr/local/bin/generate_nghttpx_config.py &&
+             /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf /var/opt/magma/certs/controller.key /var/opt/magma/certs/controller.crt"
+
+volumes:
+  gwcerts:
+  gwconfigs:


### PR DESCRIPTION
Summary: This provides functionality to run magmad as a standalone container and with no other services running. Control_proxy is also included so that the magmad container can communicate with the cloud.

Differential Revision: D16114647

