### PR TITLE
Don't require login for grafana

### DIFF
--- a/orc8r/cloud/docker/grafana/Dockerfile
+++ b/orc8r/cloud/docker/grafana/Dockerfile
@@ -1,4 +1,5 @@
 FROM grafana/grafana
 ADD docker/grafana/provisioning /etc/grafana/provisioning
+ADD docker/grafana/grafana.ini /etc/grafana/grafana.ini
 ADD docker/grafana/config.ini /etc/grafana/config.ini
 ADD docker/grafana/dashboards /var/lib/dashboards

--- a/orc8r/cloud/docker/grafana/grafana.ini
+++ b/orc8r/cloud/docker/grafana/grafana.ini
@@ -1,0 +1,8 @@
+[auth.anonymous]
+# enable anonymous access
+enabled = true
+
+# specify organization name that should be used for unauthenticated users
+org_name = Main Org.
+
+org_role = Editor


### PR DESCRIPTION
Summary: Grafana can be configured with an anonymous user. No need to login with dummy creds.

Differential Revision: D16928432

