### PR TITLE
Migrate checkin_cli to use state service instead of checkind to test connection between cloud and gateway

### DIFF
--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -60,6 +60,8 @@ func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 	return []serde.Serde{
 		// State service serdes
 		state.NewStateSerde(orc8r.GatewayStateType, &models.GatewayStatus{}),
+		// For checkin_cli.py to test cloud < - > gateway connection
+		state.NewStateSerde(state.StringMapSerdeType, &state.StringToStringMap{}),
 
 		// Device service serdes
 		serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &models.GatewayDevice{}),

--- a/orc8r/cloud/go/services/state/serdes.go
+++ b/orc8r/cloud/go/services/state/serdes.go
@@ -8,8 +8,26 @@
 
 package state
 
-import "magma/orc8r/cloud/go/serde"
+import (
+	"encoding/json"
+	"magma/orc8r/cloud/go/serde"
+)
+
+const StringMapSerdeType = "string_map"
 
 func NewStateSerde(stateType string, modelPtr serde.BinaryConvertible) serde.Serde {
 	return serde.NewBinarySerde(SerdeDomain, stateType, modelPtr)
+}
+
+// A generic map that holds key value pair both of type string. This is used on
+// the gateway side in checkin_cli.py to simply test the connection between the
+// cloud and the gateway.
+type StringToStringMap map[string]string
+
+func (m *StringToStringMap) MarshalBinary() (data []byte, err error) {
+	return json.Marshal(m)
+}
+
+func (m *StringToStringMap) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, m)
 }

--- a/orc8r/gateway/python/scripts/checkin_cli.py
+++ b/orc8r/gateway/python/scripts/checkin_cli.py
@@ -11,20 +11,22 @@ of patent rights can be found in the PATENTS file in the same directory.
 import asyncio
 import datetime
 import sys
+import json
 
 # NOTE: Uncomment following lines to get verbose logs on GRPC error.
 # import os
 # os.environ['GRPC_TRACE'] = 'all'
 # os.environ['GRPC_VERBOSITY'] = 'DEBUG'
-import psutil
 import snowflake
+from magma.common.rpc_utils import grpc_async_wrapper
 from magma.common.cert_utils import load_cert
 from magma.common.cert_validity import create_ssl_connection, \
     create_tcp_connection
 from magma.common.service_registry import ServiceRegistry
 from magma.configuration.service_configs import load_service_config
-from orc8r.protos.magmad_pb2 import CheckinRequest, SystemStatus
-from orc8r.protos.magmad_pb2_grpc import CheckindStub
+from orc8r.protos.state_pb2_grpc import StateServiceStub
+from orc8r.protos.state_pb2 import ReportStatesRequest
+from orc8r.protos.service303_pb2 import State
 
 
 def main():
@@ -53,7 +55,8 @@ def main():
             - Double check that cloud is up and gateway has been added with
               correct hardware id and key to allow bootstrap.
                 1. Run show_gateway_info.py.
-                2. Go to cloud swagger (EG. https://127.0.0.1:9443/apidocs).
+                2. Go to cloud swagger
+                   (EG. https://127.0.0.1:9443/apidocs/v1/#/).
                 3. POST to add a new gateway. Fill JSON with corresponding
                    values from step 1.
             """,
@@ -66,7 +69,11 @@ def main():
             """,
         'direct_checkin':
             """
-            - Verify checkind service is running on cloud VM.
+            - Verify state service is running on cloud VM.
+            - Double check the gateway has been registered with the cloud. You
+              can check by going to cloud swagger,
+              (EG. https://127.0.0.1:9443/apidocs/v1/#/), and query the list
+              gateways endpoint.
             - Check logs for more information (sudo tail -f /var/log/syslog).
             """,
         'proxy_checkin':
@@ -95,17 +102,17 @@ def main():
 
         print('4. -- Creating direct cloud checkin -- ')
         stage = 'direct_checkin'
-        test_send_checkin(proxy_cloud_connections=False)
+        loop.run_until_complete(test_checkin(proxy_cloud_connections=False))
 
         print('5. -- Creating proxy cloud checkin -- ')
         stage = 'proxy_checkin'
-        test_send_checkin(proxy_cloud_connections=True)
+        loop.run_until_complete(test_checkin(proxy_cloud_connections=True))
 
         print('Success!')
         sys.exit(0)
 
     except Exception as e:
-        print('> Error: %s' % e,)
+        print('> Error: %s' % e, )
         print("Suggestions:", err_suggestions[stage])
         sys.exit(1)
 
@@ -125,36 +132,28 @@ def test_check_cert(certfile):
         raise Exception('Certificate is not yet valid!')
 
 
-def create_checkin_request():
-    """Create request object to send with Checkin"""
-    cpu = psutil.cpu_times()
-    mem = psutil.virtual_memory()
-    request = CheckinRequest(
-        gateway_id=snowflake.snowflake(),
-        magma_pkg_version='fake_version',
-        system_status=SystemStatus(
-            cpu_user=int(cpu.user * 1000),  # convert second to millisecond
-            cpu_system=int(cpu.system * 1000),
-            cpu_idle=int(cpu.idle * 1000),
-            mem_total=mem.total,
-            mem_available=mem.available,
-            mem_used=mem.used,
-            mem_free=mem.free,
-        ),
-    )
-    return request
-
-
-def test_send_checkin(proxy_cloud_connections=True):
+async def test_checkin(proxy_cloud_connections=True):
     """Send checkin using either proxy or direct to cloud connection"""
     chan = ServiceRegistry.get_rpc_channel(
-            'checkind', ServiceRegistry.CLOUD,
-            proxy_cloud_connections=proxy_cloud_connections)
-    client = CheckindStub(chan)
-    request = create_checkin_request()
+        'state',
+        ServiceRegistry.CLOUD,
+        proxy_cloud_connections=proxy_cloud_connections,
+    )
+    client = StateServiceStub(chan)
 
-    checkin_timeout = 1000
-    client.Checkin(request, checkin_timeout)
+    # Construct a simple state to send for test
+    value = json.dumps({"datetime": datetime.datetime.now()}, default=str)
+    states = [
+        State(
+            type="string_map",
+            deviceID=snowflake.snowflake(),
+            value=value.encode('utf-8')
+        ),
+    ]
+    request = ReportStatesRequest(states=states)
+
+    timeout = 1000
+    await grpc_async_wrapper(client.ReportStates.future(request, timeout))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Summary: - Since checkind will be soon be deprecated, migrating the checkin_cli to send a dummy state to the state service to test cloud<->gateway connection.

Reviewed By: andreilee

Differential Revision: D17735861

