### PR TITLE
Add GRE tunnel_id/src_ip filtering

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -19,6 +19,9 @@
 ###############
 # Changes to this file has to be replicated in pipelined.yml_prod
 
+# Differentiate between the setup type(CWF or LTE)
+setup_type: CWF
+
 log_level: INFO
 # Enable the services in PipelineD. Tables will be assigned to the services in
 # the same order as the list. Cloud managed services will be initialized

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -19,6 +19,9 @@
 ###############
 # Changes to this file has to be replicated in pipelined.yml_prod
 
+# Differentiate between the setup type(CWF or LTE)
+setup_type: CWF
+
 log_level: INFO
 # Enable the services in PipelineD. Tables will be assigned to the services in
 # the same order as the list. Cloud managed services will be initialized

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -19,6 +19,9 @@
 ###############
 # Changes to this file has to be replicated in pipelined.yml_prod
 
+# Differentiate between the setup type(CWF or LTE)
+setup_type: LTE
+
 log_level: INFO
 # Enable the services in PipelineD. Tables will be assigned to the services in
 # the same order as the list. Cloud managed services will be initialized

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -19,6 +19,9 @@
 ###############
 # Changes to this file has to be replicated in pipelined.yml
 
+# Differentiate between the setup type(CWF or LTE)
+setup_type: LTE
+
 log_level: INFO
 # Enable the services in PipelineD. Tables will be assigned to the services in
 # the same order as the list. Cloud managed services will be initialized


### PR DESCRIPTION
Summary: Adds a scratch table for access control, after the ip blacklist uplink packets will go to the gre tunnel filter scratch table. The allowed_gre_peers are obtained from the cloud mconfig.

Differential Revision: D17839940

