### PR TITLE
add config generator

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -14,12 +14,6 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 find_library(NETSNMPAGENT netsnmpagent)
 find_library(NETSNMPMIBS netsnmpmibs)
 find_library(NETSNMP netsnmp)
-find_library(MGM_ASYNC_GRPC ASYNC_GRPC ${MGM_COM_DIR}/async_grpc)
-find_library(MGM_CONFIG CONFIG HINTS ${MGM_COM_DIR}/config)
-find_library(MGM_SERVICE303_LIB SERVICE303_LIB HINTS ${MGM_COM_DIR}/service303)
-find_library(MGM_DATASTORE DATASTORE HINTS ${MGM_COM_DIR}/datastore)
-find_library(MGM_POLICYDB POLICYDB HINTS ${MGM_COM_DIR}/policydb)
-find_library(MGM_SRVC_REG SERVICE_REGISTRY HINTS ${MGM_COM_DIR}/service_registry)
 
 add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/Application.cpp
@@ -53,6 +47,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/models/device/Model.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/models/interface/Model.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/models/wifi/Model.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/utils/ConfigGenerator.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/utils/Time.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/YangUtils.cpp
 )
@@ -105,6 +100,13 @@ target_link_libraries(devman_channel_snmp
   ${NETSNMPMIBS}
   ${NETSNMP})
 
+find_library(MGM_ASYNC_GRPC ASYNC_GRPC ${MGM_COM_DIR}/async_grpc)
+find_library(MGM_CONFIG CONFIG HINTS ${MGM_COM_DIR}/config)
+find_library(MGM_SERVICE303_LIB SERVICE303_LIB HINTS ${MGM_COM_DIR}/service303)
+find_library(MGM_DATASTORE DATASTORE HINTS ${MGM_COM_DIR}/datastore)
+find_library(MGM_POLICYDB POLICYDB HINTS ${MGM_COM_DIR}/policydb)
+find_library(MGM_SRVC_REG SERVICE_REGISTRY HINTS ${MGM_COM_DIR}/service_registry)
+
 add_library(devman_service_magma
   ${PROJECT_SOURCE_DIR}/src/devmand/magma/DevConf.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/magma/Service.cpp
@@ -148,6 +150,7 @@ target_link_libraries(devmand
   devman_service_magma)
 
 add_executable(devmantest
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/ConfigGeneratorTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp

--- a/devmand/gateway/deploy/symphony_agent_install
+++ b/devmand/gateway/deploy/symphony_agent_install
@@ -207,6 +207,11 @@ else
 fi
 
 ###############################################################################
+# TODO make this a cmd line arg
+HOST_PUBLIC_ADDRESS=$(curl -s -4 h.facebook.com/diagnostics | \
+    grep HTTP_TFB_ORIG_CLIENT_IP | cut -d " " -f2)
+
+###############################################################################
 cat << EOF > docker-compose.override.yml
 version: '3.7'
 services:
@@ -218,6 +223,7 @@ services:
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
       - DEVICE_CONFIG_FILE=/var/opt/magma/configs/gateway.mconfig
+      - HOST_PUBLIC_ADDRESS=${HOST_PUBLIC_ADDRESS}
 EOF
 
 ###############################################################################

--- a/devmand/gateway/docker/docker-compose.yml
+++ b/devmand/gateway/docker/docker-compose.yml
@@ -19,6 +19,10 @@ services:
         published: 162
         protocol: udp
         mode: host
+      - target: 514
+        published: 514
+        protocol: udp
+        mode: host
     tmpfs:
       - /sys/fs/cgroup
     cap_add:
@@ -38,3 +42,4 @@ services:
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
+      - HOST_PUBLIC_ADDRESS=${HOST_PUBLIC_ADDRESS}

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/bin/magma_system_prepare
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/bin/magma_system_prepare
@@ -3,7 +3,7 @@
 /bin/rm -f /etc/magma/env
 for e in $(tr "\000" "\n" < /proc/1/environ); do
   case "${e%%=*}" in
-    SNOWFLAKE|CLOUD_ADDRESS|BOOTSTRAP_CLOUD_ADDRESS|DEVICE_CONFIG_FILE)
+    SNOWFLAKE|CLOUD_ADDRESS|BOOTSTRAP_CLOUD_ADDRESS|DEVICE_CONFIG_FILE|HOST_PUBLIC_ADDRESS)
       echo "$e" >> /etc/magma/env
       ;;
     *)
@@ -24,6 +24,14 @@ fi
 
 if [ -z "${BOOTSTRAP_CLOUD_ADDRESS}" ]; then
   BOOTSTRAP_CLOUD_ADDRESS="bootstrapper-controller.magma.etagecom.io"
