### PR TITLE
Handle different metric sources more simply

### DIFF
--- a/feg/cloud/go/services/health/metrics/metrics.go
+++ b/feg/cloud/go/services/health/metrics/metrics.go
@@ -9,6 +9,7 @@ package metrics
 
 import (
 	"magma/feg/cloud/go/protos"
+	"magma/orc8r/cloud/go/metrics"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -20,19 +21,19 @@ var (
 			Name: "active_gateway_changed_total",
 			Help: "increases everytime the active gateway for a network is updated",
 		},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 	TotalGatewayCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gateway_total_count",
 			Help: "Total number of gateways that are in the network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 	HealthyGatewayCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gateway_health_count",
 			Help: "Number of gateways that are healthy in the network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 )
 

--- a/lte/cloud/go/services/eps_authentication/metrics/metrics.go
+++ b/lte/cloud/go/services/eps_authentication/metrics/metrics.go
@@ -8,7 +8,11 @@ LICENSE file in the root directory of this source tree.
 
 package metrics
 
-import "github.com/prometheus/client_golang/prometheus"
+import (
+	"magma/orc8r/cloud/go/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 var (
 	AIRequests = prometheus.NewCounter(prometheus.CounterOpts{
@@ -58,17 +62,17 @@ var (
 	AuthErrorsByNetwork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "auth_failures_total",
 		Help: "Total number of auth failures by network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 	AuthSuccessesByNetwork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "auth_successess_total",
 		Help: "Total number of auth successess by network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 	UnknowSubscribersByNetwork = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "unknown_subscribers_total",
 		Help: "Total number of unknown subscribers by network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 )
 

--- a/lte/cloud/go/services/eps_authentication/servicers/ai.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/ai.go
@@ -21,6 +21,7 @@ import (
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/eps_authentication/metrics"
 	"magma/orc8r/cloud/go/identity"
+	mcommon "magma/orc8r/cloud/go/metrics"
 )
 
 func (srv *EPSAuthServer) AuthenticationInformation(ctx context.Context, air *lteprotos.AuthenticationInformationRequest) (*lteprotos.AuthenticationInformationAnswer, error) {
@@ -48,7 +49,7 @@ func (srv *EPSAuthServer) AuthenticationInformation(ctx context.Context, air *lt
 	if err != nil {
 		glog.V(2).Infof("failed to lookup subscriber '%s': %v", air.UserName, err.Error())
 		metrics.UnknownSubscribers.Inc()
-		metrics.UnknowSubscribersByNetwork.With(prometheus.Labels{"networkId": networkID}).Inc()
+		metrics.UnknowSubscribersByNetwork.With(prometheus.Labels{mcommon.NetworkLabelName: networkID}).Inc()
 		return &lteprotos.AuthenticationInformationAnswer{ErrorCode: errorCode}, err
 	}
 
@@ -73,7 +74,7 @@ func (srv *EPSAuthServer) AuthenticationInformation(ctx context.Context, air *lt
 	if err != nil {
 		glog.V(2).Infof("could not create milenage cipher: %v", err.Error())
 		metrics.AuthErrors.Inc()
-		metrics.AuthErrorsByNetwork.With(prometheus.Labels{"networkId": networkID}).Inc()
+		metrics.AuthErrorsByNetwork.With(prometheus.Labels{mcommon.NetworkLabelName: networkID}).Inc()
 		return &lteprotos.AuthenticationInformationAnswer{ErrorCode: lteprotos.ErrorCode_AUTHORIZATION_REJECTED},
 			status.Errorf(codes.FailedPrecondition, "Could not create milenage cipher: %s", err.Error())
 	}
@@ -97,7 +98,7 @@ func (srv *EPSAuthServer) AuthenticationInformation(ctx context.Context, air *lt
 		return &lteprotos.AuthenticationInformationAnswer{ErrorCode: lteprotos.ErrorCode_AUTHENTICATION_DATA_UNAVAILABLE}, err
 	}
 
-	metrics.AuthSuccessesByNetwork.With(prometheus.Labels{"networkId": networkID}).Inc()
+	metrics.AuthSuccessesByNetwork.With(prometheus.Labels{mcommon.NetworkLabelName: networkID}).Inc()
 
 	return &lteprotos.AuthenticationInformationAnswer{
 		ErrorCode:     lteprotos.ErrorCode_SUCCESS,

--- a/orc8r/cloud/go/metrics/metrics_export.go
+++ b/orc8r/cloud/go/metrics/metrics_export.go
@@ -16,6 +16,11 @@ import (
 	prometheus_proto "github.com/prometheus/client_model/go"
 )
 
+const (
+	NetworkLabelName = "networkID"
+	GatewayLabelName = "gatewayID"
+)
+
 // This method gathers metrics from prometheus' default registry,
 // and adds a timestamp to each metric. This method is called
 // in Service303 Server's GetMetrics rpc implementation.

--- a/orc8r/cloud/go/metrics/metrics_export_test.go
+++ b/orc8r/cloud/go/metrics/metrics_export_test.go
@@ -13,7 +13,7 @@ import (
 	"math"
 	"testing"
 
-	"magma/orc8r/cloud/go/common/metrics"
+	"magma/orc8r/cloud/go/metrics"
 
 	"github.com/prometheus/client_golang/prometheus"
 	prometheus_proto "github.com/prometheus/client_model/go"

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/services/configurator"
 
 	"github.com/golang/protobuf/ptypes"
@@ -65,7 +66,7 @@ var gwExpiringCert = prometheus.NewCounterVec(
 		Name: "gateway_expiring_cert",
 		Help: "Count of GW cloud requests with soon to expire Client Certificate (indicated GW bootstrapper failure",
 	},
-	[]string{"networkId", "gatewayId"},
+	[]string{metrics.NetworkLabelName, metrics.GatewayLabelName},
 )
 
 func init() {

--- a/orc8r/cloud/go/service/service303.go
+++ b/orc8r/cloud/go/service/service303.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"magma/orc8r/cloud/go/common/metrics"
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/protos"
 
 	"golang.org/x/net/context"

--- a/orc8r/cloud/go/services/checkind/metrics/metrics.go
+++ b/orc8r/cloud/go/services/checkind/metrics/metrics.go
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 package metrics
 
 import (
+	"magma/orc8r/cloud/go/metrics"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -18,26 +20,26 @@ var (
 			Name: "gateway_checkin_status",
 			Help: "1 for checkin success, 0 for checkin failure",
 		},
-		[]string{"networkId", "gatewayId"},
+		[]string{metrics.NetworkLabelName, metrics.GatewayLabelName},
 	)
 	upGwCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gateway_up_count",
 			Help: "Number of gateways that are up in the network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 	totalGwCount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gateway_total_count",
 			Help: "Total number of gateways that are in the network"},
-		[]string{"networkId"},
+		[]string{metrics.NetworkLabelName},
 	)
 	gwMconfigAge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "gateway_mconfig_age",
 			Help: "Age of the mconfig in the gateway in seconds",
 		},
-		[]string{"networkId", "gatewayId"},
+		[]string{metrics.NetworkLabelName, metrics.GatewayLabelName},
 	)
 )
 

--- a/orc8r/cloud/go/services/metricsd/exporters/exporter.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/exporter.go
@@ -31,8 +31,30 @@ type MetricAndContext struct {
 
 // MetricsContext provides information to the exporter about where this metric
 // comes from.
-// OriginatingEntity - unique identifier for the originator of a metric
-// DecodedName       - name of the metric family
 type MetricsContext struct {
-	NetworkID, GatewayID, HardwareID, OriginatingEntity, DecodedName, MetricName string
+	MetricName        string
+	AdditionalContext AdditionalMetricContext
 }
+
+type AdditionalMetricContext interface {
+	isExtraMetricContext()
+}
+
+type CloudMetricContext struct {
+	// Hostname of the cloud host that this metric comes from
+	CloudHost string
+}
+
+func (c *CloudMetricContext) isExtraMetricContext() {}
+
+type GatewayMetricContext struct {
+	NetworkID, GatewayID string
+}
+
+func (c *GatewayMetricContext) isExtraMetricContext() {}
+
+type PushedMetricContext struct {
+	NetworkID string
+}
+
+func (c *PushedMetricContext) isExtraMetricContext() {}

--- a/orc8r/cloud/go/services/metricsd/exporters/sample_test.go
+++ b/orc8r/cloud/go/services/metricsd/exporters/sample_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package exporters
+
+import (
+	"fmt"
+	"testing"
+
+	"magma/orc8r/cloud/go/metrics"
+	tests "magma/orc8r/cloud/go/services/metricsd/test_common"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSamplesForMetrics(t *testing.T) {
+	for _, testCase := range cases {
+		t.Run(testCase.name, testCase.RunTest)
+	}
+}
+
+type getSamplesTestCase struct {
+	name            string
+	family          dto.MetricFamily
+	context         MetricsContext
+	expectedSamples []Sample
+}
+
+func (c *getSamplesTestCase) RunTest(t *testing.T) {
+	samples := GetSamplesForMetrics(MetricAndContext{Family: &c.family, Context: c.context}, c.family.Metric[0])
+	assert.Equal(t, c.expectedSamples, samples)
+}
+
+var (
+	testGateway    = "gw1"
+	testNetwork    = "nw1"
+	testMetricName = "metric1"
+	testCloudHost  = "hostA"
+	simpleLabels   = []*dto.LabelPair{{Name: tests.MakeStringPointer("testLabel"), Value: tests.MakeStringPointer("testValue")}}
+
+	cases = []getSamplesTestCase{
+		{
+			name:   "Pushed Metric with GatewayID",
+			family: *tests.MakeTestMetricFamily(dto.MetricType_GAUGE, 1, []*dto.LabelPair{{Name: tests.MakeStringPointer(metrics.GatewayLabelName), Value: &testGateway}}),
+			context: MetricsContext{
+				MetricName: testMetricName,
+				AdditionalContext: &PushedMetricContext{
+					NetworkID: testNetwork,
+				},
+			},
+			expectedSamples: []Sample{{
+				entity:      fmt.Sprintf("%s.%s", testNetwork, testGateway),
+				name:        testMetricName,
+				value:       "0",
+				timestampMs: 0,
+				labels:      []*dto.LabelPair{},
+			}},
+		},
+		{
+			name:   "Pushed Metric with no GatewayID",
+			family: *tests.MakeTestMetricFamily(dto.MetricType_GAUGE, 1, []*dto.LabelPair{}),
+			context: MetricsContext{
+				MetricName: testMetricName,
+				AdditionalContext: &PushedMetricContext{
+					NetworkID: testNetwork,
+				},
+			},
+			expectedSamples: []Sample{{
+				entity:      testNetwork,
+				name:        testMetricName,
+				value:       "0",
+				timestampMs: 0,
+				labels:      []*dto.LabelPair{},
+			}},
+		},
+		{
+			name:   "Gateway Metric",
+			family: *tests.MakeTestMetricFamily(dto.MetricType_GAUGE, 1, simpleLabels),
+			context: MetricsContext{
+				MetricName: testMetricName,
+				AdditionalContext: &GatewayMetricContext{
+					NetworkID: testNetwork,
+					GatewayID: testGateway,
+				},
+			},
+			expectedSamples: []Sample{{
+				entity:      fmt.Sprintf("%s.%s", testNetwork, testGateway),
+				name:        testMetricName,
+				value:       "0",
+				timestampMs: 0,
+				labels:      simpleLabels,
+			}},
+		},
+		{
+			name:   "Cloud Metric",
+			family: *tests.MakeTestMetricFamily(dto.MetricType_GAUGE, 1, simpleLabels),
+			context: MetricsContext{
+				MetricName: testMetricName,
+				AdditionalContext: &CloudMetricContext{
+					CloudHost: testCloudHost,
+				},
+			},
+			expectedSamples: []Sample{{
+				entity:      fmt.Sprintf("cloud.%s", testCloudHost),
+				name:        testMetricName,
+				value:       "0",
+				timestampMs: 0,
+				labels:      simpleLabels,
+			}},
+		},
+	}
+)

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule.go
@@ -11,8 +11,8 @@ package alert
 import (
 	"fmt"
 
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/security"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
@@ -81,7 +81,7 @@ func (f *File) DeleteRule(name string) error {
 // SecureRule attaches a label for networkID to the given alert expression to
 // to ensure that only metrics owned by this network can be alerted on
 func SecureRule(networkID string, rule *rulefmt.Rule) error {
-	networkLabels := map[string]string{exporters.NetworkLabelNetwork: networkID}
+	networkLabels := map[string]string{metrics.NetworkLabelName: networkID}
 	restrictor := security.NewQueryRestrictor(networkLabels)
 
 	restrictedExpression, err := restrictor.RestrictQuery(rule.Expr)
@@ -92,7 +92,7 @@ func SecureRule(networkID string, rule *rulefmt.Rule) error {
 	if rule.Labels == nil {
 		rule.Labels = make(map[string]string)
 	}
-	rule.Labels[exporters.NetworkLabelNetwork] = networkID
+	rule.Labels[metrics.NetworkLabelName] = networkID
 	return nil
 }
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/alert_rule_test.go
@@ -11,9 +11,9 @@ package alert_test
 import (
 	"testing"
 
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/security"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
@@ -93,13 +93,13 @@ func TestSecureRule(t *testing.T) {
 	err := alert.SecureRule("test", &rule)
 	assert.NoError(t, err)
 
-	networkLabels := map[string]string{exporters.NetworkLabelNetwork: "test"}
+	networkLabels := map[string]string{metrics.NetworkLabelName: "test"}
 	restrictor := security.NewQueryRestrictor(networkLabels)
 	expectedExpr, _ := restrictor.RestrictQuery(sampleRule.Expr)
 
 	assert.Equal(t, expectedExpr, rule.Expr)
 	assert.Equal(t, 2, len(rule.Labels))
-	assert.Equal(t, "test", rule.Labels[exporters.NetworkLabelNetwork])
+	assert.Equal(t, "test", rule.Labels[metrics.NetworkLabelName])
 }
 
 func TestRuleJSONWrapper_ToRuleFmt(t *testing.T) {

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/client.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/client.go
@@ -13,8 +13,8 @@ import (
 	"strings"
 	"sync"
 
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/files"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
 
 	"github.com/prometheus/alertmanager/config"
 
@@ -157,7 +157,7 @@ func (c *client) ModifyNetworkRoute(networkID string, route *config.Route) error
 		route.Match = map[string]string{}
 	}
 
-	route.Match[exporters.NetworkLabelNetwork] = networkID
+	route.Match[metrics.NetworkLabelName] = networkID
 
 	for _, childRoute := range route.Routes {
 		if childRoute == nil {

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/receiver.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/receivers/receiver.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
+	"magma/orc8r/cloud/go/metrics"
 
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/common/model"
@@ -57,7 +57,7 @@ func (c *Config) initializeNetworkBaseRoute(route *config.Route, networkID strin
 
 	c.Receivers = append(c.Receivers, &Receiver{Name: baseRouteName})
 	route.Receiver = baseRouteName
-	route.Match = map[string]string{exporters.NetworkLabelNetwork: networkID}
+	route.Match = map[string]string{metrics.NetworkLabelName: networkID}
 
 	c.Route.Routes = append(c.Route.Routes, route)
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/exporters/custom_promo_push.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/exporters/custom_promo_push.go
@@ -26,9 +26,7 @@ import (
 )
 
 const (
-	pushInterval        = time.Second * 30
-	NetworkLabelNetwork = "networkID"
-	NetworkLabelGateway = "gatewayID"
+	pushInterval = time.Second * 30
 )
 
 var (
@@ -83,7 +81,6 @@ func (e *CustomPushExporter) Submit(metrics []mxd_exp.MetricAndContext) error {
 				continue
 			}
 			for _, metric := range fam.Metric {
-				addContextLabelsToMetric(metric, metricAndContext.Context)
 				if metric.TimestampMs == nil || *metric.TimestampMs == 0 {
 					timeStamp := time.Now().Unix() * 1000
 					metric.TimestampMs = &timeStamp
@@ -111,30 +108,6 @@ func dropInvalidMetrics(metrics []*io_prometheus_client.Metric, familyName strin
 		}
 	}
 	return validMetrics
-}
-
-func addContextLabelsToMetric(metric *io_prometheus_client.Metric, ctx mxd_exp.MetricsContext) {
-	networkAdded, gatewayAdded := false, false
-	for _, label := range metric.Label {
-		if label.GetName() == NetworkLabelNetwork {
-			label.Value = makeStringPointer(ctx.NetworkID)
-			networkAdded = true
-		}
-		if label.GetName() == NetworkLabelGateway {
-			label.Value = makeStringPointer(ctx.GatewayID)
-			gatewayAdded = true
-		}
-	}
-	if !networkAdded {
-		metric.Label = append(metric.Label,
-			&io_prometheus_client.LabelPair{Name: makeStringPointer(NetworkLabelNetwork), Value: &ctx.NetworkID},
-		)
-	}
-	if !gatewayAdded {
-		metric.Label = append(metric.Label,
-			&io_prometheus_client.LabelPair{Name: makeStringPointer(NetworkLabelGateway), Value: &ctx.GatewayID},
-		)
-	}
 }
 
 func validateLabels(metric *io_prometheus_client.Metric) error {

--- a/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter_test.go
@@ -33,11 +33,11 @@ func TestHistogramToGauge(t *testing.T) {
 		name := family.GetName()
 		for _, metric := range family.Metric {
 			if name == (tests.HistogramMetricName + bucketPostfix) {
-				assert.True(t, hasLabelName(metric.Label, histogramBucketLabelName))
+				assert.True(t, tests.HasLabelName(metric.Label, histogramBucketLabelName))
 			} else if name == (tests.HistogramMetricName + sumPostfix) {
-				assert.False(t, hasLabelName(metric.Label, histogramBucketLabelName))
+				assert.False(t, tests.HasLabelName(metric.Label, histogramBucketLabelName))
 			} else if name == (tests.HistogramMetricName + countPostfix) {
-				assert.False(t, hasLabelName(metric.Label, histogramBucketLabelName))
+				assert.False(t, tests.HasLabelName(metric.Label, histogramBucketLabelName))
 			} else {
 				// Unexpected family name
 				t.Fail()
@@ -55,11 +55,11 @@ func TestSummaryToGauge(t *testing.T) {
 		name := family.GetName()
 		for _, metric := range family.Metric {
 			if name == tests.SummaryMetricName {
-				assert.True(t, hasLabelName(metric.Label, summaryQuantileLabelName))
+				assert.True(t, tests.HasLabelName(metric.Label, summaryQuantileLabelName))
 			} else if name == (tests.SummaryMetricName + sumPostfix) {
-				assert.False(t, hasLabelName(metric.Label, summaryQuantileLabelName))
+				assert.False(t, tests.HasLabelName(metric.Label, summaryQuantileLabelName))
 			} else if name == (tests.SummaryMetricName + countPostfix) {
-				assert.False(t, hasLabelName(metric.Label, summaryQuantileLabelName))
+				assert.False(t, tests.HasLabelName(metric.Label, summaryQuantileLabelName))
 			} else {
 				// Unexpected family name
 				t.Fail()

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -16,10 +16,10 @@ import (
 	"net/http"
 	neturl "net/url"
 
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/pluginimpl/handlers"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
 
 	"github.com/labstack/echo"
 	"github.com/prometheus/alertmanager/api/v2/models"
@@ -290,7 +290,7 @@ func viewFiringAlerts(networkID, alertmanagerApiURL string, c echo.Context) erro
 func getAlertsForNetwork(networkID string, alerts []models.GettableAlert) []models.GettableAlert {
 	networkAlerts := make([]models.GettableAlert, 0)
 	for _, alert := range alerts {
-		if labelVal, ok := alert.Labels[exporters.NetworkLabelNetwork]; ok {
+		if labelVal, ok := alert.Labels[metrics.NetworkLabelName]; ok {
 			if labelVal == networkID {
 				networkAlerts = append(networkAlerts, alert)
 			}

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -15,11 +15,11 @@ import (
 	"net/http"
 	"time"
 
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/pluginimpl/handlers"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/security"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/utils"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
 
 	"github.com/labstack/echo"
 	"github.com/prometheus/client_golang/api/prometheus/v1"
@@ -123,7 +123,7 @@ func preparePrometheusQuery(c echo.Context) (string, error) {
 }
 
 func preprocessQuery(query, networkID string) (string, error) {
-	restrictedLabels := map[string]string{exporters.NetworkLabelNetwork: networkID}
+	restrictedLabels := map[string]string{metrics.NetworkLabelName: networkID}
 	restrictor := security.NewQueryRestrictor(restrictedLabels)
 	return restrictor.RestrictQuery(query)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
@@ -12,7 +12,7 @@ import (
 	"fmt"
 	"testing"
 
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/exporters"
+	"magma/orc8r/cloud/go/metrics"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,6 +22,6 @@ func TestPreprocessQuery(t *testing.T) {
 	networkID := "network1"
 	preprocessedQuery, err := preprocessQuery(testQuery, networkID)
 	assert.NoError(t, err)
-	expectedQuery := fmt.Sprintf("%s{%s=\"%s\"}", testQuery, exporters.NetworkLabelNetwork, networkID)
+	expectedQuery := fmt.Sprintf("%s{%s=\"%s\"}", testQuery, metrics.NetworkLabelName, networkID)
 	assert.Equal(t, expectedQuery, preprocessedQuery)
 }

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -12,9 +12,9 @@ LICENSE file in the root directory of this source tree.
 package servicers
 
 import (
-	"strings"
 	"time"
 
+	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/metricsd/exporters"
@@ -59,7 +59,7 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 	}
 	glog.V(2).Infof("collecting %v metrics from gateway %v\n", len(in.Family), in.GatewayId)
 
-	metricsToSubmit := metricsContainerToMetricAndContexts(in, networkID, hardwareID, gatewayID)
+	metricsToSubmit := metricsContainerToMetricAndContexts(in, networkID, gatewayID)
 	for _, e := range srv.exporters {
 		err := e.Submit(metricsToSubmit)
 		if err != nil {
@@ -74,32 +74,29 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 // forever.
 func (srv *MetricsControllerServer) ConsumeCloudMetrics(inputChan chan *prometheusProto.MetricFamily, hostName string) error {
 	for family := range inputChan {
+		metricsToSubmit := preprocessCloudMetrics(family, hostName)
 		for _, e := range srv.exporters {
-			decodedName := protos.GetDecodedName(family)
-			networkID, gatewayID := unpackCloudMetricName(decodedName)
-			if networkID == "" {
-				networkID = exporters.CloudMetricID
-			}
-			if gatewayID == "" {
-				gatewayID = hostName
-			}
-			ctx := exporters.MetricsContext{
-				MetricName:        removeCloudMetricLabels(decodedName),
-				NetworkID:         networkID,
-				GatewayID:         gatewayID,
-				OriginatingEntity: networkID + "." + gatewayID,
-				DecodedName:       decodedName,
-			}
-			for _, metric := range family.Metric {
-				metric.Label = protos.GetDecodedLabel(metric)
-			}
-			err := e.Submit([]exporters.MetricAndContext{{Family: family, Context: ctx}})
+			err := e.Submit([]exporters.MetricAndContext{metricsToSubmit})
 			if err != nil {
 				glog.Error(err)
 			}
 		}
 	}
 	return nil
+}
+
+func preprocessCloudMetrics(family *prometheusProto.MetricFamily, hostName string) exporters.MetricAndContext {
+	ctx := exporters.MetricsContext{
+		MetricName: protos.GetDecodedName(family),
+		AdditionalContext: &exporters.CloudMetricContext{
+			CloudHost: hostName,
+		},
+	}
+	for _, metric := range family.Metric {
+		metric.Label = protos.GetDecodedLabel(metric)
+		addRequiredLabelToMetric(metric, "cloudHost", hostName)
+	}
+	return exporters.MetricAndContext{Family: family, Context: ctx}
 }
 
 func (srv *MetricsControllerServer) RegisterExporter(e exporters.Exporter) []exporters.Exporter {
@@ -109,20 +106,21 @@ func (srv *MetricsControllerServer) RegisterExporter(e exporters.Exporter) []exp
 
 func metricsContainerToMetricAndContexts(
 	in *protos.MetricsContainer,
-	networkID string, hardwareID string, gatewayID string,
+	networkID, gatewayID string,
 ) []exporters.MetricAndContext {
 	ret := make([]exporters.MetricAndContext, 0, len(in.Family))
 	for _, fam := range in.Family {
 		ctx := exporters.MetricsContext{
-			MetricName:        protos.GetDecodedName(fam),
-			NetworkID:         networkID,
-			HardwareID:        hardwareID,
-			GatewayID:         gatewayID,
-			OriginatingEntity: networkID + "." + gatewayID,
-			DecodedName:       protos.GetDecodedName(fam),
+			MetricName: protos.GetDecodedName(fam),
+			AdditionalContext: &exporters.GatewayMetricContext{
+				NetworkID: networkID,
+				GatewayID: gatewayID,
+			},
 		}
 		for _, metric := range fam.Metric {
 			metric.Label = protos.GetDecodedLabel(metric)
+			addRequiredLabelToMetric(metric, metrics.NetworkLabelName, networkID)
+			addRequiredLabelToMetric(metric, metrics.GatewayLabelName, gatewayID)
 		}
 		ret = append(ret, exporters.MetricAndContext{Family: fam, Context: ctx})
 	}
@@ -133,85 +131,54 @@ func pushedMetricsToMetricsAndContext(in *protos.PushedMetricsContainer) []expor
 	ret := make([]exporters.MetricAndContext, 0, len(in.Metrics))
 	for _, metric := range in.Metrics {
 		ctx := exporters.MetricsContext{
-			MetricName:  metric.MetricName,
-			DecodedName: metric.MetricName,
-			NetworkID:   in.NetworkId,
+			MetricName: metric.MetricName,
+			AdditionalContext: &exporters.PushedMetricContext{
+				NetworkID: in.NetworkId,
+			},
 		}
-		gaugeType := prometheusProto.MetricType_GAUGE
+
+		ts := metric.TimestampMS
+		if ts == 0 {
+			ts = time.Now().Unix() * 1000
+		}
 
 		prometheusLabels := make([]*prometheusProto.LabelPair, 0, len(metric.Labels))
 		for _, label := range metric.Labels {
 			prometheusLabels = append(prometheusLabels, &prometheusProto.LabelPair{Name: &label.Name, Value: &label.Value})
 		}
-		ts := metric.TimestampMS
-		if ts == 0 {
-			ts = time.Now().Unix() * 1000
+		promoMetric := &prometheusProto.Metric{
+			Label: prometheusLabels,
+			Gauge: &prometheusProto.Gauge{
+				Value: &metric.Value,
+			},
+			TimestampMs: &ts,
 		}
+		addRequiredLabelToMetric(promoMetric, metrics.NetworkLabelName, in.NetworkId)
+
+		gaugeType := prometheusProto.MetricType_GAUGE
 		fam := &prometheusProto.MetricFamily{
-			Name: &metric.MetricName,
-			Type: &gaugeType,
-			Metric: []*prometheusProto.Metric{{
-				Label: prometheusLabels,
-				Gauge: &prometheusProto.Gauge{
-					Value: &metric.Value,
-				},
-				TimestampMs: &ts,
-			},
-			},
+			Name:   &metric.MetricName,
+			Type:   &gaugeType,
+			Metric: []*prometheusProto.Metric{promoMetric},
 		}
 		ret = append(ret, exporters.MetricAndContext{Family: fam, Context: ctx})
 	}
 	return ret
 }
 
-// unpackCloudMetricName takes a "cloud" metric name and attempts to parse out
-// the networkID and gatewayID from the name. Returns an error if either do not
-// exist.
-func unpackCloudMetricName(metricName string) (string, string) {
-	const (
-		networkLabel = "networkId"
-		gatewayLabel = "gatewayId"
-	)
-	var networkID, gatewayID string
-
-	networkLabelIndex := strings.Index(metricName, networkLabel)
-	gatewayLabelIndex := strings.Index(metricName, gatewayLabel)
-	if gatewayLabelIndex == -1 {
-		if networkLabelIndex == -1 {
-			return "", ""
+func addRequiredLabelToMetric(metric *prometheusProto.Metric, labelName, labelValue string) {
+	labelAdded := false
+	for _, label := range metric.Label {
+		if label.GetName() == labelName {
+			label.Value = &labelValue
+			labelAdded = true
 		}
-		networkStart := networkLabelIndex + len(networkLabel) + 1
-		networkID = metricName[networkStart:]
-		return networkID, ""
 	}
-
-	networkStart := networkLabelIndex + len(networkLabel) + 1
-	gatewayStart := gatewayLabelIndex + len(gatewayLabel) + 1
-
-	gatewayID = metricName[gatewayStart : networkLabelIndex-1]
-	networkID = metricName[networkStart:]
-
-	return networkID, gatewayID
+	if !labelAdded {
+		metric.Label = append(metric.Label, &prometheusProto.LabelPair{Name: makeStringPointer(labelName), Value: &labelValue})
+	}
 }
 
-// removeCloudMetricLabels takes a cloud metric name and removes the networkID
-// and gatewayID labels from the name if they exist
-func removeCloudMetricLabels(metricName string) string {
-	const (
-		networkLabel = "networkId"
-		gatewayLabel = "gatewayId"
-	)
-	networkLabelIndex := strings.Index(metricName, networkLabel)
-	gatewayLabelIndex := strings.Index(metricName, gatewayLabel)
-	if gatewayLabelIndex == -1 {
-		if networkLabelIndex == -1 {
-			return metricName
-		}
-		networkStart := networkLabelIndex - 1
-		return metricName[:networkStart]
-	}
-
-	gatewayStart := gatewayLabelIndex - 1
-
-	return metricName[:gatewayStart]
+func makeStringPointer(s string) *string {
+	return &s
 }

--- a/orc8r/cloud/go/services/metricsd/test_common/utils.go
+++ b/orc8r/cloud/go/services/metricsd/test_common/utils.go
@@ -117,3 +117,21 @@ func MakeStringPointer(s string) *string {
 func MakeMetricTypePointer(t dto.MetricType) *dto.MetricType {
 	return &t
 }
+
+func HasLabelName(labels []*dto.LabelPair, name string) bool {
+	for _, label := range labels {
+		if label.GetName() == name {
+			return true
+		}
+	}
+	return false
+}
+
+func HasLabel(labels []*dto.LabelPair, name, value string) bool {
+	for _, label := range labels {
+		if label.GetName() == name {
+			return label.GetValue() == value
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Summary:
The metricsd servicer had gotten a little out of date and things had just been hacked onto it to make it work with new exporters and new metric sources. This diff aims to streamline the metricsd pipeline.

Main Changes:
* Added the concept of a `MetricSource` so exporters can handle metrics differently based on where they originate.
  * This was originally handled with `context.OriginatingEntity` but did not work well
* Move all labeling to `servicer.go`
  * Previously exporters would append labels based on what was in the context. Move this responsibility to the servicer.
  * Exporters can still manipulate labels (possible use case: based on metric source) if necessary
* Make the `networkID` label name a constant instead of having it spread across multiple packages
* Allows `cloud` metrics to be available to network operators since they are no longer tagged with `networkID="cloud"` but rather have a tag `cloudHost` and include the networkID label if necessary

Differential Revision: D17514204

