### PR TITLE
Get metricsd running on cloud proxy tier

### DIFF
--- a/orc8r/cloud/docker/proxy/Dockerfile
+++ b/orc8r/cloud/docker/proxy/Dockerfile
@@ -1,13 +1,19 @@
 FROM ubuntu:xenial
 
+ARG CNTLR_FILES=src/magma/orc8r/cloud/docker/controller
+ARG PROXY_FILES=src/magma/orc8r/cloud/docker/proxy
+
+# Install the runtime deps from apt
 # Add the magma apt repo
 RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https
+    apt-get install -y \
+        daemontools netcat openssl supervisor wget unzip \
+        apt-utils software-properties-common apt-transport-https
 COPY src/magma/orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ xenial main"
 
-# Install the deps from apt
+# Install the proxy deps from apt
 RUN apt-get update && \
     apt-get install -y \
         libssl-dev libev-dev libevent-dev libjansson-dev libjemalloc-dev libc-ares-dev magma-nghttpx=1.31.1-1 \
@@ -21,17 +27,28 @@ RUN pip3 install PyYAML jinja2
 
 # Create an empty envdir for overriding in production
 RUN mkdir -p /var/opt/magma/envdir
+# We only care to collect and report metrics on Proxy, and not much else
+ENV CONTROLLER_SERVICES METRICSD
+# TODO: fix dispatcher to work on containers
+ENV SERVICE_HOST_NAME localhost
+# TODO: fix metricsd for fetching host level metrics
+ENV HOST_NAME dev
 
-ARG PROXY_FILES=src/magma/orc8r/cloud/docker/proxy
-
-# Copy the scripts and configs from the context
+# Copy the configs
 COPY configs /etc/magma/configs
+
+# Copy proxy scripts and configs from the context
 COPY ${PROXY_FILES}/templates /etc/magma/templates
 COPY ${PROXY_FILES}/magma_headers.rb /etc/nghttpx/magma_headers.rb
 COPY ${PROXY_FILES}/run_nghttpx.py /usr/local/bin/run_nghttpx.py
 COPY ${PROXY_FILES}/squid.conf /etc/squid/squid.conf
 COPY ${PROXY_FILES}/create_test_proxy_certs /usr/local/bin/create_test_proxy_certs
 
+# Copy the build artifacts
+COPY --from=orc8r_controller /var/opt/magma/bin /var/opt/magma/bin
+COPY --from=orc8r_controller /var/opt/magma/plugins /var/opt/magma/plugins
+
 # Copy the supervisor configs
 COPY ${PROXY_FILES}/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY ${CNTLR_FILES}/supervisor_logger.py /usr/local/lib/python2.7/dist-packages/supervisor_logger.py
 CMD ["/usr/bin/supervisord"]

--- a/orc8r/cloud/docker/proxy/supervisord.conf
+++ b/orc8r/cloud/docker/proxy/supervisord.conf
@@ -33,3 +33,19 @@ stdout_logfile_maxbytes=0
 stderr_logfile_maxbytes=0
 startsecs=0
 autorestart=false
+
+[program:metricsd]
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/metricsd -logtostderr=true -v=0
+autorestart=true
+stdout_logfile=NONE
+stderr_logfile=NONE
+stdout_events_enabled = true
+stderr_events_enabled = true
+
+[eventlistener:stdout]
+command = python -m supervisor_logger
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_logger:result_handler
+stdout_logfile=NONE
+stderr_logfile=NONE

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/prometheus/client_golang v0.9.2
 	github.com/prometheus/client_model v0.0.0-20190109181635-f287a105a20e
 	github.com/prometheus/common v0.2.0
-	github.com/prometheus/procfs v0.0.0-20190104112138-b1a0a9a36d74 // indirect
+	github.com/prometheus/procfs v0.0.0-20190104112138-b1a0a9a36d74
 	github.com/prometheus/prometheus v0.0.0-20190115164134-b639fe140c1f
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1 // indirect

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -147,11 +147,14 @@ func getMetricsProfiles(metricsConfig *config.ConfigMap) []metricsd.MetricsProfi
 
 	// Controller profile - 1 collector for each service
 	allServices := registry.ListControllerServices()
-	controllerCollectors := make([]collection.MetricCollector, 0, len(allServices)+1)
+	deviceMetricsCollectors := []collection.MetricCollector{&collection.DiskUsageMetricCollector{}, &collection.ProcMetricsCollector{}}
+	controllerCollectors := make([]collection.MetricCollector, 0, len(allServices)+len(deviceMetricsCollectors))
 	for _, srv := range allServices {
 		controllerCollectors = append(controllerCollectors, collection.NewCloudServiceMetricCollector(srv))
 	}
-	controllerCollectors = append(controllerCollectors, &collection.DiskUsageMetricCollector{})
+	for _, metricCollector := range deviceMetricsCollectors {
+		controllerCollectors = append(controllerCollectors, metricCollector)
+	}
 
 	// Prometheus profile - Exports all service metric to Prometheus
 	prometheusAddresses := metricsConfig.GetRequiredStringArrayParam(confignames.PrometheusPushAddresses)


### PR DESCRIPTION
Summary:
This revision only makes sure that metricsd can run on the proxy tier, but does not ensure that the correct metrics are being collected or exported with the correct labels.

The `Dockerfile` for cloud proxy tier has been updated to include a lightweight build of orc8r with no other modules/plugins.

`supervisord.conf` has been modified so that supervisord will now run metricsd on the proxy tier, as well as the supervisor_logger.

Reviewed By: xjtian

Differential Revision: D16372814

