### PR TITLE
Duplicate Federation config test to test both magmad backed and configurator backed version

### DIFF
--- a/feg/cloud/go/services/controller/config/mconfig_builder_test.go
+++ b/feg/cloud/go/services/controller/config/mconfig_builder_test.go
@@ -32,7 +32,7 @@ func TestControllerBuilder_Build(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, map[string]proto.Message{}, actual)
 
-	defaultNetCfg := config_protos.NewDefaultNetworkConfig()
+	defaultNetCfg := config_protos.NewDefaultProtosNetworkConfig()
 	err = config.CreateConfig("network", feg.FegNetworkType, "network", defaultNetCfg)
 	assert.NoError(t, err)
 

--- a/feg/cloud/go/services/controller/obsidian/handlers/feg_handlers_legacy_test.go
+++ b/feg/cloud/go/services/controller/obsidian/handlers/feg_handlers_legacy_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package handlers_test
+
+import (
+	"fmt"
+	"testing"
+
+	fegplugin "magma/feg/cloud/go/plugin"
+	"magma/feg/cloud/go/services/controller/obsidian/models"
+	feg_protos "magma/feg/cloud/go/services/controller/protos"
+	"magma/orc8r/cloud/go/obsidian/handlers"
+	obsidian_test "magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/protos"
+	"magma/orc8r/cloud/go/services/magmad"
+	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
+	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLegacyGetNetworkConfigs(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
+	magmad_test_init.StartTestService(t)
+	restPort := obsidian_test.StartObsidian(t)
+	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
+	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
+
+	// Happy path
+	expectedConfig := &models.NetworkFederationConfigs{}
+	expectedConfig.FromServiceModel(feg_protos.NewDefaultProtosGatewayConfig())
+	marshaledCfg, err := expectedConfig.MarshalBinary()
+	assert.NoError(t, err)
+	expected := string(marshaledCfg)
+	happyPathTestCase := obsidian_test.Testcase{
+		Name:     "Get FeG Network Config Legacy",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: expected,
+	}
+	obsidian_test.RunTest(t, happyPathTestCase)
+
+	// No good way to test invalid configs from datastore without dropping down
+	// to raw magmad api/grpc or datastore fixtures, so let's skip that
+	// for now
+}
+
+func TestLegacySetNetworkConfigs(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
+	magmad_test_init.StartTestService(t)
+	restPort := obsidian_test.StartObsidian(t)
+	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
+
+	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
+
+	// Happy path
+	config := feg_protos.NewDefaultProtosNetworkConfig()
+	config.S6A.Server.Address = "192.168.11.22:555"
+	config.Gx.Server.DestHost = "pcrf.mno.com"
+	config.Gy.Server.DestHost = "ocs.mno.com"
+	config.ServedNetworkIds = []string{"lte_network_A", "lte_network_B"}
+	swaggerConfig := &models.NetworkFederationConfigs{}
+	swaggerConfig.FromServiceModel(config)
+	assert.Len(t, swaggerConfig.ServedNetworkIds, 2)
+	assert.Subset(t, swaggerConfig.ServedNetworkIds, config.ServedNetworkIds)
+	marshaledCfg, err := swaggerConfig.MarshalBinary()
+	assert.NoError(t, err)
+	swaggerConfigString := string(marshaledCfg)
+
+	setConfigTestCase := obsidian_test.Testcase{
+		Name:     "Set Federation Network Config Legacy",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
+		Payload:  swaggerConfigString,
+		Expected: "",
+	}
+	obsidian_test.RunTest(t, setConfigTestCase)
+	getConfigTestCase := obsidian_test.Testcase{
+		Name:     "Get Updated Federation Network Config Legacy",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
+		Payload:  "",
+		Expected: swaggerConfigString,
+	}
+	obsidian_test.RunTest(t, getConfigTestCase)
+
+	// Fail swagger validation
+	config.S6A.Server.Protocol = "foobar"
+	swaggerConfig.FromServiceModel(config)
+	marshaledCfg, err = swaggerConfig.MarshalBinary()
+	assert.NoError(t, err)
+	swaggerConfigString = string(marshaledCfg)
+
+	setConfigTestCase = obsidian_test.Testcase{
+		Name:                     "Set Invalid Federation Network Config Legacy",
+		Method:                   "PUT",
+		Url:                      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
+		Payload:                  swaggerConfigString,
+		Expected:                 `{"message":"Invalid config: validation failure list:\nvalidation failure list:\nvalidation failure list:\nprotocol in body should be one of [tcp tcp4 tcp6 sctp sctp4 sctp6]"}`,
+		Expect_http_error_status: true,
+	}
+	status, _, err := obsidian_test.RunTest(t, setConfigTestCase)
+	assert.Equal(t, 400, status)
+
+}
+
+func TestLegacyGetGatewayConfigs(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
+	magmad_test_init.StartTestService(t)
+	restPort := obsidian_test.StartObsidian(t)
+	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
+
+	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
+	gatewayId := registerGateway(t, networkId, "g1", restPort)
+
+	// Happy path
+	expectedConfig := &models.GatewayFegConfigs{}
+	expectedConfig.FromServiceModel(feg_protos.NewDefaultProtosGatewayConfig())
+	marshaledCfg, err := expectedConfig.MarshalBinary()
+	assert.NoError(t, err)
+	expected := string(marshaledCfg)
+	happyPathTestCase := obsidian_test.Testcase{
+		Name:     "Get Federation Gateway Config Legacy",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkId, gatewayId),
+		Payload:  "",
+		Expected: expected,
+	}
+	obsidian_test.RunTest(t, happyPathTestCase)
+
+	// No good way to test invalid configs from datastore without dropping down
+	// to raw magmad api/grpc or datastore fixtures, so let's skip that
+	// for now
+}
+
+func TestLegacySetGatewayConfigs(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
+	magmad_test_init.StartTestService(t)
+	restPort := obsidian_test.StartObsidian(t)
+	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
+
+	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
+	gatewayId := registerGateway(t, networkId, "g2", restPort)
+
+	// Happy path
+	gatewayConfig := feg_protos.NewDefaultProtosGatewayConfig()
+	gatewayConfig.S6A.Server.Address = "192.168.11.22:555"
+	swaggerConfig := &models.GatewayFegConfigs{}
+	swaggerConfig.FromServiceModel(gatewayConfig)
+
+	assert.Equal(t, gatewayConfig.S6A.Server.Address, swaggerConfig.S6a.Server.Address)
+
+	marshaledCfg, err := swaggerConfig.MarshalBinary()
+	assert.NoError(t, err)
+	swaggerConfigString := string(marshaledCfg)
+
+	setConfigTestCase := obsidian_test.Testcase{
+		Name:     "Set Federation Gateway Config Legacy",
+		Method:   "PUT",
+		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkId, gatewayId),
+		Payload:  swaggerConfigString,
+		Expected: "",
+	}
+	obsidian_test.RunTest(t, setConfigTestCase)
+	getConfigTestCase := obsidian_test.Testcase{
+		Name:     "Get Updated Federation Gateway Config Legacy",
+		Method:   "GET",
+		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkId, gatewayId),
+		Payload:  "",
+		Expected: swaggerConfigString,
+	}
+	obsidian_test.RunTest(t, getConfigTestCase)
+}
+
+func registerNetwork(t *testing.T, networkName string, networkId string, port int) string {
+	networkId, err := magmad.RegisterNetwork(
+		&magmad_protos.MagmadNetworkRecord{Name: networkName},
+		networkId)
+	assert.NoError(t, err)
+
+	config := feg_protos.NewDefaultProtosNetworkConfig()
+	swaggerConfig := &models.NetworkFederationConfigs{}
+	err = swaggerConfig.FromServiceModel(config)
+	assert.NoError(t, err)
+	marshaledCfg, err := swaggerConfig.MarshalBinary()
+	assert.NoError(t, err)
+	swaggerConfigString := string(marshaledCfg)
+
+	obsidian_test.RunTest(t, obsidian_test.Testcase{
+		Name:   "Create Default Federation Network Config Legacy",
+		Method: "POST",
+		Url: fmt.Sprintf("http://localhost:%d%s/networks/%s/configs/federation",
+			port, handlers.REST_ROOT, networkId),
+		Payload:  swaggerConfigString,
+		Expected: "\"" + networkId + "\"",
+	})
+	return networkId
+}
+
+func registerGateway(t *testing.T, networkId string, gatewayId string, port int) string {
+	gatewayRecord := &magmad_protos.AccessGatewayRecord{
+		HwId: &protos.AccessGatewayID{Id: gatewayId},
+	}
+	registeredId, err := magmad.RegisterGateway(networkId, gatewayRecord)
+	assert.NoError(t, err)
+
+	config := feg_protos.NewDefaultProtosGatewayConfig()
+	swaggerConfig := &models.GatewayFegConfigs{}
+	err = swaggerConfig.FromServiceModel(config)
+	assert.NoError(t, err)
+	marshaledCfg, err := swaggerConfig.MarshalBinary()
+	assert.NoError(t, err)
+	swaggerConfigString := string(marshaledCfg)
+
+	obsidian_test.RunTest(t, obsidian_test.Testcase{
+		Name:   "Create Default Federation Gateway Config Legacy",
+		Method: "POST",
+		Url: fmt.Sprintf(
+			"http://localhost:%d%s/networks/%s/gateways/%s/configs/federation",
+			port, handlers.REST_ROOT, networkId, registeredId),
+		Payload:  swaggerConfigString,
+		Expected: "\"" + registeredId + "\"",
+	})
+	return registeredId
+}

