### PR TITLE
Change HSS Lite to not to modify "read only" configs on Start

### DIFF
--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -65,8 +65,10 @@ github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40eg
 github.com/facebookincubator/ent v0.0.0-20191128071424-29c7b0a0d805 h1:Gqrw3IfjWQ1afKMX8OuKq3vTnjhccK0Apllv8qrLdfI=
 github.com/facebookincubator/ent v0.0.0-20191128071424-29c7b0a0d805/go.mod h1:3CGvz1m+D78JUti7JFkY6AkKj88McWuT80UcamLqEJQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fiorix/go-diameter v3.0.2+incompatible h1:PLk2NkqMYILlEdeiz0hJVB3xcuuL+Gc9iCaEgjfbs5w=
 github.com/fiorix/go-diameter/v4 v4.0.1-0.20200102140015-a6c006d17e34 h1:rj7Jhd1mw5O2wxoDZmEbRj7qVUIlxi0jQiU/qm0qpvo=
 github.com/fiorix/go-diameter/v4 v4.0.1-0.20200102140015-a6c006d17e34/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=
+github.com/fiorix/go-diameter/v4 v4.0.1 h1:IEjXnzKDej/a1Z703XGfFbgvengXIBLuWLvAGWv+ZK8=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/raven-go v0.1.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=

--- a/feg/gateway/services/testcore/hss/hss/main.go
+++ b/feg/gateway/services/testcore/hss/hss/main.go
@@ -57,14 +57,14 @@ func main() {
 		}
 	}
 	// Start diameter server
-	startedChan := make(chan struct{}, 1)
+	startedChan := make(chan string, 1)
 	go func() {
 		log.Printf("Starting home subscriber server with configs:\n\t%+v", *servicer.Config)
 		err := servicer.Start(startedChan) // blocks
 		log.Fatal(err)
 	}()
-	<-startedChan
-	log.Printf("Started home subscriber server")
+	localAddr := <-startedChan
+	log.Printf("Started home subscriber server @ %s", localAddr)
 
 	// Run the service
 	err = srv.Run()

--- a/feg/gateway/services/testcore/hss/servicers/hss.go
+++ b/feg/gateway/services/testcore/hss/servicers/hss.go
@@ -114,9 +114,9 @@ func (srv *HomeSubscriberServer) DeregisterSubscriber(ctx context.Context, req *
 }
 
 // Start begins the server and blocks, listening to the network
-// Input: a channel to signal when the server is started
+// Input: a channel to signal when the server is started & return the local server address string
 // Output: error if the server could not be started
-func (srv *HomeSubscriberServer) Start(started chan struct{}) error {
+func (srv *HomeSubscriberServer) Start(started chan string) error {
 	serverCfg := srv.Config.Server
 	settings := &sm.Settings{
 		OriginHost:       datatype.DiameterIdentity(serverCfg.DestHost),
@@ -171,13 +171,11 @@ func (srv *HomeSubscriberServer) Start(started chan struct{}) error {
 	if err != nil {
 		return err
 	}
-	// If the port is 0 or not specified, overwriting the config allows the
-	// chosen port to be known by the application.
-	serverCfg.Address = listener.Addr().String()
+	localAddress := listener.Addr().String()
 	if cap(started) > len(started) {
-		started <- struct{}{}
+		started <- localAddress
 	} else {
-		go func() { started <- struct{}{} }() // non-buffered/full chan -> use a dedicated routine, it may block
+		go func() { started <- localAddress }() // non-buffered/full chan -> use a dedicated routine, it may block
 	}
 	return server.Serve(listener)
 }


### PR DESCRIPTION
Summary:
Change HSS Lite to not to modify "read only" configs on Start
HSS Lite needs to communicate back to the caller it's "real" local address when it's
started without preconfigured port. This kind of (port-less) configuration is used by
unit tests to avoid test failures due to port availability/conflicts.
Currently HSS Lite modifies its own config during blocking Start() call which is not
thread safe as well as non-obvious for the caller. This diff changes Start's completion
chan to be used to communicate local address as well as start completion.

Differential Revision: D19335959

