### PR TITLE
Remove various references to magmad where it is not needed

### DIFF
--- a/lte/cloud/go/services/policydb/obsidian/handlers/handler_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/handler_test.go
@@ -23,7 +23,6 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -37,7 +36,6 @@ func TestPolicyDBHandlers(t *testing.T) {
 	err = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	assert.NoError(t, err)
 	configurator_test_init.StartTestService(t)
-	magmad_test_init.StartTestService(t)
 	policydb_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
 

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -21,6 +21,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 )
@@ -29,8 +30,9 @@ func TestHandlers(t *testing.T) {
 	_ = os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &lteplugin.LteOrchestratorPlugin{})
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
+	magmad_test_init.StartTestService(t)
 	sdb_test_init.StartTestService(t)
 
 	restPort := tests.StartObsidian(t)
@@ -268,4 +270,13 @@ func TestHandlers(t *testing.T) {
 	}
 	tests.RunTest(t, listSubscribersTestCase)
 
+	deleteSubscriberTestCase = tests.Testcase{
+		Name:   "Delete Subscriber",
+		Method: "DELETE",
+		Url: fmt.Sprintf(
+			"%s/%s/subscribers/IMSI12333344444", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: "",
+	}
+	tests.RunTest(t, deleteSubscriberTestCase)
 }

--- a/orc8r/cloud/go/services/accessd/obsidian/handlers/accessd_handlers_test.go
+++ b/orc8r/cloud/go/services/accessd/obsidian/handlers/accessd_handlers_test.go
@@ -27,7 +27,6 @@ import (
 	"magma/orc8r/cloud/go/services/accessd/obsidian/models"
 	"magma/orc8r/cloud/go/services/accessd/test_init"
 	certifier_test_utils "magma/orc8r/cloud/go/services/certifier/test_utils"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 	"magma/orc8r/cloud/go/test_utils"
 )
 
