### PR TITLE
Allow empty `for` field in alert rule config

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
-	golang.org/x/net v0.0.0-20190311183353-d8887717615a
+	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
 	google.golang.org/grpc v1.21.1
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go/protos v0.0.0

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -64,6 +64,7 @@ github.com/dgrijalva/jwt-go v0.0.0-20161101193935-9ed569b5d1ac/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
@@ -417,6 +418,7 @@ golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,6 +15,7 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
+	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule.go
@@ -108,11 +108,6 @@ type RuleJSONWrapper struct {
 }
 
 func (r *RuleJSONWrapper) ToRuleFmt() (rulefmt.Rule, error) {
-	modelFor, err := model.ParseDuration(r.For)
-	if err != nil {
-		return rulefmt.Rule{}, err
-	}
-
 	if r.Labels == nil {
 		r.Labels = make(map[string]string)
 	}
@@ -124,9 +119,15 @@ func (r *RuleJSONWrapper) ToRuleFmt() (rulefmt.Rule, error) {
 		Record:      r.Record,
 		Alert:       r.Alert,
 		Expr:        r.Expr,
-		For:         modelFor,
 		Labels:      r.Labels,
 		Annotations: r.Annotations,
+	}
+	if r.For != "" {
+		modelFor, err := model.ParseDuration(r.For)
+		if err != nil {
+			return rulefmt.Rule{}, err
+		}
+		rule.For = modelFor
 	}
 	return rule, nil
 }


### PR DESCRIPTION
Summary:
Allow `for` field to be empty in alert config.

`go.mod` and `go.sum` changes when I build, so I'm just including those in here

Differential Revision: D17375314

