### PR TITLE
Update MME to use new gateway directoryD service

### DIFF
--- a/lte/gateway/c/oai/lib/directoryd/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/directoryd/CMakeLists.txt
@@ -16,7 +16,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_library(LIB_DIRECTORYD
   directoryd.cpp
-  DirectorydClient.cpp
+  GatewayDirectorydClient.cpp
   ${PROTO_SRCS}
   ${PROTO_HDRS}
   )

--- a/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.h
+++ b/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.h
@@ -35,12 +35,12 @@ namespace grpc {
 class Channel;
 class ClientContext;
 class Status;
-}  // namespace grpc
+} // namespace grpc
 namespace magma {
 namespace orc8r {
 class Void;
-}  // namespace orc8r
-}  // namespace magma
+} // namespace orc8r
+} // namespace magma
 
 using grpc::Channel;
 using grpc::ClientContext;
@@ -52,27 +52,25 @@ using namespace orc8r;
 /*
  * gRPC client for DirectoryService
  */
-class DirectoryServiceClient : public GRPCReceiver {
+class GatewayDirectoryServiceClient : public GRPCReceiver {
  public:
-  static bool UpdateLocation(
-    TableID table,
-    const std::string &id,
-    const std::string &location,
+  static bool UpdateRecord(
+    const std::string& id,
+    const std::string& location,
     std::function<void(Status, Void)> callback);
 
-  static bool DeleteLocation(
-    TableID table,
-    const std::string &id,
+  static bool DeleteRecord(
+    const std::string& id,
     std::function<void(Status, Void)> callback);
 
  public:
-  DirectoryServiceClient(DirectoryServiceClient const &) = delete;
-  void operator=(DirectoryServiceClient const &) = delete;
+  GatewayDirectoryServiceClient(GatewayDirectoryServiceClient const&) = delete;
+  void operator=(GatewayDirectoryServiceClient const&) = delete;
 
  private:
-  DirectoryServiceClient();
-  static DirectoryServiceClient &get_instance();
-  std::shared_ptr<DirectoryService::Stub> stub_;
+  GatewayDirectoryServiceClient();
+  static GatewayDirectoryServiceClient& get_instance();
+  std::shared_ptr<GatewayDirectoryService::Stub> stub_;
   static const uint32_t RESPONSE_TIMEOUT = 30; // seconds
 };
 

--- a/lte/gateway/c/oai/lib/directoryd/directoryd.cpp
+++ b/lte/gateway/c/oai/lib/directoryd/directoryd.cpp
@@ -23,18 +23,17 @@
 #include <string>
 #include <iostream>
 
-#include "DirectorydClient.h"
+#include "GatewayDirectorydClient.h"
 #include "directoryd.h"
 #include "orc8r/protos/common.pb.h"
 #include "orc8r/protos/directoryd.pb.h"
 
-static void directoryd_rpc_call_done(const grpc::Status &status);
+static void directoryd_rpc_call_done(const grpc::Status& status);
 
-bool directoryd_report_location(table_id_t table, char *imsi)
+bool directoryd_report_location(char* imsi)
 {
   // Actual GW_ID will be filled in the cloud
-  magma::DirectoryServiceClient::UpdateLocation(
-    static_cast<magma::TableID>(table),
+  magma::GatewayDirectoryServiceClient::UpdateRecord(
     "IMSI" + std::string(imsi),
     std::string("GW_ID"),
     [&](grpc::Status status, magma::Void response) {
@@ -43,21 +42,18 @@ bool directoryd_report_location(table_id_t table, char *imsi)
   return true;
 }
 
-bool directoryd_remove_location(table_id_t table, char *imsi)
+bool directoryd_remove_location(char* imsi)
 {
-  magma::DirectoryServiceClient::DeleteLocation(
-    static_cast<magma::TableID>(table),
-    "IMSI" + std::string(imsi),
-    [&](grpc::Status status, magma::Void response) {
+  magma::GatewayDirectoryServiceClient::DeleteRecord(
+    "IMSI" + std::string(imsi), [&](grpc::Status status, magma::Void response) {
       directoryd_rpc_call_done(status);
     });
   return true;
 }
 
-bool directoryd_update_location(table_id_t table, char *imsi, char *location)
+bool directoryd_update_location(char* imsi, char* location)
 {
-  magma::DirectoryServiceClient::UpdateLocation(
-    static_cast<magma::TableID>(table),
+  magma::GatewayDirectoryServiceClient::UpdateRecord(
     "IMSI" + std::string(imsi),
     std::string(location),
     [&](grpc::Status status, magma::Void response) {
@@ -66,7 +62,7 @@ bool directoryd_update_location(table_id_t table, char *imsi, char *location)
   return true;
 }
 
-void directoryd_rpc_call_done(const grpc::Status &status)
+void directoryd_rpc_call_done(const grpc::Status& status)
 {
   if (!status.ok()) {
     std::cerr << "Directoryd RPC failed with code " << status.error_code()

--- a/lte/gateway/c/oai/lib/directoryd/directoryd.h
+++ b/lte/gateway/c/oai/lib/directoryd/directoryd.h
@@ -33,13 +33,12 @@ extern "C" {
  * So we will define this type table_id_t here and later
  * cast it to magma::TableID in directoryd.cpp .
  */
-typedef enum { IMSI_TO_HWID = 0, HWID_TO_HOSTNAME = 1 } table_id_t;
 
-bool directoryd_report_location(table_id_t table, char *imsi);
+bool directoryd_report_location(char* imsi);
 
-bool directoryd_remove_location(table_id_t table, char *imsi);
+bool directoryd_remove_location(char* imsi);
 
-bool directoryd_update_location(table_id_t table, char *imsi, char *location);
+bool directoryd_update_location(char* imsi, char* location);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -106,7 +106,7 @@ static void _directoryd_report_location(uint64_t imsi, uint8_t imsi_len)
 {
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi, imsi_str, imsi_len);
-  directoryd_report_location(IMSI_TO_HWID, imsi_str);
+  directoryd_report_location(imsi_str);
   OAILOG_INFO(
     LOG_MME_APP,
     "Reported UE location to directoryd, IMSI: " IMSI_64_FMT "\n",
@@ -117,7 +117,7 @@ static void _directoryd_remove_location(uint64_t imsi, uint8_t imsi_len)
 {
   char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
   IMSI64_TO_STRING(imsi, imsi_str, imsi_len);
-  directoryd_remove_location(IMSI_TO_HWID, imsi_str);
+  directoryd_remove_location(imsi_str);
   OAILOG_INFO(
     LOG_MME_APP,
     "Deleted UE location from directoryd, IMSI: " IMSI_64_FMT "\n",

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -22,3 +22,5 @@ state_protos:
 #    state_scope: - state scope used to determine deviceID.
 #                   Either 'network' or 'gateway' (defaults to 'gateway')
 json_state:
+  - redis_key: "directory_record"
+    state_scope: "network"


### PR DESCRIPTION
Summary:
This diff updates the MME to call the new
gateway directoryD service. This service uses Redis
along with the state replication service to more
robustly handle directory updates and deletions.

This should permanently fix https://github.com/facebookincubator/magma/issues/637

Reviewed By: andreilee

Differential Revision: D19086491

