### PR TITLE
Fix staging configurator crash due to imcompatible types

### DIFF
--- a/lte/cloud/go/plugin/mconfig.go
+++ b/lte/cloud/go/plugin/mconfig.go
@@ -48,7 +48,7 @@ func (*Builder) Build(networkID string, gatewayID string, graph configurator.Ent
 	if cellGW.Config == nil {
 		return nil
 	}
-	cellularGwConfig := cellGW.Config.(*cellular_models.GatewayCellularConfigs)
+	cellularGwConfig := cellGW.Config.(*models2.GatewayCellularConfigs)
 
 	if err := validateConfigs(cellularNwConfig, cellularGwConfig); err != nil {
 		return err
@@ -80,7 +80,7 @@ func (*Builder) Build(networkID string, gatewayID string, graph configurator.Ent
 			FddConfig:           getFddConfig(nwRan.FddConfig),
 			TddConfig:           getTddConfig(nwRan.TddConfig),
 			BandwidthMhz:        int32(nwRan.BandwidthMhz),
-			AllowEnodebTransmit: gwRan.TransmitEnabled,
+			AllowEnodebTransmit: swag.BoolValue(gwRan.TransmitEnabled),
 			Tac:                 int32(nwEpc.Tac),
 			PlmnidList:          fmt.Sprintf("%s%s", nwEpc.Mcc, nwEpc.Mnc),
 			CsfbRat:             nonEPSServiceMconfig.csfbRat,
@@ -110,7 +110,7 @@ func (*Builder) Build(networkID string, gatewayID string, graph configurator.Ent
 		"pipelined": &mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
 			UeIpBlock:     gwEpc.IPBlock,
-			NatEnabled:    gwEpc.NatEnabled,
+			NatEnabled:    swag.BoolValue(gwEpc.NatEnabled),
 			DefaultRuleId: swag.StringValue(nwEpc.DefaultRuleID),
 			RelayEnabled:  swag.BoolValue(nwEpc.RelayEnabled),
 			Services:      pipelineDServices,
@@ -136,7 +136,7 @@ func (*Builder) Build(networkID string, gatewayID string, graph configurator.Ent
 	return nil
 }
 
-func validateConfigs(nwConfig *models2.NetworkCellularConfigs, gwConfig *cellular_models.GatewayCellularConfigs) error {
+func validateConfigs(nwConfig *models2.NetworkCellularConfigs, gwConfig *models2.GatewayCellularConfigs) error {
 	if nwConfig == nil {
 		return errors.New("Cellular network config is nil")
 	}
@@ -176,7 +176,7 @@ type nonEPSServiceMconfigFields struct {
 	lac                  int32
 }
 
-func getNonEPSServiceMconfigFields(gwNonEpsService *cellular_models.GatewayNonEpsServiceConfigs) nonEPSServiceMconfigFields {
+func getNonEPSServiceMconfigFields(gwNonEpsService *models2.GatewayNonEpsConfigs) nonEPSServiceMconfigFields {
 	if gwNonEpsService == nil {
 		return nonEPSServiceMconfigFields{
 			csfbRat:              mconfig.EnodebD_CSFBRAT_2G,
@@ -193,12 +193,12 @@ func getNonEPSServiceMconfigFields(gwNonEpsService *cellular_models.GatewayNonEp
 		}
 
 		return nonEPSServiceMconfigFields{
-			csfbRat:              mconfig.EnodebD_CSFBRat(gwNonEpsService.CsfbRat),
+			csfbRat:              mconfig.EnodebD_CSFBRat(swag.Uint32Value(gwNonEpsService.CsfbRat)),
 			arfcn_2g:             arfcn2g,
-			nonEpsServiceControl: mconfig.MME_NonEPSServiceControl(gwNonEpsService.NonEpsServiceControl),
+			nonEpsServiceControl: mconfig.MME_NonEPSServiceControl(swag.Uint32Value(gwNonEpsService.NonEpsServiceControl)),
 			csfbMcc:              gwNonEpsService.CsfbMcc,
 			csfbMnc:              gwNonEpsService.CsfbMnc,
-			lac:                  int32(gwNonEpsService.Lac),
+			lac:                  int32(swag.Uint32Value(gwNonEpsService.Lac)),
 		}
 	}
 }

--- a/lte/cloud/go/plugin/mconfig_test.go
+++ b/lte/cloud/go/plugin/mconfig_test.go
@@ -15,7 +15,7 @@ import (
 	"magma/lte/cloud/go/plugin"
 	models2 "magma/lte/cloud/go/plugin/models"
 	"magma/lte/cloud/go/protos/mconfig"
-	cellular_models "magma/lte/cloud/go/services/cellular/obsidian/models"
+	cellularModels "magma/lte/cloud/go/services/cellular/obsidian/models"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/protos"
@@ -243,30 +243,29 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
-func newDefaultGatewayConfig() *cellular_models.GatewayCellularConfigs {
-	return &cellular_models.GatewayCellularConfigs{
-		AttachedEnodebSerials: []string{"enb1"},
-		Ran: &cellular_models.GatewayRanConfigs{
+func newDefaultGatewayConfig() *models2.GatewayCellularConfigs {
+	return &models2.GatewayCellularConfigs{
+		Ran: &models2.GatewayRanConfigs{
 			Pci:             260,
-			TransmitEnabled: true,
+			TransmitEnabled: swag.Bool(true),
 		},
-		Epc: &cellular_models.GatewayEpcConfigs{
-			NatEnabled: true,
+		Epc: &models2.GatewayEpcConfigs{
+			NatEnabled: swag.Bool(true),
 			IPBlock:    "192.168.128.0/24",
 		},
-		NonEpsService: &cellular_models.GatewayNonEpsServiceConfigs{
+		NonEpsService: &models2.GatewayNonEpsConfigs{
 			CsfbMcc:              "",
 			CsfbMnc:              "",
-			Lac:                  1,
-			CsfbRat:              0,
+			Lac:                  swag.Uint32(1),
+			CsfbRat:              swag.Uint32(0),
 			Arfcn2g:              []uint32{},
-			NonEpsServiceControl: 0,
+			NonEpsServiceControl: swag.Uint32(0),
 		},
 	}
 }
 
-func newDefaultEnodebConfig() *cellular_models.NetworkEnodebConfigs {
-	return &cellular_models.NetworkEnodebConfigs{
+func newDefaultEnodebConfig() *cellularModels.NetworkEnodebConfigs {
+	return &cellularModels.NetworkEnodebConfigs{
 		Earfcndl:               39150,
 		SubframeAssignment:     2,
 		SpecialSubframePattern: 7,


### PR DESCRIPTION
Summary:
The serde was migrated to use the new GatewayCellularConfigs defined in plugin/models while the mconfig was still trying to interpret it as the old model defined in cellular/obsidian/models. The unit test did not catch this because it was not testing the de/serialization and was using the old models.

Updated the test to use the new models.

Differential Revision: D16918313

