### PR TITLE
fix the service stop setting for ovs_deploy to A-GW

### DIFF
--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -87,7 +87,9 @@
 
 - name: Stop all magma services.
   become: yes
-  shell: service magmad@* stop
+  service:
+    name: magma@*
+    state: stopped
 
 - name: Bring up gtp_br0
   shell: ifup gtp_br0


### PR DESCRIPTION
Summary:
The following warning occurs when using shell in ansible.
・[WARNING]: Consider using the service module rather than running service.

Therefore, I fixed the code to use the service module.