### PR TITLE
Updating MME/NAS state with state_manager and redis_client utils

### DIFF
--- a/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
@@ -101,9 +101,11 @@ std::string RedisClient::read(const std::string& key)
   db_client_->sync_commit();
   auto db_read_reply = db_read_fut.get();
 
-  if (
-    db_read_reply.is_null() || db_read_reply.is_error() ||
-    !db_read_reply.is_string()) {
+  if (db_read_reply.is_null()) {
+    return "";
+  }
+
+  if(db_read_reply.is_error() || !db_read_reply.is_string()) {
     throw std::runtime_error("Could not read from redis");
   }
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state.cpp
@@ -59,8 +59,7 @@ mme_app_desc_t* get_locked_mme_nas_state(bool read_from_db)
  */
 mme_app_desc_t* get_mme_nas_state(bool read_from_db)
 {
-  return magma::lte::MmeNasStateManager::getInstance().get_mme_nas_state(
-    read_from_db);
+  return magma::lte::MmeNasStateManager::getInstance().get_state(read_from_db);
 }
 
 /**
@@ -79,6 +78,6 @@ void put_mme_nas_state(mme_app_desc_t** task_state_ptr)
  */
 void clear_mme_nas_state()
 {
-  magma::lte::MmeNasStateManager::getInstance().free_in_memory_mme_nas_state();
+  magma::lte::MmeNasStateManager::getInstance().free_state();
 }
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -124,7 +124,8 @@ void MmeNasStateConverter::hashtable_uint64_ts_to_proto(
     if (ht_rc == HASH_TABLE_OK) {
       (*proto_map)[keys->keys[i]] = mme_ue_id;
     } else {
-      OAILOG_ERROR(LOG_MME_APP, "Key %lu not in %s", keys->keys[i], table_name);
+      OAILOG_ERROR(LOG_MME_APP, "Key %lu not in %s", keys->keys[i],
+        table_name.c_str());
     }
   }
 
@@ -147,7 +148,7 @@ void MmeNasStateConverter::proto_to_hashtable_uint64_ts(
         LOG_MME_APP,
         "Failed to insert mme_ue_s1ap_id %u in table %s: error: %s\n",
         mme_ue_id,
-        table_name,
+        table_name.c_str(),
         hashtable_rc_code2string(ht_rc));
     }
   }
