### PR TITLE
Refactor and remove duplicate code from Gy code

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gy/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/model_conversion.go
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 package gy
 
 import (
+	"magma/feg/gateway/services/session_proxy/credit_control"
 	"magma/lte/cloud/go/protos"
 )
 
@@ -19,5 +20,40 @@ func (redirectServer *RedirectServer) ToProto() *protos.RedirectServer {
 	return &protos.RedirectServer{
 		RedirectAddressType:   protos.RedirectServer_RedirectAddressType(redirectServer.RedirectAddressType),
 		RedirectServerAddress: redirectServer.RedirectServerAddress,
+	}
+}
+
+func (credits *UsedCredits) FromCreditUsage(usage *protos.CreditUsage) *UsedCredits {
+	credits.RatingGroup = usage.ChargingKey
+	credits.InputOctets = usage.BytesTx  // transmit == input
+	credits.OutputOctets = usage.BytesRx // receive == output
+	credits.TotalOctets = usage.BytesTx + usage.BytesRx
+	credits.Type = UsedCreditsType(usage.Type)
+	return credits
+}
+
+func (request *CreditControlRequest) FromCreditUsageUpdate(update *protos.CreditUsageUpdate) *CreditControlRequest {
+	request.SessionID = update.SessionId
+	request.RequestNumber = update.RequestNumber
+	request.IMSI = credit_control.RemoveIMSIPrefix(update.Sid)
+	request.Msisdn = update.Msisdn
+	request.UeIPV4 = update.UeIpv4
+	request.SpgwIPV4 = update.SpgwIpv4
+	request.Apn = update.Apn
+	request.Imei = update.Imei
+	request.PlmnID = update.PlmnId
+	request.UserLocation = update.UserLocation
+	request.Type = credit_control.CRTUpdate
+	request.Credits = []*UsedCredits{(&UsedCredits{}).FromCreditUsage(update.Usage)}
+	request.RatType = GetRATType(update.GetRatType())
+	return request
+}
+
+func GetRATType(prt protos.RATType) string {
+	switch prt {
+	case protos.RATType_TGPP_WLAN:
+		return RAT_TYPE_WLAN
+	default: // including protos.RATType_TGPP_LTE
+		return RAT_TYPE_EUTRAN
 	}
 }

--- a/feg/gateway/services/session_proxy/credit_control/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/model_conversion.go
@@ -9,6 +9,8 @@ LICENSE file in the root directory of this source tree.
 package credit_control
 
 import (
+	"strings"
+
 	"magma/lte/cloud/go/protos"
 )
 
@@ -38,26 +40,10 @@ func getCreditUnit(volume *uint64) *protos.CreditUnit {
 	return &protos.CreditUnit{IsValid: true, Volume: *volume}
 }
 
