### PR TITLE
git clone fails, http instead of https for proxy

### DIFF
--- a/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
+++ b/orc8r/gateway/python/magma/magmad/upgrade/docker_upgrader.py
@@ -163,7 +163,7 @@ async def download_update(
                       format(control_proxy_config['rootca_cert']), shell=True,
                       check=True)
     await run_command("update-ca-certificates", shell=True, check=True)
-    git_clone_cmd = "git -c http.proxy=https://{}:{} -C {} clone {}".format(
+    git_clone_cmd = "git -c https.proxy=https://{}:{} -C {} clone {}".format(
         control_proxy_config['bootstrap_address'],
         control_proxy_config['bootstrap_port'], MAGMA_GITHUB_PATH,
         MAGMA_GITHUB_URL)


### PR DESCRIPTION
seeing the following error after upgrading cwags through nms
```
INFO:root:Checking for upgrade...
INFO:root:There is work to be done:
  current: 563045e1
  to_upgrade: 6126ed5e
Updating certificates in /etc/ssl/certs...
1 added, 0 removed; done.
Running hooks in /etc/ca-certificates/update.d...
done.
Cloning into 'magma'...
fatal: unable to access 'https://github.com/facebookincubator/magma.git/': Received HTTP code 502 from proxy after CONNECT
ERROR:root:Upgrade loop failed! Error: Command failed: git -c http.proxy=https://bootstrapper-orc8r-proxy.magma.svc.cluster.local:443 -C /tmp/magma_upgrade clone https://github.com/facebookincubator/magma.git
ERROR:root:GetServiceInfo Error for s6a_proxy! [StatusCode.DEADLINE_EXCEEDED] Deadline Exceeded
```

doing the same in the container fails
```
root@feg01-67b4599db8-hzdcq:~# docker exec -it magmad bash
root@feg01-67b4599db8-hzdcq:/# git -c http.proxy=https://bootstrapper-orc8r-proxy.magma.svc.cluster.local:443 -C /tmp/magma_upgrade clone https://github.com/facebookincubator/magma.git
Cloning into 'magma'...
fatal: unable to access 'https://github.com/facebookincubator/magma.git/': Received HTTP code 502 from proxy after CONNECT
```

setting the proxy to https works
```
root@feg01-67b4599db8-hzdcq:/# git -c https.proxy=https://bootstrapper-orc8r-proxy.magma.svc.cluster.local:443 -C /tmp/magma_upgrade clone https://github.com/facebookincubator/magma.git
Cloning into 'magma'...
remote: Enumerating objects: 1863, done.
remote: Counting objects: 100% (1863/1863), done.
remote: Compressing objects: 100% (1078/1078), done.
remote: Total 42665 (delta 775), reused 1764 (delta 734), pack-reused 40802
Receiving objects: 100% (42665/42665), 31.38 MiB | 20.77 MiB/s, done.
Resolving deltas: 100% (26572/26572), done.
```