### PR TITLE
Add name, description, state, device, magmad config endpoints for generic and lte gateway

### DIFF
--- a/lte/cloud/go/plugin/handlers.go
+++ b/lte/cloud/go/plugin/handlers.go
@@ -54,6 +54,7 @@ const (
 	ManageGatewayConfigPath      = ManageGatewayPath + obsidian.UrlSep + "magmad"
 	ManageGatewayDevicePath      = ManageGatewayPath + obsidian.UrlSep + "device"
 	ManageGatewayStatePath       = ManageGatewayPath + obsidian.UrlSep + "state"
+	ManageGatewayTierPath        = ManageGatewayPath + obsidian.UrlSep + "tier"
 )
 
 func GetHandlers() []obsidian.Handler {
@@ -74,6 +75,7 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.DELETE, HandlerFunc: deleteGateway},
+		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: handlers.GetStateHandler},
 	}
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "")...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "")...)
@@ -84,6 +86,12 @@ func GetHandlers() []obsidian.Handler {
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularEpcPath, &ltemodels.NetworkEpcConfigs{}, "")...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularRanPath, &ltemodels.NetworkRanConfigs{}, "")...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularFegNetworkID, new(ltemodels.FegNetworkID), "")...)
+
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8rmodels.MagmadGatewayConfigs{})...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8rmodels.TierID))...)
+	ret = append(ret, handlers.GetGatewayDeviceHandlers(ManageGatewayDevicePath)...)
 	return ret
 }
 
@@ -233,7 +241,6 @@ func listGateways(c echo.Context) error {
 	if err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load statuses"), http.StatusInternalServerError)
 	}
-
 	return c.JSON(http.StatusOK, makeLTEGateways(entsByTK, devicesByID, statusesByID))
 }
 

--- a/orc8r/cloud/go/models/conversion.go
+++ b/orc8r/cloud/go/models/conversion.go
@@ -9,6 +9,7 @@
 package models
 
 import (
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 
 	"github.com/go-openapi/swag"
@@ -45,4 +46,42 @@ func (m *NetworkDescription) ToUpdateCriteria(network configurator.Network) (con
 
 func (m *NetworkDescription) GetFromNetwork(network configurator.Network) interface{} {
 	return NetworkDescription(network.Description)
+}
+
+func (m *GatewayName) ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
+	return []configurator.EntityUpdateCriteria{
+		{
+			Key:     gatewayID,
+			Type:    orc8r.MagmadGatewayType,
+			NewName: swag.String(string(*m)),
+		},
+	}, nil
+}
+
+func (m *GatewayName) FromBackendModels(networkID string, gatewayID string) error {
+	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadMetadata: true})
+	if err != nil {
+		return err
+	}
+	*m = GatewayName(entity.Name)
+	return nil
+}
+
+func (m *GatewayDescription) ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
+	return []configurator.EntityUpdateCriteria{
+		{
+			Key:            gatewayID,
+			Type:           orc8r.MagmadGatewayType,
+			NewDescription: swag.String(string(*m)),
+		},
+	}, nil
+}
+
+func (m *GatewayDescription) FromBackendModels(networkID string, gatewayID string) error {
+	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadMetadata: true})
+	if err != nil {
+		return err
+	}
+	*m = GatewayDescription(entity.Description)
+	return nil
 }

--- a/orc8r/cloud/go/models/validate.go
+++ b/orc8r/cloud/go/models/validate.go
@@ -23,3 +23,11 @@ func (m *NetworkType) ValidateModel() error {
 func (m *NetworkDescription) ValidateModel() error {
 	return m.Validate(strfmt.Default)
 }
+
+func (m *GatewayName) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}
+
+func (m *GatewayDescription) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}

--- a/orc8r/cloud/go/pluginimpl/handlers/gateway_handlers_test.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/gateway_handlers_test.go
@@ -602,3 +602,500 @@ func TestDeleteGateway(t *testing.T) {
 	assert.Equal(t, expectedEnts, actualEnts)
 	assert.Equal(t, &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}}, actualDevice)
 }
