### PR TITLE
Parallelize docker-build and install build-essentials in CWAG CI

### DIFF
--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -32,3 +32,7 @@
       apt:
         name: tmux
         state: present
+    - name: Install build-essential pkgs
+      apt:
+        name: build-essential
+        state: present

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -76,7 +76,7 @@ def _start_gateway():
             ' -f docker-compose.yml'
             ' -f docker-compose.override.yml'
             ' -f docker-compose.integ-test.yml'
-            ' build')
+            ' build --parallel')
         run(' docker-compose'
             ' -f docker-compose.yml'
             ' -f docker-compose.override.yml'


### PR DESCRIPTION
Summary: Speeds up the cwag integration test builds by parallelizing the docker build, and also installs `build-essential` packages so the cwag_test CI box has `make`, `gcc`, and more. These are needed to build and run the tests.

Differential Revision: D16674590

