### PR TITLE
Add APN (AP MAC address & Name) to auth and session metrics on radius

### DIFF
--- a/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/sm/client.go
+++ b/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/sm/client.go
@@ -325,7 +325,7 @@ func getLocalAddresses(c diam.Conn) ([]datatype.Address, error) {
 	}
 	addr, _, err := net.SplitHostPort(addrStr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse local ip %q: %s", c.LocalAddr(), err)
+		return nil, fmt.Errorf("failed to parse local ip %s [%q]: %s", addrStr, c.LocalAddr(), err)
 	}
 	hostIPs := strings.Split(addr, "/")
 	addresses := make([]datatype.Address, 0, len(hostIPs))

--- a/feg/radius/src/filters/lbcanary/lb_canary.go
+++ b/feg/radius/src/filters/lbcanary/lb_canary.go
@@ -11,8 +11,8 @@ package lbcanary
 import (
 	"errors"
 	"fbc/cwf/radius/config"
-	"fbc/cwf/radius/monitoring"
 	"fbc/cwf/radius/modules"
+	"fbc/cwf/radius/monitoring"
 	"fbc/cwf/radius/session"
 	"fbc/lib/go/radius"
 	"math/rand"

--- a/feg/radius/src/monitoring/init.go
+++ b/feg/radius/src/monitoring/init.go
@@ -5,7 +5,7 @@ import (
 	"fbc/cwf/radius/monitoring/census"
 	"fbc/cwf/radius/monitoring/ods"
 	"fbc/cwf/radius/monitoring/scuba"
-	
+
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 )

--- a/feg/radius/src/session/storage.go
+++ b/feg/radius/src/session/storage.go
@@ -22,6 +22,7 @@ type (
 		Tier              string
 		RadiusSessionFBID uint64 // the FBID of the XWFEntRadiusSession created for this RADIUS session
 		AcctSessionID     string
+		CalledStationID   string
 	}
 
 	// GlobalStorage an interface for session-level storage, which allows


### PR DESCRIPTION
Summary:
Add APN (AP MAC address & Name) to auth and session metrics on radius
to be passes to AAA Server

Differential Revision: D18023833

