### PR TITLE
Keepalive and reconnect support for CLI stack

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -123,7 +123,11 @@ add_library(devman_channel_cli
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/Spd2Glog.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/IoConfigurationBuilder.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/ReadCachingCli.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/SshSocketReader.cpp)
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/SshSocketReader.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/KeepaliveCli.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/ReconnectingCli.cpp
+        )
 
 target_link_libraries(devman_channel_cli
   devman)
@@ -181,8 +185,15 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/ConfigGeneratorTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/RealCliDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/CliScaleTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/PromptAwareCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/SshSessionTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/QueuedCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/PromptAwareCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/ReadCachingCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/KeepaliveCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/ReconnectingCliTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/utils/Json.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/utils/Ssh.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/utils/Log.cpp
@@ -199,7 +210,9 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/FileWatcherTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/MikrotikChannelTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/test/SnmpChannelTest.cpp)
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/SnmpChannelTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/ReconnectingSshTest.cpp
+        )
 
 target_link_libraries(devmantest
   devman

--- a/devmand/gateway/src/devmand/Application.cpp
+++ b/devmand/gateway/src/devmand/Application.cpp
@@ -77,6 +77,11 @@ channels::ping::Engine& Application::getPingEngine(folly::IPAddress ip) {
   }
 }
 
+channels::cli::Engine& Application::getCliEngine() {
+  assert(cliEngine != nullptr);
+  return *cliEngine;
+}
+
 std::string Application::getName() const {
   return name;
 }

