### PR TITLE
Add streamer callback functionality for receiving updates on IMSI -> policy mappings

### DIFF
--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -8,17 +8,18 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import logging
-
 from lte.protos.mconfig import mconfigs_pb2
+from lte.protos.session_manager_pb2_grpc import SessionProxyResponderStub
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
 from magma.common.service import MagmaService
 from magma.common.service_registry import ServiceRegistry
 from magma.common.streamer import StreamerClient
 from magma.policydb.rpc_servicer import SessionRpcServicer
-
+from magma.policydb.basename_store import BaseNameDict
+from magma.policydb.reauth_handler import ReAuthHandler
+from magma.policydb.rule_map_store import RuleAssignmentsDict
 from .streamer_callback import PolicyDBStreamerCallback, \
-    RuleMappingsStreamerCallback, BaseNamesStreamerCallback
-from .basename_store import BaseNameDict
+    RuleMappingsStreamerCallback
 
 
 def main():
@@ -32,13 +33,22 @@ def main():
     session_servicer = SessionRpcServicer(service.mconfig, subscriberdb_stub)
     session_servicer.add_to_server(service.rpc_server)
 
+    assignments_dict = RuleAssignmentsDict()
+    basenames_dict = BaseNameDict()
+    sessiond_chan = ServiceRegistry.get_rpc_channel('sessiond',
+                                                    ServiceRegistry.LOCAL)
+    sessiond_stub = SessionProxyResponderStub(sessiond_chan)
+    reauth_handler = ReAuthHandler(assignments_dict, sessiond_stub)
+
     # Start a background thread to stream updates from the cloud
     if service.config['enable_streaming']:
         stream = StreamerClient(
             {
                 'policydb': PolicyDBStreamerCallback(),
-                'rule_mappings': RuleMappingsStreamerCallback(),
-                'base_names': BaseNamesStreamerCallback(BaseNameDict()),
+                'rule_mappings': RuleMappingsStreamerCallback(reauth_handler,
+                                                              basenames_dict,
+                                                              assignments_dict),
+
             },
             service.loop,
         )

--- a/lte/gateway/python/magma/policydb/reauth_handler.py
+++ b/lte/gateway/python/magma/policydb/reauth_handler.py
@@ -1,0 +1,94 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import grpc
+import logging
+from typing import Set
+from lte.protos.policydb_pb2 import InstalledPolicies
+from lte.protos.session_manager_pb2 import PolicyReAuthRequest, \
+    PolicyReAuthAnswer, ReAuthResult
+from lte.protos.session_manager_pb2_grpc import SessionProxyResponderStub
+from magma.policydb.rule_map_store import RuleAssignmentsDict
+
+
+class ReAuthHandler():
+    """
+    Handles making the RAR to sessiond, and updating Redis with the current
+    active policies for subscribers
+    """
+
+    def __init__(
+        self,
+        rules_by_sid: RuleAssignmentsDict,
+        sessiond_stub: SessionProxyResponderStub,
+    ):
+        self._rules_by_sid = rules_by_sid
+        self._sessiond_stub = sessiond_stub
+
+    def handle_policy_re_auth(self, rar: PolicyReAuthRequest) -> bool:
+        """
+        Take the RAR and make the request to sessiond
+
+        Returns whether the call was successful. Partial updates count as
+        success.
+        """
+        if not self._is_valid_rar(rar):
+            logging.error('Invalid RAR: Either installing already installed '
+                          'rules, or uninstalling rules that are not installed')
+            return False
+        try:
+            resp = self._sessiond_stub.PolicyReAuth(rar)
+            return self._handle_rar_answer(rar, resp)
+        except grpc.RpcError:
+            logging.error('Unable to apply policy updates for subscriber %s',
+                          rar.imsi)
+            return False
+
+    def _is_valid_rar(self, rar: PolicyReAuthRequest) -> bool:
+        """
+        Return false if the RAR is invalid
+        RAR is invalid if attempting to remove rules that are not installed,
+        or trying to add rules that are already installed.
+        """
+        prev_rules = self._get_prev_policies(rar.imsi)
+        install = {rule.rule_id for rule in rar.rules_to_install}
+        if install & prev_rules:
+            return False
+        if len(set(rar.rules_to_remove) - prev_rules) > 0:
+            return False
+        return True
+
+    def _handle_rar_answer(
+        self,
+        rar: PolicyReAuthRequest,
+        answer: PolicyReAuthAnswer,
+    ) -> bool:
+        if answer.result == ReAuthResult.Value('OTHER_FAILURE'):
+            logging.error('Failed to apply policy updates for subscriber %s',
+                          rar.imsi)
+            return False
+        self._rules_by_sid[rar.imsi] = InstalledPolicies(
+            installed_policies=list(self._get_updated_rules(rar, answer)),
+        )
+        return True
+
+    def _get_updated_rules(
+        self,
+        rar: PolicyReAuthRequest,
+        answer: PolicyReAuthAnswer,
+    ) -> Set[str]:
+        failed = set(answer.failed_rules)
+        installed = {rule.rule_id for rule in rar.rules_to_install} - failed
+        uninstalled = set(rar.rules_to_remove) - failed
+        return (self._get_prev_policies(rar.imsi) | installed) - uninstalled
+
+    def _get_prev_policies(self, subscriber_id: str) -> Set[str]:
+        if subscriber_id not in self._rules_by_sid:
+            return set()
+        return set(self._rules_by_sid[subscriber_id].installed_policies)