+fi
+
+if [ -z "${DEVICE_CONFIG_FILE}" ]; then
+  DEVICE_CONFIG_FILE="/var/opt/magma/configs/gateway.mconfig"
+fi
+
+if [ -z "${HOST_PUBLIC_ADDRESS}" ]; then
+  echo "WARNING! Host Public Address not set!"
 fi
 
 # TODO once the cloud supports logs set this to that.

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit-devmand.conf
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit-devmand.conf
@@ -1,0 +1,5 @@
+[FILTER]
+    Name modify
+    Match syslog
+    Condition key_value_equals MikroTik
+    Set device mikrotik

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit.conf
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit.conf
@@ -13,10 +13,21 @@
     Tag            host.*
     Systemd_Filter _SYSTEMD_UNIT=devmand.service
 
+[INPUT]
+    Name              syslog
+    Mode              udp
+    Listen            0.0.0.0
+    Port              514
+    Parser            syslog-rfc3164
+    Buffer_Chunk_Size 32
+    Buffer_Max_Size   32
+
 [FILTER]
     Name modify
     Match *
     Set hw_id "%%snowflake%%"
+
+@INCLUDE td-agent-bit-devmand.conf
 
 [OUTPUT]
     Name  forward

--- a/devmand/gateway/docker/scripts/build
+++ b/devmand/gateway/docker/scripts/build
@@ -21,6 +21,10 @@ if [ -z ${DEVICE_CONFIG_FILE+x} ]; then
   export DEVICE_CONFIG_FILE="/var/opt/magma/configs/gateway.mconfig"
 fi
 
+if [ -z ${HOST_PUBLIC_ADDRESS+x} ]; then
+  export HOST_PUBLIC_ADDRESS="192.168.90.100"
+fi
+
 if [ ! -f docker-compose.override.yml ]; then
 cat << EOF > docker-compose.override.yml
 version: '3.7'
@@ -31,6 +35,7 @@ services:
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
+      - HOST_PUBLIC_ADDRESS=${HOST_PUBLIC_ADDRESS}
 EOF
 fi
 

--- a/devmand/gateway/docker/scripts/develop
+++ b/devmand/gateway/docker/scripts/develop
@@ -16,6 +16,7 @@ build_status=${PIPESTATUS[0]}
 docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
 if [ "$build_status" -eq 0 ]; then
   docker rm -f devmand
+  # TODO see if we can use the docker compose file to run this
   docker run -it --cap-add NET_RAW --cap-add NET_ADMIN --cap-add SYS_PTRACE \
       --name devmand \
       -v "$(realpath ../):/cache/devmand/repo:ro" \

