### PR TITLE
Update health configuration to favor network level configs

### DIFF
--- a/feg/cloud/go/plugin/mconfig_test.go
+++ b/feg/cloud/go/plugin/mconfig_test.go
@@ -147,7 +147,7 @@ func TestBuilder_Build(t *testing.T) {
 			CreateSessionOnAuth:  false,
 		},
 		"health": &mconfig.GatewayHealthConfig{
-			RequiredServices:          []string{"S6A_PROXY", "SESSION_PROXY"},
+			RequiredServices:          []string{"SWX_PROXY", "SESSION_PROXY"},
 			UpdateIntervalSecs:        10,
 			UpdateFailureThreshold:    3,
 			CloudDisconnectPeriodSecs: 10,
@@ -249,14 +249,14 @@ var defaultConfig = &models.NetworkFederationConfigs{
 	},
 	ServedNetworkIds: []string{},
 	Health: &models.Health{
-		HealthServices:           []string{"S6A_PROXY", "SESSION_PROXY"},
+		HealthServices:           []string{"SWX_PROXY", "SESSION_PROXY"},
 		UpdateIntervalSecs:       10,
 		CloudDisablePeriodSecs:   10,
 		LocalDisablePeriodSecs:   1,
 		UpdateFailureThreshold:   3,
 		RequestFailureThreshold:  0.50,
 		MinimumRequestThreshold:  1,
-		CPUUtilizationThreshold:  0.90,
+		CPUUtilizationThreshold:  0.75,
 		MemoryAvailableThreshold: 0.90,
 	},
 }

--- a/feg/cloud/go/plugin/models/swagger.v1.yml
+++ b/feg/cloud/go/plugin/models/swagger.v1.yml
@@ -650,7 +650,6 @@ definitions:
           - SESSION_PROXY
           - SWX_PROXY
         example:
-        - S6A_PROXY
         - SESSION_PROXY
         - SWX_PROXY
         x-go-custom-tag: 'magma_alt_name:"RequiredServices"'
@@ -688,7 +687,7 @@ definitions:
       memory_available_threshold:
         type: number
         format: float
-        example: 0.90
+        example: 0.75
     x-go-custom-tag: 'magma_alt_name:"HEALTH"'
 
 

--- a/feg/cloud/go/services/health/servicers/config.go
+++ b/feg/cloud/go/services/health/servicers/config.go
@@ -17,12 +17,12 @@ import (
 )
 
 const (
-	defaultCpuUtilThreshold      = 0.90
+	defaultCpuUtilThreshold      = 0.75
 	defaultMemAvailableThreshold = 0.90
 	defaultStaleUpdateThreshold  = 30
 )
 
-var defaultServices = []string{"S6A_PROXY", "SESSION_PROXY"}
+var defaultServices = []string{"SWX_PROXY", "SESSION_PROXY"}
 
 func GetHealthConfigForNetwork(networkID string) *healthConfig {
 	defaultConfig := &healthConfig{

--- a/feg/cloud/go/services/health/test_utils/test_utils.go
+++ b/feg/cloud/go/services/health/test_utils/test_utils.go
@@ -38,7 +38,7 @@ func GetHealthyRequest() *protos.HealthRequest {
 	}
 
 	serviceStatsMap := make(map[string]*protos.ServiceHealthStats)
-	serviceStatsMap["S6A_PROXY"] = &serviceStats
+	serviceStatsMap["SWX_PROXY"] = &serviceStats
 	serviceStatsMap["SESSION_PROXY"] = &serviceStats
 
 	healthStats1 := &protos.HealthStats{
@@ -70,7 +70,7 @@ func GetUnhealthyRequest() *protos.HealthRequest {
 	}
 
 	serviceStatsMap := make(map[string]*protos.ServiceHealthStats)
-	serviceStatsMap["S6A_PROXY"] = &serviceStats
+	serviceStatsMap["SWX_PROXY"] = &serviceStats
 	serviceStatsMap["SESSION_PROXY"] = &serviceStats
 
 	healthStats1 := &protos.HealthStats{
@@ -83,7 +83,7 @@ func GetUnhealthyRequest() *protos.HealthRequest {
 		ServiceStatus: serviceStatsMap,
 		Health: &protos.HealthStatus{
 			Health:        protos.HealthStatus_UNHEALTHY,
-			HealthMessage: "Service: S6A_PROXY unhealthy",
+			HealthMessage: "Service: SWX_PROXY unhealthy",
 		},
 		Time: uint64(time.Now().UnixNano()) / uint64(time.Millisecond),
 	}

--- a/feg/gateway/services/gateway_health/health_manager/health_manager.go
+++ b/feg/gateway/services/gateway_health/health_manager/health_manager.go
@@ -35,7 +35,7 @@ const (
 	defaultConsecutiveFailuresThreshold = 3
 )
 
-var defaultServices = []string{registry.S6A_PROXY, registry.SESSION_PROXY}
+var defaultServices = []string{registry.SWX_PROXY, registry.SESSION_PROXY}
 
 type HealthManager struct {
 	cloudReg                  registry.CloudRegistry

--- a/feg/gateway/services/gateway_health/health_manager/health_manager_test.go
+++ b/feg/gateway/services/gateway_health/health_manager/health_manager_test.go
@@ -84,7 +84,7 @@ func initTestServices(t *testing.T, mockServiceHealth *MockServiceHealthServicer
 		"configsByKey": {
 			"health": {
    				"@type": "type.googleapis.com/magma.mconfig.GatewayHealthConfig",
-   				"requiredServices": ["S6A_PROXY", "SESSION_PROXY"],
+   				"requiredServices": ["SWX_PROXY", "SESSION_PROXY"],
    				"updateIntervalSecs": 10,
    				"consecutiveFailureThreshold": 3,
    				"cloudDisconnectPeriodSecs": 10,
@@ -97,7 +97,7 @@ func initTestServices(t *testing.T, mockServiceHealth *MockServiceHealthServicer
 		t.Log(err)
 	}
 
-	srv1, lis1 := test_utils.NewTestService(t, registry.ModuleName, registry.S6A_PROXY)
+	srv1, lis1 := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	srv2, lis2 := test_utils.NewTestService(t, registry.ModuleName, registry.SESSION_PROXY)
 	srv3, lis3 := test_utils.NewTestService(t, registry.ModuleName, registry.HEALTH)
 


### PR DESCRIPTION
Summary:
Recent testing has shown that having hierarchical configs for the health service
is causing issues. The health service always reads network level configs, while mconfig
uses gw configs if they're set (otherwise network configs).

The true home for the health configs resides in between the network and the gateway
at the cluster level. Until that concept is introduced though, we should use the network
level. This diff implements that change by always streaming network level health configs
if they're set. A subsequent diff can remove health configs from the gateway swagger
struct altogether.

Differential Revision: D18522476

