### PR TITLE
add device identifiers class

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/mikrotik/Device.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/mikrotik/Mib.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/State.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/DeviceIdentifiers.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/DhcpdConfig.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/ErrorHandler.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/ErrorQueue.cpp
@@ -153,6 +154,7 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/ConfigGeneratorTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/DeviceIdentifiersTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/ErrorQueueTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/EventBaseTest.cpp

--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -14,12 +14,6 @@ include_directories(${PROJECT_SOURCE_DIR}/src)
 find_library(NETSNMPAGENT netsnmpagent)
 find_library(NETSNMPMIBS netsnmpmibs)
 find_library(NETSNMP netsnmp)
-find_library(MGM_ASYNC_GRPC ASYNC_GRPC ${MGM_COM_DIR}/async_grpc)
-find_library(MGM_CONFIG CONFIG HINTS ${MGM_COM_DIR}/config)
-find_library(MGM_SERVICE303_LIB SERVICE303_LIB HINTS ${MGM_COM_DIR}/service303)
-find_library(MGM_DATASTORE DATASTORE HINTS ${MGM_COM_DIR}/datastore)
-find_library(MGM_POLICYDB POLICYDB HINTS ${MGM_COM_DIR}/policydb)
-find_library(MGM_SRVC_REG SERVICE_REGISTRY HINTS ${MGM_COM_DIR}/service_registry)
 
 add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/Application.cpp
@@ -53,6 +47,7 @@ add_library(devman
   ${PROJECT_SOURCE_DIR}/src/devmand/models/device/Model.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/models/interface/Model.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/models/wifi/Model.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/utils/ConfigGenerator.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/utils/Time.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/YangUtils.cpp
 )
@@ -105,6 +100,13 @@ target_link_libraries(devman_channel_snmp
   ${NETSNMPMIBS}
   ${NETSNMP})
 
+find_library(MGM_ASYNC_GRPC ASYNC_GRPC ${MGM_COM_DIR}/async_grpc)
+find_library(MGM_CONFIG CONFIG HINTS ${MGM_COM_DIR}/config)
+find_library(MGM_SERVICE303_LIB SERVICE303_LIB HINTS ${MGM_COM_DIR}/service303)
+find_library(MGM_DATASTORE DATASTORE HINTS ${MGM_COM_DIR}/datastore)
+find_library(MGM_POLICYDB POLICYDB HINTS ${MGM_COM_DIR}/policydb)
+find_library(MGM_SRVC_REG SERVICE_REGISTRY HINTS ${MGM_COM_DIR}/service_registry)
+
 add_library(devman_service_magma
   ${PROJECT_SOURCE_DIR}/src/devmand/magma/DevConf.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/magma/Service.cpp
@@ -148,6 +150,7 @@ target_link_libraries(devmand
   devman_service_magma)
 
 add_executable(devmantest
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/ConfigGeneratorTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DemoDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DevConfTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/DiffTest.cpp

--- a/devmand/gateway/deploy/symphony_agent_install
+++ b/devmand/gateway/deploy/symphony_agent_install
@@ -207,6 +207,11 @@ else
 fi
 
 ###############################################################################
+# TODO make this a cmd line arg
+HOST_PUBLIC_ADDRESS=$(curl -s -4 h.facebook.com/diagnostics | \
+    grep HTTP_TFB_ORIG_CLIENT_IP | cut -d " " -f2)
+
+###############################################################################
 cat << EOF > docker-compose.override.yml
 version: '3.7'
 services:
@@ -218,6 +223,7 @@ services:
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
       - DEVICE_CONFIG_FILE=/var/opt/magma/configs/gateway.mconfig
+      - HOST_PUBLIC_ADDRESS=${HOST_PUBLIC_ADDRESS}
 EOF
 
 ###############################################################################

--- a/devmand/gateway/docker/docker-compose.yml
+++ b/devmand/gateway/docker/docker-compose.yml
@@ -19,6 +19,10 @@ services:
         published: 162
         protocol: udp
         mode: host
+      - target: 514
+        published: 514
+        protocol: udp
+        mode: host
     tmpfs:
       - /sys/fs/cgroup
     cap_add:
@@ -38,3 +42,4 @@ services:
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
+      - HOST_PUBLIC_ADDRESS=${HOST_PUBLIC_ADDRESS}

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/bin/magma_system_prepare
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/bin/magma_system_prepare
@@ -3,7 +3,7 @@
 /bin/rm -f /etc/magma/env
 for e in $(tr "\000" "\n" < /proc/1/environ); do
   case "${e%%=*}" in
-    SNOWFLAKE|CLOUD_ADDRESS|BOOTSTRAP_CLOUD_ADDRESS|DEVICE_CONFIG_FILE)
+    SNOWFLAKE|CLOUD_ADDRESS|BOOTSTRAP_CLOUD_ADDRESS|DEVICE_CONFIG_FILE|HOST_PUBLIC_ADDRESS)
       echo "$e" >> /etc/magma/env
       ;;
     *)
