### PR TITLE
AGW: Guarded unused code under MACRO for code coverage

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -81,6 +81,7 @@ add_boolean_option(EMBEDDED_SGW                    False    "Add the SPGW task t
 add_boolean_option(LINK_GCOV                       False    "Whether to link gcov")
 
 add_boolean_option(S6A_OVER_GRPC                   True     "S6a messages sent over gRPC")
+add_boolean_option(ENABLE_CODE_COVERAGE            False     "Enable code coverage")
 
 ################################################################
 # Include CMake modules to find other library

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -1273,7 +1273,7 @@ void mme_app_dump_protocol_configuration_options(
     }
   }
 }
-
+#ifndef ENABLE_CODE_COVERAGE
 //------------------------------------------------------------------------------
 void mme_app_dump_bearer_context(
   const bearer_context_t *const bc,
@@ -1424,7 +1424,8 @@ void mme_app_dump_bearer_context(
     " ",
     bc->pdn_cx_id);
 }
-
+#endif /* ENABLE_CODE_COVERAGE */
+#ifndef ENABLE_CODE_COVERAGE
 //------------------------------------------------------------------------------
 void mme_app_dump_pdn_context(
   const struct ue_mm_context_s *const ue_mm_context,
@@ -1683,7 +1684,7 @@ void mme_app_dump_pdn_context(
     }
   }
 }
-
+#endif /* ENABLE_CODE_COVERAGE */
 //-------------------------------------------------------------------------------------------------------
 void mme_ue_context_update_ue_sig_connection_state(
   mme_ue_context_t *const mme_ue_context_p,
@@ -1797,6 +1798,7 @@ void mme_ue_context_update_ue_sig_connection_state(
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }
+#ifndef ENABLE_CODE_COVERAGE
 //------------------------------------------------------------------------------
 bool mme_app_dump_ue_context(
   const hash_key_t keyP,
@@ -1993,7 +1995,8 @@ bool mme_app_dump_ue_context(
   }
   return true;
 }
-
+#endif /* ENABLE_CODE_COVERAGE */
+#ifndef ENABLE_CODE_COVERAGE
 //------------------------------------------------------------------------------
 void mme_app_dump_ue_contexts(const mme_ue_context_t *const mme_ue_context_p)
 //------------------------------------------------------------------------------
@@ -2004,7 +2007,7 @@ void mme_app_dump_ue_contexts(const mme_ue_context_t *const mme_ue_context_p)
     NULL,
     NULL);
 }
-
+#endif /* ENABLE_CODE_COVERAGE */
 //------------------------------------------------------------------------------
 void mme_app_handle_s1ap_ue_context_release_req(
     const itti_s1ap_ue_context_release_req_t* const s1ap_ue_context_release_req)

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachAccept.c
@@ -27,6 +27,7 @@
 #include "AttachAccept.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_attach_accept(
   attach_accept_msg *attach_accept,
   uint8_t *buffer,
