### PR TITLE
Increase log verbosity for unknown message type log

### DIFF
--- a/orc8r/cloud/go/protos/marshaler.go
+++ b/orc8r/cloud/go/protos/marshaler.go
@@ -11,10 +11,10 @@ package protos
 
 import (
 	"bytes"
-	"log"
 	"reflect"
 	"strings"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 )
@@ -61,7 +61,7 @@ func (_ mconfigAnyResolver) Resolve(typeUrl string) (proto.Message, error) {
 	mt := proto.MessageType(mname)
 	var res proto.Message
 	if mt == nil {
-		log.Printf("mconfigAnyResolver: unknown message type %q", mname)
+		glog.V(4).Infof("mconfigAnyResolver: unknown message type %q", mname)
 		res = new(Void)
 	} else {
 		res = reflect.New(mt.Elem()).Interface().(proto.Message)


### PR DESCRIPTION
Summary:
The logging statement was spamming the log since this occurs on every mconfig
reload. Make this visible only when using higher verbosity levels.

Reviewed By: xjtian

Differential Revision: D17348053

