### PR TITLE
Fixes for AGW Installer

### DIFF
--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -75,6 +75,22 @@ if [ "$(uname -r)" != "4.9.0-9-amd64" ]; then
   NEED_REBOOT=1
 fi
 
+echo "Checking if kernel headers is installed"
+if [ "$(dpkg -l  | grep headers-4.9.0-9-amd64)" ]; then
+  # Get from alternative repository and add as debian packages local repo
+  wget http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-xfce-CD-1.iso
+  mkdir -p /mnt/disk
+  mount -o loop debian-9.9.0-amd64-xfce-CD-1.iso /mnt/disk
+  echo 'deb file:///mnt/disk/ stretch main contrib' >> /etc/apt/sources.list
+  sudo apt-get update --allow-unauthenticated
+  # Install kernel headers
+  sudo apt -y install linux-headers-4.9.0-9-amd64 --allow-unauthenticated
+  # Clean headers files and umount
+  umount /mnt/disk
+  rm debian-9.9.0-amd64-xfce-CD-1.iso
+  sed -i '/deb file:\/\/\/mnt\/disk\//d' /etc/apt/sources.list
+fi
+
 if [ $NEED_REBOOT = 1 ]; then
   echo "Will reboot in a few seconds, loading a boot script in order to install magma"
   if [ ! -f "$AGW_SCRIPT_PATH" ]; then

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -66,22 +66,7 @@ if [ "$(uname -r)" != "4.9.0-9-amd64" ]; then
   fi
   apt update
   # Installing prerequesites, Kvers, headers
-  apt install -y sudo python-minimal aptitude linux-image-4.9.0-9-amd64 linux-headers-4.9.0-9-amd64
-  echo "Checking if kernel headers was installed, else install"
-  if ! [ "$(dpkg -l  | grep headers-4.9.0-9-amd64)" ]; then
-    # Get from alternative repository and add as debian packages local repo
-    wget http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-xfce-CD-1.iso
-    mkdir -p /mnt/disk
-    mount -o loop debian-9.9.0-amd64-xfce-CD-1.iso /mnt/disk
-    echo 'deb file:///mnt/disk/ stretch main contrib' >> /etc/apt/sources.list
-    sudo apt-get update --allow-unauthenticated
-    # Install kernel headers
-    sudo apt -y install linux-headers-4.9.0-9-amd64 --allow-unauthenticated
-    # Clean headers files and umount
-    umount /mnt/disk
-    rm debian-9.9.0-amd64-xfce-CD-1.iso
-    sed -i '/deb file:\/\/\/mnt\/disk\//d' /etc/apt/sources.list
-  fi
+  apt install -y sudo python-minimal aptitude linux-image-4.9.0-9-amd64
   # Removing dev repository snapshot from source.list
   sed -i '/20190801T025637Z/d' /etc/apt/sources.list
   # Removing incompatible Kernel version
@@ -110,6 +95,22 @@ WantedBy=multi-user.target" > $AGW_INSTALL_CONFIG
   reboot
 fi
 
+echo "Checking if kernel headers was installed, else install"
+if ! [ "$(dpkg -l  | grep headers-4.9.0-9-amd64)" ]; then
+  # Get from alternative repository and add as debian packages local repo
+  wget http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-xfce-CD-1.iso
+  mkdir -p /mnt/disk
+  mount -o loop debian-9.9.0-amd64-xfce-CD-1.iso /mnt/disk
+  echo 'deb file:///mnt/disk/ stretch main contrib' >> /etc/apt/sources.list
+  sudo apt-get update --allow-unauthenticated
+  # Install kernel headers
+  sudo apt -y install linux-headers-4.9.0-9-amd64 --allow-unauthenticated
+  # Clean headers files and umount
+  umount /mnt/disk
+  rm debian-9.9.0-amd64-xfce-CD-1.iso
+  sed -i '/deb file:\/\/\/mnt\/disk\//d' /etc/apt/sources.list
+fi
+  
 echo "Making sure eth0 is connected to internet"
 PING_RESULT=$(ping -c 1 -I eth0 8.8.8.8 > /dev/null 2>&1 && echo "$SUCCESS_MESSAGE")
 if [ "$PING_RESULT" != "$SUCCESS_MESSAGE" ]; then

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -67,28 +67,27 @@ if [ "$(uname -r)" != "4.9.0-9-amd64" ]; then
   apt update
   # Installing prerequesites, Kvers, headers
   apt install -y sudo python-minimal aptitude linux-image-4.9.0-9-amd64 linux-headers-4.9.0-9-amd64
+  echo "Checking if kernel headers was installed, else install"
+  if ! [ "$(dpkg -l  | grep headers-4.9.0-9-amd64)" ]; then
+    # Get from alternative repository and add as debian packages local repo
+    wget http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-xfce-CD-1.iso
+    mkdir -p /mnt/disk
+    mount -o loop debian-9.9.0-amd64-xfce-CD-1.iso /mnt/disk
+    echo 'deb file:///mnt/disk/ stretch main contrib' >> /etc/apt/sources.list
+    sudo apt-get update --allow-unauthenticated
+    # Install kernel headers
+    sudo apt -y install linux-headers-4.9.0-9-amd64 --allow-unauthenticated
+    # Clean headers files and umount
+    umount /mnt/disk
+    rm debian-9.9.0-amd64-xfce-CD-1.iso
+    sed -i '/deb file:\/\/\/mnt\/disk\//d' /etc/apt/sources.list
+  fi
   # Removing dev repository snapshot from source.list
   sed -i '/20190801T025637Z/d' /etc/apt/sources.list
   # Removing incompatible Kernel version
   DEBIAN_FRONTEND=noninteractive apt remove -y linux-image-4.9.0-11-amd64
   # Setting REBOOT flag to 1 because we need to boot with the right Kernel version
   NEED_REBOOT=1
-fi
-
-echo "Checking if kernel headers is installed"
-if [ "$(dpkg -l  | grep headers-4.9.0-9-amd64)" ]; then
-  # Get from alternative repository and add as debian packages local repo
-  wget http://cdimage.debian.org/mirror/cdimage/archive/9.9.0/amd64/iso-cd/debian-9.9.0-amd64-xfce-CD-1.iso
-  mkdir -p /mnt/disk
-  mount -o loop debian-9.9.0-amd64-xfce-CD-1.iso /mnt/disk
-  echo 'deb file:///mnt/disk/ stretch main contrib' >> /etc/apt/sources.list
-  sudo apt-get update --allow-unauthenticated
-  # Install kernel headers
-  sudo apt -y install linux-headers-4.9.0-9-amd64 --allow-unauthenticated
-  # Clean headers files and umount
-  umount /mnt/disk
-  rm debian-9.9.0-amd64-xfce-CD-1.iso
-  sed -i '/deb file:\/\/\/mnt\/disk\//d' /etc/apt/sources.list
 fi
 
 if [ $NEED_REBOOT = 1 ]; then


### PR DESCRIPTION
This proposal includes:
1. Checking if magma user exists, else create it, as this is not being covered today.
2. Own the /home/magma/magma folder to have rights over it, otherwise installation fails
3. Manually install linux headers for the required version, as these are not available upstream anymore. This enables installations in virtual environments.