### PR TITLE
fix checkbox for nonexistent config (#1721)

### DIFF
--- a/symphony/app/fbcnms-projects/magmalte/app/components/devices/DevicesState.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/components/devices/DevicesState.js
@@ -83,10 +83,22 @@ function Interface({
     });
 
     const managedDevices = JSON.parse(newDevice.config?.device_config || '{}');
-    const index = findIndex(
+    let index = findIndex(
       managedDevices['openconfig-interfaces:interfaces'].interface,
       i => iface.name === i.name,
     );
+
+    if (index === -1) {
+      const newIface = {
+        name: iface.name,
+        config: JSON.parse(JSON.stringify(iface.config)),
+      };
+      managedDevices['openconfig-interfaces:interfaces'].interface.push(
+        newIface,
+      );
+      index =
+        managedDevices['openconfig-interfaces:interfaces'].interface.length - 1;
+    }
     managedDevices['openconfig-interfaces:interfaces'].interface[
       index
     ].config.enabled = event.target.checked;


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/1721

Pull Request resolved: https://github.com/facebookincubator/symphony/pull/129

Hitting the checkbox on a device for which the config doesn't exist caused a hang. The UI would go into the disabled "loading" stage and never exit.

Differential Revision: D18912902