@@ -24,6 +24,14 @@ fi
 
 if [ -z "${BOOTSTRAP_CLOUD_ADDRESS}" ]; then
   BOOTSTRAP_CLOUD_ADDRESS="bootstrapper-controller.magma.etagecom.io"
+fi
+
+if [ -z "${DEVICE_CONFIG_FILE}" ]; then
+  DEVICE_CONFIG_FILE="/var/opt/magma/configs/gateway.mconfig"
+fi
+
+if [ -z "${HOST_PUBLIC_ADDRESS}" ]; then
+  echo "WARNING! Host Public Address not set!"
 fi
 
 # TODO once the cloud supports logs set this to that.

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit-devmand.conf
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit-devmand.conf
@@ -1,0 +1,5 @@
+[FILTER]
+    Name modify
+    Match syslog
+    Condition key_value_equals MikroTik
+    Set device mikrotik

--- a/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit.conf
+++ b/devmand/gateway/docker/firstparty/symphony-agent/files/configs/td-agent-bit.conf
@@ -13,10 +13,21 @@
     Tag            host.*
     Systemd_Filter _SYSTEMD_UNIT=devmand.service
 
+[INPUT]
+    Name              syslog
+    Mode              udp
+    Listen            0.0.0.0
+    Port              514
+    Parser            syslog-rfc3164
+    Buffer_Chunk_Size 32
+    Buffer_Max_Size   32
+
 [FILTER]
     Name modify
     Match *
     Set hw_id "%%snowflake%%"
+
+@INCLUDE td-agent-bit-devmand.conf
 
 [OUTPUT]
     Name  forward

--- a/devmand/gateway/docker/scripts/build
+++ b/devmand/gateway/docker/scripts/build
@@ -21,6 +21,10 @@ if [ -z ${DEVICE_CONFIG_FILE+x} ]; then
   export DEVICE_CONFIG_FILE="/var/opt/magma/configs/gateway.mconfig"
 fi
 
+if [ -z ${HOST_PUBLIC_ADDRESS+x} ]; then
+  export HOST_PUBLIC_ADDRESS="192.168.90.100"
+fi
+
 if [ ! -f docker-compose.override.yml ]; then
 cat << EOF > docker-compose.override.yml
 version: '3.7'
@@ -31,6 +35,7 @@ services:
       - SNOWFLAKE=${SNOWFLAKE}
       - CLOUD_ADDRESS=${CLOUD_ADDRESS}
       - BOOTSTRAP_CLOUD_ADDRESS=${BOOTSTRAP_CLOUD_ADDRESS}
+      - HOST_PUBLIC_ADDRESS=${HOST_PUBLIC_ADDRESS}
 EOF
 fi
 

--- a/devmand/gateway/docker/scripts/develop
+++ b/devmand/gateway/docker/scripts/develop
@@ -16,6 +16,7 @@ build_status=${PIPESTATUS[0]}
 docker_registry=${SYMPHONY_DOCKER_REGISTRY:="facebookconnectivity-southpoll-dev-docker.jfrog.io"}
 if [ "$build_status" -eq 0 ]; then
   docker rm -f devmand
+  # TODO see if we can use the docker compose file to run this
   docker run -it --cap-add NET_RAW --cap-add NET_ADMIN --cap-add SYS_PTRACE \
       --name devmand \
       -v "$(realpath ../):/cache/devmand/repo:ro" \

--- a/devmand/gateway/docker/scripts/test
+++ b/devmand/gateway/docker/scripts/test
@@ -21,6 +21,7 @@ memcheck="valgrind \
 #--show-reachable=yes \
 
 function run_test_container {
+  # TODO see if we can use the docker compose file to run this.
   docker run -it \
     -v "$(realpath ../):/cache/devmand/repo:ro" \
     -v "$CACHE_DIR:/cache/devmand/build:rw" \

--- a/devmand/gateway/src/devmand/Config.cpp
+++ b/devmand/gateway/src/devmand/Config.cpp
@@ -19,5 +19,9 @@ DEFINE_uint64(
     debug_print_interval,
     0,
     "The debug print interval in seconds. A value of 0 disables the printing.");
+DEFINE_bool(
+    devices_readonly,
+    false,
+    "whether or not devices can be configured");
 
 } // namespace devmand

--- a/devmand/gateway/src/devmand/Config.h
+++ b/devmand/gateway/src/devmand/Config.h
@@ -15,5 +15,6 @@ DECLARE_string(listen_interface);
 DECLARE_string(device_configuration_file);
 DECLARE_uint64(poll_interval);
 DECLARE_uint64(debug_print_interval);
+DECLARE_bool(devices_readonly);
 
 } // namespace devmand

