### PR TITLE
docker compose network mode host

### DIFF
--- a/devmand/gateway/docker/docker-compose.yml
+++ b/devmand/gateway/docker/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       - NET_ADMIN
     sysctls:
       - net.ipv4.ping_group_range=0 0
+    network_mode: host
     stdin_open: true
     tty: true
     privileged: true

--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -33,6 +33,7 @@ namespace devmand {
 using Services = std::list<std::unique_ptr<Service>>;
 using ChannelEngines = std::set<std::unique_ptr<channels::Engine>>;
 using Devices = std::map<devices::Id, std::unique_ptr<devices::Device>>;
+using IPVersion = channels::ping::IPVersion;
 
 class Application final : public MetricSink {
  public:
@@ -90,7 +91,8 @@ class Application final : public MetricSink {
   DhcpdConfig& getDhcpdConfig();
 
   channels::snmp::Engine& getSnmpEngine();
-  channels::ping::Engine& getPingEngine();
+  channels::ping::Engine& getPingEngine(IPVersion ipv = IPVersion::v4);
+  channels::ping::Engine& getPingEngine(folly::IPAddress ip);
 
  private:
   void pollDevices();
@@ -137,6 +139,7 @@ class Application final : public MetricSink {
   ChannelEngines channelEngines;
   channels::snmp::Engine* snmpEngine;
   channels::ping::Engine* pingEngine;
+  channels::ping::Engine* pingEngineIpv6;
 
   /*
    * A config writer for dhcpd.

--- a/devmand/gateway/src/devmand/channels/ping/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Channel.cpp
@@ -19,25 +19,14 @@ Channel::Channel(Engine& engine_, folly::IPAddress target_)
     : engine(engine_), target(target_) {}
 
 folly::Future<Rtt> Channel::ping() {
-  icmphdr hdr = makeIcmpPacket();
-
+  auto pkt = IcmpPacket(target, getSequence());
   LOG(INFO) << "Sending ping to " << target.str() << " with sequence "
-            << hdr.un.echo.sequence;
-
-  return engine.ping(hdr, target);
+            << pkt.getSequence();
+  return engine.ping(pkt);
 }
 
 RequestId Channel::getSequence() {
   return ++sequence;
-}
-
-icmphdr Channel::makeIcmpPacket() {
-  icmphdr hdr{};
-  hdr.type = ICMP_ECHO;
-  // hdr.un.echo.id = 0;
-  hdr.un.echo.sequence = getSequence();
-  // hdr.checksum = 0; // Let the kernel fill in the checksum
-  return hdr;
 }
 
 } // namespace ping

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -31,30 +31,52 @@ namespace ping {
 
 Engine::Engine(
     folly::EventBase& _eventBase,
+    IPVersion ipv_,
     const std::chrono::milliseconds& pingTimeout_,
     const std::chrono::milliseconds& timeoutFrequency_)
     : channels::Engine("Ping"),
       folly::EventHandler(&_eventBase),
       eventBase(_eventBase),
+      ipv(ipv_),
       pingTimeout(pingTimeout_),
       timeoutFrequency(timeoutFrequency_) {
-  icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+  switch (ipv) {
+    case IPVersion::v4:
+      icmpSocket = ::socket(AF_INET, SOCK_DGRAM, IPPROTO_ICMP);
+      break;
+    case IPVersion::v6:
+      icmpSocket = ::socket(AF_INET6, SOCK_DGRAM, IPPROTO_ICMPV6);
+      break;
+  }
   if (icmpSocket < 0) {
-    LOG(ERROR) << "Failed to open dgram socket";
-    throw std::system_error(errno, std::generic_category());
+    auto err = std::system_error(errno, std::generic_category());
+    LOG(ERROR) << "Failed to open dgram socket: " << err.what();
+    if (ipv_ == IPVersion::v6) {
+      LOG(ERROR) << "ICMP over IPv6 will not work.";
+      failedIpv6Socket = true;
+    } else {
+      throw err;
+    }
+  } else {
+    if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
+      throw std::system_error(errno, std::generic_category());
+    }
+    folly::EventHandler::changeHandlerFD(
+        folly::NetworkSocket::fromFd(icmpSocket));
   }
-
-  if (fcntl(icmpSocket, F_SETFL, O_NONBLOCK) < 0) {
-    throw std::system_error(errno, std::generic_category());
-  }
-
-  folly::EventHandler::changeHandlerFD(
-      folly::NetworkSocket::fromFd(icmpSocket));
-
   registerHandler(folly::EventHandler::READ | folly::EventHandler::PERSIST);
-
   start();
 }
+
+Engine::Engine(
+    folly::EventBase& _eventBase,
+    const std::chrono::milliseconds& pingTimeout_,
+    const std::chrono::milliseconds& timeoutFrequency_)
+    : Engine::Engine(
+          _eventBase,
+          IPVersion::v4,
+          pingTimeout_,
+          timeoutFrequency_) {}
 
 Engine::~Engine() {
   unregisterHandler();
@@ -95,8 +117,11 @@ void Engine::timeout() {
 folly::Future<Rtt> Engine::ping(
     const icmphdr& hdr,
     const folly::IPAddress& destination) {
+  if (failedIpv6Socket) {
+    LOG(ERROR) << "Attempted ping on IPV6 where socket failed to open.";
+    return folly::makeFuture<Rtt>(0);
+  }
   incrementRequests();
-
   return sharedOutstandingRequests.withULockPtr([this, &hdr, &destination](
                                                     auto uOutstandingRequests) {
     auto outstandingRequests = uOutstandingRequests.moveFromUpgradeToWrite();

--- a/devmand/gateway/src/devmand/channels/ping/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.cpp
@@ -29,6 +29,146 @@ namespace devmand {
 namespace channels {
 namespace ping {
 
+// Exhaustive switch statements, even for enums, don't guarantee a return.
+// Just throw this if there's an unexpected enuenum value.
+std::out_of_range DefaultSwitchError(
+    "Reached end of exhaustive switch IPVersion.");
+
+IcmpPacket::IcmpPacket(IPVersion ipv_)
+    : packetType(PacketType::read), ipv(ipv_) {}
+
+IcmpPacket::IcmpPacket(const folly::IPAddress& addr_, RequestId sequence)
+    : packetType(PacketType::send),
+      ipv(addr_.isV4() ? IPVersion::v4 : IPVersion::v6),
+      addr(addr_) {
+  switch (ipv) {
+    case IPVersion::v4:
+      hdrV4.type = ICMP_ECHO;
+      hdrV4.un.echo.sequence = sequence;
+      break;
+    case IPVersion::v6:
+      hdrV6.icmp6_type = ICMP6_ECHO_REQUEST;
+      hdrV6.icmp6_seq = sequence;
+      break;
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+RequestId IcmpPacket::getSequence() const {
+  switch (ipv) {
+    case IPVersion::v4:
+      return hdrV4.un.echo.sequence;
+    case IPVersion::v6:
+      return hdrV6.icmp6_seq;
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+const folly::IPAddress& IcmpPacket::getAddr() const {
+  return addr;
+}
+
+bool IcmpPacket::wasSuccess() {
+  return success;
+}
+
+auto IcmpPacket::getType() {
+  switch (ipv) {
+    case IPVersion::v4:
+      return hdrV4.type;
+    case IPVersion::v6:
+      return hdrV6.icmp6_type;
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+bool IcmpPacket::isEchoReply() {
+  switch (ipv) {
+    case IPVersion::v4:
+      return getType() == ICMP_ECHOREPLY;
+    case IPVersion::v6:
+      return getType() == ICMP6_ECHO_REPLY;
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+auto IcmpPacket::getCode() {
+  switch (ipv) {
+    case IPVersion::v4:
+      return hdrV4.code;
+    case IPVersion::v6:
+      return hdrV6.icmp6_code;
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+const sockaddr_storage& IcmpPacket::getSrc() {
+  return src;
+}
+
+auto IcmpPacket::send(int socket) const {
+  assert(packetType == PacketType::send);
+  sockaddr_storage dst;
+  addr.toSockaddrStorage(&dst);
+  switch (ipv) {
+    case IPVersion::v4:
+      return sendto(
+          socket,
+          &hdrV4,
+          sizeof(hdrV4),
+          0,
+          reinterpret_cast<const sockaddr*>(&dst),
+          sizeof(dst));
+    case IPVersion::v6:
+      return sendto(
+          socket,
+          &hdrV6,
+          sizeof(hdrV6),
+          0,
+          reinterpret_cast<const sockaddr*>(&dst),
+          sizeof(dst));
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+void IcmpPacket::read(int socket) {
+  assert(packetType == PacketType::read);
+  switch (ipv) {
+    case IPVersion::v4:
+      success = recvfrom(
+                    socket,
+                    &hdrV4,
+                    sizeof(hdrV4),
+                    0,
+                    reinterpret_cast<sockaddr*>(&src),
+                    &srcLen) > 0;
+      break;
+    case IPVersion::v6:
+      success = recvfrom(
+                    socket,
+                    &hdrV6,
+                    sizeof(hdrV6),
+                    0,
+                    reinterpret_cast<sockaddr*>(&src),
+                    &srcLen) > 0;
+      break;
+    default:
+      throw DefaultSwitchError;
+  }
+}
+
+IcmpPacket Engine::read() {
+  IcmpPacket pkt(ipv);
+  pkt.read(icmpSocket);
+  return pkt;
+}
+
 Engine::Engine(
     folly::EventBase& _eventBase,
     IPVersion ipv_,
@@ -114,33 +254,22 @@ void Engine::timeout() {
   });
 }
 
-folly::Future<Rtt> Engine::ping(
-    const icmphdr& hdr,
-    const folly::IPAddress& destination) {
+folly::Future<Rtt> Engine::ping(const IcmpPacket& pkt) {
   if (failedIpv6Socket) {
     LOG(ERROR) << "Attempted ping on IPV6 where socket failed to open.";
     return folly::makeFuture<Rtt>(0);
   }
   incrementRequests();
-  return sharedOutstandingRequests.withULockPtr([this, &hdr, &destination](
+  return sharedOutstandingRequests.withULockPtr([this, &pkt](
                                                     auto uOutstandingRequests) {
     auto outstandingRequests = uOutstandingRequests.moveFromUpgradeToWrite();
     auto request = outstandingRequests->emplace(
         std::piecewise_construct,
-        std::forward_as_tuple(
-            std::make_pair(destination, hdr.un.echo.sequence)),
+        std::forward_as_tuple(std::make_pair(pkt.getAddr(), pkt.getSequence())),
         std::forward_as_tuple(Request{}));
     if (request.second) {
-      sockaddr_storage dst;
-      destination.toSockaddrStorage(&dst);
       request.first->second.start = utils::Time::now();
-      auto result = sendto(
-          icmpSocket,
-          &hdr,
-          sizeof(hdr),
-          0,
-          reinterpret_cast<const sockaddr*>(&dst),
-          sizeof(dst));
+      auto result = pkt.send(icmpSocket);
       if (result <= 0) {
         switch (result) {
           case EAGAIN: // case EWOULDBLOCK:
@@ -167,32 +296,21 @@ folly::Future<Rtt> Engine::ping(
   });
 }
 
-IcmpPacket Engine::read() {
-  IcmpPacket pkt;
-  pkt.success = recvfrom(
-                    icmpSocket,
-                    &pkt.hdr,
-                    sizeof(pkt.hdr),
-                    0,
-                    reinterpret_cast<sockaddr*>(&pkt.src),
-                    &pkt.srcLen) > 0;
-  return pkt;
-}
-
 void Engine::handlerReady(uint16_t) noexcept {
   // TODO end time isn't really precise here as we don't have a kernel time
   // need to implement kernel timestamping
   utils::TimePoint end = utils::Time::now();
-  for (IcmpPacket pkt = read(); pkt.success; pkt = read()) {
+  for (IcmpPacket pkt = read(); pkt.wasSuccess(); pkt = read()) {
     bool processed{false};
-    if (pkt.hdr.type == 0 and pkt.hdr.code == 0) {
+    if (pkt.isEchoReply() and pkt.getCode() == 0) {
       sharedOutstandingRequests.withULockPtr([this, &end, &pkt, &processed](
                                                  auto uOutstandingRequests) {
         auto outstandingRequests =
             uOutstandingRequests.moveFromUpgradeToWrite();
+        auto src = pkt.getSrc();
         auto request = outstandingRequests->find(std::make_pair(
-            folly::IPAddress(reinterpret_cast<sockaddr*>(&pkt.src)),
-            pkt.hdr.un.echo.sequence));
+            folly::IPAddress(reinterpret_cast<sockaddr*>(&src)),
+            pkt.getSequence()));
         if (request != outstandingRequests->end()) {
           auto duration = std::chrono::duration_cast<std::chrono::microseconds>(
               end - request->second.start);
@@ -207,8 +325,8 @@ void Engine::handlerReady(uint16_t) noexcept {
 
     if (not processed) {
       LOG(INFO) << "Packet received with ICMP type "
-                << static_cast<int>(pkt.hdr.type) << " code "
-                << static_cast<int>(pkt.hdr.code);
+                << static_cast<int>(pkt.getType()) << " code "
+                << static_cast<int>(pkt.getCode());
     }
   }
 }

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -10,6 +10,7 @@
 #include <map>
 #include <string>
 
+#include <netinet/icmp6.h>
 #include <netinet/ip_icmp.h>
 
 #include <folly/futures/Future.h>
@@ -23,6 +24,8 @@ namespace devmand {
 namespace channels {
 namespace ping {
 
+extern std::out_of_range DefaultSwitchError;
+
 using Rtt = uint64_t;
 
 struct Request {
@@ -31,15 +34,47 @@ struct Request {
 };
 
 enum IPVersion { v4, v6 };
+enum PacketType { send, read };
 
 using RequestId = uint16_t;
 
 using OutstandingRequests =
     std::map<std::pair<folly::IPAddress, RequestId>, Request>;
 
-struct IcmpPacket {
-  bool success;
-  icmphdr hdr{};
+// The data structure for icmp headers.
+// Generalized for v4 or v6.
+class IcmpPacket final {
+ public:
+  IcmpPacket(IPVersion ipv); // read ping
+  IcmpPacket(const folly::IPAddress& addr, RequestId sequence); // send ping
+  IcmpPacket() = delete;
+  ~IcmpPacket() = default;
+  IcmpPacket(const IcmpPacket&) = delete;
+  IcmpPacket& operator=(const IcmpPacket&) = delete;
+  IcmpPacket(IcmpPacket&&) = default;
+  IcmpPacket& operator=(IcmpPacket&&) = default;
+
+ public:
+  // getters for private members
+  RequestId getSequence() const;
+  const folly::IPAddress& getAddr() const;
+  bool wasSuccess();
+  bool isEchoReply();
+  auto getType();
+  auto getCode();
+  const sockaddr_storage& getSrc();
+
+ public:
+  auto send(int socket) const;
+  void read(int socket);
+
+ private:
+  PacketType packetType;
+  IPVersion ipv;
+  bool success{false};
+  folly::IPAddress addr;
+  icmphdr hdrV4{};
+  icmp6_hdr hdrV6{};
   sockaddr_storage src{};
   socklen_t srcLen{sizeof(sockaddr_storage)};
 };
@@ -67,16 +102,13 @@ class Engine : public channels::Engine, public folly::EventHandler {
   Engine& operator=(Engine&&) = delete;
 
  public:
-  folly::Future<Rtt> ping(
-      const icmphdr& hdr,
-      const folly::IPAddress& destination);
+  folly::Future<Rtt> ping(const IcmpPacket& pkt);
 
   // NOTE this must be called after the event base is running.
   void start();
 
  private:
   virtual void handlerReady(uint16_t events) noexcept override;
-
   void timeout();
   IcmpPacket read();
 

--- a/devmand/gateway/src/devmand/channels/ping/Engine.h
+++ b/devmand/gateway/src/devmand/channels/ping/Engine.h
@@ -30,6 +30,8 @@ struct Request {
   folly::Promise<Rtt> promise;
 };
 
+enum IPVersion { v4, v6 };
+
 using RequestId = uint16_t;
 
 using OutstandingRequests =
@@ -44,6 +46,13 @@ struct IcmpPacket {
 
 class Engine : public channels::Engine, public folly::EventHandler {
  public:
+  Engine(
+      folly::EventBase& _eventBase,
+      IPVersion ipv_,
+      const std::chrono::milliseconds& pingTimeout_ =
+          std::chrono::milliseconds(5000),
+      const std::chrono::milliseconds& timeoutFrequency_ =
+          std::chrono::milliseconds(10000));
   Engine(
       folly::EventBase& _eventBase,
       const std::chrono::milliseconds& pingTimeout_ =
@@ -75,6 +84,8 @@ class Engine : public channels::Engine, public folly::EventHandler {
   folly::EventBase& eventBase;
   folly::Synchronized<OutstandingRequests> sharedOutstandingRequests;
   int icmpSocket{-1};
+  IPVersion ipv;
+  bool failedIpv6Socket{false};
   std::chrono::milliseconds pingTimeout;
   std::chrono::milliseconds timeoutFrequency;
 };

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -30,7 +30,7 @@ PingDevice::PingDevice(
     Application& application,
     const Id& id_,
     const folly::IPAddress& ip_)
-    : Device(application, id_), channel(application.getPingEngine(), ip_) {}
+    : Device(application, id_), channel(application.getPingEngine(ip_), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
   auto state = State::make(app, getId());


### PR DESCRIPTION
Summary: Change default network mode of the agent docker container to "host". This gives the container more network permissions. This was necessary to enable ping over ipv6. This is not a security concern as any necessary firewall rules are configured on the host and will apply to the container as well.

Differential Revision: D18435415

