### PR TITLE
devmand build script should not override existing docker-compose override

### DIFF
--- a/devmand/gateway/docker/scripts/build
+++ b/devmand/gateway/docker/scripts/build
@@ -21,6 +21,7 @@ if [ -z ${DEVICE_CONFIG_FILE+x} ]; then
   export DEVICE_CONFIG_FILE="/var/opt/magma/configs/gateway.mconfig"
 fi
 
+if [ ! -f docker-compose.override.yml ]; then
 cat << EOF > docker-compose.override.yml
 version: '3.7'
 services:
@@ -31,6 +32,7 @@ services:
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
 EOF
+fi
 
 echo "Creating image..."
 docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}


### PR DESCRIPTION
Summary:
This commit makes it so the devmand build script does not override
an existing docker-compose.override.yml. This has the consequence that if a user
changes env varibles they need to delete the override if they want it
regenerated but it seems much easier for them to just edit the override and
expect that it won't be overriden.

Reviewed By: joemin

Differential Revision: D18124239

