### PR TITLE
Revert changes to flow priority and remove register check in metering

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/meter.py
+++ b/lte/gateway/python/magma/pipelined/app/meter.py
@@ -18,8 +18,7 @@ from magma.pipelined.app.base import MagmaController
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.exceptions import MagmaOFError
 from magma.pipelined.openflow.magma_match import MagmaMatch
-from magma.pipelined.openflow.registers import Direction, IMSI_REG, TestPacket,\
-    TEST_PACKET_REG
+from magma.pipelined.openflow.registers import Direction, IMSI_REG
 
 
 class MeterController(MagmaController):
@@ -105,8 +104,6 @@ class MeterController(MagmaController):
         For every packet not already matched by a flow rule, install a pair of
         flows to track all packets to/from the corresponding IMSI.
         """
-        if ev.msg.match[TEST_PACKET_REG] == TestPacket.ON.value:
-            return
 
         msg = ev.msg
         datapath = msg.datapath

--- a/lte/gateway/python/magma/pipelined/app/packet_tracer.py
+++ b/lte/gateway/python/magma/pipelined/app/packet_tracer.py
@@ -7,7 +7,7 @@ from magma.pipelined.app.inout import EGRESS
 from magma.pipelined.imsi import encode_imsi
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.events import EventSendPacket
-from magma.pipelined.openflow.flows import DROP_PRIORITY
+from magma.pipelined.openflow.flows import MINIMUM_PRIORITY
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import TestPacket, TEST_PACKET_REG, \
     IMSI_REG
@@ -62,7 +62,7 @@ class PacketTracingController(MagmaController):
                                                table=table,
                                                match=MagmaMatch(),
                                                instructions=[],
-                                               priority=DROP_PRIORITY)
+                                               priority=MINIMUM_PRIORITY)
             self.drop_flows_installed.add(table)
 
     def trace_packet(self, packet, imsi, timeout=2):

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -17,15 +17,14 @@ from magma.pipelined.openflow.registers import TestPacket, TEST_PACKET_REG
 logger = logging.getLogger(__name__)
 
 DEFAULT_PRIORITY = 10
-DROP_PRIORITY = 0
-MINIMUM_PRIORITY = 1
+MINIMUM_PRIORITY = 0
 MAXIMUM_PRIORITY = 65535
 OVS_COOKIE_MATCH_ALL = 0xffffffff
 
 
 def add_drop_flow(datapath, table, match, actions=None, instructions=None,
                   priority=MINIMUM_PRIORITY, retries=3, cookie=0x0,
-                  idle_timeout=0, hard_timeout=0, install_trace_flow=True):
+                  idle_timeout=0, hard_timeout=0, install_trace_flow=False):
     """
     Add a flow to a table that drops the packet
 
@@ -70,7 +69,7 @@ def add_drop_flow(datapath, table, match, actions=None, instructions=None,
 def add_output_flow(datapath, table, match, actions=None, instructions=None,
                     priority=MINIMUM_PRIORITY, retries=3, cookie=0x0,
                     idle_timeout=0, hard_timeout=0, output_port=None,
-                    max_len=None, install_trace_flow=True):
+                    max_len=None, install_trace_flow=False):
     """
     Add a flow to a table that sends the packet to the specified port
 


### PR DESCRIPTION
Summary:
The unittests for pipelined were failing as the flow priority was changed by
recent addition for DROP_PRIORITY in flows.py for packet_tracer app. As packet
tracer is still a work in progress, reverting these changes to maintain unit
test sanity. Also removing check for test packet in metering app.

Differential Revision: D17049813

