### PR TITLE
Fix deserialization logic for basename object

### DIFF
--- a/feg/gateway/policydb/policydb.go
+++ b/feg/gateway/policydb/policydb.go
@@ -49,8 +49,8 @@ func NewRedisPolicyDBClient(reg registry.CloudRegistry) (*RedisPolicyDBClient, e
 		BaseNameMap: object_store.NewRedisMap(
 			redisClient,
 			"policydb:base_names",
-			getProtoSerializer(),
-			getBaseNameDeserializer(),
+			GetBaseNameSerializer(),
+			GetBaseNameDeserializer(),
 		),
 		StreamerClient: streamer.NewStreamerClient(reg),
 	}


### PR DESCRIPTION
Summary: ChargingNameSet is wrapped into a RedisState when it is streamed down from the cloud, so reflecting that in the serializer/deserializer on the feg policydb as well.

Differential Revision: D18366752

