### PR TITLE
Fix for updating enb-U teid in bearer context and sending sgw-u ip ad…

### DIFF
--- a/lte/gateway/c/oai/include/mme_app_messages_types.h
+++ b/lte/gateway/c/oai/include/mme_app_messages_types.h
@@ -143,7 +143,7 @@ typedef struct itti_mme_app_create_dedicated_bearer_req_s {
   bearer_qos_t bearer_qos;
   traffic_flow_template_t *tft;
   protocol_configuration_options_t *pco;
-  teid_t gtp_teid;
+  fteid_t sgw_fteid;
 } itti_mme_app_create_dedicated_bearer_req_t;
 
 typedef struct itti_mme_app_create_dedicated_bearer_rsp_s {

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -451,7 +451,6 @@ void mme_app_handle_conn_est_cnf(
           bc->preemption_vulnerability;
         establishment_cnf_p->transport_layer_address[j] =
           fteid_ip_address_to_bstring(&bc->s_gw_fteid_s1u);
-
         establishment_cnf_p->gtp_teid[j] = bc->s_gw_fteid_s1u.teid;
         if (!j) {
           establishment_cnf_p->nas_pdu[j] = nas_conn_est_cnf_pP->nas_msg;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -451,6 +451,7 @@ void mme_app_handle_conn_est_cnf(
           bc->preemption_vulnerability;
         establishment_cnf_p->transport_layer_address[j] =
           fteid_ip_address_to_bstring(&bc->s_gw_fteid_s1u);
+
         establishment_cnf_p->gtp_teid[j] = bc->s_gw_fteid_s1u.teid;
         if (!j) {
           establishment_cnf_p->nas_pdu[j] = nas_conn_est_cnf_pP->nas_msg;
@@ -1500,10 +1501,6 @@ void mme_app_handle_e_rab_setup_rsp(
         bc->bearer_state & BEARER_STATE_MME_CREATED,
         "TO DO check bearer state");
       bc->bearer_state |= BEARER_STATE_ENB_CREATED;
-
-      if (ESM_EBR_ACTIVE == bc->esm_ebr_context.status) {
-        send_s11_response = true;
-      }
     }
   }
   for (int i = 0; i < e_rab_setup_rsp->e_rab_failed_to_setup_list.no_of_items;
@@ -1513,7 +1510,6 @@ void mme_app_handle_e_rab_setup_rsp(
     bearer_context_t *bc =
       mme_app_get_bearer_context(ue_context_p, (ebi_t) e_rab_id);
     if (bc->bearer_state & BEARER_STATE_SGW_CREATED) {
-      send_s11_response = true;
       //S1ap_Cause_t cause = e_rab_setup_rsp->e_rab_failed_to_setup_list.item[i].cause;
       AssertFatal(
         bc->bearer_state & BEARER_STATE_MME_CREATED,
@@ -2615,8 +2611,10 @@ void mme_app_handle_nw_init_ded_bearer_actv_req(
     ue_context_p->pdn_contexts[cid]->default_ebi;
   MME_APP_CREATE_DEDICATED_BEARER_REQ(message_p).bearer_qos =
     nw_init_bearer_actv_req_p->eps_bearer_qos;
-  MME_APP_CREATE_DEDICATED_BEARER_REQ(message_p).gtp_teid =
-    nw_init_bearer_actv_req_p->s1_u_sgw_fteid.teid;
+  /* Send sgw_fteid to NAS as dedicated bearer context is created in NAS.
+  This logic will be removed once NAS and MME tasks are merged*/
+  memcpy(&MME_APP_CREATE_DEDICATED_BEARER_REQ(message_p).sgw_fteid,
+    &nw_init_bearer_actv_req_p->s1_u_sgw_fteid, sizeof(fteid_t));
   if (nw_init_bearer_actv_req_p->tft.numberofpacketfilters) {
     MME_APP_CREATE_DEDICATED_BEARER_REQ(message_p).tft =
       calloc(1, sizeof(traffic_flow_template_t));

--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
@@ -835,7 +835,8 @@ static int _emm_cn_activate_dedicated_bearer_req(
   esm_sap.data.eps_dedicated_bearer_context_activate.pco = msg->pco;
   // stole ref if any
   msg->pco = NULL;
-  esm_sap.data.eps_dedicated_bearer_context_activate.gtp_teid = msg->gtp_teid;
+  memcpy(&esm_sap.data.eps_dedicated_bearer_context_activate.sgw_fteid,
+    &msg->sgw_fteid, sizeof(fteid_t));
 
   rc = esm_sap_send(&esm_sap);
 

--- a/lte/gateway/c/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -153,7 +153,7 @@ int esm_proc_dedicated_eps_bearer_context(
       mbr_ul,
       tft,
       pco,
-      sgw_fteid);//TODO-Remove this once NAS and MME tasks are merged
+      sgw_fteid); //TODO-Remove this once NAS and MME tasks are merged
 
     if (*default_ebi == ESM_EBI_UNASSIGNED) {
       /*

--- a/lte/gateway/c/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/DedicatedEpsBearerContextActivation.c
@@ -116,7 +116,7 @@ int esm_proc_dedicated_eps_bearer_context(
   const bitrate_t mbr_ul,
   traffic_flow_template_t *tft,
   protocol_configuration_options_t *pco,
-  teid_t gtp_teid,
+  fteid_t *sgw_fteid,
   esm_cause_t *esm_cause)
 {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
@@ -153,7 +153,7 @@ int esm_proc_dedicated_eps_bearer_context(
       mbr_ul,
       tft,
       pco,
-      gtp_teid);
+      sgw_fteid);//TODO-Remove this once NAS and MME tasks are merged
 
     if (*default_ebi == ESM_EBI_UNASSIGNED) {
       /*

--- a/lte/gateway/c/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/DefaultEpsBearerContextActivation.c
@@ -143,7 +143,7 @@ int esm_proc_default_eps_bearer_context(
       0,
       (traffic_flow_template_t *) NULL,
       (protocol_configuration_options_t *) NULL,
-      0);
+      NULL);
 
     if (*ebi == ESM_EBI_UNASSIGNED) {
       /*

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.c
@@ -196,8 +196,8 @@ ebi_t esm_ebr_context_create(
       if(sgw_fteid) {
         memcpy(&bearer_context->s_gw_fteid_s1u, sgw_fteid, sizeof(fteid_t));
       }
-      bearer_context->bearer_state |= BEARER_STATE_SGW_CREATED;
-      bearer_context->bearer_state |= BEARER_STATE_MME_CREATED;
+      bearer_context->bearer_state |= BEARER_STATE_SGW_CREATED |
+        BEARER_STATE_MME_CREATED;
       if (is_default) {
         /*
          * Set the PDN connection activation indicator

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.c
@@ -88,7 +88,7 @@ ebi_t esm_ebr_context_create(
   const bitrate_t mbr_ul,
   traffic_flow_template_t *tft,
   protocol_configuration_options_t *pco,
-  teid_t gtp_teid)
+  fteid_t *sgw_fteid)
 {
   int bidx = 0;
   esm_context_t *esm_ctx = NULL;
@@ -193,8 +193,11 @@ ebi_t esm_ebr_context_create(
           &bearer_context->esm_ebr_context.pco);
       }
       bearer_context->esm_ebr_context.pco = pco;
-      bearer_context->s_gw_fteid_s1u.teid = gtp_teid;
-
+      if(sgw_fteid) {
+        memcpy(&bearer_context->s_gw_fteid_s1u, sgw_fteid, sizeof(fteid_t));
+      }
+      bearer_context->bearer_state |= BEARER_STATE_SGW_CREATED;
+      bearer_context->bearer_state |= BEARER_STATE_MME_CREATED;
       if (is_default) {
         /*
          * Set the PDN connection activation indicator

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.h
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.h
@@ -76,7 +76,7 @@ ebi_t esm_ebr_context_create(
   const bitrate_t mbr_ul,
   traffic_flow_template_t *tft,
   protocol_configuration_options_t *pco,
-  teid_t gtp_teid);
+  fteid_t *sgw_fteid);
 
 void esm_ebr_context_init(esm_ebr_context_t *esm_ebr_context);
 

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_proc.h
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_proc.h
@@ -235,7 +235,7 @@ int esm_proc_dedicated_eps_bearer_context(
   const bitrate_t mbr_ul,
   traffic_flow_template_t *tft,
   protocol_configuration_options_t *pco,
-  teid_t gtp_teid,
+  fteid_t *sgw_fteid,
   esm_cause_t *esm_cause);
 
 int esm_proc_dedicated_eps_bearer_context_request(

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
@@ -252,7 +252,7 @@ int esm_sap_send(esm_sap_t *msg)
           bearer_activate->mbr_ul,
           bearer_activate->tft,
           bearer_activate->pco,
-          bearer_activate->gtp_teid,
+          &bearer_activate->sgw_fteid,
           &esm_cause);
         if (rc != RETURNok) {
           break;

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sapDef.h
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sapDef.h
@@ -42,6 +42,7 @@ Description Defines the ESM Service Access Point that provides EPS
 
 #include "bstrlib.h"
 #include "emm_data.h"
+#include "3gpp_29.274.h"
 
 /****************************************************************************/
 /*********************  G L O B A L    C O N S T A N T S  *******************/
@@ -153,7 +154,7 @@ typedef struct esm_eps_dedicated_bearer_context_activate_s {
   bitrate_t mbr_dl;
   traffic_flow_template_t *tft;
   protocol_configuration_options_t *pco;
-  teid_t gtp_teid;
+  fteid_t sgw_fteid;
 } esm_eps_dedicated_bearer_context_activate_t;
 
 /*

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -2169,7 +2169,8 @@ int sgw_handle_nw_initiated_actv_bearer_req(
     //S1U SGW F-TEID
     s11_actv_bearer_request->s1_u_sgw_fteid.teid = sgw_get_new_s1u_teid();
     s11_actv_bearer_request->s1_u_sgw_fteid.interface_type = S1_U_SGW_GTP_U;
-    s11_actv_bearer_request->s1_u_sgw_fteid.ipv4 = 1;
+    //Set IPv4 address type bit
+    s11_actv_bearer_request->s1_u_sgw_fteid.ipv4 = true;
 
     //TODO - IPv6 address
     s11_actv_bearer_request->s1_u_sgw_fteid.ipv4_address.s_addr =
@@ -2270,6 +2271,21 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
       &eps_bearer_ctxt_p->tft,
       &s11_actv_bearer_rsp->tft,
       sizeof(traffic_flow_template_t));
+
+    //PAA
+    /*Copy PAA from default bearer context as the ip address remains same for
+      dedicated bearer as well
+     */
+    sgw_eps_bearer_ctxt_t *default_eps_bearer_ctxt_p =
+      sgw_cm_get_eps_bearer_entry(
+      &spgw_context->sgw_eps_bearer_context_information.pdn_connection,
+      spgw_context->sgw_eps_bearer_context_information
+      .pdn_connection.default_bearer);
+    memcpy(
+      &eps_bearer_ctxt_p->paa,
+      &default_eps_bearer_ctxt_p->paa,
+      sizeof(paa_t));
+
   } else {
     OAILOG_INFO(
       LOG_SPGW_APP,
@@ -2402,11 +2418,6 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
       s11_pcrf_ded_bearer_deactv_rsp->s_gw_teid_s11_s4);
     OAILOG_FUNC_RETURN(LOG_SPGW_APP, rc);
   }
-  sgw_eps_bearer_ctxt_t *default_eps_bearer_entry_p =
-    sgw_cm_get_eps_bearer_entry(
-    &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection,
-    spgw_ctxt->sgw_eps_bearer_context_information
-    .pdn_connection.default_bearer);
   sgw_eps_bearer_ctxt_t *eps_bearer_ctxt_p = NULL;
   //Remove the default bearer entry
   if (s11_pcrf_ded_bearer_deactv_rsp->delete_default_bearer) {
@@ -2423,7 +2434,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
       &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection, ebi);
 
     rc = gtp_tunnel_ops->del_tunnel(
-      default_eps_bearer_entry_p->paa.ipv4_address,
+      eps_bearer_ctxt_p->paa.ipv4_address,
       eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
       eps_bearer_ctxt_p->enb_teid_S1u,
       NULL);
@@ -2469,7 +2480,7 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
         OAILOG_INFO(
           LOG_SPGW_APP, "Removed bearer context for (ebi = %d)\n", ebi);
         rc = gtp_tunnel_ops->del_tunnel(
-          default_eps_bearer_entry_p->paa.ipv4_address,
+          eps_bearer_ctxt_p->paa.ipv4_address,
           eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u,
           NULL);


### PR DESCRIPTION
1. Fix for updating enb-U teid in bearer context and sending sgw-u ip address to UE during dedicated bearer creation
2. Verified sanity
3. Verified test_attach_detach_dedicated.py TC