--- a/feg/cloud/go/services/controller/obsidian/handlers/feg_handlers_test.go
+++ b/feg/cloud/go/services/controller/obsidian/handlers/feg_handlers_test.go
@@ -10,45 +10,56 @@ package handlers_test
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	fegplugin "magma/feg/cloud/go/plugin"
-	"magma/feg/cloud/go/services/controller/obsidian/models"
-	feg_protos "magma/feg/cloud/go/services/controller/protos"
+	"magma/feg/cloud/go/services/controller/test_utils"
 	"magma/orc8r/cloud/go/obsidian/handlers"
 	obsidian_test "magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
-	"magma/orc8r/cloud/go/protos"
+	"magma/orc8r/cloud/go/pluginimpl"
+	config_test_init "magma/orc8r/cloud/go/services/config/test_init"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
-	"magma/orc8r/cloud/go/services/magmad"
-	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+	configurator_test_utils "magma/orc8r/cloud/go/services/configurator/test_utils"
+	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
+	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetNetworkConfigs(t *testing.T) {
+	os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
-	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
 	restPort := obsidian_test.StartObsidian(t)
 	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
-	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
+	networkID := "feg_obsidian_test_network"
+	registerNetworkWithDefaultConfig(t, "Test Network 1", networkID, restPort)
 
 	// Happy path
-	expectedConfig := &models.NetworkFederationConfigs{}
-	expectedConfig.FromServiceModel(feg_protos.NewDefaultGatewayConfig())
-	marshaledCfg, err := expectedConfig.MarshalBinary()
+	config := test_utils.NewDefaultNetworkConfig()
+	marshaledConfig, err := config.MarshalBinary()
 	assert.NoError(t, err)
-	expected := string(marshaledCfg)
+	expected := string(marshaledConfig)
 	happyPathTestCase := obsidian_test.Testcase{
 		Name:     "Get FeG Network Config",
 		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
+		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkID),
 		Payload:  "",
 		Expected: expected,
 	}
 	obsidian_test.RunTest(t, happyPathTestCase)
