### PR TITLE
Add OVS IPFIX exporting logic

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -23,6 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cwag.vm.hostname = "cwag-dev"
     cwag.vm.network "private_network", ip: "192.168.70.101", nic_type: "82540EM"
     cwag.vm.network "private_network", ip: "192.168.129.23", nic_type: "82540EM"
+    cwag.vm.network "private_network", ip: "192.168.40.11", nic_type: "82540EM"
     cwag.ssh.password = "vagrant"
     cwag.ssh.insert_key = true
 
@@ -46,6 +47,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cwag_test.vm.box_version = "1.9.12"
     cwag_test.vm.hostname = "cwag-test"
     cwag_test.vm.network "private_network", ip: "192.168.70.102", nic_type: "82540EM"
+    cwag_test.vm.network "private_network", ip: "192.168.40.12", nic_type: "82540EM"
     cwag_test.ssh.password = "vagrant"
     cwag_test.ssh.insert_key = true
 

--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -33,6 +33,7 @@ static_services: [
   'access_control',
   'tunnel_learn',
   'vlan_learn',
+  'ipfix',
   'ryu_rest_service',
   'startup_flows',
 #  'packet_tracer',
@@ -87,6 +88,16 @@ local_ue_eth_addr: False
 
 # For CWF, allow unknown uplink ARPs to passthrough
 allow_unknown_arps: False
+
+# Configuration for IPFIX sampling
+ipfix:
+  enabled: true
+  collector_ip: '10.22.20.116'
+  collector_port: 4740
+  probability: 30000
+  collector_set_id: 1
+  obs_domain_id: 1
+  obs_point_id: 1
 
 # Interface to NAT traffic to
 nat_iface: eth2

--- a/cwf/gateway/deploy/roles/ovs/files/install_ovs.sh
+++ b/cwf/gateway/deploy/roles/ovs/files/install_ovs.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+apt-get -y update
+apt-get -y install git
+apt-get remove -y openvswitch-common
+apt-get remove -y openvswitch-switch
+apt-get -y install automake
+apt-get -y install gcc
+apt-get -y install libtool
+apt-get -y libcap-ng-dev
+apt-get -y install linux-headers-"$(uname -r)"
+apt-get -y update
+git clone https://github.com/openvswitch/ovs.git
+cd ovs/ || exit
+git checkout v2.12.0
+git apply /tmp/v2.12.0_ipfix_custom_fields.patch
+./boot.sh
+./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-linux=/lib/modules/"$(uname -r)"/build
+make
+make install

--- a/cwf/gateway/deploy/roles/ovs/files/v2.12.0_ipfix_custom_fields.patch
+++ b/cwf/gateway/deploy/roles/ovs/files/v2.12.0_ipfix_custom_fields.patch
@@ -1,0 +1,250 @@
+diff --git a/include/openvswitch/ofp-actions.h b/include/openvswitch/ofp-actions.h
+index c8948e0d6..cd23d1322 100644
+--- a/include/openvswitch/ofp-actions.h
++++ b/include/openvswitch/ofp-actions.h
+@@ -1007,6 +1007,9 @@ struct ofpact_sample {
+         uint32_t obs_point_id;
+         ofp_port_t sampling_port;
+         enum nx_action_sample_direction direction;
++        uint8_t msisdn[16];
++        struct eth_addr apn_mac_addr;
++        uint8_t apn_name[24];
+     );
+ };
+
+diff --git a/lib/odp-util.h b/lib/odp-util.h
+index a03e82532..e78e45711 100644
+--- a/lib/odp-util.h
++++ b/lib/odp-util.h
+@@ -331,6 +331,10 @@ struct user_action_cookie {
+             uint32_t obs_point_id;  /* Observation Point ID. */
+             odp_port_t output_odp_port; /* The output odp port. */
+             enum nx_action_sample_direction direction;
++            ovs_be64 flow_metadata;
++            uint8_t msisdn[16];
++            struct eth_addr apn_mac_addr;
++            uint8_t apn_name[24];
+         } flow_sample;
+
+         struct {
+@@ -350,7 +354,7 @@ struct user_action_cookie {
+         } controller;
+     };
+ };
+-BUILD_ASSERT_DECL(sizeof(struct user_action_cookie) == 48);
++BUILD_ASSERT_DECL(sizeof(struct user_action_cookie) == 104);
+
+ size_t odp_put_userspace_action(uint32_t pid,
+                                 const void *userdata, size_t userdata_size,
+diff --git a/lib/ofp-actions.c b/lib/ofp-actions.c
+index ddef3b0c8..7c12b748a 100644
+--- a/lib/ofp-actions.c
++++ b/lib/ofp-actions.c
+@@ -6041,10 +6041,13 @@ struct nx_action_sample2 {
+     ovs_be32 obs_domain_id;         /* ID of sampling observation domain. */
+     ovs_be32 obs_point_id;          /* ID of sampling observation point. */
+     ovs_be16 sampling_port;         /* Sampling port. */
++    uint8_t  msisdn[16];
++    struct   eth_addr apn_mac_addr;
++    uint8_t  apn_name[24];
+     uint8_t  direction;             /* NXAST_SAMPLE3 only. */
+     uint8_t  zeros[5];              /* Pad to a multiple of 8 bytes */
+  };
+- OFP_ASSERT(sizeof(struct nx_action_sample2) == 32);
++ OFP_ASSERT(sizeof(struct nx_action_sample2) == 80);
+
+ static enum ofperr
+ decode_NXAST_RAW_SAMPLE(const struct nx_action_sample *nas,
+@@ -6081,6 +6084,9 @@ decode_SAMPLE2(const struct nx_action_sample2 *nas,
+     sample->obs_domain_id = ntohl(nas->obs_domain_id);
+     sample->obs_point_id = ntohl(nas->obs_point_id);
+     sample->sampling_port = u16_to_ofp(ntohs(nas->sampling_port));
++    sample->apn_mac_addr = nas->apn_mac_addr;
++    memcpy(&sample->msisdn, &nas->msisdn, 16);
++    memcpy(&sample->apn_name, &nas->apn_name, 24);
+     sample->direction = direction;
+
+     if (sample->probability == 0) {
+@@ -6127,6 +6133,9 @@ encode_SAMPLE2(const struct ofpact_sample *sample,
+     nas->obs_point_id = htonl(sample->obs_point_id);
+     nas->sampling_port = htons(ofp_to_u16(sample->sampling_port));
+     nas->direction = sample->direction;
++    memcpy(&nas->msisdn, &sample->msisdn, 16);
++    nas->apn_mac_addr = sample->apn_mac_addr;
++    memcpy(&nas->apn_name, &sample->apn_name, 24);
+ }
+
+ static void
+@@ -6159,8 +6168,11 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+     struct ofpact_sample *os = ofpact_put_SAMPLE(pp->ofpacts);
+     os->sampling_port = OFPP_NONE;
+     os->direction = NX_ACTION_SAMPLE_DEFAULT;
++    memset(&os->msisdn, 0, 16);
++    memset(&os->apn_name, 0, 24);
+
+     char *key, *value;
++    int i;
+     while (ofputil_parse_key_value(&arg, &key, &value)) {
+         char *error = NULL;
+
+@@ -6169,6 +6181,20 @@ parse_SAMPLE(char *arg, const struct ofpact_parse_params *pp)
+             if (!error && os->probability == 0) {
+                 error = xasprintf("invalid probability value \"%s\"", value);
+             }
++        } else if (!strcmp(key, "apn_name")) {
++            for (i = 0; i < 24; i++) {
++                os->apn_name[i] = (uint8_t)value[i];
++                if ((char)value[i] == '\0')
++                    break;
++            }
++        } else if (!strcmp(key, "msisdn")) {
++            for (i = 0; i < 16; i++) {
++                os->msisdn[i] = (uint8_t)value[i];
++                if ((char)value[i] == '\0')
++                    break;
++            }
++        } else if (!strcmp(key, "apn_mac_addr")) {
++            error = str_to_mac(value, &os->apn_mac_addr);
+         } else if (!strcmp(key, "collector_set_id")) {
+             error = str_to_u32(value, &os->collector_set_id);
+         } else if (!strcmp(key, "obs_domain_id")) {
+@@ -6206,12 +6232,18 @@ format_SAMPLE(const struct ofpact_sample *a,
+     ds_put_format(fp->s, "%ssample(%s%sprobability=%s%"PRIu16
+                   ",%scollector_set_id=%s%"PRIu32
+                   ",%sobs_domain_id=%s%"PRIu32
+-                  ",%sobs_point_id=%s%"PRIu32,
++                  ",%sobs_point_id=%s%"PRIu32
++                  ",%sapn_mac_addr=%s"ETH_ADDR_FMT
++                  ",%smsisdn=%s%s"
++                  ",%sapn_name=%s%s",
+                   colors.paren, colors.end,
+                   colors.param, colors.end, a->probability,
+                   colors.param, colors.end, a->collector_set_id,
+                   colors.param, colors.end, a->obs_domain_id,
+-                  colors.param, colors.end, a->obs_point_id);
++                  colors.param, colors.end, a->obs_point_id,
++                  colors.param, colors.end, ETH_ADDR_ARGS(a->apn_mac_addr),
++                  colors.param, colors.end, a->msisdn,
++                  colors.param, colors.end, a->apn_name);
+     if (a->sampling_port != OFPP_NONE) {
+         ds_put_format(fp->s, ",%ssampling_port=%s", colors.param, colors.end);
+         ofputil_format_port(a->sampling_port, fp->port_map, fp->s);
+diff --git a/ofproto/ipfix-enterprise-entities.def b/ofproto/ipfix-enterprise-entities.def
+index 73a520c25..5723ab8a7 100644
+--- a/ofproto/ipfix-enterprise-entities.def
++++ b/ofproto/ipfix-enterprise-entities.def
+@@ -14,4 +14,10 @@ IPFIX_ENTERPRISE_ENTITY(TUNNEL_SOURCE_TRANSPORT_PORT, 896, 2, tunnelSourceTransp
+ IPFIX_ENTERPRISE_ENTITY(TUNNEL_DESTINATION_TRANSPORT_PORT, 897, 2, tunnelDestinationTransportPort, IPFIX_ENTERPRISE_VMWARE)
+ IPFIX_ENTERPRISE_ENTITY(VIRTUAL_OBS_ID, 898, 0, virtualObsID, IPFIX_ENTERPRISE_VMWARE)
+
++#define IPFIX_ENTERPRISE_IPDR 6888
++IPFIX_ENTERPRISE_ENTITY(IMSI_REG, 899, 8, imsiRegister, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(MSISDN, 900, 16, msisdn, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APN_MAC_ADDRESS, 901, 6, apnMacAddress, IPFIX_ENTERPRISE_IPDR)
++IPFIX_ENTERPRISE_ENTITY(APN_NAME, 902, 24, apnName, IPFIX_ENTERPRISE_IPDR)
++
+ #undef IPFIX_ENTERPRISE_ENTITY
+diff --git a/ofproto/ofproto-dpif-ipfix.c b/ofproto/ofproto-dpif-ipfix.c
+index b8bd1b814..4bc9efbe0 100644
+--- a/ofproto/ofproto-dpif-ipfix.c
++++ b/ofproto/ofproto-dpif-ipfix.c
+@@ -404,6 +404,15 @@ struct ipfix_data_record_flow_key_tunnel {
+ });
+ BUILD_ASSERT_DECL(sizeof(struct ipfix_data_record_flow_key_tunnel) == 15);
+
++OVS_PACKED(
++struct ipfix_data_ipdr_fields {
++    ovs_be64 imsi; /* IMSI_REGISTER*/
++    uint8_t msisdn[16];
++    struct eth_addr apn_mac_address;
++    uint8_t apn_name[24];
++});
++BUILD_ASSERT_DECL(sizeof(struct ipfix_data_ipdr_fields) == 54);
++
+ /* Cf. IETF RFC 5102 Section 5.11.3. */
+ enum ipfix_flow_end_reason {
+     IDLE_TIMEOUT = 0x01,
+@@ -536,6 +545,7 @@ BUILD_ASSERT_DECL(sizeof(struct ipfix_data_record_aggregated_tcp) == 48);
+      + MAX(sizeof(struct ipfix_data_record_flow_key_icmp),      \
+            sizeof(struct ipfix_data_record_flow_key_transport)) \
+      + sizeof(struct ipfix_data_record_flow_key_tunnel)         \
++     + sizeof(struct ipfix_data_ipdr_fields)                    \
+      + MAX_TUNNEL_KEY_LEN)
+
+ #define MAX_DATA_RECORD_LEN                                 \
+@@ -1477,6 +1487,12 @@ ipfix_define_template_fields(enum ipfix_proto_l2 l2, enum ipfix_proto_l3 l3,
+         DEF(TUNNEL_KEY);
+     }
+
++    /* Custom IPDR fields */
++    DEF(IMSI_REG);
++    DEF(MSISDN);
++    DEF(APN_MAC_ADDRESS);
++    DEF(APN_NAME);
++
+     /* 2. Virtual observation ID, which is not a part of flow key. */
+     if (virtual_obs_id_set) {
+         DEF(VIRTUAL_OBS_ID);
+@@ -2092,6 +2108,8 @@ ipfix_cache_entry_init(const struct dpif_ipfix *di,
+                        uint64_t packet_delta_count, uint32_t obs_domain_id,
+                        uint32_t obs_point_id, odp_port_t output_odp_port,
+                        enum nx_action_sample_direction direction,
++                       ovs_be64 flow_metadata, uint8_t *msisdn,
++                       struct eth_addr *apn_mac_addr, uint8_t *apn_name,
+                        const struct dpif_ipfix_port *tunnel_port,
+                        const struct flow_tnl *tunnel_key,
+                        struct dpif_ipfix_global_stats *stats,
+@@ -2288,6 +2306,18 @@ ipfix_cache_entry_init(const struct dpif_ipfix *di,
+                tunnel_port->tunnel_key_length);
+     }
+
++    /* Add custom IPDR fields */
++    struct ipfix_data_ipdr_fields *ipdr_data;
++
++    ipdr_data = dp_packet_put_zeros(&msg, sizeof *ipdr_data);
++    ipdr_data->imsi = flow_metadata;
++    if (msisdn != NULL)
++        memcpy(&ipdr_data->msisdn, msisdn, 16);
++    if (apn_mac_addr != NULL)
++        memcpy(&ipdr_data->apn_mac_address, apn_mac_addr, sizeof(struct eth_addr));
++    if (apn_name != NULL)
++        memcpy(&ipdr_data->apn_name, apn_name, 24);
++
+     flow_key->flow_key_msg_part_size = dp_packet_size(&msg);
+
+     if (eth_addr_is_broadcast(flow->dl_dst)) {
+@@ -2661,6 +2691,8 @@ dpif_ipfix_sample(const struct dpif_ipfix *di,
+                   uint64_t packet_delta_count, uint32_t obs_domain_id,
+                   uint32_t obs_point_id, odp_port_t output_odp_port,
+                   enum nx_action_sample_direction direction,
++                  ovs_be64 flow_metadata, uint8_t *msisdn,
++                  struct eth_addr *apn_mac_addr, uint8_t *apn_name,
+                   const struct dpif_ipfix_port *tunnel_port,
+                   const struct flow_tnl *tunnel_key,
+                   const struct dpif_ipfix_actions *ipfix_actions)
+@@ -2676,6 +2708,8 @@ dpif_ipfix_sample(const struct dpif_ipfix *di,
+                                    flow, packet_delta_count,
+                                    obs_domain_id, obs_point_id,
+                                    output_odp_port, direction,
++                                   flow_metadata, msisdn,
++                                   apn_mac_addr, apn_name,
+                                    tunnel_port, tunnel_key,
+                                    &exporter->ipfix_global_stats,
+                                    ipfix_actions);
+@@ -2744,6 +2778,7 @@ dpif_ipfix_bridge_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                       di->bridge_exporter.options->obs_domain_id,
+                       di->bridge_exporter.options->obs_point_id,
+                       output_odp_port, NX_ACTION_SAMPLE_DEFAULT,
++                      0, NULL, NULL, NULL,  //not available for bridge export
+                       tunnel_port, tunnel_key, ipfix_actions);
+     ovs_mutex_unlock(&mutex);
+ }
+@@ -2789,6 +2824,8 @@ dpif_ipfix_flow_sample(struct dpif_ipfix *di, const struct dp_packet *packet,
+                           cookie->flow_sample.obs_domain_id,
+                           cookie->flow_sample.obs_point_id,
+                           output_odp_port, cookie->flow_sample.direction,
++                          cookie->flow_sample.flow_metadata, (uint8_t *)&cookie->flow_sample.msisdn,
++                          (struct eth_addr *)&cookie->flow_sample.apn_mac_addr, (uint8_t *)&cookie->flow_sample.apn_name,
+                           tunnel_port, tunnel_key, ipfix_actions);
+     }
+     ovs_mutex_unlock(&mutex);

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -33,6 +33,7 @@ static_services: [
   'access_control',
   'tunnel_learn',
   'vlan_learn',
+  'ipfix',
   'startup_flows',
   'ryu_rest_service',
 ]
@@ -113,6 +114,16 @@ clean_restart: true
 quota_check_ip: '192.168.128.99'
 has_quota_port: 51115
 no_quota_port: 51125
+
+# Configuration for IPFIX sampling
+ipfix:
+  enabled: true
+  collector_ip: '10.22.20.116'
+  collector_port: 4740
+  probability: 30000
+  collector_set_id: 1
+  obs_domain_id: 1
+  obs_point_id: 1
 
 ###############
 ## IMPORTANT ##

--- a/lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml
@@ -12,3 +12,4 @@ patches:
   - "0002-userspace-Add-L3-tunnel-type-GTP.patch"
   - "0003-Build-symbols-for-gtp-vport-linux-4.9-module-require.patch"
   - "0004-Linux-compat-fixes.patch"
+  - "0005-Add-custom-ipfix-fields.patch"

--- a/lte/gateway/docker/python/Dockerfile
+++ b/lte/gateway/docker/python/Dockerfile
@@ -63,16 +63,6 @@ RUN apt-get -y update && apt-get -y install \
   redis-server \
   iptables
 
-# Install OVS via Magma bionic pkg repo
-RUN apt-key add /tmp/jfrog.pub && \
-    apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ bionic main"
-
-RUN apt-get -y update && apt-get -y install \
-  libopenvswitch \
-  openvswitch-common \
-  openvswitch-switch \
-  python-openvswitch
-
 # Install orc8r python (magma.common required for lte python)
 COPY orc8r/gateway/python /tmp/orc8r
 RUN pip3 install /tmp/orc8r
@@ -89,3 +79,8 @@ COPY lte/gateway/configs /etc/magma
 COPY orc8r/gateway/configs/templates /etc/magma/templates
 COPY orc8r/cloud/docker/proxy/magma_headers.rb /etc/nghttpx/magma_headers.rb
 RUN mkdir -p /var/opt/magma/configs
+
+# Install OVS via Magma bionic pkg repo
+COPY cwf/gateway/deploy/roles/ovs/files/install_ovs.sh /tmp
+COPY cwf/gateway/deploy/roles/ovs/files/v2.12.0_ipfix_custom_fields.patch /tmp
+RUN bash /tmp/install_ovs.sh

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -94,8 +94,8 @@ class InOutController(MagmaController):
 
         match = MagmaMatch()
         flows.add_resubmit_next_service_flow(dp,
-            self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL),
-            match, [], priority=flows.DEFAULT_PRIORITY,
+            self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL), match,
+            actions=[], priority=flows.DEFAULT_PRIORITY,
             resubmit_table=logical_table)
 
     def _install_default_egress_flows(self, dp):

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -1,0 +1,176 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+import subprocess
+from typing import NamedTuple, Dict
+
+from magma.pipelined.app.base import MagmaController, ControllerType
+from magma.pipelined.openflow import flows
+from ryu.controller.controller import Datapath
+from magma.pipelined.openflow.magma_match import MagmaMatch
+from magma.pipelined.openflow.registers import Direction
+from magma.pipelined.imsi import encode_imsi
+from ryu.lib.packet import ether_types
+
+
+class IPFIXController(MagmaController):
+    """
+    IPFIXController
+
+    The IPFIX controller installs sample flows for exporting IPFIX statistics
+    to the controller. Each imsi gets a sample flow. After sampling traffic is
+    forwarded to the next table.
+    """
+
+    APP_NAME = "ipfix"
+    APP_TYPE = ControllerType.LOGICAL
+
+    IPFIXConfig = NamedTuple(
+        'IPFIXConfig',
+        [('enabled', bool), ('collector_ip', str), ('collector_port', int),
+         ('probability', int), ('collector_set_id', int),
+         ('obs_domain_id', int), ('obs_point_id', int), ('gtp_port', int)],
+    )
+
+    def __init__(self, *args, **kwargs):
+        super(IPFIXController, self).__init__(*args, **kwargs)
+        self.tbl_num = self._service_manager.get_table_num(self.APP_NAME)
+        self.next_main_table = self._service_manager.get_next_table_num(
+            self.APP_NAME)
+        self.ipfix_config = self._get_ipfix_config(kwargs['config'])
+        self._bridge_name = kwargs['config']['bridge_name']
+        self._datapath = None
+
+    def _get_ipfix_config(self, config_dict: Dict) -> NamedTuple:
+        if 'ipfix' not in config_dict or not config_dict['ipfix']['enabled']:
+            return self.IPFIXConfig(enabled=False, probability=0,
+                collector_ip='', collector_port=0, collector_set_id=0,
+                obs_domain_id=0, obs_point_id=0, gtp_port=0)
+
+        return self.IPFIXConfig(
+            enabled=config_dict['ipfix']['enabled'],
+            collector_ip=config_dict['ipfix']['collector_ip'],
+            collector_port=config_dict['ipfix']['collector_port'],
+            probability=config_dict['ipfix']['probability'],
+            collector_set_id=config_dict['ipfix']['collector_set_id'],
+            obs_domain_id=config_dict['ipfix']['obs_domain_id'],
+            obs_point_id=config_dict['ipfix']['obs_point_id'],
+            gtp_port=config_dict['ovs_gtp_port_number']
+        )
+
+    def initialize_on_connect(self, datapath: Datapath):
+        """
+        Install the default flows on datapath connect event.
+
+        Args:
+            datapath: ryu datapath struct
+        """
+        self._datapath = datapath
+        self._delete_all_flows(datapath)
+        self._install_default_flows(datapath)
+
+        action_str = (
+            'ovs-vsctl -- --id=@{} get Bridge {} -- --id=@cs create '
+            'Flow_Sample_Collector_Set id={} bridge=@{} ipfix=@i -- --id=@i '
+            'create IPFIX targets=\"{}\\:{}\" obs_domain_id={} obs_point_id={}'
+        ).format(
+            self._bridge_name, self._bridge_name,
+            self.ipfix_config.collector_set_id, self._bridge_name,
+            self.ipfix_config.collector_ip, self.ipfix_config.collector_port,
+            self.ipfix_config.obs_domain_id, self.ipfix_config.obs_point_id
+        )
+        try:
+            p = subprocess.Popen(action_str, shell=True,
+                                 stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            output, err = p.communicate()
+            err_str = err.decode('utf-8')
+            # There is a benign double init error that we ignore
+            if 'Transaction causes multiple rows in' in err_str:
+                self.logger.info("IPFIX flow sample collector already created")
+            else:
+                self.logger.error(err_str)
+        except subprocess.CalledProcessError as e:
+            raise Exception('Error: {} failed with: {}'.format(action_str, e))
+
+    def cleanup_on_disconnect(self, datapath: Datapath):
+        """
+        Cleanup flows on datapath disconnect event.
+
+        Args:
+            datapath: ryu datapath struct
+        """
+        self._delete_all_flows(datapath)
+
+    def _delete_all_flows(self, datapath: Datapath) -> None:
+        flows.delete_all_flows_from_table(datapath, self.tbl_num)
+
+    def _install_default_flows(self, datapath: Datapath) -> None:
+        """
+        For each direction set the default flows to just forward to next app.
+
+        Args:
+            datapath: ryu datapath struct
+        """
+        inbound_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
+                                   direction=Direction.IN)
+        outbound_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
+                                    direction=Direction.OUT)
+        flows.add_resubmit_next_service_flow(
+            datapath, self.tbl_num, inbound_match, [],
+            priority=flows.MINIMUM_PRIORITY,
+            resubmit_table=self.next_main_table)
+        flows.add_resubmit_next_service_flow(
+            datapath, self.tbl_num, outbound_match, [],
+            priority=flows.MINIMUM_PRIORITY,
+            resubmit_table=self.next_main_table)
+
+    def add_ue_sample_flow(self, imsi: str, msisdn: str,
+                           apn_mac_addr: str, apn_name: str) -> None:
+        """
+        Install a flow to sample packets for IPFIX for specific imsi
+
+        Args:
+            imsi (string): subscriber to install rule for
+            msisdn (string): msisdn string
+            apn_mac_addr (string): AP mac address string
+            apn_name (string): AP name
+        """
+        action_str = (
+            'ovs-ofctl add-flow {} "table={},priority={},'
+            'actions=sample(probability={},collector_set_id={},'
+            'obs_domain_id={},obs_point_id={},apn_mac_addr={},msisdn={},'
+            'apn_name={},sampling_port={}),resubmit(,{})"'
+        ).format(
+            self._bridge_name, self.tbl_num, flows.UE_FLOW_PRIORITY,
+            self.ipfix_config.probability, self.ipfix_config.collector_set_id,
+            self.ipfix_config.obs_domain_id, self.ipfix_config.obs_point_id,
+            apn_mac_addr.replace("-", ":"), msisdn, apn_name,
+            self.ipfix_config.gtp_port, self.next_main_table
+        )
+        try:
+            subprocess.Popen(action_str, shell=True).wait()
+        except subprocess.CalledProcessError as e:
+            raise Exception('Error: {} failed with: {}'.format(action_str, e))
+
+    def deactivate_rules(self, imsi: str) -> None:
+        """
+        Deactivate flows for a subscriber.
+
+        Args:
+            imsi (string): subscriber id
+        """
+        if self._datapath is None:
+            self.logger.error('Datapath not initialized')
+            return
+
+        if not imsi:
+            self.logger.error('No subscriber specified')
+            return
+
+        match = MagmaMatch(imsi=encode_imsi(imsi))
+        flows.delete_flow(self._datapath, self.tbl_num, match)

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -82,6 +82,7 @@ def main():
         manager.applications.get('DPIController', None),
         manager.applications.get('UEMacAddressController', None),
         manager.applications.get('CheckQuotaController', None),
+        manager.applications.get('IPFIXController', None),
         service_manager)
     pipelined_srv.add_to_server(service.rpc_server)
 

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -46,6 +46,7 @@ from magma.pipelined.app.vlan_learn import VlanLearnController
 from magma.pipelined.app.arp import ArpController
 from magma.pipelined.app.dpi import DPIController
 from magma.pipelined.app.enforcement import EnforcementController
+from magma.pipelined.app.ipfix import IPFIXController
 from magma.pipelined.app.enforcement_stats import EnforcementStatsController
 from magma.pipelined.app.inout import EGRESS, INGRESS, PHYSICAL_TO_LOGICAL, \
     InOutController
@@ -243,6 +244,7 @@ class ServiceManager:
     ACCESS_CONTROL_SERVICE_NAME = 'access_control'
     TUNNEL_LEARN_SERVICE_NAME = 'tunnel_learn'
     VLAN_LEARN_SERVICE_NAME = 'vlan_learn'
+    IPFIX_SERVICE_NAME = 'ipfix'
     RYU_REST_SERVICE_NAME = 'ryu_rest_service'
     STARTUP_FLOWS_RECIEVER_CONTROLLER = 'startup_flows'
     CHECK_QUOTA_SERVICE_NAME = 'check_quota'
@@ -308,6 +310,11 @@ class ServiceManager:
             App(name=VlanLearnController.APP_NAME,
                 module=VlanLearnController.__module__,
                 type=VlanLearnController.APP_TYPE),
+        ],
+        IPFIX_SERVICE_NAME: [
+            App(name=IPFIXController.APP_NAME,
+                module=IPFIXController.__module__,
+                type=IPFIXController.APP_TYPE),
         ],
         RYU_REST_SERVICE_NAME: [
             App(name='ryu_rest_app', module='ryu.app.ofctl_rest', type=None),

--- a/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
@@ -92,6 +92,9 @@ class PipelinedController(Enum):
     CheckQuotaController = Controller(
         'magma.pipelined.app.check_quota', 'check_quota'
     )
+    IPFIX = Controller(
+        'magma.pipelined.app.ipfix', 'ipfix'
+    )
     PacketTracer = Controller(
         'magma.pipelined.app.packet_tracer', 'packet_tracer'
     )

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -376,7 +376,8 @@ def get_meter_stats(controller: MeterStatsController) \
     return stats
 
 
-def create_service_manager(services: List[int], include_ue_mac=False):
+def create_service_manager(services: List[int], include_ue_mac=False,
+                           include_ipfix=False):
     """
     Creates a service manager from the given list of services.
     Args:
@@ -392,6 +393,8 @@ def create_service_manager(services: List[int], include_ue_mac=False):
                         'vlan_learn', 'check_quota']
                        if include_ue_mac
                        else ['arpd', 'access_control'])
+    if include_ipfix:
+        static_services.append('ipfix')
     magma_service.config = {
         'static_services': static_services
     }

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ipfix.IPFIXTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ipfix.IPFIXTest.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,4 @@
+ cookie=0x0, table=ipfix(main_table), n_packets=0, n_bytes=0, priority=12,metadata=0x48c2739fd9c3 actions=sample(probability=30000,collector_set_id=1,obs_domain_id=1,obs_point_id=1,sampling_port=32768),resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ipfix(main_table), n_packets=0, n_bytes=0, priority=12,metadata=0x48c273965b3b actions=sample(probability=30000,collector_set_id=1,obs_domain_id=1,obs_point_id=1,sampling_port=32768),resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ipfix(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=ipfix(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/test_ipfix.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_ipfix.py
@@ -1,0 +1,117 @@
+"""
+Copyright (c) 2019-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import warnings
+from concurrent.futures import Future
+
+from magma.pipelined.tests.app.start_pipelined import (
+    TestSetup,
+    PipelinedController,
+)
+from magma.pipelined.bridge_util import BridgeTools
+from magma.pipelined.tests.pipelined_test_util import (
+    start_ryu_app_thread,
+    stop_ryu_app_thread,
+    create_service_manager,
+    assert_bridge_snapshot_match,
+)
+from ryu.lib import hub
+
+
+@unittest.skip("Disabled")
+class IPFIXTest(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(IPFIXTest, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([], include_ipfix=True)
+
+        ipfix_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.IPFIX,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.IPFIX:
+                    ipfix_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'ipfix': {
+                    'enabled': 'true',
+                    'probability': 30000,
+                    'collector_ip': '10.22.20.116',
+                    'collector_port': 4740,
+                    'collector_set_id': 1,
+                    'obs_domain_id': 1,
+                    'obs_point_id': 1,
+                },
+                'clean_restart': True,
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.ipfix_controller = ipfix_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+
+    def testFlowSnapshotMatch(self):
+        """
+        Ensure 2 IMSIs sample flows are installed
+
+        Assert:
+            Snapshots match
+        """
+        imsi1 = 'IMSI010000000088888'
+        imsi2 = 'IMSI010000000011111'
+        msidn = 'BigTower'
+        apn_mac = '08-00-27-cd-32-07'
+        apn_name = 'MagmaBox'
+        self.ipfix_controller.add_ue_sample_flow(imsi1, msidn, apn_mac,
+                                                 apn_name)
+        self.ipfix_controller.add_ue_sample_flow(imsi2, msidn, apn_mac,
+                                                 apn_name)
+
+        # Big rule wait a bit for it to appear
+        hub.sleep(2)
+        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Adds logic for the IPFIX exporting, includes the OVS patch to properly export metadata(IMSI). Modifies the Vagrant files for cwag to include dedicated IPFIX ports.

- TODO: Change build for OVS to include patch
- Include a few extra custom IPFIX args

Differential Revision: D18248583

