### PR TITLE
Add fabfile for running cwag integration tests

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -56,5 +56,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       vb.customize ["modifyvm", :id, "--cpus", "4"]
       vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
     end
+    cwag_test.vm.provision "ansible" do |ansible|
+      ansible.host_key_checking = false
+      ansible.playbook = "deploy/cwag_test.yml"
+      ansible.inventory_path = "deploy/hosts"
+      ansible.verbose = 'v'
+    end
   end
 end

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -27,3 +27,8 @@
       apt:
         name: bzr
         state: present
+    # Required to start the UE Simulator in the background
+    - name: Install tmux
+      apt:
+        name: tmux
+        state: present

--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -4,22 +4,15 @@
 # LICENSE file in the root directory of this source tree.
 #
 ---
-- name: Set up Carrier WiFi Access Gateway for development
-  hosts: cwag
+- name: Set up Carrier WiFi Access Gateway Integration Test VM for development
+  hosts: cwag_test
   become: yes
   vars:
     - magma_root: /home/{{ ansible_user }}/magma
     - user: vagrant
     - full_provision: true
   roles:
-    - role: apt_cache
-    - role: pkgrepo
-      vars:
-        distribution: "bionic"
-    - role: ovs
     - role: golang
-    - role: cwag
-
   tasks:
     - name: Set build environment variables
       lineinfile:
@@ -29,16 +22,6 @@
       with_items:
         - MAGMA_ROOT={{ magma_root }}
       when: full_provision
-    # Only run installation for docker
-    - include_role:
-        name: docker
-        tasks_from: install
-
-    - name: Create snowflake file
-      copy:
-        content: ""
-        dest: /etc/snowflake
-
     # Required by some go libraries
     - name: Install bzr dependency
       apt:

--- a/cwf/gateway/deploy/hosts
+++ b/cwf/gateway/deploy/hosts
@@ -5,3 +5,6 @@
 
 [cwag]
 cwag ansible_ssh_host=192.168.70.101 ansible_ssh_port=22 ansible_user=vagrant ansible_python_interpreter=/usr/bin/python3
+
+[cwag_test]
+cwag_test ansible_ssh_host=192.168.70.102 ansible_ssh_port=22 ansible_user=vagrant ansible_python_interpreter=/usr/bin/python3

--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -1,0 +1,43 @@
+version: "3.7"
+
+# Standard logging for each service
+x-logging: &logging_anchor
+  driver: "json-file"
+  options:
+    max-size: "10mb"
+    max-file: "10"
+
+# Standard volumes mounted
+x-standard-volumes: &volumes_anchor
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - /etc/snowflake:/etc/snowflake
+
+x-generic-service: &service
+  volumes: *volumes_anchor
+  logging: *logging_anchor
+  restart: always
+  network_mode: host
+
+x-feg-goservice: &feggoservice
+  <<: *service
+  image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+
+services:
+  eap_aka:
+    environment:
+      USE_REMOTE_SWX_PROXY: 0
+
+  swx_proxy:
+    <<: *feggoservice
+    container_name: swx_proxy
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
+
+  hss:
+    <<: *feggoservice
+    container_name: hss
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/hss -logtostderr=true -v=0

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -1,0 +1,104 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import sys
+from distutils.util import strtobool
+
+from fabric.api import cd, env, execute, run, sudo, warn_only
+
+sys.path.append('../../orc8r/tools')
+from fab.hosts import ansible_setup, vagrant_setup
+
+AGW_ROOT = "$MAGMA_ROOT/cwf/gateway"
+AGW_INTEG_ROOT = "$MAGMA_ROOT/cwf/gateway/integ_tests"
+
+
+def integ_test(gateway_host=None, test_host=None, destroy_vm="True"):
+    """
+    Run the integration tests. This defaults to running on local vagrant
+    machines, but can also be pointed to an arbitrary host (e.g. amazon) by
+    passing "address:port" as arguments
+
+    gateway_host: The ssh address string of the machine to run the gateway
+        services on. Formatted as "host:port". If not specified, defaults to
+        the `cwag` vagrant box.
+
+    test_host: The ssh address string of the machine to run the tests on
+        on. Formatted as "host:port". If not specified, defaults to the
+        `cwag_test` vagrant box.
+    """
+
+    destroy_vm = bool(strtobool(destroy_vm))
+
+    # Setup the gateway: use the provided gateway if given, else default to the
+    # vagrant machine
+    if not gateway_host:
+        vagrant_setup("cwag", destroy_vm)
+    else:
+        ansible_setup(gateway_host, "cwag", "cwag_dev.yml")
+
+    execute(_copy_config)
+    execute(_start_gateway)
+
+    # Run the tests: use the provided test machine if given, else default to
+    # the vagrant machine
+    if not test_host:
+        vagrant_setup("cwag_test", destroy_vm)
+    else:
+        ansible_setup(test_host, "cwag_test", "cwag_test.yml")
+
+    execute(_start_ue_simulator)
+    execute(_run_unit_tests)
+    execute(_run_integ_tests)
+
+
+def _copy_config():
+    """ Copy the gateway.mconfig to /var/opt/magma/configs """
+
+    with cd(AGW_INTEG_ROOT):
+        with warn_only():
+            sudo('mkdir /var/opt/magma')
+            sudo('mkdir /var/opt/magma/configs')
+            sudo('cp gateway.mconfig /var/opt/magma/configs')
+
+
+def _start_gateway():
+    """ Starts the gateway """
+
+    with cd(AGW_ROOT + '/docker'):
+        run(' docker-compose'
+            ' -f docker-compose.yml'
+            ' -f docker-compose.override.yml'
+            ' -f docker-compose.integ-test.yml'
+            ' build')
+        run(' docker-compose'
+            ' -f docker-compose.yml'
+            ' -f docker-compose.override.yml'
+            ' -f docker-compose.integ-test.yml'
+            ' up -d')
+
+
+def _start_ue_simulator():
+    """ Starts the UE Sim Service """
+    with cd(AGW_ROOT + '/services/uesim/uesim'):
+        run('tmux new -d \'go run main.go\'')
+
+
+def _run_unit_tests():
+    """ Run the cwag unit tests """
+
+    with cd(AGW_ROOT):
+        run('make test')
+
+
+def _run_integ_tests():
+    """ Run the integration tests """
+
+    with cd(AGW_INTEG_ROOT):
+        run('make integ_test')

