### PR TITLE
Add http_config support to alertmanager configurer

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
@@ -6,12 +6,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package receivers
+package client
 
 import (
 	"regexp"
 	"testing"
 
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/receivers"
+	tc "magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/fsclient/mocks"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert"
 
@@ -77,22 +79,22 @@ templates: []`
 func TestClient_CreateReceiver(t *testing.T) {
 	client, fsClient := newTestClient()
 	// Create Slack Receiver
-	err := client.CreateReceiver(testNID, sampleSlackReceiver)
+	err := client.CreateReceiver(testNID, tc.SampleSlackReceiver)
 	assert.NoError(t, err)
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 
 	// Create Webhook Receiver
-	err = client.CreateReceiver(testNID, sampleWebhookReceiver)
+	err = client.CreateReceiver(testNID, tc.SampleWebhookReceiver)
 	assert.NoError(t, err)
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 
 	// Create Email receiver
-	err = client.CreateReceiver(testNID, sampleEmailReceiver)
+	err = client.CreateReceiver(testNID, tc.SampleEmailReceiver)
 	assert.NoError(t, err)
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 
 	// create duplicate receiver
-	err = client.CreateReceiver(testNID, Receiver{Name: "receiver"})
+	err = client.CreateReceiver(testNID, receivers.Receiver{Name: "receiver"})
 	assert.Regexp(t, regexp.MustCompile("notification config name \".*receiver\" is not unique"), err.Error())
 }
 
@@ -117,11 +119,11 @@ func TestClient_GetReceivers(t *testing.T) {
 
 func TestClient_UpdateReceiver(t *testing.T) {
 	client, fsClient := newTestClient()
-	err := client.UpdateReceiver(testNID, "slack", &Receiver{Name: "slack"})
+	err := client.UpdateReceiver(testNID, "slack", &receivers.Receiver{Name: "slack"})
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 	assert.NoError(t, err)
 
-	err = client.UpdateReceiver(testNID, "nonexistent", &Receiver{Name: "nonexistent"})
+	err = client.UpdateReceiver(testNID, "nonexistent", &receivers.Receiver{Name: "nonexistent"})
 	fsClient.AssertNumberOfCalls(t, "WriteFile", 1)
 	assert.Error(t, err)
 }

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/mocks/AlertmanagerClient.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/mocks/AlertmanagerClient.go
@@ -5,7 +5,9 @@ package mocks
 import (
 	alert "magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert"
 
-	config "github.com/prometheus/alertmanager/config"
+	alertmanagerconfig "github.com/prometheus/alertmanager/config"
+
+	config "magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -45,6 +47,29 @@ func (_m *AlertmanagerClient) DeleteReceiver(tenantID string, receiverName strin
 	return r0
 }
 
+// GetGlobalConfig provides a mock function with given fields:
+func (_m *AlertmanagerClient) GetGlobalConfig() (*config.GlobalConfig, error) {
+	ret := _m.Called()
+
+	var r0 *config.GlobalConfig
+	if rf, ok := ret.Get(0).(func() *config.GlobalConfig); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*config.GlobalConfig)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetReceivers provides a mock function with given fields: tenantID
 func (_m *AlertmanagerClient) GetReceivers(tenantID string) ([]receivers.Receiver, error) {
 	ret := _m.Called(tenantID)
@@ -69,15 +94,15 @@ func (_m *AlertmanagerClient) GetReceivers(tenantID string) ([]receivers.Receive
 }
 
 // GetRoute provides a mock function with given fields: tenantID
-func (_m *AlertmanagerClient) GetRoute(tenantID string) (*config.Route, error) {
+func (_m *AlertmanagerClient) GetRoute(tenantID string) (*alertmanagerconfig.Route, error) {
 	ret := _m.Called(tenantID)
 
-	var r0 *config.Route
-	if rf, ok := ret.Get(0).(func(string) *config.Route); ok {
+	var r0 *alertmanagerconfig.Route
+	if rf, ok := ret.Get(0).(func(string) *alertmanagerconfig.Route); ok {
 		r0 = rf(tenantID)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*config.Route)
+			r0 = ret.Get(0).(*alertmanagerconfig.Route)
 		}
 	}
 
@@ -92,11 +117,11 @@ func (_m *AlertmanagerClient) GetRoute(tenantID string) (*config.Route, error) {
 }
 
 // ModifyTenantRoute provides a mock function with given fields: tenantID, route
-func (_m *AlertmanagerClient) ModifyTenantRoute(tenantID string, route *config.Route) error {
+func (_m *AlertmanagerClient) ModifyTenantRoute(tenantID string, route *alertmanagerconfig.Route) error {
 	ret := _m.Called(tenantID, route)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *config.Route) error); ok {
+	if rf, ok := ret.Get(0).(func(string, *alertmanagerconfig.Route) error); ok {
 		r0 = rf(tenantID, route)
 	} else {
 		r0 = ret.Error(0)
@@ -112,6 +137,20 @@ func (_m *AlertmanagerClient) ReloadAlertmanager() error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func() error); ok {
 		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SetGlobalConfig provides a mock function with given fields: globalConfig
+func (_m *AlertmanagerClient) SetGlobalConfig(globalConfig config.GlobalConfig) error {
+	ret := _m.Called(globalConfig)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(config.GlobalConfig) error); ok {
+		r0 = rf(globalConfig)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/common/config.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/common/config.go
@@ -1,0 +1,49 @@
+package common
+
+import (
+	amconfig "github.com/prometheus/common/config"
+)
+
+// HTTPConfig is a copy of prometheus/common/config.HTTPClientConfig with
+// `Secret` fields replaced with strings to enable marshaling without obfuscation
+type HTTPConfig struct {
+	// The HTTP basic authentication credentials for the targets.
+	BasicAuth *BasicAuth `yaml:"basic_auth,omitempty" json:"basic_auth,omitempty"`
+	// The bearer token for the targets.
+	BearerToken string `yaml:"bearer_token,omitempty" json:"bearer_token,omitempty"`
+	// The bearer token file for the targets.
+
+	// TODO: Support file storage
+	//BearerTokenFile string `yaml:"bearer_token_file,omitempty"`
+	// HTTP proxy server to use to connect to the targets.
+	ProxyURL *amconfig.URL `yaml:"proxy_url,omitempty" json:"proxy_url,omitempty"`
+	// TLSConfig to use to connect to the targets.
+	TLSConfig TLSConfig `yaml:"tls_config,omitempty" json:"tls_config,omitempty"`
+}
+
+// BasicAuth is a copy of prometheus/common/config.BasicAuth with `Secret`
+// fields replaced with strings to enable marshaling without obfuscation
+type BasicAuth struct {
+	Username string `yaml:"username" json:"username"`
+	Password string `yaml:"password,omitempty" json:"password,omitempty"`
+
+	// TODO: Support file storage
+	//PasswordFile string `yaml:"password_file,omitempty"`
+}
+
+// TLSConfig is a copy of prometheus/common/config.TLSConfig without file fields
+// since storing files is not supported by alertmanager-configurer yet
+type TLSConfig struct {
+	// TODO: Support file storage
+	//// The CA cert to use for the targets.
+	//CAFile string `yaml:"ca_file,omitempty"`
+	//// The client cert file for the targets.
+	//CertFile string `yaml:"cert_file,omitempty"`
+	////The client key file for the targets.
+	//KeyFile string `yaml:"key_file,omitempty"`
+
+	// Used to verify the hostname for the targets.
+	ServerName string `yaml:"server_name,omitempty" json:"server_name,omitempty"`
+	// Disable target certificate validation.
+	InsecureSkipVerify bool `yaml:"insecure_skip_verify" json:"insecure_skip_verify,omitempty"`
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config/config.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config/config.go
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package config
+
+import (
+	"fmt"
+	"time"
+
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/common"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/receivers"
+
+	amconfig "github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/common/model"
+	"gopkg.in/yaml.v2"
+)
+
+const (
+	TenantBaseRoutePostfix = "tenant_base_route"
+)
+
+// Config uses a custom receiver struct to avoid scrubbing of 'secrets' during
+// marshaling
+type Config struct {
+	Global       *GlobalConfig           `yaml:"global,omitempty" json:"global,omitempty"`
+	Route        *amconfig.Route         `yaml:"route,omitempty" json:"route,omitempty"`
+	InhibitRules []*amconfig.InhibitRule `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
+	Receivers    []*receivers.Receiver   `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	Templates    []string                `yaml:"templates" json:"templates"`
+}
+
+// GetReceiver returns the receiver config with the given name
+func (c *Config) GetReceiver(name string) *receivers.Receiver {
+	for _, rec := range c.Receivers {
+		if rec.Name == name {
+			return rec
+		}
+	}
+	return nil
+}
+
+func (c *Config) GetRouteIdx(name string) int {
+	for idx, route := range c.Route.Routes {
+		if route.Receiver == name {
+			return idx
+		}
+	}
+	return -1
+}
+
+func (c *Config) InitializeNetworkBaseRoute(route *amconfig.Route, matcherLabel, tenantID string) error {
+	baseRouteName := MakeBaseRouteName(tenantID)
+	if c.GetReceiver(baseRouteName) != nil {
+		return fmt.Errorf("Base route for tenant %s already exists", tenantID)
+	}
+
+	c.Receivers = append(c.Receivers, &receivers.Receiver{Name: baseRouteName})
+	route.Receiver = baseRouteName
+
+	if matcherLabel != "" {
+		route.Match = map[string]string{matcherLabel: tenantID}
+	}
+
+	c.Route.Routes = append(c.Route.Routes, route)
+
+	return c.Validate()
+}
+
+// Validate makes sure that the config is properly formed. Unmarshal the yaml
+// data into an alertmanager Config struct to ensure that it is properly formed
+func (c *Config) Validate() error {
+	yamlData, err := yaml.Marshal(c)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(yamlData, &amconfig.Config{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// GlobalConfig is a copy of prometheus/alertmanager/config.GlobalConfig with
+// `Secret` fields replaced with strings to enable marshaling without obfuscation
+type GlobalConfig struct {
+	// ResolveTimeout is the time after which an alert is declared resolved
+	// if it has not been updated.
+	ResolveTimeout string `yaml:"resolve_timeout" json:"resolve_timeout"`
+
+	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	SMTPFrom         string        `yaml:"smtp_from,omitempty" json:"smtp_from,omitempty"`
+	SMTPHello        string        `yaml:"smtp_hello,omitempty" json:"smtp_hello,omitempty"`
+	SMTPSmarthost    string        `yaml:"smtp_smarthost,omitempty" json:"smtp_smarthost,omitempty"`
+	SMTPAuthUsername string        `yaml:"smtp_auth_username,omitempty" json:"smtp_auth_username,omitempty"`
+	SMTPAuthPassword string        `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
+	SMTPAuthSecret   string        `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
+	SMTPAuthIdentity string        `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
+	SMTPRequireTLS   bool          `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
+	SlackAPIURL      *amconfig.URL `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
+	PagerdutyURL     *amconfig.URL `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
+	HipchatAPIURL    *amconfig.URL `yaml:"hipchat_api_url,omitempty" json:"hipchat_api_url,omitempty"`
+	HipchatAuthToken string        `yaml:"hipchat_auth_token,omitempty" json:"hipchat_auth_token,omitempty"`
+	OpsGenieAPIURL   *amconfig.URL `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
+	OpsGenieAPIKey   string        `yaml:"opsgenie_api_key,omitempty" json:"opsgenie_api_key,omitempty"`
+	WeChatAPIURL     *amconfig.URL `yaml:"wechat_api_url,omitempty" json:"wechat_api_url,omitempty"`
+	WeChatAPISecret  string        `yaml:"wechat_api_secret,omitempty" json:"wechat_api_secret,omitempty"`
+	WeChatAPICorpID  string        `yaml:"wechat_api_corp_id,omitempty" json:"wechat_api_corp_id,omitempty"`
+	VictorOpsAPIURL  *amconfig.URL `yaml:"victorops_api_url,omitempty" json:"victorops_api_url,omitempty"`
+	VictorOpsAPIKey  string        `yaml:"victorops_api_key,omitempty" json:"victorops_api_key,omitempty"`
+}
+
+func DefaultGlobalConfig() GlobalConfig {
+	return GlobalConfig{
+		ResolveTimeout: model.Duration(5 * time.Minute).String(),
+		HTTPConfig:     &common.HTTPConfig{},
+
+		SMTPHello:      "localhost",
+		SMTPRequireTLS: false,
+	}
+}
+
+func MakeBaseRouteName(tenantID string) string {
+	return fmt.Sprintf("%s_%s", tenantID, TenantBaseRoutePostfix)
+}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/docs/swagger-v1.yml
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/docs/swagger-v1.yml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
   title: Alertmanager Configurer Model Definitions and Paths
   description: Alertmanager Configurer REST APIs
