### PR TITLE
make ErrorQueue synchronized

### DIFF
--- a/devmand/gateway/src/devmand/ErrorQueue.cpp
+++ b/devmand/gateway/src/devmand/ErrorQueue.cpp
@@ -10,18 +10,24 @@
 namespace devmand {
 
 void ErrorQueue::add(std::string&& error) {
-  errors.emplace_back(std::forward<std::string>(error));
-  // on max size, discard oldest error
-  if (errors.size() > maxSize) {
-    errors.pop_front();
-  }
+  errors.withWLock([this, &error](auto& queue) {
+    queue.emplace_back(std::forward<std::string>(error));
+    // on max size, discard oldest error
+    if (queue.size() > maxSize) {
+      queue.pop_front();
+    }
+  });
 }
 
 folly::dynamic ErrorQueue::get() {
   auto ret = folly::dynamic::array();
-  for (auto& error : errors) {
-    ret.push_back(error);
-  }
+  // NOTE: this is a shared read lock but if you modify "get()" to clear
+  // the errors, you'll need a write lock.
+  errors.withRLock([this, &ret](auto& queue) {
+    for (auto& error : queue) {
+      ret.push_back(error);
+    }
+  });
   return ret;
 }
 

--- a/devmand/gateway/src/devmand/ErrorQueue.h
+++ b/devmand/gateway/src/devmand/ErrorQueue.h
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <folly/dynamic.h>
+#include <folly/Synchronized.h>
 
 namespace devmand {
 
@@ -29,8 +30,7 @@ class ErrorQueue final {
   folly::dynamic get();
 
  private:
-  // TODO make sync
-  std::list<std::string> errors;
+  folly::Synchronized<std::list<std::string>> errors;
   unsigned int maxSize{0};
 };
 


### PR DESCRIPTION
Summary:
Added a `folly:Synchronized` around the list providing storage for `ErrorQueue`, using a write lock in `add()` and a read lock in `get()`.

I also added a unit test which creates 3 threads which rapidly perform 10,000 adds to the ErrorQueue. The lack of a runtime error means it's threadsafe (since in 30,000 adds in a few milliseconds you'd likely see an error otherwise).

Differential Revision: D17935120

