### PR TITLE
Fix no relay pipelined rule removal

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -65,7 +65,6 @@ class EnforcementStatsController(PolicyMixin, MagmaController):
         # No need to report usage if relay mode is not enabled.
         self._relay_enabled = kwargs['mconfig'].relay_enabled
         if not self._relay_enabled:
-            self.init_finished = True
             self.logger.info('Relay mode is not enabled. '
                              'enforcement_stats will not report usage.')
             return

--- a/lte/gateway/python/magma/pipelined/app/policy_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/policy_mixin.py
@@ -37,6 +37,10 @@ class PolicyMixin(metaclass=ABCMeta):
         self._rule_mapper = kwargs['rule_id_mapper']
         self._session_rule_version_mapper = kwargs[
             'session_rule_version_mapper']
+        self._relay_enabled = kwargs['mconfig'].relay_enabled
+        if not self._relay_enabled:
+            self.logger.info('Relay mode is not enabled, init finished')
+            self.init_finished = True
 
     def setup(self, requests: List[ActivateFlowsRequest],
               startup_flows: List[OFPFlowStats]) -> SetupFlowsResult:


### PR DESCRIPTION
Summary: pipelined currently fails to remove the rule when relay is disabled

Differential Revision: D19383001

