### PR TITLE
remove snmpwalk from Snmpv2Device

### DIFF
--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.cpp
@@ -238,11 +238,6 @@ std::shared_ptr<State> Snmpv2Device::getState() {
                             }
                           });
                         }));
-  state->addRequest(
-      snmpChannel.walk(channels::snmp::Oid(".1")).thenValue([](auto walk) {
-        LOG(INFO) << "Completed an SNMP walk with " << walk.size()
-                  << " entries";
-      }));
 
   auto addRequest = [&state, this](
                         const std::string& oid, const std::string& path) {


### PR DESCRIPTION
Summary: Removed snmpwalk. It was there to stress test the Agent and we don't need it anymore.

Differential Revision: D18512494

