### PR TITLE
Report rf_tx_desired

### DIFF
--- a/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
@@ -1,0 +1,27 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from lte.protos.mconfig import mconfigs_pb2
+
+
+def is_enb_registered(mconfig: mconfigs_pb2.EnodebD, enb_serial: str) -> bool:
+    """
+    True if either:
+        - the eNodeB is registered by serial to the Access Gateway
+        or
+        - the Access Gateway accepts all eNodeB devices
+    """
+    if mconfig.enb_configs_by_serial is not None and \
+            len(mconfig.enb_configs_by_serial) > 0:
+        if enb_serial in mconfig.enb_configs_by_serial:
+            return True
+        else:
+            return False
+    return True
+

--- a/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
+++ b/lte/gateway/python/magma/enodebd/device_config/configuration_util.py
@@ -10,6 +10,21 @@ of patent rights can be found in the PATENTS file in the same directory.
 from lte.protos.mconfig import mconfigs_pb2
 
 
+def get_enb_rf_tx_desired(
+    mconfig: mconfigs_pb2.EnodebD,
+    enb_serial: str,
+) -> bool:
+    """ True if the mconfig specifies to enable transmit on the eNB """
+    if mconfig.enb_configs_by_serial is not None and \
+            len(mconfig.enb_configs_by_serial) > 0:
+        if enb_serial in mconfig.enb_configs_by_serial:
+            enb_config = mconfig.enb_configs_by_serial[enb_serial]
+            return enb_config.transmit_enabled
+        else:
+            raise KeyError('Missing eNB from mconfig: %s' % enb_serial)
+    return mconfig.allow_enodeb_transmit
+
+
 def is_enb_registered(mconfig: mconfigs_pb2.EnodebD, enb_serial: str) -> bool:
     """
     True if either:

--- a/lte/gateway/python/magma/enodebd/exceptions.py
+++ b/lte/gateway/python/magma/enodebd/exceptions.py
@@ -24,3 +24,11 @@ class IncorrectDeviceHandlerError(Exception):
         """
         super().__init__()
         self.device_name = device_name
+
+
+class UnrecognizedEnodebError(Exception):
+    """
+    Indicates that the Access Gateway does not recognize the eNodeB.
+    The Access Gateway will not interact with the eNodeB in question.
+    """
+    pass

--- a/lte/gateway/python/magma/enodebd/metrics.py
+++ b/lte/gateway/python/magma/enodebd/metrics.py
@@ -18,6 +18,8 @@ STAT_OPSTATE_ENABLED = Gauge('enodeb_opstate_enabled',
                              'ENodeB operationally enabled')
 STAT_RF_TX_ENABLED = Gauge('enodeb_rf_tx_enabled',
                            'ENodeB RF transmitter enabled')
+STAT_RF_TX_DESIRED = Gauge('enodeb_rf_tx_desired',
+                           'ENodeB RF transmitter desired state')
 STAT_GPS_CONNECTED = Gauge('enodeb_gps_connected',
                            'ENodeB GPS synchronized')
 STAT_PTP_CONNECTED = Gauge('enodeb_ptp_connected',

--- a/lte/gateway/python/magma/enodebd/rpc_servicer.py
+++ b/lte/gateway/python/magma/enodebd/rpc_servicer.py
@@ -132,6 +132,7 @@ class EnodebdRpcServicer(EnodebdServicer):
                 configured=enb_status.configured,
                 opstate_enabled=enb_status.opstate_enabled,
                 rf_tx_on=enb_status.rf_tx_on,
+                rf_tx_desired=enb_status.rf_tx_desired,
                 gps_connected=enb_status.gps_connected,
                 ptp_connected=enb_status.ptp_connected,
                 mme_connected=enb_status.mme_connected,

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -1098,4 +1098,4 @@ class ErrorState(EnodebAcsState):
 
     @classmethod
     def state_description(cls) -> str:
-        return 'Error state - awaiting manual reboot'
+        return 'Error state - awaiting manual restart of enodebd service'

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -40,6 +40,7 @@ class StatsManagerTest(TestCase):
         handler = EnodebAcsStateMachineBuilder\
             .build_acs_state_machine(EnodebDeviceName.BAICELLS)
         handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, True)
