### PR TITLE
Add radiusd service, for getting metrics from radius server

### DIFF
--- a/feg/gateway/configs/service_registry.yml
+++ b/feg/gateway/configs/service_registry.yml
@@ -52,6 +52,10 @@ services:
     host: health
     ip_address: health
     port: 9107
+  radiusd:
+    host: radiusd
+    ip_address: radiusd
+    port: 9115
   redis:
     host: redis
     ip_address: redis

--- a/feg/gateway/deploy/roles/feg_services/files/magma_radiusd.service
+++ b/feg/gateway/deploy/roles/feg_services/files/magma_radiusd.service
@@ -1,0 +1,23 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+[Unit]
+Description=Magma Radiusd Feg service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=radiusd
+User=root
+Restart=always
+RestartSec=1s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/feg/gateway/deploy/roles/feg_services/tasks/main.yml
+++ b/feg/gateway/deploy/roles/feg_services/tasks/main.yml
@@ -39,3 +39,4 @@
     - swx_proxy
     - eap_aka
     - aaa_server
+    - radiusd

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -104,6 +104,11 @@ services:
       S6A_LOCAL_ADDR: :${S6A_LOCAL_PORT}
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/s6a_proxy -logtostderr=true -v=0
 
+  radiusd:
+    <<: *goservice
+    container_name: radiusd
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
+
   control_proxy:
     <<: *pyservice
     container_name: control_proxy

--- a/feg/gateway/registry/local_registry.go
+++ b/feg/gateway/registry/local_registry.go
@@ -29,6 +29,7 @@ const (
 	AAA_SERVER    = "AAA_SERVER"
 	EAP           = "EAP"
 	EAP_AKA       = "EAP_AKA"
+	RADIUSD       = "RADIUSD"
 	RADIUS        = "RADIUS"
 	REDIS         = "REDIS"
 	MOCK_VLR      = "MOCK_VLR"
@@ -75,6 +76,7 @@ func init() {
 	addLocalService(AAA_SERVER, 9109)
 	addLocalService(EAP_AKA, 9123)
 	addLocalService(SWX_PROXY, 9110)
+	addLocalService(RADIUSD, 9115)
 
 	addLocalService(MOCK_OCS, 9201)
 	addLocalService(MOCK_PCRF, 9202)

--- a/feg/gateway/services/radiusd/doc.go
+++ b/feg/gateway/services/radiusd/doc.go
@@ -1,0 +1,14 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// Package device contains the device service.
+// The device service is a simple blob-storage service for tracking
+// physical device.
+package radiusd
+
+const ServiceName = "RADIUSD"

--- a/feg/gateway/services/radiusd/radiusd/main.go
+++ b/feg/gateway/services/radiusd/radiusd/main.go
@@ -1,0 +1,30 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package main
+
+import (
+	"magma/feg/gateway/registry"
+	"magma/orc8r/cloud/go/service"
+
+	"github.com/golang/glog"
+)
+
+func main() {
+	// Create the service
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.RADIUSD)
+	if err != nil {
+		glog.Fatalf("Error creating RADIUSD service: %s", err)
+	}
+
+	// Run the service
+	err = srv.Run()
+	if err != nil {
+		glog.Fatalf("Error running service: %s", err)
+	}
+}


### PR DESCRIPTION
Summary:
The radius server exports metrics in Prometheus format, and the 'radiusd' service will be a connector from that format to the way that orc8r handles service metrics.

This revision implements a bare bones service with no functionality.

Reviewed By: themarwhal

Differential Revision: D16286846

