### PR TITLE
Change CMakeLists to use project dir

### DIFF
--- a/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
+++ b/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(ASYNC_GRPC
 # session_manager, etc.
 add_custom_command(TARGET ASYNC_GRPC POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
-                   ${CMAKE_SOURCE_DIR}/async_grpc/*.h
+                   ${PROJECT_SOURCE_DIR}/async_grpc/*.h
                    $<TARGET_FILE_DIR:ASYNC_GRPC>)
 
 target_include_directories(ASYNC_GRPC PUBLIC

--- a/orc8r/gateway/c/common/config/CMakeLists.txt
+++ b/orc8r/gateway/c/common/config/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(CONFIG glog)
 # session_manager, etc.
 add_custom_command(TARGET CONFIG POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
-                   ${CMAKE_SOURCE_DIR}/config/*.h $<TARGET_FILE_DIR:CONFIG>)
+                   ${PROJECT_SOURCE_DIR}/config/*.h $<TARGET_FILE_DIR:CONFIG>)
 
 target_include_directories(CONFIG PUBLIC
                   $<TARGET_FILE_DIR:CONFIG>

--- a/orc8r/gateway/c/common/datastore/CMakeLists.txt
+++ b/orc8r/gateway/c/common/datastore/CMakeLists.txt
@@ -24,7 +24,7 @@ target_link_libraries(DATASTORE
 # session_manager, etc.
 add_custom_command(TARGET DATASTORE POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
-                   ${CMAKE_SOURCE_DIR}/datastore/*.h*
+                   ${PROJECT_SOURCE_DIR}/datastore/*.h*
                    $<TARGET_FILE_DIR:DATASTORE>)
 
 target_include_directories(DATASTORE PUBLIC

--- a/orc8r/gateway/c/common/policydb/CMakeLists.txt
+++ b/orc8r/gateway/c/common/policydb/CMakeLists.txt
@@ -42,7 +42,8 @@ target_link_libraries(POLICYDB
 # session_manager, etc.
 add_custom_command(TARGET POLICYDB POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
-                   ${CMAKE_SOURCE_DIR}/policydb/*.h $<TARGET_FILE_DIR:POLICYDB>)
+                   ${PROJECT_SOURCE_DIR}/policydb/*.h
+                   $<TARGET_FILE_DIR:POLICYDB>)
 
 target_compile_definitions(POLICYDB PUBLIC LOG_WITH_GLOG)
 target_include_directories(POLICYDB PUBLIC

--- a/orc8r/gateway/c/common/service303/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service303/CMakeLists.txt
@@ -39,7 +39,7 @@ target_link_libraries(SERVICE303_LIB
 # session_manager, etc.
 add_custom_command(TARGET SERVICE303_LIB POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
-                   ${CMAKE_SOURCE_DIR}/service303/*.h
+                   ${PROJECT_SOURCE_DIR}/service303/*.h
                    $<TARGET_FILE_DIR:SERVICE303_LIB>)
 
 target_include_directories(SERVICE303_LIB PUBLIC

--- a/orc8r/gateway/c/common/service_registry/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service_registry/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(SERVICE_REGISTRY CONFIG
 # session_manager, etc.
 add_custom_command(TARGET SERVICE_REGISTRY POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
-                   ${CMAKE_SOURCE_DIR}/service_registry/*.h
+                   ${PROJECT_SOURCE_DIR}/service_registry/*.h
                    $<TARGET_FILE_DIR:SERVICE_REGISTRY>)
 
 target_include_directories(SERVICE_REGISTRY PUBLIC


### PR DESCRIPTION
Summary: Changes references to `CMAKE_SOURCE_DIR` in `common` to `PROJECT_SOURCE_DIR`. This allows external CMakeLists to include `common` without affecting the build; `PROJECT_SOURCE_DIR` will still point to the `common` directory.

Reviewed By: ilyacodesFB

Differential Revision: D17674320

