### PR TITLE
run valgrind on devmand tests

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -148,14 +148,15 @@ target_link_libraries(devmand
   devman_service_magma)
 
 add_executable(devmantest
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/MikrotikChannelTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/EventBaseTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/FileWatcherTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp)
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/MikrotikChannelTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/SnmpChannelTest.cpp)
 
 target_link_libraries(devmantest
   devman

--- a/devmand/gateway/docker/firstparty/devmand/deps
+++ b/devmand/gateway/docker/firstparty/devmand/deps
@@ -47,6 +47,8 @@ python-pip
 python-setuptools
 python3-setuptools
 scons
+snmp
+snmpd
 strace
 valgrind
 vim

--- a/devmand/gateway/docker/scripts/test
+++ b/devmand/gateway/docker/scripts/test
@@ -1,13 +1,41 @@
 #!/bin/bash
+# shellcheck disable=SC2068
 
 CACHE_DIR=${SYMPHONY_AGENT_CACHE_DIR:-$(realpath ~)/cache_devmand_build}
-docker run \
-  -v "$(realpath ../):/cache/devmand/repo:ro" \
-  -v "$CACHE_DIR:/cache/devmand/build:rw" \
-  --sysctl net.ipv4.ping_group_range="0 0" \
-  devmand-built \
-  make test
-EXIT_CODE=$?
+
+test_bin="/cache/devmand/build/devmantest --gtest_shuffle"
+memcheck="valgrind \
+    --tool=memcheck \
+    --undef-value-errors=yes \
+    --trace-children=no \
+    --child-silent-after-fork=no \
+    --fair-sched=yes \
+    --track-origins=yes \
+    --leak-check=full \
+    --suppressions=/cache/devmand/repo/docker/valgrind.supp \
+    --vgdb=yes
+    --gen-suppressions=yes --demangle=no \
+    --num-callers=100"
+
+# TODO Some day we can add this after lots of suppressions
+#--show-reachable=yes \
+
+function run_test_container {
+  docker run -it \
+    -v "$(realpath ../):/cache/devmand/repo:ro" \
+    -v "$CACHE_DIR:/cache/devmand/build:rw" \
+    --sysctl net.ipv4.ping_group_range="0 0" \
+    devmand-built $@
+  EXIT_CODE=$?
+}
+
+# This is useful if you want to test in gdb.
+# run_test_container gdb --args "${test_bin}" "$@"
+
+run_test_container "${memcheck}" "${test_bin}" "$@"
+if [ $EXIT_CODE -eq 0 ] ; then
+  run_test_container "${test_bin}" "$@"
+fi
 
 if [ $EXIT_CODE -ne 0 ] ; then
   echo "You have gotten a CI failure in devmand's unit tests."

--- a/devmand/gateway/docker/valgrind.supp
+++ b/devmand/gateway/docker/valgrind.supp
@@ -1,0 +1,21 @@
+{
+   lib_unwind_msync
+   Memcheck:Param
+   msync(start)
+   obj:/lib/x86_64-linux-gnu/libpthread-2.24.so
+   obj:/usr/lib/x86_64-linux-gnu/libunwind.so.8.0.1
+   ...
+}
+{
+   set_context_read
+   Memcheck:Addr8
+   fun:_Ux86_64_setcontext
+   ...
+}
+{
+   set_context_param
+   Memcheck:Param
+   rt_sigprocmask(set)
+   fun:_Ux86_64_setcontext
+   ...
+}

--- a/devmand/gateway/src/devmand/test/DevConfTest.cpp
+++ b/devmand/gateway/src/devmand/test/DevConfTest.cpp
@@ -200,8 +200,9 @@ TEST_F(DevConfTest, badExtension) {
   FileUtils::write(
       "/tmp/deviceConfig.txt", formatYaml("foo", "203.0.113.1", "Foo"));
   cartography::Cartographer cartographer{add, del};
-  cartographer.addDeviceDiscoveryMethod(
-      std::make_shared<magma::DevConf>(eventBase, yamlDeviceConfig));
+  EXPECT_THROW(cartographer.addDeviceDiscoveryMethod(
+      std::make_shared<magma::DevConf>(eventBase, "/tmp/deviceConfig.txt")),
+      std::runtime_error);
   stop();
 }
 

--- a/devmand/gateway/src/devmand/test/SnmpChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/SnmpChannelTest.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/snmp/Channel.h>
+#include <devmand/channels/snmp/Engine.h>
+#include <devmand/test/EventBaseTest.h>
+#include <devmand/test/TestUtils.h>
+
+#include <folly/IPAddress.h>
+
+namespace devmand {
+namespace test {
+
+class SnmpChannelTest : public EventBaseTest {
+ public:
+  SnmpChannelTest() = default;
+  ~SnmpChannelTest() override = default;
+  SnmpChannelTest(const SnmpChannelTest&) = delete;
+  SnmpChannelTest& operator=(const SnmpChannelTest&) = delete;
+  SnmpChannelTest(SnmpChannelTest&&) = delete;
+  SnmpChannelTest& operator=(SnmpChannelTest&&) = delete;
+
+ protected:
+  std::string local{"127.0.0.1"};
+  std::string community{"public"};
+  std::string version{"v1"};
+};
+
+TEST_F(SnmpChannelTest, checkSnmpTimeout) {
+  channels::snmp::Engine engine(eventBase, "checkSnmpTimeout");
+  auto channel = std::make_shared<channels::snmp::Channel>(
+      engine, local, community, version);
+  EXPECT_THROW(
+      channel->asyncGet(channels::snmp::Oid("iso.3.6.1.2.1.1.4.0")).get(),
+      std::runtime_error);
+  stop();
+}
+
+} // namespace test
+} // namespace devmand


### PR DESCRIPTION
Summary:
This commit is the start of tracking down a mem leak. I added a basic
snmp test and then I added some changes to the test scripts so in circle ci
we will run valgrind.

Reviewed By: al8

Differential Revision: D17939090

