### PR TITLE
Add a PartialGatewayRead and PartialGatewayUpdate framework to have a generic way to modify gateways.

### DIFF
--- a/lte/cloud/go/plugin/handlers.go
+++ b/lte/cloud/go/plugin/handlers.go
@@ -46,9 +46,14 @@ const (
 	ManageNetworkCellularRanPath       = ManageNetworkCellularPath + obsidian.UrlSep + "ran"
 	ManageNetworkCellularFegNetworkID  = ManageNetworkCellularPath + obsidian.UrlSep + "feg_network_id"
 
-	Gateways          = "gateways"
-	ListGatewaysPath  = ManageNetworkPath + obsidian.UrlSep + Gateways
-	ManageGatewayPath = ListGatewaysPath + obsidian.UrlSep + ":gateway_id"
+	Gateways                     = "gateways"
+	ListGatewaysPath             = ManageNetworkPath + obsidian.UrlSep + Gateways
+	ManageGatewayPath            = ListGatewaysPath + obsidian.UrlSep + ":gateway_id"
+	ManageGatewayNamePath        = ManageGatewayPath + obsidian.UrlSep + "name"
+	ManageGatewayDescriptionPath = ManageGatewayPath + obsidian.UrlSep + "description"
+	ManageGatewayConfigPath      = ManageGatewayPath + obsidian.UrlSep + "magmad"
+	ManageGatewayDevicePath      = ManageGatewayPath + obsidian.UrlSep + "device"
+	ManageGatewayStatePath       = ManageGatewayPath + obsidian.UrlSep + "state"
 )
 
 func GetHandlers() []obsidian.Handler {

--- a/lte/cloud/go/plugin/handlers_test.go
+++ b/lte/cloud/go/plugin/handlers_test.go
@@ -25,12 +25,11 @@ import (
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/security/key"
-	test_utils2 "magma/orc8r/cloud/go/services/checkind/test_utils"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/device"
-	test_init3 "magma/orc8r/cloud/go/services/device/test_init"
-	test_init2 "magma/orc8r/cloud/go/services/state/test_init"
+	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
+	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
 	"magma/orc8r/cloud/go/services/state/test_utils"
 	"magma/orc8r/cloud/go/storage"
 
@@ -716,8 +715,8 @@ func TestListAndGetGateways(t *testing.T) {
 	defer clock.GetUnfreezeClockDeferFunc(t)()
 
 	test_init.StartTestService(t)
-	test_init2.StartTestService(t)
-	test_init3.StartTestService(t)
+	stateTestInit.StartTestService(t)
+	deviceTestInit.StartTestService(t)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
 	assert.NoError(t, err)
 
@@ -790,7 +789,7 @@ func TestListAndGetGateways(t *testing.T) {
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
 	assert.NoError(t, err)
 	ctx := test_utils.GetContextWithCertificate(t, "hw1")
-	test_utils.ReportGatewayStatus(t, ctx, test_utils2.GetGatewayStatusSwaggerFixture("hw1"))
+	test_utils.ReportGatewayStatus(t, ctx, models.NewDefaultGatewayStatus("hw1"))
 
 	expected := map[string]*models2.LteGateway{
 		"g1": {
@@ -811,7 +810,7 @@ func TestListAndGetGateways(t *testing.T) {
 				Epc: &models2.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
 				Ran: &models2.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 			},
-			Status: test_utils2.GetGatewayStatusSwaggerFixture("hw1"),
+			Status: models.NewDefaultGatewayStatus("hw1"),
 		},
 		"g2": {
 			ID:   "g2",
@@ -862,7 +861,7 @@ func TestListAndGetGateways(t *testing.T) {
 			Epc: &models2.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
 			Ran: &models2.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 		},
-		Status: test_utils2.GetGatewayStatusSwaggerFixture("hw1"),
+		Status: models.NewDefaultGatewayStatus("hw1"),
 	}
 	expectedGet.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
 	expectedGet.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
@@ -912,7 +911,7 @@ func TestUpdateGateway(t *testing.T) {
 	defer clock.GetUnfreezeClockDeferFunc(t)()
 
 	test_init.StartTestService(t)
-	test_init3.StartTestService(t)
+	deviceTestInit.StartTestService(t)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
 	assert.NoError(t, err)
 
@@ -1056,7 +1055,7 @@ func TestDeleteGateway(t *testing.T) {
 	defer clock.GetUnfreezeClockDeferFunc(t)()
 
 	test_init.StartTestService(t)
-	test_init3.StartTestService(t)
+	deviceTestInit.StartTestService(t)
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
 	assert.NoError(t, err)
 

--- a/orc8r/cloud/go/obsidian/tests/unit_test_utils.go
+++ b/orc8r/cloud/go/obsidian/tests/unit_test_utils.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"encoding"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -89,7 +90,7 @@ func GetHandlerByPathAndMethod(t *testing.T, handlers []obsidian.Handler, path s
 			return handler
 		}
 	}
-	assert.Fail(t, "No handler registered for path %s", path)
+	assert.Fail(t, fmt.Sprintf("No handler registered for path %s", path))
 	return obsidian.Handler{}
 }
 

--- a/orc8r/cloud/go/pluginimpl/handlers/common.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/common.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"net/http"
+	"reflect"
+
+	"magma/orc8r/cloud/go/obsidian"
+
+	"github.com/labstack/echo"
+)
+
+// ValidateModels validates the model to be according to swagger spec, as
+// well as other custom validations.
+type ValidatableModel interface {
+	ValidateModel() error
+}
+
+// GetAndValidatePayload can be used by any model that implements ValidateModel
+// Example:
+// 	payload, nerr := GetAndValidatePayload(c, &models.DNSConfigRecord{})
+//	if nerr != nil {
+//		return nil, nerr
+//	}
+//	record := payload.(*models.DNSConfigRecord)
+func GetAndValidatePayload(c echo.Context, model interface{}) (ValidatableModel, *echo.HTTPError) {
+	iModel := reflect.New(reflect.TypeOf(model).Elem()).Interface().(ValidatableModel)
+	if err := c.Bind(iModel); err != nil {
+		return nil, obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	// Run validations specified by the swagger spec
+	if err := iModel.ValidateModel(); err != nil {
+		return nil, obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	return iModel, nil
+}

--- a/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory.go
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers
+
+import (
+	"net/http"
+
+	"magma/orc8r/cloud/go/errors"
+	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/pluginimpl/models"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/device"
+
+	"github.com/labstack/echo"
+)
+
+// PartialGatewayModel describe models that represents a portion of network
+// entity that can be read and updated.
+type PartialGatewayModel interface {
+	ValidatableModel
+	// GetFromEntity grabs the desired model from the configurator network entity.
+	// Returns nil if it is not there.
+	GetFromEntity(entity configurator.NetworkEntity) interface{}
+	// ToUpdateCriteria takes in the existing network entity and applies the
+	// change from the model to create a list of EntityUpdateCriteria.
+	ToUpdateCriteria(entity configurator.NetworkEntity) ([]configurator.EntityUpdateCriteria, error)
+}
+
+// GetPartialGatewayHandlers returns both GET and PUT handlers for modifying the portion of a
+// network entity specified by the model.
+// - path : the url at which the handler will be registered.
+// - model: the input and output of the handler and it also provides GetFromEntity
+//   and ToUpdateCriteria to go between the configurator model.
+func GetPartialGatewayHandlers(path string, model PartialGatewayModel) []obsidian.Handler {
+	return []obsidian.Handler{
+		GetPartialReadGatewayHandler(path, model),
+		GetPartialUpdateGatewayHandler(path, model),
+	}
+}
+
+// GetPartialReadGatewayHandler returns a GET obsidian handler at the specified path.
+// This function loads a portion of the gateway specified by the model's GetFromEntity function.
+// Example:
+//      (m *MagmadGatewayConfigs) GetFromEntity(ent configurator.NetworkEntity) interface{} {
+// 			return entity.Configs
+// 		}
+// 		getMagmadConfigsHandler := handlers.GetPartialReadGatewayHandler(URL, &models.MagmadGatewayConfigs{})
+//
+//      would return a GET handler that can read the magmad gateway config of a gw with the specified ID.
+func GetPartialReadGatewayHandler(path string, model PartialGatewayModel) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.GET,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, gatewayID, nerr := obsidian.GetNetworkAndGatewayIDs(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadConfig: true, LoadMetadata: true, LoadAssocsFromThis: true})
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+
+			got := model.GetFromEntity(entity)
+			if got == nil {
+				return obsidian.HttpError(errors.ErrNotFound, http.StatusNotFound)
+			}
+			return c.JSON(http.StatusOK, got)
+		},
+	}
+}
+
+// GetPartialUpdateGatewayHandler returns a PUT obsidian handler at the specified path.
+// This function updates a portion of the network entity specified by the model's ToUpdateCriteria function.
+// Example:
+//      (m *MagmadGatewayConfigs) ToUpdateCriteria(ent configurator.NetworkEntity) (configurator.EntityUpdateCriteria, error) {
+// 			return configurator.EntityUpdateCriteria{
+// 				Key: ent.Key,
+//				Type: ent.Type,
+//				NewConfig: m,
+//          }
+// 		}
+// 		updateMagmadConfigsHandler := handlers.GetPartialUpdateGatewayHandler(URL, &models.MagmadGatewayConfigs{})
+//
+//      would return a PUT handler that updates the magmad gateway config of a gw with the specified ID.
+func GetPartialUpdateGatewayHandler(path string, model PartialGatewayModel) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.PUT,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, gatewayID, nerr := obsidian.GetNetworkAndGatewayIDs(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			requestedUpdate, nerr := GetAndValidatePayload(c, model)
+			if nerr != nil {
+				return nerr
+			}
+
+			entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadConfig: true, LoadMetadata: true, LoadAssocsFromThis: true})
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+
+			updates, err := requestedUpdate.(PartialGatewayModel).ToUpdateCriteria(entity)
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusBadRequest)
+			}
+			_, err = configurator.UpdateEntities(networkID, updates)
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			return c.NoContent(http.StatusNoContent)
+		},
+	}
+}
+
+// GetGatewayDeviceHandlers returns GET and PUT handlers to read and update the
+// device attached to the gateway.
+func GetGatewayDeviceHandlers(path string) []obsidian.Handler {
+	return []obsidian.Handler{
+		GetReadGatewayDeviceHandler(path),
+		GetUpdateGatewayDeviceHandler(path),
+	}
+}
+
+// GetReadGatewayDeviceHandler returns a GET handler to read the gateway record
+// of the gateway.
+func GetReadGatewayDeviceHandler(path string) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.GET,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, gatewayID, nerr := obsidian.GetNetworkAndGatewayIDs(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			physicalID, err := configurator.GetPhysicalIDOfEntity(networkID, orc8r.MagmadGatewayType, gatewayID)
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			device, err := device.GetDevice(networkID, orc8r.AccessGatewayRecordType, physicalID)
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+
+			return c.JSON(http.StatusOK, device)
+		},
+	}
+}
+
+// GetUpdateGatewayDeviceHandler returns a PUT handler to update the gateway
+// record of the gateway.
+func GetUpdateGatewayDeviceHandler(path string) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.PUT,
+		HandlerFunc: func(c echo.Context) error {
+			networkID, gatewayID, nerr := obsidian.GetNetworkAndGatewayIDs(c)
+			if nerr != nil {
+				return nerr
+			}
+			update, nerr := GetAndValidatePayload(c, &models.GatewayDevice{})
+			if nerr != nil {
+				return nerr
+			}
+
+			physicalID, err := configurator.GetPhysicalIDOfEntity(networkID, orc8r.MagmadGatewayType, gatewayID)
+			if err == errors.ErrNotFound {
+				return obsidian.HttpError(err, http.StatusNotFound)
+			} else if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			err = device.UpdateDevice(networkID, orc8r.AccessGatewayRecordType, physicalID, update)
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			return c.NoContent(http.StatusNoContent)
+		},
+	}
+}

