### PR TITLE
Speed up controller builds with go cache base image

### DIFF
--- a/orc8r/cloud/docker/build.py
+++ b/orc8r/cloud/docker/build.py
@@ -44,10 +44,22 @@ def main() -> None:
         _create_build_context()
         _run_docker(['build', 'test'])
         _run_docker(['run', '--rm', 'test', 'make test'])
-    else:
-        # Build all containers
+    elif args.nocache:
+        # Build containers without go-cache in base image
         _create_build_context()
         _run_docker(['build'])
+    else:
+        # Check if orc8r_cache image exists
+        result = subprocess.run(['docker', 'images', '-q', 'orc8r_cache'],
+                                    capture_output=True)
+        if result.stdout == b'':
+            print("Orc8r_cache image does not exist. Building...")
+            subprocess.run(['docker-compose', '-f', 'docker-compose.cache.yml',
+                            'build'])
+
+        # Build all images using go-cache base image
+        _create_build_context()
+        _run_docker(['build', '--build-arg', 'baseImage=orc8r_cache'])
 
 
 def _run_docker(cmd: List[str]) -> None:
@@ -177,6 +189,8 @@ def _parse_args() -> argparse.Namespace:
                         help="Run unit tests")
     parser.add_argument('--mount', '-m', action='store_true',
                         help='Mount the source code and create a bash shell')
+    parser.add_argument('--nocache', '-n', action='store_true',
+                        help='Build the images without go cache base image')
     args = parser.parse_args()
     return args
 

--- a/orc8r/cloud/docker/controller/Dockerfile
+++ b/orc8r/cloud/docker/controller/Dockerfile
@@ -1,7 +1,8 @@
 # ------------------------------------------------------------------------------
 # Base image (for tests, precommit, codegen, etc.)
 # ------------------------------------------------------------------------------
-FROM ubuntu:xenial as base
+ARG baseImage="ubuntu:xenial"
+FROM ${baseImage} as base
 
 # Install the runtime deps from apt
 RUN apt-get update && \
@@ -57,6 +58,12 @@ RUN . /etc/profile.d/env.sh && make tools
 FROM base as builder
 
 RUN . /etc/profile.d/env.sh && make build
+
+# -----------------------------------------------------------------------------
+# Go-cache base image
+# -----------------------------------------------------------------------------
+FROM ubuntu:xenial as gocache
+COPY --from=builder /root/.cache /root/.cache
 
 # ------------------------------------------------------------------------------
 # Production image

--- a/orc8r/cloud/docker/docker-compose.cache.yml
+++ b/orc8r/cloud/docker/docker-compose.cache.yml
@@ -1,0 +1,8 @@
+version: "3.7"
+
+services:
+  cache:
+    build:
+      target: gocache
+      context: /tmp/magma_orc8r_build
+      dockerfile: $PWD/controller/Dockerfile


### PR DESCRIPTION
Summary:
This speeds up go builds by allowing the baseImage to be overridden
with a build argument. We then create a base xenial image that has
a gocache added to it. This makes subsequent builds faster since
the image has cached build objects. Docker builds will still work
normally without this argument supplied.

For code changes only, orc8r docker builds decreased from 4m17s to 2m10s

Reviewed By: themarwhal

Differential Revision: D16445716