--- a/lte/gateway/python/magma/policydb/streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/streamer_callback.py
@@ -8,15 +8,17 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import logging
-from typing import Any, List
-
-from lte.protos.policydb_pb2 import AssignedPolicies, PolicyRule, \
+from typing import Any, List, Set
+from lte.protos.policydb_pb2 import AssignedPolicies, PolicyRule,\
     ChargingRuleNameSet
+from lte.protos.session_manager_pb2 import PolicyReAuthRequest,\
+    StaticRuleInstall
 from magma.common.streamer import StreamerClient
 from orc8r.protos.streamer_pb2 import DataUpdate
-
-from .basename_store import BaseNameDict
-from .rule_store import PolicyRuleDict
+from magma.policydb.reauth_handler import ReAuthHandler
+from magma.policydb.rule_map_store import RuleAssignmentsDict
+from magma.policydb.rule_store import PolicyRuleDict
+from magma.policydb.basename_store import BaseNameDict
 
 
 class PolicyDBStreamerCallback(StreamerClient.Callback):
@@ -87,8 +89,15 @@ class RuleMappingsStreamerCallback(StreamerClient.Callback):
     Callback for the rule mapping streamer policy which persists the policies
     and basenames active for a subscriber.
     """
-    def __init__(self):
-        pass
+    def __init__(
+        self,
+        reauth_handler: ReAuthHandler,
+        rules_by_basename: BaseNameDict,
+        rules_by_sid: RuleAssignmentsDict,
+    ):
+        self._reauth_handler = reauth_handler
+        self._rules_by_basename = rules_by_basename
+        self._rules_by_sid = rules_by_sid
 
     def get_request_args(self, stream_name: str) -> Any:
         return None
@@ -96,10 +105,70 @@ class RuleMappingsStreamerCallback(StreamerClient.Callback):
     def process_update(self, stream_name: str, updates: List[DataUpdate],
                        resync: bool):
         logging.info('Processing %d SID -> policy updates', len(updates))
-        policies_by_sid = {}
         for update in updates:
             policies = AssignedPolicies()
             policies.ParseFromString(update.value)
-            policies_by_sid[update.key] = policies
+            self._handle_update(update.key, policies)
 
         # TODO: delta with state in Redis, send RARs, persist new state
+
+    def _handle_update(
+        self,
+        subscriber_id: str,
+        assigned_policies: AssignedPolicies,
+    ):
+        """
+        Based on the streamed updates, find the delta in added and removed
+        rules. Then make a RAR to send to sessiond. If all goes successfully,
+        update Redis with the currently installed policies for the subscriber.
+        """
+        prev_rules = self._get_prev_policies(subscriber_id)
+        desired_rules = self._get_desired_rules(assigned_policies)
+
+        rar = self._generate_rar(subscriber_id,
+                                 list(desired_rules - prev_rules),
+                                 list(prev_rules - desired_rules))
+        self._reauth_handler.handle_policy_re_auth(rar)
+
+    def _get_desired_rules(
+        self,
+        assigned_policies: AssignedPolicies,
+    ) -> Set[str]:
+        """
+        Get the desired list of all rules that should be installed for the
+        subscriber. This is built with a combination of base names and the
+        assigned policies.
+        """
+        desired_rules = set(assigned_policies.assigned_policies)
+        for basename in assigned_policies.assigned_base_names:
+            if basename not in self._rules_by_basename:
+                # They will be installed when we get the basename definition
+                # streamed down from orc8r
+                continue
+            desired_rules.update(self._rules_by_basename[basename].RuleNames)
+        return desired_rules
+
+    def _get_prev_policies(self, subscriber_id: str) -> Set[str]:
+        if subscriber_id not in self._rules_by_sid:
+            return set()
+        return set(self._rules_by_sid[subscriber_id].installed_policies)
+
+    def _generate_rar(
+        self,
+        subscriber_id: str,
+        added_rules: List[str],
+        removed_rules: List[str],
+    ) -> PolicyReAuthRequest:
+        rules_to_install = [
+            StaticRuleInstall(rule_id=rule_id) for rule_id in added_rules
+        ]
+        return PolicyReAuthRequest(
+            # Skip the session ID, so apply to all sessions of the subscriber
+            imsi=subscriber_id,
+            rules_to_install=rules_to_install,
+            rules_to_remove=removed_rules,
+            # No changes to dynamic rules
+            # No event triggers
+            # No additional usage monitoring credits
+            # No QoS info
+        )

--- a/lte/gateway/python/magma/policydb/tests/test_reauth_handler.py
+++ b/lte/gateway/python/magma/policydb/tests/test_reauth_handler.py
@@ -1,0 +1,66 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+from lte.protos.session_manager_pb2 import PolicyReAuthRequest, \
+    PolicyReAuthAnswer, ReAuthResult, StaticRuleInstall, PolicyReAuthRequest
+from magma.policydb.reauth_handler import ReAuthHandler
+
+
+class MockSessionProxyResponderStub:
+    """
+    This Mock SessionProxyResponderStub will always respond with a success to
+    a received RAR
+    """
+    def __init__(self):
+        pass
+
+    def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
+        return PolicyReAuthAnswer(
+            result=ReAuthResult.Value('UPDATE_INITIATED')
+        )
+
+
+class RuleMappingsStreamerCallbackTest(unittest.TestCase):
+    def test_SuccessfulUpdate(self):
+        """
+        Test the happy path where updates come in for added rules, and sessiond
+        accepts the RAR without issue.
+        """
+        install_dict = {}
+        handler = ReAuthHandler(
+            install_dict,
+            MockSessionProxyResponderStub(),
+        )
+
+        rar = PolicyReAuthRequest(
+            imsi='s1',
+            rules_to_install=[
+                StaticRuleInstall(rule_id=rule_id) for rule_id in ['p1', 'p2']
+            ],
+        )
+        handler.handle_policy_re_auth(rar)
+        s1_policies = install_dict['s1'].installed_policies
+        expected = 2
+        self.assertEqual(len(s1_policies), expected,
+                         'There should be 2 installed policies for s1')
+        self.assertTrue('p1' in s1_policies,
+                        'Policy p1 should be marked installed for p1')
+
+        rar = PolicyReAuthRequest(
+            imsi='s1',
+            rules_to_install=[StaticRuleInstall(rule_id='p3')],
+        )
+        handler.handle_policy_re_auth(rar)
+        s1_policies = install_dict['s1'].installed_policies
+        expected = 3
+        self.assertEqual(len(s1_policies), expected,
+                         'There should be 3 installed policies for s1')
+        self.assertTrue('p3' in s1_policies,
+                        'Policy p1 should be marked installed for p1')

--- a/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
@@ -1,0 +1,261 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+from lte.protos.policydb_pb2 import AssignedPolicies, ChargingRuleNameSet
+from lte.protos.session_manager_pb2 import PolicyReAuthRequest, \
+    PolicyReAuthAnswer, ReAuthResult
+from magma.policydb.streamer_callback import RuleMappingsStreamerCallback
+from magma.policydb.reauth_handler import ReAuthHandler
+from orc8r.protos.streamer_pb2 import DataUpdate
+
+
+class MockSessionProxyResponderStub1:
+    """
+    This Mock SessionProxyResponderStub will always respond with a success to
+    a received RAR
+    """
+    def __init__(self):
+        pass
+
+    def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
+        return PolicyReAuthAnswer(
+            result=ReAuthResult.Value('UPDATE_INITIATED')
+        )
+
+
+class MockSessionProxyResponderStub2:
+    """
+    This Mock SessionProxyResponderStub will always respond with a failure to
+    a received RAR
+    """
+    def __init__(self):
+        pass
+
+    def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
+        return PolicyReAuthAnswer(
+            result=ReAuthResult.Value('OTHER_FAILURE')
+        )
+
+
+class MockSessionProxyResponderStub3:
+    """
+    This Mock SessionProxyResponderStub will always fail to install rule p2
+    """
+    def __init__(self):
+        pass
+
+    def PolicyReAuth(self, _: PolicyReAuthRequest) -> PolicyReAuthAnswer:
+        return PolicyReAuthAnswer(
+            result=ReAuthResult.Value('UPDATE_INITIATED'),
+            failed_rules={
+                "p2": PolicyReAuthAnswer.FailureCode.Value("UNKNOWN_RULE_NAME"),
+            },
+        )
+
+
+class RuleMappingsStreamerCallbackTest(unittest.TestCase):
+    def test_SuccessfulUpdate(self):
+        """
+        Test the happy path where updates come in for added rules, and sessiond
+        accepts the RAR without issue.
+        """
+        assignments_dict = {}
+        basenames_dict = {
+            'bn1': ChargingRuleNameSet(RuleNames=['p5']),
+            'bn2': ChargingRuleNameSet(RuleNames=['p6']),
+        }
+        callback = RuleMappingsStreamerCallback(
+            ReAuthHandler(assignments_dict, MockSessionProxyResponderStub1()),
+            basenames_dict,
+            assignments_dict,
+        )
+
+        # Construct a set of updates, keyed by subscriber ID
+        updates = [
+            DataUpdate(
+                key="s1",
+                value=AssignedPolicies(
+                    assigned_policies=["p1", "p2"],
+                    assigned_base_names=["bn1"],
+                ).SerializeToString(),
+            ),
+            DataUpdate(
+                key="s2",
+                value=AssignedPolicies(
+                    assigned_policies=["p2", "p3"],
+                ).SerializeToString(),
+            ),
+        ]
+
+        callback.process_update("stream", updates, False)
+
+        # Since we used a stub which always succeeds when a RAR is made,
+        # We should expect the assignments_dict to be updated
+
+        s1_policies = assignments_dict["s1"].installed_policies
+        expected = 3
+        self.assertEqual(len(s1_policies), expected, 'There should be 3 active '
+                         'policies for s1')
+        self.assertTrue("p1" in s1_policies, 'Policy p1 should be active for '
+                        'subscriber s1')
+        self.assertTrue("p5" in s1_policies, 'Policy p5 should be active for '
+                                             'subscriber s1')
+
+        s2_policies = assignments_dict["s2"].installed_policies
+        expected = 2
+        self.assertEqual(len(s2_policies), expected, 'There should be 2 active '
+                                                     'policies for s2')
+        self.assertTrue("p3" in s2_policies, 'Policy p3 should be active for '
+                                             'subscriber s2')
+
+    def test_FailedUpdate(self):
+        """
+        Test when sessiond answers to the RAR with a failure for any re-auth.
+        """
+        assignments_dict = {}
+        basenames_dict = {}
+        callback = RuleMappingsStreamerCallback(
+            ReAuthHandler(assignments_dict, MockSessionProxyResponderStub2()),
+            basenames_dict,
+            assignments_dict,
+        )
+
+        # Construct a set of updates, keyed by subscriber ID
+        updates = [
+            DataUpdate(
+                key="s1",
+                value=AssignedPolicies(
+                    assigned_policies=["p1", "p2"],
+                ).SerializeToString(),
+            ),
+            DataUpdate(
+                key="s2",
+                value=AssignedPolicies(
+                    assigned_policies=["p2", "p3"],
+                ).SerializeToString(),
+            ),
+        ]
+
+        callback.process_update("stream", updates, False)
+
+        # Since we used a stub which always succeeds when a RAR is made,
+        # We should expect the assignments_dict to be updated
+
+        self.assertFalse("s1" in assignments_dict, 'There should be no entry '
+                         'for subscriber s1 since update failed')
+        self.assertFalse("s2" in assignments_dict, 'There should be no entry '
+                         'for subscriber s2 since update failed')
+
+    def test_FailedOnePolicy(self):
+        """
+        Test when sessiond answers to the RAR with a failure for installing p2.
+        """
+        assignments_dict = {}
+        basenames_dict = {}
+        callback = RuleMappingsStreamerCallback(
+            ReAuthHandler(assignments_dict, MockSessionProxyResponderStub3()),
+            basenames_dict,
+            assignments_dict,
+        )
+
+        # Construct a set of updates, keyed by subscriber ID
+        updates = [
+            DataUpdate(
+                key="s1",
+                value=AssignedPolicies(
+                    assigned_policies=["p1", "p2"],
+                ).SerializeToString(),
+            ),
+            DataUpdate(
+                key="s2",
+                value=AssignedPolicies(
+                    assigned_policies=["p2", "p3"],
+                ).SerializeToString(),
+            ),
+        ]
+
+        callback.process_update("stream", updates, False)
+
+        s1_policies = assignments_dict["s1"].installed_policies
+        expected = 1
+        self.assertEqual(len(s1_policies), expected, 'There should be 1 active '
+                                                     'policies for s1')
+        self.assertTrue("p1" in s1_policies, 'Policy p1 should be active for '
+                                             'subscriber s1')
+
+        s2_policies = assignments_dict["s2"].installed_policies
+        expected = 1
+        self.assertEqual(len(s2_policies), expected, 'There should be 1 active '
+                                                     'policies for s2')
+        self.assertTrue("p3" in s2_policies, 'Policy p3 should be active for '
+                                             'subscriber s2')
+
+    def test_MultiUpdate(self):
+        """
+        Test consecutive updates
+        """
+        assignments_dict = {}
+        basenames_dict = {}
+        callback = RuleMappingsStreamerCallback(
+            ReAuthHandler(assignments_dict, MockSessionProxyResponderStub3()),
+            basenames_dict,
+            assignments_dict,
+        )
+
+        # Construct a set of updates, keyed by subscriber ID
+        updates = [
+            DataUpdate(
+                key="s1",
+                value=AssignedPolicies(
+                    assigned_policies=["p1", "p2"],
+                ).SerializeToString(),
+            ),
+            DataUpdate(
+                key="s2",
+                value=AssignedPolicies(
+                    assigned_policies=["p2", "p3"],
+                ).SerializeToString(),
+            ),
+        ]
+        callback.process_update("stream", updates, False)
+
+        updates = [
+            DataUpdate(
+                key="s1",
+                value=AssignedPolicies(
+                    assigned_policies=["p4", "p5"],
+                ).SerializeToString(),
+            ),
+            DataUpdate(
+                key="s2",
+                value=AssignedPolicies(
+                    assigned_policies=["p4", "p5"],
+                ).SerializeToString(),
+            ),
+        ]
+        callback.process_update("stream", updates, False)
+
+        s1_policies = assignments_dict["s1"].installed_policies
+        expected = 2
+        self.assertEqual(len(s1_policies), expected,
+                         'There should be 2 active policies for s1')
+        self.assertTrue("p5" in s1_policies,
+                        'Policy p5 should be active for subscriber s1')
+        self.assertTrue("p4" in s1_policies,
+                        'Policy p4 should be active for subscriber s1')
+
+        s2_policies = assignments_dict["s2"].installed_policies
+        expected = 2
+        self.assertEqual(len(s2_policies), expected,
+                         'There should be 2 active policies for s2')
+        self.assertTrue("p5" in s2_policies,
+                        'Policy p5 should be active for subscriber s2')
+        self.assertTrue("p4" in s2_policies,
+                        'Policy p4 should be active for subscriber s2')


### PR DESCRIPTION
Summary:
## Changes
- RuleMappingsStreamerCallback will now take updates and send a RAR to sessiond to both install and uninstall rules as configuration is changed in orchestrator. The callback will also update RuleAssignmentsDict

NOTE: `policydb:installed` which is used for storing the active policy-rules/base-names for a subscriber will be wiped on restart of the `policydb` service. This wiping should be turned off after `sessiond` becomes stateless.

Reviewed By: xjtian

Differential Revision: D19167401

