### PR TITLE
Refactoring handler tests to get obsidian handlers from the plugin function

### DIFF
--- a/lte/cloud/go/plugin/handlers.go
+++ b/lte/cloud/go/plugin/handlers.go
@@ -38,7 +38,7 @@ const (
 	ManageNetworkDNSPath         = ManageNetworkPath + obsidian.UrlSep + "dns"
 )
 
-func getNetworkHandlers() []obsidian.Handler {
+func GetNetworkHandlers() []obsidian.Handler {
 	ret := []obsidian.Handler{
 		{Path: ListNetworksPath, Methods: obsidian.GET, HandlerFunc: ListNetworks},
 		{Path: ListNetworksPath, Methods: obsidian.POST, HandlerFunc: CreateNetwork},

--- a/lte/cloud/go/plugin/handlers_test.go
+++ b/lte/cloud/go/plugin/handlers_test.go
@@ -14,6 +14,7 @@ import (
 	"magma/lte/cloud/go/lte"
 	plugin2 "magma/lte/cloud/go/plugin"
 	models2 "magma/lte/cloud/go/plugin/models"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
@@ -34,12 +35,15 @@ func TestListNetworks(t *testing.T) {
 	test_init.StartTestService(t)
 	e := echo.New()
 
+	obsidianHandlers := plugin2.GetNetworkHandlers()
+	listNetworks := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/ltenetworks", obsidian.GET).HandlerFunc
+
 	// Test empty response
 	tc := tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/ltenetworks",
 		Payload:        nil,
-		Handler:        plugin2.ListNetworks,
+		Handler:        listNetworks,
 		ExpectedStatus: 200,
 		ExpectedResult: tests.JSONMarshaler([]string{}),
 		ExpectedError:  "",
@@ -52,7 +56,7 @@ func TestListNetworks(t *testing.T) {
 		Method:         "GET",
 		URL:            "/magma/v1/ltenetworks",
 		Payload:        nil,
-		Handler:        plugin2.ListNetworks,
+		Handler:        listNetworks,
 		ExpectedStatus: 200,
 		ExpectedResult: tests.JSONMarshaler([]string{"n1", "n3"}),
 	}
@@ -64,6 +68,9 @@ func TestCreateNetwork(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &plugin2.LteOrchestratorPlugin{})
 	test_init.StartTestService(t)
 	e := echo.New()
+
+	obsidianHandlers := plugin2.GetNetworkHandlers()
+	createNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/ltenetworks", obsidian.POST).HandlerFunc
 
 	// test validation
 	tc := tests.Test{
@@ -79,7 +86,7 @@ func TestCreateNetwork(t *testing.T) {
 				Name:        "foobar",
 			},
 		),
-		Handler:        plugin2.CreateNetwork,
+		Handler:        createNetwork,
 		ExpectedStatus: 400,
 		ExpectedError: "validation failure list:\n" +
 			"description in body should be at least 1 chars long",
@@ -99,7 +106,7 @@ func TestCreateNetwork(t *testing.T) {
 				Name:        "foobar",
 			},
 		),
-		Handler:        plugin2.CreateNetwork,
+		Handler:        createNetwork,
 		ExpectedStatus: 201,
 	}
 	tests.RunUnitTest(t, e, tc)
@@ -126,6 +133,9 @@ func TestGetNetwork(t *testing.T) {
 	test_init.StartTestService(t)
 	e := echo.New()
 
+	obsidianHandlers := plugin2.GetNetworkHandlers()
+	getNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/ltenetworks/:network_id", obsidian.GET).HandlerFunc
+
 	// Test 404
 	tc := tests.Test{
 		Method:         "GET",
@@ -133,7 +143,7 @@ func TestGetNetwork(t *testing.T) {
 		Payload:        nil,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
-		Handler:        plugin2.GetNetwork,
+		Handler:        getNetwork,
 		ExpectedStatus: 404,
 	}
 	tests.RunUnitTest(t, e, tc)
@@ -154,7 +164,7 @@ func TestGetNetwork(t *testing.T) {
 		Payload:        nil,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
-		Handler:        plugin2.GetNetwork,
+		Handler:        getNetwork,
 		ExpectedStatus: 200,
 		ExpectedResult: tests.JSONMarshaler(expectedN1),
 	}
@@ -167,7 +177,7 @@ func TestGetNetwork(t *testing.T) {
 		Payload:        nil,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n2"},
-		Handler:        plugin2.GetNetwork,
+		Handler:        getNetwork,
 		ExpectedStatus: 400,
 		ExpectedError:  "network n2 is not an LTE network",
 	}
@@ -185,7 +195,7 @@ func TestGetNetwork(t *testing.T) {
 		Payload:        nil,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n3"},
-		Handler:        plugin2.GetNetwork,
+		Handler:        getNetwork,
 		ExpectedStatus: 200,
 		ExpectedResult: tests.JSONMarshaler(expectedN3),
 	}
@@ -197,6 +207,9 @@ func TestUpdateNetwork(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &plugin2.LteOrchestratorPlugin{})
 	test_init.StartTestService(t)
 	e := echo.New()
+
+	obsidianHandlers := plugin2.GetNetworkHandlers()
+	updateNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/ltenetworks/:network_id", obsidian.PUT).HandlerFunc
 
 	// Test validation failure
 	payloadN1 := &models2.LteNetwork{
@@ -232,7 +245,7 @@ func TestUpdateNetwork(t *testing.T) {
 		Payload:        payloadN1,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
-		Handler:        plugin2.UpdateNetwork,
+		Handler:        updateNetwork,
 		ExpectedStatus: 400,
 		ExpectedError: "validation failure list:\n" +
 			"validation failure list:\n" +
@@ -263,7 +276,7 @@ func TestUpdateNetwork(t *testing.T) {
 		Payload:        payloadN1,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
-		Handler:        plugin2.UpdateNetwork,
+		Handler:        updateNetwork,
 		ExpectedStatus: 404,
 	}
 	tests.RunUnitTest(t, e, tc)
@@ -277,7 +290,7 @@ func TestUpdateNetwork(t *testing.T) {
 		Payload:        payloadN1,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
-		Handler:        plugin2.UpdateNetwork,
+		Handler:        updateNetwork,
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
@@ -305,7 +318,7 @@ func TestUpdateNetwork(t *testing.T) {
 		Payload:        payloadN1,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n2"},
-		Handler:        plugin2.UpdateNetwork,
+		Handler:        updateNetwork,
 		ExpectedStatus: 400,
 		ExpectedError:  "network n2 is not an LTE network",
 	}
@@ -318,6 +331,9 @@ func TestDeleteNetwork(t *testing.T) {
 	test_init.StartTestService(t)
 	e := echo.New()
 
+	obsidianHandlers := plugin2.GetNetworkHandlers()
+	deleteNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/ltenetworks/:network_id", obsidian.DELETE).HandlerFunc
+
 	// Test 404
 	tc := tests.Test{
 		Method:         "DELETE",
@@ -325,7 +341,7 @@ func TestDeleteNetwork(t *testing.T) {
 		Payload:        nil,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
-		Handler:        plugin2.DeleteNetwork,
+		Handler:        deleteNetwork,
 		ExpectedStatus: 404,
 	}
 	tests.RunUnitTest(t, e, tc)
@@ -346,7 +362,7 @@ func TestDeleteNetwork(t *testing.T) {
 		Payload:        nil,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n2"},
-		Handler:        plugin2.DeleteNetwork,
+		Handler:        deleteNetwork,
 		ExpectedStatus: 400,
 		ExpectedError:  "network n2 is not an LTE network",
 	}

--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -95,7 +95,7 @@ func (*LteOrchestratorPlugin) GetObsidianHandlers(metricsConfig *srvconfig.Confi
 		meteringdh.GetObsidianHandlers(),
 		policydbh.GetObsidianHandlers(),
 		subscriberdbh.GetObsidianHandlers(),
-		getNetworkHandlers(),
+		GetNetworkHandlers(),
 	)
 }
 

--- a/orc8r/cloud/go/obsidian/tests/unit_test_utils.go
+++ b/orc8r/cloud/go/obsidian/tests/unit_test_utils.go
@@ -16,6 +16,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"magma/orc8r/cloud/go/obsidian"
+
 	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
@@ -76,6 +78,19 @@ func RunUnitTest(t *testing.T, e *echo.Echo, test Test) {
 			}
 		}
 	}
+}
+
+// GetHandlerByPathAndMethod fetches the first obsidian.Handler that matches the
+// given path and method from a list of handlers. If no such handler exists, it
+// will fail.
+func GetHandlerByPathAndMethod(t *testing.T, handlers []obsidian.Handler, path string, method obsidian.HttpMethod) obsidian.Handler {
+	for _, handler := range handlers {
+		if handler.Path == path && handler.Methods == method {
+			return handler
+		}
+	}
+	assert.Fail(t, "No handler registered for path %s", path)
+	return obsidian.Handler{}
 }
 
 func JSONMarshaler(v interface{}) encoding.BinaryMarshaler {

--- a/orc8r/cloud/go/pluginimpl/handlers/gateway_handlers_test.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/gateway_handlers_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
@@ -46,11 +47,14 @@ func TestListGateways(t *testing.T) {
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks/n1/gateways"
 
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	listGateways := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways", obsidian.GET).HandlerFunc
+
 	// empty case
 	tc := tests.Test{
 		Method:         "GET",
 		URL:            testURLRoot,
-		Handler:        handlers.ListGateways,
+		Handler:        listGateways,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
 		ExpectedStatus: 200,
@@ -89,6 +93,9 @@ func TestCreateGateway(t *testing.T) {
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks/n1/gateways"
 
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	createGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways", obsidian.POST).HandlerFunc
+
 	// Register device with gateway
 	payload := &models.MagmadGateway{
 		Device: &models.GatewayDevice{
@@ -109,7 +116,7 @@ func TestCreateGateway(t *testing.T) {
 	tc := tests.Test{
 		Method:         "POST",
 		URL:            testURLRoot,
-		Handler:        handlers.CreateGateway,
+		Handler:        createGateway,
 		Payload:        payload,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
@@ -241,7 +248,7 @@ func TestCreateGateway(t *testing.T) {
 	tc = tests.Test{
 		Method:         "POST",
 		URL:            testURLRoot,
-		Handler:        handlers.CreateGateway,
+		Handler:        createGateway,
 		Payload:        payload,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
@@ -270,7 +277,7 @@ func TestCreateGateway(t *testing.T) {
 	tc = tests.Test{
 		Method:         "POST",
 		URL:            testURLRoot,
-		Handler:        handlers.CreateGateway,
+		Handler:        createGateway,
 		Payload:        payload,
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
@@ -335,6 +342,9 @@ func TestGetGateway(t *testing.T) {
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks/n1/gateways"
 
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	getGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id", obsidian.GET).HandlerFunc
+
 	// happy path
 	expected := &models.MagmadGateway{
 		ID: "g1",
@@ -358,7 +368,7 @@ func TestGetGateway(t *testing.T) {
 	tc := tests.Test{
 		Method:         "GET",
 		URL:            testURLRoot + "/g1",
-		Handler:        handlers.GetGateway,
+		Handler:        getGateway,
 		ParamNames:     []string{"network_id", "gateway_id"},
 		ParamValues:    []string{"n1", "g1"},
 		ExpectedStatus: 200,
@@ -381,7 +391,7 @@ func TestGetGateway(t *testing.T) {
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            testURLRoot + "/g2",
-		Handler:        handlers.GetGateway,
+		Handler:        getGateway,
 		ParamNames:     []string{"network_id", "gateway_id"},
 		ParamValues:    []string{"n1", "g2"},
 		ExpectedStatus: 200,
@@ -393,7 +403,7 @@ func TestGetGateway(t *testing.T) {
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            testURLRoot + "/g3",
-		Handler:        handlers.GetGateway,
+		Handler:        getGateway,
 		ParamNames:     []string{"network_id", "gateway_id"},
 		ParamValues:    []string{"n1", "g3"},
 		ExpectedStatus: 404,
@@ -439,6 +449,9 @@ func TestUpdateGateway(t *testing.T) {
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks/n1/gateways"
 
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	updateGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id", obsidian.PUT).HandlerFunc
+
 	// update everything
 	privateKey, err := key.GenerateKey("P256", 0)
 	assert.NoError(t, err)
@@ -467,7 +480,7 @@ func TestUpdateGateway(t *testing.T) {
 	tc := tests.Test{
 		Method:         "PUT",
 		URL:            testURLRoot + "/g1",
-		Handler:        handlers.UpdateGateway,
+		Handler:        updateGateway,
 		Payload:        payload,
 		ParamNames:     []string{"network_id", "gateway_id"},
 		ParamValues:    []string{"n1", "g1"},
@@ -514,7 +527,7 @@ func TestUpdateGateway(t *testing.T) {
 	tc = tests.Test{
 		Method:         "PUT",
 		URL:            testURLRoot + "/g3",
-		Handler:        handlers.UpdateGateway,
+		Handler:        updateGateway,
 		Payload:        payload,
 		ParamNames:     []string{"network_id", "gateway_id"},
 		ParamValues:    []string{"n1", "g3"},
@@ -560,10 +573,13 @@ func TestDeleteGateway(t *testing.T) {
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks/n1/gateways"
 
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	deleteGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id", obsidian.DELETE).HandlerFunc
+
 	tc := tests.Test{
 		Method:         "DELETE",
 		URL:            testURLRoot + "/g1",
-		Handler:        handlers.DeleteGateway,
+		Handler:        deleteGateway,
 		ParamNames:     []string{"network_id", "gateway_id"},
 		ParamValues:    []string{"n1", "g1"},
 		ExpectedStatus: 204,


### PR DESCRIPTION
Summary:
Refactoring handler tests to fetch obsidian handlers that are being tested from the plugin GetObsidianHandlers so that more of the pipeline is tested.

Adding `GetHandlerByPathAndMethod(t *testing.T, handlers []obsidian.Handler, path string, method obsidian.HttpMethod) obsidian.Handler` to the unit test library to help get the obsidian handler from a list of obsidian handlers by specifying its path and method.

Also renaming some of the variables to make it a bit cleaner.

Differential Revision: D16794736

