### PR TITLE
Implement a basic CentralSessionController on captive_portal

### DIFF
--- a/lte/gateway/configs/captive_portal.yml
+++ b/lte/gateway/configs/captive_portal.yml
@@ -25,6 +25,9 @@ subscriber_profile_substr_match: ''
 # Interface for finding the local ip (ie 192.168.128.1)
 bridge_interface: gtp_br0
 
+# Static rule name for captive_portal redirect
+redirect_rule_name: redirect
+
 # Specifies an {ip -> [ports]} map to allow traffic
 # NOTE: Right not we only support TCP traffic for the ports
 whitelisted_ips:

--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -9,6 +9,7 @@ PROTO_LIST:=orc8r_protos lte_protos feg_protos
 
 # Path to the test files
 TESTS=magma/tests \
+	  magma/captive_portal/tests \
       magma/enodebd/tests \
       magma/mobilityd/tests \
       magma/pipelined/openflow/tests \

--- a/lte/gateway/python/magma/captive_portal/main.py
+++ b/lte/gateway/python/magma/captive_portal/main.py
@@ -16,7 +16,7 @@ def main():
     service = MagmaService('captive_portal', None)
 
     # Add all servicers to the server
-    session_servicer = SessionRpcServicer(service)
+    session_servicer = SessionRpcServicer(service.config)
     session_servicer.add_to_server(service.rpc_server)
 
     # Run the service loop

--- a/lte/gateway/python/magma/captive_portal/rpc_servicer.py
+++ b/lte/gateway/python/magma/captive_portal/rpc_servicer.py
@@ -7,163 +7,246 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 import logging
-
-from grpc import RpcError
-from lte.protos import session_manager_pb2, session_manager_pb2_grpc
-from lte.protos.pipelined_pb2 import ActivateFlowsRequest, \
-    DeactivateFlowsRequest
-from lte.protos.pipelined_pb2_grpc import PipelinedStub
-from lte.protos.policydb_pb2 import FlowDescription, FlowMatch, PolicyRule, \
-    RedirectInformation
-from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
-from orc8r.protos.common_pb2 import Void
-
-from magma.common.misc_utils import get_ip_from_if
-from magma.common.service_registry import ServiceRegistry
+from datetime import datetime
+from typing import Any, Dict, List
+from lte.protos.policydb_pb2 import PolicyRule, FlowMatch, FlowDescription, \
+    FlowQos, QosArp
+from lte.protos.session_manager_pb2 import CreateSessionRequest, \
+    CreateSessionResponse, UpdateSessionRequest, SessionTerminateResponse, \
+    UpdateSessionResponse, DynamicRuleInstall, StaticRuleInstall, \
+    ChargingCredit, GrantedUnits, CreditUnit, CreditUpdateResponse
+from lte.protos.session_manager_pb2_grpc import \
+    CentralSessionControllerServicer, \
+    add_CentralSessionControllerServicer_to_server
 
 
-class SessionRpcServicer(session_manager_pb2_grpc.LocalSessionManagerServicer):
+class SessionRpcServicer(CentralSessionControllerServicer):
     """
-    gRPC based server for LocalSessionManager service
-    """
-    ALLOW_ALL_PRIORITY = 100
-    REDIRECT_PRIORITY = 2000
-    RPC_TIMEOUT = 5
+    gRPC based server for CentralSessionController service.
 
