### PR TITLE
Refactor SessionController so that there is Omnipresent Rules support for UseGYAuthOnly mode as well

### DIFF
--- a/feg/gateway/policydb/mocks/PolicyDBClient.go
+++ b/feg/gateway/policydb/mocks/PolicyDBClient.go
@@ -16,7 +16,7 @@ type PolicyDBClient struct {
 }
 
 // GetChargingKeysForRules provides a mock function with given fields: ruleIDs, ruleDefs
-func (_m *PolicyDBClient) GetChargingKeysForRules(ruleIDs []string, ruleDefs []*protos.PolicyRule) ([]policydb.ChargingKey, error) {
+func (_m *PolicyDBClient) GetChargingKeysForRules(ruleIDs []string, ruleDefs []*protos.PolicyRule) []policydb.ChargingKey {
 	ret := _m.Called(ruleIDs, ruleDefs)
 
 	var r0 []policydb.ChargingKey
@@ -28,14 +28,7 @@ func (_m *PolicyDBClient) GetChargingKeysForRules(ruleIDs []string, ruleDefs []*
 		}
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func([]string, []*protos.PolicyRule) error); ok {
-		r1 = rf(ruleIDs, ruleDefs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // GetOmnipresentRules provides a mock function with given fields:

--- a/feg/gateway/policydb/policydb.go
+++ b/feg/gateway/policydb/policydb.go
@@ -34,7 +34,7 @@ func (k ChargingKey) String() string {
 
 // PolicyDBClient defines interactions with the stored policy rules
 type PolicyDBClient interface {
-	GetChargingKeysForRules(ruleIDs []string, ruleDefs []*protos.PolicyRule) ([]ChargingKey, error)
+	GetChargingKeysForRules(ruleIDs []string, ruleDefs []*protos.PolicyRule) []ChargingKey
 	GetPolicyRuleByID(id string) (*protos.PolicyRule, error)
 	GetRuleIDsForBaseNames(baseNames []string) []string
 	// This gets a list of rules that should be active for all subscribers in the network
@@ -106,9 +106,7 @@ func (client *RedisPolicyDBClient) GetPolicyRuleByID(id string) (*protos.PolicyR
 
 // GetChargingKeysForRules retrieves the charging keys associated with the given
 // rule names from redis.
-func (client *RedisPolicyDBClient) GetChargingKeysForRules(
-	staticRuleIDs []string, dynamicRuleDefs []*protos.PolicyRule) ([]ChargingKey, error) {
-
+func (client *RedisPolicyDBClient) GetChargingKeysForRules(staticRuleIDs []string, dynamicRuleDefs []*protos.PolicyRule) []ChargingKey {
 	keys := []ChargingKey{}
 	for _, id := range staticRuleIDs {
 		policy, err := client.GetPolicyRuleByID(id)
@@ -125,7 +123,7 @@ func (client *RedisPolicyDBClient) GetChargingKeysForRules(
 			keys = append(keys, CreateChargingKey(policy))
 		}
 	}
-	return keys, nil
+	return keys
 }
 
 func (client *RedisPolicyDBClient) GetOmnipresentRules() ([]string, []string) {

--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -285,10 +285,7 @@ func getSingleCreditResponsesFromCCA(
 	return res
 }
 
-func getInitialCreditResponsesFromCCA(
-	answer *gy.CreditControlAnswer,
-	request *gy.CreditControlRequest,
-) []*protos.CreditUpdateResponse {
+func getInitialCreditResponsesFromCCA(request *gy.CreditControlRequest, answer *gy.CreditControlAnswer) []*protos.CreditUpdateResponse {
 	responses := make([]*protos.CreditUpdateResponse, 0, len(answer.Credits))
 	for _, credit := range answer.Credits {
 		success := credit.ResultCode == diameter.SuccessCode || credit.ResultCode == 0

--- a/feg/gateway/services/session_proxy/servicers/policy.go
+++ b/feg/gateway/services/session_proxy/servicers/policy.go
@@ -96,14 +96,6 @@ func getGxAnswerOrError(
 	}
 }
 
-func getPolicyRulesFromDefinitions(ruleDefs []*gx.RuleDefinition) []*protos.PolicyRule {
-	policyRules := make([]*protos.PolicyRule, 0, len(ruleDefs))
-	for _, def := range ruleDefs {
-		policyRules = append(policyRules, def.ToProto())
-	}
-	return policyRules
-}
-
 func getUsageMonitorsFromCCA_I(imsi string, sessionID string, gxCCAInit *gx.CreditControlAnswer) []*protos.UsageMonitoringUpdateResponse {
 	monitors := make([]*protos.UsageMonitoringUpdateResponse, 0, len(gxCCAInit.UsageMonitors))
 	// If there is a message wide revalidation time, apply it to every Usage Monitor

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -24,6 +24,7 @@ import (
 	orcprotos "magma/orc8r/cloud/go/protos"
 
 	"github.com/golang/glog"
+	"github.com/thoas/go-funk"
 	"golang.org/x/net/context"
 )
 
@@ -87,30 +88,22 @@ func (srv *CentralSessionController) CreateSession(
 	}
 	metrics.PcrfCcrInitRequests.Inc()
 
-	var staticRuleNames []string
-	var dynamicRuleDefs []*gx.RuleDefinition
-	for _, rule := range gxCCAInit.RuleInstallAVP {
-		staticRuleNames = append(staticRuleNames, rule.RuleNames...)
-		if len(rule.RuleBaseNames) > 0 {
-			staticRuleNames = append(staticRuleNames, srv.dbClient.GetRuleIDsForBaseNames(rule.RuleBaseNames)...)
-		}
-		dynamicRuleDefs = append(dynamicRuleDefs, rule.RuleDefinitions...)
-	}
+	staticRuleInstalls, dynamicRuleInstalls := gx.ParseRuleInstallAVPs(srv.dbClient, gxCCAInit.RuleInstallAVP)
+	chargingKeys := srv.getChargingKeysFromRuleInstalls(staticRuleInstalls, dynamicRuleInstalls)
 
-	policyRules := getPolicyRulesFromDefinitions(dynamicRuleDefs)
-	keys, err := srv.dbClient.GetChargingKeysForRules(staticRuleNames, policyRules)
-	if err != nil {
-		glog.Errorf("Failed to get charging keys for rules: %s", err)
-		return nil, err
-	}
-	keys = removeDuplicateChargingKeys(keys)
+	// These rules should not be tracked by OCS or PCRF, they come directly from the orc8r
+	omnipresentRuleIDs, omnipresentBaseNames := srv.dbClient.GetOmnipresentRules()
+	omnipresentRuleIDs = append(omnipresentRuleIDs, srv.dbClient.GetRuleIDsForBaseNames(omnipresentBaseNames)...)
+	staticRuleInstalls = append(staticRuleInstalls, gx.RuleIDsToProtosRuleInstalls(omnipresentRuleIDs)...)
+
+	usageMonitors := getUsageMonitorsFromCCA_I(imsi, sessionID, gxCCAInit)
 
 	if srv.cfg.UseGyForAuthOnly {
-		return srv.handleUseGyForAuthOnly(imsi, request, gxCCAInit)
+		return srv.handleUseGyForAuthOnly(imsi, request, staticRuleInstalls, dynamicRuleInstalls, usageMonitors)
 	}
 	credits := []*protos.CreditUpdateResponse{}
 
-	if len(keys) > 0 {
+	if len(chargingKeys) > 0 {
 		if srv.cfg.InitMethod == gy.PerSessionInit {
 			_, err = srv.sendSingleCreditRequest(getCCRInitRequest(imsi, request))
 			metrics.UpdateGyRecentRequestMetrics(err)
@@ -122,7 +115,7 @@ func (srv *CentralSessionController) CreateSession(
 			metrics.OcsCcrInitRequests.Inc()
 		}
 
-		gyCCRInit := getCCRInitialCreditRequest(imsi, request, keys, srv.cfg.InitMethod)
+		gyCCRInit := getCCRInitialCreditRequest(imsi, request, chargingKeys, srv.cfg.InitMethod)
 		gyCCAInit, err := srv.sendSingleCreditRequest(gyCCRInit)
 		metrics.UpdateGyRecentRequestMetrics(err)
 		if err != nil {
@@ -130,33 +123,25 @@ func (srv *CentralSessionController) CreateSession(
 			glog.Errorf("Failed to send second single credit request: %s", err)
 			return nil, err
 		}
-		credits = getInitialCreditResponsesFromCCA(gyCCAInit, gyCCRInit)
+		credits = getInitialCreditResponsesFromCCA(gyCCRInit, gyCCAInit)
 
 		metrics.OcsCcrInitRequests.Inc()
 	}
 
-	staticRules, dynamicRules := gx.ParseRuleInstallAVPs(
-		srv.dbClient,
-		gxCCAInit.RuleInstallAVP,
-	)
-
-	// These rules should not be tracked by OCS or PCRF, they come directly from the orc8r
-	omnipresentRuleIDs, omnipresentBaseNames := srv.dbClient.GetOmnipresentRules()
-	omnipresentRuleIDs = append(omnipresentRuleIDs, srv.dbClient.GetRuleIDsForBaseNames(omnipresentBaseNames)...)
-	staticRules = append(staticRules, gx.RuleIDsToProtosRuleInstalls(omnipresentRuleIDs)...)
-
 	return &protos.CreateSessionResponse{
 		Credits:       credits,
-		StaticRules:   staticRules,
-		DynamicRules:  dynamicRules,
-		UsageMonitors: getUsageMonitorsFromCCA_I(imsi, sessionID, gxCCAInit),
+		StaticRules:   staticRuleInstalls,
+		DynamicRules:  dynamicRuleInstalls,
+		UsageMonitors: usageMonitors,
 	}, nil
 }
 
 func (srv *CentralSessionController) handleUseGyForAuthOnly(
 	imsi string,
 	pReq *protos.CreateSessionRequest,
-	gxCCAInit *gx.CreditControlAnswer,
+	staticRuleInstalls []*protos.StaticRuleInstall,
+	dynamicRuleInstalls []*protos.DynamicRuleInstall,
+	usageMonitors []*protos.UsageMonitoringUpdateResponse,
 ) (*protos.CreateSessionResponse, error) {
 	gyCCRInit := getCCRInitRequest(imsi, pReq)
 	gyCCAInit, err := srv.sendSingleCreditRequest(gyCCRInit)
@@ -173,17 +158,22 @@ func (srv *CentralSessionController) handleUseGyForAuthOnly(
 		glog.Errorf("MSCC Avp Failure: %s", err)
 		return nil, err
 	}
-
-	staticRules, dynamicRules := gx.ParseRuleInstallAVPs(
-		srv.dbClient,
-		gxCCAInit.RuleInstallAVP,
-	)
-	usageMonitors := getUsageMonitorsFromCCA_I(imsi, pReq.SessionId, gxCCAInit)
 	return &protos.CreateSessionResponse{
-		StaticRules:   staticRules,
-		DynamicRules:  dynamicRules,
+		StaticRules:   staticRuleInstalls,
+		DynamicRules:  dynamicRuleInstalls,
 		UsageMonitors: usageMonitors,
 	}, nil
+}
+
+func (srv *CentralSessionController) getChargingKeysFromRuleInstalls(
+	staticRuleInstalls []*protos.StaticRuleInstall,
+	dynamicRuleInstalls []*protos.DynamicRuleInstall,
+) []policydb.ChargingKey {
+	staticRuleIDs := funk.Map(staticRuleInstalls, func(s *protos.StaticRuleInstall) string { return s.RuleId }).([]string)
+	dynamicRuleDef := funk.Map(dynamicRuleInstalls, func(d *protos.DynamicRuleInstall) *protos.PolicyRule { return d.PolicyRule }).([]*protos.PolicyRule)
+	keys := srv.dbClient.GetChargingKeysForRules(staticRuleIDs, dynamicRuleDef)
+	return removeDuplicateChargingKeys(keys)
+
 }
 
 func removeDuplicateChargingKeys(keysIn []policydb.ChargingKey) []policydb.ChargingKey {


### PR DESCRIPTION
Summary: The implementation before did not work when the UseGyForAuthOnly config was used, since that logic path diverges after the Gx reply.

Reviewed By: xjtian

Differential Revision: D19602891

