### PR TITLE
Add failure logging when provided PolicyRule has an empty flow list

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -221,6 +221,11 @@ class EnforcementController(PolicyMixin, MagmaController):
                 )
                 return RuleModResult.FAILURE
 
+        if not rule.flow_list:
+            self.logger.error('The flow list for imsi %s, rule.id - %s'
+                              'is empty, this shoudn\'t happen', imsi, rule.id)
+            return RuleModResult.FAILURE
+
         flow_adds = []
         for flow in rule.flow_list:
             try:


### PR DESCRIPTION
Summary: Previously if the policyrule was empty pipelined wouldn't insert any rules and return success. This diff adds a failure(at least an empty match is rqeuired per spec) in case such occurs.

Differential Revision: D17945114

