### PR TITLE
Fix feg policydb ser/de inconsistency with the lte ser/de

### DIFF
--- a/feg/gateway/policydb/policydb.go
+++ b/feg/gateway/policydb/policydb.go
@@ -43,8 +43,8 @@ func NewRedisPolicyDBClient(reg registry.CloudRegistry) (*RedisPolicyDBClient, e
 		PolicyMap: object_store.NewRedisMap(
 			redisClient,
 			"policydb:rules",
-			getProtoSerializer(),
-			getPolicyDeserializer(),
+			GetPolicySerializer(),
+			GetPolicyDeserializer(),
 		),
 		BaseNameMap: object_store.NewRedisMap(
 			redisClient,

--- a/feg/gateway/policydb/serializers.go
+++ b/feg/gateway/policydb/serializers.go
@@ -12,8 +12,10 @@ import (
 	"fmt"
 
 	"magma/feg/gateway/object_store"
-	"magma/lte/cloud/go/protos"
+	lteProtos "magma/lte/cloud/go/protos"
+	orc8rProtos "magma/orc8r/cloud/go/protos"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -31,9 +33,52 @@ func getProtoSerializer() object_store.Serializer {
 	}
 }
 
-func getPolicyDeserializer() object_store.Deserializer {
+func getRedisStateSerializer(serializer object_store.Serializer) object_store.Serializer {
+	return func(object interface{}) (string, error) {
+		serialized, err := serializer(object)
+		if err != nil {
+			return "", fmt.Errorf("Could not marshal message")
+		}
+		redisState := &orc8rProtos.RedisState{SerializedMsg: []byte(serialized), Version: 0}
+		bytes, err := proto.Marshal(redisState)
+		if err != nil {
+			return "", fmt.Errorf("Could not marshal message")
+		}
+		return string(bytes[:]), nil
+	}
+}
+
+func getRedisStateDeserializer(deserializer object_store.Deserializer) object_store.Deserializer {
 	return func(serialized string) (interface{}, error) {
-		policyPtr := &protos.PolicyRule{}
+		redisStatePtr := &orc8rProtos.RedisState{}
+		bytes := []byte(serialized)
+		err := proto.Unmarshal(bytes, redisStatePtr)
+		if err != nil {
+			glog.Errorf("err : %v", err)
+			return nil, err
+		}
+		return deserializer(string(redisStatePtr.SerializedMsg))
+	}
+}
+
+func GetPolicySerializer() object_store.Serializer {
+	serializer := func(object interface{}) (string, error) {
+		policy, ok := object.(*lteProtos.PolicyRule)
+		if !ok {
+			return "", fmt.Errorf("Could not cast object to protobuf")
+		}
+		bytes, err := proto.Marshal(policy)
+		if err != nil {
+			return "", fmt.Errorf("Could not marshal message")
+		}
+		return string(bytes[:]), nil
+	}
+	return getRedisStateSerializer(serializer)
+}
+
+func GetPolicyDeserializer() object_store.Deserializer {
+	deserializer := func(serialized string) (interface{}, error) {
+		policyPtr := &lteProtos.PolicyRule{}
 		bytes := []byte(serialized)
 		err := proto.Unmarshal(bytes, policyPtr)
 		if err != nil {
@@ -41,11 +86,12 @@ func getPolicyDeserializer() object_store.Deserializer {
 		}
 		return policyPtr, nil
 	}
+	return getRedisStateDeserializer(deserializer)
 }
 
 func getBaseNameDeserializer() object_store.Deserializer {
 	return func(serialized string) (interface{}, error) {
-		setPtr := &protos.ChargingRuleNameSet{}
+		setPtr := &lteProtos.ChargingRuleNameSet{}
 		bytes := []byte(serialized)
 		err := proto.Unmarshal(bytes, setPtr)
 		if err != nil {

--- a/feg/gateway/policydb/serializers_test.go
+++ b/feg/gateway/policydb/serializers_test.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package policydb_test
+
+import (
+	"testing"
+
+	"magma/feg/gateway/policydb"
+	lteProtos "magma/lte/cloud/go/protos"
+	orc8rProtos "magma/orc8r/cloud/go/protos"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPolicySerializer(t *testing.T) {
+	policy := getDefaultPolicy()
+	policySerializer := policydb.GetPolicySerializer()
+
+	// should return a serialized RedisState{SerializedMsg: <serialized policy>}
+	serializedRedisState, err := policySerializer(policy)
+	assert.NoError(t, err)
+
+	expectedSerializedPolicyRedisState := createSerializedPolicyRedisState(t, policy)
+
+	assert.Equal(t, expectedSerializedPolicyRedisState, serializedRedisState)
+}
+
+func TestPolicyDeserializer(t *testing.T) {
+	policy := getDefaultPolicy()
+	policyDeserializer := policydb.GetPolicyDeserializer()
+
+	serializedPolicyRedisState := createSerializedPolicyRedisState(t, policy)
+	iPolicy, err := policyDeserializer(serializedPolicyRedisState)
+	assert.NoError(t, err)
+	deserializedPolicy, ok := iPolicy.(*lteProtos.PolicyRule)
+	assert.True(t, ok)
+
+	// clear out meta fields
+	clearOutMetaFields(policy)
+	clearOutMetaFields(deserializedPolicy)
+
+	assert.Equal(t, policy, deserializedPolicy)
+}
+
+func getDefaultPolicy() *lteProtos.PolicyRule {
+	return &lteProtos.PolicyRule{
+		Id:            "static1",
+		Priority:      1,
+		RatingGroup:   2,
+		MonitoringKey: "mkey1",
+		Redirect:      nil,
+		FlowList:      []*lteProtos.FlowDescription{{Action: lteProtos.FlowDescription_PERMIT}},
+		Qos:           nil,
+		TrackingType:  lteProtos.PolicyRule_OCS_AND_PCRF,
+		HardTimeout:   0,
+	}
+}
+
+func createSerializedPolicyRedisState(t *testing.T, policy *lteProtos.PolicyRule) string {
+	serializedPolicy, err := proto.Marshal(policy)
+	assert.NoError(t, err)
+	expectedRedisState := &orc8rProtos.RedisState{
+		SerializedMsg: serializedPolicy,
+		Version:       0,
+	}
+	serializedRedisState, err := proto.Marshal(expectedRedisState)
+	assert.NoError(t, err)
+	return string(serializedRedisState)
+}
+
+func clearOutMetaFields(policy *lteProtos.PolicyRule) {
+	policy.XXX_NoUnkeyedLiteral = struct{}{}
+	policy.XXX_unrecognized = nil
+	policy.XXX_sizecache = 0
+}


### PR DESCRIPTION
Summary:
There was a recent change in the way PolicyRules streamed down from orc8r are serialized to be stored into redis.
Instead of directly storing the proto serialized PolicyRule, it is now wrapped into a RedisState struct and then serialized again.
The change was not propagated to the feg side, so doing that here.

Differential Revision: D18357641

