### PR TITLE
Remove hardcoded timezone avp for now

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -341,8 +341,8 @@ func (gxClient *GxClient) getInitAvps(m *diam.Message, request *CreditControlReq
 			},
 		})
 	}
-	// Argentina TZ (UTC-3hrs) TODO: Make it configurable
-	m.NewAVP(avp.TGPPMSTimeZone, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(string([]byte{0x29, 0})))
+	// Argentina TZ (UTC-3hrs) TODO: Make it so that it takes the FeG's timezone
+	//m.NewAVP(avp.TGPPMSTimeZone, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(string([]byte{0x29, 0})))
 }
 
 // getAdditionalAvps retrieves any extra AVPs based on the type of request.

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -272,8 +272,8 @@ func getServiceInfoAvp(server *diameter.DiameterServerConfig, request *CreditCon
 	psInfoAvps := []*diam.AVP{
 		// Set PDP Type as IPV4(0)
 		diam.NewAVP(avp.TGPPPDPType, avp.Vbit, diameter.Vendor3GPP, datatype.Enumerated(0)),
-		// Argentina TZ (UTC-3hrs) TODO: Make it configurable
-		diam.NewAVP(avp.TGPPMSTimeZone, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(string([]byte{0x29, 0}))),
+		// Argentina TZ (UTC-3hrs) TODO: Make it so that it takes the FeG's timezone
+		// diam.NewAVP(avp.TGPPMSTimeZone, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(string([]byte{0x29, 0}))),
 		// Set RAT Type as EUTRAN(6). See 3GPP TS 29.274, 8.17 "Table 8.17-1: RAT Type values"
 		diam.NewAVP(avp.TGPPRATType, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(ratType)),
 		// Set it to 0


### PR DESCRIPTION
Summary: As a hardcoded, wrong timezone value makes the PCRF/OCS reject the credit controls, I'm removing the AVP for now. I'll put it back in with the FeG timezone once other higher priorities issues are fixed.

Reviewed By: amarpad

Differential Revision: D18638826

