### PR TITLE
Implement basic section aware cli cache

### DIFF
--- a/devmand/gateway/CMakeLists.txt
+++ b/devmand/gateway/CMakeLists.txt
@@ -127,8 +127,9 @@ add_library(devman_channel_cli
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/ReconnectingCli.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/CliThreadWheelTimekeeper.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/CliTimekeeperWrapper.cpp
-  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/CancelableWTCallback.h
   ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/LoggingCli.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/TreeCacheCli.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/channels/cli/TreeCache.cpp
   )
 
 target_link_libraries(devman_channel_cli
@@ -245,7 +246,9 @@ add_executable(devmantest
   ${PROJECT_SOURCE_DIR}/src/devmand/test/PingChannelTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/SnmpChannelTest.cpp
   ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/ReconnectingSshTest.cpp
-        )
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/TreeCacheCliTest.cpp
+  ${PROJECT_SOURCE_DIR}/src/devmand/test/cli/TreeCacheTest.cpp
+)
 
 target_link_libraries(devmantest
   devman

--- a/devmand/gateway/docker/scripts/start_devmand_img.sh
+++ b/devmand/gateway/docker/scripts/start_devmand_img.sh
@@ -1,4 +1,7 @@
-#!/bin/bash 
+#!/bin/bash
+dirname="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd ${dirname}
 
 DEVMANDDOCKERNET="devmanddevelnet"
 DEVMANDIP="172.8.0.85"
@@ -13,4 +16,11 @@ else
     docker network create --subnet=${DEVMANDSUBNET} ${DEVMANDDOCKERNET}
 fi
 
-docker run -h devmanddevel --net ${DEVMANDDOCKERNET} --ip ${DEVMANDIP} -it "facebookconnectivity-southpoll-dev-docker.jfrog.io/devmand" /bin/bash -c "/usr/sbin/service ssh start && bash"
+docker run -d -h devmanddevel --net ${DEVMANDDOCKERNET}  \
+      --ip ${DEVMANDIP} \
+      --name 85 \
+      -v "$(realpath ../../):/cache/devmand/repo:ro" \
+      -v "$(realpath ~/cache_devmand_build):/cache/devmand/build:rw" \
+      --entrypoint /bin/bash \
+      "facebookconnectivity-southpoll-dev-docker.jfrog.io/devmand" \
+      -c 'mkdir /run/sshd && /usr/sbin/sshd && bash -c "sleep infinity && ls"'

--- a/devmand/gateway/src/devmand/channels/cli/CliFlavour.h
+++ b/devmand/gateway/src/devmand/channels/cli/CliFlavour.h
@@ -11,14 +11,11 @@
 #include <folly/Optional.h>
 #include <chrono>
 #include <memory>
+#include <regex>
 
 using devmand::channels::cli::sshsession::SessionAsync;
-using folly::Future;
-using folly::SemiFuture;
-using folly::Timekeeper;
-using folly::Unit;
-using std::shared_ptr;
-using std::string;
+using namespace std;
+using namespace folly;
 
 namespace devmand {
 namespace channels {
@@ -26,11 +23,7 @@ namespace cli {
 
 static const char* const UBIQUITI = "ubiquiti";
 
-static const std::chrono::milliseconds delayDelta =
-    std::chrono::milliseconds(100);
-
-using std::shared_ptr;
-using std::string;
+static const chrono::milliseconds delayDelta = chrono::milliseconds(100);
 
 class PromptResolver {
  public:
@@ -44,15 +37,15 @@ class PromptResolver {
 
 class DefaultPromptResolver : public PromptResolver {
  private:
-  Future<folly::Optional<string>> resolvePromptAsync(
+  Future<Optional<string>> resolvePromptAsync(
       shared_ptr<SessionAsync> session,
       const string& newline,
-      std::chrono::milliseconds delay,
+      chrono::milliseconds delay,
       shared_ptr<Timekeeper> timekeeper);
   Future<string> resolvePrompt(
       shared_ptr<SessionAsync> session,
       const string& newline,
-      std::chrono::milliseconds delay,
+      chrono::milliseconds delay,
       shared_ptr<Timekeeper> timekeeper);
 
  public:
@@ -62,7 +55,7 @@ class DefaultPromptResolver : public PromptResolver {
       shared_ptr<SessionAsync> session,
       const string& newline,
       shared_ptr<Timekeeper> timekeeper);
-  void removeEmptyStrings(std::vector<string>& split) const;
+  void removeEmptyStrings(vector<string>& split) const;
 };
 
 class CliInitializer {
@@ -89,19 +82,48 @@ class UbiquitiInitializer : public CliInitializer {
 
 class CliFlavour {
  private:
-  shared_ptr<folly::Timekeeper> timekeeper;
+  const shared_ptr<PromptResolver> resolver;
+  const shared_ptr<CliInitializer> initializer;
+  const string newline;
+  // regex that matches show config command
+  const regex baseShowConfig;
+  // match index that selects group containing just the command
+  const unsigned int baseShowConfigIdx;
+  const Optional<char> singleIndentChar;
+  const string configSubsectionEnd;
 
  public:
   static shared_ptr<CliFlavour> create(string flavour);
 
-  std::unique_ptr<PromptResolver> resolver;
-  std::unique_ptr<CliInitializer> initializer;
-  string newline;
-
   CliFlavour(
-      std::unique_ptr<PromptResolver>&& _resolver,
-      std::unique_ptr<CliInitializer>&& _initializer,
-      string _newline = "\n");
+      unique_ptr<PromptResolver>&& _resolver,
+      unique_ptr<CliInitializer>&& _initializer,
+      string _newline,
+      regex baseShowConfig,
+      unsigned int baseShowConfigIdx,
+      Optional<char> singleIndentChar,
+      string configSubsectionEnd);
+
+  shared_ptr<PromptResolver> getResolver();
+
+  shared_ptr<CliInitializer> getInitializer();
+
+  string getNewline();
+
+  /*
+   * If supplied command is command to show running config or other command
+   * where caching is supported, return index where the base command ends. E.g.
+   * 'sh run interface 0/14' should return index 6:
+   *             ^
+   * Otherwise return none value.
+   */
+  Optional<size_t> getBaseShowConfigIdx(const string cmd) const;
+
+  Optional<char> getSingleIndentChar();
+
+  string getConfigSubsectionEnd();
+
+  vector<string> splitSubcommands(string subcommands);
 };
 
 } // namespace cli

--- a/devmand/gateway/src/devmand/channels/cli/Command.h
+++ b/devmand/gateway/src/devmand/channels/cli/Command.h
@@ -47,6 +47,7 @@ class Command {
     boost::replace_all(cmd, "\n", "\\n");
     boost::replace_all(cmd, "\r", "\\r");
     boost::replace_all(cmd, "\t", "\\t");
+    boost::replace_all(cmd, "\"", "\\\"");
     return cmd;
   }
 

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
@@ -36,6 +36,22 @@ static constexpr auto configMaxCommandTimeoutSeconds =
 static constexpr auto reconnectingQuietPeriodConfig = "reconnectingQuietPeriod";
 static constexpr auto sshConnectionTimeoutConfig = "sshConnectionTimeout";
 
+
+/*
+ * Responsible for creation of cli stack for single ssh connection.
+ * CLIs can be separated to two groups:
+ * - persistent CLIs, which provide high level functions like TCP connection error detection.
+ *   - KeepaliveCli - sends keepalive commands periodically
+ *   - ReconnectingCli - reestablishes inner layers upon connection error
+ * - inner CLIs. They are destroyed and recreated whenever TCP connection is reestablished.
+ *   - QueuedCli - orders commands so that only one command can be executed at a time
+ *   - LoggingCli - logs aggregated view of device and caching layers
+ *   - TimeoutTrackingCli - errors on exceeded timeout
+ *   - TreeCacheCli - maintain high level cache
+ *   - ReadCachingCli - maintains low level cache
+ *   - LoggingCli - logs communication with device
+ *   - PromptAwareCli + SshSessionAsync - lowest level, deals with ssh, prompt resolution
+ */
 class IoConfigurationBuilder {
  public:
   struct ConnectionParameters {

--- a/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
+++ b/devmand/gateway/src/devmand/channels/cli/IoConfigurationBuilder.h
@@ -53,6 +53,7 @@ class IoConfigurationBuilder {
     shared_ptr<Executor> sshExecutor;
     shared_ptr<Executor> paExecutor;
     shared_ptr<Executor> rcExecutor;
+    shared_ptr<Executor> tcExecutor;
     shared_ptr<Executor> ttExecutor;
     shared_ptr<Executor> lExecutor;
     shared_ptr<Executor> qExecutor;

--- a/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/KeepaliveCli.cpp
@@ -76,8 +76,6 @@ SemiFuture<Unit> KeepaliveCli::destroy() {
     tk->cancelAll();
   }
 
-  // TODO cancel timekeeper futures
-
   MLOG(MDEBUG) << "[" << keepaliveParameters->id << "] "
                << "destroy: done";
   return innerDestroy;

--- a/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/PromptAwareCli.cpp
@@ -21,9 +21,9 @@ namespace channels {
 namespace cli {
 
 SemiFuture<Unit> PromptAwareCli::resolvePrompt() {
-  return sharedCliFlavour->resolver
+  return sharedCliFlavour->getResolver()
       ->resolvePrompt(
-          sharedSession, sharedCliFlavour->newline, sharedTimekeeper)
+          sharedSession, sharedCliFlavour->getNewline(), sharedTimekeeper)
       .thenValue([params = promptAwareParameters](string _prompt) {
         boost::mutex::scoped_lock scoped_lock(params->promptMutex);
         params->prompt = _prompt;
@@ -31,7 +31,7 @@ SemiFuture<Unit> PromptAwareCli::resolvePrompt() {
 }
 
 SemiFuture<Unit> PromptAwareCli::initializeCli(const string secret) {
-  return sharedCliFlavour->initializer->initialize(sharedSession, secret);
+  return sharedCliFlavour->getInitializer()->initialize(sharedSession, secret);
 }
 
 SemiFuture<std::string> PromptAwareCli::executeRead(const ReadCommand cmd) {
@@ -57,7 +57,7 @@ SemiFuture<std::string> PromptAwareCli::executeRead(const ReadCommand cmd) {
         if (auto _session = params->session.lock()) {
           if (auto _cliFlavour = params->cliFlavour.lock()) {
             if (auto _executor = params->executor.lock()) {
-              return _session->write(_cliFlavour->newline)
+              return _session->write(_cliFlavour->getNewline())
                   .via(_executor.get())
                   .thenValue([params, output, cmd](...) {
                     MLOG(MDEBUG) << "[" << params->id << "] (" << cmd
@@ -141,7 +141,7 @@ SemiFuture<std::string> PromptAwareCli::executeWrite(const WriteCommand cmd) {
             if (auto _session = params->session.lock()) {
               if (auto _executor = params->executor.lock()) {
                 if (auto _cliFlavour = params->cliFlavour.lock()) {
-                  return _session->write(_cliFlavour->newline)
+                  return _session->write(_cliFlavour->getNewline())
                       .via(_executor.get())
                       .thenValue([id = params->id, output, command, cmd](...) {
                         MLOG(MDEBUG)

--- a/devmand/gateway/src/devmand/channels/cli/QueuedCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/QueuedCli.cpp
@@ -89,7 +89,7 @@ SemiFuture<string> QueuedCli::executeWrite(const WriteCommand cmd) {
   Command command = cmd;
   if (!command.isMultiCommand()) {
     // Single line config command, execute with read
-    return executeRead(ReadCommand::create(cmd.raw(), true)); //skip cache
+    return executeRead(ReadCommand::create(cmd.raw(), true)); // skip cache
   }
 
   const vector<Command>& commands = command.splitMultiCommand();
@@ -107,7 +107,8 @@ SemiFuture<string> QueuedCli::executeWrite(const WriteCommand cmd) {
   }
 
   commmandsFutures.emplace_back(
-      executeRead(ReadCommand::create(commands.back().raw(), true)) //skip cache
+      executeRead(
+          ReadCommand::create(commands.back().raw(), true)) // skip cache
           .via(sharedSerialExecutorKeepAlive->get()));
 
   return reduce(

--- a/devmand/gateway/src/devmand/channels/cli/TreeCache.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TreeCache.cpp
@@ -1,0 +1,183 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/cli/TreeCache.h>
+
+namespace devmand::channels::cli {
+
+// public api start
+
+TreeCache::TreeCache(shared_ptr<CliFlavour> _cliFlavour)
+    : cliFlavour(_cliFlavour) {}
+
+void TreeCache::clear() {
+  treeCache.clear();
+}
+
+Optional<pair<string, vector<string>>> TreeCache::parseCommand(string cmd) {
+  Optional<pair<string, string>> split = splitSupportedCommand(cmd);
+  if (split) {
+    vector<string> subcommands;
+    if (split.value().second.size() > 0) {
+      subcommands = cliFlavour->splitSubcommands(split.value().second);
+    }
+    return make_pair(split.value().first, subcommands);
+  }
+  return none;
+}
+
+void TreeCache::update(string output) {
+  boost::replace_all(output, "\r", "");
+  treeCache = readConfigurationToMap(output, 0);
+}
+
+Optional<string> TreeCache::getSection(pair<string, vector<string>> cmd) {
+  if (cmd.second.size() == 0) {
+    throw runtime_error("Command does not have subcommands");
+  }
+  return findMatchingSubset(cmd.second, treeCache);
+}
+
+bool TreeCache::isEmpty() {
+  return treeCache.size() == 0;
+}
+
+// public api end
+
+// used in StringUtils::getFirstLine
+static const regex firstLineRegex = regex("^([^\n]*)\n");
+class StringUtils {
+ private:
+  // trim from start (in place)
+  static inline void ltrim(std::string& s) {
+    s.erase(
+        s.begin(),
+        std::find_if(
+            s.begin(),
+            s.end(),
+            std::not1(std::ptr_fun<int, int>(std::isspace))));
+  }
+
+  // trim from end (in place)
+  static inline void rtrim(std::string& s) {
+    s.erase(
+        std::find_if(
+            s.rbegin(),
+            s.rend(),
+            std::not1(std::ptr_fun<int, int>(std::isspace)))
+            .base(),
+        s.end());
+  }
+
+ public:
+  // trim from both ends (in place)
+  static inline void trim(std::string& s) {
+    ltrim(s);
+    rtrim(s);
+  }
+
+  static string getFirstLine(string input) {
+    smatch sm;
+    if (regex_search(input, sm, firstLineRegex)) {
+      return sm[1];
+    } else {
+      // no \n, return everything
+      return input;
+    }
+  }
+};
+
+size_t TreeCache::size() {
+  return treeCache.size();
+}
+
+// parsing start
+map<vector<string>, string> TreeCache::readConfigurationToMap(
+    string showRunningOutput,
+    unsigned int indentationLevel) {
+  // currently only one level of sections is supported, thus indentationLevel ==
+  // 0
+  regex regexMatch = regex(createSectionPattern(indentationLevel));
+  smatch sm;
+  map<vector<string>, string> result;
+
+  while (hasNextSection(regexMatch, sm, showRunningOutput)) {
+    string section = sm[1];
+    string firstLine = StringUtils::getFirstLine(section);
+    vector<string> args = cliFlavour->splitSubcommands(firstLine);
+    result.insert(make_pair(args, section));
+  }
+  // last piece of content that is not a section is ignored
+  return result;
+}
+
+map<vector<string>, string> TreeCache::readConfigurationToMap(
+    string showRunningOutput) {
+  return readConfigurationToMap(showRunningOutput, 0);
+}
+
+bool TreeCache::hasNextSection(regex& regexMatch, smatch& sm, string& content) {
+  if (not sm.empty()) {
+    // move content after previous section
+    content = "\n";
+    content += sm.suffix();
+  } else if (content.size() > 0 && content.substr(0, 1) != "\n") {
+    content = "\n" + content;
+  }
+  return regex_search(content, sm, regexMatch);
+}
+
+string TreeCache::createSectionPattern(unsigned int indentationLevel) {
+  return createSectionPattern(
+      cliFlavour->getSingleIndentChar(),
+      cliFlavour->getConfigSubsectionEnd(),
+      indentationLevel);
+}
+
+string TreeCache::createSectionPattern(
+    Optional<char> maybeIndentChar,
+    string configSubsectionEnd,
+    unsigned int indentationLevel) {
+  string match = "\\S[^]*?";
+  if (maybeIndentChar.hasValue()) {
+    // CONFIG_SUBSECTION_PATTERN = ^%s{LVL}\S.*?^%s{LVL}END
+    string nlIndent = "";
+    nlIndent += maybeIndentChar.value();
+    nlIndent += "{" + to_string(indentationLevel) + "}";
+    return "\n(" + nlIndent + match + "\n" + nlIndent + configSubsectionEnd +
+        "\n)";
+  } else {
+    // CONFIG_SUBSECTION_NO_INDENT_PATTERN = ^\S.*?^END
+    return "\n(" + match + "\n" + configSubsectionEnd + "\n)";
+  }
+}
+// parsing end
+// reading start
+Optional<pair<string, string>> TreeCache::splitSupportedCommand(string cmd) {
+  const Optional<size_t>& maybePosition = cliFlavour->getBaseShowConfigIdx(cmd);
+  if (maybePosition.hasValue()) {
+    string first = cmd.substr(0, maybePosition.value()); // space removed
+    string second = cmd.substr(maybePosition.value());
+    StringUtils::trim(second);
+    return make_pair(first, second);
+  } else {
+    // not a show running config command
+    return none;
+  }
+}
+
+Optional<string> TreeCache::findMatchingSubset(
+    vector<string> subcommands,
+    map<vector<string>, string> treeCache) {
+  // simplistic case: find whole key in map
+  if (treeCache.count(subcommands) == 1) {
+    return treeCache.at(subcommands);
+  }
+  return none;
+}
+// reading end
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/TreeCache.h
+++ b/devmand/gateway/src/devmand/channels/cli/TreeCache.h
@@ -1,0 +1,121 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+#include <devmand/channels/cli/CliFlavour.h>
+
+namespace devmand::channels::cli {
+
+using namespace std;
+using namespace folly;
+
+/*
+ * Thread unsafe structured cache that can serve subsets of running
+ * configuration. When running configuration is returned from the device,
+ * calling update function will split it into sections. Consequent calls to get
+ * method
+ */
+class TreeCache {
+ private:
+  shared_ptr<CliFlavour> cliFlavour;
+  // section cache
+  map<vector<string>, string> treeCache;
+
+ public:
+  // TODO: cache invalidation
+
+  TreeCache(shared_ptr<CliFlavour> sharedCliFlavour);
+
+  /*
+   * Clear cache.
+   */
+  void clear();
+
+  /*
+   * Parse command. If supported, first part will be base command,
+   * second part are parameters.
+   */
+  Optional<pair<string, vector<string>>> parseCommand(string cmd);
+
+  /*
+   * Try to update cache with actual command output. Return true
+   * iif cmd does not contain subsections and thus cache
+   * was populated.
+   */
+  // FIXME: currently only one 'show running-config' command is supported.
+  void update(string output);
+
+  /*
+   * Try to get result of supported command subsection from cache.
+   * If show running command with subcommands is passed, return result from
+   * cache.
+   * It is an error to call getSection with command pair with no second part.
+   * Argument cmd must be produced by parseCommand, so only supported
+   * (show running-config) command can be passed.
+   */
+  Optional<string> getSection(pair<string, vector<string>> cmd);
+
+  /*
+   * Return true iif cache is empty.
+   */
+  bool isEmpty();
+
+  string toString() {
+    string result = "(" + to_string(treeCache.size()) + ")[";
+    for (const auto& entry : treeCache) {
+      for (const auto& subkey : entry.first) {
+        result += "{" + subkey + "}";
+      }
+      result += ",";
+    }
+    result += "]";
+    return result;
+  }
+
+  // visible for testing:
+  size_t size();
+  // parsing start
+  map<vector<string>, string> readConfigurationToMap(string showRunningOutput);
+
+  map<vector<string>, string> readConfigurationToMap(
+      string showRunningOutput,
+      unsigned int indentationLevel);
+
+  /*
+   * Iterate over sections. If previous match is detected, content will be
+   * set to start after found section starting with newline.
+   */
+  static bool hasNextSection(regex& regexMatch, smatch& sm, string& content);
+
+  /*
+   * Assuming command output starts and ends with \n and has lines separated by
+   * \n, this regex pattern will match first section of it.
+   */
+  string createSectionPattern(unsigned int indentationLevel);
+
+  static string createSectionPattern(
+      Optional<char> maybeIndentChar,
+      string configSubsectionEnd,
+      unsigned int indentationLevel);
+  // parsing end
+  // reading from cache start
+
+  /*
+   * If supported show running command supplied, return pair of base, remainder.
+   */
+  Optional<pair<string, string>> splitSupportedCommand(string cmd);
+  /*
+   * Parse command output, return only section that was specified by subset
+   * argument. This can be one or more subcommands separated by indentation
+   * characters.
+   */
+  static Optional<string> findMatchingSubset(
+      vector<string> subcommands,
+      map<vector<string>, string> treeCache);
+};
+
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/TreeCacheCli.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/TreeCacheCli.cpp
@@ -1,0 +1,132 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#include <devmand/channels/cli/TreeCacheCli.h>
+
+namespace devmand::channels::cli {
+
+using namespace std;
+using namespace folly;
+
+TreeCacheCli::TreeCacheCli(
+    string _id,
+    shared_ptr<Cli> _cli,
+    shared_ptr<folly::Executor> _executor,
+    shared_ptr<CliFlavour> _sharedCliFlavour)
+    : id(_id),
+      cli(_cli),
+      executor(_executor),
+      sharedCliFlavour(_sharedCliFlavour) {
+  cache = make_unique<TreeCache>(_sharedCliFlavour);
+}
+
+TreeCacheCli::TreeCacheCli(
+    string _id,
+    shared_ptr<Cli> _cli,
+    shared_ptr<folly::Executor> _executor,
+    shared_ptr<CliFlavour> _sharedCliFlavour,
+    shared_ptr<TreeCache> _cache)
+    : id(_id),
+      cli(_cli),
+      executor(_executor),
+      sharedCliFlavour(_sharedCliFlavour),
+      cache(_cache) {}
+
+SemiFuture<folly::Unit> TreeCacheCli::destroy() {
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "destroy: started";
+  // call underlying destroy()
+  SemiFuture<folly::Unit> innerDestroy = cli->destroy();
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "destroy: done";
+  return innerDestroy;
+}
+
+TreeCacheCli::~TreeCacheCli() {
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~TCcli: started";
+  destroy().get();
+  executor = nullptr;
+  cli = nullptr;
+  MLOG(MDEBUG) << "[" << id << "] "
+               << "~TCcli: done";
+}
+
+void TreeCacheCli::clear() {
+  cache->clear();
+}
+
+folly::SemiFuture<std::string> TreeCacheCli::executeRead(
+    const ReadCommand cmd) {
+  if (!cmd.skipCache()) {
+    Optional<pair<string, vector<string>>> maybeParsedCommand =
+        cache->parseCommand(cmd.raw());
+    if (maybeParsedCommand) {
+      pair<string, vector<string>> parsedCommand = maybeParsedCommand.value();
+      // if it is just base command, just run it on inner cli where
+      // it will be hopefully cached
+      if (parsedCommand.second.size() > 0) {
+        Optional<string> cachedResult = cache->getSection(parsedCommand);
+        if (cachedResult) {
+          MLOG(MDEBUG) << "[" << id << "] "
+                       << "Found in cache:" << cmd;
+          return folly::SemiFuture<string>(cachedResult.value());
+        } else if (cache->isEmpty()) {
+          MLOG(MDEBUG) << "[" << id << "] "
+                       << "Cache is empty, running base of:" << cmd;
+          // the cache is empty or there is missing functionality in section
+          // parsing
+          ReadCommand baseCmd = ReadCommand::create(parsedCommand.first, false);
+          // run the base command to populate cache
+          return cli->executeRead(baseCmd)
+              .via(executor.get())
+              .thenValue([_cache = this->cache,
+                          _id = this->id,
+                          parsedCommand,
+                          cmd,
+                          _cli = this->cli](string output) {
+                _cache->update(output);
+                MLOG(MDEBUG) << "Cache keys: " << _cache->toString();
+                Optional<string> cachedResult2 =
+                    _cache->getSection(parsedCommand);
+                if (cachedResult2) {
+                  MLOG(MDEBUG) << "[" << _id << "] "
+                               << "Found in cache:" << cmd;
+                  return folly::SemiFuture<string>(cachedResult2.value());
+                }
+                MLOG(MWARNING)
+                    << "[" << _id << "] "
+                    << "Cache was updated, unexpected cache miss for:" << cmd;
+
+                // worst case scenario: we must run the exact command
+                return _cli->executeRead(cmd);
+              })
+              .semi();
+        } else {
+          MLOG(MWARNING) << "[" << id << "] "
+                         << "Unexpected cache miss for:" << cmd;
+          // there might be missing functionality in section parsing
+          // or the command is wrong. In any case just run the command
+        }
+      } else { // no subcommands, hit underlying cache
+        MLOG(MDEBUG) << "[" << id << "] "
+                     << "Pass through:" << cmd;
+      }
+    }
+  }
+  // Just run the command: Either this is not supported command,
+  // or there is missing functionality in section parsing
+  // or this is just supported base command and should be handled by underlying
+  // cache.
+  return cli->executeRead(cmd);
+}
+
+folly::SemiFuture<std::string> TreeCacheCli::executeWrite(
+    const WriteCommand cmd) {
+  return cli->executeWrite(cmd);
+}
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/TreeCacheCli.h
+++ b/devmand/gateway/src/devmand/channels/cli/TreeCacheCli.h
@@ -1,0 +1,56 @@
+// Copyright (c) 2019-present, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+
+#pragma once
+
+#include <devmand/channels/cli/Cli.h>
+#include <devmand/channels/cli/CliFlavour.h>
+#include <devmand/channels/cli/TreeCache.h>
+#include <folly/Executor.h>
+#include <folly/futures/Future.h>
+
+namespace devmand::channels::cli {
+
+using namespace std;
+using namespace folly;
+
+class TreeCacheCli : public Cli {
+ private:
+  string id;
+  shared_ptr<Cli> cli;
+  shared_ptr<folly::Executor> executor;
+  shared_ptr<CliFlavour> sharedCliFlavour;
+  shared_ptr<TreeCache> cache;
+
+ public:
+  TreeCacheCli(
+      string _id,
+      shared_ptr<Cli> _cli,
+      shared_ptr<folly::Executor> executor,
+      shared_ptr<CliFlavour> sharedCliFlavour);
+
+  // Visible for testing
+  TreeCacheCli(
+      string _id,
+      shared_ptr<Cli> _cli,
+      shared_ptr<folly::Executor> _executor,
+      shared_ptr<CliFlavour> _sharedCliFlavour,
+      shared_ptr<TreeCache> cache);
+
+  SemiFuture<folly::Unit> destroy() override;
+
+  ~TreeCacheCli() override;
+
+  /*
+   * Clear cache.
+   */
+  void clear();
+
+  folly::SemiFuture<std::string> executeRead(const ReadCommand cmd) override;
+  folly::SemiFuture<std::string> executeWrite(const WriteCommand cmd) override;
+};
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.cpp
@@ -57,7 +57,15 @@ void Engine::initLogging(uint32_t verbosity, bool callInitMlog) {
 }
 
 static uint CPU_CORES = std::max(uint(4), std::thread::hardware_concurrency());
-
+/*
+ * Keep alive cli layer needs separate executor for protecting against resource
+ * starvation - connection failures should always be detected.
+ * SSH cli (SshSessionAsync) - separate executor for ssh layer.
+ * All other layers share common threadpool executor.
+ * All executors are cpu threadpool executors, to mitigate possible deadlocks, such
+ * as when cli destructor calls destroy.get() - this would block forever
+ * on IO threadpool executor.
+ */
 Engine::Engine()
     : channels::Engine("Cli"),
       timekeeper(make_shared<CliThreadWheelTimekeeper>()),

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
@@ -68,6 +68,9 @@ class Engine : public channels::Engine {
   shared_ptr<ModelRegistry> mreg;
 
  public:
+  /*
+   * Get executor for cli layer
+   */
   shared_ptr<folly::Executor> getExecutor(
       executorRequestType requestType) const;
 

--- a/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
+++ b/devmand/gateway/src/devmand/channels/cli/engine/Engine.h
@@ -55,6 +55,7 @@ class Engine : public channels::Engine {
     sshCli,
     paCli,
     rcCli,
+    tcCli,
     ttCli,
     lCli,
     qCli,

--- a/devmand/gateway/src/devmand/test/cli/CliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/CliTest.cpp
@@ -54,9 +54,9 @@ static std::function<bool()> ensureConnected(const shared_ptr<Cli>& cli) {
   return [cli]() {
     try {
       cli->executeRead(ReadCommand::create("echo 123", true)).get();
-        return true;
+      return true;
     } catch (const exception& e) {
-        return false;
+      return false;
     }
   };
 }
@@ -76,7 +76,7 @@ TEST_F(CliTest, writeMultipleTimesAllExecute) {
   IoConfigurationBuilder ioConfigurationBuilder(deviceConfig, *cliEngine);
   const shared_ptr<Cli>& cli =
       ioConfigurationBuilder.createAll(ReadCachingCli::createCache());
-  const function<bool()> &connectionTest = ensureConnected(cli);
+  const function<bool()>& connectionTest = ensureConnected(cli);
 
   EXPECT_BECOMES_TRUE(connectionTest());
 

--- a/devmand/gateway/src/devmand/test/cli/TreeCacheCliTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/TreeCacheCliTest.cpp
@@ -1,0 +1,128 @@
+#define LOG_WITH_GLOG
+
+#include <magma_logging.h>
+
+#include <devmand/cartography/DeviceConfig.h>
+#include <devmand/channels/cli/Cli.h>
+#include <devmand/channels/cli/TreeCacheCli.h>
+#include <devmand/test/cli/TreeCacheTestData.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <folly/executors/CPUThreadPoolExecutor.h>
+#include <folly/executors/ThreadedExecutor.h>
+#include <folly/futures/ThreadWheelTimekeeper.h>
+#include <gtest/gtest.h>
+#include <chrono>
+
+namespace devmand::channels::cli {
+
+using namespace std;
+using namespace std::chrono_literals;
+using folly::CPUThreadPoolExecutor;
+
+static const shared_ptr<CliFlavour> ubiquitiFlavour =
+    CliFlavour::create(UBIQUITI);
+static const char* showRunningCommand = "show running-config";
+
+// responds to read commands using a pre populated map of commands -> outputs
+class MockedCli : public Cli {
+ private:
+  map<string, string> responseMap;
+
+ public:
+  MockedCli(map<string, string> map) : responseMap(map) {}
+
+  SemiFuture<Unit> destroy() override {
+    return makeSemiFuture(unit);
+  }
+
+  SemiFuture<std::string> executeRead(const ReadCommand cmd) override {
+    if (responseMap.count(cmd.raw()) == 1) {
+      MLOG(MDEBUG) << "MockedCli.executeRead hit ('" << cmd.raw() << "')";
+      return responseMap.at(cmd.raw());
+    } else {
+      MLOG(MDEBUG) << "MockedCli.executeRead miss ('" << cmd.raw() << "')";
+      return Future<string>(runtime_error(cmd.raw()));
+    }
+  }
+
+  SemiFuture<std::string> executeWrite(const WriteCommand cmd) override {
+    return Future<string>(runtime_error(cmd.raw()));
+  }
+
+  void clear() {
+    responseMap.clear();
+  }
+};
+
+class TreeCacheCliTest : public ::testing::Test {
+ protected:
+  shared_ptr<CPUThreadPoolExecutor> testExec =
+      make_shared<CPUThreadPoolExecutor>(1);
+  shared_ptr<MockedCli> mockedCli;
+  shared_ptr<TreeCacheCli> tested_ubiquiti;
+  shared_ptr<TreeCache> treeCache;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+
+    map<string, string> mockedResponses;
+    mockedResponses.insert(
+        make_pair(showRunningCommand, testdata::SH_RUN_UBIQUITI));
+    mockedCli = make_shared<MockedCli>(mockedResponses);
+
+    treeCache = make_shared<TreeCache>(ubiquitiFlavour);
+
+    tested_ubiquiti = make_shared<TreeCacheCli>(
+        "id", mockedCli, testExec, ubiquitiFlavour, treeCache);
+    EXPECT_TRUE(treeCache->isEmpty());
+  }
+
+  void TearDown() override {
+    MLOG(MDEBUG) << "Waiting for test executor to finish";
+    testExec->join();
+  }
+};
+
+TEST_F(TreeCacheCliTest, checkMockWorks) {
+  // just load show running config, should be handled by MockedCli
+  string shResult =
+      tested_ubiquiti
+          ->executeRead(ReadCommand::create(showRunningCommand, false))
+          .get();
+  EXPECT_EQ(testdata::SH_RUN_UBIQUITI, shResult);
+  mockedCli->clear();
+  EXPECT_THROW(
+      tested_ubiquiti
+          ->executeRead(ReadCommand::create(showRunningCommand, false))
+          .get(),
+      runtime_error);
+}
+
+TEST_F(TreeCacheCliTest, getParticularIfc_samePass) {
+  // this should execute base command on MockedCli, output will be parsed
+  string result = tested_ubiquiti
+                      ->executeRead(ReadCommand::create(
+                          "show running-config interface 0/14", false))
+                      .get();
+  EXPECT_EQ(testdata::SH_RUN_INT_GI4, result);
+}
+
+TEST_F(
+    TreeCacheCliTest,
+    getParticularIfc_populateCache_thenGoStraightToTreeCache) {
+  // first request will be passed to MockedCli
+  string result = tested_ubiquiti
+                      ->executeRead(ReadCommand::create(
+                          "show running-config interface 0/14", false))
+                      .get();
+  EXPECT_FALSE(treeCache->isEmpty());
+  EXPECT_EQ(testdata::SH_RUN_INT_GI4, result);
+  // second request should end in tree cache
+  mockedCli->clear();
+  result = tested_ubiquiti
+               ->executeRead(ReadCommand::create(
+                   "show running-config interface 0/14", false))
+               .get();
+  EXPECT_EQ(testdata::SH_RUN_INT_GI4, result);
+}
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/test/cli/TreeCacheTest.cpp
+++ b/devmand/gateway/src/devmand/test/cli/TreeCacheTest.cpp
@@ -1,0 +1,215 @@
+#define LOG_WITH_GLOG
+
+#include <magma_logging.h>
+
+#include <devmand/channels/cli/Cli.h>
+#include <devmand/channels/cli/TreeCacheCli.h>
+#include <devmand/test/TestUtils.h>
+#include <devmand/test/cli/TreeCacheTestData.h>
+#include <devmand/test/cli/utils/Log.h>
+#include <gtest/gtest.h>
+#include <magma_logging.h>
+
+namespace devmand::channels::cli {
+using namespace std;
+
+static const char* showRunningCommand = "show running-config";
+
+static const shared_ptr<CliFlavour> ubiquitiFlavour =
+    CliFlavour::create(UBIQUITI);
+
+static const shared_ptr<CliFlavour> ciscoFlavour = CliFlavour::create("cisco");
+
+class TreeCacheTest : public ::testing::Test {
+ protected:
+  unique_ptr<TreeCache> tested_ubiquiti;
+  unique_ptr<TreeCache> tested_cisco;
+
+  void SetUp() override {
+    devmand::test::utils::log::initLog();
+
+    tested_ubiquiti = make_unique<TreeCache>(ubiquitiFlavour);
+    tested_ubiquiti->update(testdata::SH_RUN_UBIQUITI);
+    EXPECT_EQ(15, tested_ubiquiti->size());
+
+    tested_cisco = make_unique<TreeCache>(ciscoFlavour);
+    tested_cisco->update(testdata::SH_RUN_CISCO);
+    EXPECT_EQ(3, tested_cisco->size());
+  }
+};
+
+TEST_F(TreeCacheTest, createSectionPattern_noIndent) {
+  auto content_chars = R"template(section1
+foo
+exit
+section2
+bar
+baz
+exit
+)template";
+  string content(content_chars);
+
+  string sectionPattern = tested_ubiquiti->createSectionPattern(0);
+  EXPECT_EQ("\n(\\S[^]*?\nexit\n)", sectionPattern);
+  regex regexMatch = regex(sectionPattern);
+  smatch sm;
+
+  EXPECT_TRUE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+  EXPECT_EQ(sm[1], "section1\nfoo\nexit\n");
+
+  EXPECT_TRUE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+  EXPECT_EQ(sm[1], "section2\nbar\nbaz\nexit\n");
+
+  EXPECT_FALSE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+}
+
+TEST_F(TreeCacheTest, createSectionPattern_noNewLineAtStart) {
+  string content = "section1\nfoo\nexit\n";
+  regex regexMatch = regex(tested_ubiquiti->createSectionPattern(0));
+  smatch sm;
+
+  EXPECT_TRUE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+  EXPECT_EQ(sm[1], "section1\nfoo\nexit\n");
+  EXPECT_FALSE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+}
+
+TEST_F(TreeCacheTest, createSectionPattern_noNewLine) {
+  string content = "section1";
+  regex regexMatch = regex(tested_ubiquiti->createSectionPattern(0));
+  smatch sm;
+
+  EXPECT_FALSE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+}
+
+TEST_F(TreeCacheTest, createSectionPattern_indent) {
+  string content(testdata::SH_RUN_TWO_IFC);
+
+  string sectionPattern = tested_ubiquiti->createSectionPattern(' ', "!", 0);
+
+  regex regexMatch = regex(sectionPattern);
+  smatch sm;
+
+  EXPECT_TRUE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+  EXPECT_EQ(
+      sm[1],
+      "interface Loopback99\n"
+      " description bla\n"
+      "!\n");
+  EXPECT_TRUE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+  EXPECT_EQ(
+      sm[1],
+      "interface Bundle-Ether103.100\n"
+      " description TOOL_TEST\n"
+      " ethernet cfm\n"
+      "  mep domain DML3 service 504 mep-id 1\n"
+      "   cos 6\n"
+      "  !\n"
+      " !\n"
+      "!\n");
+  EXPECT_FALSE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+  EXPECT_FALSE(tested_ubiquiti->hasNextSection(regexMatch, sm, content));
+}
+
+TEST_F(TreeCacheTest, readConfigurationToMap_ubiquiti) {
+  string content(testdata::SH_RUN_INT_GI4);
+  map<vector<string>, string> actual =
+      tested_ubiquiti->readConfigurationToMap(content);
+  EXPECT_EQ(actual.size(), 1);
+  map<vector<string>, string> expected;
+
+  vector<string> key = {"interface", "0/14"};
+  string value =
+      "interface 0/14\n"
+      "description 'Ruckus-AP'\n"
+      "switchport mode access\n"
+      "switch access vlan 100\n"
+      "exit\n";
+  expected.insert(make_pair(key, value));
+  EXPECT_EQ(actual, expected);
+}
+
+TEST_F(TreeCacheTest, readConfigurationToMap_cisco) {
+  string content(testdata::SH_RUN_TWO_IFC);
+  map<vector<string>, string> actual =
+      tested_cisco->readConfigurationToMap(content);
+  EXPECT_EQ(actual.size(), 2);
+
+  map<vector<string>, string> expected;
+  {
+    vector<string> key = {"interface", "Loopback99"};
+    string value =
+        "interface Loopback99\n"
+        " description bla\n"
+        "!\n";
+    expected.insert(make_pair(key, value));
+  }
+  {
+    vector<string> key = {"interface", "Bundle-Ether103.100"};
+    string value =
+        "interface Bundle-Ether103.100\n"
+        " description TOOL_TEST\n"
+        " ethernet cfm\n"
+        "  mep domain DML3 service 504 mep-id 1\n"
+        "   cos 6\n"
+        "  !\n"
+        " !\n"
+        "!\n";
+    expected.insert(make_pair(key, value));
+  }
+  EXPECT_EQ(actual, expected);
+}
+
+TEST_F(TreeCacheTest, splitSupportedCommand) {
+  Optional<pair<string, string>> split = tested_ubiquiti->splitSupportedCommand(
+      "show running-config interface 0/14");
+  EXPECT_TRUE(split);
+  EXPECT_EQ("show running-config", split->first);
+  EXPECT_EQ("interface 0/14", split->second);
+}
+
+// public api tests:
+
+TEST_F(TreeCacheTest, parseUnknownCommand) {
+  auto nothing = tested_ubiquiti->parseCommand("foo");
+  EXPECT_FALSE(nothing);
+}
+
+TEST_F(TreeCacheTest, getWholeConfig_expectException) {
+  Optional<pair<string, vector<string>>> maybeCmd =
+      tested_ubiquiti->parseCommand(showRunningCommand);
+  EXPECT_TRUE(maybeCmd);
+  EXPECT_EQ(maybeCmd->second.size(), 0);
+  EXPECT_THROW(tested_ubiquiti->getSection(maybeCmd.value()), runtime_error);
+}
+
+TEST_F(TreeCacheTest, getParticularIfc) {
+  Optional<pair<string, vector<string>>> maybeCmd =
+      tested_ubiquiti->parseCommand("sh run interface 0/14");
+  EXPECT_TRUE(maybeCmd);
+  EXPECT_EQ(maybeCmd->second.size(), 2);
+  Optional<string> wholeConfig = tested_ubiquiti->getSection(maybeCmd.value());
+  EXPECT_TRUE(wholeConfig);
+  EXPECT_EQ(testdata::SH_RUN_INT_GI4, wholeConfig.value());
+}
+
+TEST_F(TreeCacheTest, parseSH_RUN_UBNT_REAL) {
+  tested_ubiquiti->clear();
+  tested_ubiquiti->update(testdata::SH_RUN_UBNT_REAL);
+  EXPECT_EQ(tested_ubiquiti->size(), 11);
+  EXPECT_EQ(
+      tested_ubiquiti->toString(),
+      "(11)["
+      "{!},"
+      "{!Current}{Configuration:},"
+      "{interface}{0/10},"
+      "{interface}{0/11},"
+      "{interface}{0/7},"
+      "{interface}{0/8},"
+      "{interface}{0/9},"
+      "{interface}{vlan}{33},"
+      "{ip}{ssh}{protocol}{1}{2},"
+      "{line}{ssh},{line}{telnet},"
+      "]");
+}
+
+} // namespace devmand::channels::cli

--- a/devmand/gateway/src/devmand/test/cli/TreeCacheTestData.h
+++ b/devmand/gateway/src/devmand/test/cli/TreeCacheTestData.h
@@ -1,0 +1,172 @@
+#pragma once
+
+namespace devmand::channels::cli::testdata {
+
+static constexpr const char* SH_RUN_UBIQUITI =
+    R"template(*Ubiquiti Edgeswitch outdoor configs:*
+
+hostname "MPK14-11-Switch"
+network protocol none
+network parms 192.168.0.35 255.255.255.0 0.0.0.0
+network ipv6 address autoconfig
+vlan database
+vlan 10,101,302,312,345,307
+vlan name 101 "MGMT"
+exit
+
+network mgmt_vlan 101
+configure
+sntp server "10.128.203.238"
+sntp server "1.ntp.vip.facebook.com"
+clock timezone -7 minutes 0 zone "PST"
+ip name server 2620:10d:c097::c0de
+username "ubnt" password asdasdasdasdasdasdasdasdasd level 15 encrypted
+line console
+exit
+
+line ssh
+exit
+
+snmp-server sysname "MPK10-06-Switch"
+!
+
+interface 0/1
+description 'Primary-1'
+switchport mode access
+switchport access vlan 307
+exit
+
+
+interface 0/2
+description 'Secodary-3'
+switchport mode access
+switchport access vlan 307
+exit
+
+
+
+interface 0/3
+description 'Secondary-2'
+switchport mode access
+switchport access vlan 307
+exit
+
+
+
+interface 0/4
+description 'Secondary-1'
+switchport mode access
+switchport access vlan 307
+exit
+
+
+
+interface 0/5
+description 'Primary-2'
+switchport mode access
+switchport access vlan 307
+exit
+
+
+
+interface 0/6
+switchport mode access
+switchport access vlan 307
+exit
+
+interface 0/7
+switchport mode access
+switchport access vlan 101
+exit
+
+interface 0/9
+description 'SOMA-AP'
+switchport mode access
+switchport access vlan 101
+exit
+
+
+
+interface 0/10
+description 'MAGMA-CPE'
+switchport mode access
+switchport access vlan 345
+exit
+
+
+interface 0/14
+description 'Ruckus-AP'
+switchport mode access
+switch access vlan 100
+exit
+
+interface 0/15
+description 'NanoBeam'
+spanning-tree bpdufilter
+switchport mode trunk
+switchport trunk native vlan 101
+switchport trunk allowed vlan 101,307,312,345
+poe opmode passive24v
+exit
+
+interface 0/16
+description 'PDU'
+switchport mode access
+switchport access vlan 101
+exit
+
+copy system:running-config nvram:startup-config
+
+)template";
+
+static constexpr const char* SH_RUN_CISCO = R"template(Building configuration...
+Current configuration : 3781 bytes
+!
+interface FastEthernet0
+ ip address 192.1.12.2 255.255.255.0
+ no ip directed-broadcast (default)
+ ip nat outside
+ duplex auto
+ speed auto
+!
+line con 0
+ password cisco123
+ transport preferred all
+ transport output all
+line aux 0
+ transport preferred all
+ transport output all
+!
+)template";
+
+static constexpr const char* SH_RUN_INT_GI4 = R"template(interface 0/14
+description 'Ruckus-AP'
+switchport mode access
+switch access vlan 100
+exit
+)template";
+
+static constexpr const char* SH_RUN_TWO_IFC = R"template(
+
+ foo
+
+
+interface Loopback99
+ description bla
+!
+
+
+
+interface Bundle-Ether103.100
+ description TOOL_TEST
+ ethernet cfm
+  mep domain DML3 service 504 mep-id 1
+   cos 6
+  !
+ !
+!
+  )template";
+
+static constexpr const char* SH_RUN_UBNT_REAL =
+    "\r\n\r\n!Current Configuration:\r\n!\r\n!System Description \"EdgeSwitch 16-Port 150W, 1.8.1.5145168, Linux 3.6.5-1b505fb7, 1.1.0.5102011\"\r\n!System Software Version \"1.8.1.5145168\"\r\n!System Up Time          \"89 days 8 hrs 9 mins 32 secs\"\r\n!Additional Packages     QOS,IPv6 Management,Routing\r\n!Current SNTP Synchronized Time: SNTP Last Attempt Status Is Not Successful\r\n!\r\nnetwork protocol none\r\nnetwork parms 10.19.0.245 255.255.255.0 10.19.0.1\r\nvlan database\r\nvlan 77,99,787\r\nvlan name 99 \"testing\"\r\nvlan name 787 \"another\"\r\nvlan routing 33 1\r\nexit\r\n\r\nip ssh protocol 1 2\r\nconfigure\r\nip name server 10.19.0.1\r\nline console\r\nexit\r\n\r\nline telnet\r\nexit\r\n\r\nline ssh\r\nexit\r\n\r\n!\r\n\r\ninterface 0/5\r\nshutdown\r\ndescription 'testing'\r\nexit\r\n\r\n\r\n\r\ninterface 0/7\r\nswitchport access vlan 787\r\nexit\r\n\r\n\r\n\r\ninterface 0/8\r\nswitchport trunk allowed vlan 77,787\r\nexit\r\n\r\n\r\n\r\ninterface 0/9\r\nswitchport trunk native vlan 77\r\nswitchport trunk allowed vlan 787\r\nexit\r\n\r\n\r\n\r\ninterface 0/10\r\nswitchport mode trunk\r\nswitchport trunk allowed vlan 33\r\nexit\r\n\r\n\r\n\r\ninterface 0/11\r\nswitchport access vlan 77\r\nswitchport trunk allowed vlan 1-100\r\nexit\r\n\r\n\r\n\r\ninterface vlan 33\r\nshutdown\r\ndescription 'routedVlan'\r\nrouting\r\nexit\r\n\r\n\r\nexit\r\n\r\n\r\n";
+} // namespace devmand::channels::cli::testdata


### PR DESCRIPTION
Summary:
Add new Cli layer with section aware cache

Implement tree based cache that can understand basic structure
of show commands on ubiquiti. Currently only exactly matched
sections work, e.g. `sh run interface 0/11`.