### PR TITLE
Add basic error handling for CCA-Update permanent failure

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -78,7 +78,7 @@ class LocalEnforcer {
    * reset_updates resets all of the charging keys being updated in
    * failed_request. This should only be called if the *entire* request fails
    * (i.e. the entire request to the cloud timed out). Individual failures
-   * are handled when update_session_credit is called.
+   * are handled when update_session_credits_and_rules is called.
    *
    * @param failed_request - UpdateSessionRequest that couldn't be sent to the
    *                         cloud for whatever reason
@@ -105,10 +105,11 @@ class LocalEnforcer {
     const CreateSessionResponse& response);
 
   /**
-   * Update allowed credit from the cloud in the system
+   * Process the update response from the reporter and update the
+   * monitoring/charging credits and attached rules.
    * @param credit_response - message from cloud containing new credits
    */
-  void update_session_credit(const UpdateSessionResponse& response);
+  void update_session_credits_and_rules(const UpdateSessionResponse& response);
 
   /**
    * Starts the termination process for the session. When termination completes,
@@ -200,8 +201,23 @@ class LocalEnforcer {
     const std::unordered_set<uint32_t>& successful_credits,
     const std::string& imsi,
     const std::string& ip_addr,
-    RulesToProcess* rules_to_activate,
-    RulesToProcess* rules_to_deactivate);
+    RulesToProcess& rules_to_activate,
+    RulesToProcess& rules_to_deactivate);
+
+  /**
+   * Processes the charging component of UpdateSessionResponse.
+   * Updates charging credits according to the response.
+   */
+  void update_charging_credits(
+    const UpdateSessionResponse& response);
+
+  /**
+   * Processes the monitoring component of UpdateSessionResponse.
+   * Updates moniroting credits according to the response and updates rules
+   * that are installed for this session.
+   */
+  void update_monitoring_credits_and_rules(
+    const UpdateSessionResponse& response);
 
   /**
    * Process the list of rule names given and fill in rules_to_deactivate by

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -209,7 +209,8 @@ class LocalEnforcer {
    * Updates charging credits according to the response.
    */
   void update_charging_credits(
-    const UpdateSessionResponse& response);
+    const UpdateSessionResponse& response,
+    std::unordered_set<std::string>& subscribers_to_terminate);
 
   /**
    * Processes the monitoring component of UpdateSessionResponse.
@@ -217,7 +218,8 @@ class LocalEnforcer {
    * that are installed for this session.
    */
   void update_monitoring_credits_and_rules(
-    const UpdateSessionResponse& response);
+    const UpdateSessionResponse& response,
+    std::unordered_set<std::string>& subscribers_to_terminate);
 
   /**
    * Process the list of rule names given and fill in rules_to_deactivate by
@@ -346,13 +348,21 @@ class LocalEnforcer {
     const std::vector<std::unique_ptr<ServiceAction>>& actions);
 
   /**
-    * Deactive rules for certain IMSI.
+    * Deactivate rules for certain IMSI.
     * Notify AAA service if the session is a CWF session.
     */
   void terminate_service(
     const std::string& imsi,
     const std::vector<std::string>& rule_ids,
     const std::vector<PolicyRule>& dynamic_rules);
