### PR TITLE
Fix edge case in gateway full view

### DIFF
--- a/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
+++ b/orc8r/cloud/go/services/config/obsidian/configurator_gateway_handlers.go
@@ -32,7 +32,6 @@ func configuratorCreateGatewayConfig(c echo.Context, networkID string, configTyp
 	if configType == orc8r.MagmadGatewayType {
 		return configuratorCreateMagmadGatewayConfig(c, networkID, configKey, iConfig)
 	}
-
 	config, nerr := GetConfigAndValidate(c, iConfig)
 	if nerr != nil {
 		return nerr
@@ -106,7 +105,6 @@ func configuratorCreateMagmadGatewayConfig(c echo.Context, networkID string, gat
 		Key:               requestedConfig.Tier,
 		AssociationsToAdd: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: gatewayID}},
 	}
-
 	_, err := configurator.UpdateEntities(networkID, []configurator.EntityUpdateCriteria{gwUpdate, tierUpdate})
 	if err != nil {
 		return handlers.HttpError(err, http.StatusInternalServerError)

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory.go
@@ -86,7 +86,6 @@ func (f *FullGatewayViewFactoryImpl) GetGatewayViews(networkID string, gatewayID
 		} else if err != nil {
 			return nil, fmt.Errorf("Error loading status: %s", err)
 		}
-
 		ret[gateway.Key] = &GatewayState{
 			GatewayID: gateway.Key,
 			Record:    record.(*models.AccessGatewayRecord),
@@ -97,6 +96,10 @@ func (f *FullGatewayViewFactoryImpl) GetGatewayViews(networkID string, gatewayID
 
 	// load all associated configEntity entities
 	allAssociations := getAllAssociatedConfigEntities(loadedGateways)
+	if len(allAssociations) == 0 {
+		// if allAssociations is length 0 the call below will load all entities
+		return ret, nil
+	}
 	loadedConfigs, _, err := configurator.LoadEntities(networkID, nil, nil, nil, allAssociations, configurator.EntityLoadCriteria{LoadConfig: true})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Summary: Fixing an issue caused by the behavior of if LoadEntities is called with an empty array, it loads all entities in the network. This was causing a null dereference when loading all loaded configs in to the gateway status map.

Differential Revision: D16385280

