### PR TITLE
Add data-session initialization to CWF integration tests

### DIFF
--- a/cwf/gateway/deploy/cwag_test.yml
+++ b/cwf/gateway/deploy/cwag_test.yml
@@ -13,6 +13,7 @@
     - full_provision: true
   roles:
     - role: golang
+    - role: ovs
   tasks:
     - name: Set build environment variables
       lineinfile:

--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -39,7 +39,27 @@ services:
       - hss
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/swx_proxy -logtostderr=true -v=0
 
+  session_proxy:
+    <<: *feggoservice
+    container_name: session_proxy
+    depends_on:
+      - pcrf
+      - ocs
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
+
   hss:
     <<: *feggoservice
     container_name: hss
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/hss -logtostderr=true -v=0
+
+  pcrf:
+    <<: *feggoservice
+    container_name: pcrf
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/pcrf -logtostderr=true -v=0
+
+  ocs:
+    <<: *feggoservice
+    container_name: ocs
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/ocs -logtostderr=true -v=0
+
+

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -41,6 +41,7 @@ require (
 	google.golang.org/grpc v1.21.1
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go v0.0.0
+	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000
 	magma/lte/cloud/go v0.0.0
 	magma/orc8r/cloud/go v0.0.0

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -419,6 +419,7 @@ golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190213061140-3a22650c66bd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/cwf/gateway/integ_tests/gateway.mconfig
+++ b/cwf/gateway/integ_tests/gateway.mconfig
@@ -48,11 +48,17 @@
    },
    "verifyAuthorization": false
   },
+  "sessiond": {
+   "@type": "type.googleapis.com/magma.mconfig.SessionD",
+   "logLevel": "INFO",
+   "relayEnabled": true
+  },
   "aaa_server": {
    "@type": "type.googleapis.com/magma.mconfig.AAAConfig",
    "logLevel": "INFO",
    "IdleSessionTimeoutMs": 21600000,
-   "CreateSessionOnAuth": true
+   "CreateSessionOnAuth": true,
+   "AccountingEnabled": true
   },
   "control_proxy": {
    "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
@@ -98,13 +104,46 @@
    "defaultRuleId": "default_rule_1",
    "relayEnabled": true,
    "services": [
-    "ENFORCEMENT"
    ]
   },
