### PR TITLE
Refactor the way integ test config files are loaded into services

### DIFF
--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -58,6 +58,10 @@ services:
         /usr/bin/ovs-vsctl set-controller cwag_br0 tcp:127.0.0.1:6633 &&
         python3 -m magma.pipelined.main"
 
+  sessiond:
+    volumes:
+      - ../integ_tests/sessiond.yml:/etc/magma/sessiond.yml
+
   swx_proxy:
     <<: *feggoservice
     container_name: swx_proxy
@@ -92,7 +96,7 @@ services:
     <<: *pyservice
     container_name: redis
     volumes:
-      - /var/opt/magma/redis.conf:/var/opt/magma/redis.conf
+      - ../integ_tests/redis.conf:/var/opt/magma/redis.conf
     command: >
       /bin/bash -c "/usr/bin/redis-server /var/opt/magma/redis.conf --daemonize no &&
              /usr/bin/redis-cli shutdown"

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -129,9 +129,7 @@ def _set_cwag_configs():
     with cd(CWAG_INTEG_ROOT):
         sudo('mkdir -p /var/opt/magma')
         sudo('mkdir -p /var/opt/magma/configs')
-        sudo('cp gateway.mconfig /var/opt/magma/configs')
-        sudo('cp sessiond.yml /var/opt/magma/configs')
-        sudo('cp redis.conf /var/opt/magma')
+        sudo('cp gateway.mconfig /var/opt/magma/configs/')
 
 
 def _set_cwag_networking(mac):


### PR DESCRIPTION
Summary:
Some small integration test config related refactor.
- redis.conf should be mounted on as part of the docker-compose. The current setup fails if we use the docker-compose.integ_test.yml without running the fab script. This is kind of a specific case, but now it's much cleaner.
- sessiond.yml should be loaded into sessiond service the same way pipelined.yml is loaded into pipelined. This way we don't corrupt the override directory.

Reviewed By: koolzz

Differential Revision: D18835147

