### PR TITLE
Add transaction option to blobstore storage transactions

### DIFF
--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -60,7 +60,7 @@ func (srv *UESimServer) AddUE(ctx context.Context, ue *cwfprotos.UEConfig) (ret 
 		return
 	}
 	blob, err := ueToBlob(ue)
-	store, err := srv.store.StartTransaction()
+	store, err := srv.store.StartTransaction(nil)
 	if err != nil {
 		err = errors.Wrap(err, "Error while starting transaction")
 		err = ConvertStorageErrorToGrpcStatus(err)
@@ -153,7 +153,7 @@ func blobToUE(blob blobstore.Blob) (*cwfprotos.UEConfig, error) {
 
 // getUE gets the UE with the specified IMSI from the blobstore.
 func getUE(blobStoreFactory blobstore.BlobStorageFactory, imsi string) (ue *cwfprotos.UEConfig, err error) {
-	store, err := blobStoreFactory.StartTransaction()
+	store, err := blobStoreFactory.StartTransaction(nil)
 	if err != nil {
 		err = errors.Wrap(err, "Error while starting transaction")
 		return

--- a/orc8r/cloud/go/blobstore/integration_test.go
+++ b/orc8r/cloud/go/blobstore/integration_test.go
@@ -23,7 +23,7 @@ import (
 func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	// Check the contract for an empty datastore
 	err := fact.InitializeFactory()
-	store, err := fact.StartTransaction()
+	store, err := fact.StartTransaction(nil)
 	assert.NoError(t, err)
 	listActual, err := store.ListKeys("network", "type")
 	assert.NoError(t, err)
@@ -45,7 +45,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store.Commit())
 
 	// Workflow test
-	store1, err := fact.StartTransaction()
+	store1, err := fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// Create blobs on 2 networks
@@ -60,7 +60,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store1.Commit())
 
 	// network2: (t3) X (k3, k4)
-	store2, err := fact.StartTransaction()
+	store2, err := fact.StartTransaction(nil)
 	assert.NoError(t, err)
 	err = store2.CreateOrUpdate("network2", []blobstore.Blob{
 		{Type: "t3", Key: "k3", Value: []byte("v5")},
@@ -70,7 +70,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store2.Commit())
 
 	// Read tests
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	listActual, err = store.ListKeys("network1", "t1")
@@ -122,7 +122,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store.Commit())
 
 	// Update with creation, read back
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	err = store.CreateOrUpdate("network1", []blobstore.Blob{
@@ -151,7 +151,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store.Commit())
 
 	// Test CreateWithUniqueKeys fail
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	err = store.CreateWithUniqueKeys("network2", []blobstore.Blob{
@@ -162,7 +162,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store.Commit())
 
 	// Test CreateWithUniqueKeys success
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	err = store.CreateWithUniqueKeys("network2", []blobstore.Blob{
@@ -172,7 +172,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, err)
 	assert.NoError(t, store.Commit())
 
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 	getManyActual, err = store.GetMany("network2", []storage.TypeAndKey{
 		{Type: "t2", Key: "k50"},
@@ -190,7 +190,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.EqualError(t, err, "No transaction is available")
 
 	// Delete multiple
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	err = store.Delete("network1", []storage.TypeAndKey{
@@ -210,7 +210,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.NoError(t, store.Commit())
 
 	// Delete multiple, rollback, read back
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	err = store.Delete("network2", []storage.TypeAndKey{
@@ -226,7 +226,7 @@ func integration(t *testing.T, fact blobstore.BlobStorageFactory) {
 	assert.Equal(t, []blobstore.Blob{}, getManyActual)
 	assert.NoError(t, store.Rollback())
 
-	store, err = fact.StartTransaction()
+	store, err = fact.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	getManyActual, err = store.GetMany("network2", []storage.TypeAndKey{

--- a/orc8r/cloud/go/blobstore/memory.go
+++ b/orc8r/cloud/go/blobstore/memory.go
@@ -71,7 +71,7 @@ func NewMemoryBlobStorageFactory() BlobStorageFactory {
 	return &memoryBlobStoreFactory{table: blobTable{}}
 }
 
-func (fact *memoryBlobStoreFactory) StartTransaction() (TransactionalBlobStorage, error) {
+func (fact *memoryBlobStoreFactory) StartTransaction(opts *storage.TxOptions) (TransactionalBlobStorage, error) {
 	return &memoryBlobStorage{
 		shared:            sharedMemoryBlobTables{RWMutex: &fact.RWMutex, table: fact.table},
 		transactionExists: true,

--- a/orc8r/cloud/go/blobstore/memory_test.go
+++ b/orc8r/cloud/go/blobstore/memory_test.go
@@ -33,7 +33,7 @@ func TestMemoryBlobStorageStorage_CreateOrUpdate(t *testing.T) {
 	blob2 := blobstore.Blob{Type: type1, Key: key1, Value: []byte("value2")}
 	network1 := "network1"
 
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// create
@@ -61,7 +61,7 @@ func TestMemoryBlobStorage_Rollback(t *testing.T) {
 	blob1 := blobstore.Blob{Type: type1, Key: key1, Value: []byte("value1")}
 	network1 := "network1"
 
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// create
@@ -72,7 +72,7 @@ func TestMemoryBlobStorage_Rollback(t *testing.T) {
 
 	store.Rollback()
 
-	store, err = factory.StartTransaction()
+	store, err = factory.StartTransaction(nil)
 	assert.NoError(t, err)
 	_, err = store.Get(network1, storage.TypeAndKey{type1, key1})
 	assert.Equal(t, errors.ErrNotFound, err)
@@ -86,7 +86,7 @@ func TestMemoryBlobStorage_Commit(t *testing.T) {
 	network1 := "network1"
 	id1 := storage.TypeAndKey{type1, key1}
 
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// create
@@ -97,7 +97,7 @@ func TestMemoryBlobStorage_Commit(t *testing.T) {
 
 	store.Commit()
 
-	store, err = factory.StartTransaction()
+	store, err = factory.StartTransaction(nil)
 	assert.NoError(t, err)
 	blob, err := store.Get(network1, id1)
 	assert.NoError(t, err)
@@ -106,7 +106,7 @@ func TestMemoryBlobStorage_Commit(t *testing.T) {
 	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
 	store.Commit()
 
-	store, err = factory.StartTransaction()
+	store, err = factory.StartTransaction(nil)
 	blob, err = store.Get(network1, id1)
 	assert.Equal(t, []byte("value2"), blob.Value)
 }
@@ -125,7 +125,7 @@ func TestMemoryBlobStorage_GetMany(t *testing.T) {
 		{Type: blob2.Type, Key: blob2.Key},
 	}
 
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// create
@@ -155,7 +155,7 @@ func TestMemoryBlobStorage_Delete(t *testing.T) {
 		{Type: blob1.Type, Key: blob1.Key},
 	}
 
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// create, update, delete within a transaction session should end up with
@@ -165,7 +165,7 @@ func TestMemoryBlobStorage_Delete(t *testing.T) {
 	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
 	assert.NoError(t, store.Delete(network1, ids))
 	store.Commit()
-	store, err = factory.StartTransaction()
+	store, err = factory.StartTransaction(nil)
 	blobs, _ := store.GetMany(network1, ids)
 	assert.Equal(t, 0, len(blobs))
 
@@ -176,7 +176,7 @@ func TestMemoryBlobStorage_Delete(t *testing.T) {
 	assert.NoError(t, store.Delete(network1, ids))
 	assert.NoError(t, store.CreateOrUpdate(network1, []blobstore.Blob{blob1}))
 	store.Commit()
-	store, err = factory.StartTransaction()
+	store, err = factory.StartTransaction(nil)
 	blobs, _ = store.GetMany(network1, ids)
 	assert.Equal(t, 1, len(blobs))
 }
@@ -190,7 +190,7 @@ func TestMemoryBlobStorage_ListKeys(t *testing.T) {
 	blob2 := blobstore.Blob{Type: type1, Key: key2, Value: []byte("value2")}
 	network1 := "network1"
 
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	// Test local changes
@@ -199,7 +199,7 @@ func TestMemoryBlobStorage_ListKeys(t *testing.T) {
 	assert.Equal(t, []string{key1, key2}, keys)
 
 	store.Commit()
-	store, err = factory.StartTransaction()
+	store, err = factory.StartTransaction(nil)
 
 	// Test committed changes
 	keys, err = store.ListKeys(network1, type1)

--- a/orc8r/cloud/go/blobstore/sql_test.go
+++ b/orc8r/cloud/go/blobstore/sql_test.go
@@ -416,7 +416,7 @@ func runCase(t *testing.T, test *testCase) {
 	assert.NoError(t, err)
 
 	mock.ExpectBegin()
-	store, err := factory.StartTransaction()
+	store, err := factory.StartTransaction(nil)
 	assert.NoError(t, err)
 
 	test.setup(mock)

--- a/orc8r/cloud/go/blobstore/storage.go
+++ b/orc8r/cloud/go/blobstore/storage.go
@@ -26,7 +26,7 @@ type BlobStorageFactory interface {
 	// StartTransaction opens a transaction for all following blob storage
 	// operations, and returns a TransactionalBlobStorage instance tied to the
 	// opened transaction.
-	StartTransaction() (TransactionalBlobStorage, error)
+	StartTransaction(opts *storage.TxOptions) (TransactionalBlobStorage, error)
 }
 
 // TransactionalBlobStorage is the client API for blob storage operations

--- a/orc8r/cloud/go/services/configurator/servicers/northbound.go
+++ b/orc8r/cloud/go/services/configurator/servicers/northbound.go
@@ -17,6 +17,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/protos"
 	"magma/orc8r/cloud/go/services/configurator/storage"
+	orc8rStorage "magma/orc8r/cloud/go/storage"
 )
 
 type nbConfiguratorServicer struct {
@@ -33,7 +34,7 @@ func NewNorthboundConfiguratorServicer(factory storage.ConfiguratorStorageFactor
 
 func (srv *nbConfiguratorServicer) LoadNetworks(context context.Context, req *protos.LoadNetworksRequest) (*storage.NetworkLoadResult, error) {
 	res := &storage.NetworkLoadResult{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: true})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: true})
 	if err != nil {
 		return res, err
 	}
@@ -48,7 +49,7 @@ func (srv *nbConfiguratorServicer) LoadNetworks(context context.Context, req *pr
 
 func (srv *nbConfiguratorServicer) ListNetworkIDs(context context.Context, void *commonProtos.Void) (*protos.ListNetworkIDsResponse, error) {
 	res := &protos.ListNetworkIDsResponse{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: true})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: true})
 	if err != nil {
 		return res, err
 	}
@@ -67,7 +68,7 @@ func (srv *nbConfiguratorServicer) ListNetworkIDs(context context.Context, void 
 
 func (srv *nbConfiguratorServicer) CreateNetworks(context context.Context, req *protos.CreateNetworksRequest) (*protos.CreateNetworksResponse, error) {
 	emptyRes := &protos.CreateNetworksResponse{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return emptyRes, err
 	}
@@ -90,7 +91,7 @@ func (srv *nbConfiguratorServicer) CreateNetworks(context context.Context, req *
 
 func (srv *nbConfiguratorServicer) UpdateNetworks(context context.Context, req *protos.UpdateNetworksRequest) (*commonProtos.Void, error) {
 	void := &commonProtos.Void{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return void, err
 	}
@@ -113,7 +114,7 @@ func (srv *nbConfiguratorServicer) UpdateNetworks(context context.Context, req *
 
 func (srv *nbConfiguratorServicer) DeleteNetworks(context context.Context, req *protos.DeleteNetworksRequest) (*commonProtos.Void, error) {
 	void := &commonProtos.Void{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return void, err
 	}
@@ -132,7 +133,7 @@ func (srv *nbConfiguratorServicer) DeleteNetworks(context context.Context, req *
 
 func (srv *nbConfiguratorServicer) LoadEntities(context context.Context, req *protos.LoadEntitiesRequest) (*storage.EntityLoadResult, error) {
 	emptyRes := &storage.EntityLoadResult{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return emptyRes, err
 	}
@@ -147,7 +148,7 @@ func (srv *nbConfiguratorServicer) LoadEntities(context context.Context, req *pr
 
 func (srv *nbConfiguratorServicer) CreateEntities(context context.Context, req *protos.CreateEntitiesRequest) (*protos.CreateEntitiesResponse, error) {
 	emptyRes := &protos.CreateEntitiesResponse{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return emptyRes, err
 	}
@@ -169,7 +170,7 @@ func (srv *nbConfiguratorServicer) CreateEntities(context context.Context, req *
 
 func (srv *nbConfiguratorServicer) UpdateEntities(context context.Context, req *protos.UpdateEntitiesRequest) (*protos.UpdateEntitiesResponse, error) {
 	emptyRes := &protos.UpdateEntitiesResponse{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return emptyRes, err
 	}
@@ -194,7 +195,7 @@ func (srv *nbConfiguratorServicer) UpdateEntities(context context.Context, req *
 
 func (srv *nbConfiguratorServicer) DeleteEntities(context context.Context, req *protos.DeleteEntitiesRequest) (*commonProtos.Void, error) {
 	void := &commonProtos.Void{}
-	store, err := srv.factory.StartTransaction(context, &storage.TxOptions{ReadOnly: false})
+	store, err := srv.factory.StartTransaction(context, &orc8rStorage.TxOptions{ReadOnly: false})
 	if err != nil {
 		return void, err
 	}

--- a/orc8r/cloud/go/services/configurator/servicers/southbound.go
+++ b/orc8r/cloud/go/services/configurator/servicers/southbound.go
@@ -17,6 +17,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/protos"
 	"magma/orc8r/cloud/go/services/configurator/storage"
+	orc8rStorage "magma/orc8r/cloud/go/storage"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/thoas/go-funk"
@@ -47,7 +48,7 @@ func (srv *sbConfiguratorServicer) GetMconfig(ctx context.Context, void *commonP
 }
 
 func (srv *sbConfiguratorServicer) GetMconfigInternal(ctx context.Context, req *protos.GetMconfigRequest) (*protos.GetMconfigResponse, error) {
-	store, err := srv.factory.StartTransaction(context.Background(), &storage.TxOptions{ReadOnly: true})
+	store, err := srv.factory.StartTransaction(context.Background(), &orc8rStorage.TxOptions{ReadOnly: true})
 	if err != nil {
 		storage.RollbackLogOnError(store)
 		return nil, status.Errorf(codes.Aborted, "failed to start transaction: %s", err)
@@ -75,7 +76,7 @@ func (srv *sbConfiguratorServicer) GetMconfigInternal(ctx context.Context, req *
 }
 
 func (srv *sbConfiguratorServicer) getMconfigImpl(networkID string, gatewayID string) (*commonProtos.GatewayConfigs, error) {
-	store, err := srv.factory.StartTransaction(context.Background(), &storage.TxOptions{ReadOnly: true})
+	store, err := srv.factory.StartTransaction(context.Background(), &orc8rStorage.TxOptions{ReadOnly: true})
 	if err != nil {
 		storage.RollbackLogOnError(store)
 		return nil, status.Errorf(codes.Aborted, "failed to start transaction: %s", err)

--- a/orc8r/cloud/go/services/configurator/storage/sql.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql.go
@@ -229,7 +229,7 @@ func (fact *sqlConfiguratorStorageFactory) InitializeServiceStorage() (err error
 	return
 }
 
-func (fact *sqlConfiguratorStorageFactory) StartTransaction(ctx context.Context, opts *TxOptions) (ConfiguratorStorage, error) {
+func (fact *sqlConfiguratorStorageFactory) StartTransaction(ctx context.Context, opts *storage.TxOptions) (ConfiguratorStorage, error) {
 	tx, err := fact.db.BeginTx(ctx, getSqlOpts(opts))
 	if err != nil {
 		return nil, err
@@ -237,11 +237,14 @@ func (fact *sqlConfiguratorStorageFactory) StartTransaction(ctx context.Context,
 	return &sqlConfiguratorStorage{tx: tx, idGenerator: fact.idGenerator, builder: fact.builder}, nil
 }
 
-func getSqlOpts(opts *TxOptions) *sql.TxOptions {
+func getSqlOpts(opts *storage.TxOptions) *sql.TxOptions {
 	if opts == nil {
 		return nil
 	}
-	return &sql.TxOptions{ReadOnly: opts.ReadOnly}
+	if opts.Isolation == 0 {
+		return &sql.TxOptions{ReadOnly: opts.ReadOnly}
+	}
+	return &sql.TxOptions{ReadOnly: opts.ReadOnly, Isolation: sql.IsolationLevel(opts.Isolation)}
 }
 
 type sqlConfiguratorStorage struct {

--- a/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
+++ b/orc8r/cloud/go/services/configurator/storage/sql_integ_test.go
@@ -15,6 +15,7 @@ import (
 
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	"magma/orc8r/cloud/go/sqorc"
+	orc8rStorage "magma/orc8r/cloud/go/storage"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -134,7 +135,7 @@ func TestSqlConfiguratorStorage_Integration(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NoError(t, store.Commit())
 
-	store, err = factory.StartTransaction(context.Background(), &storage.TxOptions{ReadOnly: true})
+	store, err = factory.StartTransaction(context.Background(), &orc8rStorage.TxOptions{ReadOnly: true})
 	assert.NoError(t, err)
 	loadNetworksActual, err = store.LoadNetworks([]string{"n1", "n2", "n3"}, storage.FullNetworkLoadCriteria)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/configurator/storage/storage.go
+++ b/orc8r/cloud/go/services/configurator/storage/storage.go
@@ -28,13 +28,7 @@ type ConfiguratorStorageFactory interface {
 
 	// StartTransaction returns a ConfiguratorStorage implementation bound to
 	// a transaction. Transaction options can be optionally provided.
-	StartTransaction(ctx context.Context, opts *TxOptions) (ConfiguratorStorage, error)
-}
-
-// TxOptions specifies options for transactions started by
-// ConfiguratorStorageFactory
-type TxOptions struct {
-	ReadOnly bool
+	StartTransaction(ctx context.Context, opts *storage.TxOptions) (ConfiguratorStorage, error)
 }
 
 // ConfiguratorStorage is the interface for the configurator service's access

--- a/orc8r/cloud/go/services/device/servicers/device.go
+++ b/orc8r/cloud/go/services/device/servicers/device.go
@@ -35,7 +35,7 @@ func (srv *deviceServicer) RegisterDevices(ctx context.Context, req *protos.Regi
 	}
 
 	blobs := protos.EntitiesToBlobs(req.GetEntities())
-	store, err := srv.factory.StartTransaction()
+	store, err := srv.factory.StartTransaction(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func (srv *deviceServicer) GetDeviceInfo(ctx context.Context, req *protos.GetDev
 	}
 
 	ids := protos.DeviceIDsToTypeAndKey(req.DeviceIDs)
-	store, err := srv.factory.StartTransaction()
+	store, err := srv.factory.StartTransaction(nil)
 	if err != nil {
 		store.Rollback()
 		return nil, err
@@ -75,7 +75,7 @@ func (srv *deviceServicer) DeleteDevices(ctx context.Context, req *protos.Delete
 	}
 
 	ids := protos.DeviceIDsToTypeAndKey(req.DeviceIDs)
-	store, err := srv.factory.StartTransaction()
+	store, err := srv.factory.StartTransaction(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -42,7 +42,7 @@ func (srv *stateServicer) GetStates(context context.Context, req *protos.GetStat
 
 	ids := protos.StateIDsToTKs(req.GetIds())
 
-	store, err := srv.factory.StartTransaction()
+	store, err := srv.factory.StartTransaction(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -81,7 +81,7 @@ func (srv *stateServicer) ReportStates(context context.Context, req *protos.Repo
 		return response, err
 	}
 
-	store, err := srv.factory.StartTransaction()
+	store, err := srv.factory.StartTransaction(nil)
 	if err != nil {
 		return response, err
 	}
@@ -102,7 +102,7 @@ func (srv *stateServicer) DeleteStates(context context.Context, req *protos.Dele
 	networkID := req.GetNetworkID()
 	ids := protos.StateIDsToTKs(req.GetIds())
 
-	store, err := srv.factory.StartTransaction()
+	store, err := srv.factory.StartTransaction(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/storage/storage.go
+++ b/orc8r/cloud/go/storage/storage.go
@@ -10,12 +10,33 @@
 // storage interfaces
 package storage
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type TypeAndKey struct {
 	Type string
 	Key  string
 }
+
+type IsolationLevel int
+
+// TxOptions specifies options for transactions
+type TxOptions struct {
+	Isolation IsolationLevel
+	ReadOnly  bool
+}
+
+const (
+	LevelDefault IsolationLevel = iota
+	LevelReadUncommitted
+	LevelReadCommitted
+	LevelWriteCommitted
+	LevelRepeatableRead
+	LevelSnapshot
+	LevelSerializable
+	LevelLinearizable
+)
 
 func (tk TypeAndKey) String() string {
 	return fmt.Sprintf("%s-%s", tk.Type, tk.Key)


### PR DESCRIPTION
Summary:
Add transaction option parameter to `StartTransaction()` for blobstore storage, which allows configuration of the transaction isolation level on every transaction.

Move `TxOptions` struct to orc8r/storage and refactor code.

Reviewed By: themarwhal

Differential Revision: D16366570

