### PR TITLE
fix state object finalies not being cleared

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -148,14 +148,15 @@ target_link_libraries(devmand
   devman_service_magma)
 
 add_executable(devmantest
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/MikrotikChannelTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/EventBaseTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/FileWatcherTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp)
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/MikrotikChannelTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/SnmpChannelTest.cpp)
 
 target_link_libraries(devmantest
   devman

--- a/devmand/gateway/docker/firstparty/devmand/deps
+++ b/devmand/gateway/docker/firstparty/devmand/deps
@@ -47,6 +47,8 @@ python-pip
 python-setuptools
 python3-setuptools
 scons
+snmp
+snmpd
 strace
 valgrind
 vim

--- a/devmand/gateway/docker/scripts/test
+++ b/devmand/gateway/docker/scripts/test
@@ -1,13 +1,41 @@
 #!/bin/bash
+# shellcheck disable=SC2068
 
 CACHE_DIR=${SYMPHONY_AGENT_CACHE_DIR:-$(realpath ~)/cache_devmand_build}
-docker run \
-  -v "$(realpath ../):/cache/devmand/repo:ro" \
-  -v "$CACHE_DIR:/cache/devmand/build:rw" \
-  --sysctl net.ipv4.ping_group_range="0 0" \
-  devmand-built \
-  make test
-EXIT_CODE=$?
+
+test_bin="/cache/devmand/build/devmantest --gtest_shuffle"
+memcheck="valgrind \
+    --tool=memcheck \
+    --undef-value-errors=yes \
+    --trace-children=no \
+    --child-silent-after-fork=no \
+    --fair-sched=yes \
+    --track-origins=yes \
+    --leak-check=full \
+    --suppressions=/cache/devmand/repo/docker/valgrind.supp \
+    --vgdb=yes
+    --gen-suppressions=yes --demangle=no \
+    --num-callers=100"
+
+# TODO Some day we can add this after lots of suppressions
+#--show-reachable=yes \
+
+function run_test_container {
+  docker run -it \
+    -v "$(realpath ../):/cache/devmand/repo:ro" \
+    -v "$CACHE_DIR:/cache/devmand/build:rw" \
+    --sysctl net.ipv4.ping_group_range="0 0" \
+    devmand-built $@
+  EXIT_CODE=$?
+}
+
+# This is useful if you want to test in gdb.
+# run_test_container gdb --args "${test_bin}" "$@"
+
+run_test_container "${memcheck}" "${test_bin}" "$@"
+if [ $EXIT_CODE -eq 0 ] ; then
+  run_test_container "${test_bin}" "$@"
+fi
 
 if [ $EXIT_CODE -ne 0 ] ; then
   echo "You have gotten a CI failure in devmand's unit tests."

--- a/devmand/gateway/docker/valgrind.supp
+++ b/devmand/gateway/docker/valgrind.supp
@@ -1,0 +1,21 @@
+{
+   lib_unwind_msync
+   Memcheck:Param
+   msync(start)
+   obj:/lib/x86_64-linux-gnu/libpthread-2.24.so
+   obj:/usr/lib/x86_64-linux-gnu/libunwind.so.8.0.1
+   ...
+}
+{
+   set_context_read
+   Memcheck:Addr8
+   fun:_Ux86_64_setcontext
+   ...
+}
+{
+   set_context_param
+   Memcheck:Param
+   rt_sigprocmask(set)
+   fun:_Ux86_64_setcontext
+   ...
+}

--- a/devmand/gateway/src/devmand/Application.cpp
+++ b/devmand/gateway/src/devmand/Application.cpp
@@ -21,6 +21,7 @@
 #include <devmand/Config.h>
 #include <devmand/ErrorHandler.h>
 #include <devmand/devices/Device.h>
+#include <devmand/utils/LifetimeTracker.h>
 
 using namespace std::chrono_literals;
 
@@ -82,6 +83,9 @@ void Application::doDebug() {
   for (auto& device : devices) {
     LOG(INFO) << "\t\t" << device.second->getId();
   }
+
+  LOG(INFO) << "\tLiving State Objects: "
+            << utils::LifetimeTracker<devices::State>::getLivingCount();
 }
 
 UnifiedView Application::getUnifiedView() {

--- a/devmand/gateway/src/devmand/channels/snmp/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/snmp/Channel.cpp
@@ -241,7 +241,9 @@ Response Channel::processVars(netsnmp_variable_list* vars) {
       case ASN_BOOLEAN:
         return Response(oid, static_cast<bool>(*vars->val.integer));
       case ASN_OBJECT_ID:
-        return Response(oid, Oid(vars->val.objid, vars->val_len).toString());
+        return Response(
+            oid,
+            Oid(vars->val.objid, vars->val_len / sizeof(::oid)).toString());
       case ASN_BIT_STR:
       case ASN_NULL:
       default:

--- a/devmand/gateway/src/devmand/channels/snmp/Oid.h
+++ b/devmand/gateway/src/devmand/channels/snmp/Oid.h
@@ -36,6 +36,11 @@ class Oid final {
   size_t getLength() const;
   std::string toString() const;
 
+  friend bool operator==(const Oid& lhs, const Oid& rhs) {
+    return snmp_oid_compare(lhs.buffer, lhs.length, rhs.buffer, lhs.length) ==
+        0;
+  }
+
   friend bool operator<(const Oid& lhs, const Oid& rhs) {
     return snmp_oid_compare(lhs.buffer, lhs.length, rhs.buffer, lhs.length) ==
         -1;

--- a/devmand/gateway/src/devmand/channels/snmp/Response.h
+++ b/devmand/gateway/src/devmand/channels/snmp/Response.h
@@ -29,6 +29,10 @@ class Response {
 
   bool isError() const;
 
+  friend bool operator==(const Response& lhs, const Response& rhs) {
+    return lhs.oid == rhs.oid and lhs.value == lhs.value;
+  }
+
  public:
   Oid oid;
   folly::dynamic value;

--- a/devmand/gateway/src/devmand/devices/CambiumDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/CambiumDevice.cpp
@@ -223,7 +223,7 @@ std::shared_ptr<State> CambiumDevice::getState() {
   folly::dynamic returnedData = channel.getDeviceInfo(clientMac);
 
   if (returnedData.isNull()) {
-    auto state = State::make(app, *this);
+    auto state = State::make(app, getId());
     state->update() = data;
     return state;
   }
@@ -266,7 +266,7 @@ std::shared_ptr<State> CambiumDevice::getState() {
            ["addresses"]["address"][0]["ip"] =
                parsed["data"][0]["config"]["variables"]["VLAN_1_IP"];
 
-  auto state = State::make(app, *this);
+  auto state = State::make(app, getId());
   state->update() = data;
   return state;
 }

--- a/devmand/gateway/src/devmand/devices/DcsgDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/DcsgDevice.cpp
@@ -47,7 +47,7 @@ DeviceConfigType DcsgDevice::getDeviceConfigType() const {
 }
 
 std::shared_ptr<State> DcsgDevice::getState() {
-  return State::make(app, *this);
+  return State::make(app, getId());
 }
 
 void DcsgDevice::setConfig(const folly::dynamic&) {

--- a/devmand/gateway/src/devmand/devices/DemoDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/DemoDevice.cpp
@@ -21,7 +21,7 @@ DemoDevice::DemoDevice(Application& application, const Id& id_)
     : Device(application, id_) {}
 
 std::shared_ptr<State> DemoDevice::getState() {
-  auto state = State::make(app, *this);
+  auto state = State::make(*reinterpret_cast<MetricSink*>(&app), getId());
   state->update() = std::move(DemoDevice::getDemoState());
   return state;
 }

--- a/devmand/gateway/src/devmand/devices/Device.h
+++ b/devmand/gateway/src/devmand/devices/Device.h
@@ -18,6 +18,7 @@
 #include <devmand/UnifiedView.h>
 #include <devmand/YangUtils.h>
 #include <devmand/cartography/DeviceConfig.h>
+#include <devmand/devices/Id.h>
 #include <devmand/devices/State.h>
 
 namespace devmand {
@@ -25,8 +26,6 @@ namespace devmand {
 class Application;
 
 namespace devices {
-
-using Id = std::string;
 
 enum class DeviceConfigType { YangJson, NativeConfigJson };
 

--- a/devmand/gateway/src/devmand/devices/EchoDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/EchoDevice.cpp
@@ -24,7 +24,7 @@ void EchoDevice::setConfig(const folly::dynamic& config) {
 }
 
 std::shared_ptr<State> EchoDevice::getState() {
-  auto stateCopy = State::make(app, *this);
+  auto stateCopy = State::make(*reinterpret_cast<MetricSink*>(&app), getId());
   stateCopy->update() = state;
   return stateCopy;
 }

--- a/devmand/gateway/src/devmand/devices/FrinxDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/FrinxDevice.cpp
@@ -169,7 +169,7 @@ void FrinxDevice::setConfig(const folly::dynamic& config) {
 }
 
 std::shared_ptr<State> FrinxDevice::getState() {
-  auto state = State::make(app, *this);
+  auto state = State::make(app, getId());
   if (not connected) {
     return state;
   }

--- a/devmand/gateway/src/devmand/devices/Id.h
+++ b/devmand/gateway/src/devmand/devices/Id.h
@@ -1,0 +1,18 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <string>
+
+namespace devmand {
+namespace devices {
+
+using Id = std::string;
+
+} // namespace devices
+} // namespace devmand

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -33,7 +33,7 @@ PingDevice::PingDevice(
     : Device(application, id_), channel(application.getPingEngine(), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
-  auto state = State::make(app, *this);
+  auto state = State::make(app, getId());
   state->setStatus(false);
   devmand::models::device::Model::init(state->update());
 

--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
@@ -105,6 +105,7 @@ std::shared_ptr<State> Snmpv2Device::getState() {
       IfMib::getSystemName(snmpChannel).thenValue([&system](auto v) {
         system["hostname"] = v;
       }));
+
   state->addRequest(
       IfMib::getSystemContact(snmpChannel).thenValue([&system](auto v) {
         system["contact"] = v;

--- a/devmand/gateway/src/devmand/test/DevConfTest.cpp
+++ b/devmand/gateway/src/devmand/test/DevConfTest.cpp
@@ -200,8 +200,9 @@ TEST_F(DevConfTest, badExtension) {
   FileUtils::write(
       "/tmp/deviceConfig.txt", formatYaml("foo", "203.0.113.1", "Foo"));
   cartography::Cartographer cartographer{add, del};
-  cartographer.addDeviceDiscoveryMethod(
-      std::make_shared<magma::DevConf>(eventBase, yamlDeviceConfig));
+  EXPECT_THROW(cartographer.addDeviceDiscoveryMethod(
+      std::make_shared<magma::DevConf>(eventBase, "/tmp/deviceConfig.txt")),
+      std::runtime_error);
   stop();
 }
 

--- a/devmand/gateway/src/devmand/test/ErrorQueueTest.cpp
+++ b/devmand/gateway/src/devmand/test/ErrorQueueTest.cpp
@@ -5,8 +5,8 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
-#include <devmand/test/EventBaseTest.h>
 #include <devmand/ErrorQueue.h>
+#include <devmand/test/EventBaseTest.h>
 #include <folly/json.h>
 #include <future>
 

--- a/devmand/gateway/src/devmand/test/SnmpChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/SnmpChannelTest.cpp
@@ -1,0 +1,44 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/snmp/Channel.h>
+#include <devmand/channels/snmp/Engine.h>
+#include <devmand/test/EventBaseTest.h>
+#include <devmand/test/TestUtils.h>
+
+#include <folly/IPAddress.h>
+
+namespace devmand {
+namespace test {
+
+class SnmpChannelTest : public EventBaseTest {
+ public:
+  SnmpChannelTest() = default;
+  ~SnmpChannelTest() override = default;
+  SnmpChannelTest(const SnmpChannelTest&) = delete;
+  SnmpChannelTest& operator=(const SnmpChannelTest&) = delete;
+  SnmpChannelTest(SnmpChannelTest&&) = delete;
+  SnmpChannelTest& operator=(SnmpChannelTest&&) = delete;
+
+ protected:
+  std::string local{"127.0.0.1"};
+  std::string community{"public"};
+  std::string version{"v1"};
+};
+
+TEST_F(SnmpChannelTest, checkSnmpTimeout) {
+  channels::snmp::Engine engine(eventBase, "checkSnmpTimeout");
+  auto channel = std::make_shared<channels::snmp::Channel>(
+      engine, local, community, version);
+  EXPECT_THROW(
+      channel->asyncGet(channels::snmp::Oid("iso.3.6.1.2.1.1.4.0")).get(),
+      std::runtime_error);
+  stop();
+}
+
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/SnmpChannelTest.cpp
+++ b/devmand/gateway/src/devmand/test/SnmpChannelTest.cpp
@@ -5,17 +5,23 @@
 // LICENSE file in the root directory of this source tree. An additional grant
 // of patent rights can be found in the PATENTS file in the same directory.
 
+#include <folly/IPAddress.h>
+#include <folly/Subprocess.h>
+
+#include <devmand/MetricSink.h>
 #include <devmand/channels/snmp/Channel.h>
 #include <devmand/channels/snmp/Engine.h>
+#include <devmand/channels/snmp/IfMib.h>
+#include <devmand/devices/Device.h>
+#include <devmand/devices/State.h>
+#include <devmand/models/interface/Model.h>
 #include <devmand/test/EventBaseTest.h>
 #include <devmand/test/TestUtils.h>
-
-#include <folly/IPAddress.h>
 
 namespace devmand {
 namespace test {
 
-class SnmpChannelTest : public EventBaseTest {
+class SnmpChannelTest : public EventBaseTest, public MetricSink {
  public:
   SnmpChannelTest() = default;
   ~SnmpChannelTest() override = default;
@@ -25,6 +31,13 @@ class SnmpChannelTest : public EventBaseTest {
   SnmpChannelTest& operator=(SnmpChannelTest&&) = delete;
 
  protected:
+  // TODO these should be gmocked out.
+  virtual void
+  setGauge(const std::string&, double, const std::string&, const std::string&) {
+  }
+  virtual void setGauge(const std::string&, double) {}
+
+ protected:
   std::string local{"127.0.0.1"};
   std::string community{"public"};
   std::string version{"v1"};
@@ -32,12 +45,70 @@ class SnmpChannelTest : public EventBaseTest {
 
 TEST_F(SnmpChannelTest, checkSnmpTimeout) {
   channels::snmp::Engine engine(eventBase, "checkSnmpTimeout");
+  channels::snmp::Oid oid{".1.3.6.1.2.1.1.4.0"};
   auto channel = std::make_shared<channels::snmp::Channel>(
       engine, local, community, version);
-  EXPECT_THROW(
-      channel->asyncGet(channels::snmp::Oid("iso.3.6.1.2.1.1.4.0")).get(),
-      std::runtime_error);
+  EXPECT_THROW(channel->asyncGet(oid).get(), std::runtime_error);
   stop();
+}
+
+TEST_F(SnmpChannelTest, checkSnmp) {
+  folly::Subprocess snmpd(std::vector<std::string>{"/usr/sbin/snmpd", "-f"});
+  channels::snmp::Engine engine(eventBase, "checkSnmpTimeout");
+  channels::snmp::Oid oid{".1.3.6.1.2.1.1.4.0"};
+  auto channel = std::make_shared<channels::snmp::Channel>(
+      engine, local, community, version);
+  EXPECT_EQ(
+      devmand::channels::snmp::Response(oid, folly::dynamic{""}),
+      channel->asyncGet(oid).get());
+  stop();
+  snmpd.kill();
+  snmpd.wait();
+}
+
+TEST_F(SnmpChannelTest, checkSnmpWithState) {
+  folly::Subprocess snmpd(std::vector<std::string>{"/usr/sbin/snmpd", "-f"});
+  channels::snmp::Engine engine(eventBase, "checkSnmpTimeout");
+  channels::snmp::Oid oid{".1.3.6.1.2.1.1.4.0"};
+  auto channel = std::make_shared<channels::snmp::Channel>(
+      engine, local, community, version);
+
+  auto state = devices::State::make(*this, "testdid");
+  state->setStatus(false);
+  devmand::models::interface::Model::init(state->update());
+
+  for (int i = 0; i < 10; ++i) {
+    state->addRequest(
+        channel->walk(channels::snmp::Oid{".1"}).thenValue([](auto) {}));
+  }
+  state->collect().wait();
+  state = nullptr;
+
+  EXPECT_EQ(0, utils::LifetimeTracker<devices::State>::getLivingCount());
+
+  stop();
+  snmpd.kill();
+  snmpd.wait();
+}
+
+TEST_F(SnmpChannelTest, checkSnmpTimeoutWithState) {
+  channels::snmp::Engine engine(eventBase, "checkSnmpTimeout");
+  channels::snmp::Oid oid{".1.3.6.1.2.1.1.4.0"};
+  auto channel = std::make_shared<channels::snmp::Channel>(
+      engine, local, community, version);
+
+  auto state = devices::State::make(*this, "testdid");
+  state->setStatus(false);
+  devmand::models::interface::Model::init(state->update());
+
+  for (int i = 0; i < 10; ++i) {
+    state->addRequest(
+        channel->walk(channels::snmp::Oid{".1"}).thenValue([](auto) {}));
+  }
+  state->collect().wait();
+  state = nullptr;
+
+  EXPECT_EQ(0, utils::LifetimeTracker<devices::State>::getLivingCount());
 }
 
 } // namespace test

--- a/devmand/gateway/src/devmand/utils/LifetimeTracker.h
+++ b/devmand/gateway/src/devmand/utils/LifetimeTracker.h
@@ -1,0 +1,54 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+namespace devmand {
+namespace utils {
+
+template <class T>
+class LifetimeTracker {
+ public:
+  LifetimeTracker() {
+    ++allocations;
+  }
+
+  virtual ~LifetimeTracker() {
+    ++deallocations;
+  }
+
+  LifetimeTracker(const LifetimeTracker&) = default;
+  LifetimeTracker& operator=(const LifetimeTracker&) = default;
+  LifetimeTracker(LifetimeTracker&&) = delete;
+  LifetimeTracker& operator=(LifetimeTracker&&) = default;
+
+  static unsigned int getAllocations() {
+    return allocations;
+  }
+
+  static unsigned int getDeallocations() {
+    return deallocations;
+  }
+
+  static unsigned int getLivingCount() {
+    assert(allocatons > dealloactions);
+
+    return allocations - deallocations;
+  }
+
+ private:
+  static unsigned int allocations;
+  static unsigned int deallocations;
+};
+
+template <class T>
+unsigned int LifetimeTracker<T>::allocations;
+template <class T>
+unsigned int LifetimeTracker<T>::deallocations;
+
+} // namespace utils
+} // namespace devmand


### PR DESCRIPTION
Summary:
This commit fixes a bug in the state object where final callbacks are
not cleared on collect causing a loop.

Reviewed By: al8

Differential Revision: D17972783

