### PR TITLE
Fixes for multithreading in MME code

### DIFF
--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -1,7 +1,7 @@
 .PHONY: all build download fmt test clean run install build_only gen precommit
 
 ifndef MAGMA_ROOT
-MAGMA_ROOT = /home/$USER/magma
+MAGMA_ROOT = /home/${USER}/magma
 endif
 export MAGMA_ROOT
 

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.c
@@ -370,8 +370,8 @@ int itti_send_msg_to_task(
 {
   thread_id_t destination_thread_id;
   task_id_t origin_task_id;
-  message_list_t* new;
-  uint32_t priority;
+  message_list_t *new;
+  uint32_t priority, rv;
   message_number_t message_number;
   uint32_t message_id;
 
@@ -444,8 +444,11 @@ int itti_send_msg_to_task(
       /*
        * Enqueue message in destination task queue
        */
-      lfds710_queue_bmm_enqueue(
+      rv = lfds710_queue_bmm_enqueue(
         &itti_desc.tasks[destination_task_id].message_queue, NULL, new);
+      AssertFatal(
+	rv,
+	"no queue place for task id %d\n", destination_task_id);
 
       /*
         * Only use event fd for tasks, subtasks will pool the queue

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -380,10 +380,11 @@ void *mme_app_thread(void *args)
       } break;
 
       case MME_APP_DOWNLINK_DATA_CNF: {
+        bstring nas_msg = NULL;
         nas_proc_dl_transfer_cnf(
           MME_APP_DL_DATA_CNF(received_message_p).ue_id,
           MME_APP_DL_DATA_CNF(received_message_p).err_code,
-          &MME_APP_DL_DATA_REJ(received_message_p).nas_msg);
+          &nas_msg);
       } break;
 
       case MME_APP_DOWNLINK_DATA_REJ: {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1870,6 +1870,10 @@ static bool s1ap_send_enb_deregistered_ind(
     arg->current_ue_index =
         (uint8_t)(arg->handled_ues % S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE);
 
+    arg->handled_ues++;
+    arg->current_ue_index =
+      (uint8_t)(arg->handled_ues % S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE);
+
     // max ues reached
     if (arg->current_ue_index == 0 && arg->handled_ues > 0) {
       S1AP_ENB_DEREGISTERED_IND(arg->message_p).nb_ue_to_deregister =

--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -12,6 +12,8 @@
 
 # virtualenv bin and build dirs
 PYTHON_VERSION=3.5
+PYTHON_BUILD ?= ${HOME}/build/python
+PIP_CACHE_HOME ?= ${HOME}/.pip-cache
 BIN := $(PYTHON_BUILD)/bin
 SRC := $(MAGMA_ROOT)
 SITE_PACKAGES_DIR := $(PYTHON_BUILD)/lib/python$(PYTHON_VERSION)/site-packages
@@ -19,11 +21,13 @@ SITE_PACKAGES_DIR := $(PYTHON_BUILD)/lib/python$(PYTHON_VERSION)/site-packages
 # Command to pip install into the virtualenv
 VIRT_ENV_PIP_INSTALL := $(BIN)/pip3 install -q -U --cache-dir $(PIP_CACHE_HOME)
 
-install_virtualenv:
+$(PYTHON_BUILD)/bin/python$(PYTHON_VERSION):
 	@echo "Initializing virtualenv with python version $(PYTHON_VERSION)"
 	virtualenv --system-site-packages --python=/usr/bin/python$(PYTHON_VERSION) $(PYTHON_BUILD)
 	. $(PYTHON_BUILD)/bin/activate;
 	$(VIRT_ENV_PIP_INSTALL) "pip>=19.1.1"
+
+install_virtualenv: $(PYTHON_BUILD)/bin/python$(PYTHON_VERSION)
 
 setupenv: $(PYTHON_BUILD)/sysdeps $(SITE_PACKAGES_DIR)/setuptools
 


### PR DESCRIPTION
This fixes various segfaults and races in MME code:
#. Possible double allocation in itti code.
#. Multithreading race with `itti_free`.
#. Segfault with misuse of `MME_APP_DOWNLINK_DATA_REJ` for `_CNF`
#. S1AP code segfault with incorrect message allocation pattern.

To test, modify `test_attach_detach_multi_ue.py` to operate with 200 UEs and loop it forever.

Fixes: https://github.com/facebookincubator/magma/issues/955