### PR TITLE
Add unit tests for V1 API REST handlers

### DIFF
--- a/cwf/cloud/go/plugin/handlers/handlers.go
+++ b/cwf/cloud/go/plugin/handlers/handlers.go
@@ -13,6 +13,7 @@ import (
 
 	"magma/cwf/cloud/go/cwf"
 	cwfmodels "magma/cwf/cloud/go/plugin/models"
+	fegmodels "magma/feg/cloud/go/plugin/models"
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
@@ -33,6 +34,7 @@ const (
 	ManageNetworkFeaturesPath    = ManageNetworkPath + obsidian.UrlSep + "features"
 	ManageNetworkDNSPath         = ManageNetworkPath + obsidian.UrlSep + "dns"
 	ManageNetworkCarrierWifiPath = ManageNetworkPath + obsidian.UrlSep + "carrier_wifi"
+	ManageNetworkFederationPath  = ManageNetworkPath + obsidian.UrlSep + "federation"
 
 	Gateways                     = "gateways"
 	ListGatewaysPath             = ManageNetworkPath + obsidian.UrlSep + Gateways
@@ -63,6 +65,7 @@ func GetHandlers() []obsidian.Handler {
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8rmodels.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSPath, &orc8rmodels.NetworkDNSConfig{}, orc8r.DnsdNetworkType)...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCarrierWifiPath, &cwfmodels.NetworkCarrierWifiConfigs{}, cwf.CwfNetworkType)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFederationPath, &fegmodels.FederatedNetworkConfigs{}, cwf.CwfNetworkType)...)
 
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)

