### PR TITLE
Change client_api to return deserialized states instead of serialized

### DIFF
--- a/orc8r/cloud/go/services/state/obsidian/handlers/stateh.go
+++ b/orc8r/cloud/go/services/state/obsidian/handlers/stateh.go
@@ -13,7 +13,6 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
 	"magma/orc8r/cloud/go/orc8r"
-	"magma/orc8r/cloud/go/serde"
 	checkind_models "magma/orc8r/cloud/go/services/checkind/obsidian/models"
 	stateservice "magma/orc8r/cloud/go/services/state"
 
@@ -52,12 +51,7 @@ func GetGWStatus(networkID string, deviceID string) (*checkind_models.GatewaySta
 	if err != nil {
 		return nil, err
 	}
-	deserializedValue, err := serde.Deserialize(
-		stateservice.SerdeDomain,
-		orc8r.GatewayStateType,
-		state.ReportedValue,
-	)
-	gwStatus := deserializedValue.(checkind_models.GatewayStatus)
+	gwStatus := state.ReportedState.(checkind_models.GatewayStatus)
 	gwStatus.CheckinTime = state.Time
 	gwStatus.CertExpirationTime = state.CertExpirationTime
 	// Use the hardware ID from the middleware


### PR DESCRIPTION
Summary: As we expand the number of states reported through the state service, it becomes a lot additional code to deserialize each state each time.  The change moves the deserialization logic into the client api so that the behavior is the same as device and configurator.

Differential Revision: D16265036

