### PR TITLE
Add DNSD large interface netmask error

### DIFF
--- a/orc8r/gateway/python/scripts/generate_dnsd_config.py
+++ b/orc8r/gateway/python/scripts/generate_dnsd_config.py
@@ -56,6 +56,12 @@ def get_context():
         logging.warning("Error! Using default config because: %s", err)
         mconfig = DnsD()
     ip = get_ip_from_if_cidr(cfg['enodeb_interface'])
+    if int(ip.split('/')[1]) < 16:
+        logging.fatal("Large interface netmasks hang dnsmasq, consider using a "
+                      "netmask in range /16 - /24")
+        raise Exception("Interface %s netmask is to large."
+                        % cfg['enodeb_interface'])
+
     dhcp_block_size = cfg['dhcp_block_size']
     available_hosts = list(ipaddress.IPv4Interface(ip).network.hosts())
 


### PR DESCRIPTION
Summary: Fixes the case where dnsd hangs if the interface netmask is too large.

Differential Revision: D18121112

