### PR TITLE
fixing "you are not logged in" notice when user is still logged in (#246)

### DIFF
--- a/symphony/app/fbcnms-packages/fbcnms-auth/__tests__/express-test.js
+++ b/symphony/app/fbcnms-packages/fbcnms-auth/__tests__/express-test.js
@@ -18,7 +18,6 @@ import fbcPassport from '../passport';
 import passport from 'passport';
 import request from 'supertest';
 import userMiddleware from '../express';
-import {ErrorCodes} from '../errorCodes';
 import {USERS, USERS_EXPECTED} from '../test/UserModel';
 import {User} from '@fbcnms/sequelize-models';
 
@@ -308,27 +307,19 @@ describe('user tests', () => {
 
   describe('endpoints as normal user', () => {
     const app = getApp('validorg', 'valid@123.com');
-    const expectedErrorResponse = {
-      errorCode: ErrorCodes.USER_NOT_LOGGED_IN,
-      description: 'You must login to see this',
-    };
-    it('403 error for restricted urls, axios handles redirect', async () => {
+    it('redirects restricted urls to login', async () => {
       await request(app)
         .get('/user/async/')
-        .expect(403)
-        .expect(expectedErrorResponse);
+        .expect(302);
       await request(app)
         .post('/user/async/')
-        .expect(403)
-        .expect(expectedErrorResponse);
+        .expect(302);
       await request(app)
         .put('/user/async/1')
-        .expect(403)
-        .expect(expectedErrorResponse);
+        .expect(302);
       await request(app)
         .delete('/user/async/1/')
-        .expect(403)
-        .expect(expectedErrorResponse);
+        .expect(302);
     });
   });
 });

--- a/symphony/app/fbcnms-packages/fbcnms-auth/access.js
+++ b/symphony/app/fbcnms-packages/fbcnms-auth/access.js
@@ -76,29 +76,33 @@ export const access = (level: AccessRoleLevel) => {
     }
 
     logger.info(
-      'Client has no permission to view route: [%s]',
+      `Client has no permission to view route: [%s]. They are ${
+        req.user ? '' : 'not'
+      } logged in`,
       req.hostname + req.originalUrl,
     );
 
-    // if there is a logged in user, we shouldn't redirect to login page
-    // because it would create an infinite loop since the login page redirects
-    // back if ther user is logged in
-    const redirectURL = req.user
-      ? '/'
-      : addQueryParamsToUrl(req.access.loginUrl, {
-          to: req.originalUrl,
-        });
-
-    res.format({
-      // for axios requests, redirect does not work, so we return 403 error.
-      json: () =>
-        res.status(403).json({
-          errorCode: ErrorCodes.USER_NOT_LOGGED_IN,
-          description: 'You must login to see this',
-        }),
-      // for browser requests, simply redirect
-      html: () => res.redirect(redirectURL),
-      default: () => res.redirect(redirectURL),
-    });
+    if (!req.user) {
+      // No logged in user, attempt to redirect to login url
+      const loginURL = addQueryParamsToUrl(req.access.loginUrl, {
+        to: req.originalUrl,
+      });
+      res.format({
+        // for axios requests, redirect does not work, so we return 403 error.
+        json: () =>
+          res.status(403).json({
+            errorCode: ErrorCodes.USER_NOT_LOGGED_IN,
+            description: 'You must login to see this',
+          }),
+        // for browser requests, simply redirect
+        html: () => res.redirect(loginURL),
+        default: () => res.redirect(loginURL),
+      });
+    } else {
+      // if there is a logged in user, we shouldn't redirect to login page
+      // because it would create an infinite loop since the login page redirects
+      // back if ther user is logged in.
+      res.redirect('/');
+    }
   };
 };


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/symphony/pull/246

Some people are having issues with the login notice popping up in workorders even when they were logged in. Not sure why they're requesting routes they don't have permission for (could be a cookie issue?), but I took a look at the code again and it looks like I didn't actually check to see if the user was logged out before returning the 403 error.  This should fix the notice popping up when they're logged in.

Reviewed By: rckclmbr

Differential Revision: D19519916

