### PR TITLE
Fix issue where data model param presence is unmarked

### DIFF
--- a/lte/gateway/python/magma/enodebd/data_models/data_model.py
+++ b/lte/gateway/python/magma/enodebd/data_models/data_model.py
@@ -48,7 +48,8 @@ class DataModel(ABC):
         if not param_info.is_optional:
             return True
         if param_name not in self._presence_by_param:
-            raise KeyError('Parameter presence not yet marked in data model')
+            raise KeyError('Parameter presence not yet marked in data '
+                           'model: %s' % param_name)
         return self._presence_by_param[param_name]
 
     def set_parameter_presence(

--- a/lte/gateway/python/magma/enodebd/devices/baicells.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells.py
@@ -49,7 +49,7 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
         self._state_map = {
             'wait_inform': WaitInformState(self, when_done='wait_empty', when_boot='wait_rem'),
             'wait_rem': BaicellsRemWaitState(self, when_done='wait_inform'),
-            'wait_empty': WaitEmptyMessageState(self, when_done='check_optional_params'),
+            'wait_empty': WaitEmptyMessageState(self, when_done='get_transient_params', when_missing='check_optional_params'),
             'check_optional_params': CheckOptionalParamsState(self, when_done='get_transient_params'),
             'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
             'wait_get_transient_params': WaitGetTransientParametersState(self, when_get='get_params', when_get_obj_params='get_obj_params', when_delete='delete_objs', when_add='add_objs', when_set='set_params', when_skip='end_session'),
@@ -70,7 +70,7 @@ class BaicellsHandler(BasicEnodebAcsStateMachine):
             # After rebooting, we don't need to query optional params again.
             'wait_inform_post_reboot': WaitInformState(self, when_done='wait_empty_post_reboot', when_boot='wait_rem_post_reboot'),
             'wait_rem_post_reboot': BaicellsRemWaitState(self, when_done='wait_inform_post_reboot'),
-            'wait_empty_post_reboot': WaitEmptyMessageState(self, when_done='get_transient_params'),
+            'wait_empty_post_reboot': WaitEmptyMessageState(self, when_done='get_transient_params', when_missing='check_optional_params'),
             # The states below are entered when an unexpected message type is
             # received
             'unexpected_fault': ErrorState(self),

--- a/lte/gateway/python/magma/enodebd/devices/baicells_old.py
+++ b/lte/gateway/python/magma/enodebd/devices/baicells_old.py
@@ -49,7 +49,7 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
         self._state_map = {
             'wait_inform': WaitInformState(self, when_done='wait_empty', when_boot='wait_rem'),
             'wait_rem': BaicellsRemWaitState(self, when_done='wait_inform'),
-            'wait_empty': WaitEmptyMessageState(self, when_done='check_optional_params'),
+            'wait_empty': WaitEmptyMessageState(self, when_done='get_transient_params', when_missing='check_optional_params'),
             'check_optional_params': CheckOptionalParamsState(self, when_done='get_transient_params'),
             'get_transient_params': SendGetTransientParametersState(self, when_done='wait_get_transient_params'),
             'wait_get_transient_params': WaitGetTransientParametersState(self, when_get='get_params', when_get_obj_params='get_obj_params', when_delete='delete_objs', when_add='add_objs', when_set='set_params', when_skip='end_session'),
@@ -70,7 +70,7 @@ class BaicellsOldHandler(BasicEnodebAcsStateMachine):
             # After rebooting, we don't need to query optional params again.
             'wait_inform_post_reboot': WaitInformState(self, when_done='wait_empty_post_reboot', when_boot='wait_rem_post_reboot'),
             'wait_rem_post_reboot': BaicellsRemWaitState(self, when_done='wait_inform_post_reboot'),
-            'wait_empty_post_reboot': WaitEmptyMessageState(self, when_done='get_transient_params'),
+            'wait_empty_post_reboot': WaitEmptyMessageState(self, when_done='get_transient_params', when_missing='check_optional_params'),
             # The states below are entered when an unexpected message type is
             # received
             'unexpected_fault': ErrorState(self),

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -216,10 +216,16 @@ class BaicellsRemWaitState(EnodebAcsState):
 
 
 class WaitEmptyMessageState(EnodebAcsState):
-    def __init__(self, acs: EnodebAcsStateMachine, when_done: str):
+    def __init__(
+        self,
+        acs: EnodebAcsStateMachine,
+        when_done: str,
+        when_missing: Optional[str] = None,
+    ):
         super().__init__()
         self.acs = acs
         self.done_transition = when_done
+        self.unknown_param_transition = when_missing
 
     def read_msg(self, message: Any) -> AcsReadMsgResult:
         """
@@ -230,7 +236,9 @@ class WaitEmptyMessageState(EnodebAcsState):
         """
         if not isinstance(message, models.DummyInput):
             return AcsReadMsgResult(False, None)
-        return AcsReadMsgResult(True, self.done_transition)
+        if get_optional_param_to_check(self.acs.data_model) is None:
+            return AcsReadMsgResult(True, self.done_transition)
+        return AcsReadMsgResult(True, self.unknown_param_transition)
 
     @classmethod
     def state_description(cls) -> str:

--- a/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/baicells_old_tests.py
@@ -375,3 +375,85 @@ class BaicellsOldHandlerTests(EnodebHandlerTestCase):
                         'enodebd should be requesting params')
         self.assertTrue(len(resp.ParameterNames.string) > 1,
                         'Should be requesting transient params.')
+
+    def test_reboot_without_getting_optional(self) -> None:
+        """
+        The state machine should not skip figuring out which optional
+        parameters are present.
+        """
+        acs_state_machine = \
+            EnodebAcsStateMachineBuilder \
+                .build_acs_state_machine(EnodebDeviceName.BAICELLS_OLD)
+
+        # Send an Inform message, wait for an InformResponse
+        inform_msg = \
+            Tr069MessageBuilder.get_inform('48BF74',
+                                           'BaiStation_V100R001C00B110SPC002',
+                                           '120200002618AGP0003',
+                                           ['2 PERIODIC'])
+        resp = acs_state_machine.handle_tr069_message(inform_msg)
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'Should respond with an InformResponse')
+
+        # And now reboot the eNodeB
+        acs_state_machine.transition('reboot')
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.Reboot))
+        req = Tr069MessageBuilder.get_reboot_response()
+        resp = acs_state_machine.handle_tr069_message(req)
+
+        # After the reboot has been received, enodebd should end the
+        # provisioning session
+        self.assertTrue(isinstance(resp, models.DummyInput),
+                        'After sending command to reboot the Baicells eNodeB, '
+                        'enodeb should end the TR-069 session.')
+
+        # At this point, sometime after the eNodeB reboots, we expect it to
+        # send an Inform indicating reboot. Since it should be in REM process,
+        # we hold off on finishing configuration, and end TR-069 sessions.
+        req = \
+            Tr069MessageBuilder.get_inform('48BF74',
+                                           'BaiStation_V100R001C00B110SPC002',
+                                           '120200002618AGP0003',
+                                           ['1 BOOT', 'M Reboot'])
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.DummyInput),
+                        'After receiving a post-reboot Inform, enodebd '
+                        'should end TR-069 sessions for 10 minutes to wait '
+                        'for REM process to finish.')
+
+        # Pretend that we have waited, and now we are in normal operation again
+        acs_state_machine.transition('wait_inform_post_reboot')
+        req = \
+            Tr069MessageBuilder.get_inform('48BF74',
+                                           'BaiStation_V100R001C00B110SPC002',
+                                           '120200002618AGP0003',
+                                           ['2 PERIODIC'])
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.InformResponse),
+                        'After receiving a post-reboot Inform, enodebd '
+                        'should end TR-069 sessions for 10 minutes to wait '
+                        'for REM process to finish.')
+
+        # Since we haven't figured out the presence of optional parameters, the
+        # state machine should be requesting them now. There are three for the
+        # Baicells state machine.
+        req = models.DummyInput()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'enodebd should be requesting params')
+        self.assertTrue(len(resp.ParameterNames.string) == 1,
+                        'Should be requesting optional params.')
+        req = Tr069MessageBuilder.get_fault()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param')
+        self.assertTrue(len(resp.ParameterNames.string) == 1,
+                        'Should be requesting optional params.')
+        req = Tr069MessageBuilder.get_fault()
+        resp = acs_state_machine.handle_tr069_message(req)
+        self.assertTrue(isinstance(resp, models.GetParameterValues),
+                        'State machine should be requesting param')
+        self.assertTrue(len(resp.ParameterNames.string) == 1,
+                        'Should be requesting optional params.')

--- a/lte/gateway/python/magma/enodebd/tests/data_model_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/data_model_tests.py
@@ -19,6 +19,15 @@ class BaicellsTrDataModelTest(TestCase):
     Tests for BaicellsTrDataModel
     """
 
+    def test_is_parameter_present(self):
+        data_model = BaicellsTrDataModel()
+        with self.assertRaises(KeyError):
+            data_model.is_parameter_present(ParameterName.GPS_LONG)
+
+        result = data_model.is_parameter_present(ParameterName.DEVICE)
+        self.assertTrue(result, "Should have the device parameter")
+
+
     def test_get_parameter(self):
         param_info =\
             BaicellsTrDataModel.get_parameter(ParameterName.GPS_STATUS)


### PR DESCRIPTION
Summary:
https://github.com/facebookincubator/magma/issues/479

It is assumed that by the time enodebd is fetching parameter values, the state machine is aware of which parameters are present, and which are not. This fixes an edge case which raises an error:

- state machine should be in initial REM state
- set the state machine to reboot the enodeb
- now the state machine will be in a state that assumes parameter presences are known

Differential Revision: D16722891

