### PR TITLE
Create common handlers for typed gateways

### DIFF
--- a/lte/cloud/go/plugin/handlers/handlers.go
+++ b/lte/cloud/go/plugin/handlers/handlers.go
@@ -20,7 +20,6 @@ import (
 	"magma/orc8r/cloud/go/pluginimpl/handlers"
 	orc8rmodels "magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/services/configurator"
-	"magma/orc8r/cloud/go/services/device"
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/storage"
 
@@ -77,11 +76,7 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageNetworkDNSRecordByDomainPath, Methods: obsidian.PUT, HandlerFunc: handlers.UpdateDNSRecord},
 		{Path: ManageNetworkDNSRecordByDomainPath, Methods: obsidian.DELETE, HandlerFunc: handlers.DeleteDNSRecord},
 
-		{Path: ListGatewaysPath, Methods: obsidian.GET, HandlerFunc: listGateways},
-		{Path: ListGatewaysPath, Methods: obsidian.POST, HandlerFunc: createGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
-		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
-		{Path: ManageGatewayPath, Methods: obsidian.DELETE, HandlerFunc: deleteGateway},
 		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: handlers.GetStateHandler},
 
 		{Path: ListEnodebsPath, Methods: obsidian.GET, HandlerFunc: listEnodebs},
@@ -113,6 +108,11 @@ func GetHandlers() []obsidian.Handler {
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularRanPath, &ltemodels.NetworkRanConfigs{}, "")...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularFegNetworkID, new(ltemodels.FegNetworkID), "")...)
 
+	ret = append(ret, handlers.GetListGatewaysHandler(ListGatewaysPath, lte.CellularGatewayType, makeLTEGateways))
+	ret = append(ret, handlers.GetCreateGatewayHandler(ListGatewaysPath, lte.CellularGatewayType, &ltemodels.MutableLteGateway{}))
+	ret = append(ret, handlers.GetUpdateGatewayHandler(ManageGatewayPath, lte.CellularGatewayType, &ltemodels.MutableLteGateway{}))
+	ret = append(ret, handlers.GetDeleteGatewayHandler(ManageGatewayPath, lte.CellularGatewayType))
+
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8rmodels.MagmadGatewayConfigs{})...)
@@ -124,79 +124,6 @@ func GetHandlers() []obsidian.Handler {
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularNonEpsPath, &ltemodels.GatewayNonEpsConfigs{})...)
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConnectedEnodebsPath, &ltemodels.EnodebSerials{})...)
 	return ret
