### PR TITLE
sdf_template bad free fix on spgw_state

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/pgw_pcef_emulation.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_pcef_emulation.c
@@ -62,12 +62,13 @@ int pgw_pcef_emulation_init(spgw_state_t* state_p,
   //--------------------------
   // Predefined PCC rules
   //--------------------------
-  pcc_rule_t* pcc_rule = (pcc_rule_t*) calloc(1, sizeof(pcc_rule_t));
+  pcc_rule_t* pcc_rule;
   // Initializing PCC rules only if PGW state doesn't already contain them
   hrc = hashtable_ts_is_key_exists(
       state_p->pgw_state.deactivated_predefined_pcc_rules,
       SDF_ID_GBR_VOLTE_40K);
   if (hrc == HASH_TABLE_KEY_NOT_EXISTS) {
+    pcc_rule = (pcc_rule_t*) calloc(1, sizeof(pcc_rule_t));
     pcc_rule->name = bfromcstr("VOLTE_40K_PCC_RULE");
     pcc_rule->is_activated = false;
     pcc_rule->sdf_id = SDF_ID_GBR_VOLTE_40K;

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -98,10 +98,6 @@ void pgw_free_pcc_rule(void** rule)
       if (pcc_rule->name) {
         bdestroy_wrapper(&pcc_rule->name);
       }
-      auto* sdf_template = (sdf_template_t*) &pcc_rule->sdf_template;
-      if (sdf_template) {
-        free_wrapper((void**) (&pcc_rule->sdf_template));
-      }
       free_wrapper(rule);
     }
   }

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -738,7 +738,6 @@ void SpgwStateConverter::proto_to_packet_filter(
   const gateway::spgw::PacketFilter &packet_filter_proto,
   packet_filter_t *packet_filter)
 {
-  packet_filter = (packet_filter_t *) calloc(1, sizeof(packet_filter_t));
   packet_filter->spare = packet_filter_proto.spare();
   packet_filter->direction = packet_filter_proto.direction();
   packet_filter->identifier = packet_filter_proto.identifier();


### PR DESCRIPTION
Summary: - Fixing bad_free error that was causing SegFault when stopping MME, packet_filter inside pcc_rule didn't need to be calloc'ed as it was previously allocated when pcc_rule was initiated

Reviewed By: ssanadhya

Differential Revision: D18711909

