### PR TITLE
Modify DeleteDevices to take in []storage.TypeAndKey not protos.DeviceID

### DIFF
--- a/orc8r/cloud/go/services/device/client_test.go
+++ b/orc8r/cloud/go/services/device/client_test.go
@@ -15,8 +15,8 @@ import (
 
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/device"
-	"magma/orc8r/cloud/go/services/device/protos"
 	"magma/orc8r/cloud/go/services/device/test_init"
+	"magma/orc8r/cloud/go/storage"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -67,7 +67,7 @@ func TestDeviceService(t *testing.T) {
 	updateDevicesAssertNoError(t, networkID, bundle1)
 
 	// Test deletion
-	err = device.DeleteDevices(networkID, []*protos.DeviceID{{DeviceID: bundle1.deviceKey, Type: bundle1.deviceType}})
+	err = device.DeleteDevices(networkID, []storage.TypeAndKey{{Type: bundle1.deviceType, Key: bundle1.deviceKey}})
 	assert.NoError(t, err)
 	assertDevicesNotRegistered(t, bundle1)
 	assertDevicesAreRegistered(t, bundle2)


### PR DESCRIPTION
Summary:
Minor refactoring for DeleteDevices to use []storage.TypeAndKey

themarwhal - please let me know if this is in the right direction, thanks!

Differential Revision: D17319398

