### PR TITLE
Get interface indices via snmpwalk

### DIFF
--- a/devmand/gateway/src/devmand/channels/snmp/IfMib.h
+++ b/devmand/gateway/src/devmand/channels/snmp/IfMib.h
@@ -67,13 +67,6 @@ class IfMib {
       channels::snmp::Channel& channel,
       const std::string& oid,
       const std::function<std::string(std::string)>& formatter = nullptr);
-
- private:
-  static folly::Future<InterfaceIndicies> handleNextInterfaceIndex(
-      channels::snmp::Channel& channel,
-      int numInterfacesRemaining,
-      InterfaceIndicies indicies,
-      channels::snmp::Oid marker);
 };
 
 } // namespace snmp


### PR DESCRIPTION
Summary:
The getNumberOfInterfaces function returns the number of physical and virtual interfaces, wich messes with our logic of reading interface indices. This gets the interface indices by doing an snmpwalk over the mib which has those interfaces.

This is slightly less efficient because walk happens in series instead of parallel, but the next diff in this stack will save the indices so that they're not read repeatedly retrieved, leading to an overall perf gain.

Differential Revision: D18645543

