### PR TITLE
This diff includes number of improvements to helm charts

### DIFF
--- a/cwf/gateway/helm/cwf/Chart.yaml
+++ b/cwf/gateway/helm/cwf/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: "1.0"
 description: Magma Carrier Gateway
 name: cwf
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/cwf/gateway/helm/cwf/templates/config-secrets.yaml
+++ b/cwf/gateway/helm/cwf/templates/config-secrets.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# Config secrets for CWF module
+{{- if .Values.secret.configs }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $envAll.Release.Name }}-secrets-configs
+  namespace: {{ $envAll.Release.Namespace }}
+  labels:
+{{ tuple $envAll "cwf" "gateway" | include "labels" | indent 4 }}
+data:
+{{- (.Files.Glob ".configs/*.yml").AsSecrets | nindent 2 }}
+{{- end }}

--- a/cwf/gateway/helm/cwf/templates/deployment.yaml
+++ b/cwf/gateway/helm/cwf/templates/deployment.yaml
@@ -175,6 +175,10 @@ spec:
             - name: orc8r-secrets-certs
               mountPath: /opt/magma/certs/rootCA.pem
               subPath: rootCA.pem
+            {{- if .Values.secret.configs }}
+            - name: {{ $envAll.Values.secret.configs.cwf }}
+              mountPath: /var/opt/magma/configs
+            {{- end }}
       volumes:
         - name: cwf-bin
           configMap:
@@ -188,4 +192,9 @@ spec:
           secret:
             secretName: {{ required "secret.certs must be provided" .Values.secret.certs }}
             defaultMode: 0444
+        {{- if .Values.secret.configs }}
+        - name: {{ $envAll.Values.secret.configs.cwf }}
+          secret:
+            secretName: {{ $envAll.Values.secret.configs.cwf }}
+        {{- end }}
 {{- end }}

--- a/cwf/gateway/helm/cwf/templates/deployment.yaml
+++ b/cwf/gateway/helm/cwf/templates/deployment.yaml
@@ -186,6 +186,6 @@ spec:
             defaultMode: 0755
         - name: orc8r-secrets-certs
           secret:
-            secretName: orc8r-secrets-certs
+            secretName: {{ required "secret.certs must be provided" .Values.secret.certs }}
             defaultMode: 0444
 {{- end }}

--- a/cwf/gateway/helm/cwf/values.yaml
+++ b/cwf/gateway/helm/cwf/values.yaml
@@ -17,6 +17,10 @@ release_group: null
 imagePullSecrets: []
 # - name: orc8r-secrets-registry
 
+# Define which secrets should be mounted by pods.
+secret:
+  certs: orc8r-secrets-certs
+
 ## Key Values for docker inside VM
 cwf:
   type: cwag

--- a/cwf/gateway/helm/cwf/values.yaml
+++ b/cwf/gateway/helm/cwf/values.yaml
@@ -20,6 +20,8 @@ imagePullSecrets: []
 # Define which secrets should be mounted by pods.
 secret:
   certs: orc8r-secrets-certs
+  configs:
+    cwf: cwf01-secrets-configs
 
 ## Key Values for docker inside VM
 cwf:

--- a/feg/gateway/helm/feg/Chart.yaml
+++ b/feg/gateway/helm/feg/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: "1.0"
 description: Magma Federated Gateway
 name: feg
-version: 0.1.1
+version: 0.1.2
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/feg/gateway/helm/feg/templates/config-secrets.yaml
+++ b/feg/gateway/helm/feg/templates/config-secrets.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# Config secrets for FeG module
+{{- if .Values.secret.configs }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $envAll.Release.Name }}-secrets-configs
+  namespace: {{ $envAll.Release.Namespace }}
+  labels:
+{{ tuple $envAll "feg" "gateway" | include "labels" | indent 4 }}
+data:
+{{- (.Files.Glob ".configs/*.yml").AsSecrets | nindent 2 }}
+{{- end }}

--- a/feg/gateway/helm/feg/templates/deployment.yaml
+++ b/feg/gateway/helm/feg/templates/deployment.yaml
@@ -175,6 +175,10 @@ spec:
             - name: orc8r-secrets-certs
               mountPath: /opt/magma/certs/rootCA.pem
               subPath: rootCA.pem
+            {{- if .Values.secret.configs }}
+            - name: {{ $envAll.Values.secret.configs.feg }}
+              mountPath: /var/opt/magma/configs
+            {{- end }}
       volumes:
         - name: feg-bin
           configMap:
@@ -188,4 +192,9 @@ spec:
           secret:
             secretName: {{ required "secret.certs must be provided" .Values.secret.certs }}
             defaultMode: 0444
