### PR TITLE
Upgrade magmad image to bionic to allow for proxied github clones

### DIFF
--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
       - /etc/snowflake:/etc/snowflake
       - /var/run/docker.sock:/var/run/docker.sock
-    command: python3 -m magma.magmad.main
+    command: python3.5 -m magma.magmad.main
 
   pipelined:
     <<: *ltepyservice

--- a/feg/gateway/docker/docker-compose.override.yml
+++ b/feg/gateway/docker/docker-compose.override.yml
@@ -64,7 +64,7 @@ services:
       - |
          ip -4 route list match 0/0 | awk '{print $$3 " controller.magma.test"}' >> /etc/hosts
          ip -4 route list match 0/0 | awk '{print $$3 " bootstrapper-controller.magma.test"}' >> /etc/hosts
-         python3 -m magma.magmad.main
+         python3.5 -m magma.magmad.main
 
   radius:
     build:

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -134,7 +134,7 @@ services:
       DOCKER_REGISTRY: ${DOCKER_REGISTRY}
       DOCKER_USERNAME: ${DOCKER_USERNAME}
       DOCKER_PASSWORD: ${DOCKER_PASSWORD}
-    command: python3 -m magma.magmad.main
+    command: python3.5 -m magma.magmad.main
 
   redis:
     <<: *pyservice

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -1,10 +1,11 @@
 # -----------------------------------------------------------------------------
 # Builder image to generate proto files
 # -----------------------------------------------------------------------------
-FROM ubuntu:xenial AS builder
+FROM ubuntu:bionic AS builder
 
 # Install the runtime deps from apt.
-RUN apt-get -y update && apt-get -y install curl make virtualenv zip
+RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
+ apt-utils software-properties-common apt-transport-https
 
 # Install protobuf compiler.
 RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
@@ -14,6 +15,10 @@ RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc
   cp -r protoc3/include/google /usr/include/ && \
   chmod -R a+Xr /usr/include/google && \
   rm -rf protoc3.zip protoc3
+
+# Install python3.5 since it's not native on bionic
+RUN apt-add-repository "ppa:deadsnakes/ppa"
+RUN apt-get -y update && apt-get -y install python3.5
 
 ENV MAGMA_ROOT /magma
 ENV PYTHON_BUILD /build/python
@@ -32,7 +37,7 @@ RUN make -C $MAGMA_ROOT/lte/gateway/python protos
 # -----------------------------------------------------------------------------
 # Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:xenial AS gateway_python
+FROM ubuntu:bionic AS gateway_python
 
 # Add the magma apt repo
 RUN apt-get update && \
@@ -41,12 +46,16 @@ COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ xenial main"
 
+# Install python3.5 since it's not native on bionic
+RUN apt-add-repository "ppa:deadsnakes/ppa"
+RUN apt-get -y update && apt-get -y install python3.5
+
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install \
   curl \
+  iproute2 \
   libc-ares2 \
   libev4 \
-  libevent-openssl-2.0-5 \
   libffi-dev \
   libjansson4 \
   libjemalloc1 \
@@ -59,6 +68,7 @@ RUN apt-get -y update && apt-get -y install \
   pkg-config \
   python-cffi \
   python3-pip \
+  python3.5-dev \
   redis-server \
   git
 
@@ -74,7 +84,7 @@ RUN chmod 755 /usr/bin/docker-compose
 
 # Install python code.
 COPY orc8r/gateway/python /tmp/orc8r
-RUN pip3 install /tmp/orc8r
+RUN python3.5 -m pip install /tmp/orc8r
 
 # Copy the build artifacts.
 COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/


### PR DESCRIPTION
Summary:
This diff updates the base image used for magmad to bionic. This is necessary
to allow for FeG updates to be proxied through the orc8r. Specifically, the libcurl
version included in Xenial is too old to be used with an HTTPS proxy. As such, when
we clone the github repo to extract to new docker-compose file, the clone fails.

Unfortunately, there are no suitable backports for this library,
so the only option seems to be to upgrade. Since we use python3.5 and python3.6 comes
by default on bionic, we must install from the python `deadsnakes` PPA.

Reviewed By: xjtian

Differential Revision: D16935073

