### PR TITLE
install script get UID on debian

### DIFF
--- a/devmand/gateway/deploy/symphony_agent_install
+++ b/devmand/gateway/deploy/symphony_agent_install
@@ -147,7 +147,13 @@ case "$dist" in
     fi
     
     # generate a UID
-    for eth in /sys/class/net/ens*/address ; do
+    if [ "$dist" == "debian" ] ; then
+      mac_addr_file="/sys/class/net/eth*/address"
+    else
+      mac_addr_file="/sys/class/net/ens*/address"
+    fi
+
+    for eth in $mac_addr_file ; do
       uid="$(sed 's/://g' "${eth}")"
       break
     done


### PR DESCRIPTION
Summary: While installing symphony agent on gigamonster's VM I got an error that the file I was checking didn't exist. It's in a different place on debian. I modified the script to handle that.

Differential Revision: D18143740

