### PR TITLE
Fixing fluent_bit copy file step

### DIFF
--- a/orc8r/tools/ansible/roles/fluent_bit/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/fluent_bit/tasks/main.yml
@@ -34,7 +34,7 @@
 
 - name: Copy fluent bit config script
   copy:
-    src: '{{ magma_root }}/lte/gateway/python/scripts/generate_fluent_bit_config.py'
+    src: '{{ magma_root }}/orc8r/gateway/python/scripts/generate_fluent_bit_config.py'
     dest: /usr/local/bin/generate_fluent_bit_config.py
     force: yes
     remote_src: yes


### PR DESCRIPTION
Summary: fluent_bit role was moved from lte to orc8r, there's an old reference for the copy file step, updating it.

Differential Revision: D18506870

