### PR TITLE
Allow prometheus configurer to be non-multitenant

### DIFF
--- a/orc8r/cloud/docker/config-manager/supervisord.conf
+++ b/orc8r/cloud/docker/config-manager/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:prom_alertconfig]
-command=prom_alertconfig -port=%(ENV_PROM_ALERTCONFIG_PORT)s -rules-dir=%(ENV_RULES_DIR)s -prometheusURL=%(ENV_PROMETHEUS_URL)s
+command=prom_alertconfig -port=%(ENV_PROM_ALERTCONFIG_PORT)s -rules-dir=%(ENV_RULES_DIR)s -prometheusURL=%(ENV_PROMETHEUS_URL)s -multitenant
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/alert/client_test.go
@@ -75,7 +75,7 @@ var (
 )
 
 func TestClient_ValidateRule(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 
 	err := client.ValidateRule(sampleRule)
 	assert.NoError(t, err)
@@ -89,7 +89,7 @@ func TestClient_ValidateRule(t *testing.T) {
 	assert.Error(t, err)
 }
 func TestClient_RuleExists(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 	assert.True(t, client.RuleExists(testNID, "test_rule_1"))
 	assert.True(t, client.RuleExists(testNID, "test_rule_2"))
 	assert.False(t, client.RuleExists(testNID, "no_rule"))
@@ -102,13 +102,13 @@ func TestClient_RuleExists(t *testing.T) {
 }
 
 func TestClient_WriteRule(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 	err := client.WriteRule(testNID, sampleRule)
 	assert.NoError(t, err)
 }
 
 func TestClient_UpdateRule(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 
 	err := client.UpdateRule(testNID, testRule1)
 	assert.NoError(t, err)
@@ -119,7 +119,7 @@ func TestClient_UpdateRule(t *testing.T) {
 }
 
 func TestClient_ReadRules(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 
 	rules, err := client.ReadRules(testNID, "")
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestClient_ReadRules(t *testing.T) {
 }
 
 func TestClient_DeleteRule(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 	err := client.DeleteRule(testNID, "test_rule_1")
 	assert.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestClient_DeleteRule(t *testing.T) {
 }
 
 func TestClient_BulkUpdateRules(t *testing.T) {
-	client := newTestClient()
+	client := newTestClient(true)
 	results, err := client.BulkUpdateRules(testNID, []rulefmt.Rule{sampleRule, testRule1})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(results.Statuses))
@@ -165,7 +165,7 @@ func TestClient_BulkUpdateRules(t *testing.T) {
 	assert.Equal(t, 1, len(results.Errors))
 }
 
-func newTestClient() alert.PrometheusAlertClient {
+func newTestClient(multitenant bool) alert.PrometheusAlertClient {
 	dClient := newHealthyDirClient("test")
 	fileLocks, _ := alert.NewFileLocker(dClient)
 	fsClient := &mocks.FSClient{}
@@ -173,5 +173,5 @@ func newTestClient() alert.PrometheusAlertClient {
 	fsClient.On("ReadFile", "test_rules/test_rules.yml").Return([]byte(testRuleFile), nil)
 	fsClient.On("ReadFile", "test_rules/other_rules.yml").Return([]byte(otherRuleFile), nil)
 	fsClient.On("WriteFile", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	return alert.NewClient(fileLocks, "test_rules", fsClient)
+	return alert.NewClient(fileLocks, "test_rules", fsClient, multitenant)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/handlers.go
@@ -41,18 +41,18 @@ func GetConfigureAlertHandler(client alert.PrometheusAlertClient, prometheusURL 
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		networkID := getNetworkID(c)
+		filePrefix := getFilePrefix(c)
 
 		err = client.ValidateRule(rule)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
-		if client.RuleExists(networkID, rule.Alert) {
+		if client.RuleExists(filePrefix, rule.Alert) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rule '%s' already exists", rule.Alert))
 		}
 
-		err = client.WriteRule(networkID, rule)
+		err = client.WriteRule(filePrefix, rule)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -68,8 +68,8 @@ func GetConfigureAlertHandler(client alert.PrometheusAlertClient, prometheusURL 
 func GetRetrieveAlertHandler(client alert.PrometheusAlertClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ruleName := c.QueryParam(ruleNameQueryParam)
-		networkID := getNetworkID(c)
-		rules, err := client.ReadRules(networkID, ruleName)
+		filePrefix := getFilePrefix(c)
+		rules, err := client.ReadRules(filePrefix, ruleName)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -85,11 +85,11 @@ func GetRetrieveAlertHandler(client alert.PrometheusAlertClient) func(c echo.Con
 func GetDeleteAlertHandler(client alert.PrometheusAlertClient, prometheusURL string) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ruleName := c.QueryParam(ruleNameQueryParam)
-		networkID := getNetworkID(c)
+		filePrefix := getFilePrefix(c)
 		if ruleName == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "No rule name provided")
 		}
-		err := client.DeleteRule(networkID, ruleName)
+		err := client.DeleteRule(filePrefix, ruleName)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -104,12 +104,12 @@ func GetDeleteAlertHandler(client alert.PrometheusAlertClient, prometheusURL str
 func GetUpdateAlertHandler(client alert.PrometheusAlertClient, prometheusURL string) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ruleName := c.Param(RuleNamePathParam)
-		networkID := getNetworkID(c)
+		filePrefix := getFilePrefix(c)
 		if ruleName == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "No rule name provided")
 		}
 
-		if !client.RuleExists(networkID, ruleName) {
+		if !client.RuleExists(filePrefix, ruleName) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rule '%s' does not exist", ruleName))
 		}
 
@@ -123,7 +123,7 @@ func GetUpdateAlertHandler(client alert.PrometheusAlertClient, prometheusURL str
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
-		err = client.UpdateRule(networkID, rule)
+		err = client.UpdateRule(filePrefix, rule)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -138,7 +138,7 @@ func GetUpdateAlertHandler(client alert.PrometheusAlertClient, prometheusURL str
 
 func GetBulkAlertUpdateHandler(client alert.PrometheusAlertClient, prometheusURL string) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		networkID := getNetworkID(c)
+		filePrefix := getFilePrefix(c)
 
 		rules, err := decodeBulkRulesPostRequest(c)
 		if err != nil {
@@ -152,7 +152,7 @@ func GetBulkAlertUpdateHandler(client alert.PrometheusAlertClient, prometheusURL
 			}
 		}
 
-		results, err := client.BulkUpdateRules(networkID, rules)
+		results, err := client.BulkUpdateRules(filePrefix, rules)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -207,8 +207,8 @@ func reloadPrometheus(url string) error {
 	return nil
 }
 
-func getNetworkID(c echo.Context) string {
-	return c.Param("network_id")
+func getFilePrefix(c echo.Context) string {
+	return c.Param("file_prefix")
 }
 
 func rulesToJSON(rules []rulefmt.Rule) ([]alert.RuleJSONWrapper, error) {

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/handlers_test.go
@@ -110,7 +110,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	updateAlert := GetUpdateAlertHandler(client, "")
 
 	c, rec := buildContext(sampleAlert1, http.MethodPut, "/", handlers.AlertConfigURL, testNID)
-	c.SetParamNames("network_id", RuleNamePathParam)
+	c.SetParamNames("file_prefix", RuleNamePathParam)
 	c.SetParamValues(testNID, sampleAlert1.Alert)
 
 	err := updateAlert(c)
@@ -140,8 +140,8 @@ func TestGetBulkAlertUpdateHandler(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	c := echo.New().NewContext(req, rec)
-	c.SetPath("/networks/:network_id/prometheus/alert_config/bulk")
-	c.SetParamNames("network_id")
+	c.SetPath("/networks/:file_prefix/prometheus/alert_config/bulk")
+	c.SetParamNames("file_prefix")
 	c.SetParamValues(testNID)
 
 	err = bulkUpdateFunc(c)

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/receiver_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/receiver_handlers.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	rootPath     = "/:network_id"
+	rootPath     = "/:file_prefix"
 	ReceiverPath = rootPath + "/receiver"
 	RoutePath    = ReceiverPath + "/route"
 
@@ -41,7 +41,7 @@ func GetReceiverPostHandler(client receivers.AlertmanagerClient, alertmanagerURL
 		if err != nil {
 			return c.String(http.StatusInternalServerError, fmt.Sprintf("%s", err))
 		}
-		err = client.CreateReceiver(getNetworkID(c), receiver)
+		err = client.CreateReceiver(getFilePrefix(c), receiver)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -55,11 +55,11 @@ func GetReceiverPostHandler(client receivers.AlertmanagerClient, alertmanagerURL
 }
 
 // GetGetReceiversHandler returns a handler function to retrieve receivers for
-// a network
+// a filePrefix
 func GetGetReceiversHandler(client receivers.AlertmanagerClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		networkID := getNetworkID(c)
-		recs, err := client.GetReceivers(networkID)
+		getFilePrefix := getFilePrefix(c)
+		recs, err := client.GetReceivers(getFilePrefix)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -70,13 +70,13 @@ func GetGetReceiversHandler(client receivers.AlertmanagerClient) func(c echo.Con
 // GetUpdateReceiverHandler returns a handler function to update a receivers
 func GetUpdateReceiverHandler(client receivers.AlertmanagerClient, alertmanagerURL string) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		networkID := getNetworkID(c)
+		getFilePrefix := getFilePrefix(c)
 		newReceiver, err := decodeReceiverPostRequest(c)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
-		err = client.UpdateReceiver(networkID, &newReceiver)
+		err = client.UpdateReceiver(getFilePrefix, &newReceiver)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -91,10 +91,10 @@ func GetUpdateReceiverHandler(client receivers.AlertmanagerClient, alertmanagerU
 
 func GetDeleteReceiverHandler(client receivers.AlertmanagerClient, alertmanagerURL string) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		networkID := getNetworkID(c)
+		getFilePrefix := getFilePrefix(c)
 		receiverName := c.QueryParam(ReceiverNameQueryParam)
 
-		err := client.DeleteReceiver(networkID, receiverName)
+		err := client.DeleteReceiver(getFilePrefix, receiverName)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -109,8 +109,8 @@ func GetDeleteReceiverHandler(client receivers.AlertmanagerClient, alertmanagerU
 
 func GetGetRouteHandler(client receivers.AlertmanagerClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		networkID := getNetworkID(c)
-		route, err := client.GetRoute(networkID)
+		getFilePrefix := getFilePrefix(c)
+		route, err := client.GetRoute(getFilePrefix)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -120,12 +120,12 @@ func GetGetRouteHandler(client receivers.AlertmanagerClient) func(c echo.Context
 
 func GetUpdateRouteHandler(client receivers.AlertmanagerClient, alertmanagerURL string) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		networkID := getNetworkID(c)
+		getFilePrefix := getFilePrefix(c)
 		newRoute, err := decodeRoutePostRequest(c)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		err = client.ModifyNetworkRoute(networkID, &newRoute)
+		err = client.ModifyNetworkRoute(getFilePrefix, &newRoute)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/receiver_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/handlers/receiver_handlers_test.go
@@ -222,7 +222,7 @@ func buildContext(body interface{}, method, target, path, networkID string) (ech
 	rec := httptest.NewRecorder()
 	c := echo.New().NewContext(req, rec)
 	c.SetPath(path)
-	c.SetParamNames("network_id")
+	c.SetParamNames("file_prefix")
 	c.SetParamValues(networkID)
 	return c, rec
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/alerting/prom_alertconfig/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/alerting/prom_alertconfig/server.go
@@ -30,12 +30,13 @@ func main() {
 	port := flag.String("port", defaultPort, fmt.Sprintf("Port to listen for requests. Default is %s", defaultPort))
 	rulesDir := flag.String("rules-dir", ".", "Directory to write rules files. Default is '.'")
 	prometheusURL := flag.String("prometheusURL", defaultPrometheusURL, fmt.Sprintf("URL of the prometheus instance that is reading these rules. Default is %s", defaultPrometheusURL))
+	multitenancy := flag.Bool("multitenant", false, "Set this flag to enable multi-tenant support, having each tenant's alerts in a separate file")
 	flag.Parse()
 
 	e := echo.New()
 
 	fileLocks, err := alert.NewFileLocker(alert.NewDirectoryClient(*rulesDir))
-	alertClient := alert.NewClient(fileLocks, *rulesDir, files.NewFSClient())
+	alertClient := alert.NewClient(fileLocks, *rulesDir, files.NewFSClient(), *multitenancy)
 	if err != nil {
 		glog.Errorf("error creating alert client: %v", err)
 		return


### PR DESCRIPTION
Summary:
Add a flag to the service which toggles multitenancy. This prevents the manager from labeling each alert with a networkID meaning that the alerts will work on any metric in prometheus.
* Renamed "networkID" to "filePrefix" in code to better represent how files are split up.
* Single-tenant clients still use the same handlers and can split rules between different files through the path parameter.

Reviewed By: xjtian

Differential Revision: D17737763

