### PR TITLE
generalized IcmpPacket (ping works)

### DIFF
--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -33,6 +33,7 @@ namespace devmand {
 using Services = std::list<std::unique_ptr<Service>>;
 using ChannelEngines = std::set<std::unique_ptr<channels::Engine>>;
 using Devices = std::map<devices::Id, std::unique_ptr<devices::Device>>;
+using IPVersion = channels::ping::IPVersion;
 
 class Application final : public MetricSink {
  public:
@@ -90,7 +91,8 @@ class Application final : public MetricSink {
   DhcpdConfig& getDhcpdConfig();
 
   channels::snmp::Engine& getSnmpEngine();
-  channels::ping::Engine& getPingEngine();
+  channels::ping::Engine& getPingEngine(IPVersion ipv = IPVersion::v4);
+  channels::ping::Engine& getPingEngine(folly::IPAddress ip);
 
  private:
   void pollDevices();
@@ -137,6 +139,7 @@ class Application final : public MetricSink {
   ChannelEngines channelEngines;
   channels::snmp::Engine* snmpEngine;
   channels::ping::Engine* pingEngine;
+  channels::ping::Engine* pingEngineIpv6;
 
   /*
    * A config writer for dhcpd.

--- a/devmand/gateway/src/devmand/channels/ping/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.cpp
@@ -19,25 +19,14 @@ Channel::Channel(Engine& engine_, folly::IPAddress target_)
     : engine(engine_), target(target_) {}
 
 folly::Future<Rtt> Channel::ping() {
-  icmphdr hdr = makeIcmpPacket();
-
+  auto pkt = channels::ping::IcmpPacket(target, getSequence());
   LOG(INFO) << "Sending ping to " << target.str() << " with sequence "
-            << hdr.un.echo.sequence;
-
-  return engine.ping(hdr, target);
+            << pkt.getSequence();
+  return engine.ping(pkt);
 }
 
 RequestId Channel::getSequence() {
   return ++sequence;
-}
-
-icmphdr Channel::makeIcmpPacket() {
-  icmphdr hdr{};
-  hdr.type = ICMP_ECHO;
-  // hdr.un.echo.id = 0;
-  hdr.un.echo.sequence = getSequence();
-  // hdr.checksum = 0; // Let the kernel fill in the checksum
-  return hdr;
 }
 
 } // namespace ping

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -30,6 +30,8 @@ struct Request {
   folly::Promise<Rtt> promise;
 };
 
+enum IPVersion { v4, v6 };
+
 using RequestId = uint16_t;
 
 using OutstandingRequests =
@@ -44,6 +46,13 @@ struct IcmpPacket {
 
 class Engine : public channels::Engine, public folly::EventHandler {
  public:
+  Engine(
+      folly::EventBase& _eventBase,
+      IPVersion ipv_,
+      const std::chrono::milliseconds& pingTimeout_ =
+          std::chrono::milliseconds(5000),
+      const std::chrono::milliseconds& timeoutFrequency_ =
+          std::chrono::milliseconds(10000));
   Engine(
       folly::EventBase& _eventBase,
       const std::chrono::milliseconds& pingTimeout_ =
@@ -75,6 +84,8 @@ class Engine : public channels::Engine, public folly::EventHandler {
   folly::EventBase& eventBase;
   folly::Synchronized<OutstandingRequests> sharedOutstandingRequests;
   int icmpSocket{-1};
+  IPVersion ipv;
+  bool failedIpv6Socket{false};
   std::chrono::milliseconds pingTimeout;
   std::chrono::milliseconds timeoutFrequency;
 };

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -30,7 +30,7 @@ PingDevice::PingDevice(
     Application& application,
     const Id& id_,
     const folly::IPAddress& ip_)
-    : Device(application, id_), channel(application.getPingEngine(), ip_) {}
+    : Device(application, id_), channel(application.getPingEngine(ip_), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
   auto state = State::make(app, getId());


### PR DESCRIPTION
Summary: This diff generalizes the data structure required for sending and reading pings (ICMP Header) because the header is different for ipv4 and ipv6. This means that the send and read logic that worked previous for v4 now works for both v4 and v6.

Differential Revision: D18435190

