### PR TITLE
create Snmpv2Config

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -93,6 +93,7 @@ add_library(devman_channel_snmp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Pdu.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Request.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/snmp/Response.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/devices/Snmpv2Config.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/devices/Snmpv2Device.cpp)
 
 target_link_libraries(devman_channel_snmp

--- a/devmand/gateway/src/devmand/devices/Snmpv2Config.cpp
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Config.cpp
@@ -1,0 +1,16 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/devices/Snmpv2Config.h>
+
+namespace devmand {
+namespace devices {
+
+Snmpv2Config::Snmpv2Config() {}
+
+} // namespace devices
+} // namespace devmand

--- a/devmand/gateway/src/devmand/devices/Snmpv2Config.h
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Config.h
@@ -1,0 +1,91 @@
+// Copyright (c) 2016-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <list>
+#include <map>
+#include <set>
+#include <string>
+
+#include <devmand/channels/snmp/Channel.h>
+
+namespace devmand {
+namespace devices {
+
+// These enums describe items in the config file.
+// To understand what is happening here, refer to:
+// https://fburl.com/6w5jyint
+
+enum ResultType { SINGLE, ITERABLE };
+
+enum ActionType { STORE, SET_GAUGE_COUNTER };
+
+enum ActionArgType { TOP_LEVEL, PATH, VALUE };
+
+enum ActionTopLevelEnum { IETF_SYSTEM, OPENCONFIG_INTERFACES };
+
+enum ActionValueEnum {
+  RESULT,
+  RESULT_TO_STATUS_STR,
+  RESULT_IS_ENABLED_BOOLEAN
+};
+
+struct ActionArgValue {
+  ActionTopLevelEnum topLevel;
+  std::string path;
+  ActionValueEnum value;
+};
+
+using ActionArgMap = std::map<ActionArgType, ActionArgValue>;
+
+struct Action {
+  ActionType actionType;
+  ActionArgMap args;
+};
+
+using ActionList = std::list<Action>;
+
+struct OidConfig {
+  channels::snmp::Oid oid;
+  ResultType resultType;
+  ActionList resultActions;
+  ActionList forEachResultActions;
+};
+
+using OidConfigList = std::list<OidConfig>;
+
+enum GeneralConfigType {
+  INTERFACE_INDICES,
+  NUMBER_OF_INTERFACES,
+  POLLING_INTERVAL,
+  SNMP_TIMEOUT_INTERVAL,
+  SNMP_RETRIES
+};
+
+using GeneralConfigMap = std::map<GeneralConfigType, std::string>;
+
+class Snmpv2Config final {
+ public:
+  Snmpv2Config();
+  ~Snmpv2Config() = default;
+  Snmpv2Config(const Snmpv2Config&) = delete;
+  Snmpv2Config& operator=(const Snmpv2Config&) = delete;
+  Snmpv2Config(Snmpv2Config&&) = delete;
+  Snmpv2Config& operator=(Snmpv2Config&&) = delete;
+
+ public:
+  const GeneralConfigMap& getGeneralConfig();
+  const OidConfigList& getOidConfigs();
+
+ private:
+  GeneralConfigMap generalConfigs;
+  OidConfigList oidConfigs;
+};
+
+} // namespace devices
+} // namespace devmand

--- a/devmand/gateway/src/devmand/devices/Snmpv2Device.h
+++ b/devmand/gateway/src/devmand/devices/Snmpv2Device.h
@@ -9,6 +9,7 @@
 
 #include <devmand/channels/snmp/Channel.h>
 #include <devmand/devices/PingDevice.h>
+#include <devmand/devices/Snmpv2Config.h>
 
 /* TODO use this
 #include <ydk/netconf_provider.hpp>
@@ -65,6 +66,7 @@ class Snmpv2Device : public PingDevice {
   }
 
  protected:
+  Snmpv2Config snmpConfig;
   channels::snmp::Channel snmpChannel;
 };
 


### PR DESCRIPTION
Summary: Create a class called Snmpv2Config with some datatypes which will be used in a later diff. These datatypes describe the config data structure. To understand what's going on you can refer to the google docs document for the project https://fburl.com/54tz0tw2

Differential Revision: D18579569

