### PR TITLE
Obsidian access control for REST V1

### DIFF
--- a/orc8r/cloud/go/obsidian/access/identity_finder.go
+++ b/orc8r/cloud/go/obsidian/access/identity_finder.go
@@ -9,18 +9,10 @@ LICENSE file in the root directory of this source tree.
 package access
 
 import (
-	"strings"
-
 	"magma/orc8r/cloud/go/identity"
-	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/protos"
 
 	"github.com/labstack/echo"
-)
-
-const (
-	MAGMA_ROOT_PART     = obsidian.RestRoot + obsidian.UrlSep
-	MAGMA_ROOT_PART_LEN = len(MAGMA_ROOT_PART)
 )
 
 // FindRequestedIdentities examines the request URL and finds Identities of
@@ -32,25 +24,9 @@ const (
 // which would correspond to an ACL typical for a supervisor/admin "can do all"
 // operators
 func FindRequestedIdentities(c echo.Context) []*protos.Identity {
-	if c != nil {
-		path := c.Path()
-		if strings.HasPrefix(path, MAGMA_ROOT_PART) {
-			parts := strings.Split(path[MAGMA_ROOT_PART_LEN:], obsidian.UrlSep)
-			if len(parts) > 0 {
-				p := parts[0]
-				registry, ok := finderRegistries[p]
-				if ok && len(parts) > 1 {
-					p = parts[1]
-				} else {
-					// fall back to "versionless" V0
-					registry, ok = finderRegistries[obsidian.V0]
-				}
-				fr, ok := registry[p]
-				if ok {
-					return fr.finder(c)
-				}
-			}
-		}
+	finder := GetIdentityFinder(c)
+	if finder != nil {
+		return finder(c)
 	}
 	return SupervisorWildcards()
 }

--- a/orc8r/cloud/go/obsidian/access/tests/identity_finder_test.go
+++ b/orc8r/cloud/go/obsidian/access/tests/identity_finder_test.go
@@ -20,6 +20,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const RegisterLteNetworkV1 = "/magma/v1/lte"
+const ManageLteNetworkV1 = RegisterLteNetworkV1 + "/:network_id"
+const RegisterNetworkV1 = "/magma/v1/networks"
+const ManageNetworkV1 = RegisterNetworkV1 + "/:network_id"
+
 func TestIdentityFinder(t *testing.T) {
 	e := startTestIdentityServer(t)
 	listener := WaitForTestServer(t, e)
@@ -29,6 +34,10 @@ func TestIdentityFinder(t *testing.T) {
 
 		// Test a network entity
 		testGet(t, urlPrefix+magmadh.RegisterNetwork+"/"+TEST_NETWORK_ID)
+		// Test V1 network entity
+		testGet(t, urlPrefix+RegisterNetworkV1+"/"+TEST_NETWORK_ID)
+		// Test V1 LTE network entity
+		testGet(t, urlPrefix+RegisterLteNetworkV1+"/"+TEST_NETWORK_ID)
 		// Test network wildcard
 		testGet(t, urlPrefix+magmadh.RegisterNetwork)
 		// Test operator entity
@@ -81,6 +90,28 @@ func startTestIdentityServer(t *testing.T) *echo.Echo {
 
 	// Endpoint requiring a specific Network Entity Access Permissions
 	e.GET(magmadh.ManageNetwork, func(c echo.Context) error {
+		assert.NotNil(t, c)
+		ents := access.FindRequestedIdentities(c)
+		assert.Len(t, ents, 1)
+		networkIdentity, ok := ents[0].Value.(*protos.Identity_Network)
+		assert.True(t, ok)
+		assert.Equal(t, networkIdentity.Network, TEST_NETWORK_ID)
+		return c.String(http.StatusOK, "All good!")
+	})
+
+	// V1 Endpoint requiring a specific Network Entity Access Permissions
+	e.GET(ManageNetworkV1, func(c echo.Context) error {
+		assert.NotNil(t, c)
+		ents := access.FindRequestedIdentities(c)
+		assert.Len(t, ents, 1)
+		networkIdentity, ok := ents[0].Value.(*protos.Identity_Network)
+		assert.True(t, ok)
+		assert.Equal(t, networkIdentity.Network, TEST_NETWORK_ID)
+		return c.String(http.StatusOK, "All good!")
+	})
+
+	// V1 LTE Endpoint requiring a specific Network Entity Access Permissions
+	e.GET(ManageLteNetworkV1, func(c echo.Context) error {
 		assert.NotNil(t, c)
 		ents := access.FindRequestedIdentities(c)
 		assert.Len(t, ents, 1)


### PR DESCRIPTION
Summary:
Fix for Obsidian access control /magma/vX/lte|cwf|etc./<network ID>/... URLs
NOTE: the added default Identity finder will interpret any valid magma URL with specified network_id as the network level access
therefore, it should only be used if none of fixed route finders match. Othervice, a handler for URL with path: /magma/v123/operators/<Operator ID, I shouldn't have access to>/.../<network ID that I have access to>/...
may potentially break the intended protection for the given <Operator ID>

Differential Revision: D18108109