+        handler.device_cfg.set_parameter(ParameterName.SERIAL_NUMBER, '123454')
         with mock.patch('magma.enodebd.stats_manager.StatsManager'
                         '._clear_stats') as func:
             self.mgr._check_rf_tx_for_handler(handler)

--- a/lte/gateway/python/scripts/enodebd_cli.py
+++ b/lte/gateway/python/scripts/enodebd_cli.py
@@ -86,7 +86,8 @@ def get_status(client, args):
     print_status_param(meta, 'all_enodeb_configured', 'All eNodeB configured')
     print_status_param(meta, 'all_enodeb_opstate_enabled',
                        'All eNB Opstate enabled')
-    print_status_param(meta, 'all_enodeb_rf_tx_on', 'All eNB RF TX on')
+    print_status_param(meta, 'all_enodeb_rf_tx_configured',
+                       'All eNB RF TX configured to desired state')
     print_status_param(meta, 'any_enodeb_gps_connected',
                        'Any eNB GPS connected')
     print_status_param(meta, 'all_enodeb_ptp_connected',
@@ -107,6 +108,7 @@ def get_all_status(client, args):
         _print_status_line('eNodeB Configured', enb_status.configured)
         _print_status_line('Opstate Enabled', enb_status.opstate_enabled)
         _print_status_line('RF TX on', enb_status.rf_tx_on)
+        _print_status_line('RF TX desired', enb_status.rf_tx_desired)
         _print_status_line('GPS Connected', enb_status.gps_connected)
         _print_status_line('PTP Connected', enb_status.ptp_connected)
         _print_status_line('MME Connected', enb_status.mme_connected)
@@ -136,6 +138,7 @@ def get_enb_status(client, args):
     _print_status_line('eNodeB Configured', enb_status.configured)
     _print_status_line('Opstate Enabled', enb_status.opstate_enabled)
     _print_status_line('RF TX on', enb_status.rf_tx_on)
+    _print_status_line('RF TX desired', enb_status.rf_tx_desired)
     _print_status_line('GPS Connected', enb_status.gps_connected)
     _print_status_line('PTP Connected', enb_status.ptp_connected)
     _print_status_line('MME Connected', enb_status.mme_connected)

--- a/lte/protos/enodebd.proto
+++ b/lte/protos/enodebd.proto
@@ -81,6 +81,7 @@ message SingleEnodebStatus {
   string gps_longitude = 10;
   string gps_latitude = 11;
   string fsm_state = 12;
+  string rf_tx_desired = 13;
 }
 
 // --------------------------------------------------------------------------

--- a/orc8r/protos/metricsd.proto
+++ b/orc8r/protos/metricsd.proto
@@ -75,6 +75,7 @@ enum MetricName {
   enodeb_mgmt_configured         = 227;
   enodeb_reboot_timer_active     = 228;
   enodeb_reboots                 = 229;
+  enodeb_rf_tx_desired           = 230;
 
   // Magmad metrics
   magmad_ping_rtt_ms             = 300;

--- a/orc8r/protos/service303.proto
+++ b/orc8r/protos/service303.proto
@@ -29,6 +29,7 @@ message EnodebdStatus {
   google.protobuf.BoolValue enodeb_configured = 7;
   google.protobuf.FloatValue gps_latitude = 8;
   google.protobuf.FloatValue gps_longitude = 9;
+  google.protobuf.BoolValue rf_tx_desired = 10;
 }
 
 message ServiceStatus {


### PR DESCRIPTION
Summary:
This revision adds reporting from the AGW enodebd service, reporting for each eNodeB that is connected whether the configuration is to enable/disable the radio transmit function.

This will allow us to alert on whether the radio transmit function is mis-matched with the configuration.

Reviewed By: xjtian

Differential Revision: D16744855

