### PR TITLE
Add tunnel controller to learn ue to tunnel mapping

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -30,6 +30,7 @@ static_services: [
   'ue_mac',
   'arpd',
   'access_control',
+  'tunnel_learn',
   'ryu_rest_service',
 #  'packet_tracer',
 ]

--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -37,7 +37,6 @@ services:
     environment:
       USE_REMOTE_SWX_PROXY: 0
 
-  # TODO: Remove this override once GRE tun_dst logic is added to pipelined
   pipelined:
     privileged: true
     volumes:
@@ -53,7 +52,7 @@ services:
     command: >
       sh -c "/usr/bin/ovs-vsctl --if-exists del-port cwag_br0 gre0 &&
         /usr/bin/ovs-vsctl --if-exists del-port cwag_br0 eth2 &&
-        /usr/bin/ovs-vsctl --may-exist add-port cwag_br0 gre0 -- set interface gre0 ofport_request=32768 type=gre options:remote_ip=192.168.70.102 options:key=5001 &&
+        /usr/bin/ovs-vsctl --may-exist add-port cwag_br0 gre0 -- set interface gre0 ofport_request=32768 type=gre options:remote_ip=flow options:key=flow &&
         /usr/bin/ovs-vsctl set-controller cwag_br0 tcp:127.0.0.1:6633 &&
         python3 -m magma.pipelined.main"
 

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -30,6 +30,7 @@ static_services: [
   'ue_mac',
   'arpd',
   'access_control',
+  'tunnel_learn',
   'ryu_rest_service',
 ]
 

