### PR TITLE
state models should be validatable

### DIFF
--- a/lte/cloud/go/plugin/models/validate.go
+++ b/lte/cloud/go/plugin/models/validate.go
@@ -213,6 +213,10 @@ func (m *LteSubscription) ValidateModel() error {
 	return nil
 }
 
+func (m *EnodebState) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}
+
 // validateIPBlocks parses and validates IP networks containing subnet masks.
 // Returns an error in case any IP network in list is invalid.
 func validateIPBlocks(ipBlocks []string) error {

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/validate.go
@@ -6,12 +6,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package state
+package models
 
-import (
-	"magma/orc8r/cloud/go/serde"
-)
+import "github.com/go-openapi/strfmt"
 
-func NewStateSerde(stateType string, modelPtr serde.ValidateableBinaryConvertible) serde.Serde {
-	return serde.NewBinarySerde(SerdeDomain, stateType, modelPtr)
+func (m *SubscriberState) ValidateModel() error {
+	return m.Validate(strfmt.Default)
 }

--- a/orc8r/cloud/go/pluginimpl/handlers/common.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/common.go
@@ -13,15 +13,10 @@ import (
 	"reflect"
 
 	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/serde"
 
 	"github.com/labstack/echo"
 )
-
-// ValidateModels validates the model to be according to swagger spec, as
-// well as other custom validations.
-type ValidatableModel interface {
-	ValidateModel() error
-}
 
 // GetAndValidatePayload can be used by any model that implements ValidateModel
 // Example:
@@ -30,8 +25,8 @@ type ValidatableModel interface {
 //		return nil, nerr
 //	}
 //	record := payload.(*models.DNSConfigRecord)
-func GetAndValidatePayload(c echo.Context, model interface{}) (ValidatableModel, *echo.HTTPError) {
-	iModel := reflect.New(reflect.TypeOf(model).Elem()).Interface().(ValidatableModel)
+func GetAndValidatePayload(c echo.Context, model interface{}) (serde.ValidatableModel, *echo.HTTPError) {
+	iModel := reflect.New(reflect.TypeOf(model).Elem()).Interface().(serde.ValidatableModel)
 	if err := c.Bind(iModel); err != nil {
 		return nil, obsidian.HttpError(err, http.StatusBadRequest)
 	}

--- a/orc8r/cloud/go/pluginimpl/handlers/eneity_handler_factory.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/eneity_handler_factory.go
@@ -13,6 +13,7 @@ import (
 
 	"magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 
 	"github.com/labstack/echo"
@@ -21,7 +22,7 @@ import (
 // PartialEntityModel describe models that represents a portion of network
 // entity that can be read and updated.
 type PartialEntityModel interface {
-	ValidatableModel
+	serde.ValidatableModel
 	// FromBackendModels the same PartialEntityModel from the configurator
 	// entities attached to the networkID and key.
 	FromBackendModels(networkID string, key string) error

--- a/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory.go
@@ -15,6 +15,7 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/pluginimpl/models"
+	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
 
@@ -24,7 +25,7 @@ import (
 // PartialGatewayModel describe models that represents a portion of network
 // entity that can be read and updated.
 type PartialGatewayModel interface {
-	ValidatableModel
+	serde.ValidatableModel
 	// FromBackendModels the same PartialGatewayModel from the configurator
 	// entities attached to the networkID and gatewayID.
 	FromBackendModels(networkID string, gatewayID string) error

--- a/orc8r/cloud/go/pluginimpl/handlers/network_handler_factory.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/network_handler_factory.go
@@ -14,6 +14,7 @@ import (
 
 	"magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 
 	"github.com/labstack/echo"
@@ -22,7 +23,7 @@ import (
 // PartialNetworkModel describe models that represents a portion of network
 // that can be read, updated, and deleted.
 type PartialNetworkModel interface {
-	ValidatableModel
+	serde.ValidatableModel
 	// GetFromNetwork grabs the desired model from the configurator network.
 	// Returns nil if it is not there.
 	GetFromNetwork(network configurator.Network) interface{}

--- a/orc8r/cloud/go/pluginimpl/models/validate.go
+++ b/orc8r/cloud/go/pluginimpl/models/validate.go
@@ -105,3 +105,7 @@ func (m *TierImages) ValidateModel() error {
 func (m *TierImage) ValidateModel() error {
 	return m.Validate(strfmt.Default)
 }
+
+func (m *GatewayStatus) ValidateModel() error {
+	return m.Validate(strfmt.Default)
+}

--- a/orc8r/cloud/go/serde/serde.go
+++ b/orc8r/cloud/go/serde/serde.go
@@ -35,6 +35,15 @@ type Serde interface {
 	Deserialize(in []byte) (interface{}, error)
 }
 
+type ValidatableModel interface {
+	ValidateModel() error
+}
+
+type ValidateableBinaryConvertible interface {
+	BinaryConvertible
+	ValidatableModel
+}
+
 // BinaryConvertible wraps encoding.BinaryMarshaler and
 // encoding.BinaryUnmarshaler for use in generic serde factory functions.
 type BinaryConvertible interface {

--- a/orc8r/cloud/go/services/state/client_test.go
+++ b/orc8r/cloud/go/services/state/client_test.go
@@ -11,6 +11,7 @@ package state_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"magma/orc8r/cloud/go/errors"
@@ -54,7 +55,7 @@ func TestStateService(t *testing.T) {
 	// Set up test networkID, hwID, and encode into context
 	stateTestInit.StartTestService(t)
 	err := serde.RegisterSerdes(
-		&Serde{},
+		state.NewStateSerde("test-serde", &Name{}),
 		serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &models2.GatewayDevice{}))
 	assert.NoError(t, err)
 
@@ -68,9 +69,9 @@ func TestStateService(t *testing.T) {
 	value0 := Name{Name: "name0"}
 	value1 := Name{Name: "name1"}
 	value2 := NameAndAge{Name: "name2", Age: 20}
-	bundle0 := makeStateBundle(typeName, "key0", value0)
-	bundle1 := makeStateBundle(typeName, "key1", value1)
-	bundle2 := makeStateBundle(typeName, "key2", value2)
+	bundle0 := makeStateBundle("test-serde", "key0", value0)
+	bundle1 := makeStateBundle("test-serde", "key1", value1)
+	bundle2 := makeStateBundle("test-serde", "key2", value2)
 
 	// Check contract for empty network
 	states, err := state.GetStates(networkID, []state.StateID{bundle0.ID})
@@ -101,10 +102,13 @@ func TestStateService(t *testing.T) {
 
 	// Send a valid state and a state with no corresponding serde
 	unserializableBundle := makeStateBundle("nonexistent-serde", "key3", value0)
-	resp, err := reportStates(ctx, bundle0, unserializableBundle)
+	invalidBundle := makeStateBundle("test-serde", "key1", Name{Name: "BADNAME"})
+	resp, err := reportStates(ctx, bundle0, unserializableBundle, invalidBundle)
 	assert.NoError(t, err)
 	assert.Equal(t, "nonexistent-serde", resp.UnreportedStates[0].Type)
 	assert.Equal(t, "No Serde found for type nonexistent-serde", resp.UnreportedStates[0].Error)
+	assert.Equal(t, "test-serde", resp.UnreportedStates[1].Type)
+	assert.Equal(t, "This name: BADNAME is not allowed!", resp.UnreportedStates[1].Error)
 	// Valid state should still be reported
 	states, err = state.GetStates(networkID, []state.StateID{bundle0.ID, bundle1.ID, bundle2.ID})
 	assert.NoError(t, err)
@@ -124,26 +128,31 @@ type Name struct {
 	Name string `json:"name"`
 }
 
-type Serde struct {
-}
-
-func (*Serde) GetDomain() string {
+func (*Name) GetDomain() string {
 	return state.SerdeDomain
 }
 
-func (*Serde) GetType() string {
-	return typeName
+func (*Name) GetType() string {
+	return "test-serde"
 }
 
-func (*Serde) Serialize(in interface{}) ([]byte, error) {
-	return json.Marshal(in)
+func (m *Name) MarshalBinary() ([]byte, error) {
+	return json.Marshal(m)
 
 }
 
-func (*Serde) Deserialize(message []byte) (interface{}, error) {
+func (m *Name) UnmarshalBinary(message []byte) error {
 	res := Name{}
 	err := json.Unmarshal(message, &res)
-	return res, err
+	*m = res
+	return err
+}
+
+func (m *Name) ValidateModel() error {
+	if m.Name == "BADNAME" {
+		return fmt.Errorf("This name: %s is not allowed!", m.Name)
+	}
+	return nil
 }
 
 func getClient() (protos.StateServiceClient, error) {

--- a/orc8r/cloud/go/services/state/servicers/proto_validation.go
+++ b/orc8r/cloud/go/services/state/servicers/proto_validation.go
@@ -43,15 +43,25 @@ func PartitionStatesBySerializability(req *protos.ReportStatesRequest) ([]*proto
 		return nil, nil, errors.New("States value must be specified and non-empty")
 	}
 	for _, state := range states {
-		_, err := serde.Deserialize(stateservice.SerdeDomain, state.GetType(), state.GetValue())
+		model, err := serde.Deserialize(stateservice.SerdeDomain, state.GetType(), state.GetValue())
 		if err != nil {
 			stateAndError := &protos.IDAndError{
 				Type:     state.Type,
 				DeviceID: state.DeviceID,
-				Error:    err.Error(),
+				Error:    err.Error(), // deserialization error
 			}
 			invalidStates = append(invalidStates, stateAndError)
 		} else {
+			if err := model.(serde.ValidateableBinaryConvertible).ValidateModel(); err != nil {
+				stateAndError := &protos.IDAndError{
+					Type:     state.Type,
+					DeviceID: state.DeviceID,
+					Error:    err.Error(), // validation error
+				}
+				invalidStates = append(invalidStates, stateAndError)
+				continue
+			}
+
 			validatedStates = append(validatedStates, state)
 		}
 	}


### PR DESCRIPTION
Summary:
## What's changed?
- Models used as states now require a `Validate() error` function to be implemented
- This doesn't change much for now since swagger generates this for each model already.

## Note
- Not landing this until enodebd stops reporting the EnodebStatus protobuf struct as state since it doesn't implement Validate.

Reviewed By: xjtian

Differential Revision: D17235565