--- a/cwf/cloud/go/plugin/handlers/handlers_test.go
+++ b/cwf/cloud/go/plugin/handlers/handlers_test.go
@@ -1,0 +1,475 @@
+package handlers_test
+
+import (
+	"testing"
+	"time"
+
+	"magma/cwf/cloud/go/cwf"
+	plugin2 "magma/cwf/cloud/go/plugin"
+	"magma/cwf/cloud/go/plugin/handlers"
+	models2 "magma/cwf/cloud/go/plugin/models"
+	"magma/feg/cloud/go/feg"
+	plugin3 "magma/feg/cloud/go/plugin"
+	models3 "magma/feg/cloud/go/plugin/models"
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/pluginimpl/models"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/configurator/test_init"
+	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
+	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
+	"magma/orc8r/cloud/go/services/state/test_utils"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCwfNetworks(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin2.CwfOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin3.FegOrchestratorPlugin{})
+	test_init.StartTestService(t)
+	e := echo.New()
+
+	obsidianHandlers := handlers.GetHandlers()
+	listNetworks := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf", obsidian.GET).HandlerFunc
+	createNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf", obsidian.POST).HandlerFunc
+	getNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id", obsidian.GET).HandlerFunc
+	updateNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id", obsidian.PUT).HandlerFunc
+	deleteNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id", obsidian.DELETE).HandlerFunc
+	getNetworkFederationConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/federation", obsidian.GET).HandlerFunc
+	getCarrierWifiConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/carrier_wifi", obsidian.GET).HandlerFunc
+
+	// Test ListNetworks
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{}),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	seedCwfNetworks(t)
+	fegNetworkID := "n5"
+
+	// Test CreateNetwork
+	tc = tests.Test{
+		Method: "POST",
+		URL:    "/magma/v1/cwf",
+		Payload: tests.JSONMarshaler(
+			&models2.CwfNetwork{
+				CarrierWifi: models2.NewDefaultNetworkCarrierWifiConfigs(),
+				Federation: &models3.FederatedNetworkConfigs{
+					FegNetworkID: &fegNetworkID,
+				},
+				Description: "Foo Bar",
+				DNS:         models.NewDefaultDNSConfig(),
+				Features:    models.NewDefaultFeaturesConfig(),
+				ID:          "n4",
+				Name:        "foobar",
+			},
+		),
+		Handler:        createNetwork,
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test ListNetworks
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{"n1", "n3", "n4"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test GetNetwork
+	expectedN1 := &models2.CwfNetwork{
+		CarrierWifi: models2.NewDefaultNetworkCarrierWifiConfigs(),
+		Federation: &models3.FederatedNetworkConfigs{
+			FegNetworkID: &fegNetworkID,
+		},
+		Description: "Foo Bar",
+		DNS:         models.NewDefaultDNSConfig(),
+		Features:    models.NewDefaultFeaturesConfig(),
+		ID:          "n1",
+		Name:        "foobar",
+	}
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getNetwork,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(expectedN1),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test UpdateNetwork
+	payloadN1 := &models2.CwfNetwork{
+		ID:          "n1",
+		Name:        "updated foobar",
+		Description: "Updated Foo Bar",
+		CarrierWifi: models2.NewDefaultModifiedNetworkCarrierWifiConfigs(),
+		Federation: &models3.FederatedNetworkConfigs{
+			FegNetworkID: &fegNetworkID,
+		},
+		Features: &models.NetworkFeatures{
+			Features: map[string]string{
+				"bar": "baz",
+				"baz": "quz",
+			},
+		},
+		DNS: &models.NetworkDNSConfig{
+			EnableCaching: swag.Bool(true),
+			LocalTTL:      swag.Uint32(120),
+			Records: []*models.DNSConfigRecord{
+				{
+					Domain:  "foobar.com",
+					ARecord: []strfmt.IPv4{"127.0.0.1", "127.0.0.2"},
+					AaaaRecord: []strfmt.IPv6{
+						"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+						"1234:0db8:85a3:0000:0000:8a2e:0370:1234",
+					},
+				},
+				{
+					Domain:  "facebook.com",
+					ARecord: []strfmt.IPv4{"127.0.0.3"},
+				},
+			},
+		},
+	}
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/cwf/n1",
+		Payload:        payloadN1,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        updateNetwork,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	assert.NoError(t, err)
+	expected := configurator.Network{
+		ID:          "n1",
+		Type:        cwf.CwfNetworkType,
+		Name:        "updated foobar",
+		Description: "Updated Foo Bar",
+		Configs: map[string]interface{}{
+			cwf.CwfNetworkType: models2.NewDefaultModifiedNetworkCarrierWifiConfigs(),
+			feg.FederatedNetworkType: &models3.FederatedNetworkConfigs{
+				FegNetworkID: &fegNetworkID,
+			},
+			orc8r.DnsdNetworkType:       payloadN1.DNS,
+			orc8r.NetworkFeaturesConfig: payloadN1.Features,
+		},
+		Version: 1,
+	}
+	assert.Equal(t, expected, actualN1)
+
+	// Test GetFederationPartialGet
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/federation",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getNetworkFederationConfig,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(&models3.FederatedNetworkConfigs{
+			FegNetworkID: &fegNetworkID,
+		}),
+		ExpectedError: "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test GetCarrierWifiPartialGet
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/carrier_wifi",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getCarrierWifiConfig,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(models2.NewDefaultModifiedNetworkCarrierWifiConfigs()),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test DeleteNetwork
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/cwf/n1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        deleteNetwork,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{"n3", "n4"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+func TestCwfGateways(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin2.CwfOrchestratorPlugin{})
+	clock.SetAndFreezeClock(t, time.Unix(1000000, 0))
+	defer clock.GetUnfreezeClockDeferFunc(t)()
+	test_init.StartTestService(t)
+	stateTestInit.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+
+	e := echo.New()
+
+	obsidianHandlers := handlers.GetHandlers()
+	createGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/gateways", obsidian.POST).HandlerFunc
+	listGateways := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/gateways", obsidian.GET).HandlerFunc
+	getGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/gateways/:gateway_id", obsidian.GET).HandlerFunc
+	updateGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/gateways/:gateway_id", obsidian.PUT).HandlerFunc
+	deleteGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/gateways/:gateway_id", obsidian.DELETE).HandlerFunc
+
+	seedCwfNetworks(t)
+
+	// setup fixtures in backend
+	_, err := configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
+		},
+	)
+	assert.NoError(t, err)
+
+	// Test CreateGateway
+	payload := &models2.MutableCwfGateway{
+		Device: &models.GatewayDevice{
+			HardwareID: "hw1",
+			Key:        &models.ChallengeKey{KeyType: "ECHO"},
+		},
+		ID:          "g1",
+		Name:        "foobar",
+		Description: "foo bar",
+		Magmad: &models.MagmadGatewayConfigs{
+			CheckinInterval:         15,
+			CheckinTimeout:          5,
+			AutoupgradePollInterval: 300,
+			AutoupgradeEnabled:      swag.Bool(true),
+		},
+		Tier: "t1",
+	}
+	tc := tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/cwf/n1/gateways",
+		Handler:        createGateway,
+		Payload:        payload,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test ListGateways
+	ctx := test_utils.GetContextWithCertificate(t, "hw1")
+	test_utils.ReportGatewayStatus(t, ctx, models.NewDefaultGatewayStatus("hw1"))
+
+	expected := map[string]*models2.CwfGateway{
+		"g1": {
+			ID: "g1",
+			Device: &models.GatewayDevice{
+				HardwareID: "hw1",
+				Key:        &models.ChallengeKey{KeyType: "ECHO"},
+			},
+			Name: "foobar", Description: "foo bar",
+			Tier: "t1",
+			Magmad: &models.MagmadGatewayConfigs{
+				AutoupgradeEnabled:      swag.Bool(true),
+				AutoupgradePollInterval: 300,
+				CheckinInterval:         15,
+				CheckinTimeout:          5,
+			},
+			Status: models.NewDefaultGatewayStatus("hw1"),
+		},
+	}
+	expected["g1"].Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
+	expected["g1"].Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/gateways",
+		Handler:        listGateways,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(expected),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test GetGateway
+	expectedGet := &models2.CwfGateway{
+		ID: "g1",
+		Device: &models.GatewayDevice{
+			HardwareID: "hw1",
+			Key:        &models.ChallengeKey{KeyType: "ECHO"},
+		},
+		Name: "foobar", Description: "foo bar",
+		Tier: "t1",
+		Magmad: &models.MagmadGatewayConfigs{
+			AutoupgradeEnabled:      swag.Bool(true),
+			AutoupgradePollInterval: 300,
+			CheckinInterval:         15,
+			CheckinTimeout:          5,
+		},
+		Status: models.NewDefaultGatewayStatus("hw1"),
+	}
+	expectedGet.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
+	expectedGet.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/gateways/g1",
+		Handler:        getGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: expectedGet,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test UpdateGateway
+	payload = &models2.MutableCwfGateway{
+		Device: &models.GatewayDevice{
+			HardwareID: "hw1",
+			Key:        &models.ChallengeKey{KeyType: "ECHO"},
+		},
+		ID:          "g1",
+		Name:        "newname",
+		Description: "bar baz",
+		Magmad: &models.MagmadGatewayConfigs{
+			AutoupgradeEnabled:      swag.Bool(true),
+			AutoupgradePollInterval: 300,
+			CheckinInterval:         15,
+			CheckinTimeout:          5,
+		},
+		Tier: "t1",
+	}
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/cwf/n1/gateways/g1",
+		Handler:        updateGateway,
+		Payload:        payload,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	expectedGet.Name = "newname"
+	expectedGet.Description = "bar baz"
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/gateways/g1",
+		Handler:        getGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: expectedGet,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test DeleteGateway
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/cwf/n1/gateways/g1",
+		Handler:        deleteGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/gateways/g1",
+		Handler:        getGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+}
+
+// n1, n3 are cwf networks, n2, n5 are not
+func seedCwfNetworks(t *testing.T) {
+	fegNetworkID := "n5"
+	_, err := configurator.CreateNetworks(
+		[]configurator.Network{
+			{
+				ID:          fegNetworkID,
+				Type:        feg.FederationNetworkType,
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs: map[string]interface{}{
+					feg.FegNetworkType:          models3.NewDefaultNetworkFederationConfigs(),
+					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+				},
+			},
+		},
+	)
+	assert.NoError(t, err)
+	_, err = configurator.CreateNetworks(
+		[]configurator.Network{
+			{
+				ID:          "n1",
+				Type:        cwf.CwfNetworkType,
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs: map[string]interface{}{
+					cwf.CwfNetworkType: models2.NewDefaultNetworkCarrierWifiConfigs(),
+					feg.FederatedNetworkType: &models3.FederatedNetworkConfigs{
+						FegNetworkID: &fegNetworkID,
+					},
+					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+				},
+			},
+			{
+				ID:          "n2",
+				Type:        "blah",
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs:     map[string]interface{}{},
+			},
+			{
+				ID:          "n3",
+				Type:        cwf.CwfNetworkType,
+				Name:        "barfoo",
+				Description: "Bar Foo",
+				Configs:     map[string]interface{}{},
+			},
+		},
+	)
+	assert.NoError(t, err)
+}

