### PR TITLE
Switch to the fork of go-diameter with CER/CEA AppID Validation fix

### DIFF
--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -7,7 +7,7 @@
 module magma/feg/gateway
 
 replace (
-	github.com/fiorix/go-diameter/v4 => github.com/emakeev/go-diameter/v4 v4.0.3
+	github.com/fiorix/go-diameter/v4 => github.com/emakeev/go-diameter/v4 v4.0.4
 
 	magma/feg/cloud/go => ../../feg/cloud/go
 	magma/feg/cloud/go/protos => ../../feg/cloud/go/protos

--- a/feg/gateway/go.sum
+++ b/feg/gateway/go.sum
@@ -61,6 +61,8 @@ github.com/elastic/gosigar v0.9.0/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyC
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/emakeev/go-diameter/v4 v4.0.3 h1:OfqohL/nCqfylmA0coIdN5UGCUvR2YD7sGobfsju2n8=
 github.com/emakeev/go-diameter/v4 v4.0.3/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=
+github.com/emakeev/go-diameter/v4 v4.0.4 h1:QZ8734e0Pyrp9NQtFH87HxOYcAUKuLx+cyAn9Q4cZlw=
+github.com/emakeev/go-diameter/v4 v4.0.4/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40egUymuWXxAe151lTNnCv97MddSOVsjpPPkityA=


### PR DESCRIPTION
Summary:
The fix includes:
 Capabilities-Exchange validation fix to verify AppIDs in common vs. all AppIDs"
 pull request: https://github.com/fiorix/go-diameter/pull/126

Reviewed By: xjtian

Differential Revision: D19505108

