### PR TITLE
[BugFix] [nas] [ESM_Information] Fix for ue_mm_context lock while Attach request come with wrong APN name

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/emm_cn.c
@@ -326,7 +326,8 @@ static int _emm_cn_pdn_config_res(emm_cn_pdn_config_res_t *msg_pP)
      * provided by HSS or if we fail to select the APN provided
      * by HSS,send Attach Reject to UE
      */
-     _handle_apn_mismatch(ue_mm_context);
+    _handle_apn_mismatch(ue_mm_context);
+    unlock_ue_contexts(ue_mm_context);
     return RETURNerror;
   }
 


### PR DESCRIPTION
Summary:
When wrong APN is received in ESM information message, MME sends attach reject and returns without unlocking the ue context. Hence 2nd run of the test case "test_attach_esm_information_wrong_apn.py" was failing. This PR fixes the issue.

Test Plan:
Sanity with S1-Simulator is verfied.
Executed test_attach_esm_information_wrong_apn.py