### PR TITLE
Always call to sessiond LocalSessionManager regardless of whether relay is enabled

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -236,9 +236,7 @@ int pgw_handle_create_bearer_request(
       bearer_req_p->context_teid);
     sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_CONTEXT_NOT_FOUND;
   }
-  if (
-    spgw_config.pgw_config.relay_enabled &&
-    sgi_create_endpoint_resp.status == SGI_STATUS_OK) {
+  if (sgi_create_endpoint_resp.status == SGI_STATUS_OK) {
     // create session in PCEF and return
     char ip_str[INET_ADDRSTRLEN];
     inet_ntop(AF_INET, &(inaddr.s_addr), ip_str, INET_ADDRSTRLEN);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1309,12 +1309,9 @@ int sgw_handle_delete_session_request(
       delete_session_resp_p->teid =
         ctx_p->sgw_eps_bearer_context_information.mme_teid_S11;
 
-      if (spgw_config.pgw_config.relay_enabled) {
-        // TODO make async
-        char *imsi =
-          (char *) ctx_p->sgw_eps_bearer_context_information.imsi.digit;
-        pcef_end_session(imsi);
-      }
+      // TODO make async
+      char* imsi = (char*) ctx_p->sgw_eps_bearer_context_information.imsi.digit;
+      pcef_end_session(imsi);
 
       itti_sgi_delete_end_point_request_t sgi_delete_end_point_request;
       sgw_eps_bearer_ctxt_t *eps_bearer_ctxt_p = NULL;

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -82,8 +82,8 @@ add_library(SESSION_MANAGER
     SessionCredit.h
     RuleStore.cpp
     RuleStore.h
-    CloudReporter.cpp
-    CloudReporter.h
+    SessionReporter.cpp
+    SessionReporter.h
     SessionID.cpp
     SessionID.h
     ServiceAction.h

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -51,7 +51,7 @@ static void mark_rule_failures(
   PolicyReAuthAnswer& answer_out);
 
 LocalEnforcer::LocalEnforcer(
-  std::shared_ptr<SessionCloudReporter> reporter,
+  std::shared_ptr<SessionReporter> reporter,
   std::shared_ptr<StaticRuleStore> rule_store,
   std::shared_ptr<PipelinedClient> pipelined_client,
   std::shared_ptr<SpgwServiceClient> spgw_client,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -15,7 +15,7 @@
 #include <folly/io/async/EventBaseManager.h>
 
 #include "AAAClient.h"
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
 #include "SessionState.h"
@@ -37,7 +37,7 @@ class LocalEnforcer {
   LocalEnforcer();
 
   LocalEnforcer(
-    std::shared_ptr<SessionCloudReporter> reporter,
+    std::shared_ptr<SessionReporter> reporter,
     std::shared_ptr<StaticRuleStore> rule_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<SpgwServiceClient> spgw_client,
@@ -150,7 +150,7 @@ class LocalEnforcer {
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
   };
-  std::shared_ptr<SessionCloudReporter> reporter_;
+  std::shared_ptr<SessionReporter> reporter_;
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
   std::shared_ptr<SpgwServiceClient> spgw_client_;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -78,8 +78,8 @@ const std::string LocalSessionManagerHandlerImpl::hex_digit_ =
         "0123456789abcdef";
 
 LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
-  LocalEnforcer* enforcer,
-  SessionCloudReporter* reporter):
+  LocalEnforcer *enforcer,
+  SessionReporter *reporter):
   enforcer_(enforcer),
   reporter_(reporter),
   current_epoch_(0),
@@ -340,8 +340,8 @@ std::string LocalSessionManagerHandlerImpl::convert_mac_addr_to_str(
 }
 
 static void report_termination(
-  SessionCloudReporter& reporter,
-  const SessionTerminateRequest& term_req)
+  SessionReporter &reporter,
+  const SessionTerminateRequest &term_req)
 {
   reporter.report_terminate_session(
     term_req,

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -15,7 +15,7 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 
 #include "LocalEnforcer.h"
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "SessionID.h"
 
 using grpc::Server;
@@ -102,8 +102,8 @@ class LocalSessionManagerStub : public LocalSessionManagerHandler {
 class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
  public:
   LocalSessionManagerHandlerImpl(
-    LocalEnforcer* monitor,
-    SessionCloudReporter* reporter);
+    LocalEnforcer *monitor,
+    SessionReporter *reporter);
 
   ~LocalSessionManagerHandlerImpl() {}
   /**
@@ -132,8 +132,8 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
     std::function<void(Status, LocalEndSessionResponse)> response_callback);
 
  private:
-  LocalEnforcer* enforcer_;
-  SessionCloudReporter* reporter_;
+  LocalEnforcer *enforcer_;
+  SessionReporter *reporter_;
   SessionIDGenerator id_gen_;
   uint64_t current_epoch_;
   uint64_t reported_epoch_;

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -8,7 +8,9 @@
  */
 #include <iostream>
 #include <glog/logging.h>
-#include "CloudReporter.h"
+#include "ServiceRegistrySingleton.h"
+#include "SessionReporter.h"
+#include "magma_logging.h"
 
 namespace magma {
 
@@ -31,7 +33,7 @@ void AsyncEvbResponse<ResponseType>::handle_response()
   });
 }
 
-SessionCloudReporterImpl::SessionCloudReporterImpl(
+SessionReporterImpl::SessionReporterImpl(
   folly::EventBase *base,
   std::shared_ptr<grpc::Channel> channel):
   base_(base),
@@ -39,7 +41,7 @@ SessionCloudReporterImpl::SessionCloudReporterImpl(
 {
 }
 
-void SessionCloudReporterImpl::report_updates(
+void SessionReporterImpl::report_updates(
   const UpdateSessionRequest &request,
   std::function<void(grpc::Status, UpdateSessionResponse)> callback)
 {
@@ -49,7 +51,7 @@ void SessionCloudReporterImpl::report_updates(
     cloud_response->get_context(), request, &queue_)));
 }
 
-void SessionCloudReporterImpl::report_create_session(
+void SessionReporterImpl::report_create_session(
   const CreateSessionRequest &request,
   std::function<void(grpc::Status, CreateSessionResponse)> callback)
 {
@@ -59,7 +61,7 @@ void SessionCloudReporterImpl::report_create_session(
     cloud_response->get_context(), request, &queue_)));
 }
 
-void SessionCloudReporterImpl::report_terminate_session(
+void SessionReporterImpl::report_terminate_session(
   const SessionTerminateRequest &request,
   std::function<void(grpc::Status, SessionTerminateResponse)> callback)
 {

--- a/lte/gateway/c/session_manager/SessionReporter.h
+++ b/lte/gateway/c/session_manager/SessionReporter.h
@@ -38,7 +38,7 @@ class AsyncEvbResponse : public AsyncGRPCResponse<ResponseType> {
   folly::EventBase *base_;
 };
 
-class SessionCloudReporter : public GRPCReceiver{
+class SessionReporter : public GRPCReceiver {
  public:
   /**
    * Proxy an UpdateSessionRequest gRPC call to the cloud
@@ -62,9 +62,9 @@ class SessionCloudReporter : public GRPCReceiver{
     std::function<void(grpc::Status, SessionTerminateResponse)> callback) = 0;
 };
 
-class SessionCloudReporterImpl : public SessionCloudReporter {
+class SessionReporterImpl : public SessionReporter {
  public:
-  SessionCloudReporterImpl(
+  SessionReporterImpl(
     folly::EventBase *base,
     std::shared_ptr<grpc::Channel> channel);
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -18,7 +18,7 @@
 
 #include <folly/io/async/EventBase.h>
 
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "LocalSessionManagerHandler.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
@@ -164,7 +164,7 @@ class MockSessionHandler final : public LocalSessionManagerHandler {
       std::function<void(Status, LocalEndSessionResponse)>));
 };
 
-class MockSessionCloudReporter : public SessionCloudReporter {
+class MockSessionReporter : public SessionReporter {
   public:
     MOCK_METHOD2(
       report_updates,

--- a/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
@@ -14,7 +14,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 #include "ServiceRegistrySingleton.h"
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "MagmaService.h"
 #include "SessiondMocks.h"
 
@@ -24,7 +24,7 @@ using ::testing::Test;
 
 namespace magma {
 
-class CloudReporterTest : public ::testing::Test {
+class SessionReporterTest : public ::testing::Test {
  protected:
   /**
    * Create magma service and run in separate thread
@@ -38,7 +38,7 @@ class CloudReporterTest : public ::testing::Test {
     mock_cloud = std::make_shared<MockCentralController>();
     magma_service->AddServiceToServer(mock_cloud.get());
 
-    reporter = std::make_shared<SessionCloudReporterImpl>(&evb, channel);
+    reporter = std::make_shared<SessionReporterImpl>(&evb, channel);
 
     std::thread reporter_thread([&]() {
       std::cout << "Started reporter thread\n";
@@ -78,7 +78,7 @@ class CloudReporterTest : public ::testing::Test {
  protected:
   std::shared_ptr<service303::MagmaService> magma_service;
   std::shared_ptr<MockCentralController> mock_cloud;
-  std::shared_ptr<SessionCloudReporter> reporter;
+  std::shared_ptr<SessionReporter> reporter;
   folly::EventBase evb;
   MockCallback mock_callback;
 };
@@ -89,7 +89,7 @@ MATCHER_P(CheckCreateResponseRuleSize, size, "")
 }
 
 // Test requests on single thread
-TEST_F(CloudReporterTest, test_single_call)
+TEST_F(SessionReporterTest, test_single_call)
 {
   EXPECT_CALL(mock_callback, create_callback(_, CheckCreateResponseRuleSize(1)))
     .Times(1);
@@ -114,7 +114,7 @@ TEST_F(CloudReporterTest, test_single_call)
 }
 
 // Test multiple calls at the same time, wait for all to finish
-TEST_F(CloudReporterTest, test_multi_call)
+TEST_F(SessionReporterTest, test_multi_call)
 {
   EXPECT_CALL(mock_callback, create_callback(_, _)).Times(2);
   EXPECT_CALL(mock_callback, update_callback(_, _)).Times(1);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -39,7 +39,7 @@ class LocalEnforcerTest : public ::testing::Test {
  protected:
   virtual void SetUp()
   {
-    reporter = std::make_shared<MockSessionCloudReporter>();
+    reporter = std::make_shared<MockSessionReporter>();
     rule_store = std::make_shared<StaticRuleStore>();
     pipelined_client = std::make_shared<MockPipelinedClient>();
     spgw_client = std::make_shared<MockSpgwServiceClient>();
@@ -107,7 +107,7 @@ class LocalEnforcerTest : public ::testing::Test {
   }
 
  protected:
-  std::shared_ptr<MockSessionCloudReporter> reporter;
+  std::shared_ptr<MockSessionReporter> reporter;
   std::shared_ptr<StaticRuleStore> rule_store;
   std::unique_ptr<LocalEnforcer> local_enforcer;
   std::shared_ptr<MockPipelinedClient> pipelined_client;

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -30,7 +30,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
   protected:
   protected:
     virtual void SetUp() {
-        reporter = std::make_shared<MockSessionCloudReporter>();
+        reporter = std::make_shared<MockSessionReporter>();
         auto rule_store = std::make_shared<StaticRuleStore>();
         auto pipelined_client = std::make_shared<MockPipelinedClient>();
         auto spgw_client = std::make_shared<MockSpgwServiceClient>();
@@ -50,7 +50,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
 
   protected:
     std::shared_ptr<LocalSessionManagerHandlerImpl> session_manager;
-    std::shared_ptr<MockSessionCloudReporter> reporter;
+    std::shared_ptr<MockSessionReporter> reporter;
     std::shared_ptr <LocalEnforcer> local_enforcer;
     SessionIDGenerator id_gen_;
     folly::EventBase *evb;

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -16,7 +16,7 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
-#include "CloudReporter.h"
+#include "SessionReporter.h"
 #include "MagmaService.h"
 #include "ProtobufCreators.h"
 #include "ServiceRegistrySingleton.h"
@@ -52,7 +52,7 @@ class SessiondTest : public ::testing::Test {
     insert_static_rule(rule_store, 1, "rule2");
     insert_static_rule(rule_store, 2, "rule3");
 
-    reporter = std::make_shared<SessionCloudReporterImpl>(evb, test_channel);
+    reporter = std::make_shared<SessionReporterImpl>(evb, test_channel);
     monitor = std::make_shared<LocalEnforcer>(
       reporter,
       rule_store,
@@ -144,7 +144,7 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<MockCentralController> controller_mock;
   std::shared_ptr<MockPipelined> pipelined_mock;
   std::shared_ptr<LocalEnforcer> monitor;
-  std::shared_ptr<SessionCloudReporterImpl> reporter;
+  std::shared_ptr<SessionReporterImpl> reporter;
   std::shared_ptr<LocalSessionManagerAsyncService> session_manager;
   std::shared_ptr<SessionProxyResponderAsyncService> proxy_responder;
   std::shared_ptr<service303::MagmaService> local_service;

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -33,3 +33,7 @@ session_force_termination_timeout_ms: 5000
 
 # Set to true to enable sessiond support of carrier wifi
 support_carrier_wifi: false
+
+# If enabled, will use the local CentralSessionManager running in captive_portal
+# when relay is not enabled.
+captive_portal_enabled: false


### PR DESCRIPTION
Summary:
# What's Changed
- `mme` makes a CreateSession call to `sessiond` regardless of whether relay is enabled
- `mme` makes an EndSession call to `sessiond` regardless of whether relay is enabled

# Upcoming
- In the process of having a local PCRF and OCS

NOTE: `mme` is still checking whether relay is enabled to determine whether it talks to HSS through the FeG, or if it talks to subscriberdb

Reviewed By: xjtian

Differential Revision: D18496389

