### PR TITLE
Update sessiond restart handler to use retries with directoryD rpc call

### DIFF
--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -41,6 +41,7 @@ private:
    SessionReporter* reporter_;
    std::unordered_map<std::string, std::string> sessions_to_terminate_;
    static const uint max_cleanup_retries_;
+   static const uint directoryd_rpc_interval_s_;
 
 };
 } // namespace sessiond


### PR DESCRIPTION
Summary:
This adds retries to sessiond's restart handler to ensure that we don't
have service dependencies.

Differential Revision: D18737023

