### PR TITLE
/[sessiond] Avoid simultaneous activation of flows for static & dynamic rules

### DIFF
--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -164,6 +164,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
                                        static_rule_ids: List[str],
                                        dynamic_rules: List[PolicyRule]
                                        ) -> ActivateFlowsResult:
+        # TODO: this will crash pipelined if called with both static rules
+        # and dynamic rules at the same time
         enforcement_res = self._enforcer_app.activate_rules(
             imsi, ip_addr, static_rule_ids, dynamic_rules)
         _report_enforcement_failures(enforcement_res, imsi)


### PR DESCRIPTION
Summary: Likely due to an incompatibility between greenlets and asyncio running in pipelined. This is a mitigation allowing us to sort out the issue a little later

Differential Revision: D18452196

