### PR TITLE
Send only active subscribers down to the gateway

### DIFF
--- a/lte/cloud/go/services/subscriberdb/streamer/provider.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/provider.go
@@ -45,8 +45,11 @@ func (provider *SubscribersProvider) GetUpdates(gatewayId string, extraArgs *any
 		if err != nil {
 			return nil, err
 		}
-		subProto.NetworkId = &protos.NetworkID{Id: ent.NetworkID}
-		subProtos = append(subProtos, subProto)
+		// Only stream down subscriber if it is ACTIVE
+		if subProto.Lte.State == protos2.LTESubscription_ACTIVE {
+			subProto.NetworkId = &protos.NetworkID{Id: ent.NetworkID}
+			subProtos = append(subProtos, subProto)
+		}
 	}
 	return subscribersToUpdates(subProtos)
 }

--- a/lte/cloud/go/services/subscriberdb/streamer/provider_test.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/provider_test.go
@@ -65,12 +65,6 @@ func TestSubscriberdbStreamer(t *testing.T) {
 			NetworkId:  &orcprotos.NetworkID{Id: "n1"},
 			SubProfile: "default",
 		},
-		{
-			Sid:        &protos.SubscriberID{Id: "67890", Type: protos.SubscriberID_IMSI},
-			Lte:        &protos.LTESubscription{State: protos.LTESubscription_INACTIVE},
-			NetworkId:  &orcprotos.NetworkID{Id: "n1"},
-			SubProfile: "foo",
-		},
 	}
 	expected := funk.Map(
 		expectedProtos,


### PR DESCRIPTION
Summary:
## What this fixes
- There is a bug in the subscriber streaming logic where the cloud sends all subscribers in the system with its state attached (Active/Inactive) while the gateway takes in those subscribers assuming that it is a list of active subscribers.
- This was leading to a partner-reported issue where deactivating a subscriber would not properly work.
- I'm fixing this on the cloud's end to reduce the number of subscribers being sent.

Reviewed By: ssanadhya

Differential Revision: D17878962

