### PR TITLE
Change enforcement_test to use static rules not dynamic

### DIFF
--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -21,15 +21,12 @@ import (
 
 func TestAuthenticate(t *testing.T) {
 	fmt.Printf("Running TestAuthenticate...\n")
-	tr, _ := NewTestRunner()
+	tr := NewTestRunner()
 	ues, err := tr.ConfigUEs(3)
 	assert.NoError(t, err)
 
 	for _, ue := range ues {
 		radiusP, err := tr.Authenticate(ue.GetImsi())
-		assert.NoError(t, err)
-
-		err = tr.AddPassThroughPCRFRules(ue.GetImsi())
 		assert.NoError(t, err)
 
 		eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)

--- a/cwf/gateway/integ_tests/auth_ul_test.go
+++ b/cwf/gateway/integ_tests/auth_ul_test.go
@@ -21,12 +21,15 @@ import (
 
 func TestAuthenticateUplinkTraffic(t *testing.T) {
 	fmt.Printf("Running TestAuthenticateUplinkTraffic...\n")
-	tr, _ := NewTestRunner()
+	tr := NewTestRunner()
+	ruleManager, err := NewRuleManager()
+	assert.NoError(t, err)
+
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
 
 	ue := ues[0]
-	err = tr.AddPassThroughPCRFRules(ue.GetImsi())
+	err = ruleManager.AddDynamicPassAll(ue.GetImsi(), "dynamic-pass-all", "mkey1")
 	assert.NoError(t, err)
 	radiusP, err := tr.Authenticate(ue.GetImsi())
 	assert.NoError(t, err)
@@ -39,5 +42,6 @@ func TestAuthenticateUplinkTraffic(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Clear hss, ocs, and pcrf
+	assert.NoError(t, ruleManager.RemoveInstalledRules())
 	assert.NoError(t, tr.CleanUp())
 }

--- a/cwf/gateway/integ_tests/enforcement_test.go
+++ b/cwf/gateway/integ_tests/enforcement_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"fbc/lib/go/radius/rfc2869"
-	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/eap"
 
 	"github.com/go-openapi/swag"
@@ -23,26 +22,37 @@ import (
 )
 
 func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
-	tr, _ := NewTestRunner()
+	tr := NewTestRunner()
+	ruleManager, err := NewRuleManager()
+	assert.NoError(t, err)
+
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
+	imsi := ues[0].GetImsi()
 
-	ue := ues[0]
-	err = tr.AddPCRFRules(getAllAcceptingPCRFRule(ue.GetImsi()))
+	// setup policy rules & monitor
+	// 1. Install a usage monitor
+	// 2. Install a static rule that passes all traffic tied to the usage monitor above
+	// 3. Install a dynamic rule that points to the static rule above
+	err = ruleManager.AddUsageMonitor(imsi, "mkey1", 4096, 1024)
 	assert.NoError(t, err)
-	err = tr.AddPCRFUsageMonitors(getUsageMonitor(ue.GetImsi()))
+	err = ruleManager.AddStaticPassAll("static-pass-all", "mkey1")
 	assert.NoError(t, err)
-	fmt.Printf("************************* Successfully added PCRF rules and monitors for IMSI: %s\n", ue.GetImsi())
+	err = ruleManager.AddDynamicRules(imsi, []string{"static-pass-all"}, nil)
+	assert.NoError(t, err)
 
-	radiusP, err := tr.Authenticate(ue.GetImsi())
+	// wait for the rules to be synced into sessiond
+	time.Sleep(1 * time.Second)
+
+	radiusP, err := tr.Authenticate(imsi)
 	assert.NoError(t, err)
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
 	assert.NotNil(t, eapMessage)
 	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
 
-	// Send a small amount of data to start the session
-	err = tr.GenULTraffic(ue.GetImsi(), swag.String("2048K"))
+	// TODO assert CCR-I
+	err = tr.GenULTraffic(imsi, swag.String("2048K"))
 	assert.NoError(t, err)
 
 	// Wait for the traffic to go through
@@ -52,45 +62,15 @@ func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
 	// amount of data was passed through
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
-	subID := "IMSI" + ue.Imsi
-	record := recordsBySubID[subID]
-	assert.NotNil(t, recordsBySubID[subID])
-	assert.Equal(t, makeRuleIDFromIMSI(ue.Imsi), record.RuleId)
+	record := recordsBySubID["IMSI"+imsi]
+	assert.NotNil(t, record)
+	assert.Equal(t, "static-pass-all", record.RuleId)
 	// We should not be seeing > 1024k data here
-	assert.True(t, record.BytesTx > uint64(0))
-	assert.True(t, record.BytesTx <= uint64(2048000))
+	assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
+	assert.True(t, record.BytesTx <= uint64(2048000), fmt.Sprintf("policy usage: %v", record))
 	// TODO Talk to PCRF and verify appropriate CCRs propagate up
 
 	// Clear hss, ocs, and pcrf
+	assert.NoError(t, ruleManager.RemoveInstalledRules())
 	assert.NoError(t, tr.CleanUp())
-}
-
-func getAllAcceptingPCRFRule(imsi string) *protos.AccountRules {
-	return &protos.AccountRules{
-		Imsi:          imsi,
-		RuleNames:     []string{},
-		RuleBaseNames: []string{},
-		RuleDefinitions: []*protos.RuleDefinition{
-			{
-				MonitoringKey:    "mkey1",
-				ChargineRuleName: makeRuleIDFromIMSI(imsi),
-				Precedence:       100,
-				FlowDescriptions: []string{"permit out ip from any to any", "permit in ip from any to any"},
-			},
-		},
-	}
-}
-
-func getUsageMonitor(imsi string) *protos.UsageMonitorInfo {
-	return &protos.UsageMonitorInfo{
-		Imsi: imsi,
-		UsageMonitorCredits: []*protos.UsageMonitorCredit{
-			{
-				MonitoringKey:   "mkey1",
-				Volume:          4096,
-				ReturnBytes:     1024,
-				MonitoringLevel: protos.UsageMonitorCredit_RuleLevel,
-			},
-		},
-	}
 }

--- a/cwf/gateway/integ_tests/rule_manager.go
+++ b/cwf/gateway/integ_tests/rule_manager.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package integ_tests
+
+import (
+	"fmt"
+
+	fegProtos "magma/feg/cloud/go/protos"
+	lteProtos "magma/lte/cloud/go/protos"
+)
+
+// RuleManager keeps track of rules and monitors for the integration
+// test. It keeps track of all successfully installed static/dynamic rules
+// along with usage monitors. The dynamic rules and usage monitors are added
+// into the mock PCRF service. The static rules are usually streamed down into
+// gateway policyDB from the cloud. Since this integration test does not cover
+// the cloud component, we will directly insert the static policies into the
+// redis database by using policyDBWrapper.
+type RuleManager struct {
+	// List of static rules successfully inserted into the policyDB store
+	staticRules []*lteProtos.PolicyRule
+	// List of dynamic rules successfully installed into PCRF
+	dynamicRules []*fegProtos.AccountRules
+	// List of usage monitors successfully installed into PCRF
+	monitors []*fegProtos.UsageMonitorInfo
+	// Wrapper around redis operations for policyDB objects
+	policyDBWrapper *policyDBWrapper
+}
+
+// NewRuleManager initialized the struct
+func NewRuleManager() (*RuleManager, error) {
+	policyDBWrapper, err := initializePolicyDBWrapper()
+	if err != nil {
+		return nil, err
+	}
+	return &RuleManager{
+		policyDBWrapper: policyDBWrapper,
+	}, nil
+}
+
+// AddStaticPassAll adds a static rule that passes all traffic to policyDB
+// storage
+func (manager *RuleManager) AddStaticPassAll(ruleID string, monitoringKey string) error {
+	fmt.Printf("************************* Adding a Pass-All static rule: %s\n", ruleID)
+	staticPassAll, err := getStaticPassAll(ruleID, monitoringKey)
+	if err != nil {
+		return err
+	}
+	return manager.insertStaticRuleIntoRedis(staticPassAll)
+}
+
+// AddStaticRule adds the static rule to policyDB storage
+func (manager *RuleManager) AddStaticRule(rule *lteProtos.PolicyRule) error {
+	fmt.Printf("************************* Adding a static rule: %s\n", rule.Id)
+	return manager.insertStaticRuleIntoRedis(rule)
+}
+
+// AddDynamicPassAll adds a dynamic rule that passes all traffic into PCRF
+func (manager *RuleManager) AddDynamicPassAll(imsi, ruleID, monitoringKey string) error {
+	fmt.Printf("************************* Adding Pass-All Dynamic Rule for UE with IMSI: %s, ruleID: %s\n", imsi, ruleID)
+	dynamicPassAll := getDynamicPassAll(imsi, ruleID, monitoringKey)
+	return manager.addDynamicRules(dynamicPassAll)
+}
+
+// AddDynamicRules adds the dynamic rule into PCRF
+func (manager *RuleManager) AddDynamicRules(imsi string, ruleNames, baseNames []string) error {
+	fmt.Printf("************************* Adding PCRF Rule for UE with IMSI: %s"+
+		" with ruleNames=%v, baseNames=%v\n", imsi, ruleNames, baseNames)
+	rules := makeDynamicRules(imsi, ruleNames, baseNames)
+	return manager.addDynamicRules(rules)
+}
+
+// GetInstalledRulesByIMSI returns all dynamic rule ids and static rules
+// referenced by dynamic rules keyed by the IMSI they are attached to.
+func (manager *RuleManager) GetInstalledRulesByIMSI() map[string][]string {
+	installedRulesByIMSI := map[string][]string{}
+	for _, dynamicRules := range manager.dynamicRules {
+		rules, exists := installedRulesByIMSI[dynamicRules.Imsi]
+		if !exists {
+			rules = []string{}
+		}
+		for _, ruleID := range dynamicRules.RuleNames {
+			rules = append(rules, ruleID)
+		}
+		for _, dynamicRule := range dynamicRules.RuleDefinitions {
+			rules = append(rules, dynamicRule.ChargineRuleName)
+		}
+		installedRulesByIMSI[dynamicRules.Imsi] = rules
+	}
+	return installedRulesByIMSI
+}
+
+// RemoveInstalledRules removes previously installed rules from PCRF and policyDB
+func (manager *RuleManager) RemoveInstalledRules() error {
+	rulesIDsByIMSI := manager.GetInstalledRulesByIMSI()
+	for imsi, ruleIDs := range rulesIDsByIMSI {
+		err := deactivateSubscriberFlows(imsi, ruleIDs)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AddUsageMonitor constructs a usage monitor according to the parameters and
+// inserts it into PCRF
+func (manager *RuleManager) AddUsageMonitor(imsi, monitoringKey string, volume, bytesPerGrant uint64) error {
+	fmt.Printf("************************* Adding PCRF Usage Monitor for UE with IMSI: %s\n", imsi)
+	usageMonitor := makeUsageMonitor(imsi, monitoringKey, volume, bytesPerGrant)
+	manager.monitors = append(manager.monitors, usageMonitor)
+	return addPCRFUsageMonitors(usageMonitor)
+}
+
+func (manager *RuleManager) insertStaticRuleIntoRedis(rule *lteProtos.PolicyRule) error {
+	err := manager.policyDBWrapper.policyMap.Set(rule.Id, rule)
+	if err != nil {
+		manager.staticRules = append(manager.staticRules, rule)
+	}
+	return err
+}
+
+func (manager *RuleManager) addDynamicRules(rules *fegProtos.AccountRules) error {
+	err := addPCRFRules(rules)
+	if err != nil {
+		manager.dynamicRules = append(manager.dynamicRules, rules)
+	}
+	return err
+}
+
+func getDynamicPassAll(imsi, ruleID, monitoringKey string) *fegProtos.AccountRules {
+	return &fegProtos.AccountRules{
+		Imsi:          imsi,
+		RuleNames:     []string{},
+		RuleBaseNames: []string{},
+		RuleDefinitions: []*fegProtos.RuleDefinition{
+			{
+				ChargineRuleName: ruleID,
+				Precedence:       100,
+				FlowDescriptions: []string{"permit out ip from any to any", "permit in ip from any to any"},
+				MonitoringKey:    monitoringKey,
+			},
+		},
+	}
+}
+
+func makeDynamicRules(imsi string, ruleNames []string, baseNames []string) *fegProtos.AccountRules {
+	return &fegProtos.AccountRules{
+		Imsi:          imsi,
+		RuleNames:     ruleNames,
+		RuleBaseNames: baseNames,
+	}
+}
+
+func makeUsageMonitor(imsi, monitoringKey string, volume, bytesPerGrant uint64) *fegProtos.UsageMonitorInfo {
+	return &fegProtos.UsageMonitorInfo{
+		Imsi: imsi,
+		UsageMonitorCredits: []*fegProtos.UsageMonitorCredit{
+			{
+				MonitoringKey:   monitoringKey,
+				Volume:          volume,
+				ReturnBytes:     bytesPerGrant,
+				MonitoringLevel: fegProtos.UsageMonitorCredit_RuleLevel,
+			},
+		},
+	}
+}

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -215,12 +215,12 @@ func getPipelinedClient() (*pipelinedClient, error) {
 	}, err
 }
 
-func deactivateSubscriberFlows(imsi string) error {
+func deactivateSubscriberFlows(imsi string, ruleIDs []string) error {
 	cli, err := getPipelinedClient()
 	if err == nil && cli != nil {
 		_, err = cli.DeactivateFlows(context.Background(), &lteprotos.DeactivateFlowsRequest{
 			Sid:     &lteprotos.SubscriberID{Id: imsi},
-			RuleIds: []string{makeRuleIDFromIMSI(imsi)},
+			RuleIds: ruleIDs,
 		})
 	}
 	return err

--- a/cwf/gateway/integ_tests/static_rules.go
+++ b/cwf/gateway/integ_tests/static_rules.go
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package integ_tests
+
+import (
+	lteProtos "magma/lte/cloud/go/protos"
+	"magma/lte/cloud/go/services/policydb/obsidian/models"
+
+	"github.com/go-openapi/swag"
+)
+
+func getStaticPassAll(ruleID string, monitoringKey string) (*lteProtos.PolicyRule, error) {
+	rule := &models.PolicyRule{
+		FlowList: []*models.FlowDescription{
+			{
+				Action: swag.String("PERMIT"),
+				Match: &models.FlowMatch{
+					Direction: "UPLINK",
+					IPProto:   swag.String("IPPROTO_IP"),
+					IPV4Dst:   "0.0.0.0/0",
+					IPV4Src:   "0.0.0.0/0",
+				},
+			},
+			{
+				Action: swag.String("PERMIT"),
+				Match: &models.FlowMatch{
+					Direction: "DOWNLINK",
+					IPProto:   swag.String("IPPROTO_IP"),
+					IPV4Dst:   "0.0.0.0/0",
+					IPV4Src:   "0.0.0.0/0",
+				},
+			},
+		},
+		ID:            ruleID,
+		MonitoringKey: swag.String(monitoringKey),
+		Priority:      swag.Uint32(3),
+		TrackingType:  models.PolicyRuleTrackingTypeONLYPCRF,
+	}
+	protoRule := &lteProtos.PolicyRule{}
+	err := rule.ToProto(protoRule)
+	if err != nil {
+		return nil, err
+	}
+	return protoRule, nil
+}

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,7 +15,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1


### PR DESCRIPTION
Summary:
- Since most of the rules will be in forms of static policies, referenced by dynamic policies in PCRF, I'm modifying the enforcement test to use static rules.
- I've written a very basic static rule to allow all traffic for now. But I will followup after this diff with the 3 static rules that we will be using with our partners.
- I've refactored the test a bit to make a rule_manager struct that keeps track of all static/dynami rules and monitors.

Reviewed By: amarpad

Differential Revision: D18372671