+
+	deleteConfigTestCase := obsidian_test.Testcase{
+		Name:   "Delete Federation Network Config",
+		Method: "DELETE",
+		Url:    fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkID),
+	}
+	_, _, err = obsidian_test.RunTest(t, deleteConfigTestCase)
+	assert.NoError(t, err)
 
 	// No good way to test invalid configs from datastore without dropping down
 	// to raw magmad api/grpc or datastore fixtures, so let's skip that
@@ -56,89 +67,105 @@ func TestGetNetworkConfigs(t *testing.T) {
 }
 
 func TestSetNetworkConfigs(t *testing.T) {
+	os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
-	magmad_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
 	restPort := obsidian_test.StartObsidian(t)
 	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
 
-	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
+	networkID := "feg_obsidian_test_network"
+	registerNetworkWithDefaultConfig(t, "Test Network 1", networkID, restPort)
 
 	// Happy path
-	config := feg_protos.NewDefaultNetworkConfig()
-	config.S6A.Server.Address = "192.168.11.22:555"
+	config := test_utils.NewDefaultNetworkConfig()
+	config.S6a.Server.Address = "192.168.11.22:555"
 	config.Gx.Server.DestHost = "pcrf.mno.com"
 	config.Gy.Server.DestHost = "ocs.mno.com"
 	config.ServedNetworkIds = []string{"lte_network_A", "lte_network_B"}
-	swaggerConfig := &models.NetworkFederationConfigs{}
-	swaggerConfig.FromServiceModel(config)
-	assert.Len(t, swaggerConfig.ServedNetworkIds, 2)
-	assert.Subset(t, swaggerConfig.ServedNetworkIds, config.ServedNetworkIds)
-	marshaledCfg, err := swaggerConfig.MarshalBinary()
+	marshaledConfig, err := config.MarshalBinary()
 	assert.NoError(t, err)
-	swaggerConfigString := string(marshaledCfg)
+	expected := string(marshaledConfig)
 
 	setConfigTestCase := obsidian_test.Testcase{
 		Name:     "Set Federation Network Config",
 		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
-		Payload:  swaggerConfigString,
+		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkID),
+		Payload:  expected,
 		Expected: "",
 	}
 	obsidian_test.RunTest(t, setConfigTestCase)
 	getConfigTestCase := obsidian_test.Testcase{
 		Name:     "Get Updated Federation Network Config",
 		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
+		Url:      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkID),
 		Payload:  "",
