### PR TITLE
Add CWAG precommit to travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,24 @@ matrix:
         - make -C ${MAGMA_ROOT}/feg/gateway precommit
 
     - language: go
+      name: CWAG precommit
+      go:
+        - 1.12.x
+      os: linux
+      dist: xenial
+
+      env:
+        - MAGMA_ROOT=$TRAVIS_BUILD_DIR GO111MODULE=on GOPROXY=https://proxy.golang.org
+
+      before_install:
+        - ./travis/golang_before_install.sh
+
+      script:
+        - cd ${MAGMA_ROOT}/cwf/gateway
+        - travis_retry travis_wait go mod download
+        - make -C ${MAGMA_ROOT}/cwf/gateway precommit
+
+    - language: go
       name: orc8r gateway go tests
       go:
         - 1.12.x


### PR DESCRIPTION
Summary:
This diff add CWAG precommit tests to travis. This ensures
that any breakages to cwf unit tests can be caught before the diff
is landed.

Reviewed By: themarwhal

Differential Revision: D17862904

