### PR TITLE
clang-format should be consitent no matter where run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,8 +55,9 @@ jobs:
             CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=docusaurus-bot yarn run publish-gh-pages
 
   southpoll_lint:
-    docker:
-      - image: fedora:latest
+    machine:
+      image: circleci/classic:latest
+      docker_layer_caching: true
     steps:
       - checkout
       - build/determinator:
@@ -64,14 +65,14 @@ jobs:
       - run:
           name: Running lints on the devmand image
           command: |
-            sudo dnf update -y
-            sudo dnf install -y clang-format
-            cd ./devmand/gateway/
+            sudo apt-get update -y
+            sudo apt-get install -y realpath
+            cd devmand/gateway/format
             ./format
             if [[ $(git diff HEAD --name-only) ]]; then
                echo "############################"
                echo "Changes required!"
-               git diff HEAD | less
+               git diff --no-pager HEAD
                echo "Please run the format script"
                echo "############################"
                exit 1

--- a/devmand/gateway/format
+++ b/devmand/gateway/format
@@ -1,3 +1,0 @@
-#!/bin/bash
-find ./src \( -name "*.[hc]pp" -or -name "*.h" \) \
-    -exec clang-format -i --style=file {} \;

--- a/devmand/gateway/format/Dockerfile
+++ b/devmand/gateway/format/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:latest AS formatter
+
+RUN dnf update -y && dnf install -y clang findutils
+WORKDIR /cache/devmand/repo/gateway
+CMD find ./src \( -name "*.[hc]pp" -or -name "*.h" \) \
+    -exec clang-format -i --style=file {} \;

--- a/devmand/gateway/format/format
+++ b/devmand/gateway/format/format
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker build -f Dockerfile --tag formatter ..
+docker run -v "$(realpath ../../):/cache/devmand/repo:rw" formatter

--- a/devmand/gateway/src/devmand/ErrorHandler.h
+++ b/devmand/gateway/src/devmand/ErrorHandler.h
@@ -30,7 +30,9 @@ class ErrorHandler final {
       std::function<void()> onFailure = []() {});
 
   template <class Future>
-  static auto thenError(Future&& f, std::function<void()> onFailure = []() {}) {
+  static auto thenError(
+      Future&& f,
+      std::function<void()> onFailure = []() {}) {
     return std::move(f)
         .thenError(
             folly::tag_t<std::exception>{},

--- a/devmand/gateway/src/devmand/devices/CambiumDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/CambiumDevice.cpp
@@ -310,7 +310,9 @@ void CambiumDevice::updateYang(
     case folly::dynamic::DOUBLE:
     case folly::dynamic::INT64:
     case folly::dynamic::STRING:
-    default: { return; }
+    default: {
+      return;
+    }
   }
 }
 

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -34,7 +34,8 @@ PingDevice::PingDevice(
     const Id& id_,
     bool readonly_,
     const folly::IPAddress& ip_)
-    : Device(application, id_, readonly_), channel(application.getPingEngine(ip_), ip_) {}
+    : Device(application, id_, readonly_),
+      channel(application.getPingEngine(ip_), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
   auto state = State::make(app, getId());


### PR DESCRIPTION
Summary:
This commit makes clang-format consitent no matter where is it run by
running it in docker.

Differential Revision: D18587205