--- a/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory_test.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory_test.go
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers_test
+
+import (
+	"fmt"
+	"testing"
+
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/pluginimpl/handlers"
+	"magma/orc8r/cloud/go/pluginimpl/models"
+	"magma/orc8r/cloud/go/services/configurator"
+	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
+	"magma/orc8r/cloud/go/services/configurator/test_utils"
+	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
+
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_GetPartialReadGatewayHandler(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configuratorTestInit.StartTestService(t)
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks"
+
+	// register a network without any configs
+	networkID := "test-network"
+	network := configurator.Network{
+		ID:          networkID,
+		Name:        "Test Network 1",
+		Description: "Test Network 1",
+	}
+
+	gatewayRoot := fmt.Sprintf("%s/:network_id/gateways/:gateway_id", testURLRoot)
+
+	// Test 404
+	getGatewayName := handlers.GetPartialReadGatewayHandler(fmt.Sprintf("%s/Name", gatewayRoot), &testName{})
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            gatewayRoot,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "gw1"},
+		Payload:        nil,
+		Handler:        getGatewayName.HandlerFunc,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	assert.NoError(t, configurator.CreateNetwork(network))
+	gateway := configurator.NetworkEntity{
+		Key:  "gw1",
+		Type: orc8r.MagmadGatewayType,
+		Name: "gateway 1",
+	}
+	_, err := configurator.CreateEntity(networkID, gateway)
+	assert.NoError(t, err)
+
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            gatewayRoot,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "gw1"},
+		Payload:        nil,
+		Handler:        getGatewayName.HandlerFunc,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler("gateway 1"),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configuratorTestInit.StartTestService(t)
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks"
+
+	// register a network without any configs
+	networkID := "test-network"
+	network := configurator.Network{
+		ID:          networkID,
+		Name:        "Test Network 1",
+		Description: "Test Network 1",
+	}
+
+	gatewayRoot := fmt.Sprintf("%s/:network_id/gateways/:gateway_id", testURLRoot)
+
+	// Test 404
+	updateGatewayName := handlers.GetPartialUpdateGatewayHandler(fmt.Sprintf("%s/Name", gatewayRoot), &testName{})
+	tc := tests.Test{
+		Method:         "PUT",
+		URL:            gatewayRoot,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "test_gateway_1"},
+		Payload:        tests.JSONMarshaler(&testName{Name: "updated Name!"}),
+		Handler:        updateGatewayName.HandlerFunc,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	assert.NoError(t, configurator.CreateNetwork(network))
+	Gateway := configurator.NetworkEntity{
+		Key:  "test_gateway_1",
+		Type: orc8r.MagmadGatewayType,
+		Name: "Gateway 1",
+	}
+	_, err := configurator.CreateEntity(networkID, Gateway)
+	assert.NoError(t, err)
+
+	// validation failure
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            gatewayRoot,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "test_gateway_1"},
+		Payload:        tests.JSONMarshaler(&testName{Name: ""}),
+		Handler:        updateGatewayName.HandlerFunc,
+		ExpectedStatus: 400,
+		ExpectedError:  "Name cannot be empty",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            gatewayRoot,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "test_gateway_1"},
+		Payload:        tests.JSONMarshaler(&testName{Name: "updated Name!"}),
+		Handler:        updateGatewayName.HandlerFunc,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	Gateway, err = configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, "test_gateway_1", configurator.EntityLoadCriteria{LoadMetadata: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "updated Name!", Gateway.Name)
+}
+
+func Test_GetGatewayDeviceHandler(t *testing.T) {
+	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configuratorTestInit.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks"
+
+	// register a network without any configs
+	networkID := "test-network"
+	test_utils.RegisterNetwork(t, networkID, "Name")
+
+	gatewayRoot := fmt.Sprintf("%s/:network_id/gateways/:gateway_id", testURLRoot)
+	getDevice := handlers.GetReadGatewayDeviceHandler(fmt.Sprintf("%s/device", gatewayRoot))
+
+	// 404
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            fmt.Sprintf("%s/device", gatewayRoot),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "test_gateway_1"},
+		Handler:        getDevice.HandlerFunc,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	test_utils.RegisterGateway(t, networkID, "test_gateway_1", &models.GatewayDevice{HardwareID: "test_hardware_id"})
+
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            fmt.Sprintf("%s/device", gatewayRoot),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{networkID, "test_gateway_1"},
+		Handler:        getDevice.HandlerFunc,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(&models.GatewayDevice{HardwareID: "test_hardware_id"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+type testName struct {
+	Name string
+}
+
+func (m *testName) ValidateModel() error {
+	if m == nil {
+		return fmt.Errorf("Cannot be nil")
+	}
+	if len(m.Name) == 0 {
+		return fmt.Errorf("Name cannot be empty")
+	}
+	return nil
+}
+
+func (m *testName) GetFromEntity(entity configurator.NetworkEntity) interface{} {
+	return entity.Name
+}
+
+func (m *testName) ToUpdateCriteria(entity configurator.NetworkEntity) ([]configurator.EntityUpdateCriteria, error) {
+	return []configurator.EntityUpdateCriteria{
+		{
+			Type:    entity.Type,
+			Key:     entity.Key,
+			NewName: swag.String(m.Name),
+		},
+	}, nil
+}

--- a/orc8r/cloud/go/pluginimpl/handlers/network_handler_factory_test.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/network_handler_factory_test.go
@@ -37,7 +37,7 @@ type (
 	}
 )
 
-func TestGetReadNetworkConfigHandler(t *testing.T) {
+func Test_GetPartialReadNetworkHandler(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	configuratorTestInit.StartTestService(t)
 	serde.RegisterSerdes(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))

--- a/orc8r/cloud/go/pluginimpl/handlers/network_handlers.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/network_handlers.go
@@ -235,13 +235,12 @@ func getExistingDNSConfig(networkID string) (*models.NetworkDNSConfig, *echo.HTT
 }
 
 func getRecordAndValidate(c echo.Context, domain string) (*models.DNSConfigRecord, *echo.HTTPError) {
-	record := &models.DNSConfigRecord{}
-	if err := c.Bind(record); err != nil {
-		return nil, obsidian.HttpError(err, http.StatusBadRequest)
+	payload, nerr := GetAndValidatePayload(c, &models.DNSConfigRecord{})
+	if nerr != nil {
+		return nil, nerr
 	}
-	if err := record.Validate(strfmt.Default); err != nil {
-		return nil, obsidian.HttpError(err, http.StatusBadRequest)
-	}
+	record := payload.(*models.DNSConfigRecord)
+
 	if record.Domain != domain {
 		return nil, obsidian.HttpError(fmt.Errorf("Domain name in param and record don't match"), http.StatusBadRequest)
 	}

--- a/orc8r/cloud/go/pluginimpl/models/defaults.go
+++ b/orc8r/cloud/go/pluginimpl/models/defaults.go
@@ -44,3 +44,75 @@ func NewDefaultNetwork(networkID string, name string, description string) *Netwo
 		Features:    NewDefaultFeaturesConfig(),
 	}
 }
+
+func NewDefaultGatewayStatus(hardwareID string) *GatewayStatus {
+	return &GatewayStatus{
+		CheckinTime:        0,
+		CertExpirationTime: 0,
+		Meta:               map[string]string{"hello": "world"},
+		SystemStatus: &SystemStatus{
+			Time:       1495484735606,
+			CPUUser:    31498,
+			CPUSystem:  8361,
+			CPUIDLE:    1869111,
+			MemTotal:   1016084,
+			MemUsed:    54416,
+			MemFree:    412772,
+			UptimeSecs: 1234,
+			SwapTotal:  1016081,
+			SwapUsed:   54415,
+			SwapFree:   412771,
+			DiskPartitions: []*DiskPartition{
+				{
+					Device:     "/dev/sda1",
+					MountPoint: "/",
+					Total:      1,
+					Used:       2,
+					Free:       3,
+				},
+			},
+		},
+		PlatformInfo: &PlatformInfo{
+			VpnIP: "facebook.com",
+			Packages: []*Package{
+				{
+					Name:    "magma",
+					Version: "0.0.0.0",
+				},
+			},
+			KernelVersion:           "42",
+			KernelVersionsInstalled: []string{"42", "43"},
+			ConfigInfo: &ConfigInfo{
+				MconfigCreatedAt: 1552968732,
+			},
+		},
+		MachineInfo: &MachineInfo{
+			CPUInfo: &MachineInfoCPUInfo{
+				CoreCount:      4,
+				ThreadsPerCore: 1,
+				Architecture:   "x86_64",
+				ModelName:      "Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz",
+			},
+			NetworkInfo: &MachineInfoNetworkInfo{
+				NetworkInterfaces: []*NetworkInterface{
+					{
+						NetworkInterfaceID: "gtp_br0",
+						Status:             NetworkInterfaceStatusUP,
+						MacAddress:         "08:00:27:1e:8a:32",
+						IPAddresses:        []string{"10.10.10.1"},
+						IPV6Addresses:      []string{"fe80::a00:27ff:fe1e:8332"},
+					},
+				},
+				RoutingTable: []*Route{
+					{
+						DestinationIP:      "0.0.0.0",
+						GatewayIP:          "10.10.10.1",
+						Genmask:            "255.255.255.0",
+						NetworkInterfaceID: "eth0",
+					},
+				},
+			},
+		},
+		HardwareID: hardwareID,
+	}
+}

--- a/orc8r/cloud/go/pluginimpl/models/validate.go
+++ b/orc8r/cloud/go/pluginimpl/models/validate.go
@@ -31,6 +31,10 @@ func (m NetworkDNSRecords) ValidateModel() error {
 	return m.Validate(strfmt.Default)
 }
 
+func (m DNSConfigRecord) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}
+
 func (m *MagmadGateway) ValidateModel() error {
 	return m.Validate(strfmt.Default)
 }

--- a/orc8r/cloud/go/services/checkind/obsidian/handlers/checkindh_test.go
+++ b/orc8r/cloud/go/services/checkind/obsidian/handlers/checkindh_test.go
@@ -10,16 +10,14 @@ package handlers_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
-	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/pluginimpl/models"
 	checkindTestInit "magma/orc8r/cloud/go/services/checkind/test_init"
-	"magma/orc8r/cloud/go/services/checkind/test_utils"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
 	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
@@ -33,7 +31,6 @@ const testAgHwId = "Test-AGW-Hw-Id"
 // TestCheckind is Obsidian Gateway Status Integration Test intended to be run
 // on cloud VM
 func TestCheckind(t *testing.T) {
-	os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	configuratorTestInit.StartTestService(t)
 	checkindTestInit.StartTestService(t)
@@ -57,11 +54,9 @@ func TestCheckind(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	ctx := stateTestUtils.GetContextWithCertificate(t, testAgHwId)
-
 	// put one checkin state into state service
-	gwStatus := test_utils.GetGatewayStatusSwaggerFixture(testAgHwId)
-
+	ctx := stateTestUtils.GetContextWithCertificate(t, testAgHwId)
+	gwStatus := models.NewDefaultGatewayStatus(testAgHwId)
 	stateTestUtils.ReportGatewayStatus(t, ctx, gwStatus)
 
 	getGWStatusNoError(t, restPort, networkID, testAgHwId)

--- a/orc8r/cloud/go/services/checkind/servicers/checkind_test.go
+++ b/orc8r/cloud/go/services/checkind/servicers/checkind_test.go
@@ -15,12 +15,12 @@ import (
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/registry"
 	"magma/orc8r/cloud/go/services/checkind"
-	checkind_test_init "magma/orc8r/cloud/go/services/checkind/test_init"
+	"magma/orc8r/cloud/go/services/checkind/test_init"
 	"magma/orc8r/cloud/go/services/checkind/test_utils"
-	logger_test_init "magma/orc8r/cloud/go/services/logger/test_init"
+	loggerTestInit "magma/orc8r/cloud/go/services/logger/test_init"
 	"magma/orc8r/cloud/go/services/magmad"
-	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+	magmadProtos "magma/orc8r/cloud/go/services/magmad/protos"
+	magmadTestInit "magma/orc8r/cloud/go/services/magmad/test_init"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -58,12 +58,12 @@ func checkinRound(t *testing.T,
 }
 
 func TestCheckind(t *testing.T) {
-	magmad_test_init.StartTestService(t)
-	checkind_test_init.StartTestService(t)
-	logger_test_init.StartTestService(t)
+	magmadTestInit.StartTestService(t)
+	test_init.StartTestService(t)
+	loggerTestInit.StartTestService(t)
 
 	testNetworkId, err := magmad.RegisterNetwork(
-		&magmad_protos.MagmadNetworkRecord{Name: "Test Network Name"},
+		&magmadProtos.MagmadNetworkRecord{Name: "Test Network Name"},
 		"checkind_servicers_test_network")
 	assert.NoError(t, err)
 
@@ -71,14 +71,14 @@ func TestCheckind(t *testing.T) {
 
 	hwId := protos.AccessGatewayID{Id: testAgHwId}
 	logicalId, err := magmad.RegisterGateway(testNetworkId,
-		&magmad_protos.AccessGatewayRecord{HwId: &hwId, Name: "Test GW Name"})
+		&magmadProtos.AccessGatewayRecord{HwId: &hwId, Name: "Test GW Name"})
 	assert.NoError(t, err)
 	assert.NotEqual(t, logicalId, "")
 
 	testAgHwId2 := testAgHwId + "second"
 	hwId = protos.AccessGatewayID{Id: testAgHwId2}
 	logicalId2, err := magmad.RegisterGateway(
-		testNetworkId, &magmad_protos.AccessGatewayRecord{HwId: &hwId, Name: "bla2"})
+		testNetworkId, &magmadProtos.AccessGatewayRecord{HwId: &hwId, Name: "bla2"})
 	assert.NoError(t, err)
 	assert.NotEqual(t, logicalId2, "")
 

--- a/orc8r/cloud/go/services/checkind/store/store_test.go
+++ b/orc8r/cloud/go/services/checkind/store/store_test.go
@@ -14,12 +14,12 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/protos"
-	checkin_store "magma/orc8r/cloud/go/services/checkind/store"
-	checkin_test_utils "magma/orc8r/cloud/go/services/checkind/test_utils"
-	logger_test_init "magma/orc8r/cloud/go/services/logger/test_init"
+	checkinStore "magma/orc8r/cloud/go/services/checkind/store"
+	checkinTestUtils "magma/orc8r/cloud/go/services/checkind/test_utils"
+	loggerTestInit "magma/orc8r/cloud/go/services/logger/test_init"
 	"magma/orc8r/cloud/go/services/magmad"
-	magmad_protos "magma/orc8r/cloud/go/services/magmad/protos"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
+	magmadProtos "magma/orc8r/cloud/go/services/magmad/protos"
+	magmadTestInit "magma/orc8r/cloud/go/services/magmad/test_init"
 	"magma/orc8r/cloud/go/test_utils"
 
 	"github.com/stretchr/testify/assert"
@@ -28,23 +28,23 @@ import (
 const testAgHwId = "test_ag_HW_id"
 
 func TestCheckinStore(t *testing.T) {
-	magmad_test_init.StartTestService(t)
-	logger_test_init.StartTestService(t)
+	magmadTestInit.StartTestService(t)
+	loggerTestInit.StartTestService(t)
 	testNetworkName := "Gateway Checkin Test Network"
-	store, err := checkin_store.NewCheckinStore(test_utils.NewMockDatastore())
+	store, err := checkinStore.NewCheckinStore(test_utils.NewMockDatastore())
 	assert.NoError(t, err)
 
 	testNetworkId, err := magmad.RegisterNetwork(
-		&magmad_protos.MagmadNetworkRecord{Name: testNetworkName},
+		&magmadProtos.MagmadNetworkRecord{Name: testNetworkName},
 		"checkind_store_test_network")
 	assert.NoError(t, err)
 
 	logicalId, err :=
-		magmad.RegisterGateway(testNetworkId, &magmad_protos.AccessGatewayRecord{HwId: &protos.AccessGatewayID{Id: testAgHwId}})
+		magmad.RegisterGateway(testNetworkId, &magmadProtos.AccessGatewayRecord{HwId: &protos.AccessGatewayID{Id: testAgHwId}})
 	assert.NoError(t, err)
 	assert.NotEqual(t, logicalId, "")
 
-	status := checkin_test_utils.GetGatewayStatusProtoFixture(testAgHwId)
+	status := checkinTestUtils.GetGatewayStatusProtoFixture(testAgHwId)
 
 	err = store.UpdateGatewayStatus(status)
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/checkind/test_utils/utils.go
+++ b/orc8r/cloud/go/services/checkind/test_utils/utils.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"testing"
 
-	models2 "magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/registry"
 	"magma/orc8r/cloud/go/services/checkind"
@@ -108,81 +107,5 @@ func GetGatewayStatusProtoFixture(gatewayId string) *protos.GatewayStatus {
 	return &protos.GatewayStatus{
 		Time:    0,
 		Checkin: GetCheckinRequestProtoFixture(gatewayId),
-	}
-}
-
-func GetGatewayStatusSwaggerFixture(gatewayId string) *models2.GatewayStatus {
-	return &models2.GatewayStatus{
-		CheckinTime:        0,
-		CertExpirationTime: 0,
-		Meta:               map[string]string{"hello": "world"},
-		SystemStatus: &models2.SystemStatus{
-			Time:       1495484735606,
-			CPUUser:    31498,
-			CPUSystem:  8361,
-			CPUIDLE:    1869111,
-			MemTotal:   1016084,
-			MemUsed:    54416,
-			MemFree:    412772,
-			UptimeSecs: 1234,
-			SwapTotal:  1016081,
-			SwapUsed:   54415,
-			SwapFree:   412771,
-			DiskPartitions: []*models2.DiskPartition{
-				{
-					Device:     "/dev/sda1",
-					MountPoint: "/",
-					Total:      1,
-					Used:       2,
-					Free:       3,
-				},
-			},
-		},
-		PlatformInfo: &models2.PlatformInfo{
-			VpnIP: "facebook.com",
-			Packages: []*models2.Package{
-				{
-					Name:    "magma",
-					Version: "0.0.0.0",
-				},
-			},
-			KernelVersion:           "42",
-			KernelVersionsInstalled: []string{"42", "43"},
-			ConfigInfo: &models2.ConfigInfo{
-				MconfigCreatedAt: 1552968732,
-			},
-		},
-		MachineInfo: &models2.MachineInfo{
-			CPUInfo: &models2.MachineInfoCPUInfo{
-				CoreCount:      4,
-				ThreadsPerCore: 1,
-				Architecture:   "x86_64",
-				ModelName:      "Intel(R) Core(TM) i9-8950HK CPU @ 2.90GHz",
-			},
-			NetworkInfo: &models2.MachineInfoNetworkInfo{
-				NetworkInterfaces: []*models2.NetworkInterface{
-					{
-						NetworkInterfaceID: "gtp_br0",
-						Status:             models2.NetworkInterfaceStatusUP,
-						MacAddress:         "08:00:27:1e:8a:32",
-						IPAddresses:        []string{"10.10.10.1"},
-						IPV6Addresses:      []string{"fe80::a00:27ff:fe1e:8332"},
-					},
-				},
-				RoutingTable: []*models2.Route{
-					{
-						DestinationIP:      "0.0.0.0",
-						GatewayIP:          "10.10.10.1",
-						Genmask:            "255.255.255.0",
-						NetworkInterfaceID: "eth0",
-					},
-				},
-			},
-		},
-		HardwareID:              gatewayId,
-		KernelVersion:           "42",
-		KernelVersionsInstalled: []string{"42", "43"},
-		Version:                 "0.0.0.0",
-		VpnIP:                   "facebook.com",
 	}
 }

--- a/orc8r/cloud/go/services/device/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/device/test_init/test_service_init.go
@@ -17,6 +17,8 @@ import (
 	"magma/orc8r/cloud/go/services/device/protos"
 	"magma/orc8r/cloud/go/services/device/servicers"
 	"magma/orc8r/cloud/go/test_utils"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // StartTestService instantiates a service backed by an in-memory storage
@@ -24,9 +26,7 @@ func StartTestService(t *testing.T) {
 	factory := blobstore.NewMemoryBlobStorageFactory()
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, device.ServiceName)
 	server, err := servicers.NewDeviceServicer(factory)
-	if err != nil {
-		t.Fatalf("Failure to start state test service: %v", err)
-	}
+	assert.NoError(t, err)
 	protos.RegisterDeviceServer(srv.GrpcServer, server)
 	go srv.RunTest(lis)
 }

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/gateways_full_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/gateways_full_test.go
@@ -11,32 +11,27 @@ package handlers_test
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"testing"
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/obsidian/tests"
-	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
-	"magma/orc8r/cloud/go/services/checkind/test_utils"
-	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
-	device_test_init "magma/orc8r/cloud/go/services/device/test_init"
+	"magma/orc8r/cloud/go/pluginimpl/models"
+	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
+	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
 	"magma/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory"
-	magmad_test_init "magma/orc8r/cloud/go/services/magmad/test_init"
-	state_test_init "magma/orc8r/cloud/go/services/state/test_init"
-	state_test_utils "magma/orc8r/cloud/go/services/state/test_utils"
+	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
+	stateTestUtils "magma/orc8r/cloud/go/services/state/test_utils"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestGetViewsForNetwork_Full(t *testing.T) {
-	_ = os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	configurator_test_init.StartTestService(t)
-	device_test_init.StartTestService(t)
-	state_test_init.StartTestService(t)
-	magmad_test_init.StartTestService(t)
+	configuratorTestInit.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
 	restPort := tests.StartObsidian(t)
 
 	testURLRoot := fmt.Sprintf(
@@ -100,9 +95,9 @@ func TestGetViewsForNetwork_Full(t *testing.T) {
 	tests.RunTest(t, getGatewaysFullView)
 
 	// Test Gateway Full View with state
-	ctx := state_test_utils.GetContextWithCertificate(t, "TestAGHwId00001")
-	gwStatus := test_utils.GetGatewayStatusSwaggerFixture("TestAGHwId00001")
-	state_test_utils.ReportGatewayStatus(t, ctx, gwStatus)
+	ctx := stateTestUtils.GetContextWithCertificate(t, "TestAGHwId00001")
+	gwStatus := models.NewDefaultGatewayStatus("TestAGHwId00001")
+	stateTestUtils.ReportGatewayStatus(t, ctx, gwStatus)
 	status, response, err := tests.SendHttpRequest("GET", fmt.Sprintf("%s/%s/gateways?view=full", testURLRoot, networkID), "")
 	assert.NoError(t, err)
 	assert.Equal(t, 200, status)

--- a/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory_test.go
+++ b/orc8r/cloud/go/services/magmad/obsidian/handlers/view_factory/factory_test.go
@@ -9,13 +9,11 @@ LICENSE file in the root directory of this source tree.
 package view_factory_test
 
 import (
-	"os"
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/serde"
-	checkintu "magma/orc8r/cloud/go/services/checkind/test_utils"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorti "magma/orc8r/cloud/go/services/configurator/test_init"
 	configuratortu "magma/orc8r/cloud/go/services/configurator/test_utils"
@@ -35,7 +33,6 @@ var cfg1 = &storagetu.Conf1{Value1: 1, Value2: "foo", Value3: []byte("bar")}
 var cfg2 = &storagetu.Conf2{Value1: []string{"foo", "bar"}, Value2: 1}
 
 func TestFullGatewayViewFactoryImpl_GetGatewayViewsForNetwork(t *testing.T) {
-	_ = os.Setenv(orc8r.UseConfiguratorEnv, "1")
 	// Test setup
 	configuratorti.StartTestService(t)
 	deviceti.StartTestService(t)
@@ -103,7 +100,7 @@ func TestFullGatewayViewFactoryImpl_GetGatewayViewsForNetwork(t *testing.T) {
 
 	// put status into gw1
 	ctx := statetu.GetContextWithCertificate(t, hwID1)
-	gwStatus := checkintu.GetGatewayStatusSwaggerFixture(hwID1)
+	gwStatus := models.NewDefaultGatewayStatus(hwID1)
 	statetu.ReportGatewayStatus(t, ctx, gwStatus)
 
 	fact := &view_factory.FullGatewayViewFactoryImpl{}
@@ -126,7 +123,7 @@ func TestFullGatewayViewFactoryImpl_GetGatewayViewsForNetwork(t *testing.T) {
 				orc8r.MagmadGatewayType:                             nil,
 			},
 			Name:   "111",
-			Status: checkintu.GetGatewayStatusSwaggerFixture(hwID1),
+			Status: models.NewDefaultGatewayStatus(hwID1),
 			Record: record1,
 		},
 		gatewayID2: {

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -54,7 +54,7 @@ type StateID struct {
 var connSingleton = (*grpc.ClientConn)(nil)
 var connGuard = sync.Mutex{}
 
-func getStateClient() (protos.StateServiceClient, error) {
+func GetStateClient() (protos.StateServiceClient, error) {
 	if connSingleton == nil {
 		// Reading the conn optimistically to avoid unnecessary overhead
 		connGuard.Lock()
@@ -75,7 +75,7 @@ func getStateClient() (protos.StateServiceClient, error) {
 
 // GetState returns the state specified by the networkID, typeVal, and hwID
 func GetState(networkID string, typeVal string, hwID string) (State, error) {
-	client, err := getStateClient()
+	client, err := GetStateClient()
 	if err != nil {
 		return State{}, err
 	}
@@ -103,7 +103,7 @@ func GetState(networkID string, typeVal string, hwID string) (State, error) {
 
 // GetStates returns a map of states specified by the networkID and a list of type and key
 func GetStates(networkID string, stateIDs []StateID) (map[StateID]State, error) {
-	client, err := getStateClient()
+	client, err := GetStateClient()
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +132,7 @@ func GetStates(networkID string, stateIDs []StateID) (map[StateID]State, error) 
 
 // DeleteStates deletes states specified by the networkID and a list of type and key
 func DeleteStates(networkID string, stateIDs []StateID) error {
-	client, err := getStateClient()
+	client, err := GetStateClient()
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/state/obsidian/handlers/stateh_test.go
+++ b/orc8r/cloud/go/services/state/obsidian/handlers/stateh_test.go
@@ -16,7 +16,6 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/pluginimpl/models"
-	checkindTestUtils "magma/orc8r/cloud/go/services/checkind/test_utils"
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
 	configuratorTestUtils "magma/orc8r/cloud/go/services/configurator/test_utils"
 	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
@@ -43,7 +42,7 @@ func TestState(t *testing.T) {
 	ctx := test_utils.GetContextWithCertificate(t, testAgHwId)
 
 	// put one checkin state into state service
-	gwStatus := checkindTestUtils.GetGatewayStatusSwaggerFixture(testAgHwId)
+	gwStatus := models.NewDefaultGatewayStatus(testAgHwId)
 	test_utils.ReportGatewayStatus(t, ctx, gwStatus)
 
 	getStateNoError(t, restPort, testNetworkID)

--- a/orc8r/cloud/go/services/state/servicers/servicer.go
+++ b/orc8r/cloud/go/services/state/servicers/servicer.go
@@ -16,7 +16,7 @@ import (
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/protos"
-	state_service "magma/orc8r/cloud/go/services/state"
+	stateService "magma/orc8r/cloud/go/services/state"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
@@ -116,7 +116,7 @@ func (srv *stateServicer) DeleteStates(context context.Context, req *protos.Dele
 }
 
 func wrapStateWithAdditionalInfo(state *protos.State, hwID string, time uint64, certExpiry int64) ([]byte, error) {
-	wrap := state_service.SerializedStateWithMeta{
+	wrap := stateService.SerializedStateWithMeta{
 		ReporterID:              hwID,
 		Time:                    time,
 		CertExpirationTime:      certExpiry,

--- a/orc8r/cloud/go/services/state/test_init/test_service_init.go
+++ b/orc8r/cloud/go/services/state/test_init/test_service_init.go
@@ -17,6 +17,8 @@ import (
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/servicers"
 	"magma/orc8r/cloud/go/test_utils"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // StartTestService instantiates a service backed by an in-memory storage
@@ -24,9 +26,7 @@ func StartTestService(t *testing.T) {
 	factory := blobstore.NewMemoryBlobStorageFactory()
 	srv, lis := test_utils.NewTestService(t, orc8r.ModuleName, state.ServiceName)
 	server, err := servicers.NewStateServicer(factory)
-	if err != nil {
-		t.Fatalf("Failure to start state test service: %v", err)
-	}
+	assert.NoError(t, err)
 	protos.RegisterStateServiceServer(srv.GrpcServer, server)
 	go srv.RunTest(lis)
 }

--- a/orc8r/cloud/go/services/state/test_utils/utils.go
+++ b/orc8r/cloud/go/services/state/test_utils/utils.go
@@ -9,7 +9,6 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/protos"
-	"magma/orc8r/cloud/go/registry"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/service/middleware/unary/test_utils"
 	"magma/orc8r/cloud/go/services/state"
@@ -20,9 +19,8 @@ import (
 )
 
 func ReportGatewayStatus(t *testing.T, ctx context.Context, req *models.GatewayStatus) {
-	conn, err := registry.GetConnection(state.ServiceName)
+	client, err := state.GetStateClient()
 	assert.NoError(t, err)
-	client := protos.NewStateServiceClient(conn)
 
 	serializedGWStatus, err := serde.Serialize(state.SerdeDomain, orc8r.GatewayStateType, req)
 	assert.NoError(t, err)


### PR DESCRIPTION
Summary:
Added the following to have a generic way to modify all entity components that implement PartialEntityModels as well as reading the physical device/state attached to the entity.
The setup is relatively similar to the PartialNetwork Update/Read framework. The main difference is that we pass in paramName to grab the appropriate entityKey, and the entityType.

- `GetPartialReadGatewayHandler(path string, model PartialGatewayModel) obsidian.Handler`
- `GetPartialUpdateGatewayHandler(path string, model PartialGatewayModel) obsidian.Handler`
- `GetReadGatewayStateHandler(path string) obsidian.Handler`
- `GetReadGatewayDeviceHandler(path string) obsidian.Handler`

Reviewed By: xjtian

Differential Revision: D16912731

