### PR TITLE
Close the event loop correctly during exit

### DIFF
--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -40,6 +40,14 @@ from .metrics_export import get_metrics
 from .service_registry import ServiceRegistry
 
 
+async def loop_exit():
+    """
+    Stop the loop in an async context
+    """
+    loop = asyncio.get_event_loop()
+    loop.stop()
+
+
 class MagmaService(Service303Servicer):
     """
     MagmaService provides the framework for all Magma services.
@@ -237,10 +245,10 @@ class MagmaService(Service303Servicer):
 
         for pending_task in asyncio.Task.all_tasks(self._loop):
             pending_task.cancel()
-        self._loop.stop()
 
         self._state = ServiceInfo.STOPPED
         self._health = ServiceInfo.APP_UNHEALTHY
+        asyncio.ensure_future(loop_exit())
 
     def _set_grpc_poll_strategy(self):
         """


### PR DESCRIPTION
Summary:
Task cancel unlike Future cancel doesn't cancel the wrapped coroutine but instead per documentation
"This arranges for a CancelledError to be thrown into the wrapped coroutine on the next cycle through the event loop"
Do the loop close in an async loop to allow for the wrapped coroutines to handle/throw CancelledError

Reviewed By: mpgermano

Differential Revision: D18220939