-}
-
-func listGateways(c echo.Context) error {
-	nid, nerr := obsidian.GetNetworkId(c)
-	if nerr != nil {
-		return nerr
-	}
-
-	ids, err := configurator.ListEntityKeys(nid, lte.CellularGatewayType)
-	if err != nil {
-		return obsidian.HttpError(err, http.StatusInternalServerError)
-	}
-
-	// for each ID, we want to load the cellular gateway and the magmad gateway
-	entityTKs := make([]storage.TypeAndKey, 0, len(ids)*2)
-	for _, id := range ids {
-		entityTKs = append(
-			entityTKs,
-			storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: id},
-			storage.TypeAndKey{Type: lte.CellularGatewayType, Key: id},
-		)
-	}
-	ents, _, err := configurator.LoadEntities(nid, nil, nil, nil, entityTKs, configurator.FullEntityLoadCriteria())
-	if err != nil {
-		return obsidian.HttpError(err, http.StatusInternalServerError)
-	}
-	entsByTK := ents.ToEntitiesByID()
-
-	// for each magmad gateway, we have to load its corresponding device and
-	// its reported status
-	deviceIDs := make([]string, 0, len(ids))
-	for tk, ent := range entsByTK {
-		if tk.Type == orc8r.MagmadGatewayType && ent.PhysicalID != "" {
-			deviceIDs = append(deviceIDs, ent.PhysicalID)
-		}
-	}
-	devicesByID, err := device.GetDevices(nid, orc8r.AccessGatewayRecordType, deviceIDs)
-	if err != nil {
-		return obsidian.HttpError(errors.Wrap(err, "failed to load devices"), http.StatusInternalServerError)
-	}
-	statusesByID, err := state.GetGatewayStatuses(nid, deviceIDs)
-	if err != nil {
-		return obsidian.HttpError(errors.Wrap(err, "failed to load statuses"), http.StatusInternalServerError)
-	}
-	return c.JSON(http.StatusOK, makeLTEGateways(entsByTK, devicesByID, statusesByID))
-}
-
-func createGateway(c echo.Context) error {
-	nid, nerr := obsidian.GetNetworkId(c)
-	if nerr != nil {
-		return nerr
-	}
-
-	payload := &ltemodels.MutableLteGateway{}
-	if err := c.Bind(payload); err != nil {
-		return obsidian.HttpError(err, http.StatusBadRequest)
-	}
-	if err := payload.ValidateModel(); err != nil {
-		return obsidian.HttpError(err, http.StatusBadRequest)
-	}
-
-	if nerr := handlers.CreateMagmadGatewayFromModel(nid, payload.GetMagmadGateway()); nerr != nil {
-		return nerr
-	}
-
-	if _, err := configurator.CreateEntity(nid, payload.ToConfiguratorEntity()); err != nil {
-		return obsidian.HttpError(errors.Wrap(err, "failed to create cellular gateway"), http.StatusInternalServerError)
-	}
-	if _, err := configurator.UpdateEntity(nid, payload.GetMagmadGatewayUpdateCriteria()); err != nil {
-		return obsidian.HttpError(errors.Wrap(err, "failed to associate cellular and magmad gateways"), http.StatusInternalServerError)
-	}
-
-	return c.NoContent(http.StatusCreated)
 }
 
 func getGateway(c echo.Context) error {
@@ -236,61 +163,6 @@ func getGateway(c echo.Context) error {
 	return c.JSON(http.StatusOK, ret)
 }
 
-func updateGateway(c echo.Context) error {
-	nid, gid, nerr := obsidian.GetNetworkAndGatewayIDs(c)
-	if nerr != nil {
-		return nerr
-	}
-
-	payload := &ltemodels.MutableLteGateway{}
-	if err := c.Bind(payload); err != nil {
-		return obsidian.HttpError(err, http.StatusBadRequest)
-	}
-	if err := payload.ValidateModel(); err != nil {
-		return obsidian.HttpError(err, http.StatusBadRequest)
-	}
-
-	_, err := configurator.LoadEntity(
-		nid, lte.CellularGatewayType, gid,
-		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
-	)
-	switch {
-	case err == merrors.ErrNotFound:
-		return echo.ErrNotFound
-	case err != nil:
-		return obsidian.HttpError(errors.Wrap(err, "failed to load cellular gateway"), http.StatusInternalServerError)
-	}
-
-	if nerr := handlers.UpdateMagmadGatewayFromModel(nid, gid, payload.GetMagmadGateway()); nerr != nil {
-		return nerr
-	}
-	if _, err := configurator.UpdateEntity(nid, payload.ToEntityUpdateCriteria()); err != nil {
-		return obsidian.HttpError(errors.Wrap(err, "failed to update cellular gateway"), http.StatusInternalServerError)
-	}
-
-	return c.NoContent(http.StatusNoContent)
-}
-
-func deleteGateway(c echo.Context) error {
-	nid, gid, nerr := obsidian.GetNetworkAndGatewayIDs(c)
-	if nerr != nil {
-		return nerr
-	}
-
-	err := configurator.DeleteEntities(
-		nid,
-		[]storage.TypeAndKey{
-			{Type: orc8r.MagmadGatewayType, Key: gid},
-			{Type: lte.CellularGatewayType, Key: gid},
-		},
-	)
-	if err != nil {
-		return obsidian.HttpError(err, http.StatusInternalServerError)
-	}
-	return c.NoContent(http.StatusNoContent)
-
-}
-
 type cellularAndMagmadGateway struct {
 	magmadGateway, cellularGateway configurator.NetworkEntity
 }
@@ -299,7 +171,7 @@ func makeLTEGateways(
 	entsByTK map[storage.TypeAndKey]configurator.NetworkEntity,
 	devicesByID map[string]interface{},
 	statusesByID map[string]*orc8rmodels.GatewayStatus,
-) map[string]*ltemodels.LteGateway {
+) map[string]handlers.GatewayModel {
 	gatewayEntsByKey := map[string]*cellularAndMagmadGateway{}
 	for tk, ent := range entsByTK {
 		existing, found := gatewayEntsByKey[tk.Key]
@@ -316,7 +188,7 @@ func makeLTEGateways(
 		}
 	}
 
-	ret := make(map[string]*ltemodels.LteGateway, len(gatewayEntsByKey))
+	ret := make(map[string]handlers.GatewayModel, len(gatewayEntsByKey))
 	for key, ents := range gatewayEntsByKey {
 		hwID := ents.magmadGateway.PhysicalID
 		var devCasted *orc8rmodels.GatewayDevice

--- a/lte/cloud/go/plugin/models/conversion.go
+++ b/lte/cloud/go/plugin/models/conversion.go
@@ -142,7 +142,7 @@ func (m *LteGateway) FromBackendModels(
 	magmadGateway, cellularGateway configurator.NetworkEntity,
 	device *models2.GatewayDevice,
 	status *models2.GatewayStatus,
-) *LteGateway {
+) handlers.GatewayModel {
 	// delegate most of the fillin to magmad gateway struct
 	mdGW := (&models2.MagmadGateway{}).FromBackendModels(magmadGateway, device, status)
 	// TODO: we should change this to a reflection based shallow copy
@@ -161,6 +161,10 @@ func (m *LteGateway) FromBackendModels(
 
 func (m *MutableLteGateway) ValidateModel() error {
 	return m.Validate(strfmt.Default)
+}
+
+func (m *MutableLteGateway) GetEmptyGateway() handlers.MutableGatewayModel {
+	return &MutableLteGateway{}
 }
 
 func (m *MutableLteGateway) GetMagmadGateway() *models2.MagmadGateway {

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -50,13 +50,6 @@ services:
       # - maria
     command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 && /usr/bin/supervisord"]
     # command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 maria:[port] && /usr/bin/supervisord"]
-    logging:
-      driver: fluentd
-      options:
-        fluentd-address: ':24224'
-        tag: orc8r.controller
-        fluentd-retry-wait: '1s'
-        fluentd-max-retries: '30'
     restart: always
 
   proxy:
@@ -77,13 +70,6 @@ services:
       - fluentd
     links:
       - fluentd
-    logging:
-      driver: fluentd
-      options:
-        fluentd-address: ':24224'
-        tag: orc8r.proxy
-        fluentd-retry-wait: '1s'
-        fluentd-max-retries: '30'
     restart: always
 
   elasticsearch:

--- a/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory.go
+++ b/orc8r/cloud/go/pluginimpl/handlers/gateway_handler_factory.go
@@ -9,17 +9,47 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 
-	"magma/orc8r/cloud/go/errors"
+	merrors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/pluginimpl/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
+	"magma/orc8r/cloud/go/services/state"
+	"magma/orc8r/cloud/go/storage"
 
 	"github.com/labstack/echo"
+	"github.com/pkg/errors"
 )
+
+// NetworkModel describes models that represent a certain type of gateway.
+// For example, an LTE gateway, that can be read/updated/deleted
+type GatewayModel interface {
+	ValidatableModel
+	// FromBackendModels the same PartialGatewayModel from the configurator
+	// entities attached to the networkID and gatewayID.
+	FromBackendModels(magmadGateway, cellularGateway configurator.NetworkEntity, device *models.GatewayDevice, status *models.GatewayStatus) GatewayModel
+}
+
+type MutableGatewayModel interface {
+	ValidatableModel
+	// GetEmptyGateway creates a new instance of the typed GatewayModel.
+	// It should be empty
+	GetEmptyGateway() MutableGatewayModel
+	// GetMagmadGateway returns a MagmadGateway of the gateway.
+	GetMagmadGateway() *models.MagmadGateway
+	// ToConfiguratorEntity returns a NetworkEntity of the gateway.
+	ToConfiguratorEntity() configurator.NetworkEntity
+	// GetMagmadGatewayUpdateCriteria returns an EntityUpdateCriteria needed
+	// to apply the change to the model.
+	GetMagmadGatewayUpdateCriteria() configurator.EntityUpdateCriteria
+	// ToEntityUpdateCriteria returns an EntityUpdateCriteria needed to apply
+	// the change in the model.
+	ToEntityUpdateCriteria() configurator.EntityUpdateCriteria
+}
 
 // PartialGatewayModel describe models that represents a portion of network
 // entity that can be read and updated.
@@ -32,6 +62,12 @@ type PartialGatewayModel interface {
 	// the change in the model.
 	ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error)
 }
+
+type MakeTypedGateways func(
+	entsByTK map[storage.TypeAndKey]configurator.NetworkEntity,
+	devicesByID map[string]interface{},
+	statusesByID map[string]*models.GatewayStatus,
+) map[string]GatewayModel
 
 // GetPartialGatewayHandlers returns both GET and PUT handlers for modifying the portion of a
 // network entity specified by the model.
@@ -65,7 +101,7 @@ func GetPartialReadGatewayHandler(path string, model PartialGatewayModel) obsidi
 			}
 
 			err := model.FromBackendModels(networkID, gatewayID)
-			if err == errors.ErrNotFound {
+			if err == merrors.ErrNotFound {
 				return obsidian.HttpError(err, http.StatusNotFound)
 			} else if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
@@ -140,13 +176,13 @@ func GetReadGatewayDeviceHandler(path string) obsidian.Handler {
 			}
 
 			physicalID, err := configurator.GetPhysicalIDOfEntity(networkID, orc8r.MagmadGatewayType, gatewayID)
-			if err == errors.ErrNotFound {
+			if err == merrors.ErrNotFound {
 				return obsidian.HttpError(err, http.StatusNotFound)
 			} else if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
 			}
 			device, err := device.GetDevice(networkID, orc8r.AccessGatewayRecordType, physicalID)
-			if err == errors.ErrNotFound {
+			if err == merrors.ErrNotFound {
 				return obsidian.HttpError(err, http.StatusNotFound)
 			} else if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
@@ -174,12 +210,163 @@ func GetUpdateGatewayDeviceHandler(path string) obsidian.Handler {
 			}
 
 			physicalID, err := configurator.GetPhysicalIDOfEntity(networkID, orc8r.MagmadGatewayType, gatewayID)
-			if err == errors.ErrNotFound {
+			if err == merrors.ErrNotFound {
 				return obsidian.HttpError(err, http.StatusNotFound)
 			} else if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
 			}
 			err = device.UpdateDevice(networkID, orc8r.AccessGatewayRecordType, physicalID, update)
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			return c.NoContent(http.StatusNoContent)
+		},
+	}
+}
+
+func GetListGatewaysHandler(path string, gatewayType string, makeTypedGateways MakeTypedGateways) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.GET,
+		HandlerFunc: func(c echo.Context) error {
+			nid, nerr := obsidian.GetNetworkId(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			ids, err := configurator.ListEntityKeys(nid, gatewayType)
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+
+			// for each ID, we want to load the carrier wifi gateway and the magmad gateway
+			entityTKs := make([]storage.TypeAndKey, 0, len(ids)*2)
+			for _, id := range ids {
+				entityTKs = append(
+					entityTKs,
+					storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: id},
+					storage.TypeAndKey{Type: gatewayType, Key: id},
+				)
+			}
+			ents, _, err := configurator.LoadEntities(nid, nil, nil, nil, entityTKs, configurator.FullEntityLoadCriteria())
+			if err != nil {
+				return obsidian.HttpError(err, http.StatusInternalServerError)
+			}
+			entsByTK := ents.ToEntitiesByID()
+
+			// for each magmad gateway, we have to load its corresponding device and
+			// its reported status
+			deviceIDs := make([]string, 0, len(ids))
+			for tk, ent := range entsByTK {
+				if tk.Type == orc8r.MagmadGatewayType && ent.PhysicalID != "" {
+					deviceIDs = append(deviceIDs, ent.PhysicalID)
+				}
+			}
+			devicesByID, err := device.GetDevices(nid, orc8r.AccessGatewayRecordType, deviceIDs)
+			if err != nil {
+				return obsidian.HttpError(errors.Wrap(err, "failed to load devices"), http.StatusInternalServerError)
+			}
+			statusesByID, err := state.GetGatewayStatuses(nid, deviceIDs)
+			if err != nil {
+				return obsidian.HttpError(errors.Wrap(err, "failed to load statuses"), http.StatusInternalServerError)
+			}
+			return c.JSON(http.StatusOK, makeTypedGateways(entsByTK, devicesByID, statusesByID))
+		},
+	}
+}
+
+func GetCreateGatewayHandler(path string, gatewayType string, gatewayModel MutableGatewayModel) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.POST,
+		HandlerFunc: func(c echo.Context) error {
+			nid, nerr := obsidian.GetNetworkId(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			payload := gatewayModel.GetEmptyGateway()
+			if err := c.Bind(payload); err != nil {
+				return obsidian.HttpError(err, http.StatusBadRequest)
+			}
+			if err := payload.ValidateModel(); err != nil {
+				return obsidian.HttpError(err, http.StatusBadRequest)
+			}
+
+			if nerr := CreateMagmadGatewayFromModel(nid, payload.GetMagmadGateway()); nerr != nil {
+				return nerr
+			}
+
+			if _, err := configurator.CreateEntity(nid, payload.ToConfiguratorEntity()); err != nil {
+				return obsidian.HttpError(errors.Wrap(err, fmt.Sprintf("failed to create %s gateway", gatewayType)), http.StatusInternalServerError)
+			}
+			if _, err := configurator.UpdateEntity(nid, payload.GetMagmadGatewayUpdateCriteria()); err != nil {
+				return obsidian.HttpError(errors.Wrap(err, fmt.Sprintf("failed to associate %s and magmad gateways", gatewayType)), http.StatusInternalServerError)
+			}
+
+			return c.NoContent(http.StatusCreated)
+		},
+	}
+}
+
+func GetUpdateGatewayHandler(path string, gatewayType string, gatewayModel MutableGatewayModel) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.PUT,
+		HandlerFunc: func(c echo.Context) error {
+			nid, gid, nerr := obsidian.GetNetworkAndGatewayIDs(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			payload := gatewayModel.GetEmptyGateway()
+			if err := c.Bind(payload); err != nil {
+				return obsidian.HttpError(err, http.StatusBadRequest)
+			}
+			if err := payload.ValidateModel(); err != nil {
+				return obsidian.HttpError(err, http.StatusBadRequest)
+			}
+
+			_, err := configurator.LoadEntity(
+				nid, gatewayType, gid,
+				configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+			)
+			switch {
+			case err == merrors.ErrNotFound:
+				return echo.ErrNotFound
+			case err != nil:
+				return obsidian.HttpError(errors.Wrap(err, fmt.Sprintf("failed to load %s gateway", gatewayType)), http.StatusInternalServerError)
+			}
+
+			if nerr := UpdateMagmadGatewayFromModel(nid, gid, payload.GetMagmadGateway()); nerr != nil {
+				return nerr
+			}
+			if _, err := configurator.UpdateEntity(nid, payload.ToEntityUpdateCriteria()); err != nil {
+				return obsidian.HttpError(errors.Wrap(err, fmt.Sprintf("failed to update %s gateway", gatewayType)), http.StatusInternalServerError)
+			}
+
+			return c.NoContent(http.StatusNoContent)
+		},
+	}
+}
+
+func GetDeleteGatewayHandler(path string, gatewayType string) obsidian.Handler {
+	return obsidian.Handler{
+		Path:    path,
+		Methods: obsidian.DELETE,
+		HandlerFunc: func(c echo.Context) error {
+			nid, gid, nerr := obsidian.GetNetworkAndGatewayIDs(c)
+			if nerr != nil {
+				return nerr
+			}
+
+			err := configurator.DeleteEntities(
+				nid,
+				[]storage.TypeAndKey{
+					{Type: orc8r.MagmadGatewayType, Key: gid},
+					{Type: gatewayType, Key: gid},
+				},
+			)
 			if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
 			}


### PR DESCRIPTION
Summary: Typed gateways have similar REST handler implementations, so this diff creates those handlers now. Used for LTE gateways so far.

Reviewed By: themarwhal

Differential Revision: D17418112