-    def __init__(self, service):
-        chan = ServiceRegistry.get_rpc_channel('pipelined',
-                                               ServiceRegistry.LOCAL)
-        self._pipelined = PipelinedStub(chan)
-        chan = ServiceRegistry.get_rpc_channel('subscriberdb',
-                                               ServiceRegistry.LOCAL)
-        self._subscriberdb = SubscriberDBStub(chan)
-        self._enabled = service.config['captive_portal_enabled']
-        self._captive_portal_address = service.config['captive_portal_url']
-        self._local_ip = get_ip_from_if(service.config['bridge_interface'])
-        self._whitelisted_ips = service.config['whitelisted_ips']
-        self._sub_profile_substr = service.config[
-            'subscriber_profile_substr_match']
+    This will act as a bare-bones local PCRF and OCS.
+    In current implementation, it is only used for enabling the Captive Portal
+    feature.
+    """
+
+    def __init__(self, service_config):
+        self._config = service_config
+
+    @property
+    def config(self) -> Dict[str, Any]:
+        return self._config
+
+    @property
+    def redirect_rule_name(self) -> str:
+        return self._config['redirect_rule_name']
+
+    @property
+    def ip_whitelist(self) -> Dict[str, List[int]]:
+        """
+        Get whitelisted IP/port combinations which have all traffic allowed.
+
+        Returns: A dict keyed by IP, with values being a list of ports
+        """
+        return self._config['whitelisted_ips']
 
     def add_to_server(self, server):
-        """
-        Add the servicer to a gRPC server
-        """
-        session_manager_pb2_grpc.add_LocalSessionManagerServicer_to_server(
+        """ Add the servicer to a gRPC server """
+        add_CentralSessionControllerServicer_to_server(
             self, server,
         )
 
-    def CreateSession(self, request, context):
+    def CreateSession(
+        self,
+        request: CreateSessionRequest,
+        context,
+    ) -> CreateSessionResponse:
         """
         Handles create session request from MME by installing the necessary
         flows in pipelined's enforcement app.
         """
-        sid = request.sid
-        logging.info('Create session request for sid: %s', sid.id)
-        try:
-            # Gather the set of policy rules to use
-            if self._captive_portal_enabled(sid):
-                rules = []
-                rules.extend(self._get_whitelisted_policies())
-                rules.extend(self._get_redirect_policies())
-            else:
-                rules = self._get_allow_all_traffic_policies()
+        logging.info('Creating a session for subscriber ID: %s',
+                     request.subscriber.id)
+        return CreateSessionResponse(
+            credits=[self._get_credit_update_response(request.imsi_plmn_id)],
+            static_rules=[self._get_static_rule()],
+            dynamic_rules=self._get_whitelist_rules(),
+        )
 
-            # Activate the flows in the enforcement app in pipelined
-            act_request = ActivateFlowsRequest(
-                sid=sid, ip_addr=request.ue_ipv4, dynamic_rules=rules)
-            act_response = self._pipelined.ActivateFlows(
-                act_request, timeout=self.RPC_TIMEOUT)
-            for res in act_response.dynamic_rule_results:
-                if res.result != res.SUCCESS:
-                    # Hmm rolling back partial success is difficult
-                    # Let's just log this for now
-                    logging.error('Failed to activate rule: %s', res.rule_id)
-        except RpcError as err:
-            self._set_rpc_error(context, err)
-        return session_manager_pb2.LocalCreateSessionResponse()
-
-    def EndSession(self, sid, context):  # pylint: disable=arguments-differ
+    def UpdateSession(
+            self,
+            request: UpdateSessionRequest,
+            context,
+    ) -> UpdateSessionResponse:
         """
-        Handles end session request from MME by removing all the flows
-        for the subscriber in pipelined's enforcement app.
+        On UpdateSession, return an arbitrarily large amount of additional
+        credit for the session.
         """
-        logging.info('End session request for sid: %s', sid.id)
-        try:
-            self._pipelined.DeactivateFlows(
-                DeactivateFlowsRequest(sid=sid), timeout=self.RPC_TIMEOUT)
-        except RpcError as err:
-            self._set_rpc_error(context, err)
-        return session_manager_pb2.LocalEndSessionResponse()
+        logging.debug('Updating sessions')
+        resp = UpdateSessionResponse()
+        for credit_usage_update in request.updates:
+            resp.responses.extend(
+                [self._get_credit_update_response(credit_usage_update.sid)],
+            )
+        return resp
 
-    def ReportRuleStats(self, request, context):
+    def TerminateSession(
+            self,
+            request: SessionTerminateResponse,
+            context,
+    ) -> SessionTerminateResponse:
+        logging.info('Terminating a session for session ID: %s',
+                     request.session_id)
+        return SessionTerminateResponse(
+            sid=request.sid,
+            session_id=request.session_id,
+        )
+
+    def _get_whitelist_rules(self) -> List[DynamicRuleInstall]:
         """