--- a/devmand/gateway/src/devmand/Application.h
+++ b/devmand/gateway/src/devmand/Application.h
@@ -96,6 +96,7 @@ class Application : public MetricSink {
   channels::snmp::Engine& getSnmpEngine();
   channels::ping::Engine& getPingEngine(IPVersion ipv = IPVersion::v4);
   channels::ping::Engine& getPingEngine(folly::IPAddress ip);
+  channels::cli::Engine& getCliEngine();
 
   syslog::Manager& getSyslogManager();
 

--- a/devmand/gateway/src/devmand/channels/cli/Channel.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/Channel.cpp
@@ -18,20 +18,20 @@ Channel::Channel(
 
 Channel::~Channel() {}
 
-folly::Future<std::string> Channel::executeAndRead(const Command& cmd) {
+folly::SemiFuture<std::string> Channel::executeRead(const ReadCommand cmd) {
   MLOG(MDEBUG) << "[" << id << "] "
                << "Executing command and reading: "
                << "\"" << cmd << "\"";
 
-  return cli->executeAndRead(cmd);
+  return cli->executeRead(cmd);
 }
 
-folly::Future<std::string> Channel::execute(const Command& cmd) {
+folly::SemiFuture<std::string> Channel::executeWrite(const WriteCommand cmd) {
   MLOG(MDEBUG) << "[" << id << "]"
                << "Executing command"
                << "\"" << cmd << "\"";
 
-  return cli->execute(cmd);
+  return cli->executeWrite(cmd);
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/Channel.h
+++ b/devmand/gateway/src/devmand/channels/cli/Channel.h
@@ -27,8 +27,8 @@ class Channel : public channels::Channel, public devmand::channels::cli::Cli {
   Channel(Channel&&) = delete;
   Channel& operator=(Channel&&) = delete;
 
-  folly::Future<std::string> executeAndRead(const Command& cmd) override;
-  folly::Future<std::string> execute(const Command& cmd) override;
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override;
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override;
 
  private:
   string id;

--- a/devmand/gateway/src/devmand/channels/cli/Cli.h
+++ b/devmand/gateway/src/devmand/channels/cli/Cli.h
@@ -38,6 +38,26 @@ class Cli {
       const WriteCommand cmd) = 0;
 };
 
+class CliException : public std::runtime_error {
+ public:
+  CliException(string msg) : std::runtime_error(msg) {}
+};
+
+class DisconnectedException : public CliException {
+ public:
+  DisconnectedException(string msg = "Not connected") : CliException(msg) {}
+};
+
+class CommandExecutionException : public CliException {
+ public:
+  CommandExecutionException(string msg = "Command execution failed") : CliException(msg) {}
+};
+
+class CommandTimeoutException : public CommandExecutionException {
+ public:
+  CommandTimeoutException(string msg = "Command execution timed out") : CommandExecutionException(msg) {}
+};
+
 } // namespace cli
 } // namespace channels
 } // namespace devmand

--- a/devmand/gateway/src/devmand/channels/cli/Cli.h
+++ b/devmand/gateway/src/devmand/channels/cli/Cli.h
@@ -32,9 +32,10 @@ class Cli {
   Cli& operator=(Cli&&) = delete;
 
  public:
-  virtual folly::Future<std::string> executeAndRead(const Command& cmd) = 0;
+  virtual folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) = 0;
 
-  virtual folly::Future<std::string> execute(const Command& cmd) = 0;
+  virtual folly::SemiFuture<std::string> executeWrite(
+      const WriteCommand cmd) = 0;
 };
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/Cli.h
+++ b/devmand/gateway/src/devmand/channels/cli/Cli.h
@@ -50,12 +50,14 @@ class DisconnectedException : public CliException {
 
 class CommandExecutionException : public CliException {
  public:
-  CommandExecutionException(string msg = "Command execution failed") : CliException(msg) {}
+  CommandExecutionException(string msg = "Command execution failed")
+      : CliException(msg) {}
 };
 
 class CommandTimeoutException : public CommandExecutionException {
  public:
-  CommandTimeoutException(string msg = "Command execution timed out") : CommandExecutionException(msg) {}
+  CommandTimeoutException(string msg = "Command execution timed out")
+      : CommandExecutionException(msg) {}
 };
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/Command.h
+++ b/devmand/gateway/src/devmand/channels/cli/Command.h
@@ -43,16 +43,15 @@ class Command {
     return skipCache_;
   }
 
-  int getIdx() const {
-    return idx;
+  static string escape(string cmd) {
+    boost::replace_all(cmd, "\n", "\\n");
+    boost::replace_all(cmd, "\r", "\\r");
+    boost::replace_all(cmd, "\t", "\\t");
+    return cmd;
   }
 
   friend std::ostream& operator<<(std::ostream& _stream, Command const& c) {
-    auto rawCmd = c.raw();
-    boost::replace_all(rawCmd, "\n", "\\n");
-    boost::replace_all(rawCmd, "\r", "\\r");
-    boost::replace_all(rawCmd, "\t", "\\t");
-    _stream << rawCmd;
+    _stream << "[" << c.idx << "] " << Command::escape(c.raw());
     return _stream;
   }
 };

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.cpp
@@ -6,17 +6,20 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 
 #define LOG_WITH_GLOG
+
 #include <magma_logging.h>
 
 #include <devmand/channels/cli/IoConfigurationBuilder.h>
+#include <devmand/channels/cli/KeepaliveCli.h>
 #include <devmand/channels/cli/PromptAwareCli.h>
 #include <devmand/channels/cli/QueuedCli.h>
 #include <devmand/channels/cli/ReadCachingCli.h>
+#include <devmand/channels/cli/ReconnectingCli.h>
 #include <devmand/channels/cli/SshSession.h>
 #include <devmand/channels/cli/SshSessionAsync.h>
 #include <devmand/channels/cli/SshSocketReader.h>
+#include <devmand/channels/cli/TimeoutTrackingCli.h>
 #include <folly/Singleton.h>
-#include <folly/executors/IOThreadPoolExecutor.h>
 
 namespace devmand {
 namespace channels {
@@ -28,60 +31,202 @@ using devmand::channels::cli::sshsession::readCallback;
 using devmand::channels::cli::sshsession::SshSession;
 using devmand::channels::cli::sshsession::SshSessionAsync;
 using folly::EvictingCacheMap;
-using folly::IOThreadPoolExecutor;
-using std::make_shared;
-using std::string;
-
-// TODO executor?
-shared_ptr<IOThreadPoolExecutor> executor =
-    std::make_shared<IOThreadPoolExecutor>(10);
 
 IoConfigurationBuilder::IoConfigurationBuilder(
-    const DeviceConfig& _deviceConfig)
-    : deviceConfig(_deviceConfig) {}
+    shared_ptr<ConnectionParameters> _connectionParams)
+    : connectionParameters(_connectionParams) {}
 
-shared_ptr<Cli> IoConfigurationBuilder::getIo(
+IoConfigurationBuilder::IoConfigurationBuilder(
+    const DeviceConfig& deviceConfig,
+    channels::cli::Engine& engine) {
+  const std::map<std::string, std::string>& plaintextCliKv =
+      deviceConfig.channelConfigs.at("cli").kvPairs;
+
+  connectionParameters = makeConnectionParameters(
+      deviceConfig.id,
+      deviceConfig.ip,
+      plaintextCliKv.at("username"),
+      plaintextCliKv.at("password"),
+      loadConfigValue(plaintextCliKv, "flavour", ""),
+      std::stoi(plaintextCliKv.at("port")),
+      toSeconds(loadConfigValue(
+          plaintextCliKv, configKeepAliveIntervalSeconds, "60")),
+      toSeconds(loadConfigValue(
+          plaintextCliKv, configMaxCommandTimeoutSeconds, "60")),
+      toSeconds(
+          loadConfigValue(plaintextCliKv, reconnectingQuietPeriodConfig, "5")),
+      std::stol(
+          loadConfigValue(plaintextCliKv, sshConnectionTimeoutConfig, "30")),
+      engine.getTimekeeper(),
+      engine.getExecutor(Engine::executorRequestType::sshCli),
+      engine.getExecutor(Engine::executorRequestType::paCli),
+      engine.getExecutor(Engine::executorRequestType::rcCli),
+      engine.getExecutor(Engine::executorRequestType::ttCli),
+      engine.getExecutor(Engine::executorRequestType::qCli),
+      engine.getExecutor(Engine::executorRequestType::rCli),
+      engine.getExecutor(Engine::executorRequestType::kaCli));
+}
+
+IoConfigurationBuilder::~IoConfigurationBuilder() {
+  MLOG(MDEBUG) << "~IoConfigurationBuilder";
+}
+
+shared_ptr<Cli> IoConfigurationBuilder::createAll(
     shared_ptr<CliCache> commandCache) {
-  MLOG(MDEBUG) << "Creating CLI ssh device for " << deviceConfig.id
-               << " (host: " << deviceConfig.ip << ")";
+  return createAllUsingFactory(commandCache);
+}
 
-  const auto& plaintextCliKv = deviceConfig.channelConfigs.at("cli").kvPairs;
-  // crate session
-  const std::shared_ptr<SshSessionAsync>& session =
-      std::make_shared<SshSessionAsync>(deviceConfig.id, executor);
-  // opening SSH connection
+chrono::seconds IoConfigurationBuilder::toSeconds(const string& value) {
+  return chrono::seconds(stoi(value));
+}
+
+shared_ptr<Cli> IoConfigurationBuilder::createAllUsingFactory(
+    shared_ptr<CliCache> commandCache) {
+  function<SemiFuture<shared_ptr<Cli>>()> cliFactory =
+      [params = connectionParameters, commandCache]() {
+        return createPromptAwareCli(params).thenValue(
+            [params, commandCache](shared_ptr<Cli> sshCli) -> shared_ptr<Cli> {
+              MLOG(MDEBUG) << "[" << params->id << "] "
+                           << "Creating cli layers rcclli, ttcli, qcli";
+              // create caching cli
+              const shared_ptr<ReadCachingCli>& rccli =
+                  std::make_shared<ReadCachingCli>(
+                      params->id, sshCli, commandCache, params->rcExecutor);
+              // create timeout tracker
+              shared_ptr<TimeoutTrackingCli> ttcli = TimeoutTrackingCli::make(
+                  params->id,
+                  rccli,
+                  params->timekeeper,
+                  params->ttExecutor,
+                  params->cmdTimeout);
+              // create Queued cli
+              shared_ptr<QueuedCli> qcli =
+                  QueuedCli::make(params->id, ttcli, params->qExecutor);
+              return qcli;
+            });
+      };
+
+  // create reconnecting cli that uses cliFactory to establish ssh connection
+  shared_ptr<ReconnectingCli> rcli = ReconnectingCli::make(
+      connectionParameters->id,
+      connectionParameters->rExecutor,
+      move(cliFactory),
+      connectionParameters->timekeeper,
+      connectionParameters->reconnectingQuietPeriod);
+  // create keepalive cli
+  shared_ptr<KeepaliveCli> kaCli = KeepaliveCli::make(
+      connectionParameters->id,
+      rcli,
+      connectionParameters->kaExecutor,
+      connectionParameters->timekeeper,
+      connectionParameters->kaTimeout);
+  return kaCli;
+}
+
+Future<shared_ptr<Cli>> IoConfigurationBuilder::createPromptAwareCli(
+    shared_ptr<ConnectionParameters> params) {
+  MLOG(MDEBUG) << "Creating CLI ssh device for " << params->id << " ("
+               << params->ip << ":" << params->port << ")";
+
+  // create session
+  std::shared_ptr<SshSessionAsync> session =
+      std::make_shared<SshSessionAsync>(params->id, params->sshExecutor);
+  // open SSH connection
+
+  MLOG(MDEBUG) << "[" << params->id << "] "
+               << "Opening shell";
+  // TODO: do this using future chaining
   session
       ->openShell(
-          deviceConfig.ip,
-          std::stoi(plaintextCliKv.at("port")),
-          plaintextCliKv.at("username"),
-          plaintextCliKv.at("password"))
+          params->ip,
+          params->port,
+          params->username,
+          params->password,
+          params->sshConnectionTimeout)
       .get();
 
-  shared_ptr<CliFlavour> cl =
-      plaintextCliKv.find("flavour") != plaintextCliKv.end()
-      ? CliFlavour::create(plaintextCliKv.at("flavour"))
-      : CliFlavour::create("");
+  MLOG(MDEBUG) << "[" << params->id << "] "
+               << "Setting flavour";
+  shared_ptr<CliFlavour> cl = params->flavour;
 
-  // create CLI - how to create a CLI stack?
-  const shared_ptr<PromptAwareCli>& cli =
-      std::make_shared<PromptAwareCli>(session, cl);
-
+  // create CLI
+  shared_ptr<PromptAwareCli> cli =
+      PromptAwareCli::make(params->id, session, cl, params->paExecutor);
+  MLOG(MDEBUG) << "[" << params->id << "] "
+               << "Initializing cli";
   // initialize CLI
-  cli->initializeCli();
+  // TODO: do this using future chaining:
+  //  via(executor.get())
+  //      .thenValue([params, cli, session](...) -> SemiFuture<shared_ptr<Cli>>
+  //      {
+
+  cli->initializeCli(params->password).get();
   // resolve prompt needs to happen
-  cli->resolvePrompt();
-  // create async data reader
+  MLOG(MDEBUG) << "[" << params->id << "] "
+               << "Resolving prompt";
+  // TODO: do this using future chaining
+  cli->resolvePrompt().get();
+
+  MLOG(MDEBUG) << "[" << params->id << "] "
+               << "Creating async data reader";
   event* sessionEvent = SshSocketReader::getInstance().addSshReader(
       readCallback, session->getSshFd(), session.get());
   session->setEvent(sessionEvent);
+  MLOG(MDEBUG) << "[" << params->id << "] "
+               << "SSH layer configured";
+  return makeFuture(cli);
+}
 
-  // create caching cli
-  const shared_ptr<ReadCachingCli>& ccli =
-      std::make_shared<ReadCachingCli>(deviceConfig.id, cli, commandCache);
+shared_ptr<IoConfigurationBuilder::ConnectionParameters>
+IoConfigurationBuilder::makeConnectionParameters(
+    string id,
+    string hostname,
+    string username,
+    string password,
+    string flavour,
+    int port,
+    chrono::seconds kaTimeout,
+    chrono::seconds cmdTimeout,
+    chrono::seconds reconnectingQuietPeriod,
+    long sshConnectionTimeout,
+    shared_ptr<Timekeeper> timekeeper,
+    shared_ptr<Executor> sshExecutor,
+    shared_ptr<Executor> paExecutor,
+    shared_ptr<Executor> rcExecutor,
+    shared_ptr<Executor> ttExecutor,
+    shared_ptr<Executor> qExecutor,
+    shared_ptr<Executor> rExecutor,
+    shared_ptr<Executor> kaExecutor) {
+  shared_ptr<IoConfigurationBuilder::ConnectionParameters>
+      connectionParameters =
+          make_shared<IoConfigurationBuilder::ConnectionParameters>();
+  connectionParameters->id = id;
+  connectionParameters->ip = hostname;
+  connectionParameters->username = username;
+  connectionParameters->password = password;
+  connectionParameters->port = port;
+  connectionParameters->flavour = CliFlavour::create(flavour);
+  connectionParameters->kaTimeout = kaTimeout;
+  connectionParameters->cmdTimeout = cmdTimeout;
+  connectionParameters->reconnectingQuietPeriod = reconnectingQuietPeriod;
+  connectionParameters->sshConnectionTimeout = sshConnectionTimeout;
+  connectionParameters->timekeeper = timekeeper;
+  connectionParameters->sshExecutor = sshExecutor;
+  connectionParameters->paExecutor = paExecutor;
+  connectionParameters->rcExecutor = rcExecutor;
+  connectionParameters->ttExecutor = ttExecutor;
+  connectionParameters->qExecutor = qExecutor;
+  connectionParameters->rExecutor = rExecutor;
+  connectionParameters->kaExecutor = kaExecutor;
 
-  // create Queued cli
-  return std::make_shared<QueuedCli>(deviceConfig.id, ccli, executor);
+  return connectionParameters;
+}
+
+string IoConfigurationBuilder::loadConfigValue(
+    const std::map<std::string, std::string>& config,
+    const string& key,
+    const string& defaultValue) {
+  return config.find(key) != config.end() ? config.at(key) : defaultValue;
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
@@ -10,7 +10,9 @@
 #include <devmand/cartography/DeviceConfig.h>
 #include <devmand/channels/cli/Cli.h>
 #include <devmand/channels/cli/CliFlavour.h>
+#include <devmand/channels/cli/PromptAwareCli.h>
 #include <devmand/channels/cli/ReadCachingCli.h>
+#include <devmand/channels/cli/SshSessionAsync.h>
 #include <devmand/channels/cli/engine/Engine.h>
 #include <folly/Executor.h>
 
@@ -19,6 +21,7 @@ namespace devmand::channels::cli {
 using devmand::cartography::DeviceConfig;
 using devmand::channels::cli::Cli;
 using devmand::channels::cli::CliFlavour;
+using devmand::channels::cli::sshsession::SshSessionAsync;
 using namespace std;
 
 using folly::Executor;
@@ -98,5 +101,11 @@ class IoConfigurationBuilder {
       const std::map<std::string, std::string>& plaintextCliKv,
       const string& key,
       const string& defaultValue);
+
+  static Future<shared_ptr<Cli>> configurePromptAwareCli(
+      shared_ptr<PromptAwareCli> cli,
+      shared_ptr<SshSessionAsync> session,
+      shared_ptr<ConnectionParameters> params,
+      shared_ptr<Executor> executor);
 };
 } // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
@@ -11,21 +11,92 @@
 #include <devmand/channels/cli/Cli.h>
 #include <devmand/channels/cli/CliFlavour.h>
 #include <devmand/channels/cli/ReadCachingCli.h>
+#include <devmand/channels/cli/engine/Engine.h>
+#include <folly/Executor.h>
+
+namespace devmand::channels::cli {
 
 using devmand::cartography::DeviceConfig;
 using devmand::channels::cli::Cli;
 using devmand::channels::cli::CliFlavour;
-using std::shared_ptr;
+using namespace std;
 
-namespace devmand::channels::cli {
+using folly::Executor;
+using folly::SemiFuture;
+using folly::Timekeeper;
+
+static constexpr auto configKeepAliveIntervalSeconds =
+    "keepAliveIntervalSeconds";
+static constexpr auto configMaxCommandTimeoutSeconds =
+    "maxCommandTimeoutSeconds";
+static constexpr auto reconnectingQuietPeriodConfig = "reconnectingQuietPeriod";
+static constexpr auto sshConnectionTimeoutConfig = "sshConnectionTimeout";
+
 class IoConfigurationBuilder {
- private:
-  DeviceConfig deviceConfig;
-
  public:
-  IoConfigurationBuilder(const DeviceConfig& deviceConfig);
+  struct ConnectionParameters {
+    string username;
+    string password;
+    string ip;
+    string id;
+    int port;
+    shared_ptr<CliFlavour> flavour;
+    chrono::seconds kaTimeout;
+    chrono::seconds cmdTimeout;
+    chrono::seconds reconnectingQuietPeriod;
+    long sshConnectionTimeout; /* in seconds */
+    shared_ptr<Timekeeper> timekeeper;
+    shared_ptr<Executor> sshExecutor;
+    shared_ptr<Executor> paExecutor;
+    shared_ptr<Executor> rcExecutor;
+    shared_ptr<Executor> ttExecutor;
+    shared_ptr<Executor> qExecutor;
+    shared_ptr<Executor> rExecutor;
+    shared_ptr<Executor> kaExecutor;
+  };
 
-  shared_ptr<Cli> getIo(
-      shared_ptr<CliCache> commandCache = ReadCachingCli::createCache());
+  IoConfigurationBuilder(
+      const DeviceConfig& deviceConfig,
+      channels::cli::Engine& engine);
+  IoConfigurationBuilder(shared_ptr<ConnectionParameters> _connectionParams);
+
+  ~IoConfigurationBuilder();
+
+  shared_ptr<Cli> createAll(shared_ptr<CliCache> commandCache);
+
+  static Future<shared_ptr<Cli>> createPromptAwareCli(
+      shared_ptr<ConnectionParameters> params);
+
+  static shared_ptr<ConnectionParameters> makeConnectionParameters(
+      string id,
+      string hostname,
+      string username,
+      string password,
+      string flavour,
+      int port,
+      chrono::seconds kaTimeout,
+      chrono::seconds cmdTimeout,
+      chrono::seconds reconnectingQuietPeriod,
+      long sshConnectionTimeout,
+      shared_ptr<Timekeeper> timekeeper,
+      shared_ptr<Executor> sshExecutor,
+      shared_ptr<Executor> paExecutor,
+      shared_ptr<Executor> rcExecutor,
+      shared_ptr<Executor> ttExecutor,
+      shared_ptr<Executor> qExecutor,
+      shared_ptr<Executor> rExecutor,
+      shared_ptr<Executor> kaExecutor);
+
+ private:
+  shared_ptr<ConnectionParameters> connectionParameters;
+
+  shared_ptr<Cli> createAllUsingFactory(shared_ptr<CliCache> commandCache);
+
+  static chrono::seconds toSeconds(const string& value);
+
+  static string loadConfigValue(
+      const std::map<std::string, std::string>& plaintextCliKv,
+      const string& key,
+      const string& defaultValue);
 };
 } // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
@@ -86,26 +86,26 @@ void KeepaliveCli::triggerSendKeepAliveCommand(
   }
   ReadCommand cmd =
       ReadCommand::create(keepaliveParameters->keepAliveCommand, true);
-  MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd.getIdx()
+  MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd
                << ") "
                << "triggerSendKeepAliveCommand created new command";
 
   via(keepaliveParameters->serialExecutorKeepAlive)
       .thenValue([params = keepaliveParameters, cmd](auto) {
         MLOG(MDEBUG)
-            << "[" << params->id << "] (" << cmd.getIdx() << ") "
+            << "[" << params->id << "] (" << cmd << ") "
             << "triggerSendKeepAliveCommand executing keepalive command";
 
         return params->cli->executeRead(cmd);
       })
       .thenValue([params = keepaliveParameters, cmd](auto) -> SemiFuture<Unit> {
-        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd << ") "
                      << "Creating sleep future";
         return futures::sleep(
             params->heartbeatInterval, params->timekeeper.get());
       })
       .thenValue([keepaliveParameters, cmd](auto) -> Unit {
-        MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd.getIdx()
+        MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd
                      << ") "
                      << "Woke up after sleep";
         triggerSendKeepAliveCommand(keepaliveParameters);
@@ -116,7 +116,7 @@ void KeepaliveCli::triggerSendKeepAliveCommand(
           [params = keepaliveParameters,
            cmd](std::exception const& e) -> Future<Unit> {
             MLOG(MINFO)
-                << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                << "[" << params->id << "] (" << cmd << ") "
                 << "Got error running keepalive, backing off "
                 << e.what(); // FIXME: real exception is not propagated here
 
@@ -126,7 +126,7 @@ void KeepaliveCli::triggerSendKeepAliveCommand(
                 .via(params->serialExecutorKeepAlive)
                 .thenValue([params, cmd](auto) -> Unit {
                   MLOG(MDEBUG)
-                      << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                      << "[" << params->id << "] (" << cmd << ") "
                       << "Woke up after backing off";
                   triggerSendKeepAliveCommand(params);
                   return Unit{};

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/cli/Command.h>
+#include <devmand/channels/cli/KeepaliveCli.h>
+#include <magma_logging.h>
+
+namespace devmand::channels::cli {
+
+using devmand::channels::cli::Command;
+using namespace std;
+using namespace folly;
+
+shared_ptr<KeepaliveCli> KeepaliveCli::make(
+    string id,
+    shared_ptr<Cli> cli,
+    shared_ptr<folly::Executor> parentExecutor,
+    shared_ptr<folly::Timekeeper> timekeeper,
+    chrono::milliseconds heartbeatInterval,
+    string keepAliveCommand,
+    chrono::milliseconds backoffAfterKeepaliveTimeout) {
+  const shared_ptr<KeepaliveCli>& result =
+      shared_ptr<KeepaliveCli>(new KeepaliveCli(
+          id,
+          cli,
+          parentExecutor,
+          timekeeper,
+          heartbeatInterval,
+          move(keepAliveCommand),
+          backoffAfterKeepaliveTimeout));
+  return result;
+}
+
+KeepaliveCli::KeepaliveCli(
+    string _id,
+    shared_ptr<Cli> _cli,
+    shared_ptr<Executor> _parentExecutor,
+    shared_ptr<Timekeeper> _timekeeper,
+    chrono::milliseconds _heartbeatInterval,
+    string _keepAliveCommand,
+    chrono::milliseconds _backoffAfterKeepaliveTimeout) {
+  keepaliveParameters = shared_ptr<KeepaliveParameters>(new KeepaliveParameters{
+      /* id */ _id,
+      /* cli */ _cli,
+      /* timekeeper */ _timekeeper,
+      /* parentExecutor */ _parentExecutor,
+      /* serialExecutorKeepAlive */
+      SerialExecutor::create(
+          Executor::getKeepAliveToken(_parentExecutor.get())),
+      /* keepAliveCommand */ move(_keepAliveCommand),
+      /* heartbeatInterval */ _heartbeatInterval,
+      /* backoffAfterKeepaliveTimeout */ _backoffAfterKeepaliveTimeout,
+      /* shutdown */ {false}});
+
+  MLOG(MDEBUG) << "[" << _id << "] "
+               << "initialized";
+  triggerSendKeepAliveCommand(keepaliveParameters);
+}
+
+KeepaliveCli::~KeepaliveCli() {
+  string id = keepaliveParameters->id;
+  keepaliveParameters->shutdown = true;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~KeepaliveCli started";
+  while (keepaliveParameters.use_count() >
+         1) { // TODO cancel currently running future
+    MLOG(MDEBUG) << "[" << id << "] "
+                 << "~KeepaliveCli sleeping";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+  keepaliveParameters = nullptr;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~KeepaliveCli done";
+}
+
+void KeepaliveCli::triggerSendKeepAliveCommand(
+    shared_ptr<KeepaliveParameters> keepaliveParameters) {
+  if (keepaliveParameters->shutdown) {
+    MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] "
+                 << "triggerSendKeepAliveCommand shutting down";
+    return;
+  }
+  ReadCommand cmd =
+      ReadCommand::create(keepaliveParameters->keepAliveCommand, true);
+  MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd.getIdx()
+               << ") "
+               << "triggerSendKeepAliveCommand created new command";
+
+  via(keepaliveParameters->serialExecutorKeepAlive)
+      .thenValue([params = keepaliveParameters, cmd](auto) {
+        MLOG(MDEBUG)
+            << "[" << params->id << "] (" << cmd.getIdx() << ") "
+            << "triggerSendKeepAliveCommand executing keepalive command";
+
+        return params->cli->executeRead(cmd);
+      })
+      .thenValue([params = keepaliveParameters, cmd](auto) -> SemiFuture<Unit> {
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                     << "Creating sleep future";
+        return futures::sleep(
+            params->heartbeatInterval, params->timekeeper.get());
+      })
+      .thenValue([keepaliveParameters, cmd](auto) -> Unit {
+        MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] (" << cmd.getIdx()
+                     << ") "
+                     << "Woke up after sleep";
+        triggerSendKeepAliveCommand(keepaliveParameters);
+        return Unit{};
+      })
+      .thenError(
+          folly::tag_t<std::exception>{},
+          [params = keepaliveParameters,
+           cmd](std::exception const& e) -> Future<Unit> {
+            MLOG(MINFO)
+                << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                << "Got error running keepalive, backing off "
+                << e.what(); // FIXME: real exception is not propagated here
+
+            return futures::sleep(
+                       params->backoffAfterKeepaliveTimeout,
+                       params->timekeeper.get())
+                .via(params->serialExecutorKeepAlive)
+                .thenValue([params, cmd](auto) -> Unit {
+                  MLOG(MDEBUG)
+                      << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                      << "Woke up after backing off";
+                  triggerSendKeepAliveCommand(params);
+                  return Unit{};
+                });
+          });
+}
+
+folly::SemiFuture<std::string> KeepaliveCli::executeRead(
+    const ReadCommand cmd) {
+  return keepaliveParameters->cli->executeRead(cmd);
+}
+
+folly::SemiFuture<std::string> KeepaliveCli::executeWrite(
+    const WriteCommand cmd) {
+  return keepaliveParameters->cli->executeWrite(cmd);
+}
+
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.h
@@ -1,0 +1,71 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <devmand/channels/cli/Cli.h>
+#include <folly/Executor.h>
+#include <folly/executors/SerialExecutor.h>
+#include <folly/futures/Future.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+
+namespace devmand::channels::cli {
+using namespace std;
+using devmand::channels::cli::Command;
+
+static constexpr chrono::seconds defaultKeepaliveInterval = chrono::seconds(60);
+
+// CLI layer that should be above QueuedCli. Periodically schedules keepalive
+// command to prevent dropping
+// of inactive connection.
+class KeepaliveCli : public Cli {
+ public:
+  static shared_ptr<KeepaliveCli> make(
+      string id,
+      shared_ptr<Cli> _cli,
+      shared_ptr<folly::Executor> parentExecutor,
+      shared_ptr<folly::Timekeeper> _timekeeper,
+      chrono::milliseconds heartbeatInterval = defaultKeepaliveInterval,
+      string keepAliveCommand = "",
+      chrono::milliseconds backoffAfterKeepaliveTimeout = chrono::seconds(5));
+
+  ~KeepaliveCli() override;
+
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override;
+
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override;
+
+ private:
+  struct KeepaliveParameters {
+    string id;
+    shared_ptr<Cli> cli; // underlying cli layer
+    shared_ptr<folly::Timekeeper> timekeeper;
+    shared_ptr<folly::Executor> parentExecutor;
+    folly::Executor::KeepAlive<folly::SerialExecutor> serialExecutorKeepAlive;
+    string keepAliveCommand;
+    chrono::milliseconds heartbeatInterval;
+    chrono::milliseconds backoffAfterKeepaliveTimeout;
+    atomic<bool> shutdown;
+
+    KeepaliveParameters(KeepaliveParameters&&) = default;
+  };
+
+  shared_ptr<KeepaliveParameters> keepaliveParameters;
+
+  KeepaliveCli(
+      string id,
+      shared_ptr<Cli> _cli,
+      shared_ptr<folly::Executor> parentExecutor,
+      shared_ptr<folly::Timekeeper> _timekeeper,
+      chrono::milliseconds heartbeatInterval,
+      string keepAliveCommand,
+      chrono::milliseconds backoffAfterKeepaliveTimeout);
+
+  static void triggerSendKeepAliveCommand(
+      shared_ptr<KeepaliveParameters> keepaliveParameters);
+};
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
@@ -43,11 +43,11 @@ folly::SemiFuture<std::string> PromptAwareCli::executeRead(
       .semi()
       .via(promptAwareParameters->executor.get())
       .thenValue([params = promptAwareParameters, command, cmd](...) {
-        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd
                      << ") written command";
         SemiFuture<string> result =
             params->session->readUntilOutput(command).semi();
-        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd
                      << ") obtained future readUntilOutput";
         return move(result);
       })
@@ -58,7 +58,7 @@ folly::SemiFuture<std::string> PromptAwareCli::executeRead(
             .semi()
             .via(params->executor.get())
             .thenValue([params, output, cmd](...) {
-              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd
                            << ") written newline";
               return output;
             })
@@ -73,7 +73,7 @@ folly::SemiFuture<std::string> PromptAwareCli::executeRead(
             .thenValue(
                 [id = params->id, output, cmd](const string& readUntilOutput) {
                   // this might never run, do not capture params
-                  MLOG(MDEBUG) << "[" << id << "] (" << cmd.getIdx()
+                  MLOG(MDEBUG) << "[" << id << "] (" << cmd
                                << ") readUntilOutput - read result";
                   return output + readUntilOutput;
                 })
@@ -116,11 +116,11 @@ folly::SemiFuture<std::string> PromptAwareCli::executeWrite(
       .semi()
       .via(promptAwareParameters->executor.get())
       .thenValue([params = promptAwareParameters, command, cmd](...) {
-        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd
                      << ") written command";
         SemiFuture<string> result =
             params->session->readUntilOutput(command).semi();
-        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd
                      << ") obtained future readUntilOutput";
         return move(result);
       })
@@ -130,7 +130,7 @@ folly::SemiFuture<std::string> PromptAwareCli::executeWrite(
                 .semi()
                 .via(params->executor.get())
                 .thenValue([id = params->id, output, command, cmd](...) {
-                  MLOG(MDEBUG) << "[" << id << "] (" << cmd.getIdx()
+                  MLOG(MDEBUG) << "[" << id << "] (" << cmd
                                << ") written newline";
                   return output + command;
                 })

--- a/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
@@ -20,56 +20,134 @@ namespace devmand {
 namespace channels {
 namespace cli {
 
-void PromptAwareCli::resolvePrompt() {
-  this->prompt =
-      cliFlavour->resolver->resolvePrompt(session, cliFlavour->newline);
-}
-
-void PromptAwareCli::initializeCli() {
-  cliFlavour->initializer->initialize(session);
-}
-
-folly::Future<string> PromptAwareCli::executeAndRead(const Command& cmd) {
-  const string& command = cmd.toString();
-
-  return session->write(command)
-      .thenValue([=](...) { return session->readUntilOutput(command); })
-      .thenValue([=](const string& output) {
-        auto returnOutputParameter = [output](...) { return output; };
-        return session->write(cliFlavour->newline)
-            .thenValue(returnOutputParameter);
-      })
-      .thenValue([=](const string& output) {
-        auto concatOutputParameter = [output](const string& readUntilOutput) {
-          return output + readUntilOutput;
-        };
-        return session->readUntilOutput(prompt).thenValue(
-            concatOutputParameter);
+SemiFuture<Unit> PromptAwareCli::resolvePrompt() {
+  return promptAwareParameters->cliFlavour->resolver
+      ->resolvePrompt(
+          promptAwareParameters->session,
+          promptAwareParameters->cliFlavour->newline)
+      .thenValue([params = promptAwareParameters](string _prompt) {
+        params->prompt = _prompt;
       });
+}
+
+SemiFuture<Unit> PromptAwareCli::initializeCli(const string secret) {
+  return promptAwareParameters->cliFlavour->initializer->initialize(
+      promptAwareParameters->session, secret);
+}
+
+folly::SemiFuture<std::string> PromptAwareCli::executeRead(
+    const ReadCommand cmd) {
+  const string& command = cmd.raw();
+
+  return promptAwareParameters->session->write(command)
+      .semi()
+      .via(promptAwareParameters->executor.get())
+      .thenValue([params = promptAwareParameters, command, cmd](...) {
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+                     << ") written command";
+        SemiFuture<string> result =
+            params->session->readUntilOutput(command).semi();
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+                     << ") obtained future readUntilOutput";
+        return move(result);
+      })
+      .semi()
+      .via(promptAwareParameters->executor.get())
+      .thenValue([params = promptAwareParameters, cmd](const string& output) {
+        return params->session->write(params->cliFlavour->newline)
+            .semi()
+            .via(params->executor.get())
+            .thenValue([params, output, cmd](...) {
+              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+                           << ") written newline";
+              return output;
+            })
+            .semi();
+      })
+      .semi()
+      .via(promptAwareParameters->executor.get())
+      .thenValue([params = promptAwareParameters, cmd](const string& output) {
+        return params->session->readUntilOutput(params->prompt)
+            .semi()
+            .via(params->executor.get())
+            .thenValue(
+                [id = params->id, output, cmd](const string& readUntilOutput) {
+                  // this might never run, do not capture params
+                  MLOG(MDEBUG) << "[" << id << "] (" << cmd.getIdx()
+                               << ") readUntilOutput - read result";
+                  return output + readUntilOutput;
+                })
+            .semi();
+      })
+      .semi();
 }
 
 PromptAwareCli::PromptAwareCli(
-    shared_ptr<SshSessionAsync> _session,
-    shared_ptr<CliFlavour> _cliFlavour)
-    : session(_session), cliFlavour(_cliFlavour) {}
-
-void PromptAwareCli::init( // TODO remove
-    const string hostname,
-    const int port,
-    const string username,
-    const string password) {
-  session->openShell(hostname, port, username, password).get();
+    string id,
+    shared_ptr<SessionAsync> _session,
+    shared_ptr<CliFlavour> _cliFlavour,
+    shared_ptr<Executor> _executor) {
+  promptAwareParameters = shared_ptr<PromptAwareParameters>(
+      new PromptAwareParameters{id, _session, _cliFlavour, _executor, {}});
 }
 
-folly::Future<std::string> PromptAwareCli::execute(const Command& cmd) {
-  const string& command = cmd.toString();
-  return session->write(command)
-      .thenValue([=](...) { return session->readUntilOutput(command); })
-      .thenValue([=](const string& output) {
-        return session->write(cliFlavour->newline)
-            .thenValue([output, command](...) { return output + command; });
-      });
+PromptAwareCli::~PromptAwareCli() {
+  string id = promptAwareParameters->id;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~PromptAwareCli started";
+  while (promptAwareParameters.use_count() > 1) {
+    MLOG(MDEBUG) << "[" << id << "] "
+                 << "~PromptAwareCli sleeping";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  // Closing session explicitly to finish executing future and disconnect before
+  // releasing the rest of state
+  promptAwareParameters->session = nullptr;
+  promptAwareParameters = nullptr;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~PromptAwareCli done";
 }
+
+folly::SemiFuture<std::string> PromptAwareCli::executeWrite(
+    const WriteCommand cmd) {
+  const string& command = cmd.raw();
+  return promptAwareParameters->session->write(command)
+      .semi()
+      .via(promptAwareParameters->executor.get())
+      .thenValue([params = promptAwareParameters, command, cmd](...) {
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+                     << ") written command";
+        SemiFuture<string> result =
+            params->session->readUntilOutput(command).semi();
+        MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx()
+                     << ") obtained future readUntilOutput";
+        return move(result);
+      })
+      .thenValue(
+          [params = promptAwareParameters, command, cmd](const string& output) {
+            return params->session->write(params->cliFlavour->newline)
+                .semi()
+                .via(params->executor.get())
+                .thenValue([id = params->id, output, command, cmd](...) {
+                  MLOG(MDEBUG) << "[" << id << "] (" << cmd.getIdx()
+                               << ") written newline";
+                  return output + command;
+                })
+                .semi();
+          })
+      .semi();
+}
+
+shared_ptr<PromptAwareCli> PromptAwareCli::make(
+    string id,
+    shared_ptr<SessionAsync> session,
+    shared_ptr<CliFlavour> cliFlavour,
+    shared_ptr<Executor> executor) {
+  return shared_ptr<PromptAwareCli>(
+      new PromptAwareCli(id, session, cliFlavour, executor));
+}
+
 } // namespace cli
 } // namespace channels
 } // namespace devmand

--- a/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
@@ -124,18 +124,17 @@ folly::SemiFuture<std::string> PromptAwareCli::executeWrite(
                      << ") obtained future readUntilOutput";
         return move(result);
       })
-      .thenValue(
-          [params = promptAwareParameters, command, cmd](const string& output) {
-            return params->session->write(params->cliFlavour->newline)
-                .semi()
-                .via(params->executor.get())
-                .thenValue([id = params->id, output, command, cmd](...) {
-                  MLOG(MDEBUG) << "[" << id << "] (" << cmd
-                               << ") written newline";
-                  return output + command;
-                })
-                .semi();
-          })
+      .thenValue([params = promptAwareParameters, command, cmd](
+                     const string& output) {
+        return params->session->write(params->cliFlavour->newline)
+            .semi()
+            .via(params->executor.get())
+            .thenValue([id = params->id, output, command, cmd](...) {
+              MLOG(MDEBUG) << "[" << id << "] (" << cmd << ") written newline";
+              return output + command;
+            })
+            .semi();
+      })
       .semi();
 }
 

--- a/devmand/gateway/src/devmand/channels/cli/ReadCachingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/ReadCachingCli.cpp
@@ -6,6 +6,7 @@
 // of patent rights can be found in the PATENTS file in the same directory.
 
 #include <devmand/channels/cli/ReadCachingCli.h>
+#include <folly/Optional.h>
 #include <folly/Synchronized.h>
 #include <folly/container/EvictingCacheMap.h>
 #include <magma_logging.h>
@@ -14,44 +15,56 @@ using devmand::channels::cli::Cli;
 using devmand::channels::cli::Command;
 using folly::EvictingCacheMap;
 using folly::Future;
+using folly::Optional;
 using folly::Synchronized;
 using std::shared_ptr;
 using std::string;
 using CliCache = Synchronized<EvictingCacheMap<string, string>>;
 
-Future<string> devmand::channels::cli::ReadCachingCli::executeAndRead(
-    const Command& cmd) {
-  const string command = cmd.toString();
+folly::SemiFuture<std::string>
+devmand::channels::cli::ReadCachingCli::executeRead(const ReadCommand cmd) {
+  if (!cmd.skipCache()) {
+    Optional<string> cachedResult =
+        cache->withWLock([cmd, this](auto& cache_) -> Optional<string> {
+          if (cache_.exists(cmd.raw())) {
+            MLOG(MDEBUG) << "[" << id << "] "
+                         << "Found command: " << cmd << " in cache";
+            return Optional<string>(cache_.get(cmd.raw()));
+          } else {
+            return Optional<string>(folly::none);
+          }
+        });
 
-  string cachedResult = cache->withWLock([=](auto& cache_) {
-    if (cache_.exists(command)) {
-      MLOG(MDEBUG) << "[" << id << "] "
-                   << "Found command: " << command << " in cache";
-      return cache_.get(command);
-    } else {
-      return string("");
+    if (cachedResult) {
+      return folly::SemiFuture<string>(*cachedResult.get_pointer());
     }
-  });
-
-  if (!cachedResult.empty()) {
-    return Future<string>(cachedResult);
   }
 
-  return cli->executeAndRead(cmd).thenValue([=](string output) {
-    cache->wlock()->insert(command, output);
-    return output;
-  });
+  return cli->executeRead(cmd)
+      .via(executor.get())
+      .thenValue([=](string output) {
+        cache->wlock()->insert(cmd.raw(), output);
+        return output;
+      })
+      .semi();
 }
 
 devmand::channels::cli::ReadCachingCli::ReadCachingCli(
     string _id,
     const std::shared_ptr<Cli>& _cli,
-    const shared_ptr<CliCache>& _cache)
-    : id(_id), cli(_cli), cache(_cache) {}
+    const shared_ptr<CliCache>& _cache,
+    const shared_ptr<folly::Executor> _executor)
 
-Future<string> devmand::channels::cli::ReadCachingCli::execute(
-    const Command& cmd) {
-  return cli->execute(cmd);
+    : id(_id), cli(_cli), cache(_cache), executor(_executor) {}
+
+folly::SemiFuture<std::string>
+devmand::channels::cli::ReadCachingCli::executeWrite(const WriteCommand cmd) {
+  return cli->executeWrite(cmd);
+}
+
+devmand::channels::cli::ReadCachingCli::~ReadCachingCli() {
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~RCcli";
 }
 
 shared_ptr<CliCache> devmand::channels::cli::ReadCachingCli::createCache() {

--- a/devmand/gateway/src/devmand/channels/cli/ReadCachingCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/ReadCachingCli.h
@@ -25,15 +25,19 @@ class ReadCachingCli : public Cli {
   string id;
   shared_ptr<Cli> cli{};
   shared_ptr<CliCache> cache;
+  shared_ptr<folly::Executor> executor;
 
  public:
   ReadCachingCli(
       string _id,
       const shared_ptr<Cli>& _cli,
-      const shared_ptr<CliCache>& _cache);
+      const shared_ptr<CliCache>& _cache,
+      const shared_ptr<folly::Executor> executor);
+
+  ~ReadCachingCli() override;
 
   static shared_ptr<CliCache> createCache();
-  Future<string> executeAndRead(const Command& cmd) override;
-  Future<string> execute(const Command& cmd) override;
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override;
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override;
 };
 } // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.cpp
@@ -92,6 +92,7 @@ void ReconnectingCli::triggerReconnect(shared_ptr<ReconnectParameters> params) {
                 return unit;
               });
         }) // TODO: Add onTimeout here to handle establish session timeouts?
+
         .thenError(
             folly::tag_t<std::exception>{},
             [params](std::exception const& e) -> Future<Unit> {
@@ -153,20 +154,11 @@ SemiFuture<string> ReconnectingCli::executeSomething(
   if (cliOrNull != nullptr) {
     return innerFunc(cliOrNull)
         .via(reconnectParameters->executor.get())
-        .thenValue(
-            [params = reconnectParameters, loggingPrefix, cmd](
-                string result) -> string {
-              // TODO: move this to deeper layer
-              // auto dis = shared_from_this();
-              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
-                           << loggingPrefix << " succeeded";
-              return result;
-            })
         .thenError( // TODO: only reconnect on timeout exception
             folly::tag_t<std::exception>{},
             [params = reconnectParameters, loggingPrefix, cmd](
                 exception const& e) -> Future<string> {
-              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd << ") "
                            << loggingPrefix
                            << " failed with error : " << e.what();
 

--- a/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/cli/ReconnectingCli.h>
+#include <magma_logging.h>
+
+namespace devmand {
+namespace channels {
+namespace cli {
+
+using namespace std;
+using namespace folly;
+
+shared_ptr<ReconnectingCli> ReconnectingCli::make(
+    string id,
+    shared_ptr<Executor> executor,
+    function<SemiFuture<shared_ptr<Cli>>()>&& createCliStack,
+    shared_ptr<Timekeeper> timekeeper,
+    chrono::milliseconds quietPeriod) {
+  return shared_ptr<ReconnectingCli>(new ReconnectingCli(
+      id, executor, move(createCliStack), move(timekeeper), move(quietPeriod)));
+}
+
+ReconnectingCli::ReconnectingCli(
+    string id,
+    shared_ptr<Executor> executor,
+    function<SemiFuture<shared_ptr<Cli>>()>&& createCliStack,
+    shared_ptr<Timekeeper> timekeeper,
+    chrono::milliseconds quietPeriod) {
+  reconnectParameters = make_shared<ReconnectParameters>();
+  reconnectParameters->id = id;
+  reconnectParameters->executor = executor;
+  reconnectParameters->createCliStack = move(createCliStack);
+  reconnectParameters->maybeCli = nullptr;
+  reconnectParameters->shutdown = false;
+  reconnectParameters->isReconnecting = false;
+  reconnectParameters->quietPeriod = quietPeriod;
+  reconnectParameters->timekeeper = timekeeper;
+  // start async (re)connect
+  triggerReconnect(reconnectParameters);
+}
+
+ReconnectingCli::~ReconnectingCli() {
+  string id = reconnectParameters->id;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~RCli started";
+  reconnectParameters->shutdown = true;
+  while (reconnectParameters.use_count() >
+         1) { // TODO cancel currently running future
+    MLOG(MDEBUG) << "[" << id << "] "
+                 << "~RCli sleeping";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  reconnectParameters = nullptr;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~RCli done";
+}
+
+void ReconnectingCli::triggerReconnect(shared_ptr<ReconnectParameters> params) {
+  if (params->shutdown)
+    return;
+  bool f = false;
+  if (params->isReconnecting.compare_exchange_strong(f, true)) {
+    via(params->executor.get(),
+        [params]() -> Future<Unit> {
+          MLOG(MDEBUG) << "[" << params->id << "] "
+                       << "Recreating cli stack";
+          {
+            boost::mutex::scoped_lock scoped_lock(params->cliMutex);
+            params->maybeCli = nullptr;
+            MLOG(MDEBUG) << "[" << params->id << "] "
+                         << "Recreating cli stack - destroyed old stack";
+          }
+          Future<shared_ptr<Cli>> newCliFuture =
+              params->createCliStack().via(params->executor.get());
+
+          return move(newCliFuture)
+              .thenValue([params](shared_ptr<Cli> newCli) -> Unit {
+                {
+                  boost::mutex::scoped_lock scoped_lock(params->cliMutex);
+
+                  params->maybeCli = std::move(newCli);
+                }
+                params->isReconnecting = false;
+                MLOG(MDEBUG) << "[" << params->id << "] "
+                             << "Recreating cli stack - done";
+                return unit;
+              });
+        }) // TODO: Add onTimeout here to handle establish session timeouts?
+        .thenError(
+            folly::tag_t<std::exception>{},
+            [params](std::exception const& e) -> Future<Unit> {
+              // quiet period
+              MLOG(MDEBUG)
+                  << "[" << params->id << "] "
+                  << "triggerReconnect started quiet period, got error : "
+                  << e.what();
+
+              return futures::sleep(
+                         params->quietPeriod, params->timekeeper.get())
+                  .via(params->executor.get())
+                  .thenValue([params](Unit) -> Future<Unit> {
+                    MLOG(MDEBUG)
+                        << "[" << params->id << "] "
+                        << "triggerReconnect reconnecting after quiet period";
+                    params->isReconnecting = false;
+                    triggerReconnect(params);
+                    return makeFuture();
+                  });
+            });
+  } else {
+    MLOG(MDEBUG) << "[" << params->id << "] "
+                 << "Already reconnecting";
+  }
+}
+
+folly::SemiFuture<std::string> ReconnectingCli::executeRead(
+    const ReadCommand cmd) {
+  // capturing this is ok here - lambda is evaluated synchronously
+  return executeSomething(
+      "RCli.executeRead",
+      [cmd](shared_ptr<Cli> cli) { return cli->executeRead(cmd); },
+      cmd);
+}
+
+folly::SemiFuture<std::string> ReconnectingCli::executeWrite(
+    const WriteCommand cmd) {
+  // capturing this is ok here - lambda is evaluated synchronously
+  return executeSomething(
+      "RCli.executeWrite",
+      [cmd](shared_ptr<Cli> cli) { return cli->executeWrite(cmd); },
+      cmd);
+}
+
+SemiFuture<string> ReconnectingCli::executeSomething(
+    const string&& loggingPrefix,
+    const function<SemiFuture<string>(shared_ptr<Cli>)>& innerFunc,
+    const Command cmd) {
+  shared_ptr<Cli> cliOrNull = nullptr;
+  if (reconnectParameters->isReconnecting) {
+    return makeFuture<string>(runtime_error("Not connected"));
+  }
+  { // TODO: trylock and throw on already locked. This means reconnect is in
+    // progress
+    boost::mutex::scoped_lock scoped_lock(reconnectParameters->cliMutex);
+    cliOrNull = reconnectParameters->maybeCli;
+  }
+  if (cliOrNull != nullptr) {
+    return innerFunc(cliOrNull)
+        .via(reconnectParameters->executor.get())
+        .thenValue(
+            [params = reconnectParameters, loggingPrefix, cmd](
+                string result) -> string {
+              // TODO: move this to deeper layer
+              // auto dis = shared_from_this();
+              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                           << loggingPrefix << " succeeded";
+              return result;
+            })
+        .thenError( // TODO: only reconnect on timeout exception
+            folly::tag_t<std::exception>{},
+            [params = reconnectParameters, loggingPrefix, cmd](
+                exception const& e) -> Future<string> {
+              MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                           << loggingPrefix
+                           << " failed with error : " << e.what();
+
+              // Using "this" raw pointer, however we have the
+              // shared_ptr<params> to protect against destructor call
+              triggerReconnect(params);
+              auto cpException = runtime_error(e.what());
+              // TODO: exception type is not preserved,
+              // queueEntry.promise->setException(e) results in std::exception
+              throw cpException;
+            })
+        .semi();
+  } else {
+    return makeFuture<string>(runtime_error("Not connected"));
+  }
+}
+
+} // namespace cli
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/ReconnectingCli.h
@@ -1,0 +1,83 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <boost/thread/mutex.hpp>
+#include <devmand/channels/cli/Cli.h>
+#include <devmand/channels/cli/Command.h>
+#include <folly/Executor.h>
+#include <folly/executors/SerialExecutor.h>
+#include <folly/futures/Future.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+
+namespace devmand {
+namespace channels {
+namespace cli {
+
+using namespace std;
+using namespace folly;
+using boost::mutex;
+using devmand::channels::cli::Cli;
+using devmand::channels::cli::Command;
+
+class ReconnectingCli : public Cli {
+ public:
+  static shared_ptr<ReconnectingCli> make(
+      string id,
+      shared_ptr<Executor> executor,
+      function<SemiFuture<shared_ptr<Cli>>()>&& createCliStack,
+      shared_ptr<Timekeeper> timekeeper,
+      chrono::milliseconds quietPeriod);
+
+  ~ReconnectingCli() override;
+
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override;
+
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override;
+
+ private:
+  struct ReconnectParameters {
+    string id;
+
+    atomic<bool> isReconnecting; // TODO: merge with maybeCli
+
+    atomic<bool> shutdown;
+
+    shared_ptr<Executor> executor;
+
+    function<SemiFuture<shared_ptr<Cli>>()> createCliStack;
+
+    mutex cliMutex;
+
+    // guarded by mutex
+    shared_ptr<Cli> maybeCli;
+
+    std::chrono::milliseconds quietPeriod;
+
+    shared_ptr<Timekeeper> timekeeper;
+  };
+
+  shared_ptr<ReconnectParameters> reconnectParameters;
+
+  ReconnectingCli(
+      string id,
+      shared_ptr<Executor> executor,
+      function<SemiFuture<shared_ptr<Cli>>()>&& createCliStack,
+      shared_ptr<Timekeeper> timekeeper,
+      chrono::milliseconds quietPeriod);
+
+  SemiFuture<string> executeSomething(
+      const string&& loggingPrefix,
+      const function<SemiFuture<string>(shared_ptr<Cli>)>& innerFunc,
+      const Command cmd);
+
+  static void triggerReconnect(shared_ptr<ReconnectParameters> params);
+};
+} // namespace cli
+} // namespace channels
+} // namespace devmand

--- a/devmand/gateway/src/devmand/channels/cli/SshSession.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/SshSession.cpp
@@ -77,7 +77,7 @@ void SshSession::openShell(
 
   sessionState.channel.store(ssh_channel_new(sessionState.session));
   if (sessionState.channel == nullptr) {
-    terminate();
+    terminate<CliException>();
   }
 
   rc = ssh_channel_open_session(sessionState.channel);
@@ -97,10 +97,11 @@ bool SshSession::checkSuccess(int return_code, int OK_RETURN_CODE) {
   if (return_code == OK_RETURN_CODE) {
     return true;
   }
-  terminate(); // TODO is this an appropriate reaction to every problem??
+  terminate<CliException>(); // TODO is this an appropriate reaction to every problem??
   return false;
 }
 
+template <typename E>
 void SshSession::terminate() {
   const char* error_message = sessionState.session != nullptr
       ? ssh_get_error(sessionState.session)
@@ -110,7 +111,7 @@ void SshSession::terminate() {
                << " port: " << sessionState.port
                << " with error: " << error_message;
   string error = "Error with SSH: ";
-  throw std::runtime_error(error + error_message);
+  throw E(error + error_message);
 }
 
 string SshSession::read(int timeoutMillis) {
@@ -133,7 +134,7 @@ string SshSession::read(int timeoutMillis) {
       MLOG(MERROR) << "[" << id << "] "
                    << "Error reading data from SSH connection, read bytes: "
                    << bytes_read;
-      terminate();
+      terminate<CommandExecutionException>();
     } else if (bytes_read == 0) {
       return result;
     } else {
@@ -159,7 +160,7 @@ void SshSession::write(const string& command) {
   if (bytes == SSH_ERROR) {
     MLOG(MERROR) << "[" << id << "] "
                  << "Error while executing command " << command;
-    terminate();
+    terminate<CommandExecutionException>();
   }
 }
 

--- a/devmand/gateway/src/devmand/channels/cli/SshSession.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/SshSession.cpp
@@ -97,7 +97,8 @@ bool SshSession::checkSuccess(int return_code, int OK_RETURN_CODE) {
   if (return_code == OK_RETURN_CODE) {
     return true;
   }
-  terminate<CliException>(); // TODO is this an appropriate reaction to every problem??
+  terminate<CliException>(); // TODO is this an appropriate reaction to every
+                             // problem??
   return false;
 }
 

--- a/devmand/gateway/src/devmand/channels/cli/SshSession.h
+++ b/devmand/gateway/src/devmand/channels/cli/SshSession.h
@@ -44,7 +44,8 @@ class SshSession {
       const string& ip,
       int port,
       const string& username,
-      const string& password);
+      const string& password,
+      const long timeout);
   void close();
   bool isOpen();
   void write(const string& command);

--- a/devmand/gateway/src/devmand/channels/cli/SshSession.h
+++ b/devmand/gateway/src/devmand/channels/cli/SshSession.h
@@ -33,6 +33,7 @@ class SshSession {
   int verbosity;
 
   bool checkSuccess(int return_code, int OK_RETURN_CODE);
+  template <typename E>
   void terminate();
 
  public:

--- a/devmand/gateway/src/devmand/channels/cli/SshSessionAsync.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/SshSessionAsync.cpp
@@ -8,7 +8,7 @@
 #include <ErrorHandler.h>
 #include <devmand/channels/cli/SshSession.h>
 #include <devmand/channels/cli/SshSessionAsync.h>
-#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/IOExecutor.h>
 #include <folly/futures/Future.h>
 #include <chrono>
 #include <condition_variable>
@@ -25,27 +25,57 @@ using devmand::channels::cli::sshsession::SshSession;
 using devmand::channels::cli::sshsession::SshSessionAsync;
 using std::lock_guard;
 using std::unique_lock;
+using namespace std::chrono_literals;
 
 SshSessionAsync::SshSessionAsync(
     string _id,
-    shared_ptr<IOThreadPoolExecutor> _executor)
-    : executor(_executor), session(_id), reading(false) {}
+    shared_ptr<folly::Executor> _executor)
+    : id(_id),
+      executor(_executor),
+      serialExecutor(SerialExecutor::create(
+          folly::Executor::getKeepAliveToken(_executor.get()))),
+      session(_id),
+      reading(false),
+      callbackFinished(false),
+      matchingExpectedOutput(false) {}
+
+static const int EVENT_FINISH = 9999;
 
 SshSessionAsync::~SshSessionAsync() {
-  if (this->sessionEvent != nullptr &&
-      event_get_base(this->sessionEvent) != nullptr) {
-    event_free(this->sessionEvent);
+  MLOG(MDEBUG) << "~SshSessionAsync started";
+
+  // Let the NIO callback finish by injecting artificial event and waiting for
+  // callback to finish
+  if (sessionEvent != nullptr && event_get_base(sessionEvent) != nullptr) {
+    event_active(this->sessionEvent, EVENT_FINISH, -1);
+    while (!callbackFinished) {
+      std::this_thread::sleep_for(100ms);
+    }
   }
+
   this->session.close();
 
   while (reading.load()) {
-    // waiting for any pending read to run out
+    // waiting for last read run out
   }
+
+  failCurrentRead(
+      runtime_error("Session is closed"), this->readingState.promise);
+
+  MLOG(MDEBUG) << "~SshSessionAsync finished";
+}
+
+void SshSessionAsync::unregisterEvent() {
+  if (sessionEvent != nullptr && event_get_base(sessionEvent) != nullptr) {
+    MLOG(MDEBUG) << "SshSessionAsync unregisterEvent";
+    event_free(sessionEvent);
+  }
+  callbackFinished = true;
 }
 
 Future<string> SshSessionAsync::read(int timeoutMillis) {
-  return via(executor.get(), [this, timeoutMillis] {
-    return session.read(timeoutMillis);
+  return via(serialExecutor.get(), [dis = shared_from_this(), timeoutMillis] {
+    return dis->session.read(timeoutMillis);
   });
 }
 
@@ -53,20 +83,35 @@ Future<Unit> SshSessionAsync::openShell(
     const string& ip,
     int port,
     const string& username,
-    const string& password) {
-  return via(executor.get(), [this, ip, port, username, password] {
-    session.openShell(ip, port, username, password);
-  });
+    const string& password,
+    const long sshConnectionTimeout) {
+  return via(
+      serialExecutor.get(),
+      [dis = shared_from_this(),
+       ip,
+       port,
+       username,
+       password,
+       sshConnectionTimeout] {
+        dis->session.openShell(
+            ip, port, username, password, sshConnectionTimeout);
+      });
 }
 
 Future<Unit> SshSessionAsync::write(const string& command) {
-  return via(executor.get(), [this, command] { session.write(command); });
+  return via(serialExecutor.get(), [dis = shared_from_this(), command] {
+    dis->session.write(command);
+  });
 }
 
 Future<string> SshSessionAsync::readUntilOutput(const string& lastOutput) {
-  return via(executor.get(), [this, lastOutput] {
-    return this->readUntilOutputBlocking(lastOutput);
-  });
+  this->readingState.currentLastOutput = lastOutput;
+  this->readingState.promise = std::make_shared<Promise<string>>();
+  this->readingState.outputSoFar = "";
+  matchingExpectedOutput.store(true);
+  processDataInBuffer(); // we could have had something already waiting in the
+                         // queue
+  return this->readingState.promise->getFuture();
 }
 
 void SshSessionAsync::setEvent(event* event) {
@@ -75,58 +120,78 @@ void SshSessionAsync::setEvent(event* event) {
 
 void readCallback(evutil_socket_t fd, short what, void* ptr) {
   (void)fd;
-  (void)what;
-  ((SshSessionAsync*)ptr)->readToBuffer();
+  if (what == EVENT_FINISH) {
+    ((SshSessionAsync*)ptr)->unregisterEvent();
+    return;
+  }
+  ((SshSessionAsync*)ptr)->readSshDataToBuffer();
+  ((SshSessionAsync*)ptr)->processDataInBuffer();
 }
 
 socket_t SshSessionAsync::getSshFd() {
   return this->session.getSshFd();
 }
 
-void SshSessionAsync::readToBuffer() {
-  {
-    std::lock_guard<mutex> guard(mutex1);
-    ErrorHandler::executeWithCatch([this]() {
-      const string& output = this->session.read();
-      if (!output.empty()) {
-        readQueue.push(output);
-      }
-    });
-  }
-  condition.notify_one();
+void SshSessionAsync::readSshDataToBuffer() {
+  ErrorHandler::executeWithCatch([dis = shared_from_this()]() {
+    const string& output = dis->session.read();
+    if (!output.empty()) {
+      dis->readQueue.push(output);
+    }
+  });
 }
 
-using namespace std::chrono_literals;
-
-string SshSessionAsync::readUntilOutputBlocking(string lastOutput) {
+void SshSessionAsync::matchExpectedOutput() {
+  if (not matchingExpectedOutput) { // we are not allowed to match unless
+                                    // readUntilOutput is called because we
+                                    // don't know against what to match
+    return;
+  }
   reading.store(true);
-  string result;
-  while (this->session.isOpen()) {
-    unique_lock<mutex> lck(mutex1);
-    bool satisfied = condition.wait_for(
-        lck, 1000ms, [this] { return this->readQueue.read_available() != 0; });
 
-    if (!satisfied) {
-      continue;
-    }
+  // If we are expecting empty string as output, we can complete right away
+  // Why ? because keepalive is empty string
+  if (this->readingState.currentLastOutput.empty()) {
+    matchingExpectedOutput.store(false);
+    this->readingState.promise->setValue("");
+  }
 
+  while (this->readQueue.read_available() != 0) {
     string output;
-    if (!readQueue.pop(output) ||
-        output.empty()) { // sometimes we get the string "" or " " back, we can
-                          // ignore that ...
-      continue;
-    }
-
-    result.append(output);
-    std::size_t found = result.find(lastOutput);
+    readQueue.pop(output);
+    this->readingState.outputSoFar.append(output);
+    std::size_t found = this->readingState.outputSoFar.find(
+        this->readingState.currentLastOutput);
     if (found != std::string::npos) {
-      // TODO check for any additional output after lastOutput
-      reading.store(false);
-      return result.substr(0, found);
+      string final = this->readingState.outputSoFar.substr(0, found);
+
+      // Check for any outstanding output
+      size_t consumedLength =
+          final.length() + this->readingState.currentLastOutput.length();
+      if (consumedLength < this->readingState.outputSoFar.length()) {
+        MLOG(MWARNING) << "[" << id << "] "
+                       << "Unexpected output from device: ("
+                       << this->readingState.outputSoFar.substr(consumedLength)
+                       << "). This output will be lost";
+      }
+      matchingExpectedOutput.store(false);
+      this->readingState.promise->setValue(final);
     }
   }
   reading.store(false);
-  throw std::runtime_error("Session is closed");
+}
+
+void SshSessionAsync::processDataInBuffer() {
+  via(serialExecutor.get(),
+      [dis = shared_from_this()] { dis->matchExpectedOutput(); });
+}
+
+void SshSessionAsync::failCurrentRead(
+    runtime_error e,
+    shared_ptr<Promise<string>> ptr) {
+  if (ptr != nullptr and !ptr->isFulfilled()) {
+    ptr->setException(folly::make_exception_wrapper<runtime_error>(e));
+  }
 }
 
 } // namespace sshsession

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -103,7 +103,7 @@ Future<string> TimeoutTrackingCli::executeSomething(
             // executor
             MLOG(MDEBUG) << "[" << params->id << "] (" << cmd << ") "
                          << "timing out";
-            throw FutureTimeout();
+            throw CommandTimeoutException();
           },
           timeoutTrackingParameters->timekeeper.get())
       .thenValue(

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -84,14 +84,14 @@ Future<string> TimeoutTrackingCli::executeSomething(
     const Command& cmd,
     const string&& loggingPrefix,
     const function<SemiFuture<string>()>& innerFunc) {
-  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd.getIdx()
+  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd
                << ") " << loggingPrefix << "('" << cmd << "') called";
   if (timeoutTrackingParameters->shutdown) {
     return Future<string>(runtime_error("TTCli Shutting down"));
   }
   SemiFuture<string> inner =
       innerFunc(); // we expect that this method does not block
-  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd.getIdx()
+  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd
                << ") "
                << "Obtained future from underlying cli";
   return move(inner)
@@ -101,14 +101,14 @@ Future<string> TimeoutTrackingCli::executeSomething(
           [params = timeoutTrackingParameters, cmd](...) -> Future<string> {
             // NOTE: timeoutTrackingParameters must be captured mainly for
             // executor
-            MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+            MLOG(MDEBUG) << "[" << params->id << "] (" << cmd << ") "
                          << "timing out";
             throw FutureTimeout();
           },
           timeoutTrackingParameters->timekeeper.get())
       .thenValue(
           [params = timeoutTrackingParameters, cmd](string result) -> string {
-            MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+            MLOG(MDEBUG) << "[" << params->id << "] (" << cmd << ") "
                          << "succeeded";
             return result;
           });

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/cli/Command.h>
+#include <devmand/channels/cli/TimeoutTrackingCli.h>
+#include <magma_logging.h>
+
+namespace devmand::channels::cli {
+
+using namespace std;
+using namespace folly;
+using devmand::channels::cli::Command;
+
+shared_ptr<TimeoutTrackingCli> TimeoutTrackingCli::make(
+    string id,
+    shared_ptr<Cli> cli,
+    shared_ptr<folly::Timekeeper> timekeeper,
+    shared_ptr<folly::Executor> executor,
+    std::chrono::milliseconds timeoutInterval) {
+  return shared_ptr<TimeoutTrackingCli>(
+      new TimeoutTrackingCli(id, cli, timekeeper, executor, timeoutInterval));
+}
+
+TimeoutTrackingCli::TimeoutTrackingCli(
+    string _id,
+    shared_ptr<Cli> _cli,
+    shared_ptr<folly::Timekeeper> _timekeeper,
+    shared_ptr<folly::Executor> _executor,
+    std::chrono::milliseconds _timeoutInterval) {
+  timeoutTrackingParameters =
+      shared_ptr<TimeoutTrackingParameters>(new TimeoutTrackingParameters{
+          _id, _cli, _timekeeper, _executor, _timeoutInterval, {false}});
+}
+
+TimeoutTrackingCli::~TimeoutTrackingCli() {
+  string id = timeoutTrackingParameters->id;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~TTCli started";
+  timeoutTrackingParameters->shutdown = true;
+  while (timeoutTrackingParameters.use_count() >
+         1) { // TODO cancel currently running future
+    MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] "
+                 << "~TTCli sleeping";
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+  }
+
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~TTCli nulling timeoutTrackingParameters.cli";
+  timeoutTrackingParameters->cli = nullptr;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~TTCli nulling timeoutTrackingParameters";
+  timeoutTrackingParameters = nullptr;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~TTCli done";
+}
+
+folly::SemiFuture<std::string> TimeoutTrackingCli::executeRead(
+    const ReadCommand cmd) {
+  return executeSomething(
+             cmd,
+             "TTCli.executeRead",
+             [params = timeoutTrackingParameters, cmd]() {
+               return params->cli->executeRead(cmd);
+             })
+      .semi();
+}
+
+folly::SemiFuture<std::string> TimeoutTrackingCli::executeWrite(
+    const WriteCommand cmd) {
+  return executeSomething(
+             cmd,
+             "TTCli.executeWrite",
+             [params = timeoutTrackingParameters, cmd]() {
+               return params->cli->executeWrite(cmd);
+             })
+      .semi();
+}
+
+Future<string> TimeoutTrackingCli::executeSomething(
+    const Command& cmd,
+    const string&& loggingPrefix,
+    const function<SemiFuture<string>()>& innerFunc) {
+  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd.getIdx()
+               << ") " << loggingPrefix << "('" << cmd << "') called";
+  if (timeoutTrackingParameters->shutdown) {
+    return Future<string>(runtime_error("TTCli Shutting down"));
+  }
+  SemiFuture<string> inner =
+      innerFunc(); // we expect that this method does not block
+  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd.getIdx()
+               << ") "
+               << "Obtained future from underlying cli";
+  return move(inner)
+      .via(timeoutTrackingParameters->executor.get())
+      .onTimeout(
+          timeoutTrackingParameters->timeoutInterval,
+          [params = timeoutTrackingParameters, cmd](...) -> Future<string> {
+            // NOTE: timeoutTrackingParameters must be captured mainly for
+            // executor
+            MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                         << "timing out";
+            throw FutureTimeout();
+          },
+          timeoutTrackingParameters->timekeeper.get())
+      .thenValue(
+          [params = timeoutTrackingParameters, cmd](string result) -> string {
+            MLOG(MDEBUG) << "[" << params->id << "] (" << cmd.getIdx() << ") "
+                         << "succeeded";
+            return result;
+          });
+}
+
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.cpp
@@ -84,15 +84,14 @@ Future<string> TimeoutTrackingCli::executeSomething(
     const Command& cmd,
     const string&& loggingPrefix,
     const function<SemiFuture<string>()>& innerFunc) {
-  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd
-               << ") " << loggingPrefix << "('" << cmd << "') called";
+  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd << ") "
+               << loggingPrefix << "('" << cmd << "') called";
   if (timeoutTrackingParameters->shutdown) {
     return Future<string>(runtime_error("TTCli Shutting down"));
   }
   SemiFuture<string> inner =
       innerFunc(); // we expect that this method does not block
-  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd
-               << ") "
+  MLOG(MDEBUG) << "[" << timeoutTrackingParameters->id << "] (" << cmd << ") "
                << "Obtained future from underlying cli";
   return move(inner)
       .via(timeoutTrackingParameters->executor.get())

--- a/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/TimeoutTrackingCli.h
@@ -1,0 +1,67 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <devmand/channels/cli/Cli.h>
+#include <folly/Executor.h>
+#include <folly/executors/SerialExecutor.h>
+#include <folly/futures/Future.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+
+namespace devmand::channels::cli {
+
+using namespace std;
+using namespace folly;
+using devmand::channels::cli::Command;
+
+static constexpr std::chrono::seconds defaultCommandTimeout =
+    std::chrono::seconds(5);
+
+// CLI layer that should be instanciated below QueuedCli. It throws
+// FutureTimeout if Future returned by
+// underlying layer does not return result within specified time period
+// (timeout).
+class TimeoutTrackingCli : public Cli {
+ public:
+  static shared_ptr<TimeoutTrackingCli> make(
+      string id,
+      shared_ptr<Cli> cli,
+      shared_ptr<folly::Timekeeper> timekeeper,
+      shared_ptr<folly::Executor> executor,
+      std::chrono::milliseconds _timeoutInterval = defaultCommandTimeout);
+
+  ~TimeoutTrackingCli() override;
+
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override;
+
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override;
+
+ private:
+  struct TimeoutTrackingParameters {
+    string id;
+    shared_ptr<Cli> cli; // underlying cli layer
+    shared_ptr<folly::Timekeeper> timekeeper;
+    shared_ptr<folly::Executor> executor;
+    const std::chrono::milliseconds timeoutInterval;
+    atomic<bool> shutdown;
+  };
+  shared_ptr<TimeoutTrackingParameters> timeoutTrackingParameters;
+
+  TimeoutTrackingCli(
+      string id,
+      shared_ptr<Cli> _cli,
+      shared_ptr<folly::Timekeeper> _timekeeper,
+      shared_ptr<folly::Executor> _executor,
+      std::chrono::milliseconds _timeoutInterval);
+
+  Future<string> executeSomething(
+      const Command& cmd,
+      const string&& loggingPrefix,
+      const function<SemiFuture<string>()>& innerFunc);
+};
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
@@ -66,7 +66,6 @@ Engine::Engine()
           5,
           std::make_shared<folly::NamedThreadFactory>("kaCli"))) {
   // TODO use singleton when folly is initialized
-  // TODO switch to IOThreadPool for common pool once blocking issues are solved
   Engine::initSsh();
   Engine::initLogging();
   MLOG(MERROR) << "Cli engine started";

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
@@ -53,7 +53,7 @@ void Engine::initLogging(uint32_t verbosity, bool callInitMlog) {
   }
 }
 
-static uint CPU_CORES = std::max(uint(2), std::thread::hardware_concurrency());
+static uint CPU_CORES = std::max(uint(4), std::thread::hardware_concurrency());
 
 Engine::Engine()
     : channels::Engine("Cli"),

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
@@ -53,22 +53,24 @@ void Engine::initLogging(uint32_t verbosity, bool callInitMlog) {
   }
 }
 
+static uint CPU_CORES = std::max(uint(2), std::thread::hardware_concurrency());
+
 Engine::Engine()
     : channels::Engine("Cli"),
       timekeeper(make_shared<folly::ThreadWheelTimekeeper>()),
       sshCliExecutor(std::make_shared<folly::IOThreadPoolExecutor>(
-          5,
+          CPU_CORES,
           std::make_shared<folly::NamedThreadFactory>("sshCli"))),
       commonExecutor(std::make_shared<folly::IOThreadPoolExecutor>(
-          5,
+          CPU_CORES,
           std::make_shared<folly::NamedThreadFactory>("commonCli"))),
       kaCliExecutor(std::make_shared<folly::CPUThreadPoolExecutor>(
-          5,
+          CPU_CORES,
           std::make_shared<folly::NamedThreadFactory>("kaCli"))) {
   // TODO use singleton when folly is initialized
   Engine::initSsh();
   Engine::initLogging();
-  MLOG(MERROR) << "Cli engine started";
+  MLOG(MINFO) << "Cli engine started with concurrency set to " << CPU_CORES;
 }
 
 Engine::~Engine() {

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
@@ -7,42 +7,66 @@
 
 #include <devmand/channels/cli/Spd2Glog.h>
 #include <devmand/channels/cli/engine/Engine.h>
+#include <event2/thread.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <folly/executors/thread_factory/NamedThreadFactory.h>
 #include <libssh/callbacks.h>
 #include <libssh/libssh.h>
 #include <spdlog/spdlog.h>
 #include <iostream>
-#include <event2/thread.h>
 
 namespace devmand {
 namespace channels {
 namespace cli {
 
-void Engine::closeSsh() {
-  ssh_finalize();
-}
+void Engine::closeSsh() {}
 
 void Engine::closeLogging() {
   spdlog::drop("ydk");
 }
 
 void Engine::initSsh() {
-  ssh_threads_set_callbacks(ssh_threads_get_pthread());
-  ssh_init();
-  ssh_set_log_level(SSH_LOG_NOLOG);
-  evthread_use_pthreads();
+  bool f = false;
+  if (sshInitialized.compare_exchange_strong(f, true)) {
+    ssh_threads_set_callbacks(ssh_threads_get_pthread());
+    ssh_init();
+    ssh_set_log_level(SSH_LOG_NOLOG);
+    evthread_use_pthreads();
+  } else {
+    MLOG(MWARNING) << "SSH already initialized";
+  }
 }
 
 void Engine::initLogging(uint32_t verbosity, bool callInitMlog) {
-  if (callInitMlog) {
-    magma::init_logging("devmand");
+  bool f = false;
+  if (loggingInitialized.compare_exchange_strong(f, true)) {
+    if (callInitMlog) {
+      magma::init_logging("devmand");
+    }
+    magma::set_verbosity(verbosity);
+    // IInitialize spd -> glog sink for YDK lib
+    spdlog::create<Spd2Glog>("ydk");
+    spdlog::set_level(spdlog::level::level_enum::info);
+  } else {
+    MLOG(MWARNING) << "Logging already initialized";
   }
-  magma::set_verbosity(verbosity);
-  // IInitialize spd -> glog sink for YDK lib
-  spdlog::create<Spd2Glog>("ydk");
-  spdlog::set_level(spdlog::level::level_enum::info);
 }
 
-Engine::Engine() : channels::Engine("Cli") {
+Engine::Engine()
+    : channels::Engine("Cli"),
+      timekeeper(make_shared<folly::ThreadWheelTimekeeper>()),
+      sshCliExecutor(std::make_shared<folly::IOThreadPoolExecutor>(
+          5,
+          std::make_shared<folly::NamedThreadFactory>("sshCli"))),
+      commonExecutor(std::make_shared<folly::IOThreadPoolExecutor>(
+          5,
+          std::make_shared<folly::NamedThreadFactory>("commonCli"))),
+      kaCliExecutor(std::make_shared<folly::CPUThreadPoolExecutor>(
+          5,
+          std::make_shared<folly::NamedThreadFactory>("kaCli"))) {
+  // TODO use singleton when folly is initialized
+  // TODO switch to IOThreadPool for common pool once blocking issues are solved
   Engine::initSsh();
   Engine::initLogging();
   MLOG(MERROR) << "Cli engine started";
@@ -52,6 +76,20 @@ Engine::~Engine() {
   Engine::closeSsh();
   Engine::closeLogging();
   MLOG(MDEBUG) << "Cli engine closed";
+}
+
+shared_ptr<folly::ThreadWheelTimekeeper> Engine::getTimekeeper() {
+  return timekeeper;
+}
+
+shared_ptr<folly::Executor> Engine::getExecutor(
+    Engine::executorRequestType requestType) const {
+  if (requestType == kaCli) {
+    return kaCliExecutor;
+  } else if (requestType == sshCli) {
+    return sshCliExecutor;
+  }
+  return commonExecutor;
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
@@ -10,11 +10,19 @@
 #define LOG_WITH_GLOG
 
 #include <devmand/channels/Engine.h>
+#include <folly/Executor.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
 #include <magma_logging.h>
+#include <atomic>
 
 namespace devmand {
 namespace channels {
 namespace cli {
+
+using namespace std;
+
+static atomic<bool> loggingInitialized(false);
+static atomic<bool> sshInitialized(false);
 
 class Engine : public channels::Engine {
  public:
@@ -31,6 +39,27 @@ class Engine : public channels::Engine {
   static void closeLogging();
   static void initSsh();
   static void closeSsh();
+
+  shared_ptr<folly::ThreadWheelTimekeeper> timekeeper;
+  shared_ptr<folly::Executor> sshCliExecutor;
+  shared_ptr<folly::Executor> commonExecutor;
+  shared_ptr<folly::Executor> kaCliExecutor;
+
+  shared_ptr<folly::ThreadWheelTimekeeper> getTimekeeper();
+
+  enum executorRequestType {
+    sshCli,
+    paCli,
+    rcCli,
+    ttCli,
+    qCli,
+    rCli,
+    kaCli,
+    plaintextCliDevice
+  };
+
+  shared_ptr<folly::Executor> getExecutor(
+      executorRequestType requestType) const;
 };
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/devices/PingDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/PingDevice.cpp
@@ -34,7 +34,8 @@ PingDevice::PingDevice(
     const Id& id_,
     bool readonly_,
     const folly::IPAddress& ip_)
-    : Device(application, id_, readonly_), channel(application.getPingEngine(ip_), ip_) {}
+    : Device(application, id_, readonly_),
+      channel(application.getPingEngine(ip_), ip_) {}
 
 std::shared_ptr<State> PingDevice::getState() {
   auto state = State::make(app, getId());

--- a/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.cpp
@@ -74,26 +74,28 @@ std::shared_ptr<State> PlaintextCliDevice::getState() {
   cmdCache->wlock()->clear();
   auto state = State::make(*reinterpret_cast<MetricSink*>(&app), getId());
 
-  state->addRequest(channel->executeRead(stateCommand)
-                        .via(executor.get())
-                        .thenValue([state, cmd = stateCommand](std::string v) {
-                          state->setStatus(true);
-                          state->update([&v, &cmd](auto& lockedState) {
-                            lockedState[cmd.raw()] = v;
-                          });
-                        })
-                        .thenError(
-                            folly::tag_t<std::exception>{},
-                            [state, id = this->id](std::exception const& e) {
-                              MLOG(MWARNING)
-                                  << "[" << id << "] "
-                                  << "Retrieving state failed: " << e.what();
-                              // FIXME catching exception type instead strcmp ?
-                              if (strcmp(e.what(), "Not connected") == 0) {
-                                state->setStatus(false);
-                              }
-                              state->addError(e.what());
-                            }));
+  state->addRequest(
+      channel->executeRead(stateCommand)
+          .via(executor.get())
+          .thenValue([state, cmd = stateCommand](std::string v) {
+            state->setStatus(true);
+            state->update(
+                [&v, &cmd](auto& lockedState) { lockedState[cmd.raw()] = v; });
+          })
+          .thenError(
+              folly::tag_t<DisconnectedException>{},
+              [state,
+               id = this->id](DisconnectedException const& e) -> Future<Unit> {
+                state->setStatus(false);
+                throw e;
+              })
+          .thenError(
+              folly::tag_t<std::exception>{},
+              [state, id = this->id](std::exception const& e) {
+                MLOG(MWARNING) << "[" << id << "] "
+                               << "Retrieving state failed: " << e.what();
+                state->addError(e.what());
+              }));
 
   return state;
 }

--- a/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.cpp
+++ b/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.cpp
@@ -13,8 +13,10 @@
 #include <devmand/channels/cli/Channel.h>
 #include <devmand/channels/cli/Cli.h>
 #include <devmand/channels/cli/IoConfigurationBuilder.h>
+#include <devmand/channels/cli/engine/Engine.h>
 #include <devmand/devices/State.h>
 #include <devmand/devices/cli/PlaintextCliDevice.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
 
 namespace devmand {
 namespace devices {
@@ -26,14 +28,23 @@ using namespace devmand::channels::cli::sshsession;
 std::unique_ptr<devices::Device> PlaintextCliDevice::createDevice(
     Application& app,
     const cartography::DeviceConfig& deviceConfig) {
-  IoConfigurationBuilder ioConfigurationBuilder(deviceConfig);
+  return createDeviceWithEngine(app, deviceConfig, app.getCliEngine());
+}
+
+std::unique_ptr<devices::Device> PlaintextCliDevice::createDeviceWithEngine(
+    Application& app,
+    const cartography::DeviceConfig& deviceConfig,
+    Engine& engine) {
+  IoConfigurationBuilder ioConfigurationBuilder(deviceConfig, engine);
 
   auto cmdCache = ReadCachingCli::createCache();
+
   const std::shared_ptr<Channel>& channel = std::make_shared<Channel>(
-      deviceConfig.id, ioConfigurationBuilder.getIo(cmdCache));
+      deviceConfig.id, ioConfigurationBuilder.createAll(cmdCache));
 
   return std::make_unique<devices::cli::PlaintextCliDevice>(
       app,
+      engine,
       deviceConfig.id,
       deviceConfig.channelConfigs.at("cli").kvPairs.at("stateCommand"),
       channel,
@@ -42,14 +53,18 @@ std::unique_ptr<devices::Device> PlaintextCliDevice::createDevice(
 
 PlaintextCliDevice::PlaintextCliDevice(
     Application& application,
+    Engine& engine,
     const Id id_,
     const std::string _stateCommand,
     const std::shared_ptr<Channel> _channel,
     const std::shared_ptr<CliCache> _cmdCache)
     : Device(application, id_, true),
       channel(_channel),
-      stateCommand(Command::makeReadCommand(_stateCommand)),
-      cmdCache(_cmdCache) {}
+      stateCommand(ReadCommand::create(_stateCommand)),
+      cmdCache(_cmdCache),
+      executor(
+          engine.getExecutor(Engine::executorRequestType::plaintextCliDevice)) {
+}
 
 std::shared_ptr<State> PlaintextCliDevice::getState() {
   MLOG(MINFO) << "[" << id << "] "
@@ -57,16 +72,29 @@ std::shared_ptr<State> PlaintextCliDevice::getState() {
 
   // Reset cache
   cmdCache->wlock()->clear();
-
   auto state = State::make(*reinterpret_cast<MetricSink*>(&app), getId());
 
-  state->addRequest(channel->executeAndRead(stateCommand)
+  state->addRequest(channel->executeRead(stateCommand)
+                        .via(executor.get())
                         .thenValue([state, cmd = stateCommand](std::string v) {
                           state->setStatus(true);
                           state->update([&v, &cmd](auto& lockedState) {
-                            lockedState[cmd.toString()] = v;
+                            lockedState[cmd.raw()] = v;
                           });
-                        }));
+                        })
+                        .thenError(
+                            folly::tag_t<std::exception>{},
+                            [state, id = this->id](std::exception const& e) {
+                              MLOG(MWARNING)
+                                  << "[" << id << "] "
+                                  << "Retrieving state failed: " << e.what();
+                              // FIXME catching exception type instead strcmp ?
+                              if (strcmp(e.what(), "Not connected") == 0) {
+                                state->setStatus(false);
+                              }
+                              state->addError(e.what());
+                            }));
+
   return state;
 }
 

--- a/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.h
+++ b/devmand/gateway/src/devmand/devices/cli/PlaintextCliDevice.h
@@ -10,6 +10,7 @@
 #define LOG_WITH_GLOG
 #include <magma_logging.h>
 
+#include <devmand/Application.h>
 #include <devmand/channels/cli/Channel.h>
 #include <devmand/channels/cli/Command.h>
 #include <devmand/channels/cli/ReadCachingCli.h>
@@ -25,6 +26,7 @@ class PlaintextCliDevice : public Device {
  public:
   PlaintextCliDevice(
       Application& application,
+      Engine& engine,
       const Id id,
       const std::string stateCommand,
       const std::shared_ptr<Channel> channel,
@@ -40,6 +42,12 @@ class PlaintextCliDevice : public Device {
       Application& app,
       const cartography::DeviceConfig& deviceConfig);
 
+  // visible for testing
+  static std::unique_ptr<devices::Device> createDeviceWithEngine(
+      Application& app,
+      const cartography::DeviceConfig& deviceConfig,
+      Engine& engine);
+
  public:
   std::shared_ptr<State> getState() override;
 
@@ -52,8 +60,9 @@ class PlaintextCliDevice : public Device {
 
  private:
   std::shared_ptr<Channel> channel;
-  const Command stateCommand;
+  const ReadCommand stateCommand;
   std::shared_ptr<CliCache> cmdCache;
+  std::shared_ptr<folly::Executor> executor;
 };
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/devices/cli/StructuredUbntDevice.h
+++ b/devmand/gateway/src/devmand/devices/cli/StructuredUbntDevice.h
@@ -10,6 +10,7 @@
 #define LOG_WITH_GLOG
 #include <magma_logging.h>
 
+#include <devmand/Application.h>
 #include <devmand/channels/cli/Channel.h>
 #include <devmand/channels/cli/Command.h>
 #include <devmand/channels/cli/ReadCachingCli.h>
@@ -40,15 +41,17 @@ class StructuredUbntDevice : public Device {
       Application& app,
       const cartography::DeviceConfig& deviceConfig);
 
+  // visible for testing
+  static std::unique_ptr<devices::Device> createDeviceWithEngine(
+      Application& app,
+      const cartography::DeviceConfig& deviceConfig,
+      Engine& engine);
+
  public:
   std::shared_ptr<State> getState() override;
 
  protected:
-  void setConfig(const folly::dynamic& config) override {
-    (void)config;
-    MLOG(MERROR) << "[" << id << "] "
-                 << "set config on unconfigurable device";
-  }
+  void setConfig(const folly::dynamic& config) override;
 
  private:
   std::shared_ptr<Channel> channel;

--- a/devmand/gateway/src/devmand/test/cli/CommandTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/CommandTest.cpp
@@ -29,19 +29,20 @@ class CommandTest : public ::testing::Test {
 
 TEST_F(CommandTest, api) {
   std::string foo("foo");
-  Command cmd = Command::makeReadCommand(foo);
-  EXPECT_EQ("foo", cmd.toString());
+  ReadCommand cmd = ReadCommand::create(foo);
+  EXPECT_EQ("foo", cmd.raw());
   foo.clear();
-  EXPECT_EQ("foo", cmd.toString());
-  cmd.toString().clear();
-  EXPECT_EQ("foo", cmd.toString());
+  EXPECT_EQ("foo", cmd.raw());
+  cmd.raw().clear();
+  EXPECT_EQ("foo", cmd.raw());
 
   const auto mockCli = std::make_shared<EchoCli>();
-  folly::Future<std::string> future = mockCli->executeAndRead(cmd);
+  folly::SemiFuture<std::string> future = mockCli->executeRead(cmd);
   EXPECT_EQ("foo", std::move(future).get());
 
   Channel cliChannel("cmdTEst", std::make_shared<EchoCli>());
-  folly::Future<std::string> futureFromChannel = cliChannel.executeAndRead(cmd);
+  folly::SemiFuture<std::string> futureFromChannel =
+      cliChannel.executeRead(cmd);
   EXPECT_EQ("foo", std::move(futureFromChannel).get());
 }
 

--- a/devmand/gateway/src/devmand/test/cli/KeepaliveCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/KeepaliveCliTest.cpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <devmand/cartography/DeviceConfig.h>
+#include <devmand/channels/cli/KeepaliveCli.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <gtest/gtest.h>
+#include <chrono>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::channels::cli;
+using namespace devmand::test::utils::cli;
+using namespace std;
+using namespace folly;
+
+class KeepaliveCliTest : public ::testing::Test {
+ protected:
+  shared_ptr<CPUThreadPoolExecutor> testExec;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    devmand::test::utils::ssh::initSsh();
+    testExec = make_shared<CPUThreadPoolExecutor>(1);
+  }
+
+  void TearDown() override {
+    MLOG(MDEBUG) << "Waiting for test executor to finish";
+    testExec->join();
+  }
+};
+
+static const chrono::seconds interval = 1s;
+
+static shared_ptr<KeepaliveCli> getCli(shared_ptr<Cli> delegate) {
+  shared_ptr<KeepaliveCli> cli = KeepaliveCli::make(
+      "test",
+      delegate,
+      make_shared<CPUThreadPoolExecutor>(1),
+      make_shared<folly::ThreadWheelTimekeeper>(),
+      interval);
+  return cli;
+}
+
+TEST_F(KeepaliveCliTest, cleanDestructOnSuccess) {
+  shared_ptr<AsyncCli> delegate = getMockCli<EchoCli>(0, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+TEST_F(KeepaliveCliTest, cleanDestructOnSuccessWithDelay) {
+  shared_ptr<AsyncCli> delegate = getMockCli<EchoCli>(2, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+TEST_F(KeepaliveCliTest, cleanDestructOnError) {
+  shared_ptr<AsyncCli> delegate = getMockCli<ErrCli>(0, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+TEST_F(KeepaliveCliTest, cleanDestructOnErrorWithDelay) {
+  shared_ptr<AsyncCli> delegate = getMockCli<ErrCli>(2, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/ModelRegistryTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ModelRegistryTest.cpp
@@ -165,7 +165,7 @@ TEST_F(ModelRegistryTest, jsonDeserializationFail) {
 TEST_F(ModelRegistryTest, jsonSerializationNestedMultiThread) {
   folly::CPUThreadPoolExecutor executor(8);
 
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < 100; i++) {
     folly::Future<folly::Unit> f = folly::via(&executor, [&, i]() {
       Bundle& bundleOpenconfig = mreg.getBundle(Model::OPENCONFIG_0_1_6);
 

--- a/devmand/gateway/src/devmand/test/cli/PlaintextCliDeviceTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/PlaintextCliDeviceTest.cpp
@@ -39,7 +39,7 @@ class PlaintextCliDeviceTest : public ::testing::Test {
   unique_ptr<channels::cli::Engine> cliEngine;
 
   void SetUp() override {
-    devmand::test::utils::log::initLog();
+    devmand::test::utils::log::initLog(MDEBUG);
     cliEngine = make_unique<channels::cli::Engine>();
     ssh = startSshServer();
   }

--- a/devmand/gateway/src/devmand/test/cli/PlaintextCliDeviceTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/PlaintextCliDeviceTest.cpp
@@ -16,6 +16,7 @@
 #include <devmand/test/cli/utils/MockCli.h>
 #include <devmand/test/cli/utils/Ssh.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/json.h>
 #include <gtest/gtest.h>
 
 namespace devmand {
@@ -34,10 +35,12 @@ using namespace devmand::test::utils::ssh;
 class PlaintextCliDeviceTest : public ::testing::Test {
  protected:
   shared_ptr<server> ssh;
+  Application app;
+  unique_ptr<channels::cli::Engine> cliEngine;
 
   void SetUp() override {
     devmand::test::utils::log::initLog();
-    devmand::test::utils::ssh::initSsh();
+    cliEngine = make_unique<channels::cli::Engine>();
     ssh = startSshServer();
   }
 
@@ -47,24 +50,22 @@ class PlaintextCliDeviceTest : public ::testing::Test {
 };
 
 TEST_F(PlaintextCliDeviceTest, checkEcho) {
-  devmand::Application app;
   cartography::DeviceConfig deviceConfig;
   devmand::cartography::ChannelConfig chnlCfg;
-  std::map<std::string, std::string> kvPairs;
-  kvPairs.insert(std::make_pair("stateCommand", "show interfaces brief"));
+  map<string, string> kvPairs;
+  kvPairs.insert(make_pair("stateCommand", "show interfaces brief"));
   chnlCfg.kvPairs = kvPairs;
-  deviceConfig.channelConfigs.insert(std::make_pair("cli", chnlCfg));
+  deviceConfig.channelConfigs.insert(make_pair("cli", chnlCfg));
 
-  const std::shared_ptr<EchoCli>& echoCli = std::make_shared<EchoCli>();
-  const std::shared_ptr<Channel>& channel =
-      std::make_shared<Channel>("test", echoCli);
-  std::unique_ptr<devices::Device> dev = std::make_unique<PlaintextCliDevice>(
-      app, deviceConfig.id, "show interfaces brief", channel);
+  const shared_ptr<EchoCli>& echoCli = make_shared<EchoCli>();
+  const shared_ptr<Channel>& channel = make_shared<Channel>("test", echoCli);
+  unique_ptr<devices::Device> dev = make_unique<PlaintextCliDevice>(
+      app, *cliEngine, deviceConfig.id, "show interfaces brief", channel);
 
-  std::shared_ptr<State> state = dev->getState();
+  shared_ptr<State> state = dev->getState();
   const folly::dynamic& stateResult = state->collect().get();
 
-  std::stringstream buffer;
+  stringstream buffer;
   buffer << stateResult["show interfaces brief"];
   EXPECT_EQ("show interfaces brief", buffer.str());
 }
@@ -72,45 +73,64 @@ TEST_F(PlaintextCliDeviceTest, checkEcho) {
 static DeviceConfig getConfig(string port) {
   DeviceConfig deviceConfig;
   ChannelConfig chnlCfg;
-  std::map<std::string, std::string> kvPairs;
-  kvPairs.insert(std::make_pair("stateCommand", "echo 123"));
-  kvPairs.insert(std::make_pair("port", port));
-  kvPairs.insert(std::make_pair("username", "root"));
-  kvPairs.insert(std::make_pair("password", "root"));
+  map<string, string> kvPairs;
+  kvPairs.insert(make_pair("stateCommand", "echo 123"));
+  kvPairs.insert(make_pair("port", port));
+  kvPairs.insert(make_pair("username", "root"));
+  kvPairs.insert(make_pair("password", "root"));
+  kvPairs.insert(make_pair("keepAliveIntervalSeconds", "5"));
+  kvPairs.insert(make_pair("maxCommandTimeoutSeconds", "60"));
   chnlCfg.kvPairs = kvPairs;
-  deviceConfig.channelConfigs.insert(std::make_pair("cli", chnlCfg));
+  deviceConfig.channelConfigs.insert(make_pair("cli", chnlCfg));
   deviceConfig.ip = "localhost";
   deviceConfig.id = "ubuntu-test-device";
   return deviceConfig;
 }
 
 TEST_F(PlaintextCliDeviceTest, plaintextCliDevicesError) {
-  Application app;
-  EXPECT_ANY_THROW(PlaintextCliDevice::createDevice(app, getConfig("9998")));
+  auto plaintextDevice = PlaintextCliDevice::createDeviceWithEngine(
+      app, getConfig("9998"), *cliEngine);
+  const shared_ptr<State>& ptr = plaintextDevice->getState();
+  auto state = ptr->collect().get();
+
+  // FIXME State class overrides status set from device to always say UP
+  //  EXPECT_EQ(state["fbc-symphony-device:system"]["status"], "DOWN");
+  EXPECT_EQ(state["fbc-symphony-device:errors"][0], "Not connected");
 }
 
-TEST_F(PlaintextCliDeviceTest, DISABLED_plaintextCliDevice) {
-  Application app;
+TEST_F(PlaintextCliDeviceTest, plaintextCliDevice) {
+  unique_ptr<Device> dev = PlaintextCliDevice::createDeviceWithEngine(
+      app, getConfig("9999"), *cliEngine);
 
-  std::vector<std::unique_ptr<Device>> ds;
-  for (int i = 0; i < 1; i++) {
-    ds.push_back(
-        std::move(PlaintextCliDevice::createDevice(app, getConfig("9999"))));
-  }
+  int i = 0;
+  string output = "";
+  do {
+    if (i > 0) {
+      this_thread::sleep_for(chrono::seconds(1));
+    }
 
-  for (const auto& dev : ds) {
-    std::shared_ptr<State> state = dev->getState();
-    auto t1 = std::chrono::high_resolution_clock::now();
+    i++;
+
+    shared_ptr<State> state = dev->getState();
+    auto t1 = chrono::high_resolution_clock::now();
     const folly::dynamic& stateResult = state->collect().get();
-    auto t2 = std::chrono::high_resolution_clock::now();
+    auto t2 = chrono::high_resolution_clock::now();
     auto duration =
-        std::chrono::duration_cast<std::chrono::microseconds>(t2 - t1).count();
+        chrono::duration_cast<chrono::microseconds>(t2 - t1).count();
     MLOG(MDEBUG) << "Retrieving state took: " << duration << " mu.";
-    std::stringstream buffer;
 
-    buffer << stateResult["echo 123"];
-    EXPECT_EQ("123", boost::algorithm::trim_copy(buffer.str()));
-  }
+    // FIXME instead of checking if there is output, check status once properly
+    // reported by State class
+    output = stateResult.getDefault("echo 123", "").asString();
+
+    if (i > 20) {
+      FAIL()
+          << "Unable to execute command, probably not connected, last state: "
+          << folly::toJson(stateResult);
+    }
+  } while (output == "");
+
+  EXPECT_EQ(string("123"), boost::algorithm::trim_copy(output));
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/test/cli/PromptAwareCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/PromptAwareCliTest.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <devmand/cartography/DeviceConfig.h>
+#include <devmand/channels/cli/Cli.h>
+#include <devmand/channels/cli/PromptAwareCli.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+#include <gtest/gtest.h>
+#include <chrono>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::channels::cli;
+using namespace std;
+using namespace folly;
+using namespace std::chrono_literals;
+
+class PromptAwareCliTest : public ::testing::Test {
+ protected:
+  shared_ptr<CPUThreadPoolExecutor> testExec;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    devmand::test::utils::ssh::initSsh();
+    testExec = make_shared<CPUThreadPoolExecutor>(1);
+  }
+
+  void TearDown() override {
+    MLOG(MDEBUG) << "Waiting for test executor to finish";
+    testExec->join();
+  }
+};
+
+class MockSession : public SessionAsync {
+ private:
+  int counter = 0;
+  shared_ptr<CPUThreadPoolExecutor> testExec;
+
+ public:
+  MockSession(shared_ptr<CPUThreadPoolExecutor> _testExec)
+      : testExec(_testExec){};
+
+  virtual Future<Unit> write(const string& command) {
+    (void)command;
+    return via(testExec.get(), [command]() {
+      if (command == "error") {
+        throw std::runtime_error("error");
+      }
+      return unit;
+    });
+  };
+
+  virtual Future<string> read(int timeoutMillis) {
+    (void)timeoutMillis;
+    counter++;
+    return via(testExec.get(), [c = counter]() {
+      if (c == 1) {
+        return "PROMPT>\nPROMPT>";
+      }
+      return "";
+    });
+  };
+
+  virtual Future<string> readUntilOutput(const string& lastOutput) {
+    (void)lastOutput;
+    return via(testExec.get(), []() { return ""; });
+  };
+};
+
+static shared_ptr<PromptAwareCli> getCli(
+    shared_ptr<CPUThreadPoolExecutor> testExec) {
+  return PromptAwareCli::make(
+      "test",
+      make_shared<MockSession>(testExec),
+      CliFlavour::create(""),
+      std::make_shared<folly::CPUThreadPoolExecutor>(1));
+}
+
+TEST_F(PromptAwareCliTest, cleanDestructOnSuccess) {
+  auto testedCli = getCli(testExec);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "");
+}
+
+TEST_F(PromptAwareCliTest, cleanDestructOnWriteSuccess) {
+  auto testedCli = getCli(testExec);
+
+  SemiFuture<string> future =
+      testedCli->executeWrite(WriteCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+TEST_F(PromptAwareCliTest, cleanDestructOnError) {
+  auto testedCli = getCli(testExec);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("error"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/QueuedCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/QueuedCliTest.cpp
@@ -188,11 +188,11 @@ class CustomErr : public runtime_error {
 class CustomErrCli : public Cli {
  public:
   folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override {
-    return folly::Future<string>(CustomErr(cmd.raw()));
+    return folly::Future<string>(CustomErr(Command::escape(cmd.raw())));
   }
 
   folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override {
-    return folly::Future<string>(CustomErr(cmd.raw()));
+    return folly::Future<string>(CustomErr(Command::escape(cmd.raw())));
   }
 };
 
@@ -209,7 +209,7 @@ TEST_F(QueuedCliTest, preserveExType) {
   } catch (const CustomErr& e) {
     // Proper ex type caught
   } catch (const exception& e) {
-    FAIL() << "Wrong exception thrown";
+    FAIL() << "Wrong exception thrown " << e.what();
   }
 
   MLOG(MDEBUG) << "Waiting for test executor to finish";

--- a/devmand/gateway/src/devmand/test/cli/QueuedCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/QueuedCliTest.cpp
@@ -14,8 +14,10 @@
 #include <devmand/channels/cli/QueuedCli.h>
 #include <devmand/test/cli/utils/Log.h>
 #include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/Executor.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
-#include <folly/executors/ThreadedExecutor.h>
+#include <folly/futures/Future.h>
 #include <gtest/gtest.h>
 #include <chrono>
 
@@ -33,13 +35,14 @@ shared_ptr<CPUThreadPoolExecutor> executor =
 class QueuedCliTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    devmand::test::utils::log::initLog();
+    devmand::test::utils::log::initLog(MWARNING);
+    devmand::test::utils::ssh::initSsh();
   }
 };
 
 TEST_F(QueuedCliTest, queuedCli) {
   vector<unsigned int> durations = {2};
-  QueuedCli cli(
+  shared_ptr<QueuedCli> cli = QueuedCli::make(
       "testConnection",
       make_shared<AsyncCli>(make_shared<EchoCli>(), executor, durations),
       executor);
@@ -49,14 +52,14 @@ TEST_F(QueuedCliTest, queuedCli) {
   // create requests
   vector<Command> cmds;
   for (const auto& str : results) {
-    cmds.push_back(Command::makeReadCommand(str));
+    cmds.push_back(ReadCommand::create(str));
   }
 
   // send requests
-  vector<folly::Future<string>> futures;
+  vector<folly::SemiFuture<string>> futures;
   for (const auto& cmd : cmds) {
     MLOG(MDEBUG) << "Executing command '" << cmd;
-    futures.push_back(cli.executeAndRead(cmd));
+    futures.push_back(cli->executeRead(ReadCommand::create(cmd)));
   }
 
   // collect values
@@ -70,22 +73,47 @@ TEST_F(QueuedCliTest, queuedCli) {
   }
 }
 
+TEST_F(QueuedCliTest, queueOrderingTest) {
+  unsigned int iterations = 200;
+  unsigned int parallelThreads = 165;
+  shared_ptr<CPUThreadPoolExecutor> queuedCliParallelExecutor =
+      make_shared<CPUThreadPoolExecutor>(parallelThreads);
+  WriteCommand cmd = WriteCommand::create("1\n2\n3\n4\n5\n6\n7\n8\n9", true);
+  const shared_ptr<QueuedCli>& cli =
+      QueuedCli::make("testOrder", make_shared<EchoCli>(), executor);
+
+  vector<Future<string>> queuedFutures;
+
+  for (unsigned long i = 0; i < iterations; i++) {
+    queuedFutures.emplace_back(folly::via(
+        queuedCliParallelExecutor.get(),
+        [cli, cmd]() { return cli->executeWrite(cmd); }));
+  }
+
+  vector<string> output =
+      collect(queuedFutures.begin(), queuedFutures.end()).get();
+
+  for (unsigned long i = 0; i < iterations; i++) {
+    EXPECT_EQ(output[i], "123456789");
+  }
+}
+
 TEST_F(QueuedCliTest, queuedCliMT) {
   const int loopcount = 10;
   vector<unsigned int> durations = {1};
 
-  QueuedCli cli(
+  shared_ptr<QueuedCli> cli = QueuedCli::make(
       "testConnection",
       make_shared<AsyncCli>(make_shared<EchoCli>(), executor, durations),
       executor);
 
   // create requests
   vector<folly::Future<string>> futures;
-  Command cmd = Command::makeReadCommand("hello");
+  ReadCommand cmd = ReadCommand::create("hello");
   for (int i = 0; i < loopcount; ++i) {
     MLOG(MDEBUG) << "Executing command '" << cmd;
     futures.push_back(
-        folly::via(executor.get(), [&]() { return cli.executeAndRead(cmd); }));
+        folly::via(executor.get(), [&]() { return cli->executeRead(cmd); }));
   }
 
   // collect values
@@ -97,6 +125,95 @@ TEST_F(QueuedCliTest, queuedCliMT) {
   for (auto v : values) {
     EXPECT_EQ(boost::algorithm::trim_copy(v.value()), "hello");
   }
+}
+
+TEST_F(QueuedCliTest, threadSafety) {
+  int iterations = 1000;
+  shared_ptr<CPUThreadPoolExecutor> testExec =
+      make_shared<CPUThreadPoolExecutor>(32, 1, iterations);
+
+  shared_ptr<QueuedCli> cli =
+      QueuedCli::make("testConnection", make_shared<EchoCli>(), executor);
+
+  vector<Future<string>> execs;
+  for (int i = 0; i < iterations; i++) {
+    Future<string> future = via(testExec.get(), [cli, i]() {
+      return cli->executeRead(ReadCommand::create(to_string(i))).get();
+    });
+    execs.push_back(std::move(future));
+  }
+
+  for (uint i = 0; i < execs.size(); i++) {
+    const string& basicString = std::move(execs.at(i)).get();
+  }
+}
+
+TEST_F(QueuedCliTest, cleanDestructOnSuccess) {
+  auto testExec = make_shared<CPUThreadPoolExecutor>(1);
+  auto delegate = getMockCli<EchoCli>(3, testExec);
+  auto testedCli = QueuedCli::make(
+      "testConnection", delegate, make_shared<CPUThreadPoolExecutor>(1));
+
+  vector<SemiFuture<string>> futures;
+  for (int i = 0; i < 10; i++) {
+    futures.emplace_back(
+        testedCli->executeRead(ReadCommand::create("command")));
+  }
+
+  // Destruct cli
+  testedCli.reset();
+
+  // First request can succeed, other are canceled
+  try {
+    ASSERT_EQ(move(futures.at(0)).via(testExec.get()).get(10s), "command");
+  } catch (const runtime_error& e) {
+    // The first one can succeed or be canceled, depends on timing
+    // But since we are only testing clean destruct, we don't care
+  }
+
+  for (uint i = 1; i < 10; i++) {
+    EXPECT_THROW(
+        move(futures.at(i)).via(testExec.get()).get(10s), runtime_error);
+  }
+
+  MLOG(MDEBUG) << "Waiting for test executor to finish";
+  testExec->join();
+}
+
+class CustomErr : public runtime_error {
+ public:
+  CustomErr(string msg) : runtime_error(msg){};
+};
+
+class CustomErrCli : public Cli {
+ public:
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override {
+    return folly::Future<string>(CustomErr(cmd.raw()));
+  }
+
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override {
+    return folly::Future<string>(CustomErr(cmd.raw()));
+  }
+};
+
+TEST_F(QueuedCliTest, preserveExType) {
+  auto testExec = make_shared<CPUThreadPoolExecutor>(1);
+  auto delegate = getMockCli<CustomErrCli>(0, testExec);
+  auto testedCli = QueuedCli::make(
+      "testConnection", delegate, make_shared<CPUThreadPoolExecutor>(1));
+  try {
+    testedCli->executeRead(ReadCommand::create("command"))
+        .via(testExec.get())
+        .get(10s);
+    FAIL() << "No exception thrown";
+  } catch (const CustomErr& e) {
+    // Proper ex type caught
+  } catch (const exception& e) {
+    FAIL() << "Wrong exception thrown";
+  }
+
+  MLOG(MDEBUG) << "Waiting for test executor to finish";
+  testExec->join();
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/test/cli/ReadCachingCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReadCachingCliTest.cpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <devmand/cartography/DeviceConfig.h>
+#include <devmand/channels/cli/ReadCachingCli.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/IOThreadPoolExecutor.h>
+#include <gtest/gtest.h>
+#include <chrono>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::channels::cli;
+using namespace devmand::test::utils::cli;
+using namespace std;
+using namespace folly;
+
+class ReadCachingCliTest : public ::testing::Test {
+ protected:
+  shared_ptr<CPUThreadPoolExecutor> testExec;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    devmand::test::utils::ssh::initSsh();
+    testExec = make_shared<CPUThreadPoolExecutor>(1);
+  }
+
+  void TearDown() override {
+    MLOG(MDEBUG) << "Waiting for test executor to finish";
+    testExec->join();
+  }
+};
+
+template <typename NESTED>
+static shared_ptr<AsyncCli> getMockCli(
+    uint delay,
+    shared_ptr<CPUThreadPoolExecutor> exec) {
+  vector<unsigned int> durations = {delay};
+  return make_shared<AsyncCli>(make_shared<NESTED>(), exec, durations);
+}
+
+static shared_ptr<ReadCachingCli> getCli(shared_ptr<Cli> delegate) {
+  return make_shared<ReadCachingCli>(
+      "test",
+      delegate,
+      ReadCachingCli::createCache(),
+      std::make_shared<folly::IOThreadPoolExecutor>(
+          1, std::make_shared<folly::NamedThreadFactory>("rccli")));
+}
+
+TEST_F(ReadCachingCliTest, cleanDestructOnSuccess) {
+  shared_ptr<AsyncCli> delegate = getMockCli<EchoCli>(0, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+TEST_F(ReadCachingCliTest, cleanDestructOnError) {
+  shared_ptr<AsyncCli> delegate = getMockCli<ErrCli>(0, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("error"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/RealCliDeviceTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/RealCliDeviceTest.cpp
@@ -15,6 +15,9 @@
 #include <devmand/devices/Device.h>
 #include <devmand/devices/State.h>
 #include <devmand/devices/cli/PlaintextCliDevice.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
 #include <folly/executors/ThreadedExecutor.h>
 #include <gtest/gtest.h>
 #include <chrono>
@@ -32,9 +35,19 @@ using devmand::devices::Device;
 using devmand::devices::State;
 using devmand::devices::cli::PlaintextCliDevice;
 
-class RealCliDeviceTest : public ::testing::Test {};
+class RealCliDeviceTest : public ::testing::Test {
+ protected:
+  unique_ptr<channels::cli::Engine> cliEngine;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    cliEngine = make_unique<channels::cli::Engine>();
+  }
+};
 
 TEST_F(RealCliDeviceTest, DISABLED_ubiquiti) {
+  int i = 0;
+  string output = "";
   Application app;
   cartography::DeviceConfig deviceConfig;
   devmand::cartography::ChannelConfig chnlCfg;
@@ -48,16 +61,25 @@ TEST_F(RealCliDeviceTest, DISABLED_ubiquiti) {
   deviceConfig.channelConfigs.insert(std::make_pair("cli", chnlCfg));
   deviceConfig.ip = "10.19.0.245";
   deviceConfig.id = "ubiquiti-test-device";
+
   std::unique_ptr<devices::Device> dev =
-      PlaintextCliDevice::createDevice(app, deviceConfig);
+      PlaintextCliDevice::createDeviceWithEngine(app, deviceConfig, *cliEngine);
+  do {
+    if (i > 0) {
+      std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
-  std::shared_ptr<State> state = dev->getState();
-  const folly::dynamic& stateResult = state->collect().get();
+    i++;
 
-  std::stringstream buffer;
-  buffer << stateResult[kvPairs.at("stateCommand")];
-  EXPECT_EQ(
-      "No ACLs are configured", boost::algorithm::trim_copy(buffer.str()));
+    std::shared_ptr<State> state = dev->getState();
+    const folly::dynamic& stateResult = state->collect().get();
+
+    output = stateResult.getDefault(kvPairs.at("stateCommand"), "").asString();
+    if (i > 20) {
+      FAIL() << "Unable to execute command, probably not connected";
+    }
+  } while (output.empty());
+  EXPECT_EQ("No ACLs are configured", boost::algorithm::trim_copy(output));
 }
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/test/cli/ReconnectingCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReconnectingCliTest.cpp
@@ -1,0 +1,143 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <devmand/cartography/DeviceConfig.h>
+#include <devmand/channels/cli/ReconnectingCli.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/Executor.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <gtest/gtest.h>
+#include <chrono>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::channels::cli;
+using namespace devmand::test::utils::cli;
+using namespace std;
+using namespace folly;
+
+class ReconnectingCliTest : public ::testing::Test {
+ protected:
+  shared_ptr<CPUThreadPoolExecutor> testExec;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    devmand::test::utils::ssh::initSsh();
+    testExec = make_shared<CPUThreadPoolExecutor>(1);
+  }
+
+  void TearDown() override {
+    MLOG(MDEBUG) << "Waiting for test executor to finish";
+    testExec->join();
+  }
+};
+
+static shared_ptr<ReconnectingCli> getCli(
+    function<SemiFuture<shared_ptr<Cli>>()> createCliStack) {
+  shared_ptr<ReconnectingCli> cli = ReconnectingCli::make(
+      "test",
+      make_shared<CPUThreadPoolExecutor>(1),
+      move(createCliStack),
+      make_shared<folly::ThreadWheelTimekeeper>(),
+      2s);
+  return cli;
+}
+
+static void waitTillCliRecreated() {
+  std::this_thread::sleep_for(2s);
+}
+
+TEST_F(ReconnectingCliTest, cleanDestructNotConnected) {
+  auto factory = [this]() {
+    std::this_thread::sleep_for(2s);
+    return SemiFuture<shared_ptr<Cli>>(getMockCli<EchoCli>(0, testExec));
+  };
+  auto testedCli = getCli(factory);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("not returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+TEST_F(ReconnectingCliTest, cleanDestructConnected) {
+  auto factory = [this]() {
+    return SemiFuture<shared_ptr<Cli>>(getMockCli<EchoCli>(0, testExec));
+  };
+  auto testedCli = getCli(factory);
+  waitTillCliRecreated();
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+TEST_F(ReconnectingCliTest, cleanDestructConnectedWithDelay) {
+  auto factory = [this]() {
+    return SemiFuture<shared_ptr<Cli>>(getMockCli<EchoCli>(2, testExec));
+  };
+  auto testedCli = getCli(factory);
+  waitTillCliRecreated();
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+TEST_F(ReconnectingCliTest, cleanDestructOnError) {
+  auto factory = [this]() {
+    return SemiFuture<shared_ptr<Cli>>(getMockCli<ErrCli>(0, testExec));
+  };
+  auto testedCli = getCli(factory);
+  waitTillCliRecreated();
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("not returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+TEST_F(ReconnectingCliTest, cleanDestructOnErrorWithDelay) {
+  auto factory = [this]() {
+    return SemiFuture<shared_ptr<Cli>>(getMockCli<ErrCli>(2, testExec));
+  };
+  auto testedCli = getCli(factory);
+  waitTillCliRecreated();
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("not returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), runtime_error);
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
@@ -108,16 +108,8 @@ TEST_F(ReconnectingSshTest, commandTimeout) {
   string sleepCommand = "sleep ";
   sleepCommand.append(to_string(cmdTimeout + 1));
   EXPECT_THROW(
-      {
-        try {
-          cli->executeRead(ReadCommand::create(sleepCommand, true))
-              .get(); // timeout exception
-        } catch (const exception& e) {
-          EXPECT_STREQ("Timed out", e.what());
-          throw;
-        }
-      },
-      exception);
+      { cli->executeRead(ReadCommand::create(sleepCommand, true)).get(); },
+      CommandTimeoutException);
 
   ssh->close();
   ssh = startSshServer();

--- a/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/ReconnectingSshTest.cpp
@@ -1,0 +1,207 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <devmand/Application.h>
+#include <devmand/channels/cli/IoConfigurationBuilder.h>
+#include <devmand/channels/cli/KeepaliveCli.h>
+#include <devmand/channels/cli/TimeoutTrackingCli.h>
+#include <devmand/devices/cli/PlaintextCliDevice.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/Singleton.h>
+#include <gtest/gtest.h>
+#include <chrono>
+#include <ctime>
+#include <thread>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::channels::cli;
+using namespace devmand::test::utils::ssh;
+using namespace std;
+using namespace folly;
+using devmand::channels::cli::sshsession::readCallback;
+using devmand::channels::cli::sshsession::SshSession;
+using devmand::channels::cli::sshsession::SshSessionAsync;
+using namespace devmand::cartography;
+using namespace devmand::devices;
+using namespace devmand::devices::cli;
+
+using namespace chrono_literals;
+
+class ReconnectingSshTest : public ::testing::Test {
+ protected:
+  shared_ptr<server> ssh;
+  unique_ptr<channels::cli::Engine> cliEngine;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    ssh = startSshServer();
+    cliEngine = make_unique<channels::cli::Engine>();
+  }
+
+  void TearDown() override {
+    ssh->close();
+  }
+};
+
+static DeviceConfig getConfig(
+    string port,
+    chrono::seconds commandTimeout = defaultCommandTimeout,
+    chrono::seconds keepaliveTimeout = 5s) {
+  DeviceConfig deviceConfig;
+  ChannelConfig chnlCfg;
+  map<string, string> kvPairs;
+  kvPairs.insert(make_pair("stateCommand", "echo 123"));
+  kvPairs.insert(make_pair("port", port));
+  kvPairs.insert(make_pair("username", "root"));
+  kvPairs.insert(make_pair("password", "root"));
+  kvPairs.insert(make_pair(
+      configMaxCommandTimeoutSeconds, to_string(commandTimeout.count())));
+  kvPairs.insert(make_pair(
+      configKeepAliveIntervalSeconds, to_string(keepaliveTimeout.count())));
+  chnlCfg.kvPairs = kvPairs;
+  deviceConfig.channelConfigs.insert(make_pair("cli", chnlCfg));
+  deviceConfig.ip = "localhost";
+  deviceConfig.id = "ubuntu-test-device";
+  return deviceConfig;
+}
+
+static void ensureConnected(const shared_ptr<Cli>& cli) {
+  bool connected = false;
+  int attempts = 0;
+  while (!connected && attempts++ < 40) {
+    MLOG(MDEBUG) << "Testing connection attempt:" << attempts;
+    try {
+      const string& echoResult =
+          cli->executeRead(ReadCommand::create("echo 123", true)).get();
+      EXPECT_EQ("123", boost::algorithm::trim_copy(echoResult));
+      connected = true;
+    } catch (const exception& e) {
+      MLOG(MDEBUG) << "Not connected:" << e.what();
+      this_thread::sleep_for(500ms);
+    }
+  }
+  EXPECT_TRUE(connected);
+}
+
+TEST_F(ReconnectingSshTest, commandTimeout) {
+  int cmdTimeout = 5;
+  IoConfigurationBuilder ioConfigurationBuilder(
+      getConfig(
+          "9999", std::chrono::seconds(cmdTimeout), std::chrono::seconds(10)),
+      *cliEngine);
+  shared_ptr<Cli> cli =
+      ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
+  ensureConnected(cli);
+  // sleep so that cli stack will be destroyed
+  string sleepCommand = "sleep ";
+  sleepCommand.append(to_string(cmdTimeout + 1));
+  EXPECT_THROW(
+      {
+        try {
+          cli->executeRead(ReadCommand::create(sleepCommand, true))
+              .get(); // timeout exception
+        } catch (const exception& e) {
+          EXPECT_STREQ("Timed out", e.what());
+          throw;
+        }
+      },
+      exception);
+
+  ssh->close();
+  ssh = startSshServer();
+  ensureConnected(cli);
+}
+
+TEST_F(ReconnectingSshTest, serverDisconnectSendCommands) {
+  int cmdTimeout = 60;
+  IoConfigurationBuilder ioConfigurationBuilder(
+      getConfig(
+          "9999", std::chrono::seconds(cmdTimeout), std::chrono::seconds(60)),
+      *cliEngine);
+  shared_ptr<Cli> cli =
+      ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
+
+  ensureConnected(cli);
+  ssh->close();
+  ssh = startSshServer();
+  ensureConnected(cli);
+}
+
+TEST_F(ReconnectingSshTest, serverDisconnectWaithForKeepalive) {
+  int cmdTimeout = 5;
+  int keepaliveFreq = 5;
+  IoConfigurationBuilder ioConfigurationBuilder(
+      getConfig(
+          "9999",
+          std::chrono::seconds(cmdTimeout),
+          std::chrono::seconds(keepaliveFreq)),
+      *cliEngine);
+  shared_ptr<Cli> cli =
+      ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
+
+  ensureConnected(cli);
+
+  // Disconnect from server side
+  ssh->close();
+  ssh = startSshServer();
+
+  MLOG(MDEBUG) << "Waiting for CLI to reconnect";
+
+  int attempt = 0;
+  while (true) {
+    if (ssh->isConnected()) {
+      break;
+    }
+    if ((attempt++) == 30) {
+      FAIL() << "CLI did not reconnect, something went wrong";
+    }
+
+    this_thread::sleep_for(1s);
+  }
+}
+
+TEST_F(ReconnectingSshTest, keepalive) {
+  int cmdTimeout = 5;
+  int keepaliveTimeout = 5;
+  IoConfigurationBuilder ioConfigurationBuilder(
+      getConfig(
+          "9999",
+          std::chrono::seconds(cmdTimeout),
+          std::chrono::seconds(keepaliveTimeout)),
+      *cliEngine);
+  shared_ptr<Cli> cli =
+      ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
+
+  int attempt = 0;
+  while (true) {
+    auto receivedOnServer = ssh->getReceived();
+    // Make sure at least 4 newlines have been executed
+    // 2 for prompt resolution and 2 for keepalives
+    if (count(receivedOnServer.begin(), receivedOnServer.end(), '\n') > 3) {
+      break;
+    }
+    if ((attempt++) == 30) {
+      FAIL()
+          << "Keepalive did not occur, something went wrong. Server received: "
+          << receivedOnServer;
+    }
+
+    this_thread::sleep_for(1s);
+  }
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/StructuredUbntDeviceTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/StructuredUbntDeviceTest.cpp
@@ -38,9 +38,9 @@ class StructuredUbntDeviceTest : public testing::Test {
 
 class UbntFakeCli : public Cli {
  public:
-  folly::Future<string> executeAndRead(const Command& cmd) override {
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override {
     (void)cmd;
-    if (cmd.toString() == "show interfaces description") {
+    if (cmd.raw() == "show interfaces description") {
       return "\n"
              "Interface  Admin      Link    Description\n"
              "---------  ---------  ------  ----------------------------------------------------------------\n"
@@ -53,9 +53,9 @@ class UbntFakeCli : public Cli {
              "0/7        Enable     Down\r\n"
              "0/8        Enable     Down\n"
              "3/6        Enable     Down\n";
-    } else if (cmd.toString().find("show running-config interface ") == 0) {
-      string ifcId = cmd.toString().substr(
-          string("show running-config interface ").size() - 1);
+    } else if (cmd.raw().find("show running-config interface ") == 0) {
+      string ifcId =
+          cmd.raw().substr(string("show running-config interface ").size() - 1);
 
       return "\n"
              "!Current Configuration:\n"
@@ -69,7 +69,7 @@ class UbntFakeCli : public Cli {
           "mtu 1500\n"
           "exit\n"
           "";
-    } else if (cmd.toString().find("show interface ethernet") == 0) {
+    } else if (cmd.raw().find("show interface ethernet") == 0) {
       return "\n"
              "Total Packets Received (Octets)................ 427066814515\n"
              "\n"
@@ -110,7 +110,7 @@ class UbntFakeCli : public Cli {
              "Packets Per Second Transmitted................. 1\n"
              "\n"
              "Time Since Counters Last Cleared............... 7 day 1 hr 24 min 53 sec";
-    } else if (cmd.toString() == "show interfaces description") {
+    } else if (cmd.raw() == "show interfaces description") {
       return "\n"
              "Interface  Admin      Link    Description\n"
              "---------  ---------  ------  ----------------------------------------------------------------\n"
@@ -129,7 +129,7 @@ class UbntFakeCli : public Cli {
     return "";
   }
 
-  folly::Future<string> execute(const Command& cmd) override {
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override {
     (void)cmd;
     return folly::Future<string>("");
   }

--- a/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
@@ -79,7 +79,8 @@ TEST_F(TimeoutCliTest, cleanDestructOnTimeout) {
   // Destruct cli
   testedCli.reset();
 
-  EXPECT_THROW(move(future).via(testExec.get()).get(10s), FutureTimeout);
+  EXPECT_THROW(
+      move(future).via(testExec.get()).get(10s), CommandTimeoutException);
 }
 
 TEST_F(TimeoutCliTest, cleanDestructOnError) {

--- a/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <devmand/cartography/DeviceConfig.h>
+#include <devmand/channels/cli/Cli.h>
+#include <devmand/channels/cli/IoConfigurationBuilder.h>
+#include <devmand/channels/cli/TimeoutTrackingCli.h>
+#include <devmand/devices/Device.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/ThreadedExecutor.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+#include <gtest/gtest.h>
+#include <atomic>
+#include <chrono>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::test::utils::cli;
+using namespace std;
+using namespace std::chrono_literals;
+using namespace devmand::channels::cli;
+using devmand::Application;
+using devmand::cartography::ChannelConfig;
+using devmand::cartography::DeviceConfig;
+using devmand::devices::Device;
+using devmand::devices::State;
+using devmand::test::utils::cli::AsyncCli;
+using devmand::test::utils::cli::EchoCli;
+using folly::CPUThreadPoolExecutor;
+using namespace devmand::test::utils::ssh;
+
+class TimeoutCliTest : public ::testing::Test {
+ protected:
+  shared_ptr<CPUThreadPoolExecutor> testExec;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+    devmand::test::utils::ssh::initSsh();
+    testExec = make_shared<CPUThreadPoolExecutor>(1);
+  }
+
+  void TearDown() override {
+    MLOG(MDEBUG) << "Waiting for test executor to finish";
+    testExec->join();
+  }
+};
+
+static const chrono::milliseconds timeout = 1s;
+
+static shared_ptr<TimeoutTrackingCli> getCli(shared_ptr<Cli> delegate) {
+  shared_ptr<TimeoutTrackingCli> cli = TimeoutTrackingCli::make(
+      "test",
+      delegate,
+      make_shared<folly::ThreadWheelTimekeeper>(),
+      make_shared<CPUThreadPoolExecutor>(1),
+      timeout);
+  return cli;
+}
+
+TEST_F(TimeoutCliTest, cleanDestructOnTimeout) {
+  shared_ptr<AsyncCli> delegate = getMockCli<EchoCli>(3, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("not returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW(move(future).via(testExec.get()).get(10s), FutureTimeout);
+}
+
+TEST_F(TimeoutCliTest, cleanDestructOnError) {
+  shared_ptr<AsyncCli> delegate = getMockCli<ErrCli>(0, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("not returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  EXPECT_THROW({ move(future).via(testExec.get()).get(10s); }, runtime_error);
+}
+
+TEST_F(TimeoutCliTest, cleanDestructOnSuccess) {
+  shared_ptr<AsyncCli> delegate = getMockCli<EchoCli>(0, testExec);
+  auto testedCli = getCli(delegate);
+
+  SemiFuture<string> future =
+      testedCli->executeRead(ReadCommand::create("returning"));
+
+  // Destruct cli
+  testedCli.reset();
+
+  ASSERT_EQ(move(future).via(testExec.get()).get(10s), "returning");
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand

--- a/devmand/gateway/src/devmand/test/cli/utils/Log.cpp
+++ b/devmand/gateway/src/devmand/test/cli/utils/Log.cpp
@@ -18,11 +18,12 @@ using namespace devmand::channels::cli;
 
 atomic_bool loggingInitialized(false);
 
-void initLog() {
+void initLog(uint32_t verbosity) {
   if (loggingInitialized.load()) {
+    magma::set_verbosity(verbosity);
     return;
   }
-  Engine::initLogging(MDEBUG, true);
+  Engine::initLogging(verbosity, true);
   loggingInitialized.store(true);
   MLOG(MDEBUG) << "Logging for test initialized";
 }

--- a/devmand/gateway/src/devmand/test/cli/utils/Log.h
+++ b/devmand/gateway/src/devmand/test/cli/utils/Log.h
@@ -10,7 +10,6 @@
 #define LOG_WITH_GLOG
 
 #include <magma_logging.h>
-#include <atomic>
 
 namespace devmand {
 namespace test {
@@ -19,9 +18,7 @@ namespace log {
 
 using namespace std;
 
-extern atomic_bool loggingInitialized;
-
-extern void initLog();
+extern void initLog(uint32_t verbosity = MDEBUG);
 
 } // namespace log
 } // namespace utils


### PR DESCRIPTION
- Keepalive makes sure the connection stays up
- TimeoutTracker makes sure commands complete within a predefined window
- Reconnect closes existing stack and recreates/reconnects in case of
failure

+ Support basic setConfig() for structuredUbntDevice
+ Make CLI stack fully asynchronous
+ Add many unit tests to verify correctness of CLI stack

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>