### PR TITLE
Add arp passthrough to ue_mac app in pipelined

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_add_two_subscribers.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_add_two_subscribers.snapshot
@@ -1,3 +1,4 @@
+ cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,arp actions=set_field:0x2->reg1,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_src=5e:cc:cc:b1:49:4b,tp_src=68,tp_dst=67 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_src=5e:cc:cc:aa:aa:fe,tp_src=68,tp_dst=67 actions=set_field:0x2->reg1,set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_dst=5e:cc:cc:b1:49:4b,tp_src=67,tp_dst=68 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_delete_one_subscriber.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_mac.UEMacAddressTest.test_delete_one_subscriber.snapshot
@@ -1,3 +1,4 @@
+ cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,arp actions=set_field:0x2->reg1,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_src=5e:cc:cc:aa:aa:fe,tp_src=68,tp_dst=67 actions=set_field:0x2->reg1,set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_dst=5e:cc:cc:aa:aa:fe,tp_src=67,tp_dst=68 actions=set_field:0x2->reg1,set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_src=5e:cc:cc:aa:aa:fe,tp_dst=53 actions=set_field:0x2->reg1,set_field:0x48c273a134fb->metadata,resubmit(,ingress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
@@ -1,14 +1,15 @@
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_src=5e:cc:cc:b1:49:4b,tp_src=68,tp_dst=67 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=1, n_bytes=42, priority=15,udp,dl_dst=5e:cc:cc:b1:49:4b,tp_src=67,tp_dst=68 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,udp,dl_src=5e:cc:cc:b1:49:4b,tp_dst=53 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ue_mac(main_table), n_packets=1, n_bytes=42, priority=15,arp actions=set_field:0x2->reg1,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,tcp,dl_src=5e:cc:cc:b1:49:4b,tp_dst=53 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=1, n_bytes=42, priority=15,udp,dl_dst=5e:cc:cc:b1:49:4b,tp_src=53 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=15,tcp,dl_dst=5e:cc:cc:b1:49:4b,tp_src=53 actions=set_field:0x2->reg1,set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,dl_src=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ue_mac(main_table), n_packets=1, n_bytes=14, priority=10,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ingress(main_table)),set_field:0->reg0
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=15,reg1=0x2,in_port=32768 actions=set_field:0x1->reg1,resubmit(,egress(main_table)),set_field:0->reg0
- cookie=0x0, table=ingress(main_table), n_packets=2, n_bytes=84, priority=15,reg1=0x2,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ingress(main_table), n_packets=3, n_bytes=126, priority=15,reg1=0x2,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,egress(main_table)),set_field:0->reg0
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0
  cookie=0x0, table=ingress(main_table), n_packets=1, n_bytes=14, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,arpd(main_table)),set_field:0->reg0
- cookie=0x0, table=egress(main_table), n_packets=2, n_bytes=84, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=3, n_bytes=126, priority=0,reg1=0x10 actions=output:32768
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=LOCAL

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_mac.py
@@ -119,9 +119,9 @@ class UEMacAddressTest(unittest.TestCase):
         ]
 
         # =========================== Verification ===========================
-        # Verify 16 flows installed and 2 total pkts matched (one for each UE)
+        # Verify 17 flows installed and 2 total pkts matched (one for each UE)
         flow_verifier = FlowVerifier(
-            [FlowTest(FlowQuery(self._tbl_num, self.testing_controller), 2, 16)]
+            [FlowTest(FlowQuery(self._tbl_num, self.testing_controller), 2, 17)]
             + [FlowTest(query, 1, 4) for query in flow_queries],
             lambda: wait_after_send(self.testing_controller))
 
@@ -166,11 +166,11 @@ class UEMacAddressTest(unittest.TestCase):
         ]
 
         # =========================== Verification ===========================
-        # Verify 8 flows installed and 1 total pkt matched
+        # Verify 9 flows installed and 1 total pkt matched
         flow_verifier = FlowVerifier(
             [
                 FlowTest(FlowQuery(self._tbl_num, self.testing_controller), 1,
-                         8),
+                         9),
                 FlowTest(flow_queries[0], 0, 0),
                 FlowTest(flow_queries[1], 1, 4),
             ], lambda: wait_after_send(self.testing_controller))


### PR DESCRIPTION
Summary:
After DHCP completes, arp request sent from the device should
bypass the pipelined and exit from eth2. This diff adds that functionality
to `ue_mac` which sits on Table0.

Reviewed By: amarpad

Differential Revision: D17481289

