### PR TITLE
Mock load_service_mconfig_as_json for test

### DIFF
--- a/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_init.py
@@ -128,7 +128,7 @@ def _get_enb_yang_config(
         enb_serial = \
             device_config.get_parameter(ParameterName.SERIAL_NUMBER)
         config = json.loads(
-            load_service_mconfig_as_json('yang').get('value', ''))
+            load_service_mconfig_as_json('yang').get('value', '{}'))
         enb.extend(filter(lambda entry: entry['serial'] == enb_serial,
                           config.get('cellular', {}).get('enodeb', [])))
     except (ValueError, KeyError, LoadConfigError):

--- a/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
@@ -8,18 +8,16 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase, mock
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.tr069 import models
 from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
-from magma.enodebd.tests.test_utils.mock_functions import \
-    mock_get_ip_from_if, GET_IP_FROM_IF_PATH
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
 
 
-class BaicellsOldHandlerTests(TestCase):
+class BaicellsOldHandlerTests(EnodebHandlerTestCase):
     def test_initial_enb_bootup(self) -> None:
         """
         Baicells does not support configuration during initial bootup of
@@ -125,8 +123,7 @@ class BaicellsOldHandlerTests(TestCase):
                         'State machine should end TR-069 session after '
                         'receiving a RebootResponse')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_provision_without_invasive_changes(self, _mock_func) -> None:
+    def test_provision_without_invasive_changes(self) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration
@@ -242,8 +239,7 @@ class BaicellsOldHandlerTests(TestCase):
         self.assertTrue(isinstance(resp, models.GetParameterValues),
                         'State machine should be requesting param values')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_reboot_after_invasive_changes(self, _mock_func) -> None:
+    def test_reboot_after_invasive_changes(self) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration

--- a/lte/gateway/python/magma/enodebd/tests/baicells_qafb_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_qafb_tests.py
@@ -8,18 +8,16 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase, mock
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.tr069 import models
 from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
-from magma.enodebd.tests.test_utils.mock_functions import \
-    mock_get_ip_from_if, GET_IP_FROM_IF_PATH
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
 
 
-class BaicellsQAFBHandlerTests(TestCase):
+class BaicellsQAFBHandlerTests(EnodebHandlerTestCase):
     def test_manual_reboot(self) -> None:
         """
         Test a scenario where a Magma user goes through the enodebd CLI to
@@ -100,8 +98,7 @@ class BaicellsQAFBHandlerTests(TestCase):
                         'State machine should end TR-069 session after '
                         'receiving a RebootResponse')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_provision(self, _mock_func) -> None:
+    def test_provision(self) -> None:
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
                 .build_acs_state_machine(EnodebDeviceName.BAICELLS_QAFB)

--- a/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_tests.py
@@ -8,7 +8,6 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase, mock
 from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.tr069 import models
@@ -16,11 +15,10 @@ from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
-from magma.enodebd.tests.test_utils.mock_functions import \
-    mock_get_ip_from_if, GET_IP_FROM_IF_PATH
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
 
 
-class BaicellsHandlerTests(TestCase):
+class BaicellsHandlerTests(EnodebHandlerTestCase):
     def test_initial_enb_bootup(self) -> None:
         """
         Baicells does not support configuration during initial bootup of
@@ -186,8 +184,7 @@ class BaicellsHandlerTests(TestCase):
                         'State machine should end TR-069 session after '
                         'receiving a RebootResponse')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_missing_param_during_provisioning(self, _mock_func) -> None:
+    def test_missing_param_during_provisioning(self) -> None:
         """
         Test the scenario where:
         - enodebd is configuring the eNodeB
@@ -248,8 +245,7 @@ class BaicellsHandlerTests(TestCase):
         self.assertTrue(isinstance(resp, models.DummyInput),
                         'State machine should be ending session')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_provision_multi_without_invasive_changes(self, _mock_func) -> None:
+    def test_provision_multi_without_invasive_changes(self) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration
@@ -329,8 +325,7 @@ class BaicellsHandlerTests(TestCase):
                         'while old enodebd config does not '
                         'enable transmit. Use eNB config.')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_provision_without_invasive_changes(self, _mock_func) -> None:
+    def test_provision_without_invasive_changes(self) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration
@@ -430,8 +425,7 @@ class BaicellsHandlerTests(TestCase):
         self.assertTrue(isinstance(resp, models.GetParameterValues),
                         'State machine should be requesting param values')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_reboot_after_invasive_changes(self, _mock_func) -> None:
