### PR TITLE
Add flat-dictionary Redis implementation

### DIFF
--- a/lte/gateway/python/magma/policydb/rule_store.py
+++ b/lte/gateway/python/magma/policydb/rule_store.py
@@ -10,14 +10,14 @@ of patent rights can be found in the PATENTS file in the same directory.
 from lte.protos.policydb_pb2 import PolicyRule
 
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 
 
-class PolicyRuleDict(RedisDict):
+class PolicyRuleDict(RedisHashDict):
     """
-    PolicyRuleDict uses the RedisDict collection to store a mapping of policy
+    PolicyRuleDict uses the RedisHashDict collection to store a mapping of policy
     rule ids to PolicyRules. Setting and deleting items in the dictionary syncs
     with Redis automatically
     """

--- a/lte/gateway/python/magma/redirectd/redirect_store.py
+++ b/lte/gateway/python/magma/redirectd/redirect_store.py
@@ -10,14 +10,14 @@ of patent rights can be found in the PATENTS file in the same directory.
 from lte.protos.policydb_pb2 import RedirectInformation
 
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 
 
-class RedirectDict(RedisDict):
+class RedirectDict(RedisHashDict):
     """
-    RedirectDict uses the RedisDict collection to store a mapping of ips
+    RedirectDict uses the RedisHashDict collection to store a mapping of ips
     to RedirectInformation. Setting and deleting items in the dictionary syncs
     with Redis automatically
     """

--- a/orc8r/gateway/python/magma/common/redis/containers.py
+++ b/orc8r/gateway/python/magma/common/redis/containers.py
@@ -6,10 +6,13 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
-
+import collections.abc as collections_abc
 from copy import deepcopy
+import redis
 import redis_collections
+from typing import Dict
 
+from magma.common.redis.serializers import RedisSerde
 from orc8r.protos.redis_pb2 import RedisState
 
 # NOTE: these containers replace the serialization methods exposed by
@@ -93,9 +96,10 @@ class RedisSet(redis_collections.Set):
         return {deepcopy(elt, memo) for elt in self}
 
 
-class RedisDict(redis_collections.DefaultDict):
+class RedisHashDict(redis_collections.DefaultDict):
     """
-    Dict-like interface serializing elements to a Redis datastore.
+    Dict-like interface serializing elements to a Redis datastore. This dict
+    utilizes Redis's hashmap functionality
 
     Notes:
         - Keys must be string-like and are serialized to plaintext (UTF-8)
@@ -139,8 +143,8 @@ class RedisDict(redis_collections.DefaultDict):
             redis_dict (redis_collections.Dict): persistent dict-like interface
         """
         # Key serialization (to/from plaintext)
-        self._pickle_key = RedisDict.serialize_key
-        self._unpickle_key = RedisDict.deserialize_key
+        self._pickle_key = RedisHashDict.serialize_key
+        self._unpickle_key = RedisHashDict.deserialize_key
         # Value serialization
         self._pickle_value = serialize
         self._unpickle = deserialize
@@ -181,3 +185,99 @@ class RedisDict(redis_collections.DefaultDict):
         proto_wrapper = RedisState()
         proto_wrapper.ParseFromString(value)
         return proto_wrapper.version
+
+
+class RedisFlatDict(collections_abc.MutableMapping):
+    """
+    Dict-like interface serializing elements to a Redis datastore. This
+    dict stores key directly (i.e. without a hashmap).
+    """
+
+    def __init__(self, client: redis.Redis, serdes: Dict[str, RedisSerde]):
+        """
+        Args:
+            client (redis.Redis): Redis client object
+            serdes (): RedisSerdes for each type of object that can be stored
+        """
+        super().__init__()
+        self.redis = client
+        self.serdes = serdes
+
+    def __len__(self):
+        """Return the number of items in the dictionary."""
+        return len(self.redis.keys())
+
+    def __iter__(self):
+        """Return an iterator over the keys of the dictionary."""
+        for k in self.redis.keys():
+            yield k.decode('utf-8')
+
+    def __contains__(self, key):
+        """Return ``True`` if *key* is present, else ``False``."""
+        return bool(self.redis.exists(key))
+
+    def __getitem__(self, key):
+        """Return the item of dictionary with key *key*. Raises a
+        :exc:`KeyError` if key is not in the map.
+        """
+        if ':' not in key:
+            raise ValueError('key must be of format <id>:<type>')
+        serde = self._get_serde(key)
+        serialized_value = self.redis.get(key)
+        if serialized_value is None:
+            raise KeyError(key)
+
+        value = serde.deserialize(serialized_value)
+        return value
+
+    def __setitem__(self, key, value):
+        """Set ``d[key]`` to *value*."""
+        if ':' not in key:
+            raise ValueError('key must be of format <id>:<type>')
+        serde = self._get_serde(key)
+        version = self._get_version(key)
+        serialized_value = serde.serialize(value, version + 1)
+
+        self.redis.set(key, serialized_value)
+
+        return self.redis.get(key)
+
+    def __delitem__(self, key):
+        """Remove ``d[key]`` from dictionary.
+        Raises a :func:`KeyError` if *key* is not in the map.
+        """
+        deleted_count = self.redis.delete(key)
+        if not deleted_count:
+            raise KeyError(key)
+
+    def clear(self):
+        for key in self.keys():
+            self.redis.delete(key)
+
+    def get_version(self, idval, typeval):
+        """Return the version of the value for key *key*. Returns 0 if
+        key is not in the map
+        """
+        flat_key = idval + ":" + typeval
+        return self._get_version(flat_key)
+
+    def _get_version(self, key):
+        value = self.redis.get(key)
+        if value is None:
+            return 0
+
+        proto_wrapper = RedisState()
+        proto_wrapper.ParseFromString(value)
+        return proto_wrapper.version
+
+    def _get_serde(self, key):
+        parsed_key = key.split(':')
+        if len(parsed_key) != 2:
+            raise ValueError("Dictionary key must be of format <id>:<type>")
+        typeval = parsed_key[1]
+
+        if typeval not in self.serdes:
+            raise ValueError("Dictionary is not configured for object type:"
+                             " %s" % typeval)
+
+        return self.serdes[typeval]

