### PR TITLE
Add mac_addr conversion to sessiond

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -99,11 +99,14 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   uint64_t current_epoch_;
   uint64_t reported_epoch_;
   std::chrono::seconds retry_timeout_;
+  static const std::string hex_digit_;
 
  private:
   void check_usage_for_reporting();
   bool is_pipelined_restarted();
   bool restart_pipelined(const std::uint64_t &epoch);
+
+  std::string convert_mac_addr_to_str(const std::string& mac_addr);
 
   void send_create_session(
     const CreateSessionRequest &request,

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -12,7 +12,8 @@ add_library(SESSIOND_TEST_LIB
 
 target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
-foreach(session_test session_credit local_enforcer cloud_reporter async_service sessiond_integ session_state)
+foreach(session_test session_credit local_enforcer cloud_reporter async_service
+        session_manager_handler sessiond_integ session_state)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <memory>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <folly/io/async/EventBaseManager.h>
+
+#include "MagmaService.h"
+#include "LocalEnforcer.h"
+#include "ProtobufCreators.h"
+#include "RuleStore.h"
+#include "ServiceRegistrySingleton.h"
+#include "SessiondMocks.h"
+#include "magma_logging.h"
+
+
+using ::testing::Test;
+
+namespace magma {
+
+class SessionManagerHandlerTest : public ::testing::Test {
+  protected:
+  protected:
+    virtual void SetUp() {
+        reporter = std::make_shared<MockSessionCloudReporter>();
+        auto rule_store = std::make_shared<StaticRuleStore>();
+        auto pipelined_client = std::make_shared<MockPipelinedClient>();
+        auto aaa_client = std::make_shared<MockAAAClient>();
+        local_enforcer = std::make_shared<LocalEnforcer>(
+                reporter, rule_store, pipelined_client, aaa_client, 0);
+        evb = folly::EventBaseManager::get()->getEventBase();
+        local_enforcer->attachEventBase(evb);
+        session_manager = std::make_shared<LocalSessionManagerHandlerImpl>(
+                local_enforcer.get(), reporter.get());
+    }
+
+  protected:
+    std::shared_ptr<LocalSessionManagerHandlerImpl> session_manager;
+    std::shared_ptr<MockSessionCloudReporter> reporter;
+    std::shared_ptr <LocalEnforcer> local_enforcer;
+    SessionIDGenerator id_gen_;
+    folly::EventBase *evb;
+};
+
+TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
+{
+    LocalCreateSessionRequest request;
+    CreateSessionResponse response;
+    std::string hardware_addr_bytes = {0x0f,0x10,0x2e,0x12,0x3a,0x55};
+    std::string imsi = "IMSI1";
+    std::string msisdn = "5100001234";
+    std::string radius_session_id = "AA-AA-AA-AA-AA-AA:TESTAP__"
+                                    "0F-10-2E-12-3A-55";
+    auto sid = id_gen_.gen_session_id(imsi);
+    SessionState::Config cfg = {.ue_ipv4 = "",
+            .spgw_ipv4 = "",
+            .msisdn = msisdn,
+            .apn = "",
+            .imei = "",
+            .plmn_id = "",
+            .imsi_plmn_id = "",
+            .user_location = "",
+            .rat_type = RATType::TGPP_WLAN,
+            .mac_addr = "0f:10:2e:12:3a:55",
+            .radius_session_id = radius_session_id};
+
+    local_enforcer->init_session_credit(imsi, sid, cfg, response);
+
+    grpc::ServerContext create_context;
+    request.mutable_sid()->set_id("IMSI1");
+    request.set_rat_type(RATType::TGPP_WLAN);
+    request.set_hardware_addr(hardware_addr_bytes);
+    request.set_msisdn(msisdn);
+    request.set_radius_session_id(radius_session_id);
+
+    // Ensure session is not reported as its a duplicate
+    EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
+    session_manager->CreateSession(&create_context, &request, [this](
+            grpc::Status status, LocalCreateSessionResponse response_out) {});
+}
+
+int main(int argc, char **argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+} // namespace magma


### PR DESCRIPTION
Summary:
Sessiond recevies Mac address from the AAA
server as a bytes field. For C++ a bytes field is
represented as a std::string. Despite this, each char
is still a byte, not a properly formatted UTF-8 char. Thus
when this field is sent to the pipelined service as a string.

The following error occurs:
  sessiond         | I0904 05:11:23.442327     1 CreditPool.cpp:132] Credit init failed for imsi 001010000000087 and charging key 1
  sessiond         | [libprotobuf ERROR google/protobuf/wire_format_lite.cc:534] String field 'magma.lte.UEMacFlowRequest.mac_addr' contains invalid UTF-8 data when serializing a protocol buffer. Use the 'bytes' type if you intend to send raw bytes.
  sessiond         | I0904 05:11:23.442504     1 LocalSessionManagerHandler.cpp:163] Successfully initialized new session in sessiond for subscriber 001010000000087
  sessiond         | I0904 05:11:23.444804    10 PipelinedClient.cpp:141] Could not add flow for subscriber with UE MAC�_>��: Exception deserializing request!

This diff fixes this bug by converting the mac_addr to format <hex>:<hex>:<hex>:<hex>:<hex>:<hex> (modeled off of Go's net.ParseMAC().String())

Reviewed By: amarpad

Differential Revision: D17185217

