### PR TITLE
Fix for MME Crash when UE sends Authentication Failure message

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Authentication.c
@@ -614,7 +614,7 @@ static int _auth_info_proc_failure_cb(struct emm_context_s *emm_ctx)
         emm_sap.u.emm_reg.ue_id = ue_id;
         emm_sap.u.emm_reg.ctx = emm_ctx;
         emm_sap.u.emm_reg.notify = true;
-        emm_sap.u.emm_reg.free_proc = true;
+        emm_sap.u.emm_reg.free_proc = false;
         emm_sap.u.emm_reg.u.common.common_proc = &auth_proc->emm_com_proc;
         emm_sap.u.emm_reg.u.common.previous_emm_fsm_state =
           auth_proc->emm_com_proc.emm_proc.previous_emm_fsm_state;


### PR DESCRIPTION
MME was crashing while handling the Authentication failure message from UE.
Crash was due to double free of pointer while deleting nas procedure in MME.
as part of this fix added new S1APTester test script to reproduce the scenario.

files changed: Authentication.c
verify:  using S1APTester