### PR TITLE
Add cloud docker tests and build to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,85 +5,45 @@
 # LICENSE file in the root directory of this source tree.
 matrix:
   include:
-    - language: go
-      name: Verifying generated files are in-sync
-      go:
-        - 1.11.x
+    - stage: Tests
+      language: python
+      name: Run container-based Orchestrator cloud tests for FWA
       os: linux
       dist: xenial
-
+      python:
+        - "3.7"
+      services:
+        - docker
       env:
-        - MAGMA_ROOT=$TRAVIS_BUILD_DIR GO111MODULE=on
+        - MAGMA_ROOT=$TRAVIS_BUILD_DIR
 
-      before_install:
-        - ./travis/golang_before_install.sh
-
-      before_script:
-        - sudo mkdir -p /etc/magma/configs
-        - ./travis/link_cloud_configs.sh
-
+      install:
+        - pip3 install PyYAML
       script:
-        - travis_retry travis_retry travis_wait make -C ${MAGMA_ROOT}/orc8r/cloud download
-        - cd ${MAGMA_ROOT}/feg/gateway
-        - travis_retry travis_wait go mod download
+        - cd ${MAGMA_ROOT}/orc8r/cloud/docker
+        - python3 build.py -t
 
-        # Clear temp files (e.g. travis_retry/travis_wait logs)
-        - cd ${MAGMA_ROOT}
-        - git clean -fd
-
-        - make -C ${MAGMA_ROOT}/orc8r/cloud gen
-        - make -C ${MAGMA_ROOT}/feg/gateway gen
-        - cd ${MAGMA_ROOT}
-        - git add .
-        - git status
-        # This command will exit 1 if there are any changes to the git clone
-        - git diff-index --quiet HEAD
-
-    - language: go
-      name: Cloud precommit
-      go:
-        - 1.11.x
-      os: linux
-      dist: xenial
-
-      env:
-        - MAGMA_ROOT=$TRAVIS_BUILD_DIR GO111MODULE=on
-
-      before_install:
-        - ./travis/golang_before_install.sh
-        - ./travis/start_dynamo_local.sh
-
-      before_script:
-        - sudo mkdir -p /etc/magma/configs
-        - ./travis/link_cloud_configs.sh
-
-      script:
-        - travis_retry travis_retry travis_wait make -C ${MAGMA_ROOT}/orc8r/cloud download
-        - make -C ${MAGMA_ROOT}/orc8r/cloud tools
-        - make -C ${MAGMA_ROOT}/orc8r/cloud precommit
-
-    - language: go
+    - stage: Tests
+      language: go
       name: FeG precommit
-      go:
-        - 1.11.x
       os: linux
       dist: xenial
-
+      go:
+        - 1.11.x
       env:
         - MAGMA_ROOT=$TRAVIS_BUILD_DIR GO111MODULE=on
 
       before_install:
         - ./travis/golang_before_install.sh
-
       before_script:
         - sudo ln -s $MAGMA_ROOT/config/feg /etc/magma
-
       script:
         - cd ${MAGMA_ROOT}/feg/gateway
         - travis_retry travis_wait go mod download
         - make -C ${MAGMA_ROOT}/feg/gateway precommit
 
-    - language: go
+    - stage: Tests
+      language: go
       name: CWAG precommit
       go:
         - 1.12.x
@@ -101,7 +61,8 @@ matrix:
         - travis_retry travis_wait go mod download
         - make -C ${MAGMA_ROOT}/cwf/gateway precommit
 
-    - language: go
+    - stage: Tests
+      language: go
       name: orc8r gateway go tests
       go:
         - 1.12.x
@@ -117,11 +78,11 @@ matrix:
         - go test ./...
         - go vet ./...
 
-    - language: minimal
+    - stage: Tests
+      language: minimal
       name: LTE gateway python unit tests
       os: linux
       dist: xenial
-
       env:
         - MAGMA_ROOT=$TRAVIS_BUILD_DIR PYTHON_BUILD=$TRAVIS_BUILD_DIR/build PIP_CACHE_HOME=$TRAVIS_BUILD_DIR/.pipcache MAGMA_DEV_MODE=1 SKIP_SUDO_TESTS=1
 
@@ -138,26 +99,91 @@ matrix:
         - sudo mv protoc3/include/google /usr/include/
         - sudo chmod -R a+Xr /usr/include/google
         - sudo rm -rf protoc3.zip protoc3
