### PR TITLE
Fix feg_relay and health service to use configurator

### DIFF
--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
@@ -19,15 +19,14 @@ import (
 	"strings"
 
 	"magma/feg/cloud/go/feg"
-	feg_protos "magma/feg/cloud/go/services/controller/protos"
+	"magma/feg/cloud/go/services/controller/obsidian/models"
 	"magma/feg/cloud/go/services/health"
 	"magma/lte/cloud/go/lte"
-	lte_protos "magma/lte/cloud/go/services/cellular/protos"
+	ltemodels "magma/lte/cloud/go/plugin/models"
 	"magma/orc8r/cloud/go/http2"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/service/middleware/unary"
-	"magma/orc8r/cloud/go/services/config"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 	"magma/orc8r/cloud/go/services/magmad"
@@ -167,24 +166,24 @@ func getFeGHwIdForNetwork(agNwId string) (string, error) {
 	if err == nil {
 		return fegEnvHwID, nil
 	}
-	cfg, err := config.GetConfig(agNwId, lte.CellularNetworkType, agNwId)
+	cfg, err := configurator.GetNetworkConfigsByType(agNwId, lte.CellularNetworkType)
 	if err != nil || cfg == nil {
 		return "", fmt.Errorf("Unable to retrieve cellular config for AG network: %s", agNwId)
 	}
-	cellularConfig, ok := cfg.(*lte_protos.CellularNetworkConfig)
+	cellularConfig, ok := cfg.(*ltemodels.NetworkCellularConfigs)
 	if !ok {
 		return "", fmt.Errorf("Invalid cellular config found for AG network: %s", agNwId)
 	}
-	fegNetworkID := cellularConfig.FegNetworkId
+	fegNetworkID := cellularConfig.FegNetworkID
 	if fegNetworkID == "" {
 		return "", fmt.Errorf("FegNetworkID is not set in cellular config for network: %s", agNwId)
 	}
 
-	fegCfg, err := config.GetConfig(fegNetworkID, feg.FegNetworkType, fegNetworkID)
+	fegCfg, err := configurator.GetNetworkConfigsByType(string(fegNetworkID), feg.FegNetworkType)
 	if err != nil || fegCfg == nil {
 		return "", fmt.Errorf("Unable to retrieve config for FeG network: %s", fegNetworkID)
 	}
-	fegNetworkConfig, ok := fegCfg.(*feg_protos.Config)
+	fegNetworkConfig, ok := fegCfg.(*models.NetworkFederationConfigs)
 	if !ok {
 		return "", fmt.Errorf("Invalid feg config found for FeG network: %s", fegNetworkID)
 	}
@@ -192,7 +191,7 @@ func getFeGHwIdForNetwork(agNwId string) (string, error) {
 	servedNetworkIDs := fegNetworkConfig.ServedNetworkIds
 	for _, network := range servedNetworkIDs {
 		if agNwId == network {
-			return getActiveFeGForNetwork(fegNetworkID)
+			return getActiveFeGForNetwork(string(fegNetworkID))
 		}
 	}
 	return "", fmt.Errorf("Federated Gateway Network: %s is not configured to serve network: %s", fegNetworkID, agNwId)

--- a/feg/cloud/go/services/health/servicers/config.go
+++ b/feg/cloud/go/services/health/servicers/config.go
@@ -10,8 +10,8 @@ package servicers
 
 import (
 	"magma/feg/cloud/go/feg"
-	cfgprotos "magma/feg/cloud/go/services/controller/protos"
-	orc8rcfg "magma/orc8r/cloud/go/services/config"
+	"magma/feg/cloud/go/services/controller/obsidian/models"
+	"magma/orc8r/cloud/go/services/configurator"
 
 	"github.com/golang/glog"
 )
@@ -31,38 +31,38 @@ func GetHealthConfigForNetwork(networkID string) *healthConfig {
 		memAvailableThreshold: defaultMemAvailableThreshold,
 		staleUpdateThreshold:  defaultStaleUpdateThreshold,
 	}
-	config, err := orc8rcfg.GetConfig(networkID, feg.FegNetworkType, networkID)
+	config, err := configurator.GetNetworkConfigsByType(networkID, feg.FegNetworkType)
 	if err != nil {
 		glog.V(2).Infof("Using default health configuration for network %s; %s", networkID, err)
 		return defaultConfig
 	}
-	cloudFegConfig, ok := config.(*cfgprotos.Config)
+	cloudFegConfig, ok := config.(*models.NetworkFederationConfigs)
 	if !ok {
 		glog.V(2).Infof("Using default health configuration for network %s; Invalid config format", networkID)
 		return defaultConfig
 	}
-	healthParams := cloudFegConfig.GetHealth()
+	healthParams := cloudFegConfig.Health
 	if healthParams == nil {
 		glog.V(2).Infof("Using default health configuration for network %s; Health config not found", networkID)
 		return defaultConfig
 	}
-	if healthParams.GetCpuUtilizationThreshold() == 0 {
+	if healthParams.CPUUtilizationThreshold == 0 {
 		glog.V(2).Infof("Using default health configuration for network %s; Cpu utilization threshold cannot be 0", networkID)
 		return defaultConfig
 	}
-	if healthParams.GetMemoryAvailableThreshold() == 0 {
+	if healthParams.MemoryAvailableThreshold == 0 {
 		glog.V(2).Infof("Using default health configuration for network %s; Memory available threshold cannot be 0", networkID)
 		return defaultConfig
 	}
-	staleUpdateThreshold := healthParams.GetUpdateFailureThreshold() * healthParams.GetUpdateIntervalSecs()
+	staleUpdateThreshold := healthParams.UpdateFailureThreshold * healthParams.UpdateIntervalSecs
 	if staleUpdateThreshold == 0 {
 		glog.V(2).Infof("Using default health configuration for network %s; Stale update threshold cannot be 0", networkID)
 		return defaultConfig
 	}
 	return &healthConfig{
-		services:              healthParams.GetHealthServices(),
-		cpuUtilThreshold:      healthParams.GetCpuUtilizationThreshold(),
-		memAvailableThreshold: healthParams.GetMemoryAvailableThreshold(),
+		services:              healthParams.HealthServices,
+		cpuUtilThreshold:      healthParams.CPUUtilizationThreshold,
+		memAvailableThreshold: healthParams.MemoryAvailableThreshold,
 		staleUpdateThreshold:  staleUpdateThreshold,
 	}
 }

--- a/feg/cloud/go/services/health/test_utils/test_utils.go
+++ b/feg/cloud/go/services/health/test_utils/test_utils.go
@@ -14,10 +14,11 @@ import (
 	"testing"
 	"time"
 
+	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/protos"
-	orcprotos "magma/orc8r/cloud/go/protos"
-	"magma/orc8r/cloud/go/services/magmad"
-	mdprotos "magma/orc8r/cloud/go/services/magmad/protos"
+	"magma/orc8r/cloud/go/pluginimpl/models"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/configurator/test_utils"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -91,25 +92,20 @@ func GetUnhealthyRequest() *protos.HealthRequest {
 	}
 }
 
-func RegisterNetwork(t *testing.T, networkID string) string {
-	netID, err := magmad.RegisterNetwork(&mdprotos.MagmadNetworkRecord{Name: "Test Feg Network"}, networkID)
+func RegisterNetwork(t *testing.T, networkID string) {
+	err := configurator.CreateNetwork(configurator.Network{
+		ID:   TestFegNetwork,
+		Type: feg.FegNetworkType,
+	})
 	assert.NoError(t, err)
-	assert.Equal(t, networkID, netID)
-
-	return netID
 }
 
-func RegisterGateway(t *testing.T, networkID, hwID, logicalID string) string {
-	gw1Record := &mdprotos.AccessGatewayRecord{
-		HwId: &orcprotos.AccessGatewayID{Id: hwID},
-		Name: logicalID,
-		Key: &orcprotos.ChallengeKey{
-			KeyType: orcprotos.ChallengeKey_ECHO,
+func RegisterGateway(t *testing.T, networkID, hwID, logicalID string) {
+	gwRecord := &models.GatewayDevice{
+		HardwareID: hwID,
+		Key: &models.ChallengeKey{
+			KeyType: "ECHO",
 		},
 	}
-	gwID, err := magmad.RegisterGatewayWithId(networkID, gw1Record, logicalID)
-	assert.NoError(t, err)
-	assert.Equal(t, logicalID, gwID)
-
-	return gwID
+	test_utils.RegisterGateway(t, networkID, logicalID, gwRecord)
 }


### PR DESCRIPTION
Summary:
Recent configurator changes didn't get propagated to the orc8r.
This diff fixes that by properly loading the new config types.

Differential Revision: D16838350