--- a/devmand/gateway/docker/scripts/test
+++ b/devmand/gateway/docker/scripts/test
@@ -21,6 +21,7 @@ memcheck="valgrind \
 #--show-reachable=yes \
 
 function run_test_container {
+  # TODO see if we can use the docker compose file to run this.
   docker run -it \
     -v "$(realpath ../):/cache/devmand/repo:ro" \
     -v "$CACHE_DIR:/cache/devmand/build:rw" \

--- a/devmand/gateway/src/devmand/channels/mikrotik/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/mikrotik/Channel.cpp
@@ -255,6 +255,8 @@ bool Channel::handle(const Sentence& sentence) {
       if (sentence.front() == "!done") {
         if (sentence.size() == 1) {
           state = State::FullyConnected;
+          // TODO make this conditional on readonly flag
+          // enableSyslog();
           return true;
         } else if (sentence.size() == 2 and sentence[1].size() > 5) {
           std::string code = sentence[1];
@@ -293,6 +295,15 @@ void Channel::readErr(const folly::AsyncSocketException& ex) noexcept {
 
 State Channel::getState() const {
   return state;
+}
+
+void Channel::enableSyslog() {
+  // TODO don't just assume success
+  writeWordAndLength("/system/logging/action/add");
+  writeWordAndLength("=name=syslog");
+  writeWordAndLength("=target=remote");
+  writeWordAndLength(folly::sformat("=remote={}", "192.168.90.100"));
+  terminateSentence();
 }
 
 } // namespace mikrotik

--- a/devmand/gateway/src/devmand/channels/mikrotik/Channel.h
+++ b/devmand/gateway/src/devmand/channels/mikrotik/Channel.h
@@ -97,6 +97,8 @@ class Channel : public channels::Channel,
 
   void debugPrintHex(const std::string& prefix, const std::string& buf);
 
+  void enableSyslog();
+
  private:
   folly::EventBase& eventBase;
   folly::SocketAddress address;

--- a/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
@@ -259,7 +259,8 @@ std::shared_ptr<State> Device::getState() {
   state->addFinally([state]() {
     state->update([](auto& lockedState) {
       auto* field = lockedState.get_ptr("ietf-system:system");
-      if (field != nullptr and ((field = field->get_ptr("name")) != nullptr)) {
+      if (field != nullptr and
+          ((field = field->get_ptr("hostname")) != nullptr)) {
         auto hostname = field->asString();
         PAPC(lockedState)["hostname"] = hostname;
         PAPT(lockedState)["hostname"] = hostname;

--- a/devmand/gateway/src/devmand/test/ConfigGeneratorTest.cpp
+++ b/devmand/gateway/src/devmand/test/ConfigGeneratorTest.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <gtest/gtest.h>
+
+#include <experimental/filesystem>
+#include <list>
+#include <set>
+
+#include <devmand/FileUtils.h>
+#include <devmand/utils/ConfigGenerator.h>
+
+namespace devmand {
+namespace utils {
+namespace test {
+
+static std::experimental::filesystem::path getFilename() {
+  std::string ret = "/tmp/";
+  auto* testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+  ret += testInfo->name();
+  return ret;
+}
+
+TEST(ConfigGeneratorTest, singleAdd) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "a");
+
+  EXPECT_EQ("sae", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, doubleAdd) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "a");
+  cg.add("{}", "b");
+
+  EXPECT_EQ("sabe", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, newlinesAdd) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s\n{}\ne\n"};
+  cg.add("{}", "a\nb");
+  cg.add("{}", "c\nd");
+
+  EXPECT_EQ("s\na\nbc\nd\ne\n", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, doubleAddThenRm) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "a");
+  cg.add("{}", "b");
+
+  EXPECT_EQ("sabe", FileUtils::readContents(filename));
+
+  cg.remove("{}", "b");
+
+  EXPECT_EQ("sae", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, doubleAddOrder) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "b");
+  cg.add("{}", "a");
+  cg.add("{}", "c");
+
+  EXPECT_EQ("sabce", FileUtils::readContents(filename));
+}
+
+} // namespace test
+} // namespace utils
+} // namespace devmand

--- a/devmand/gateway/src/devmand/utils/ConfigGenerator.cpp
+++ b/devmand/gateway/src/devmand/utils/ConfigGenerator.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <algorithm>
+#include <experimental/filesystem>
+
+#include <folly/Format.h>
+#include <folly/GLog.h>
+
+#include <devmand/FileUtils.h>
+#include <devmand/utils/ConfigGenerator.h>
+
+#include <boost/algorithm/string/join.hpp>
+
+namespace devmand {
+
+namespace utils {
+
+ConfigGenerator::ConfigGenerator(
+    const std::string& configFile_,
+    const std::string& fileTemplate_)
+    : configFile(configFile_), fileTemplate(fileTemplate_) {
+  FileUtils::mkdir(
+      std::experimental::filesystem::path(configFile).parent_path());
+}
+
+void ConfigGenerator::rewrite() {
+  // TODO make this async
+  FileUtils::write(
+      configFile,
+      folly::sformat(fileTemplate, boost::algorithm::join(entries, "")));
+}
+
+} // namespace utils
+
+} // namespace devmand

--- a/devmand/gateway/src/devmand/utils/ConfigGenerator.h
+++ b/devmand/gateway/src/devmand/utils/ConfigGenerator.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <set>
+#include <string>
+#include <tuple>
+
+#include <folly/Format.h>
+#include <folly/GLog.h>
+
+namespace devmand {
+
+namespace utils {
+
+class ConfigGenerator final {
+ public:
+  ConfigGenerator(
+      const std::string& configFile_,
+      const std::string& fileTemplate_);
+  ConfigGenerator() = delete;
+  ~ConfigGenerator() = default;
+  ConfigGenerator(const ConfigGenerator&) = delete;
+  ConfigGenerator& operator=(const ConfigGenerator&) = delete;
+  ConfigGenerator(ConfigGenerator&&) = delete;
+  ConfigGenerator& operator=(ConfigGenerator&&) = delete;
+
+ public:
+  template <class... Args>
+  void add(const std::string& templateS, Args&&... args) {
+    if (entries.emplace(folly::sformat(templateS, std::forward<Args>(args)...))
+            .second) {
+      rewrite();
+    } else {
+      LOG(ERROR) << "Failed to add entry";
+    }
+  }
+
+  template <class... Args>
+  void remove(Args&&... args) {
+    if (entries.erase(folly::sformat(std::forward<Args>(args)...)) != 1) {
+      LOG(ERROR) << "Failed to delete entry ";
+    } else {
+      rewrite();
+    }
+  }
+
+ private:
+  void rewrite();
+
+ private:
+  std::string configFile;
+  std::string fileTemplate;
+  std::set<std::string> entries;
+};
+
+} // namespace utils
+
+} // namespace devmand


### PR DESCRIPTION
Summary:
This commit adds a config generator with unit tests for devmand. It
also starts preparing for the use of this config generator with td-agent.

Differential Revision: D18460423

