### PR TITLE
Add GetBootstrapGrpcChannel to ServiceRegistrySingleton

### DIFF
--- a/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
+++ b/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
@@ -160,4 +160,20 @@ const std::shared_ptr<Channel> ServiceRegistrySingleton::CreateGrpcChannel(
 
   return CreateCustomChannel(ss.str(), creds, arg);
 }
+
+const std::shared_ptr<Channel>
+ServiceRegistrySingleton::GetBootstrapperGrpcChannel() {
+  YAML::Node proxyConfig = *(this->proxy_config_);
+  auto ip = proxyConfig["bootstrap_address"].as<std::string>();
+  auto port = proxyConfig["bootstrap_port"].as<std::string>();
+  auto authority = ip;
+
+  SslCredentialsOptions options;
+  options.pem_root_certs = LoadCertFile(
+      proxyConfig["rootca_cert"].as<std::string>());
+  auto sslCreds = SslCredentials(options);
+
+  return CreateGrpcChannel(ip, port, authority, sslCreds);
+}
+
 }

--- a/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.h
+++ b/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.h
@@ -88,6 +88,11 @@ class ServiceRegistrySingleton {
       const std::string& service,
       const std::string& destination);
 
+    /*
+     * Returns a grpc connection to the bootstrapper service
+     */
+    const std::shared_ptr<Channel> GetBootstrapperGrpcChannel();
+
   private:
     ServiceRegistrySingleton(); // Prevent construction
     // Prevent construction by copying


### PR DESCRIPTION
Summary: Adds a function to create a gRPC channel to the bootstrap service

Reviewed By: xjtian

Differential Revision: D17954702