-  "sessiond": {
-   "@type": "type.googleapis.com/magma.mconfig.SessionD",
+  "session_proxy": {
+   "@type": "type.googleapis.com/magma.mconfig.SessionProxyConfig",
    "logLevel": "INFO",
-   "relayEnabled": true
+   "gx": {
+    "server": {
+     "protocol": "tcp",
+     "address": "127.0.0.1:3870",
+     "retransmits": 0,
+     "watchdogInterval": 0,
+     "retryCount": 0,
+     "localAddress": "127.0.0.1:3871",
+     "productName": "magma",
+     "realm": "magma.svc.cluster.local",
+     "host": "feg.magma.svc.cluster.local",
+     "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+     "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
+     "disableDestHost": false
+    }
+   },
+   "gy": {
+    "server": {
+     "protocol": "tcp",
+     "address": "127.0.0.1:3872",
+     "retransmits": 0,
+     "watchdogInterval": 0,
+     "retryCount": 0,
+     "localAddress": "127.0.0.1:3873",
+     "productName": "magma",
+     "realm": "magma.svc.cluster.local",
+     "host": "feg.magma.svc.cluster.local",
+     "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+     "destHost": "sdp1c.epc.mnc001.mcc001.3gppnetwork.org",
+     "disableDestHost": false
+    },
+    "initMethod": "PER_KEY"
+   },
+   "requestFailureThreshold": 0.5,
+   "minimumRequestThreshold": 1
   }
  },
  "metadata": {

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -1,0 +1,35 @@
+---
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+log_level: INFO
+rule_update_inteval_sec: 1
+use_proxied_controller: false
+local_controller_port: 9097
+
+# Session manager will report the usage when the usage is greater than
+# usage_reporting_threshold * available quota since last update
+# In this way, session manager will report the usage before the subscriber
+# completely uses up the quota. 
+usage_reporting_threshold: 0.8
+
+# Extra number of bytes an user could use after the quota is exhausted
+extra_quota_margin: 0
+
+# Set to true to terminate service when the quota of a session is exhausted.
+# An user can still use up to the extra margin.
+# Set to false to allow users to use without any constraint.
+terminate_service_when_quota_exhausted: true
+
+# Maximum time to wait for the flow to be deleted by pipelined before forcefully
+# terminating the session. This should be at least twice the poll interval of
+# pipelined
+session_force_termination_timeout_ms: 5000
+
+# Set to true to enable sessiond support of carrier wifi
+support_carrier_wifi: true

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -30,11 +30,15 @@ import (
 
 // todo make Op configurable, or export it in the UESimServer.
 const (
-	Op            = "\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"
-	Secret        = "123456"
-	MockHSSRemote = "HSS_REMOTE"
-	HSSHostIp     = "192.168.70.101"
-	HSSPort       = 9204
+	Op             = "\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"
+	Secret         = "123456"
+	MockHSSRemote  = "HSS_REMOTE"
+	MockPCRFRemote = "PCRF_REMOTE"
+	MockOCSRemote  = "OCS_REMOTE"
+	CwagIP         = "192.168.70.101"
+	HSSPort        = 9204
+	OCSPort        = 9201
+	PCRFPort       = 9202
 )
 
 type TestRunner struct {
@@ -44,6 +48,18 @@ type TestRunner struct {
 // Wrapper for GRPC Client functionality
 type hssClient struct {
 	fegprotos.HSSConfiguratorClient
+	cc *grpc.ClientConn
+}
+
+// Wrapper for GRPC Client functionality
+type pcrfClient struct {
+	fegprotos.MockPCRFClient
+	cc *grpc.ClientConn
+}
+
+// Wrapper for GRPC Client functionality
+type ocsClient struct {
+	fegprotos.MockOCSClient
 	cc *grpc.ClientConn
 }
 
@@ -64,11 +80,45 @@ func getHSSClient() (*hssClient, error) {
 	}, err
 }
 
-// addSubscriber tries to add this subscriber to the server.
+// getPCRFClient is a utility function to get an RPC connection to a
+// remote PCRF service.
+func getPCRFClient() (*pcrfClient, error) {
+	var conn *grpc.ClientConn
+	var err error
+	conn, err = registry.GetConnection(MockPCRFRemote)
+	if err != nil {
+		errMsg := fmt.Sprintf("PCRF client initialization error: %s", err)
+		glog.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	return &pcrfClient{
+		fegprotos.NewMockPCRFClient(conn),
+		conn,
+	}, err
+}
+
+// getOCSClient is a utility function to an RPC connection to a
+// remote OCS service.
+func getOCSClient() (*ocsClient, error) {
+	var conn *grpc.ClientConn
+	var err error
+	conn, err = registry.GetConnection(MockOCSRemote)
+	if err != nil {
+		errMsg := fmt.Sprintf("PCRF client initialization error: %s", err)
+		glog.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	return &ocsClient{
+		fegprotos.NewMockOCSClient(conn),
+		conn,
+	}, err
+}
+
+// addSubscriber tries to add this subscriber to the HSS server.
 // This function returns an AlreadyExists error if the subscriber has already
 // been added.
 // Input: The subscriber data which will be added.
-func addSubscriber(sub *lteprotos.SubscriberData) error {
+func addSubscriberToHss(sub *lteprotos.SubscriberData) error {
 	err := hss.VerifySubscriberData(sub)
 	if err != nil {
 		errMsg := fmt.Errorf("Invalid AddSubscriberRequest provided: %s", err)
@@ -82,6 +132,28 @@ func addSubscriber(sub *lteprotos.SubscriberData) error {
 	return err
 }
 
+// addSubscriber tries to add this subscriber to the PCRF server.
+// Input: The subscriber data which will be added.
+func addSubscriberToPcrf(sub *lteprotos.SubscriberID) error {
+	cli, err := getPCRFClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.CreateAccount(context.Background(), sub)
+	return err
+}
+
+// addSubscriber tries to add this subscriber to the OCS server.
+// Input: The subscriber data which will be added.
+func addSubscriberToOcs(sub *lteprotos.SubscriberID) error {
+	cli, err := getOCSClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.CreateAccount(context.Background(), sub)
+	return err
+}
+
 // NewTestRunner initializes a new TestRunner by making a UESim client and
 // and setting the next IMSI.
 func NewTestRunner() *TestRunner {
@@ -89,8 +161,12 @@ func NewTestRunner() *TestRunner {
 	testRunner := &TestRunner{}
 
 	testRunner.Imsis = make(map[string]bool)
-	fmt.Printf("Adding Mock HSS service at %s:%d\n", HSSHostIp, HSSPort)
-	registry.AddService(MockHSSRemote, HSSHostIp, HSSPort)
+	fmt.Printf("Adding Mock HSS service at %s:%d\n", CwagIP, HSSPort)
+	registry.AddService(MockHSSRemote, CwagIP, HSSPort)
+	fmt.Printf("Adding Mock PCRF service at %s:%d\n", CwagIP, PCRFPort)
+	registry.AddService(MockPCRFRemote, CwagIP, PCRFPort)
+	fmt.Printf("Adding Mock OCS service at %s:%d\n", CwagIP, OCSPort)
+	registry.AddService(MockOCSRemote, CwagIP, OCSPort)
 
 	return testRunner
 }
@@ -122,14 +198,21 @@ func (testRunner *TestRunner) ConfigUEs(numUEs int) ([]*cwfprotos.UEConfig, erro
 		if err != nil {
 			return nil, errors.Wrap(err, "Error adding UE to UESimServer")
 		}
-
-		err = addSubscriber(sub)
+		err = addSubscriberToHss(sub)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error adding Subscriber to HSS")
 		}
+		err = addSubscriberToPcrf(sub.GetSid())
+		if err != nil {
+			return nil, errors.Wrap(err, "Error adding Subscriber to PCRF")
+		}
+		err = addSubscriberToOcs(sub.GetSid())
+		if err != nil {
+			return nil, errors.Wrap(err, "Error adding Subscriber to OCS")
+		}
 
 		ues = append(ues, ue)
-		fmt.Printf("Added UE to Simulator and HSS:\n"+
+		fmt.Printf("Added UE to Simulator, HSS, PCRF, and OCS:\n"+
 			"\tIMSI: %s\tKey: %x\tOpc: %x\tSeq: %d\n", imsi, key, opc, seq)
 		testRunner.Imsis[imsi] = true
 	}


### PR DESCRIPTION
Summary:
Previously, the CWF integration test system only supported
running auth only tests. This diff updates the system to support
data session initialization by running the mock-PCRF and mock-OCS.

This will allow to run traffic tests as well as basic PCEF testing
in our CI.

Reviewed By: xjtian

Differential Revision: D17537475

