### PR TITLE
Support reception of empty HTTP request after provisioning session end

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_states.py
@@ -863,6 +863,15 @@ class EndSessionState(EnodebAcsState):
         self.acs = acs
 
     def read_msg(self, message: Any) -> AcsReadMsgResult:
+        """
+        No message is expected after enodebd sends the eNodeB
+        an empty HTTP response.
+
+        If a device sends an empty HTTP request, we can just
+        ignore it and send another empty response.
+        """
+        if isinstance(message, models.DummyInput):
+            return AcsReadMsgResult(True, None)
         return AcsReadMsgResult(False, None)
 
     def get_msg(self) -> AcsMsgAndTransition:


### PR DESCRIPTION
Summary:
After a TR-069 provisioning session, which is ended by `enodebd` sending an empty HTTP response, it is expected that the eNodeB will not send any TR-069 messages other than an `Inform` to start a new provisioning session. It is found that for at least one device/software combination, the eNodeB will send an empty HTTP request, which is unhandled and will cause `enodebd` to go into an error state.

## Changes
Service `enodebd` will handle an empty HTTP request outside of a TR-069 provisioning session by ignoring it.

Differential Revision: D18901078