-		Expected: swaggerConfigString,
+		Expected: expected,
 	}
 	obsidian_test.RunTest(t, getConfigTestCase)
 
 	// Fail swagger validation
-	config.S6A.Server.Protocol = "foobar"
-	swaggerConfig.FromServiceModel(config)
-	marshaledCfg, err = swaggerConfig.MarshalBinary()
+	config.S6a.Server.Protocol = "foobar"
+	marshaledConfig, err = config.MarshalBinary()
 	assert.NoError(t, err)
-	swaggerConfigString = string(marshaledCfg)
+	expected = string(marshaledConfig)
 
 	setConfigTestCase = obsidian_test.Testcase{
 		Name:                     "Set Invalid Federation Network Config",
 		Method:                   "PUT",
-		Url:                      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkId),
-		Payload:                  swaggerConfigString,
+		Url:                      fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkID),
+		Payload:                  expected,
 		Expected:                 `{"message":"Invalid config: validation failure list:\nvalidation failure list:\nvalidation failure list:\nprotocol in body should be one of [tcp tcp4 tcp6 sctp sctp4 sctp6]"}`,
 		Expect_http_error_status: true,
 	}
 	status, _, err := obsidian_test.RunTest(t, setConfigTestCase)
 	assert.Equal(t, 400, status)
 
