### PR TITLE
fix failing circleci tests in prod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ jobs:
             : "${ARTIFACTORY_API_KEY?Artifactory USER and API Key must be set as Environment variables before running this command.}"
             sudo apt-get update -y
             sudo apt-get install -y realpath
+            export SYMPHONY_DOCKER_REGISTRY=facebookconnectivity-southpoll-prod-docker.jfrog.io
             docker login -u ${ARTIFACTORY_USER} -p ${ARTIFACTORY_API_KEY} facebookconnectivity-southpoll-prod-docker.jfrog.io
             cd ./devmand/gateway/docker
             ./scripts/build

--- a/devmand/gateway/docker/scripts/build
+++ b/devmand/gateway/docker/scripts/build
@@ -28,19 +28,21 @@ services:
 EOF
 
 echo "Creating image..."
+docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
 CACHE_DIR=${SYMPHONY_AGENT_CACHE_DIR:-$(realpath ~)/cache_devmand_build}
 
 # shellcheck source=/dev/null
 . scripts/build_image firstparty devmand | tee /tmp/devmand_build.log
 build_status=${PIPESTATUS[0]}
 if [ "$build_status" -eq 0 ]; then
+
   [ ! -d "$CACHE_DIR" ] && mkdir "$CACHE_DIR"
 
   docker rm -f devmand &>/dev/null || true
   docker run --name devmand \
     -v "$(realpath ../):/cache/devmand/repo:ro" \
     -v "$CACHE_DIR:/cache/devmand/build:rw" \
-    facebookconnectivity-southpoll-dev-docker.jfrog.io/devmand
+    ${docker_registry}/devmand
   docker cp devmand:/cache/devmand/install firstparty
   # shellcheck source=/dev/null
   . scripts/build_image firstparty symphony-agent | tee /tmp/symphony_agent_build.log

--- a/devmand/gateway/docker/scripts/build_image
+++ b/devmand/gateway/docker/scripts/build_image
@@ -9,7 +9,7 @@ bi_start=$(date +%s)
 (
   cd "$dir"
 
-  docker_registry="facebookconnectivity-southpoll-dev-docker.jfrog.io"
+  docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
   tag="${docker_registry}/${pkg}"
 
   [[ -f "${pkg}/deps" ]]    && deps=$(cat ${pkg}/deps)         || deps=""

--- a/devmand/gateway/docker/scripts/build_thirdparty_image
+++ b/devmand/gateway/docker/scripts/build_thirdparty_image
@@ -1,12 +1,14 @@
 #!/bin/bash
 set -e
 
-tag="facebookconnectivity-southpoll-dev-docker.jfrog.io/thirdparty:latest"
+
+docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
+tag="${docker_registry}/thirdparty:latest"
 (
   echo "FROM scratch AS thirdparty"
   cd thirdparty
   for pkg in *; do
-    echo "COPY --from=facebookconnectivity-southpoll-dev-docker.jfrog.io/${pkg} /cache/${pkg}/install /cache/install"
+    echo "COPY --from=${docker_registry}/${pkg} /cache/${pkg}/install /cache/install"
   done
   cd ..
 ) | docker build - --tag ${tag}

--- a/devmand/gateway/docker/scripts/develop
+++ b/devmand/gateway/docker/scripts/develop
@@ -13,10 +13,11 @@
 # shellcheck source=/dev/null
 . scripts/build_image firstparty devmand | tee /tmp/devmand_build.log
 build_status=${PIPESTATUS[0]}
+docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
 if [ "$build_status" -eq 0 ]; then
   docker rm -f devmand
   docker run -it --name devmand \
       -v "$(realpath ../):/cache/devmand/repo:ro" \
       -v "$(realpath ~/cache_devmand_build):/cache/devmand/build:rw" \
-      facebookconnectivity-southpoll-dev-docker.jfrog.io/devmand /bin/bash
+      ${docker_registry}/devmand /bin/bash
 fi


### PR DESCRIPTION
Summary: the build script always builds with the southpoll-dev prefix. let's make that overrideable with an environment variable.

Reviewed By: Mokon, themarwhal

Differential Revision: D17816451

