### PR TITLE
remove duplicate check ping test

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/models/device/Model.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/models/interface/Model.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/models/wifi/Model.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/utils/Time.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/YangUtils.cpp
 )
 

--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/mikrotik/WriteTask.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/packet/Engine.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/ping/Channel.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/ping/Engine.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/Config.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/CambiumDevice.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/DemoDevice.cpp

--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/mikrotik/Channel.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/mikrotik/WriteTask.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/packet/Engine.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/ping/Channel.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/Config.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/CambiumDevice.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/DemoDevice.cpp
@@ -144,6 +145,7 @@ target_link_libraries(devmand
 
 add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/MikrotikChannelTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/EventBaseTest.cpp

--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/Factory.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/EchoDevice.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/FrinxDevice.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/devices/PingDevice.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/mikrotik/Device.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/mikrotik/Mib.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/State.cpp

--- a/devmand/gateway/Makefile
+++ b/devmand/gateway/Makefile
@@ -1,6 +1,6 @@
 all:
 	cd ${PKG_BUILD_DIR}; \
-	cmake -GNinja -DCMAKE_BUILD_TYPE=release  \
+	cmake -GNinja -DCMAKE_BUILD_TYPE=release \
 		-DCMAKE_INSTALL_PREFIX=${PKG_INSTALL_DIR} \
 		${PKG_REPO_DIR}
 	cd ${PKG_BUILD_DIR}; ninja -C .

--- a/devmand/gateway/docker/docker-compose.yml
+++ b/devmand/gateway/docker/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - SYS_ADMIN
       - NET_ADMIN
     sysctls:
-      - net.ipv4.ping_group_range="0 0"
+      - net.ipv4.ping_group_range=0 0
     stdin_open: true
     tty: true
     privileged: true

--- a/devmand/gateway/docker/docker-compose.yml
+++ b/devmand/gateway/docker/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       - /sys/fs/cgroup
     cap_add:
       - SYS_ADMIN
+      - NET_ADMIN
+    sysctls:
+      - net.ipv4.ping_group_range="0 0"
     stdin_open: true
     tty: true
     privileged: true

--- a/devmand/gateway/docker/firstparty/devmand/deps
+++ b/devmand/gateway/docker/firstparty/devmand/deps
@@ -47,6 +47,7 @@ python-pip
 python-setuptools
 python3-setuptools
 scons
+strace
 valgrind
 vim
 virtualenv

--- a/devmand/gateway/docker/scripts/develop
+++ b/devmand/gateway/docker/scripts/develop
@@ -16,8 +16,10 @@ build_status=${PIPESTATUS[0]}
 docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
 if [ "$build_status" -eq 0 ]; then
   docker rm -f devmand
-  docker run -it --name devmand \
+  docker run -it --cap-add NET_RAW --cap-add NET_ADMIN --cap-add SYS_PTRACE \
+      --name devmand \
       -v "$(realpath ../):/cache/devmand/repo:ro" \
       -v "$(realpath ~/cache_devmand_build):/cache/devmand/build:rw" \
+      --sysctl net.ipv4.ping_group_range="0 0" \
       ${docker_registry}/devmand /bin/bash
 fi

--- a/devmand/gateway/docker/scripts/test
+++ b/devmand/gateway/docker/scripts/test
@@ -4,5 +4,6 @@ CACHE_DIR=${SYMPHONY_AGENT_CACHE_DIR:-$(realpath ~)/cache_devmand_build}
 docker run \
   -v "$(realpath ../):/cache/devmand/repo:ro" \
   -v "$CACHE_DIR:/cache/devmand/build:rw" \
+  --sysctl net.ipv4.ping_group_range="0 0" \
   devmand-built \
   make test

--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -23,6 +23,7 @@
 #include <devmand/cartography/Cartographer.h>
 #include <devmand/channels/Engine.h>
 #include <devmand/channels/packet/Engine.h>
+#include <devmand/channels/ping/Engine.h>
 #include <devmand/channels/snmp/Engine.h>
 #include <devmand/devices/Device.h>
 #include <devmand/devices/Factory.h>
@@ -83,13 +84,16 @@ class Application final : public MetricSink {
 
   DhcpdConfig& getDhcpdConfig();
 
+  channels::ping::Engine& getPingEngine();
+
  private:
   void pollDevices();
 
   template <class EngineType, class... Args>
-  EngineType* addEngine(Args... args) {
+  EngineType* addEngine(Args&&... args) {
     return static_cast<EngineType*>(
-        channelEngines.emplace(std::make_unique<EngineType>(args...))
+        channelEngines
+            .emplace(std::make_unique<EngineType>(std::forward<Args>(args)...))
             .first->get());
   }
 
@@ -125,6 +129,7 @@ class Application final : public MetricSink {
    */
   ChannelEngines channelEngines;
   channels::snmp::Engine* snmpEngine;
+  channels::ping::Engine* pingEngine;
 
   /*
    * A config writer for dhcpd.

--- a/devmand/gateway/src/devmand/channels/ping/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.cpp
@@ -24,15 +24,7 @@ folly::Future<Rtt> Channel::ping() {
   LOG(INFO) << "Sending ping to " << target.str() << " with sequence "
             << hdr.un.echo.sequence;
 
-  // TODO BOOTCAMP this handles ipv4 only we should support ipv6 as well.
-  sockaddr_in destination;
-  if (inet_pton(AF_INET, target.str().c_str(), &destination.sin_addr) != 1) {
-    LOG(ERROR) << "Invalid IPv4 Address " << target.str();
-    return folly::makeFuture<Rtt>(0);
-  }
-  destination.sin_family = AF_INET;
-
-  return engine.ping(hdr, destination);
+  return engine.ping(hdr, target);
 }
 
 RequestId Channel::getSequence() {

--- a/devmand/gateway/src/devmand/channels/ping/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.cpp
@@ -1,0 +1,100 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/ip_icmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <folly/GLog.h>
+
+#include <devmand/channels/ping/Channel.h>
+
+namespace devmand {
+namespace channels {
+namespace ping {
+
+Channel::Channel(folly::EventBase& _eventBase, folly::IPAddress target_)
+    : eventBase(_eventBase), target(target_) {
+  icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+  if (icmpSocket < 0) {
+    throw std::system_error(errno, std::generic_category());
+  }
+
+  if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
+    throw std::system_error(errno, std::generic_category());
+  }
+}
+
+// TODO first pass sync
+folly::Future<Rtt> Channel::ping() {
+  auto hdr = makeIcmpPacket();
+
+  LOG(INFO) << "Sending ping to " << target.str() << " with sequence "
+            << hdr.un.echo.sequence;
+
+  // TODO BOOTCAMP this handles ipv4 only we should support ipv6 as well.
+  sockaddr_in destination;
+  if (inet_pton(AF_INET, target.str().c_str(), &destination.sin_addr) != 1) {
+    LOG(ERROR) << "Invalid IPv4 Address " << target.str();
+    return folly::makeFuture<Rtt>(0);
+  }
+  destination.sin_family = AF_INET;
+
+  auto result = sendto(
+      icmpSocket,
+      &hdr,
+      sizeof(hdr),
+      0,
+      reinterpret_cast<sockaddr*>(&destination),
+      sizeof(destination));
+  if (result <= 0) {
+    switch (result) {
+      case EAGAIN:
+        // case EWOULDBLOCK:
+        // TODO if the ping fail because of a kernel buffer I'm not going to
+        // implement retry logic as something is filling up the buffers. We
+        // should probably alarm if this is the case.
+        LOG(ERROR) << "Buffer full so ping failed to " << target.str();
+        break;
+      default:
+        // TODO BOOTCAMP get errno string from syserror
+        LOG(ERROR) << "Failed to send packet with errno " << errno;
+        break;
+    }
+    return folly::makeFuture<Rtt>(0);
+  }
+
+  // TODO setup promise
+
+  return folly::makeFuture<Rtt>(0);
+}
+
+uint16_t Channel::getSequence() {
+  return ++sequence;
+}
+
+icmphdr Channel::makeIcmpPacket() {
+  icmphdr hdr{};
+  hdr.type = ICMP_ECHO;
+  // hdr.un.echo.id = 0;
+  hdr.un.echo.sequence = getSequence();
+  // hdr.checksum = 0; // Let the kernel fill in the checksum
+  return hdr;
+}
+
+} // namespace ping
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/ping/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.cpp
@@ -6,44 +6,17 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 
 #include <arpa/inet.h>
-#include <fcntl.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <netinet/ip_icmp.h>
-#include <signal.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-#include <sys/types.h>
-#include <time.h>
-#include <unistd.h>
 
 #include <folly/GLog.h>
 
 #include <devmand/channels/ping/Channel.h>
-#include <devmand/utils/Time.h>
 
 namespace devmand {
 namespace channels {
 namespace ping {
 
-Channel::Channel(folly::EventBase& _eventBase, folly::IPAddress target_)
-    : folly::EventHandler(&_eventBase), eventBase(_eventBase), target(target_) {
-  // TODO this socket needs to be moved to an engine...
-  icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
-  if (icmpSocket < 0) {
-    throw std::system_error(errno, std::generic_category());
-  }
-
-  if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
-    throw std::system_error(errno, std::generic_category());
-  }
-
-  folly::EventHandler::changeHandlerFD(
-      folly::NetworkSocket::fromFd(icmpSocket));
-
-  registerHandler(folly::EventHandler::READ | folly::EventHandler::PERSIST);
-}
+Channel::Channel(Engine& engine_, folly::IPAddress target_)
+    : engine(engine_), target(target_) {}
 
 folly::Future<Rtt> Channel::ping() {
   icmphdr hdr = makeIcmpPacket();
@@ -59,42 +32,7 @@ folly::Future<Rtt> Channel::ping() {
   }
   destination.sin_family = AF_INET;
 
-  auto request = outstandingRequests.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(hdr.un.echo.sequence),
-      std::forward_as_tuple(Request{}));
-  if (request.second) {
-    request.first->second.start = utils::Time::now();
-    auto result = sendto(
-        icmpSocket,
-        &hdr,
-        sizeof(hdr),
-        0,
-        reinterpret_cast<sockaddr*>(&destination),
-        sizeof(destination));
-    if (result <= 0) {
-      switch (result) {
-        case EAGAIN: // case EWOULDBLOCK:
-          // TODO if the ping fail because of a kernel buffer I'm not going to
-          // implement retry logic as something is filling up the buffers. We
-          // should probably alarm if this is the case.
-          LOG(ERROR) << "Buffer full so ping failed to " << target.str();
-          break;
-        default:
-          // TODO BOOTCAMP get errno string from syserror
-          LOG(ERROR) << "Failed to send packet with errno " << errno;
-          break;
-      }
-      outstandingRequests.erase(request.first);
-      return folly::makeFuture<Rtt>(0);
-    } else {
-      return request.first->second.promise.getFuture();
-    }
-  } else {
-    LOG(ERROR) << "ICMP Echo Id rollover with outstanding requests";
-    return folly::makeFuture<Rtt>(0);
-  }
-  // TODO implement timeout
+  return engine.ping(hdr, destination);
 }
 
 RequestId Channel::getSequence() {
@@ -108,28 +46,6 @@ icmphdr Channel::makeIcmpPacket() {
   hdr.un.echo.sequence = getSequence();
   // hdr.checksum = 0; // Let the kernel fill in the checksum
   return hdr;
-}
-
-void Channel::handlerReady(uint16_t) noexcept {
-  // TODO end time isn't really precise here as we don't have a kernel time
-  // need to implement kernel timestamping
-  utils::TimePoint end = utils::Time::now();
-  icmphdr hdr;
-  while (recv(icmpSocket, &hdr, sizeof(hdr), 0) > 0) {
-    LOG(INFO) << "Packet received with ICMP type " << static_cast<int>(hdr.type)
-              << " code " << static_cast<int>(hdr.code);
-
-    if (hdr.type == 0 and hdr.code == 0) {
-      auto request = outstandingRequests.find(hdr.un.echo.sequence);
-      if (request != outstandingRequests.end()) {
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
-            end - request->second.start);
-        LOG(INFO) << "Received ICMP response after " << duration.count()
-                  << " microseconds";
-        request->second.promise.setValue(duration.count());
-      }
-    }
-  }
 }
 
 } // namespace ping

--- a/devmand/gateway/src/devmand/channels/ping/Channel.h
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.h
@@ -5,35 +5,16 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
-#include <map>
-#include <string>
-
-#include <netinet/ip_icmp.h>
-
-#include <folly/futures/Future.h>
-#include <folly/io/async/AsyncSocket.h>
-
 #include <devmand/channels/Channel.h>
-#include <devmand/utils/Time.h>
+#include <devmand/channels/ping/Engine.h>
 
 namespace devmand {
 namespace channels {
 namespace ping {
 
-using Rtt = uint64_t;
-
-struct Request {
-  utils::TimePoint start;
-  folly::Promise<Rtt> promise;
-};
-
-using RequestId = uint16_t;
-
-using OutstandingRequests = std::map<RequestId, Request>;
-
-class Channel : public channels::Channel, public folly::EventHandler {
+class Channel : public channels::Channel {
  public:
-  Channel(folly::EventBase& _eventBase, folly::IPAddress target_);
+  Channel(Engine& engine, folly::IPAddress target_);
   Channel() = delete;
   ~Channel() override = default;
   Channel(const Channel&) = delete;
@@ -48,13 +29,9 @@ class Channel : public channels::Channel, public folly::EventHandler {
   RequestId getSequence();
   icmphdr makeIcmpPacket();
 
-  virtual void handlerReady(uint16_t events) noexcept override;
-
  private:
-  folly::EventBase& eventBase;
-  OutstandingRequests outstandingRequests;
+  Engine& engine;
   folly::IPAddress target;
-  int icmpSocket{-1};
   // TODO BOOTCAMP make this randomly initilized to minimize collisions.
   RequestId sequence{0};
 };

--- a/devmand/gateway/src/devmand/channels/ping/Channel.h
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.h
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
+#pragma once
+
 #include <devmand/channels/Channel.h>
 #include <devmand/channels/ping/Engine.h>
 

--- a/devmand/gateway/src/devmand/channels/ping/Channel.h
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.h
@@ -18,7 +18,7 @@ namespace devmand {
 namespace channels {
 namespace ping {
 
-using Rtt = uint32_t;
+using Rtt = uint64_t;
 
 class Channel : public channels::Channel {
  public:
@@ -41,6 +41,7 @@ class Channel : public channels::Channel {
   folly::EventBase& eventBase;
   folly::IPAddress target;
   int icmpSocket{-1};
+  // TODO BOOTCAMP make this randomly initilized to prevent collisions.
   uint16_t sequence{0};
 };
 

--- a/devmand/gateway/src/devmand/channels/ping/Channel.h
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <string>
+
+#include <netinet/ip_icmp.h>
+
+#include <folly/futures/Future.h>
+#include <folly/io/async/AsyncSocket.h>
+
+#include <devmand/channels/Channel.h>
+
+namespace devmand {
+namespace channels {
+namespace ping {
+
+using Rtt = uint32_t;
+
+class Channel : public channels::Channel {
+ public:
+  Channel(folly::EventBase& _eventBase, folly::IPAddress target_);
+  Channel() = delete;
+  ~Channel() override = default;
+  Channel(const Channel&) = delete;
+  Channel& operator=(const Channel&) = delete;
+  Channel(Channel&&) = delete;
+  Channel& operator=(Channel&&) = delete;
+
+ public:
+  folly::Future<Rtt> ping();
+
+ private:
+  uint16_t getSequence();
+  icmphdr makeIcmpPacket();
+
+ private:
+  folly::EventBase& eventBase;
+  folly::IPAddress target;
+  int icmpSocket{-1};
+  uint16_t sequence{0};
+};
+
+} // namespace ping
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -1,0 +1,114 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/ip_icmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <folly/GLog.h>
+
+#include <devmand/channels/ping/Engine.h>
+#include <devmand/utils/Time.h>
+
+namespace devmand {
+namespace channels {
+namespace ping {
+
+Engine::Engine(folly::EventBase& _eventBase)
+    : folly::EventHandler(&_eventBase), eventBase(_eventBase) {
+  // TODO this socket needs to be moved to an engine...
+  icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+  if (icmpSocket < 0) {
+    throw std::system_error(errno, std::generic_category());
+  }
+
+  if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
+    throw std::system_error(errno, std::generic_category());
+  }
+
+  folly::EventHandler::changeHandlerFD(
+      folly::NetworkSocket::fromFd(icmpSocket));
+
+  registerHandler(folly::EventHandler::READ | folly::EventHandler::PERSIST);
+}
+
+folly::Future<Rtt> Engine::ping(
+    const icmphdr& hdr,
+    const sockaddr_in& destination) {
+  // TODO key needs to be on seq and ip
+  auto request = outstandingRequests.emplace(
+      std::piecewise_construct,
+      std::forward_as_tuple(hdr.un.echo.sequence),
+      std::forward_as_tuple(Request{}));
+  if (request.second) {
+    request.first->second.start = utils::Time::now();
+    auto result = sendto(
+        icmpSocket,
+        &hdr,
+        sizeof(hdr),
+        0,
+        reinterpret_cast<const sockaddr*>(&destination),
+        sizeof(destination));
+    if (result <= 0) {
+      switch (result) {
+        case EAGAIN: // case EWOULDBLOCK:
+          // TODO if the ping fail because of a kernel buffer I'm not going to
+          // implement retry logic as something is filling up the buffers. We
+          // should probably alarm if this is the case.
+          LOG(ERROR) << "Buffer full so ping failed";
+          break;
+        default:
+          // TODO BOOTCAMP get errno string from syserror
+          LOG(ERROR) << "Failed to send packet with errno " << errno;
+          break;
+      }
+      outstandingRequests.erase(request.first);
+      return folly::makeFuture<Rtt>(0);
+    } else {
+      return request.first->second.promise.getFuture();
+    }
+  } else {
+    LOG(ERROR) << "ICMP Echo Id rollover with outstanding requests";
+    return folly::makeFuture<Rtt>(0);
+  }
+  // TODO implement timeout
+}
+
+void Engine::handlerReady(uint16_t) noexcept {
+  // TODO end time isn't really precise here as we don't have a kernel time
+  // need to implement kernel timestamping
+  utils::TimePoint end = utils::Time::now();
+  icmphdr hdr;
+  while (recv(icmpSocket, &hdr, sizeof(hdr), 0) > 0) {
+    LOG(INFO) << "Packet received with ICMP type " << static_cast<int>(hdr.type)
+              << " code " << static_cast<int>(hdr.code);
+
+    if (hdr.type == 0 and hdr.code == 0) {
+      auto request = outstandingRequests.find(hdr.un.echo.sequence);
+      if (request != outstandingRequests.end()) {
+        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+            end - request->second.start);
+        LOG(INFO) << "Received ICMP response after " << duration.count()
+                  << " microseconds";
+        request->second.promise.setValue(duration.count());
+      }
+    }
+  }
+}
+
+} // namespace ping
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -18,6 +18,8 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <algorithm>
+
 #include <folly/GLog.h>
 
 #include <devmand/channels/ping/Engine.h>
@@ -27,9 +29,14 @@ namespace devmand {
 namespace channels {
 namespace ping {
 
-Engine::Engine(folly::EventBase& _eventBase)
-    : folly::EventHandler(&_eventBase), eventBase(_eventBase) {
-  // TODO this socket needs to be moved to an engine...
+Engine::Engine(
+    folly::EventBase& _eventBase,
+    const std::chrono::milliseconds& pingTimeout_,
+    const std::chrono::milliseconds& timeoutFrequency_)
+    : folly::EventHandler(&_eventBase),
+      eventBase(_eventBase),
+      pingTimeout(pingTimeout_),
+      timeoutFrequency(timeoutFrequency_) {
   icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
   if (icmpSocket < 0) {
     throw std::system_error(errno, std::generic_category());
@@ -45,77 +52,123 @@ Engine::Engine(folly::EventBase& _eventBase)
   registerHandler(folly::EventHandler::READ | folly::EventHandler::PERSIST);
 }
 
+Engine::~Engine() {
+  unregisterHandler();
+}
+
+void Engine::start() {
+  EventBaseUtils::scheduleEvery(
+      eventBase, [this]() { timeout(); }, timeoutFrequency);
+}
+
+void Engine::timeout() {
+  sharedOutstandingRequests.withULockPtr([this](auto uOutstandingRequests) {
+    auto outstandingRequests = uOutstandingRequests.moveFromUpgradeToWrite();
+    LOG(INFO) << "Processing ping timeouts";
+    for (auto it = outstandingRequests->begin();
+         it != outstandingRequests->end();) {
+      utils::TimePoint end = utils::Time::now();
+      if ((end - it->second.start) > pingTimeout) {
+        LOG(ERROR) << "Ping request timed out";
+        it->second.promise.setValue(0);
+        it = outstandingRequests->erase(it);
+      } else {
+        ++it;
+      }
+    }
+  });
+}
+
 folly::Future<Rtt> Engine::ping(
     const icmphdr& hdr,
     const folly::IPAddress& destination) {
-  auto request = outstandingRequests.emplace(
-      std::piecewise_construct,
-      std::forward_as_tuple(std::make_pair(destination, hdr.un.echo.sequence)),
-      std::forward_as_tuple(Request{}));
-  if (request.second) {
-    sockaddr_storage dst;
-    destination.toSockaddrStorage(&dst);
-    request.first->second.start = utils::Time::now();
-    auto result = sendto(
-        icmpSocket,
-        &hdr,
-        sizeof(hdr),
-        0,
-        reinterpret_cast<const sockaddr*>(&dst),
-        sizeof(dst));
-    if (result <= 0) {
-      switch (result) {
-        case EAGAIN: // case EWOULDBLOCK:
-          // TODO if the ping fail because of a kernel buffer I'm not going to
-          // implement retry logic as something is filling up the buffers. We
-          // should probably alarm if this is the case.
-          LOG(ERROR) << "Buffer full so ping failed";
-          break;
-        default:
-          // TODO BOOTCAMP get errno string from syserror
-          LOG(ERROR) << "Failed to send packet with errno " << errno;
-          break;
+  return sharedOutstandingRequests.withULockPtr([this, &hdr, &destination](
+                                                    auto uOutstandingRequests) {
+    auto outstandingRequests = uOutstandingRequests.moveFromUpgradeToWrite();
+    auto request = outstandingRequests->emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(
+            std::make_pair(destination, hdr.un.echo.sequence)),
+        std::forward_as_tuple(Request{}));
+    if (request.second) {
+      sockaddr_storage dst;
+      destination.toSockaddrStorage(&dst);
+      request.first->second.start = utils::Time::now();
+      auto result = sendto(
+          icmpSocket,
+          &hdr,
+          sizeof(hdr),
+          0,
+          reinterpret_cast<const sockaddr*>(&dst),
+          sizeof(dst));
+      if (result <= 0) {
+        switch (result) {
+          case EAGAIN: // case EWOULDBLOCK:
+            // TODO if the ping fail because of a kernel buffer I'm not going to
+            // implement retry logic as something is filling up the buffers. We
+            // should probably alarm if this is the case.
+            LOG(ERROR) << "Buffer full so ping failed";
+            break;
+          default:
+            // TODO BOOTCAMP get errno string from syserror
+            LOG(ERROR) << "Failed to send packet with errno " << errno;
+            break;
+        }
+        outstandingRequests->erase(request.first);
+        return folly::makeFuture<Rtt>(0);
+      } else {
+        auto ret = request.first->second.promise.getFuture();
+        return ret;
       }
-      outstandingRequests.erase(request.first);
-      return folly::makeFuture<Rtt>(0);
     } else {
-      return request.first->second.promise.getFuture();
+      LOG(ERROR) << "ICMP Echo Id rollover with outstanding requests";
+      return folly::makeFuture<Rtt>(0);
     }
-  } else {
-    LOG(ERROR) << "ICMP Echo Id rollover with outstanding requests";
-    return folly::makeFuture<Rtt>(0);
-  }
-  // TODO implement timeout
+  });
+}
+
+IcmpPacket Engine::read() {
+  IcmpPacket pkt;
+  pkt.success = recvfrom(
+                    icmpSocket,
+                    &pkt.hdr,
+                    sizeof(pkt.hdr),
+                    0,
+                    reinterpret_cast<sockaddr*>(&pkt.src),
+                    &pkt.srcLen) > 0;
+  return pkt;
 }
 
 void Engine::handlerReady(uint16_t) noexcept {
   // TODO end time isn't really precise here as we don't have a kernel time
   // need to implement kernel timestamping
   utils::TimePoint end = utils::Time::now();
-  icmphdr hdr;
-  sockaddr_storage src;
-  socklen_t srcLen = sizeof(sockaddr_storage);
-  while (recvfrom(
-             icmpSocket,
-             &hdr,
-             sizeof(hdr),
-             0,
-             reinterpret_cast<sockaddr*>(&src),
-             &srcLen) > 0) {
-    LOG(INFO) << "Packet received with ICMP type " << static_cast<int>(hdr.type)
-              << " code " << static_cast<int>(hdr.code);
+  for (IcmpPacket pkt = read(); pkt.success; pkt = read()) {
+    bool processed{false};
+    if (pkt.hdr.type == 0 and pkt.hdr.code == 0) {
+      sharedOutstandingRequests.withULockPtr([this, &end, &pkt, &processed](
+                                                 auto uOutstandingRequests) {
+        auto outstandingRequests =
+            uOutstandingRequests.moveFromUpgradeToWrite();
+        auto request = outstandingRequests->find(std::make_pair(
+            folly::IPAddress(reinterpret_cast<sockaddr*>(&pkt.src)),
+            pkt.hdr.un.echo.sequence));
+        if (request != outstandingRequests->end()) {
+          auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
+              end - request->second.start);
+          LOG(INFO) << "Received ICMP response after " << duration.count()
+                    << " microseconds";
+          request->second.promise.setValue(duration.count());
+          outstandingRequests->erase(request);
+          processed = true;
+        }
+      });
+    }
 
-    if (hdr.type == 0 and hdr.code == 0) {
-      auto request = outstandingRequests.find(std::make_pair(
-          folly::IPAddress(reinterpret_cast<sockaddr*>(&src)),
-          hdr.un.echo.sequence));
-      if (request != outstandingRequests.end()) {
-        auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
-            end - request->second.start);
-        LOG(INFO) << "Received ICMP response after " << duration.count()
-                  << " microseconds";
-        request->second.promise.setValue(duration.count());
-      }
+    if (not processed ) {
+      LOG(INFO) << "Packet received with ICMP type "
+                << static_cast<int>(pkt.hdr.type) << " code "
+                << static_cast<int>(pkt.hdr.code);
     }
   }
 }

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -165,7 +165,7 @@ void Engine::handlerReady(uint16_t) noexcept {
       });
     }
 
-    if (not processed ) {
+    if (not processed) {
       LOG(INFO) << "Packet received with ICMP type "
                 << static_cast<int>(pkt.hdr.type) << " code "
                 << static_cast<int>(pkt.hdr.code);

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -57,6 +57,13 @@ Engine::~Engine() {
 }
 
 void Engine::start() {
+  // TODO I implement a very simple type of timeout here where ever n
+  // milliseconds we walk the pending requests and timeout ones that have
+  // exceeded their time. This is neither the most efficient (we walk the entire
+  // list) or the most accurate (we only guarentee and eventual timeout not a
+  // precise timeout). Given this usecase I dont think either of these are that
+  // important but I'm making this note so we know in the future we could
+  // improve this by using one of the nice timeout queues that exist.
   EventBaseUtils::scheduleEvery(
       eventBase, [this]() { timeout(); }, timeoutFrequency);
 }

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -29,7 +29,8 @@ struct Request {
 
 using RequestId = uint16_t;
 
-using OutstandingRequests = std::map<RequestId, Request>;
+using OutstandingRequests =
+    std::map<std::pair<folly::IPAddress, RequestId>, Request>;
 
 class Engine : public channels::Engine, public folly::EventHandler {
  public:
@@ -42,7 +43,9 @@ class Engine : public channels::Engine, public folly::EventHandler {
   Engine& operator=(Engine&&) = delete;
 
  public:
-  folly::Future<Rtt> ping(const icmphdr& hdr, const sockaddr_in& destination);
+  folly::Future<Rtt> ping(
+      const icmphdr& hdr,
+      const folly::IPAddress& destination);
 
  private:
   virtual void handlerReady(uint16_t events) noexcept override;

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -1,0 +1,58 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <map>
+#include <string>
+
+#include <netinet/ip_icmp.h>
+
+#include <folly/futures/Future.h>
+#include <folly/io/async/AsyncSocket.h>
+
+#include <devmand/channels/Engine.h>
+#include <devmand/utils/Time.h>
+
+namespace devmand {
+namespace channels {
+namespace ping {
+
+using Rtt = uint64_t;
+
+struct Request {
+  utils::TimePoint start;
+  folly::Promise<Rtt> promise;
+};
+
+using RequestId = uint16_t;
+
+using OutstandingRequests = std::map<RequestId, Request>;
+
+class Engine : public channels::Engine, public folly::EventHandler {
+ public:
+  Engine(folly::EventBase& _eventBase);
+  Engine() = delete;
+  ~Engine() override = default;
+  Engine(const Engine&) = delete;
+  Engine& operator=(const Engine&) = delete;
+  Engine(Engine&&) = delete;
+  Engine& operator=(Engine&&) = delete;
+
+ public:
+  folly::Future<Rtt> ping(const icmphdr& hdr, const sockaddr_in& destination);
+
+ private:
+  virtual void handlerReady(uint16_t events) noexcept override;
+
+ private:
+  folly::EventBase& eventBase;
+  OutstandingRequests outstandingRequests;
+  int icmpSocket{-1};
+};
+
+} // namespace ping
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -5,6 +5,8 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
+#pragma once
+
 #include <map>
 #include <string>
 

--- a/devmand/gateway/src/devmand/devices/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Device.cpp
@@ -41,15 +41,16 @@ void Device::updateSharedView(SharedUnifiedView& sharedUnifiedView) {
   ErrorHandler::thenError(
       getState()->collect().thenValue([idL, &sharedUnifiedView](auto data) {
         sharedUnifiedView.withULockPtr([&idL, &data](auto uUnifiedView) {
-          auto& unifiedView = *uUnifiedView.moveFromUpgradeToWrite();
+          auto unifiedView = uUnifiedView.moveFromUpgradeToWrite();
 
           // TODO this is an expensive hack... fix later. Prob. just store in
           // dyn and have the magma service convert it.
-          folly::dynamic dyn = unifiedView.find("devmand") != unifiedView.end()
-              ? folly::parseJson(unifiedView["devmand"])
+          folly::dynamic dyn =
+              unifiedView->find("devmand") != unifiedView->end()
+              ? folly::parseJson((*unifiedView)["devmand"])
               : folly::dynamic::object;
           dyn[idL] = data;
-          unifiedView["devmand"] = folly::toJson(dyn);
+          (*unifiedView)["devmand"] = folly::toJson(dyn);
         });
       }));
 }

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -1,0 +1,48 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <iostream>
+#include <stdexcept>
+
+#include <folly/Format.h>
+
+#include <devmand/Application.h>
+#include <devmand/ErrorHandler.h>
+#include <devmand/devices/PingDevice.h>
+#include <devmand/devices/State.h>
+#include <devmand/models/device/Model.h>
+
+namespace devmand {
+namespace devices {
+
+std::unique_ptr<devices::Device> PingDevice::createDevice(
+    Application& app,
+    const cartography::DeviceConfig& deviceConfig) {
+  return std::make_unique<devices::PingDevice>(
+      app, deviceConfig.id, folly::IPAddress(deviceConfig.ip));
+}
+
+PingDevice::PingDevice(
+    Application& application,
+    const Id& id_,
+    const folly::IPAddress& ip_)
+    : Device(application, id_), channel(application.getPingEngine(), ip_) {}
+
+std::shared_ptr<State> PingDevice::getState() {
+  auto state = State::make(app, *this);
+  state->setStatus(false);
+  devmand::models::device::Model::init(state->update());
+
+  state->addRequest(channel.ping().thenValue([state](auto rtt) {
+    devmand::models::device::Model::addLatency(
+        state->update(), "ping", "agent", "device", rtt);
+  }));
+  return state;
+}
+
+} // namespace devices
+} // namespace devmand

--- a/devmand/gateway/src/devmand/devices/PingDevice.h
+++ b/devmand/gateway/src/devmand/devices/PingDevice.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <devmand/channels/ping/Channel.h>
+#include <devmand/devices/Device.h>
+
+namespace devmand {
+namespace devices {
+
+class PingDevice : public Device {
+ public:
+  PingDevice(
+      Application& application,
+      const Id& id,
+      const folly::IPAddress& ip_);
+  PingDevice() = delete;
+  virtual ~PingDevice() = default;
+  PingDevice(const PingDevice&) = delete;
+  PingDevice& operator=(const PingDevice&) = delete;
+  PingDevice(PingDevice&&) = delete;
+  PingDevice& operator=(PingDevice&&) = delete;
+
+  static std::unique_ptr<devices::Device> createDevice(
+      Application& app,
+      const cartography::DeviceConfig& deviceConfig);
+
+ public:
+  std::shared_ptr<State> getState() override;
+
+ protected:
+  void setConfig(const folly::dynamic& config) override {
+    (void)config;
+    LOG(ERROR) << "set config on unconfigurable device";
+  }
+
+ protected:
+  channels::ping::Channel channel;
+};
+
+} // namespace devices
+} // namespace devmand

--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
@@ -81,8 +81,8 @@ Snmpv2Device::Snmpv2Device(
     const std::string& securityName,
     const channels::snmp::SecurityLevel& securityLevel,
     oid proto[])
-    : Device(application, id_),
-      channel(
+    : PingDevice(application, id_, folly::IPAddress(peer)),
+      snmpChannel(
           peer,
           community,
           version,
@@ -95,19 +95,24 @@ std::shared_ptr<State> Snmpv2Device::getState() {
   using IfMib = devmand::channels::snmp::IfMib;
   using IModel = devmand::models::interface::Model;
 
-  auto state = State::make(app, *this);
-  state->setStatus(false);
+  auto state = PingDevice::getState();
   IModel::init(state->update());
   auto& system = state->update()["ietf-system:system"] = folly::dynamic::object;
 
-  state->addRequest(IfMib::getSystemName(channel).thenValue(
-      [&system](auto v) { system["hostname"] = v; }));
-  state->addRequest(IfMib::getSystemContact(channel).thenValue(
-      [&system](auto v) { system["contact"] = v; }));
-  state->addRequest(IfMib::getSystemLocation(channel).thenValue(
-      [&system](auto v) { system["location"] = v; }));
   state->addRequest(
-      IfMib::getInterfaceNames(channel).thenValue([state](auto results) {
+      IfMib::getSystemName(snmpChannel).thenValue([&system](auto v) {
+        system["hostname"] = v;
+      }));
+  state->addRequest(
+      IfMib::getSystemContact(snmpChannel).thenValue([&system](auto v) {
+        system["contact"] = v;
+      }));
+  state->addRequest(
+      IfMib::getSystemLocation(snmpChannel).thenValue([&system](auto v) {
+        system["location"] = v;
+      }));
+  state->addRequest(
+      IfMib::getInterfaceNames(snmpChannel).thenValue([state](auto results) {
         for (auto result : results) {
           IModel::updateInterface(
               state->update(), result.index, "name", result.value);
@@ -118,35 +123,40 @@ std::shared_ptr<State> Snmpv2Device::getState() {
         }
       }));
   state->addRequest(
-      IfMib::getInterfaceOperStatuses(channel).thenValue([state](auto results) {
-        for (auto result : results) {
-          // TODO this is not valid according to the model but we need to fix
-          // the front-end.
-          IModel::updateInterface(
-              state->update(), result.index, "oper-status", result.value);
-          IModel::updateInterface(
-              state->update(), result.index, "state/oper-status", result.value);
-        }
-      }));
-
-  state->addRequest(IfMib::getInterfaceAdminStatuses(channel).thenValue(
-      [state](auto results) {
-        for (auto result : results) {
-          bool isEnabled = result.value == "UP";
-          IModel::updateInterface(
-              state->update(),
-              result.index,
-              "state/admin-status",
-              result.value);
-          IModel::updateInterface(
-              state->update(), result.index, "config/enabled", isEnabled);
-          IModel::updateInterface(
-              state->update(), result.index, "state/enabled", isEnabled);
-        }
-      }));
+      IfMib::getInterfaceOperStatuses(snmpChannel)
+          .thenValue([state](auto results) {
+            for (auto result : results) {
+              // TODO this is not valid according to the model but we need to
+              // fix the front-end.
+              IModel::updateInterface(
+                  state->update(), result.index, "oper-status", result.value);
+              IModel::updateInterface(
+                  state->update(),
+                  result.index,
+                  "state/oper-status",
+                  result.value);
+            }
+          }));
 
   state->addRequest(
-      IfMib::getInterfaceMtus(channel).thenValue([state](auto results) {
+      IfMib::getInterfaceAdminStatuses(snmpChannel)
+          .thenValue([state](auto results) {
+            for (auto result : results) {
+              bool isEnabled = result.value == "UP";
+              IModel::updateInterface(
+                  state->update(),
+                  result.index,
+                  "state/admin-status",
+                  result.value);
+              IModel::updateInterface(
+                  state->update(), result.index, "config/enabled", isEnabled);
+              IModel::updateInterface(
+                  state->update(), result.index, "state/enabled", isEnabled);
+            }
+          }));
+
+  state->addRequest(
+      IfMib::getInterfaceMtus(snmpChannel).thenValue([state](auto results) {
         for (auto result : results) {
           IModel::updateInterface(
               state->update(), result.index, "config/mtu", result.value);
@@ -156,7 +166,7 @@ std::shared_ptr<State> Snmpv2Device::getState() {
       }));
 
   state->addRequest(
-      IfMib::getInterfaceTypes(channel).thenValue([state](auto results) {
+      IfMib::getInterfaceTypes(snmpChannel).thenValue([state](auto results) {
         for (auto result : results) {
           int ifMibType = folly::to<int>(result.value);
           std::string interfaceType = getTypeString(ifMibType);
@@ -179,31 +189,37 @@ std::shared_ptr<State> Snmpv2Device::getState() {
         }
       }));
 
-  state->addRequest(
-      IfMib::getInterfaceDescriptions(channel).thenValue([state](auto results) {
-        for (auto result : results) {
-          IModel::updateInterface(
-              state->update(),
-              result.index,
-              "config/description",
-              result.value);
-          IModel::updateInterface(
-              state->update(), result.index, "state/description", result.value);
-        }
-      }));
+  state->addRequest(IfMib::getInterfaceDescriptions(snmpChannel)
+                        .thenValue([state](auto results) {
+                          for (auto result : results) {
+                            IModel::updateInterface(
+                                state->update(),
+                                result.index,
+                                "config/description",
+                                result.value);
+                            IModel::updateInterface(
+                                state->update(),
+                                result.index,
+                                "state/description",
+                                result.value);
+                          }
+                        }));
 
-  state->addRequest(
-      IfMib::getInterfaceLastChange(channel).thenValue([state](auto results) {
-        for (auto result : results) {
-          IModel::updateInterface(
-              state->update(), result.index, "state/last-change", result.value);
-        }
-      }));
+  state->addRequest(IfMib::getInterfaceLastChange(snmpChannel)
+                        .thenValue([state](auto results) {
+                          for (auto result : results) {
+                            IModel::updateInterface(
+                                state->update(),
+                                result.index,
+                                "state/last-change",
+                                result.value);
+                          }
+                        }));
 
   auto addRequest = [&state, this](
                         const std::string& oid, const std::string& path) {
     state->addRequest(
-        IfMib::getInterfaceField(channel, oid)
+        IfMib::getInterfaceField(snmpChannel, oid)
             .thenValue([state, path](auto results) {
               for (auto result : results) {
                 IModel::updateInterface(

--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.h
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.h
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <devmand/channels/snmp/Channel.h>
-#include <devmand/devices/Device.h>
+#include <devmand/devices/PingDevice.h>
 
 /* TODO use this
 #include <ydk/netconf_provider.hpp>
@@ -31,7 +31,7 @@
 namespace devmand {
 namespace devices {
 
-class Snmpv2Device : public Device {
+class Snmpv2Device : public PingDevice {
  public:
   Snmpv2Device(
       Application& application,
@@ -64,7 +64,7 @@ class Snmpv2Device : public Device {
   }
 
  protected:
-  channels::snmp::Channel channel;
+  channels::snmp::Channel snmpChannel;
 };
 
 } // namespace devices

--- a/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
@@ -83,8 +83,8 @@ std::shared_ptr<State> Device::getState() {
           .thenError(
               folly::tag_t<channels::snmp::Exception>{},
               [&geol, this](const channels::snmp::Exception&) {
-                auto v = lookup(
-                    "fbc-symphony-device:system/geo-location/longitude");
+                auto v =
+                    lookup("fbc-symphony-device:system/geo-location/longitude");
                 if (not v.isNull()) {
                   geol["longitude"] = v.asString();
                 }

--- a/devmand/gateway/src/devmand/main.cpp
+++ b/devmand/gateway/src/devmand/main.cpp
@@ -19,12 +19,14 @@
 #include <devmand/devices/DemoDevice.h>
 #include <devmand/devices/EchoDevice.h>
 #include <devmand/devices/FrinxDevice.h>
+#include <devmand/devices/PingDevice.h>
 #include <devmand/devices/Snmpv2Device.h>
 #include <devmand/devices/mikrotik/Device.h>
 #include <devmand/magma/DevConf.h>
 #include <devmand/magma/Service.h>
 
 int main(int argc, char* argv[]) {
+  // TODO Work around for magma issue. Get rid of this...
   std::this_thread::sleep_for(std::chrono::seconds(10));
 
   folly::init(&argc, &argv);
@@ -34,17 +36,25 @@ int main(int argc, char* argv[]) {
   // Add services which export the shared view
   app.add(std::make_unique<devmand::magma::Service>(app));
 
-  // Add platforms/device drivers
-  app.addPlatform("Cambium", devmand::devices::CambiumDevice::createDevice);
-  app.addPlatform("Dcsg", devmand::devices::DcsgDevice::createDevice);
-  app.addPlatform("Demo", devmand::devices::DemoDevice::createDevice);
-  app.addPlatform("Echo", devmand::devices::EchoDevice::createDevice);
-  app.addPlatform(
-      "Cisco Catalyst 3750", devmand::devices::FrinxDevice::createDevice);
-  app.addPlatform(
-      "Unifi Switch 16", devmand::devices::FrinxDevice::createDevice);
-  app.addPlatform("MikroTik", devmand::devices::mikrotik::Device::createDevice);
-  app.addPlatform("Snmp", devmand::devices::Snmpv2Device::createDevice);
+  // Add Demo Platforms
+  {
+    app.addPlatform("Cambium", devmand::devices::CambiumDevice::createDevice);
+    app.addPlatform("Dcsg", devmand::devices::DcsgDevice::createDevice);
+    app.addPlatform(
+        "Cisco Catalyst 3750", devmand::devices::FrinxDevice::createDevice);
+    app.addPlatform(
+        "Unifi Switch 16", devmand::devices::FrinxDevice::createDevice);
+  }
+
+  // Add Production Ready Platforms
+  {
+    app.addPlatform("Demo", devmand::devices::DemoDevice::createDevice);
+    app.addPlatform("Echo", devmand::devices::EchoDevice::createDevice);
+    app.addPlatform(
+        "MikroTik", devmand::devices::mikrotik::Device::createDevice);
+    app.addPlatform("Ping", devmand::devices::PingDevice::createDevice);
+    app.addPlatform("Snmp", devmand::devices::Snmpv2Device::createDevice);
+  }
 
   app.setDefaultPlatform(devmand::devices::Snmpv2Device::createDevice);
 

--- a/devmand/gateway/src/devmand/models/device/Model.cpp
+++ b/devmand/gateway/src/devmand/models/device/Model.cpp
@@ -13,6 +13,7 @@ namespace device {
 
 void Model::init(folly::dynamic& state) {
   auto& system = state["fbc-symphony-device:system"] = folly::dynamic::object;
+  assert(state.isObject());
 
   // ietf-geo-location ########################################################
   // Inits all of these to defaults. Some are left out as they are to be filled
@@ -32,6 +33,25 @@ void Model::init(folly::dynamic& state) {
   // vel["v-east"] = 0;
   // vel["v-up"] = 0;
   // geol["timestamp"] = 0;
+
+  // latencies ########################################################
+  auto& latencies = system["latencies"] = folly::dynamic::object;
+  latencies["latency"] = folly::dynamic::array;
+}
+
+void Model::addLatency(
+    folly::dynamic& state,
+    const std::string& type,
+    const std::string& src,
+    const std::string& dst,
+    channels::ping::Rtt rtt) {
+  auto& latencies = state["fbc-symphony-device:system"]["latencies"]["latency"];
+  folly::dynamic latency = folly::dynamic::object;
+  latency["type"] = type;
+  latency["src"] = src;
+  latency["dst"] = dst;
+  latency["rtt"] = rtt;
+  latencies.push_back(latency);
 }
 
 } // namespace device

--- a/devmand/gateway/src/devmand/models/device/Model.h
+++ b/devmand/gateway/src/devmand/models/device/Model.h
@@ -9,6 +9,8 @@
 
 #include <folly/dynamic.h>
 
+#include <devmand/channels/ping/Engine.h>
+
 namespace devmand {
 namespace models {
 namespace device {
@@ -24,6 +26,13 @@ class Model {
 
  public:
   static void init(folly::dynamic& state);
+
+  static void addLatency(
+      folly::dynamic& state,
+      const std::string& type,
+      const std::string& src,
+      const std::string& dst,
+      channels::ping::Rtt rtt);
 };
 
 } // namespace device

--- a/devmand/gateway/src/devmand/test/DevConfTest.cpp
+++ b/devmand/gateway/src/devmand/test/DevConfTest.cpp
@@ -16,6 +16,9 @@
 namespace devmand {
 namespace test {
 
+static constexpr const char* yamlDeviceConfig = "/tmp/deviceConfig.yml";
+static constexpr const char* mconfigDeviceConfig = "/tmp/deviceConfig.mconfig";
+
 const char* yamlTemplate = R"template(devices:
 {})template";
 
@@ -142,10 +145,6 @@ class DevConfTest : public EventBaseTest {
   unsigned int expectedNumDel = 0;
   std::list<cartography::DeviceConfig> adds;
   std::list<cartography::DeviceConfig> dels;
-
-  static constexpr const char* yamlDeviceConfig = "/tmp/deviceConfig.yml";
-  static constexpr const char* mconfigDeviceConfig =
-      "/tmp/deviceConfig.mconfig";
 
   template <typename... Args>
   static std::string formatYaml(Args... args) {

--- a/devmand/gateway/src/devmand/test/PingChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/PingChannelTest.cpp
@@ -24,13 +24,13 @@ class PingChannelTest : public EventBaseTest {
 TEST_F(PingChannelTest, checkPing) {
   folly::IPAddress address("127.0.0.1");
   auto channel = std::make_shared<channels::ping::Channel>(eventBase, address);
-  channel->ping();
+  EXPECT_NE(0, channel->ping().get());
 }
 
 TEST_F(PingChannelTest, checkPingGoogle) {
   folly::IPAddress address("127.0.0.2");
   auto channel = std::make_shared<channels::ping::Channel>(eventBase, address);
-  channel->ping();
+  EXPECT_NE(0, channel->ping().get());
 }
 
 } // namespace test

--- a/devmand/gateway/src/devmand/test/PingChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/PingChannelTest.cpp
@@ -19,19 +19,31 @@ class PingChannelTest : public EventBaseTest {
   PingChannelTest& operator=(const PingChannelTest&) = delete;
   PingChannelTest(PingChannelTest&&) = delete;
   PingChannelTest& operator=(PingChannelTest&&) = delete;
+
+ protected:
+  folly::IPAddress local{"127.0.0.1"};
+  folly::IPAddress google{"127.0.0.2"};
 };
 
 TEST_F(PingChannelTest, checkPing) {
-  folly::IPAddress address("127.0.0.1");
   channels::ping::Engine engine(eventBase);
-  auto channel = std::make_shared<channels::ping::Channel>(engine, address);
+  auto channel = std::make_shared<channels::ping::Channel>(engine, local);
   EXPECT_NE(0, channel->ping().get());
 }
 
 TEST_F(PingChannelTest, checkPingGoogle) {
-  folly::IPAddress address("127.0.0.2");
   channels::ping::Engine engine(eventBase);
-  auto channel = std::make_shared<channels::ping::Channel>(engine, address);
+  auto channel = std::make_shared<channels::ping::Channel>(engine, google);
+  EXPECT_NE(0, channel->ping().get());
+}
+
+TEST_F(PingChannelTest, checkMultiPing) {
+  channels::ping::Engine engine(eventBase);
+  auto channel = std::make_shared<channels::ping::Channel>(engine, local);
+  auto channel2 = std::make_shared<channels::ping::Channel>(engine, google);
+  EXPECT_NE(0, channel->ping().get());
+  EXPECT_NE(0, channel2->ping().get());
+  EXPECT_NE(0, channel2->ping().get());
   EXPECT_NE(0, channel->ping().get());
 }
 

--- a/devmand/gateway/src/devmand/test/PingChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/PingChannelTest.cpp
@@ -23,13 +23,15 @@ class PingChannelTest : public EventBaseTest {
 
 TEST_F(PingChannelTest, checkPing) {
   folly::IPAddress address("127.0.0.1");
-  auto channel = std::make_shared<channels::ping::Channel>(eventBase, address);
+  channels::ping::Engine engine(eventBase);
+  auto channel = std::make_shared<channels::ping::Channel>(engine, address);
   EXPECT_NE(0, channel->ping().get());
 }
 
 TEST_F(PingChannelTest, checkPingGoogle) {
   folly::IPAddress address("127.0.0.2");
-  auto channel = std::make_shared<channels::ping::Channel>(eventBase, address);
+  channels::ping::Engine engine(eventBase);
+  auto channel = std::make_shared<channels::ping::Channel>(engine, address);
   EXPECT_NE(0, channel->ping().get());
 }
 

--- a/devmand/gateway/src/devmand/test/PingChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/PingChannelTest.cpp
@@ -27,5 +27,11 @@ TEST_F(PingChannelTest, checkPing) {
   channel->ping();
 }
 
+TEST_F(PingChannelTest, checkPingGoogle) {
+  folly::IPAddress address("127.0.0.2");
+  auto channel = std::make_shared<channels::ping::Channel>(eventBase, address);
+  channel->ping();
+}
+
 } // namespace test
 } // namespace devmand

--- a/devmand/gateway/src/devmand/test/PingChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/PingChannelTest.cpp
@@ -23,20 +23,13 @@ class PingChannelTest : public EventBaseTest {
 
  protected:
   folly::IPAddress local{"127.0.0.1"};
-  folly::IPAddress google{"127.0.0.2"};
+  folly::IPAddress local2{"127.0.0.2"};
   folly::IPAddress dne{"203.0.113.0"};
 };
 
 TEST_F(PingChannelTest, checkPing) {
   channels::ping::Engine engine(eventBase);
   auto channel = std::make_shared<channels::ping::Channel>(engine, local);
-  EXPECT_NE(0, channel->ping().get());
-  stop();
-}
-
-TEST_F(PingChannelTest, checkPingGoogle) {
-  channels::ping::Engine engine(eventBase);
-  auto channel = std::make_shared<channels::ping::Channel>(engine, google);
   EXPECT_NE(0, channel->ping().get());
   stop();
 }
@@ -65,7 +58,7 @@ TEST_F(PingChannelTest, checkPingTimeout) {
 TEST_F(PingChannelTest, checkMultiPing) {
   channels::ping::Engine engine(eventBase);
   auto channel = std::make_shared<channels::ping::Channel>(engine, local);
-  auto channel2 = std::make_shared<channels::ping::Channel>(engine, google);
+  auto channel2 = std::make_shared<channels::ping::Channel>(engine, local2);
   EXPECT_NE(0, channel->ping().get());
   EXPECT_NE(0, channel2->ping().get());
   EXPECT_NE(0, channel2->ping().get());

--- a/devmand/gateway/src/devmand/test/PingChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/PingChannelTest.cpp
@@ -1,0 +1,31 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/ping/Channel.h>
+#include <devmand/test/EventBaseTest.h>
+
+namespace devmand {
+namespace test {
+
+class PingChannelTest : public EventBaseTest {
+ public:
+  PingChannelTest() = default;
+  ~PingChannelTest() override = default;
+  PingChannelTest(const PingChannelTest&) = delete;
+  PingChannelTest& operator=(const PingChannelTest&) = delete;
+  PingChannelTest(PingChannelTest&&) = delete;
+  PingChannelTest& operator=(PingChannelTest&&) = delete;
+};
+
+TEST_F(PingChannelTest, checkPing) {
+  folly::IPAddress address("127.0.0.1");
+  auto channel = std::make_shared<channels::ping::Channel>(eventBase, address);
+  channel->ping();
+}
+
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/utils/Time.cpp
+++ b/devmand/gateway/src/devmand/utils/Time.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/utils/Time.h>
+
+#include <sstream>
+
+namespace devmand {
+namespace utils {
+namespace Time {
+
+TimePoint now() {
+  return Clock::now();
+}
+
+TimePoint from(struct timeval tv) {
+  return TimePoint{std::chrono::seconds{tv.tv_sec} +
+                   std::chrono::microseconds{tv.tv_usec}};
+}
+
+std::string toString(const TimePoint& time) {
+  std::stringstream stream;
+  stream << time;
+  return stream.str();
+}
+
+} // namespace Time
+} // namespace utils
+} // namespace devmand
+
+std::ostream& operator<<(std::ostream& stream, const devmand::utils::TimePoint& time) {
+  std::time_t epoch =
+      std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch())
+          .count();
+  return stream << std::put_time(std::localtime(&epoch), "%F %T");
+}

--- a/devmand/gateway/src/devmand/utils/Time.cpp
+++ b/devmand/gateway/src/devmand/utils/Time.cpp
@@ -32,7 +32,9 @@ std::string toString(const TimePoint& time) {
 } // namespace utils
 } // namespace devmand
 
-std::ostream& operator<<(std::ostream& stream, const devmand::utils::TimePoint& time) {
+std::ostream& operator<<(
+    std::ostream& stream,
+    const devmand::utils::TimePoint& time) {
   std::time_t epoch =
       std::chrono::duration_cast<std::chrono::seconds>(time.time_since_epoch())
           .count();

--- a/devmand/gateway/src/devmand/utils/Time.h
+++ b/devmand/gateway/src/devmand/utils/Time.h
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <ostream>
+
+namespace devmand {
+
+namespace utils {
+
+using Clock = std::chrono::steady_clock;
+using SteadyTimePoint = std::chrono::steady_clock::time_point;
+using SystemTimePoint = std::chrono::system_clock::time_point;
+using TimePoint = SteadyTimePoint;
+
+namespace Time {
+
+extern TimePoint now();
+
+extern TimePoint from(struct timeval tv);
+
+extern std::string toString(const TimePoint& time);
+
+} // namespace Time
+
+} // namespace utils
+
+} // namespace devmand
+
+extern std::ostream& operator<<(
+    std::ostream& stream,
+    const devmand::utils::TimePoint& time);


### PR DESCRIPTION
Summary:
This commit removes a test which use to ping externally as that was
really just done in development. Having two tests which pinged locally was just
redundant.

Reviewed By: joemin

Differential Revision: D17764061