@@ -748,8 +749,8 @@ void MmeNasStateConverter::proto_to_ue_mm_context(
 * Functions to serialize/desearialize MME app state      *
 * The caller is responsible for all memory management    *
 **********************************************************/
-void MmeNasStateConverter::mme_nas_state_to_proto(
-  mme_app_desc_t* mme_nas_state_p,
+void MmeNasStateConverter::state_to_proto(
+  const mme_app_desc_t* mme_nas_state_p,
   MmeNasState* state_proto)
 {
   state_proto->set_nb_enb_connected(mme_nas_state_p->nb_enb_connected);
@@ -791,24 +792,23 @@ void MmeNasStateConverter::mme_nas_state_to_proto(
     guti_table_to_proto(
     mme_nas_state_p->mme_ue_contexts.guti_ue_context_htbl,
     mme_ue_ctxts_proto->mutable_guti_ue_id_htbl());*/
-  return;
 }
 
-void MmeNasStateConverter::mme_nas_proto_to_state(
-  MmeNasState* state_proto,
+void MmeNasStateConverter::proto_to_state(
+  const MmeNasState& state_proto,
   mme_app_desc_t* mme_nas_state_p)
 {
   OAILOG_INFO(LOG_MME_APP, "Converting proto to state");
-  mme_nas_state_p->nb_enb_connected = state_proto->nb_enb_connected();
-  mme_nas_state_p->nb_ue_attached = state_proto->nb_ue_attached();
-  mme_nas_state_p->nb_ue_connected = state_proto->nb_ue_connected();
+  mme_nas_state_p->nb_enb_connected = state_proto.nb_enb_connected();
+  mme_nas_state_p->nb_ue_attached = state_proto.nb_ue_attached();
+  mme_nas_state_p->nb_ue_connected = state_proto.nb_ue_connected();
   mme_nas_state_p->nb_default_eps_bearers =
-    state_proto->nb_default_eps_bearers();
-  mme_nas_state_p->nb_s1u_bearers = state_proto->nb_s1u_bearers();
+    state_proto.nb_default_eps_bearers();
+  mme_nas_state_p->nb_s1u_bearers = state_proto.nb_s1u_bearers();
   OAILOG_INFO(LOG_MME_APP, "Read MME statistics from data store");
 
   // copy mme_ue_contexts
-  MmeUeContext mme_ue_ctxts_proto = state_proto->mme_ue_contexts();
+  MmeUeContext mme_ue_ctxts_proto = state_proto.mme_ue_contexts();
   mme_nas_state_p->mme_ue_contexts.nb_ue_managed =
     mme_ue_ctxts_proto.nb_ue_managed();
   mme_nas_state_p->mme_ue_contexts.nb_ue_idle = mme_ue_ctxts_proto.nb_ue_idle();

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.h
@@ -40,7 +40,7 @@ extern "C" {
 namespace magma {
 namespace lte {
 
-class MmeNasStateConverter : StateConverter {
+class MmeNasStateConverter : public StateConverter {
  public:
   // Constructor
   MmeNasStateConverter();
@@ -49,13 +49,13 @@ class MmeNasStateConverter : StateConverter {
   ~MmeNasStateConverter();
 
   // Serialize mme_app_desc_t to MmeNasState proto
-  static void mme_nas_state_to_proto(
-    mme_app_desc_t* mme_nas_state_p,
+  static void state_to_proto(
+    const mme_app_desc_t* mme_nas_state_p,
     MmeNasState* state_proto);
 
   // Deserialize mme_app_desc_t from MmeNasState proto
-  static void mme_nas_proto_to_state(
-    MmeNasState* state_proto,
+  static void proto_to_state(
+    const MmeNasState& state_proto,
     mme_app_desc_t* mme_nas_state_p);
 
  private:

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -30,7 +30,6 @@ extern "C" {
 #include "mme_app_state_manager.h"
 
 namespace {
-const char* LOCALHOST = "127.0.0.1";
 const char* MME_NAS_STATE_KEY = "mme_nas_state";
 const int NUM_MAX_UE_HTBL_LISTS = 6;
 const char* UE_ID_UE_CTXT_TABLE_NAME = "mme_app_mme_ue_s1ap_id_ue_context_htbl";
@@ -56,11 +55,7 @@ MmeNasStateManager& MmeNasStateManager::getInstance()
 
 // Constructor for MME NAS state object
 MmeNasStateManager::MmeNasStateManager():
-  is_initialized_(false),
-  mme_nas_state_p_(nullptr),
   mme_nas_state_dirty_(false),
-  persist_state_(false),
-  mme_nas_db_client_(nullptr),
   max_ue_htbl_lists_(NUM_MAX_UE_HTBL_LISTS),
   mme_statistic_timer_(10)
 {
@@ -69,53 +64,45 @@ MmeNasStateManager::MmeNasStateManager():
 // Destructor for MME NAS state object
 MmeNasStateManager::~MmeNasStateManager()
 {
-  free_in_memory_mme_nas_state();
+  free_state();
 }
 
 int MmeNasStateManager::initialize_state(const mme_config_t* mme_config_p)
 {
-  persist_state_ = mme_config_p->use_stateless;
+  persist_state_enabled = mme_config_p->use_stateless;
   max_ue_htbl_lists_ = mme_config_p->max_ues;
   mme_statistic_timer_ = mme_config_p->mme_statistic_timer;
 
   // Allocate the local mme state
-  create_mme_nas_state();
+  create_state();
 
-  int rc = RETURNok;
-  if (persist_state_) {
-    // initialize the db client
-    if (initialize_db_connection() != RETURNok) {
-      OAILOG_ERROR(LOG_MME_APP, "Failed to initiate db connection");
-      return RETURNerror;
-    }
-    rc = read_state_from_db();
-  }
-  is_initialized_ = true;
+  int rc = read_state_from_db();
+  is_initialized = true;
   return rc;
 }
 
 void MmeNasStateManager::lock_mme_nas_state()
 {
   AssertFatal(
-    is_initialized_, "Trying to lock state without initializing state manager");
+    is_initialized, "Trying to lock state without initializing state manager");
   OAILOG_DEBUG(LOG_MME_APP, "Acquiring lock");
-  pthread_rwlock_wrlock(&mme_nas_state_p_->rw_lock);
+  pthread_rwlock_wrlock(&state_cache_p->rw_lock);
 }
 
 void MmeNasStateManager::unlock_mme_nas_state()
 {
   AssertFatal(
-    is_initialized_,
+    is_initialized,
     "Trying to unlock state without initializing state manager");
   OAILOG_DEBUG(LOG_MME_APP, "Releasing lock");
-  pthread_rwlock_unlock(&mme_nas_state_p_->rw_lock);
+  pthread_rwlock_unlock(&state_cache_p->rw_lock);
   OAILOG_DEBUG(LOG_MME_APP, "Lock released");
 }
 
 void MmeNasStateManager::write_state_to_db(mme_app_desc_t** task_state_ptr)
 {
   AssertFatal(
-    is_initialized_, "Calling write without initializing MME state manager");
+    is_initialized, "Calling write without initializing MME state manager");
   if (!mme_nas_state_dirty_) {
     OAILOG_ERROR(
       LOG_MME_APP, "Tried to put mme_nas_state without getting it first");
@@ -124,18 +111,17 @@ void MmeNasStateManager::write_state_to_db(mme_app_desc_t** task_state_ptr)
 
   // check if the calling thread owns the lock on state
   AssertFatal(
-    pthread_rwlock_trywrlock(&mme_nas_state_p_->rw_lock),
+    pthread_rwlock_trywrlock(&state_cache_p->rw_lock),
     "Thread trying to write state without locking");
 
   // clear up the local ptr of the task holding the state pointer
   *task_state_ptr = nullptr;
 
-  if (persist_state_) {
+  if (persist_state_enabled) {
     std::string serialized_state;
     // convert the in-memory state to proto message
     MmeNasState state_proto = MmeNasState();
-    MmeNasStateConverter::mme_nas_state_to_proto(
-      mme_nas_state_p_, &state_proto);
+    MmeNasStateConverter::state_to_proto(state_cache_p, &state_proto);
 
     if (!state_proto.SerializeToString(&serialized_state)) {
       OAILOG_ERROR(LOG_MME_APP, "Failed to serialize MME state");
@@ -145,17 +131,12 @@ void MmeNasStateManager::write_state_to_db(mme_app_desc_t** task_state_ptr)
 
     OAILOG_DEBUG(LOG_MME_APP, "Writing serialized MME state to redis");
     // write the proto to redis store
-    auto db_write =
-      mme_nas_db_client_->set(MME_NAS_STATE_KEY, serialized_state);
-    mme_nas_db_client_->sync_commit();
-    auto reply = db_write.get();
-
-    if (reply.is_error()) {
-      OAILOG_ERROR(LOG_MME_APP, "Failed to write to data store");
-      goto error;
+    if (
+      redis_client->write(MME_NAS_STATE_KEY, serialized_state) !=
+      RETURNok) {
+      OAILOG_ERROR(LOG_MME_APP, "Failed to write state to db");
       return;
     }
-
     OAILOG_DEBUG(LOG_MME_APP, "MME NAS state written to redis");
   }
   mme_nas_state_dirty_ = false;
@@ -165,45 +146,45 @@ error:
 
 /**
  * Getter function to lock the state before returning the pointer to in-memory
- * user state. The read_from_db flag is a bebug flag to force read from the
- * data store insted of just returning the pointer.
+ * user state. The read_from_db flag is a debug flag to force read from the
+ * data store instead of just returning the pointer.
  */
 mme_app_desc_t* MmeNasStateManager::get_locked_mme_nas_state(bool read_from_db)
 {
   AssertFatal(
-    is_initialized_,
+    is_initialized,
     "Calling get_locked_mme_nas_state without initializing state manager");
   OAILOG_DEBUG(
     LOG_MME_APP,
     "Inside get_locked_mme_nas_state with read_from_db %d",
     read_from_db);
   lock_mme_nas_state();
-  return get_mme_nas_state(read_from_db);
+  return get_state(read_from_db);
 }
 
 /**
  * Getter function to get the pointer to the in-memory user state. The
  * read_from_db flag is a debug flag to force read from data store instead of
  * just returning the pointer. In non-debug mode, the state is only read from
- * data store when initialize_state is called and get_mme_nas_state just
- * returns the pointer to that structure.
+ * data store when initialize_state is called and get_state just returns the
+ * pointer to that structure.
  */
-mme_app_desc_t* MmeNasStateManager::get_mme_nas_state(bool read_from_db)
+mme_app_desc_t* MmeNasStateManager::get_state(bool read_from_db)
 {
   AssertFatal(
-    is_initialized_,
-    "Calling get_mme_nas_state without initializing state manager");
-  AssertFatal(mme_nas_state_p_, "mme_nas_state is NULL");
+    is_initialized,
+    "Calling get_state without initializing state manager");
+  AssertFatal(state_cache_p, "mme_nas_state is NULL");
   OAILOG_DEBUG(
-    LOG_MME_APP, "Inside get_mme_nas_state with read_from_db %d", read_from_db);
+    LOG_MME_APP, "Inside get_state with read_from_db %d", read_from_db);
 
   // check if the calling thread owns the lock on state
   AssertFatal(
-    pthread_rwlock_trywrlock(&mme_nas_state_p_->rw_lock),
+    pthread_rwlock_trywrlock(&state_cache_p->rw_lock),
     "Thread trying to get state without locking");
 
   mme_nas_state_dirty_ = true;
-  if (persist_state_ && read_from_db) {
+  if (persist_state_enabled && read_from_db) {
     // free up the memory allocated to hashtables
     OAILOG_DEBUG(LOG_MME_APP, "Freeing up in-memory hashtables");
     clear_mme_nas_hashtables();
@@ -212,30 +193,9 @@ mme_app_desc_t* MmeNasStateManager::get_mme_nas_state(bool read_from_db)
     create_hashtables();
     // read the state from data store
     int rc = read_state_from_db();
-    AssertFatal(mme_nas_state_p_, "mme_nas_state is NULL");
+    AssertFatal(state_cache_p, "mme_nas_state is NULL");
   }
-  return mme_nas_state_p_;
-}
-
-int MmeNasStateManager::initialize_db_connection()
-{
-  // initialize the db client
-  magma::ServiceConfigLoader loader;
-
-  auto config = loader.load_service_config("redis");
-  auto port = config["port"].as<uint32_t>();
-
-  mme_nas_db_client_ = std::make_unique<cpp_redis::client>();
-  mme_nas_db_client_->connect(LOCALHOST, port, nullptr);
-
-  if (!mme_nas_db_client_->is_connected()) {
-    return RETURNerror;
-  }
-
-  OAILOG_DEBUG(
-    LOG_MME_APP, "Connected to redis datastore on %s:%u\n", LOCALHOST, port);
-
-  return RETURNok;
+  return state_cache_p;
 }
 
 // This is a helper function for debugging. If the state manager needs to clear
@@ -244,12 +204,9 @@ void MmeNasStateManager::clear_db_state()
 {
   OAILOG_DEBUG(LOG_MME_APP, "Clearing state in data store");
   std::vector<std::string> keys_to_del;
-  keys_to_del.push_back(MME_NAS_STATE_KEY);
-  auto db_write = mme_nas_db_client_->del(keys_to_del);
-  mme_nas_db_client_->sync_commit();
-  auto reply = db_write.get();
+  keys_to_del.emplace_back(MME_NAS_STATE_KEY);
 
-  if (reply.is_error()) {
+  if (redis_client->clear_keys(keys_to_del) != RETURNok) {
     OAILOG_ERROR(LOG_MME_APP, "Failed to clear the state in data store");
     return;
   }
@@ -259,10 +216,10 @@ void MmeNasStateManager::clear_db_state()
 void MmeNasStateManager::mme_nas_state_init_local_state()
 {
   // create local lock for this state
-  pthread_rwlock_init(&mme_nas_state_p_->rw_lock, nullptr);
+  pthread_rwlock_init(&state_cache_p->rw_lock, nullptr);
 
   // create statistic timer locally
-  mme_nas_state_p_->statistic_timer_period = mme_statistic_timer_;
+  state_cache_p->statistic_timer_period = mme_statistic_timer_;
 
   // Request for periodic timer to print statistics in debug mode
   if (
@@ -274,83 +231,50 @@ void MmeNasStateManager::mme_nas_state_init_local_state()
       TIMER_PERIODIC,
       nullptr,
       0,
-      &(mme_nas_state_p_->statistic_timer_id)) < 0) {
+      &(state_cache_p->statistic_timer_id)) < 0) {
     OAILOG_ERROR(
       LOG_MME_APP,
       "Failed to request new timer for statistics with %ds "
       "of periocidity\n",
       mme_statistic_timer_);
-    mme_nas_state_p_->statistic_timer_id = 0;
+    state_cache_p->statistic_timer_id = 0;
   }
-}
-
-int MmeNasStateManager::read_state_from_db()
-{
-  OAILOG_FUNC_IN(LOG_MME_APP);
-  // convert the datastore proto message to in-memory state
-
-  OAILOG_DEBUG(LOG_MME_APP, "Reading MME NAS state from redis");
-  // read the proto from redis store
-  auto db_read = mme_nas_db_client_->get(MME_NAS_STATE_KEY);
-  mme_nas_db_client_->sync_commit();
-  auto reply = db_read.get();
-
-  if (reply.is_null()) {
-    OAILOG_DEBUG(LOG_MME_APP, "Reading MME NAS state from DB returned NULL");
-    return RETURNok;
-  }
-
-  if (reply.is_error() || !reply.is_string()) {
-    OAILOG_ERROR(LOG_MME_APP, "Reading MME NAS state from DB gave an error");
-    return RETURNerror;
-  }
-
-  OAILOG_DEBUG(LOG_MME_APP, "Parsing MME NAS state from protobuf");
-  MmeNasState state_proto;
-  if (!state_proto.ParseFromString(reply.as_string())) {
-    return RETURNerror;
-  }
-
-  MmeNasStateConverter::mme_nas_proto_to_state(&state_proto, mme_nas_state_p_);
-
-  OAILOG_DEBUG(LOG_MME_APP, "Done reading MME NAS state from redis");
-  return RETURNok;
 }
 
 // Create the hashtables for MME NAS state
 void MmeNasStateManager::create_hashtables()
 {
   bstring b = bfromcstr(IMSI_UE_ID_TABLE_NAME);
-  mme_nas_state_p_->mme_ue_contexts.imsi_ue_context_htbl =
+  state_cache_p->mme_ue_contexts.imsi_ue_context_htbl =
     hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
   btrunc(b, 0);
   bassigncstr(b, TUN_UE_ID_TABLE_NAME);
-  mme_nas_state_p_->mme_ue_contexts.tun11_ue_context_htbl =
+  state_cache_p->mme_ue_contexts.tun11_ue_context_htbl =
     hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
   AssertFatal(
     sizeof(uintptr_t) >= sizeof(uint64_t),
     "Problem with mme_ue_s1ap_id_ue_context_htbl in MME_APP");
   btrunc(b, 0);
   bassigncstr(b, UE_ID_UE_CTXT_TABLE_NAME);
-  mme_nas_state_p_->mme_ue_contexts.mme_ue_s1ap_id_ue_context_htbl =
+  state_cache_p->mme_ue_contexts.mme_ue_s1ap_id_ue_context_htbl =
     hashtable_ts_create(
       max_ue_htbl_lists_, nullptr, mme_app_state_free_ue_context, b);
   btrunc(b, 0);
   bassigncstr(b, ENB_UE_ID_MME_UE_ID_TABLE_NAME);
-  mme_nas_state_p_->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl =
+  state_cache_p->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl =
     hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
   btrunc(b, 0);
   bassigncstr(b, GUTI_UE_ID_TABLE_NAME);
-  mme_nas_state_p_->mme_ue_contexts.guti_ue_context_htbl =
+  state_cache_p->mme_ue_contexts.guti_ue_context_htbl =
     obj_hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, nullptr, b);
   bdestroy_wrapper(&b);
 }
 
 // Initialize memory for MME state before reading from data-store
-void MmeNasStateManager::create_mme_nas_state()
+void MmeNasStateManager::create_state()
 {
-  mme_nas_state_p_ = (mme_app_desc_t*) calloc(1, sizeof(mme_app_desc_t));
-  if (!mme_nas_state_p_) {
+  state_cache_p = (mme_app_desc_t*) calloc(1, sizeof(mme_app_desc_t));
+  if (!state_cache_p) {
     return;
   }
   create_hashtables();
@@ -361,34 +285,34 @@ void MmeNasStateManager::create_mme_nas_state()
 // Delete the hashtables for MME NAS state
 void MmeNasStateManager::clear_mme_nas_hashtables()
 {
-  if (!mme_nas_state_p_) {
+  if (!state_cache_p) {
     return;
   }
 
   hashtable_uint64_ts_destroy(
-    mme_nas_state_p_->mme_ue_contexts.imsi_ue_context_htbl);
+    state_cache_p->mme_ue_contexts.imsi_ue_context_htbl);
   hashtable_uint64_ts_destroy(
-    mme_nas_state_p_->mme_ue_contexts.tun11_ue_context_htbl);
+    state_cache_p->mme_ue_contexts.tun11_ue_context_htbl);
   hashtable_ts_destroy(
-    mme_nas_state_p_->mme_ue_contexts.mme_ue_s1ap_id_ue_context_htbl);
+    state_cache_p->mme_ue_contexts.mme_ue_s1ap_id_ue_context_htbl);
   hashtable_uint64_ts_destroy(
-    mme_nas_state_p_->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl);
+    state_cache_p->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl);
   obj_hashtable_uint64_ts_destroy(
-    mme_nas_state_p_->mme_ue_contexts.guti_ue_context_htbl);
+    state_cache_p->mme_ue_contexts.guti_ue_context_htbl);
 }
 
 // Free the memory allocated to state pointer and destroy the read/write lock
-void MmeNasStateManager::free_in_memory_mme_nas_state()
+void MmeNasStateManager::free_state()
 {
-  if (!mme_nas_state_p_) {
+  if (!state_cache_p) {
     return;
   }
   lock_mme_nas_state();
   clear_mme_nas_hashtables();
-  timer_remove(mme_nas_state_p_->statistic_timer_id, nullptr);
-  pthread_rwlock_destroy(&mme_nas_state_p_->rw_lock);
-  free(mme_nas_state_p_);
-  mme_nas_state_p_ = nullptr;
+  timer_remove(state_cache_p->statistic_timer_id, nullptr);
+  pthread_rwlock_destroy(&state_cache_p->rw_lock);
+  free(state_cache_p);
+  state_cache_p = nullptr;
 }
 
 } // namespace lte


### PR DESCRIPTION
Summary:
This diff:

- Converts MME app and NAS state to use state manager class, also using common redis_client class
- Fix redis_client read function in case null reply is retrieved from redis
- Updates state_to_proto, proto_to_state converter functions naming on MME to use base class functions

Reviewed By: ssanadhya

Differential Revision: D19451523

