### PR TITLE
Fix configurator-based create gateway rollback logic on error

### DIFF
--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/gateway_handlers.go
@@ -112,6 +112,12 @@ func createGateway(c echo.Context) error {
 	}
 	_, err = configurator.CreateEntity(networkID, gwEntity)
 	if err != nil {
+		derr := device.DeleteDevice(networkID, orc8r.AccessGatewayRecordType, record.HwID.ID)
+		if derr != nil {
+			return handlers.HttpError(
+				fmt.Errorf("Failed to create gateway entity: %v, failed to delete device entity: %v", err, derr),
+				http.StatusInternalServerError)
+		}
 		return handlers.HttpError(err, http.StatusInternalServerError)
 	}
 


### PR DESCRIPTION
Summary: create gateway involves two entry creations: one in configurator and one in device. If the second fails, we should make sure to rollback the first change.

Reviewed By: xjtian

Differential Revision: D16114072