+
+func TestGetPartialReadHandlers(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+
+	clock.SetAndFreezeClock(t, time.Unix(1000000, 0))
+	defer clock.GetUnfreezeClockDeferFunc(t)()
+
+	test_init.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
+
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	assert.NoError(t, err)
+
+	gwConfig := &models.MagmadGatewayConfigs{
+		AutoupgradeEnabled:      swag.Bool(true),
+		AutoupgradePollInterval: 300,
+		CheckinInterval:         15,
+		CheckinTimeout:          5,
+	}
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: orc8r.MagmadGatewayType, Key: "g1",
+				Name: "foobar", Description: "foo bar",
+				PhysicalID: "hw1",
+				Config:     gwConfig,
+			},
+			{
+				Type: orc8r.MagmadGatewayType, Key: "g2",
+				Name: "barfoo", Description: "bar foo",
+				PhysicalID: "hw2",
+			},
+		},
+	)
+	assert.NoError(t, err)
+	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
+	assert.NoError(t, err)
+	ctx := test_utils.GetContextWithCertificate(t, "hw1")
+	test_utils.ReportGatewayStatus(t, ctx, models.NewDefaultGatewayStatus("hw1"))
+
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks/n1/gateways"
+
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	getGatewayName := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/name", obsidian.GET).HandlerFunc
+	getGatewayDescription := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/description", obsidian.GET).HandlerFunc
+	getGatewayState := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/state", obsidian.GET).HandlerFunc
+	getGatewayDevice := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/device", obsidian.GET).HandlerFunc
+	getGatewayConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/magmad", obsidian.GET).HandlerFunc
+
+	// happy path name
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/name",
+		Handler:        getGatewayName,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler("foobar"),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// happy path desc
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/description",
+		Handler:        getGatewayDescription,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler("foo bar"),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	expectedState := models.NewDefaultGatewayStatus("hw1")
+	expectedState.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
+	expectedState.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
+
+	// happy path state
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/state",
+		Handler:        getGatewayState,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: expectedState,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// 404 state
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g2/state",
+		Handler:        getGatewayState,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g2"},
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// happy path device
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/device",
+		Handler:        getGatewayDevice,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}},
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// 404 device
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g2/device",
+		Handler:        getGatewayDevice,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g2"},
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// happy case magmad config
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/magmad",
+		Handler:        getGatewayConfig,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: gwConfig,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// 404 magmad config
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g2/magmad",
+		Handler:        getGatewayConfig,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g2"},
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+func TestGetGatewayTierHandler(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+
+	test_init.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
+
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks/n1/gateways"
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	getGatewayTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/tier", obsidian.GET).HandlerFunc
+
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: orc8r.MagmadGatewayType, Key: "g1",
+				Name: "foobar", Description: "foo bar",
+				PhysicalID: "hw1",
+			},
+		},
+	)
+	// 404 tier
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/tier",
+		Handler:        getGatewayTier,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(""),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// add a tier and tier -> gateway association
+	_, err = configurator.CreateEntity(
+		"n1",
+		configurator.NetworkEntity{
+			Type: orc8r.UpgradeTierEntityType,
+			Key:  "t1",
+			Associations: []storage.TypeAndKey{
+				{
+					Type: orc8r.MagmadGatewayType,
+					Key:  "g1",
+				},
+			},
+		},
+	)
+	assert.NoError(t, err)
+
+	// happy
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            testURLRoot + "/g1/tier",
+		Handler:        getGatewayTier,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler("t1"),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+func TestUpdateGatewayTierHandler(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+
+	test_init.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
+
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks/n1/gateways"
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	updateGatewayTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/tier", obsidian.PUT).HandlerFunc
+
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: orc8r.MagmadGatewayType, Key: "g1",
+				Name: "foobar", Description: "foo bar",
+				PhysicalID: "hw1",
+			},
+		},
+	)
+	// 404 tier
+	tc := tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g1/tier",
+		Handler:        updateGatewayTier,
+		Payload:        tests.JSONMarshaler(models.TierID("t1")),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 400,
+		ExpectedError:  "Tier t1 does not exist",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// add 2 tiers
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: orc8r.UpgradeTierEntityType,
+				Key:  "t1",
+			},
+			{
+				Type: orc8r.UpgradeTierEntityType,
+				Key:  "t2",
+			},
+		},
+	)
+	assert.NoError(t, err)
+
+	// happy add a tier
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g1/tier",
+		Handler:        updateGatewayTier,
+		Payload:        tests.JSONMarshaler(models.TierID("t1")),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	entities, _, err := configurator.LoadEntities(
+		"n1",
+		swag.String(orc8r.UpgradeTierEntityType),
+		nil,
+		nil,
+		nil,
+		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+	)
+	assert.NoError(t, err)
+	expectedTiers := configurator.NetworkEntities{
+		{
+			NetworkID: "n1",
+			Type:      orc8r.UpgradeTierEntityType,
+			Key:       "t1",
+			Associations: []storage.TypeAndKey{
+				{
+					Type: orc8r.MagmadGatewayType,
+					Key:  "g1",
+				},
+			},
+			GraphID: "2",
+			Version: 1,
+		},
+		{
+			NetworkID: "n1",
+			Type:      orc8r.UpgradeTierEntityType,
+			Key:       "t2",
+			GraphID:   "6",
+			Version:   0,
+		},
+	}
+	assert.Equal(t, expectedTiers, entities)
+
+	// happy switch to a different tier
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g1/tier",
+		Handler:        updateGatewayTier,
+		Payload:        tests.JSONMarshaler(models.TierID("t2")),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+	entities, _, err = configurator.LoadEntities(
+		"n1",
+		swag.String(orc8r.UpgradeTierEntityType),
+		nil,
+		nil,
+		nil,
+		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+	)
+	expectedTiers = configurator.NetworkEntities{
+		{
+			NetworkID: "n1",
+			Type:      orc8r.UpgradeTierEntityType,
+			Key:       "t1",
+			GraphID:   "2",
+			Version:   2,
+		},
+		{
+			NetworkID: "n1",
+			Type:      orc8r.UpgradeTierEntityType,
+			Key:       "t2",
+			Associations: []storage.TypeAndKey{
+				{
+					Type: orc8r.MagmadGatewayType,
+					Key:  "g1",
+				},
+			},
+			GraphID: "6",
+			Version: 1,
+		},
+	}
+	assert.Equal(t, expectedTiers, entities)
+}
+
+func TestGetPartialUpdateHandlers(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+
+	test_init.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	assert.NoError(t, err)
+
+	gwConfig := &models.MagmadGatewayConfigs{
+		AutoupgradeEnabled:      swag.Bool(true),
+		AutoupgradePollInterval: 300,
+		CheckinInterval:         15,
+		CheckinTimeout:          5,
+	}
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: orc8r.MagmadGatewayType, Key: "g1",
+				Name: "foobar", Description: "foo bar",
+				PhysicalID: "hw1",
+				Config:     gwConfig,
+			},
+			{
+				Type: orc8r.MagmadGatewayType, Key: "g2",
+				Name: "barfoo", Description: "bar foo",
+				PhysicalID: "hw2",
+			},
+		},
+	)
+	assert.NoError(t, err)
+	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
+	assert.NoError(t, err)
+
+	e := echo.New()
+	testURLRoot := "/magma/v1/networks/n1/gateways"
+
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	updateGatewayName := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/name", obsidian.PUT).HandlerFunc
+	updateGatewayDesc := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/description", obsidian.PUT).HandlerFunc
+	updateGatewayDevice := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/device", obsidian.PUT).HandlerFunc
+	updateGatewayConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/magmad", obsidian.PUT).HandlerFunc
+
+	// validation error name
+	tc := tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g1/name",
+		Handler:        updateGatewayName,
+		Payload:        tests.JSONMarshaler(""),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 400,
+		ExpectedError:  " in body should be at least 1 chars long",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// happy path name
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g1/name",
+		Handler:        updateGatewayName,
+		Payload:        tests.JSONMarshaler("newname"),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	entity, err := configurator.LoadEntity("n1", orc8r.MagmadGatewayType, "g1", configurator.EntityLoadCriteria{LoadMetadata: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "newname", entity.Name)
+
+	// happy path desc
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g1/description",
+		Handler:        updateGatewayDesc,
+		Payload:        tests.JSONMarshaler("newdesc"),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	entity, err = configurator.LoadEntity("n1", orc8r.MagmadGatewayType, "g1", configurator.EntityLoadCriteria{LoadMetadata: true})
+	assert.NoError(t, err)
+	assert.Equal(t, "newdesc", entity.Description)
+
+	// happy path device
+	tc = tests.Test{
+		Method:  "PUT",
+		URL:     testURLRoot + "/g2/device",
+		Handler: updateGatewayDevice,
+		Payload: tests.JSONMarshaler(&models.GatewayDevice{HardwareID: "hw2",
+			Key: &models.ChallengeKey{KeyType: "ECHO"}}),
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g2"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	device, err := device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hw2")
+	assert.NoError(t, err)
+	assert.Equal(t, &models.GatewayDevice{HardwareID: "hw2", Key: &models.ChallengeKey{KeyType: "ECHO"}}, device)
+
+	// happy case magmad config
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g2/magmad",
+		Handler:        updateGatewayConfig,
+		Payload:        gwConfig,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g2"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	entity, err = configurator.LoadEntity("n1", orc8r.MagmadGatewayType, "g1", configurator.EntityLoadCriteria{LoadConfig: true})
+	assert.NoError(t, err)
+	assert.Equal(t, gwConfig, entity.Config)
+
+	// 404 magmad config (no gateway registered)
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            testURLRoot + "/g3/magmad",
+		Handler:        updateGatewayConfig,
+		Payload:        gwConfig,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g3"},
+		ExpectedStatus: 400,
+		ExpectedError:  "Gateway g3 does not exist",
+	}
+	tests.RunUnitTest(t, e, tc)
+}