--- a/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
+++ b/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
@@ -1,0 +1,113 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from .base import MagmaController
+from magma.pipelined.openflow import flows
+from magma.pipelined.openflow.magma_match import MagmaMatch
+from magma.pipelined.openflow.registers import Direction, DIRECTION_REG
+
+
+class TunnelLearnController(MagmaController):
+    """
+    A controller that sets up tunnel/ue learn flows based on uplink UE traffic
+    to properly route downlink packets back to the UE (through the correct GRE
+    flow tunnel).
+
+    This is an optional controller and will only be used for setups with flow
+    based GRE tunnels.
+    """
+
+    APP_NAME = "tunnel_learn"
+
+    def __init__(self, *args, **kwargs):
+        super(TunnelLearnController, self).__init__(*args, **kwargs)
+        self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
+        self.next_table = self._service_manager.get_next_table_num(
+            self.APP_NAME)
+        self.tunnel_learn_scratch = \
+            self._service_manager.allocate_scratch_tables(self.APP_NAME, 1)[0]
+        self._datapath = None
+
+    def initialize_on_connect(self, datapath):
+        self._datapath = datapath
+        self._install_default_tunnel_classify_flows(self._datapath)
+
+    def _install_default_tunnel_classify_flows(self, dp):
+        """
+        For direction OUT:
+            add flow with learn action(which will add a rule matching on UE
+            mac_addr in a scratch table, that will load the necessary
+            gre infomration for the incoming(direction IN) flow)
+        For direction IN:
+            Will get forwarded to the scratch table and matched on the flow
+                from the learn action
+            Finally will get forwarded to the next table
+        """
+        parser = dp.ofproto_parser
+
+        # Add a learn action that will match on UE mac, and:
+        #   load gre tun_id, swap and load gre tun src and gre tun dst mac
+        # Example learned flow:
+        #   reg1=0x10,dl_dst=aa:29:3e:95:64:40
+        #   actions=load:0x1389->NXM_NX_TUN_ID[0..31],
+        #           load:0xc0a84666->NXM_NX_TUN_IPV4_DST[],
+        #           load:0xc0a84665->NXM_NX_TUN_IPV4_SRC[]
+        #
+        outbound_match = MagmaMatch(direction=Direction.OUT)
+        actions = [
+            parser.NXActionLearn(
+                table_id=self.tunnel_learn_scratch,
+                priority=flows.DEFAULT_PRIORITY,
+                specs=[
+                    parser.NXFlowSpecMatch(
+                        src=('eth_src_nxm', 0),
+                        dst=('eth_dst_nxm', 0),
+                        n_bits=48
+                    ),
+                    parser.NXFlowSpecMatch(
+                        src=Direction.IN,
+                        dst=(DIRECTION_REG, 0),
+                        n_bits=32
+                    ),
+                    parser.NXFlowSpecLoad(
+                        src=('tunnel_id_nxm', 0),
+                        dst=('tunnel_id_nxm', 0),
+                        n_bits=32
+                    ),
+                    parser.NXFlowSpecLoad(
+                        src=('tun_ipv4_src', 0),
+                        dst=('tun_ipv4_dst', 0),
+                        n_bits=32
+                    ),
+                    # TODO This might be getting overwritten by the IP stack,
+                    # check if its required
+                    parser.NXFlowSpecLoad(
+                        src=('tun_ipv4_dst', 0),
+                        dst=('tun_ipv4_src', 0),
+                        n_bits=32
+                    ),
+                ]
+            )
+        ]
+        flows.add_resubmit_next_service_flow(dp, self.tbl_num,
+                                             outbound_match, actions,
+                                             priority=flows.MINIMUM_PRIORITY,
+                                             resubmit_table=self.next_table)
+
+        # The inbound match will first send packets to the scratch table,
+        # where global registers will be set and the packet will be dropped
+        # Then the final action will send packet down the pipelined(with the
+        # necessary tunnel information loaded from the scratch table)
+        inbound_match = MagmaMatch(direction=Direction.IN)
+        actions = [
+            parser.NXActionResubmitTable(table_id=self.tunnel_learn_scratch)]
+        flows.add_resubmit_next_service_flow(dp, self.tbl_num,
+                                             inbound_match, actions,
+                                             priority=flows.MINIMUM_PRIORITY,
+                                             resubmit_table=self.next_table)

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -319,8 +319,6 @@ def get_add_resubmit_next_service_flow_msg(datapath, table, match,
     """
     ofproto, parser = datapath.ofproto, datapath.ofproto_parser
 
-    _check_resubmit_action(actions, parser)
-
     if actions is None:
         actions = []
     actions = actions + [

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -40,6 +40,7 @@ from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub
 from magma.pipelined.app import of_rest_server
 from magma.pipelined.app.access_control import AccessControlController
+from magma.pipelined.app.tunnel_learn import TunnelLearnController
 from magma.pipelined.app.arp import ArpController
 from magma.pipelined.app.dpi import DPIController
 from magma.pipelined.app.enforcement import EnforcementController
@@ -194,6 +195,7 @@ class ServiceManager:
     UE_MAC_ADDRESS_SERVICE_NAME = 'ue_mac'
     ARP_SERVICE_NAME = 'arpd'
     ACCESS_CONTROL_SERVICE_NAME = 'access_control'
+    TUNNEL_LEARN_SERVICE_NAME = 'tunnel_learn'
     RYU_REST_SERVICE_NAME = 'ryu_rest_service'
 
     # Mapping between services defined in mconfig and the names and modules of
@@ -233,6 +235,10 @@ class ServiceManager:
         ACCESS_CONTROL_SERVICE_NAME: [
             App(name=AccessControlController.APP_NAME,
                 module=AccessControlController.__module__),
+        ],
+        TUNNEL_LEARN_SERVICE_NAME: [
+            App(name=TunnelLearnController.APP_NAME,
+                module=TunnelLearnController.__module__),
         ],
         RYU_REST_SERVICE_NAME: [
             App(name='ryu_rest_app', module='ryu.app.ofctl_rest'),


### PR DESCRIPTION
Summary: Sets up the ue mac to tunnel id learn for flow based gre tunnels. This is done by using a new Tunnel controller in pipelined. The uplink flows will trigger a learn action that will match dlink packets and set the appropriate tunnel values.

Differential Revision: D18067098

