### PR TITLE
orc8r/helm: adding extra annotations to legacy proxy services

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.2.0
+version: 1.2.1
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -22,6 +22,8 @@ The following table list the configurable parameters of the orchestrator chart a
 | `proxy.service.enabled` | Enables proxy service. | `true` |
 | `proxy.service.lagacyEnabled` | Enables proxy legacy service. | `true` |
 | `proxy.service.annotations` | Annotations to be added to the proxy service. | `{}` |
+| `proxy.service.extraAnnotations.bootstrapLagacy` | Extra annotations to be added to the bootstrap-legacy proxy service. | `{}` |
+| `proxy.service.extraAnnotations.clientcertLegacy` | Extra annotations to be added to the clientcert-legacy proxy service. | `{}` |
 | `proxy.service.labels` | Proxy service labels. | `{}` |
 | `proxy.service.type` | Proxy service type. | `ClusterIP` |
 | `proxy.service.port.clientcert.port` | Proxy client certificate service external port. | `9443` |

--- a/orc8r/cloud/helm/orc8r/templates/bootstrap-legacy.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrap-legacy.service.yaml
@@ -25,9 +25,10 @@ metadata:
     {{- with .Values.proxy.service.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.proxy.service.annotations }}
+  {{- if or .Values.proxy.service.annotations .Values.proxy.service.extraAnnotations.bootstrapLagacy }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ with .Values.proxy.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
+{{ with .Values.proxy.service.extraAnnotations.bootstrapLagacy }}{{ toYaml . | indent 4 }}{{ end }}
   {{- end }}
 spec:
   selector:

--- a/orc8r/cloud/helm/orc8r/templates/clientcert-legacy.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/clientcert-legacy.service.yaml
@@ -25,9 +25,10 @@ metadata:
     {{- with .Values.proxy.service.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
-  {{- with .Values.proxy.service.annotations }}
+  {{- if or .Values.proxy.service.annotations .Values.proxy.service.extraAnnotations.clientcertLegacy }}
   annotations:
-{{ toYaml . | indent 4 }}
+{{ with .Values.proxy.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
+{{ with .Values.proxy.service.extraAnnotations.clientcertLegacy }}{{ toYaml . | indent 4 }}{{ end }}
   {{- end }}
 spec:
   selector:

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -68,6 +68,9 @@ proxy:
     legacyEnabled: true
     name: bootstrapper-orc8r-proxy
     annotations: {}
+    extraAnnotations:
+      bootstrapLagacy: {}
+      clientcertLegacy: {}
     labels: {}
     type: ClusterIP
     port:
@@ -187,7 +190,7 @@ controller:
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   affinity: {}
 
-# Set True to create a CloudWatch agent to monitor metrics 
+# Set True to create a CloudWatch agent to monitor metrics
 cloudwatch:
   create: false
 


### PR DESCRIPTION
Summary: Allows passing individual annotations to bootstrap-legacy / clientcert-legacy services.

Differential Revision: D18470577

