### PR TITLE
Add directoryD call in pipelined to associate IMSI and IP

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/app/ue_mac.py
@@ -5,8 +5,8 @@ All rights reserved.
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
-
 from collections import namedtuple
+import threading
 
 from ryu.controller import ofp_event
 from ryu.controller.handler import MAIN_DISPATCHER, set_ev_cls
@@ -15,6 +15,7 @@ from ryu.lib.packet import ether_types, dhcp
 from ryu.ofproto.inet import IPPROTO_TCP, IPPROTO_UDP
 
 from .base import MagmaController
+from magma.pipelined.directoryd_client import update_record
 from magma.pipelined.imsi import encode_imsi
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.exceptions import MagmaOFError
@@ -97,6 +98,10 @@ class UEMacAddressController(MagmaController):
             self.arp_contoller.add_ue_arp_flows(self._datapath,
                                                 yiaddr, chaddr)
             self.logger.debug("Learned arp for imsi %s, ip %s", imsi, yiaddr)
+
+            # Associate IMSI to IPv4 addr in directory service
+            threading.Thread(target=update_record, args=(str(imsi),
+                                                         yiaddr)).start()
         else:
             self.logger.error("ARPD controller not ready, ARP learn FAILED")
 

--- a/lte/gateway/python/magma/pipelined/directoryd_client.py
+++ b/lte/gateway/python/magma/pipelined/directoryd_client.py
@@ -1,0 +1,46 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+import grpc
+import logging
+
+from magma.common.service_registry import ServiceRegistry
+from orc8r.protos.directoryd_pb2 import UpdateRecordRequest
+from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
+
+DIRECTORYD_SERVICE_NAME = "directoryd"
+DEFAULT_GRPC_TIMEOUT = 10
+IPV4_ADDR_KEY = "ipv4_addr"
+
+
+def update_record(imsi: str, ip_addr: str) -> None:
+    """
+    Make RPC call to 'UpdateRecord' method of local directoryD service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(DIRECTORYD_SERVICE_NAME,
+                                               ServiceRegistry.LOCAL)
+    except ValueError:
+        logging.error('Cant get RPC channel to %s', DIRECTORYD_SERVICE_NAME)
+        return
+    client = GatewayDirectoryServiceStub(chan)
+    if not imsi.startswith("IMSI"):
+        imsi = "IMSI" + imsi
+    try:
+        # Location will be filled in by directory service
+        req = UpdateRecordRequest(id=imsi, location="hwid")
+        directoryField = req.fields.add()
+        directoryField.key = IPV4_ADDR_KEY
+        directoryField.value = ip_addr
+        client.UpdateRecord(req, DEFAULT_GRPC_TIMEOUT)
+    except grpc.RpcError as err:
+        logging.error(
+            "UpdateRecordRequest error for id: %s, ipv4_addr: %s! [%s] %s",
+            imsi,
+            ip_addr,
+            err.code(),
+            err.details())


### PR DESCRIPTION
Summary:
This diff adds a directoryD call to pipelined to allow
for the associating a learned IP for a given subscriber IMSI.
By adding this mapping, sessiond can fetch from directoryD to allow
for redirection to work properly.

Reviewed By: koolzz

Differential Revision: D18410821

