### PR TITLE
Add nil check for gateway status reporting and error logs

### DIFF
--- a/orc8r/cloud/go/services/checkind/metrics/gateway_status_reporter.go
+++ b/orc8r/cloud/go/services/checkind/metrics/gateway_status_reporter.go
@@ -65,9 +65,13 @@ func (reporter *GatewayStatusReporter) reportCheckinStatus() error {
 			}
 
 			// report mconfig age
-			mconfigCreatedAt := status.PlatformInfo.ConfigInfo.MconfigCreatedAt
-			if mconfigCreatedAt != 0 {
-				gwMconfigAge.WithLabelValues(networkID, gatewayID).Set(float64(status.CheckinTime/1000 - mconfigCreatedAt))
+			if status.PlatformInfo != nil && status.PlatformInfo.ConfigInfo != nil {
+				mconfigCreatedAt := status.PlatformInfo.ConfigInfo.MconfigCreatedAt
+				if mconfigCreatedAt != 0 {
+					gwMconfigAge.WithLabelValues(networkID, gatewayID).Set(float64(status.CheckinTime/1000 - mconfigCreatedAt))
+				}
+			} else {
+				glog.Errorf("Status for networkID %s, gatewayID %s is missing the MconfigCreatedAt field", networkID, gatewayID)
 			}
 		}
 		upGwCount.WithLabelValues(networkID).Set(float64(numUpGateways))


### PR DESCRIPTION
Summary: prod cloud's checkind service is failling due to a nil dereference which is not happening in staging of now. Not sure why this is happening since this code was not changed recently, but adding nil check and logs to avoid this in the future and investigate why this is happening.

Differential Revision: D17911087

