### PR TITLE
Reset testcase failure fixes

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_complete_reset.py
@@ -54,8 +54,8 @@ class TestEnbCompleteReset(unittest.TestCase):
             s1ap_types.NasNonDelCauseType.TFW_CAUSE_MISC.value
         # Set the cause to MISC.hardware-failure
         reset_req.cause.causeVal = 3
-        reset_req.u = s1ap_types.U()
-        reset_req.u.completeRst = s1ap_types.CompleteReset()
+        reset_req.r = s1ap_types.R()
+        reset_req.r.completeRst = s1ap_types.CompleteReset()
         self._s1ap_wrapper.s1_util.issue_cmd(
             s1ap_types.tfwCmd.RESET_REQ, reset_req)
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset.py
@@ -50,17 +50,17 @@ class TestEnbPartialReset(unittest.TestCase):
         reset_req.cause.causeType = s1ap_types.NasNonDelCauseType.TFW_CAUSE_MISC.value
         # Set the cause to MISC.hardware-failure
         reset_req.cause.causeVal = 3
-        #reset_req.u = s1ap_types.U()
-        reset_req.u.partialRst = s1ap_types.PartialReset()
-        reset_req.u.partialRst.numOfConn = num_ues
-        reset_req.u.partialRst.ueIdLst = (
-            ctypes.c_ubyte * reset_req.u.partialRst.numOfConn
+        reset_req.r = s1ap_types.R()
+        reset_req.r.partialRst = s1ap_types.PartialReset()
+        reset_req.r.partialRst.numOfConn = num_ues
+        reset_req.r.partialRst.ueIdLst = (
+            ctypes.c_ubyte * reset_req.r.partialRst.numOfConn
         )()
-        for indx in range(reset_req.u.partialRst.numOfConn):
-            reset_req.u.partialRst.ueIdLst[indx] = ue_ids[indx]
+        for indx in range(reset_req.r.partialRst.numOfConn):
+            reset_req.r.partialRst.ueIdLst[indx] = ue_ids[indx]
             print(
-                "Reset_req.u.partialRst.ueIdLst[indx]",
-                reset_req.u.partialRst.ueIdLst[indx],
+                "Reset_req.r.partialRst.ueIdLst[indx]",
+                reset_req.r.partialRst.ueIdLst[indx],
                 indx,
             )
         print("ue_ids", ue_ids)

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
@@ -91,15 +91,15 @@ class TestEnbPartialReset(unittest.TestCase):
             s1ap_types.NasNonDelCauseType.TFW_CAUSE_MISC.value
         # Set the cause to MISC.hardware-failure
         reset_req.cause.causeVal = 3
-        #reset_req.u = s1ap_types.U()
-        reset_req.u.partialRst = s1ap_types.PartialReset()
-        reset_req.u.partialRst.numOfConn = num_ues
-        reset_req.u.partialRst.ueIdLst = \
-            (ctypes.c_ubyte * reset_req.u.partialRst.numOfConn)()
-        for indx in range(reset_req.u.partialRst.numOfConn):
-            reset_req.u.partialRst.ueIdLst[indx] = ue_ids[indx]
-            print("Reset_req.u.partialRst.ueIdLst[indx]",
-                  reset_req.u.partialRst.ueIdLst[indx], indx)
+        reset_req.r = s1ap_types.R()
+        reset_req.r.partialRst = s1ap_types.PartialReset()
+        reset_req.r.partialRst.numOfConn = num_ues
+        reset_req.r.partialRst.ueIdLst = \
+            (ctypes.c_ubyte * reset_req.r.partialRst.numOfConn)()
+        for indx in range(reset_req.r.partialRst.numOfConn):
+            reset_req.r.partialRst.ueIdLst[indx] = ue_ids[indx]
+            print("Reset_req.r.partialRst.ueIdLst[indx]",
+                  reset_req.r.partialRst.ueIdLst[indx], indx)
         print("ue_ids", ue_ids)
         self._s1ap_wrapper.s1_util.issue_cmd(
             s1ap_types.tfwCmd.RESET_REQ, reset_req)

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_complete_reset.py
@@ -70,9 +70,9 @@ class TestMultipleEnbAttachDetach(unittest.TestCase):
             s1ap_types.NasNonDelCauseType.TFW_CAUSE_MISC.value
         # Set the cause to MISC.hardware-failure
         reset_req.cause.causeVal = 3
-        #reset_req.u = s1ap_types.U()
-        reset_req.u.completeRst = s1ap_types.CompleteReset()
-        reset_req.u.completeRst.enbId = 2
+        reset_req.r = s1ap_types.R()
+        reset_req.r.completeRst = s1ap_types.CompleteReset()
+        reset_req.r.completeRst.enbId = 2
         self._s1ap_wrapper.s1_util.issue_cmd(
             s1ap_types.tfwCmd.RESET_REQ, reset_req)
         response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -69,17 +69,17 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
             s1ap_types.NasNonDelCauseType.TFW_CAUSE_MISC.value
         # Set the cause to MISC.hardware-failure
         reset_req.cause.causeVal = 3
-        # reset_req.u = s1ap_types.U()
-        reset_req.u.partialRst = s1ap_types.PartialReset()
-        reset_req.u.partialRst.numOfConn = num_ues
-        reset_req.u.partialRst.ueIdLst = (
-            ctypes.c_ubyte * reset_req.u.partialRst.numOfConn
+        reset_req.r = s1ap_types.R()
+        reset_req.r.partialRst = s1ap_types.PartialReset()
+        reset_req.r.partialRst.numOfConn = num_ues
+        reset_req.r.partialRst.ueIdLst = (
+            ctypes.c_ubyte * reset_req.r.partialRst.numOfConn
         )()
-        for indx in range(reset_req.u.partialRst.numOfConn):
-            reset_req.u.partialRst.ueIdLst[indx] = ue_ids[indx]
+        for indx in range(reset_req.r.partialRst.numOfConn):
+            reset_req.r.partialRst.ueIdLst[indx] = ue_ids[indx]
             print(
-                "Reset_req.u.partialRst.ueIdLst[indx]",
-                reset_req.u.partialRst.ueIdLst[indx],
+                "Reset_req.r.partialRst.ueIdLst[indx]",
+                reset_req.r.partialRst.ueIdLst[indx],
                 indx,
             )
         print("ue_ids", ue_ids)


### PR DESCRIPTION
Reset testcase failures  issue fixed in reset test scripts 
Issue: Reset testcase were failing with below error message

 reset_req.u = s1ap_types.U()
TypeError: incompatible types, U instance instead of U instance

verified by: s1ap-tester
