### PR TITLE
longer snmp timeout

### DIFF
--- a/devmand/gateway/src/devmand/Config.cpp
+++ b/devmand/gateway/src/devmand/Config.cpp
@@ -14,7 +14,7 @@ DEFINE_string(
     device_configuration_file,
     "/etc/devmand/devices.yml",
     "Accepts .yml or .mconfig files. Inotify watches the file, and applies necessary changes.");
-DEFINE_uint64(poll_interval, 10, "The polling interval in seconds.");
+DEFINE_uint64(poll_interval, 55, "The polling interval in seconds.");
 DEFINE_uint64(
     debug_print_interval,
     0,

--- a/devmand/gateway/src/devmand/channels/snmp/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/snmp/Engine.cpp
@@ -18,7 +18,8 @@ namespace channels {
 namespace snmp {
 
 // TODO make this configurable
-const constexpr std::chrono::seconds timeoutInterval{15};
+const constexpr std::chrono::seconds timeoutCheckInterval{1};
+const constexpr std::chrono::seconds timeoutInterval{50}; // polling interval 55
 
 Engine::Engine(folly::EventBase& eventBase_, const std::string& appName)
     : channels::Engine("SNMP"), eventBase(eventBase_) {
@@ -26,7 +27,7 @@ Engine::Engine(folly::EventBase& eventBase_, const std::string& appName)
 
   eventBase.runInEventBaseThread([this]() {
     EventBaseUtils::scheduleEvery(
-        eventBase, [this]() { this->timeout(); }, timeoutInterval);
+        eventBase, [this]() { this->timeout(); }, timeoutCheckInterval);
   });
 }
 
@@ -51,7 +52,7 @@ void Engine::sync() {
   int maxfd{0};
   int block{0};
   timeval timeout{};
-  timeout.tv_sec = 5;
+  timeout.tv_sec = timeoutInterval.count();
   timeout.tv_usec = 0;
 
   fd_set fdset{};


### PR DESCRIPTION
Summary:
Increase SNMP timeout to 50 seconds (instead of 5 seconds) and polling interval to 55 seconds instead of 10 seconds.

I increased the SNMP timeout because we were seeing issues with ENS's core switches. They have lots of interfaces and as such the many snmp requests get slowed down a LOT. I created a task to batch our SNMP requests, which will hopefully quicken everything, and we can lower the timeout to a reasonable length.

By making the polling interval 55s, since the UI updates every minute, we should still see an update.

This slows the tests down a bit (the ones that wait for snmp timeouts). We'll address that when this is resolved.

Reviewed By: Mokon

Differential Revision: D18620310

