### PR TITLE
Fix docker upgrader pylint error

### DIFF
--- a/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
@@ -92,8 +92,7 @@ class DockerUpgrader(Upgrader2):
                           shell=True, check=True)
         # Update any mounted template configs
         await run_command("cp -TR {}/magma/orc8r/gateway/configs/templates "
-                          "/etc/magma/templates".format(MAGMA_GITHUB_PATH,
-                                              gw_module),
+                          "/etc/magma/templates".format(MAGMA_GITHUB_PATH),
                           shell=True, check=True)
         # Copy updated docker-compose
         await run_command("cp {}/magma/{}/gateway/docker/docker-compose.yml "


### PR DESCRIPTION
Summary:
A format string in the docker upgrader included one too many
args due to a copy-paste error. This was causing LTE gateway pylint
tests to fail. This diff corrects this issue.

Differential Revision: D17678936

