### PR TITLE
Add de-register to HSS client_api and CLI

### DIFF
--- a/feg/gateway/services/testcore/hss/client_api.go
+++ b/feg/gateway/services/testcore/hss/client_api.go
@@ -120,6 +120,26 @@ func DeleteSubscriber(id string) error {
 	return err
 }
 
+// DeRegisterSubscriber de-registers a subscriber by their Id.
+// If the subscriber is not found, an error is returned instead.
+// Input: The id of the subscriber to be deleted.
+func DeregisterSubscriber(id string) error {
+	err := verifyID(id)
+	if err != nil {
+		errMsg := fmt.Errorf("Invalid DeregisterSubscriberRequest provided: %s", err)
+		return errors.New(errMsg.Error())
+	}
+	cli, err := getHSSClient()
+	if err != nil {
+		return err
+	}
+	subID := &lteprotos.SubscriberID{
+		Id: id,
+	}
+	_, err = cli.DeregisterSubscriber(context.Background(), subID)
+	return err
+}
+
 func VerifySubscriberData(sub *lteprotos.SubscriberData) error {
 	if sub == nil {
 		return fmt.Errorf("subscriber is nil")

--- a/feg/gateway/tools/hss_cli/main.go
+++ b/feg/gateway/tools/hss_cli/main.go
@@ -160,6 +160,23 @@ func deleteSubscriber(_ *commands.Command, _ []string) int {
 	return 0
 }
 
+// deregisterSubscriber handles the DEREG command (deregisters a subscriber from the hss)
+func deregisterSubscriber(_ *commands.Command, _ []string) int {
+	client, err := connectToHss()
+	if err != nil {
+		fmt.Printf("Failed to connect to hss: %v\n", err)
+		return 1
+	}
+	id := &lteprotos.SubscriberID{Id: subscriberID}
+	_, err = client.DeregisterSubscriber(context.Background(), id)
+	if err != nil {
+		fmt.Printf("Failed to deregister subscriber: %v\n", err)
+		return 1
+	}
+
+	return 0
+}
+
 func init() {
 	getCmd := cmdRegistry.Add(
 		"GET",
@@ -208,6 +225,18 @@ func init() {
 		delFlags.PrintDefaults()
 	}
 	delFlags.StringVar(&subscriberID, "subscriber_id", subscriberID, "IMSI of the subscriber to delete")
+
+	deregCmd := cmdRegistry.Add(
+		"DEREG",
+		"Deregister a subscriber",
+		deregisterSubscriber)
+	deregFlags := deregCmd.Flags()
+	deregFlags.Usage = func() {
+		fmt.Fprintf(os.Stderr, // std Usage() & PrintDefaults() use Stderr
+			"\tUsage: %s [OPTIONS] %s [%s OPTIONS] <IMSI>\n", os.Args[0], deregCmd.Name(), deregCmd.Name())
+		deregFlags.PrintDefaults()
+	}
+	deregFlags.StringVar(&subscriberID, "subscriber_id", subscriberID, "IMSI of the subscriber to deregister")
 }
 
 // addSubscriberDataFlags adds all of the flags needed to fill a SubscriberData proto.


### PR DESCRIPTION
Summary:
This diff updates the HSS-Lite's client api and CLI to
allow the newly implemented Registration-Termination to be called
easily.

Reviewed By: fishlinghu

Differential Revision: D16662632

