### PR TITLE
Update state replication service to use RedisFlatDict

### DIFF
--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -7,6 +7,8 @@
 ## LICENSE file in the root directory of this source tree. An additional grant
 ## of patent rights can be found in the PATENTS file in the same directory.
 
+log_level: INFO
+
 #state_protos:
 #  - proto_file:  - file to load proto from
 #    proto_msg:   - msg to load from proto file

--- a/lte/gateway/python/magma/policydb/rule_store.py
+++ b/lte/gateway/python/magma/policydb/rule_store.py
@@ -10,14 +10,14 @@ of patent rights can be found in the PATENTS file in the same directory.
 from lte.protos.policydb_pb2 import PolicyRule
 
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 
 
-class PolicyRuleDict(RedisDict):
+class PolicyRuleDict(RedisHashDict):
     """
-    PolicyRuleDict uses the RedisDict collection to store a mapping of policy
+    PolicyRuleDict uses the RedisHashDict collection to store a mapping of policy
     rule ids to PolicyRules. Setting and deleting items in the dictionary syncs
     with Redis automatically
     """

--- a/lte/gateway/python/magma/redirectd/redirect_store.py
+++ b/lte/gateway/python/magma/redirectd/redirect_store.py
@@ -10,14 +10,14 @@ of patent rights can be found in the PATENTS file in the same directory.
 from lte.protos.policydb_pb2 import RedirectInformation
 
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 
 
-class RedirectDict(RedisDict):
+class RedirectDict(RedisHashDict):
     """
-    RedirectDict uses the RedisDict collection to store a mapping of ips
+    RedirectDict uses the RedisHashDict collection to store a mapping of ips
     to RedirectInformation. Setting and deleting items in the dictionary syncs
     with Redis automatically
     """

--- a/orc8r/gateway/configs/state.yml
+++ b/orc8r/gateway/configs/state.yml
@@ -7,6 +7,8 @@
 ## LICENSE file in the root directory of this source tree. An additional grant
 ## of patent rights can be found in the PATENTS file in the same directory.
 
+log_level: INFO
+
 #state_protos:
 #  - proto_file:  - file to load proto from
 #    proto_msg:   - msg to load from proto file

--- a/orc8r/gateway/python/magma/common/redis/containers.py
+++ b/orc8r/gateway/python/magma/common/redis/containers.py
@@ -210,7 +210,10 @@ class RedisFlatDict(collections_abc.MutableMapping):
     def __iter__(self):
         """Return an iterator over the keys of the dictionary."""
         for k in self.redis.keys():
-            yield k.decode('utf-8')
+            try:
+                yield k.decode('utf-8')
+            except AttributeError:
+                yield k
 
     def __contains__(self, key):
         """Return ``True`` if *key* is present, else ``False``."""

--- a/orc8r/gateway/python/magma/common/redis/containers.py
+++ b/orc8r/gateway/python/magma/common/redis/containers.py
@@ -6,10 +6,13 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
-
+import collections.abc as collections_abc
 from copy import deepcopy
+import redis
 import redis_collections
+from typing import Dict
 
+from magma.common.redis.serializers import RedisSerde
 from orc8r.protos.redis_pb2 import RedisState
 
 # NOTE: these containers replace the serialization methods exposed by
@@ -93,9 +96,10 @@ class RedisSet(redis_collections.Set):
         return {deepcopy(elt, memo) for elt in self}
 
 
-class RedisDict(redis_collections.DefaultDict):
+class RedisHashDict(redis_collections.DefaultDict):
     """
-    Dict-like interface serializing elements to a Redis datastore.
+    Dict-like interface serializing elements to a Redis datastore. This dict
+    utilizes Redis's hashmap functionality
 
     Notes:
         - Keys must be string-like and are serialized to plaintext (UTF-8)
@@ -139,8 +143,8 @@ class RedisDict(redis_collections.DefaultDict):
             redis_dict (redis_collections.Dict): persistent dict-like interface
         """
         # Key serialization (to/from plaintext)
-        self._pickle_key = RedisDict.serialize_key
-        self._unpickle_key = RedisDict.deserialize_key
+        self._pickle_key = RedisHashDict.serialize_key
+        self._unpickle_key = RedisHashDict.deserialize_key
         # Value serialization
         self._pickle_value = serialize
         self._unpickle = deserialize
