### PR TITLE
Change state machine error state messaging

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -1098,4 +1098,4 @@ class ErrorState(EnodebAcsState):
 
     @classmethod
     def state_description(cls) -> str:
-        return 'Error state - awaiting manual reboot'
+        return 'Error state - awaiting manual restart of enodebd service'


### PR DESCRIPTION
Summary: In the state machine error state, the description needs to be changed - the error state just triggers when something unexpected happens, which is most likely a gap in the functionality of enodebd, rather than a legitimate detection of an issue in the eNodeB which requires a reboot.

Reviewed By: fishlinghu

Differential Revision: D16744856

