### PR TITLE
Add dependency from controller to postgres container

### DIFF
--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -57,4 +57,8 @@ services:
       # DATABASE_SOURCE: "magma_dev:magma_dev@(maria)/magma_dev"
       # SQL_DIALECT: maria
     restart: always
-    command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -t 30 postgres:5432 && /usr/bin/supervisord"]
+    depends_on:
+      - postgres
+      # - maria
+    command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 && /usr/bin/supervisord"]
+    # command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 maria:[port] && /usr/bin/supervisord"]


### PR DESCRIPTION
Summary:
In local cloud setup, configurator, state, device services were having trouble starting since they were querying for the database before it could accept connections. I tried to fix this with (D16268758). But it seems it occasionally does not work.
Adding the dependency seems to help.

Reviewed By: xjtian

Differential Revision: D16360826

