### PR TITLE
Fixing error count on log_count_handler.py

### DIFF
--- a/orc8r/gateway/python/magma/common/log_count_handler.py
+++ b/orc8r/gateway/python/magma/common/log_count_handler.py
@@ -25,6 +25,6 @@ class MsgCounterHandler(logging.Handler):
         self.count_by_level[level] += 1
 
     def pop_error_count(self) -> int:
-        error_count = self.count_by_level['ERROR']
+        error_count = self.count_by_level.get('ERROR', 0)
         self.count_by_level['ERROR'] = 0
         return error_count


### PR DESCRIPTION
Summary:
Some magma services throw KeyError in case there's no ERROR level count
```
Dec 09 22:58:46 magma-dev mobilityd[7991]: ERROR:root:Exception from _run: 'ERROR'
Dec 09 22:58:46 magma-dev mobilityd[7991]: Traceback (most recent call last):
Dec 09 22:58:46 magma-dev mobilityd[7991]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/job.py", line 117, in _periodic
Dec 09 22:58:46 magma-dev mobilityd[7991]:     await self._run()
Dec 09 22:58:46 magma-dev mobilityd[7991]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/log_counter.py", line 35, in _run
Dec 09 22:58:46 magma-dev mobilityd[7991]:     error_count = self._handler.pop_error_count()
Dec 09 22:58:46 magma-dev mobilityd[7991]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/log_count_handler.py", line 28, in pop_error_count
Dec 09 22:58:46 magma-dev mobilityd[7991]:     error_count = self.count_by_level['ERROR']
Dec 09 22:58:46 magma-dev mobilityd[7991]: KeyError: 'ERROR'
```

Differential Revision: D19036842

