### PR TITLE
Fix fab register_vm command to use the new gateway config

### DIFF
--- a/orc8r/tools/fab/dev_utils.py
+++ b/orc8r/tools/fab/dev_utils.py
@@ -48,7 +48,7 @@ def register_vm(vm_type="magma", admin_cert=(
     gateways = _cloud_get('/networks/%s/gateways' % network_id, admin_cert)
     gateway_id = 'gw' + str(len(gateways) + 1)
     print('Provisioning gateway as %s...' % gateway_id)
-    data = {'hw_id': {'id': hardware_id}, 'name': 'TestGateway',
+    data = {'hardware_id': hardware_id, 'name': 'TestGateway',
             'key': {'key_type': 'ECHO'}}
     _cloud_post('/networks/%s/gateways' % network_id,
                 data=data, params={'requested_id': gateway_id}, admin_cert=admin_cert)


### PR DESCRIPTION
Summary: The lte gateway fab command for registering a gateway was still using the old gateway config, resulting in an error `Exception: Received a 400 response: {"message":"Invalid Gateway Record, Error: validation failure list:\nhardware_id in body is required"}`. This changes it so that it's able to properly register a gw.

Differential Revision: D16779947