@@ -181,3 +185,99 @@ class RedisDict(redis_collections.DefaultDict):
         proto_wrapper = RedisState()
         proto_wrapper.ParseFromString(value)
         return proto_wrapper.version
+
+
+class RedisFlatDict(collections_abc.MutableMapping):
+    """
+    Dict-like interface serializing elements to a Redis datastore. This
+    dict stores key directly (i.e. without a hashmap).
+    """
+
+    def __init__(self, client: redis.Redis, serdes: Dict[str, RedisSerde]):
+        """
+        Args:
+            client (redis.Redis): Redis client object
+            serdes (): RedisSerdes for each type of object that can be stored
+        """
+        super().__init__()
+        self.redis = client
+        self.serdes = serdes
+
+    def __len__(self):
+        """Return the number of items in the dictionary."""
+        return len(self.redis.keys())
+
+    def __iter__(self):
+        """Return an iterator over the keys of the dictionary."""
+        for k in self.redis.keys():
+            yield k.decode('utf-8')
+
+    def __contains__(self, key):
+        """Return ``True`` if *key* is present, else ``False``."""
+        return bool(self.redis.exists(key))
+
+    def __getitem__(self, key):
+        """Return the item of dictionary with key *key*. Raises a
+        :exc:`KeyError` if key is not in the map.
+        """
+        if ':' not in key:
+            raise ValueError('key must be of format <id>:<type>')
+        serde = self._get_serde(key)
+        serialized_value = self.redis.get(key)
+        if serialized_value is None:
+            raise KeyError(key)
+
+        value = serde.deserialize(serialized_value)
+        return value
+
+    def __setitem__(self, key, value):
+        """Set ``d[key]`` to *value*."""
+        if ':' not in key:
+            raise ValueError('key must be of format <id>:<type>')
+        serde = self._get_serde(key)
+        version = self._get_version(key)
+        serialized_value = serde.serialize(value, version + 1)
+
+        self.redis.set(key, serialized_value)
+
+        return self.redis.get(key)
+
+    def __delitem__(self, key):
+        """Remove ``d[key]`` from dictionary.
+        Raises a :func:`KeyError` if *key* is not in the map.
+        """
+        deleted_count = self.redis.delete(key)
+        if not deleted_count:
+            raise KeyError(key)
+
+    def clear(self):
+        for key in self.keys():
+            self.redis.delete(key)
+
+    def get_version(self, idval, typeval):
+        """Return the version of the value for key *key*. Returns 0 if
+        key is not in the map
+        """
+        flat_key = idval + ":" + typeval
+        return self._get_version(flat_key)
+
+    def _get_version(self, key):
+        value = self.redis.get(key)
+        if value is None:
+            return 0
+
+        proto_wrapper = RedisState()
+        proto_wrapper.ParseFromString(value)
+        return proto_wrapper.version
+
+    def _get_serde(self, key):
+        parsed_key = key.split(':')
+        if len(parsed_key) != 2:
+            raise ValueError("Dictionary key must be of format <id>:<type>")
+        typeval = parsed_key[1]
+
+        if typeval not in self.serdes:
+            raise ValueError("Dictionary is not configured for object type:"
+                             " %s" % typeval)
+
+        return self.serdes[typeval]

--- a/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
+++ b/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
@@ -29,8 +29,9 @@ class MockRedis(object):
 
     def delete(self, key):
         """Mock delete."""
-        if key in self.redis:
-            del self.redis[key]
+        skey = self.serialize_key(key)
+        if skey in self.redis:
+            del self.redis[skey]
             return 1
         return 0
 
@@ -40,11 +41,13 @@ class MockRedis(object):
 
     def get(self, key):
         """Mock get."""
-        return self.redis[key] if key in self.redis else None
+        skey = self.serialize_key(key)
+        return self.redis[skey] if skey in self.redis else None
 
     def set(self, key, value):
         """Mock set."""
-        self.redis[key] = value
+        skey = self.serialize_key(key)
+        self.redis[skey] = value
 
     def keys(self):
         """ Mock keys."""

--- a/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
+++ b/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
@@ -31,6 +31,8 @@ class MockRedis(object):
         """Mock delete."""
         if key in self.redis:
             del self.redis[key]
+            return 1
+        return 0
 
     def exists(self, key):
         """Mock exists."""
