### PR TITLE
Fix prometheus data swagger type

### DIFF
--- a/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
@@ -87,9 +87,7 @@ paths:
           description:
             List of PromQL metrics results
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/promql_return_object'
+            $ref: '#/definitions/promql_return_object'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
@@ -124,9 +122,7 @@ paths:
         '200':
           description: List of PromQL metrics results
           schema:
-            type: array
-            items:
-              $ref: '#/definitions/promql_return_object'
+            $ref: '#/definitions/promql_return_object'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 


### PR DESCRIPTION
Summary: Swagger type for return value of prometheus/query and prometheus/query_range was an array of objects when it should just be a singular object

Differential Revision: D17945502

