### PR TITLE
Moving state protos to OAI directory

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -57,6 +57,11 @@ if (NOT FUZZ)
 endif (NOT FUZZ)
 
 ################################################################
+# Set proto directory for state proto definitions
+################################################################
+set(STATE_PROTO_DIR ${PROJECT_SOURCE_DIR}/protos)
+
+################################################################
 # S1AP LAYER OPTIONS
 ################################################################
 add_boolean_option(S1AP_DEBUG_LIST                 False    "Traces, option to be removed soon")

--- a/lte/gateway/c/oai/protos/common_types.proto
+++ b/lte/gateway/c/oai/protos/common_types.proto
@@ -2,8 +2,6 @@ syntax = "proto3";
 
 package magma.lte;
 
-option go_package = "magma/lte/cloud/go/protos";
-
 // Proto file to serialize the structures in
 // magma/lte/gateway/c/oai/common/common_types.h
 

--- a/lte/gateway/c/oai/protos/mme_nas_state.proto
+++ b/lte/gateway/c/oai/protos/mme_nas_state.proto
@@ -1,11 +1,9 @@
 syntax = "proto3";
 
-import "lte/protos/common_types.proto";
-import "lte/protos/nas_state.proto";
+import "lte/gateway/c/oai/protos/common_types.proto";
+import "lte/gateway/c/oai/protos/nas_state.proto";
 
 package magma.lte;
-
-option go_package = "magma/lte/cloud/go/protos";
 
 // sgs_context_t
 message SgsContext {

--- a/lte/gateway/c/oai/protos/nas_state.proto
+++ b/lte/gateway/c/oai/protos/nas_state.proto
@@ -1,10 +1,8 @@
 syntax = "proto3";
 
-import "lte/protos/common_types.proto";
+import "lte/gateway/c/oai/protos/common_types.proto";
 
 package magma.lte;
-
-option go_package = "magma/lte/cloud/go/protos";
 
 // Timers for MME and Nas
 // mme_app_timer_t and nas_timer_t


### PR DESCRIPTION
Summary:
As the state protos are only used by the OAI code, they need to be placed inside
the OAI directory. This change moves the MME and NAS state protos into oai.

Differential Revision: D17188943

