### PR TITLE
Include functional in Serializers header

### DIFF
--- a/orc8r/gateway/c/common/datastore/Serializers.h
+++ b/orc8r/gateway/c/common/datastore/Serializers.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <functional>
 #include <google/protobuf/message.h>
 
 using google::protobuf::Message;

--- a/orc8r/gateway/c/common/service303/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service303/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SERVICE303_GRPC_PROTOS service303)
 generate_grpc_protos("${SERVICE303_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
 
+generate_prometheus_proto("${PROTO_SRCS}" "${PROTO_HDRS}" ${CPP_OUT_DIR})
+
 message("Proto_srcs are ${PROTO_SRCS}")
 
 add_library(SERVICE303_LIB


### PR DESCRIPTION
Summary: Compiling the Magma C++ library produces an error indicating a missing include. This diff adds it

Reviewed By: ilyacodesFB

Differential Revision: D17677585