-func GetRATType(pRATType protos.RATType) RATType {
-	switch pRATType {
-	case protos.RATType_TGPP_LTE:
-		return RAT_EUTRAN
-	case protos.RATType_TGPP_WLAN:
-		return RAT_WLAN
-	default:
-		return RAT_EUTRAN
-	}
+func RemoveIMSIPrefix(imsi string) string {
+	return strings.TrimPrefix(imsi, "IMSI")
 }
 
-// Since we don't specify the IP CAN type at session initialization, and we
-// only support WLAN and EUTRAN, we will infer the IP CAN type from RAT type.
-func GetIPCANType(pRATType protos.RATType) IPCANType {
-	switch pRATType {
-	case protos.RATType_TGPP_LTE:
-		return IPCAN_3GPP
-	case protos.RATType_TGPP_WLAN:
-		return IPCAN_Non3GPP
-	default:
-		return IPCAN_Non3GPP
-	}
+func AddIMSIPrefix(imsi string) string {
+	return "IMSI" + imsi
 }

--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -11,7 +11,6 @@ package servicers
 import (
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"magma/feg/gateway/diameter"
@@ -79,7 +78,7 @@ func getCCRInitRequest(
 		GcID:          pReq.GcId,
 		Qos:           qos,
 		Type:          credit_control.CRTInit,
-		RatType:       getCreditRATType(pReq.GetRatType()),
+		RatType:       gy.GetRATType(pReq.GetRatType()),
 	}
 }
 
@@ -130,7 +129,7 @@ func getCCRInitialCreditRequest(
 		Qos:           qos,
 		Credits:       usedCredits,
 		Type:          msgType,
-		RatType:       getCreditRATType(pReq.GetRatType()),
+		RatType:       gy.GetRATType(pReq.GetRatType()),
 	}
 }
 
@@ -247,7 +246,7 @@ func addMissingResponses(
 	for _, ccr := range leftoverRequests {
 		resp := &protos.CreditUpdateResponse{
 			Success:     false,
-			Sid:         addSidPrefix(ccr.IMSI),
+			Sid:         credit_control.AddIMSIPrefix(ccr.IMSI),
 			ChargingKey: ccr.Credits[0].RatingGroup,
 		}
 		if ccr.Credits[0].ServiceIdentifier != nil {
@@ -265,7 +264,7 @@ func getSingleCreditResponsesFromCCA(
 	request *gy.CreditControlRequest,
 ) *protos.CreditUpdateResponse {
 	success := answer.ResultCode == diameter.SuccessCode
-	imsi := addSidPrefix(request.IMSI)
+	imsi := credit_control.AddIMSIPrefix(request.IMSI)
 	if len(answer.Credits) == 0 {
 		return &protos.CreditUpdateResponse{
 			Success: false,
@@ -295,7 +294,7 @@ func getInitialCreditResponsesFromCCA(
 		success := credit.ResultCode == diameter.SuccessCode || credit.ResultCode == 0
 		response := &protos.CreditUpdateResponse{
 			Success:     success,
-			Sid:         addSidPrefix(request.IMSI),
+			Sid:         credit_control.AddIMSIPrefix(request.IMSI),
 			ChargingKey: credit.RatingGroup,
 			Credit:      getSingleChargingCreditFromCCA(credit),
 			ResultCode:  credit.ResultCode,
@@ -330,7 +329,7 @@ func getGyUpdateRequestsFromUsage(updates []*protos.CreditUsageUpdate) []*gy.Cre
 		requests = append(requests, &gy.CreditControlRequest{
 			SessionID:     update.SessionId,
 			RequestNumber: update.RequestNumber,
-			IMSI:          removeSidPrefix(update.Sid),
+			IMSI:          credit_control.RemoveIMSIPrefix(update.Sid),
 			Msisdn:        update.Msisdn,
 			UeIPV4:        update.UeIpv4,
 			SpgwIPV4:      update.SpgwIpv4,
@@ -346,7 +345,7 @@ func getGyUpdateRequestsFromUsage(updates []*protos.CreditUsageUpdate) []*gy.Cre
 				TotalOctets:  update.Usage.BytesTx + update.Usage.BytesRx,
 				Type:         gy.UsedCreditsType(update.Usage.Type),
 			}},
-			RatType: getCreditRATType(update.GetRatType()),
+			RatType: gy.GetRATType(update.GetRatType()),
 		})
 	}
 	return requests
@@ -356,17 +355,11 @@ func getGyUpdateRequestsFromUsage(updates []*protos.CreditUsageUpdate) []*gy.Cre
 func getTerminateRequestFromUsage(termination *protos.SessionTerminateRequest) *gy.CreditControlRequest {
 	usedCredits := make([]*gy.UsedCredits, 0, len(termination.CreditUsages))
 	for _, usage := range termination.CreditUsages {
-		usedCredits = append(usedCredits, &gy.UsedCredits{
-			RatingGroup:  usage.ChargingKey,
-			InputOctets:  usage.BytesTx, // transmit == input
-			OutputOctets: usage.BytesRx, // receive == output
-			TotalOctets:  usage.BytesTx + usage.BytesRx,
-			Type:         gy.UsedCreditsType(usage.Type),
-		})
+		usedCredits = append(usedCredits, (&gy.UsedCredits{}).FromCreditUsage(usage))
 	}
 	return &gy.CreditControlRequest{
 		SessionID:     termination.SessionId,
-		IMSI:          removeSidPrefix(termination.Sid),
+		IMSI:          credit_control.RemoveIMSIPrefix(termination.Sid),
 		Apn:           termination.Apn,
 		RequestNumber: termination.RequestNumber,
 		Credits:       usedCredits,
@@ -377,23 +370,6 @@ func getTerminateRequestFromUsage(termination *protos.SessionTerminateRequest) *
 		PlmnID:        termination.PlmnId,
 		UserLocation:  termination.UserLocation,
 		Type:          credit_control.CRTTerminate,
-		RatType:       getCreditRATType(termination.GetRatType()),
-	}
-}
-
-func removeSidPrefix(imsi string) string {
-	return strings.TrimPrefix(imsi, "IMSI")
-}
-
-func addSidPrefix(imsi string) string {
-	return "IMSI" + imsi
-}
-
-func getCreditRATType(prt protos.RATType) string {
-	switch prt {
-	case protos.RATType_TGPP_WLAN:
-		return gy.RAT_TYPE_WLAN
-	default: // including protos.RATType_TGPP_LTE
-		return gy.RAT_TYPE_EUTRAN
+		RatType:       gy.GetRATType(termination.GetRatType()),
 	}
 }

--- a/feg/gateway/services/session_proxy/servicers/policy.go
+++ b/feg/gateway/services/session_proxy/servicers/policy.go
@@ -43,8 +43,8 @@ func (srv *CentralSessionController) sendInitialGxRequest(imsi string, pReq *pro
 		GcID:          pReq.GcId,
 		Qos:           qos,
 		HardwareAddr:  pReq.HardwareAddr,
-		RATType:       credit_control.GetRATType(pReq.RatType),
-		IPCANType:     credit_control.GetIPCANType(pReq.RatType),
+		RATType:       gx.GetRATType(pReq.RatType),
+		IPCANType:     gx.GetIPCANType(pReq.RatType),
 	}
 
 	return getGxAnswerOrError(request, srv.policyClient, srv.cfg.PCRFConfig, srv.cfg.RequestTimeout)
@@ -58,12 +58,12 @@ func (srv *CentralSessionController) sendTerminationGxRequest(pRequest *protos.S
 	request := &gx.CreditControlRequest{
 		SessionID:     pRequest.SessionId,
 		Type:          credit_control.CRTTerminate,
-		IMSI:          removeSidPrefix(pRequest.Sid),
+		IMSI:          credit_control.AddIMSIPrefix(pRequest.Sid),
 		RequestNumber: pRequest.RequestNumber,
 		IPAddr:        pRequest.UeIpv4,
 		UsageReports:  reports,
-		RATType:       credit_control.GetRATType(pRequest.RatType),
-		IPCANType:     credit_control.GetIPCANType(pRequest.RatType),
+		RATType:       gx.GetRATType(pRequest.RatType),
+		IPCANType:     gx.GetIPCANType(pRequest.RatType),
 	}
 	return getGxAnswerOrError(request, srv.policyClient, srv.cfg.PCRFConfig, srv.cfg.RequestTimeout)
 }
@@ -112,7 +112,7 @@ func getUsageMonitorsFromCCA_I(imsi string, sessionID string, gxCCAInit *gx.Cred
 		monitors = append(monitors, &protos.UsageMonitoringUpdateResponse{
 			Credit:           monitor.ToUsageMonitoringCredit(),
 			SessionId:        sessionID,
-			Sid:              addSidPrefix(imsi),
+			Sid:              credit_control.AddIMSIPrefix(imsi),
 			Success:          true,
 			EventTriggers:    triggers,
 			RevalidationTime: revalidationTime,
@@ -242,7 +242,7 @@ func addMissingGxResponses(
 		responses = append(responses, &protos.UsageMonitoringUpdateResponse{
 			Success:   false,
 			SessionId: ccr.SessionID,
-			Sid:       addSidPrefix(ccr.IMSI),
+			Sid:       credit_control.AddIMSIPrefix(ccr.IMSI),
 			Credit: &protos.UsageMonitoringCredit{
 				MonitoringKey: []byte(ccr.UsageReports[0].MonitoringKey),
 				Level:         protos.MonitoringLevel(ccr.UsageReports[0].Level),
@@ -266,7 +266,7 @@ func (srv *CentralSessionController) getSingleUsageMonitorResponseFromCCA(answer
 	res := &protos.UsageMonitoringUpdateResponse{
 		Success:               answer.ResultCode == diameter.SuccessCode || answer.ResultCode == 0,
 		SessionId:             request.SessionID,
-		Sid:                   addSidPrefix(request.IMSI),
+		Sid:                   credit_control.AddIMSIPrefix(request.IMSI),
 		ResultCode:            answer.ResultCode,
 		RulesToRemove:         rulesToRemove,
 		StaticRulesToInstall:  staticRules,

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -16,6 +16,7 @@ import (
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/policydb"
+	"magma/feg/gateway/services/session_proxy/credit_control"
 	"magma/feg/gateway/services/session_proxy/credit_control/gx"
 	"magma/feg/gateway/services/session_proxy/credit_control/gy"
 	"magma/feg/gateway/services/session_proxy/metrics"
@@ -75,7 +76,7 @@ func (srv *CentralSessionController) CreateSession(
 	request *protos.CreateSessionRequest,
 ) (*protos.CreateSessionResponse, error) {
 	glog.V(2).Info("Trying to create session")
-	imsi := removeSidPrefix(request.Subscriber.Id)
+	imsi := credit_control.RemoveIMSIPrefix(request.Subscriber.Id)
 	sessionID := request.SessionId
 	gxCCAInit, err := srv.sendInitialGxRequest(imsi, request)
 	metrics.UpdateGxRecentRequestMetrics(err)


### PR DESCRIPTION
Summary:
- Some functions used by both gy and gx pipeline have moved to the greater credit_control directory
- Moving conversion code in `credit.go` into gy `model_conversion.go`

Reviewed By: xjtian

Differential Revision: D19158308

