### PR TITLE
Add unit tests to test gx/gy CCR-I failures

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -32,7 +32,6 @@ require (
 	github.com/go-redis/redis v6.15.5+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.2
-	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.3.0
@@ -43,7 +42,6 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	golang.org/x/tools v0.0.0-20191025023517-2077df36852e // indirect
 	golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 // indirect
-	google.golang.org/api v0.3.1 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20190425155659-357c62f0e4bb // indirect
 	google.golang.org/grpc v1.21.1

--- a/feg/gateway/diameter/definitions.go
+++ b/feg/gateway/diameter/definitions.go
@@ -10,8 +10,9 @@ package diameter
 
 const (
 	// SuccessCode is the result code returned from a successful diameter call
-	SuccessCode        = 2001
-	LimitedSuccessCode = 2002
+	SuccessCode          = 2001
+	LimitedSuccessCode   = 2002
+	DiameterRatingFailed = 5031
 )
 
 var diamCodeToNameMap = map[uint32]string{

--- a/feg/gateway/policydb/policydb.go
+++ b/feg/gateway/policydb/policydb.go
@@ -75,11 +75,11 @@ func (client *RedisPolicyDBClient) GetPolicyRuleByID(id string) (*protos.PolicyR
 // GetChargingKeysForRules retrieves the charging keys associated with the given
 // rule names from redis.
 func (client *RedisPolicyDBClient) GetChargingKeysForRules(
-	ruleIDs []string,
-	ruleDefs []*protos.PolicyRule,
+	staticRuleIDs []string,
+	dynamicRuleDefs []*protos.PolicyRule,
 ) ([]uint32, error) {
 	keys := []uint32{}
-	for _, id := range ruleIDs {
+	for _, id := range staticRuleIDs {
 		policy, err := client.GetPolicyRuleByID(id)
 		if err != nil {
 			glog.Errorf("Unable to get rating group for policy %s: %s", id, err)
@@ -89,7 +89,7 @@ func (client *RedisPolicyDBClient) GetChargingKeysForRules(
 			keys = append(keys, policy.RatingGroup)
 		}
 	}
-	for _, policy := range ruleDefs {
+	for _, policy := range dynamicRuleDefs {
 		if needsCharging(policy) {
 			keys = append(keys, policy.RatingGroup)
 		}

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -227,7 +227,7 @@ func (gyClient *GyClient) createCreditControlMessage(
 	if len(request.Msisdn) > 0 {
 		m.NewAVP(avp.SubscriptionID, avp.Mbit, 0, &diam.GroupedAVP{
 			AVP: []*diam.AVP{
-				diam.NewAVP(avp.SubscriptionIDType, avp.Mbit, 0, datatype.Enumerated(0)),
+				diam.NewAVP(avp.SubscriptionIDType, avp.Mbit, 0, datatype.Enumerated(credit_control.EndUserE164)),
 				diam.NewAVP(avp.SubscriptionIDData, avp.Mbit, 0, datatype.UTF8String(request.Msisdn)),
 			},
 		})

--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -274,10 +274,6 @@ func getInitialCreditResponsesFromCCA(
 	answer *gy.CreditControlAnswer,
 	request *gy.CreditControlRequest,
 ) []*protos.CreditUpdateResponse {
-	if answer.ResultCode != diameter.SuccessCode {
-		glog.Errorf("unsuccessful result code %d for init request for %s", answer.ResultCode, request.IMSI)
-		return []*protos.CreditUpdateResponse{}
-	}
 	responses := make([]*protos.CreditUpdateResponse, 0, len(answer.Credits))
 	for _, credit := range answer.Credits {
 		success := credit.ResultCode == diameter.SuccessCode || credit.ResultCode == 0


### PR DESCRIPTION
Summary: Add some failure cases to ensure error handling properly happens in CreateSession

Reviewed By: xjtian

Differential Revision: D18511268

