### PR TITLE
orc8r/helm: unset default volume specs in metrics sub-chart

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 0.2.0
+version: 0.2.1
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 0.1.1
+version: 1.1.1
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/alertmanager.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/alertmanager.deployment.yaml
@@ -47,8 +47,6 @@ spec:
       volumes:
         - name: "prometheus-config"
 {{ toYaml .Values.metrics.volumes.prometheusConfig.volumeSpec | indent 10 }}
-        - name: "prometheus-data"
-{{ toYaml .Values.metrics.volumes.prometheusData.volumeSpec | indent 10 }}
 
       containers:
         - name: "alertmanager"

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -6,15 +6,15 @@ metrics:
   # alertmanager, and configmanager pods
   volumes:
     prometheusData:
-      volumeSpec:
-        hostPath:
-          path: /prometheusData
-          type: DirectoryOrCreate
+      volumeSpec: {}
+        # hostPath:
+        #   path: /prometheusData
+        #   type: DirectoryOrCreate
     prometheusConfig:
-      volumeSpec:
-        hostPath:
-          path: /configs/prometheus
-          type: DirectoryOrCreate
+      volumeSpec: {}
+        # hostPath:
+        #   path: /configs/prometheus
+        #   type: DirectoryOrCreate
 
 prometheus:
   # Enable/Disable chart

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.1.3
 - name: metrics
   repository: ""
-  version: 0.1.1
+  version: 1.1.1
 - name: nms
   repository: ""
   version: 0.1.0
 - name: logging
   repository: ""
   version: 0.1.5
-digest: sha256:cedff42b68c8313013e69d2e1df2273b9929e78a1e699d78d7fa1afa3b154545
-generated: "2019-11-05T12:05:24.037374-08:00"
+digest: sha256:8c03efe942a9989cd4f261d35d43b88247d71132c8e4205702bf856279451099
+generated: "2019-11-06T15:16:23.777126-08:00"

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -11,7 +11,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 0.1.1
+    version: 1.1.1
     repository: ""
     condition: metrics.enabled
   - name: nms


### PR DESCRIPTION
Summary:
Clearing default volume spec allows usage of other volume types (e.g. pvc).

Bumping major chart version is this is a breaking change for users which relied on volume spec defaults.

Reviewed By: Scott8440

Differential Revision: D18360842