@@ -39,6 +41,14 @@ class MockRedis(object):
     def get(self, key):
         """Mock get."""
         return self.redis[key] if key in self.redis else None
+
+    def set(self, key, value):
+        """Mock set."""
+        self.redis[key] = value
+
+    def keys(self):
+        """ Mock keys."""
+        return list(self.redis.keys())
 
     def hget(self, hashkey, key):
         """Mock hget."""

--- a/orc8r/gateway/python/magma/common/redis/serializers.py
+++ b/orc8r/gateway/python/magma/common/redis/serializers.py
@@ -9,6 +9,27 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 from orc8r.protos.redis_pb2 import RedisState
 
+
+class RedisSerde:
+    """
+    serialize (function (any) -> bytes):
+                function called to serialize a value
+    deserialize (function (bytes) -> any):
+                function called to deserialize a value
+    """
+
+    def __init__(self, typeval, serializer, deserializer):
+        self.type = typeval
+        self.serializer = serializer
+        self.deserializer = deserializer
+
+    def serialize(self, msg, version=0):
+        return self.serializer(msg, version)
+
+    def deserialize(self, obj):
+        return self.deserializer(obj)
+
+
 def get_proto_serializer():
     """
     Return a proto serializer that serializes the proto, adds the associated

--- a/orc8r/gateway/python/magma/common/redis/tests/dict_tests.py
+++ b/orc8r/gateway/python/magma/common/redis/tests/dict_tests.py
@@ -8,61 +8,116 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict, RedisFlatDict
 from magma.common.redis.mocks.mock_redis import MockRedis
 from magma.common.redis.serializers import get_proto_deserializer, \
-    get_proto_serializer
+    get_proto_serializer, RedisSerde
 from orc8r.protos.service303_pb2 import LogVerbosity
 from unittest import TestCase, main, mock
 
 
-class RedisTests(TestCase):
+class RedisDictTests(TestCase):
     """