-
       script:
         - make -C $MAGMA_ROOT/lte/gateway/python test_all
 
-    - language: minimal
-      name: nms builds
+    - stage: Tests
+      language: go
+      name: Verifying generated files are in-sync
       os: linux
       dist: xenial
-
+      go:
+        - 1.11.x
       env:
-        - NMS_ROOT=$TRAVIS_BUILD_DIR/symphony/app
+        - MAGMA_ROOT=$TRAVIS_BUILD_DIR GO111MODULE=on
 
-      addons:
-        apt:
-          packages:
-            - docker-ce
+      before_install:
+        - ./travis/golang_before_install.sh
+      before_script:
+        - sudo mkdir -p /etc/magma/configs
+        - ./travis/link_cloud_configs.sh
+      script:
+        - travis_retry travis_retry travis_wait make -C ${MAGMA_ROOT}/orc8r/cloud download
+        - cd ${MAGMA_ROOT}/feg/gateway
+        - travis_retry travis_wait go mod download
 
+        # Clear temp files (e.g. travis_retry/travis_wait logs)
+        - cd ${MAGMA_ROOT}
+        - git clean -fd
+
+        - make -C ${MAGMA_ROOT}/orc8r/cloud gen
+        - make -C ${MAGMA_ROOT}/feg/gateway gen
+        - cd ${MAGMA_ROOT}
+        - git add .
+        - git status
+        # This command will exit 1 if there are any changes to the git clone
+        - git diff-index --quiet HEAD
+
+    - stage: Build
+      language: python
+      name: Build core Orchestrator containers
+      os: linux
+      dist: xenial
+      python:
+        - "3.7"
+      services:
+        - docker
+      env:
+        - MAGMA_ROOT=$TRAVIS_BUILD_DIR
+      install:
+        - pip3 install PyYAML
+      script:
+        - cd ${MAGMA_ROOT}/orc8r/cloud/docker
+        - python3 build.py --nocache
+
+    - stage: Build
+      language: python
+      name: Build noncore Orchestrator containers
+      os: linux
+      dist: xenial
+      python:
+        - "3.7"
+      services:
+        - docker
+      env:
+        - MAGMA_ROOT=$TRAVIS_BUILD_DIR
+      install:
+        - pip3 install PyYAML
+      script:
+        - cd ${MAGMA_ROOT}/orc8r/cloud/docker
+        - python3 build.py -nc
+
+    - stage: Build
+      language: minimal
+      name: Build NMS
+      os: linux
+      dist: xenial
+      services:
+        - docker
+      env:
+        - NMS_ROOT=$TRAVIS_BUILD_DIR/symphony/app/fbcnms-projects/magmalte
       script:
         - cd ${NMS_ROOT}
-        - docker build -t magmalte -f fbcnms-projects/magmalte/Dockerfile .
+        - docker-compose build magmalte
+
+stages:
+  - Tests
+  - Build
 
 notifications:
   slack:

--- a/orc8r/cloud/docker/build.py
+++ b/orc8r/cloud/docker/build.py
@@ -16,7 +16,7 @@ import glob
 import subprocess
 from collections import namedtuple
 from subprocess import PIPE
-from typing import List
+from typing import List, Iterable
 
 import os
 import shutil
@@ -40,6 +40,7 @@ COMPOSE_FILES = [
 
     'docker-compose.override.yml',
 ]
+CORE_COMPOSE_FILES = {'docker-compose.yml', 'docker-compose.override.yml'}
 
 # Root directory where external modules will be mounted
 GUEST_MODULE_ROOT = 'modules'
@@ -55,8 +56,7 @@ def main() -> None:
     # If we're building, we always need to build controller first because proxy
     # copies metricsd binary and plugins from controller
     files_args = _get_docker_files_command_args(args)
-    if not args.mount:
-        _create_build_context()
+    _create_build_context_if_necessary(args)
     _build_cache_if_necessary(args)
     _build_controller_if_necessary(args)
 
@@ -67,30 +67,50 @@ def main() -> None:
         # Run unit tests
         _run_docker(['build', 'test'])
         _run_docker(['run', '--rm', 'test', 'make test'])
-    elif args.nocache:
-        # Build containers without go-cache in base image
-        _run_docker(files_args + ['build'])
     else:
