### PR TITLE
Fix async bugs in sessiond's RestartHandler

### DIFF
--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -8,6 +8,8 @@
  */
 #pragma once
 
+#include <future>
+
 #include "SessionReporter.h"
 #include "DirectorydClient.h"
 #include "LocalEnforcer.h"
@@ -30,19 +32,18 @@ class RestartHandler {
    */
   void cleanup_previous_sessions();
 
-private:
+ private:
   void terminate_previous_session(
     const std::string& sid,
     const std::string& session_id);
 
  private:
-   std::shared_ptr<LocalEnforcer> enforcer_;
-   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
-   SessionReporter* reporter_;
-   std::unordered_map<std::string, std::string> sessions_to_terminate_;
-   static const uint max_cleanup_retries_;
-   static const uint directoryd_rpc_interval_s_;
-
+  std::shared_ptr<LocalEnforcer> enforcer_;
+  std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
+  SessionReporter* reporter_;
+  std::unordered_map<std::string, std::string> sessions_to_terminate_;
+  static const uint max_cleanup_retries_;
+  static const uint rpc_retry_interval_s_;
 };
 } // namespace sessiond
 } // namespace magma

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -188,12 +188,12 @@ int main(int argc, char *argv[])
   auto proxy_handler =
     std::make_unique<magma::SessionProxyResponderHandlerImpl>(monitor);
 
-  /*auto restart_handler = std::make_shared<magma::sessiond::RestartHandler>(
+  auto restart_handler = std::make_shared<magma::sessiond::RestartHandler>(
     directoryd_client, monitor, reporter.get());
   std::thread restart_handler_thread([&]() {
     MLOG(MINFO) << "Started sessiond restart handler thread";
     restart_handler->cleanup_previous_sessions();
-  });*/
+  });
 
   magma::LocalSessionManagerAsyncService local_service(
     server.GetNewCompletionQueue(), std::move(local_handler));
@@ -224,7 +224,7 @@ int main(int argc, char *argv[])
   proxy_thread.join();
   rule_manager_thread.join();
   directoryd_thread.join();
-  //restart_handler_thread.join();
+  restart_handler_thread.join();
   policy_loader_thread.join();
   optional_client_thread.join();
 


### PR DESCRIPTION
Summary:
This diff re-enables sessiond's RestartHandler and
fixes two bugs that were producing service crashes:
    1. The directoryd promise was being set multiple times, causing an exception
    2. The `terminate_subscriber_call` was being treated like a synchronous call

This diff fixes these bugs by making better use of c++ async's functionality.
Now, sessiond fetches all previous sessions, retrying if necessary, and then
attempts to terminate each session.

Note: This diff also contains changes produced from `clang-format`

Reviewed By: andreilee

Differential Revision: D18778319

