### PR TITLE
Modifying docker-compose so that the controller service waits for postgres to be ready

### DIFF
--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -82,6 +82,8 @@ ENV SERVICE_HOST_NAME localhost
 # TODO: fix metricsd for fetching host level metrics
 ENV HOST_NAME dev
 
+COPY src/magma/orc8r/cloud/docker/wait-for-it.sh /usr/local/bin
+
 # Copy the configs
 COPY configs /etc/magma/configs
 

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -57,3 +57,4 @@ services:
       # DATABASE_SOURCE: "magma_dev:magma_dev@(maria)/magma_dev"
       # SQL_DIALECT: maria
     restart: always
+    command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -t 30 postgres:5432 && /usr/bin/supervisord"]

--- a/orc8r/cloud/docker/wait-for-it.sh
+++ b/orc8r/cloud/docker/wait-for-it.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+#   Taken from  https://github.com/vishnubob/wait-for-it
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi

--- a/orc8r/cloud/go/services/configurator/configurator/main.go
+++ b/orc8r/cloud/go/services/configurator/configurator/main.go
@@ -14,8 +14,6 @@ and meta data for the network and network entity structures.
 package main
 
 import (
-	"database/sql"
-
 	"magma/orc8r/cloud/go/datastore"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
@@ -34,13 +32,16 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}
-	db, err := sql.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
+	db, err := sqorc.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}
 
 	factory := storage.NewSQLConfiguratorStorageFactory(db, &storage.DefaultIDGenerator{}, sqorc.GetSqlBuilder())
 	err = factory.InitializeServiceStorage()
+	if err != nil {
+		glog.Fatalf("Failed to initialize configurator databse: %s", err)
+	}
 
 	nbServicer, err := servicers.NewNorthboundConfiguratorServicer(factory)
 	if err != nil {

--- a/orc8r/cloud/go/services/device/device/main.go
+++ b/orc8r/cloud/go/services/device/device/main.go
@@ -9,8 +9,6 @@ LICENSE file in the root directory of this source tree.
 package main
 
 import (
-	"database/sql"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/datastore"
 	"magma/orc8r/cloud/go/orc8r"
@@ -28,11 +26,10 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating device service %s", err)
 	}
-	db, err := sql.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
+	db, err := sqorc.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}
-
 	store := blobstore.NewSQLBlobStorageFactory(device.DBTableName, db, sqorc.GetSqlBuilder())
 	err = store.InitializeFactory()
 	if err != nil {

--- a/orc8r/cloud/go/services/device/servicers/device.go
+++ b/orc8r/cloud/go/services/device/servicers/device.go
@@ -60,6 +60,10 @@ func (srv *deviceServicer) GetDeviceInfo(ctx context.Context, req *protos.GetDev
 		return nil, err
 	}
 	blobs, err := store.GetMany(req.NetworkID, ids)
+	if err != nil {
+		store.Rollback()
+		return response, err
+	}
 	response.DeviceMap = protos.BlobsToEntityByDeviceID(blobs)
 	return response, store.Commit()
 }

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -47,8 +47,11 @@ func (srv *stateServicer) GetStates(context context.Context, req *protos.GetStat
 		return nil, err
 	}
 	states, err := store.GetMany(req.GetNetworkID(), ids)
-	store.Commit()
-	return &protos.GetStatesResponse{States: protos.BlobsToStates(states)}, nil
+	if err != nil {
+		store.Rollback()
+		return nil, err
+	}
+	return &protos.GetStatesResponse{States: protos.BlobsToStates(states)}, store.Commit()
 }
 
 // ReportStates saves states into blobstorage

--- a/orc8r/cloud/go/services/state/state/main.go
+++ b/orc8r/cloud/go/services/state/state/main.go
@@ -9,8 +9,6 @@
 package main
 
 import (
-	"database/sql"
-
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/datastore"
 	"magma/orc8r/cloud/go/orc8r"
@@ -28,8 +26,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating state service %s", err)
 	}
-
-	db, err := sql.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
+	db, err := sqorc.Open(datastore.SQL_DRIVER, datastore.DATABASE_SOURCE)
 	if err != nil {
 		glog.Fatalf("Failed to connect to database: %s", err)
 	}


### PR DESCRIPTION
Summary:
Currently, the state/device/configurator services fail to start properly because they make calls to the db (postgres) container before it is ready. Adding a script to wait until the db is ready.
References: https://docs.docker.com/compose/startup-order/, wait-for-it script taken from https://github.com/vishnubob/wait-for-it

Also adding error checking where it was missing in state / configurator.

Reviewed By: xjtian

Differential Revision: D16268758

