### PR TITLE
Report number of open file descriptors

### DIFF
--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20190109181635-f287a105a20e
 	github.com/prometheus/common v0.2.0
-	github.com/prometheus/procfs v0.0.0-20190104112138-b1a0a9a36d74 // indirect
+	github.com/prometheus/procfs v0.0.0-20190104112138-b1a0a9a36d74
 	github.com/prometheus/prometheus v0.0.0-20190115164134-b639fe140c1f
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1 // indirect

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -147,11 +147,14 @@ func getMetricsProfiles(metricsConfig *config.ConfigMap) []metricsd.MetricsProfi
 
 	// Controller profile - 1 collector for each service
 	allServices := registry.ListControllerServices()
-	controllerCollectors := make([]collection.MetricCollector, 0, len(allServices)+1)
+	deviceMetricsCollectors := []collection.MetricCollector{&collection.DiskUsageMetricCollector{}, &collection.ProcMetricsCollector{}}
+	controllerCollectors := make([]collection.MetricCollector, 0, len(allServices)+len(deviceMetricsCollectors))
 	for _, srv := range allServices {
 		controllerCollectors = append(controllerCollectors, collection.NewCloudServiceMetricCollector(srv))
 	}
-	controllerCollectors = append(controllerCollectors, &collection.DiskUsageMetricCollector{})
+	for _, metricCollector := range deviceMetricsCollectors {
+		controllerCollectors = append(controllerCollectors, metricCollector)
+	}
 
 	// Prometheus profile - Exports all service metric to Prometheus
 	prometheusAddresses := metricsConfig.GetRequiredStringArrayParam(confignames.PrometheusPushAddresses)


### PR DESCRIPTION
Summary: Add reporting of file descriptor count, as a proxy for the number of open sockets. This should be useful for measuring network resource usage.

Reviewed By: Scott8440

Differential Revision: D16341592

