### PR TITLE
Add missing nil checks to prevent potential nil dereference

### DIFF
--- a/orc8r/cloud/go/pluginimpl/mconfig_builders.go
+++ b/orc8r/cloud/go/pluginimpl/mconfig_builders.go
@@ -40,18 +40,20 @@ func (*BaseOrchestratorMconfigBuilder) Build(networkID string, gatewayID string,
 		return errors.WithStack(err)
 	}
 
-	magmadGatewayConfig := magmadGateway.Config.(*models2.MagmadGatewayConfig)
-	mconfigOut["magmad"] = &mconfig.MagmaD{
-		LogLevel:                protos.LogLevel_INFO,
-		CheckinInterval:         magmadGatewayConfig.CheckinInterval,
-		CheckinTimeout:          magmadGatewayConfig.CheckinTimeout,
-		AutoupgradeEnabled:      magmadGatewayConfig.AutoupgradeEnabled,
-		AutoupgradePollInterval: magmadGatewayConfig.AutoupgradePollInterval,
-		PackageVersion:          version,
-		Images:                  images,
-		TierId:                  magmadGatewayConfig.Tier,
-		DynamicServices:         magmadGatewayConfig.DynamicServices,
-		FeatureFlags:            magmadGatewayConfig.FeatureFlags,
+	if magmadGateway.Config != nil {
+		magmadGatewayConfig := magmadGateway.Config.(*models2.MagmadGatewayConfig)
+		mconfigOut["magmad"] = &mconfig.MagmaD{
+			LogLevel:                protos.LogLevel_INFO,
+			CheckinInterval:         magmadGatewayConfig.CheckinInterval,
+			CheckinTimeout:          magmadGatewayConfig.CheckinTimeout,
+			AutoupgradeEnabled:      magmadGatewayConfig.AutoupgradeEnabled,
+			AutoupgradePollInterval: magmadGatewayConfig.AutoupgradePollInterval,
+			PackageVersion:          version,
+			Images:                  images,
+			TierId:                  magmadGatewayConfig.Tier,
+			DynamicServices:         magmadGatewayConfig.DynamicServices,
+			FeatureFlags:            magmadGatewayConfig.FeatureFlags,
+		}
 	}
 
 	mconfigOut["control_proxy"] = &mconfig.ControlProxy{LogLevel: protos.LogLevel_INFO}

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -413,6 +413,9 @@ func LoadEntityConfig(networkID, entityType, entityKey string) (interface{}, err
 	if err != nil {
 		return nil, err
 	}
+	if entity.Config == nil {
+		return nil, merrors.ErrNotFound
+	}
 	return entity.Config, nil
 }
 


### PR DESCRIPTION
Summary:
Saw that the mconfig builder was crashing when trying to build a mconfig for gateways without configs, so adding a nil check.
GetEntityConfig should return ErrNotFound when Config is nil.

Reviewed By: mpgermano

Differential Revision: D16426410

