### PR TITLE
Prioritize new static config location for Go GW services

### DIFF
--- a/orc8r/cloud/go/service/config/service_config.go
+++ b/orc8r/cloud/go/service/config/service_config.go
@@ -104,12 +104,11 @@ func getServiceConfigImpl(moduleName, serviceName, configDir, oldConfigDir, conf
 	moduleName = strings.ToLower(moduleName)
 	serviceName = strings.ToLower(serviceName)
 
-	configFileName := filepath.Join(oldConfigDir, moduleName, fmt.Sprintf("%s.yml", serviceName))
+	configFileName := filepath.Join(configDir, moduleName, fmt.Sprintf("%s.yml", serviceName))
 	if fi, err := os.Stat(configFileName); err != nil || fi.IsDir() {
-		configFileName = filepath.Join(configDir, moduleName,
-			fmt.Sprintf("%s.yml", serviceName))
-	} else {
-		log.Printf("Using Legacy Service Registry Configuration: %s", configFileName)
+		old := configFileName
+		configFileName = filepath.Join(oldConfigDir, moduleName, fmt.Sprintf("%s.yml", serviceName))
+		log.Printf("Cannot load '%s': %v, using Legacy Service Registry Configuration: %s", old, err, configFileName)
 	}
 
 	config, err := loadYamlFile(configFileName)
@@ -127,6 +126,8 @@ func getServiceConfigImpl(moduleName, serviceName, configDir, oldConfigDir, conf
 			return config, err
 		}
 		config = updateMap(config, overrides)
+	} else {
+		log.Printf("No Override configs found at: %s", overrideFileName)
 	}
 	return config, err
 }

--- a/orc8r/gateway/go/mconfig/impl.go
+++ b/orc8r/gateway/go/mconfig/impl.go
@@ -38,9 +38,9 @@ func init() {
 	go func() {
 		for {
 			<-refreshTicker.C
-			err := RefreshConfigs()
+			cfgPath, err := RefreshConfigs()
 			if err == nil {
-				log.Print("Mconfig refresh succeeded")
+				log.Print("Mconfig refresh succeeded from: ", cfgPath)
 			} else {
 				log.Printf("Mconfig refresh error: %v", err)
 			}
@@ -52,14 +52,16 @@ func init() {
 // and tries to reload mamaged configs from the file
 // refreshConfigs is thread safe and can be safely called while current configs are in use by
 // other threads/routines
-func RefreshConfigs() error {
-	dynamicConfigPath := configFilePath()
-	err := RefreshConfigsFrom(dynamicConfigPath)
+func RefreshConfigs() (string, error) {
+	// get dynamic config path
+	configPath := configFilePath()
+	err := RefreshConfigsFrom(configPath)
 	if err != nil {
-		log.Printf("Cannot load configs from %s: %v", dynamicConfigPath, err)
-		err = RefreshConfigsFrom(defaultConfigFilePath())
+		log.Printf("Cannot load configs from %s: %v", configPath, err)
+		configPath = defaultConfigFilePath()
+		err = RefreshConfigsFrom(configPath)
 	}
-	return err
+	return configPath, err
 }
 
 // RefreshConfigsFrom checks if Managed Config File mcpath has changed


### PR DESCRIPTION
Summary:
Old way: check legacy config location, if missing - use new config location
New way: check new config location, if missing - use legacy location

Reviewed By: themarwhal

Differential Revision: D18946762