--- a/cwf/cloud/go/plugin/models/conversion.go
+++ b/cwf/cloud/go/plugin/models/conversion.go
@@ -10,6 +10,8 @@ package models
 
 import (
 	"magma/cwf/cloud/go/cwf"
+	"magma/feg/cloud/go/feg"
+	models3 "magma/feg/cloud/go/plugin/models"
 	merrors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/orc8r"
@@ -34,6 +36,7 @@ func (m *CwfNetwork) ToConfiguratorNetwork() configurator.Network {
 		Description: string(m.Description),
 		Configs: map[string]interface{}{
 			cwf.CwfNetworkType:          m.CarrierWifi,
+			feg.FederatedNetworkType:    m.Federation,
 			orc8r.DnsdNetworkType:       m.DNS,
 			orc8r.NetworkFeaturesConfig: m.Features,
 		},
@@ -47,6 +50,7 @@ func (m *CwfNetwork) ToUpdateCriteria() configurator.NetworkUpdateCriteria {
 		NewDescription: swag.String(string(m.Description)),
 		ConfigsToAddOrUpdate: map[string]interface{}{
 			cwf.CwfNetworkType:          m.CarrierWifi,
+			feg.FederatedNetworkType:    m.Federation,
 			orc8r.DnsdNetworkType:       m.DNS,
 			orc8r.NetworkFeaturesConfig: m.Features,
 		},
@@ -59,6 +63,9 @@ func (m *CwfNetwork) FromConfiguratorNetwork(n configurator.Network) interface{}
 	m.Description = models.NetworkDescription(n.Description)
 	if cfg := n.Configs[cwf.CwfNetworkType]; cfg != nil {
 		m.CarrierWifi = cfg.(*NetworkCarrierWifiConfigs)
+	}
+	if cfg := n.Configs[feg.FederatedNetworkType]; cfg != nil {
+		m.Federation = cfg.(*models3.FederatedNetworkConfigs)
 	}
 	if cfg := n.Configs[orc8r.DnsdNetworkType]; cfg != nil {
 		m.DNS = cfg.(*models2.NetworkDNSConfig)

--- a/cwf/cloud/go/plugin/models/defaults.go
+++ b/cwf/cloud/go/plugin/models/defaults.go
@@ -1,0 +1,29 @@
+package models
+
+func NewDefaultNetworkCarrierWifiConfigs() *NetworkCarrierWifiConfigs {
+	defaultRuleID := "default_rule_1"
+	return &NetworkCarrierWifiConfigs{
+		AaaServer: &AaaServer{
+			AccountingEnabled:    false,
+			CreateSessionOnAuth:  false,
+			IDLESessionTimeoutMs: 21600000,
+		},
+		DefaultRuleID: &defaultRuleID,
+		EapAka: &EapAka{
+			PlmnIds: []string{"123456"},
+			Timeout: &EapAkaTimeout{
+				ChallengeMs:            20000,
+				ErrorNotificationMs:    10000,
+				SessionAuthenticatedMs: 5000,
+				SessionMs:              43200000,
+			},
+		},
+		NetworkServices: []string{"policy_enforcement"},
+	}
+}
+
+func NewDefaultModifiedNetworkCarrierWifiConfigs() *NetworkCarrierWifiConfigs {
+	configs := NewDefaultNetworkCarrierWifiConfigs()
+	configs.AaaServer.AccountingEnabled = true
+	return configs
+}

--- a/feg/cloud/go/plugin/handlers/handlers.go
+++ b/feg/cloud/go/plugin/handlers/handlers.go
@@ -53,7 +53,7 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: handlers.GetStateHandler},
 	}
 
-	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegNetworksPath, ManageFegNetworkPath, feg.FederatedLteNetworkType, &fegmodels.FegLteNetwork{})...)
+	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegNetworksPath, ManageFegNetworkPath, feg.FederationNetworkType, &fegmodels.FegNetwork{})...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkFederationPath, &fegmodels.NetworkFederationConfigs{}, "")...)
 	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayFederationPath, &fegmodels.GatewayFederationConfigs{})...)
 

