### PR TITLE
increased snmp timeout

### DIFF
--- a/devmand/gateway/src/devmand/channels/snmp/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/snmp/Engine.cpp
@@ -18,7 +18,7 @@ namespace channels {
 namespace snmp {
 
 // TODO make this configurable
-const constexpr std::chrono::seconds timeoutInterval{1};
+const constexpr std::chrono::seconds timeoutInterval{15};
 
 Engine::Engine(folly::EventBase& eventBase_, const std::string& appName)
     : channels::Engine("SNMP"), eventBase(eventBase_) {


### PR DESCRIPTION
Summary: Increased SNMP timeout to 10 seconds (instead of 1 sec). This is necessary for ENS, whose devices sometimes respond a bit slower. In the future this should be configurable.

Differential Revision: D18530051

