### PR TITLE
Simplify report_termination calls

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -101,6 +101,8 @@ add_library(SESSION_MANAGER
     PipelinedClient.h
     DirectorydClient.cpp
     DirectorydClient.h
+    DiameterCodes.cpp
+    DiameterCodes.h
     SessionRules.cpp
     SessionRules.h
     CreditKey.h

--- a/lte/gateway/c/session_manager/DiameterCodes.cpp
+++ b/lte/gateway/c/session_manager/DiameterCodes.cpp
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "DiameterCodes.h"
+
+namespace magma {
+bool DiameterCodeHandler::is_transient_failure(const uint32_t code)
+{
+  return 4000 <= code && code < 5000;
+}
+
+// Diameter code of form 5xxx marks a permanent failure
+bool DiameterCodeHandler::is_permanent_failure(const uint32_t code)
+{
+  return 5000 <= code && code < 6000;
+}
+} // namespace magma

--- a/lte/gateway/c/session_manager/DiameterCodes.h
+++ b/lte/gateway/c/session_manager/DiameterCodes.h
@@ -6,6 +6,10 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+#pragma once
+
+#include <stdint.h>
+
 namespace magma {
   enum DiameterResultCode {
     DIAMETER_MULTI_ROUND_AUTH = 1001,
@@ -33,6 +37,7 @@ namespace magma {
     DIAMETER_UNKNOWN_PEER = 3010,
     DIAMETER_REALM_REDIRECT_INDICATION = 3011,
 
+    // Transient Failures
     DIAMETER_AUTHENTICATION_REJECTED = 4001,
     DIAMETER_OUT_OF_SPACE = 4002,
     DIAMETER_ELECTION_LOST = 4003,
@@ -66,6 +71,7 @@ namespace magma {
     DIAMETER_NO_AVAILABLE_POLICY_COUNTERS = 4241,
     DIAMETER_SERVICE_TEMPORARILY_NOT_AUTHORIZED = 4261,
 
+    // Permanent Failures
     DIAMETER_AVP_UNSUPPORTED = 5001,
     DIAMETER_UNKNOWN_SESSION_ID = 5002,
     DIAMETER_AUTHORIZATION_REJECTED = 5003,
@@ -102,7 +108,7 @@ namespace magma {
     DIAMETER_NO_ACCESS_INDEPENDENT_SUBSCRIPTION,
     DIAMETER_USER_NO_W_APN_SUBSCRIPTION,
     DIAMETER_UNSUITABLE_NETWORK,
-    DIAMETER_EAP_CODE_UNKNOWN,
+    DIAMETER_EAP_CODE_UNKNOWN = 5048,
     DIAMETER_INVALID_SERVICE_INFORMATION = 5061,
     DIAMETER_FILTER_RESTRICTIONS,
     DIAMETER_REQUESTED_SERVICE_NOT_AUTHORIZED,
@@ -147,5 +153,12 @@ namespace magma {
     DIAMETER_TIMED_OUT_REQUEST,
     DIAMETER_ERROR_SUBSESSION = 5470,
     DIAMETER_V2X_NOT_ALLOWED = 5691,
+  };
+
+  class DiameterCodeHandler {
+    public:
+      static bool is_transient_failure(const uint32_t code);
+
+      static bool is_permanent_failure(const uint32_t code);
   };
 } // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -201,22 +201,10 @@ void LocalEnforcer::terminate_service(
   for (const auto &session : it->second) {
     session->start_termination([this](SessionTerminateRequest term_req) {
       // report to cloud
-      reporter_->report_terminate_session(
-        term_req,
-        [&term_req](Status status, SessionTerminateResponse response) {
-          if (!status.ok()) {
-            MLOG(MERROR)
-              << "Failed to terminate service in controller for subscriber "
-              << term_req.sid() << ": " << status.error_message();
-          } else {
-            MLOG(MDEBUG)
-              << "Termination successful in controller for subscriber "
-              << term_req.sid();
-         }
-        }
-      );
+      auto logging_cb =
+        SessionReporter::get_terminate_logging_cb(term_req);
+      reporter_->report_terminate_session(term_req, logging_cb);
     });
-
 
     // tell AAA service to terminate radius session if necessary
     if (session->is_radius_cwf_session()) {

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -315,25 +315,6 @@ std::string LocalSessionManagerHandlerImpl::convert_mac_addr_to_str(
   return res;
 }
 
-static void report_termination(
-  SessionReporter& reporter,
-  const SessionTerminateRequest& term_req)
-{
-  reporter.report_terminate_session(
-    term_req,
-    [&reporter, term_req](Status status, SessionTerminateResponse response) {
-      if (!status.ok()) {
-        MLOG(MERROR) << "Failed to terminate session in controller for "
-                        "subscriber "
-                     << term_req.sid() << ": " << status.error_message();
-      } else {
-        MLOG(MDEBUG) << "Termination successful in controller for "
-                        "subscriber "
-                     << term_req.sid();
-      }
-    });
-}
-
 /**
  * EndSession completes the entire termination procedure with the OCS & PCRF.
  * The process for session termination is as follows:
@@ -360,7 +341,9 @@ void LocalSessionManagerHandlerImpl::EndSession(
           request_cpy.apn(),
           [reporter](SessionTerminateRequest term_req) {
             // report to cloud
-            report_termination(*reporter, term_req);
+            auto logging_cb =
+              SessionReporter::get_terminate_logging_cb(term_req);
+            reporter->report_terminate_session(term_req, logging_cb);
           });
         response_callback(grpc::Status::OK, LocalEndSessionResponse());
       } catch (const SessionNotFound &ex) {

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -19,13 +19,6 @@ float SessionCredit::USAGE_REPORTING_THRESHOLD = 0.8;
 uint64_t SessionCredit::EXTRA_QUOTA_MARGIN = 1024;
 bool SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
 
-const std::set<uint32_t> SessionCredit::transient_result_codes_ = {
-  DIAMETER_CREDIT_CONTROL_NOT_APPLICABLE,
-  DIAMETER_CREDIT_LIMIT_REACHED,
-  DIAMETER_NO_AVAILABLE_POLICY_COUNTERS,
-  DIAMETER_SERVICE_TEMPORARILY_NOT_AUTHORIZED,
-};
-
 SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state):
   credit_type_(credit_type),
   reporting_(false),
@@ -85,7 +78,7 @@ void SessionCredit::reset_reporting_credit()
 
 void SessionCredit::mark_failure(uint32_t code)
 {
-  if (transient_result_codes_.find(code) != transient_result_codes_.end()) {
+  if (DiameterCodeHandler::is_transient_failure(code)) {
     buckets_[REPORTED_RX] += buckets_[REPORTING_RX];
     buckets_[REPORTED_TX] += buckets_[REPORTING_TX];
   }


### PR DESCRIPTION
Summary:
`report_termination` currently takes in a callback function that gets called after the reporting grpc call is made. Since we don't do anything other than log the status of the call, I added a separate function that returns a callback fn that logs the result, to clean up the codebase a bit.

Eventually, we should properly handle the error since there could be many reasons behind the error.

Reviewed By: xjtian

Differential Revision: D18943087