--- a/devmand/gateway/src/devmand/DeviceIdentifiers.cpp
+++ b/devmand/gateway/src/devmand/DeviceIdentifiers.cpp
@@ -1,0 +1,38 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/DeviceIdentifiers.h>
+
+namespace devmand {
+
+void DeviceIdentifiers::addIdentifier(
+    const std::string& identifer,
+    const devices::Id& id) {
+  identifiers.emplace(identifer, id);
+}
+
+void DeviceIdentifiers::removeIdentifier(
+    const std::string& identifer,
+    const devices::Id& id) {
+  auto range = identifiers.equal_range(identifer);
+  for (auto it = range.first; it != range.second; ++it) {
+    if (it->second == id) {
+      identifiers.erase(it);
+      break;
+    }
+  }
+}
+
+devices::Id DeviceIdentifiers::lookup(const std::string& identifer) const {
+  auto range = identifiers.equal_range(identifer);
+  for (auto it = range.first; it != range.second; ++it) {
+    return it->second;
+  }
+  return "";
+}
+
+} // namespace devmand

--- a/devmand/gateway/src/devmand/DeviceIdentifiers.h
+++ b/devmand/gateway/src/devmand/DeviceIdentifiers.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <map>
+
+#include <devmand/devices/Id.h>
+
+namespace devmand {
+
+// This class provides a mapping between
+class DeviceIdentifiers final {
+ public:
+  DeviceIdentifiers() = default;
+  ~DeviceIdentifiers() = default;
+  DeviceIdentifiers(const DeviceIdentifiers&) = delete;
+  DeviceIdentifiers& operator=(const DeviceIdentifiers&) = delete;
+  DeviceIdentifiers(DeviceIdentifiers&&) = delete;
+  DeviceIdentifiers& operator=(DeviceIdentifiers&&) = delete;
+
+ public:
+  void addIdentifier(const std::string& identifer, const devices::Id& id);
+  void removeIdentifier(const std::string& identifer, const devices::Id& id);
+
+  devices::Id lookup(const std::string& identifer) const;
+
+ private:
+  std::multimap<std::string, devices::Id> identifiers;
+};
+
+} // namespace devmand

--- a/devmand/gateway/src/devmand/cartography/DeviceConfig.h
+++ b/devmand/gateway/src/devmand/cartography/DeviceConfig.h
@@ -38,6 +38,7 @@ struct DeviceConfig {
   std::string platform;
   std::string ip;
   std::string yangConfig;
+  bool readonly;
 
   std::map<std::string, ChannelConfig> channelConfigs;
 
@@ -45,7 +46,8 @@ struct DeviceConfig {
     out << "id=" << c.id << ", "
         << "platform=" << c.platform << ", "
         << "ip=" << c.ip << ", "
-        << "yangConfig=" << c.yangConfig << ", channels {";
+        << "yangConfig=" << c.yangConfig << ", "
+        << "readonly=" << c.readonly << ", channels {";
     for (auto& channel : c.channelConfigs) {
       out << channel.first << ", ";
     }
@@ -59,12 +61,14 @@ struct DeviceConfig {
                lhs.platform,
                lhs.ip,
                lhs.yangConfig,
+               lhs.readonly,
                lhs.channelConfigs) <
         std::tie(
                rhs.id,
                rhs.platform,
                rhs.ip,
                rhs.yangConfig,
+               rhs.readonly,
                rhs.channelConfigs);
   }
 
@@ -74,12 +78,14 @@ struct DeviceConfig {
                lhs.platform,
                lhs.ip,
                lhs.yangConfig,
+               lhs.readonly,
                lhs.channelConfigs) ==
         std::tie(
                rhs.id,
                rhs.platform,
                rhs.ip,
                rhs.yangConfig,
+               rhs.readonly,
                rhs.channelConfigs);
   }
 
@@ -89,12 +95,14 @@ struct DeviceConfig {
                lhs.platform,
                lhs.ip,
                lhs.yangConfig,
+               lhs.readonly,
                lhs.channelConfigs) !=
         std::tie(
                rhs.id,
                rhs.platform,
                rhs.ip,
                rhs.yangConfig,
+               rhs.readonly,
                rhs.channelConfigs);
   }
 };

