### PR TITLE
Add `use_local_session_proxy` to unbreak sessiond <-> session proxy connection in the CWAG integration test

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -9,7 +9,6 @@
 
 log_level: INFO
 rule_update_inteval_sec: 1
-use_proxied_controller: true
 
 # Session manager will report the usage when the usage is greater than
 # usage_reporting_threshold * available quota since last update

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -7,10 +7,8 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+log_level: DEBUG
 rule_update_inteval_sec: 1
-use_proxied_controller: false
-local_controller_port: 9097
 
 # Session manager will report the usage when the usage is greater than
 # usage_reporting_threshold * available quota since last update
@@ -33,3 +31,11 @@ session_force_termination_timeout_ms: 5000
 
 # Set to true to enable sessiond support of carrier wifi
 support_carrier_wifi: true
+
+# For Testing
+# Set to use a locally running session proxy instance. If
+# use_local_session_proxy is set to true sessiond will use 127.0.0.1:<port> as
+# the address for the session proxy service.
+# Note: these flags are only relevant when relay is turned on
+use_local_session_proxy: true
+local_session_proxy_port: 9097

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -9,8 +9,6 @@
 
 log_level: INFO
 rule_update_inteval_sec: 1
-use_proxied_controller: false
-local_controller_port: 9999
 
 # Session manager will report the usage when the usage is greater than
 # usage_reporting_threshold * available quota since last update

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -9,7 +9,6 @@
 
 log_level: INFO
 rule_update_inteval_sec: 15
-use_proxied_controller: true
 
 # Session manager will report the usage when the usage is greater than
 # usage_reporting_threshold * available quota since last update


### PR DESCRIPTION
Summary:
The CWAG Integration test relies on talking to a locally running Session Proxy service to run the test. Originally, it used a flag in sessiond to specifiy a local port. But sessiond was modified in D18073209 to no longer use these flags. Leading to a http `502` error when sessiond tries to talk to sessionProxy.
I'm putting back in a similar piece of code back into sessiond, but to avoid confusion I'm now calling this flag `use_local_session_proxy` and documented that it is used for testing.

Differential Revision: D18837829

