### PR TITLE
Add s1aptests with mobilityd restart

### DIFF
--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -9,4 +9,4 @@
 
 log_level: INFO
 persist_to_redis: false
-redis_port: 6379  # this is the default port for redis-server
+redis_port: 6380

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -292,7 +292,7 @@ class SubscriberUtil(object):
         self._subscriber_client.wait_for_changes()
         return subscribers
 
-    def clean_up(self):
+    def cleanup(self):
         """ Cleanup added subscriber from subscriberdb """
         self._subscriber_client.clean_up()
         # block until changes propagate
@@ -368,6 +368,11 @@ class MobilityUtil(object):
         """
         removed_blocks = self._mobility_client.remove_ip_blocks(blocks)
         return removed_blocks
+
+    def cleanup(self):
+        """ Cleanup added IP blocks """
+        blocks = self.list_ip_blocks()
+        self.remove_ip_blocks(blocks)
 
     def wait_for_changes(self):
         self._mobility_client.wait_for_changes()

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -47,8 +47,9 @@ class TestWrapper(object):
         magmad_client = MagmadServiceGrpc()
         self._sub_util = SubscriberUtil(subscriber_client)
         # Remove existing subscribers to start
-        self._sub_util.clean_up()
+        self._sub_util.cleanup()
         self._mobility_util = MobilityUtil(mobility_client)
+        self._mobility_util.cleanup()
         self._magmad_util = MagmadUtil(magmad_client)
         # gateway tests don't require restart, just wait for healthy now
         self._gateway_services = GatewayServicesUtil()
@@ -286,8 +287,9 @@ class TestWrapper(object):
         print("************************* send SCTP SHUTDOWN")
         self._s1_util.issue_cmd(s1ap_types.tfwCmd.SCTP_SHUTDOWN_REQ, None)
         self._s1_util.cleanup()
-        self._sub_util.clean_up()
+        self._sub_util.cleanup()
         self._trf_util.cleanup()
+        self._mobility_util.cleanup()
 
         # Cloud cleanup needs to happen after cleanup for
         # subscriber util and mobility util

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
@@ -1,0 +1,70 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+from time import sleep
+
+import s1ap_types
+import s1ap_wrapper
+
+
+class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self._ip_block = '192.168.125.0/24'
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach_multiple_ip_blocks(self):
+        """
+        Attaching and detaching UE in mobilityd with multiple IP blocks across
+        restart
+        """
+        self._s1ap_wrapper.configUEDevice(1)
+
+        self._s1ap_wrapper.mobility_util.add_ip_block(
+            self._ip_block)
+
+        blocks = self._s1ap_wrapper.mobility_util.list_ip_blocks()
+        assert len(blocks) > 1, "More than 1 IP block should be allocated in " \
+                                "IP allocator "
+
+        print("************************* Restarting mobilityd")
+        self._s1ap_wrapper.magmad_util.restart_services(["mobilityd"])
+        for j in range(10):
+            print("Waiting for", j, "seconds")
+            sleep(1)
+
+        blocks = self._s1ap_wrapper.mobility_util.list_ip_blocks()
+        assert len(blocks) > 1, "More than 1 IP block should be allocated in " \
+                                "IP allocator "
+
+        req = self._s1ap_wrapper.ue_req
+        print("************************* Running End to End attach for ",
+              "UE id ", req.ue_id)
+
+        # Now actually attempt the attach
+        self._s1ap_wrapper.s1_util.attach(
+            req.ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t)
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # Detach previously attached UE
+        self._s1ap_wrapper.s1_util.detach(
+            req.ue_id,
+            s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
@@ -1,0 +1,58 @@
+#  Copyright (c) Facebook, Inc. and its affiliates.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree.
+import unittest
+from time import sleep
+
+import s1ap_types
+from integ_tests.s1aptests import s1ap_wrapper
+
+
+class TestAttachDetachMobilitydRestart(unittest.TestCase):
+
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach_mobility_restart(self):
+        """ Basic attach/detach test with a single UE and mobilityd restart """
+        num_ues = 2
+        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        wait_for_s1 = [True, False]
+        self._s1ap_wrapper.configUEDevice(num_ues)
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print("************************* Running End to End attach for ",
+                  "UE id ", req.ue_id)
+
+            # Now actually complete the attach
+            self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t)
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            print('************************* Restarting mobilityd')
+            self._s1ap_wrapper.magmad_util.restart_services(['mobilityd'])
+            # Timeout for mobilityd restart
+            for j in range(30):
+                print("Waiting for", j, "seconds")
+                sleep(1)
+
+            print("************************* Running UE detach for UE id ",
+                  req.ue_id)
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id, detach_type[i], wait_for_s1[i])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_without_ips_available.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_without_ips_available.py
@@ -20,7 +20,6 @@ class TestAttachWithoutIpsAvailable(unittest.TestCase):
         self._blocks = []
 
     def tearDown(self):
-        # TODO(wlq): Add back original blocks/restore state
         for block in self._blocks:
             self._s1ap_wrapper.mobility_util.add_ip_block(block)
         self._s1ap_wrapper.cleanup()
@@ -30,8 +29,7 @@ class TestAttachWithoutIpsAvailable(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
 
         # Clear blocks
-        self._blocks.extend(self._s1ap_wrapper.mobility_util.list_ip_blocks())
-        self._s1ap_wrapper.mobility_util.remove_ip_blocks(self._blocks)
+        self._s1ap_wrapper.mobility_util.cleanup()
 
         req = self._s1ap_wrapper.ue_req
         print("************************* Running End to End attach for ",

--- a/lte/gateway/python/magma/mobilityd/ip_allocator.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator.py
@@ -132,12 +132,6 @@ class IPAllocator:
                 lambda key: store.ip_states(client, key))
             self._sid_ips_map = store.SIDIPsDict(client)
 
-        # TODO: once we are no longer clearing all values on initialization,
-        # we should add unit tests to ensure values are written to Redis
-        # correctly.
-        self._assigned_ip_blocks.clear()
-        self._sid_ips_map.clear()
-
     def add_ip_block(self, ipblock: ip_network):
         """ Add a block of IP addresses to the free IP list
 
@@ -239,6 +233,8 @@ class IPAllocator:
             for sid in remove_sids:
                 self._sid_ips_map.pop(sid)
 
+            for block in remove_blocks:
+                logging.info('Removed IP block %s from IPv4 address pool', block)
             return remove_blocks
 
     def list_added_ip_blocks(self) -> List[ip_network]:
@@ -395,7 +391,7 @@ class IPAllocator:
                     "(%s, %s) pair is not found", sid, str(ip))
             if not self._test_ip_state(ip, IPState.ALLOCATED):
                 logging.error("IP not found in used list, check if IP is "
-                             "already released: <%s, %s>", sid, ip)
+                              "already released: <%s, %s>", sid, ip)
                 raise IPNotInUseError("IP not found in used list: %s", str(ip))
 
             self._mark_ip_state(ip, IPState.RELEASED)

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -41,8 +41,6 @@ def ip_states(client, key):
         serialize_utils.serialize_ip_desc,
         serialize_utils.deserialize_ip_desc,
     )
-    # TODO: Remove clear of container once mobilityd is not dependent on MME
-    redis_dict.clear()
     return redis_dict
 
 


### PR DESCRIPTION
Summary:
- Adding related mobilityd s1ap tests, with restart using magmad_client on s1ap_wrapper
-  Changed redis port for mobilityd.yml config to 6380
- Removing clear() on mobility store objects

Differential Revision: D19043341

