### PR TITLE
Fix s1aptest test_attach_detach.py

### DIFF
--- a/lte/gateway/python/magma/captive_portal/rpc_servicer.py
+++ b/lte/gateway/python/magma/captive_portal/rpc_servicer.py
@@ -105,7 +105,8 @@ class SessionRpcServicer(CentralSessionControllerServicer):
 
     def _get_static_rules(self) -> List[StaticRuleInstall]:
         """ Return a static rule for redirection to captive portal """
-        if self.redirect_rule_name in self._rules:
+        if self.redirect_rule_name is not None and\
+                self.redirect_rule_name in self._rules:
             return [StaticRuleInstall(rule_id=self.redirect_rule_name)]
         return []
 


### PR DESCRIPTION
Summary:
**Previously:**

```
vagrant@magma-test:~/magma/lte/gateway/python/integ_tests$ make integ_test TESTS=s1aptests/test_attach_detach.py
. /home/vagrant/build/python/bin/activate
echo "Running test: s1aptests/test_attach_detach.py"
Running test: s1aptests/test_attach_detach.py
sudo -E PATH=/usr/lib/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin PYTHONPATH=:/home/vagrant/s1ap-tester/bin /home/vagrant/build/python/bin/nosetests -x -s s1aptests/test_attach_detach.py || exit 1
tag: AUTH_TYPE tagVal: MILENAGE
************************* Enb tester config

**********************TPT open server******** 0

 Server Socket FD =[12]
************* Testing *Time elapsed(in usec): for timer expiry               :13680 usec
Using subscriber IMSI IMSI001010000000001
************************* UE device config for ue_id  1
************************* Configuring IP block
************************* Waiting for IP changes to propagate
************************* S1 setup
************************* UE App config
************************* Running End to End attach for  UE id  1
ue id 1 found
************************* send SCTP SHUTDOWN
F
======================================================================
FAIL: Basic attach/detach test with a single UE
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py", line 41, in test_attach_detach
    s1ap_types.ueAttachAccept_t)
  File "/home/vagrant/magma/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py", line 178, in attach
    assert(resp_type.value == response.msg_type)
AssertionError:
-------------------- >> begin captured logging << --------------------
root: ERROR: Could not load magmad yml config for mconfig modules
root: INFO: Adding subscriber : IMSI001010000000001
root: DEBUG: s1ap response expected, received: 12, 23
root: INFO: Deleting subscriber : IMSI001010000000001
--------------------- >> end captured logging << ---------------------

----------------------------------------------------------------------
Ran 1 test in 1.089s

FAILED (failures=1)
Makefile:32: recipe for target 'integ_test' failed
make: *** [integ_test] Error 1
```

Differential Revision: D18723682

