### PR TITLE
Make multitenant flag pull from env var

### DIFF
--- a/orc8r/cloud/docker/config-manager/supervisord.conf
+++ b/orc8r/cloud/docker/config-manager/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:prom_alertconfig]
-command=prometheus_configmanager -port=%(ENV_PROM_ALERTCONFIG_PORT)s -rules-dir=%(ENV_RULES_DIR)s -prometheusURL=%(ENV_PROMETHEUS_URL)s -multitenant
+command=prometheus_configmanager -port=%(ENV_PROM_ALERTCONFIG_PORT)s -rules-dir=%(ENV_RULES_DIR)s -prometheusURL=%(ENV_PROMETHEUS_URL)s -multitenant=%(ENV_MULTITENANT)s
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE

--- a/orc8r/cloud/docker/docker-compose.metrics.yml
+++ b/orc8r/cloud/docker/docker-compose.metrics.yml
@@ -44,6 +44,7 @@ services:
       - ALERTMANAGER_CONFIG_PORT=9101
       - ALERTMANAGER_CONF_PATH=/etc/configs/alertmanager.yml
       - ALERTMANAGER_URL=alertmanager:9093
+      - MULTITENANT=true
     restart: always
 
   grafana:

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/client.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/client.go
@@ -90,6 +90,12 @@ func (c *client) WriteRule(filePrefix string, rule rulefmt.Rule) error {
 	if err != nil {
 		return err
 	}
+	if c.multitenancy {
+		err = SecureRule(filePrefix, &rule)
+		if err != nil {
+			return err
+		}
+	}
 	ruleFile.AddRule(rule)
 
 	err = c.writeRuleFile(ruleFile, filename)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/fsclient"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert"
@@ -29,13 +30,14 @@ func main() {
 	port := flag.String("port", defaultPort, fmt.Sprintf("Port to listen for requests. Default is %s", defaultPort))
 	rulesDir := flag.String("rules-dir", ".", "Directory to write rules files. Default is '.'")
 	prometheusURL := flag.String("prometheusURL", defaultPrometheusURL, fmt.Sprintf("URL of the prometheus instance that is reading these rules. Default is %s", defaultPrometheusURL))
-	multitenancy := flag.Bool("multitenant", false, "Set this flag to enable multi-tenant support, having each tenant's alerts in a separate file")
+	multitenancy := flag.String("multitenant", "false", "Set this flag to enable multi-tenant support, having each tenant's alerts in a separate file")
 	flag.Parse()
 
 	e := echo.New()
 
 	fileLocks, err := alert.NewFileLocker(alert.NewDirectoryClient(*rulesDir))
-	alertClient := alert.NewClient(fileLocks, *rulesDir, *prometheusURL, fsclient.NewFSClient(), *multitenancy)
+	multitenancyBool, _ := strconv.ParseBool(*multitenancy)
+	alertClient := alert.NewClient(fileLocks, *rulesDir, *prometheusURL, fsclient.NewFSClient(), multitenancyBool)
 	if err != nil {
 		glog.Errorf("error creating alert client: %v", err)
 		return


### PR DESCRIPTION
Summary: This makes it easier to deploy configmanager as either multitenant or not.

Reviewed By: aclave1

Differential Revision: D19339000