--- a/orc8r/cloud/go/pluginimpl/handlers/handlers.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/handlers.go
@@ -28,9 +28,15 @@ const (
 	ManageNetworkDNSRecordsPath        = ManageNetworkDNSPath + obsidian.UrlSep + "records"
 	ManageNetworkDNSRecordByDomainPath = ManageNetworkDNSRecordsPath + obsidian.UrlSep + ":domain"
 
-	Gateways          = "gateways"
-	ListGatewaysPath  = ManageNetworkPath + obsidian.UrlSep + Gateways
-	ManageGatewayPath = ListGatewaysPath + obsidian.UrlSep + ":gateway_id"
+	Gateways                     = "gateways"
+	ListGatewaysPath             = ManageNetworkPath + obsidian.UrlSep + Gateways
+	ManageGatewayPath            = ListGatewaysPath + obsidian.UrlSep + ":gateway_id"
+	ManageGatewayNamePath        = ManageGatewayPath + obsidian.UrlSep + "name"
+	ManageGatewayDescriptionPath = ManageGatewayPath + obsidian.UrlSep + "description"
+	ManageGatewayConfigPath      = ManageGatewayPath + obsidian.UrlSep + "magmad"
+	ManageGatewayDevicePath      = ManageGatewayPath + obsidian.UrlSep + "device"
+	ManageGatewayStatePath       = ManageGatewayPath + obsidian.UrlSep + "state"
+	ManageGatewayTierPath        = ManageGatewayPath + obsidian.UrlSep + "tier"
 )
 
 // GetObsidianHandlers returns all plugin-level obsidian handlers for orc8r
