### PR TITLE
Add interface to create blobs with universally unique keys

### DIFF
--- a/orc8r/cloud/go/blobstore/storage.go
+++ b/orc8r/cloud/go/blobstore/storage.go
@@ -60,6 +60,12 @@ type TransactionalBlobStorage interface {
 	// storage implementation.
 	CreateOrUpdate(networkID string, blobs []Blob) error
 
+	// CreateWithUniqueKeys creates blobs. It ensures its keys are unique
+	// across networks. The Version field of Blobs passed in here is
+	// ignored - all version incrementation is done internally inside the
+	// storage implementation.
+	CreateWithUniqueKeys(networkID string, blob []Blob) error
+
 	// Delete deletes specified blobs from storage.
 	Delete(networkID string, ids []storage.TypeAndKey) error
 }


### PR DESCRIPTION
Summary: Adding an interface to blobstore to create blobs with universally unique keys. This will be used by the device service in a diff to come.

Reviewed By: andreilee

Differential Revision: D16340205

