### PR TITLE
Adding support for band 39 to orc8r

### DIFF
--- a/lte/cloud/go/services/cellular/utils/lte_bands.go
+++ b/lte/cloud/go/services/cellular/utils/lte_bands.go
@@ -37,6 +37,7 @@ var bands = [...]LTEBand{
 	{ID: 4, Mode: FDDMode, StartEarfcnDl: 1950, StartEarfcnUl: 19950, CountEarfcn: 450},
 	{ID: 28, Mode: FDDMode, StartEarfcnDl: 9210, StartEarfcnUl: 27210, CountEarfcn: 450},
 	// TDDMode
+	{ID: 39, Mode: TDDMode, StartEarfcnDl: 38250, CountEarfcn: 400},	
 	{ID: 40, Mode: TDDMode, StartEarfcnDl: 38650, CountEarfcn: 1000},
 	{ID: 41, Mode: TDDMode, StartEarfcnDl: 39650, CountEarfcn: 1940},
 	{ID: 42, Mode: TDDMode, StartEarfcnDl: 41590, CountEarfcn: 2000},


### PR DESCRIPTION
Summary:
Band39 is already supported by issue #481 and PR #482 .
However, this patch (#481 , #482 ) was only support A-GW and Orc8r was not supported.
This PR adds band39 support to orc8r by adding the network cellular config on orc8r.