### PR TITLE
Fix aaa service name in sessiond

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -37,7 +37,7 @@ AsyncAAAClient::AsyncAAAClient(
 
 AsyncAAAClient::AsyncAAAClient():
   AsyncAAAClient(magma::ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-    "aaa",
+    "aaa_server",
     magma::ServiceRegistrySingleton::LOCAL))
 {
 }


### PR DESCRIPTION
Summary:
This diff fixes an error in sessiond that
uses the wrong AAA service name.

Reviewed By: ssanadhya

Differential Revision: D16189093

