### PR TITLE
Fix potential nil pointer dereference bug in GatewayViews

### DIFF
--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory.go
@@ -95,22 +95,27 @@ func (f *FullGatewayViewFactoryImpl) GetGatewayViews(networkID string, gatewayID
 		}
 	}
 
-	// load all associated config entities
-	allAssociations := getAllAssociations(loadedGateways)
+	// load all associated configEntity entities
+	allAssociations := getAllAssociatedConfigEntities(loadedGateways)
 	loadedConfigs, _, err := configurator.LoadEntities(networkID, nil, nil, nil, allAssociations, configurator.EntityLoadCriteria{LoadConfig: true})
 	if err != nil {
 		return nil, err
 	}
-	for _, config := range loadedConfigs {
-		ret[config.Key].Config[config.Type] = config.Config
+	for _, configEntity := range loadedConfigs {
+		ret[configEntity.Key].Config[configEntity.Type] = configEntity.Config
 	}
 	return ret, nil
 }
 
-func getAllAssociations(gateways []configurator.NetworkEntity) []storage.TypeAndKey {
+// Relies on config entities sharing its key with the parent gateway entity
+func getAllAssociatedConfigEntities(queriedGateways []configurator.NetworkEntity) []storage.TypeAndKey {
 	ret := []storage.TypeAndKey{}
-	for _, gateway := range gateways {
-		ret = append(ret, gateway.Associations...)
+	for _, gatewayEnt := range queriedGateways {
+		for _, associatedEnt := range gatewayEnt.Associations {
+			if associatedEnt.Key == gatewayEnt.Key {
+				ret = append(ret, associatedEnt)
+			}
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
Summary:
There is a possibility for a nil dereference that could be causing some issues in GatewayViews.
The logic for loading all configs works by first loading all gateway entities requested. And then looking through their associations for configs.
Gateway Configs are stored as follows, which each config entity has the gatewayID as its key:
```                [magmad_gateway_entity]
                       |           |
[lte_gateway_config_entity]  [wifi_gateway_config_entity]
```
The current logic breaks if the magmad gateway has associations to non-config entities.

Reviewed By: andreilee

Differential Revision: D16224700

