### PR TITLE
Fix issue of reporting eNB status before getting serial number

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -246,8 +246,12 @@ def get_enb_status(enodeb: EnodebAcsStateMachine) -> EnodebStatus:
     enodeb_connected = enodeb.is_enodeb_connected()
     opstate_enabled = _parse_param_as_bool(enodeb, ParameterName.OP_STATE)
     rf_tx_on = _parse_param_as_bool(enodeb, ParameterName.RF_TX_STATUS)
-    enb_serial = enodeb.device_cfg.get_parameter(ParameterName.SERIAL_NUMBER)
-    rf_tx_desired = get_enb_rf_tx_desired(enodeb.mconfig, enb_serial)
+    try:
+        enb_serial =\
+            enodeb.device_cfg.get_parameter(ParameterName.SERIAL_NUMBER)
+        rf_tx_desired = get_enb_rf_tx_desired(enodeb.mconfig, enb_serial)
+    except (KeyError, ConfigurationError):
+        rf_tx_desired = False
     mme_connected = _parse_param_as_bool(enodeb, ParameterName.MME_STATUS)
     gps_connected = _get_gps_status_as_bool(enodeb)
     ptp_connected = _parse_param_as_bool(enodeb, ParameterName.PTP_STATUS)

--- a/lte/gateway/python/magma/enodebd/tests/enodeb_status_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enodeb_status_tests.py
@@ -9,7 +9,9 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 # pylint: disable=protected-access
 from unittest import TestCase
-from magma.enodebd.enodeb_status import get_service_status_old, get_all_enb_status
+from magma.enodebd.devices.device_utils import EnodebDeviceName
+from magma.enodebd.enodeb_status import get_service_status_old, \
+    get_all_enb_status, get_enb_status
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
 from magma.enodebd.tests.test_utils.tr069_msg_builder import \
     Tr069MessageBuilder
@@ -38,6 +40,16 @@ class EnodebStatusTests(TestCase):
                         'Should report an eNB as conencted')
         self.assertTrue(status['enodeb_serial'] == '120200002618AGP0001',
                         'eNodeB serial should match the earlier Inform')
+
+    def test_get_enb_status(self):
+        acs_state_machine = \
+            EnodebAcsStateMachineBuilder\
+                .build_acs_state_machine(EnodebDeviceName.BAICELLS)
+        try:
+            get_enb_status(acs_state_machine)
+        except KeyError:
+            self.fail('Getting eNB status should succeed after constructor '
+                      'runs.')
 
     def test_get_enodeb_all_status(self):
         manager = self._get_manager()


### PR DESCRIPTION
Summary: An unhandled exception would be raised in the scenario where the eNB handler has been instantiated but has not yet processed a TR-069 message. This handles the exception.

Reviewed By: themarwhal

Differential Revision: D17797425

