### PR TITLE
Setting psutil version back to target 5.2.2

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -15,7 +15,7 @@ shopt -s extglob
 
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
-VERSION=1.0.0 # magma version number
+VERSION=1.0.1 # magma version number
 
 # RelWithDebInfo or Debug
 BUILD_TYPE=Debug

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -244,7 +244,7 @@
       "root": false,
       "source": "pypi",
       "sysdep": "python3-tinyrpc",
-      "version": "1.0.3"
+      "version": "1.0.4"
     },
     "urllib3": {
       "root": true,

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -67,7 +67,7 @@ setup(
         'pytz>=2014.4',
         'prometheus_client==0.3.1',
         'snowflake>=0.0.3',
-        'psutil==5.6.3',
+        'psutil==5.2.2',
         'cryptography>=1.9',
         'systemd-python>=234',
         'itsdangerous>=0.24',


### PR DESCRIPTION
Summary:
- setup.py was using psutil version `>=5.2.2`, which was pulling latest pkg version, discussing with Ken, we should specify direct version as previous stable version.
- updating build-magma.sh to version `1.0.1`

Differential Revision: D18495164

