### PR TITLE
Change cwag_test role to download golang with ansible_user

### DIFF
--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -9,7 +9,7 @@
   become: yes
   vars:
     - magma_root: /home/{{ ansible_user }}/magma
-    - user: vagrant
+    - user: "{{ ansible_user }}"
     - full_provision: true
   roles:
     - role: golang


### PR DESCRIPTION
Summary: The cwag_test ansible role also needs the `user` variable set to the `ansible_user`.

Reviewed By: mpgermano

Differential Revision: D16663741

