### PR TITLE
Use Radius Acct-Session-IDs when available

### DIFF
--- a/feg/radius/src/modules/eap/methods/akamagma/aka_magma.go
+++ b/feg/radius/src/modules/eap/methods/akamagma/aka_magma.go
@@ -87,6 +87,8 @@ func (m EapAkaMagmaMethod) Handle(
 	attr, err = rfc2865.CalledStationID_Lookup(r.Packet)
 	if err == nil {
 		apn = string(attr)
+	} else {
+		eapLogger.Warn("Error Getting Called-Station_ID ", zap.Error(err))
 	}
 
 	UnmarshalProtocolState.Start()
@@ -113,6 +115,10 @@ func (m EapAkaMagmaMethod) Handle(
 				zap.String("previous", eapContext.MacAddr),
 				zap.String("current", clientMac),
 			)
+		}
+		if len(eapContext.Apn) == 0 {
+			eapLogger.Warn("Empty Context APN,", zap.String("setting to Called-Station-Id", apn))
+			eapContext.Apn = apn
 		}
 	}
 

--- a/feg/radius/src/server/session_id.go
+++ b/feg/radius/src/server/session_id.go
@@ -13,10 +13,21 @@ import (
 
 	"fbc/lib/go/radius"
 	"fbc/lib/go/radius/rfc2865"
+	"fbc/lib/go/radius/rfc2866"
 )
+
+const MinAccSessionIdLen = 7
 
 // GetSessionID Extracts the radius session id from the given radius request
 func (s *Server) GetSessionID(r *radius.Request) string {
+	if asid, err := rfc2866.AcctSessionID_LookupString(r.Packet); err == nil && len(asid) >= MinAccSessionIdLen {
+		return asid
+	}
+	return s.GenSessionID(r)
+}
+
+// GenSessionID generates radius session id from the request's CalledStationID & CallingStationID
+func (s *Server) GenSessionID(r *radius.Request) string {
 	calledStationIDAttr, _ := rfc2865.CalledStationID_Lookup(r.Packet)
 	callingStationIDAttr, _ := rfc2865.CallingStationID_Lookup(r.Packet)
 

--- a/feg/radius/src/server/udp_listener.go
+++ b/feg/radius/src/server/udp_listener.go
@@ -143,13 +143,14 @@ func generatePacketHandler(
 		// Get session ID from the request, if exists, and setup correlation ID
 		var correlationField = zap.Uint32("correlation", rand.Uint32())
 		sessionID := server.GetSessionID(r)
+		generatedSessionID := server.GenSessionID(r)
 
 		// Create request context
 		requestContext := modules.RequestContext{
 			RequestID:      correlationField.Integer,
 			Logger:         server.logger.With(correlationField),
 			SessionID:      sessionID,
-			SessionStorage: session.NewSessionStorage(server.multiSessionStorage, sessionID),
+			SessionStorage: session.NewSessionStorageExt(server.multiSessionStorage, sessionID, generatedSessionID),
 		}
 
 		// Execute filters


### PR DESCRIPTION
Summary:
Magma Radius Server does not generate unique Session IDs.
The Session IDs generated by the server consist of Calling-Station-ID + Called-Station-ID and are not unique per session.
Most of APs/WACs provide VALID, UNIQUE and consistent Acct-Session-ID with Auth and Accounting requests and we would be better off
using them instead of Radius server's non-unique IDs.

Reviewed By: nivnoach

Differential Revision: D18181602