@@ -258,6 +259,7 @@ int decode_attach_accept(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 //------------------------------------------------------------------------------
 int encode_attach_accept(

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachComplete.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachComplete.c
@@ -53,6 +53,7 @@ int decode_attach_complete(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_attach_complete(
   attach_complete_msg *attach_complete,
   uint8_t *buffer,
@@ -79,3 +80,4 @@ int encode_attach_complete(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachReject.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachReject.c
@@ -26,6 +26,7 @@
 #include "AttachReject.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_attach_reject(
   attach_reject_msg *attach_reject,
   uint8_t *buffer,
@@ -83,6 +84,7 @@ int decode_attach_reject(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_attach_reject(
   attach_reject_msg *attach_reject,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
@@ -379,6 +379,7 @@ int decode_attach_request(
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, decoded);
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_attach_request(
   attach_request_msg *attach_request,
   uint8_t *buffer,
@@ -648,3 +649,4 @@ int encode_attach_request(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationFailure.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationFailure.c
@@ -85,6 +85,7 @@ int decode_authentication_failure(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_authentication_failure(
   authentication_failure_msg *authentication_failure,
   uint8_t *buffer,
@@ -125,3 +126,4 @@ int encode_authentication_failure(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationRequest.c
@@ -26,6 +26,7 @@
 #include "TLVDecoder.h"
 #include "AuthenticationRequest.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_authentication_request(
   authentication_request_msg *authentication_request,
   uint8_t *buffer,
@@ -73,6 +74,7 @@ int decode_authentication_request(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_authentication_request(
   authentication_request_msg *authentication_request,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationResponse.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationResponse.c
@@ -53,6 +53,7 @@ int decode_authentication_response(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_authentication_response(
   authentication_response_msg *authentication_response,
   uint8_t *buffer,
@@ -79,3 +80,4 @@ int encode_authentication_response(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/DetachAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/DetachAccept.c
@@ -25,6 +25,7 @@
 #include "TLVDecoder.h"
 #include "DetachAccept.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_detach_accept(
   detach_accept_msg *detach_accept,
   uint8_t *buffer,
@@ -40,6 +41,7 @@ int decode_detach_accept(
    */
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_detach_accept(
   detach_accept_msg *detach_accept,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/DetachRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/DetachRequest.c
@@ -68,6 +68,7 @@ int decode_detach_request(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_detach_request(
   detach_request_msg *detach_request,
   uint8_t *buffer,
@@ -97,6 +98,7 @@ int encode_detach_request(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_nw_detach_request(
   nw_detach_request_msg *nw_detach_request,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/EmmInformation.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/EmmInformation.c
@@ -26,6 +26,7 @@
 #include "EmmInformation.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_emm_information(
   emm_information_msg *emm_information,
   uint8_t *buffer,
@@ -144,6 +145,7 @@ int decode_emm_information(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_emm_information(
   emm_information_msg *emm_information,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/EmmStatus.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/EmmStatus.c
@@ -46,6 +46,7 @@ int decode_emm_status(emm_status_msg *emm_status, uint8_t *buffer, uint32_t len)
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_emm_status(emm_status_msg *emm_status, uint8_t *buffer, uint32_t len)
 {
   int encoded = 0;
@@ -66,3 +67,4 @@ int encode_emm_status(emm_status_msg *emm_status, uint8_t *buffer, uint32_t len)
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/IdentityRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/IdentityRequest.c
@@ -26,6 +26,7 @@
 #include "TLVDecoder.h"
 #include "IdentityRequest.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_identity_request(
   identity_request_msg *identity_request,
   uint8_t *buffer,
@@ -52,6 +53,7 @@ int decode_identity_request(
   decoded++;
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_identity_request(
   identity_request_msg *identity_request,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/IdentityResponse.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/IdentityResponse.c
@@ -53,6 +53,7 @@ int decode_identity_response(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_identity_response(
   identity_response_msg *identity_response,
   uint8_t *buffer,
@@ -79,3 +80,4 @@ int encode_identity_response(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeCommand.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeCommand.c
@@ -32,6 +32,7 @@
 #include "UeSecurityCapability.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_security_mode_command(
   security_mode_command_msg *security_mode_command,
   uint8_t *buffer,
@@ -153,6 +154,7 @@ int decode_security_mode_command(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_security_mode_command(
   security_mode_command_msg *security_mode_command,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeComplete.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeComplete.c
@@ -78,6 +78,7 @@ int decode_security_mode_complete(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_security_mode_complete(
   security_mode_complete_msg *security_mode_complete,
   uint8_t *buffer,
@@ -110,3 +111,4 @@ int encode_security_mode_complete(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.c
@@ -27,6 +27,7 @@
 #include "TrackingAreaUpdateAccept.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_tracking_area_update_accept(
   tracking_area_update_accept_msg *tracking_area_update_accept,
   uint8_t *buffer,
@@ -291,6 +292,7 @@ int decode_tracking_area_update_accept(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_tracking_area_update_accept(
   tracking_area_update_accept_msg *tracking_area_update_accept,

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.c
@@ -436,6 +436,7 @@ int decode_tracking_area_update_request(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_tracking_area_update_request(
   tracking_area_update_request_msg *tracking_area_update_request,
   uint8_t *buffer,
@@ -759,3 +760,4 @@ int encode_tracking_area_update_request(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/emm_msg.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/emm_msg.c
@@ -106,8 +106,10 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
 
   switch (msg->header.message_type) {
     case EMM_INFORMATION:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result =
         decode_emm_information(&msg->emm_information, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case UPLINK_NAS_TRANSPORT:
@@ -126,7 +128,9 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case DETACH_ACCEPT:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_detach_accept(&msg->detach_accept, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case SERVICE_REJECT:
@@ -134,8 +138,10 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case AUTHENTICATION_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_authentication_request(
         &msg->authentication_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case TRACKING_AREA_UPDATE_REQUEST:
@@ -157,8 +163,10 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case IDENTITY_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result =
         decode_identity_request(&msg->identity_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case GUTI_REALLOCATION_COMMAND:
@@ -172,7 +180,9 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ATTACH_ACCEPT:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_attach_accept(&msg->attach_accept, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case SECURITY_MODE_COMPLETE:
@@ -181,12 +191,16 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case TRACKING_AREA_UPDATE_ACCEPT:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_tracking_area_update_accept(
         &msg->tracking_area_update_accept, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ATTACH_REJECT:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_attach_reject(&msg->attach_reject, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ATTACH_COMPLETE:
@@ -219,8 +233,10 @@ int emm_msg_decode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case SECURITY_MODE_COMMAND:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result =
         decode_security_mode_command(&msg->security_mode_command, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case DOWNLINK_NAS_TRANSPORT:
@@ -308,8 +324,10 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ATTACH_COMPLETE:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result =
         encode_attach_complete(&msg->attach_complete, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ATTACH_REJECT:
@@ -317,8 +335,10 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case AUTHENTICATION_FAILURE:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_authentication_failure(
         &msg->authentication_failure, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case AUTHENTICATION_REJECT:
@@ -332,8 +352,10 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case AUTHENTICATION_RESPONSE:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_authentication_response(
         &msg->authentication_response, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case CS_SERVICE_NOTIFICATION:
@@ -346,7 +368,9 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case DETACH_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_detach_request(&msg->detach_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case DOWNLINK_NAS_TRANSPORT:
@@ -360,7 +384,9 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case EMM_STATUS:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_emm_status(&msg->emm_status, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case EXTENDED_SERVICE_REQUEST:
@@ -384,8 +410,10 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case IDENTITY_RESPONSE:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result =
         encode_identity_response(&msg->identity_response, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case SECURITY_MODE_COMMAND:
@@ -394,8 +422,10 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case SECURITY_MODE_COMPLETE:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_security_mode_complete(
         &msg->security_mode_complete, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case SECURITY_MODE_REJECT:
@@ -428,8 +458,10 @@ int emm_msg_encode(EMM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case TRACKING_AREA_UPDATE_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_tracking_area_update_request(
         &msg->tracking_area_update_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case NW_DETACH_REQUEST:

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextAccept.c
@@ -80,6 +80,7 @@ int decode_activate_dedicated_eps_bearer_context_accept(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_activate_dedicated_eps_bearer_context_accept(
   activate_dedicated_eps_bearer_context_accept_msg
     *activate_dedicated_eps_bearer_context_accept,
@@ -114,3 +115,4 @@ int encode_activate_dedicated_eps_bearer_context_accept(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.c
@@ -27,6 +27,7 @@
 #include "ActivateDedicatedEpsBearerContextRequest.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_activate_dedicated_eps_bearer_context_request(
   activate_dedicated_eps_bearer_context_request_msg
     *activate_dedicated_eps_bearer_context_request,
@@ -196,6 +197,7 @@ int decode_activate_dedicated_eps_bearer_context_request(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_activate_dedicated_eps_bearer_context_request(
   activate_dedicated_eps_bearer_context_request_msg

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextAccept.c
@@ -80,6 +80,7 @@ int decode_activate_default_eps_bearer_context_accept(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_activate_default_eps_bearer_context_accept(
   activate_default_eps_bearer_context_accept_msg
     *activate_default_eps_bearer_context_accept,
@@ -114,3 +115,4 @@ int encode_activate_default_eps_bearer_context_accept(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextReject.c
@@ -90,6 +90,7 @@ int decode_activate_default_eps_bearer_context_reject(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_activate_default_eps_bearer_context_reject(
   activate_default_eps_bearer_context_reject_msg
     *activate_default_eps_bearer_context_reject,
@@ -134,3 +135,4 @@ int encode_activate_default_eps_bearer_context_reject(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextRequest.c
@@ -28,6 +28,7 @@
 #include "ActivateDefaultEpsBearerContextRequest.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_activate_default_eps_bearer_context_request(
   activate_default_eps_bearer_context_request_msg
     *activate_default_eps_bearer_context_request,
@@ -230,6 +231,7 @@ int decode_activate_default_eps_bearer_context_request(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_activate_default_eps_bearer_context_request(
   activate_default_eps_bearer_context_request_msg

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextAccept.c
@@ -80,6 +80,7 @@ int decode_deactivate_eps_bearer_context_accept(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_deactivate_eps_bearer_context_accept(
   deactivate_eps_bearer_context_accept_msg
     *deactivate_eps_bearer_context_accept,
@@ -113,3 +114,4 @@ int encode_deactivate_eps_bearer_context_accept(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextRequest.c
@@ -27,6 +27,7 @@
 #include "DeactivateEpsBearerContextRequest.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_deactivate_eps_bearer_context_request(
   deactivate_eps_bearer_context_request_msg
     *deactivate_eps_bearer_context_request,
@@ -89,6 +90,7 @@ int decode_deactivate_eps_bearer_context_request(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_deactivate_eps_bearer_context_request(
   deactivate_eps_bearer_context_request_msg

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/EsmInformationRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/EsmInformationRequest.c
@@ -26,6 +26,7 @@
 #include "TLVDecoder.h"
 #include "EsmInformationRequest.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_esm_information_request(
   esm_information_request_msg *esm_information_request,
   uint8_t *buffer,
@@ -42,6 +43,7 @@ int decode_esm_information_request(
    */
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, decoded);
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_esm_information_request(
   esm_information_request_msg *esm_information_request,

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/EsmInformationResponse.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/EsmInformationResponse.c
@@ -99,6 +99,7 @@ int decode_esm_information_response(
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, decoded);
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_esm_information_response(
   esm_information_response_msg *esm_information_response,
   uint8_t *buffer,
@@ -148,3 +149,4 @@ int encode_esm_information_response(
 
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, encoded);
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityReject.c
@@ -28,6 +28,7 @@
 #include "PdnConnectivityReject.h"
 #include "common_defs.h"
 
+#ifndef ENABLE_CODE_COVERAGE
 int decode_pdn_connectivity_reject(
   pdn_connectivity_reject_msg *pdn_connectivity_reject,
   uint8_t *buffer,
@@ -88,6 +89,7 @@ int decode_pdn_connectivity_reject(
 
   return decoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */
 
 int encode_pdn_connectivity_reject(
   pdn_connectivity_reject_msg *pdn_connectivity_reject,

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityRequest.c
@@ -142,6 +142,7 @@ int decode_pdn_connectivity_request(
   return decoded;
 }
 
+#ifndef ENABLE_CODE_COVERAGE
 int encode_pdn_connectivity_request(
   pdn_connectivity_request_msg *pdn_connectivity_request,
   uint8_t *buffer,
@@ -210,3 +211,4 @@ int encode_pdn_connectivity_request(
 
   return encoded;
 }
+#endif /* ENABLE_CODE_COVERAGE */

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/esm_msg.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/esm_msg.c
@@ -144,8 +144,10 @@ int esm_msg_decode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case PDN_CONNECTIVITY_REJECT:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_pdn_connectivity_reject(
         &msg->pdn_connectivity_reject, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case MODIFY_EPS_BEARER_CONTEXT_REJECT:
@@ -164,8 +166,10 @@ int esm_msg_decode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case DEACTIVATE_EPS_BEARER_CONTEXT_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_deactivate_eps_bearer_context_request(
         &msg->deactivate_eps_bearer_context_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_ACCEPT:
@@ -189,8 +193,10 @@ int esm_msg_decode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_activate_dedicated_eps_bearer_context_request(
         &msg->activate_dedicated_eps_bearer_context_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case BEARER_RESOURCE_MODIFICATION_REJECT:
@@ -204,8 +210,10 @@ int esm_msg_decode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_activate_default_eps_bearer_context_request(
         &msg->activate_default_eps_bearer_context_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case PDN_CONNECTIVITY_REQUEST:
@@ -224,8 +232,10 @@ int esm_msg_decode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ESM_INFORMATION_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       decode_result = decode_esm_information_request(
         &msg->esm_information_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ESM_STATUS:
@@ -305,8 +315,10 @@ int esm_msg_encode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case DEACTIVATE_EPS_BEARER_CONTEXT_ACCEPT:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_deactivate_eps_bearer_context_accept(
         &msg->deactivate_eps_bearer_context_accept, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case BEARER_RESOURCE_ALLOCATION_REQUEST:
@@ -315,8 +327,10 @@ int esm_msg_encode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_ACCEPT:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_activate_default_eps_bearer_context_accept(
         &msg->activate_default_eps_bearer_context_accept, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case PDN_CONNECTIVITY_REJECT:
@@ -345,13 +359,17 @@ int esm_msg_encode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case ACTIVATE_DEDICATED_EPS_BEARER_CONTEXT_ACCEPT:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_activate_dedicated_eps_bearer_context_accept(
         &msg->activate_dedicated_eps_bearer_context_accept, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ACTIVATE_DEFAULT_EPS_BEARER_CONTEXT_REJECT:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_activate_default_eps_bearer_context_reject(
         &msg->activate_default_eps_bearer_context_reject, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case MODIFY_EPS_BEARER_CONTEXT_REQUEST:
@@ -385,13 +403,17 @@ int esm_msg_encode(ESM_msg *msg, uint8_t *buffer, uint32_t len)
       break;
 
     case PDN_CONNECTIVITY_REQUEST:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_pdn_connectivity_request(
         &msg->pdn_connectivity_request, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case ESM_INFORMATION_RESPONSE:
+#ifndef ENABLE_CODE_COVERAGE
       encode_result = encode_esm_information_response(
         &msg->esm_information_response, buffer, len);
+#endif /* ENABLE_CODE_COVERAGE */
       break;
 
     case BEARER_RESOURCE_MODIFICATION_REQUEST:


### PR DESCRIPTION
Added Macro to guard unused code for code coverage.
Added MACRO - "ENABLE_CODE_COVERAGE"
By default the above macro will be set to 'False'. whenever its required need to be set to 'True'