### PR TITLE
orc8r/helm: allow proxy service to be disabled

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.1.0
+version: 1.2.0
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.0.0
+version: 1.1.0
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -16,6 +16,9 @@ The following table list the configurable parameters of the orchestrator chart a
 | `secret.certs` | Secret name containing orchestrator certs. | `orc8r-secrets-certs` |
 | `secret.configs` | Secret name containing orchestrator configs. | `orc8r-secrets-configs` |
 | `secret.envdir` | Secret name containing orchestrator envdir. | `orc8r-secrets-envdir` |
+| `proxy.podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for proxy. | `false` |
+| `proxy.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled. | `1` |
+| `proxy.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable. | `""` |
 | `proxy.service.annotations` | Annotations to be added to the proxy service. | `{}` |
 | `proxy.service.labels` | Proxy service labels. | `{}` |
 | `proxy.service.type` | Proxy service type. | `ClusterIP` |
@@ -34,6 +37,9 @@ The following table list the configurable parameters of the orchestrator chart a
 | `proxy.nodeSelector` | Define which Nodes the Pods are scheduled on. | `{}` |
 | `proxy.tolerations` | If specified, the pod's tolerations. | `[]` |
 | `proxy.affinity` | Assign the orchestrator proxy to run on specific nodes. | `{}` |
+| `controller.podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for proxy. | `false` |
+| `controller.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled. | `1` |
+| `controller.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable. | `""` |
 | `controller.service.annotations` | Annotations to be added to the controller service. | `{}` |
 | `controller.service.labels` | Controller service labels. | `{}` |
 | `controller.service.type` | Controller service type. | `ClusterIP` |

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -19,6 +19,8 @@ The following table list the configurable parameters of the orchestrator chart a
 | `proxy.podDisruptionBudget.enabled` | Enables creation of a PodDisruptionBudget for proxy. | `false` |
 | `proxy.podDisruptionBudget.minAvailable` | Minimum number / percentage of pods that should remain scheduled. | `1` |
 | `proxy.podDisruptionBudget.maxUnavailable` | Maximum number / percentage of pods that may be made unavailable. | `""` |
+| `proxy.service.enabled` | Enables proxy service. | `true` |
+| `proxy.service.lagacyEnabled` | Enables proxy legacy service. | `true` |
 | `proxy.service.annotations` | Annotations to be added to the proxy service. | `{}` |
 | `proxy.service.labels` | Proxy service labels. | `{}` |
 | `proxy.service.type` | Proxy service type. | `ClusterIP` |

--- a/orc8r/cloud/helm/orc8r/templates/bootstrap-legacy.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrap-legacy.service.yaml
@@ -1,16 +1,19 @@
-# Copyright (c) 2018-present, Facebook, Inc.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
 
 {{/*
-  Chart for a legacy open service for gateway bootstrapping.
-  We need this in place because old gateways are configured to connect to
-  cloud boostrap controller via port 443, not 9444. This service can go away
-  after all gateways in the field have been upgraded to talk to ports 9443/9444
+Chart for a legacy open service for gateway bootstrapping.
+We need this in place because old gateways are configured to connect to
+cloud boostrap controller via port 443, not 9444. This service can go away
+after all gateways in the field have been upgraded to talk to ports 9443/9444
 */}}
+{{- if .Values.proxy.service.legacyEnabled }}
 {{ $serviceType := .Values.proxy.service.type }}
 apiVersion: v1
 kind: Service
@@ -40,3 +43,4 @@ spec:
       nodePort: {{ .nodePort }}
       {{- end }}
     {{- end }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/clientcert-legacy.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/clientcert-legacy.service.yaml
@@ -1,16 +1,19 @@
-# Copyright (c) 2018-present, Facebook, Inc.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
 
 {{/*
-  Chart for a legacy clientcert-secured service. We need this in place because
-  old gateways are configured to connect to cloud via port 443, not 9443. This
-  service can go away after all gateways in the field have been upgraded to
-  talk to ports 9443/9444.
+Chart for a legacy clientcert-secured service. We need this in place because
+old gateways are configured to connect to cloud via port 443, not 9443. This
+service can go away after all gateways in the field have been upgraded to
+talk to ports 9443/9444.
 */}}
+{{- if .Values.proxy.service.legacyEnabled }}
 {{ $serviceType := .Values.proxy.service.type }}
 apiVersion: v1
 kind: Service
@@ -40,3 +43,4 @@ spec:
       nodePort: {{ .nodePort }}
       {{- end }}
     {{- end }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/controller.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.pdb.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
+{{- if and .Values.controller.podDisruptionBudget.enabled (gt .Values.controller.replicas 1.0 )}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-controller
+  labels:
+    app.kubernetes.io/component: controller
+{{ include "labels" . | indent 4 }}
+spec:
+  {{- with .Values.controller.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.controller.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: controller
+{{ include "selector-labels" . | indent 6 }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/controller.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.secret.yaml
@@ -1,10 +1,11 @@
-# Copyright (c) 2018-present, Facebook, Inc.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
 
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/orc8r/cloud/helm/orc8r/templates/proxy.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/proxy.pdb.yaml
@@ -1,0 +1,28 @@
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
+{{- if and .Values.proxy.podDisruptionBudget.enabled (gt .Values.proxy.replicas 1.0 )}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-proxy
+  labels:
+    app.kubernetes.io/component: proxy
+{{ include "labels" . | indent 4 }}
+spec:
+  {{- with .Values.proxy.podDisruptionBudget.minAvailable }}
+  minAvailable: {{ . }}
+  {{- end }}
+  {{- with .Values.proxy.podDisruptionBudget.maxUnavailable }}
+  maxUnavailable: {{ . }}
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: proxy
+{{ include "selector-labels" . | indent 6 }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/proxy.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/proxy.service.yaml
@@ -1,10 +1,12 @@
-# Copyright (c) 2018-present, Facebook, Inc.
-# All rights reserved.
-#
-# This source code is licensed under the BSD-style license found in the
-# LICENSE file in the root directory of this source tree. An additional grant
-# of patent rights can be found in the PATENTS file in the same directory.
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
 
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
+{{- if .Values.proxy.service.enabled }}
 {{ $serviceType := .Values.proxy.service.type }}
 apiVersion: v1
 kind: Service
@@ -53,3 +55,4 @@ spec:
   {{- end }}
   {{- end -}}
 {{- end -}}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -55,6 +55,13 @@ secret:
   envdir: orc8r-secrets-envdir
 
 proxy:
+  # Configure pod disruption budgets for proxy
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
   # Service configuration.
   service:
     name: bootstrapper-orc8r-proxy
@@ -113,6 +120,13 @@ proxy:
   affinity: {}
 
 controller:
+  # Configure pod disruption budgets for controller
+  # ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+  podDisruptionBudget:
+    enabled: false
+    minAvailable: 1
+    maxUnavailable: ""
+
   # Service configuration.
   service:
     annotations: {}

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -64,6 +64,8 @@ proxy:
 
   # Service configuration.
   service:
+    enabled: true
+    legacyEnabled: true
     name: bootstrapper-orc8r-proxy
     annotations: {}
     labels: {}


### PR DESCRIPTION
Summary: Both legacy/latest services are not required. Adding toggle to disable each while keeping both on for backward compatability.

Differential Revision: D18463937

