### PR TITLE
Fix feg policy de/serializer to use the correct type

### DIFF
--- a/lte/cloud/go/services/policydb/streamer/provider.go
+++ b/lte/cloud/go/services/policydb/streamer/provider.go
@@ -153,14 +153,10 @@ func (provider *BaseNamesProvider) GetUpdates(gatewayId string, extraArgs *any.A
 
 	bnProtos := make([]*lteProtos.ChargingRuleBaseNameRecord, 0, len(bnEnts))
 	for _, bn := range bnEnts {
-		bnConfig := bn.Config.(*lteModels.BaseNameRecord)
-		ruleNames := make([]string, 0, len(bn.Associations))
-		for _, assoc := range bn.Associations {
-			ruleNames = append(ruleNames, assoc.Key)
-		}
+		baseNameRecord := (&lteModels.BaseNameRecord{}).FromEntity(bn)
 		bnProto := &lteProtos.ChargingRuleBaseNameRecord{
-			Name:         string(bnConfig.Name),
-			RuleNamesSet: &lteProtos.ChargingRuleNameSet{RuleNames: ruleNames},
+			Name:         string(baseNameRecord.Name),
+			RuleNamesSet: &lteProtos.ChargingRuleNameSet{RuleNames: baseNameRecord.RuleNames},
 		}
 		bnProtos = append(bnProtos, bnProto)
 	}
@@ -170,7 +166,8 @@ func (provider *BaseNamesProvider) GetUpdates(gatewayId string, extraArgs *any.A
 func bnsToUpdates(bns []*lteProtos.ChargingRuleBaseNameRecord) ([]*protos.DataUpdate, error) {
 	ret := make([]*protos.DataUpdate, 0, len(bns))
 	for _, bn := range bns {
-		marshaledBN, err := proto.Marshal(bn)
+		// We only send the rule names set here
+		marshaledBN, err := proto.Marshal(bn.RuleNamesSet)
 		if err != nil {
 			return nil, err
 		}

--- a/lte/cloud/go/services/policydb/streamer/provider_test.go
+++ b/lte/cloud/go/services/policydb/streamer/provider_test.go
@@ -148,7 +148,7 @@ func TestPolicyStreamers(t *testing.T) {
 	expected = funk.Map(
 		expectedBNProtos,
 		func(bn *protos.ChargingRuleBaseNameRecord) *orcprotos.DataUpdate {
-			data, err := proto.Marshal(bn)
+			data, err := proto.Marshal(bn.RuleNamesSet)
 			assert.NoError(t, err)
 			return &orcprotos.DataUpdate{Key: bn.Name, Value: data}
 		},


### PR DESCRIPTION
Summary:
## What was wrong
In `lte/cloud/go/services/policydb/streamer/provider.go`, we stream down a `RedisState` wrapped `lteProtos.ChargingRuleBaseNameRecord`. In the FeG policydb side, we expect `ChargingRuleNameSet`.

## Fix
Since we only need the `ChargingRuleNameSet` keyed by its name on the FeG side, I've modified the provider to send only the name set.

Reviewed By: koolzz

Differential Revision: D18628288

