### PR TITLE
Store cached subscribers in a file

### DIFF
--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -15,8 +15,9 @@ host_address: 0.0.0.0 # Bind to all interfaces
 # Enable streaming from the cloud for subscriber updates
 enable_streaming: True
 
-# Keep subscriberdb in memory. Change to path to persist
-db_path: file::memory:?cache=shared
+# Keep subscriberdb in a file.
+# Change filename to :memory: to store subscribers in memory.
+db_path: file:/var/opt/magma/subscriber.db?cache=shared
 
 # S6A Peer Configurations
 mme_host_name: hss.magma.com


### PR DESCRIPTION
Summary:
- To prevent cached subscribers from getting wiped everytime magma@subscriberdb is restarted, we want to store the subscribers in a file instead.
- There already exists a SqliteStore that can do this, but it treats the database as an in-memory one.
- The file is stored in /var/opt/magma, together with redis_dump.rdb

Reviewed By: andreilee

Differential Revision: D19565974

