### PR TITLE
Pull prometheus query restrictor out of Obsidian

### DIFF
--- a/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
@@ -59,7 +59,7 @@ func GetTestSubscribers() []*protos.SubscriberData {
 	return subs
 }
 
-func generateDefaultSub(subscriberID string) *protos.SubscriberData{
+func generateDefaultSub(subscriberID string) *protos.SubscriberData {
 	// Default user
 	sub := &protos.SubscriberData{
 		Sid:       &protos.SubscriberID{Id: subscriberID},

--- a/orc8r/cloud/docker/docker-compose.metrics.yml
+++ b/orc8r/cloud/docker/docker-compose.metrics.yml
@@ -41,6 +41,7 @@ services:
       - '-port=9100'
       - '-rules-dir=/etc/configs/alert_rules'
       - '-prometheusURL=prometheus:9090'
+      - '-multitenant-label=networkID'
     restart: always
 
   alertmanager-configurer:

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/alert_rule.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/alert_rule.go
@@ -11,7 +11,7 @@ package alert
 import (
 	"fmt"
 
-	"magma/orc8r/cloud/go/services/metricsd/obsidian/security"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/restrictor"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
@@ -81,9 +81,9 @@ func (f *File) DeleteRule(name string) error {
 // to ensure that only metrics owned by this tenant can be alerted on
 func SecureRule(matcherName, matcherValue string, rule *rulefmt.Rule) error {
 	tenantLabels := map[string]string{matcherName: matcherValue}
-	restrictor := security.NewQueryRestrictor(tenantLabels)
+	queryRestrictor := restrictor.NewQueryRestrictor(networkLabels)
 
-	restrictedExpression, err := restrictor.RestrictQuery(rule.Expr)
+	restrictedExpression, err := queryRestrictor.RestrictQuery(rule.Expr)
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/alert_rule_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/alert_rule_test.go
@@ -11,7 +11,6 @@ package alert_test
 import (
 	"testing"
 
-	"magma/orc8r/cloud/go/metrics"
 	"magma/orc8r/cloud/go/services/metricsd/obsidian/security"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert"
 
@@ -90,24 +89,24 @@ func TestFile_DeleteRule(t *testing.T) {
 
 func TestSecureRule(t *testing.T) {
 	rule := sampleRule
-	err := alert.SecureRule("test", &rule)
+	err := alert.SecureRule("tenantID", "test", &rule)
 	assert.NoError(t, err)
 
-	networkLabels := map[string]string{metrics.NetworkLabelName: "test"}
-	restrictor := security.NewQueryRestrictor(networkLabels)
+	restrictorLabels := map[string]string{"tenantID": "test"}
+	restrictor := security.NewQueryRestrictor(restrictorLabels)
 	expectedExpr, _ := restrictor.RestrictQuery(sampleRule.Expr)
 
 	assert.Equal(t, expectedExpr, rule.Expr)
 	assert.Equal(t, 2, len(rule.Labels))
-	assert.Equal(t, "test", rule.Labels[metrics.NetworkLabelName])
+	assert.Equal(t, "test", rule.Labels["tenantID"])
 
 	existingNetworkIDRule := rulefmt.Rule{
 		Alert:  alertName2,
-		Expr:   `up{networkID="test"} == 0`,
-		Labels: map[string]string{"name": "value", "networkID": "test"},
+		Expr:   `up{tenantID="test"} == 0`,
+		Labels: map[string]string{"name": "value", "tenantID": "test"},
 	}
 	restricted, _ := restrictor.RestrictQuery(existingNetworkIDRule.Expr)
-	// assert networkID isn't appended twice
+	// assert tenantID isn't appended twice
 	assert.Equal(t, expectedExpr, restricted)
 	assert.Equal(t, 2, len(rule.Labels))
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/alert_rule_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/alert_rule_test.go
@@ -11,8 +11,8 @@ package alert_test
 import (
 	"testing"
 
-	"magma/orc8r/cloud/go/services/metricsd/obsidian/security"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/restrictor"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/pkg/rulefmt"
@@ -93,8 +93,8 @@ func TestSecureRule(t *testing.T) {
 	assert.NoError(t, err)
 
 	restrictorLabels := map[string]string{"tenantID": "test"}
-	restrictor := security.NewQueryRestrictor(restrictorLabels)
-	expectedExpr, _ := restrictor.RestrictQuery(sampleRule.Expr)
+	queryRestrictor := restrictor.NewQueryRestrictor(restrictorLabels)
+	expectedExpr, _ := queryRestrictor.RestrictQuery(sampleRule.Expr)
 
 	assert.Equal(t, expectedExpr, rule.Expr)
 	assert.Equal(t, 2, len(rule.Labels))
@@ -105,7 +105,7 @@ func TestSecureRule(t *testing.T) {
 		Expr:   `up{tenantID="test"} == 0`,
 		Labels: map[string]string{"name": "value", "tenantID": "test"},
 	}
-	restricted, _ := restrictor.RestrictQuery(existingNetworkIDRule.Expr)
+	restricted, _ := queryRestrictor.RestrictQuery(existingNetworkIDRule.Expr)
 	// assert tenantID isn't appended twice
 	assert.Equal(t, expectedExpr, restricted)
 	assert.Equal(t, 2, len(rule.Labels))

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/client_test.go
@@ -26,17 +26,17 @@ const (
 - name: test
   rules:
   - alert: test_rule_1
-    expr: up == 0{networkID="test"}
+    expr: up == 0{tenantID="test"}
     for: 5s
     labels:
       severity: major
-      networkID: test
+      tenantID: test
   - alert: test_rule_2
-    expr: up == 1{networkID="test"}
+    expr: up == 1{tenantID="test"}
     for: 5s
     labels:
       severity: critical
-      networkID: test
+      tenantID: test
     annotations:
       summary: A test rule`
 
@@ -45,17 +45,17 @@ const (
 - name: other
   rules:
   - alert: other_rule_1
-    expr: up == 0{networkID="other"}
+    expr: up == 0{tenantID="other"}
     for: 5s
     labels:
       severity: major
-      networkID: other
+      tenantID: other
   - alert: test_rule_2
-    expr: up == 1{networkID="other"}
+    expr: up == 1{tenantID="other"}
     for: 5s
     labels:
       severity: critical
-      networkID: other
+      tenantID: other
     annotations:
       summary: A test rule`
 )
@@ -66,7 +66,7 @@ var (
 		Alert:  "test_rule_1",
 		Expr:   "up==0",
 		For:    fiveSeconds,
-		Labels: map[string]string{"severity": "major", "networkID": testNID},
+		Labels: map[string]string{"severity": "major", "tenantID": testNID},
 	}
 	badRule = rulefmt.Rule{
 		Alert: "bad_rule",
@@ -75,7 +75,7 @@ var (
 )
 
 func TestClient_ValidateRule(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 
 	err := client.ValidateRule(sampleRule)
 	assert.NoError(t, err)
@@ -89,7 +89,7 @@ func TestClient_ValidateRule(t *testing.T) {
 	assert.Error(t, err)
 }
 func TestClient_RuleExists(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 	assert.True(t, client.RuleExists(testNID, "test_rule_1"))
 	assert.True(t, client.RuleExists(testNID, "test_rule_2"))
 	assert.False(t, client.RuleExists(testNID, "no_rule"))
@@ -102,13 +102,13 @@ func TestClient_RuleExists(t *testing.T) {
 }
 
 func TestClient_WriteRule(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 	err := client.WriteRule(testNID, sampleRule)
 	assert.NoError(t, err)
 }
 
 func TestClient_UpdateRule(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 
 	err := client.UpdateRule(testNID, testRule1)
 	assert.NoError(t, err)
@@ -119,7 +119,7 @@ func TestClient_UpdateRule(t *testing.T) {
 }
 
 func TestClient_ReadRules(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 
 	rules, err := client.ReadRules(testNID, "")
 	assert.NoError(t, err)
@@ -144,7 +144,7 @@ func TestClient_ReadRules(t *testing.T) {
 }
 
 func TestClient_DeleteRule(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 	err := client.DeleteRule(testNID, "test_rule_1")
 	assert.NoError(t, err)
 
@@ -153,7 +153,7 @@ func TestClient_DeleteRule(t *testing.T) {
 }
 
 func TestClient_BulkUpdateRules(t *testing.T) {
-	client := newTestClient(true)
+	client := newTestClient("tenantID")
 	results, err := client.BulkUpdateRules(testNID, []rulefmt.Rule{sampleRule, testRule1})
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(results.Statuses))
@@ -165,7 +165,7 @@ func TestClient_BulkUpdateRules(t *testing.T) {
 	assert.Equal(t, 1, len(results.Errors))
 }
 
-func newTestClient(multitenant bool) alert.PrometheusAlertClient {
+func newTestClient(multitenantLabel string) alert.PrometheusAlertClient {
 	dClient := newHealthyDirClient("test")
 	fileLocks, _ := alert.NewFileLocker(dClient)
 	fsClient := &mocks.FSClient{}
@@ -173,5 +173,5 @@ func newTestClient(multitenant bool) alert.PrometheusAlertClient {
 	fsClient.On("ReadFile", "test_rules/test_rules.yml").Return([]byte(testRuleFile), nil)
 	fsClient.On("ReadFile", "test_rules/other_rules.yml").Return([]byte(otherRuleFile), nil)
 	fsClient.On("WriteFile", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	return alert.NewClient(fileLocks, "test_rules", "prometheus-host.com", fsClient, multitenant)
+	return alert.NewClient(fileLocks, "test_rules", "prometheus-host.com", fsClient, multitenantLabel)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/mocks/PrometheusAlertClient.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert/mocks/PrometheusAlertClient.go
@@ -101,6 +101,22 @@ func (_m *PrometheusAlertClient) RuleExists(filePrefix string, rulename string) 
 	return r0
 }
 
+// Tenancy provides a mock function with given fields:
+func (_m *PrometheusAlertClient) Tenancy() *alert.TenancyConfig {
+	ret := _m.Called()
+
+	var r0 *alert.TenancyConfig
+	if rf, ok := ret.Get(0).(func() *alert.TenancyConfig); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*alert.TenancyConfig)
+		}
+	}
+
+	return r0
+}
+
 // UpdateRule provides a mock function with given fields: filePrefix, rule
 func (_m *PrometheusAlertClient) UpdateRule(filePrefix string, rule rulefmt.Rule) error {
 	ret := _m.Called(filePrefix, rule)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/docs/swagger-v1.yml
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/docs/swagger-v1.yml
@@ -1,0 +1,162 @@
+---
+swagger: '2.0'
+info:
+  title: Prometheus Configurer Model Definitions and Paths
+  description: Prometheus Configurer REST APIs
+  version: 1.0.0
+
+paths:
+  /alert:
+    get:
+      summary: Retrieve alerting rule configurations
+      parameters:
+      - $ref: '#/parameters/tenant_id'
+      - in: query
+        name: alert_name
+        type: string
+        description: Optional name of alert to retrieve
+        required: false
+      responses:
+        '200':
+          description:
+            List of alert configurations
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/alert_config'
+        default:
+          $ref: '#/responses/UnexpectedError'
+    post:
+      summary: Configure alerting rule
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: body
+          name: alert_config
+          description: Alerting rule that is to be added
+          required: true
+          schema:
+            $ref: '#/definitions/alert_config'
+      responses:
+        '201':
+          description: Created
+        default:
+          $ref: '#/responses/UnexpectedError'
+    delete:
+      summary: Delete an alerting rule
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: query
+          name: alert_name
+          description: Name of alert to be deleted
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Deleted
+        default:
+          $ref: '#/responses/UnexpectedError'
+    put:
+      summary: Update an existing alerting rule
+      parameters:
+      - $ref: '#/parameters/tenant_id'
+      - in: query
+        name: alert_name
+        description: Name of alert to be updated
+        required: true
+        type: string
+      - in: body
+        name: alert_config
+        description: Updated alerting rule
+        required: true
+        schema:
+          $ref: '#/definitions/alert_config'
+      responses:
+        '200':
+          description: Updated
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+  /alert/bulk:
+    put:
+      summary: Bulk update/create alerting rules
+      parameters:
+        - $ref: '#/parameters/tenant_id'
+        - in: body
+          name: alert_configs
+          description: Alerting rules to be updated or created
+          required: true
+          schema:
+            $ref: '#/definitions/alert_config_list'
+      responses:
+        '200':
+          description: Success
+          schema:
+            $ref: '#/definitions/alert_bulk_upload_response'
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+parameters:
+  tenant_id:
+    description: Tenant ID
+    in: query
+    name: tenant_id
+    required: false
+    type: string
+
+definitions:
+  alert_config:
+    type: object
+    required:
+      - alert
+      - expr
+    properties:
+      alert:
+        type: string
+      expr:
+        type: string
+      labels:
+        $ref: '#/definitions/alert_labels'
+      for:
+        type: string
+      annotations:
+        $ref: '#/definitions/alert_labels'
+
+  alert_config_list:
+    type: array
+    items:
+        $ref: '#/definitions/alert_config'
+
+  alert_bulk_upload_response:
+    type: object
+    required:
+      - errors
+      - statuses
+    properties:
+      errors:
+        type: object
+        additionalProperties:
+          type: string
+      statuses:
+        type: object
+        additionalProperties:
+          type: string
+
+  alert_labels:
+    type: object
+    additionalProperties:
+      type: string
+
+  error:
+    type: object
+    required:
+      - message
+    properties:
+      message:
+        example: Error string
+        type: string
+
+responses:
+  UnexpectedError:
+    description: Unexpected Error
+    schema:
+      $ref: '#/definitions/error'

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/handlers.go
@@ -22,14 +22,48 @@ import (
 )
 
 const (
-	rootPath        = "/:file_prefix"
+	rootPath        = "/:tenant_id"
 	AlertPath       = rootPath + "/alert"
 	AlertUpdatePath = AlertPath + "/:" + RuleNamePathParam
 	AlertBulkPath   = AlertPath + "/bulk"
 
 	ruleNameQueryParam = "alert_name"
 	RuleNamePathParam  = "alert_name"
+
+	tenantIDParam = "tenant_id"
 )
+
+func statusHandler(c echo.Context) error {
+	return c.String(http.StatusOK, "Prometheus Config server")
+}
+
+func RegisterV0Handlers(e *echo.Echo, alertClient alert.PrometheusAlertClient) {
+	e.GET("/", statusHandler)
+
+	e.POST(AlertPath, GetConfigureAlertHandler(alertClient))
+	e.GET(AlertPath, GetRetrieveAlertHandler(alertClient))
+	e.DELETE(AlertPath, GetDeleteAlertHandler(alertClient))
+
+	e.PUT(AlertUpdatePath, GetUpdateAlertHandler(alertClient))
+
+	e.PUT(AlertBulkPath, GetBulkAlertUpdateHandler(alertClient))
+
+	e.Use(tenancyMiddlewareProvider(alertClient))
+}
+
+// Returns middleware func to check for tenant_id dependent on tenancy of the client
+func tenancyMiddlewareProvider(client alert.PrometheusAlertClient) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			providedTenantID := c.Param(tenantIDParam)
+			if client.Tenancy() != nil && providedTenantID == "" {
+				return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Must provide tenant_id parameter"))
+			}
+			c.Set(tenantIDParam, providedTenantID)
+			return next(c)
+		}
+	}
+}
 
 // GetConfigureAlertHandler returns a handler that calls the client method WriteAlert() to
 // write the alert configuration from the body of this request
@@ -39,18 +73,18 @@ func GetConfigureAlertHandler(client alert.PrometheusAlertClient) func(c echo.Co
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
-		filePrefix := getFilePrefix(c)
+		tenantID := c.Get(tenantIDParam).(string)
 
 		err = client.ValidateRule(rule)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
-		if client.RuleExists(filePrefix, rule.Alert) {
+		if client.RuleExists(tenantID, rule.Alert) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rule '%s' already exists", rule.Alert))
 		}
 
-		err = client.WriteRule(filePrefix, rule)
+		err = client.WriteRule(tenantID, rule)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -66,8 +100,9 @@ func GetConfigureAlertHandler(client alert.PrometheusAlertClient) func(c echo.Co
 func GetRetrieveAlertHandler(client alert.PrometheusAlertClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ruleName := c.QueryParam(ruleNameQueryParam)
-		filePrefix := getFilePrefix(c)
-		rules, err := client.ReadRules(filePrefix, ruleName)
+		tenantID := c.Get(tenantIDParam).(string)
+
+		rules, err := client.ReadRules(tenantID, ruleName)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -83,11 +118,12 @@ func GetRetrieveAlertHandler(client alert.PrometheusAlertClient) func(c echo.Con
 func GetDeleteAlertHandler(client alert.PrometheusAlertClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ruleName := c.QueryParam(ruleNameQueryParam)
-		filePrefix := getFilePrefix(c)
+		tenantID := c.Get(tenantIDParam).(string)
+
 		if ruleName == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "No rule name provided")
 		}
-		err := client.DeleteRule(filePrefix, ruleName)
+		err := client.DeleteRule(tenantID, ruleName)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -102,12 +138,13 @@ func GetDeleteAlertHandler(client alert.PrometheusAlertClient) func(c echo.Conte
 func GetUpdateAlertHandler(client alert.PrometheusAlertClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
 		ruleName := c.Param(RuleNamePathParam)
-		filePrefix := getFilePrefix(c)
+		tenantID := c.Get(tenantIDParam).(string)
+
 		if ruleName == "" {
 			return echo.NewHTTPError(http.StatusBadRequest, "No rule name provided")
 		}
 
-		if !client.RuleExists(filePrefix, ruleName) {
+		if !client.RuleExists(tenantID, ruleName) {
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("Rule '%s' does not exist", ruleName))
 		}
 
@@ -121,7 +158,7 @@ func GetUpdateAlertHandler(client alert.PrometheusAlertClient) func(c echo.Conte
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
 
-		err = client.UpdateRule(filePrefix, rule)
+		err = client.UpdateRule(tenantID, rule)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 		}
@@ -136,7 +173,7 @@ func GetUpdateAlertHandler(client alert.PrometheusAlertClient) func(c echo.Conte
 
 func GetBulkAlertUpdateHandler(client alert.PrometheusAlertClient) func(c echo.Context) error {
 	return func(c echo.Context) error {
-		filePrefix := getFilePrefix(c)
+		tenantID := c.Get(tenantIDParam).(string)
 
 		rules, err := decodeBulkRulesPostRequest(c)
 		if err != nil {
@@ -150,7 +187,7 @@ func GetBulkAlertUpdateHandler(client alert.PrometheusAlertClient) func(c echo.C
 			}
 		}
 
-		results, err := client.BulkUpdateRules(filePrefix, rules)
+		results, err := client.BulkUpdateRules(tenantID, rules)
 		if err != nil {
 			return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 		}
@@ -196,10 +233,6 @@ func decodeBulkRulesPostRequest(c echo.Context) ([]rulefmt.Rule, error) {
 	return payload, nil
 }
 
-func getFilePrefix(c echo.Context) string {
-	return c.Param("file_prefix")
-}
-
 func rulesToJSON(rules []rulefmt.Rule) ([]alert.RuleJSONWrapper, error) {
 	ret := make([]alert.RuleJSONWrapper, 0)
 
@@ -226,5 +259,4 @@ func rulefmtToJSON(rule rulefmt.Rule) (*alert.RuleJSONWrapper, error) {
 		Labels:      rule.Labels,
 		Annotations: rule.Annotations,
 	}, nil
-
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/handlers_test.go
@@ -276,9 +276,10 @@ func TestGetBulkAlertUpdateHandler(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	c := echo.New().NewContext(req, rec)
-	c.SetPath("/networks/:file_prefix/prometheus/alert_config/bulk")
+	c.SetPath("/:file_prefix/alert/bulk")
 	c.SetParamNames("file_prefix")
 	c.SetParamValues(testNID)
+	c.Set(tenantIDParam, testNID)
 
 	err = GetBulkAlertUpdateHandler(client)(c)
 	assert.NoError(t, err)
@@ -291,13 +292,14 @@ func TestGetBulkAlertUpdateHandler(t *testing.T) {
 	assert.Equal(t, sampleUpdateResult, results)
 }
 
-func buildContext(body interface{}, method, target, path, networkID string) (echo.Context, *httptest.ResponseRecorder) {
+func buildContext(body interface{}, method, target, path, tenantID string) (echo.Context, *httptest.ResponseRecorder) {
 	bytes, _ := json.Marshal(body)
 	req := httptest.NewRequest(method, target, strings.NewReader(string(bytes)))
 	rec := httptest.NewRecorder()
 	c := echo.New().NewContext(req, rec)
 	c.SetPath(path)
 	c.SetParamNames("file_prefix")
-	c.SetParamValues(networkID)
+	c.SetParamValues(tenantID)
+	c.Set(tenantIDParam, tenantID) // to emulate middleware
 	return c, rec
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/handlers_test.go
@@ -188,7 +188,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	c.SetParamNames("file_prefix", RuleNamePathParam)
 	c.SetParamValues(testNID, sampleAlert1.Alert)
 
-	err := GetUpdateAlertHandler(client)(c)
+	err := GetUpdateAlertHandler(client, pathAlertNameProvider)(c)
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	client.AssertExpectations(t)
@@ -197,7 +197,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	client = &mocks.PrometheusAlertClient{}
 	c, _ = buildContext(sampleAlert1, http.MethodPut, "/", AlertPath, testNID)
 
-	err = GetUpdateAlertHandler(client)(c)
+	err = GetUpdateAlertHandler(client, pathAlertNameProvider)(c)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
 	assert.EqualError(t, err, `code=400, message=No rule name provided`)
 	client.AssertExpectations(t)
@@ -209,7 +209,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	c.SetParamNames("file_prefix", RuleNamePathParam)
 	c.SetParamValues(testNID, sampleAlert1.Alert)
 
-	err = GetUpdateAlertHandler(client)(c)
+	err = GetUpdateAlertHandler(client, pathAlertNameProvider)(c)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
 	assert.EqualError(t, err, `code=400, message=Rule 'testAlert1' does not exist`)
 	client.AssertExpectations(t)
@@ -222,7 +222,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	c.SetParamNames("file_prefix", RuleNamePathParam)
 	c.SetParamValues(testNID, sampleAlert1.Alert)
 
-	err = GetUpdateAlertHandler(client)(c)
+	err = GetUpdateAlertHandler(client, pathAlertNameProvider)(c)
 	assert.Equal(t, http.StatusBadRequest, err.(*echo.HTTPError).Code)
 	assert.EqualError(t, err, `code=400, message=error`)
 	client.AssertExpectations(t)
@@ -236,7 +236,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	c.SetParamNames("file_prefix", RuleNamePathParam)
 	c.SetParamValues(testNID, sampleAlert1.Alert)
 
-	err = GetUpdateAlertHandler(client)(c)
+	err = GetUpdateAlertHandler(client, pathAlertNameProvider)(c)
 	assert.Equal(t, http.StatusInternalServerError, err.(*echo.HTTPError).Code)
 	assert.EqualError(t, err, `code=500, message=error`)
 	client.AssertExpectations(t)
@@ -251,7 +251,7 @@ func TestUpdateAlertHandler(t *testing.T) {
 	c.SetParamNames("file_prefix", RuleNamePathParam)
 	c.SetParamValues(testNID, sampleAlert1.Alert)
 
-	err = GetUpdateAlertHandler(client)(c)
+	err = GetUpdateAlertHandler(client, pathAlertNameProvider)(c)
 	assert.Equal(t, http.StatusInternalServerError, err.(*echo.HTTPError).Code)
 	assert.EqualError(t, err, `code=500, message=error`)
 	client.AssertExpectations(t)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
@@ -41,6 +41,7 @@ func main() {
 	}
 
 	RegisterV0Handlers(e, alertClient)
+	RegisterV1Handlers(e, alertClient)
 
 	glog.Infof("Prometheus Config server listening on port: %s\n", *port)
 	e.Logger.Fatal(e.Start(fmt.Sprintf(":%s", *port)))

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -120,7 +120,7 @@ func configurePrometheusAlert(networkID, url string, c echo.Context) error {
 		return obsidian.HttpError(fmt.Errorf("misconfigured rule: %v", err), http.StatusBadRequest)
 	}
 
-	err = alert.SecureRule(networkID, &rule)
+	err = alert.SecureRule(metrics.NetworkLabelName, networkID, &rule)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/restrictor/query_restrictor.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/restrictor/query_restrictor.go
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package security
+package restrictor
 
 import (
 	"fmt"

--- a/orc8r/cloud/go/services/metricsd/prometheus/restrictor/query_restrictor_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/restrictor/query_restrictor_test.go
@@ -6,7 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package security
+package restrictor
 
 import (
 	"testing"

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus-configurer.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus-configurer.deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - "-port={{ .Values.prometheusConfigurer.prometheusConfigurerPort }}"
             - "-rules-dir={{ .Values.prometheusConfigurer.rulesDir }}"
             - "-prometheusURL={{ .Values.prometheusConfigurer.prometheusURL }}"
-            - "-multitenant=true"
+            - "-multitenant-label=networkID"
           resources:
 {{ toYaml .Values.prometheusConfigurer.resources | indent 12 }}
 {{- end }}


### PR DESCRIPTION
Summary: As part of the decoupling of metrics components from magma it makes sense to move the query restrictor to it's own directory under prometheus since it's used throughout many prometheus components

Differential Revision: D19418788

