### PR TITLE
Free sdf_template object from pcc_rule

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -21,7 +21,7 @@
 
 #include "spgw_state.h"
 
-#include <stdlib.h>
+#include <cstdlib>
 
 extern "C" {
 #include "assertions.h"
@@ -97,6 +97,10 @@ void pgw_free_pcc_rule(void** rule)
     if (pcc_rule) {
       if (pcc_rule->name) {
         bdestroy_wrapper(&pcc_rule->name);
+      }
+      auto* sdf_template = (sdf_template_t*) &pcc_rule->sdf_template;
+      if (sdf_template) {
+        free_wrapper((void**) (&pcc_rule->sdf_template));
       }
       free_wrapper(rule);
     }


### PR DESCRIPTION
Summary:
- when converting the proto to pcc_rule and back, there's a memory leak through the pcc_rule hashtables due to sdf_template object not being freed, this fixes it.
- updating `stdlib.h` as its deprecated to cpp version `cstdlib`

Reviewed By: ssanadhya

Differential Revision: D18661312