--- a/cwf/gateway/integ_tests/gateway.mconfig
+++ b/cwf/gateway/integ_tests/gateway.mconfig
@@ -1,0 +1,113 @@
+{
+ "configsByKey": {
+  "hss": {
+   "@type": "type.googleapis.com/magma.mconfig.HSSConfig",
+   "server": {
+    "protocol": "sctp",
+    "address": "localhost:3868",
+    "localAddress": "localhost:3869",
+    "destHost": "hw-hss.epc.mnc001.mcc01.3gppnetwork.org",
+    "destRealm": "epc.mnc001.mcc01.3gppnetwork.org"
+   },
+   "lteAuthOp": "EREREREREREREREREREREQ==",
+   "lteAuthAmf": "Z0E=",
+   "subProfiles": {
+    "additionalProp1": {
+     "maxUlBitRate": "100000000",
+     "maxDlBitRate": "200000000"
+    },
+    "additionalProp2": {
+     "maxUlBitRate": "100000000",
+     "maxDlBitRate": "200000000"
+    },
+    "additionalProp3": {
+     "maxUlBitRate": "100000000",
+     "maxDlBitRate": "200000000"
+    }
+   },
+   "defaultSubProfile": {
+    "maxUlBitRate": "100000000",
+    "maxDlBitRate": "200000000"
+   }
+  },
+  "swx_proxy": {
+   "@type": "type.googleapis.com/magma.mconfig.SwxConfig",
+   "logLevel": "INFO",
+   "server": {
+    "protocol": "sctp",
+    "address": "localhost:3868",
+    "retransmits": 0,
+    "watchdogInterval": 0,
+    "retryCount": 0,
+    "localAddress": "localhost:3869",
+    "productName": "magma",
+    "realm": "epc.mnc001.mcc01.3gppnetwork.org",
+    "host": "swx-mgm1.epc.mnc001.mcc01.3gppnetwork.org",
+    "destRealm": "epc.mnc001.mcc01.3gppnetwork.org",
+    "destHost": "hw-hss.epc.mnc001.mcc01.3gppnetwork.org"
+   },
+   "verifyAuthorization": false
+  },
+  "aaa_server": {
+   "@type": "type.googleapis.com/magma.mconfig.AAAConfig",
+   "logLevel": "INFO",
+   "IdleSessionTimeoutMs": 21600000,
+   "CreateSessionOnAuth": true
+  },
+  "control_proxy": {
+   "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
+   "logLevel": "INFO"
+  },
+  "eap_aka": {
+   "@type": "type.googleapis.com/magma.mconfig.EapAkaConfig",
+   "logLevel": "INFO",
+   "timeout": {
+    "ChallengeMs": 20000,
+    "ErrorNotificationMs": 10000,
+    "SessionMs": 43200000,
+    "SessionAuthenticatedMs": 5000
+   }
+  },
+  "magmad": {
+   "@type": "type.googleapis.com/magma.mconfig.MagmaD",
+   "logLevel": "INFO",
+   "checkinInterval": 60,
+   "checkinTimeout": 10,
+   "autoupgradeEnabled": true,
+   "autoupgradePollInterval": 300,
+   "packageVersion": "0.0.0-0",
+   "images": [
+   ],
+   "tierId": "default",
+   "featureFlags": {
+    "newfeature1": true,
+    "newfeature2": false
+   },
+   "dynamicServices": [
+   ]
+  },
+  "metricsd": {
+   "@type": "type.googleapis.com/magma.mconfig.MetricsD",
+   "logLevel": "INFO"
+  },
+  "pipelined": {
+   "@type": "type.googleapis.com/magma.mconfig.PipelineD",
+   "logLevel": "INFO",
+   "ueIpBlock": "192.168.128.0/24",
+   "natEnabled": true,
+   "defaultRuleId": "default_rule_1",
+   "relayEnabled": true,
+   "services": [
+    "ENFORCEMENT"
+   ]
+  },
+  "sessiond": {
+   "@type": "type.googleapis.com/magma.mconfig.SessionD",
+   "logLevel": "INFO",
+   "relayEnabled": true
+  }
+ },
+ "metadata": {
+  "createdAt": "1561709117"
+ }
+}


### PR DESCRIPTION
Summary: Adds a fabric function to bring up the cwag and cwag_test VMs, set them up, and run the integration tests. This function will be run by jenkins in the CI later on.

Differential Revision: D16296271

