### PR TITLE
Initialize gateway state serde properly

### DIFF
--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -24,6 +24,7 @@ import (
 	"magma/orc8r/cloud/go/service/serviceregistry"
 	accessdh "magma/orc8r/cloud/go/services/accessd/obsidian/handlers"
 	checkinh "magma/orc8r/cloud/go/services/checkind/obsidian/handlers"
+	checkindmodels "magma/orc8r/cloud/go/services/checkind/obsidian/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
 	dnsdconfig "magma/orc8r/cloud/go/services/dnsd/config"
@@ -38,6 +39,7 @@ import (
 	graphite_exp "magma/orc8r/cloud/go/services/metricsd/graphite/exporters"
 	metricsdh "magma/orc8r/cloud/go/services/metricsd/obsidian/handlers"
 	promo_exp "magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
+	"magma/orc8r/cloud/go/services/state"
 	stateh "magma/orc8r/cloud/go/services/state/obsidian/handlers"
 	"magma/orc8r/cloud/go/services/streamer/mconfig"
 	"magma/orc8r/cloud/go/services/streamer/mconfig/factory"
@@ -66,7 +68,7 @@ func (*BaseOrchestratorPlugin) GetServices() []registry.ServiceLocation {
 func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 	return []serde.Serde{
 		// State service serdes
-		&GatewayStatusSerde{},
+		state.NewStateSerde(orc8r.GatewayStateType, &checkindmodels.GatewayStatus{}),
 
 		// Inventory service serdes
 		serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &magmadmodels.AccessGatewayRecord{}),

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory_test.go
@@ -13,8 +13,8 @@ import (
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
-	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/serde"
+	checkindmodels "magma/orc8r/cloud/go/services/checkind/obsidian/models"
 	checkintu "magma/orc8r/cloud/go/services/checkind/test_utils"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorti "magma/orc8r/cloud/go/services/configurator/test_init"
@@ -24,6 +24,7 @@ import (
 	storagetu "magma/orc8r/cloud/go/services/magmad/obsidian/handlers/test_utils"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/models"
+	"magma/orc8r/cloud/go/services/state"
 	stateti "magma/orc8r/cloud/go/services/state/test_init"
 	statetu "magma/orc8r/cloud/go/services/state/test_utils"
 	"magma/orc8r/cloud/go/storage"
@@ -41,11 +42,10 @@ func TestFullGatewayViewFactoryImpl_GetGatewayViewsForNetwork(t *testing.T) {
 	deviceti.StartTestService(t)
 	stateti.StartTestService(t)
 
-	serde.UnregisterAllSerdes(t)
 	err := serde.RegisterSerdes(
 		storagetu.NewConfig1ConfiguratorManager(),
 		storagetu.NewConfig2ConfiguratorManager(),
-		&pluginimpl.GatewayStatusSerde{},
+		state.NewStateSerde(orc8r.GatewayStateType, &checkindmodels.GatewayStatus{}),
 		serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &models.AccessGatewayRecord{}),
 	)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -154,7 +154,7 @@ func GetGatewayStatus(networkID string, deviceID string) (*models.GatewayStatus,
 		return nil, errors.ErrNotFound
 	}
 
-	gwStatus := state.ReportedState.(models.GatewayStatus)
+	gwStatus := state.ReportedState.(*models.GatewayStatus)
 	gwStatus.CheckinTime = state.Time
 	gwStatus.CertExpirationTime = state.CertExpirationTime
 	// Use the hardware ID from the middleware
@@ -162,7 +162,7 @@ func GetGatewayStatus(networkID string, deviceID string) (*models.GatewayStatus,
 	// Populate deprecated fields to support API backwards compatibility
 	// TODO: Remove this and related tests when deprecated fields are no longer used
 	gwStatus.FillDeprecatedFields()
-	return &gwStatus, nil
+	return gwStatus, nil
 }
 
 func toProtosStateIDs(stateIDs []StateID) []*protos.StateID {


### PR DESCRIPTION
Summary: Serdes should be initialized through the Binary Convertible interface.

Reviewed By: jpbesgen

Differential Revision: D16682207

