### PR TITLE
Avoid prompt popup about removing kernel package in AWS_HOST script

### DIFF
--- a/docs/readmes/lte/setup_deb.md
+++ b/docs/readmes/lte/setup_deb.md
@@ -61,8 +61,6 @@ wget https://raw.githubusercontent.com/facebookincubator/magma/v1.0.0/lte/gatewa
 sh agw_prepare.sh
 ```
 
-A prompt will pop up to as you if you want to stop removing linux-image-4.9.0-11-amd64 please hit: No
-
 ### 3. Prepare AGW_DEPLOY
 - [AGW_DEPLOY] Build and run AGW_DEPLOY container
 

--- a/lte/gateway/deploy/agw_prepare.sh
+++ b/lte/gateway/deploy/agw_prepare.sh
@@ -38,6 +38,6 @@ fi
 mkdir -p /home/magma/.ssh
 chown magma:magma /home/magma/.ssh
 # Removing incompatible Kernel version
-apt remove -y linux-image-4.9.0-11-amd64
+DEBIAN_FRONTEND=noninteractive apt remove -y linux-image-4.9.0-11-amd64
 
 reboot


### PR DESCRIPTION
During installation procedures, there is an unecessary dialog about removal of kernel. This patch should remove it.