+	deleteConfigTestCase := obsidian_test.Testcase{
+		Name:   "Delete Federation Network Config",
+		Method: "DELETE",
+		Url:    fmt.Sprintf("%s/%s/configs/federation", testUrlRoot, networkID),
+	}
+	_, _, err = obsidian_test.RunTest(t, deleteConfigTestCase)
+	assert.NoError(t, err)
 }
 
 func TestGetGatewayConfigs(t *testing.T) {
+	os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
-	magmad_test_init.StartTestService(t)
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	configurator_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
+	device_test_init.StartTestService(t)
 	restPort := obsidian_test.StartObsidian(t)
 	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
 
-	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
-	gatewayId := registerGateway(t, networkId, "g1", restPort)
+	networkID := "feg_obsidian_test_network"
+	registerNetworkWithDefaultConfig(t, "Test Network 1", networkID, restPort)
+	gatewayID := "g1"
+	registerGatewayWithDefaultConfig(t, networkID, gatewayID, restPort)
 
 	// Happy path
-	expectedConfig := &models.GatewayFegConfigs{}
-	expectedConfig.FromServiceModel(feg_protos.NewDefaultGatewayConfig())
-	marshaledCfg, err := expectedConfig.MarshalBinary()
+	config := test_utils.NewDefaultGatewayConfig()
+	marshaledConfig, err := config.MarshalBinary()
 	assert.NoError(t, err)
-	expected := string(marshaledCfg)
+	expected := string(marshaledConfig)
 	happyPathTestCase := obsidian_test.Testcase{
 		Name:     "Get Federation Gateway Config",
 		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkId, gatewayId),
+		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkID, gatewayID),
 		Payload:  "",
 		Expected: expected,
 	}
 	obsidian_test.RunTest(t, happyPathTestCase)
+
+	deleteConfigTestCase := obsidian_test.Testcase{
+		Name:   "Delete Federation Gateway Config",
+		Method: "DELETE",
+		Url:    fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkID, gatewayID),
+	}
+	_, _, err = obsidian_test.RunTest(t, deleteConfigTestCase)
+	assert.NoError(t, err)
 
 	// No good way to test invalid configs from datastore without dropping down
 	// to raw magmad api/grpc or datastore fixtures, so let's skip that
@@ -146,93 +173,91 @@ func TestGetGatewayConfigs(t *testing.T) {
 }
 
 func TestSetGatewayConfigs(t *testing.T) {
+	os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &fegplugin.FegOrchestratorPlugin{})
-	magmad_test_init.StartTestService(t)
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	device_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
+	config_test_init.StartTestService(t)
 	restPort := obsidian_test.StartObsidian(t)
 	testUrlRoot := fmt.Sprintf("http://localhost:%d%s/networks", restPort, handlers.REST_ROOT)
 
-	networkId := registerNetwork(t, "Test Network 1", "feg_obsidian_test_network", restPort)
-	gatewayId := registerGateway(t, networkId, "g2", restPort)
+	networkID := "feg_obsidian_test_network"
+	registerNetworkWithDefaultConfig(t, "Test Network 1", networkID, restPort)
+	gatewayID := "g2"
+	registerGatewayWithDefaultConfig(t, networkID, gatewayID, restPort)
 
 	// Happy path
-	gatewayConfig := feg_protos.NewDefaultGatewayConfig()
-	gatewayConfig.S6A.Server.Address = "192.168.11.22:555"
-	swaggerConfig := &models.GatewayFegConfigs{}
-	swaggerConfig.FromServiceModel(gatewayConfig)
-
-	assert.Equal(t, gatewayConfig.S6A.Server.Address, swaggerConfig.S6a.Server.Address)
-
-	marshaledCfg, err := swaggerConfig.MarshalBinary()
+	config := test_utils.NewDefaultGatewayConfig()
+	config.S6a.Server.Address = "192.168.11.22:555"
+	marshaledConfig, err := config.MarshalBinary()
 	assert.NoError(t, err)