+
+
+  /**
+    * Deactivate rules for multiple IMSIs.
+    * Notify AAA service if the session is a CWF session.
+    */
+  void terminate_multiple_services(
+    const std::unordered_set<std::string>& imsis);
 
   /**
     * Install flow for redirection through pipelined

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -75,7 +75,7 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting()
                      << " to OCS failed entirely: " << status.error_message();
       } else {
         MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
-        enforcer_->update_session_credit(response);
+        enforcer_->update_session_credits_and_rules(response);
         // Check if we need to report more updates
         check_usage_for_reporting();
       }

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -335,7 +335,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates)
     local_enforcer->get_charging_credit("IMSI1", 1, REPORTING_TX), 2048);
 }
 
-TEST_F(LocalEnforcerTest, test_update_session_credit)
+TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules)
 {
   insert_static_rule(1, "", "rule1");
 
@@ -371,7 +371,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credit)
     time(NULL),
     monitor_updates_response->Add());
   EXPECT_CALL(*reporter, report_updates(_, _)).Times(1);
-  local_enforcer->update_session_credit(update_response);
+  local_enforcer->update_session_credits_and_rules(update_response);
   EXPECT_EQ(
     local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 2072);
 }
@@ -560,7 +560,7 @@ TEST_F(LocalEnforcerTest, test_all)
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
   create_credit_update_response("IMSI2", 2, 4096, updates->Add());
-  local_enforcer->update_session_credit(update_response);
+  local_enforcer->update_session_credits_and_rules(update_response);
 
   EXPECT_EQ(
     local_enforcer->get_charging_credit("IMSI2", 2, ALLOWED_TOTAL), 6144);
@@ -607,7 +607,7 @@ TEST_F(LocalEnforcerTest, test_re_auth)
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
   create_credit_update_response("IMSI1", 1, 4096, updates->Add());
-  local_enforcer->update_session_credit(update_response);
+  local_enforcer->update_session_credits_and_rules(update_response);
 
   // when next update is collected, this should trigger an action to activate
   // the flow in pipelined
@@ -847,7 +847,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
     monitor_updates->Add());
   create_monitor_update_response(
     "IMSI1", "4", MonitoringLevel::SESSION_LEVEL, 2048, monitor_updates->Add());
-  local_enforcer->update_session_credit(update_response);
+  local_enforcer->update_session_credits_and_rules(update_response);
   assert_monitor_credit("IMSI1", REPORTING_RX, {{"3", 0}, {"4", 0}});
   assert_monitor_credit("IMSI1", REPORTING_TX, {{"3", 0}, {"4", 0}});
   assert_monitor_credit("IMSI1", REPORTED_RX, {{"3", 1024}, {"4", 1049}});
@@ -872,7 +872,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
       std::vector<std::string>{"pcrf_only"}, CheckCount(0)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->update_session_credit(update_response);
+  local_enforcer->update_session_credits_and_rules(update_response);
 
   // Test rule installation in usage monitor response for CCA-Update
   update_response.Clear();
@@ -897,7 +897,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
       std::vector<std::string>{"pcrf_only"}, CheckCount(0)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->update_session_credit(update_response);
+  local_enforcer->update_session_credits_and_rules(update_response);
 }
 
 TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer)

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -363,7 +363,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules)
   auto monitor_updates_response =
     update_response.mutable_usage_monitor_responses();
   create_monitor_update_response(
-    "IMSI",
+    "IMSI1",
     "1",
     MonitoringLevel::PCC_RULE_LEVEL,
     2048,
@@ -374,6 +374,57 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules)
   local_enforcer->update_session_credits_and_rules(update_response);
   EXPECT_EQ(
     local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 2072);
+}
+
+TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure)
+{
+  insert_static_rule(0, "1", "rule1");
+
+  CreateSessionResponse response;
+  response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  auto monitor_updates = response.mutable_usage_monitors();
+  create_monitor_update_response(
+    "IMSI1",
+    "1",
+    MonitoringLevel::PCC_RULE_LEVEL,
+    1024,
+    monitor_updates->Add());
+  local_enforcer->init_session_credit("IMSI1", "1", test_cfg, response);
+  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
+  assert_charging_credit("IMSI1", ALLOWED_TOTAL, {});
+
+  // receive usages from pipelined
+  RuleRecordTable table;
+  auto record_list = table.mutable_records();
+  create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
+  local_enforcer->aggregate_records(table);
+  assert_monitor_credit("IMSI1", USED_RX, {{"1", 10}});
+  assert_monitor_credit("IMSI1", USED_TX, {{"1", 20}});
+
+  UpdateSessionResponse update_response;
+  auto monitor_updates_responses =
+    update_response.mutable_usage_monitor_responses();
+  auto monitor_response = monitor_updates_responses->Add();
+  create_monitor_update_response(
+    "IMSI1",
+    "1",
+    MonitoringLevel::PCC_RULE_LEVEL,
+    2048,
+    monitor_response);
+  monitor_response->set_success(false);
+  monitor_response->set_result_code(5001); // USER_UNKNOWN permanent failure
+
+  // expect all rules attached to this session should be removed
+  EXPECT_CALL(
+    *pipelined_client,
+    deactivate_flows_for_rules("IMSI1", std::vector<std::string>{"rule1"}, CheckCount(0)))
+    .Times(1)
+    .WillOnce(testing::Return(true));
+  local_enforcer->update_session_credits_and_rules(update_response);
+
+  // expect no update to credit
+  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
+  assert_charging_credit("IMSI1", ALLOWED_TOTAL, {});
 }
 
 TEST_F(LocalEnforcerTest, test_terminate_credit)


### PR DESCRIPTION
Summary:
This diff adds some error handling for CCA-Updates for permanent diameter error codes.  (between 5000 & 6000).
For usage monitor updates and charging credit updates, if we receive a permanent error, we should terminate that service. Since SessionProxy sends each monitoring update and charging update as separate requests, this is error handling on a command level.
(It's not great that we are leaking session proxy logic into sessiond, but that has to be tackled with a much larger refactor)

Reviewed By: xjtian

Differential Revision: D19538531

