### PR TITLE
remove `__name__` from prometheus_labelset swagger definition`

### DIFF
--- a/orc8r/cloud/go/services/metricsd/obsidian/models/prometheus_labelset_swaggergen.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/prometheus_labelset_swaggergen.go
@@ -6,142 +6,14 @@ package models
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
-	"encoding/json"
-
 	strfmt "github.com/go-openapi/strfmt"
-
-	"github.com/go-openapi/errors"
-	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // PrometheusLabelset prometheus labelset
 // swagger:model prometheus_labelset
-type PrometheusLabelset struct {
-
-	// name
-	// Required: true
-	Name *string `json:"__name__"`
-
-	// prometheus labelset
-	PrometheusLabelset map[string]string `json:"-"`
-}
-
-// UnmarshalJSON unmarshals this object with additional properties from JSON
-func (m *PrometheusLabelset) UnmarshalJSON(data []byte) error {
-	// stage 1, bind the properties
-	var stage1 struct {
-
-		// name
-		// Required: true
-		Name *string `json:"__name__"`
-	}
-	if err := json.Unmarshal(data, &stage1); err != nil {
-		return err
-	}
-	var rcv PrometheusLabelset
-
-	rcv.Name = stage1.Name
-
-	*m = rcv
-
-	// stage 2, remove properties and add to map
-	stage2 := make(map[string]json.RawMessage)
-	if err := json.Unmarshal(data, &stage2); err != nil {
-		return err
-	}
-
-	delete(stage2, "__name__")
-
-	// stage 3, add additional properties values
-	if len(stage2) > 0 {
-		result := make(map[string]string)
-		for k, v := range stage2 {
-			var toadd string
-			if err := json.Unmarshal(v, &toadd); err != nil {
-				return err
-			}
-			result[k] = toadd
-		}
-		m.PrometheusLabelset = result
-	}
-
-	return nil
-}
-
-// MarshalJSON marshals this object with additional properties into a JSON object
-func (m PrometheusLabelset) MarshalJSON() ([]byte, error) {
-	var stage1 struct {
-
-		// name
-		// Required: true
-		Name *string `json:"__name__"`
-	}
-
-	stage1.Name = m.Name
-
-	// make JSON object for known properties
-	props, err := json.Marshal(stage1)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(m.PrometheusLabelset) == 0 {
-		return props, nil
-	}
-
-	// make JSON object for the additional properties
-	additional, err := json.Marshal(m.PrometheusLabelset)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(props) < 3 {
-		return additional, nil
-	}
-
-	// concatenate the 2 objects
-	props[len(props)-1] = ','
-	return append(props, additional[1:]...), nil
-}
+type PrometheusLabelset map[string]string
 
 // Validate validates this prometheus labelset
-func (m *PrometheusLabelset) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateName(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *PrometheusLabelset) validateName(formats strfmt.Registry) error {
-
-	if err := validate.Required("__name__", "body", m.Name); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// MarshalBinary interface implementation
-func (m *PrometheusLabelset) MarshalBinary() ([]byte, error) {
-	if m == nil {
-		return nil, nil
-	}
-	return swag.WriteJSON(m)
-}
-
-// UnmarshalBinary interface implementation
-func (m *PrometheusLabelset) UnmarshalBinary(b []byte) error {
-	var res PrometheusLabelset
-	if err := swag.ReadJSON(b, &res); err != nil {
-		return err
-	}
-	*m = res
+func (m PrometheusLabelset) Validate(formats strfmt.Registry) error {
 	return nil
 }

--- a/orc8r/cloud/go/services/metricsd/obsidian/models/promql_metric_swaggergen.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/promql_metric_swaggergen.go
@@ -8,66 +8,19 @@ package models
 import (
 	strfmt "github.com/go-openapi/strfmt"
 
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/swag"
-	"github.com/go-openapi/validate"
 )
 
 // PromqlMetric promql metric
 // swagger:model promql_metric
 type PromqlMetric struct {
 
-	// name
-	// Required: true
-	Name *string `json:"__name__"`
-
-	// gateway
-	Gateway string `json:"gateway,omitempty"`
-
-	// host
-	Host string `json:"host,omitempty"`
-
-	// instance
-	// Required: true
-	Instance *string `json:"instance"`
-
-	// job
-	Job string `json:"job,omitempty"`
+	// additional properties
+	AdditionalProperties string `json:"additionalProperties,omitempty"`
 }
 
 // Validate validates this promql metric
 func (m *PromqlMetric) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateName(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateInstance(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *PromqlMetric) validateName(formats strfmt.Registry) error {
-
-	if err := validate.Required("__name__", "body", m.Name); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (m *PromqlMetric) validateInstance(formats strfmt.Registry) error {
-
-	if err := validate.Required("instance", "body", m.Instance); err != nil {
-		return err
-	}
-
 	return nil
 }
 

--- a/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
@@ -56,7 +56,7 @@ magma-gen-meta:
 info:
   title:
   description: Orchestrator REST APIs
-  version: 1.0.0
+  version: 1.0.1
 
 tags:
   - name: Metrics
@@ -471,34 +471,17 @@ definitions:
         $ref: '#/definitions/metric_datapoints'
   promql_metric:
     type: object
-    required:
-    - __name__
-    - instance
     properties:
-      __name__:
-        type: string
-      gateway:
-        type: string
-      instance:
-        type: string
-      job:
-        type: string
-      host:
+      additionalProperties:
         type: string
     example:
-      __name__: gateway_up_time
-      gateway: "NFHDZAQU8Pyw2N91nbNdGjk5e.22ffea10-7fc4-4427-975a-b9e4ce8f6f4d"
-      instance: "NFHDZAQU8Pyw2N91nbNdGjk5e"
-      job: "sample_service"
-      host: "magma_controller_a"
+      __name__: "response_status"
+      gatewayID: "gateway01"
+      networkID: "network01"
+      code: "200"
 
   prometheus_labelset:
     type: object
-    required:
-    - __name__
-    properties:
-      __name__:
-        type: string
     additionalProperties:
       type: string
 


### PR DESCRIPTION
Summary: This field causes issues with GraphQL, and since it isn't important we're just getting rid of it. This will only affect clients using the prometheus endpoints if they rely on the guarantee that `__name__` exists in the return field.

Differential Revision: D18488775

