### PR TITLE
Fix LTE access control default rule forwarding

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/access_control.py
+++ b/lte/gateway/python/magma/pipelined/app/access_control.py
@@ -101,7 +101,7 @@ class AccessControlController(MagmaController):
         else:
             # TODO add LTE WLAN peers
             flows.add_resubmit_next_service_flow(
-                datapath, self.tbl_num, MagmaMatch(), [],
+                datapath, self._tunnel_acl_scratch, MagmaMatch(), [],
                 priority=flows.MINIMUM_PRIORITY, resubmit_table=self.next_table)
 
     def _install_gre_allow_flows(self, datapath):

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTest.test_inbound_ip_match.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTest.test_inbound_ip_match.snapshot
@@ -2,4 +2,6 @@
  cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=10,ip,reg1=0x1,nw_dst=127.2.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x10,nw_src=127.1.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x10,nw_src=127.2.0.1 actions=drop
- cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=resubmit(,access_control(scratch_table_0)),set_field:0->reg0
+ cookie=0x0, table=access_control(scratch_table_0), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,egress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTest.test_no_match.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTest.test_no_match.snapshot
@@ -2,4 +2,6 @@
  cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=10,ip,reg1=0x1,nw_dst=127.2.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x10,nw_src=127.1.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=0, n_bytes=0, priority=10,ip,reg1=0x10,nw_src=127.2.0.1 actions=drop
- cookie=0x0, table=access_control(main_table), n_packets=2, n_bytes=68, priority=0 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=0,reg1=0x10 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=0,reg1=0x1 actions=resubmit(,access_control(scratch_table_0)),set_field:0->reg0
+ cookie=0x0, table=access_control(scratch_table_0), n_packets=1, n_bytes=34, priority=0 actions=resubmit(,egress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTest.test_outbound_ip_match.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_access_control.AccessControlTest.test_outbound_ip_match.snapshot
@@ -2,4 +2,6 @@
  cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=10,ip,reg1=0x1,nw_dst=127.2.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=10,ip,reg1=0x10,nw_src=127.1.0.1 actions=drop
  cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=10,ip,reg1=0x10,nw_src=127.2.0.1 actions=drop
- cookie=0x0, table=access_control(main_table), n_packets=2, n_bytes=68, priority=0 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=0,reg1=0x10 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=access_control(main_table), n_packets=1, n_bytes=34, priority=0,reg1=0x1 actions=resubmit(,access_control(scratch_table_0)),set_field:0->reg0
+ cookie=0x0, table=access_control(scratch_table_0), n_packets=1, n_bytes=34, priority=0 actions=resubmit(,egress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/test_access_control.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_access_control.py
@@ -11,6 +11,7 @@ import unittest
 import warnings
 from concurrent.futures import Future
 
+from lte.protos.mconfig.mconfigs_pb2 import PipelineD
 from magma.pipelined.app.access_control import \
     AccessControlController
 from magma.pipelined.openflow.magma_match import MagmaMatch
@@ -67,6 +68,7 @@ class AccessControlTest(unittest.TestCase):
                     testing_controller_reference
             },
             config={
+                'setup_type': 'LTE',
                 'bridge_name': cls.BRIDGE,
                 'bridge_ip_address': cls.BRIDGE_IP,
                 'nat_iface': 'eth2',
@@ -88,7 +90,9 @@ class AccessControlTest(unittest.TestCase):
                     ]
                 }
             },
-            mconfig=None,
+            mconfig=PipelineD(
+                allowed_gre_peers=[],
+            ),
             loop=None,
             service_manager=cls.service_manager,
             integ_test=False,


### PR DESCRIPTION
Summary: The rule was accidentally added to the access control table, it should instead be added to the scratch

Differential Revision: D18047177

