### PR TITLE
add test for ErrorQueue

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -152,7 +152,8 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/EventBaseTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/FileWatcherTest.cpp)
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/FileWatcherTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp)
 
 target_link_libraries(devmantest
   devman

--- a/devmand/gateway/src/devmand/ErrorQueue.cpp
+++ b/devmand/gateway/src/devmand/ErrorQueue.cpp
@@ -10,15 +10,15 @@
 namespace devmand {
 
 void ErrorQueue::add(std::string&& error) {
-  errors.emplace_front(std::forward<std::string>(error));
-
-  if (maxSize > errors.size()) {
-    errors.pop_back();
+  errors.emplace_back(std::forward<std::string>(error));
+  // on max size, discard oldest error
+  if (errors.size() > maxSize) {
+    errors.pop_front();
   }
 }
 
 folly::dynamic ErrorQueue::get() {
-  folly::dynamic ret = folly::dynamic::array;
+  auto ret = folly::dynamic::array();
   for (auto& error : errors) {
     ret.push_back(error);
   }

--- a/devmand/gateway/src/devmand/test/ErrorQueueTest.cpp
+++ b/devmand/gateway/src/devmand/test/ErrorQueueTest.cpp
@@ -1,0 +1,45 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/test/EventBaseTest.h>
+#include <devmand/ErrorQueue.h>
+#include <folly/json.h>
+
+namespace devmand {
+namespace test {
+
+TEST(ErrorQueueTest, SimpleEnqueueDequeue) {
+  // create some errors (queue max length 5)
+  ErrorQueue errors{5};
+  errors.add("str one");
+  errors.add("str two");
+  errors.add("three");
+
+  // get back the errors in order
+  auto errs1 = folly::toJson(errors.get());
+  auto expected1 =
+      folly::toJson(folly::dynamic::array("str one", "str two", "three"));
+  EXPECT_EQ(errs1, expected1);
+
+  // add an error and "get" again
+  errors.add("four!");
+  auto errs2 = folly::toJson(errors.get());
+  auto expected2 = folly::toJson(
+      folly::dynamic::array("str one", "str two", "three", "four!"));
+  EXPECT_EQ(errs2, expected2);
+
+  // add two more errors, expect the oldest error to be discarded
+  errors.add("FIVE");
+  errors.add("sixth");
+  auto errs3 = folly::toJson(errors.get());
+  auto expected3 = folly::toJson(
+      folly::dynamic::array("str two", "three", "four!", "FIVE", "sixth"));
+  EXPECT_EQ(errs3, expected3);
+}
+
+} // namespace test
+} // namespace devmand


### PR DESCRIPTION
Summary:
Changed ErrorQueue to `emplace_back` and `pop_front` instead of `emplace_front` and `pop_back` so that when using "get" the items are returned in the order they were enqueued  (previously they were in reverse order).

Flipped comparison operator of `maxSize` and `errors.size()`.

Added a unit test for ErrorQueue.

Differential Revision: D17930426

