### PR TITLE
install script docker override device config file

### DIFF
--- a/devmand/gateway/deploy/symphony_agent_install
+++ b/devmand/gateway/deploy/symphony_agent_install
@@ -217,6 +217,7 @@ services:
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
+      - DEVICE_CONFIG_FILE=/var/opt/magma/configs/gateway.mconfig
 EOF
 
 ###############################################################################


### PR DESCRIPTION
Summary: Added a `DEVICE_CONFIG_FILE` line to the docker-compose.override.yml file which gets created during the install script. This was necessary to get symphony agent to work on both the ENS and GigaMonster VMs.

Differential Revision: D18213227

