### PR TITLE
Parallel process families for prometheus cache scrape with a worker pool

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/cache/cache.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/cache/cache.go
@@ -176,6 +176,7 @@ func (c *MetricCache) exposeMetrics(metricFamiliesByName map[string]*familyAndMe
 	case respStr := <-respStrChannel:
 		return respStr
 	case <-time.After(time.Duration(c.scrapeTimeout) * time.Second):
+		glog.Errorf("Timeout reached for building metrics string. Returning empty string.")
 		return ""
 	}
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/cache/cache_benchmark_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/cache/cache_benchmark_test.go
@@ -37,7 +37,7 @@ const (
 func BenchmarkReceiveMetrics(b *testing.B) {
 	familiesMap := prepareNewFamiliesMap(powersOfTenToTest)
 
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 
 	req := httptest.NewRequest(http.MethodPost, "/", strings.NewReader(generateRandomMetricsString(0)))
 	rec := httptest.NewRecorder()
@@ -62,7 +62,7 @@ func BenchmarkReceiveMetrics(b *testing.B) {
 func BenchmarkScrapeMetrics(b *testing.B) {
 	familiesMap := prepareNewFamiliesMap(powersOfTenToTest)
 
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 
 	req := httptest.NewRequest(http.MethodGet, "/", nil)
 	rec := httptest.NewRecorder()
@@ -105,7 +105,7 @@ func prepareNewFamiliesMap(powersOfTen []int) map[int]map[string]*familyAndMetri
 	familiesMap := make(map[int]map[string]*familyAndMetrics)
 
 	for _, n := range powersOfTen {
-		cache := NewMetricCache(0)
+		cache := NewMetricCache(0, 10)
 		total := int(math.Pow(10, float64(n)))
 		insertNRecordsIntoCacheBucketRange(cache, total, 0, numBucketsToTest[0])
 		familiesMap[int(n)] = cache.metricFamiliesByName

--- a/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/cache/cache_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/cache/cache_test.go
@@ -55,7 +55,7 @@ var (
 )
 
 func TestReceiveMetrics(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	resp, err := receiveString(cache, sampleReceiveString)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, resp.Code)
@@ -66,7 +66,7 @@ func TestReceiveMetrics(t *testing.T) {
 }
 
 func TestReceiveOverLimit(t *testing.T) {
-	cache := NewMetricCache(1)
+	cache := NewMetricCache(1, 10)
 	resp, err := receiveString(cache, sampleReceiveString)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusNotAcceptable, resp.Code)
@@ -76,7 +76,7 @@ func TestReceiveOverLimit(t *testing.T) {
 }
 
 func TestReceiveBadMetrics(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	resp, _ := receiveString(cache, "bad metric string")
 	assert.Equal(t, http.StatusBadRequest, resp.Code)
 }
@@ -91,7 +91,7 @@ func receiveString(cache *MetricCache, receiveString string) (*httptest.Response
 }
 
 func TestScrape(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	_, err := receiveString(cache, sampleReceiveString)
 	assert.NoError(t, err)
 
@@ -124,7 +124,7 @@ func TestScrapeBadMetrics(t *testing.T) {
 }
 
 func TestDebugEndpoint(t *testing.T) {
-	cache := NewMetricCache(20)
+	cache := NewMetricCache(20, 10)
 	_, err := receiveString(cache, sampleReceiveString)
 	assert.NoError(t, err)
 
@@ -154,7 +154,7 @@ func TestCacheMetrics(t *testing.T) {
 }
 
 func cacheSingleFamily(t *testing.T, metricsInFamily int) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	mf := makeFamily(dto.MetricType_GAUGE, "metricA", metricsInFamily, testLabels, timestamp)
 	metrics := map[string]*dto.MetricFamily{"metricA": mf}
 
@@ -170,7 +170,7 @@ func cacheSingleFamily(t *testing.T, metricsInFamily int) {
 }
 
 func cacheMultipleFamilies(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	mf1 := makeFamily(dto.MetricType_GAUGE, "mf1", 5, testLabels, timestamp)
 	mf2 := makeFamily(dto.MetricType_GAUGE, "mf2", 10, testLabels, timestamp)
 	metrics := map[string]*dto.MetricFamily{"mf1": mf1, "mf2": mf2}
@@ -194,7 +194,7 @@ func cacheMultipleFamilies(t *testing.T) {
 }
 
 func cacheMultipleSeries(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	mf1 := makeFamily(dto.MetricType_GAUGE, "mf1", 1, testLabels, timestamp)
 	mf2 := makeFamily(dto.MetricType_GAUGE, "mf1", 1, []*dto.LabelPair{}, timestamp)
 	mf1Map := map[string]*dto.MetricFamily{"mf1": mf1}
@@ -210,7 +210,7 @@ func cacheMultipleSeries(t *testing.T) {
 }
 
 func assertTimestampsSortedProperly(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	counterValues := []float64{123, 234, 456}
 	counterTimes := []int64{1, 2, 3}
 	counter1 := dto.Counter{
@@ -252,7 +252,7 @@ mf1 456 3
 }
 
 func assertWorkerPoolHandlesError(t *testing.T) {
-	cache := NewMetricCache(0)
+	cache := NewMetricCache(0, 10)
 	counterValues := []float64{123, 234, 456}
 	counterTimes := []int64{1, 2, 3}
 	counter1 := dto.Counter{

--- a/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/main.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/prometheus-cache/main.go
@@ -18,16 +18,18 @@ import (
 )
 
 const (
-	defaultPort  = "9091"
-	defaultLimit = -1
+	defaultPort          = "9091"
+	defaultLimit         = -1
+	defaultScrapeTimeout = 10 // seconds
 )
 
 func main() {
 	port := flag.String("port", defaultPort, fmt.Sprintf("Port to listen for requests. Default is %s", defaultPort))
 	totalMetricsLimit := flag.Int("limit", defaultLimit, fmt.Sprintf("Limit the total metrics in the cache at one time. Will reject a push if cache is full. Default is %d which is no limit.", defaultLimit))
+	scrapeTimeout := flag.Int("scrapeTimeout", defaultScrapeTimeout, fmt.Sprintf("Timeout for scrape calls. Default is %d", defaultScrapeTimeout))
 	flag.Parse()
 
-	metricCache := cache.NewMetricCache(*totalMetricsLimit)
+	metricCache := cache.NewMetricCache(*totalMetricsLimit, *scrapeTimeout)
 	e := echo.New()
 
 	e.POST("/metrics", metricCache.Receive)


### PR DESCRIPTION
In scrape, we iterate over the families to convert them to a string one by one. This can be done concurrently. I implement a worker pool to ensure we don't run out of memory when there are too many buckets. 

I can't seem to run the benchmark tests on my end, so I'm not sure if the worker pool should be larger or smaller.