### PR TITLE
Add latency metrics for AIRs and ULRs requests in Magma

### DIFF
--- a/feg/gateway/services/s6a_proxy/metrics/metrics.go
+++ b/feg/gateway/services/s6a_proxy/metrics/metrics.go
@@ -67,6 +67,17 @@ var (
 		Name: "s6a_failures_since_last_success",
 		Help: "The total number of s6a request failures since the last successful request completed",
 	})
+	// Latencies
+	AIRLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "air_lat",
+		Help:       "Latency of AIR requests (milliseconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	ULRLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "ulr_lat",
+		Help:       "Latency of ULR requests (milliseconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
 )
 
 type S6aHealthMetrics struct {
@@ -123,7 +134,7 @@ func NewS6aHealthTracker() *S6aHealthTracker {
 func init() {
 	prometheus.MustRegister(AIRRequests, AIRSendFailures, ULRRequests,
 		ULRSendFailures, S6aTimeouts, S6aUnparseableMsg, S6aResultCodes,
-		S6aSuccessTimestamp, S6aFailuresSinceLastSuccess)
+		S6aSuccessTimestamp, S6aFailuresSinceLastSuccess, AIRLatency, ULRLatency)
 }
 
 func UpdateS6aRecentRequestMetrics(err error) {

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
@@ -137,7 +137,11 @@ func NewS6aProxy(
 func (s *s6aProxy) AuthenticationInformation(
 	ctx context.Context, req *protos.AuthenticationInformationRequest) (*protos.AuthenticationInformationAnswer, error,
 ) {
+	airStartTime := time.Now()
 	res, err := s.AuthenticationInformationImpl(req)
+	if err == nil {
+		metrics.AIRLatency.Observe(float64(time.Since(airStartTime)) / float64(time.Millisecond))
+	}
 	metrics.UpdateS6aRecentRequestMetrics(err)
 	return res, err
 }
@@ -147,7 +151,11 @@ func (s *s6aProxy) AuthenticationInformation(
 func (s *s6aProxy) UpdateLocation(
 	ctx context.Context, req *protos.UpdateLocationRequest) (*protos.UpdateLocationAnswer, error,
 ) {
+	ulrStartTime := time.Now()
 	res, err := s.UpdateLocationImpl(req)
+	if err == nil {
+		metrics.ULRLatency.Observe(float64(time.Since(ulrStartTime)) / float64(time.Millisecond))
+	}
 	metrics.UpdateS6aRecentRequestMetrics(err)
 	return res, err
 }


### PR DESCRIPTION
Summary: Add latency metrics for AIRs and ULRs requests in Magma.

Differential Revision: D16389395

