### PR TITLE
Always calls to sessiond for LocalSessionManager

### DIFF
--- a/lte/gateway/c/oai/lib/pcef/PCEFClient.cpp
+++ b/lte/gateway/c/oai/lib/pcef/PCEFClient.cpp
@@ -41,28 +41,9 @@ class SubscriberID;
 }  // namespace lte
 }  // namespace magma
 
-#define POLICYDB_SERVICE "policydb"
 #define MAGMAD_SERVICE "magmad"
 
 using grpc::Status;
-
-static bool local_pcrf_enabled()
-{
-  magma::mconfig::MagmaD mconfig;
-  magma::MConfigLoader loader;
-  if (!loader.load_service_mconfig(MAGMAD_SERVICE, &mconfig)) {
-    std::cout << "[ERROR] Unable to load mconfig for mme, using default" << std::endl;
-    return false;
-  }
-  for (int i = 0; i < mconfig.dynamic_services_size(); ++i) {
-    const auto &service_name = mconfig.dynamic_services(i);
-    if (service_name == POLICYDB_SERVICE) {
-      std::cout << "[DEBUG] Local PCRF enabled." << std::endl;
-      return true;
-    }
-  }
-  return false;
-}
 
 namespace magma {
 
@@ -76,13 +57,8 @@ PCEFClient::PCEFClient()
 {
   // Create channel
   std::shared_ptr<Channel> channel;
-  if (local_pcrf_enabled()) {
-    channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-      POLICYDB_SERVICE, ServiceRegistrySingleton::LOCAL);
-  } else {
-    channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-      "sessiond", ServiceRegistrySingleton::LOCAL);
-  }
+channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+  "sessiond", ServiceRegistrySingleton::LOCAL);
   // Create stub for LocalSessionManager gRPC service
   stub_ = LocalSessionManager::NewStub(channel);
   std::thread resp_loop_thread([&]() { rpc_response_loop(); });


### PR DESCRIPTION
Summary:
## Changes

Fixed an issue where mme would make calls to `policydb` instead of `sessiond` through `LocalSessionManagerStub`.

`policydb` service does not run `LocalSessionManagerService`.

Differential Revision: D18836045

