### PR TITLE
add way to use yml device config in agent

### DIFF
--- a/devmand/gateway/docker/docker-compose.yml
+++ b/devmand/gateway/docker/docker-compose.yml
@@ -31,7 +31,9 @@ services:
     privileged: true
     volumes:
       - $PWD/../../../fb/config/certs/rootCA.pem:/var/opt/magma/certs/rootCA.pem:ro
+      - $PWD/devman:/etc/devman:ro
     environment:
+      - DEVICE_CONFIG_FILE=${DEVICE_CONFIG_FILE}
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/bin/magma_system_prepare
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/bin/magma_system_prepare
@@ -1,8 +1,18 @@
 #!/bin/bash
 
+/bin/rm -f /etc/magma/env
 for e in $(tr "\000" "\n" < /proc/1/environ); do
-  eval "export $e"
+  case "${e%%=*}" in
+    SNOWFLAKE|CLOUD_ADDRESS|BOOTSTRAP_CLOUD_ADDRESS|DEVICE_CONFIG_FILE)
+      echo "$e" >> /etc/magma/env
+      ;;
+    *)
+      ;;
+  esac
 done
+
+# shellcheck source=/dev/null
+. /etc/magma/env
 
 if [ -z "${SNOWFLAKE}" ]; then
   SNOWFLAKE="faceb00c-face-b00c-face-fbb05fbcface"

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/services/devmand.service
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/services/devmand.service
@@ -7,10 +7,12 @@
 #
 [Unit]
 Description=Devmand
+After=magmad.service
 
 [Service]
+EnvironmentFile=/etc/magma/env
 WorkingDirectory=/usr/bin
-ExecStart=/bin/devmand --logtostderr=1 --device_configuration_file=/var/opt/magma/configs/gateway.mconfig
+ExecStart=/bin/devmand --logtostderr=1 --device_configuration_file=${DEVICE_CONFIG_FILE}
 KillMode=mixed
 Restart=always
 Delegate=yes

--- a/devmand/gateway/docker/scripts/build
+++ b/devmand/gateway/docker/scripts/build
@@ -17,11 +17,16 @@ if [ -z ${SNOWFLAKE+x} ]; then
     export SNOWFLAKE
 fi
 
+if [ -z ${DEVICE_CONFIG_FILE+x} ]; then
+  export DEVICE_CONFIG_FILE="/var/opt/magma/configs/gateway.mconfig"
+fi
+
 cat << EOF > docker-compose.override.yml
 version: '3.7'
 services:
   symphony-agent:
     environment:
+      - DEVICE_CONFIG_FILE=${DEVICE_CONFIG_FILE}
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -39,6 +39,7 @@ Engine::Engine(
       timeoutFrequency(timeoutFrequency_) {
   icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
   if (icmpSocket < 0) {
+    LOG(ERROR) << "Failed to open dgram socket";
     throw std::system_error(errno, std::generic_category());
   }
 

--- a/devmand/gateway/src/devmand/devices/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Device.cpp
@@ -51,6 +51,7 @@ void Device::updateSharedView(SharedUnifiedView& sharedUnifiedView) {
               : folly::dynamic::object;
           dyn[idL] = data;
           (*unifiedView)["devmand"] = folly::toJson(dyn);
+          LOG(INFO) << "state for " << idL << " is " << folly::toJson(dyn);
         });
       }));
 }

--- a/devmand/gateway/src/devmand/devices/Factory.cpp
+++ b/devmand/gateway/src/devmand/devices/Factory.cpp
@@ -41,6 +41,7 @@ std::unique_ptr<devices::Device> Factory::createDevice(
   PlatformBuilder builder{nullptr};
   auto builderIt = platformBuilders.find(platformLowerCase);
   if (builderIt == platformBuilders.end()) {
+    LOG(INFO) << "Didn't find matching platform so using default.";
     builder = defaultPlatformBuilder;
   } else {
     builder = builderIt->second;


### PR DESCRIPTION
Summary:
This commit adds a way for yml configs to be used rather than mconfigs
in the symphony agent. It does this similar to how other env vars setup
deployment usecases.

Differential Revision: D17858378

