### PR TITLE
Add metrics containers setup to github documentation

### DIFF
--- a/docs/readmes/basics/quick_start_guide.md
+++ b/docs/readmes/basics/quick_start_guide.md
@@ -45,6 +45,16 @@ HOST [magma/orc8r/cloud/docker]$ ./build.py
 
 This will build the docker images for the orc8r.
 
+
+#### Terminal Tab 3:
+
+Now we'll set up the orchestrator metrics docker containers.
+
+```console
+HOST [magma]$ cd orc8r/cloud/docker
+HOST [magma/orc8r/cloud/docker]$ docker-compose -f docker-compose.metrics.yml up -d
+```
+
 #### Initial Run
 
 Once all those jobs finish (should only be 5 minutes or so), we can build the

--- a/docs/readmes/orc8r/docker_setup.md
+++ b/docs/readmes/orc8r/docker_setup.md
@@ -6,7 +6,9 @@ title: Docker Setup
 
 Orc8r consists of 2 containers: one for the proxy, and one for all the
 controller services. We use supervisord to spin multiple services within
-these containers.
+these containers. There are an additional 5 containers for metrics. These are
+used to monitor system and gateway metrics, but are optional if you don't need
+that for your setup.
 
 NOTE: The multiple services per container model was adopted to model the
 legacy Vagrant setup and for easier migration, and we will soon migrate to
@@ -55,6 +57,14 @@ docker-compose logs -f controller
 To create a shell inside a container, run:
 ```
 docker-compose exec controller bash
+```
+
+Similarly for the metrics containers just specify the docker-compose file
+before running a command, such as:
+```
+docker-compose -f docker-compose.metrics.yml up -d
+docker-compose -f docker-compose.metrics.yml ps
+docker-compose -f docker-compose.metrics.yml down
 ```
 
 ## How to run unit tests

--- a/orc8r/cloud/configs/metricsd.yml
+++ b/orc8r/cloud/configs/metricsd.yml
@@ -6,13 +6,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-profile: "default"
-
-graphiteExportAddresses:
-  - "graphite:2003"
-
-graphiteQueryAddress: "graphite"
-graphiteQueryPort: 8080
+profile: "prometheus"
 
 prometheusPushAddresses:
   - "http://prometheus-cache:9091/metrics"

--- a/orc8r/cloud/docker/docker-compose.metrics.yml
+++ b/orc8r/cloud/docker/docker-compose.metrics.yml
@@ -46,16 +46,6 @@ services:
       - ALERTMANAGER_URL=alertmanager:9093
     restart: always
 
-  graphite:
-    environment:
-      - REDIS_TAGDB=1
-    ports:
-      - 8001:80/tcp
-    volumes:
-      - $PWD/graphite/storage-schemas.conf:/opt/graphite/conf/storage-schemas.conf
-      - $PWD/graphite/carbon.conf:/opt/graphite/conf/carbon.conf
-    image: graphiteapp/graphite-statsd
-
   grafana:
     build:
       context: $PWD/../../../orc8r/cloud


### PR DESCRIPTION
Summary:
Spinning up the metrics containers wasn't in the documentation for docker setup.
* Make graphite yml parameters optional
* remove graphite configs from metricsd.yml

Differential Revision: D16656452

