### PR TITLE
Size down recommended Orchestrator infra

### DIFF
--- a/orc8r/cloud/deploy/terraform/db.tf
+++ b/orc8r/cloud/deploy/terraform/db.tf
@@ -1,6 +1,6 @@
 resource "aws_db_instance" "default" {
   identifier        = "orc8rdb"
-  allocated_storage = 128
+  allocated_storage = 32
   engine            = "postgres"
   engine_version    = "9.6.11"
   instance_class    = "db.m4.large"
@@ -12,6 +12,11 @@ resource "aws_db_instance" "default" {
   vpc_security_group_ids = [aws_security_group.default.id]
 
   db_subnet_group_name = module.vpc.database_subnet_group
+
+  skip_final_snapshot = true
+  # we only need this as a placeholder value for `terraform destroy` to work,
+  # this won't actually create a final snapshot on destroy
+  final_snapshot_identifier = "foo"
 }
 
 resource "aws_db_instance" "nms" {
@@ -28,4 +33,9 @@ resource "aws_db_instance" "nms" {
   vpc_security_group_ids = [aws_security_group.default.id]
 
   db_subnet_group_name = module.vpc.database_subnet_group
+
+  skip_final_snapshot = true
+  # we only need this as a placeholder value for `terraform destroy` to work,
+  # this won't actually create a final snapshot on destroy
+  final_snapshot_identifier = "nms_foo"
 }

--- a/orc8r/cloud/deploy/terraform/main.tf
+++ b/orc8r/cloud/deploy/terraform/main.tf
@@ -72,8 +72,8 @@ module "eks" {
   worker_groups = [
     {
       name                 = "wg-1"
-      instance_type        = "m4.xlarge"
-      asg_desired_capacity = 3
+      instance_type        = "t3.small"
+      asg_desired_capacity = 2
       key_name             = var.key_name
       kubelet_extra_args   = "--node-labels=worker-type=controller"
 
@@ -87,7 +87,7 @@ module "eks" {
     },
     {
       name                 = "wg-metrics"
-      instance_type        = "t2.xlarge"
+      instance_type        = "t3.medium"
       asg_desired_capacity = 1
       key_name             = var.key_name
       kubelet_extra_args   = "--node-labels=worker-type=metrics"
@@ -144,7 +144,7 @@ resource "aws_security_group" "default" {
 # EBS volume for prometheus metrics.
 resource "aws_ebs_volume" "prometheus-ebs-eks" {
   availability_zone = data.aws_availability_zones.available.names[0]
-  size              = 400
+  size              = 64
 
   tags = {
     Name = "orc8r-prometheus-data"


### PR DESCRIPTION
Summary:
For already-deployed Orchestrators, this will involve some manual steps because AWS does not allow you to downsize RDS or EBS.

First, update the `.tf` files in your terraform directory to reflect the new changes.

For EBS:

1. Undeploy the prometheus pod (set `create: false` in the Helm values)
2. Delete the old metrics EBS volume using AWS console (you may have to detach it from the metrics ec2 worker first)
3. terraform plan/apply, which should create a new EBS volume
4. Redeploy the prometheus pod

For RDS:

1. Log into a controller pod (`kubectl exec`) and install `postgres-client-9.6` via `apt` - https://wiki.postgresql.org/wiki/Apt
2. Use `pg_dump` and the connection parameters in `/var/opt/magma/envdir/DATABASE_SOURCE` to dump the contents of the `orc8r` database from RDS (e.g. as `dump.sql`)
3. Manually delete the RDS instance from the AWS console
4. terraform plan/apply, which should create a new RDS instance
5. From the same controller pod in step 1, load the pg dump into the `orc8r` database of your new RDS instance - note that the RDS hostname will change!
6. Update the `DATABASE_SOURCE` file in your `secrets/envdir`, then redeploy the Helm application

Summary of changes:

- Controller worker group -> 2x t3.small
- Metrics worker group -> t3.medium
- Metrics datasink -> 64GB EBS volume
- Orchestrator RDS instance -> 32GB size

Differential Revision: D17403400

