### PR TITLE
Script to setup default uplink bridge

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -107,4 +107,4 @@ monitored_ifaces: ['cwag_br0',
 ## IMPORTANT ##
 ###############
 ovs_gtp_port_number: 32768
-ovs_uplink_port_name: eth2
+ovs_uplink_port_name: cwag_patch

--- a/cwf/gateway/deploy/roles/cwag/files/create_gre_tunnel.sh
+++ b/cwf/gateway/deploy/roles/cwag/files/create_gre_tunnel.sh
@@ -12,4 +12,3 @@ sudo sysctl net.ipv4.ip_forward=1
 sudo iptables -t mangle -A FORWARD -i cwag_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
 sudo iptables -t mangle -A FORWARD -o cwag_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
 sudo ovs-vsctl --may-exist add-port cwag_br0 gre0 -- set interface gre0 ofport_request=32768 type=gre options:remote_ip=flow options:key=flow
-sudo ovs-vsctl --may-exist add-port cwag_br0 eth2

--- a/cwf/gateway/deploy/roles/cwag/files/setup_default_uplink_bridge.sh
+++ b/cwf/gateway/deploy/roles/cwag/files/setup_default_uplink_bridge.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+sudo ovs-vsctl add-br uplink_br0
+
+sudo ovs-vsctl add-port uplink_br0 uplink_patch
+sudo ovs-vsctl add-port cwag_br0 cwag_patch
+sudo ovs-vsctl set interface uplink_patch type=patch options:peer=cwag_patch
+sudo ovs-vsctl set interface cwag_patch type=patch options:peer=uplink_patch
+
+sudo ovs-vsctl add-bond uplink_br0 uplink_bond eth2 eth3

--- a/cwf/gateway/deploy/roles/cwag/tasks/main.yml
+++ b/cwf/gateway/deploy/roles/cwag/tasks/main.yml
@@ -8,6 +8,10 @@
   become: true
   script: create_gre_tunnel.sh
 
+- name: Create OVS bridge uplink_br0 and add peer patch port to connect it to cwag_br0
+  become: true
+  script: setup_default_uplink_bridge.sh
+
 - name: Enable IP forwarding
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
 

--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -52,6 +52,8 @@ services:
       - /var/run/openvswitch:/var/run/openvswitch
     command: >
       sh -c "/usr/bin/ovs-vsctl --if-exists del-port cwag_br0 gre0 &&
+        /usr/bin/ovs-vsctl --if-exists del-br uplink_br0 &&
+        /usr/bin/ovs-vsctl --if-exists del-port cwag_br0 cwag_patch &&
         /usr/bin/ovs-vsctl --if-exists del-port cwag_br0 eth2 &&
         /usr/bin/ovs-vsctl --may-exist add-port cwag_br0 gre0 -- set interface gre0 ofport_request=32768 type=gre options:remote_ip=192.168.70.102 options:key=5001 &&
         /usr/bin/ovs-vsctl set-controller cwag_br0 tcp:127.0.0.1:6633 &&
@@ -95,4 +97,3 @@ services:
     command: >
       /bin/bash -c "/usr/bin/redis-server /var/opt/magma/redis.conf --daemonize no &&
              /usr/bin/redis-cli shutdown"
-

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -106,4 +106,4 @@ monitored_ifaces: ['cwag_br0',
 ## IMPORTANT ##
 ###############
 ovs_gtp_port_number: 32768
-#ovs_uplink_port_name: eth2
+#ovs_uplink_port_name: cwag_patch


### PR DESCRIPTION
Summary: Adds a default uplink br to the cwag setup. Uses patch ports to connect the cwag_br and uplink_br. Adds a active-backup bond for the 2uplink ports.

Reviewed By: emakeev

Differential Revision: D18248646

