### PR TITLE
Make calls to read from redis synchronous

### DIFF
--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -104,12 +104,11 @@ uint32_t get_log_verbosity(const YAML::Node &config) {
 void init_rules(const YAML::Node &config,
                 std::shared_ptr<magma::StaticRuleStore> &rule_store) {
   magma::PolicyLoader policy_loader{};
-  policy_loader.load_config_async(
+  assert(policy_loader.load_config_sync(
       [&](const std::vector<magma::PolicyRule> &rules) {
         rule_store->sync_rules(rules);
         },
-        config["rule_update_inteval_sec"].as<uint32_t>());
-  policy_loader.stop();
+        config["rule_update_inteval_sec"].as<uint32_t>()));
 }
 
 void init_pipelined_client(std::vector<std::thread> &threads,

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <iostream>
+#include <string>
 
 #include <lte/protos/mconfig/mconfigs.pb.h>
 
@@ -21,27 +22,27 @@
 #include "magma_logging.h"
 #include "SessionCredit.h"
 
-#define SESSIOND_SERVICE "sessiond"
-#define SESSION_PROXY_SERVICE "session_proxy"
-#define SESSIOND_VERSION "1.0"
-#define MIN_USAGE_REPORTING_THRESHOLD 0.4
-#define MAX_USAGE_REPORTING_THRESHOLD 1.1
-#define DEFAULT_USAGE_REPORTING_THRESHOLD 0.8
-
 #ifdef DEBUG
 extern "C" void __gcov_flush(void);
 #endif
 
-static magma::mconfig::SessionD get_default_mconfig()
-{
+namespace {
+
+const char *SESSIOND_SERVICE = "sessiond";
+const char *SESSION_PROXY_SERVICE = "session_proxy";
+const char *SESSIOND_VERSION = "1.0";
+const double MIN_USAGE_REPORTING_THRESHOLD = 0.4;
+const double MAX_USAGE_REPORTING_THRESHOLD = 1.1;
+const double DEFAULT_USAGE_REPORTING_THRESHOLD = 0.8;
+
+magma::mconfig::SessionD get_default_mconfig() {
   magma::mconfig::SessionD mconfig;
   mconfig.set_log_level(magma::orc8r::LogLevel::INFO);
   mconfig.set_relay_enabled(false);
   return mconfig;
 }
 
-static magma::mconfig::SessionD load_mconfig()
-{
+magma::mconfig::SessionD load_mconfig() {
   magma::mconfig::SessionD mconfig;
   magma::MConfigLoader loader;
   if (!loader.load_service_mconfig(SESSIOND_SERVICE, &mconfig)) {
@@ -51,38 +52,34 @@ static magma::mconfig::SessionD load_mconfig()
   return mconfig;
 }
 
-static void run_bare_service303()
-{
+void run_bare_service303() {
   magma::service303::MagmaService server(SESSIOND_SERVICE, SESSIOND_VERSION);
   server.Start();
   server.WaitForShutdown(); // blocks forever
   server.Stop();
 }
 
-static bool sessiond_enabled(const magma::mconfig::SessionD &mconfig)
-{
+bool sessiond_enabled(const magma::mconfig::SessionD &mconfig) {
   return mconfig.relay_enabled();
 }
 
-static const std::shared_ptr<grpc::Channel> get_controller_channel(
-  const YAML::Node &config)
-{
+std::shared_ptr<grpc::Channel> get_controller_channel(
+    const YAML::Node &config) {
   if (
-    !config["use_proxied_controller"].IsDefined() ||
-    config["use_proxied_controller"].as<bool>()) {
+      !config["use_proxied_controller"].IsDefined() ||
+          config["use_proxied_controller"].as<bool>()) {
     MLOG(MINFO) << "Using proxied sessiond controller";
     return magma::ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-      SESSION_PROXY_SERVICE, magma::ServiceRegistrySingleton::CLOUD);
+        SESSION_PROXY_SERVICE, magma::ServiceRegistrySingleton::CLOUD);
   }
   auto port = config["local_controller_port"].as<std::string>();
   auto addr = "127.0.0.1:" + port;
   MLOG(MINFO) << "Using local address " << addr << " for controller";
   return grpc::CreateCustomChannel(
-    addr, grpc::InsecureChannelCredentials(), grpc::ChannelArguments {});
+      addr, grpc::InsecureChannelCredentials(), grpc::ChannelArguments{});
 }
 
-static uint32_t get_log_verbosity(const YAML::Node &config)
-{
+uint32_t get_log_verbosity(const YAML::Node &config) {
   if (!config["log_level"].IsDefined()) {
     return MINFO;
   }
@@ -104,67 +101,51 @@ static uint32_t get_log_verbosity(const YAML::Node &config)
   }
 }
 
-int main(int argc, char *argv[])
-{
-#ifdef DEBUG
-  __gcov_flush();
-#endif
-
-  MLOG(MINFO) << "Starting Session Manager";
-  magma::init_logging(argv[0]);
-  auto mconfig = load_mconfig();
-  auto config =
-    magma::ServiceConfigLoader {}.load_service_config(SESSIOND_SERVICE);
-  magma::set_verbosity(get_log_verbosity(config));
-
-  if (!sessiond_enabled(mconfig)) {
-    MLOG(MINFO) << "Credit control disabled, local enforcer not running";
-    run_bare_service303();
-    return 0;
-  }
-
-  folly::EventBase *evb = folly::EventBaseManager::get()->getEventBase();
-
-  // prep rule manager and rule update loop
-  auto rule_store = std::make_shared<magma::StaticRuleStore>();
-  magma::PolicyLoader policy_loader;
-  std::thread policy_loader_thread([&]() {
+void init_rules(const YAML::Node &config,
+                std::vector<std::thread> &threads,
+                std::shared_ptr<magma::StaticRuleStore> &rule_store) {
+  magma::PolicyLoader policy_loader{};
+  threads.emplace_back([&]() {
     policy_loader.start_loop(
-      [&](std::vector<magma::PolicyRule> rules) {
-        rule_store->sync_rules(rules);
-      },
-      config["rule_update_inteval_sec"].as<uint32_t>());
+        [&](const std::vector<magma::PolicyRule> &rules) {
+          rule_store->sync_rules(rules);
+        },
+        config["rule_update_inteval_sec"].as<uint32_t>());
     policy_loader.stop();
   });
+}
 
-  auto pipelined_client = std::make_shared<magma::AsyncPipelinedClient>();
-  std::thread rule_manager_thread([&]() {
+void init_pipelined_client(std::vector<std::thread> &threads,
+    std::shared_ptr<magma::AsyncPipelinedClient> &pipelined_client) {
+  pipelined_client = std::make_shared<magma::AsyncPipelinedClient>();
+  threads.emplace_back([&]() {
     MLOG(MINFO) << "Started pipelined response thread";
     pipelined_client->rpc_response_loop();
   });
+}
 
-  std::shared_ptr<magma::AsyncSpgwServiceClient> spgw_client;
-  std::shared_ptr<aaa::AsyncAAAClient> aaa_client;
+void init_cwf(std::vector<std::thread> &threads,
+              std::shared_ptr<aaa::AsyncAAAClient> &aaa_client) {
+  aaa_client = std::make_shared<aaa::AsyncAAAClient>();
+  threads.emplace_back(([&]() {
+    MLOG(MINFO) << "Started AAA Client response thread";
+    aaa_client->rpc_response_loop();
+  }));
+}
 
-  std::thread optional_client_thread;
-  if (config["support_carrier_wifi"].as<bool>()) {
-    aaa_client = std::make_shared<aaa::AsyncAAAClient>();
-    optional_client_thread = std::thread([&]() {
-      MLOG(MINFO) << "Started AAA Client response thread";
-      aaa_client->rpc_response_loop();
-    });
+void init_lte(std::vector<std::thread> &threads,
+              std::shared_ptr<magma::AsyncSpgwServiceClient> &spgw_client) {
+  spgw_client = std::make_shared<magma::AsyncSpgwServiceClient>();
+  threads.emplace_back([&]() {
+    MLOG(MINFO) << "Started SPGW response thread";
+    spgw_client->rpc_response_loop();
+  });
+}
 
-    spgw_client = nullptr;
-  } else {
-    aaa_client = nullptr;
-
-    spgw_client = std::make_shared<magma::AsyncSpgwServiceClient>();
-    optional_client_thread = std::thread([&]() {
-      MLOG(MINFO) << "Started SPGW response thread";
-      spgw_client->rpc_response_loop();
-    });
-  }
-
+void init_reporting(const YAML::Node &config,
+    folly::EventBase *evb,
+    std::vector<std::thread>& threads,
+    std::shared_ptr<magma::SessionCloudReporterImpl> &reporter) {
   auto reporting_threshold = config["usage_reporting_threshold"].as<float>();
   if (reporting_threshold <= MIN_USAGE_REPORTING_THRESHOLD ||
       reporting_threshold >= MAX_USAGE_REPORTING_THRESHOLD) {
@@ -176,61 +157,127 @@ int main(int argc, char *argv[])
   }
   magma::SessionCredit::USAGE_REPORTING_THRESHOLD = reporting_threshold;
   magma::SessionCredit::EXTRA_QUOTA_MARGIN =
-    config["extra_quota_margin"].as<uint64_t>();
+      config["extra_quota_margin"].as<uint64_t>();
   magma::SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED =
-   config["terminate_service_when_quota_exhausted"].as<bool>();
+      config["terminate_service_when_quota_exhausted"].as<bool>();
 
-  auto reporter = std::make_shared<magma::SessionCloudReporterImpl>(
-    evb, get_controller_channel(config));
-  std::thread reporter_thread([&]() {
+  reporter = std::make_shared<magma::SessionCloudReporterImpl>(
+      evb, get_controller_channel(config));
+  threads.emplace_back([&]() {
     MLOG(MINFO) << "Started reporter thread";
     reporter->rpc_response_loop();
   });
+}
 
-  auto monitor = magma::LocalEnforcer(
-    reporter,
-    rule_store,
-    pipelined_client,
-    spgw_client,
-    aaa_client,
-    config["session_force_termination_timeout_ms"].as<long>());
-
-  magma::service303::MagmaService server(SESSIOND_SERVICE, SESSIOND_VERSION);
+void init_async_server(std::vector<std::thread> &threads,
+    magma::LocalEnforcer &monitor,
+    std::shared_ptr<magma::SessionCloudReporterImpl> &reporter,
+    magma::service303::MagmaService &server) {
   auto local_handler = std::make_unique<magma::LocalSessionManagerHandlerImpl>(
-    &monitor, reporter.get());
+      &monitor, reporter.get());
   auto proxy_handler =
-    std::make_unique<magma::SessionProxyResponderHandlerImpl>(&monitor);
+      std::make_unique<magma::SessionProxyResponderHandlerImpl>(&monitor);
 
   magma::LocalSessionManagerAsyncService local_service(
-    server.GetNewCompletionQueue(), std::move(local_handler));
+      server.GetNewCompletionQueue(), std::move(local_handler));
   magma::SessionProxyResponderAsyncService proxy_service(
-    server.GetNewCompletionQueue(), std::move(proxy_handler));
+      server.GetNewCompletionQueue(), std::move(proxy_handler));
   server.AddServiceToServer(&local_service);
   server.AddServiceToServer(&proxy_service);
   server.Start();
 
-  std::thread local_thread([&]() {
+  threads.emplace_back([&]() {
     MLOG(MINFO) << "Started local service thread";
     local_service.wait_for_requests(); // block here instead of on server
     local_service.stop();              // stop queue after server shuts down
   });
-  std::thread proxy_thread([&]() {
+  threads.emplace_back([&]() {
     MLOG(MINFO) << "Started proxy service thread";
     proxy_service.wait_for_requests(); // block here instead of on server
     proxy_service.stop();              // stop queue after server shuts down
   });
+}
+}  // anonymous
+
+/* Sessiond is the control plane for the PCEF.
+ * Sessiond consists of the following.
+ * An async GRPC server that implements three services
+ * 1 - LocalSessionManager that handles within the gateway call (e.g. MME)
+ * 2 - Proxy responder for servicing requests from the FeG
+ * 3 - Service303
+ * Service303 runs in the main thread, a completion queue for the other services
+ * run on dedicated threads of their own.
+ * Additionally the process has:
+ * - An async client to the pipelined enforcement service for pushing rules
+ * to the PCEF
+ * - An async client to the MME/AAA to perform network initiated detaches
+ * - An async client to communicate towards the cloud for PCRF and OCS
+ *   related updates.
+ *   TODO: Service needs a signal handler.
+ */
+int main(int argc, char *argv[]) {
+#ifdef DEBUG
+  __gcov_flush();
+#endif
+
+  MLOG(MINFO) << "Starting Session Manager";
+  magma::init_logging(argv[0]);
+  auto mconfig = load_mconfig();
+  auto config =
+      magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
+  magma::set_verbosity(get_log_verbosity(config));
+
+  if (!sessiond_enabled(mconfig)) {
+    MLOG(MINFO) << "Credit control disabled, local enforcer not running";
+    run_bare_service303();
+    return 0;
+  }
+
+  std::vector<std::thread> threads;
+
+  // prep rule manager and rule update loop
+  std::shared_ptr<magma::StaticRuleStore> rule_store;
+  init_rules(config, threads, rule_store);
+
+  std::shared_ptr<magma::AsyncPipelinedClient> pipelined_client;
+  init_pipelined_client(threads, pipelined_client);
+
+  // init connection to AAA/MME.
+  // TODO: Ideally this should be abstracted behind a single client interface
+  std::shared_ptr<magma::AsyncSpgwServiceClient> spgw_client;
+  std::shared_ptr<aaa::AsyncAAAClient> aaa_client;
+  if (config["support_carrier_wifi"].as<bool>()) {
+    init_cwf(threads, aaa_client);
+  } else {
+    init_lte(threads, spgw_client);
+  }
+
+  // init reporting
+  std::shared_ptr<magma::SessionCloudReporterImpl> reporter;
+  folly::EventBase *evb = folly::EventBaseManager::get()->getEventBase();
+  init_reporting(config, evb, threads, reporter);
+
+
+  // Create the local enforcer and
+  auto monitor = magma::LocalEnforcer(
+      reporter,
+      rule_store,
+      pipelined_client,
+      spgw_client,
+      aaa_client,
+      config["session_force_termination_timeout_ms"].as<long>());
+
+  magma::service303::MagmaService server(SESSIOND_SERVICE, SESSIOND_VERSION);
+  init_async_server(threads, monitor, reporter, server);
 
   // Block on main monitor (to keep evb in this thread)
   monitor.attachEventBase(evb);
   monitor.start();
   server.Stop();
 
-  reporter_thread.join();
-  local_thread.join();
-  proxy_thread.join();
-  rule_manager_thread.join();
-  policy_loader_thread.join();
-  optional_client_thread.join();
+  for (auto &thread : threads) {
+    thread.join();
+  }
 
   return 0;
 }

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -102,17 +102,14 @@ uint32_t get_log_verbosity(const YAML::Node &config) {
 }
 
 void init_rules(const YAML::Node &config,
-                std::vector<std::thread> &threads,
                 std::shared_ptr<magma::StaticRuleStore> &rule_store) {
   magma::PolicyLoader policy_loader{};
-  threads.emplace_back([&]() {
-    policy_loader.start_loop(
-        [&](const std::vector<magma::PolicyRule> &rules) {
-          rule_store->sync_rules(rules);
+  policy_loader.load_config_async(
+      [&](const std::vector<magma::PolicyRule> &rules) {
+        rule_store->sync_rules(rules);
         },
         config["rule_update_inteval_sec"].as<uint32_t>());
-    policy_loader.stop();
-  });
+  policy_loader.stop();
 }
 
 void init_pipelined_client(std::vector<std::thread> &threads,
@@ -237,7 +234,7 @@ int main(int argc, char *argv[]) {
 
   // prep rule manager and rule update loop
   std::shared_ptr<magma::StaticRuleStore> rule_store;
-  init_rules(config, threads, rule_store);
+  init_rules(config, rule_store);
 
   std::shared_ptr<magma::AsyncPipelinedClient> pipelined_client;
   init_pipelined_client(threads, pipelined_client);

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -14,7 +14,9 @@
 
 namespace magma {
 
-static bool try_redis_connect(cpp_redis::client& client) {
+namespace {
+
+bool try_redis_connect(cpp_redis::client& client) {
   ServiceConfigLoader loader;
   auto config = loader.load_service_config("redis");
   auto port = config["port"].as<uint32_t>();
@@ -34,13 +36,13 @@ static bool try_redis_connect(cpp_redis::client& client) {
   }
 }
 
-static void do_loop(
+bool do_loop(
     cpp_redis::client& client,
     RedisMap<PolicyRule>& policy_map,
-    std::function<void(std::vector<PolicyRule>)>& processor) {
+    const std::function<void(std::vector<PolicyRule>)>& processor) {
   if (!client.is_connected()) {
     if (!try_redis_connect(client)) {
-      return;
+      return False;
     }
     MLOG(MINFO) << "Connected to redis server";
   }
@@ -48,14 +50,15 @@ static void do_loop(
   auto result = policy_map.getall(rules);
   if (result != SUCCESS) {
     MLOG(MERROR) << "Failed to get rules from map because map error " << result;
-    return;
+    return False;
   }
   processor(rules);
   MLOG(MDEBUG) << "Rules synced";
+  return True;
 }
 
 void PolicyLoader::load_config_async(
-    std::function<void(std::vector<PolicyRule>)> processor,
+    const std::function<void(std::vector<PolicyRule>)>& processor,
     uint32_t loop_interval_seconds) {
   is_running_ = true;
   auto client = std::make_shared<cpp_redis::client>();
@@ -77,4 +80,22 @@ void PolicyLoader::stop() {
   redis_client_thread_.join();
 }
 
+bool PolicyLoader::load_config_sync(
+    std::function<void(std::vector<PolicyRule>)> processor,
+    uint32_t loop_interval_seconds) {
+  auto client = std::make_shared<cpp_redis::client>();
+  auto policy_map = RedisMap<PolicyRule>(
+      client,
+      "policydb:rules",
+      get_proto_serializer(),
+      get_proto_deserializer());
+  auto retries = NUM_RETRIES;
+  bool success = False;
+  while (!success && retries--) {
+    sucess = do_loop(*client, policy_map, processor));
+    std::this_thread::sleep_for(std::chrono::seconds(loop_interval_seconds));
+  }
+  return success;
 }
+
+}  // namespace magma

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.h
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.h
@@ -25,7 +25,7 @@ public:
    * redis, and call the processor callback.
    */
   void load_config_async(
-      std::function<void(std::vector<PolicyRule>)> processor,
+      const std::function<void(std::vector<PolicyRule>)>& processor,
       uint32_t loop_interval_seconds);
 
   /**
@@ -33,6 +33,18 @@ public:
    * completes.
    */
   void stop();
+
+
+  /**
+   * Sync version of load_config. Attempts retires fixed number of times
+   * based on interval between load attempts.
+   * @returns True if config was loaded correctly, False otherwise
+   */
+  bool load_config_sync(std::function<void(std::vector<PolicyRule>)> processor,
+                        uint32_t loop_interval_seconds);
+
+  // Number of retries for the sync version
+  const int NUM_RETRIES = 3;
 private:
   std::atomic<bool> is_running_;
   std::thread redis_client_thread_;

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.h
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.h
@@ -20,19 +20,21 @@ class PolicyLoader {
 public:
 
   /**
-   * start_loop is the main function to call to initiate a load loop. Based on
+   * load_config_async initiates an async loop to load config. Based on
    * the given loop interval length, this function will load the policies from
    * redis, and call the processor callback.
    */
-  void start_loop(
-    std::function<void(std::vector<PolicyRule>)> processor,
-    uint32_t loop_interval_seconds);
+  void load_config_async(
+      std::function<void(std::vector<PolicyRule>)> processor,
+      uint32_t loop_interval_seconds);
 
   /**
-   * Stop the config loop on the next loop
+   * Stop the config loop on the next loop. Blocks until the async thread
+   * completes.
    */
   void stop();
 private:
   std::atomic<bool> is_running_;
+  std::thread redis_client_thread_;
 };
 }


### PR DESCRIPTION
Summary:
Currently we read static policies from redis in an async thread. This is overly complicated as sessiond is anyway
not functional until static policies are initialized. Update to use a synchronous interface for the same.
Change also
1 - Introduces a synchronous interface for PolicyLoader
2 - Moves static functions to an anonymous namespace

Reviewed By: themarwhal

Differential Revision: D18128149

