### PR TITLE
Setting python-grpcio version to 1.16.1

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -100,7 +100,7 @@ setup(
             # Keep grpcio and grpcio-tools on same version for now
             # If you update this version here, you probably also want to
             # update it in lte/gateway/python/Makefile
-            'grpcio-tools==1.25.0',
+            'grpcio-tools==1.16.1',
             'nose==1.3.7',
             'pyroute2',
             'iperf3',

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -52,7 +52,7 @@ prometheus_proto:
 
 # If you update the version here, you probably also want to update it in setup.py
 $(BIN)/grpcio-tools: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) "grpcio-tools==1.25.0"
+	$(VIRT_ENV_PIP_INSTALL) "grpcio-tools==1.16.1"
 
 .test: .tests .sudo_tests
 

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -61,7 +61,7 @@ setup(
         'redis>=2.10.5',  # redis-py (Python bindings to redis)
         'redis-collections>=0.4.2',
         'aiohttp>=0.17.2',
-        'grpcio==1.25.0',
+        'grpcio==1.16.1',
         'protobuf==3.6.1',
         'Jinja2>=2.8',
         'netifaces>=0.10.4',


### PR DESCRIPTION
Summary: - python-grpcio was updated to version 1.25.0, this is creating unmet dependencies by other python dependencies on lower version while building magma package, setting version back to 1.16.1

Differential Revision: D18978970

