### PR TITLE
Move isTruthy function into broader util.go for environment variables

### DIFF
--- a/feg/gateway/services/aaa/servicers/common.go
+++ b/feg/gateway/services/aaa/servicers/common.go
@@ -12,7 +12,6 @@ package servicers
 import (
 	"fmt"
 	"log"
-	"strings"
 	"time"
 
 	"magma/feg/cloud/go/protos/mconfig"
@@ -30,18 +29,6 @@ func GetIdleSessionTimeout(cfg *mconfig.AAAConfig) time.Duration {
 		}
 	}
 	return aaa.DefaultSessionTimeout
-}
-
-func isThruthy(value string) bool {
-	value = strings.TrimSpace(value)
-	if len(value) == 0 {
-		return false
-	}
-	value = strings.ToLower(value)
-	if value == "0" || strings.HasPrefix(value, "false") || strings.HasPrefix(value, "n") {
-		return false
-	}
-	return true
 }
 
 func Errorf(code codes.Code, format string, a ...interface{}) error {

--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -12,7 +12,6 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/fiorix/go-diameter/diam"
@@ -23,6 +22,7 @@ import (
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/session_proxy/credit_control"
+	"magma/orc8r/cloud/go/util"
 )
 
 const (
@@ -70,24 +70,11 @@ func NewConnectedGxClient(
 	}
 	return &GxClient{
 		diamClient:             diamClient,
-		pcrf91Compliant:        *pcrf91Compliant || isThruthy(os.Getenv(PCRF91CompliantEnv)),
-		dontUseEUIIpIfEmpty:    *disableEUIIpIfEmpty || isThruthy(os.Getenv(DisableEUIIPv6IfNoIPEnv)),
-		framedIpv4AddrRequired: isThruthy(os.Getenv(FramedIPv4AddrRequiredEnv)),
+		pcrf91Compliant:        *pcrf91Compliant || util.IsTruthyEnv(PCRF91CompliantEnv),
+		dontUseEUIIpIfEmpty:    *disableEUIIpIfEmpty || util.IsTruthyEnv(DisableEUIIPv6IfNoIPEnv),
+		framedIpv4AddrRequired: util.IsTruthyEnv(FramedIPv4AddrRequiredEnv),
 	}
 
-}
-
-// isThruthy returns true for any value not "false", "0", "no..."
-func isThruthy(value string) bool {
-	value = strings.TrimSpace(value)
-	if len(value) == 0 {
-		return false
-	}
-	value = strings.ToLower(value)
-	if value == "0" || strings.HasPrefix(value, "false") || strings.HasPrefix(value, "no") {
-		return false
-	}
-	return true
 }
 
 // NewGxClient contructs a new GxClient with the magma diameter settings

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -28,6 +28,7 @@ import (
 	"magma/feg/gateway/services/session_proxy/servicers"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/service"
+	"magma/orc8r/cloud/go/util"
 
 	"github.com/golang/glog"
 )
@@ -61,7 +62,7 @@ func main() {
 		PCRFConfig:       gx.GetPCRFConfiguration(),
 		RequestTimeout:   3 * time.Second,
 		InitMethod:       initMethod,
-		UseGyForAuthOnly: os.Getenv(gy.UseGyForAuthOnlyEnv) == "1",
+		UseGyForAuthOnly: util.IsTruthyEnv(gy.UseGyForAuthOnlyEnv),
 	}
 	cloudReg := registry.NewCloudRegistry()
 	policyDBClient, err := policydb.NewRedisPolicyDBClient(cloudReg)

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,7 +15,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -15,8 +15,6 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"os"
-	"strings"
 	"time"
 
 	"magma/orc8r/cloud/go/plugin"
@@ -24,6 +22,7 @@ import (
 	"magma/orc8r/cloud/go/registry"
 	"magma/orc8r/cloud/go/service/config"
 	"magma/orc8r/cloud/go/service/middleware/unary"
+	"magma/orc8r/cloud/go/util"
 
 	"github.com/golang/glog"
 	"google.golang.org/grpc"
@@ -118,7 +117,7 @@ func NewServiceWithOptions(moduleName string, serviceName string, serverOptions 
 	}
 
 	// Check if service was started with print-grpc-payload flag or MAGMA_PRINT_GRPC_PAYLOAD env is set
-	if ev := strings.ToLower(os.Getenv(PrintGrpcPayloadEnv)); printGrpcPayload || isTruthy(ev) {
+	if printGrpcPayload || util.IsTruthyEnv(PrintGrpcPayloadEnv) {
 		ls := logCodec{encoding.GetCodec(grpc_proto.Name)}
 		if ls.protoCodec != nil {
 			glog.Errorf("Adding Debug Codec for service %s", serviceName)
@@ -178,14 +177,4 @@ func (service *Service) RunTest(lis net.Listener) error {
 // GetDefaultKeepaliveParameters returns the default keepalive server parameters.
 func GetDefaultKeepaliveParameters() keepalive.ServerParameters {
 	return defaultKeepaliveParams
-}
-
-func isTruthy(value string) bool {
-	if len(value) == 0 {
-		return false
-	}
-	if value == "0" || value == "false" || value == "no" {
-		return false
-	}
-	return true
 }

--- a/orc8r/cloud/go/util/util.go
+++ b/orc8r/cloud/go/util/util.go
@@ -15,6 +15,7 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"reflect"
 	"strings"
 )
@@ -123,4 +124,18 @@ func FormatPkixSubject(s *pkix.Name) string {
 		s.CommonName,
 	})
 	return string(res)
+}
+
+// IsTruthyEnv returns true for any value not "false", "0", "no..."
+func IsTruthyEnv(envName string) bool {
+	value := os.Getenv(envName)
+	value = strings.TrimSpace(value)
+	if len(value) == 0 {
+		return false
+	}
+	value = strings.ToLower(value)
+	if value == "0" || strings.HasPrefix(value, "false") || strings.HasPrefix(value, "no") {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Summary: There were several implementations of checking a string to be isTruthy scattered around so consolidating it into orc8r/cloud/go/utils.

Reviewed By: mpgermano

Differential Revision: D18533842

