### PR TITLE
TR-069 sessions with unregistered devices will be rejected

### DIFF
--- a/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
@@ -1,0 +1,26 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from lte.protos.mconfig import mconfigs_pb2
+
+
+def is_enb_registered(mconfig: mconfigs_pb2.EnodebD, enb_serial: str) -> bool:
+    """
+    True if either:
+        - the eNodeB is registered by serial to the Access Gateway
+        or
+        - the Access Gateway accepts all eNodeB devices
+    """
+    if mconfig.enb_configs_by_serial is not None and \
+            len(mconfig.enb_configs_by_serial) > 0:
+        if enb_serial in mconfig.enb_configs_by_serial:
+            return True
+        else:
+            return False
+    return True

--- a/lte/gateway/python/magma/enodebd/exceptions.py
+++ b/lte/gateway/python/magma/enodebd/exceptions.py
@@ -24,3 +24,11 @@ class IncorrectDeviceHandlerError(Exception):
         """
         super().__init__()
         self.device_name = device_name
+
+
+class UnrecognizedEnodebError(Exception):
+    """
+    Indicates that the Access Gateway does not recognize the eNodeB.
+    The Access Gateway will not interact with the eNodeB in question.
+    """
+    pass

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -1098,4 +1098,4 @@ class ErrorState(EnodebAcsState):
 
     @classmethod
     def state_description(cls) -> str:
-        return 'Error state - awaiting manual reboot'
+        return 'Error state - awaiting manual restart of enodebd service'


### PR DESCRIPTION
Summary: This revision changes the behavior of enodebd service to reject TR-069 sessions initiated by eNB devices that have not been registered to the Access Gateway, if at least one is registered. This is a step in fully removing support for the old method of configuring eNB. Unregistered eNB devices should not be configured by the Access Gateway and should not work.

Reviewed By: fishlinghu

Differential Revision: D16744857

