### PR TITLE
Fix deserialization of static policies from Redis to sessiond

### DIFF
--- a/orc8r/gateway/c/common/datastore/CMakeLists.txt
+++ b/orc8r/gateway/c/common/datastore/CMakeLists.txt
@@ -9,11 +9,27 @@ add_compile_options(-std=c++14)
 
 include_directories("${PROJECT_SOURCE_DIR}/../common/logging")
 
+list(APPEND PROTO_SRCS "")
+list(APPEND PROTO_HDRS "")
+
+set(ASYNC_ORC8R_CPP_PROTOS common redis)
+set(ASYNC_LTE_CPP_PROTOS session_manager policydb subscriberdb)
+set(ASYNC_LTE_GRPC_PROTOS session_manager)
+set(ASYNC_ORC8R_GRPC_PROTOS "")
+
+generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
+        "${ASYNC_LTE_GRPC_PROTOS}"
+        "${ASYNC_ORC8R_GRPC_PROTOS}" "${PROTO_SRCS}" "${PROTO_HDRS}")
+
+message("Async Proto_srcs are ${PROTO_SRCS}")
+
 add_library(DATASTORE
     RedisMap.hpp
     ObjectMap.h
     Serializers.cpp
     Serializers.h
+    ${PROTO_SRCS}
+    ${PROTO_HDRS}
     )
 
 target_link_libraries(DATASTORE

--- a/orc8r/gateway/c/common/datastore/Serializers.cpp
+++ b/orc8r/gateway/c/common/datastore/Serializers.cpp
@@ -7,19 +7,36 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 #include "Serializers.h"
+#include <orc8r/protos/redis.pb.h>
 
+using magma::orc8r::RedisState;
 using google::protobuf::Message;
 namespace magma {
 
-std::function<bool(const Message&, std::string&)> get_proto_serializer() {
-  return [](const Message& message, std::string& str_out) -> bool {
-    return message.SerializeToString(&str_out);
+std::function<bool(
+  const Message&,
+  std::string&,
+  uint64_t&)> get_proto_serializer() {
+  return [](const Message& message, std::string& str_out, uint64_t& version) -> bool {
+    auto can_parse = message.SerializeToString(&str_out);
+    if (!can_parse) {
+      return false;
+    }
+    auto redis_state = RedisState();
+    redis_state.set_version(version);
+    redis_state.set_serialized_msg(str_out);
+    return redis_state.SerializeToString(&str_out);
   };
 }
 
 std::function<bool(const std::string&, Message&)> get_proto_deserializer() {
   return [](const std::string& str, Message& msg_out) -> bool {
-    return msg_out.ParseFromString(str);
+    RedisState redis_state;
+    auto can_parse = redis_state.ParseFromString(str);
+    if (!can_parse) {
+      return false;
+    }
+    return msg_out.ParseFromString(redis_state.serialized_msg());
   };
 }
 }

--- a/orc8r/gateway/c/common/datastore/Serializers.h
+++ b/orc8r/gateway/c/common/datastore/Serializers.h
@@ -18,7 +18,8 @@ namespace magma {
 /**
  * Serialize a protobuf message into the standard string form
  */
-std::function<bool(const Message&, std::string&)> get_proto_serializer();
+std::function<bool(const Message&, std::string&, uint64_t&)>
+get_proto_serializer();
 
 /**
  * Deserialize a string into a protobuf message


### PR DESCRIPTION
Summary: Static policies have not been deserializing properly in sessiond. In policydb, the PolicyRule protobufs are stored within a RedisState protobuf before being serialized and stored in Redis. This revision adds that extra deserialization step to sessiond. Now, sessiond will deserialize the policy first as a RedisState, and then from the serialized_msg field, deserialize that into the PolicyRule.

Reviewed By: themarwhal

Differential Revision: D18323885

