### PR TITLE
SessionCredit can be created with unlimited quota

### DIFF
--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -31,13 +31,27 @@ SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state):
   reporting_(false),
   reauth_state_(REAUTH_NOT_NEEDED),
   service_state_(start_state),
+  unlimited_quota_(false),
+  buckets_ {}
+{
+}
+
+SessionCredit::SessionCredit(
+  CreditType credit_type,
+  ServiceState start_state,
+  bool unlimited_quota):
+  credit_type_(credit_type),
+  reporting_(false),
+  reauth_state_(REAUTH_NOT_NEEDED),
+  service_state_(start_state),
+  unlimited_quota_(unlimited_quota),
   buckets_ {}
 {
 }
 
 // by default, enable service
 SessionCredit::SessionCredit(CreditType credit_type):
-  SessionCredit(credit_type, SERVICE_ENABLED)
+  SessionCredit(credit_type, SERVICE_ENABLED, false)
 {
 }
 
@@ -195,7 +209,7 @@ bool SessionCredit::quota_exhausted(
 
 bool SessionCredit::should_deactivate_service()
 {
-  return credit_type_ == CreditType::CHARGING &&
+  return credit_type_ == CreditType::CHARGING && !unlimited_quota_ &&
     SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED &&
     ((no_more_grant() && quota_exhausted()) ||
       quota_exhausted(1, SessionCredit::EXTRA_QUOTA_MARGIN));

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -84,6 +84,11 @@ class SessionCredit {
 
   SessionCredit(CreditType credit_type, ServiceState start_state);
 
+  SessionCredit(
+    CreditType credit_type,
+    ServiceState start_state,
+    bool unlimited_quota);
+
   /**
    * add_used_credit increments USED_TX and USED_RX
    * as being recently updated
@@ -186,6 +191,7 @@ class SessionCredit {
  private:
   bool reporting_;
   bool is_final_;
+  bool unlimited_quota_;
   FinalActionInfo final_action_info_;
   ReAuthState reauth_state_;
   ServiceState service_state_;


### PR DESCRIPTION
Summary:
## What's Changed
- removed sessiond.yml option for keeping subscriber service after quota runs out
- add an option to `SessionCredit` for unlimited quota

## Upcoming
- Support for unlimited credit grants from policydb
- unlimited quota credit grants will have the option of being unmonitored

Reviewed By: xjtian

Differential Revision: D18740159

