### PR TITLE
Change cwag role to download golang with ansible_user

### DIFF
--- a/cwf/gateway/deploy/cwag_dev.yml
+++ b/cwf/gateway/deploy/cwag_dev.yml
@@ -9,7 +9,7 @@
   become: yes
   vars:
     - magma_root: /home/{{ ansible_user }}/magma
-    - user: vagrant
+    - user: "{{ ansible_user }}"
     - full_provision: true
   roles:
     - role: apt_cache


### PR DESCRIPTION
Summary: The cwag_dev role was always downloading Golang to the vagrant user. This updates it to download Go to whatever ansible_user is, so it works on the ubuntu gateway box.

Reviewed By: mpgermano

Differential Revision: D16658687

