### PR TITLE
Moving hashtable_uint64 to proto conversion functions to base state converter

### DIFF
--- a/lte/gateway/c/oai/include/state_converter.h
+++ b/lte/gateway/c/oai/include/state_converter.h
@@ -135,6 +135,14 @@ class StateConverter {
     }
   }
 
+  static void hashtable_uint64_ts_to_proto(
+    hash_table_uint64_ts_t* htbl,
+    google::protobuf::Map<unsigned long, unsigned long>* proto_map);
+
+  static void proto_to_hashtable_uint64_ts(
+    const google::protobuf::Map<unsigned long, unsigned long>& proto_map,
+    hash_table_uint64_ts_t* state_htbl);
+
   static void guti_to_proto(const guti_t& guti_state, Guti* guti_proto);
 
   static void ecgi_to_proto(const ecgi_t& state_ecgi, Ecgi* ecgi_proto);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.h
@@ -77,16 +77,6 @@ class MmeNasStateConverter : public StateConverter {
     const google::protobuf::Map<unsigned long, UeContext>& proto_map,
     hash_table_ts_t* state_htbl);
 
-  static void hashtable_uint64_ts_to_proto(
-    hash_table_uint64_ts_t* htbl,
-    google::protobuf::Map<unsigned long, unsigned long>* proto_map,
-    const std::string& table_name);
-
-  static void proto_to_hashtable_uint64_ts(
-    const google::protobuf::Map<unsigned long, unsigned long>& proto_map,
-    hash_table_uint64_ts_t* state_htbl,
-    const std::string& table_name);
-
   static void guti_table_to_proto(
     const obj_hash_table_uint64_t* guti_htbl,
     google::protobuf::Map<std::string, unsigned long>* proto_map);


### PR DESCRIPTION
Summary:
- Moving hashtable_uint64 to proto conversion functions to StateConverter, so it can be used for other tasks,
previously was on MmeNasStateConverter

Differential Revision: D19502874

