### PR TITLE
Support for CEA with multiple vendor IDs

### DIFF
--- a/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/diamtest/server.go
+++ b/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/diamtest/server.go
@@ -70,6 +70,7 @@ func newLocalListener(network string) net.Listener {
 	}
 	l, err := diam.MultistreamListen(network, "127.0.0.1:0")
 	if err != nil {
+		fmt.Printf("diamtest: failed initial listen on network %s: %v", network, err)
 		switch network {
 		case "sctp":
 			network = "sctp6"

--- a/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/sctp_diam_test.go
+++ b/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/sctp_diam_test.go
@@ -8,6 +8,7 @@
 package diam_test
 
 import (
+	"crypto/tls"
 	"testing"
 	"time"
 
@@ -56,7 +57,12 @@ func TestCapabilitiesExchangeSCTP_TLS(t *testing.T) {
 	tm := 100 * time.Millisecond
 	srv.Config.ReadTimeout = tm
 	srv.Config.WriteTimeout = tm
+	srv.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS10,
+		MaxVersion: tls.VersionTLS10,
+	}
 	srv.StartTLS()
+	time.Sleep(time.Millisecond * 10) // let srv start
 	defer srv.Close()
 
 	wait := make(chan struct{})

--- a/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/serve_test.go
+++ b/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/serve_test.go
@@ -5,6 +5,7 @@
 package diam_test
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io"
 	"net"
@@ -55,28 +56,38 @@ func TestCapabilitiesExchangeTLS(t *testing.T) {
 	smux.Handle("CER", handleCER(errc, true))
 
 	srv := diamtest.NewUnstartedServer(smux, nil)
-	tm := 100 * time.Millisecond
+	tm := time.Second
 	srv.Config.ReadTimeout = tm
 	srv.Config.WriteTimeout = tm
+	srv.TLS = &tls.Config{
+		MinVersion: tls.VersionTLS10,
+		MaxVersion: tls.VersionTLS10,
+	}
 	srv.StartTLS()
+	time.Sleep(time.Millisecond * 10) // let srv start
 	defer srv.Close()
-
 	wait := make(chan struct{})
 	cmux := diam.NewServeMux()
 	cmux.Handle("CEA", handleCEA(errc, wait))
 
 	cli, err := diam.DialTLS(srv.Addr, "", "", cmux, nil)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("diam.DialTLS Error: %v", err)
 	}
 
-	sendCER(cli)
+	n, err := sendCER(cli)
+	if err != nil {
+		t.Fatalf("sendCER Error: %v", err)
+	}
+	if n <= 0 {
+		t.Fatalf("sendCER: %d bytes sent", n)
+	}
 
 	select {
 	case <-wait:
 	case err := <-errc:
 		t.Fatal(err)
-	case <-time.After(time.Second):
+	case <-time.After(time.Second * 3):
 		t.Fatal("Timed out: no CER or CEA received")
 	}
 }

--- a/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/sm/smparser/app.go
+++ b/feg/gateway/third-party/go/src/github.com/fiorix/go-diameter/diam/sm/smparser/app.go
@@ -41,10 +41,13 @@ func (app *Application) Parse(d *dict.Parser, localRole Role) (failedAVP *diam.A
 	}
 	if app.VendorSpecificApplicationID != nil {
 		for _, vs := range app.VendorSpecificApplicationID {
-			failedAVP, err := app.handleGroup(d, vs)
-			if err != nil {
-				return failedAVP, err
+			failedAVP, err = app.handleGroup(d, vs)
+			if err == nil {
+				break
 			}
+		}
+		if err != nil {
+			return failedAVP, err
 		}
 	}
 	if app.ID() == nil {
@@ -117,9 +120,7 @@ func (app *Application) validate(d *dict.Parser, appType uint32, appAVP *diam.AV
 	if err != nil {
 		//TODO Log informational message to console?
 	} else if len(avp.Type) > 0 && avp.Type != typ {
-		//return nil, ErrNoCommonApplication
-		// Let the validate loop continue to the next AVP as
-		// we might find a common application there. 
+		return nil, ErrNoCommonApplication
 	} else {
 		app.id = append(app.id, id)
 	}


### PR DESCRIPTION
Summary: Support for CEA with multiple vendor IDs when only a subset of the IDs is supported by the dictionary. Fix for TLS unit tests under Go 1.13.5 (TLS 1.3)

Differential Revision: D19233485

