### PR TITLE
Add Cisco-required attributes to GRPC CoA listener

### DIFF
--- a/feg/radius/src/modules/magmaacct/magma_acct.go
+++ b/feg/radius/src/modules/magmaacct/magma_acct.go
@@ -15,6 +15,7 @@ import (
 	"fbc/cwf/radius/modules/protos"
 	"fbc/cwf/radius/session"
 	"fmt"
+	"strings"
 
 	"fbc/cwf/radius/modules"
 	"fbc/lib/go/radius"
@@ -90,6 +91,7 @@ func Handle(m modules.Context, ctx *modules.RequestContext, r *radius.Request, _
 		SessionId: ctx.SessionID,
 		Msisdn:    state.MSISDN,
 		MacAddr:   state.MACAddress,
+		IpAddr:    strings.Split(r.RemoteAddr.String(), ":")[0],
 	}
 
 	// Call magma client

--- a/feg/radius/src/server/grpc_listener.go
+++ b/feg/radius/src/server/grpc_listener.go
@@ -21,6 +21,7 @@ import (
 	"net"
 
 	"fbc/lib/go/radius"
+	"fbc/lib/go/radius/rfc2865"
 	"fbc/lib/go/radius/rfc2866"
 
 	"github.com/mitchellh/mapstructure"
@@ -176,6 +177,7 @@ func (s *authorizationServer) handleCoaRequest(ctx *protos.Context, request *rad
 	// Add Acct-Session-Id attribute
 	request.Attributes = radius.Attributes{}
 	request.Set(rfc2866.AcctSessionID_Type, radius.Attribute(state.AcctSessionID))
+	request.Set(rfc2865.CallingStationID_Type, radius.Attribute(ctx.MacAddr))
 
 	// Set Identifier
 	request.Identifier = state.NextCoAIdentifier


### PR DESCRIPTION
Summary: Cisco require both `NAS_IP_ADDRESS` and `CALLING_STATION_ID` to appear in CoA-Request and Disconnect-Request in order to route it to the specific AP.

Reviewed By: emakeev

Differential Revision: D17601724

