### PR TITLE
fix snmp hanging

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(devman
 add_library(devman_channel_snmp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Channel.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Engine.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/EventHandler.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/IfMib.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Oid.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Pdu.cpp

--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -84,10 +84,12 @@ class Application final : public MetricSink {
 
   DhcpdConfig& getDhcpdConfig();
 
+  channels::snmp::Engine& getSnmpEngine();
   channels::ping::Engine& getPingEngine();
 
  private:
   void pollDevices();
+  void doDebug();
 
   template <class EngineType, class... Args>
   EngineType* addEngine(Args&&... args) {

--- a/devmand/gateway/src/devmand/Config.cpp
+++ b/devmand/gateway/src/devmand/Config.cpp
@@ -15,5 +15,9 @@ DEFINE_string(
     "/etc/devmand/devices.yml",
     "Accepts .yml or .mconfig files. Inotify watches the file, and applies necessary changes.");
 DEFINE_uint64(poll_interval, 10, "The polling interval in seconds.");
+DEFINE_uint64(
+    debug_print_interval,
+    0,
+    "The debug print interval in seconds. A value of 0 disables the printing.");
 
 } // namespace devmand

--- a/devmand/gateway/src/devmand/Config.h
+++ b/devmand/gateway/src/devmand/Config.h
@@ -14,5 +14,6 @@ namespace devmand {
 DECLARE_string(listen_interface);
 DECLARE_string(device_configuration_file);
 DECLARE_uint64(poll_interval);
+DECLARE_uint64(debug_print_interval);
 
 } // namespace devmand

--- a/devmand/gateway/src/devmand/channels/Engine.h
+++ b/devmand/gateway/src/devmand/channels/Engine.h
@@ -18,12 +18,41 @@ namespace channels {
  */
 class Engine {
  public:
-  Engine() = default;
+  Engine(const std::string& engineName_) : engineName(engineName_) {}
+
+  Engine() = delete;
   virtual ~Engine() = default;
   Engine(const Engine&) = delete;
   Engine& operator=(const Engine&) = delete;
   Engine(Engine&&) = delete;
   Engine& operator=(Engine&&) = delete;
+
+ public:
+  unsigned long long getNumIterations() const {
+    return iterations;
+  }
+
+  unsigned long long getNumRequests() const {
+    return requests;
+  }
+
+  std::string getName() const {
+    return engineName;
+  }
+
+  void incrementRequests() {
+    ++requests;
+  }
+
+ protected:
+  void incrementIterations() {
+    ++iterations;
+  }
+
+ private:
+  unsigned long long iterations{0};
+  unsigned long long requests{0};
+  std::string engineName;
 };
 
 } // namespace channels

--- a/devmand/gateway/src/devmand/channels/packet/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/packet/Engine.cpp
@@ -27,7 +27,7 @@ namespace devmand {
 namespace channels {
 namespace packet {
 
-Engine::Engine(const std::string& interfaceName) {
+Engine::Engine(const std::string& interfaceName) : channels::Engine("Packet") {
   LOG(INFO) << "Listening on interface " << interfaceName;
 
   fd = ::socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));

--- a/devmand/gateway/src/devmand/channels/snmp/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/snmp/Channel.cpp
@@ -12,6 +12,7 @@
 #include <folly/ScopeGuard.h>
 
 #include <devmand/channels/snmp/Channel.h>
+#include <devmand/channels/snmp/Engine.h>
 
 namespace devmand {
 namespace channels {
@@ -65,6 +66,7 @@ static inline int parseSecurityLevel(const SecurityLevel& lvl) {
 }
 
 Channel::Channel(
+    Engine& engine_,
     const Peer& peer_,
     const Community& community,
     const Version& version,
@@ -72,7 +74,7 @@ Channel::Channel(
     const std::string& securityName,
     const SecurityLevel& securityLevel,
     oid proto[])
-    : peer(peer_) {
+    : engine(engine_), peer(peer_) {
   snmp_session sessionIn;
 
   snmp_sess_init(&sessionIn);
@@ -125,7 +127,7 @@ void Channel::handleAsyncResponse(
     snmp_pdu* response) {
   switch (operation) {
     case NETSNMP_CALLBACK_OP_RECEIVED_MESSAGE: {
-      Response pr = processResponse(*response);
+      Response pr = processResponse(request, *response);
       if (not pr.isError()) {
         request->responsePromise.setValue(pr);
       } else {
@@ -134,8 +136,8 @@ void Channel::handleAsyncResponse(
       break;
     }
     case NETSNMP_CALLBACK_OP_TIMED_OUT:
-      request->responsePromise.setException(
-          Exception(folly::sformat("snmp timeout {}", peer)));
+      request->responsePromise.setException(Exception(folly::sformat(
+          "snmp timeout {} on oid {}", peer, request->oid.toString())));
       break;
     default:
       request->responsePromise.setException(Exception("snmp error"));
@@ -162,6 +164,7 @@ folly::Future<Response> Channel::asyncSend(
     return 1;
   };
 
+  engine.incrementRequests();
   if (snmp_async_send(session, pdu.get(), handler, &result->second)) {
     pdu.release();
     return result->second.responsePromise.getFuture();
@@ -176,7 +179,7 @@ folly::Future<Response> Channel::asyncGet(const Oid& _oid) {
   auto result = outstandingRequests.emplace(
       std::piecewise_construct,
       std::forward_as_tuple(pdu.get()->reqid),
-      std::forward_as_tuple(Request{this}));
+      std::forward_as_tuple(Request{this, _oid}));
   if (result.second) {
     return asyncSend(pdu, result.first);
   } else {
@@ -189,7 +192,7 @@ folly::Future<Response> Channel::asyncGetNext(const Oid& _oid) {
   auto result = outstandingRequests.emplace(
       std::piecewise_construct,
       std::forward_as_tuple(pdu.get()->reqid),
-      std::forward_as_tuple(Request{this}));
+      std::forward_as_tuple(Request{this, _oid}));
   if (result.second) {
     return asyncSend(pdu, result.first);
   } else {
@@ -209,6 +212,10 @@ Response Channel::processVars(netsnmp_variable_list* vars) {
   for (; vars != nullptr; vars = vars->next_variable) {
     Oid oid(vars->name, vars->name_length);
     switch (vars->type) {
+      case SNMP_ENDOFMIBVIEW:
+      case SNMP_NOSUCHOBJECT:
+      case SNMP_NOSUCHINSTANCE:
+        return Response(oid, nullptr);
       case ASN_OCTET_STR:
         return Response(
             oid,
@@ -233,6 +240,8 @@ Response Channel::processVars(netsnmp_variable_list* vars) {
         return Response(oid, *vars->val.integer);
       case ASN_BOOLEAN:
         return Response(oid, static_cast<bool>(*vars->val.integer));
+      case ASN_OBJECT_ID:
+        return Response(oid, Oid(vars->val.objid, vars->val_len).toString());
       case ASN_BIT_STR:
       case ASN_NULL:
       default:
@@ -244,18 +253,55 @@ Response Channel::processVars(netsnmp_variable_list* vars) {
   return ErrorResponse("error");
 }
 
-Response Channel::processResponse(snmp_pdu& response) {
+Response Channel::processResponse(Request* request, snmp_pdu& response) {
   switch (response.errstat) {
     case SNMP_ERR_NOERROR:
       return processVars(response.variables);
     case SNMPERR_TIMEOUT:
-      return ErrorResponse(folly::sformat("snmp timeout {}", peer));
-    default:
-      return ErrorResponse(
-          std::string("snmp packet error ") +
-          snmp_errstring(static_cast<int>(response.errstat)) + " for oid " +
-          firstOid(response.variables).toString());
+      return ErrorResponse(folly::sformat(
+          "snmp timeout {} on oid {}", peer, request->oid.toString()));
+    case SNMP_ERR_NOSUCHNAME:
+      for (netsnmp_variable_list* vars = response.variables; vars != nullptr;
+           vars = vars->next_variable) {
+        Oid oid(vars->name, vars->name_length);
+        switch (vars->type) {
+          case SNMP_ENDOFMIBVIEW:
+          case SNMP_NOSUCHOBJECT:
+          case SNMP_NOSUCHINSTANCE:
+          case ASN_NULL:
+            return Response(oid, nullptr);
+          default:
+            break;
+        }
+      }
+      [[fallthrough]] default
+          : return ErrorResponse(
+                std::string("snmp packet error ") +
+                snmp_errstring(static_cast<int>(response.errstat)) +
+                " for oid " + firstOid(response.variables).toString() +
+                " errno " + folly::to<std::string>(response.errstat));
   }
+}
+
+folly::Future<Responses> Channel::walk(const channels::snmp::Oid& tree) {
+  return walk(tree, tree, {});
+}
+
+folly::Future<Responses> Channel::walk(
+    const channels::snmp::Oid& tree,
+    const channels::snmp::Oid& current,
+    Responses responses) {
+  return asyncGetNext(current).thenValue(
+      [this, tree, current, responses = std::move(responses)](
+          auto response) mutable {
+        // TODO handle error
+        if (not response.value.isNull() and response.oid.isDescendant(tree)) {
+          responses.emplace_back(response);
+          return this->walk(tree, response.oid, std::move(responses));
+        } else {
+          return folly::makeFuture<Responses>(std::move(responses));
+        }
+      });
 }
 
 } // namespace snmp

--- a/devmand/gateway/src/devmand/channels/snmp/Engine.h
+++ b/devmand/gateway/src/devmand/channels/snmp/Engine.h
@@ -7,9 +7,14 @@
 
 #pragma once
 
+#include <list>
+#include <memory>
 #include <string>
 
+#include <folly/io/async/EventHandler.h>
+
 #include <devmand/channels/Engine.h>
+#include <devmand/channels/snmp/EventHandler.h>
 
 namespace devmand {
 namespace channels {
@@ -17,7 +22,7 @@ namespace snmp {
 
 class Engine final : public channels::Engine {
  public:
-  Engine(const std::string& appName);
+  Engine(folly::EventBase& eventBase_, const std::string& appName);
 
   Engine() = delete;
   ~Engine() override = default;
@@ -27,11 +32,17 @@ class Engine final : public channels::Engine {
   Engine& operator=(Engine&&) = delete;
 
  public:
-  void run();
-  void stopEventually();
+  folly::EventBase& getEventBase();
+  void sync();
 
  private:
-  bool stopping{false};
+  void timeout();
+
+  void enableDebug();
+
+ private:
+  folly::EventBase& eventBase;
+  std::list<std::unique_ptr<EventHandler>> handlers;
 };
 
 } // namespace snmp

--- a/devmand/gateway/src/devmand/channels/snmp/EventHandler.cpp
+++ b/devmand/gateway/src/devmand/channels/snmp/EventHandler.cpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/snmp/Engine.h>
+#include <devmand/channels/snmp/EventHandler.h>
+#include <devmand/channels/snmp/Snmp.h>
+
+namespace devmand {
+namespace channels {
+namespace snmp {
+
+EventHandler::EventHandler(Engine& engine_, int fd_)
+    : folly::EventHandler(&engine_.getEventBase()), engine(engine_), fd(fd_) {
+  folly::EventHandler::changeHandlerFD(folly::NetworkSocket::fromFd(fd));
+  registerHandler(folly::EventHandler::READ | folly::EventHandler::PERSIST);
+}
+
+EventHandler::~EventHandler() {
+  if (fd != -1) {
+    unregisterHandler();
+  }
+}
+
+int EventHandler::getFd() const {
+  return fd;
+}
+
+void EventHandler::handlerReady(uint16_t) noexcept {
+  fd_set fdset;
+  FD_ZERO(&fdset);
+  FD_SET(fd, &fdset);
+  snmp_read(&fdset);
+  engine.sync();
+}
+
+} // namespace snmp
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/snmp/EventHandler.h
+++ b/devmand/gateway/src/devmand/channels/snmp/EventHandler.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <folly/io/async/EventHandler.h>
+
+namespace devmand {
+namespace channels {
+namespace snmp {
+
+class Engine;
+
+class EventHandler final : public folly::EventHandler {
+ public:
+  EventHandler(Engine& engine_, int fd_);
+  EventHandler() = delete;
+  ~EventHandler() override;
+  EventHandler(const EventHandler&) = delete;
+  EventHandler& operator=(const EventHandler&) = delete;
+  EventHandler(EventHandler&& e) = delete;
+  EventHandler& operator=(EventHandler&&) = delete;
+
+ public:
+  int getFd() const;
+
+ private:
+  void handlerReady(uint16_t events) noexcept override;
+  void read();
+
+ private:
+  Engine& engine;
+  int fd{-1};
+};
+
+} // namespace snmp
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/snmp/Oid.h
+++ b/devmand/gateway/src/devmand/channels/snmp/Oid.h
@@ -14,6 +14,7 @@
 #undef WRITE
 
 #include <folly/Conv.h>
+#include <folly/GLog.h>
 
 namespace devmand {
 namespace channels {
@@ -34,6 +35,16 @@ class Oid final {
   const oid* const get() const;
   size_t getLength() const;
   std::string toString() const;
+
+  friend bool operator<(const Oid& lhs, const Oid& rhs) {
+    return snmp_oid_compare(lhs.buffer, lhs.length, rhs.buffer, lhs.length) ==
+        -1;
+  }
+
+  bool isDescendant(const Oid& tree) const {
+    return tree.length <= length and
+        snmp_oidtree_compare(tree.buffer, tree.length, buffer, length) == 0;
+  }
 
  public:
   static const Oid error;

--- a/devmand/gateway/src/devmand/channels/snmp/Request.cpp
+++ b/devmand/gateway/src/devmand/channels/snmp/Request.cpp
@@ -11,7 +11,7 @@ namespace devmand {
 namespace channels {
 namespace snmp {
 
-Request::Request(Channel* channel_) : channel(channel_) {}
+Request::Request(Channel* channel_, Oid oid_) : channel(channel_), oid(oid_) {}
 
 } // namespace snmp
 } // namespace channels

--- a/devmand/gateway/src/devmand/channels/snmp/Request.h
+++ b/devmand/gateway/src/devmand/channels/snmp/Request.h
@@ -19,7 +19,7 @@ class Channel;
 
 class Request final {
  public:
-  Request(Channel* channel_);
+  Request(Channel* channel_, Oid oid_);
   Request() = delete;
   ~Request() = default;
   Request(const Request&) = delete;
@@ -29,6 +29,7 @@ class Request final {
 
  public:
   Channel* channel{nullptr};
+  Oid oid;
   folly::Promise<Response> responsePromise{};
 };
 

--- a/devmand/gateway/src/devmand/channels/snmp/Response.h
+++ b/devmand/gateway/src/devmand/channels/snmp/Response.h
@@ -7,6 +7,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include <folly/dynamic.h>
 
 #include <devmand/channels/snmp/Oid.h>
@@ -42,6 +44,8 @@ class ErrorResponse final : public Response {
   ErrorResponse(ErrorResponse&&) = default;
   ErrorResponse& operator=(ErrorResponse&&) = default;
 };
+
+using Responses = std::vector<Response>;
 
 } // namespace snmp
 } // namespace channels

--- a/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
@@ -154,6 +154,30 @@ std::shared_ptr<State> Device::getState() {
     japt["model"] = v;
   }));
 
+  state->addRequest(
+      snmpChannel.walk(channels::snmp::Oid(".1.3.6.1.4.1.14988.1.1.1.3.1.4"))
+          .thenValue([](auto ssids) {
+            for (auto& ssid : ssids) {
+              LOG(INFO) << "Ssid = " << ssid.value.asString();
+            }
+          }));
+
+  state->addRequest(
+      snmpChannel.walk(channels::snmp::Oid(".1.3.6.1.4.1.14988.1.1.1.3.1.5"))
+          .thenValue([](auto bssids) {
+            for (auto& bssid : bssids) {
+              LOG(INFO) << "Bssid = " << bssid.value.asString();
+            }
+          }));
+
+  state->addRequest(
+      snmpChannel.walk(channels::snmp::Oid(".1.3.6.1.4.1.14988.1.1.1.3.1.7"))
+          .thenValue([](auto freqs) {
+            for (auto& freq : freqs) {
+              LOG(INFO) << "Freq = " << freq.value.asString();
+            }
+          }));
+
   state->addFinally([state, &papc, &papt, &jap, &japt]() {
     auto* field = state->update().get_ptr("ietf-system:system");
     if (field != nullptr and ((field = field->get_ptr("name")) != nullptr)) {


### PR DESCRIPTION
Summary:
This commit fixes a problem where the snmp event thread was hanging and
thus preventing new snmp requests from being fullfilled. The issue stemed from
the fact that net-snmp without per session useage is not thread safe. We were
using it in two threads though. The epoll thread to make requests and the snmp
loop thread to process responses. This causes an issue where a list becomes
infinite in size and the function never returns.

To get around this I moved the snmp loop thread into the epoll thread loop which
I was already meaning to do. In the future we can just confine snmp requests/
responses to a single thread by using future.via and then we can use the other
cores for other channels.

Reviewed By: al8

Differential Revision: D17915832

