### PR TITLE
sessiond will call into captive_portal if relay is disabled

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -82,8 +82,8 @@ add_library(SESSION_MANAGER
     SessionCredit.h
     RuleStore.cpp
     RuleStore.h
-    CloudReporter.cpp
-    CloudReporter.h
+    SessionReporter.cpp
+    SessionReporter.h
     SessionID.cpp
     SessionID.h
     ServiceAction.h

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -51,7 +51,7 @@ static void mark_rule_failures(
   PolicyReAuthAnswer& answer_out);
 
 LocalEnforcer::LocalEnforcer(
-  std::shared_ptr<SessionCloudReporter> reporter,
+  std::shared_ptr<SessionReporter> reporter,
   std::shared_ptr<StaticRuleStore> rule_store,
   std::shared_ptr<PipelinedClient> pipelined_client,
   std::shared_ptr<SpgwServiceClient> spgw_client,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -15,7 +15,7 @@
 #include <folly/io/async/EventBaseManager.h>
 
 #include "AAAClient.h"
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
 #include "SessionState.h"
@@ -37,7 +37,7 @@ class LocalEnforcer {
   LocalEnforcer();
 
   LocalEnforcer(
-    std::shared_ptr<SessionCloudReporter> reporter,
+    std::shared_ptr<SessionReporter> reporter,
     std::shared_ptr<StaticRuleStore> rule_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<SpgwServiceClient> spgw_client,
@@ -150,7 +150,7 @@ class LocalEnforcer {
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
   };
-  std::shared_ptr<SessionCloudReporter> reporter_;
+  std::shared_ptr<SessionReporter> reporter_;
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
   std::shared_ptr<SpgwServiceClient> spgw_client_;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -23,7 +23,7 @@ const std::string LocalSessionManagerHandlerImpl::hex_digit_ =
 
 LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
   LocalEnforcer* enforcer,
-  SessionCloudReporter* reporter):
+  SessionReporter* reporter):
   enforcer_(enforcer),
   reporter_(reporter),
   current_epoch_(0),
@@ -284,7 +284,7 @@ std::string LocalSessionManagerHandlerImpl::convert_mac_addr_to_str(
 }
 
 static void report_termination(
-  SessionCloudReporter& reporter,
+  SessionReporter& reporter,
   const SessionTerminateRequest& term_req)
 {
   reporter.report_terminate_session(

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -14,7 +14,7 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 
 #include "LocalEnforcer.h"
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "SessionID.h"
 
 using grpc::Server;
@@ -32,8 +32,8 @@ class LocalSessionManagerHandler {
    * Report flow stats from pipelined and track the usage per rule
    */
   virtual void ReportRuleStats(
-    ServerContext *context,
-    const RuleRecordTable *request,
+    ServerContext* context,
+    const RuleRecordTable* request,
     std::function<void(Status, Void)> response_callback) = 0;
 
   /**
@@ -64,7 +64,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
  public:
   LocalSessionManagerHandlerImpl(
     LocalEnforcer* monitor,
-    SessionCloudReporter* reporter);
+    SessionReporter* reporter);
 
   ~LocalSessionManagerHandlerImpl() {}
   /**
@@ -94,7 +94,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
 
  private:
   LocalEnforcer* enforcer_;
-  SessionCloudReporter* reporter_;
+  SessionReporter* reporter_;
   SessionIDGenerator id_gen_;
   uint64_t current_epoch_;
   uint64_t reported_epoch_;

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -8,7 +8,9 @@
  */
 #include <iostream>
 #include <glog/logging.h>
-#include "CloudReporter.h"
+#include "ServiceRegistrySingleton.h"
+#include "SessionReporter.h"
+#include "magma_logging.h"
 
 namespace magma {
 
@@ -31,7 +33,7 @@ void AsyncEvbResponse<ResponseType>::handle_response()
   });
 }
 
-SessionCloudReporterImpl::SessionCloudReporterImpl(
+SessionReporterImpl::SessionReporterImpl(
   folly::EventBase *base,
   std::shared_ptr<grpc::Channel> channel):
   base_(base),
@@ -39,7 +41,7 @@ SessionCloudReporterImpl::SessionCloudReporterImpl(
 {
 }
 
-void SessionCloudReporterImpl::report_updates(
+void SessionReporterImpl::report_updates(
   const UpdateSessionRequest &request,
   std::function<void(grpc::Status, UpdateSessionResponse)> callback)
 {
@@ -49,7 +51,7 @@ void SessionCloudReporterImpl::report_updates(
     cloud_response->get_context(), request, &queue_)));
 }
 
-void SessionCloudReporterImpl::report_create_session(
+void SessionReporterImpl::report_create_session(
   const CreateSessionRequest &request,
   std::function<void(grpc::Status, CreateSessionResponse)> callback)
 {
@@ -59,7 +61,7 @@ void SessionCloudReporterImpl::report_create_session(
     cloud_response->get_context(), request, &queue_)));
 }
 
-void SessionCloudReporterImpl::report_terminate_session(
+void SessionReporterImpl::report_terminate_session(
   const SessionTerminateRequest &request,
   std::function<void(grpc::Status, SessionTerminateResponse)> callback)
 {

--- a/lte/gateway/c/session_manager/SessionReporter.h
+++ b/lte/gateway/c/session_manager/SessionReporter.h
@@ -38,33 +38,36 @@ class AsyncEvbResponse : public AsyncGRPCResponse<ResponseType> {
   folly::EventBase *base_;
 };
 
-class SessionCloudReporter : public GRPCReceiver{
+class SessionReporter : public GRPCReceiver {
  public:
   /**
-   * Proxy an UpdateSessionRequest gRPC call to the cloud
+   * Either proxy an UpdateSessionRequest gRPC call to the cloud
+   * or send the request to the local PCRF/OCS on the gateway
    */
   virtual void report_updates(
     const UpdateSessionRequest &request,
     std::function<void(grpc::Status, UpdateSessionResponse)> callback) = 0;
 
   /**
-   * Proxy a CreateSessionRequest gRPC call to the cloud
+   * Either proxy a CreateSessionRequest gRPC call to the cloud
+   * or send the request to the local PCRF/OCS on the gateway
    */
   virtual void report_create_session(
     const CreateSessionRequest &request,
     std::function<void(grpc::Status, CreateSessionResponse)> callback) = 0;
 
   /**
-   * Proxy a SessionTerminateRequest gRPC call to the cloud
+   * Either proxy a SessionTerminateRequest gRPC call to the cloud
+   * or send the request to the local PCRF/OCS on the gateway
    */
   virtual void report_terminate_session(
     const SessionTerminateRequest &request,
     std::function<void(grpc::Status, SessionTerminateResponse)> callback) = 0;
 };
 
-class SessionCloudReporterImpl : public SessionCloudReporter {
+class SessionReporterImpl : public SessionReporter {
  public:
-  SessionCloudReporterImpl(
+  SessionReporterImpl(
     folly::EventBase *base,
     std::shared_ptr<grpc::Channel> channel);
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -18,7 +18,7 @@
 
 #include <folly/io/async/EventBase.h>
 
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "LocalSessionManagerHandler.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
@@ -164,7 +164,7 @@ class MockSessionHandler final : public LocalSessionManagerHandler {
       std::function<void(Status, LocalEndSessionResponse)>));
 };
 
-class MockSessionCloudReporter : public SessionCloudReporter {
+class MockSessionReporter : public SessionReporter {
   public:
     MOCK_METHOD2(
       report_updates,

--- a/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
@@ -14,7 +14,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "ServiceRegistrySingleton.h"
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "MagmaService.h"
 #include "SessiondMocks.h"
 
@@ -24,7 +24,7 @@ using ::testing::Test;
 
 namespace magma {
 
-class CloudReporterTest : public ::testing::Test {
+class SessionReporterTest : public ::testing::Test {
  protected:
   /**
    * Create magma service and run in separate thread
@@ -38,7 +38,7 @@ class CloudReporterTest : public ::testing::Test {
     mock_cloud = std::make_shared<MockCentralController>();
     magma_service->AddServiceToServer(mock_cloud.get());
 
-    reporter = std::make_shared<SessionCloudReporterImpl>(&evb, channel);
+    reporter = std::make_shared<SessionReporterImpl>(&evb, channel);
 
     std::thread reporter_thread([&]() {
       std::cout << "Started reporter thread\n";
@@ -78,7 +78,7 @@ class CloudReporterTest : public ::testing::Test {
  protected:
   std::shared_ptr<service303::MagmaService> magma_service;
   std::shared_ptr<MockCentralController> mock_cloud;
-  std::shared_ptr<SessionCloudReporter> reporter;
+  std::shared_ptr<SessionReporter> reporter;
   folly::EventBase evb;
   MockCallback mock_callback;
 };
@@ -89,7 +89,7 @@ MATCHER_P(CheckCreateResponseRuleSize, size, "")
 }
 
 // Test requests on single thread
-TEST_F(CloudReporterTest, test_single_call)
+TEST_F(SessionReporterTest, test_single_call)
 {
   EXPECT_CALL(mock_callback, create_callback(_, CheckCreateResponseRuleSize(1)))
     .Times(1);
@@ -114,7 +114,7 @@ TEST_F(CloudReporterTest, test_single_call)
 }
 
 // Test multiple calls at the same time, wait for all to finish
-TEST_F(CloudReporterTest, test_multi_call)
+TEST_F(SessionReporterTest, test_multi_call)
 {
   EXPECT_CALL(mock_callback, create_callback(_, _)).Times(2);
   EXPECT_CALL(mock_callback, update_callback(_, _)).Times(1);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -39,7 +39,7 @@ class LocalEnforcerTest : public ::testing::Test {
  protected:
   virtual void SetUp()
   {
-    reporter = std::make_shared<MockSessionCloudReporter>();
+    reporter = std::make_shared<MockSessionReporter>();
     rule_store = std::make_shared<StaticRuleStore>();
     pipelined_client = std::make_shared<MockPipelinedClient>();
     spgw_client = std::make_shared<MockSpgwServiceClient>();
@@ -107,7 +107,7 @@ class LocalEnforcerTest : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<MockSessionCloudReporter> reporter;
+  std::shared_ptr<MockSessionReporter> reporter;
   std::shared_ptr<StaticRuleStore> rule_store;
   std::unique_ptr<LocalEnforcer> local_enforcer;
   std::shared_ptr<MockPipelinedClient> pipelined_client;

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -30,7 +30,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
   protected:
   protected:
     virtual void SetUp() {
-        reporter = std::make_shared<MockSessionCloudReporter>();
+        reporter = std::make_shared<MockSessionReporter>();
         auto rule_store = std::make_shared<StaticRuleStore>();
         auto pipelined_client = std::make_shared<MockPipelinedClient>();
         auto spgw_client = std::make_shared<MockSpgwServiceClient>();
@@ -50,7 +50,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
 
   protected:
     std::shared_ptr<LocalSessionManagerHandlerImpl> session_manager;
-    std::shared_ptr<MockSessionCloudReporter> reporter;
+    std::shared_ptr<MockSessionReporter> reporter;
     std::shared_ptr <LocalEnforcer> local_enforcer;
     SessionIDGenerator id_gen_;
     folly::EventBase *evb;

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "MagmaService.h"
 #include "ProtobufCreators.h"
 #include "ServiceRegistrySingleton.h"
@@ -52,7 +52,7 @@ class SessiondTest : public ::testing::Test {
     insert_static_rule(rule_store, 1, "rule2");
     insert_static_rule(rule_store, 2, "rule3");
 
-    reporter = std::make_shared<SessionCloudReporterImpl>(evb, test_channel);
+    reporter = std::make_shared<SessionReporterImpl>(evb, test_channel);
     monitor = std::make_shared<LocalEnforcer>(
       reporter,
       rule_store,
@@ -144,7 +144,7 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<MockCentralController> controller_mock;
   std::shared_ptr<MockPipelined> pipelined_mock;
   std::shared_ptr<LocalEnforcer> monitor;
-  std::shared_ptr<SessionCloudReporterImpl> reporter;
+  std::shared_ptr<SessionReporterImpl> reporter;
   std::shared_ptr<LocalSessionManagerAsyncService> session_manager;
   std::shared_ptr<SessionProxyResponderAsyncService> proxy_responder;
   std::shared_ptr<service303::MagmaService> local_service;

--- a/lte/gateway/configs/captive_portal.yml
+++ b/lte/gateway/configs/captive_portal.yml
@@ -8,9 +8,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 log_level: INFO
 
-# If disabled, allows all traffic from the subscribers
-captive_portal_enabled: True
-
 # Captive Portal URL to redirect the subscribers
 # If the portal is running locally, use DNSd to resolve the host to
 # 192.168.128.1
@@ -26,11 +23,6 @@ subscriber_profile_substr_match: ''
 bridge_interface: gtp_br0
 
 # Static rule name for captive_portal redirect
-redirect_rule_name: redirect
-
-# Specifies an {ip -> [ports]} map to allow traffic
-# NOTE: Right not we only support TCP traffic for the ports
-whitelisted_ips:
-  local: [80, 443]
-  # 'local' is the same as using:
-  # 192.168.128.1: [80, 443]
+# To disable, leave empty
+# If disabled, allows all traffic from the subscribers
+redirect_rule_name:

--- a/lte/gateway/python/magma/captive_portal/rpc_servicer.py
+++ b/lte/gateway/python/magma/captive_portal/rpc_servicer.py
@@ -7,10 +7,7 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 import logging
-from datetime import datetime
 from typing import Any, Dict, List
-from lte.protos.policydb_pb2 import PolicyRule, FlowMatch, FlowDescription, \
-    FlowQos, QosArp
 from lte.protos.session_manager_pb2 import CreateSessionRequest, \
     CreateSessionResponse, UpdateSessionRequest, SessionTerminateResponse, \
     UpdateSessionResponse, DynamicRuleInstall, StaticRuleInstall, \
@@ -18,6 +15,7 @@ from lte.protos.session_manager_pb2 import CreateSessionRequest, \
 from lte.protos.session_manager_pb2_grpc import \
     CentralSessionControllerServicer, \
     add_CentralSessionControllerServicer_to_server
+from magma.policydb.rule_store import PolicyRuleDict
 
 
 class SessionRpcServicer(CentralSessionControllerServicer):
@@ -31,6 +29,7 @@ class SessionRpcServicer(CentralSessionControllerServicer):
 
     def __init__(self, service_config):
         self._config = service_config
+        self._rules = PolicyRuleDict()
 
     @property
     def config(self) -> Dict[str, Any]:
@@ -67,21 +66,24 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         logging.info('Creating a session for subscriber ID: %s',
                      request.subscriber.id)
         return CreateSessionResponse(
-            credits=[self._get_credit_update_response(request.imsi_plmn_id)],
-            static_rules=[self._get_static_rule()],
-            dynamic_rules=self._get_whitelist_rules(),
+            credits=[],
+            static_rules=self._get_static_rules(),
+            dynamic_rules=[],
         )
 
     def UpdateSession(
-            self,
-            request: UpdateSessionRequest,
-            context,
+        self,
+        request: UpdateSessionRequest,
+        context,
     ) -> UpdateSessionResponse:
         """
         On UpdateSession, return an arbitrarily large amount of additional
         credit for the session.
+
+        NOTE: This really shouldn't be called, as no credit should have been
+        granted on CreateSession.
         """
-        logging.debug('Updating sessions')
+        logging.info('UpdateSession called')
         resp = UpdateSessionResponse()
         for credit_usage_update in request.updates:
             resp.responses.extend(
@@ -90,9 +92,9 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         return resp
 
     def TerminateSession(
-            self,
-            request: SessionTerminateResponse,
-            context,
+        self,
+        request: SessionTerminateResponse,
+        context,
     ) -> SessionTerminateResponse:
         logging.info('Terminating a session for session ID: %s',
                      request.session_id)
@@ -101,116 +103,11 @@ class SessionRpcServicer(CentralSessionControllerServicer):
             session_id=request.session_id,
         )
 
-    def _get_whitelist_rules(self) -> List[DynamicRuleInstall]:
-        """
-        Get a list of dynamic rules to install for whitelisting.
-        These rules will whitelist traffic to/from the captive portal server.
-        """
-        dynamic_rules = []
-        for ip, ports in self.ip_whitelist.items():
-            if ip == 'local':
-                ip = '192.168.128.1'
-            for port in ports:
-                # Build the rule id to be globally unique
-                rule_id_info = {
-                    'ip': ip,
-                    'port': port,
-                }
-                rule_id = "whitelist_policy_id-{ip}:{port}"\
-                    .format(**rule_id_info)
-
-                rule = DynamicRuleInstall(
-                    policy_rule=self._get_whitelist_policy_rule(
-                        rule_id, ip, port
-                    ),
-                )
-                # Activate now, and deactivate long in the future
-                t2 = datetime.now()
-                t2 = t2.replace(year=t2.year + 1)
-                rule.activation_time.FromDatetime(datetime.now())
-                rule.deactivation_time.FromDatetime(t2)
-                dynamic_rules.append(rule)
-        return dynamic_rules
-
-    def _get_whitelist_policy_rule(
-        self,
-        policy_id: str,
-        ip: str,
-        port: int,
-    ) -> PolicyRule:
-        return PolicyRule(
-            # Don't set the rating group
-            # Don't set the monitoring key
-            # Don't set the hard timeout
-            id=policy_id,
-            priority=100,
-            qos=self._get_default_qos(),
-            flow_list=self._get_whitelist_flows(ip, port),
-            tracking_type=PolicyRule.TrackingType.Value("NO_TRACKING"),
-        )
-
-    def _get_whitelist_flows(self, ip: str, port: int) -> List[FlowDescription]:
-        """
-        Args:
-            ip: IP address to allow traffic to. This should be the captive
-                portal address
-            port:  Port of the captive portal server. Probably 80.
-
-        Returns:
-            Two flows, one for traffic towards the captive portal server, and a
-            second for traffic from the captive portal server.
-        """
-        return [
-            # Set flow match for outgoing TCP packets to whitelisted IP
-            # Don't set the app_name field
-            FlowDescription(  # uplink flow
-                match=FlowMatch(
-                    ipv4_dst=ip,
-                    tcp_dst=port,
-                    ip_proto=FlowMatch.IPProto.Value("IPPROTO_TCP"),
-                    direction=FlowMatch.Direction.Value("UPLINK"),
-                ),
-                action=FlowDescription.Action.Value("PERMIT"),
-            ),
-            # Set flow match for incoming TCP packets from whitelisted IP
-            # Don't set the app_name field
-            FlowDescription(  # downlink flow
-                match=FlowMatch(
-                    ipv4_src=ip,
-                    tcp_src=port,
-                    ip_proto=FlowMatch.IPProto.Value("IPPROTO_TCP"),
-                    direction=FlowMatch.Direction.Value("DOWNLINK"),
-                ),
-                action=FlowDescription.Action.Value("PERMIT"),
-            ),
-        ]
-
-    def _get_default_qos(self) -> FlowQos:
-        """
-        Get a default QoS, usable for an allow-all flow, and for redirection to
-        a captive_portal.
-        """
-        return FlowQos(
-            max_req_bw_ul=2 * 1024 * 1024 * 1024,  # 2G
-            max_req_bw_dl=2 * 1024 * 1024 * 1024,  # 2G
-            gbr_ul=1 * 1024 * 1024,  # 1 Mb/s
-            gbr_dl=1 * 1024 * 1024,  # 1 Mb/s
-            qci=FlowQos.Qci.Value('QCI_3'),
-            # Allocation and Retention Policy
-            # Set to high priority, and disallow pre-emption
-            # capability/vulnerability
-            arp=QosArp(
-                priority_level=1,
-                pre_capability=QosArp.PreCap.Value("PRE_CAP_DISABLED"),
-                pre_vulnerability=QosArp.PreVul.Value("PRE_VUL_DISABLED"),
-            ),
-        )
-
-    def _get_static_rule(self) -> StaticRuleInstall:
+    def _get_static_rules(self) -> List[StaticRuleInstall]:
         """ Return a static rule for redirection to captive portal """
-        return StaticRuleInstall(
-            rule_id = self.redirect_rule_name,
-        )
+        if self.redirect_rule_name in self._rules:
+            return [StaticRuleInstall(rule_id=self.redirect_rule_name)]
+        return []
 
     def _get_credit_update_response(
         self,

--- a/lte/gateway/python/scripts/captive_portal_cli.py
+++ b/lte/gateway/python/scripts/captive_portal_cli.py
@@ -19,22 +19,22 @@ from lte.protos.session_manager_pb2_grpc import CentralSessionControllerStub
 @grpc_wrapper
 def create_session(client, args):
     message = CreateSessionRequest()
-    client.CreateSession(message)
-    print('Successfully got a response from CreateSession')
+    resp = client.CreateSession(message)
+    print('Successfully got a response from CreateSession:\n', resp)
 
 
 @grpc_wrapper
 def update_session(client, args):
     message = UpdateSessionRequest()
-    client.UpdateSession(message)
-    print('Successfully got a response from UpdateSession')
+    resp = client.UpdateSession(message)
+    print('Successfully got a response from UpdateSession:\n', resp)
 
 
 @grpc_wrapper
 def terminate_session(client, args):
     message = SessionTerminateRequest()
-    client.TerminateSession(message)
-    print('Successfully got a response from TerminateSession')
+    resp = client.TerminateSession(message)
+    print('Successfully got a response from TerminateSession:\n', resp)
 
 
 def create_parser():


### PR DESCRIPTION
Summary:
## What's Changed
- CloudSessionReporter renamed to SessionReporter to denote that it can be either used to report session changes through FeG, or to the local PCRF/OCS
- Based on whether relay is enabled/disabled, sessiond will report session changes to either FeG or captive_portal using a local channel

Reviewed By: xjtian

Differential Revision: D18073209