-    Tests for the RedisDict container
+    Tests for the RedisHashDict and RedisFlatDict containers
     """
     @mock.patch("redis.Redis", MockRedis)
     def setUp(self):
+        client = get_default_client()
         # Use arbitrary orc8r proto to test with
-        self._dict = RedisDict(
-            get_default_client(),
+        self._hash_dict = RedisHashDict(
+            client,
             "unittest",
             get_proto_serializer(),
             get_proto_deserializer(LogVerbosity))
 
+        serdes = {}
+        serdes['log_verbosity'] = RedisSerde('log_verbosity',
+                                get_proto_serializer(),
+                                get_proto_deserializer(LogVerbosity))
+        self._flat_dict = RedisFlatDict(client, serdes)
+
     @mock.patch("redis.Redis", MockRedis)
-    def test_insert(self):
+    def test_hash_insert(self):
         expected = LogVerbosity(verbosity=0)
         expected2 = LogVerbosity(verbosity=1)
 
         # insert proto
-        self._dict['key1'] = expected
-        version = self._dict.get_version("key1")
-        actual = self._dict['key1']
+        self._hash_dict['key1'] = expected
+        version = self._hash_dict.get_version("key1")
+        actual = self._hash_dict['key1']
         self.assertEqual(1, version)
         self.assertEqual(expected, actual)
 
         # update proto
-        self._dict['key1'] = expected2
-        version2 = self._dict.get_version("key1")
-        actual2 = self._dict['key1']
+        self._hash_dict['key1'] = expected2
+        version2 = self._hash_dict.get_version("key1")
+        actual2 = self._hash_dict['key1']
         self.assertEqual(2, version2)
         self.assertEqual(expected2, actual2)
 
     @mock.patch("redis.Redis", MockRedis)
     def test_missing_version(self):
-        missing_version = self._dict.get_version("key2")
+        missing_version = self._hash_dict.get_version("key2")
         self.assertEqual(0, missing_version)
 
     @mock.patch("redis.Redis", MockRedis)
-    def test_delete(self):
+    def test_hash_delete(self):
         expected = LogVerbosity(verbosity=2)
-        self._dict['key3'] = expected
+        self._hash_dict['key3'] = expected
 
-        actual = self._dict['key3']
+        actual = self._hash_dict['key3']
         self.assertEqual(expected, actual)
 
-        self._dict.pop('key3')
-        self.assertRaises(KeyError, self._dict.__getitem__, 'key3')
+        self._hash_dict.pop('key3')
+        self.assertRaises(KeyError, self._hash_dict.__getitem__, 'key3')
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_insert(self):
+        expected = LogVerbosity(verbosity=5)
+        expected2 = LogVerbosity(verbosity=1)
+
+        # insert proto
+        self._flat_dict['key1:log_verbosity'] = expected
+        version = self._flat_dict.get_version("key1", "log_verbosity")
+        actual = self._flat_dict['key1:log_verbosity']
+        self.assertEqual(1, version)
+        self.assertEqual(expected, actual)
+
+        # update proto
+        self._flat_dict["key1:log_verbosity"] = expected2
+        version2 = self._flat_dict.get_version("key1", "log_verbosity")
+        actual2 = self._flat_dict["key1:log_verbosity"]
+        self.assertEqual(2, version2)
+        self.assertEqual(expected2, actual2)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_missing_version(self):
+        missing_version = self._flat_dict.get_version("key2", "log_verbosity")
+        self.assertEqual(0, missing_version)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_invalid_key(self):
+        expected = LogVerbosity(verbosity=5)
+        self.assertRaises(ValueError, self._flat_dict.__setitem__, 'key3',
+                          expected)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_invalid_serde(self):
+        expected = LogVerbosity(verbosity=5)
+        self.assertRaises(ValueError, self._flat_dict.__setitem__,
+                          'key3:missing_serde', expected)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_delete(self):
+        expected = LogVerbosity(verbosity=2)
+        self._flat_dict['key3:log_verbosity'] = expected
+
+        actual = self._flat_dict['key3:log_verbosity']
+        self.assertEqual(expected, actual)
+
+        self._flat_dict.pop('key3:log_verbosity')
+        self.assertRaises(KeyError, self._flat_dict.__getitem__,
+                          'key3:log_verbosity')
 
 
 if __name__ == "__main__":

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -16,9 +16,9 @@ import grpc
 
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisHashDict
+from magma.common.redis.containers import RedisFlatDict
 from magma.common.redis.serializers import get_proto_deserializer, \
-    get_proto_serializer
+    get_proto_serializer, RedisSerde
 from magma.common.service import MagmaService
 from magma.common.sdwatchdog import SDWatchdogTask
 from orc8r.protos.state_pb2 import ReportStatesRequest, SyncStatesRequest, \
@@ -31,19 +31,16 @@ from google.protobuf.json_format import MessageToDict
 DEFAULT_SYNC_INTERVAL = 60
 DEFAULT_GRPC_TIMEOUT = 10
 MINIMUM_SYNC_INTERVAL = 30
+REDIS_KEY_DELIMITER = ':'
 
 
-class StateDict(RedisHashDict):
+class StateSerde(RedisSerde):
     """
