### PR TITLE
Add match filter to prometheus series api endpoint

### DIFF
--- a/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
@@ -136,6 +136,14 @@ paths:
       parameters:
         - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
         - in: query
+          name: match
+          type: array
+          items:
+            type: string
+          collectionFormat: ssv
+          description: Matcher for metric series query
+          required: false
+        - in: query
           name: start
           type: string
           description: start time of the requested range (UnixTime or RFC3339)

--- a/orc8r/cloud/go/services/metricsd/obsidian/security/query_restrictor_test.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/security/query_restrictor_test.go
@@ -45,6 +45,14 @@ func TestQueryWithMatrixAndFunctions(t *testing.T) {
 	testQueryHelper(t, "sum_over_time(metric1[5m]) or sum_over_time(metric2[5m])", []string{"metric1", "metric2"})
 }
 
+func TestLabelSelectorQuery(t *testing.T) {
+	restrictor := NewQueryRestrictor(map[string]string{"networkID": "test"})
+	inputSelector := `{label1="value1"}`
+	restricted, err := restrictor.RestrictQuery(inputSelector)
+	assert.NoError(t, err)
+	assert.Equal(t, `{label1="value1",networkID="test"}`, restricted)
+}
+
 func testQueryHelper(t *testing.T, query string, metricsInQuery []string) {
 	singleLabel := map[string]string{"name1": "value1"}
 	restrictedBasicQuery, err := createRestrictedQuery(query, singleLabel)

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers_test.go
@@ -10,10 +10,13 @@ package handlers
 
 import (
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"magma/orc8r/cloud/go/metrics"
 
+	"github.com/labstack/echo"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +27,55 @@ func TestPreprocessQuery(t *testing.T) {
 	assert.NoError(t, err)
 	expectedQuery := fmt.Sprintf("%s{%s=\"%s\"}", testQuery, metrics.NetworkLabelName, networkID)
 	assert.Equal(t, expectedQuery, preprocessedQuery)
+}
+
+type seriesHandlerTestCase struct {
+	name            string
+	inputURL        string
+	nID             string
+	expectedStrings []string
+}
+
+func (tc *seriesHandlerTestCase) RunTest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, tc.inputURL, nil)
+	rec := httptest.NewRecorder()
+
+	c := echo.New().NewContext(req, rec)
+	params, err := getSeriesMatches(c, tc.nID)
+	assert.NoError(t, err)
+	assert.Equal(t, tc.expectedStrings, params)
+}
+
+func TestGetPrometheusSeriesHandler(t *testing.T) {
+
+	testCases := []seriesHandlerTestCase{
+		{
+			name:            "single match",
+			inputURL:        "/?match=up",
+			nID:             "test",
+			expectedStrings: []string{`up{networkID="test"}`},
+		},
+		{
+			name:            "two match",
+			inputURL:        "/?match=up%20down",
+			nID:             "test",
+			expectedStrings: []string{`up{networkID="test"}`, `down{networkID="test"}`},
+		},
+		{
+			name:            "complicated match",
+			inputURL:        "/?match=up%20down%20{gatewayID=\"gw1\"}",
+			nID:             "test",
+			expectedStrings: []string{`up{networkID="test"}`, `down{networkID="test"}`, `{gatewayID="gw1",networkID="test"}`},
+		},
+		{
+			name:            "no match",
+			inputURL:        "/",
+			nID:             "test",
+			expectedStrings: []string{`{networkID="test"}`},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, tc.RunTest)
+	}
 }


### PR DESCRIPTION
Summary: We currently do all filtering in JS after the api call. It makes things easier to be able to specify the filters in the request.

Reviewed By: xjtian

Differential Revision: D18800290

