### PR TITLE
Added Namespace 'magma' in kubectl commands for consistency

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.0.0/orc8r/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/orc8r/deploy_install.md
@@ -465,7 +465,7 @@ Wait for the NMS pods (`nms-magmalte`, `nms-nginx-proxy`) to transition into
 `Running` state, then create a user on the NMS:
 
 ```bash
-kubectl -n magma exec -it -n magma \
+kubectl exec -it -n magma \
   $(kubectl -n magma get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}') -- \
   yarn setAdminPassword <admin user email> <admin user password>
 ```

--- a/docs/docusaurus/versioned_docs/version-1.0.0/orc8r/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/orc8r/deploy_install.md
@@ -366,7 +366,7 @@ orc8r-proxy-57cf989fcc-xn2cw              1/1     Running   0          X
 Then:
 
 ```bash
-export CNTLR_POD=$(kubectl get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+export CNTLR_POD=$(kubectl -n magma get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
 kubectl exec -it ${CNTLR_POD} bash
 
 # The following commands are to be run inside the pod
@@ -387,7 +387,7 @@ just created into the secrets directory:
 cd ~/secrets/certs
 for certfile in admin_operator.pem admin_operator.key.pem admin_operator.pfx
 do
-    kubectl cp ${CNTLR_POD}:/var/opt/magma/bin/${certfile} ./${certfile}
+    kubectl -n magma cp ${CNTLR_POD}:/var/opt/magma/bin/${certfile} ./${certfile}
 done
 ```
 
@@ -465,8 +465,8 @@ Wait for the NMS pods (`nms-magmalte`, `nms-nginx-proxy`) to transition into
 `Running` state, then create a user on the NMS:
 
 ```bash
-kubectl exec -it -n magma \
-  $(kubectl get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}') -- \
+kubectl -n magma exec -it -n magma \
+  $(kubectl -n magma get pod -l app.kubernetes.io/component=magmalte -o jsonpath='{.items[0].metadata.name}') -- \
   yarn setAdminPassword <admin user email> <admin user password>
 ```
 


### PR DESCRIPTION
While working on the project i noticed someone submitted an issue
https://github.com/facebookincubator/magma/issues/937

I also had this issue and i solved it by adding namespace  magma to the kubectl commands.

Others might also be stuck with this issue, and i thought adding the namespace would be helpful. 