-    StateDict is a wrapper around RedisHashDict, allowing for storage of state
+    StateDict is a wrapper around RedisFlatDict, allowing for storage of state
     metadata
     """
-    def __init__(self, redis_key, proto_msg, state_scope):
-        super().__init__(
-            get_default_client(),
-            redis_key,
-            get_proto_serializer(),
-            get_proto_deserializer(proto_msg))
+    def __init__(self, redis_key, serializer, deserializer, state_scope):
+        super().__init__(redis_key, serializer, deserializer)
         # Scope determines the deviceID to report the state with
         self.state_scope = state_scope
 
@@ -60,8 +57,11 @@ class StateReplicator(SDWatchdogTask):
         self._service = service
         # In memory mapping of states to version
         self._state_versions = {}
-        # Clients for each type of state to replicate
-        self._redis_clients = self._get_redis_clients()
+        # Serdes for each type of state to replicate
+        self._serdes = {}
+        self._get_proto_redis_serdes()
+        self._redis_client = RedisFlatDict(get_default_client(),
+                                           self._serdes)
 
         # _grpc_client_manager to manage grpc client recyclings
         self._grpc_client_manager = grpc_client_manager
@@ -70,8 +70,7 @@ class StateReplicator(SDWatchdogTask):
         # Replication cannot proceed until this flag is True
         self._has_resync_completed = False
 
-    def _get_redis_clients(self):
-        clients = []
+    def _get_proto_redis_serdes(self):
         state_protos = self._service.config.get('state_protos', []) or []
         for proto_cfg in state_protos:
             is_invalid_cfg = 'proto_msg' not in proto_cfg or \
@@ -88,14 +87,15 @@ class StateReplicator(SDWatchdogTask):
             try:
                 proto_module = importlib.import_module(proto_cfg['proto_file'])
                 msg = getattr(proto_module, proto_cfg['proto_msg'])
-                client = StateDict(proto_cfg['redis_key'], msg,
+                redis_key = proto_cfg['redis_key']
+                serde = StateSerde(redis_key,
+                                   get_proto_serializer(),
+                                   get_proto_deserializer(msg),
                                    proto_cfg['state_scope'])
-                clients.append(client)
+                self._serdes[redis_key] = serde
 
             except (ImportError, AttributeError) as err:
                 logging.error(err)
-
-        return clients
 
     async def _run(self):
         if not self._has_resync_completed:
@@ -105,21 +105,25 @@ class StateReplicator(SDWatchdogTask):
                 logging.error("GRPC call failed for initial state re-sync: %s",
                               err)
                 return
-
         request = await self._collect_states_to_replicate()
         if request is not None:
             await self._send_to_state_service(request)
 
     async def _resync(self):
         states_to_sync = []
-        for client in self._redis_clients:
-            for id in client:
-                state_type = client.key
-                version = client.get_version(id)
-                device_id = self.make_scoped_device_id(id, client.state_scope)
-                state_id = StateID(type=state_type, deviceID=device_id)
-                id_and_version = IDAndVersion(id=state_id, version=version)
-                states_to_sync.append(id_and_version)
+        for key in self._redis_client:
+            try:
+                idval, state_type = self._parse_key(key)
+            except ValueError as err:
+                logging.debug(err)
+                continue
+
+            state_scope = self._serdes[state_type].state_scope
+            version = self._redis_client.get_version(idval, state_type)
+            device_id = self.make_scoped_device_id(idval, state_scope)
+            state_id = StateID(type=state_type, deviceID=device_id)
+            id_and_version = IDAndVersion(id=state_id, version=version)
+            states_to_sync.append(id_and_version)
 
         if len(states_to_sync) == 0:
             logging.debug("Not re-syncing state. No local state found.")
@@ -138,7 +142,7 @@ class StateReplicator(SDWatchdogTask):
                                  id_and_version.id.deviceID))
         # Update in-memory map to add already synced states
         for state in request.states:
-            in_mem_key = self.make_mem_key(state.id.type, state.id.deviceID)
+            in_mem_key = self.make_mem_key(state.id.deviceID, state.id.type)
             if (state.id.type, state.id.deviceID) not in unsynced_states:
                 self._state_versions[in_mem_key] = state.version
 
@@ -147,25 +151,32 @@ class StateReplicator(SDWatchdogTask):
 
     async def _collect_states_to_replicate(self):
         states_to_report = []
-        for client in self._redis_clients:
-            for id in client:
-                state_type = client.key
-                device_id = self.make_scoped_device_id(id, client.state_scope)
-                in_mem_key = self.make_mem_key(state_type, device_id)
-                redis_version = client.get_version(id)
+        for key in self._redis_client:
+            try:
+                idval, state_type = self._parse_key(key)
+            except ValueError as err:
+                logging.debug(err)
+                continue
 
-                if in_mem_key in self._state_versions and \
-                        self._state_versions[in_mem_key] == redis_version:
-                    continue
+            state_scope = self._serdes[state_type].state_scope
+            device_id = self.make_scoped_device_id(idval, state_scope)
+            in_mem_key = self.make_mem_key(device_id, state_type)
+            redis_version = self._redis_client.get_version(idval,
+                                                           state_type)
 
-                redis_state = client.get(id)
-                json_converted_state = MessageToDict(redis_state)
-                serialized_json_state = json.dumps(json_converted_state)
-                state_proto = State(type=state_type,
-                      deviceID=device_id,
-                      value=serialized_json_state.encode("utf-8"),
-                      version=redis_version)
-                states_to_report.append(state_proto)
+            if in_mem_key in self._state_versions and \
+                    self._state_versions[in_mem_key] == redis_version:
+                continue
+
+            redis_state = self._redis_client.get(key)
+            json_converted_state = MessageToDict(redis_state)
+            serialized_json_state = json.dumps(json_converted_state)
+            state_proto = State(type=state_type,
+                  deviceID=device_id,
+                  value=serialized_json_state.encode("utf-8"),
+                  version=redis_version)
+
+            states_to_report.append(state_proto)
 
         if len(states_to_report) == 0:
             logging.debug("Not replicating state. No state has changed!")
@@ -195,24 +206,37 @@ class StateReplicator(SDWatchdogTask):
             for state in request.states:
                 if (state.type, state.deviceID) in unreplicated_states:
                     continue
-                in_mem_key = self.make_mem_key(state.type, state.deviceID)
+                in_mem_key = self.make_mem_key(state.deviceID, state.type)
                 self._state_versions[in_mem_key] = state.version
 
                 logging.debug("Successfully replicated state for: "
                               "deviceID: %s,"
                               "type: %s, "
                               "version: %d",
-                              state.type, state.deviceID, state.version)
+                              state.deviceID, state.type, state.version)
         finally:
             # reset timeout to config-specified + some buffer
             self.set_timeout(self._interval * 2)
 
+    def _parse_key(self, key):
+        split_key = key.split(REDIS_KEY_DELIMITER, 1)
+        if len(split_key) != 2:
+            raise ValueError("Redis key: %s is not of format <id>:<<type>. "
+                          "Not replicating." % key)
+        idval = split_key[0]
+        state_type = split_key[1]
+        if state_type not in self._serdes:
+            raise ValueError("No serde found for state type: %s. "
+                             "Not replicating key: %s" % (state_type, idval))
+
+        return idval, state_type
+
     @staticmethod
-    def make_mem_key(state_type, device_id):
+    def make_mem_key(device_id, state_type):
         """