-  version: 1.0.0
+  version: 1.0.1
 
 paths:
   /{tenant_id}/receiver:
@@ -128,6 +128,33 @@ paths:
         default:
           $ref: '#/responses/UnexpectedError'
 
+  /global:
+    get:
+      summary: Retrieve alertmanager global config
+      tags:
+        - Routes
+      responses:
+        '200':
+          description: Alerting tree
+          schema:
+            $ref: '#/definitions/global_config'
+      post:
+        summary: Modify alertmanager global config
+        tags:
+          - Routes
+        parameters:
+          - in: body
+            name: global_config
+            description: Global config to be set
+            required: true
+            schema:
+              $ref: '#/definitions/global_config'
+        responses:
+          '200':
+            description: OK
+          default:
+            $ref: '#/responses/UnexpectedError'
+
 parameters:
   tenant_id:
     description: Tenant ID
@@ -154,6 +181,8 @@ definitions:
     required:
       - api_url
     properties:
+      http_config:
+        $ref: '#/definitions/http_config'
       api_url:
         type: string
       channel:
@@ -284,6 +313,79 @@ definitions:
         type: string
       repeat_interval:
         type: string
+
+  global_config:
+    type: object
+    properties:
+      resolve_timeout:
+        type: string
+      http_config:
+        $ref: '#/definitions/http_config'
+      smtp_from:
+        type: string
+      smtp_hello:
+        type: string
+      smtp_smarthost:
+        type: string
+      smtp_auth_username:
+        type: string
+      smtp_auth_password:
+        type: string
+      smtp_auth_secret:
+        type: string
+      smtp_auth_identity:
+        type: string
+      smtp_require_tls:
+        type: string
+      slack_api_url:
+        type: string
+      pagerduty_url:
+        type: string
+      hipchat_api_url:
+        type: string
+      hipchat_auth_token:
+        type: string
+      opsgenie_api_url:
+        type: string
+      opsgenie_api_key:
+        type: string
+      wechat_api_url:
+        type: string
+      wechat_api_corp_id:
+        type: string
+      victorops_api_url:
+        type: string
+      victorops_api_key:
+        type: string
+
+  http_config:
+    type: object
+    properties:
+      basic_auth:
+        $ref: '#/definitions/basic_auth'
+      bearer_token:
+        type: string
+      proxy_url:
+        type: string
+      tls_config:
+        $ref: '#/definitions/tls_config'
+
+  basic_auth:
+    type: object
+    properties:
+      username:
+        type: string
+      password:
+        type: string
+
+  tls_config:
+    type: object
+    properties:
+      server_name:
+        type: string
+      insecure_skip_verify:
+        type: boolean
+
 
   error:
     type: object

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/migration/migration.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/migration/migration.go
@@ -14,7 +14,7 @@ import (
 	"regexp"
 	"strings"
 
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/receivers"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/fsclient"
 
 	"github.com/golang/glog"
@@ -32,7 +32,7 @@ func main() {
 	fsClient := fsclient.NewFSClient()
 
 	// Read config file
-	configFile := receivers.Config{}
+	configFile := config.Config{}
 	file, err := fsClient.ReadFile(*alertmanagerConfPath)
 	if err != nil {
 		glog.Fatalf("error reading config files: %v", err)
@@ -62,18 +62,18 @@ func main() {
 // based tenancy. Replaces 'network_base_route' with 'tenant_base_route'
 const deprecatedTenancyPostfix = "network_base_route"
 
-func migrateToTenantBasedConfig(conf *receivers.Config) {
+func migrateToTenantBasedConfig(conf *config.Config) {
 	for _, route := range conf.Route.Routes {
 		matched, _ := regexp.MatchString(fmt.Sprintf(".*_%s", deprecatedTenancyPostfix), route.Receiver)
 		if matched {
-			migratedName := strings.Replace(route.Receiver, deprecatedTenancyPostfix, receivers.TenantBaseRoutePostfix, 1)
+			migratedName := strings.Replace(route.Receiver, deprecatedTenancyPostfix, config.TenantBaseRoutePostfix, 1)
 			route.Receiver = migratedName
 		}
 	}
 	for _, receiver := range conf.Receivers {
 		matched, _ := regexp.MatchString(fmt.Sprintf(".*_%s", deprecatedTenancyPostfix), receiver.Name)
 		if matched {
-			migratedName := strings.Replace(receiver.Name, deprecatedTenancyPostfix, receivers.TenantBaseRoutePostfix, 1)
+			migratedName := strings.Replace(receiver.Name, deprecatedTenancyPostfix, config.TenantBaseRoutePostfix, 1)
 			receiver.Name = migratedName
 		}
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/server.go
@@ -12,8 +12,8 @@ import (
 	"flag"
 	"fmt"
 
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/handlers"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/receivers"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/fsclient"
 	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/alert"
 
@@ -40,7 +40,7 @@ func main() {
 
 	e := echo.New()
 
-	receiverClient := receivers.NewClient(*alertmanagerConfPath, *alertmanagerURL, tenancy, fsclient.NewFSClient())
+	receiverClient := client.NewClient(*alertmanagerConfPath, *alertmanagerURL, tenancy, fsclient.NewFSClient())
 
 	handlers.RegisterBaseHandlers(e)
 	handlers.RegisterV0Handlers(e, receiverClient)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
@@ -1,0 +1,62 @@
+package test_common
+
+import (
+	"net/url"
+
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config"
+	"magma/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/receivers"
+
+	amconfig "github.com/prometheus/alertmanager/config"
+)
+
+var (
+	sampleURL, _ = url.Parse("http://test.com")
+	SampleRoute  = amconfig.Route{
+		Receiver: "testReceiver",
+		Routes: []*amconfig.Route{
+			{
+				Receiver: "testReceiver",
+			},
+			{
+				Receiver: "slack_receiver",
+			},
+		},
+	}
+	SampleReceiver = receivers.Receiver{
+		Name: "testReceiver",
+	}
+	SampleSlackReceiver = receivers.Receiver{
+		Name: "slack_receiver",
+		SlackConfigs: []*receivers.SlackConfig{{
+			APIURL:   "http://slack.com/12345",
+			Username: "slack_user",
+			Channel:  "slack_alert_channel",
+		}},
+	}
+	SampleWebhookReceiver = receivers.Receiver{
+		Name: "webhook_receiver",
+		WebhookConfigs: []*receivers.WebhookConfig{{
+			URL: &amconfig.URL{
+				URL: sampleURL,
+			},
+			NotifierConfig: amconfig.NotifierConfig{
+				VSendResolved: true,
+			},
+		}},
+	}
+	SampleEmailReceiver = receivers.Receiver{
+		Name: "email_receiver",
+		EmailConfigs: []*receivers.EmailConfig{{
+			To:        "test@mail.com",
+			From:      "sampleUser",
+			Headers:   map[string]string{"header": "value"},
+			Smarthost: "http://mail-server.com",
+		}},
+	}
+	SampleConfig = config.Config{
+		Route: &SampleRoute,
+		Receivers: []*receivers.Receiver{
+			&SampleSlackReceiver, &SampleReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
+		},
+	}
+)

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_receiver_handlers_test.go
@@ -37,7 +37,7 @@ var (
     }`, webhookURL, slackURL)
 
 	testWebhookURL, _ = url.Parse(webhookURL)
-	testWebhookConfig = config.WebhookConfig{
+	testWebhookConfig = receivers.WebhookConfig{
 		NotifierConfig: config.NotifierConfig{
 			VSendResolved: true,
 		},


### PR DESCRIPTION
Summary:
Adds `http_config` support to alertmanger configurer. This struct is used both globally for alertmanager and in some receiver configs.
* Due to the way prometheus coded their structs, I had to copy some of them and make small modifications to enable JSON marshaling to work
* Had to rearrange some directories to avoid import cycles

Differential Revision: D19623469

