### PR TITLE
Refactor table managment into physical and logical controllers

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -30,6 +30,7 @@ static_services: [
   'ue_mac',
   'arpd',
   'access_control',
+  'tunnel_learn',
   'ryu_rest_service',
 #  'packet_tracer',
 ]

--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -37,7 +37,6 @@ services:
     environment:
       USE_REMOTE_SWX_PROXY: 0
 
-  # TODO: Remove this override once GRE tun_dst logic is added to pipelined
   pipelined:
     privileged: true
     volumes:
@@ -53,7 +52,7 @@ services:
     command: >
       sh -c "/usr/bin/ovs-vsctl --if-exists del-port cwag_br0 gre0 &&
         /usr/bin/ovs-vsctl --if-exists del-port cwag_br0 eth2 &&
-        /usr/bin/ovs-vsctl --may-exist add-port cwag_br0 gre0 -- set interface gre0 ofport_request=32768 type=gre options:remote_ip=192.168.70.102 options:key=5001 &&
+        /usr/bin/ovs-vsctl --may-exist add-port cwag_br0 gre0 -- set interface gre0 ofport_request=32768 type=gre options:remote_ip=flow options:key=flow &&
         /usr/bin/ovs-vsctl set-controller cwag_br0 tcp:127.0.0.1:6633 &&
         python3 -m magma.pipelined.main"
 

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -30,6 +30,7 @@ static_services: [
   'ue_mac',
   'arpd',
   'access_control',
+  'tunnel_learn',
   'ryu_rest_service',
 ]
 

--- a/docs/readmes/lte/pipelined.md
+++ b/docs/readmes/lte/pipelined.md
@@ -42,7 +42,7 @@ Static services include mandatory services (such as OAI and inout) which are alw
         |                   |
         V                   V
     -------------------------------
-    |            Table 0          |
+    |       Table 0 (SPECIAL)     |
     |         GTP APP (OAI)       |
     |- sets IMSI metadata         |
     |- sets tunnel id on downlink |
@@ -51,14 +51,14 @@ Static services include mandatory services (such as OAI and inout) which are alw
                   |
                   V
     -------------------------------
-    |          Table 1            |
+    |      Table 1 (PHYSICAL)     |
     |           inout             |
     |- sets direction bit         |
     -------------------------------
                   |
                   V
     -------------------------------
-    |          Table 2            |
+    |      Table 2 (PHYSICAL)     |
     |            ARP              |
     |- Forwards non-ARP traffic   |
     |- Responds to ARP requests w/| ---> Arp traffic - LOCAL
@@ -67,7 +67,7 @@ Static services include mandatory services (such as OAI and inout) which are alw
                   |
                   V
     -------------------------------
-    |          Table 3            |
+    |      Table 3 (PHYSICAL)     |
     |       access control        |
     |- Forwards normal traffic    |
     |- Drops traffic with ip      |
@@ -76,12 +76,26 @@ Static services include mandatory services (such as OAI and inout) which are alw
     -------------------------------
                   |
                   V
-   Configurable apps managed by cloud <---> Scratch tables
-            (Tables 4-19)                  (Tables 21 - 254)
+   Configurable PHYSICAL apps managed by cloud <---> Scratch tables
+            (Tables 4-9)                            (Tables 21 - 254)
                   |
                   V
     -------------------------------
-    |          Table 20           |
+    |      Table 10 (SPECIAL)     |
+    |           inout             |
+    |- Forwards uplink traffic to |
+    |  LOCAL port                 |
+    |- Forwards downlink traffic  |
+    |  to GTP port                |
+    -------------------------------
+                  |
+                  V
+   Configurable LOGICAL apps managed by cloud <---> Scratch tables
+            (Tables 11-19)                         (Tables 21 - 254)
+                  |
+                  V
+    -------------------------------
+    |      Table 20 (SPECIAL)     |
     |           inout             |
     |- Forwards uplink traffic to |
     |  LOCAL port                 |
