### PR TITLE
Modify UseGyForAuthOnly case to only send the bare minimum CCR-I

### DIFF
--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -96,6 +96,10 @@ func (srv *CentralSessionController) CreateSession(
 		dynamicRuleDefs = append(dynamicRuleDefs, rule.RuleDefinitions...)
 	}
 
+	if srv.cfg.UseGyForAuthOnly {
+		return srv.handleUseGyForAuthOnly(imsi, request, gxCCAInit)
+	}
+
 	policyRules := getPolicyRulesFromDefinitions(dynamicRuleDefs)
 	keys, err := srv.dbClient.GetChargingKeysForRules(staticRuleNames, policyRules)
 	if err != nil {
@@ -105,7 +109,7 @@ func (srv *CentralSessionController) CreateSession(
 	keys = removeDuplicateChargingKeys(keys)
 	credits := []*protos.CreditUpdateResponse{}
 
-	if len(keys) > 0 || srv.cfg.UseGyForAuthOnly {
+	if len(keys) > 0 {
 		if srv.cfg.InitMethod == gy.PerSessionInit {
 			_, err = srv.sendSingleCreditRequest(getCCRInitRequest(imsi, request))
 			metrics.UpdateGyRecentRequestMetrics(err)
@@ -127,18 +131,6 @@ func (srv *CentralSessionController) CreateSession(
 		}
 		credits = getInitialCreditResponsesFromCCA(gyCCAInit, gyCCRInit)
 
-		if srv.cfg.UseGyForAuthOnly {
-			// For this case we want all Multiple-Services-Credit-Control
-			// diameter code to succeed as well.
-			for _, credit := range credits {
-				if credit.ResultCode != diameter.SuccessCode {
-					err = fmt.Errorf("Received unsuccessful result code from OCS in the MSCC: %v "+
-						"for session: %s, IMSI: %s", credit.ResultCode, request.SessionId, imsi)
-					glog.Errorf("Failed to send second single credit request: %s", err)
-					return nil, err
-				}
-			}
-		}
 		metrics.OcsCcrInitRequests.Inc()
 	}
 
@@ -151,6 +143,33 @@ func (srv *CentralSessionController) CreateSession(
 		StaticRules:   staticRules,
 		DynamicRules:  dynamicRules,
 		UsageMonitors: getUsageMonitorsFromCCA(imsi, sessionID, gxCCAInit),
+	}, nil
+}
+
+func (srv *CentralSessionController) handleUseGyForAuthOnly(
+	imsi string,
+	pReq *protos.CreateSessionRequest,
+	gxCCAInit *gx.CreditControlAnswer,
+) (*protos.CreateSessionResponse, error) {
+	gyCCRInit := getCCRInitRequest(imsi, pReq)
+	_, err := srv.sendSingleCreditRequest(gyCCRInit)
+	metrics.UpdateGyRecentRequestMetrics(err)
+	if err != nil {
+		metrics.OcsCcrInitSendFailures.Inc()
+		glog.Errorf("Failed to send second single credit request: %s", err)
+		return nil, err
+	}
+	metrics.OcsCcrInitRequests.Inc()
+
+	staticRules, dynamicRules := gx.ParseRuleInstallAVPs(
+		srv.dbClient,
+		gxCCAInit.RuleInstallAVP,
+	)
+	usageMonitors := getUsageMonitorsFromCCA(imsi, pReq.SessionId, gxCCAInit)
+	return &protos.CreateSessionResponse{
+		StaticRules:   staticRules,
+		DynamicRules:  dynamicRules,
+		UsageMonitors: usageMonitors,
 	}, nil
 }
 

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -24,7 +24,6 @@ import (
 	orcprotos "magma/orc8r/cloud/go/protos"
 	"magma/orc8r/gateway/mconfig"
 
-	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1099,6 +1098,38 @@ func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 		policydb: &MockPolicyDBClient{},
 	}
 
+	// send static rules back
+	mocks.gx.On("SendCreditControlRequest", mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		done := args.Get(1).(chan interface{})
+		request := args.Get(2).(*gx.CreditControlRequest)
+		activationTime := time.Unix(1, 0)
+		deactivationTime := time.Unix(2, 0)
+		ruleInstalls := []*gx.RuleInstallAVP{
+			&gx.RuleInstallAVP{
+				RuleNames:            []string{"static_rule_1"},
+				RuleActivationTime:   &activationTime,
+				RuleDeactivationTime: &deactivationTime,
+			},
+		}
+
+		done <- &gx.CreditControlAnswer{
+			ResultCode:     uint32(diameter.SuccessCode),
+			SessionID:      request.SessionID,
+			RequestNumber:  request.RequestNumber,
+			RuleInstallAVP: ruleInstalls,
+		}
+	}).Once()
+
+	mocks.policydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+		[]policydb.ChargingKey{{RatingGroup: 3}}, nil).Once()
+
+	mocks.gy.On(
+		"SendCreditControlRequest",
+		mock.Anything,
+		mock.Anything,
+		mock.MatchedBy(getGyCCRMatcher(credit_control.CRTInit)),
+	).Return(nil).Run(returnGySuccessNoRatingGroup).Once()
+
 	cfg := getTestConfig(gy.PerKeyInit)
 	cfg.UseGyForAuthOnly = true
 	srv := servicers.NewCentralSessionController(
@@ -1107,8 +1138,15 @@ func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 		mocks.policydb,
 		cfg,
 	)
-
-	standardUsageTest(t, srv, mocks, gy.PerKeyInit)
+	ctx := context.Background()
+	_, err := srv.CreateSession(ctx, &protos.CreateSessionRequest{
+		Subscriber: &protos.SubscriberID{
+			Id: IMSI1,
+		},
+		SessionId: "00101-1234",
+	})
+	mocks.gx.AssertExpectations(t)
+	assert.NoError(t, err)
 }
 
 func TestSessionControllerUseGyForAuthOnlyNoRatingGroup(t *testing.T) {
@@ -1165,88 +1203,6 @@ func TestSessionControllerUseGyForAuthOnlyNoRatingGroup(t *testing.T) {
 	})
 	mocks.gx.AssertExpectations(t)
 	assert.NoError(t, err)
