### PR TITLE
Move string format (ipv4, ipv6) validation to swagger

### DIFF
--- a/lte/cloud/go/plugin/handlers.go
+++ b/lte/cloud/go/plugin/handlers.go
@@ -19,6 +19,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/configurator"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/labstack/echo"
 	"github.com/pkg/errors"
 )
@@ -51,6 +52,9 @@ func ListNetworks(c echo.Context) error {
 func CreateNetwork(c echo.Context) error {
 	payload := &models.LteNetwork{}
 	if err := c.Bind(payload); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	if err := payload.Validate(strfmt.Default); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	err := configurator.CreateNetwork(payload.ToConfiguratorNetwork())
@@ -90,6 +94,9 @@ func UpdateNetwork(c echo.Context) error {
 	payload := &models.LteNetwork{}
 	err := c.Bind(payload)
 	if err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	if err := payload.Validate(strfmt.Default); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 

--- a/orc8r/cloud/go/pluginimpl/handlers.go
+++ b/orc8r/cloud/go/pluginimpl/handlers.go
@@ -67,7 +67,7 @@ func RegisterNetwork(c echo.Context) error {
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerNetwork.ValidateModel(); err != nil {
+	if err := swaggerNetwork.Validate(strfmt.Default); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
@@ -103,7 +103,7 @@ func UpdateNetwork(c echo.Context) error {
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	if err := swaggerNetwork.ValidateModel(); err != nil {
+	if err := swaggerNetwork.Validate(strfmt.Default); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 	update := swaggerNetwork.ToUpdateCriteria()

--- a/orc8r/cloud/go/pluginimpl/handlers_test.go
+++ b/orc8r/cloud/go/pluginimpl/handlers_test.go
@@ -247,7 +247,7 @@ func Test_PostNetworkHandlers(t *testing.T) {
 		Payload:        tests.JSONMarshaler(network1),
 		Handler:        pluginimpl.RegisterNetwork,
 		ExpectedStatus: 400,
-		ExpectedError:  "ARecord must be in the form of an IpV4 address.",
+		ExpectedError:  "validation failure list:\nvalidation failure list:\nvalidation failure list:\na_record.0 in body must be of type ipv4: \"not ipv4\"",
 	}
 	tests.RunUnitTest(t, e, postNetwork)
 
@@ -260,7 +260,7 @@ func Test_PostNetworkHandlers(t *testing.T) {
 		Payload:        tests.JSONMarshaler(network1),
 		Handler:        pluginimpl.RegisterNetwork,
 		ExpectedStatus: 400,
-		ExpectedError:  "AaaaRecord must be in the form of an IpV6 address.",
+		ExpectedError:  "validation failure list:\nvalidation failure list:\nvalidation failure list:\naaaa_record.0 in body must be of type ipv6: \"not ipv6\"",
 	}
 	tests.RunUnitTest(t, e, postNetwork)
 

--- a/orc8r/cloud/go/pluginimpl/mconfig_builders.go
+++ b/orc8r/cloud/go/pluginimpl/mconfig_builders.go
@@ -17,9 +17,11 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	upgrade_models "magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
 	"github.com/pkg/errors"
+	"github.com/thoas/go-funk"
 )
 
 type BaseOrchestratorMconfigBuilder struct{}
@@ -95,6 +97,8 @@ func (*DnsdMconfigBuilder) Build(networkID string, gatewayID string, graph confi
 	for _, record := range dnsConfig.Records {
 		mconfigRecord := &mconfig.NetworkDNSConfigRecordsItems{}
 		protos.FillIn(record, mconfigRecord)
+		mconfigRecord.ARecord = funk.Map(record.ARecord, func(a strfmt.IPv4) string { return string(a) }).([]string)
+		mconfigRecord.AaaaRecord = funk.Map(record.AaaaRecord, func(a strfmt.IPv6) string { return string(a) }).([]string)
 		mconfigDnsd.Records = append(mconfigDnsd.Records, mconfigRecord)
 	}
 

--- a/orc8r/cloud/go/pluginimpl/mconfig_builders_test.go
+++ b/orc8r/cloud/go/pluginimpl/mconfig_builders_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	upgrade_models "magma/orc8r/cloud/go/services/upgrade/obsidian/models"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -140,13 +141,13 @@ func TestDnsdMconfigBuilder_Build(t *testing.T) {
 			LocalTTL:      swag.Uint32(100),
 			Records: []*models.DNSConfigRecord{
 				{
-					ARecord:     []string{"hello", "world"},
-					AaaaRecord:  []string{"foo", "bar"},
+					ARecord:     []strfmt.IPv4{"127.0.0.1", "127.0.0.2"},
+					AaaaRecord:  []strfmt.IPv6{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1234:0db8:85a3:0000:0000:8a2e:0370:1234"},
 					CnameRecord: []string{"baz"},
 					Domain:      "facebook.com",
 				},
 				{
-					ARecord: []string{"quz"},
+					ARecord: []strfmt.IPv4{"quz"},
 				},
 			},
 		},
@@ -163,8 +164,8 @@ func TestDnsdMconfigBuilder_Build(t *testing.T) {
 			LocalTTL:      100,
 			Records: []*mconfig.NetworkDNSConfigRecordsItems{
 				{
-					ARecord:     []string{"hello", "world"},
-					AaaaRecord:  []string{"foo", "bar"},
+					ARecord:     []string{"127.0.0.1", "127.0.0.2"},
+					AaaaRecord:  []string{"2001:0db8:85a3:0000:0000:8a2e:0370:7334", "1234:0db8:85a3:0000:0000:8a2e:0370:1234"},
 					CnameRecord: []string{"baz"},
 					Domain:      "facebook.com",
 				},
@@ -174,5 +175,5 @@ func TestDnsdMconfigBuilder_Build(t *testing.T) {
 			},
 		},
 	}
-	assert.Equal(t, expected, actual)
+	assert.Equal(t, expected["dnsd"].String(), actual["dnsd"].String())
 }

--- a/orc8r/cloud/go/pluginimpl/models/defaults.go
+++ b/orc8r/cloud/go/pluginimpl/models/defaults.go
@@ -11,6 +11,7 @@ package models
 import (
 	"magma/orc8r/cloud/go/models"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
 
@@ -20,8 +21,8 @@ func NewDefaultDNSConfig() *NetworkDNSConfig {
 		LocalTTL:      swag.Uint32(60),
 		Records: []*DNSConfigRecord{
 			{
-				ARecord:     []string{"192.88.99.142"},
-				AaaaRecord:  []string{"2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
+				ARecord:     []strfmt.IPv4{"192.88.99.142"},
+				AaaaRecord:  []strfmt.IPv6{"2001:0db8:85a3:0000:0000:8a2e:0370:7334"},
 				CnameRecord: []string{"cname.example.com"},
 				Domain:      "example.com",
 			},

--- a/orc8r/cloud/go/pluginimpl/models/dns_config_record_swaggergen.go
+++ b/orc8r/cloud/go/pluginimpl/models/dns_config_record_swaggergen.go
@@ -20,10 +20,10 @@ import (
 type DNSConfigRecord struct {
 
 	// a record
-	ARecord []string `json:"a_record"`
+	ARecord []strfmt.IPv4 `json:"a_record"`
 
 	// aaaa record
-	AaaaRecord []string `json:"aaaa_record"`
+	AaaaRecord []strfmt.IPv6 `json:"aaaa_record"`
 
 	// cname record
 	CnameRecord []string `json:"cname_record"`
@@ -72,6 +72,10 @@ func (m *DNSConfigRecord) validateARecord(formats strfmt.Registry) error {
 			return err
 		}
 
+		if err := validate.FormatOf("a_record"+"."+strconv.Itoa(i), "body", "ipv4", m.ARecord[i].String(), formats); err != nil {
+			return err
+		}
+
 	}
 
 	return nil
@@ -86,6 +90,10 @@ func (m *DNSConfigRecord) validateAaaaRecord(formats strfmt.Registry) error {
 	for i := 0; i < len(m.AaaaRecord); i++ {
 
 		if err := validate.MinLength("aaaa_record"+"."+strconv.Itoa(i), "body", string(m.AaaaRecord[i]), 1); err != nil {
+			return err
+		}
+
+		if err := validate.FormatOf("aaaa_record"+"."+strconv.Itoa(i), "body", "ipv6", m.AaaaRecord[i].String(), formats); err != nil {
 			return err
 		}
 

--- a/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
+++ b/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
@@ -517,6 +517,7 @@ definitions:
         items:
           type: string
           minLength: 1
+          format: ipv4
           x-nullable: false
           example: 192.88.99.142
       aaaa_record:
@@ -524,8 +525,9 @@ definitions:
         items:
           type: string
           minLength: 1
+          format: ipv6
           x-nullable: false
-          example: 2001:0db8:85a3:0000:0000:8a2e:0370:7334 # TODO: Regex?
+          example: 2001:0db8:85a3:0000:0000:8a2e:0370:7334
       cname_record:
         type: array
         items:

--- a/orc8r/cloud/go/pluginimpl/models/validate.go
+++ b/orc8r/cloud/go/pluginimpl/models/validate.go
@@ -12,7 +12,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"net"
 
 	"github.com/go-openapi/strfmt"
 )
@@ -20,23 +19,7 @@ import (
 const echoKeyType = "ECHO"
 const ecdsaKeyType = "SOFTWARE_ECDSA_SHA256"
 
-func (m *Network) ValidateModel() error {
-	if m == nil {
-		return errors.New("Network is nil.")
-	}
-	if err := m.Validate(strfmt.Default); err != nil {
-		return err
-	}
-	if err := m.DNS.ValidateModel(); err != nil {
-		return err
-	}
-	return nil
-}
-
 func (m *NetworkDNSConfig) ValidateModel() error {
-	if err := validateNetworkDNSRecordsConfig(m.Records); err != nil {
-		return err
-	}
 	return m.Validate(strfmt.Default)
 }
 
@@ -75,52 +58,6 @@ func (m *ChallengeKey) ValidateModel() error {
 func (m *MagmadGatewayConfigs) ValidateModel() error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
-	}
-	return nil
-}
-
-func validateNetworkDNSRecordsConfig(records []*DNSConfigRecord) error {
-	if records == nil {
-		return nil
-	}
-
-	for _, item := range records {
-		if err := validateNetworkDNSConfigRecordsItems(item); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func validateNetworkDNSConfigRecordsItems(config *DNSConfigRecord) error {
-	if config == nil {
-		return errors.New("NetworkDNSconfig Records Item is nil.")
-	}
-
-	if err := validateNetworkDNSConfigARecord(config.ARecord); err != nil {
-		return err
-	}
-	if err := validateNetworkDNSConfigAaaaRecord(config.AaaaRecord); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateNetworkDNSConfigARecord(ARecord []string) error {
-	for _, record := range ARecord {
-		if net.ParseIP(record).To4() == nil {
-			return errors.New("ARecord must be in the form of an IpV4 address.")
-		}
-	}
-	return nil
-}
-
-func validateNetworkDNSConfigAaaaRecord(AaaaRecord []string) error {
-	for _, record := range AaaaRecord {
-		if net.ParseIP(record).To16() == nil {
-			return errors.New("AaaaRecord must be in the form of an IpV6 address.")
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Summary:
Realized it's possible to validate string formats with swagger. (!)
So removing the custom validation that is no longer needed.

Reviewed By: xjtian

Differential Revision: D16702922