--- a/devmand/gateway/src/devmand/channels/mikrotik/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/mikrotik/Channel.cpp
@@ -255,8 +255,6 @@ bool Channel::handle(const Sentence& sentence) {
       if (sentence.front() == "!done") {
         if (sentence.size() == 1) {
           state = State::FullyConnected;
-          // TODO make this conditional on readonly flag
-          // enableSyslog();
           return true;
         } else if (sentence.size() == 2 and sentence[1].size() > 5) {
           std::string code = sentence[1];

--- a/devmand/gateway/src/devmand/channels/mikrotik/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/mikrotik/Channel.cpp
@@ -255,6 +255,8 @@ bool Channel::handle(const Sentence& sentence) {
       if (sentence.front() == "!done") {
         if (sentence.size() == 1) {
           state = State::FullyConnected;
+          // TODO make this conditional on readonly flag
+          // enableSyslog();
           return true;
         } else if (sentence.size() == 2 and sentence[1].size() > 5) {
           std::string code = sentence[1];
@@ -293,6 +295,15 @@ void Channel::readErr(const folly::AsyncSocketException& ex) noexcept {
 
 State Channel::getState() const {
   return state;
+}
+
+void Channel::enableSyslog() {
+  // TODO don't just assume success
+  writeWordAndLength("/system/logging/action/add");
+  writeWordAndLength("=name=syslog");
+  writeWordAndLength("=target=remote");
+  writeWordAndLength(folly::sformat("=remote={}", "192.168.90.100"));
+  terminateSentence();
 }
 
 } // namespace mikrotik

--- a/devmand/gateway/src/devmand/channels/mikrotik/Channel.h
+++ b/devmand/gateway/src/devmand/channels/mikrotik/Channel.h
@@ -97,6 +97,8 @@ class Channel : public channels::Channel,
 
   void debugPrintHex(const std::string& prefix, const std::string& buf);
 
+  void enableSyslog();
+
  private:
   folly::EventBase& eventBase;
   folly::SocketAddress address;

--- a/devmand/gateway/src/devmand/devices/CambiumDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/CambiumDevice.cpp
@@ -26,6 +26,7 @@ std::unique_ptr<devices::Device> CambiumDevice::createDevice(
   return std::make_unique<devices::CambiumDevice>(
       app,
       deviceConfig.id,
+      deviceConfig.readonly,
       folly::IPAddress(deviceConfig.ip),
       cambiumKv.at("client-mac"),
       cambiumKv.at("client-id"),
@@ -35,11 +36,12 @@ std::unique_ptr<devices::Device> CambiumDevice::createDevice(
 CambiumDevice::CambiumDevice(
     Application& application,
     const Id& id_,
+    bool readonly_,
     const folly::IPAddress& deviceIp_,
     const std::string& clientMac_,
     const std::string& clientId_,
     const std::string& clientSecret_)
-    : Device(application, id_),
+    : Device(application, id_, readonly_),
       channel(deviceIp_.str(), clientId_, clientSecret_),
       deviceIp(deviceIp_),
       clientMac(clientMac_) {

--- a/devmand/gateway/src/devmand/devices/CambiumDevice.h
+++ b/devmand/gateway/src/devmand/devices/CambiumDevice.h
@@ -24,6 +24,7 @@ class CambiumDevice : public Device {
   CambiumDevice(
       Application& application,
       const Id& id_,
+      bool readonly_,
       const folly::IPAddress& deviceIp_,
       const std::string& clientMac_,
       const std::string& clientId_,

--- a/devmand/gateway/src/devmand/devices/DcsgDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/DcsgDevice.cpp
@@ -27,11 +27,16 @@ std::unique_ptr<devices::Device> DcsgDevice::createDevice(
   Host host{deviceConfig.id,
             folly::MacAddress(otherKv.at("mac")),
             folly::IPAddress(deviceConfig.ip)};
-  return std::make_unique<devices::DcsgDevice>(app, deviceConfig.id, host);
+  return std::make_unique<devices::DcsgDevice>(
+      app, deviceConfig.id, deviceConfig.readonly, host);
 }
 
-DcsgDevice::DcsgDevice(Application& application, const Id& id_, Host& host_)
-    : Device(application, id_), host(host_) {
+DcsgDevice::DcsgDevice(
+    Application& application,
+    const Id& id_,
+    bool readonly_,
+    Host& host_)
+    : Device(application, id_, readonly_), host(host_) {
   app.getDhcpdConfig().add(host);
   FileUtils::mkdir(
       std::experimental::filesystem::path(deviceConfigFilePathTemplate)

--- a/devmand/gateway/src/devmand/devices/DcsgDevice.h
+++ b/devmand/gateway/src/devmand/devices/DcsgDevice.h
@@ -15,7 +15,11 @@ namespace devices {
 
 class DcsgDevice : public Device {
  public:
-  DcsgDevice(Application& application, const Id& id_, Host& host_);
+  DcsgDevice(
+      Application& application,
+      const Id& id_,
+      bool readonly_,
+      Host& host_);
 
   DcsgDevice() = delete;
   virtual ~DcsgDevice();

--- a/devmand/gateway/src/devmand/devices/DemoDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/DemoDevice.cpp
@@ -14,11 +14,12 @@ namespace devices {
 std::unique_ptr<devices::Device> DemoDevice::createDevice(
     Application& app,
     const cartography::DeviceConfig& deviceConfig) {
-  return std::make_unique<devices::DemoDevice>(app, deviceConfig.id);
+  return std::make_unique<devices::DemoDevice>(
+      app, deviceConfig.id, deviceConfig.readonly);
 }
 
-DemoDevice::DemoDevice(Application& application, const Id& id_)
-    : Device(application, id_) {}
+DemoDevice::DemoDevice(Application& application, const Id& id_, bool readonly_)
+    : Device(application, id_, readonly_) {}
 
 std::shared_ptr<State> DemoDevice::getState() {
   auto state = State::make(*reinterpret_cast<MetricSink*>(&app), getId());

--- a/devmand/gateway/src/devmand/devices/DemoDevice.h
+++ b/devmand/gateway/src/devmand/devices/DemoDevice.h
@@ -14,7 +14,7 @@ namespace devices {
 
 class DemoDevice : public Device {
  public:
-  DemoDevice(Application& application, const Id& id);
+  DemoDevice(Application& application, const Id& id, bool readonly_);
 
   DemoDevice() = delete;
   virtual ~DemoDevice() = default;

--- a/devmand/gateway/src/devmand/devices/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Device.cpp
@@ -12,13 +12,14 @@
 #include <folly/json.h>
 
 #include <devmand/Application.h>
+#include <devmand/Config.h>
 #include <devmand/ErrorHandler.h>
 
 namespace devmand {
 namespace devices {
 
-Device::Device(Application& application, const Id& id_)
-    : app(application), id(id_) {}
+Device::Device(Application& application, const Id& id_, bool readonly_)
+    : app(application), id(id_), readonly(readonly_) {}
 
 Id Device::getId() const {
   return id;
@@ -56,6 +57,12 @@ void Device::updateSharedView(SharedUnifiedView& sharedUnifiedView) {
 }
 
 void Device::applyConfig(const std::string& config) {
+  if (isReadonly()) {
+    LOG(INFO) << "Not applying configuration on device " << id
+              << " as the device is read only.";
+    return;
+  }
+
   LOG(INFO) << "Applying config '" << config;
   if (not config.empty()) {
     switch (getDeviceConfigType()) {
@@ -75,6 +82,10 @@ void Device::applyConfig(const std::string& config) {
         break;
     }
   }
+}
+
+bool Device::isReadonly() const {
+  return readonly or FLAGS_devices_readonly;
 }
 
 } // namespace devices

--- a/devmand/gateway/src/devmand/devices/Device.h
+++ b/devmand/gateway/src/devmand/devices/Device.h
@@ -31,7 +31,7 @@ enum class DeviceConfigType { YangJson, NativeConfigJson };
 
 class Device {
  public:
-  Device(Application& application, const Id& id_);
+  Device(Application& application, const Id& id_, bool readonly_);
   Device() = delete;
   virtual ~Device() = default;
   Device(const Device&) = delete;
@@ -80,9 +80,13 @@ class Device {
 
   folly::dynamic lookup(const YangPath& path) const;
 
+ private:
+  bool isReadonly() const;
+
  protected:
   Application& app;
   Id id;
+  const bool readonly;
   folly::dynamic lastConfig;
 };
 

--- a/devmand/gateway/src/devmand/devices/EchoDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/EchoDevice.cpp
@@ -13,11 +13,12 @@ namespace devices {
 std::unique_ptr<devices::Device> EchoDevice::createDevice(
     Application& app,
     const cartography::DeviceConfig& deviceConfig) {
-  return std::make_unique<devices::EchoDevice>(app, deviceConfig.id);
+  return std::make_unique<devices::EchoDevice>(
+      app, deviceConfig.id, deviceConfig.readonly);
 }
 
-EchoDevice::EchoDevice(Application& application, const Id& id_)
-    : Device(application, id_) {}
+EchoDevice::EchoDevice(Application& application, const Id& id_, bool readonly_)
+    : Device(application, id_, readonly_) {}
 
 void EchoDevice::setConfig(const folly::dynamic& config) {
   state = config;

--- a/devmand/gateway/src/devmand/devices/EchoDevice.h
+++ b/devmand/gateway/src/devmand/devices/EchoDevice.h
@@ -14,7 +14,7 @@ namespace devices {
 
 class EchoDevice : public Device {
  public:
-  EchoDevice(Application& application, const Id& id);
+  EchoDevice(Application& application, const Id& id, bool readonly_);
 
   EchoDevice() = delete;
   virtual ~EchoDevice() = default;

--- a/devmand/gateway/src/devmand/devices/FrinxDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/FrinxDevice.cpp
@@ -55,6 +55,7 @@ std::unique_ptr<devices::Device> FrinxDevice::createDevice(
   return std::make_unique<devices::FrinxDevice>(
       app,
       deviceConfig.id,
+      deviceConfig.readonly,
       frinxKv.at("host"),
       folly::to<int>(frinxKv.at("frinxPort")),
       folly::IPAddress(deviceConfig.ip),
@@ -72,6 +73,7 @@ std::unique_ptr<devices::Device> FrinxDevice::createDevice(
 FrinxDevice::FrinxDevice(
     Application& application,
     const Id& id_,
+    bool readonly_,
     const std::string& controllerHost,
     const int controllerPort,
     const folly::IPAddress& deviceIp_,
@@ -83,7 +85,7 @@ FrinxDevice::FrinxDevice(
     const std::string& deviceVersion_,
     const std::string& deviceUsername_,
     const std::string& devicePassword_)
-    : Device(application, id_),
+    : Device(application, id_, readonly_),
       channel(controllerHost, controllerPort),
       headers({{"Authorization", authorization_},
                {"Accept", contentTypeJson},

--- a/devmand/gateway/src/devmand/devices/FrinxDevice.h
+++ b/devmand/gateway/src/devmand/devices/FrinxDevice.h
@@ -25,6 +25,7 @@ class FrinxDevice : public Device {
   FrinxDevice(
       Application& application,
       const Id& id_,
+      bool readonly_,
       const std::string& controllerHost,
       const int controllerPort,
       const folly::IPAddress& deviceIp_,

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -23,14 +23,18 @@ std::unique_ptr<devices::Device> PingDevice::createDevice(
     Application& app,
     const cartography::DeviceConfig& deviceConfig) {
   return std::make_unique<devices::PingDevice>(
-      app, deviceConfig.id, folly::IPAddress(deviceConfig.ip));
+      app,
+      deviceConfig.id,
+      deviceConfig.readonly,
+      folly::IPAddress(deviceConfig.ip));
 }
 
 PingDevice::PingDevice(
     Application& application,
     const Id& id_,
+    bool readonly_,
     const folly::IPAddress& ip_)
-    : Device(application, id_), channel(application.getPingEngine(ip_), ip_) {}
+    : Device(application, id_, readonly_), channel(application.getPingEngine(ip_), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
   auto state = State::make(app, getId());

--- a/devmand/gateway/src/devmand/devices/PingDevice.h
+++ b/devmand/gateway/src/devmand/devices/PingDevice.h
@@ -18,6 +18,7 @@ class PingDevice : public Device {
   PingDevice(
       Application& application,
       const Id& id,
+      bool readonly_,
       const folly::IPAddress& ip_);
   PingDevice() = delete;
   virtual ~PingDevice() = default;

--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
@@ -67,6 +67,7 @@ std::unique_ptr<devices::Device> Snmpv2Device::createDevice(
   return std::make_unique<devices::Snmpv2Device>(
       app,
       deviceConfig.id,
+      deviceConfig.readonly,
       deviceConfig.ip,
       snmpKv.at("community"),
       snmpKv.at("version"));
@@ -75,6 +76,7 @@ std::unique_ptr<devices::Device> Snmpv2Device::createDevice(
 Snmpv2Device::Snmpv2Device(
     Application& application,
     const Id& id_,
+    bool readonly_,
     const channels::snmp::Peer& peer,
     const channels::snmp::Community& community,
     const channels::snmp::Version& version,
@@ -82,7 +84,7 @@ Snmpv2Device::Snmpv2Device(
     const std::string& securityName,
     const channels::snmp::SecurityLevel& securityLevel,
     oid proto[])
-    : PingDevice(application, id_, folly::IPAddress(peer)),
+    : PingDevice(application, id_, readonly_, folly::IPAddress(peer)),
       snmpChannel(
           application.getSnmpEngine(),
           peer,

--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.h
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.h
@@ -36,6 +36,7 @@ class Snmpv2Device : public PingDevice {
   Snmpv2Device(
       Application& application,
       const Id& id,
+      bool readonly_,
       const channels::snmp::Peer& peer,
       const channels::snmp::Community& community,
       const channels::snmp::Version& version,

--- a/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
@@ -29,6 +29,7 @@ std::unique_ptr<devices::Device> Device::createDevice(
   return std::make_unique<Device>(
       app,
       deviceConfig.id,
+      deviceConfig.readonly,
       folly::IPAddress(deviceConfig.ip),
       otherKv.at("username"),
       otherKv.at("password"),
@@ -40,6 +41,7 @@ std::unique_ptr<devices::Device> Device::createDevice(
 Device::Device(
     Application& application,
     const Id& id_,
+    bool readonly_,
     const folly::IPAddress& _ip,
     const std::string& _username,
     const std::string& _password,
@@ -53,6 +55,7 @@ Device::Device(
     : Snmpv2Device(
           application,
           id_,
+          readonly_,
           peer,
           community,
           version,

--- a/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
+++ b/devmand/gateway/src/devmand/devices/mikrotik/Device.cpp
@@ -259,7 +259,8 @@ std::shared_ptr<State> Device::getState() {
   state->addFinally([state]() {
     state->update([](auto& lockedState) {
       auto* field = lockedState.get_ptr("ietf-system:system");
-      if (field != nullptr and ((field = field->get_ptr("name")) != nullptr)) {
+      if (field != nullptr and
+          ((field = field->get_ptr("hostname")) != nullptr)) {
         auto hostname = field->asString();
         PAPC(lockedState)["hostname"] = hostname;
         PAPT(lockedState)["hostname"] = hostname;

--- a/devmand/gateway/src/devmand/devices/mikrotik/Device.h
+++ b/devmand/gateway/src/devmand/devices/mikrotik/Device.h
@@ -20,6 +20,7 @@ class Device : public Snmpv2Device {
   Device(
       Application& application,
       const Id& id,
+      bool readonly,
       const folly::IPAddress& _ip,
       const std::string& _username,
       const std::string& _password,

--- a/devmand/gateway/src/devmand/magma/DevConf.cpp
+++ b/devmand/gateway/src/devmand/magma/DevConf.cpp
@@ -125,6 +125,7 @@ cartography::DeviceConfigs DevConf::parseYamlDeviceConfigs(
       deviceConfig.id = device["id"].as<std::string>();
       deviceConfig.platform = device["platform"].as<std::string>();
       deviceConfig.ip = device["ip"].as<std::string>();
+      deviceConfig.readonly = device["readonly"].as<bool>();
 
       if (device["yangConfig"]) {
         deviceConfig.yangConfig =
@@ -208,6 +209,10 @@ cartography::DeviceConfigs DevConf::parseMconfigDeviceConfigs(
         deviceConfig.id = device.first.asString();
         deviceConfig.platform = device.second["platform"].asString();
         deviceConfig.ip = device.second["host"].asString();
+        if (device.second.get_ptr("readonly") != nullptr) {
+          deviceConfig.readonly = device.second["readonly"].asBool();
+        }
+
         if (device.second.get_ptr("deviceConfig") != nullptr) {
           deviceConfig.yangConfig = device.second["deviceConfig"].asString();
         }

--- a/devmand/gateway/src/devmand/test/ConfigGeneratorTest.cpp
+++ b/devmand/gateway/src/devmand/test/ConfigGeneratorTest.cpp
@@ -1,0 +1,79 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <gtest/gtest.h>
+
+#include <experimental/filesystem>
+#include <list>
+#include <set>
+
+#include <devmand/FileUtils.h>
+#include <devmand/utils/ConfigGenerator.h>
+
+namespace devmand {
+namespace utils {
+namespace test {
+
+static std::experimental::filesystem::path getFilename() {
+  std::string ret = "/tmp/";
+  auto* testInfo = ::testing::UnitTest::GetInstance()->current_test_info();
+  ret += testInfo->name();
+  return ret;
+}
+
+TEST(ConfigGeneratorTest, singleAdd) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "a");
+
+  EXPECT_EQ("sae", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, doubleAdd) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "a");
+  cg.add("{}", "b");
+
+  EXPECT_EQ("sabe", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, newlinesAdd) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s\n{}\ne\n"};
+  cg.add("{}", "a\nb");
+  cg.add("{}", "c\nd");
+
+  EXPECT_EQ("s\na\nbc\nd\ne\n", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, doubleAddThenRm) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "a");
+  cg.add("{}", "b");
+
+  EXPECT_EQ("sabe", FileUtils::readContents(filename));
+
+  cg.remove("{}", "b");
+
+  EXPECT_EQ("sae", FileUtils::readContents(filename));
+}
+
+TEST(ConfigGeneratorTest, doubleAddOrder) {
+  auto filename = getFilename();
+  ConfigGenerator cg{filename, "s{}e"};
+  cg.add("{}", "b");
+  cg.add("{}", "a");
+  cg.add("{}", "c");
+
+  EXPECT_EQ("sabce", FileUtils::readContents(filename));
+}
+
+} // namespace test
+} // namespace utils
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/DevConfTest.cpp
+++ b/devmand/gateway/src/devmand/test/DevConfTest.cpp
@@ -26,6 +26,7 @@ const char* yamlDeviceTemplate = R"template(    - id: {}
       ip: {}
       type: Device
       platform: {}
+      readonly: true
       poll:
           seconds: 10
       channels:
@@ -84,6 +85,7 @@ const char* mconfigDeviceTemplate = R"template(
             ],
             "host": "{}",
             "platform": "{}",
+            "readonly": true,
             "channels" : {{
               "frinxChannel": {{
                   "authorization": "Basic",
@@ -172,6 +174,7 @@ TEST_F(DevConfTest, initialReadYaml) {
       "Foo",
       "203.0.113.1",
       "",
+      true,
       std::map<std::string, cartography::ChannelConfig>{
           {"snmp",
            {std::map<std::string, std::string>{{"version", "v1"},
@@ -239,6 +242,7 @@ TEST_F(DevConfTest, initialReadMConfig) {
       "Foo",
       "203.0.113.1",
       "foobar",
+      true,
       std::map<std::string, cartography::ChannelConfig>{
           {"snmp",
            {std::map<std::string, std::string>{{"version", "v1"},

--- a/devmand/gateway/src/devmand/test/DeviceIdentifiersTest.cpp
+++ b/devmand/gateway/src/devmand/test/DeviceIdentifiersTest.cpp
@@ -1,0 +1,57 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <gtest/gtest.h>
+
+#include <devmand/DeviceIdentifiers.h>
+
+namespace devmand {
+namespace test {
+
+TEST(DeviceIdentifiersTest, addAndLookup) {
+  DeviceIdentifiers dis;
+  dis.addIdentifier("1.1.1.1", "foo");
+  EXPECT_EQ("foo", dis.lookup("1.1.1.1"));
+}
+
+TEST(DeviceIdentifiersTest, addRemAndLookup) {
+  DeviceIdentifiers dis;
+  dis.addIdentifier("1.1.1.1", "foo");
+  dis.removeIdentifier("1.1.1.1", "foo");
+  EXPECT_EQ("", dis.lookup("1.1.1.1"));
+}
+
+TEST(DeviceIdentifiersTest, addDupAndLookup) {
+  DeviceIdentifiers dis;
+  dis.addIdentifier("1.1.1.1", "foo");
+  dis.addIdentifier("2.2.2.2", "foo");
+  EXPECT_EQ("foo", dis.lookup("1.1.1.1"));
+}
+
+TEST(DeviceIdentifiersTest, addDupDiffAndLookup) {
+  DeviceIdentifiers dis;
+  dis.addIdentifier("1.1.1.1", "foo");
+  dis.addIdentifier("2.2.2.2", "bar");
+  EXPECT_EQ("foo", dis.lookup("1.1.1.1"));
+}
+
+TEST(DeviceIdentifiersTest, addDupIdenAndLookup) {
+  DeviceIdentifiers dis;
+  dis.addIdentifier("1.1.1.1", "foo");
+  dis.addIdentifier("1.1.1.1", "foo");
+  EXPECT_EQ("foo", dis.lookup("1.1.1.1"));
+}
+
+TEST(DeviceIdentifiersTest, addDupIdenDiffAndLookup) {
+  DeviceIdentifiers dis;
+  dis.addIdentifier("1.1.1.1", "foo");
+  dis.addIdentifier("1.1.1.1", "bar");
+  EXPECT_EQ("foo", dis.lookup("1.1.1.1"));
+}
+
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/utils/ConfigGenerator.cpp
+++ b/devmand/gateway/src/devmand/utils/ConfigGenerator.cpp
@@ -1,0 +1,40 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <algorithm>
+#include <experimental/filesystem>
+
+#include <folly/Format.h>
+#include <folly/GLog.h>
+
+#include <devmand/FileUtils.h>
+#include <devmand/utils/ConfigGenerator.h>
+
+#include <boost/algorithm/string/join.hpp>
+
+namespace devmand {
+
+namespace utils {
+
+ConfigGenerator::ConfigGenerator(
+    const std::string& configFile_,
+    const std::string& fileTemplate_)
+    : configFile(configFile_), fileTemplate(fileTemplate_) {
+  FileUtils::mkdir(
+      std::experimental::filesystem::path(configFile).parent_path());
+}
+
+void ConfigGenerator::rewrite() {
+  // TODO make this async
+  FileUtils::write(
+      configFile,
+      folly::sformat(fileTemplate, boost::algorithm::join(entries, "")));
+}
+
+} // namespace utils
+
+} // namespace devmand

--- a/devmand/gateway/src/devmand/utils/ConfigGenerator.h
+++ b/devmand/gateway/src/devmand/utils/ConfigGenerator.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <set>
+#include <string>
+#include <tuple>
+
+#include <folly/Format.h>
+#include <folly/GLog.h>
+
+namespace devmand {
+
+namespace utils {
+
+class ConfigGenerator final {
+ public:
+  ConfigGenerator(
+      const std::string& configFile_,
+      const std::string& fileTemplate_);
+  ConfigGenerator() = delete;
+  ~ConfigGenerator() = default;
+  ConfigGenerator(const ConfigGenerator&) = delete;
+  ConfigGenerator& operator=(const ConfigGenerator&) = delete;
+  ConfigGenerator(ConfigGenerator&&) = delete;
+  ConfigGenerator& operator=(ConfigGenerator&&) = delete;
+
+ public:
+  template <class... Args>
+  void add(const std::string& templateS, Args&&... args) {
+    if (entries.emplace(folly::sformat(templateS, std::forward<Args>(args)...))
+            .second) {
+      rewrite();
+    } else {
+      LOG(ERROR) << "Failed to add entry";
+    }
+  }
+
+  template <class... Args>
+  void remove(Args&&... args) {
+    if (entries.erase(folly::sformat(std::forward<Args>(args)...)) != 1) {
+      LOG(ERROR) << "Failed to delete entry ";
+    } else {
+      rewrite();
+    }
+  }
+
+ private:
+  void rewrite();
+
+ private:
+  std::string configFile;
+  std::string fileTemplate;
+  std::set<std::string> entries;
+};
+
+} // namespace utils
+
+} // namespace devmand


### PR DESCRIPTION
Summary:
This commit adds the device identifiers class which will encapsulate
the logic around how device ids are mapped for sys log use. It also will handle
duplicates and logic as such.

Reviewed By: al8

Differential Revision: D18460425

