### PR TITLE
Update doc related to oneline agw installation

### DIFF
--- a/docs/readmes/lte/setup_deb.md
+++ b/docs/readmes/lte/setup_deb.md
@@ -48,7 +48,7 @@ installation process to get an IP using DHCP.
 ```bash
 su
 wget https://raw.githubusercontent.com/facebookincubator/magma/master/lte/gateway/deploy/agw_install.sh
-sh agw_prepare.sh
+sh agw_install.sh
 ```
 
 The machine will reboot but It's not finished yet, the script is still running in the background.


### PR DESCRIPTION
Summary:
The script for oneline agw installation (agw_install.sh) was added by PR #980.
This PR updates the doc related to agw_install.sh.