### PR TITLE
fix parameter of upgrade in ansible-playbook for ovs-prepare

### DIFF
--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -50,7 +50,7 @@
   become: yes
   apt:
     update_cache: yes
-    upgrade: yes
+    upgrade: "yes"
 
 - name: Install build dependencies.
   become: yes


### PR DESCRIPTION
Summary:
The following warning occurs when building openvswitch on access gateway by ansible-playbook.
```
TASK [ovs_prepare : Update and upgrade apt packages] ***************************
[WARNING]: The value True (type bool) in a string field was converted to u'True' (type string). 
ok: [10.0.2.1]
```
This warning is due to a type mismatch of apt-upgrade.
[In the documentation](https://docs.ansible.com/ansible/latest/modules/apt_module.html), upgrade parameter is not a boolean, but a string ("dist", "full", "no", "safe", "yes")

This PR changed the parameter of upgrade to a string.