+        {{- if .Values.secret.configs }}
+        - name: {{ $envAll.Values.secret.configs.feg }}
+          secret:
+            secretName: {{ $envAll.Values.secret.configs.feg }}
+        {{- end }}
 {{- end }}

--- a/feg/gateway/helm/feg/templates/deployment.yaml
+++ b/feg/gateway/helm/feg/templates/deployment.yaml
@@ -186,6 +186,6 @@ spec:
             defaultMode: 0755
         - name: orc8r-secrets-certs
           secret:
-            secretName: orc8r-secrets-certs
+            secretName: {{ required "secret.certs must be provided" .Values.secret.certs }}
             defaultMode: 0444
 {{- end }}

--- a/feg/gateway/helm/feg/values.yaml
+++ b/feg/gateway/helm/feg/values.yaml
@@ -20,6 +20,8 @@ imagePullSecrets: []
 # Define which secrets should be mounted by pods.
 secret:
   certs: orc8r-secrets-certs
+  configs:
+    feg: feg01-secrets-configs
 
 ## Key Values for docker inside VM
 feg:

--- a/feg/gateway/helm/feg/values.yaml
+++ b/feg/gateway/helm/feg/values.yaml
@@ -17,6 +17,10 @@ release_group: null
 imagePullSecrets: []
 # - name: orc8r-secrets-registry
 
+# Define which secrets should be mounted by pods.
+secret:
+  certs: orc8r-secrets-certs
+
 ## Key Values for docker inside VM
 feg:
   type: feg

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 description: Magma NMS
 name: nms
-version: 0.1.0
+version: 0.1.1
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
@@ -58,9 +58,9 @@ spec:
             - start:dev
           env:
             - name: API_CERT_FILENAME
-              value: /usr/src/fbcnms-projects/magmalte/certs/admin_operator.pem
+              value: /run/secrets/admin_operator.pem
             - name: API_PRIVATE_KEY_FILENAME
-              value: /usr/src/fbcnms-projects/magmalte/certs/admin_operator.key.pem
+              value: /run/secrets/admin_operator.key.pem
             - name: API_HOST
               value: {{ .Values.magmalte.env.api_host | quote }}
             - name: HOST
@@ -86,21 +86,21 @@ spec:
           livenessProbe:
             exec:
               command:
-              - curl 
+              - curl
               - http://localhost:8081/healthz
             initialDelaySeconds: 60
           ports:
             - containerPort: 8081
           volumeMounts:
             - name: orc8r-secrets-certs
-              mountPath: /usr/src/fbcnms-projects/magmalte/certs/admin_operator.pem
-              subPath: admin_operator.pem
+              mountPath: /run/secrets/admin_operator.pem
+              subPath: {{ .Values.magmalte.deployment.spec.operator_cert_name }}
             - name: orc8r-secrets-certs
-              mountPath: /usr/src/fbcnms-projects/magmalte/certs/admin_operator.key.pem
-              subPath: admin_operator.key.pem
+              mountPath: /run/secrets/admin_operator.key.pem
+              subPath: {{ .Values.magmalte.deployment.spec.operator_key_name }}
       volumes:
         - name: orc8r-secrets-certs
           secret:
-            secretName: orc8r-secrets-certs
+            secretName: {{ required "secret.certs must be provided" .Values.secret.certs }}
             defaultMode: 0444
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/nginx-proxy-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/nginx-proxy-deployment.yaml
@@ -76,6 +76,6 @@ spec:
             defaultMode: 0555
         - name: orc8r-secrets-certs
           secret:
-            secretName: orc8r-secrets-certs
+            secretName: {{ required "secret.certs must be provided" .Values.secret.certs }}
             defaultMode: 0444
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
@@ -12,6 +12,10 @@ release_group: null
 imagePullSecrets: []
 # - name: orc8r-secrets-registry
 
+# Define which secrets should be mounted by pods.
+secret:
+  certs: orc8r-secrets-certs
+
 magmalte:
   manifests:
     secrets: true
@@ -37,6 +41,11 @@ magmalte:
     repository:
     tag: latest
     pullPolicy: Always
+
+  deployment:
+    spec:
+      operator_cert_name: admin_operator.pem
+      operator_key_name: admin_operator.key.pem
 
   service:
     type: ClusterIP


### PR DESCRIPTION
This is PR number of improvements are included to helm charts

1. provide the cert mount volume name over values for NMS, FeG and CWF charts
2. bring in config override feature for both feg and cwf charts
3. bump chart version to 1.0.2 

Signed-off-by: reddydodda <reddydodda@gmail.com>