@@ -54,6 +60,7 @@ func GetObsidianHandlers() []obsidian.Handler {
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: GetGatewayHandler},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: UpdateGatewayHandler},
 		{Path: ManageGatewayPath, Methods: obsidian.DELETE, HandlerFunc: DeleteGatewayHandler},
+		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: GetStateHandler},
 	}
 	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "")...)
 	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkTypePath, new(models.NetworkType), "")...)
@@ -61,5 +68,11 @@ func GetObsidianHandlers() []obsidian.Handler {
 	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &models2.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
 	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDNSPath, &models2.NetworkDNSConfig{}, orc8r.DnsdNetworkType)...)
 	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDNSRecordsPath, new(models2.NetworkDNSRecords), "")...)
+
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayConfigPath, &models2.MagmadGatewayConfigs{})...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayTierPath, new(models2.TierID))...)
+	ret = append(ret, GetGatewayDeviceHandlers(ManageGatewayDevicePath)...)
 	return ret
 }

--- a/orc8r/cloud/go/pluginimpl/models/conversion.go
+++ b/orc8r/cloud/go/pluginimpl/models/conversion.go
@@ -9,6 +9,9 @@
 package models
 
 import (
+	"fmt"
+
+	merrors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -138,15 +141,13 @@ func (m *MagmadGateway) ToEntityUpdateCriteria(existingEnt configurator.NetworkE
 
 	oldTierTK, _ := existingEnt.GetFirstParentOfType(orc8r.UpgradeTierEntityType)
 	if oldTierTK.Key != string(m.Tier) {
-		if oldTierTK.Key != "" {
-			ret = append(
-				ret,
-				configurator.EntityUpdateCriteria{
-					Type: orc8r.UpgradeTierEntityType, Key: oldTierTK.Key,
-					AssociationsToDelete: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: string(m.ID)}},
-				},
-			)
-		}
+		ret = append(
+			ret,
+			configurator.EntityUpdateCriteria{
+				Type: orc8r.UpgradeTierEntityType, Key: oldTierTK.Key,
+				AssociationsToDelete: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: string(m.ID)}},
+			},
+		)
 
 		ret = append(
 			ret,
@@ -160,6 +161,89 @@ func (m *MagmadGateway) ToEntityUpdateCriteria(existingEnt configurator.NetworkE
 	// do the tier update to delete the old assoc first
 	ret = append(ret, gatewayUpdate)
 	return ret
+}
+
+func (m *MagmadGatewayConfigs) ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
+	exists, err := configurator.DoesEntityExist(networkID, orc8r.MagmadGatewayType, gatewayID)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, fmt.Errorf("Gateway %s does not exist", gatewayID)
+	}
+
+	return []configurator.EntityUpdateCriteria{
+		{
+			Key:       gatewayID,
+			Type:      orc8r.MagmadGatewayType,
+			NewConfig: m,
+		},
+	}, nil
+}
+
+func (m *MagmadGatewayConfigs) FromBackendModels(networkID string, gatewayID string) error {
+	config, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID)
+	if err != nil {
+		return err
+	}
+	*m = *config.(*MagmadGatewayConfigs)
+	return nil
+}
+
+func (m *TierID) FromBackendModels(networkID string, gatewayID string) error {
+	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsToThis: true})
+	if err != nil {
+		return err
+	}
+	for _, parentAssoc := range entity.ParentAssociations {
+		if parentAssoc.Type == orc8r.UpgradeTierEntityType {
+			*m = TierID(parentAssoc.Key)
+			return nil
+		}
+	}
+	return nil
+}
+
+func (m *TierID) ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
+	tierID := string(*m)
+	updateCriteria := []configurator.EntityUpdateCriteria{}
+
+	exists, err := configurator.DoesEntityExist(networkID, orc8r.UpgradeTierEntityType, tierID)
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to look up tier")
+	}
+	if !exists {
+		return nil, fmt.Errorf("Tier %s does not exist", tierID)
+	}
+
+	// Remove association from old tier
+	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsToThis: true})
+	if err != nil {
+		return nil, err
+	}
+
+	tierTK, err := entity.GetFirstParentOfType(orc8r.UpgradeTierEntityType)
+	if err != merrors.ErrNotFound {
+		if tierTK.Key == tierID {
+			// no change
+			return []configurator.EntityUpdateCriteria{}, nil
+		}
+		deleteCurrentTierAssoc := configurator.EntityUpdateCriteria{
+			Type:                 tierTK.Type,
+			Key:                  tierTK.Key,
+			AssociationsToDelete: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: gatewayID}},
+		}
+		updateCriteria = append(updateCriteria, deleteCurrentTierAssoc)
+	}
+
+	// Add association to new tier
+	addNewTierAssoc := configurator.EntityUpdateCriteria{
+		Type:              orc8r.UpgradeTierEntityType,
+		Key:               tierID,
+		AssociationsToAdd: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: gatewayID}},
+	}
+	updateCriteria = append(updateCriteria, addNewTierAssoc)
+	return updateCriteria, nil
 }
 
 func GetNetworkConfig(network configurator.Network, key string) interface{} {

--- a/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
+++ b/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
@@ -612,6 +612,39 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /networks/{network_id}/gateways/{gateway_id}/tier:
+    get:
+      summary: Get the ID of the upgrade tier a gateway belongs to
+      tags:
+        - Gateways
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './orc8r-swagger-common.yml#/parameters/gateway_id'
+      responses:
+        '200':
+          description: The ID of the upgrade tier
+          schema:
+            $ref: '#/definitions/tier_id'
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    put:
+      summary: Update the ID of the upgrade tier a gateway belongs to
+      tags:
+        - Gateways
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './orc8r-swagger-common.yml#/parameters/gateway_id'
+        - name: tier_id
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/tier_id'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /networks/{network_id}/gateways/{gateway_id}/status:
     get:
       summary: Get the status of a gateway

--- a/orc8r/cloud/go/pluginimpl/models/validate.go
+++ b/orc8r/cloud/go/pluginimpl/models/validate.go
@@ -73,3 +73,7 @@ func (m *MagmadGatewayConfigs) ValidateModel() error {
 	}
 	return nil
 }
