### PR TITLE
Make prometheus retention.time a helm variable

### DIFF
--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/metrics.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/metrics.deployment.yaml
@@ -75,6 +75,7 @@ spec:
           ports:
             - containerPort: 9090
           args: ['--config.file=/etc/prometheus/prometheus.yml',
+                 '--storage.tsdb.retention.time={{ .Values.metrics.retention.time }}',
                  '--storage.tsdb.path=/data',
                  '--web.enable-lifecycle']
           livenessProbe:

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -8,6 +8,10 @@ metrics:
   # Set to 1 if using a minikube setup
   useMinikube:
 
+  # Retention configurations for prometheus
+  retention:
+    time: 30d
+
   # Service configuration.
   service:
     annotations: {}


### PR DESCRIPTION
Summary: Make `retention.time` a helm chart variable for easy configuration. Default value is 30 days.

Differential Revision: D16687977

