### PR TITLE
improved Diff.h algorithm

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -154,7 +154,8 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/EventBaseTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/FileWatcherTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp)
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp)
 
 target_link_libraries(devmantest
   devman

--- a/devmand/gateway/src/devmand/Diff.h
+++ b/devmand/gateway/src/devmand/Diff.h
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <set>
+#include <algorithm>
+#include <functional>
 
 namespace devmand {
 
@@ -20,33 +22,70 @@ enum class DiffEvent {
 template <class Type>
 using DiffEventHandler = std::function<void(DiffEvent, const Type&)>;
 
-// TODO First this can be made more generic with SFINAE second the imlementation
-// below is quite poor algorithmically but it works for now.
-template <class Type>
-void diff(
-    const std::set<Type>& oldCollection,
-    const std::set<Type>& newCollection,
+// TODO this can be made more generic with SFINAE
+
+/* This implementation is based on std::set_difference, but I've gone ahead
+ * re-implemented it because we're looking for modified elements (not just
+ * added or removed elements) which requires slightly different logic, and
+ * doing it with our own diff function let's us do it in a single pass.
+ *
+ * diffSorted() runs in O(n) time (linear) because it takes advantage of the
+ * fact that both collections are sorted. It iterates a single time through
+ * both.
+ *
+ * std::set is sorted by definition. Lists or vecs need to be sorted before
+ * calling diffSorted(), making the whole thing O(n log n) time.
+ */
+
+template <class Iterator, class Type>
+inline static void doHandle(
+    DiffEvent event,
+    Iterator& iter,
     const DiffEventHandler<Type>& handler) {
-  for (auto& oldElem : oldCollection) {
-    const auto& newElem = std::find(
-        std::cbegin(newCollection), std::cend(newCollection), oldElem);
-    if (newElem != newCollection.end()) {
-      if (oldElem != *newElem) {
-        handler(DiffEvent::Modify, *newElem);
-      } else {
-        // NOTE handler(DiffEvent::Same, *newElem);
-      }
+  handler(event, *iter);
+  ++iter;
+}
+
+template <class Type>
+void diffSorted(
+    const std::set<Type>& oldC,
+    const std::set<Type>& newC,
+    const DiffEventHandler<Type>& handler) {
+  // two iterators move through both collections together
+  auto oldIt = oldC.begin();
+  auto newIt = newC.begin();
+  // keep going until you reach the end of both collections
+  while (oldIt != oldC.end() || newIt != newC.end()) {
+    if (oldIt == oldC.end()) {
+      doHandle(DiffEvent::Add, newIt, handler);
+    } else if (newIt == newC.end()) {
+      doHandle(DiffEvent::Delete, oldIt, handler);
     } else {
-      handler(DiffEvent::Delete, oldElem);
-    }
-  }
-  for (auto& newElem : newCollection) {
-    const auto& oldElem = std::find(
-        std::cbegin(oldCollection), std::cend(oldCollection), newElem);
-    if (oldElem == oldCollection.end()) {
-      handler(DiffEvent::Add, newElem);
+      // not at the end of either collection
+      if (*oldIt < *newIt) {
+        doHandle(DiffEvent::Delete, oldIt, handler);
+      } else if (*newIt < *oldIt) {
+        doHandle(DiffEvent::Add, newIt, handler);
+      } else {
+        // element is unchanged, step forward
+        ++oldIt;
+        ++newIt;
+      }
     }
   }
 }
+
+// separate definition for std::set to bypass sorting,
+// std::set is sorted in it's implementation
+template <class Type>
+void diff(
+    const std::set<Type>& oldSet,
+    const std::set<Type>& newSet,
+    const DiffEventHandler<Type>& handler) {
+  diffSorted(oldSet, newSet, handler);
+}
+
+// TODO: generic definition for various containers, including std::list and
+// std::vec. Make sure to sort the container before passing it to diffSorted.
 
 } // namespace devmand

--- a/devmand/gateway/src/devmand/test/DiffTest.cpp
+++ b/devmand/gateway/src/devmand/test/DiffTest.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <gtest/gtest.h>
+
+#include <devmand/Diff.h>
+
+namespace devmand {
+namespace test {
+
+template <class Type>
+static void diffAddDelete(
+    const std::set<Type>& s1,
+    const std::set<Type>& s2,
+    std::set<Type>& added,
+    std::set<Type>& deleted) {
+  DiffEventHandler<Type> deh =
+    [&added, &deleted](DiffEvent de, const Type& val) {
+      switch (de) {
+        case DiffEvent::Add:
+          added.insert(val);
+          break;
+        case DiffEvent::Delete:
+          deleted.insert(val);
+          break;
+        case DiffEvent::Modify:
+          FAIL() << "This case can't be reached.";
+          break;
+      }
+    };
+  diff(s1, s2, deh);
+}
+
+TEST(DiffTest, IntegerSets) {
+  std::set<int> s1 = {2,5,8,4,6};
+  std::set<int> s2 = {9,7,4,2,8,1};
+  std::set<int> expectedAdded = {9,7,1};
+  std::set<int> expectedRemoved = {5,6};
+  std::set<int> added;
+  std::set<int> deleted;
+  diffAddDelete(s1, s2, added, deleted);
+  EXPECT_EQ(added, expectedAdded);
+  EXPECT_EQ(deleted, expectedRemoved);
+}
+
+TEST(DiffTest, StringSet) {
+  std::set<std::string> s1 = {"hi", "my", "name", "is", "ken"};
+  std::set<std::string> s2 = {"hi", "name", "dog", "my"};
+  std::set<std::string> expectedAdded = {"dog"};
+  std::set<std::string> expectedRemoved = {"is", "ken"};
+  std::set<std::string> added;
+  std::set<std::string> deleted;
+  diffAddDelete(s1, s2, added, deleted);
+  EXPECT_EQ(added, expectedAdded);
+  EXPECT_EQ(deleted, expectedRemoved);
+}
+
+// TODO: write tests for diff on DeviceConfig
+
+// TODO: write tests for diff on std::list, std::vec, and std::map
+// (once you implement that - right now only std::set supported)
+
+} // namespace test
+} // namespace devmand


### PR DESCRIPTION
Summary:
Updated the diff algorithm to a linear-time implementation based on the std::set_difference algorithm.

std::set_difference only finds the difference between two sets - it doesn't differentiate between added and removed elements, so I re-implemented it instead of just using it.

I created a helper function "diffSorted". In a later diff i'll make it generic and it'll be able to handle any sorted collection.

I also created a couple unit tests for the diff function.

Differential Revision: D17978968

