### PR TITLE
Limit size of prometheus-cache

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus-cache.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus-cache.deployment.yaml
@@ -50,6 +50,7 @@ spec:
           imagePullPolicy: {{ .Values.prometheusCache.image.pullPolicy }}
           ports:
             - containerPort: 9091
+          args: ["-limit={{ .Values.prometheusCache.limit }}"]
           livenessProbe:
             httpGet:
               path: /

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -157,6 +157,9 @@ prometheusCache:
     tag: latest
     pullPolicy: Always
 
+  # Maximum number of datapoints in the cache at one time. Unlimited if <= 0.
+  limit: 0
+
   # Number of metrics replicas desired
   replicas: 1
 


### PR DESCRIPTION
Summary:
* In the situation where prometheus stops scraping the cache, but metrics still get sent to it, we want to limit the size of the cache so it doesn't use up all the memory of the host.
* Also add this information to the /debug page and add a flag to show the full text or just stats.
* Add internal metrics which are scraped by prometheus to provide something to be alerted on

Differential Revision: D16456353