-	swaggerConfigString := string(marshaledCfg)
+	expected := string(marshaledConfig)
 
 	setConfigTestCase := obsidian_test.Testcase{
 		Name:     "Set Federation Gateway Config",
 		Method:   "PUT",
-		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkId, gatewayId),
-		Payload:  swaggerConfigString,
+		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkID, gatewayID),
+		Payload:  expected,
 		Expected: "",
 	}
 	obsidian_test.RunTest(t, setConfigTestCase)
 	getConfigTestCase := obsidian_test.Testcase{
 		Name:     "Get Updated Federation Gateway Config",
 		Method:   "GET",
-		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkId, gatewayId),
+		Url:      fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkID, gatewayID),
 		Payload:  "",
-		Expected: swaggerConfigString,
+		Expected: expected,
 	}
 	obsidian_test.RunTest(t, getConfigTestCase)
+
+	deleteConfigTestCase := obsidian_test.Testcase{
+		Name:   "Delete Federation Gateway Config",
+		Method: "DELETE",
+		Url:    fmt.Sprintf("%s/%s/gateways/%s/configs/federation", testUrlRoot, networkID, gatewayID),
+	}
+	_, _, err = obsidian_test.RunTest(t, deleteConfigTestCase)
+	assert.NoError(t, err)
 }
 