-        # Build images using go-cache base image
-        _run_docker(files_args + ['build',
-                                  '--build-arg', 'baseImage=orc8r_cache'])
+        _run_docker(files_args + _get_docker_build_args(args))
 
 
 def _get_docker_files_command_args(args: argparse.Namespace) -> List[str]:
-    if args.all:
+    def make_file_args(files: Iterable[str]) -> List[str]:
         ret = []
-        for f in COMPOSE_FILES:
+        for f in files:
             ret.append('-f')
             ret.append(f)
         return ret
+
+    if args.all:
+        return make_file_args(COMPOSE_FILES)
+
+    if args.noncore:
+        return make_file_args(
+            filter(lambda f: f not in CORE_COMPOSE_FILES, COMPOSE_FILES),
+        )
 
     # docker-compose uses docker-compose.yml and docker-compose.override.yml
     # by default
     return []
 
 
+def _create_build_context_if_necessary(args: argparse.Namespace) -> None:
+    """ Clear out the build context from the previous run """
+    if args.mount or args.noncore:
+        return
+
+    if os.path.exists(BUILD_CONTEXT):
+        shutil.rmtree(BUILD_CONTEXT)
+    os.mkdir(BUILD_CONTEXT)
+
+    print("Creating build context in '%s'..." % BUILD_CONTEXT)
+    modules = []
+    for module in _get_modules():
+        _copy_module(module)
+        modules.append(module.name)
+    print('Context created for modules: %s' % ', '.join(modules))
+
+
 def _build_cache_if_necessary(args: argparse.Namespace) -> None:
-    if args.nocache or args.mount or args.tests:
+    if args.nocache or args.mount or args.tests or args.noncore:
         return
 
     # Check if orc8r_cache image exists
@@ -103,8 +123,8 @@ def _build_cache_if_necessary(args: argparse.Namespace) -> None:
 
 def _build_controller_if_necessary(args: argparse.Namespace) -> None:
     # We don't build the controller container if we're running tests or
-    # generating code
-    if args.mount or args.tests:
+    # generating code or just creating noncore containers
+    if args.mount or args.tests or args.noncore:
         return
 
     # controller will always only use docker-compose.yml and override so we
@@ -116,6 +136,14 @@ def _build_controller_if_necessary(args: argparse.Namespace) -> None:
                      'controller'])
 
 
+def _get_docker_build_args(args: argparse.Namespace) -> List[str]:
+    # noncore containers don't need the orc8r cache
+    if args.noncore or args.nocache:
+        return ['build']
+    else:
+        return ['build', '--build-arg', 'baseImage=orc8r_cache']
+
+
 def _run_docker(cmd: List[str]) -> None:
     """ Run the required docker-compose command """
     print("Running 'docker-compose %s'..." % " ".join(cmd))
@@ -123,20 +151,6 @@ def _run_docker(cmd: List[str]) -> None:
         subprocess.run(['docker-compose'] + cmd, check=True)
     except subprocess.CalledProcessError as err:
         exit(err.returncode)
-
-
-def _create_build_context() -> None:
-    """ Clear out the build context from the previous run """
-    if os.path.exists(BUILD_CONTEXT):
-        shutil.rmtree(BUILD_CONTEXT)
-    os.mkdir(BUILD_CONTEXT)
-
-    print("Creating build context in '%s'..." % BUILD_CONTEXT)
-    modules = []
-    for module in _get_modules():
-        _copy_module(module)
-        modules.append(module.name)
-    print('Context created for modules: %s' % ', '.join(modules))
 
 
 def _copy_module(module: MagmaModule) -> None:
@@ -248,6 +262,9 @@ def _parse_args() -> argparse.Namespace:
                         help='Build the images without go cache base image')
     parser.add_argument('--all', '-a', action='store_true',
                         help='Build all containers')
+    parser.add_argument('--noncore', '-nc', action='store_true',
+                        help='Build only non-core containers '
+                             '(i.e. no proxy, controller images)')
     args = parser.parse_args()
     return args
 


### PR DESCRIPTION
Summary:
- Run container-based Orchestrator tests on Travis so we get coverage over the build script and documented development workflow
- Add a `--noncore` option to the docker build.py script to build only supporting containers (i.e. containers which don't depend on orc8r modules to build)
- Add a job to build the core orc8r containers and a job to build the supporting containers - split into 2 jobs so we save some total job time

Differential Revision: D18629245