-        Handles stats update from the enforcement app in pipelined. We are
-        ignoring this for now, since the applications can poll pipelined for
-        the flow stats.
+        Get a list of dynamic rules to install for whitelisting.
+        These rules will whitelist traffic to/from the captive portal server.
         """
-        logging.debug('Ignoring ReportRuleStats rpc')
-        return Void()
-
-    def _captive_portal_enabled(self, sid):
-        if not self._enabled:
-            return False  # Service is disabled
-
-        if self._sub_profile_substr == '':
-            return True  # Allow all subscribers
-
-        sub = self._subscriberdb.GetSubscriberData(
-            sid, timeout=self.RPC_TIMEOUT)
-        return self._sub_profile_substr in sub.sub_profile
-
-    def _get_allow_all_traffic_policies(self):
-        """ Policy to allow all traffic to the internet """
-        return [PolicyRule(
-            id='allow_all_traffic',
-            priority=self.ALLOW_ALL_PRIORITY,
-            flow_list=[
-                FlowDescription(match=FlowMatch(direction=FlowMatch.UPLINK)),
-                FlowDescription(match=FlowMatch(direction=FlowMatch.DOWNLINK)),
-            ],
-        )]
-
-    def _get_whitelisted_policies(self):
-        """ Policies to allow http traffic to the whitelisted sites """
-        rules = []
-        for ip, ports in self._whitelisted_ips.items():
+        dynamic_rules = []
+        for ip, ports in self.ip_whitelist.items():
+            if ip == 'local':
+                ip = '192.168.128.1'
             for port in ports:
-                if ip == 'local':
-                    ip = self._local_ip
-                rules.append(PolicyRule(
-                    id='whitelist',
-                    priority=self.ALLOW_ALL_PRIORITY,
-                    flow_list=[
-                        FlowDescription(
-                            match=FlowMatch(
-                                direction=FlowMatch.UPLINK,
-                                ip_proto=FlowMatch.IPPROTO_TCP,
-                                ipv4_dst=ip,
-                                tcp_dst=port)),
-                        FlowDescription(
-                            match=FlowMatch(
-                                direction=FlowMatch.DOWNLINK,
-                                ip_proto=FlowMatch.IPPROTO_TCP,
-                                ipv4_src=ip,
-                                tcp_src=port)),
-                    ]))
-        return rules
+                # Build the rule id to be globally unique
+                rule_id_info = {
+                    'ip': ip,
+                    'port': port,
+                }
+                rule_id = "whitelist_policy_id-{ip}:{port}"\
+                    .format(**rule_id_info)
 
-    def _get_redirect_policies(self):
-        """ Policy to redirect traffic to the captive portal """
-        redirect_info = RedirectInformation(
-            support=RedirectInformation.ENABLED,
-            address_type=RedirectInformation.URL,
-            server_address=self._captive_portal_address)
-        return [PolicyRule(
-            id='redirect',
-            priority=self.REDIRECT_PRIORITY,
-            redirect=redirect_info)]
+                rule = DynamicRuleInstall(
+                    policy_rule=self._get_whitelist_policy_rule(
+                        rule_id, ip, port
+                    ),
+                )
+                # Activate now, and deactivate long in the future
+                t2 = datetime.now()
+                t2 = t2.replace(year=t2.year + 1)
+                rule.activation_time.FromDatetime(datetime.now())
+                rule.deactivation_time.FromDatetime(t2)
+                dynamic_rules.append(rule)
+        return dynamic_rules
 
-    def _set_rpc_error(self, context, err):
-        logging.error(err.details())
-        context.set_details(err.details())
-        context.set_code(err.code())
+    def _get_whitelist_policy_rule(
+        self,
+        policy_id: str,
+        ip: str,
+        port: int,
+    ) -> PolicyRule:
+        return PolicyRule(
+            # Don't set the rating group
+            # Don't set the monitoring key
+            # Don't set the hard timeout
+            id=policy_id,
+            priority=100,
+            qos=self._get_default_qos(),
+            flow_list=self._get_whitelist_flows(ip, port),
+            tracking_type=PolicyRule.TrackingType.Value("NO_TRACKING"),
+        )
+
+    def _get_whitelist_flows(self, ip: str, port: int) -> List[FlowDescription]:
+        """
+        Args:
+            ip: IP address to allow traffic to. This should be the captive
+                portal address
+            port:  Port of the captive portal server. Probably 80.
+
+        Returns:
+            Two flows, one for traffic towards the captive portal server, and a
+            second for traffic from the captive portal server.
+        """
+        return [
+            # Set flow match for outgoing TCP packets to whitelisted IP
+            # Don't set the app_name field
+            FlowDescription(  # uplink flow
+                match=FlowMatch(
+                    ipv4_dst=ip,
+                    tcp_dst=port,
+                    ip_proto=FlowMatch.IPProto.Value("IPPROTO_TCP"),
+                    direction=FlowMatch.Direction.Value("UPLINK"),
+                ),
+                action=FlowDescription.Action.Value("PERMIT"),
+            ),
+            # Set flow match for incoming TCP packets from whitelisted IP
+            # Don't set the app_name field
+            FlowDescription(  # downlink flow
+                match=FlowMatch(
+                    ipv4_src=ip,
+                    tcp_src=port,
+                    ip_proto=FlowMatch.IPProto.Value("IPPROTO_TCP"),
+                    direction=FlowMatch.Direction.Value("DOWNLINK"),
+                ),
+                action=FlowDescription.Action.Value("PERMIT"),
+            ),
+        ]
+
+    def _get_default_qos(self) -> FlowQos:
+        """
+        Get a default QoS, usable for an allow-all flow, and for redirection to
+        a captive_portal.
+        """
+        return FlowQos(
+            max_req_bw_ul=2 * 1024 * 1024 * 1024,  # 2G
+            max_req_bw_dl=2 * 1024 * 1024 * 1024,  # 2G
+            gbr_ul=1 * 1024 * 1024,  # 1 Mb/s
+            gbr_dl=1 * 1024 * 1024,  # 1 Mb/s
+            qci=FlowQos.Qci.Value('QCI_3'),
+            # Allocation and Retention Policy
+            # Set to high priority, and disallow pre-emption
+            # capability/vulnerability
+            arp=QosArp(
+                priority_level=1,
+                pre_capability=QosArp.PreCap.Value("PRE_CAP_DISABLED"),
+                pre_vulnerability=QosArp.PreVul.Value("PRE_VUL_DISABLED"),
+            ),
+        )
+
+    def _get_static_rule(self) -> StaticRuleInstall:
+        """ Return a static rule for redirection to captive portal """
+        return StaticRuleInstall(
+            rule_id = self.redirect_rule_name,
+        )
+
+    def _get_credit_update_response(
+        self,
+        sid: str,
+    ) -> CreditUpdateResponse:
+        return CreditUpdateResponse(
+            success=True,
+            sid=sid,
+            charging_key=1,
+            credit=self._get_max_charging_credit(),
+            type=CreditUpdateResponse.ResponseType.Value('UPDATE'),
+            result_code=1,
+        )
+
+    def _get_max_charging_credit(self) -> ChargingCredit:
+        return ChargingCredit(
+            type=ChargingCredit.UnitType.Value('SECONDS'),
+            validity_time=86400,  # One day
+            is_final=False,
+            final_action=ChargingCredit.FinalAction.Value('TERMINATE'),
+            granted_units=self._get_max_granted_units(),
+        )
+
+    def _get_max_granted_units(self) -> GrantedUnits:
+        """ Get an arbitrarily large amount of granted credit """
+        return GrantedUnits(
+            total=CreditUnit(
+                is_valid=True,
+                volume=100 * 1024 * 1024 * 1024,  # 100 GiB
+            ),
+            rx=CreditUnit(
+                is_valid=True,
+                volume=50 * 1024 * 1024 * 1024,  # 50 GiB
+            ),
+            tx=CreditUnit(
+                is_valid=True,
+                volume=50 * 1024 * 1024 * 1024,  # 50 GiB
+            ),
+        )

--- a/lte/gateway/python/magma/captive_portal/tests/test_rpc_servicer.py
+++ b/lte/gateway/python/magma/captive_portal/tests/test_rpc_servicer.py
@@ -1,0 +1,226 @@
+"""
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+from typing import Any, Dict
+from lte.protos.session_manager_pb2 import CreateSessionRequest, \
+    UpdateSessionRequest, CreditUsageUpdate, SessionTerminateRequest
+from magma.captive_portal.rpc_servicer import SessionRpcServicer
+
+
+CSR_CREDITS = '''
+  [success: true
+  sid: "00101"
+  charging_key: 1
+  credit {
+    type: SECONDS
+    validity_time: 86400
+    granted_units {
+      total {
+        is_valid: true
+        volume: 107374182400
+      }
+      tx {
+        is_valid: true
+        volume: 53687091200
+      }
+      rx {
+        is_valid: true
+        volume: 53687091200
+      }
+    }
+  }
+  result_code: 1]'''
+
+CSR_STATIC_RULES = '[rule_id: "redirect"]'
+
+CSR_DYNAMIC_POLICY_1 = '''
+  id: "whitelist_policy_id-192.168.128.1:80"
+  priority: 100
+  flow_list {
+    match {
+      ipv4_dst: "192.168.128.1"
+      tcp_dst: 80
+      ip_proto: IPPROTO_TCP
+    }
+  }
+  flow_list {
+    match {
+      ipv4_src: "192.168.128.1"
+      tcp_src: 80
+      ip_proto: IPPROTO_TCP
+      direction: DOWNLINK
+    }
+  }
+  qos {
+    max_req_bw_ul: 2147483648
+    max_req_bw_dl: 2147483648
+    gbr_ul: 1048576
+    gbr_dl: 1048576
+    qci: QCI_3
+    arp {
+      priority_level: 1
+      pre_capability: PRE_CAP_DISABLED
+      pre_vulnerability: PRE_VUL_DISABLED
+    }
+  }
+  tracking_type: NO_TRACKING'''
+
+CSR_DYNAMIC_POLICY_2 = '''
+  id: "whitelist_policy_id-192.168.128.1:443"
+  priority: 100
+  flow_list {
+    match {
+      ipv4_dst: "192.168.128.1"
+      tcp_dst: 443
+      ip_proto: IPPROTO_TCP
+    }
+  }
+  flow_list {
+    match {
+      ipv4_src: "192.168.128.1"
+      tcp_src: 443
+      ip_proto: IPPROTO_TCP
+      direction: DOWNLINK
+    }
+  }
+  qos {
+    max_req_bw_ul: 2147483648
+    max_req_bw_dl: 2147483648
+    gbr_ul: 1048576
+    gbr_dl: 1048576
+    qci: QCI_3
+    arp {
+      priority_level: 1
+      pre_capability: PRE_CAP_DISABLED
+      pre_vulnerability: PRE_VUL_DISABLED
+    }
+  }
+  tracking_type: NO_TRACKING'''
+
+USR = '''
+  responses {
+    success: true
+    sid: "abc"
+    charging_key: 1
+    credit {
+      type: SECONDS
+      validity_time: 86400
+      granted_units {
+        total {
+          is_valid: true
+          volume: 107374182400
+        }
+        tx {
+          is_valid: true
+          volume: 53687091200
+        }
+        rx {
+          is_valid: true
+          volume: 53687091200
+        }
+      }
+    }
+    result_code: 1
+  }'''
+
+
+class SessionRpcServicerTest(unittest.TestCase):
+    def setUp(self):
+        self.servicer = SessionRpcServicer(self._get_config())
+
+    def _get_config(self) -> Dict[str, Any]:
+        return {
+            'redirect_rule_name': 'redirect',
+            'whitelisted_ips': {
+                'local': [80, 443],
+            },
+        }
+
+    def tearDown(self):
+        # TODO: not sure if this is actually needed
+        self.servicer = None
+
+    def test_CreateSession(self):
+        """
+        Create a session
+
+        Assert:
+            There is a high volume of granted credits
+            A static rule is installed for redirection to the captive portal
+            server
+            Two dynamic rules are installed for traffic from UE to captive
+            portal and vice versa
+        """
+        msg = CreateSessionRequest()
+        msg.session_id = '1234'
+        msg.imsi_plmn_id = '00101'
+        resp = self.servicer.CreateSession(msg, None)
+
+        # Check the granted credits
+        credits = self._rm_whitespace(str(resp.credits))
+        expected = self._rm_whitespace(CSR_CREDITS)
+        self.assertEqual(credits, expected, 'Expected that there is a high '
+                         'volume of granted credits which will be permissive '
+                         'for access to captive portal.')
+
+        # There should be a static rule installed for the redirection
+        static_rules = self._rm_whitespace(str(resp.static_rules))
+        expected = self._rm_whitespace(CSR_STATIC_RULES)
+        self.assertEqual(static_rules, expected, 'There should be one static '
+                         'rule installed for redirection.')
+
+        # There should be two dynamic rules:
+        #   one for uplink traffic to the captive portal server from the UE
+        #   one for downlink traffic from the captive portal server to the UE
+        p1 = self._rm_whitespace(str(resp.dynamic_rules[0].policy_rule))
+        expected = self._rm_whitespace(CSR_DYNAMIC_POLICY_1)
+        self.assertEqual(p1, expected, 'There should be a dynamic rule '
+                         'installed for UE traffic to the captive portal '
+                         'server')
+
+        p2 = self._rm_whitespace(str(resp.dynamic_rules[1].policy_rule))
+        expected = self._rm_whitespace(CSR_DYNAMIC_POLICY_2)
+        self.assertEqual(p2, expected, 'There should be a dynamic rule '
+                         'installed for captive portal traffic to the UE')
+
+    def test_UpdateSession(self):
+        """
+        Update a session
+
+        Assert:
+            An arbitrarily large amount of credit should be granted.
+        """
+        msg = UpdateSessionRequest()
+        credit_update = CreditUsageUpdate()
+        credit_update.sid = 'abc'
+        msg.updates.extend([credit_update])
+        resp = self.servicer.UpdateSession(msg, None)
+        session_response = self._rm_whitespace(str(resp))
+        expected = self._rm_whitespace(USR)
+        self.assertEqual(session_response, expected, 'There should be a large '
+                         'amount of additional credit granted')
+
+    def test_TerminateSession(self):
+        """
+        Terminate a session
+
+        Assert:
+            The session can be terminated successfully. Will always succeed.
+        """
+        msg = SessionTerminateRequest()
+        msg.sid = 'abc'
+        msg.session_id = 'session_id_123'
+        resp = self.servicer.TerminateSession(msg, None)
+        self.assertEqual(resp.sid, 'abc', 'SID should be same as request')
+        self.assertEqual(resp.session_id, 'session_id_123', 'session ID should '
+                         'be same as request')
+
+    def _rm_whitespace(self, inp: str) -> str:
+        return inp.replace(' ', '').replace('\n', '')

