### PR TITLE
Fix bug in configurator backed network handler that did not properly display network features

### DIFF
--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/network_handlers.go
@@ -89,7 +89,7 @@ func getNetwork(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	network, err := configurator.LoadNetwork(networkID, true, false)
+	network, err := configurator.LoadNetwork(networkID, true, true)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
@@ -128,7 +128,10 @@ func updateNetwork(c echo.Context) error {
 			orc8r.NetworkFeaturesConfig: &models.NetworkFeatures{Features: record.Features},
 		},
 	}
-	configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
+	err := configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
+	if err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
 	return c.NoContent(http.StatusNoContent)
 }
 


### PR DESCRIPTION
Summary: GET handler for network was not returning everything described in the spec.

Reviewed By: xjtian

Differential Revision: D16562740

