### PR TITLE
Fix api discrepancy between spec and actual result

### DIFF
--- a/feg/cloud/go/plugin/models/swagger.v1.yml
+++ b/feg/cloud/go/plugin/models/swagger.v1.yml
@@ -176,10 +176,10 @@ paths:
       - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
       responses:
         '200':
-          description: List of all federation gateways inside the network
+          description: Map of all federated gateways inside the network by gatewayID
           schema:
-            type: array
-            items:
+            type: object
+            additionalProperties:
               $ref: '#/definitions/federation_gateway'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'

--- a/lte/cloud/go/plugin/models/swagger.v1.yml
+++ b/lte/cloud/go/plugin/models/swagger.v1.yml
@@ -503,7 +503,7 @@ paths:
         - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
       responses:
         '200':
-          description: List of all LTE gateways inside the network
+          description: Map of all LTE gateways inside the network by gatewayID
           schema:
             type: object
             additionalProperties:

--- a/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
+++ b/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
@@ -415,10 +415,10 @@ paths:
         - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
       responses:
         '200':
-          description: List of all gateways inside the network
+          description: Map of all gateways inside the network by gatewayID
           schema:
-            type: array
-            items:
+            type: object
+            additionalProperties:
               $ref: '#/definitions/magmad_gateway'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'


### PR DESCRIPTION
Summary: Murtadha reported there's a discrepancy in the API spec vs what it actually returns. It says it'll report back a list of objects but it actually gives back a map of gatewayID -> gateway object. Fixed the spec so that it matches the functionality.

Reviewed By: xjtian

Differential Revision: D17711663

