### PR TITLE
Fix URL typo / implement unimplemented connected_enodeb_serials functions

### DIFF
--- a/lte/cloud/go/plugin/models/conversion.go
+++ b/lte/cloud/go/plugin/models/conversion.go
@@ -308,6 +308,20 @@ func (m *EnodebSerials) ToUpdateCriteria(networkID string, gatewayID string) ([]
 	}, nil
 }
 
+func (m *EnodebSerials) ToDeleteUpdateCriteria(networkID, gatewayID, enodebID string) configurator.EntityUpdateCriteria {
+	return configurator.EntityUpdateCriteria{
+		Type: lte.CellularGatewayType, Key: gatewayID,
+		AssociationsToDelete: []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: enodebID}},
+	}
+}
+
+func (m *EnodebSerials) ToCreateUpdateCriteria(networkID, gatewayID, enodebID string) configurator.EntityUpdateCriteria {
+	return configurator.EntityUpdateCriteria{
+		Type: lte.CellularGatewayType, Key: gatewayID,
+		AssociationsToAdd: []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: enodebID}},
+	}
+}
+
 func (m *Enodeb) FromBackendModels(ent configurator.NetworkEntity) *Enodeb {
 	m.Name = ent.Name
 	m.Serial = ent.Key


### PR DESCRIPTION
Summary:
There was a typo in the lte gateway handlers' url for  /status and /connected_enodeb_serials that mismatched the swagger spec.
The partial delete and post functions for connected enodeb_serials were missing so adding that now.

Differential Revision: D17241852

