### PR TITLE
Add rpc functionality to test controller service (#1164)

### DIFF
--- a/orc8r/cloud/deploy/files/docker/docker-compose.controller.yml
+++ b/orc8r/cloud/deploy/files/docker/docker-compose.controller.yml
@@ -16,7 +16,7 @@ services:
       - /var/opt/magma/envdir:/var/opt/magma/envdir
     ports:
       - "8080:8080"
-      - "9079-9108:9079-9108"
+      - "9079-9108:9079-9112"
     ulimits:
       nofile:
         soft: 65536


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/1164

This outlines the gateway code for an RPC connection between the testcontroller service in the cloud and on the gateway. The cloud side is not yet implemented.

When a gateway finishes upgrading the magmad version, it sends a message to the cloud service, which will send back the path to a script on the gateway to be run. Intended use is for CI: test scripts will be run automatically after every package upgrade.

NOTE: Since the testcontroller service is in the fbinternal package, _pb2.py files are not generated automatically in the builds. Similarly to vpnservice in D15200752, the _pb2.py files will need to be copied manually onto any gateway we wish to integrate with this setup. These proto files should be placed on the gateway in `/usr/local/lib/python3.5/dist-packages/` at the directory `fbinternal/protos`

Differential Revision: D16269581

