### PR TITLE
CentralSessionController will not return credits for CreateSession

### DIFF
--- a/lte/gateway/configs/captive_portal.yml
+++ b/lte/gateway/configs/captive_portal.yml
@@ -8,9 +8,6 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 log_level: INFO
 
-# If disabled, allows all traffic from the subscribers
-captive_portal_enabled: True
-
 # Captive Portal URL to redirect the subscribers
 # If the portal is running locally, use DNSd to resolve the host to
 # 192.168.128.1
@@ -26,11 +23,6 @@ subscriber_profile_substr_match: ''
 bridge_interface: gtp_br0
 
 # Static rule name for captive_portal redirect
-redirect_rule_name: redirect
-
-# Specifies an {ip -> [ports]} map to allow traffic
-# NOTE: Right not we only support TCP traffic for the ports
-whitelisted_ips:
-  local: [80, 443]
-  # 'local' is the same as using:
-  # 192.168.128.1: [80, 443]
+# To disable, leave empty
+# If disabled, allows all traffic from the subscribers
+redirect_rule_name:

--- a/lte/gateway/python/magma/captive_portal/rpc_servicer.py
+++ b/lte/gateway/python/magma/captive_portal/rpc_servicer.py
@@ -7,10 +7,7 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 import logging
-from datetime import datetime
 from typing import Any, Dict, List
-from lte.protos.policydb_pb2 import PolicyRule, FlowMatch, FlowDescription, \
-    FlowQos, QosArp
 from lte.protos.session_manager_pb2 import CreateSessionRequest, \
     CreateSessionResponse, UpdateSessionRequest, SessionTerminateResponse, \
     UpdateSessionResponse, DynamicRuleInstall, StaticRuleInstall, \
@@ -18,6 +15,7 @@ from lte.protos.session_manager_pb2 import CreateSessionRequest, \
 from lte.protos.session_manager_pb2_grpc import \
     CentralSessionControllerServicer, \
     add_CentralSessionControllerServicer_to_server
+from magma.policydb.rule_store import PolicyRuleDict
 
 
 class SessionRpcServicer(CentralSessionControllerServicer):
@@ -31,6 +29,7 @@ class SessionRpcServicer(CentralSessionControllerServicer):
 
     def __init__(self, service_config):
         self._config = service_config
+        self._rules = PolicyRuleDict()
 
     @property
     def config(self) -> Dict[str, Any]:
@@ -67,21 +66,24 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         logging.info('Creating a session for subscriber ID: %s',
                      request.subscriber.id)
         return CreateSessionResponse(
-            credits=[self._get_credit_update_response(request.imsi_plmn_id)],
-            static_rules=[self._get_static_rule()],
-            dynamic_rules=self._get_whitelist_rules(),
+            credits=[],
+            static_rules=self._get_static_rules(),
+            dynamic_rules=[],
         )
 
     def UpdateSession(
-            self,
-            request: UpdateSessionRequest,
-            context,
+        self,
+        request: UpdateSessionRequest,
+        context,
     ) -> UpdateSessionResponse:
         """
         On UpdateSession, return an arbitrarily large amount of additional
         credit for the session.
+
+        NOTE: This really shouldn't be called, as no credit should have been
+        granted on CreateSession.
         """
-        logging.debug('Updating sessions')
+        logging.info('UpdateSession called')
         resp = UpdateSessionResponse()
         for credit_usage_update in request.updates:
             resp.responses.extend(
@@ -90,9 +92,9 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         return resp
 
     def TerminateSession(
-            self,
-            request: SessionTerminateResponse,
-            context,
+        self,
+        request: SessionTerminateResponse,
+        context,
     ) -> SessionTerminateResponse:
         logging.info('Terminating a session for session ID: %s',
                      request.session_id)
@@ -101,116 +103,11 @@ class SessionRpcServicer(CentralSessionControllerServicer):
             session_id=request.session_id,
         )
 
