### PR TITLE
create ipv6 ping engine

### DIFF
--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -33,6 +33,7 @@ namespace devmand {
 using Services = std::list<std::unique_ptr<Service>>;
 using ChannelEngines = std::set<std::unique_ptr<channels::Engine>>;
 using Devices = std::map<devices::Id, std::unique_ptr<devices::Device>>;
+using IPVersion = channels::ping::IPVersion;
 
 class Application final : public MetricSink {
  public:
@@ -90,7 +91,8 @@ class Application final : public MetricSink {
   DhcpdConfig& getDhcpdConfig();
 
   channels::snmp::Engine& getSnmpEngine();
-  channels::ping::Engine& getPingEngine();
+  channels::ping::Engine& getPingEngine(IPVersion ipv = IPVersion::v4);
+  channels::ping::Engine& getPingEngine(folly::IPAddress ip);
 
  private:
   void pollDevices();
@@ -137,6 +139,7 @@ class Application final : public MetricSink {
   ChannelEngines channelEngines;
   channels::snmp::Engine* snmpEngine;
   channels::ping::Engine* pingEngine;
+  channels::ping::Engine* pingEngineIpv6;
 
   /*
    * A config writer for dhcpd.

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -31,30 +31,52 @@ namespace ping {
 
 Engine::Engine(
     folly::EventBase& _eventBase,
+    IPVersion ipv_,
     const std::chrono::milliseconds& pingTimeout_,
     const std::chrono::milliseconds& timeoutFrequency_)
     : channels::Engine("Ping"),
       folly::EventHandler(&_eventBase),
       eventBase(_eventBase),
+      ipv(ipv_),
       pingTimeout(pingTimeout_),
       timeoutFrequency(timeoutFrequency_) {
-  icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+  switch (ipv) {
+    case IPVersion::v4:
+      icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+      break;
+    case IPVersion::v6:
+      icmpSocket = ::socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
+      break;
+  }
   if (icmpSocket < 0) {
-    LOG(ERROR) << "Failed to open dgram socket";
-    throw std::system_error(errno, std::generic_category());
+    auto err = std::system_error(errno, std::generic_category());
+    LOG(ERROR) << "Failed to open dgram socket: " << err.what();
+    if (ipv_ == IPVersion::v6) {
+      LOG(ERROR) << "ICMP over IPv6 will not work.";
+      failedIpv6Socket = true;
+    } else {
+      throw err;
+    }
+  } else {
+    if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
+      throw std::system_error(errno, std::generic_category());
+    }
+    folly::EventHandler::changeHandlerFD(
+        folly::NetworkSocket::fromFd(icmpSocket));
   }
-
-  if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
-    throw std::system_error(errno, std::generic_category());
-  }
-
-  folly::EventHandler::changeHandlerFD(
-      folly::NetworkSocket::fromFd(icmpSocket));
-
   registerHandler(folly::EventHandler::READ | folly::EventHandler::PERSIST);
-
   start();
 }
+
+Engine::Engine(
+    folly::EventBase& _eventBase,
+    const std::chrono::milliseconds& pingTimeout_,
+    const std::chrono::milliseconds& timeoutFrequency_)
+    : Engine::Engine(
+          _eventBase,
+          IPVersion::v4,
+          pingTimeout_,
+          timeoutFrequency_) {}
 
 Engine::~Engine() {
   unregisterHandler();
@@ -95,8 +117,11 @@ void Engine::timeout() {
 folly::Future<Rtt> Engine::ping(
     const icmphdr& hdr,
     const folly::IPAddress& destination) {
+  if (failedIpv6Socket) {
+    LOG(ERROR) << "Attempted ping on IPV6 where socket failed to open.";
+    return folly::makeFuture<Rtt>(0);
+  }
   incrementRequests();
-
   return sharedOutstandingRequests.withULockPtr([this, &hdr, &destination](
                                                     auto uOutstandingRequests) {
     auto outstandingRequests = uOutstandingRequests.moveFromUpgradeToWrite();

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -30,6 +30,8 @@ struct Request {
   folly::Promise<Rtt> promise;
 };
 
+enum IPVersion { v4, v6 };
+
 using RequestId = uint16_t;
 
 using OutstandingRequests =
@@ -44,6 +46,13 @@ struct IcmpPacket {
 
 class Engine : public channels::Engine, public folly::EventHandler {
  public:
+  Engine(
+      folly::EventBase& _eventBase,
+      IPVersion ipv_,
+      const std::chrono::milliseconds& pingTimeout_ =
+          std::chrono::milliseconds(5000),
+      const std::chrono::milliseconds& timeoutFrequency_ =
+          std::chrono::milliseconds(10000));
   Engine(
       folly::EventBase& _eventBase,
       const std::chrono::milliseconds& pingTimeout_ =
@@ -75,6 +84,8 @@ class Engine : public channels::Engine, public folly::EventHandler {
   folly::EventBase& eventBase;
   folly::Synchronized<OutstandingRequests> sharedOutstandingRequests;
   int icmpSocket{-1};
+  IPVersion ipv;
+  bool failedIpv6Socket{false};
   std::chrono::milliseconds pingTimeout;
   std::chrono::milliseconds timeoutFrequency;
 };

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -30,7 +30,7 @@ PingDevice::PingDevice(
     Application& application,
     const Id& id_,
     const folly::IPAddress& ip_)
-    : Device(application, id_), channel(application.getPingEngine(), ip_) {}
+    : Device(application, id_), channel(application.getPingEngine(ip_), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
   auto state = State::make(app, getId());


### PR DESCRIPTION
Summary:
This diff creates an IPV6 ping engine. The ping engine opens an ipv6 socket. It doesn't yet send or read them (that's in the next diff of the stack).

Docker for mac doesn't work with ipv6 but this diff handles a failed socket open gracefully. Whether or not a machine supports v6, this won't break it.

Differential Revision: D18434701