--- a/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
+++ b/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
@@ -31,6 +31,8 @@ class MockRedis(object):
         """Mock delete."""
         if key in self.redis:
             del self.redis[key]
+            return 1
+        return 0
 
     def exists(self, key):
         """Mock exists."""
@@ -39,6 +41,14 @@ class MockRedis(object):
     def get(self, key):
         """Mock get."""
         return self.redis[key] if key in self.redis else None
+
+    def set(self, key, value):
+        """Mock set."""
+        self.redis[key] = value
+
+    def keys(self):
+        """ Mock keys."""
+        return list(self.redis.keys())
 
     def hget(self, hashkey, key):
         """Mock hget."""

--- a/orc8r/gateway/python/magma/common/redis/serializers.py
+++ b/orc8r/gateway/python/magma/common/redis/serializers.py
@@ -9,6 +9,27 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 from orc8r.protos.redis_pb2 import RedisState
 
+
+class RedisSerde:
+    """
+    serialize (function (any) -> bytes):
+                function called to serialize a value
+    deserialize (function (bytes) -> any):
+                function called to deserialize a value
+    """
+
+    def __init__(self, typeval, serializer, deserializer):
+        self.type = typeval
+        self.serializer = serializer
+        self.deserializer = deserializer
+
+    def serialize(self, msg, version=0):
+        return self.serializer(msg, version)
+
+    def deserialize(self, obj):
+        return self.deserializer(obj)
+
+
 def get_proto_serializer():
     """
     Return a proto serializer that serializes the proto, adds the associated

--- a/orc8r/gateway/python/magma/common/redis/tests/dict_tests.py
+++ b/orc8r/gateway/python/magma/common/redis/tests/dict_tests.py
@@ -8,61 +8,116 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict, RedisFlatDict
 from magma.common.redis.mocks.mock_redis import MockRedis
 from magma.common.redis.serializers import get_proto_deserializer, \
-    get_proto_serializer
+    get_proto_serializer, RedisSerde
 from orc8r.protos.service303_pb2 import LogVerbosity
 from unittest import TestCase, main, mock
 
 
-class RedisTests(TestCase):
+class RedisDictTests(TestCase):
     """
