### PR TITLE
Add logging on Policy Rule MonitoringKey decode failure, clenup MonitoringKey type conversions

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/definitions.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/definitions.go
@@ -73,7 +73,7 @@ type CreditControlAnswer struct {
 }
 
 type UsageReport struct {
-	MonitoringKey string
+	MonitoringKey []byte
 	Level         MonitoringLevel
 	InputOctets   uint64
 	OutputOctets  uint64
@@ -104,7 +104,7 @@ type RuleDefinition struct {
 	RuleName            string               `avp:"Charging-Rule-Name"`
 	RatingGroup         *uint32              `avp:"Rating-Group"`
 	Precedence          uint32               `avp:"Precedence"`
-	MonitoringKey       *string              `avp:"Monitoring-Key"`
+	MonitoringKey       []byte               `avp:"Monitoring-Key"`
 	FlowDescriptions    []string             `avp:"Flow-Description"`
 	FlowInformations    []*FlowInformation   `avp:"Flow-Information"`
 	RedirectInformation *RedirectInformation `avp:"Redirect-Information"`
@@ -138,7 +138,7 @@ type RuleRemoveAVP struct {
 }
 
 type UsageMonitoringInfo struct {
-	MonitoringKey      string                             `avp:"Monitoring-Key"`
+	MonitoringKey      []byte                             `avp:"Monitoring-Key"`
 	GrantedServiceUnit *credit_control.GrantedServiceUnit `avp:"Granted-Service-Unit"`
 	Level              MonitoringLevel                    `avp:"Usage-Monitoring-Level"`
 }

--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
@@ -86,7 +86,7 @@ func TestGxClient(t *testing.T) {
 	assert.ElementsMatch(t, imsi1BaseRules, ruleBaseNames)
 	assert.Equal(t, 1, len(ruleDefinitions))
 	assert.Equal(t, "dynrule1", ruleDefinitions[0].RuleName)
-	assert.Equal(t, "mkey", *ruleDefinitions[0].MonitoringKey)
+	assert.Equal(t, "mkey", string(ruleDefinitions[0].MonitoringKey))
 	assert.Equal(t, uint32(128000), *ruleDefinitions[0].Qos.MaxReqBwUL)
 	assert.Equal(t, uint32(128000), *ruleDefinitions[0].Qos.MaxReqBwDL)
 	if ruleDefinitions[0].Qos.GbrUL != nil {
@@ -140,7 +140,7 @@ func TestGxClient(t *testing.T) {
 	assert.ElementsMatch(t, imsi3BaseRules, ruleBaseNames)
 	assert.Equal(t, 1, len(ruleDefinitions))
 	assert.Equal(t, "dynrule3", ruleDefinitions[0].RuleName)
-	assert.Equal(t, "mkey3", *ruleDefinitions[0].MonitoringKey)
+	assert.Equal(t, "mkey3", string(ruleDefinitions[0].MonitoringKey))
 	assert.Equal(t, uint32(1), ruleDefinitions[0].RedirectInformation.RedirectSupport)
 	assert.Equal(t, uint32(2), ruleDefinitions[0].RedirectInformation.RedirectAddressType)
 	assert.Equal(t, "http://www.example.com/", ruleDefinitions[0].RedirectInformation.RedirectServerAddress)
@@ -207,10 +207,10 @@ func TestGxClientUsageMonitoring(t *testing.T) {
 	assert.Equal(t, init.RequestNumber, initAnswer.RequestNumber)
 	assert.Equal(t, 2, len(initAnswer.UsageMonitors))
 	for _, monitor := range initAnswer.UsageMonitors {
-		if monitor.MonitoringKey == "mkey" {
+		if string(monitor.MonitoringKey) == "mkey" {
 			assert.Equal(t, *(*monitor.GrantedServiceUnit).TotalOctets, uint64(1024))
 			assert.Equal(t, monitor.Level, gx.RuleLevel)
-		} else if monitor.MonitoringKey == "mkey3" {
+		} else if string(monitor.MonitoringKey) == "mkey3" {
 			assert.Equal(t, *(*monitor.GrantedServiceUnit).TotalOctets, uint64(2048))
 			assert.Equal(t, monitor.Level, gx.SessionLevel)
 		} else {
@@ -226,14 +226,14 @@ func TestGxClientUsageMonitoring(t *testing.T) {
 		IPAddr:        "192.168.1.1",
 		UsageReports: []*gx.UsageReport{
 			{
-				MonitoringKey: "mkey",
+				MonitoringKey: []byte("mkey"),
 				Level:         gx.RuleLevel,
 				InputOctets:   24,
 				OutputOctets:  0,
 				TotalOctets:   24,
 			},
 			{
-				MonitoringKey: "mkey3",
+				MonitoringKey: []byte("mkey3"),
 				Level:         gx.SessionLevel,
 				InputOctets:   4000,
 				OutputOctets:  0,
@@ -247,10 +247,10 @@ func TestGxClientUsageMonitoring(t *testing.T) {
 	assert.Equal(t, update.RequestNumber, updateAnswer.RequestNumber)
 	assert.Equal(t, 2, len(updateAnswer.UsageMonitors))
 	for _, monitor := range updateAnswer.UsageMonitors {
-		if monitor.MonitoringKey == "mkey" {
+		if string(monitor.MonitoringKey) == "mkey" {
 			assert.Equal(t, *(*monitor.GrantedServiceUnit).TotalOctets, uint64(1024))
 			assert.Equal(t, monitor.Level, gx.RuleLevel)
-		} else if monitor.MonitoringKey == "mkey3" {
+		} else if string(monitor.MonitoringKey) == "mkey3" {
 			assert.Equal(t, *(*monitor.GrantedServiceUnit).TotalOctets, uint64(96))
 			assert.Equal(t, monitor.Level, gx.SessionLevel)
 		} else {

--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
@@ -26,8 +26,8 @@ import (
 
 func TestReAuthRequest_ToProto(t *testing.T) {
 	// Check nil, 1-element, multiple elements, and empty arrays
-	monitoringKey := "monitor"
-	monitoringKey2 := "monitor2"
+	monitoringKey := []byte("monitor")
+	monitoringKey2 := []byte("monitor2")
 	bearerID := "bearer1"
 	var ratingGroup uint32 = 42
 	var totalOctets uint64 = 2048
@@ -50,7 +50,10 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 				RuleNames:     nil,
 				RuleBaseNames: nil,
 				RuleDefinitions: []*gx.RuleDefinition{
-					{RuleName: "dynamic1", MonitoringKey: &monitoringKey, Precedence: 100, RatingGroup: &ratingGroup},
+					{RuleName: "dynamic1",
+						MonitoringKey: []byte(monitoringKey),
+						Precedence:    100,
+						RatingGroup:   &ratingGroup},
 				},
 			},
 			{RuleNames: []string{"install3"}, RuleBaseNames: []string{}},
@@ -183,7 +186,7 @@ func TestReAuthAnswer_FromProto(t *testing.T) {
 
 func TestRuleDefinition_ToProto(t *testing.T) {
 	// Check nil, 1-element, multiple elements, and empty arrays
-	monitoringKey := "monitor"
+	monitoringKey := []byte("monitor")
 	var ratingGroup uint32 = 10
 	var ruleOut *protos.PolicyRule = nil
 
@@ -198,7 +201,7 @@ func TestRuleDefinition_ToProto(t *testing.T) {
 
 	ruleOut = (&gx.RuleDefinition{
 		RuleName:      "mkonly",
-		MonitoringKey: &monitoringKey,
+		MonitoringKey: monitoringKey,
 		RatingGroup:   nil,
 	}).ToProto()
 	assert.Equal(t, []byte("monitor"), ruleOut.MonitoringKey)
@@ -207,7 +210,7 @@ func TestRuleDefinition_ToProto(t *testing.T) {
 
 	ruleOut = (&gx.RuleDefinition{
 		RuleName:      "both",
-		MonitoringKey: &monitoringKey,
+		MonitoringKey: monitoringKey,
 		RatingGroup:   &ratingGroup,
 	}).ToProto()
 	assert.Equal(t, []byte("monitor"), ruleOut.MonitoringKey)

--- a/feg/gateway/services/session_proxy/servicers/policy.go
+++ b/feg/gateway/services/session_proxy/servicers/policy.go
@@ -244,7 +244,7 @@ func addMissingGxResponses(
 			SessionId: ccr.SessionID,
 			Sid:       credit_control.AddIMSIPrefix(ccr.IMSI),
 			Credit: &protos.UsageMonitoringCredit{
-				MonitoringKey: []byte(ccr.UsageReports[0].MonitoringKey),
+				MonitoringKey: ccr.UsageReports[0].MonitoringKey,
 				Level:         protos.MonitoringLevel(ccr.UsageReports[0].Level),
 			},
 		})
@@ -277,7 +277,7 @@ func (srv *CentralSessionController) getSingleUsageMonitorResponseFromCCA(answer
 		res.Credit =
 			&protos.UsageMonitoringCredit{
 				Action:        protos.UsageMonitoringCredit_DISABLE,
-				MonitoringKey: []byte(request.UsageReports[0].MonitoringKey),
+				MonitoringKey: request.UsageReports[0].MonitoringKey,
 				Level:         protos.MonitoringLevel(request.UsageReports[0].Level)}
 	} else {
 		res.Credit = answer.UsageMonitors[0].ToUsageMonitoringCredit()

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -255,7 +255,7 @@ func standardUsageTest(
 
 	maxReqBWUL := uint32(128000)
 	maxReqBWDL := uint32(128000)
-	key1 := "key1"
+	key1 := []byte("key1")
 
 	// send static rules back
 	mocks.gx.On("SendCreditControlRequest", mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -285,7 +285,7 @@ func standardUsageTest(
 						RatingGroup:         &rg20,
 						ServiceIdentifier:   &si20,
 						Precedence:          100,
-						MonitoringKey:       &key1,
+						MonitoringKey:       key1,
 						RedirectInformation: &redirect,
 						Qos:                 &qos,
 						FlowDescriptions: []string{

--- a/lte/cloud/go/plugin/models/conversion.go
+++ b/lte/cloud/go/plugin/models/conversion.go
@@ -11,6 +11,7 @@ package models
 import (
 	"encoding/base64"
 	"fmt"
+	"log"
 	"sort"
 
 	"magma/lte/cloud/go/lte"
@@ -546,6 +547,8 @@ func (m *PolicyRuleConfig) ToProto(id string) *protos.PolicyRule {
 	)
 	if len(m.MonitoringKey) > 0 {
 		if protoMKey, err = base64.StdEncoding.DecodeString(m.MonitoringKey); err != nil {
+			log.Printf("Error decoding Monitoring Key '%q' for rule ID '%s', will use as is. Err: %v",
+				m.MonitoringKey, id, err)
 			protoMKey = []byte(m.MonitoringKey)
 		}
 	}

--- a/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
+++ b/lte/cloud/go/services/eps_authentication/servicers/test_utils/test_subscribers.go
@@ -59,7 +59,7 @@ func GetTestSubscribers() []*protos.SubscriberData {
 	return subs
 }
 
-func generateDefaultSub(subscriberID string) *protos.SubscriberData{
+func generateDefaultSub(subscriberID string) *protos.SubscriberData {
 	// Default user
 	sub := &protos.SubscriberData{
 		Sid:       &protos.SubscriberID{Id: subscriberID},


### PR DESCRIPTION
Summary:
Add logging on Policy Rule MonitoringKey decode failure, clenup MonitoringKey type conversions
change all MonitoringKey types to []byte.

Reviewed By: themarwhal

Differential Revision: D19523348

