### PR TITLE
Warning logs for unrecognized device model/software

### DIFF
--- a/lte/gateway/python/magma/enodebd/devices/device_utils.py
+++ b/lte/gateway/python/magma/enodebd/devices/device_utils.py
@@ -9,6 +9,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 import logging
 import re
+from magma.enodebd.exceptions import UnrecognizedEnodebError
 
 
 class EnodebDeviceName():
@@ -60,12 +61,12 @@ def get_device_name(
         elif sw_version.startswith('BaiBS_RTS_'):
             return EnodebDeviceName.BAICELLS
         else:
-            raise KeyError("Device %s unsupported: Software (%s)" %
-                           (device_oui, sw_version))
+            raise UnrecognizedEnodebError("Device %s unsupported: Software (%s)"
+                                         % (device_oui, sw_version))
     elif device_oui in {'000FB7', }:
         return EnodebDeviceName.CAVIUM
     else:
-        raise KeyError("Device %s unsupported" % device_oui)
+        raise UnrecognizedEnodebError("Device %s unsupported" % device_oui)
 
 
 def _parse_sw_version(version_str):

--- a/lte/gateway/python/magma/enodebd/tests/device_utils_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/device_utils_tests.py
@@ -12,6 +12,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 from unittest import TestCase
 from magma.enodebd.devices.device_utils import get_device_name, \
     _parse_sw_version, EnodebDeviceName
+from magma.enodebd.exceptions import UnrecognizedEnodebError
 
 
 class EnodebConfigUtilsTest(TestCase):
@@ -47,13 +48,13 @@ class EnodebConfigUtilsTest(TestCase):
         # Unsupported device OUI
         oui = 'beepboopbeep'
         version = 'boopboopboop'
-        with self.assertRaises(KeyError):
+        with self.assertRaises(UnrecognizedEnodebError):
             get_device_name(oui, version)
 
         # Unsupported software version for Baicells
         oui = '34ED0B'
         version = 'blingblangblong'
-        with self.assertRaises(KeyError):
+        with self.assertRaises(UnrecognizedEnodebError):
             get_device_name(oui, version)
 
     def test_parse_version(self):

--- a/lte/gateway/python/magma/enodebd/tests/enb_acs_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/enb_acs_manager_tests.py
@@ -118,7 +118,7 @@ class StateMachineManagerTests(TestCase):
         ctx2 = get_spyne_context_with_ip(ip2)
         inform_msg = Tr069MessageBuilder.get_inform('48BF74',
                                                     'BaiBS_RTS_3.1.6',
-                                                    'unregistered_ip')
+                                                    'unregistered_serial')
 
         resp2 = manager.handle_tr069_message(ctx2, inform_msg)
         self.assertTrue(isinstance(resp2, models.DummyInput),
@@ -195,6 +195,21 @@ class StateMachineManagerTests(TestCase):
         resp1 = manager.handle_tr069_message(ctx1, inform_msg)
         self.assertTrue(isinstance(resp1, models.InformResponse),
                         'Should respond with an InformResponse')
+
+    def test_inform_from_unrecognized(self) -> None:
+        manager = self._get_manager()
+        ip = "192.168.60.145"
+
+        # Send an Inform
+        ctx1 = get_spyne_context_with_ip(ip)
+        inform_msg = Tr069MessageBuilder.get_qafb_inform('48BF74',
+                                                         'Unrecognized device',
+                                                         '120200002618AGP0001')
+        resp1 = manager.handle_tr069_message(ctx1, inform_msg)
+        self.assertTrue(isinstance(resp1, models.DummyInput),
+                        'Should end provisioninng session with empty response')
+
+
 
     def _get_manager(self) -> StateMachineManager:
         service = EnodebAcsStateMachineBuilder.build_magma_service()


### PR DESCRIPTION
Summary: To help users understand what enodebd is doing better, this revision adds better logging for seeing when enodebd does not recognize a device.

Reviewed By: themarwhal

Differential Revision: D17773632

