### PR TITLE
Fix gateway status endpoint 404 error & ListGateways spec/handler mismatch

### DIFF
--- a/orc8r/cloud/go/pluginimpl/handlers/handlers.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/handlers.go
@@ -35,7 +35,7 @@ const (
 	ManageGatewayDescriptionPath = ManageGatewayPath + obsidian.UrlSep + "description"
 	ManageGatewayConfigPath      = ManageGatewayPath + obsidian.UrlSep + "magmad"
 	ManageGatewayDevicePath      = ManageGatewayPath + obsidian.UrlSep + "device"
-	ManageGatewayStatePath       = ManageGatewayPath + obsidian.UrlSep + "state"
+	ManageGatewayStatePath       = ManageGatewayPath + obsidian.UrlSep + "status"
 	ManageGatewayTierPath        = ManageGatewayPath + obsidian.UrlSep + "tier"
 
 	Channels               = "channels"

--- a/orc8r/cloud/go/pluginimpl/models/conversion.go
+++ b/orc8r/cloud/go/pluginimpl/models/conversion.go
@@ -111,7 +111,9 @@ func (m *MagmadGateway) FromBackendModels(ent configurator.NetworkEntity, device
 	m.ID = models.GatewayID(ent.Key)
 	m.Name = models.GatewayName(ent.Name)
 	m.Description = models.GatewayDescription(ent.Description)
-	m.Magmad = ent.Config.(*MagmadGatewayConfigs)
+	if ent.Config != nil {
+		m.Magmad = ent.Config.(*MagmadGatewayConfigs)
+	}
 	m.Device = device
 	m.Status = status
 	tierTK, err := ent.GetFirstParentOfType(orc8r.UpgradeTierEntityType)


### PR DESCRIPTION
Summary:
The handler was pointing to /state where the swagger spec points to /status
Modifying ListGateways handler to reflect what is specified in the swagger spec

{F206771016}

{F206773758}

Differential Revision: D17193878