-    Tests for the RedisDict container
+    Tests for the RedisHashDict and RedisFlatDict containers
     """
     @mock.patch("redis.Redis", MockRedis)
     def setUp(self):
+        client = get_default_client()
         # Use arbitrary orc8r proto to test with
-        self._dict = RedisDict(
-            get_default_client(),
+        self._hash_dict = RedisHashDict(
+            client,
             "unittest",
             get_proto_serializer(),
             get_proto_deserializer(LogVerbosity))
 
+        serdes = {}
+        serdes['log_verbosity'] = RedisSerde('log_verbosity',
+                                get_proto_serializer(),
+                                get_proto_deserializer(LogVerbosity))
+        self._flat_dict = RedisFlatDict(client, serdes)
+
     @mock.patch("redis.Redis", MockRedis)
-    def test_insert(self):
+    def test_hash_insert(self):
         expected = LogVerbosity(verbosity=0)
         expected2 = LogVerbosity(verbosity=1)
 
         # insert proto
-        self._dict['key1'] = expected
-        version = self._dict.get_version("key1")
-        actual = self._dict['key1']
+        self._hash_dict['key1'] = expected
+        version = self._hash_dict.get_version("key1")
+        actual = self._hash_dict['key1']
         self.assertEqual(1, version)
         self.assertEqual(expected, actual)
 
         # update proto
-        self._dict['key1'] = expected2
-        version2 = self._dict.get_version("key1")
-        actual2 = self._dict['key1']
+        self._hash_dict['key1'] = expected2
+        version2 = self._hash_dict.get_version("key1")
+        actual2 = self._hash_dict['key1']
         self.assertEqual(2, version2)
         self.assertEqual(expected2, actual2)
 
     @mock.patch("redis.Redis", MockRedis)
     def test_missing_version(self):
-        missing_version = self._dict.get_version("key2")
+        missing_version = self._hash_dict.get_version("key2")
         self.assertEqual(0, missing_version)
 
     @mock.patch("redis.Redis", MockRedis)
-    def test_delete(self):
+    def test_hash_delete(self):
         expected = LogVerbosity(verbosity=2)
-        self._dict['key3'] = expected
+        self._hash_dict['key3'] = expected
 
-        actual = self._dict['key3']
+        actual = self._hash_dict['key3']
         self.assertEqual(expected, actual)
 
-        self._dict.pop('key3')
-        self.assertRaises(KeyError, self._dict.__getitem__, 'key3')
+        self._hash_dict.pop('key3')
+        self.assertRaises(KeyError, self._hash_dict.__getitem__, 'key3')
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_insert(self):
+        expected = LogVerbosity(verbosity=5)
+        expected2 = LogVerbosity(verbosity=1)
+
+        # insert proto
+        self._flat_dict['key1:log_verbosity'] = expected
+        version = self._flat_dict.get_version("key1", "log_verbosity")
+        actual = self._flat_dict['key1:log_verbosity']
+        self.assertEqual(1, version)
+        self.assertEqual(expected, actual)
+
+        # update proto
+        self._flat_dict["key1:log_verbosity"] = expected2
+        version2 = self._flat_dict.get_version("key1", "log_verbosity")
+        actual2 = self._flat_dict["key1:log_verbosity"]
+        self.assertEqual(2, version2)
+        self.assertEqual(expected2, actual2)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_missing_version(self):
+        missing_version = self._flat_dict.get_version("key2", "log_verbosity")
+        self.assertEqual(0, missing_version)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_invalid_key(self):
+        expected = LogVerbosity(verbosity=5)
+        self.assertRaises(ValueError, self._flat_dict.__setitem__, 'key3',
+                          expected)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_invalid_serde(self):
+        expected = LogVerbosity(verbosity=5)
+        self.assertRaises(ValueError, self._flat_dict.__setitem__,
+                          'key3:missing_serde', expected)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def test_flat_delete(self):
+        expected = LogVerbosity(verbosity=2)
+        self._flat_dict['key3:log_verbosity'] = expected
+
+        actual = self._flat_dict['key3:log_verbosity']
+        self.assertEqual(expected, actual)
+
+        self._flat_dict.pop('key3:log_verbosity')
+        self.assertRaises(KeyError, self._flat_dict.__getitem__,
+                          'key3:log_verbosity')
 
 
 if __name__ == "__main__":

--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -16,7 +16,7 @@ import grpc
 
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 from magma.common.service import MagmaService
@@ -33,9 +33,9 @@ DEFAULT_GRPC_TIMEOUT = 10
 MINIMUM_SYNC_INTERVAL = 30
 
 
-class StateDict(RedisDict):
+class StateDict(RedisHashDict):
     """
-    StateDict is a wrapper around RedisDict, allowing for storage of state
+    StateDict is a wrapper around RedisHashDict, allowing for storage of state
     metadata
     """
     def __init__(self, redis_key, proto_msg, state_scope):

--- a/orc8r/gateway/python/magma/state/tests/state_replicator_test.py
+++ b/orc8r/gateway/python/magma/state/tests/state_replicator_test.py
@@ -17,7 +17,7 @@ from orc8r.protos.state_pb2 import ReportStatesResponse, \
 from unittest.mock import MagicMock
 from orc8r.protos.service303_pb2 import LogVerbosity
 from magma.common.redis.client import get_default_client
-from magma.common.redis.containers import RedisDict
+from magma.common.redis.containers import RedisHashDict
 from magma.common.redis.serializers import get_proto_deserializer, \
     get_proto_serializer
 from magma.state.state_replicator import StateReplicator
@@ -105,16 +105,16 @@ class StateReplicatorTests(TestCase):
         # Create a rpc stub
         self.channel = grpc.insecure_channel('0.0.0.0:{}'.format(port))
 
-        self.nid_mock_client = RedisDict(get_default_client(),
+        self.nid_mock_client = RedisHashDict(get_default_client(),
                                                NID_TYPE,
                                                get_proto_serializer(),
                                                get_proto_deserializer(
                                                    NetworkID))
-        self.id_mock_client = RedisDict(get_default_client(),
+        self.id_mock_client = RedisHashDict(get_default_client(),
                                             IDList_TYPE,
                                             get_proto_serializer(),
                                             get_proto_deserializer(IDList))
-        self.log_mock_client = RedisDict(get_default_client(),
+        self.log_mock_client = RedisHashDict(get_default_client(),
                                           LOG_TYPE,
                                           get_proto_serializer(),
                                           get_proto_deserializer(LogVerbosity))


### PR DESCRIPTION
Summary:
Recent design dicussions have determined that the MME
will store redis state using <IMSI>:<State Type> format. To support
this, the state replication service must support loading a Redis state
with keys of format <IMSI>:<State Type>, rather than using
Redis' hashmap functionality.

This diff implements the underlying container needed. Rather
than having multiple Redis clients, the GSR will have one client
and multiple serdes that determine state type and de/serialize methods.

Reviewed By: themarwhal

Differential Revision: D18120608