--- a/lte/gateway/python/scripts/captive_portal_cli.py
+++ b/lte/gateway/python/scripts/captive_portal_cli.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import argparse
+from magma.common.rpc_utils import grpc_wrapper
+from lte.protos.session_manager_pb2 import CreateSessionRequest, \
+    UpdateSessionRequest, SessionTerminateRequest
+from lte.protos.session_manager_pb2_grpc import CentralSessionControllerStub
+
+
+@grpc_wrapper
+def create_session(client, args):
+    message = CreateSessionRequest()
+    client.CreateSession(message)
+    print('Successfully got a response from CreateSession')
+
+
+@grpc_wrapper
+def update_session(client, args):
+    message = UpdateSessionRequest()
+    client.UpdateSession(message)
+    print('Successfully got a response from UpdateSession')
+
+
+@grpc_wrapper
+def terminate_session(client, args):
+    message = SessionTerminateRequest()
+    client.TerminateSession(message)
+    print('Successfully got a response from TerminateSession')
+
+
+def create_parser():
+    """
+    Creates the argparse parser with all the arguments.
+    """
+    parser = argparse.ArgumentParser(
+        description='Management CLI for Captive Portal',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    # Add subcommands
+    subparsers = parser.add_subparsers(title='subcommands', dest='cmd')
+
+    parser_create_session = subparsers.add_parser(
+        'create_session', help='Send CreateSessionRequest message')
+
+    parser_update_session = subparsers.add_parser(
+        'update_session', help='Send UpdateSessionRequest message')
+
+    parser_terminate_session = subparsers.add_parser(
+        'terminate_session', help='Send SessionTerminateRequest message')
+
+    # Add function callbacks
+    parser_create_session.set_defaults(func=create_session)
+    parser_update_session.set_defaults(func=update_session)
+    parser_terminate_session.set_defaults(func=terminate_session)
+    return parser
+
+
+def main():
+    parser = create_parser()
+
+    # Parse the args
+    args = parser.parse_args()
+    if not args.cmd:
+        parser.print_usage()
+        exit(1)
+
+    # Execute the subcommand function
+    args.func(args, CentralSessionControllerStub, 'captive_portal')
+
+
+if __name__ == "__main__":
+    main()

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -47,13 +47,6 @@ services:
       # - maria
     command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 postgres:5432 && /usr/bin/supervisord"]
     # command: ["/bin/sh", "-c", "/usr/local/bin/wait-for-it.sh -s -t 30 maria:[port] && /usr/bin/supervisord"]
-    logging:
-      driver: fluentd
-      options:
-        fluentd-address: ':24224'
-        tag: orc8r.controller
-        fluentd-retry-wait: '1s'
-        fluentd-max-retries: '30'
     restart: always
 
   proxy:
@@ -74,13 +67,6 @@ services:
       - fluentd
     links:
       - fluentd
-    logging:
-      driver: fluentd
-      options:
-        fluentd-address: ':24224'
-        tag: orc8r.proxy
-        fluentd-retry-wait: '1s'
-        fluentd-max-retries: '30'
     restart: always
 
   elasticsearch:


### PR DESCRIPTION
Summary: This is a bare-bones CentralSessionController just used for captive_portal. Unlimited credit is given on calls. It is planned for future use that captive_portal will be combined with policydb, and will be used as a local PCRF/OCS.

Reviewed By: xjtian

Differential Revision: D18073211

