### PR TITLE
Updating sync_rpc_client to retry connection on 'Socket closed' failures

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -100,7 +100,7 @@ setup(
             # Keep grpcio and grpcio-tools on same version for now
             # If you update this version here, you probably also want to
             # update it in lte/gateway/python/Makefile
-            'grpcio-tools==1.16.1',
+            'grpcio-tools==1.25.0',
             'nose==1.3.7',
             'pyroute2',
             'iperf3',

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -13,11 +13,14 @@ import threading
 import time
 
 import grpc
-from orc8r.protos.sync_rpc_service_pb2 import SyncRPCResponse
+import random
+from magma.common.service_registry import ServiceRegistry
+from magma.common.rpc_utils import is_grpc_error_retryable
+from magma.magmad.proxy_client import ControlProxyHttpClient
+from orc8r.protos.sync_rpc_service_pb2 import SyncRPCResponse, SyncRPCRequest
 from orc8r.protos.sync_rpc_service_pb2_grpc import SyncRPCServiceStub
 
-from magma.common.service_registry import ServiceRegistry
-from magma.magmad.proxy_client import ControlProxyHttpClient
+from typing import List
 
 
 class SyncRPCClient(threading.Thread):
@@ -28,7 +31,7 @@ class SyncRPCClient(threading.Thread):
 
     RETRY_MAX_DELAY_SECS = 10  # seconds
 
-    def __init__(self, loop, response_timeout):
+    def __init__(self, loop, response_timeout: int):
         threading.Thread.__init__(self)
         # a synchronized queue
         self._response_queue = queue.Queue()
@@ -59,18 +62,23 @@ class SyncRPCClient(threading.Thread):
                 client = SyncRPCServiceStub(chan)
                 self._set_connect_time()
                 self.process_streams(client)
+            except grpc.RpcError as err:
+                if is_grpc_error_retryable(err):
+                    logging.error(
+                        "[SyncRPC] Transient gRPC error, retrying: %s",
+                        err.details())
+                    self._retry_connect_sleep()
+                    continue
+                else:
+                    logging.error("[SyncRPC] gRPC error: %s, reconnecting to "
+                                  "cloud.", err.details())
+                    self._cleanup_and_reconnect()
             except Exception as exp:  # pylint: disable=broad-except
                 conn_time = time.time() - start_time
                 logging.error("[SyncRPC] Error after %ds: %s", conn_time, exp)
-            # If the connection is terminated, wait for a period of time
-            # before connecting back to the cloud.
-            # Also clear the conn closed table since cloud may reuse req IDs,
-            # and clear current proxy client connections
-            self._conn_closed_table.clear()
-            self._proxy_client.close_all_connections()
-            self._retry_connect_sleep()
+                self._cleanup_and_reconnect()
 
-    def process_streams(self, client):
+    def process_streams(self, client: SyncRPCServiceStub) -> None:
         """
         Calls rpc function EstablishSyncRPCStream on the client to establish
         a stream with dispatcher in the cloud, processes all requests from
@@ -108,7 +116,8 @@ class SyncRPCClient(threading.Thread):
                 logging.debug("[SyncRPC] Sending heartbeat")
                 yield SyncRPCResponse(heartBeat=True)
 
-    def forward_requests(self, sync_rpc_requests):
+    def forward_requests(self,
+                         sync_rpc_requests: List[SyncRPCRequest]) -> None:
         """
         Send requests in the sync_rpc_requests iterator.
         Args:
@@ -124,11 +133,9 @@ class SyncRPCClient(threading.Thread):
                 req = next(sync_rpc_requests)
                 self.forward_request(req)
         except grpc.RpcError as err:
-            # server end closed connection; retry rpc connection.
-            raise Exception("Error when retrieving request: [{}] {}".format(
-                err.code(), err.details()))
+            raise err
 
-    def forward_request(self, request):
+    def forward_request(self, request: SyncRPCRequest) -> None:
         if request.heartBeat:
             logging.info("[SyncRPC] Got heartBeat from cloud")
             return
@@ -145,24 +152,31 @@ class SyncRPCClient(threading.Thread):
                                     self._conn_closed_table),
             self._loop)
 
-    def _retry_connect_sleep(self):
+    def _retry_connect_sleep(self) -> None:
         """
-        Sleep for a current delay amount of time.
-        If last connection time was over 60 seconds ago, sleep for 0 seconds.
+        Sleep for a current delay amount of time, with random backoff
         If current delay is less than RETRY_MAX_DELAY_SECS, exponentially
         increase current delay. If it exceeds RETRY_MAX_DELAY_SECS, sleep for
         RETRY_MAX_DELAY_SECS
         """
