### PR TITLE
Make policydb/servicers into a package by adding an __init__.py

### DIFF
--- a/lte/gateway/python/magma/policydb/servicers/__init__.py
+++ b/lte/gateway/python/magma/policydb/servicers/__init__.py
@@ -1,0 +1,8 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""


### PR DESCRIPTION
Summary: Make `magma/policydb/servicers` into a package. As a requirement of this, the directory needs an `__init__.py`

Reviewed By: themarwhal

Differential Revision: D19502840

