### PR TITLE
Delete terragraph module

### DIFF
--- a/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration.go
+++ b/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration.go
@@ -47,31 +47,26 @@ const DnsdGatewayType = "dnsd_gateway" // Technically this is unused
 const MagmadGatewayType = "magmad_gateway"
 const MagmadNetworkType = "magmad_network"
 const MeshType = "mesh"
-const TerragraphNetworkType = "terragraph_network"
-const TerragraphGatewayType = "terragraph_gateway"
 const WifiNetworkType = "wifi_network"
 const WifiGatewayType = "wifi_gateway"
 
 const CellularConfigKey = "cellular"
 const DnsConfigKey = "dns"
 const MagmadConfigKey = "magmad"
-const TerragraphConfigKey = "terragraph"
 const WifiConfigKey = "wifi"
 
 var newNetworkTypesByOldKey = map[string]string{
-	CellularConfigKey:   CellularNetworkType,
-	DnsConfigKey:        DnsdNetworkType,
-	MagmadConfigKey:     MagmadNetworkType,
-	TerragraphConfigKey: TerragraphNetworkType,
-	WifiConfigKey:       WifiNetworkType,
+	CellularConfigKey: CellularNetworkType,
+	DnsConfigKey:      DnsdNetworkType,
+	MagmadConfigKey:   MagmadNetworkType,
+	WifiConfigKey:     WifiNetworkType,
 }
 
 var newGatewayTypesByOldKey = map[string]string{
-	CellularConfigKey:   CellularGatewayType,
-	DnsConfigKey:        DnsdGatewayType,
-	MagmadConfigKey:     MagmadGatewayType,
-	TerragraphConfigKey: TerragraphGatewayType,
-	WifiConfigKey:       WifiGatewayType,
+	CellularConfigKey: CellularGatewayType,
+	DnsConfigKey:      DnsdGatewayType,
+	MagmadConfigKey:   MagmadGatewayType,
+	WifiConfigKey:     WifiGatewayType,
 }
 
 // Entry point for the migration. Everything runs in 1 serializable postgres

--- a/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration_test.go
+++ b/orc8r/cloud/go/tools/migrations/m001_config_service/migration/migration_test.go
@@ -37,7 +37,7 @@ func TestMigrateNetworkConfigs(t *testing.T) {
 		WillReturnRows(
 			sqlmock.NewRows([]string{"key", "value"}).
 				AddRow("network1", getDefaultConfigFixture(t)).
-				AddRow("network2", getConfigFixture(t, map[string][]byte{"terragraph": []byte("terragraph")})),
+				AddRow("network2", getConfigFixture(t, map[string][]byte{"cellular": []byte("cellular")})),
 		)
 
 	expectCreateTable(mock, "network1_configurations")
@@ -50,7 +50,7 @@ func TestMigrateNetworkConfigs(t *testing.T) {
 
 	expectCreateTable(mock, "network2_configurations")
 	network2Prepare := mock.ExpectPrepare("INSERT INTO network2_configurations")
-	network2Prepare.ExpectExec().WithArgs("terragraph_network", "network2", []byte("terragraph"), []byte("terragraph")).
+	network2Prepare.ExpectExec().WithArgs("cellular_network", "network2", []byte("cellular"), []byte("cellular")).
 		WillReturnResult(mockResult)
 	network2Prepare.WillBeClosed()
 


### PR DESCRIPTION
Summary: deleting all references of terragraph in fbsource/fbcode/magma and fbsource/fbcode/fbc/orc8r

Reviewed By: xjtian

Differential Revision: D16204503