-}
-
-func TestSessionControllerUseGyForAuthOnlyFail(t *testing.T) {
-	mocks := &sessionMocks{
-		gy:       &MockCreditClient{},
-		gx:       &MockPolicyClient{},
-		policydb: &MockPolicyDBClient{},
-	}
-
-	// Send back DIAMETER_SUCCESS (2001) from gx
-	mocks.gx.On("SendCreditControlRequest", mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		done := args.Get(1).(chan interface{})
-		request := args.Get(2).(*gx.CreditControlRequest)
-
-		activationTime := time.Unix(1, 0)
-		deactivationTime := time.Unix(2, 0)
-		ruleInstalls := []*gx.RuleInstallAVP{
-			&gx.RuleInstallAVP{
-				RuleNames: []string{"static_rule_1"},
-				RuleDefinitions: []*gx.RuleDefinition{
-					&gx.RuleDefinition{
-						RuleName:    "dyn_rule_20",
-						RatingGroup: swag.Uint32(20),
-					},
-				},
-				RuleActivationTime:   &activationTime,
-				RuleDeactivationTime: &deactivationTime,
-			},
-		}
-
-		done <- &gx.CreditControlAnswer{
-			ResultCode:     uint32(diameter.SuccessCode),
-			SessionID:      request.SessionID,
-			RequestNumber:  request.RequestNumber,
-			RuleInstallAVP: ruleInstalls,
-		}
-	}).Once()
-	mocks.policydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
-		[]policydb.ChargingKey{{RatingGroup: 1}, {RatingGroup: 20}}, nil).Once()
-
-	// return success for CCA but Diameter-Rating-Failed for Multiple-Services-Credit-Control
-	mocks.gy.On(
-		"SendCreditControlRequest",
-		mock.Anything,
-		mock.Anything,
-		mock.MatchedBy(getGyCCRMatcher(credit_control.CRTInit)),
-	).Return(nil).Run(returnGyMSCCDiameterRatingFailed).Once()
-
-	cfg := getTestConfig(gy.PerKeyInit)
-	cfg.UseGyForAuthOnly = true
-	srv := servicers.NewCentralSessionController(
-		mocks.gy,
-		mocks.gx,
-		mocks.policydb,
-		cfg,
-	)
-	ctx := context.Background()
-	_, err := srv.CreateSession(ctx, &protos.CreateSessionRequest{
-		Subscriber: &protos.SubscriberID{
-			Id: IMSI1,
-		},
-		SessionId: "00101-1234",
-	})
-	mocks.gx.AssertExpectations(t)
-	assert.Error(t, err)
-}
-
-func returnGyMSCCDiameterRatingFailed(args mock.Arguments) {
-	done := args.Get(1).(chan interface{})
-	request := args.Get(2).(*gy.CreditControlRequest)
-	credits := make([]*gy.ReceivedCredits, 0, len(request.Credits))
-	for _ = range request.Credits {
-		credits = append(credits, &gy.ReceivedCredits{
-			ResultCode: diameter.DiameterRatingFailed,
-		})
-	}
-	done <- &gy.CreditControlAnswer{
-		ResultCode:    uint32(diameter.SuccessCode),
-		SessionID:     request.SessionID,
-		RequestNumber: request.RequestNumber,
-		Credits:       credits,
-	}
 }
 
 func returnGySuccessNoRatingGroup(args mock.Arguments) {


### PR DESCRIPTION
Summary:
When we are using USE_GY_FOR_AUTH_ONLY, we do not care about any rating group that might be returned as part of gx CCA-I. We will always send a gy CCR-I with no MSCC specified.
To simplify the logic, I've created a separate function that deals with this specific case that CreateSession will call.

Differential Revision: D18648956