-        # if last connect time was over 60 secs ago, reset current_delay to 0
-        if time.time() - self._last_conn_time > 60:
-            self._current_delay = 0
-        elif self._current_delay == 0:
-            self._current_delay = 1
-        else:
-            self._current_delay = min(2 * self._current_delay,
-                                      self.RETRY_MAX_DELAY_SECS)
-        time.sleep(self._current_delay)
+        sleep_time = self._current_delay + (random.randint(0, 1000) / 1000)
+        self._current_delay = min(2 * self._current_delay,
+                                  self.RETRY_MAX_DELAY_SECS)
+        self._current_delay = max(self._current_delay, 1)
+        time.sleep(sleep_time)
 
-    def _set_connect_time(self):
+    def _set_connect_time(self) -> None:
         logging.info("[SyncRPC] Opening stream to cloud")
+        self._current_delay = 0
         self._last_conn_time = time.time()
+
+    def _cleanup_and_reconnect(self):
+        """
+        If the connection is terminated, wait for a period of time
+        before connecting back to the cloud. Also clear the conn
+        closed table since cloud may reuse req IDs, and clear
+        current proxy client connections
+        """
+        self._conn_closed_table.clear()
+        self._proxy_client.close_all_connections()
+        self._retry_connect_sleep()

--- a/orc8r/gateway/python/magma/magmad/tests/sync_rpc_client_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/sync_rpc_client_tests.py
@@ -69,7 +69,6 @@ class SyncRPCClientTests(unittest.TestCase):
     def test_retry_connect_sleep(self):
         self._sync_rpc_client._current_delay = 0
         for i in range(5):
-            self._sync_rpc_client._set_connect_time()
             self._sync_rpc_client._retry_connect_sleep()
             if i == 4:
                 self.assertEqual(self._sync_rpc_client.RETRY_MAX_DELAY_SECS,

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -52,7 +52,7 @@ prometheus_proto:
 
 # If you update the version here, you probably also want to update it in setup.py
 $(BIN)/grpcio-tools: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) "grpcio-tools==1.16.1"
+	$(VIRT_ENV_PIP_INSTALL) "grpcio-tools==1.25.0"
 
 .test: .tests .sudo_tests
 

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -61,7 +61,7 @@ setup(
         'redis>=2.10.5',  # redis-py (Python bindings to redis)
         'redis-collections>=0.4.2',
         'aiohttp>=0.17.2',
-        'grpcio==1.16.1',
+        'grpcio==1.25.0',
         'protobuf==3.6.1',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',


### PR DESCRIPTION
Summary:
During TeraVM SGs tests, SyncRPC server on cloud suffers transient failures on the gRPC stream, if this happens, the syncRPC client on AGW doesn't recover:

```
Nov  6 12:38:31 magma-ag control_proxy[48086]: 2019-11-06T12:38:31.956-08:00 [127.0.0.1 -> metricsd-controller-staging.magma.etagecom.io,8443] "POST /magma.orc8r.MetricsCont
roller/Collect HTTP/2" 200 5bytes 0.316s
Nov  6 12:38:32 magma-ag control_proxy[48086]: 2019-11-06T12:38:32.308-08:00 [127.0.0.1 -> logger-controller-staging.magma.etagecom.io,8443] "POST /magma.orc8r.LoggingServic
e/Log HTTP/2" 200 5bytes 0.163s
Nov  6 12:38:32 magma-ag nghttpx[48091]: [FATAL] IPC socket is closed.  Perform immediate shutdown. (shrpx_worker_process.cc:163)
Nov  6 12:38:32 magma-ag magmad[47961]: ERROR:root:[SyncRPC] Error after 2509s: Error when retrieving request: [StatusCode.UNAVAILABLE] Socket closed
Nov  6 12:38:32 magma-ag systemd[1]: Stopping Magma control_proxy service...
Nov  6 12:38:32 magma-ag systemd[1]: Stopped Magma control_proxy service.
Nov  6 12:38:32 magma-ag systemd[1]: Starting Magma control_proxy service...
Nov  6 12:38:33 magma-ag control_proxy[54100]: ERROR:root:Error retrieving config for control_proxy, key not found: allow_http_proxy
Nov  6 12:38:33 magma-ag systemd[1]: Started Magma control_proxy service.
Nov  6 12:38:33 magma-ag magmad[47961]: Exception in thread Thread-2:
Nov  6 12:38:33 magma-ag magmad[47961]: Traceback (most recent call last):
```

This diff:

- Updates SyncRPC client implementation to retry connection on UNAVAILABLE error, so the client can continue sending and receiving updates from the server.
- Updates grpcio python dependencies version, from 1.16.1 to 1.25.0, to match gRPC server version.

Differential Revision: D18604597

