### PR TITLE
Migrate to configurator datastore (#1253)

### DIFF
--- a/orc8r/cloud/go/errors/client_errors.go
+++ b/orc8r/cloud/go/errors/client_errors.go
@@ -16,6 +16,7 @@ import (
 // Client APIs should raise ErrNotFound to indicate that a resource requested
 // in a get/read does not exist.
 var ErrNotFound = errors.New("Not found")
+var ErrAlreadyExists = errors.New("Already exists")
 
 func NewInitError(err error, service string) error {
 	return ClientInitError{Err: err, Service: service}

--- a/orc8r/cloud/go/services/configurator/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/configurator/test_init/test_service_init.go
@@ -23,7 +23,7 @@ import (
 )
 
 func StartTestService(t *testing.T) {
-	db, err := sqorc.Open("sqlite3", ":memory:")
+	db, err := sqorc.Open("sqlite3", ":memory:?_foreign_keys=1")
 	if err != nil {
 		t.Fatalf("Could not initialize sqlite DB: %s", err)
 	}


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/1253

* Migrates GW config types to "yang_config" entity type that is bound to a "rhino_gateway" which groups all configs for a GW
* Migrates templates to "yang_template" entity type that is bound to a "rhino_template" which groups all templates for a NW
* Introduces ConfiguratorYANG as a serializer/deserializer wrapper for YANG types. Besides JSON this also stores metadata needed for deserialization

Reviewed By: xjtian

Differential Revision: D16659956