@@ -42,7 +41,6 @@ const (
 )
 
 func testInit(t *testing.T) (string, map[models.OperatorID]models.Certificate, map[models.OperatorID]models.ACLType) {
-	magmad_test_init.StartTestService(t)
 	test_init.StartTestService(t)
 	testOperatorSerialNumber := access_tests.StartMockAccessControl(t, testAdminOperatorID)
 	certificates := make(map[models.OperatorID]models.Certificate)

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/magmadh_test.go
@@ -23,7 +23,6 @@ import (
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +30,6 @@ import (
 func TestMagmad(t *testing.T) {
 	_ = os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
 	device_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)

--- a/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_legacy_test.go
+++ b/orc8r/cloud/go/services/upgrade/obsidian/handlers/handlers_legacy_test.go
@@ -1,10 +1,10 @@
 /*
-Copyright (c) Facebook, Inc. and its affiliates.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-*/
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 
 package handlers_test
 
@@ -20,7 +20,7 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/services/configurator"
-	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
 	"magma/orc8r/cloud/go/services/upgrade"
 	"magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 	upgrade_test_init "magma/orc8r/cloud/go/services/upgrade/test_init"
@@ -28,13 +28,13 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Obsidian integration test for release channel migrated API endpoints backed by configurator
-func TestReleaseChannels(t *testing.T) {
-	_ = os.Setenv(orc8r.UseConfiguratorEnv, "1")
+// Obsidian integration test for release channel legacy API endpoints
+func TestLegacyReleaseChannels(t *testing.T) {
+	_ = os.Setenv(orc8r.UseConfiguratorEnv, "0")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	configurator.NewNetworkEntityConfigSerde(upgrade.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{})
+	magmad_test_init.StartTestService(t)
 	upgrade_test_init.StartTestService(t)
-	configurator_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
 	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/channels", restPort, handlers.REST_ROOT)
 
@@ -133,14 +133,14 @@ func TestReleaseChannels(t *testing.T) {
 	assert.Equal(t, 500, status)
 }
 
-// Obsidian integration test for tiers migrated API endpoints backed by configurator
-func TestTiers(t *testing.T) {
-	_ = os.Setenv(orc8r.UseConfiguratorEnv, "1")
+// Obsidian integration test for tier legacy API endpoints
+func TestLegacyTiers(t *testing.T) {
+	_ = os.Setenv(orc8r.UseConfiguratorEnv, "0")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	configurator.NewNetworkEntityConfigSerde(orc8r.UpgradeTierEntityType, &models.Tier{})
+	magmad_test_init.StartTestService(t)
 	upgrade_test_init.StartTestService(t)
 	restPort := tests.StartObsidian(t)
-	configurator_test_init.StartTestService(t)
 	netUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
 
 	registerNetworkTestCase := tests.Testcase{

--- a/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration.go
+++ b/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration.go
@@ -47,31 +47,26 @@ const DnsdGatewayType = "dnsd_gateway" // Technically this is unused
 const MagmadGatewayType = "magmad_gateway"
 const MagmadNetworkType = "magmad_network"
 const MeshType = "mesh"
-const TerragraphNetworkType = "terragraph_network"
-const TerragraphGatewayType = "terragraph_gateway"
 const WifiNetworkType = "wifi_network"
 const WifiGatewayType = "wifi_gateway"
 
 const CellularConfigKey = "cellular"
 const DnsConfigKey = "dns"
 const MagmadConfigKey = "magmad"
-const TerragraphConfigKey = "terragraph"
 const WifiConfigKey = "wifi"
 
 var newNetworkTypesByOldKey = map[string]string{
-	CellularConfigKey:   CellularNetworkType,
-	DnsConfigKey:        DnsdNetworkType,
-	MagmadConfigKey:     MagmadNetworkType,
-	TerragraphConfigKey: TerragraphNetworkType,
-	WifiConfigKey:       WifiNetworkType,
+	CellularConfigKey: CellularNetworkType,
+	DnsConfigKey:      DnsdNetworkType,
+	MagmadConfigKey:   MagmadNetworkType,
+	WifiConfigKey:     WifiNetworkType,
 }
 
 var newGatewayTypesByOldKey = map[string]string{
-	CellularConfigKey:   CellularGatewayType,
-	DnsConfigKey:        DnsdGatewayType,
-	MagmadConfigKey:     MagmadGatewayType,
-	TerragraphConfigKey: TerragraphGatewayType,
-	WifiConfigKey:       WifiGatewayType,
+	CellularConfigKey: CellularGatewayType,
+	DnsConfigKey:      DnsdGatewayType,
+	MagmadConfigKey:   MagmadGatewayType,
+	WifiConfigKey:     WifiGatewayType,
 }
 
 // Entry point for the migration. Everything runs in 1 serializable postgres

--- a/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration_test.go
+++ b/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration_test.go
@@ -37,7 +37,7 @@ func TestMigrateNetworkConfigs(t *testing.T) {
 		WillReturnRows(
 			sqlmock.NewRows([]string{"key", "value"}).
 				AddRow("network1", getDefaultConfigFixture(t)).
-				AddRow("network2", getConfigFixture(t, map[string][]byte{"terragraph": []byte("terragraph")})),
+				AddRow("network2", getConfigFixture(t, map[string][]byte{"cellular": []byte("cellular")})),
 		)
 
 	expectCreateTable(mock, "network1_configurations")
@@ -50,7 +50,7 @@ func TestMigrateNetworkConfigs(t *testing.T) {
 
 	expectCreateTable(mock, "network2_configurations")
 	network2Prepare := mock.ExpectPrepare("INSERT INTO network2_configurations")
-	network2Prepare.ExpectExec().WithArgs("terragraph_network", "network2", []byte("terragraph"), []byte("terragraph")).
+	network2Prepare.ExpectExec().WithArgs("cellular_network", "network2", []byte("cellular"), []byte("cellular")).
 		WillReturnResult(mockResult)
 	network2Prepare.WillBeClosed()
 


### PR DESCRIPTION
Summary: I found a lot of the migrated tests could use a bit of refactoring / clean up (remove references to magmad where it's not needed, use test_util functions, etc)

Reviewed By: xjtian

Differential Revision: D16205711

