### PR TITLE
Migrate dnsd network configs model and network features model usages to point to new models defined under pluginimpl

### DIFF
--- a/lte/cloud/go/plugin/mconfig_test.go
+++ b/lte/cloud/go/plugin/mconfig_test.go
@@ -14,11 +14,11 @@ import (
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/plugin"
 	"magma/lte/cloud/go/protos/mconfig"
-	"magma/lte/cloud/go/services/cellular/obsidian/models"
+	cellular_models "magma/lte/cloud/go/services/cellular/obsidian/models"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/configurator"
-	models2 "magma/orc8r/cloud/go/services/dnsd/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
 
 	"github.com/golang/protobuf/proto"
@@ -28,12 +28,13 @@ import (
 func TestBuilder_Build(t *testing.T) {
 	builder := &plugin.Builder{}
 
+	trueValue := true
 	nw := configurator.Network{
 		ID: "n1",
 		Configs: map[string]interface{}{
 			lte.CellularNetworkType: newDefaultTDDNetworkConfig(),
-			orc8r.DnsdNetworkType: &models2.NetworkDNSConfig{
-				EnableCaching: true,
+			orc8r.DnsdNetworkType: &models.NetworkDNSConfig{
+				EnableCaching: &trueValue,
 			},
 		},
 	}
@@ -247,20 +248,20 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func newDefaultTDDNetworkConfig() *models.NetworkCellularConfigs {
-	return &models.NetworkCellularConfigs{
-		Ran: &models.NetworkRanConfigs{
+func newDefaultTDDNetworkConfig() *cellular_models.NetworkCellularConfigs {
+	return &cellular_models.NetworkCellularConfigs{
+		Ran: &cellular_models.NetworkRanConfigs{
 			BandwidthMhz:           20,
 			Earfcndl:               44590,
 			SubframeAssignment:     2,
 			SpecialSubframePattern: 7,
-			TddConfig: &models.NetworkRanConfigsTddConfig{
+			TddConfig: &cellular_models.NetworkRanConfigsTddConfig{
 				Earfcndl:               44590,
 				SubframeAssignment:     2,
 				SpecialSubframePattern: 7,
 			},
 		},
-		Epc: &models.NetworkEpcConfigs{
+		Epc: &cellular_models.NetworkEpcConfigs{
 			Mcc: "001",
 			Mnc: "01",
 			Tac: 1,
@@ -271,18 +272,18 @@ func newDefaultTDDNetworkConfig() *models.NetworkCellularConfigs {
 	}
 }
 
-func newDefaultGatewayConfig() *models.GatewayCellularConfigs {
-	return &models.GatewayCellularConfigs{
+func newDefaultGatewayConfig() *cellular_models.GatewayCellularConfigs {
+	return &cellular_models.GatewayCellularConfigs{
 		AttachedEnodebSerials: []string{"enb1"},
-		Ran: &models.GatewayRanConfigs{
+		Ran: &cellular_models.GatewayRanConfigs{
 			Pci:             260,
 			TransmitEnabled: true,
 		},
-		Epc: &models.GatewayEpcConfigs{
+		Epc: &cellular_models.GatewayEpcConfigs{
 			NatEnabled: true,
 			IPBlock:    "192.168.128.0/24",
 		},
-		NonEpsService: &models.GatewayNonEpsServiceConfigs{
+		NonEpsService: &cellular_models.GatewayNonEpsServiceConfigs{
 			CsfbMcc:              "",
 			CsfbMnc:              "",
 			Lac:                  1,
@@ -293,8 +294,8 @@ func newDefaultGatewayConfig() *models.GatewayCellularConfigs {
 	}
 }
 
-func newDefaultEnodebConfig() *models.NetworkEnodebConfigs {
-	return &models.NetworkEnodebConfigs{
+func newDefaultEnodebConfig() *cellular_models.NetworkEnodebConfigs {
+	return &cellular_models.NetworkEnodebConfigs{
 		Earfcndl:               39150,
 		SubframeAssignment:     2,
 		SpecialSubframePattern: 7,

--- a/orc8r/cloud/go/pluginimpl/mconfig_builders.go
+++ b/orc8r/cloud/go/pluginimpl/mconfig_builders.go
@@ -11,12 +11,12 @@ package pluginimpl
 import (
 	merrors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/protos/mconfig"
 	"magma/orc8r/cloud/go/services/configurator"
-	models3 "magma/orc8r/cloud/go/services/dnsd/obsidian/models"
-	models2 "magma/orc8r/cloud/go/services/magmad/obsidian/models"
-	"magma/orc8r/cloud/go/services/upgrade/obsidian/models"
+	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	upgrade_models "magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func (*BaseOrchestratorMconfigBuilder) Build(networkID string, gatewayID string,
 	}
 
 	if magmadGateway.Config != nil {
-		magmadGatewayConfig := magmadGateway.Config.(*models2.MagmadGatewayConfig)
+		magmadGatewayConfig := magmadGateway.Config.(*magmad_models.MagmadGatewayConfig)
 		mconfigOut["magmad"] = &mconfig.MagmaD{
 			LogLevel:                protos.LogLevel_INFO,
 			CheckinInterval:         magmadGatewayConfig.CheckinInterval,
@@ -71,7 +71,7 @@ func getPackageVersionAndImages(magmadGateway configurator.NetworkEntity, graph 
 		return "0.0.0-0", []*mconfig.ImageSpec{}, errors.Wrap(err, "failed to load upgrade tier")
 	}
 
-	tierConfig := tier.Config.(*models.Tier)
+	tierConfig := tier.Config.(*upgrade_models.Tier)
 	retImages := make([]*mconfig.ImageSpec, 0, len(tierConfig.Images))
 	for _, image := range tierConfig.Images {
 		retImages = append(retImages, &mconfig.ImageSpec{Name: image.Name, Order: image.Order})
@@ -87,9 +87,15 @@ func (*DnsdMconfigBuilder) Build(networkID string, gatewayID string, graph confi
 		return nil
 	}
 
-	dnsConfig := iConfig.(*models3.NetworkDNSConfig)
+	dnsConfig := iConfig.(*models.NetworkDNSConfig)
 	mconfigDnsd := &mconfig.DnsD{}
 	protos.FillIn(dnsConfig, mconfigDnsd)
+	if dnsConfig.LocalTTL != nil {
+		mconfigDnsd.LocalTTL = *dnsConfig.LocalTTL
+	}
+	if dnsConfig.EnableCaching != nil {
+		mconfigDnsd.EnableCaching = *dnsConfig.EnableCaching
+	}
 	mconfigDnsd.LogLevel = protos.LogLevel_INFO
 	for _, record := range dnsConfig.Records {
 		mconfigRecord := &mconfig.NetworkDNSConfigRecordsItems{}

--- a/orc8r/cloud/go/pluginimpl/mconfig_builders_test.go
+++ b/orc8r/cloud/go/pluginimpl/mconfig_builders_test.go
@@ -13,12 +13,12 @@ import (
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/protos/mconfig"
 	"magma/orc8r/cloud/go/services/configurator"
-	models3 "magma/orc8r/cloud/go/services/dnsd/obsidian/models"
-	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
-	models2 "magma/orc8r/cloud/go/services/upgrade/obsidian/models"
+	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	upgrade_models "magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +29,7 @@ func TestBaseOrchestratorMconfigBuilder_Build(t *testing.T) {
 	gw := configurator.NetworkEntity{
 		Type: orc8r.MagmadGatewayType,
 		Key:  "gw1",
-		Config: &models.MagmadGatewayConfig{
+		Config: &magmad_models.MagmadGatewayConfig{
 			AutoupgradeEnabled:      true,
 			AutoupgradePollInterval: 300,
 			CheckinInterval:         60,
@@ -68,10 +68,10 @@ func TestBaseOrchestratorMconfigBuilder_Build(t *testing.T) {
 	tier := configurator.NetworkEntity{
 		Type: orc8r.UpgradeTierEntityType,
 		Key:  "default",
-		Config: &models2.Tier{
+		Config: &upgrade_models.Tier{
 			Name:    "default",
 			Version: "1.0.0-0",
-			Images: []*models2.TierImagesItems0{
+			Images: []*upgrade_models.TierImagesItems0{
 				{Name: "Image1", Order: 42},
 				{Name: "Image2", Order: 1},
 			},
@@ -112,7 +112,7 @@ func TestDnsdMconfigBuilder_Build(t *testing.T) {
 	gw := configurator.NetworkEntity{
 		Type: orc8r.MagmadGatewayType,
 		Key:  "gw1",
-		Config: &models.MagmadGatewayConfig{
+		Config: &magmad_models.MagmadGatewayConfig{
 			AutoupgradeEnabled:      true,
 			AutoupgradePollInterval: 300,
 			CheckinInterval:         60,
@@ -135,10 +135,10 @@ func TestDnsdMconfigBuilder_Build(t *testing.T) {
 	assert.Equal(t, expected, actual)
 
 	nw.Configs = map[string]interface{}{
-		"dnsd_network": &models3.NetworkDNSConfig{
-			EnableCaching: true,
-			LocalTTL:      100,
-			Records: []*models3.NetworkDNSConfigRecordsItems0{
+		"dnsd_network": &models.NetworkDNSConfig{
+			EnableCaching: toBoolPointer(true),
+			LocalTTL:      toInt32Pointer(100),
+			Records: []*models.DNSConfigRecord{
 				{
 					ARecord:     []string{"hello", "world"},
 					AaaaRecord:  []string{"foo", "bar"},
@@ -175,4 +175,12 @@ func TestDnsdMconfigBuilder_Build(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expected, actual)
+}
+
+func toBoolPointer(b bool) *bool {
+	return &b
+}
+
+func toInt32Pointer(i int32) *int32 {
+	return &i
 }

--- a/orc8r/cloud/go/pluginimpl/models/config_conversion.go
+++ b/orc8r/cloud/go/pluginimpl/models/config_conversion.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// These are only here to support backward compatibility until we fully
+// deprecate magma v0.
+// Todo delete after magma v0 is deprecated
+
+package models
+
+import (
+	"fmt"
+	"reflect"
+
+	"magma/orc8r/cloud/go/protos"
+	dnsdprotos "magma/orc8r/cloud/go/services/dnsd/protos"
+
+	"github.com/go-openapi/strfmt"
+)
+
+var formatsRegistry strfmt.Registry = strfmt.NewFormats()
+
+func (m *NetworkDNSConfig) ValidateModel() error {
+	if err := m.ValidateNetworkConfig(); err != nil {
+		return err
+	}
+	return m.Validate(formatsRegistry)
+}
+
+func (m *NetworkDNSConfig) ToServiceModel() (interface{}, error) {
+	magmadConfig := &dnsdprotos.NetworkDNSConfig{}
+
+	protos.FillIn(m, magmadConfig)
+	if err := dnsdprotos.ValidateNetworkConfig(magmadConfig); err != nil {
+		return nil, err
+	}
+	return magmadConfig, nil
+}
+
+func (m *NetworkDNSConfig) FromServiceModel(magmadModel interface{}) error {
+	_, ok := magmadModel.(*dnsdprotos.NetworkDNSConfig)
+	if !ok {
+		return fmt.Errorf(
+			"Invalid magmad config type to convert to. Expected *NetworkDNSConfig but got %s",
+			reflect.TypeOf(magmadModel),
+		)
+	}
+	protos.FillIn(magmadModel, m)
+	return nil
+}

--- a/orc8r/cloud/go/pluginimpl/models/validations.go
+++ b/orc8r/cloud/go/pluginimpl/models/validations.go
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package models
+
+import (
+	"errors"
+	"net"
+)
+
+func (m *NetworkDNSConfig) ValidateNetworkConfig() error {
+	if m == nil {
+		return errors.New("NetworkDNSconfig is nil.")
+	}
+	if err := validateNetworkDNSRecordsConfig(m.Records); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateNetworkDNSRecordsConfig(records []*DNSConfigRecord) error {
+	if records == nil {
+		return nil
+	}
+
+	for _, item := range records {
+		if err := validateNetworkDNSConfigRecordsItems(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateNetworkDNSConfigRecordsItems(config *DNSConfigRecord) error {
+	if config == nil {
+		return errors.New("NetworkDNSconfig Records Item is nil.")
+	}
+
+	if err := ValidateNetworkDNSConfigARecord(config.ARecord); err != nil {
+		return err
+	}
+	if err := ValidateNetworkDNSConfigAaaaRecord(config.AaaaRecord); err != nil {
+		return err
+	}
+
+	if err := ValidateNetworkDNSConfigDomain(config.Domain); err != nil {
+		return err
+	}
+
+	if err := ValidateNetworkDNSConfigCname(config.CnameRecord); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidateNetworkDNSConfigARecord(ARecord []string) error {
+	if ARecord == nil {
+		return nil
+	}
+	for _, record := range ARecord {
+		if net.ParseIP(record).To4() == nil {
+			return errors.New("ARecord must be in the form of an IpV4 address.")
+		}
+	}
+	return nil
+}
+
+func ValidateNetworkDNSConfigAaaaRecord(AaaaRecord []string) error {
+	if AaaaRecord == nil {
+		return nil
+	}
+	for _, record := range AaaaRecord {
+		if net.ParseIP(record).To16() == nil {
+			return errors.New("AaaaRecord must be in the form of an IpV6 address.")
+		}
+	}
+	return nil
+}
+
+func ValidateNetworkDNSConfigDomain(domain string) error {
+	// TODO: Figure out how to validate a string is a domain
+	if domain == "" {
+		return errors.New("Domain cannot be empty string.")
+	}
+	return nil
+}
+
+func ValidateNetworkDNSConfigCname(CnameRecord []string) error {
+	if CnameRecord == nil {
+		return nil
+	}
+	for _, record := range CnameRecord {
+		if err := ValidateNetworkDNSConfigDomain(record); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -17,6 +17,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/registry"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/service/config"
@@ -28,7 +29,6 @@ import (
 	"magma/orc8r/cloud/go/services/device"
 	dnsdconfig "magma/orc8r/cloud/go/services/dnsd/config"
 	dnsdh "magma/orc8r/cloud/go/services/dnsd/obsidian/handlers"
-	dnsdmodels "magma/orc8r/cloud/go/services/dnsd/obsidian/models"
 	magmadconfig "magma/orc8r/cloud/go/services/magmad/config"
 	magmadh "magma/orc8r/cloud/go/services/magmad/obsidian/handlers"
 	magmadmodels "magma/orc8r/cloud/go/services/magmad/obsidian/models"
@@ -73,8 +73,8 @@ func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 		serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &magmadmodels.AccessGatewayRecord{}),
 
 		// Config manager serdes
-		configurator.NewNetworkConfigSerde(orc8r.DnsdNetworkType, &dnsdmodels.NetworkDNSConfig{}),
-		configurator.NewNetworkConfigSerde(orc8r.NetworkFeaturesConfig, &magmadmodels.NetworkFeatures{}),
+		configurator.NewNetworkConfigSerde(orc8r.DnsdNetworkType, &models.NetworkDNSConfig{}),
+		configurator.NewNetworkConfigSerde(orc8r.NetworkFeaturesConfig, &models.NetworkFeatures{}),
 
 		configurator.NewNetworkEntityConfigSerde(orc8r.MagmadGatewayType, &magmadmodels.MagmadGatewayConfig{}),
 		configurator.NewNetworkEntityConfigSerde(orc8r.UpgradeReleaseChannelEntityType, &upgrademodels.ReleaseChannel{}),

--- a/orc8r/cloud/go/services/dnsd/obsidian/handlers/dns_handlers.go
+++ b/orc8r/cloud/go/services/dnsd/obsidian/handlers/dns_handlers.go
@@ -11,8 +11,8 @@ package handlers
 import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	cfgObsidian "magma/orc8r/cloud/go/services/config/obsidian"
-	"magma/orc8r/cloud/go/services/dnsd/obsidian/models"
 	magmad_handlers "magma/orc8r/cloud/go/services/magmad/obsidian/handlers"
 )
 

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorh "magma/orc8r/cloud/go/services/configurator/obsidian/handlers"
 	magmad_models "magma/orc8r/cloud/go/services/magmad/obsidian/models"
@@ -72,7 +73,7 @@ func registerNetwork(c echo.Context) error {
 		Name: record.Name,
 		ID:   requestedID,
 		Configs: map[string]interface{}{
-			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
+			orc8r.NetworkFeaturesConfig: &models.NetworkFeatures{Features: record.Features},
 		},
 	}
 
@@ -93,10 +94,10 @@ func getNetwork(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	networkFeatures := &magmad_models.NetworkFeatures{}
+	networkFeatures := &models.NetworkFeatures{}
 	features, ok := network.Configs[orc8r.NetworkFeaturesConfig]
 	if ok {
-		networkFeatures = features.(*magmad_models.NetworkFeatures)
+		networkFeatures = features.(*models.NetworkFeatures)
 	}
 
 	record := magmad_models.NetworkRecord{
@@ -124,7 +125,7 @@ func updateNetwork(c echo.Context) error {
 		ID:      networkID,
 		NewName: &record.Name,
 		ConfigsToAddOrUpdate: map[string]interface{}{
-			orc8r.NetworkFeaturesConfig: &magmad_models.NetworkFeatures{Features: record.Features},
+			orc8r.NetworkFeaturesConfig: &models.NetworkFeatures{Features: record.Features},
 		},
 	}
 	configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})


### PR DESCRIPTION
Summary:
Changing the network config serdes and other references of NetworkDNSConfig and NetworkFeatures to point to the models defined in pluginimpl/models.
The corresponding models defined in services/dns and services/magmad should be deprecated when magma-v0 is deprecated.

I'm only touching the two models in this diff but others will have to be migrated similarly as well. Will do that in following diffs.

Reviewed By: xjtian

Differential Revision: D16552186

