### PR TITLE
All services will trigger service_util.py to mark whether service restart was due to failure

### DIFF
--- a/orc8r/tools/ansible/roles/gateway_services/files/magma.service
+++ b/orc8r/tools/ansible/roles/gateway_services/files/magma.service
@@ -11,6 +11,7 @@ Description=Magma %i service
 Type=simple
 EnvironmentFile=/etc/environment
 ExecStart=/usr/bin/env python3 -m magma.%i.main
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py %i
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=%i


### PR DESCRIPTION
Summary: All gateway services are now covered after this change.

Differential Revision: D19351915