+    def test_reboot_after_invasive_changes(self) -> None:
         """
         Test the scenario where:
         - eNodeB has already been powered for 10 minutes without configuration
@@ -558,8 +552,7 @@ class BaicellsHandlerTests(TestCase):
         self.assertTrue(len(resp.ParameterNames.string) > 1,
                         'Should be requesting transient params.')
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_missing_mme_timeout_handler(self, _mock_func) -> None:
+    def test_missing_mme_timeout_handler(self) -> None:
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
             .build_acs_state_machine(EnodebDeviceName.BAICELLS)
@@ -584,8 +577,7 @@ class BaicellsHandlerTests(TestCase):
                                                     ['2 PERIODIC'])
         acs_state_machine.handle_tr069_message(inform_msg)
 
-    @mock.patch(GET_IP_FROM_IF_PATH, side_effect=mock_get_ip_from_if)
-    def test_fault_after_set_parameters(self, _mock_func) -> None:
+    def test_fault_after_set_parameters(self) -> None:
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
                 .build_acs_state_machine(EnodebDeviceName.BAICELLS)

--- a/lte/gateway/python/magma/enodebd/tests/cavium_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/cavium_tests.py
@@ -8,7 +8,6 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 # pylint: disable=protected-access
-from unittest import TestCase, mock
 from magma.enodebd.devices.device_utils import EnodebDeviceName
 from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.tr069 import models
@@ -16,12 +15,11 @@ from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
 from magma.enodebd.tests.test_utils.enb_acs_builder import \
     EnodebAcsStateMachineBuilder
+from magma.enodebd.tests.test_utils.enodeb_handler import EnodebHandlerTestCase
 
 
-class CaviumHandlerTests(TestCase):
-    @mock.patch('magma.enodebd.device_config.configuration_init.'
-                'get_ip_from_if')
-    def test_count_plmns_less(self, get_ip_from_if_mock) -> None:
+class CaviumHandlerTests(EnodebHandlerTestCase):
+    def test_count_plmns_less(self) -> None:
         """
         Tests the Cavium provisioning up to GetObjectParameters.
 
@@ -31,8 +29,6 @@ class CaviumHandlerTests(TestCase):
 
         Verifies that the number of PLMNs is correctly accounted.
         """
-        get_ip_from_if_mock.return_value = '127.0.0.1'
-
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
                 .build_acs_state_machine(EnodebDeviceName.CAVIUM)
@@ -84,17 +80,13 @@ class CaviumHandlerTests(TestCase):
                 .device_cfg.get_parameter(ParameterName.NUM_PLMNS)
         self.assertEqual(num_plmns_cur, 2)
 
-    @mock.patch('magma.enodebd.device_config.configuration_init.'
-                'get_ip_from_if')
-    def test_count_plmns_more_defined(self, get_ip_from_if_mock) -> None:
+    def test_count_plmns_more_defined(self) -> None:
         """
         Tests the Cavium provisioning up to GetObjectParameters.
 
         In particular tests when the eNB has more PLMNs than is
         currently defined in our data model (NUM_PLMNS_IN_CONFIG)
         """
-        get_ip_from_if_mock.return_value = '127.0.0.1'
-
         acs_state_machine = \
             EnodebAcsStateMachineBuilder \
                 .build_acs_state_machine(EnodebDeviceName.CAVIUM)

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/enodeb_handler.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/enodeb_handler.py
@@ -1,0 +1,30 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from unittest import TestCase, mock
+import magma.enodebd.tests.test_utils.mock_functions as enb_mock
+
+
+class EnodebHandlerTestCase(TestCase):
+    """
+    Sets up test class with a set of patches needed for eNodeB handlers
+    """
+    def setUp(self):
+        self.patches = {
+            enb_mock.GET_IP_FROM_IF_PATH:
+                mock.Mock(side_effect=enb_mock.mock_get_ip_from_if),
+            enb_mock.LOAD_SERVICE_MCONFIG_PATH:
+                mock.Mock(
+                    side_effect=enb_mock.mock_load_service_mconfig_as_json),
+        }
+        self.applied_patches = [mock.patch(patch, data) for patch, data in
+                                self.patches.items()]
+        for patch in self.applied_patches:
+            patch.start()
+        self.addCleanup(mock.patch.stopall)

--- a/lte/gateway/python/magma/enodebd/tests/test_utils/mock_functions.py
+++ b/lte/gateway/python/magma/enodebd/tests/test_utils/mock_functions.py
@@ -13,9 +13,16 @@ from typing import Any
 GET_IP_FROM_IF_PATH = \
     'magma.enodebd.device_config.configuration_init.get_ip_from_if'
 
+LOAD_SERVICE_MCONFIG_PATH = \
+    'magma.enodebd.device_config.configuration_init.load_service_mconfig_as_json'
+
 
 def mock_get_ip_from_if(
     _iface_name: str,
     _preference: Any = None,
 ) -> str:
     return '192.168.60.142'
+
+
+def mock_load_service_mconfig_as_json(_service_name: str) -> Any:
+    return {}


### PR DESCRIPTION
Summary:
error in travis
```
  File "/home/travis/build/facebookincubator/magma/orc8r/gateway/python/magma/configuration/mconfig_managers.py", line 162, in load_service_mconfig_as_json
    with open(cfg_file_name, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: '/etc/magma/gateway.mconfig'
```

Differential Revision: D16207372

