### PR TITLE
Add a handler generator for partial update,get,delete for networks

### DIFF
--- a/orc8r/cloud/go/pluginimpl/handlers/handler_factory.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/handler_factory.go
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+
+	"magma/orc8r/cloud/go/errors"
+	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/services/configurator"
+
+	"github.com/labstack/echo"
+)
+
+// PartialNetworkModels describe models that represents a portion of network
+// that can be read, updated, and deleted.
+type PartialNetworkModels interface {
+	// ValidateModel validates the model to be according to swagger spec, as
+	// well as other custom validations
+	ValidateModel() error
+	// GetFromNetwork grabs the desired model from the configurator network.
+	// Returns nil if it is not there.
+	GetFromNetwork(network configurator.Network) interface{}
+	// ToUpdateCriteria takes in the existing network and applies the change
+	// from the model to create a NetworkUpdateCriteria
+	ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error)
+}
+
+// GetPartialNetworkHandlers returns a set of GET/PUT/DELETE handlers according to the parameters.
+// If the configKey is not "", it will add a delete handler for the network config for that key.
+func GetPartialNetworkHandlers(path string, model PartialNetworkModels, configKey string) []obsidian.Handler {
+	ret := []obsidian.Handler{
+		GetPartialReadNetworkHandler(path, model),
+		GetPartialUpdateNetworkHandler(path, model),
+	}
+	if configKey != "" {
+		ret = append(ret, GetPartialDeleteNetworkHandler(path, configKey))
+	}
+	return []obsidian.Handler{
+		GetPartialReadNetworkHandler(path, model),
+		GetPartialUpdateNetworkHandler(path, model),
+		GetPartialDeleteNetworkHandler(path, configKey),
+	}
+}
+
+// GetPartialReadNetworkHandler returns a GET obsidian handler at the specified path.
+// This function loads a network specified by the networkID and returns the
+// part of the network that corresponds to the given model.
+// Example:
+//      (m *NetworkName) GetFromNetwork(network configurator.Network) interface{} {
+// 			return string(network.Name)
+// 		}
+// 		getNameHandler := handlers.GetPartialReadNetworkHandler(URL, &models.NetworkName{})
+//
+//      would return a GET handler that can read the network name of a network with the specified ID.
+func GetPartialReadNetworkHandler(path string, model PartialNetworkModels) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.GET,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, nerr := obsidian.GetNetworkId(c)
+			if nerr != nil {
+				return nerr
+			}
+			network, err := configurator.LoadNetwork(networkID, true, true)
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			ret := model.GetFromNetwork(network)
+			if ret == nil {
+				return obsidian.HttpError(fmt.Errorf("Not found"), http.StatusNotFound)
+			}
+			return c.JSON(http.StatusOK, ret)
+		},
+	}
+}
+
+// GetPartialUpdateNetworkHandler returns a PUT obsidian handler at the specified path.
+// The handler will fetch the payload into the configModel and perform validations according to the swagger spec.
+// updater will take the model and apply the change into an existing network.
+// Example:
+//      (m *NetworkName) ToUpdateCriteria(network configurator.Network) interface{} {
+// 			return configurator.NetworkUpdateCriteria{
+//				ID:   network.ID,
+// 				Name: *m,
+//			}
+//      }
+// 		putNameHandler := handlers.GetPartialUpdateNetworkHandler(URL, &models.NetworkName{})
+//
+//      would return a PUT handler that will intake a NetworkName model and update the corresponding network
+func GetPartialUpdateNetworkHandler(path string, model PartialNetworkModels) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.PUT,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, nerr := obsidian.GetNetworkId(c)
+			if nerr != nil {
+				return nerr
+			}
+			requestedUpdate, nerr := getPayload(c, model)
+			if nerr != nil {
+				return nerr
+			}
+
+			network, err := configurator.LoadNetwork(networkID, true, true)
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+
+			updateCriteria, err := requestedUpdate.ToUpdateCriteria(network)
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusBadRequest)
+			}
+			err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria})
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			return c.NoContent(http.StatusNoContent)
+		},
+	}
+}
+
+// GetPartialDeleteNetworkHandler returns a DELETE obsidian handler at the specified path.
+// The handler will delete a network config specified by the key.
+// Example:
+// 		deleteNetworkFeaturesHandler := handlers.GetPartialDeleteNetworkHandler(URL, "orc8r_features")
+//
+//      would return a DELETE handler that will remove the network features config from the corresponding network
+func GetPartialDeleteNetworkHandler(path string, key string) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.DELETE,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, nerr := obsidian.GetNetworkId(c)
+			if nerr != nil {
+				return nerr
+			}
+			update := configurator.NetworkUpdateCriteria{
+				ID:              networkID,
+				ConfigsToDelete: []string{key},
+			}
+			err := configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update})
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			return c.NoContent(http.StatusNoContent)
+		},
+	}
+}
+
+func getPayload(c echo.Context, model interface{}) (PartialNetworkModels, *echo.HTTPError) {
+	iModel := reflect.New(reflect.TypeOf(model).Elem()).Interface().(PartialNetworkModels)
+	if err := c.Bind(iModel); err != nil {
+		return nil, obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	// Run validations specified by the swagger spec
+	if err := iModel.ValidateModel(); err != nil {
+		return nil, obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	return iModel, nil
+}

--- a/orc8r/cloud/go/pluginimpl/handlers/handler_factory_test.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/handler_factory_test.go
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"magma/orc8r/cloud/go/errors"
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/pluginimpl/handlers"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+type (
+	ID struct {
+		Name string
+	}
+	TestFeature1 struct {
+		ID   *ID
+		Desc string
+	}
+)
+
+func TestGetReadNetworkConfigHandler(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configuratorTestInit.StartTestService(t)
+	serde.RegisterSerdes(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks"
+
+	// register a network without any configs
+	networkID := "test-network"
+	network := configurator.Network{
+		ID:          networkID,
+		Name:        "Test Network 1",
+		Description: "Test Network 1",
+	}
+	assert.NoError(t, configurator.CreateNetwork(network))
+
+	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
+
+	// Test 404
+	getFullConfig := handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{})
+	getFeatures := tests.Test{
+		Method:         "GET",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        nil,
+		Handler:        getFullConfig.HandlerFunc,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, getFeatures)
+
+	getPartialConfig := handlers.GetPartialReadNetworkHandler(networkURL, &ID{})
+	getName := tests.Test{
+		Method:         "GET",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        nil,
+		Handler:        getPartialConfig.HandlerFunc,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, getName)
+
+	// add config to network
+	update := configurator.NetworkUpdateCriteria{
+		ID: networkID,
+		ConfigsToAddOrUpdate: map[string]interface{}{
+			"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"},
+		},
+	}
+	assert.NoError(t, configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update}))
+
+	// happy full case
+	getFullConfig = handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{})
+	getFeatures = tests.Test{
+		Method:         "GET",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        nil,
+		Handler:        getFullConfig.HandlerFunc,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(&TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}),
+	}
+	tests.RunUnitTest(t, e, getFeatures)
+
+	// happy partial case
+	getPartialConfig = handlers.GetPartialReadNetworkHandler(networkURL, &ID{})
+	getName = tests.Test{
+		Method:         "GET",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        nil,
+		Handler:        getPartialConfig.HandlerFunc,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(&ID{Name: "hello!"}),
+	}
+	tests.RunUnitTest(t, e, getName)
+}
+
+func TestGetUpdateNetworkConfigHandler(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	serde.RegisterSerdes(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
+	configuratorTestInit.StartTestService(t)
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks"
+
+	// register a network
+	networkID := "test-network"
+	network := configurator.Network{
+		ID:          networkID,
+		Type:        "lte",
+		Name:        "Test Network 1",
+		Description: "Test Network 1",
+		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
+	}
+	assert.NoError(t, configurator.CreateNetwork(network))
+
+	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
+
+	updateConfigsFull := handlers.GetPartialUpdateNetworkHandler(networkURL, &TestFeature1{})
+	updateConfigsPartial := handlers.GetPartialUpdateNetworkHandler(networkURL, &ID{})
+
+	// name is empty
+	badConfig := &TestFeature1{ID: &ID{Name: ""}, Desc: "goodbye!"}
+	updateFullConfig := tests.Test{
+		Method:         "PUT",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        tests.JSONMarshaler(badConfig),
+		Handler:        updateConfigsFull.HandlerFunc,
+		ExpectedStatus: 400,
+		ExpectedError:  "Name cannot be nil",
+	}
+	tests.RunUnitTest(t, e, updateFullConfig)
+
+	badPartialConfig := &ID{Name: ""}
+	updatePartialConfig := tests.Test{
+		Method:         "PUT",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        tests.JSONMarshaler(badPartialConfig),
+		Handler:        updateConfigsFull.HandlerFunc,
+		ExpectedStatus: 400,
+		ExpectedError:  "Cannot be nil",
+	}
+	tests.RunUnitTest(t, e, updatePartialConfig)
+
+	expectedConfig := &TestFeature1{ID: &ID{Name: "hello world!"}, Desc: "goodbye world!"}
+	// happy full case
+	updateFullConfig = tests.Test{
+		Method:         "PUT",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        tests.JSONMarshaler(expectedConfig),
+		Handler:        updateConfigsFull.HandlerFunc,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, updateFullConfig)
+
+	config, err := configurator.LoadNetworkConfig(networkID, "test")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedConfig, config)
+
+	expectedConfig.ID.Name = "foo! bar!"
+	// happy partial case
+	updateFullConfig = tests.Test{
+		Method:         "PUT",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Payload:        tests.JSONMarshaler(expectedConfig.ID),
+		Handler:        updateConfigsPartial.HandlerFunc,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, updateFullConfig)
+
+	config, err = configurator.LoadNetworkConfig(networkID, "test")
+	assert.NoError(t, err)
+	assert.Equal(t, expectedConfig, config)
+}
+
+func TestGetDeleteNetworkConfigHandler(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	serde.RegisterSerdes(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
+	configuratorTestInit.StartTestService(t)
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks"
+
+	// register a network
+	networkID := "test-network"
+	network := configurator.Network{
+		ID:          networkID,
+		Type:        "lte",
+		Name:        "Test Network 1",
+		Description: "Test Network 1",
+		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
+	}
+	assert.NoError(t, configurator.CreateNetwork(network))
+
+	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
+
+	deleteHandler := handlers.GetPartialDeleteNetworkHandler(networkURL, "test")
+	deleteTestConfig := tests.Test{
+		Method:         "DELETE",
+		URL:            networkURL,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{networkID},
+		Handler:        deleteHandler.HandlerFunc,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, deleteTestConfig)
+
+	_, err := configurator.LoadNetworkConfig(networkID, "test")
+	assert.EqualError(t, errors.ErrNotFound, err.Error())
+}
+
+func (m *ID) Validate(_ strfmt.Registry) error {
+	if m == nil {
+		return fmt.Errorf("Cannot be nil")
+	}
+	if m.Name != "" {
+		return nil
+	}
+	return fmt.Errorf("Name cannot be nil")
+}
+
+func (m *ID) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}
+
+func (m *ID) GetFromNetwork(network configurator.Network) interface{} {
+	feature := (&TestFeature1{}).GetFromNetwork(network)
+	if feature == nil {
+		return nil
+	}
+	return feature.(*TestFeature1).ID
+}
+
+func (m *ID) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
+	feature := (&TestFeature1{}).GetFromNetwork(network)
+	feature.(*TestFeature1).ID = m
+	return configurator.NetworkUpdateCriteria{
+		ID:                   network.ID,
+		ConfigsToAddOrUpdate: map[string]interface{}{"test": feature},
+	}, nil
+}
+
+func (m *TestFeature1) Validate(str strfmt.Registry) error {
+	if err := m.ID.Validate(str); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *TestFeature1) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}
+
+// MarshalBinary interface implementation
+func (m *TestFeature1) MarshalBinary() ([]byte, error) {
+	return json.Marshal(m)
+}
+
+// UnmarshalBinary interface implementation
+func (m *TestFeature1) UnmarshalBinary(b []byte) error {
+	return json.Unmarshal(b, m)
+}
+
+func (m *TestFeature1) GetFromNetwork(network configurator.Network) interface{} {
+	if network.Configs == nil {
+		return nil
+	}
+	config, exists := network.Configs["test"]
+	if !exists {
+		return nil
+	}
+	return config
+}
+
+func (m *TestFeature1) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
+	return configurator.NetworkUpdateCriteria{
+		ID:                   network.ID,
+		ConfigsToAddOrUpdate: map[string]interface{}{"test": m},
+	}, nil
+}

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -233,6 +233,21 @@ func LoadNetwork(networkID string, loadMetadata bool, loadConfigs bool) (Network
 	return networks[0], nil
 }
 
+// LoadNetworkConfig loads network config of type configType registered under the networkID
+func LoadNetworkConfig(networkID, configType string) (interface{}, error) {
+	network, err := LoadNetwork(networkID, false, true)
+	if err != nil {
+		return nil, err
+	}
+	if network.Configs == nil {
+		return nil, merrors.ErrNotFound
+	}
+	if _, exists := network.Configs[configType]; !exists {
+		return nil, merrors.ErrNotFound
+	}
+	return network.Configs[configType], nil
+}
+
 func UpdateNetworkConfig(networkID, configType string, config interface{}) error {
 	updateCriteria := NetworkUpdateCriteria{
 		ID:                   networkID,


### PR DESCRIPTION
Summary:
Since for v1 we are planning on supporting many partial updates, reads, deletes (read only the records from dns network config, etc.) these set of functions help defining those handlers easier.

The functions take in custom functions (`customRead`, `customUpdate`, `customDelete`) that lets you specify which parts of the network to update/read/delete.

Reviewed By: xjtian

Differential Revision: D16691112

