### PR TITLE
[new tcs][s1 sim][multi pdn]Additional s1 sim tcs for multi pdn

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
@@ -21,7 +21,7 @@ class TestDisconnectDefaultPdn(unittest.TestCase):
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
 
-    def test_seconday_pdn_conn_req(self):
+    def test_disconnect_default_pdn(self):
         """ Attach a single UE and send PDN disconnect request
         for the default bearer """
 
@@ -52,7 +52,7 @@ class TestDisconnectDefaultPdn(unittest.TestCase):
             s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req
         )
 
-        # Receive UE_DEACTIVATE_BER_REQ
+        # Receive PDN Disconnect Reject
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertTrue(
             response, s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_disconnect_default_pdn.py
@@ -1,0 +1,68 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+
+
+class TestDisconnectDefaultPdn(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_seconday_pdn_conn_req(self):
+        """ Attach a single UE and send PDN disconnect request
+        for the default bearer """
+
+        self._s1ap_wrapper.configUEDevice(1)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
+        # Attach
+        self._s1ap_wrapper.s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        time.sleep(5)
+        # Send PDN Disconnect
+        pdn_disconnect_req = s1ap_types.uepdnDisconnectReq_t()
+        pdn_disconnect_req.ue_Id = ue_id
+        pdn_disconnect_req.epsBearerId = 5
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REQ, pdn_disconnect_req
+        )
+
+        # Receive UE_DEACTIVATE_BER_REQ
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(
+            response, s1ap_types.tfwCmd.UE_PDN_DISCONNECT_REJ.value
+        )
+
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_max_pdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_max_pdns.py
@@ -15,7 +15,7 @@ import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 
 
-class TestMaximumBearersPeeUe(unittest.TestCase):
+class TestMaximumBearersPerUe(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
         self._spgw_util = SpgwUtil()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_max_pdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_max_pdns.py
@@ -1,0 +1,131 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+from integ_tests.s1aptests.s1ap_utils import SpgwUtil
+
+
+class TestMaximumBearersPeeUe(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self._spgw_util = SpgwUtil()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_max_bearers_per_ue(self):
+        """ Attach a single UE and send standalone PDN Connectivity
+        Request + add 9 dedicated bearers + detach"""
+        num_ues = 1
+        self._s1ap_wrapper.configUEDevice(num_ues)
+        # 1 oai PDN + 1 dedicated bearer, 1 ims pdn + 8 dedicated bearers
+        loop = 8
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            ue_id = req.ue_id
+            print(
+                "********************* Running End to End attach for UE id ",
+                ue_id,
+            )
+            # Attach
+            self._s1ap_wrapper.s1_util.attach(
+                ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            # Add dedicated bearer for default bearer 5
+            print(
+                "********************** Adding dedicated bearer to oai.ipv4"
+                " PDN"
+            )
+            self._spgw_util.create_bearer(
+                "IMSI" + "".join([str(i) for i in req.imsi]), 5
+            )
+
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertTrue(
+                response, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
+            act_ded_ber_req_oai_apn = response.cast(
+                s1ap_types.UeActDedBearCtxtReq_t
+            )
+            self._s1ap_wrapper.sendActDedicatedBearerAccept(
+                req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            )
+
+            time.sleep(5)
+            # Send PDN Connectivity Request
+            apn = "ims"
+            self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
+            # Receive PDN CONN RSP/Activate default EPS bearer context req
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
+            act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+            print(
+                "********************** Sending Activate default EPS bearer "
+                "context accept for UE id ",
+                ue_id,
+            )
+
+            time.sleep(5)
+            for _ in range(loop):
+                # Add dedicated bearer to 2nd PDN
+                print(
+                    "********************** Adding dedicated bearer to ims"
+                    " PDN"
+                )
+                self._spgw_util.create_bearer(
+                    "IMSI" + "".join([str(i) for i in req.imsi]),
+                    act_def_bearer_req.m.pdnInfo.epsBearerId,
+                )
+
+                response = self._s1ap_wrapper.s1_util.get_response()
+                self.assertTrue(
+                    response, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+                )
+                act_ded_ber_req_ims_apn = response.cast(
+                    s1ap_types.UeActDedBearCtxtReq_t
+                )
+                self._s1ap_wrapper.sendActDedicatedBearerAccept(
+                    req.ue_id, act_ded_ber_req_ims_apn.bearerId
+                )
+                print(
+                    "************ Added dedicated bearer",
+                    act_ded_ber_req_ims_apn.bearerId,
+                )
+                time.sleep(2)
+
+            print(
+                "************************ Running UE detach (switch-off) for ",
+                "UE id ",
+                ue_id,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id,
+                s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+                False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py
@@ -1,0 +1,66 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+
+import s1ap_types
+import s1ap_wrapper
+
+
+class TestSecondaryPdnConnReqWrongAPN(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_seconday_pdn_conn_req(self):
+        """ Attach a single UE and send standalone PDN Connectivity
+        Request with wrong APN"""
+
+        self._s1ap_wrapper.configUEDevice(1)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
+        # Attach
+        self._s1ap_wrapper.s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # Send PDN Connectivity Request
+        apn = "VZWINTERNET"
+        self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
+        # Receive PDN CONN REJ
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+        )
+
+        print(
+            "************************* Running UE detach (switch-off) for ",
+            "UE id ",
+            ue_id,
+        )
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_invalid_apn.py
@@ -13,16 +13,16 @@ import s1ap_types
 import s1ap_wrapper
 
 
-class TestSecondaryPdnConnReqWrongAPN(unittest.TestCase):
+class TestSecondaryPdnConnReqInvalidAPN(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
 
-    def test_seconday_pdn_conn_req(self):
+    def test_seconday_pdn_conn_req_invalid_apn(self):
         """ Attach a single UE and send standalone PDN Connectivity
-        Request with wrong APN"""
+        Request with invalid APN"""
 
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
@@ -1,0 +1,80 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+
+
+class TestSecondaryPdnConnReq(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_seconday_pdn_conn_req(self):
+        """ Attach a single UE and send standalone PDN Connectivity
+        Request """
+
+        self._s1ap_wrapper.configUEDevice(1)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+        loop = 3
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
+        # Attach
+        for i in range(loop):
+            time.sleep(5)
+            self._s1ap_wrapper.s1_util.attach(
+                ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            # Send PDN Connectivity Request
+            apn = "ims"
+            self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
+            # Receive PDN CONN RSP/Activate default EPS bearer context request
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
+
+            print(
+                "************************* Sending Activate default EPS "
+                "bearer context accept for UE id ",
+                ue_id,
+            )
+
+            time.sleep(5)
+
+            print(
+                "************************* Running UE detach (switch-off)"
+                " for UE id ",
+                ue_id,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id,
+                s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+                True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_looped.py
@@ -14,16 +14,16 @@ import s1ap_types
 import s1ap_wrapper
 
 
-class TestSecondaryPdnConnReq(unittest.TestCase):
+class TestSecondaryPdnConnLooped(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
 
-    def test_seconday_pdn_conn_req(self):
+    def test_seconday_pdn_conn_looped(self):
         """ Attach a single UE and send standalone PDN Connectivity
-        Request """
+        Request + detach. Repeat 3 times """
 
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
@@ -1,0 +1,171 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+from integ_tests.s1aptests.s1ap_utils import SpgwUtil
+
+
+class TestSecondaryPdnConnWithDedBearerDeactivateReq(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self._spgw_util = SpgwUtil()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_seconday_pdn_conn_ded_bearer_deactivate(self):
+        """ Attach a single UE and send standalone PDN Connectivity
+        Request + add dedicated bearer to each default bearer + deactivate
+        dedicated bearers + detach"""
+        num_ues = 1
+        self._s1ap_wrapper.configUEDevice(num_ues)
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            ue_id = req.ue_id
+            print(
+                "********************* Running End to End attach for UE id ",
+                ue_id,
+            )
+            # Attach
+            self._s1ap_wrapper.s1_util.attach(
+                ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            # Add dedicated bearer for default bearer 5
+            print(
+                "********************** Adding dedicated bearer to oai.ipv4"
+                " PDN"
+            )
+            self._spgw_util.create_bearer(
+                "IMSI" + "".join([str(i) for i in req.imsi]), 5
+            )
+
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertTrue(
+                response, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
+            act_ded_ber_req_oai_apn = response.cast(
+                s1ap_types.UeActDedBearCtxtReq_t
+            )
+            self._s1ap_wrapper.sendActDedicatedBearerAccept(
+                req.ue_id, act_ded_ber_req_oai_apn.bearerId
+            )
+
+            time.sleep(5)
+            # Send PDN Connectivity Request
+            apn = "ims"
+            self._s1ap_wrapper.sendPdnConnectivityReq(ue_id, apn)
+            # Receive PDN CONN RSP/Activate default EPS bearer context request
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
+            act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+            print(
+                "********************** Sending Activate default EPS bearer "
+                "context accept for UE id ",
+                ue_id,
+            )
+
+            time.sleep(5)
+            # Add dedicated bearer to 2nd PDN
+            print("********************** Adding dedicated bearer to ims PDN")
+            self._spgw_util.create_bearer(
+                "IMSI" + "".join([str(i) for i in req.imsi]),
+                act_def_bearer_req.m.pdnInfo.epsBearerId,
+            )
+
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertTrue(
+                response, s1ap_types.tfwCmd.UE_ACT_DED_BER_REQ.value
+            )
+            act_ded_ber_req_ims_apn = response.cast(
+                s1ap_types.UeActDedBearCtxtReq_t
+            )
+            self._s1ap_wrapper.sendActDedicatedBearerAccept(
+                req.ue_id, act_ded_ber_req_ims_apn.bearerId
+            )
+            print(
+                "************* Added dedicated bearer",
+                act_ded_ber_req_ims_apn.bearerId,
+            )
+
+            time.sleep(5)
+            # Delete dedicated bearer of secondary PDN (ims apn)
+            print(
+                "********************** Deleting dedicated bearer for ims"
+                " apn"
+            )
+            self._spgw_util.delete_bearer(
+                "IMSI" + "".join([str(i) for i in req.imsi]),
+                act_def_bearer_req.m.pdnInfo.epsBearerId,
+                act_ded_ber_req_ims_apn.bearerId,
+            )
+
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertTrue(
+                response, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            )
+
+            deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
+
+            # Send Deactivate dedicated bearer rsp
+            self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
+                req.ue_id, deactv_bearer_req.bearerId
+            )
+
+            print(
+                "********************** Deleted dedicated bearer ",
+                deactv_bearer_req.bearerId,
+            )
+            time.sleep(5)
+            # Delete dedicated bearer of secondary PDN (oai.ipv4 apn)
+            self._spgw_util.delete_bearer(
+                "IMSI" + "".join([str(i) for i in req.imsi]),
+                5,
+                act_ded_ber_req_oai_apn.bearerId,
+            )
+
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertTrue(
+                response, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+            )
+
+            deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
+            # Send Deactivate dedicated bearer rsp
+            self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
+                req.ue_id, deactv_bearer_req.bearerId
+            )
+
+            print(
+                "********************** Deleted dedicated bearer ",
+                deactv_bearer_req.bearerId,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                ue_id,
+                s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+                False,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
Added the following new TCs to test multi pdn support:
1. test_attach_detach_disconnect_default_pdn.py (Send PDN disconnect to remove the default bearer)
2. test_attach_detach_max_pdns.py (add 11 bearers)
3. test_attach_detach_secondary_pdn_invalid_apn.py (send wrong APN in PDN connectivity request)
4. test_attach_detach_secondary_pdn_looped.py (attach+add secondary pdn+detach. Repeat 3 times)
5. test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py (attach+add secondary pdn+add dedicated bearers+deactivate dedicated bearers+detach)

Test Plan:
1. Executed s1 sim sanity
2. Executed multi PDN TCs 
3. Executed dedicated bearer TCs

Note:This PR has dependency on magma PR #1051 and s1 sim PR #6 (https://github.com/facebookexperimental/S1APTester/pull/6)