### PR TITLE
Generate prometheus protos in service303

### DIFF
--- a/orc8r/gateway/c/common/service303/CMakeLists.txt
+++ b/orc8r/gateway/c/common/service303/CMakeLists.txt
@@ -19,6 +19,8 @@ set(SERVICE303_GRPC_PROTOS service303)
 generate_grpc_protos("${SERVICE303_GRPC_PROTOS}" "${PROTO_SRCS}"
   "${PROTO_HDRS}" ${ORC8R_PROTO_DIR} ${CPP_OUT_DIR})
 
+generate_prometheus_proto("${PROTO_SRCS}" "${PROTO_HDRS}" ${CPP_OUT_DIR})
+
 message("Proto_srcs are ${PROTO_SRCS}")
 
 add_library(SERVICE303_LIB


### PR DESCRIPTION
Summary: When compiling the c++ library, there are some missing protos when building service303 without this change.

Reviewed By: ilyacodesFB

Differential Revision: D17677583

