### PR TITLE
Migrate gateway status read in checkin metrics report to be from configurator

### DIFF
--- a/orc8r/cloud/go/services/checkind/obsidian/handlers/checkindh.go
+++ b/orc8r/cloud/go/services/checkind/obsidian/handlers/checkindh.go
@@ -14,7 +14,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/magmad"
-	stateh "magma/orc8r/cloud/go/services/state/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/state"
 
 	"github.com/labstack/echo"
 
@@ -42,7 +42,7 @@ func GetObsidianHandlers() []handlers.Handler {
 					return handlers.HttpError(err, http.StatusNotFound)
 				}
 				hwid := gwRecord.HwId.Id
-				gwStatus, err := stateh.GetGWStatus(networkID, hwid)
+				gwStatus, err := state.GetGatewayStatus(networkID, hwid)
 				if err != nil {
 					return handlers.HttpError(err, http.StatusNotFound)
 				}
@@ -59,7 +59,7 @@ func GetObsidianHandlers() []handlers.Handler {
 				if err != nil {
 					return handlers.HttpError(err, http.StatusNotFound)
 				}
-				gwStatus, err := stateh.GetGWStatus(networkID, gwPhysicalID)
+				gwStatus, err := state.GetGatewayStatus(networkID, gwPhysicalID)
 				if err != nil {
 					return handlers.HttpError(err, http.StatusNotFound)
 				}

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory.go
@@ -19,7 +19,7 @@ import (
 	"magma/orc8r/cloud/go/services/device"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
 	magmadprotos "magma/orc8r/cloud/go/services/magmad/protos"
-	stateh "magma/orc8r/cloud/go/services/state/obsidian/handlers"
+	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/storage"
 
 	"github.com/thoas/go-funk"
@@ -80,7 +80,7 @@ func (f *FullGatewayViewFactoryImpl) GetGatewayViews(networkID string, gatewayID
 			return nil, fmt.Errorf("Error loading record: %s", err)
 		}
 
-		status, err := stateh.GetGWStatus(networkID, gateway.PhysicalID)
+		status, err := state.GetGatewayStatus(networkID, gateway.PhysicalID)
 		if err == magmaerrors.ErrNotFound {
 			status = nil
 		} else if err != nil {

--- a/orc8r/cloud/go/services/state/obsidian/handlers/stateh.go
+++ b/orc8r/cloud/go/services/state/obsidian/handlers/stateh.go
@@ -13,7 +13,6 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
 	"magma/orc8r/cloud/go/orc8r"
-	"magma/orc8r/cloud/go/serde"
 	checkind_models "magma/orc8r/cloud/go/services/checkind/obsidian/models"
 	stateservice "magma/orc8r/cloud/go/services/state"
 
@@ -52,12 +51,7 @@ func GetGWStatus(networkID string, deviceID string) (*checkind_models.GatewaySta
 	if err != nil {
 		return nil, err
 	}
-	deserializedValue, err := serde.Deserialize(
-		stateservice.SerdeDomain,
-		orc8r.GatewayStateType,
-		state.ReportedValue,
-	)
-	gwStatus := deserializedValue.(checkind_models.GatewayStatus)
+	gwStatus := state.ReportedState.(checkind_models.GatewayStatus)
 	gwStatus.CheckinTime = state.Time
 	gwStatus.CertExpirationTime = state.CertExpirationTime
 	// Use the hardware ID from the middleware

--- a/orc8r/cloud/go/services/state/obsidian/handlers/stateh.go
+++ b/orc8r/cloud/go/services/state/obsidian/handlers/stateh.go
@@ -12,9 +12,7 @@ import (
 	"net/http"
 
 	"magma/orc8r/cloud/go/obsidian/handlers"
-	"magma/orc8r/cloud/go/orc8r"
-	checkind_models "magma/orc8r/cloud/go/services/checkind/obsidian/models"
-	stateservice "magma/orc8r/cloud/go/services/state"
+	"magma/orc8r/cloud/go/services/state"
 
 	"github.com/labstack/echo"
 )
@@ -38,26 +36,10 @@ func AGStatusByDeviceIDHandler(c echo.Context) error {
 		return nerr
 	}
 	deviceID := c.Param("device_id")
-	gwStatusModel, err := GetGWStatus(networkID, deviceID)
+	gwStatusModel, err := state.GetGatewayStatus(networkID, deviceID)
 	if err != nil {
 		return handlers.HttpError(err, http.StatusNotFound)
 	}
 
 	return c.JSON(http.StatusOK, &gwStatusModel)
-}
-
-func GetGWStatus(networkID string, deviceID string) (*checkind_models.GatewayStatus, error) {
-	state, err := stateservice.GetState(networkID, orc8r.GatewayStateType, deviceID)
-	if err != nil {
-		return nil, err
-	}
-	gwStatus := state.ReportedState.(checkind_models.GatewayStatus)
-	gwStatus.CheckinTime = state.Time
-	gwStatus.CertExpirationTime = state.CertExpirationTime
-	// Use the hardware ID from the middleware
-	gwStatus.HardwareID = state.ReporterID
-	// Populate deprecated fields to support API backwards compatibility
-	// TODO: Remove this and related tests when deprecated fields are no longer used
-	gwStatus.FillDeprecatedFields()
-	return &gwStatus, nil
 }

--- a/orc8r/cloud/go/services/state/test_utils/utils.go
+++ b/orc8r/cloud/go/services/state/test_utils/utils.go
@@ -13,7 +13,6 @@ import (
 	"magma/orc8r/cloud/go/service/middleware/unary/test_utils"
 	checkind_models "magma/orc8r/cloud/go/services/checkind/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
-	stateh "magma/orc8r/cloud/go/services/state/obsidian/handlers"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
@@ -52,7 +51,7 @@ func GetGWStatusViaHTTPNoError(t *testing.T, url string, networkID string, key s
 	status, response, err := tests.SendHttpRequest("GET", url, "")
 	assert.NoError(t, err)
 	assert.Equal(t, 200, status)
-	expected, err := stateh.GetGWStatus(networkID, key)
+	expected, err := state.GetGatewayStatus(networkID, key)
 	assert.NoError(t, err)
 	expectedJSON, err := json.Marshal(*expected)
 	assert.NoError(t, err)


### PR DESCRIPTION
Summary: Updating gateway status reporter to read from configurator and not checkin.

Reviewed By: xjtian

Differential Revision: D16269178