-        Create a key of the format <type>:<id>
+        Create a key of the format <id>:<type>
         """
-        return state_type + ":" + device_id
+        return device_id + ":" + state_type
 
     @staticmethod
     def make_scoped_device_id(id, scope):

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -16,7 +16,7 @@ import grpc
 
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 from magma.common.service import MagmaService
@@ -33,9 +33,9 @@ DEFAULT_GRPC_TIMEOUT = 10
 MINIMUM_SYNC_INTERVAL = 30
 
 
-class StateDict(RedisDict):
+class StateDict(RedisHashDict):
     """
-    StateDict is a wrapper around RedisDict, allowing for storage of state
+    StateDict is a wrapper around RedisHashDict, allowing for storage of state
     metadata
     """
     def __init__(self, redis_key, proto_msg, state_scope):

--- a/orc8r/gateway/python/magma/state/tests/state_replicator_test.py
+++ b/orc8r/gateway/python/magma/state/tests/state_replicator_test.py
@@ -17,7 +17,7 @@ from orc8r.protos.state_pb2 import ReportStatesResponse, \
 from unittest.mock import MagicMock
 from orc8r.protos.service303_pb2 import LogVerbosity
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 from magma.state.state_replicator import StateReplicator
@@ -105,16 +105,16 @@ class StateReplicatorTests(TestCase):
         # Create a rpc stub
         self.channel = grpc.insecure_channel('0.0.0.0:{}'.format(port))
 
-        self.nid_mock_client = RedisDict(get_default_client(),
+        self.nid_mock_client = RedisHashDict(get_default_client(),
                                                NID_TYPE,
                                                get_proto_serializer(),
                                                get_proto_deserializer(
                                                    NetworkID))
-        self.id_mock_client = RedisDict(get_default_client(),
+        self.id_mock_client = RedisHashDict(get_default_client(),
                                             IDList_TYPE,
                                             get_proto_serializer(),
                                             get_proto_deserializer(IDList))
-        self.log_mock_client = RedisDict(get_default_client(),
+        self.log_mock_client = RedisHashDict(get_default_client(),
                                           LOG_TYPE,
                                           get_proto_serializer(),
                                           get_proto_deserializer(LogVerbosity))


### PR DESCRIPTION
Summary:
This diff changes the container that the gateway state replication service
uses to load Redis state. The GSR service now use a RedisFlatDict and expects keys
to be in the format <id>:<type>. The type must have an associated Serde that's been
configured in the `state.yml` config file.

This change was made due to recent design discussions that determined the MME should
be able to key using IMSI:* and be able to fetch all state for a given subscriber.

Differential Revision: D18124573

