### PR TITLE
Fix state reporting failure on routing table parse error

### DIFF
--- a/cwf/cloud/go/plugin/handlers/handlers_test.go
+++ b/cwf/cloud/go/plugin/handlers/handlers_test.go
@@ -473,7 +473,6 @@ func TestCwfGateways(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-
 	// Test DeleteGateway
 	tc = tests.Test{
 		Method:         "DELETE",

--- a/cwf/cloud/go/plugin/mconfig_test.go
+++ b/cwf/cloud/go/plugin/mconfig_test.go
@@ -53,7 +53,7 @@ func TestBuilder_Build(t *testing.T) {
 	}
 	cwfGW := configurator.NetworkEntity{
 		Type: cwf.CwfGatewayType, Key: "gw1",
-		Config: defaultgwConfig,
+		Config:             defaultgwConfig,
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
 	graph = configurator.EntityGraph{

--- a/cwf/cloud/go/plugin/models/conversion.go
+++ b/cwf/cloud/go/plugin/models/conversion.go
@@ -143,8 +143,8 @@ func (m *MutableCwfGateway) GetAdditionalWritesOnUpdate(
 	}
 
 	entUpdate := configurator.EntityUpdateCriteria{
-		Type: cwf.CwfGatewayType,
-		Key:  string(m.ID),
+		Type:      cwf.CwfGatewayType,
+		Key:       string(m.ID),
 		NewConfig: m.CarrierWifi,
 	}
 	if string(m.Name) != existingEnt.Name {

--- a/orc8r/gateway/python/magma/magmad/check/network_check/tests/routing_table_tests.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/tests/routing_table_tests.py
@@ -15,7 +15,7 @@ from magma.magmad.check.network_check import routing_table
 class RoutingTableParseTests(unittest.TestCase):
     def test_parse_bad_output(self):
         expected = routing_table.RouteCommandResult(error='err',
-                                                    routing_table=None)
+                                                    routing_table=[])
         actual = routing_table.parse_route_output('output', 'err', None)
         self.assertEqual(expected, actual)
 
@@ -25,7 +25,7 @@ class RoutingTableParseTests(unittest.TestCase):
         ''').strip().encode('ascii')
         expected = routing_table.RouteCommandResult(
             error='Unexpected heading: bad',
-            routing_table=None)
+            routing_table=[])
         actual = routing_table.parse_route_output(output, '', None)
         self.assertEqual(expected, actual)
 
@@ -45,65 +45,41 @@ class RoutingTableParseTests(unittest.TestCase):
             error=None,
             routing_table=[
                 routing_table.Route(
-                    destination='0.0.0.0',
-                    gateway='10.0.2.2',
+                    destination_ip='0.0.0.0',
+                    gateway_ip='10.0.2.2',
                     genmask='0.0.0.0',
-                    flags='UG',
-                    metric='0',
-                    ref='0',
-                    use='0',
-                    interface='eth0',
-                ),
+                    network_interface_id='eth0',
+                )._asdict(),
                 routing_table.Route(
-                    destination='10.0.2.0',
-                    gateway='0.0.0.0',
+                    destination_ip='10.0.2.0',
+                    gateway_ip='0.0.0.0',
                     genmask='255.255.255.0',
-                    flags='U',
-                    metric='0',
-                    ref='0',
-                    use='0',
-                    interface='eth0',
-                ),
+                    network_interface_id='eth0',
+                )._asdict(),
                 routing_table.Route(
-                    destination='169.254.0.0',
-                    gateway='0.0.0.0',
+                    destination_ip='169.254.0.0',
+                    gateway_ip='0.0.0.0',
                     genmask='255.255.0.0',
-                    flags='U',
-                    metric='1000',
-                    ref='0',
-                    use='0',
-                    interface='eth0',
-                ),
+                    network_interface_id='eth0',
+                )._asdict(),
                 routing_table.Route(
-                    destination='192.168.60.0',
-                    gateway='0.0.0.0',
+                    destination_ip='192.168.60.0',
+                    gateway_ip='0.0.0.0',
                     genmask='255.255.255.0',
-                    flags='U',
-                    metric='0',
-                    ref='0',
-                    use='0',
-                    interface='eth1',
-                ),
+                    network_interface_id='eth1',
+                )._asdict(),
                 routing_table.Route(
-                    destination='192.168.128.0',
-                    gateway='0.0.0.0',
+                    destination_ip='192.168.128.0',
+                    gateway_ip='0.0.0.0',
                     genmask='255.255.255.0',
-                    flags='U',
-                    metric='0',
-                    ref='0',
-                    use='0',
-                    interface='gtp_br0',
-                ),
+                    network_interface_id='gtp_br0',
+                )._asdict(),
                 routing_table.Route(
-                    destination='192.168.129.0',
-                    gateway='0.0.0.0',
+                    destination_ip='192.168.129.0',
+                    gateway_ip='0.0.0.0',
                     genmask='255.255.255.0',
-                    flags='U',
-                    metric='0',
-                    ref='0',
-                    use='0',
-                    interface='eth2',
-                ),
+                    network_interface_id='eth2',
+                )._asdict(),
             ])
         actual = routing_table.parse_route_output(output, '', None)
         self.assertEqual(expected, actual)


### PR DESCRIPTION
Summary:
## What this fixes
- A partner reported that when the system language was set to Portuguese, the state reporting was not working even though there was no network issues. This was due to an undocumented dependency on the system language being English in the logic that constructs the gateway's status. More specifically, the logic uses linux's `route -n` command and expects the heading section to be in English.
```    if heading.split() != ['Destination', 'Gateway', 'Genmask', 'Flags',
                           'Metric', 'Ref', 'Use', 'Iface']:
        return RouteCommandResult(error='Unexpected heading: %s' % heading,
                                  routing_table=[])
```
- I experimented a bit with using `pyroute2` package to avoid using the command and make it language independent, but it ends up being a little bit complicated. So for now, I'm just going to change it so that it prints error and returns an empty list so that it no longer prohibits the state from being sent.

## Notes
- We should probably mention `checkin_cli.py` in the documentation of setting up GW <-> cloud connection so that there is a way to check the cloud connection independently from state collecting logic. I've modified checkin_cli to send a dummy state in (D17735861), so it should be an accurate indication on whether a gateway is connected to the cloud.
- Until I come up with a good language independent solution, we should probably mention in the doc that English is preferred.

Reviewed By: koolzz

Differential Revision: D17763312

