### PR TITLE
Fixing device write problem and adding unit test

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -185,6 +185,7 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/ConfigGeneratorTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/RealCliDeviceTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/CliScaleTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/CliTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/PromptAwareCliTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/TimeoutTrackingCliTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/SshSessionTest.cpp

--- a/devmand/gateway/src/devmand/channels/cli/QueuedCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/QueuedCli.cpp
@@ -100,7 +100,7 @@ SemiFuture<string> QueuedCli::executeWrite(const WriteCommand cmd) {
   Command command = cmd;
   if (!command.isMultiCommand()) {
     // Single line config command, execute with read
-    return executeRead(ReadCommand::create(cmd));
+    return executeRead(ReadCommand::create(cmd.raw(), true)); //skip cache
   }
 
   const vector<Command>& commands = command.splitMultiCommand();
@@ -119,7 +119,7 @@ SemiFuture<string> QueuedCli::executeWrite(const WriteCommand cmd) {
   }
 
   commmandsFutures.emplace_back(
-      executeRead(ReadCommand::create(commands.back()))
+      executeRead(ReadCommand::create(commands.back().raw(), true)) //skip cache
           .via(queuedParameters->serialExecutorKeepAlive));
 
   return reduce(

--- a/devmand/gateway/src/devmand/test/cli/CliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/CliTest.cpp
@@ -1,0 +1,96 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#define LOG_WITH_GLOG
+#include <magma_logging.h>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <devmand/Application.h>
+#include <devmand/channels/cli/IoConfigurationBuilder.h>
+#include <devmand/channels/cli/ReadCachingCli.h>
+#include <devmand/devices/State.h>
+#include <devmand/devices/cli/PlaintextCliDevice.h>
+#include <devmand/test/TestUtils.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <devmand/test/cli/utils/MockCli.h>
+#include <devmand/test/cli/utils/Ssh.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+namespace devmand {
+namespace test {
+namespace cli {
+
+using namespace devmand::channels::cli;
+using namespace devmand::cartography;
+using namespace devmand::devices;
+using namespace devmand::devices::cli;
+using namespace devmand::test::utils::cli;
+using namespace std;
+using namespace folly;
+using namespace devmand::test::utils::ssh;
+using devmand::channels::cli::IoConfigurationBuilder;
+using devmand::channels::cli::ReadCachingCli;
+using namespace std::chrono;
+
+class CliTest : public ::testing::Test {
+ protected:
+  shared_ptr<server> ssh;
+  unique_ptr<channels::cli::Engine> cliEngine;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog(MDEBUG);
+    cliEngine = make_unique<channels::cli::Engine>();
+    ssh = startSshServer();
+  }
+
+  void TearDown() override {
+    ssh->close();
+  }
+};
+
+static std::function<bool()> ensureConnected(const shared_ptr<Cli>& cli) {
+  return [cli]() {
+    try {
+      cli->executeRead(ReadCommand::create("echo 123", true)).get();
+        return true;
+    } catch (const exception& e) {
+        return false;
+    }
+  };
+}
+
+TEST_F(CliTest, writeMultipleTimesAllExecute) {
+  cartography::DeviceConfig deviceConfig;
+  devmand::cartography::ChannelConfig chnlCfg;
+  std::map<std::string, std::string> kvPairs;
+  kvPairs.insert(std::make_pair("port", "9999"));
+  kvPairs.insert(std::make_pair("username", "root"));
+  kvPairs.insert(std::make_pair("password", "root"));
+  chnlCfg.kvPairs = kvPairs;
+  deviceConfig.channelConfigs.insert(std::make_pair("cli", chnlCfg));
+  deviceConfig.ip = "localhost";
+  deviceConfig.id = "localhost-test-device";
+
+  IoConfigurationBuilder ioConfigurationBuilder(deviceConfig, *cliEngine);
+  const shared_ptr<Cli>& cli =
+      ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
+  const function<bool()> &connectionTest = ensureConnected(cli);
+
+  EXPECT_BECOMES_TRUE(connectionTest());
+
+  cli->executeWrite(WriteCommand::create("sleep 2\nsleep2")).get();
+  steady_clock::time_point begin = steady_clock::now();
+  cli->executeWrite(WriteCommand::create("sleep 2")).get();
+  steady_clock::time_point end = steady_clock::now();
+  EXPECT_GE(duration_cast<milliseconds>(end - begin).count(), 2000);
+}
+
+} // namespace cli
+} // namespace test
+} // namespace devmand


### PR DESCRIPTION
Last command in a composite write command to the device was being cached and subsequent
last commands of other composite write commands have not been executed on the device