-    def _get_whitelist_rules(self) -> List[DynamicRuleInstall]:
-        """
-        Get a list of dynamic rules to install for whitelisting.
-        These rules will whitelist traffic to/from the captive portal server.
-        """
-        dynamic_rules = []
-        for ip, ports in self.ip_whitelist.items():
-            if ip == 'local':
-                ip = '192.168.128.1'
-            for port in ports:
-                # Build the rule id to be globally unique
-                rule_id_info = {
-                    'ip': ip,
-                    'port': port,
-                }
-                rule_id = "whitelist_policy_id-{ip}:{port}"\
-                    .format(**rule_id_info)
-
-                rule = DynamicRuleInstall(
-                    policy_rule=self._get_whitelist_policy_rule(
-                        rule_id, ip, port
-                    ),
-                )
-                # Activate now, and deactivate long in the future
-                t2 = datetime.now()
-                t2 = t2.replace(year=t2.year + 1)
-                rule.activation_time.FromDatetime(datetime.now())
-                rule.deactivation_time.FromDatetime(t2)
-                dynamic_rules.append(rule)
-        return dynamic_rules
-
-    def _get_whitelist_policy_rule(
-        self,
-        policy_id: str,
-        ip: str,
-        port: int,
-    ) -> PolicyRule:
-        return PolicyRule(
-            # Don't set the rating group
-            # Don't set the monitoring key
-            # Don't set the hard timeout
-            id=policy_id,
-            priority=100,
-            qos=self._get_default_qos(),
-            flow_list=self._get_whitelist_flows(ip, port),
-            tracking_type=PolicyRule.TrackingType.Value("NO_TRACKING"),
-        )
-
-    def _get_whitelist_flows(self, ip: str, port: int) -> List[FlowDescription]:
-        """
-        Args:
-            ip: IP address to allow traffic to. This should be the captive
-                portal address
-            port:  Port of the captive portal server. Probably 80.
-
-        Returns:
-            Two flows, one for traffic towards the captive portal server, and a
-            second for traffic from the captive portal server.
-        """
-        return [
-            # Set flow match for outgoing TCP packets to whitelisted IP
-            # Don't set the app_name field
-            FlowDescription(  # uplink flow
-                match=FlowMatch(
-                    ipv4_dst=ip,
-                    tcp_dst=port,
-                    ip_proto=FlowMatch.IPProto.Value("IPPROTO_TCP"),
-                    direction=FlowMatch.Direction.Value("UPLINK"),
-                ),
-                action=FlowDescription.Action.Value("PERMIT"),
-            ),
-            # Set flow match for incoming TCP packets from whitelisted IP
-            # Don't set the app_name field
-            FlowDescription(  # downlink flow
-                match=FlowMatch(
-                    ipv4_src=ip,
-                    tcp_src=port,
-                    ip_proto=FlowMatch.IPProto.Value("IPPROTO_TCP"),
-                    direction=FlowMatch.Direction.Value("DOWNLINK"),
-                ),
-                action=FlowDescription.Action.Value("PERMIT"),
-            ),
-        ]
-
-    def _get_default_qos(self) -> FlowQos:
-        """
-        Get a default QoS, usable for an allow-all flow, and for redirection to
-        a captive_portal.
-        """
-        return FlowQos(
-            max_req_bw_ul=2 * 1024 * 1024 * 1024,  # 2G
-            max_req_bw_dl=2 * 1024 * 1024 * 1024,  # 2G
-            gbr_ul=1 * 1024 * 1024,  # 1 Mb/s
-            gbr_dl=1 * 1024 * 1024,  # 1 Mb/s
-            qci=FlowQos.Qci.Value('QCI_3'),
-            # Allocation and Retention Policy
-            # Set to high priority, and disallow pre-emption
-            # capability/vulnerability
-            arp=QosArp(
-                priority_level=1,
-                pre_capability=QosArp.PreCap.Value("PRE_CAP_DISABLED"),
-                pre_vulnerability=QosArp.PreVul.Value("PRE_VUL_DISABLED"),
-            ),
-        )
-
-    def _get_static_rule(self) -> StaticRuleInstall:
+    def _get_static_rules(self) -> List[StaticRuleInstall]:
         """ Return a static rule for redirection to captive portal """
-        return StaticRuleInstall(
-            rule_id = self.redirect_rule_name,
-        )
+        if self.redirect_rule_name in self._rules:
+            return [StaticRuleInstall(rule_id=self.redirect_rule_name)]
+        return []
 
     def _get_credit_update_response(
         self,

--- a/lte/gateway/python/scripts/captive_portal_cli.py
+++ b/lte/gateway/python/scripts/captive_portal_cli.py
@@ -19,22 +19,22 @@ from lte.protos.session_manager_pb2_grpc import CentralSessionControllerStub
 @grpc_wrapper
 def create_session(client, args):
     message = CreateSessionRequest()
-    client.CreateSession(message)
-    print('Successfully got a response from CreateSession')
+    resp = client.CreateSession(message)
+    print('Successfully got a response from CreateSession:\n', resp)
 
 
 @grpc_wrapper
 def update_session(client, args):
     message = UpdateSessionRequest()
-    client.UpdateSession(message)
-    print('Successfully got a response from UpdateSession')
+    resp = client.UpdateSession(message)
+    print('Successfully got a response from UpdateSession:\n', resp)
 
 
 @grpc_wrapper
 def terminate_session(client, args):
     message = SessionTerminateRequest()
-    client.TerminateSession(message)
-    print('Successfully got a response from TerminateSession')
+    resp = client.TerminateSession(message)
+    print('Successfully got a response from TerminateSession:\n', resp)
 
 
 def create_parser():


### PR DESCRIPTION
Summary:
## What's Changed
*CreateSession calls to captive_portal's CentralSessionController no longer get a response with any allocated credits*
- sessiond will then not track credit usage, but will still enable the redirect static rule
- pipelined will still track credit usage, but its flow reporting to sessiond will never trigger the redirect rule to be deactivated

### Upcoming
- Add in pipelined support for untracked policy rules. This is not necessary to get the captive portal actually working

Reviewed By: xjtian

Differential Revision: D18655851