--- a/feg/cloud/go/plugin/handlers/handlers_test.go
+++ b/feg/cloud/go/plugin/handlers/handlers_test.go
@@ -1,0 +1,654 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package handlers_test
+
+import (
+	"testing"
+	"time"
+
+	"magma/feg/cloud/go/feg"
+	plugin2 "magma/feg/cloud/go/plugin"
+	"magma/feg/cloud/go/plugin/handlers"
+	models2 "magma/feg/cloud/go/plugin/models"
+	"magma/lte/cloud/go/lte"
+	plugin3 "magma/lte/cloud/go/plugin"
+	models3 "magma/lte/cloud/go/plugin/models"
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/pluginimpl/models"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/configurator/test_init"
+	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
+	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
+	"magma/orc8r/cloud/go/services/state/test_utils"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFederationNetworks(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin2.FegOrchestratorPlugin{})
+	test_init.StartTestService(t)
+	e := echo.New()
+
+	obsidianHandlers := handlers.GetHandlers()
+	listNetworks := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg", obsidian.GET).HandlerFunc
+	createNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg", obsidian.POST).HandlerFunc
+	getNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id", obsidian.GET).HandlerFunc
+	updateNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id", obsidian.PUT).HandlerFunc
+	deleteNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id", obsidian.DELETE).HandlerFunc
+	getNetworkFederationConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id/federation", obsidian.GET).HandlerFunc
+
+	// Test ListNetworks
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{}),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	seedFederationNetworks(t)
+
+	// Test CreateNetwork
+	tc = tests.Test{
+		Method: "POST",
+		URL:    "/magma/v1/feg",
+		Payload: tests.JSONMarshaler(
+			&models2.FegNetwork{
+				Federation:  models2.NewDefaultNetworkFederationConfigs(),
+				Description: "Foo Bar",
+				DNS:         models.NewDefaultDNSConfig(),
+				Features:    models.NewDefaultFeaturesConfig(),
+				ID:          "n4",
+				Name:        "foobar",
+			},
+		),
+		Handler:        createNetwork,
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test ListNetworks
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{"n1", "n3", "n4"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test GetNetwork
+	expectedN1 := &models2.FegNetwork{
+		Federation:  models2.NewDefaultNetworkFederationConfigs(),
+		Description: "Foo Bar",
+		DNS:         models.NewDefaultDNSConfig(),
+		Features:    models.NewDefaultFeaturesConfig(),
+		ID:          "n1",
+		Name:        "foobar",
+	}
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg/n1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getNetwork,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(expectedN1),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test UpdateNetwork
+	payloadN1 := &models2.FegNetwork{
+		ID:          "n1",
+		Name:        "updated foobar",
+		Description: "Updated Foo Bar",
+		Federation:  models2.NewDefaultModifiedNetworkFederationConfigs(),
+		Features: &models.NetworkFeatures{
+			Features: map[string]string{
+				"bar": "baz",
+				"baz": "quz",
+			},
+		},
+		DNS: &models.NetworkDNSConfig{
+			EnableCaching: swag.Bool(true),
+			LocalTTL:      swag.Uint32(120),
+			Records: []*models.DNSConfigRecord{
+				{
+					Domain:  "foobar.com",
+					ARecord: []strfmt.IPv4{"127.0.0.1", "127.0.0.2"},
+					AaaaRecord: []strfmt.IPv6{
+						"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+						"1234:0db8:85a3:0000:0000:8a2e:0370:1234",
+					},
+				},
+				{
+					Domain:  "facebook.com",
+					ARecord: []strfmt.IPv4{"127.0.0.3"},
+				},
+			},
+		},
+	}
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/feg/n1",
+		Payload:        payloadN1,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        updateNetwork,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	assert.NoError(t, err)
+	expected := configurator.Network{
+		ID:          "n1",
+		Type:        feg.FederationNetworkType,
+		Name:        "updated foobar",
+		Description: "Updated Foo Bar",
+		Configs: map[string]interface{}{
+			feg.FegNetworkType:          models2.NewDefaultModifiedNetworkFederationConfigs(),
+			orc8r.DnsdNetworkType:       payloadN1.DNS,
+			orc8r.NetworkFeaturesConfig: payloadN1.Features,
+		},
+		Version: 1,
+	}
+	assert.Equal(t, expected, actualN1)
+
+	// Test GetFederationPartialGet
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg/n1/federation",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getNetworkFederationConfig,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(models2.NewDefaultModifiedNetworkFederationConfigs()),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test DeleteNetwork
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/feg/n1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        deleteNetwork,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{"n3", "n4"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+func TestFederationGateways(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin2.FegOrchestratorPlugin{})
+	clock.SetAndFreezeClock(t, time.Unix(1000000, 0))
+	defer clock.GetUnfreezeClockDeferFunc(t)()
+	test_init.StartTestService(t)
+	stateTestInit.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+
+	e := echo.New()
+
+	obsidianHandlers := handlers.GetHandlers()
+	createGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id/gateways", obsidian.POST).HandlerFunc
+	listGateways := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id/gateways", obsidian.GET).HandlerFunc
+	getGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id/gateways/:gateway_id", obsidian.GET).HandlerFunc
+	updateGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id/gateways/:gateway_id", obsidian.PUT).HandlerFunc
+	deleteGateway := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg/:network_id/gateways/:gateway_id", obsidian.DELETE).HandlerFunc
+
+	seedFederationNetworks(t)
+
+	// setup fixtures in backend
+	_, err := configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
+		},
+	)
+	assert.NoError(t, err)
+
+	// Test CreateGateway
+	payload := &models2.MutableFederationGateway{
+		Device: &models.GatewayDevice{
+			HardwareID: "hw1",
+			Key:        &models.ChallengeKey{KeyType: "ECHO"},
+		},
+		ID:          "g1",
+		Name:        "foobar",
+		Description: "foo bar",
+		Magmad: &models.MagmadGatewayConfigs{
+			CheckinInterval:         15,
+			CheckinTimeout:          5,
+			AutoupgradePollInterval: 300,
+			AutoupgradeEnabled:      swag.Bool(true),
+		},
+		Federation: models2.NewDefaultGatewayFederationConfig(),
+		Tier:       "t1",
+	}
+	tc := tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/feg/n1/gateways",
+		Handler:        createGateway,
+		Payload:        payload,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test ListGateways
+	ctx := test_utils.GetContextWithCertificate(t, "hw1")
+	test_utils.ReportGatewayStatus(t, ctx, models.NewDefaultGatewayStatus("hw1"))
+
+	expected := map[string]*models2.FederationGateway{
+		"g1": {
+			ID: "g1",
+			Device: &models.GatewayDevice{
+				HardwareID: "hw1",
+				Key:        &models.ChallengeKey{KeyType: "ECHO"},
+			},
+			Name: "foobar", Description: "foo bar",
+			Tier: "t1",
+			Magmad: &models.MagmadGatewayConfigs{
+				AutoupgradeEnabled:      swag.Bool(true),
+				AutoupgradePollInterval: 300,
+				CheckinInterval:         15,
+				CheckinTimeout:          5,
+			},
+			Federation: models2.NewDefaultGatewayFederationConfig(),
+			Status:     models.NewDefaultGatewayStatus("hw1"),
+		},
+	}
+	expected["g1"].Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
+	expected["g1"].Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg/n1/gateways",
+		Handler:        listGateways,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(expected),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test GetGateway
+	expectedGet := &models2.FederationGateway{
+		ID: "g1",
+		Device: &models.GatewayDevice{
+			HardwareID: "hw1",
+			Key:        &models.ChallengeKey{KeyType: "ECHO"},
+		},
+		Name: "foobar", Description: "foo bar",
+		Tier: "t1",
+		Magmad: &models.MagmadGatewayConfigs{
+			AutoupgradeEnabled:      swag.Bool(true),
+			AutoupgradePollInterval: 300,
+			CheckinInterval:         15,
+			CheckinTimeout:          5,
+		},
+		Federation: models2.NewDefaultGatewayFederationConfig(),
+		Status:     models.NewDefaultGatewayStatus("hw1"),
+	}
+	expectedGet.Status.CheckinTime = uint64(time.Unix(1000000, 0).UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond)))
+	expectedGet.Status.CertExpirationTime = time.Unix(1000000, 0).Add(time.Hour * 4).Unix()
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg/n1/gateways/g1",
+		Handler:        getGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: expectedGet,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test UpdateGateway
+	payload = &models2.MutableFederationGateway{
+		Device: &models.GatewayDevice{
+			HardwareID: "hw1",
+			Key:        &models.ChallengeKey{KeyType: "ECHO"},
+		},
+		ID:          "g1",
+		Name:        "newname",
+		Description: "bar baz",
+		Magmad: &models.MagmadGatewayConfigs{
+			AutoupgradeEnabled:      swag.Bool(true),
+			AutoupgradePollInterval: 300,
+			CheckinInterval:         15,
+			CheckinTimeout:          5,
+		},
+		Tier:       "t1",
+		Federation: models2.NewDefaultGatewayFederationConfig(),
+	}
+	payload.Federation.AaaServer.AccountingEnabled = true
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/feg/n1/gateways/g1",
+		Handler:        updateGateway,
+		Payload:        payload,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	expectedGet.Federation.AaaServer.AccountingEnabled = true
+	expectedGet.Name = "newname"
+	expectedGet.Description = "bar baz"
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg/n1/gateways/g1",
+		Handler:        getGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 200,
+		ExpectedResult: expectedGet,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test DeleteGateway
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/feg/n1/gateways/g1",
+		Handler:        deleteGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg/n1/gateways/g1",
+		Handler:        getGateway,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n1", "g1"},
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+}
+
+func TestFederatedLteNetworks(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin2.FegOrchestratorPlugin{})
+	_ = plugin.RegisterPluginForTests(t, &plugin3.LteOrchestratorPlugin{})
+	test_init.StartTestService(t)
+	e := echo.New()
+
+	obsidianHandlers := handlers.GetHandlers()
+	listNetworks := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg_lte", obsidian.GET).HandlerFunc
+	createNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg_lte", obsidian.POST).HandlerFunc
+	getNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg_lte/:network_id", obsidian.GET).HandlerFunc
+	updateNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg_lte/:network_id", obsidian.PUT).HandlerFunc
+	deleteNetwork := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg_lte/:network_id", obsidian.DELETE).HandlerFunc
+	getNetworkFederationConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/feg_lte/:network_id/federation", obsidian.GET).HandlerFunc
+
+	// Test ListNetworks
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg_lte",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{}),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	seedFederatedLteNetworks(t)
+
+	// CreateNetwork
+	tc = tests.Test{
+		Method: "POST",
+		URL:    "/magma/v1/feg_lte",
+		Payload: tests.JSONMarshaler(
+			&models2.FegLteNetwork{
+				Cellular:    models3.NewDefaultTDDNetworkConfig(),
+				Federation:  models2.NewDefaultFederatedNetworkConfigs(),
+				Description: "Foo Bar",
+				DNS:         models.NewDefaultDNSConfig(),
+				Features:    models.NewDefaultFeaturesConfig(),
+				ID:          "n4",
+				Name:        "foobar",
+			},
+		),
+		Handler:        createNetwork,
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test ListNetworks
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg_lte",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{"n1", "n3", "n4"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test GetNetwork
+	expectedN1 := &models2.FegLteNetwork{
+		Cellular:    models3.NewDefaultTDDNetworkConfig(),
+		Federation:  models2.NewDefaultFederatedNetworkConfigs(),
+		Description: "Foo Bar",
+		DNS:         models.NewDefaultDNSConfig(),
+		Features:    models.NewDefaultFeaturesConfig(),
+		ID:          "n1",
+		Name:        "foobar",
+	}
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg_lte/n1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getNetwork,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(expectedN1),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test UpdateNetwork
+	payloadN1 := &models2.FegLteNetwork{
+		ID:          "n1",
+		Name:        "updated foobar",
+		Description: "Updated Foo Bar",
+		Cellular:    models3.NewDefaultFDDNetworkConfig(),
+		Federation:  models2.NewDefaultFederatedNetworkConfigs(),
+		Features: &models.NetworkFeatures{
+			Features: map[string]string{
+				"bar": "baz",
+				"baz": "quz",
+			},
+		},
+		DNS: &models.NetworkDNSConfig{
+			EnableCaching: swag.Bool(true),
+			LocalTTL:      swag.Uint32(120),
+			Records: []*models.DNSConfigRecord{
+				{
+					Domain:  "foobar.com",
+					ARecord: []strfmt.IPv4{"127.0.0.1", "127.0.0.2"},
+					AaaaRecord: []strfmt.IPv6{
+						"2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+						"1234:0db8:85a3:0000:0000:8a2e:0370:1234",
+					},
+				},
+				{
+					Domain:  "facebook.com",
+					ARecord: []strfmt.IPv4{"127.0.0.3"},
+				},
+			},
+		},
+	}
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/feg_lte/n1",
+		Payload:        payloadN1,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        updateNetwork,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	assert.NoError(t, err)
+	expected := configurator.Network{
+		ID:          "n1",
+		Type:        feg.FederatedLteNetworkType,
+		Name:        "updated foobar",
+		Description: "Updated Foo Bar",
+		Configs: map[string]interface{}{
+			lte.CellularNetworkType:     models3.NewDefaultFDDNetworkConfig(),
+			feg.FederatedNetworkType:    models2.NewDefaultFederatedNetworkConfigs(),
+			orc8r.DnsdNetworkType:       payloadN1.DNS,
+			orc8r.NetworkFeaturesConfig: payloadN1.Features,
+		},
+		Version: 1,
+	}
+	assert.Equal(t, expected, actualN1)
+
+	// Test GetFederationPartialGet
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg_lte/n1/federation",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        getNetworkFederationConfig,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(models2.NewDefaultFederatedNetworkConfigs()),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test DeleteNetwork
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/feg_lte/n1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        deleteNetwork,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/feg_lte",
+		Payload:        nil,
+		Handler:        listNetworks,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler([]string{"n3", "n4"}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
+// n1, n3 are feg networks, n2 is not
+func seedFederationNetworks(t *testing.T) {
+	_, err := configurator.CreateNetworks(
+		[]configurator.Network{
+			{
+				ID:          "n1",
+				Type:        feg.FederationNetworkType,
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs: map[string]interface{}{
+					feg.FegNetworkType:          models2.NewDefaultNetworkFederationConfigs(),
+					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+				},
+			},
+			{
+				ID:          "n2",
+				Type:        "blah",
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs:     map[string]interface{}{},
+			},
+			{
+				ID:          "n3",
+				Type:        feg.FederationNetworkType,
+				Name:        "barfoo",
+				Description: "Bar Foo",
+				Configs:     map[string]interface{}{},
+			},
+		},
+	)
+	assert.NoError(t, err)
+}
+
+// n1, n3 are feg networks, n2 is not
+func seedFederatedLteNetworks(t *testing.T) {
+	_, err := configurator.CreateNetworks(
+		[]configurator.Network{
+			{
+				ID:          "n1",
+				Type:        feg.FederatedLteNetworkType,
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs: map[string]interface{}{
+					feg.FederatedNetworkType:    models2.NewDefaultFederatedNetworkConfigs(),
+					lte.CellularNetworkType:     models3.NewDefaultTDDNetworkConfig(),
+					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+				},
+			},
+			{
+				ID:          "n2",
+				Type:        "blah",
+				Name:        "foobar",
+				Description: "Foo Bar",
+				Configs:     map[string]interface{}{},
+			},
+			{
+				ID:          "n3",
+				Type:        feg.FederatedLteNetworkType,
+				Name:        "barfoo",
+				Description: "Bar Foo",
+				Configs:     map[string]interface{}{},
+			},
+		},
+	)
+	assert.NoError(t, err)
+}

--- a/feg/cloud/go/plugin/models/conversion.go
+++ b/feg/cloud/go/plugin/models/conversion.go
@@ -134,11 +134,11 @@ func (m *FegLteNetwork) FromConfiguratorNetwork(n configurator.Network) interfac
 }
 
 func (m *NetworkFederationConfigs) GetFromNetwork(network configurator.Network) interface{} {
-	return models2.GetNetworkConfig(network, feg.FederatedNetworkType)
+	return models2.GetNetworkConfig(network, feg.FegNetworkType)
 }
 
 func (m *NetworkFederationConfigs) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
-	return models2.GetNetworkConfigUpdateCriteria(network.ID, feg.FederatedNetworkType, m), nil
+	return models2.GetNetworkConfigUpdateCriteria(network.ID, feg.FegNetworkType, m), nil
 }
 
 func (m *FederationGateway) ValidateModel() error {

--- a/feg/cloud/go/plugin/models/defaults.go
+++ b/feg/cloud/go/plugin/models/defaults.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package models
+
+func NewDefaultNetworkFederationConfigs() *NetworkFederationConfigs {
+	return &NetworkFederationConfigs{
+		AaaServer:        newDefaultAaaServer(),
+		EapAka:           newDefaultEapAka(),
+		Gx:               newDefaultGx(),
+		Gy:               newDefaultGy(),
+		Health:           newDefaultHealth(),
+		Hss:              newDefaultHss(),
+		S6a:              newDefaultS6a(),
+		ServedNetworkIds: newDefaultServedNetworkIds(),
+		Swx:              newDefaultSwx(),
+	}
+}
+
+func NewDefaultModifiedNetworkFederationConfigs() *NetworkFederationConfigs {
+	configs := NewDefaultNetworkFederationConfigs()
+	configs.AaaServer = &AaaServer{
+		AccountingEnabled:    true,
+		CreateSessionOnAuth:  true,
+		IDLESessionTimeoutMs: 11600000,
+	}
+	return configs
+}
+
+func NewDefaultGatewayFederationConfig() *GatewayFederationConfigs {
+	return &GatewayFederationConfigs{
+		AaaServer:        newDefaultAaaServer(),
+		EapAka:           newDefaultEapAka(),
+		Gx:               newDefaultGx(),
+		Gy:               newDefaultGy(),
+		Health:           newDefaultHealth(),
+		Hss:              newDefaultHss(),
+		S6a:              newDefaultS6a(),
+		ServedNetworkIds: newDefaultServedNetworkIds(),
+		Swx:              newDefaultSwx(),
+	}
+}
+
+func NewDefaultFederatedNetworkConfigs() *FederatedNetworkConfigs {
+	fegNetworkID := "n1"
+	return &FederatedNetworkConfigs{
+		FegNetworkID: &fegNetworkID,
+	}
+}
+
+func newDefaultAaaServer() *AaaServer {
+	return &AaaServer{
+		AccountingEnabled:    false,
+		CreateSessionOnAuth:  false,
+		IDLESessionTimeoutMs: 21600000,
+	}
+}
+
+func newDefaultEapAka() *EapAka {
+	return &EapAka{
+		PlmnIds: []string{"123456"},
+		Timeout: &EapAkaTimeouts{
+			ChallengeMs:            20000,
+			ErrorNotificationMs:    10000,
+			SessionAuthenticatedMs: 5000,
+			SessionMs:              43200000,
+		},
+	}
+}
+
+func newDefaultGx() *Gx {
+	return &Gx{
+		Server: newDefaultDiameterClientConfigs(),
+	}
+}
+
+func newDefaultGy() *Gy {
+	initMethod := uint32(float32(1))
+	return &Gy{
+		InitMethod: &initMethod,
+		Server:     newDefaultDiameterClientConfigs(),
+	}
+}
+
+func newDefaultDiameterClientConfigs() *DiameterClientConfigs {
+	return &DiameterClientConfigs{
+		Address:          "foo.bar.com:5555",
+		DestHost:         "magma-fedgw.magma.com",
+		DestRealm:        "magma.com",
+		DisableDestHost:  false,
+		Host:             "string",
+		LocalAddress:     ":56789",
+		ProductName:      "string",
+		Protocol:         "tcp",
+		Realm:            "string",
+		Retransmits:      0,
+		RetryCount:       0,
+		WatchdogInterval: 0,
+	}
+}
+
+func newDefaultHealth() *Health {
+	return &Health{
+		CloudDisablePeriodSecs:   10,
+		CPUUtilizationThreshold:  0.9,
+		HealthServices:           []string{"S6A_PROXY", "SESSION_PROXY", "SWX_PROXY"},
+		LocalDisablePeriodSecs:   1,
+		MemoryAvailableThreshold: 0.9,
+		MinimumRequestThreshold:  1,
+		RequestFailureThreshold:  0.5,
+		UpdateFailureThreshold:   3,
+		UpdateIntervalSecs:       10,
+	}
+}
+
+func newDefaultHss() *Hss {
+	return &Hss{
+		DefaultSubProfile: &SubscriptionProfile{
+			MaxDlBitRate: 200000000,
+			MaxUlBitRate: 100000000,
+		},
+		LteAuthAmf: []byte("gAA="),
+		LteAuthOp:  []byte("EREREREREREREREREREREQ=="),
+		Server: &DiameterServerConfigs{
+			Address:      "foo.bar.com:5555",
+			DestHost:     "magma-fedgw.magma.com",
+			DestRealm:    "magma.com",
+			LocalAddress: ":56789",
+			Protocol:     "tcp",
+		},
+		StreamSubscribers: false,
+		SubProfiles: map[string]SubscriptionProfile{
+			"additionalProp1": {
+				MaxDlBitRate: 200000000,
+				MaxUlBitRate: 100000000,
+			},
+			"additionalProp2": {
+				MaxDlBitRate: 200000000,
+				MaxUlBitRate: 100000000,
+			},
+			"additionalProp3": {
+				MaxDlBitRate: 200000000,
+				MaxUlBitRate: 100000000,
+			},
+		},
+	}
+}
+
+func newDefaultS6a() *S6a {
+	return &S6a{
+		Server: newDefaultDiameterClientConfigs(),
+	}
+}
+
+func newDefaultSwx() *Swx {
+	return &Swx{
+		CacheTTLSeconds:       10800,
+		DeriveUnregisterRealm: false,
+		RegisterOnAuth:        false,
+		Server:                newDefaultDiameterClientConfigs(),
+		VerifyAuthorization:   false,
+	}
+}
+
+func newDefaultServedNetworkIds() []string {
+	return []string{"string"}
+}


### PR DESCRIPTION
Summary: Adding unit tests for carrier wifi v1 REST API handlers.

Reviewed By: xjtian

Differential Revision: D17512416

