### PR TITLE
Using IMSI from ITTI for SGW/PGW messages

### DIFF
--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -22,6 +22,7 @@
 #include <grpcpp/impl/codegen/status.h>
 #include <string.h>
 #include <string>
+#include <conversions.h>
 
 #include "pcef_handlers.h"
 #include "PCEFClient.h"
@@ -54,6 +55,8 @@ static void create_session_response(
   s5_response->eps_bearer_id = bearer_request.eps_bearer_id;
   s5_response->sgi_create_endpoint_resp = sgi_response;
   s5_response->failure_cause = S5_OK;
+
+  IMSI_STRING_TO_IMSI64((char*) imsi.c_str(), &message_p->ittiMsgHeader.imsi);
 
   if (!status.ok()) {
     struct in_addr addr;

--- a/lte/gateway/c/oai/tasks/grpc_service/spgw_service_handler.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/spgw_service_handler.c
@@ -20,6 +20,7 @@
  */
 #include <string.h>
 #include <sys/types.h>
+#include <conversions.h>
 
 #include "common_types.h"
 #include "intertask_interface.h"
@@ -35,15 +36,21 @@ int send_activate_bearer_request_itti(
   MessageDef *message_p = itti_alloc_new_message(
     TASK_GRPC_SERVICE, PGW_NW_INITIATED_ACTIVATE_BEARER_REQ);
   message_p->ittiMsg.pgw_nw_init_actv_bearer_request = *itti_msg;
+
+  IMSI_STRING_TO_IMSI64((char*) itti_msg->imsi, &message_p->ittiMsgHeader.imsi);
+
   return itti_send_msg_to_task(TASK_PGW_APP, INSTANCE_DEFAULT, message_p);
 }
 
 int send_deactivate_bearer_request_itti(
-  itti_pgw_nw_init_deactv_bearer_request_t *itti_msg)
+  itti_pgw_nw_init_deactv_bearer_request_t* itti_msg)
 {
   OAILOG_DEBUG(LOG_SPGW_APP, "Sending pgw_nw_init_deactv_bearer_request\n");
-  MessageDef *message_p = itti_alloc_new_message(
+  MessageDef* message_p = itti_alloc_new_message(
     TASK_GRPC_SERVICE, PGW_NW_INITIATED_DEACTIVATE_BEARER_REQ);
   message_p->ittiMsg.pgw_nw_init_deactv_bearer_request = *itti_msg;
+
+  IMSI_STRING_TO_IMSI64((char*) itti_msg->imsi, &message_p->ittiMsgHeader.imsi);
+
   return itti_send_msg_to_task(TASK_PGW_APP, INSTANCE_DEFAULT, message_p);
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -185,6 +185,8 @@ int send_modify_bearer_req(mme_ue_s1ap_id_t ue_id, ebi_t ebi)
     sizeof(s11_modify_bearer_request->indication_flags));
   s11_modify_bearer_request->rat_type = RAT_EUTRAN;
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_INFO(
     LOG_MME_APP,
     "Sending S11_MODIFY_BEARER_REQUEST to SGW for ue" MME_UE_S1AP_ID_FMT "\n",
@@ -250,6 +252,8 @@ int _send_pcrf_bearer_actv_rsp(
   s11_nw_init_actv_bearer_rsp->bearer_contexts.bearer_contexts[msg_bearer_index]
     .s1u_sgw_fteid = bc->s_gw_fteid_s1u;
   s11_nw_init_actv_bearer_rsp->bearer_contexts.num_bearer_context++;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
 
   OAILOG_INFO(
     LOG_MME_APP,
@@ -1301,6 +1305,9 @@ void mme_app_handle_initial_context_setup_rsp(mme_app_desc_t *mme_app_desc_p,
    * S11 stack specific parameter. Not used in standalone epc mode
    */
   s11_modify_bearer_request->trxn = NULL;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_INFO(
     TASK_MME_APP, "Sending S11 MODIFY BEARER REQ to SPGW for ue_id = (%d), teid = (%u)\n",
     initial_ctxt_setup_rsp_pP->ue_id, s11_modify_bearer_request->teid);
@@ -2090,6 +2097,8 @@ int mme_app_send_s11_suspend_notification(
   */
   suspend_notification_p->lbi = ue_context_pP->pdn_contexts[pdn_index]->default_ebi;
 
+  message_p->ittiMsgHeader.imsi = ue_context_pP->emm_context._imsi64;
+
   OAILOG_INFO(
     LOG_MME_APP,
     "Send Suspend Notification for IMSI = " IMSI_64_FMT "\n",
@@ -2758,6 +2767,8 @@ void send_delete_dedicated_bearer_rsp(
   s11_deact_ded_bearer_rsp->imsi = ue_context_p->emm_context._imsi64;
   s11_deact_ded_bearer_rsp->s_gw_teid_s11_s4 = s_gw_teid_s11_s4;
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_INFO(
     LOG_MME_APP,
     " Sending nw_initiated_deactv_bearer_rsp to SGW with %d bearers\n",
@@ -3063,6 +3074,9 @@ void mme_app_handle_path_switch_request(mme_app_desc_t *mme_app_desc_p,
    * S11 stack specific parameter. Not used in standalone epc mode
    */
   s11_modify_bearer_request->trxn = NULL;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_DEBUG(
     LOG_MME_APP,
     "MME_APP send S11_MODIFY_BEARER_REQUEST to teid %u \n",

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
@@ -96,6 +96,8 @@ void mme_app_send_delete_session_request(
     ue_context_p->pdn_contexts[cid]->s_gw_address_s11_s4.address.ipv4_address;
   mme_config_unlock(&mme_config);
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   itti_send_msg_to_task(TASK_SPGW, INSTANCE_DEFAULT, message_p);
   increment_counter("mme_spgw_delete_session_req", 1, NO_LABELS);
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -148,6 +148,8 @@ int mme_app_send_s11_release_access_bearers_req(
 
   release_access_bearers_request_p->originating_node = NODE_TYPE_MME;
 
+  message_p->ittiMsgHeader.imsi = ue_mm_context->emm_context._imsi64;
+
   rc = itti_send_msg_to_task(TASK_SPGW, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
@@ -229,6 +231,8 @@ int mme_app_send_s11_create_session_req(
     (char*) (&session_request_p->imsi.digit),
     ue_mm_context->emm_context._imsi.length);
   session_request_p->imsi.length = ue_mm_context->emm_context._imsi.length;
+
+  message_p->ittiMsgHeader.imsi = ue_mm_context->emm_context._imsi64;
 
   /*
    * Copy the MSISDN

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_procedures.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_procedures.c
@@ -134,6 +134,8 @@ void mme_app_s11_procedure_create_bearer_send_response(
     itti_alloc_new_message(TASK_MME_APP, S11_CREATE_BEARER_RESPONSE);
   AssertFatal(message_p, "itti_alloc_new_message Failed");
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   itti_s11_create_bearer_response_t *s11_create_bearer_response =
     &message_p->ittiMsg.s11_create_bearer_response;
   s11_create_bearer_response->local_teid = ue_context_p->mme_teid_s11;

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
@@ -34,15 +34,18 @@
 
 int pgw_handle_create_bearer_request(
   spgw_state_t *spgw_state,
-  const itti_s5_create_bearer_request_t *const bearer_req_p);
+  const itti_s5_create_bearer_request_t *const bearer_req_p,
+  imsi64_t imsi64);
 uint32_t pgw_handle_nw_init_activate_bearer_rsp(
   const itti_s5_nw_init_actv_bearer_rsp_t *const act_ded_bearer_rsp);
 uint32_t pgw_handle_nw_initiated_bearer_actv_req(
   spgw_state_t *spgw_state,
-  const itti_pgw_nw_init_actv_bearer_request_t *const bearer_req_p);
+  const itti_pgw_nw_init_actv_bearer_request_t *const bearer_req_p,
+  imsi64_t imsi64);
 uint32_t pgw_handle_nw_init_deactivate_bearer_rsp(
   const itti_s5_nw_init_deactv_bearer_rsp_t *const deact_ded_bearer_rsp);
 uint32_t pgw_handle_nw_initiated_bearer_deactv_req(
   spgw_state_t *spgw_state,
-  const itti_pgw_nw_init_deactv_bearer_request_t *const bearer_req_p);
+  const itti_pgw_nw_init_deactv_bearer_request_t *const bearer_req_p,
+  imsi64_t imsi64);
 #endif /* FILE_PGW_HANDLERS_SEEN */

--- a/lte/gateway/c/oai/tasks/sgw/pgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_task.c
@@ -59,6 +59,12 @@ static void *pgw_intertask_interface(void *args_p)
 
     itti_receive_msg(TASK_PGW_APP, &received_message_p);
 
+    imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+    OAILOG_DEBUG(
+      LOG_PGW_APP,
+      "Received message with imsi: " IMSI_64_FMT,
+      imsi64);
+
     if (ITTI_MSG_ID(received_message_p) != TERMINATE_MESSAGE) {
       spgw_state_p = get_spgw_state(false);
       AssertFatal(
@@ -69,18 +75,21 @@ static void *pgw_intertask_interface(void *args_p)
       case PGW_NW_INITIATED_ACTIVATE_BEARER_REQ: {
         pgw_handle_nw_initiated_bearer_actv_req(
           spgw_state_p,
-          &received_message_p->ittiMsg.pgw_nw_init_actv_bearer_request);
+          &received_message_p->ittiMsg.pgw_nw_init_actv_bearer_request,
+          imsi64);
       } break;
 
       case PGW_NW_INITIATED_DEACTIVATE_BEARER_REQ: {
         pgw_handle_nw_initiated_bearer_deactv_req(
           spgw_state_p,
-          &received_message_p->ittiMsg.pgw_nw_init_deactv_bearer_request);
+          &received_message_p->ittiMsg.pgw_nw_init_deactv_bearer_request,
+          imsi64);
       } break;
 
       case S5_CREATE_BEARER_REQUEST: {
         pgw_handle_create_bearer_request(
-          spgw_state_p, &received_message_p->ittiMsg.s5_create_bearer_request);
+          spgw_state_p, &received_message_p->ittiMsg.s5_create_bearer_request,
+          imsi64);
       } break;
 
       case S5_NW_INITIATED_ACTIVATE_BEARER_RESP: {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
@@ -38,54 +38,66 @@
 
 int sgw_handle_create_session_request(
   spgw_state_t *state,
-  const itti_s11_create_session_request_t *const session_req_p);
+  const itti_s11_create_session_request_t *const session_req_p,
+  imsi64_t imsi64);
 int sgw_handle_sgi_endpoint_created(
   spgw_state_t *state,
-  itti_sgi_create_end_point_response_t *const resp_p);
+  itti_sgi_create_end_point_response_t *const resp_p,
+  imsi64_t imsi64);
 int sgw_handle_sgi_endpoint_updated(
   spgw_state_t *state,
-  const itti_sgi_update_end_point_response_t *const resp_p);
+  const itti_sgi_update_end_point_response_t *const resp_p,
+  imsi64_t imsi64);
 int sgw_handle_gtpv1uCreateTunnelResp(
   spgw_state_t *state,
-  const Gtpv1uCreateTunnelResp *const endpoint_created_p);
+  const Gtpv1uCreateTunnelResp *const endpoint_created_p, imsi64_t imsi64);
 int sgw_handle_gtpv1uUpdateTunnelResp(
   spgw_state_t *state,
-  const Gtpv1uUpdateTunnelResp *const endpoint_updated_p);
+  const Gtpv1uUpdateTunnelResp *const endpoint_updated_p, imsi64_t imsi64);
 int sgw_handle_gtpv1uDeleteTunnelResp(
   const Gtpv1uDeleteTunnelResp *const endpoint_deleted_p);
 int sgw_handle_modify_bearer_request(
   spgw_state_t *state,
-  const itti_s11_modify_bearer_request_t *const modify_bearer_p);
+  const itti_s11_modify_bearer_request_t *const modify_bearer_p,
+  imsi64_t imsi64);
 int sgw_handle_delete_session_request(
   spgw_state_t *state,
-  const itti_s11_delete_session_request_t *const delete_session_p);
+  const itti_s11_delete_session_request_t *const delete_session_p,
+  imsi64_t imsi64);
 int sgw_handle_release_access_bearers_request(
   spgw_state_t *state,
   const itti_s11_release_access_bearers_request_t
-    *const release_access_bearers_req_pP);
+    *const release_access_bearers_req_pP,
+    imsi64_t imsi64);
 int sgw_handle_s5_create_bearer_response(
   spgw_state_t *state,
-  const itti_s5_create_bearer_response_t *const bearer_resp_p);
+  const itti_s5_create_bearer_response_t *const bearer_resp_p,
+  imsi64_t imsi64);
 int sgw_handle_suspend_notification(
   spgw_state_t *state,
-  const itti_s11_suspend_notification_t *const suspend_notification_pP);
-int sgw_no_pcef_create_dedicated_bearer(spgw_state_t *state, s11_teid_t teid);
+  const itti_s11_suspend_notification_t *const suspend_notification_pP,
+  imsi64_t imsi64);
+int sgw_no_pcef_create_dedicated_bearer(spgw_state_t *state, s11_teid_t teid,
+  imsi64_t imsi64);
 int sgw_handle_create_bearer_response(
   spgw_state_t *state,
   const itti_s11_create_bearer_response_t *const create_bearer_response_pP);
 int sgw_handle_nw_initiated_actv_bearer_req(
   spgw_state_t *state,
-  const itti_s5_nw_init_actv_bearer_request_t *const itti_s5_actv_bearer_req);
+  const itti_s5_nw_init_actv_bearer_request_t *const itti_s5_actv_bearer_req,
+  imsi64_t imsi64);
 int sgw_handle_nw_initiated_actv_bearer_rsp(
   spgw_state_t *state,
-  const itti_s11_nw_init_actv_bearer_rsp_t *const s11_actv_bearer_rsp);
+  const itti_s11_nw_init_actv_bearer_rsp_t *const s11_actv_bearer_rsp,
+  imsi64_t imsi64);
 uint32_t sgw_handle_nw_initiated_deactv_bearer_req(
   const itti_s5_nw_init_deactv_bearer_request_t
-    *const itti_s5_deactiv_ded_bearer_req);
+    *const itti_s5_deactiv_ded_bearer_req, imsi64_t imsi64);
 int sgw_handle_nw_initiated_deactv_bearer_rsp(
   spgw_state_t *state,
   const itti_s11_nw_init_deactv_bearer_rsp_t
-    *const s11_pcrf_ded_bearer_deactv_rsp);
+    *const s11_pcrf_ded_bearer_deactv_rsp,
+    imsi64_t imsi64);
 bool is_enb_ip_address_same(const fteid_t *fte_p, ip_address_t *ip_p);
 int send_activate_dedicated_bearer_rsp_to_pgw(
   spgw_state_t* state,
@@ -93,5 +105,6 @@ int send_activate_dedicated_bearer_rsp_to_pgw(
   teid_t s_gw_teid_S11_S4,
   ebi_t ebi,
   teid_t enb_u_teid,
-  teid_t sgw_u_teid);
+  teid_t sgw_u_teid,
+  imsi64_t imsi64);
 #endif /* FILE_SGW_HANDLERS_SEEN */


### PR DESCRIPTION
Summary:
- Setting and retrieving IMSI on msg header from MME, pcef_handlers to be used by SGW/PGW itti messages
- Adding get_associated_imsi on SGW and PGW task to retrieve IMSI, adding debug messages to log retrieved IMSI

This will enable SGW and PGW tasks with a defined method to retrieve the IMSI, this will be used to retrieve only specific state per UE from redis, so the entire state shouldn't be retrieved and parsed, just for the UE that the messages are processing. Also this will help for a cleaner way to add IMSI prefix to all logging messages.

Reviewed By: koolzz

Differential Revision: D19627417

