### PR TITLE
Refactor and improve error messages on sessiond

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -258,8 +258,8 @@ void LocalSessionManagerHandlerImpl::send_create_session(
           add_session_to_directory_record(imsi, sid);
         }
       } else {
-        MLOG(MERROR) << "Failed to initialize session in OCS for IMSI "
-                     << imsi << ": " << status.error_message();
+        MLOG(MERROR) << "Failed to initialize session in SessionProxy "
+                     << "for IMSI " << imsi << ": " << status.error_message();
       }
       LocalCreateSessionResponse resp;
       resp.set_session_id(response.session_id());


### PR DESCRIPTION
Summary: `Failed to initialize session in OCS for IMSI...` is a misleading error message when handling error from SessionProxy as it does not necessarily mean the communication with gy  failed.

Reviewed By: andreilee

Differential Revision: D18768386