+
+func (m TierID) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}

--- a/orc8r/cloud/go/services/device/client_api.go
+++ b/orc8r/cloud/go/services/device/client_api.go
@@ -111,6 +111,9 @@ func GetDevice(networkID, deviceType, deviceKey string) (interface{}, error) {
 }
 
 func GetDevices(networkID string, deviceType string, deviceIDs []string) (map[string]interface{}, error) {
+	if len(deviceIDs) == 0 {
+		return map[string]interface{}{}, nil
+	}
 	client, err := getDeviceClient()
 	if err != nil {
 		return nil, err

--- a/orc8r/cloud/go/services/state/client_api.go
+++ b/orc8r/cloud/go/services/state/client_api.go
@@ -103,6 +103,10 @@ func GetState(networkID string, typeVal string, hwID string) (State, error) {
 
 // GetStates returns a map of states specified by the networkID and a list of type and key
 func GetStates(networkID string, stateIDs []StateID) (map[StateID]State, error) {
+	if len(stateIDs) == 0 {
+		return map[StateID]State{}, nil
+	}
+
 	client, err := GetStateClient()
 	if err != nil {
 		return nil, err

--- a/orc8r/cloud/go/services/state/client_test.go
+++ b/orc8r/cloud/go/services/state/client_test.go
@@ -3,10 +3,10 @@
  * All rights reserved.
  *
  * This source code is licensed under the BSD-style license found in the
- *  LICENSE file in the root directory of this source tree.
+ * LICENSE file in the root directory of this source tree.
  */
 
-package tests
+package state_test
 
 import (
 	"context"


### PR DESCRIPTION
Summary: Adding metadata read/update, magmad config read/update, tier read/update to both generic and lte gateway.

Reviewed By: xjtian

Differential Revision: D16970493

