### PR TITLE
Add docker-compose for integration test services in cwag

### DIFF
--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -1,0 +1,43 @@
+version: "3.7"
+
+# Standard logging for each service
+x-logging: &logging_anchor
+  driver: "json-file"
+  options:
+    max-size: "10mb"
+    max-file: "10"
+
+# Standard volumes mounted
+x-standard-volumes: &volumes_anchor
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - /etc/snowflake:/etc/snowflake
+
+x-generic-service: &service
+  volumes: *volumes_anchor
+  logging: *logging_anchor
+  restart: always
+  network_mode: host
+
+x-feg-goservice: &feggoservice
+  <<: *service
+  image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+
+services:
+  eap_aka:
+    environment:
+      USE_REMOTE_SWX_PROXY: 0
+
+  swx_proxy:
+    <<: *feggoservice
+    container_name: swx_proxy
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
+
+  hss:
+    <<: *feggoservice
+    container_name: hss
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/hss -logtostderr=true -v=0


### PR DESCRIPTION
Summary: The cwag integration tests require certain magma services to be built differently from how they're run in development and prod. This diff adds a new docker-compose file specifically for the cwag integration tests.

Reviewed By: mpgermano

Differential Revision: D16452836

