### PR TITLE
Remove unused migration related fields from handler

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -33,7 +33,6 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/groupcache v0.0.0-20191025150517-4a4ac3fbac33 // indirect
 	github.com/golang/protobuf v1.3.2
-	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/google/pprof v0.0.0-20191025152101-a8b9f9d2d3ce // indirect
 	github.com/hashicorp/golang-lru v0.5.3 // indirect
@@ -53,7 +52,6 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20191025023517-2077df36852e // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
-	google.golang.org/api v0.3.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.21.1
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,7 +15,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -39,9 +39,6 @@ services:
       # SQL_DRIVER: mysql
       # DATABASE_SOURCE: "magma_dev:magma_dev@(maria)/magma_dev"
       # SQL_DIALECT: maria
-
-      USE_NEW_HANDLERS: '1'
-      USE_NEW_MCONFIGS: '1'
     links:
       - fluentd
     depends_on:

--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -11,7 +11,6 @@ package orc8r
 const (
 	ModuleName string = "orc8r"
 
-	MagmadNetworkType       = "magmad_network"
 	NetworkFeaturesConfig   = "orc8r_features"
 	MagmadGatewayType       = "magmad_gateway"
 	AccessGatewayRecordType = "access_gateway_record"
@@ -21,14 +20,4 @@ const (
 	UpgradeReleaseChannelEntityType = "upgrade_release_channel"
 
 	DnsdNetworkType = "dnsd_network"
-
-	// used to migrate network/gateway lookup magmad dependencies
-	UseConfiguratorEnv = "USE_NEW_HANDLERS"
-
-	// separate flag to control mconfig builders because this has significant
-	// implications on production gateways
-	UseConfiguratorMconfigsEnv = "USE_NEW_MCONFIGS"
-
-	// comma-separated list of networks to run new mconfig builders for
-	MconfigWhitelistEnv = "NEW_MCONFIGS_WHITELIST"
 )

--- a/orc8r/cloud/helm/orc8r/templates/controller.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.deployment.yaml
@@ -107,12 +107,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
-            - name: USE_NEW_HANDLERS
-              value: "{{ .Values.controller.migration.new_handlers }}"
-            - name: USE_NEW_MCONFIGS
-              value: "{{ .Values.controller.migration.new_mconfigs }}"
-            - name: NEW_MCONFIGS_WHITELIST
-              value: {{ .Values.controller.migration.mconfig_whitelist }}
           livenessProbe:
             tcpSocket:
               port: 9081


### PR DESCRIPTION
Summary:
The fields `MigratedHandlerFunc` and `MultiplexAfterMigration` were added into the `Handler` struct for the migration a few months ago. Removing them since they are no longer used.
This also removes the last references to the `USE_NEW_HANDLERS` env variable.

Reviewed By: xjtian

Differential Revision: D17664201

