### PR TITLE
Update diameter services to maintain connections when active

### DIFF
--- a/feg/gateway/diameter/diameter_client.go
+++ b/feg/gateway/diameter/diameter_client.go
@@ -135,15 +135,17 @@ func logErrors(ec <-chan *diam.ErrorReport) {
 }
 
 // BeginConnection attempts to begin a new connection with the server
-func (client *Client) BeginConnection(server *DiameterServerConfig) {
+func (client *Client) BeginConnection(server *DiameterServerConfig) error {
 	if client.connMan == nil {
-		glog.Errorf("No connection manager to initiate connection with")
-		return
+		err := fmt.Errorf("No connection manager to initiate connection with")
+		glog.Error(err)
+		return err
 	}
 	_, err := client.connMan.GetConnection(client.smClient, server)
 	if err != nil {
 		glog.Error(err)
 	}
+	return err
 }
 
 func (client *Client) Retries() uint {

--- a/feg/gateway/services/gateway_health/health_manager/health_manager.go
+++ b/feg/gateway/services/gateway_health/health_manager/health_manager.go
@@ -203,7 +203,7 @@ func (hm *HealthManager) takeSystemUp() error {
 		}
 	}
 	if len(allActionErrors) > 0 {
-		return fmt.Errorf("Encountered the following errors while taking SYSTEM_DOWN:\n%s\n",
+		return fmt.Errorf("Encountered the following errors while taking SYSTEM_UP:\n%s\n",
 			strings.Join(allActionErrors, "\n"),
 		)
 	}

--- a/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
+++ b/feg/gateway/services/s6a_proxy/servicers/s6a_proxy.go
@@ -178,11 +178,13 @@ func (s *s6aProxy) Disable(ctx context.Context, req *protos.DisableMessage) (*or
 	return &orcprotos.Void{}, nil
 }
 
-// Enable enables diameter connection creation
-// If creation is already enabled, Enable has no effect
+// Enable enables diameter connection creation and gets a connection to the
+// diameter server. If creation is already enabled and a connection already
+// exists, Enable has no effect
 func (s *s6aProxy) Enable(ctx context.Context, req *orcprotos.Void) (*orcprotos.Void, error) {
 	s.connMan.Enable()
-	return &orcprotos.Void{}, nil
+	_, err := s.connMan.GetConnection(s.smClient, s.serverCfg)
+	return &orcprotos.Void{}, err
 }
 
 // GetHealthStatus retrieves a health status object which contains the current

--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -38,7 +38,7 @@ type PolicyClient interface {
 		request *CreditControlRequest,
 	) error
 	IgnoreAnswer(request *CreditControlRequest)
-	EnableConnections()
+	EnableConnections() error
 	DisableConnections(period time.Duration)
 }
 
@@ -48,6 +48,7 @@ type PolicyClient interface {
 // allowed AVPs, and purposes are different
 type GxClient struct {
 	diamClient             *diameter.Client
+	serverCfg              *diameter.DiameterServerConfig
 	pcrf91Compliant        bool // to support PCRF which is 29.212 release 9.1 compliant
 	dontUseEUIIpIfEmpty    bool // Disable using MAC derived EUI-64 IPv6 address for CCR if IP is not provided
 	framedIpv4AddrRequired bool // PCRF requires FramedIpv4Addr to be included
@@ -56,6 +57,7 @@ type GxClient struct {
 // NewConnectedGxClient contructs a new GxClient with the magma diameter settings
 func NewConnectedGxClient(
 	diamClient *diameter.Client,
+	serverCfg *diameter.DiameterServerConfig,
 	reAuthHandler ReAuthHandler,
 	cloudRegistry registry.CloudRegistry,
 ) *GxClient {
@@ -70,6 +72,7 @@ func NewConnectedGxClient(
 	}
 	return &GxClient{
 		diamClient:             diamClient,
+		serverCfg:              serverCfg,
 		pcrf91Compliant:        *pcrf91Compliant || util.IsTruthyEnv(PCRF91CompliantEnv),
 		dontUseEUIIpIfEmpty:    *disableEUIIpIfEmpty || util.IsTruthyEnv(DisableEUIIPv6IfNoIPEnv),
 		framedIpv4AddrRequired: util.IsTruthyEnv(FramedIPv4AddrRequiredEnv),
@@ -80,15 +83,13 @@ func NewConnectedGxClient(
 // NewGxClient contructs a new GxClient with the magma diameter settings
 func NewGxClient(
 	clientCfg *diameter.DiameterClientConfig,
-	servers []*diameter.DiameterServerConfig,
+	serverCfg *diameter.DiameterServerConfig,
 	reAuthHandler ReAuthHandler,
 	cloudRegistry registry.CloudRegistry,
 ) *GxClient {
 	diamClient := diameter.NewClient(clientCfg)
-	for _, server := range servers {
-		diamClient.BeginConnection(server)
-	}
-	return NewConnectedGxClient(diamClient, reAuthHandler, cloudRegistry)
+	diamClient.BeginConnection(serverCfg)
+	return NewConnectedGxClient(diamClient, serverCfg, reAuthHandler, cloudRegistry)
 }
 
 // SendCreditControlRequest sends a Gx Credit Control Requests to the
@@ -134,8 +135,9 @@ func (gxClient *GxClient) IgnoreAnswer(request *CreditControlRequest) {
 	)
 }
 
-func (gxClient *GxClient) EnableConnections() {
+func (gxClient *GxClient) EnableConnections() error {
 	gxClient.diamClient.EnableConnectionCreation()
+	return gxClient.diamClient.BeginConnection(gxClient.serverCfg)
 }
 
 func (gxClient *GxClient) DisableConnections(period time.Duration) {

--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
@@ -52,7 +52,7 @@ func TestGxClient(t *testing.T) {
 	startServer(clientConfig, serverConfig)
 	gxClient := gx.NewGxClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getMockReAuthHandler(),
 		nil,
 	)
@@ -185,7 +185,7 @@ func TestGxClientUsageMonitoring(t *testing.T) {
 	startServer(clientConfig, serverConfig)
 	gxClient := gx.NewGxClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getMockReAuthHandler(),
 		nil,
 	)

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client_test.go
@@ -45,7 +45,7 @@ func TestGyClient(t *testing.T) {
 	serverConfig, _ = startServer(clientConfig, serverConfig, gy.PerSessionInit)
 	gyClient := gy.NewGyClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getReAuthHandler(), nil,
 	)
 
@@ -146,7 +146,7 @@ func TestGyClientOutOfCredit(t *testing.T) {
 	serverConfig, _ = startServer(clientConfig, serverConfig, gy.PerSessionInit)
 	gyClient := gy.NewGyClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getReAuthHandler(), nil,
 	)
 
@@ -194,7 +194,7 @@ func TestGyClientPerKeyInit(t *testing.T) {
 	serverConfig, _ = startServer(clientConfig, serverConfig, gy.PerKeyInit)
 	gyClient := gy.NewGyClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getReAuthHandler(), nil,
 	)
 
@@ -248,7 +248,7 @@ func TestGyClientMultipleCredits(t *testing.T) {
 	serverConfig, _ = startServer(clientConfig, serverConfig, gy.PerKeyInit)
 	gyClient := gy.NewGyClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getReAuthHandler(), nil,
 	)
 
@@ -297,7 +297,7 @@ func TestGyReAuth(t *testing.T) {
 	serverConfig, ocs := startServer(clientConfig, serverConfig, gy.PerKeyInit)
 	gyClient := gy.NewGyClient(
 		clientConfig,
-		[]*diameter.DiameterServerConfig{serverConfig},
+		serverConfig,
 		getReAuthHandler(), nil,
 	)
 

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -268,14 +268,19 @@ func (srv *CentralSessionController) Disable(
 	return &orcprotos.Void{}, nil
 }
 
-// Enable enables diameter connection creation
-// If creation is already enabled, Enable has no effect
+// Enable enables diameter connection creation and gets a connection to the
+// diameter server(s). If creation is already enabled and a connection already
+// exists, Enable has no effect
 func (srv *CentralSessionController) Enable(
 	ctx context.Context,
 	void *orcprotos.Void,
 ) (*orcprotos.Void, error) {
-	srv.policyClient.EnableConnections()
-	srv.creditClient.EnableConnections()
+	pcErr := srv.policyClient.EnableConnections()
+	ccErr := srv.creditClient.EnableConnections()
+	if pcErr != nil || ccErr != nil {
+		return &orcprotos.Void{}, fmt.Errorf("An error occurred while enabling connections; policyClient err: %s, creditClient err: %s",
+			pcErr, ccErr)
+	}
 	return &orcprotos.Void{}, nil
 }
 

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -52,9 +52,9 @@ func (p *MockPolicyClient) IgnoreAnswer(request *gx.CreditControlRequest) {
 	return
 }
 
-func (p *MockPolicyClient) EnableConnections() {
+func (p *MockPolicyClient) EnableConnections() error {
 	p.Called()
-	return
+	return nil
 }
 
 func (p *MockPolicyClient) DisableConnections(period time.Duration) {
@@ -99,9 +99,9 @@ func (cc *MockCreditClient) IgnoreAnswer(request *gy.CreditControlRequest) {
 	return
 }
 
-func (cc *MockCreditClient) EnableConnections() {
+func (cc *MockCreditClient) EnableConnections() error {
 	cc.Called()
-	return
+	return nil
 }
 
 func (cc *MockCreditClient) DisableConnections(period time.Duration) {

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -91,10 +91,12 @@ func main() {
 
 		gyClnt = gy.NewConnectedGyClient(
 			diamClient,
+			ocsDiamCfg,
 			gy.GetGyReAuthHandler(cloudReg),
 			cloudReg)
 		gxClnt = gx.NewConnectedGxClient(
 			diamClient,
+			ocsDiamCfg,
 			gx.GetGxReAuthHandler(cloudReg, policyDBClient), cloudReg)
 	} else {
 		glog.Infof("Using distinct Gy: %+v & Gx: %+v connection",
@@ -102,11 +104,11 @@ func main() {
 
 		gyClnt = gy.NewGyClient(
 			gy.GetGyClientConfiguration(),
-			[]*diameter.DiameterServerConfig{ocsDiamCfg},
+			ocsDiamCfg,
 			gy.GetGyReAuthHandler(cloudReg), cloudReg)
 		gxClnt = gx.NewGxClient(
 			gx.GetGxClientConfiguration(),
-			[]*diameter.DiameterServerConfig{pcrfDiamCfg},
+			pcrfDiamCfg,
 			gx.GetGxReAuthHandler(cloudReg, policyDBClient), cloudReg)
 	}
 	// Add servicers to the service

--- a/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
@@ -199,11 +199,13 @@ func (s *swxProxy) Disable(ctx context.Context, req *protos.DisableMessage) (*or
 	return &orcprotos.Void{}, nil
 }
 
-// Enable enables diameter connection creation
-// If creation is already enabled, Enable has no effect
+// Enable enables diameter connection creation and gets a connection to the
+// diameter server. If creation is already enabled and a connection already
+// exists, Enable has no effect
 func (s *swxProxy) Enable(ctx context.Context, req *orcprotos.Void) (*orcprotos.Void, error) {
 	s.connMan.Enable()
-	return &orcprotos.Void{}, nil
+	_, err := s.connMan.GetConnection(s.smClient, s.config.ServerCfg)
+	return &orcprotos.Void{}, err
 }
 
 // GetHealthStatus retrieves a health status object which contains the current

--- a/feg/gateway/tools/gx_client_cli/main.go
+++ b/feg/gateway/tools/gx_client_cli/main.go
@@ -98,7 +98,7 @@ func main() {
 
 	config := &cliConfig{
 		serverCfg: serverCfg,
-		gxClient:  gx.NewGxClient(clientCfg, []*diameter.DiameterServerConfig{serverCfg}, handleReAuth, nil),
+		gxClient:  gx.NewGxClient(clientCfg, serverCfg, handleReAuth, nil),
 		imsi:      imsi,
 		sessionID: fmt.Sprintf("%s-%s", imsi, sid),
 		ueIP:      ueIP,

--- a/feg/gateway/tools/gy_client_cli/main.go
+++ b/feg/gateway/tools/gy_client_cli/main.go
@@ -110,7 +110,7 @@ func main() {
 
 	config := &cliConfig{
 		serverCfg:    serverCfg,
-		gyClient:     gy.NewGyClient(clientCfg, []*diameter.DiameterServerConfig{serverCfg}, handleReAuth, nil),
+		gyClient:     gy.NewGyClient(clientCfg, serverCfg, handleReAuth, nil),
 		imsi:         imsi,
 		sessionID:    fmt.Sprintf("%s-%s", imsi, sid),
 		ueIP:         ueIP,


### PR DESCRIPTION
Summary:
When the health manager on the FeG sends ENABLE to diameter services,
the current behavior is to ensure connection creation is enabled. However, a
connection is not created if one does not exist. This means that after a
failover, the Active FeG services won't have connection to core services.
This causes errors on the core side. Additionally, messages that originate
from the core (RTR, RAR, etc.) won't be handled properly until a connection
is created from a AG -> FeG request. This diff fixes this by ensuring a connection
exists (GetConnection) on each Enable call.

Reviewed By: themarwhal

Differential Revision: D18627673