-func registerNetwork(t *testing.T, networkName string, networkId string, port int) string {
-	networkId, err := magmad.RegisterNetwork(
-		&magmad_protos.MagmadNetworkRecord{Name: networkName},
-		networkId)
+func registerNetworkWithDefaultConfig(t *testing.T, networkName string, networkID string, port int) {
+	configurator_test_utils.RegisterNetwork(t, networkID, networkName)
+
+	config := test_utils.NewDefaultNetworkConfig()
+	marshaledConfig, err := config.MarshalBinary()
 	assert.NoError(t, err)
 
-	config := feg_protos.NewDefaultNetworkConfig()
-	swaggerConfig := &models.NetworkFederationConfigs{}
-	err = swaggerConfig.FromServiceModel(config)
-	assert.NoError(t, err)
-	marshaledCfg, err := swaggerConfig.MarshalBinary()
-	assert.NoError(t, err)
-	swaggerConfigString := string(marshaledCfg)
-
-	obsidian_test.RunTest(t, obsidian_test.Testcase{
+	_, _, err = obsidian_test.RunTest(t, obsidian_test.Testcase{
 		Name:   "Create Default Federation Network Config",
 		Method: "POST",
 		Url: fmt.Sprintf("http://localhost:%d%s/networks/%s/configs/federation",
-			port, handlers.REST_ROOT, networkId),
-		Payload:  swaggerConfigString,
-		Expected: "\"" + networkId + "\"",
+			port, handlers.REST_ROOT, networkID),
+		Payload:  string(marshaledConfig),
+		Expected: "\"" + networkID + "\"",
 	})
-	return networkId
+	assert.NoError(t, err)
 }
 
-func registerGateway(t *testing.T, networkId string, gatewayId string, port int) string {
-	gatewayRecord := &magmad_protos.AccessGatewayRecord{
-		HwId: &protos.AccessGatewayID{Id: gatewayId},
+func registerGatewayWithDefaultConfig(t *testing.T, networkID string, gatewayID string, port int) {
+	gatewayRecord := &magmad_models.AccessGatewayRecord{
+		HwID: &magmad_models.HwGatewayID{
+			ID: gatewayID,
+		},
 	}
-	registeredId, err := magmad.RegisterGateway(networkId, gatewayRecord)
+	configurator_test_utils.RegisterGateway(t, networkID, gatewayID, gatewayRecord)
+
+	config := test_utils.NewDefaultGatewayConfig()
+	marshaledConfig, err := config.MarshalBinary()
 	assert.NoError(t, err)
 
-	config := feg_protos.NewDefaultGatewayConfig()
-	swaggerConfig := &models.GatewayFegConfigs{}
-	err = swaggerConfig.FromServiceModel(config)
-	assert.NoError(t, err)
-	marshaledCfg, err := swaggerConfig.MarshalBinary()
-	assert.NoError(t, err)
-	swaggerConfigString := string(marshaledCfg)
-
-	obsidian_test.RunTest(t, obsidian_test.Testcase{
+	_, _, err = obsidian_test.RunTest(t, obsidian_test.Testcase{
 		Name:   "Create Default Federation Gateway Config",
 		Method: "POST",
 		Url: fmt.Sprintf(
 			"http://localhost:%d%s/networks/%s/gateways/%s/configs/federation",
-			port, handlers.REST_ROOT, networkId, registeredId),
-		Payload:  swaggerConfigString,
-		Expected: "\"" + registeredId + "\"",
+			port, handlers.REST_ROOT, networkID, gatewayID),
+		Payload:  string(marshaledConfig),
+		Expected: "\"" + gatewayID + "\"",
 	})
-	return registeredId
+	assert.NoError(t, err)
 }

--- a/feg/cloud/go/services/controller/protos/defaults.go
+++ b/feg/cloud/go/services/controller/protos/defaults.go
@@ -103,10 +103,10 @@ var defaultConfig = Config{
 	},
 }
 
-func NewDefaultNetworkConfig() *Config {
+func NewDefaultProtosNetworkConfig() *Config {
 	return proto.Clone(&defaultConfig).(*Config)
 }
 
-func NewDefaultGatewayConfig() *Config {
+func NewDefaultProtosGatewayConfig() *Config {
 	return proto.Clone(&defaultConfig).(*Config)
 }

--- a/feg/cloud/go/services/controller/protos/proto_validation_test.go
+++ b/feg/cloud/go/services/controller/protos/proto_validation_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestValidateGatewayConfig(t *testing.T) {
-	config := protos.NewDefaultGatewayConfig()
+	config := protos.NewDefaultProtosGatewayConfig()
 	err := protos.ValidateGatewayConfig(config)
 	assert.NoError(t, err)
 
@@ -26,7 +26,7 @@ func TestValidateGatewayConfig(t *testing.T) {
 }
 
 func TestValidateNetworkConfig(t *testing.T) {
-	config := protos.NewDefaultNetworkConfig()
+	config := protos.NewDefaultProtosNetworkConfig()
 	err := protos.ValidateNetworkConfig(config)
 	assert.NoError(t, err)
 

--- a/feg/cloud/go/services/controller/test_utils/defaults.go
+++ b/feg/cloud/go/services/controller/test_utils/defaults.go
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package test_utils
+
+import "magma/feg/cloud/go/services/controller/obsidian/models"
+
+func NewDefaultNetworkConfig() *models.NetworkFederationConfigs {
+	// GyInitMethod_PER_SESSION
+	gyInitMethodPerSession := uint32(1)
+
+	return &models.NetworkFederationConfigs{
+		S6a: &models.NetworkFederationConfigsS6a{
+			Server: &models.DiameterClientConfigs{
+				Protocol:         "sctp",
+				Retransmits:      3,
+				WatchdogInterval: 1,
+				RetryCount:       5,
+				ProductName:      "magma",
+				Host:             "magma-fedgw.magma.com",
+				Realm:            "magma.com",
+			},
+		},
+		Gx: &models.NetworkFederationConfigsGx{
+			Server: &models.DiameterClientConfigs{
+				Protocol:         "tcp",
+				Retransmits:      3,
+				WatchdogInterval: 1,
+				RetryCount:       5,
+				ProductName:      "magma",
+				Host:             "magma-fedgw.magma.com",
+				Realm:            "magma.com",
+			},
+		},
+		Gy: &models.NetworkFederationConfigsGy{
+			Server: &models.DiameterClientConfigs{
+				Protocol:         "tcp",
+				Retransmits:      3,
+				WatchdogInterval: 1,
+				RetryCount:       5,
+				ProductName:      "magma",
+				Host:             "magma-fedgw.magma.com",
+				Realm:            "magma.com",
+			},
+			InitMethod: &gyInitMethodPerSession,
+		},
+		Hss: &models.NetworkFederationConfigsHss{
+			Server: &models.DiameterServerConfigs{
+				Protocol:  "tcp",
+				DestHost:  "magma.com",
+				DestRealm: "magma.com",
+			},
+			LteAuthOp:  []byte("EREREREREREREREREREREQ=="),
+			LteAuthAmf: []byte("gA"),
+			DefaultSubProfile: &models.SubscriptionProfile{
+				MaxUlBitRate: 100000000, // 100 Mbps
+				MaxDlBitRate: 200000000, // 200 Mbps
+			},
+			SubProfiles:       make(map[string]models.SubscriptionProfile),
+			StreamSubscribers: false,
+		},
+		Swx: &models.NetworkFederationConfigsSwx{
+			Server: &models.DiameterClientConfigs{
+				Protocol:         "sctp",
+				Retransmits:      3,
+				WatchdogInterval: 1,
+				RetryCount:       5,
+				ProductName:      "magma",
+				Host:             "magma-fedgw.magma.com",
+				Realm:            "magma.com",
+			},
+			VerifyAuthorization: false,
+			CacheTTLSeconds:     10800,
+		},
+		EapAka: &models.NetworkFederationConfigsEapAka{
+			Timeout: &models.EapAkaTimeouts{
+				ChallengeMs:            20000,
+				ErrorNotificationMs:    10000,
+				SessionMs:              43200000,
+				SessionAuthenticatedMs: 5000,
+			},
+			PlmnIds: []string{},
+		},
+		AaaServer: &models.NetworkFederationConfigsAaaServer{
+			IDLESessionTimeoutMs: 21600000,
+			AccountingEnabled:    false,
+			CreateSessionOnAuth:  false,
+		},
+		ServedNetworkIds: []string{},
+		Health: &models.NetworkFederationConfigsHealth{
+			HealthServices:           []string{"S6A_PROXY", "SESSION_PROXY"},
+			UpdateIntervalSecs:       10,
+			CloudDisablePeriodSecs:   10,
+			LocalDisablePeriodSecs:   1,
+			UpdateFailureThreshold:   3,
+			RequestFailureThreshold:  0.50,
+			MinimumRequestThreshold:  1,
+			CPUUtilizationThreshold:  0.90,
+			MemoryAvailableThreshold: 0.90,
+		}}
+}
+
+func NewDefaultGatewayConfig() *models.GatewayFegConfigs {
+	return &models.GatewayFegConfigs{
+		NetworkFederationConfigs: *NewDefaultNetworkConfig(),
+	}
+}

--- a/orc8r/cloud/go/services/configurator/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/configurator/test_init/test_service_init.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
+	accessd_test_init "magma/orc8r/cloud/go/services/accessd/test_init"
+	certifier_test_init "magma/orc8r/cloud/go/services/certifier/test_init"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/protos"
 	"magma/orc8r/cloud/go/services/configurator/servicers"
@@ -28,6 +30,9 @@ func StartTestService(t *testing.T) {
 	idGenerator := storage.DefaultIDGenerator{}
 	storageFactory := storage.NewSQLConfiguratorStorageFactory(db, &idGenerator, sqorc.GetSqlBuilder())
 	storageFactory.InitializeServiceStorage()
+
+	accessd_test_init.StartTestService(t)
+	certifier_test_init.StartTestService(t)
 
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, configurator.ServiceName)
 	nb, err := servicers.NewNorthboundConfiguratorServicer(storageFactory)


### PR DESCRIPTION
Summary: Since magmad/config handlers will be deprecated soon, duplicating tests to test the configurator backed version as well.

Reviewed By: xjtian

Differential Revision: D16205950

