### PR TITLE
dont push fp and tp automatically for symphony agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
   southpoll_test:
     machine:
       image: circleci/classic:latest
-      docker_layer_caching: true
+      docker_layer_caching: false
     steps:
       - checkout
       - build/determinator:
@@ -100,7 +100,7 @@ jobs:
 
   southpoll_publish_dev:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
     steps:
       - checkout
       - build/determinator:
@@ -120,7 +120,7 @@ jobs:
 
   southpoll_publish_prod:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
     steps:
       - checkout
       - build/determinator:
@@ -141,7 +141,7 @@ jobs:
 
   southpoll_firstparty:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
     steps:
       - checkout
       - build/determinator:
@@ -161,7 +161,7 @@ jobs:
 
   southpoll_thirdparty:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
     steps:
       - checkout
       - build/determinator:

--- a/devmand/gateway/docker/scripts/push
+++ b/devmand/gateway/docker/scripts/push
@@ -1,6 +1,4 @@
 #!/bin/bash
 set -e
 
-docker push facebookconnectivity-southpoll-dev-docker.jfrog.io/firstparty
-docker push facebookconnectivity-southpoll-dev-docker.jfrog.io/thirdparty
 docker push facebookconnectivity-southpoll-dev-docker.jfrog.io/symphony-agent

--- a/devmand/gateway/docker/scripts/push_all
+++ b/devmand/gateway/docker/scripts/push_all
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+
+docker push facebookconnectivity-southpoll-dev-docker.jfrog.io/firstparty
+docker push facebookconnectivity-southpoll-dev-docker.jfrog.io/thirdparty
+docker push facebookconnectivity-southpoll-dev-docker.jfrog.io/symphony-agent

--- a/devmand/gateway/docker/scripts/push_prod
+++ b/devmand/gateway/docker/scripts/push_prod
@@ -1,6 +1,4 @@
 #!/bin/bash
 set -e
 
-docker push facebookconnectivity-southpoll-prod-docker.jfrog.io/firstparty
-docker push facebookconnectivity-southpoll-prod-docker.jfrog.io/thirdparty
 docker push facebookconnectivity-southpoll-prod-docker.jfrog.io/symphony-agent


### PR DESCRIPTION
Summary:
This commit makes it so fp and tp are not pushed automatically for
symphony agent.

Reviewed By: KenG98

Differential Revision: D18639001

