### PR TITLE
Add support for upgrading gateways through orc8r

### DIFF
--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       PROXY_BACKENDS: controller  # Uses Docker internal DNS for controller
       # HTTP_PROXY_HOSTNAME: proxy.magma.test
       # HTTP_PROXY_BACKEND: www.magma.test
+      HTTP_PROXY_DOCKER_HOSTNAME: docker.io
+      HTTP_PROXY_GITHUB_HOSTNAME: github.com
       TEST_MODE: "1"  # Used to run dev scripts on startup
     restart: always
 

--- a/orc8r/cloud/docker/proxy/Dockerfile
+++ b/orc8r/cloud/docker/proxy/Dockerfile
@@ -13,7 +13,8 @@ RUN apt-get update && \
         libssl-dev libev-dev libevent-dev libjansson-dev libjemalloc-dev libc-ares-dev magma-nghttpx=1.31.1-1 \
         daemontools \
         supervisor \
-        python3-pip
+        python3-pip \
+        squid
 
 # Install python3 deps from pip
 RUN pip3 install PyYAML jinja2
@@ -28,6 +29,7 @@ COPY configs /etc/magma/configs
 COPY ${PROXY_FILES}/templates /etc/magma/templates
 COPY ${PROXY_FILES}/magma_headers.rb /etc/nghttpx/magma_headers.rb
 COPY ${PROXY_FILES}/run_nghttpx.py /usr/local/bin/run_nghttpx.py
+COPY ${PROXY_FILES}/squid.conf /etc/squid/squid.conf
 COPY ${PROXY_FILES}/create_test_proxy_certs /usr/local/bin/create_test_proxy_certs
 
 # Copy the supervisor configs

--- a/orc8r/cloud/docker/proxy/squid.conf
+++ b/orc8r/cloud/docker/proxy/squid.conf
@@ -1,0 +1,55 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Default Squid Configuration File
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# http_access allow localhost
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Log to standard location
+access_log /var/log/squid/access.log
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/spool/squid
+
+# Default refresh patterns
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+refresh_pattern .		0	20%	4320

--- a/orc8r/cloud/docker/proxy/supervisord.conf
+++ b/orc8r/cloud/docker/proxy/supervisord.conf
@@ -17,6 +17,14 @@ stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 autorestart=true
 
+[program:forward_proxy]
+command=/usr/bin/envdir /var/opt/magma/envdir /usr/sbin/squid -f /etc/squid/squid.conf -N
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+autorestart=true
+
 [program:dev_setup]
 command=/usr/local/bin/create_test_proxy_certs
 stdout_logfile=/dev/fd/1

--- a/orc8r/cloud/docker/proxy/templates/nghttpx_open.conf.j2
+++ b/orc8r/cloud/docker/proxy/templates/nghttpx_open.conf.j2
@@ -27,6 +27,20 @@ host-rewrite=yes
 backend-address-family=IPv4
 {% endif -%}
 
+{% if 'HTTP_PROXY_DOCKER_HOSTNAME' in env and env['HTTP_PROXY_DOCKER_HOSTNAME']|length > 0 -%}
+# HTTP proxy config to forward HTTP requests for docker images
+backend=localhost,3128;{{ env['HTTP_PROXY_DOCKER_HOSTNAME'] }}
+host-rewrite=yes
+backend-address-family=IPv4
+{% endif -%}
+
+{% if 'HTTP_PROXY_GITHUB_HOSTNAME' in env and env['HTTP_PROXY_GITHUB_HOSTNAME']|length > 0 -%}
+# HTTP proxy config to forward HTTP requests for github
+backend=localhost,3128;{{ env['HTTP_PROXY_GITHUB_HOSTNAME'] }}
+host-rewrite=yes
+backend-address-family=IPv4
+{% endif -%}
+
 # Magma services
 {% for backend in proxy_backends.split(',') -%}
 {% for service, value in service_registry.items() -%}

--- a/orc8r/cloud/helm/orc8r/templates/proxy.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/proxy.deployment.yaml
@@ -73,6 +73,10 @@ spec:
               value: {{ .Values.proxy.spec.http_proxy_hostname | quote }}
             - name: HTTP_PROXY_BACKEND
               value: {{ .Values.proxy.spec.http_proxy_backend | quote }}
+            - name: HTTP_PROXY_DOCKER_HOSTNAME
+              value: {{ .Values.proxy.spec.http_proxy_docker_hostname | quote }}
+            - name: HTTP_PROXY_GITHUB_HOSTNAME
+              value: {{ .Values.proxy.spec.http_proxy_github_hostname | quote }}
             # Hostname override for metricsd
             - name: HOST_NAME
               valueFrom:

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -79,6 +79,8 @@ proxy:
     hostname: ""
     http_proxy_hostname: ""
     http_proxy_backend: ""
+    http_proxy_docker_hostname: ""
+    http_proxy_github_hostname: ""
 
   # Number of proxy replicas desired
   replicas: 1


### PR DESCRIPTION
Summary:
This diff enables proxying docker and github requests
through the orc8r. This is useful for production gateways that
cannot access any other parts of the internet. It works by
forwarding from nghttpx's 9444 to localhost 3128 where a
squid forward proxy is running. This is necessary as nghttpx
does not work as a forward proxy for anything other than
simple GET,POST forward proxying. Thus without squid,
HTTP CONNECT requests fail.

The squid configuration is the default for minimum access.

Reviewed By: amarpad

Differential Revision: D16403892

