### PR TITLE
[BugFix] [nas] [Security_Mode_Complete] Fix for MME crash with duplicate Security Mode Complete message

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/SecurityModeControl.c
@@ -486,20 +486,11 @@ int emm_proc_security_mode_complete(
     unlock_ue_contexts(ue_mm_context);
     OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
   } else {
-    OAILOG_ERROR(LOG_NAS_EMM, "EMM-PROC  - No EPS security context exists\n");
-    /*
-     * Notify EMM that the authentication procedure failed
-     */
-    emm_sap_t emm_sap = {0};
-    emm_sap.primitive = EMMREG_COMMON_PROC_REJ;
-    emm_sap.u.emm_reg.ue_id = ue_id;
-    emm_sap.u.emm_reg.ctx = emm_ctx;
-    emm_sap.u.emm_reg.notify = true;
-    emm_sap.u.emm_reg.free_proc = true;
-    emm_sap.u.emm_reg.u.common.common_proc = &smc_proc->emm_com_proc;
-    emm_sap.u.emm_reg.u.common.previous_emm_fsm_state =
-      smc_proc->emm_com_proc.emm_proc.previous_emm_fsm_state;
-    rc = emm_sap_send(&emm_sap);
+    OAILOG_ERROR(
+      LOG_NAS_EMM,
+      "EMM-PROC  - No EPS security context exists. Ignoring the Security Mode "
+      "Complete message\n");
+    rc = RETURNerror;
   }
 
   unlock_ue_contexts(ue_mm_context);


### PR DESCRIPTION
Summary:
	MME re-transmits duplicate Security Mode Command message in case of T360 timer expiry. If MME gets Security Mode Complete message for both the Security Mode Command messages, for the first one it proceeds with security success and clears the smc_proc data which MME again tries to access when it receives the 2nd Security Mode Complete Message leading to crash. This PR fixes the issue.
	
Test Plan:
	Sanity with S1-Simulator is verified.
	Verified with a new test case test_attach_detach_duplicate_nas_resp_messages.py