### PR TITLE
Add nms build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,23 @@ matrix:
       script:
         - make -C $MAGMA_ROOT/lte/gateway/python test_all
 
+    - language: minimal
+      name: nms builds
+      os: linux
+      dist: xenial
+
+      env:
+        - NMS_ROOT=$TRAVIS_BUILD_DIR/nms
+
+      addons:
+        apt:
+          packages:
+            - docker-ce
+
+      script:
+        - cd ${NMS_ROOT}
+        - docker build -t magmalte -f fbcnms-projects/magmalte/Dockerfile .
+
 notifications:
   slack:
     rooms:


### PR DESCRIPTION
Summary: Tries to build the nms in docker.  This gives better signal on status

Differential Revision: D17352073