@@ -95,6 +109,13 @@ Static services include mandatory services (such as OAI and inout) which are alw
     downlink              uplink
 
 ```
+
+### Service types
+
+Services(controllers) are split into two: Physical and Logical.
+Physical controllers: arpd, access_control.
+Logical controllers: metering, dpi, enforcement.
+
 
 ### Configurable Services
 

--- a/lte/gateway/python/magma/pipelined/app/access_control.py
+++ b/lte/gateway/python/magma/pipelined/app/access_control.py
@@ -14,7 +14,7 @@ from ryu.lib.packet import ether_types
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import Direction
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 
 
 class AccessControlController(MagmaController):
@@ -28,6 +28,7 @@ class AccessControlController(MagmaController):
     """
 
     APP_NAME = "access_control"
+    APP_TYPE = ControllerType.PHYSICAL
     CONFIG_INBOUND_DIRECTION = 'inbound'
     CONFIG_OUTBOUND_DIRECTION = 'outbound'
 

--- a/lte/gateway/python/magma/pipelined/app/arp.py
+++ b/lte/gateway/python/magma/pipelined/app/arp.py
@@ -10,7 +10,7 @@ import netifaces
 from collections import namedtuple
 
 from magma.common.misc_utils import cidr_to_ip_netmask_tuple
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import Direction
@@ -34,6 +34,7 @@ class ArpController(MagmaController):
     with MAC address of the default gateway.
     """
     APP_NAME = 'arpd'
+    APP_TYPE = ControllerType.PHYSICAL
     FLOW_PUSH_INTERVAL_SECS = 15
 
     # Inherited from app_manager.RyuApp

--- a/lte/gateway/python/magma/pipelined/app/base.py
+++ b/lte/gateway/python/magma/pipelined/app/base.py
@@ -6,6 +6,8 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
+from enum import Enum
+
 from ryu import utils
 from ryu.base import app_manager
 from ryu.controller import dpset
@@ -19,6 +21,12 @@ from ryu.ofproto import ofproto_v1_4
 from magma.pipelined.bridge_util import BridgeTools, DatapathLookupError
 from magma.pipelined.metrics import OPENFLOW_ERROR_MSG
 from magma.pipelined.openflow.exceptions import MagmaOFError
+
+
+class ControllerType(Enum):
+    PHYSICAL = 1
+    LOGICAL = 2
+    SPECIAL = 3
 
 
 class MagmaController(app_manager.RyuApp):

--- a/lte/gateway/python/magma/pipelined/app/dpi.py
+++ b/lte/gateway/python/magma/pipelined/app/dpi.py
@@ -8,7 +8,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 from magma.pipelined.openflow import flows
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import Direction
 import shlex
@@ -29,6 +29,7 @@ class DPIController(MagmaController):
     """
 
     APP_NAME = "dpi"
+    APP_TYPE = ControllerType.LOGICAL
     UPDATE_INTERVAL = 10  # seconds
 
     def __init__(self, *args, **kwargs):

--- a/lte/gateway/python/magma/pipelined/app/enforcement.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement.py
@@ -8,7 +8,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 from lte.protos.pipelined_pb2 import RuleModResult, SetupFlowsResult
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.app.enforcement_stats import EnforcementStatsController, \
     global_epoch
 from magma.pipelined.app.policy_mixin import PolicyMixin
@@ -42,6 +42,7 @@ class EnforcementController(PolicyMixin, MagmaController):
     """
 
     APP_NAME = "enforcement"
+    APP_TYPE = ControllerType.LOGICAL
     ENFORCE_DROP_PRIORITY = flows.MINIMUM_PRIORITY + 1
     # Should not overlap with the drop flow as drop matches all packets.
     MIN_ENFORCE_PROGRAMMED_FLOW = ENFORCE_DROP_PRIORITY + 1

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -18,7 +18,7 @@ from ryu.controller.handler import MAIN_DISPATCHER, set_ev_cls
 from ryu.lib import hub
 from ryu.ofproto.ofproto_v1_4 import OFPMPF_REPLY_MORE
 
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.app.policy_mixin import PolicyMixin
 from magma.pipelined.openflow import messages, flows
 from magma.pipelined.openflow.exceptions import MagmaOFError
@@ -50,6 +50,7 @@ class EnforcementStatsController(PolicyMixin, MagmaController):
     """
 
     APP_NAME = 'enforcement_stats'
+    APP_TYPE = ControllerType.LOGICAL
     SESSIOND_RPC_TIMEOUT = 10
     # 0xffffffffffffffff is reserved in openflow
     DEFAULT_FLOW_COOKIE = 0xfffffffffffffffe

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -80,8 +80,9 @@ class InOutController(MagmaController):
         Raises:
             MagmaOFError if any of the default flows fail to install.
         """
-        #TODO fix
-        next_main_table = self._service_manager.get_table_num('enforcement')
+        tbl_num = self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL)
+        logical_table = \
+            self._service_manager.get_next_table_num(PHYSICAL_TO_LOGICAL)
         egress = self._service_manager.get_table_num(EGRESS)
 
         # Allow passthrough pkts(skip enforcement and send to egress table)
@@ -94,7 +95,7 @@ class InOutController(MagmaController):
         flows.add_resubmit_next_service_flow(dp,
             self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL),
             match, [], priority=flows.DEFAULT_PRIORITY,
-            resubmit_table=next_main_table)
+            resubmit_table=logical_table)
 
     def _install_default_egress_flows(self, dp):
         """

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -18,6 +18,7 @@ from magma.pipelined.openflow.registers import load_direction, Direction
 # ingress and egress service names -- used by other controllers
 INGRESS = "ingress"
 EGRESS = "egress"
+PHYSICAL_TO_LOGICAL = "middle"
 
 
 class InOutController(MagmaController):
@@ -58,6 +59,7 @@ class InOutController(MagmaController):
         self._clear_ingress_egress_tables(datapath)
         self._install_default_egress_flows(datapath)
         self._install_default_ingress_flows(datapath)
+        self._install_default_middle_flows(datapath)
 
     def cleanup_on_disconnect(self, datapath):
         self._clear_ingress_egress_tables(datapath)
@@ -69,6 +71,30 @@ class InOutController(MagmaController):
         flows.delete_all_flows_from_table(datapath,
                                           self._service_manager.get_table_num(
                                               EGRESS))
+
+    def _install_default_middle_flows(self, dp):
+        """
+        Egress table is the last table that a packet touches in the pipeline.
+        Output downlink traffic to gtp port, uplink trafic to LOCAL
+
+        Raises:
+            MagmaOFError if any of the default flows fail to install.
+        """
+        #TODO fix
+        next_main_table = self._service_manager.get_table_num('enforcement')
+        egress = self._service_manager.get_table_num(EGRESS)
+
+        # Allow passthrough pkts(skip enforcement and send to egress table)
+        ps_match = MagmaMatch(passthrough=PASSTHROUGH_REG_VAL)
+        flows.add_resubmit_next_service_flow(dp, tbl_num, ps_match,
+            actions=[], priority=flows.PASSTHROUGH_PRIORITY,
+            resubmit_table=egress)
+
+        match = MagmaMatch()
+        flows.add_resubmit_next_service_flow(dp,
+            self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL),
+            match, [], priority=flows.DEFAULT_PRIORITY,
+            resubmit_table=next_main_table)
 
     def _install_default_egress_flows(self, dp):
         """
@@ -109,7 +135,6 @@ class InOutController(MagmaController):
         parser = dp.ofproto_parser
         tbl_num = self._service_manager.get_table_num(INGRESS)
         next_table = self._service_manager.get_next_table_num(INGRESS)
-        egress_table = self._service_manager.get_table_num(EGRESS)
 
         # set traffic direction bits
         # set a direction bit for outgoing (pn -> inet) traffic.
@@ -120,14 +145,6 @@ class InOutController(MagmaController):
                                              priority=flows.DEFAULT_PRIORITY,
                                              resubmit_table=next_table)
 
-        # Allow passthrough pkts(skip pipeline and send to egress table)
-        match = MagmaMatch(in_port=self.config.gtp_port,
-                           direction=Direction.PASSTHROUGH)
-        flows.add_resubmit_next_service_flow(dp, tbl_num, match,
-                                             actions=actions,
-                                             priority=flows.PASSTHROUGH_PRIORITY,
-                                             resubmit_table=egress_table)
-
         # set a direction bit for incoming (internet -> UE) traffic.
         match = MagmaMatch(in_port=self._uplink_port)
         actions = [load_direction(parser, Direction.IN)]
@@ -135,11 +152,3 @@ class InOutController(MagmaController):
                                              actions=actions,
                                              priority=flows.DEFAULT_PRIORITY,
                                              resubmit_table=next_table)
-
-        # Allow passthrough pkts(skip pipeline and send to egress table)
-        match = MagmaMatch(in_port=self._uplink_port,
-                           direction=Direction.PASSTHROUGH)
-        flows.add_resubmit_next_service_flow(dp, tbl_num, match,
-                                             actions=actions,
-                                             priority=flows.PASSTHROUGH_PRIORITY,
-                                             resubmit_table=egress_table)

--- a/lte/gateway/python/magma/pipelined/app/meter.py
+++ b/lte/gateway/python/magma/pipelined/app/meter.py
@@ -14,7 +14,7 @@ from ryu.controller import ofp_event
 from ryu.controller.handler import MAIN_DISPATCHER, set_ev_cls
 from ryu.lib.packet import ether_types
 
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.exceptions import MagmaOFError
 from magma.pipelined.openflow.magma_match import MagmaMatch
@@ -32,6 +32,7 @@ class MeterController(MagmaController):
     """
 
     APP_NAME = "meter"
+    APP_TYPE = ControllerType.LOGICAL
     DEFAULT_FLOW_COOKIE = 0x1
     DEFAULT_IDLE_TIMEOUT_SEC = 60
 

--- a/lte/gateway/python/magma/pipelined/app/meter_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/meter_stats.py
@@ -10,7 +10,7 @@ from collections import defaultdict, namedtuple
 
 from lte.protos.meteringd_pb2 import FlowRecord, \
     FlowTable
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.app.meter import MeterController
 from magma.pipelined.imsi import decode_imsi
 from magma.pipelined.openflow import messages
@@ -50,6 +50,7 @@ class MeterStatsController(MagmaController):
     """
 
     APP_NAME = 'meter_stats'
+    APP_TYPE = ControllerType.LOGICAL
     CLOUD_RPC_TIMEOUT = 10
     _CONTEXTS = {
         'dpset': dpset.DPSet,

--- a/lte/gateway/python/magma/pipelined/app/subscriber.py
+++ b/lte/gateway/python/magma/pipelined/app/subscriber.py
@@ -15,7 +15,7 @@ from ryu.controller import ofp_event
 from ryu.controller.handler import MAIN_DISPATCHER, set_ev_cls
 from ryu.lib import hub
 
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.app.meter import MeterController
 from magma.pipelined.imsi import encode_imsi
 from magma.pipelined.openflow import flows
@@ -32,6 +32,7 @@ class SubscriberController(MagmaController):
     """
 
     APP_NAME = 'subscriber'
+    APP_TYPE = ControllerType.LOGICAL
     POLL_TIMEOUT = 3
 
     SubscriberConfig = namedtuple('SubscriberConfig',

--- a/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
+++ b/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
@@ -7,8 +7,7 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-from .base import MagmaController
-from magma.pipelined.app.inout import PHYSICAL_TO_LOGICAL
+from .base import MagmaController, ControllerType
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import Direction, DIRECTION_REG
@@ -25,12 +24,13 @@ class TunnelLearnController(MagmaController):
     """
 
     APP_NAME = "tunnel_learn"
+    APP_TYPE = ControllerType.PHYSICAL
 
     def __init__(self, *args, **kwargs):
         super(TunnelLearnController, self).__init__(*args, **kwargs)
         self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
         self.next_table = \
-            self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL)
+            self._service_manager.get_next_table_num(self.APP_NAME)
         self.tunnel_learn_scratch = \
             self._service_manager.allocate_scratch_tables(self.APP_NAME, 1)[0]
         self._datapath = None

--- a/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
+++ b/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
@@ -1,0 +1,113 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+from .base import MagmaController
+from magma.pipelined.openflow import flows
+from magma.pipelined.openflow.magma_match import MagmaMatch
+from magma.pipelined.openflow.registers import Direction, DIRECTION_REG
+
+
+class TunnelLearnController(MagmaController):
+    """
+    A controller that sets up tunnel/ue learn flows based on uplink UE traffic
+    to properly route downlink packets back to the UE (through the correct GRE
+    flow tunnel).
+
+    This is an optional controller and will only be used for setups with flow
+    based GRE tunnels.
+    """
+
+    APP_NAME = "tunnel_learn"
+
+    def __init__(self, *args, **kwargs):
+        super(TunnelLearnController, self).__init__(*args, **kwargs)
+        self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
+        self.next_table = self._service_manager.get_next_table_num(
+            self.APP_NAME)
+        self.tunnel_learn_scratch = \
+            self._service_manager.allocate_scratch_tables(self.APP_NAME, 1)[0]
+        self._datapath = None
+
+    def initialize_on_connect(self, datapath):
+        self._datapath = datapath
+        self._install_default_tunnel_classify_flows(self._datapath)
+
+    def _install_default_tunnel_classify_flows(self, dp):
+        """
+        For direction OUT:
+            add flow with learn action(which will add a rule matching on UE
+            mac_addr in a scratch table, that will load the necessary
+            gre infomration for the incoming(direction IN) flow)
+        For direction IN:
+            Will get forwarded to the scratch table and matched on the flow
+                from the learn action
+            Finally will get forwarded to the next table
+        """
+        parser = dp.ofproto_parser
+
+        # Add a learn action that will match on UE mac, and:
+        #   load gre tun_id, swap and load gre tun src and gre tun dst mac
+        # Example learned flow:
+        #   reg1=0x10,dl_dst=aa:29:3e:95:64:40
+        #   actions=load:0x1389->NXM_NX_TUN_ID[0..31],
+        #           load:0xc0a84666->NXM_NX_TUN_IPV4_DST[],
+        #           load:0xc0a84665->NXM_NX_TUN_IPV4_SRC[]
+        #
+        outbound_match = MagmaMatch(direction=Direction.OUT)
+        actions = [
+            parser.NXActionLearn(
+                table_id=self.tunnel_learn_scratch,
+                priority=flows.DEFAULT_PRIORITY,
+                specs=[
+                    parser.NXFlowSpecMatch(
+                        src=('eth_src_nxm', 0),
+                        dst=('eth_dst_nxm', 0),
+                        n_bits=48
+                    ),
+                    parser.NXFlowSpecMatch(
+                        src=Direction.IN,
+                        dst=(DIRECTION_REG, 0),
+                        n_bits=32
+                    ),
+                    parser.NXFlowSpecLoad(
+                        src=('tunnel_id_nxm', 0),
+                        dst=('tunnel_id_nxm', 0),
+                        n_bits=32
+                    ),
+                    parser.NXFlowSpecLoad(
+                        src=('tun_ipv4_src', 0),
+                        dst=('tun_ipv4_dst', 0),
+                        n_bits=32
+                    ),
+                    # TODO This might be getting overwritten by the IP stack,
+                    # check if its required
+                    parser.NXFlowSpecLoad(
+                        src=('tun_ipv4_dst', 0),
+                        dst=('tun_ipv4_src', 0),
+                        n_bits=32
+                    ),
+                ]
+            )
+        ]
+        flows.add_resubmit_next_service_flow(dp, self.tbl_num,
+                                             outbound_match, actions,
+                                             priority=flows.MINIMUM_PRIORITY,
+                                             resubmit_table=self.next_table)
+
+        # The inbound match will first send packets to the scratch table,
+        # where global registers will be set and the packet will be dropped
+        # Then the final action will send packet down the pipelined(with the
+        # necessary tunnel information loaded from the scratch table)
+        inbound_match = MagmaMatch(direction=Direction.IN)
+        actions = [
+            parser.NXActionResubmitTable(table_id=self.tunnel_learn_scratch)]
+        flows.add_resubmit_next_service_flow(dp, self.tbl_num,
+                                             inbound_match, actions,
+                                             priority=flows.MINIMUM_PRIORITY,
+                                             resubmit_table=self.next_table)

--- a/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
+++ b/lte/gateway/python/magma/pipelined/app/tunnel_learn.py
@@ -8,6 +8,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 from .base import MagmaController
+from magma.pipelined.app.inout import PHYSICAL_TO_LOGICAL
 from magma.pipelined.openflow import flows
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import Direction, DIRECTION_REG
@@ -28,8 +29,8 @@ class TunnelLearnController(MagmaController):
     def __init__(self, *args, **kwargs):
         super(TunnelLearnController, self).__init__(*args, **kwargs)
         self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
-        self.next_table = self._service_manager.get_next_table_num(
-            self.APP_NAME)
+        self.next_table = \
+            self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL)
         self.tunnel_learn_scratch = \
             self._service_manager.allocate_scratch_tables(self.APP_NAME, 1)[0]
         self._datapath = None

--- a/lte/gateway/python/magma/pipelined/app/ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/app/ue_mac.py
@@ -142,7 +142,7 @@ class UEMacAddressController(MagmaController):
 
     def _add_dns_passthrough_flows(self, sid, mac_addr):
         parser = self._datapath.ofproto_parser
-        # Set so inout knows to skip tables and send to egress
+        # Set so packet skips enforcement and send to egress
         action = load_direction(parser, Direction.PASSTHROUGH)
 
         # Install UDP flows for DNS
@@ -177,7 +177,7 @@ class UEMacAddressController(MagmaController):
 
     def _delete_dns_passthrough_flows(self, sid, mac_addr):
         parser = self._datapath.ofproto_parser
-        # Set so inout knows to skip tables and send to egress
+        # Set so packet skips enforcement controller
         action = load_direction(parser, Direction.PASSTHROUGH)
 
         # Install UDP flows for DNS
@@ -209,7 +209,7 @@ class UEMacAddressController(MagmaController):
     def _add_dhcp_passthrough_flows(self, sid, mac_addr):
         ofproto, parser = self._datapath.ofproto, self._datapath.ofproto_parser
 
-        # Set so inout knows to skip tables and send to egress
+        # Set so packet skips enforcement controller
         action = load_direction(parser, Direction.PASSTHROUGH)
         uplink_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
                                   ip_proto=IPPROTO_UDP,
@@ -240,7 +240,7 @@ class UEMacAddressController(MagmaController):
     def _delete_dhcp_passthrough_flows(self, sid, mac_addr):
         parser = self._datapath.ofproto_parser
 
-        # Set so inout knows to skip tables and send to egress
+        # Set so packet skips enforcement controller
         action = load_direction(parser, Direction.PASSTHROUGH)
         uplink_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
                                   ip_proto=IPPROTO_UDP,

--- a/lte/gateway/python/magma/pipelined/openflow/flows.py
+++ b/lte/gateway/python/magma/pipelined/openflow/flows.py
@@ -319,8 +319,6 @@ def get_add_resubmit_next_service_flow_msg(datapath, table, match,
     """
     ofproto, parser = datapath.ofproto, datapath.ofproto_parser
 
-    _check_resubmit_action(actions, parser)
-
     if actions is None:
         actions = []
     actions = actions + [

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -45,7 +45,8 @@ from magma.pipelined.app.arp import ArpController
 from magma.pipelined.app.dpi import DPIController
 from magma.pipelined.app.enforcement import EnforcementController
 from magma.pipelined.app.enforcement_stats import EnforcementStatsController
-from magma.pipelined.app.inout import EGRESS, INGRESS, InOutController
+from magma.pipelined.app.inout import EGRESS, INGRESS, PHYSICAL_TO_LOGICAL, \
+    InOutController
 from magma.pipelined.app.meter import MeterController
 from magma.pipelined.app.meter_stats import MeterStatsController
 from magma.pipelined.app.subscriber import SubscriberController
@@ -83,15 +84,19 @@ class _TableManager:
     """
 
     INGRESS_TABLE_NUM = 1
+    PHYSICAL_TO_LOGICAL_TABLE_NUM = 21
     EGRESS_TABLE_NUM = 20
     MAIN_TABLE_START_NUM = 2
-    MAIN_TABLE_LIMIT_NUM = EGRESS_TABLE_NUM  # exclusive
-    SCRATCH_TABLE_START_NUM = EGRESS_TABLE_NUM + 1  # 21
+    # TODO temp fix, with the new inout middle table(physical->logical) we need
+    # to redo the table allocation and split controllers into physical|logical
+    MAIN_TABLE_LIMIT_NUM = PHYSICAL_TO_LOGICAL_TABLE_NUM  # exclusive
+    SCRATCH_TABLE_START_NUM = PHYSICAL_TO_LOGICAL_TABLE_NUM + 1  # 22
     SCRATCH_TABLE_LIMIT_NUM = 255  # exclusive
 
     def __init__(self):
         self._tables_by_app = {
             INGRESS: Tables(main_table=self.INGRESS_TABLE_NUM),
+            PHYSICAL_TO_LOGICAL: Tables(main_table=self.PHYSICAL_TO_LOGICAL_TABLE_NUM),
             EGRESS: Tables(main_table=self.EGRESS_TABLE_NUM),
         }
 

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -38,6 +38,7 @@ from lte.protos.mconfig.mconfigs_pb2 import PipelineD
 from lte.protos.meteringd_pb2_grpc import MeteringdRecordsControllerStub
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub
+from magma.pipelined.app.base import ControllerType
 from magma.pipelined.app import of_rest_server
 from magma.pipelined.app.access_control import AccessControlController
 from magma.pipelined.app.tunnel_learn import TunnelLearnController
@@ -60,11 +61,15 @@ from magma.common.service_registry import ServiceRegistry
 from magma.configuration import environment
 
 
-class Tables:
-    __slots__ = ['main_table', 'scratch_tables']
+App = namedtuple('App', ['name', 'module', 'type'])
 
-    def __init__(self, main_table, scratch_tables=None):
+
+class Tables:
+    __slots__ = ['main_table', 'type', 'scratch_tables']
+
+    def __init__(self, main_table, type, scratch_tables=None):
         self.main_table = main_table
+        self.type = type
         self.scratch_tables = scratch_tables
         if self.scratch_tables is None:
             self.scratch_tables = []
@@ -77,6 +82,37 @@ class TableNumException(Exception):
     pass
 
 
+class TableRange():
+    """
+    Used to generalize different table ranges.
+    """
+    def __init__(self, start: int, end: int):
+        self._start = start
+        self._end = end
+        self._next_table = self._start
+
+    def allocate_table(self):
+        if (self._next_table == self._end):
+            raise TableNumException('Cannot generate more tables. Table limit'
+                'of %s reached!' % self._end)
+        table_num = self._next_table
+        self._next_table += 1
+        return table_num
+
+    def allocate_tables(self, count: int):
+        if self._next_table + count >= self._end:
+            raise TableNumException('Cannot generate more tables. Table limit'
+                'of %s reached!' % self._end)
+        tables = [self.allocate_table() for i in range(0, count)]
+        return tables
+
+    def get_next_table(self, table:int):
+        if table + 1 < self._next_table:
+            return table + 1
+        else:
+            return self._end
+
+
 class _TableManager:
     """
     TableManager maintains an internal mapping between apps to their
@@ -84,49 +120,56 @@ class _TableManager:
     """
 
     INGRESS_TABLE_NUM = 1
-    PHYSICAL_TO_LOGICAL_TABLE_NUM = 21
+    PHYSICAL_TO_LOGICAL_TABLE_NUM = 10
     EGRESS_TABLE_NUM = 20
-    MAIN_TABLE_START_NUM = 2
-    # TODO temp fix, with the new inout middle table(physical->logical) we need
-    # to redo the table allocation and split controllers into physical|logical
-    MAIN_TABLE_LIMIT_NUM = PHYSICAL_TO_LOGICAL_TABLE_NUM  # exclusive
-    SCRATCH_TABLE_START_NUM = PHYSICAL_TO_LOGICAL_TABLE_NUM + 1  # 22
+    LOGICAL_TABLE_LIMIT_NUM = EGRESS_TABLE_NUM  # exclusive
+    SCRATCH_TABLE_START_NUM = EGRESS_TABLE_NUM + 1  # 21
     SCRATCH_TABLE_LIMIT_NUM = 255  # exclusive
 
     def __init__(self):
+        self._table_ranges = {
+            ControllerType.PHYSICAL: TableRange(self.INGRESS_TABLE_NUM + 1,
+                self.PHYSICAL_TO_LOGICAL_TABLE_NUM),
+            ControllerType.LOGICAL:
+                TableRange(self.PHYSICAL_TO_LOGICAL_TABLE_NUM + 1,
+                           self.EGRESS_TABLE_NUM)
+        }
+        self._scratch_range = TableRange(self.SCRATCH_TABLE_START_NUM,
+                                         self.SCRATCH_TABLE_LIMIT_NUM)
         self._tables_by_app = {
-            INGRESS: Tables(main_table=self.INGRESS_TABLE_NUM),
-            PHYSICAL_TO_LOGICAL: Tables(main_table=self.PHYSICAL_TO_LOGICAL_TABLE_NUM),
-            EGRESS: Tables(main_table=self.EGRESS_TABLE_NUM),
+            INGRESS: Tables(main_table=self.INGRESS_TABLE_NUM,
+                            type=ControllerType.SPECIAL),
+            PHYSICAL_TO_LOGICAL: Tables(
+                main_table=self.PHYSICAL_TO_LOGICAL_TABLE_NUM,
+                type=ControllerType.SPECIAL),
+            EGRESS: Tables(main_table=self.EGRESS_TABLE_NUM,
+                           type=ControllerType.SPECIAL),
         }
 
-        self._next_main_table = self.MAIN_TABLE_START_NUM
-        self._next_scratch_table = self.SCRATCH_TABLE_START_NUM
+    def _allocate_main_table(self, type: ControllerType) -> int:
+        if type not in self._table_ranges:
+            raise TableNumException('Cannot generate a table for %s' % type)
+        return self._table_ranges[type].allocate_table()
 
-    def _allocate_main_table(self) -> int:
-        if self._next_main_table == self.MAIN_TABLE_LIMIT_NUM:
-            raise TableNumException(
-                'Cannot generate more tables. Table limit of %s '
-                'reached!' % self.MAIN_TABLE_LIMIT_NUM)
-
-        table_num = self._next_main_table
-        self._next_main_table += 1
-        return table_num
-
-    def register_apps_for_service(self, app_names: List[str]):
+    def register_apps_for_service(self, apps: List[App]):
         """
-        Register the apps for a service with a main table.
+        Register the apps for a service with a main table. All Apps must share
+        the same contoller type
         """
-        table_num = self._allocate_main_table()
-        for app in app_names:
-            self._tables_by_app[app] = Tables(main_table=table_num)
+        if not all(apps[0].type == app.type for app in apps):
+            raise TableNumException('Cannot register apps with different'
+                                    'controller type')
+        table_num = self._allocate_main_table(apps[0].type)
+        for app in apps:
+            self._tables_by_app[app.name] = Tables(main_table=table_num,
+                                                   type=app.type)
 
-    def register_apps_for_table0_service(self, app_names: List[str]):
+    def register_apps_for_table0_service(self, apps: List[App]):
         """
         Register the apps for a service with main table 0
         """
-        for app in app_names:
-            self._tables_by_app[app] = Tables(main_table=0)
+        for app in apps:
+            self._tables_by_app[app.name] = Tables(main_table=0, type=app.type)
 
     def get_table_num(self, app_name: str) -> int:
         if app_name not in self._tables_by_app:
@@ -141,11 +184,17 @@ class _TableManager:
         """
         if app_name not in self._tables_by_app:
             raise Exception('App is not registered: %s' % app_name)
-        main_table = self._tables_by_app[app_name].main_table
-        next_table = main_table + 1
-        if next_table < self._next_main_table:
-            return next_table
-        return self.EGRESS_TABLE_NUM
+
+        app = self._tables_by_app[app_name]
+        if app.type == ControllerType.SPECIAL:
+            if app_name == INGRESS:
+                return self._table_ranges[ControllerType.PHYSICAL].get_next_table(app.main_table)
+            elif app_name == PHYSICAL_TO_LOGICAL:
+                return self._table_ranges[ControllerType.LOGICAL].get_next_table(app.main_table)
+            else:
+                raise TableNumException('No next table found for %s' % app_name)
+
+        return self._table_ranges[app.type].get_next_table(app.main_table)
 
     def is_app_enabled(self, app_name: str) -> bool:
         return app_name in self._tables_by_app or \
@@ -153,16 +202,8 @@ class _TableManager:
 
     def allocate_scratch_tables(self, app_name: str, count: int) -> \
             List[int]:
-        if self._next_scratch_table + count > self.SCRATCH_TABLE_LIMIT_NUM:
-            raise TableNumException(
-                'Cannot generate more tables. Table limit of %s '
-                'reached!' % self.SCRATCH_TABLE_LIMIT_NUM)
 
-        tbl_nums = []
-        for _ in range(count):
-            tbl_nums.append(self._next_scratch_table)
-            self._next_scratch_table += 1
-
+        tbl_nums = self._scratch_range.allocate_tables(count)
         self._tables_by_app[app_name].scratch_tables.extend(tbl_nums)
         return tbl_nums
 
@@ -176,7 +217,7 @@ class _TableManager:
                                   key=lambda kv: (kv[1].main_table, kv[0])))
         # Include table 0 when it is managed by the EPC, for completeness.
         if 'ue_mac' not in self._tables_by_app:
-            resp['mme'] = Tables(main_table=0)
+            resp['mme'] = Tables(main_table=0, type=None)
             resp.move_to_end('mme', last=False)
         return resp
 
@@ -195,8 +236,6 @@ class ServiceManager:
         - Main & scratch tables management
     """
 
-    App = namedtuple('App', ['name', 'module'])
-
     UE_MAC_ADDRESS_SERVICE_NAME = 'ue_mac'
     ARP_SERVICE_NAME = 'arpd'
     ACCESS_CONTROL_SERVICE_NAME = 'access_control'
@@ -210,20 +249,26 @@ class ServiceManager:
     DYNAMIC_SERVICE_TO_APPS = {
         PipelineD.METERING: [
             App(name=MeterController.APP_NAME,
-                module=MeterController.__module__),
+                module=MeterController.__module__,
+                type=MeterController.APP_TYPE),
             App(name=MeterStatsController.APP_NAME,
-                module=MeterStatsController.__module__),
+                module=MeterStatsController.__module__,
+                type=MeterStatsController.APP_TYPE),
             App(name=SubscriberController.APP_NAME,
-                module=SubscriberController.__module__),
+                module=SubscriberController.__module__,
+                type=SubscriberController.APP_TYPE),
         ],
         PipelineD.DPI: [
-            App(name=DPIController.APP_NAME, module=DPIController.__module__),
+            App(name=DPIController.APP_NAME, module=DPIController.__module__,
+                type=DPIController.APP_TYPE),
         ],
         PipelineD.ENFORCEMENT: [
             App(name=EnforcementController.APP_NAME,
-                module=EnforcementController.__module__),
+                module=EnforcementController.__module__,
+                type=EnforcementController.APP_TYPE),
             App(name=EnforcementStatsController.APP_NAME,
-                module=EnforcementStatsController.__module__),
+                module=EnforcementStatsController.__module__,
+                type=EnforcementStatsController.APP_TYPE),
         ],
     }
 
@@ -232,21 +277,25 @@ class ServiceManager:
     STATIC_SERVICE_TO_APPS = {
         UE_MAC_ADDRESS_SERVICE_NAME: [
             App(name=UEMacAddressController.APP_NAME,
-                module=UEMacAddressController.__module__),
+                module=UEMacAddressController.__module__,
+                type=None),
         ],
         ARP_SERVICE_NAME: [
-            App(name=ArpController.APP_NAME, module=ArpController.__module__),
+            App(name=ArpController.APP_NAME, module=ArpController.__module__,
+            type=ArpController.APP_TYPE),
         ],
         ACCESS_CONTROL_SERVICE_NAME: [
             App(name=AccessControlController.APP_NAME,
-                module=AccessControlController.__module__),
+                module=AccessControlController.__module__,
+                type=AccessControlController.APP_TYPE),
         ],
         TUNNEL_LEARN_SERVICE_NAME: [
             App(name=TunnelLearnController.APP_NAME,
-                module=TunnelLearnController.__module__),
+                module=TunnelLearnController.__module__,
+                type=TunnelLearnController.APP_TYPE),
         ],
         RYU_REST_SERVICE_NAME: [
-            App(name='ryu_rest_app', module='ryu.app.ofctl_rest'),
+            App(name='ryu_rest_app', module='ryu.app.ofctl_rest', type=None),
         ],
     }
 
@@ -258,10 +307,13 @@ class ServiceManager:
 
     def __init__(self, magma_service: MagmaService):
         self._magma_service = magma_service
-        # inout is a mandatory app and it occupies both table 1(for ingress)
-        # and table 20(for egress).
-        self._apps = [self.App(name=InOutController.APP_NAME,
-                               module=InOutController.__module__)]
+        # inout is a mandatory app and it occupies:
+        #   table 1(for ingress)
+        #   table 10(for middle)
+        #   table 20(for egress)
+        self._apps = [App(name=InOutController.APP_NAME,
+                          module=InOutController.__module__,
+                          type=None)]
         self._table_manager = _TableManager()
         self.session_rule_version_mapper = SessionRuleToVersionMapper()
 
@@ -285,13 +337,12 @@ class ServiceManager:
             [service for service in static_services if
              service not in self.STATIC_SERVICE_WITH_NO_TABLE]
         for service in services_with_tables:
-            app_names = [app.name for app in
-                         self.STATIC_SERVICE_TO_APPS[service]]
+            apps = self.STATIC_SERVICE_TO_APPS[service]
             # UE MAC service must be registered with Table 0
             if service == self.UE_MAC_ADDRESS_SERVICE_NAME:
-                self._table_manager.register_apps_for_table0_service(app_names)
+                self._table_manager.register_apps_for_table0_service(apps)
                 continue
-            self._table_manager.register_apps_for_service(app_names)
+            self._table_manager.register_apps_for_service(apps)
 
     def _init_dynamic_services(self):
         """
@@ -306,9 +357,8 @@ class ServiceManager:
         # Register dynamic apps for each service to a main table. Filter out
         # any apps that do not need a table.
         for service in dynamic_services:
-            app_names = [app.name for app in
-                         self.DYNAMIC_SERVICE_TO_APPS[service]]
-            self._table_manager.register_apps_for_service(app_names)
+            apps = self.DYNAMIC_SERVICE_TO_APPS[service]
+            self._table_manager.register_apps_for_service(apps)
 
     def load(self):
         """

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -40,6 +40,7 @@ from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from lte.protos.session_manager_pb2_grpc import LocalSessionManagerStub
 from magma.pipelined.app import of_rest_server
 from magma.pipelined.app.access_control import AccessControlController
+from magma.pipelined.app.tunnel_learn import TunnelLearnController
 from magma.pipelined.app.arp import ArpController
 from magma.pipelined.app.dpi import DPIController
 from magma.pipelined.app.enforcement import EnforcementController
@@ -194,6 +195,7 @@ class ServiceManager:
     UE_MAC_ADDRESS_SERVICE_NAME = 'ue_mac'
     ARP_SERVICE_NAME = 'arpd'
     ACCESS_CONTROL_SERVICE_NAME = 'access_control'
+    TUNNEL_LEARN_SERVICE_NAME = 'tunnel_learn'
     RYU_REST_SERVICE_NAME = 'ryu_rest_service'
 
     # Mapping between services defined in mconfig and the names and modules of
@@ -233,6 +235,10 @@ class ServiceManager:
         ACCESS_CONTROL_SERVICE_NAME: [
             App(name=AccessControlController.APP_NAME,
                 module=AccessControlController.__module__),
+        ],
+        TUNNEL_LEARN_SERVICE_NAME: [
+            App(name=TunnelLearnController.APP_NAME,
+                module=TunnelLearnController.__module__),
         ],
         RYU_REST_SERVICE_NAME: [
             App(name='ryu_rest_app', module='ryu.app.ofctl_rest'),

--- a/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 from concurrent.futures import Future
 
 from magma.pipelined.rule_mappers import RuleIDToNumMapper
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.tests.app.exceptions import ServiceRunningError,\
     BadConfigError
 

--- a/lte/gateway/python/magma/pipelined/tests/old_tests/test_controller.py
+++ b/lte/gateway/python/magma/pipelined/tests/old_tests/test_controller.py
@@ -19,7 +19,7 @@ from ryu.base.app_manager import AppManager
 
 from magma.pipelined.openflow.exceptions import MagmaOFError
 from magma.pkt_tester.tests.test_topology_builder import check_env
-from magma.pipelined.app.base import MagmaController
+from magma.pipelined.app.base import MagmaController, ControllerType
 
 
 

--- a/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ue_passthrough.py
@@ -163,9 +163,9 @@ class UEMacAddressTest(unittest.TestCase):
                 FlowTest(FlowQuery(self._tbl_num,
                                    self.testing_controller), 4, 9),
                 FlowTest(FlowQuery(self._ingress_tbl_num,
-                                   self.testing_controller), 4, 4),
+                                   self.testing_controller), 4, 2),
                 FlowTest(FlowQuery(self._egress_tbl_num,
-                                   self.testing_controller), 2, 2),
+                                   self.testing_controller), 0, 2),
                 FlowTest(flow_queries[0], 4, 4),
             ], lambda: wait_after_send(self.testing_controller))
 


### PR DESCRIPTION
Summary: Split the dataplane into 2 components separated by the InMiddleOut(old InOut controller, we need a better name...) the physical plane is processing arp/acl/tunnel_learn, the logical is enforcing policies, dpi,, stats, etc. The new table InOut manages sits between the two. The passtrhough traffic(dhcp/dns) will skip the logical plane. All controllers have a new field apptype. Currently special controllers have a None type, might change that to a reserved value to make it less error prone.

Reviewed By: amarpad

Differential Revision: D18386176

