### PR TITLE
Add swagger API docs for prometheus and alertmanager configurer

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/docs/swagger.yml
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/docs/swagger.yml
@@ -1,0 +1,283 @@
+---
+swagger: '2.0'
+info:
+  title: Alertmanager Configurer Model Definitions and Paths
+  description: Alertmanager Configurer REST APIs
+  version: 0.1.0
+
+paths:
+  /{tenant_id}/alert_receiver:
+    post:
+      summary: Create new alert receiver
+      tags:
+        - Receivers
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: body
+          name: receiver_config
+          description: Alert receiver that is to be added
+          required: true
+          schema:
+            $ref: '#/definitions/receiver_config'
+      responses:
+        '201':
+          description: Created
+        default:
+          $ref: '#/responses/UnexpectedError'
+    get:
+      summary: Retrive alert receivers
+      tags:
+        - Receivers
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+      responses:
+        '200':
+          description: List of alert receivers
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/receiver_config'
+        default:
+          $ref: '#/responses/UnexpectedError'
+    delete:
+      summary: Delete alert receiver
+      tags:
+        - Receivers
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: query
+          name: receiver
+          description: Receiver name to be deleted
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Deleted
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+  /{tenant_id}/receiver/{receiver_name}:
+    put:
+      summary: Update existing alert receiver
+      tags:
+        - Receivers
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: path
+          name: receiver_name
+          description: Name of receiver to be updated
+          required: true
+          type: string
+        - in: body
+          name: receiver_config
+          description: Updated alert receiver
+          required: true
+          schema:
+            $ref: '#/definitions/receiver_config'
+      responses:
+        '200':
+          description: Updated
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+  /{tenant_id}/receiver/route:
+    get:
+      summary: Retrieve alert routing tree
+      tags:
+        - Routes
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+      responses:
+        '200':
+          description: Alerting tree
+          schema:
+            $ref: '#/definitions/routing_tree'
+    post:
+      summary: Modify alert routing tree
+      tags:
+        - Routes
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: body
+          name: route
+          description: Alert routing tree to be used
+          required: true
+          schema:
+            $ref: '#/definitions/routing_tree'
+      responses:
+        '200':
+          description: OK
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+parameters:
+  tenant_id:
+    description: Tenant ID
+    in: path
+    name: tenant_id
+    required: true
+    type: string
+
+definitions:
+  receiver_config:
+    type: object
+    required:
+      - name
+    properties:
+      name:
+        type: string
+      slack_configs:
+        type: array
+        items:
+          $ref: '#/definitions/slack_receiver'
+
+  slack_receiver:
+    type: object
+    required:
+      - api_url
+    properties:
+      api_url:
+        type: string
+      channel:
+        type: string
+      username:
+        type: string
+      color:
+        type: string
+      title:
+        type: string
+      pretext:
+        type: string
+      text:
+        type: string
+      fields:
+        type: array
+        items:
+          $ref: '#/definitions/slack_field'
+      short_fields:
+        type: boolean
+      footer:
+        type: string
+      fallback:
+        type: string
+      callback_id:
+        type: string
+      icon_emoji:
+        type: string
+      icon_url:
+        type: string
+      image_url:
+        type: string
+      thumb_url:
+        type: string
+      link_names:
+        type: boolean
+      actions:
+        type: array
+        items:
+          $ref: '#/definitions/slack_action'
+
+  slack_field:
+    type: object
+    required:
+      - title
+      - value
+    properties:
+      title:
+        type: string
+      value:
+        type: string
+      short:
+        type: boolean
+
+  slack_action:
+    type: object
+    required:
+      - type
+      - text
+      - url
+    properties:
+      type:
+        type: string
+      text:
+        type: string
+      url:
+        type: string
+      style:
+        type: string
+      name:
+        type: string
+      value:
+        type: string
+      confirm:
+        $ref: '#/definitions/slack_confirm_field'
+
+  slack_confirm_field:
+    type: object
+    required:
+      - text
+      - title
+      - ok_text
+      - dismiss_text
+    properties:
+      text:
+        type: string
+      title:
+        type: string
+      ok_text:
+        type: string
+      dismiss_text:
+        type: string
+
+  routing_tree:
+    type: object
+    required:
+      - receiver
+    properties:
+      receiver:
+        type: string
+      group_by:
+        type: array
+        items:
+          type: string
+      match:
+        type: object
+        properties:
+          label:
+            type: string
+          value:
+            type: string
+      match_re:
+        type: object
+        properties:
+          label:
+            type: string
+          value:
+            type: string
+      continue:
+        type: boolean
+      routes:
+        type: array
+        items:
+          $ref: '#/definitions/routing_tree'
+      group_wait:
+        type: string
+      group_interval:
+        type: string
+      repeat_interval:
+        type: string
+
+  error:
+    type: object
+    required:
+      - message
+    properties:
+      message:
+        example: Error string
+        type: string
+
+responses:
+  UnexpectedError:
+    description: Unexpected Error
+    schema:
+      $ref: '#/definitions/error'

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/docs/swagger.yml
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/docs/swagger.yml
@@ -1,0 +1,164 @@
+---
+swagger: '2.0'
+info:
+  title: Prometheus Configurer Model Definitions and Paths
+  description: Prometheus Configurer REST APIs
+  version: 0.1.0
+
+paths:
+  /{tenant_id}/alert:
+    get:
+      summary: Retrieve alerting rule configurations
+      parameters:
+      - $ref: '#/parameters/tenant_id'
+      - in: query
+        name: alert_name
+        type: string
+        description: Optional name of alert to retrieve
+        required: false
+      responses:
+        '200':
+          description:
+            List of alert configurations
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/alert_config'
+        default:
+          $ref: '#/responses/UnexpectedError'
+    post:
+      summary: Configure alerting rule
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: body
+          name: alert_config
+          description: Alerting rule that is to be added
+          required: true
+          schema:
+            $ref: '#/definitions/alert_config'
+      responses:
+        '201':
+          description: Created
+        default:
+          $ref: '#/responses/UnexpectedError'
+    delete:
+      summary: Delete an alerting rule
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: query
+          name: alert_name
+          description: Name of alert to be deleted
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Deleted
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+  /{tenant_id}/alert/{alert_name}:
+    put:
+      summary: Update an existing alerting rule
+      parameters:
+      - $ref: '#/parameters/tenant_id'
+      - in: path
+        name: alert_name
+        description: Name of alert to be updated
+        required: true
+        type: string
+      - in: body
+        name: alert_config
+        description: Updated alerting rule
+        required: true
+        schema:
+          $ref: '#/definitions/alert_config'
+      responses:
+        '200':
+          description: Updated
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+  /{tenant_id}/alert/bulk:
+    put:
+      summary: Bulk update/create alerting rules
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: body
+          name: alert_configs
+          description: Alerting rules to be updated or created
+          required: true
+          schema:
+            $ref: '#/definitions/alert_config_list'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/alert_bulk_upload_response'
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+parameters:
+  tenant_id:
+    description: Tenant ID
+    in: path
+    name: tenant_id
+    required: true
+    type: string
+
+definitions:
+  alert_config:
+    type: object
+    required:
+      - alert
+      - expr
+    properties:
+      alert:
+        type: string
+      expr:
+        type: string
+      labels:
+        $ref: '#/definitions/alert_labels'
+      for:
+        type: string
+      annotations:
+        $ref: '#/definitions/alert_labels'
+
+  alert_config_list:
+    type: array
+    items:
+        $ref: '#/definitions/alert_config'
+
+  alert_bulk_upload_response:
+    type: object
+    required:
+      - errors
+      - statuses
+    properties:
+      errors:
+        type: object
+        additionalProperties:
+          type: string
+      statuses:
+        type: object
+        additionalProperties:
+          type: string
+
+  alert_labels:
+    type: object
+    additionalProperties:
+      type: string
+
+  error:
+    type: object
+    required:
+      - message
+    properties:
+      message:
+        example: Error string
+        type: string
+
+responses:
+  UnexpectedError:
+    description: Unexpected Error
+    schema:
+      $ref: '#/definitions/error'

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
@@ -47,6 +47,7 @@ func main() {
 	e.POST(AlertPath, GetConfigureAlertHandler(alertClient))
 	e.GET(AlertPath, GetRetrieveAlertHandler(alertClient))
 	e.DELETE(AlertPath, GetDeleteAlertHandler(alertClient))
+
 	e.PUT(AlertUpdatePath, GetUpdateAlertHandler(alertClient))
 
 	e.PUT(AlertBulkPath, GetBulkAlertUpdateHandler(alertClient))


### PR DESCRIPTION
Summary: Not dealing with hosting the interactive UI at all, the docs themselves should be useful enough. Will make developing on these products much easier. Also will be useful when I begin versioning and redesigning the API for v1.

Reviewed By: aclave1

Differential Revision: D19377230

