### PR TITLE
Adding SPGW IMSI map

### DIFF
--- a/lte/gateway/c/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.c
@@ -91,7 +91,7 @@ typedef volatile enum task_state_s {
 
 /* This list acts as a FIFO of messages received by tasks (RRC, NAS, ...) */
 typedef struct message_list_s {
-  MessageDef *msg; ///< Pointer to the message
+  MessageDef* msg; ///< Pointer to the message
 
   message_number_t message_number; ///< Unique message number
   uint32_t message_priority;       ///< Message priority
@@ -120,12 +120,12 @@ typedef struct task_desc_s {
    */
   struct lfds710_queue_bmm_state message_queue
     __attribute__((aligned(LFDS710_PAL_ATOMIC_ISOLATION_IN_BYTES)));
-  struct lfds710_queue_bmm_element *qbmme;
+  struct lfds710_queue_bmm_element* qbmme;
 } task_desc_t;
 
 typedef struct itti_desc_s {
-  thread_desc_t *threads;
-  task_desc_t *tasks;
+  thread_desc_t* threads;
+  task_desc_t* tasks;
 
   /*
    * Current message number. Incremented every call to send_msg_to_task
@@ -139,8 +139,8 @@ typedef struct itti_desc_s {
   bool thread_handling_signals;
   pthread_t thread_ref;
 
-  const task_info_t *tasks_info;
-  const message_info_t *messages_info;
+  const task_info_t* tasks_info;
+  const message_info_t* messages_info;
 
   int running;
 
@@ -158,7 +158,7 @@ static itti_desc_t itti_desc;
  * \param size size of the payload to send
  * @returns NULL in case of failure or newly allocated mesage ref
  **/
-MessageDef *itti_alloc_new_message_sized(
+MessageDef* itti_alloc_new_message_sized(
   task_id_t origin_task_id,
   MessagesIds message_id,
   MessageHeaderSize size);
@@ -167,23 +167,23 @@ MessageDef *itti_alloc_new_message_sized(
  \param message_p Pointer to the message to send
  @returns < 0 on failure, 0 otherwise
  **/
-int itti_send_broadcast_message(MessageDef *message_p);
+int itti_send_broadcast_message(MessageDef* message_p);
 
-void *itti_malloc(
+void* itti_malloc(
   task_id_t origin_task_id,
   task_id_t destination_task_id,
   ssize_t size)
 {
-  void *ptr = NULL;
+  void* ptr = NULL;
 
   ptr = memory_pools_allocate(
     itti_desc.memory_pools_handle, size, origin_task_id, destination_task_id);
 
   if (ptr == NULL) {
-    char *statistics = memory_pools_statistics(itti_desc.memory_pools_handle);
+    char* statistics = memory_pools_statistics(itti_desc.memory_pools_handle);
 
     OAILOG_ERROR(LOG_ITTI, " Memory pools statistics:\n%s", statistics);
-    free_wrapper((void **) &statistics);
+    free_wrapper((void**) &statistics);
 
     Fatal(
       "Memory allocation of %d bytes failed (%d -> %d)!\n",
@@ -195,7 +195,7 @@ void *itti_malloc(
   return ptr;
 }
 
-void itti_free(task_id_t task_id, void *ptr)
+void itti_free(task_id_t task_id, void* ptr)
 {
   int rc = EXIT_SUCCESS;
 
@@ -227,7 +227,7 @@ static inline uint32_t itti_get_message_priority(MessagesIds message_id)
   return (itti_desc.messages_info[message_id].priority);
 }
 
-const char *itti_get_message_name(MessagesIds message_id)
+const char* itti_get_message_name(MessagesIds message_id)
 {
   AssertFatal(
     message_id < itti_desc.messages_id_max,
@@ -237,7 +237,7 @@ const char *itti_get_message_name(MessagesIds message_id)
   return (itti_desc.messages_info[message_id].name);
 }
 
-const char *itti_get_task_name(task_id_t task_id)
+const char* itti_get_task_name(task_id_t task_id)
 {
   if (itti_desc.task_max > 0) {
     AssertFatal(
@@ -269,7 +269,7 @@ static task_id_t itti_get_current_task_id(void)
   return TASK_UNKNOWN;
 }
 
-int itti_send_broadcast_message(MessageDef *message_p)
+int itti_send_broadcast_message(MessageDef* message_p)
 {
   task_id_t destination_task_id;
   task_id_t origin_task_id;
@@ -285,7 +285,7 @@ int itti_send_broadcast_message(MessageDef *message_p)
 
   for (thread_id = THREAD_FIRST; thread_id < itti_desc.thread_max;
        thread_id++) {
-    MessageDef *new_message_p;
+    MessageDef* new_message_p;
 
     while (thread_id != TASK_GET_THREAD_ID(destination_task_id)) {
       destination_task_id++;
@@ -322,12 +322,12 @@ int itti_send_broadcast_message(MessageDef *message_p)
   return ret;
 }
 
-MessageDef *itti_alloc_new_message_sized(
+MessageDef* itti_alloc_new_message_sized(
   task_id_t origin_task_id,
   MessagesIds message_id,
   MessageHeaderSize size)
 {
-  MessageDef *new_msg = NULL;
+  MessageDef* new_msg = NULL;
 
   AssertFatal(
     message_id < itti_desc.messages_id_max,
@@ -355,7 +355,7 @@ MessageDef *itti_alloc_new_message_sized(
   return new_msg;
 }
 
-MessageDef *itti_alloc_new_message(
+MessageDef* itti_alloc_new_message(
   task_id_t origin_task_id,
   MessagesIds message_id)
 {
@@ -366,11 +366,11 @@ MessageDef *itti_alloc_new_message(
 int itti_send_msg_to_task(
   task_id_t destination_task_id,
   instance_t instance,
-  MessageDef *message)
+  MessageDef* message)
 {
   thread_id_t destination_thread_id;
   task_id_t origin_task_id;
-  message_list_t *new;
+  message_list_t* new;
   uint32_t priority;
   message_number_t message_number;
   uint32_t message_id;
@@ -433,7 +433,7 @@ int itti_send_msg_to_task(
       /*
        * Allocate new list element
        */
-      new = (message_list_t *) itti_malloc(
+      new = (message_list_t*) itti_malloc(
         origin_task_id, destination_task_id, sizeof(struct message_list_s));
       /*
        * Fill in members
@@ -490,10 +490,10 @@ int itti_send_msg_to_task(
   return 0;
 }
 
-void itti_receive_msg(task_id_t task_id, MessageDef **received_msg)
+void itti_receive_msg(task_id_t task_id, MessageDef** received_msg)
 {
   thread_id_t thread_id;
-  struct message_list_s *message = NULL;
+  struct message_list_s* message = NULL;
   eventfd_t sem_counter;
   ssize_t n_read;
 
@@ -520,8 +520,9 @@ void itti_receive_msg(task_id_t task_id, MessageDef **received_msg)
 
   if (
     lfds710_queue_bmm_dequeue(
-      &itti_desc.tasks[task_id].message_queue, NULL, (void **) &message) == 0) {
-    OAILOG_WARNING(LOG_ITTI,
+      &itti_desc.tasks[task_id].message_queue, NULL, (void**) &message) == 0) {
+    OAILOG_WARNING(
+      LOG_ITTI,
       "No message in queue for task %d while there are %zu and some "
       "for the messages queue!\n",
       task_id,
@@ -537,8 +538,8 @@ void itti_receive_msg(task_id_t task_id, MessageDef **received_msg)
 
 int itti_create_task(
   task_id_t task_id,
-  void *(*start_routine)(void *),
-  void *args_p)
+  void* (*start_routine)(void*),
+  void* args_p)
 {
   thread_id_t thread_id = TASK_GET_THREAD_ID(task_id);
   int result = 0;
@@ -618,10 +619,10 @@ int itti_init(
   task_id_t task_max,
   thread_id_t thread_max,
   MessagesIds messages_id_max,
-  const task_info_t *tasks_info,
-  const message_info_t *messages_info,
-  const char *const messages_definition_xml,
-  const char *const dump_file_name)
+  const task_info_t* tasks_info,
+  const message_info_t* messages_info,
+  const char* const messages_definition_xml,
+  const char* const dump_file_name)
 {
   task_id_t task_id;
   thread_id_t thread_id;
@@ -721,11 +722,11 @@ int itti_init(
   memory_pools_add_pool(itti_desc.memory_pools_handle, 400, 20050);
   memory_pools_add_pool(itti_desc.memory_pools_handle, 100, 30050);
   {
-    char *statistics = memory_pools_statistics(itti_desc.memory_pools_handle);
+    char* statistics = memory_pools_statistics(itti_desc.memory_pools_handle);
 
     ITTI_DEBUG(
       ITTI_DEBUG_MP_STATISTICS, " Memory pools statistics:\n%s", statistics);
-    free_wrapper((void **) &statistics);
+    free_wrapper((void**) &statistics);
   }
 
   CHECK_INIT_RETURN(timer_init());
@@ -733,6 +734,20 @@ int itti_init(
   shared_log_itti_connect();
   OAILOG_ITTI_CONNECT();
   return 0;
+}
+
+imsi64_t itti_get_associated_imsi(MessageDef* msg)
+{
+  if (msg->ittiMsgHeader.imsi == 0) {
+    OAILOG_DEBUG(
+      LOG_ITTI,
+      "IMSI associated to msg: %d, origin task id: %d, dest task id: %d is not "
+      "set",
+      msg->ittiMsgHeader.messageId,
+      msg->ittiMsgHeader.originTaskId,
+      msg->ittiMsgHeader.destinationTaskId);
+  }
+  return msg->ittiMsgHeader.imsi;
 }
 
 void itti_wait_tasks_end(void)
@@ -801,19 +816,19 @@ void itti_wait_tasks_end(void)
   OAILOG_INFO(LOG_ITTI, "ready_tasks %d", ready_tasks);
   itti_desc.running = 0;
   {
-    char *statistics = memory_pools_statistics(itti_desc.memory_pools_handle);
+    char* statistics = memory_pools_statistics(itti_desc.memory_pools_handle);
 
     ITTI_DEBUG(
       ITTI_DEBUG_MP_STATISTICS, " Memory pools statistics:\n%s\n", statistics);
-    free_wrapper((void **) &statistics);
+    free_wrapper((void**) &statistics);
   }
 
   for (task_id = TASK_FIRST; task_id < itti_desc.task_max; task_id++) {
-    free_wrapper((void **) &itti_desc.tasks[task_id].qbmme);
+    free_wrapper((void**) &itti_desc.tasks[task_id].qbmme);
   }
 
-  free_wrapper((void **) &itti_desc.tasks);
-  free_wrapper((void **) &itti_desc.threads);
+  free_wrapper((void**) &itti_desc.tasks);
+  free_wrapper((void**) &itti_desc.threads);
 
   if (ready_tasks > 0) {
     ITTI_DEBUG(
@@ -824,7 +839,7 @@ void itti_wait_tasks_end(void)
 
 void itti_send_terminate_message(task_id_t task_id)
 {
-  MessageDef *terminate_message_p;
+  MessageDef* terminate_message_p;
 
   terminate_message_p = itti_alloc_new_message(task_id, TERMINATE_MESSAGE);
   itti_send_broadcast_message(terminate_message_p);

--- a/lte/gateway/c/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.h
@@ -158,6 +158,13 @@ MessageDef *itti_alloc_new_message(
   task_id_t origin_task_id,
   MessagesIds message_id);
 
+/**
+ * \brief Returns IMSI of ITTI task
+ * @param msg MessageDef struct
+ * @return uint64 IMSI
+ */
+imsi64_t itti_get_associated_imsi(MessageDef* msg);
+
 /** \brief handle signals and wait for all threads to join when the process complete.
  * This function should be called from the main thread after having created all ITTI tasks.
  **/

--- a/lte/gateway/c/oai/lib/itti/intertask_interface_types.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface_types.h
@@ -136,6 +136,7 @@ typedef struct MessageHeader_s {
   task_id_t originTaskId;      /**< ID of the sender task */
   task_id_t destinationTaskId; /**< ID of the destination task */
   instance_t instance;         /**< Task instance for virtualization */
+  imsi64_t imsi;               /** IMSI associated to sender task */
 
   MessageHeaderSize
     ittiMsgSize; /**< Message size (not including header size) */

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -22,6 +22,7 @@
 #include <grpcpp/impl/codegen/status.h>
 #include <string.h>
 #include <string>
+#include <conversions.h>
 
 #include "pcef_handlers.h"
 #include "PCEFClient.h"
@@ -54,6 +55,8 @@ static void create_session_response(
   s5_response->eps_bearer_id = bearer_request.eps_bearer_id;
   s5_response->sgi_create_endpoint_resp = sgi_response;
   s5_response->failure_cause = S5_OK;
+
+  IMSI_STRING_TO_IMSI64((char*) imsi.c_str(), &message_p->ittiMsgHeader.imsi);
 
   if (!status.ok()) {
     struct in_addr addr;

--- a/lte/gateway/c/oai/protos/spgw_state.proto
+++ b/lte/gateway/c/oai/protos/spgw_state.proto
@@ -237,3 +237,7 @@ message SpgwState {
     SgwState sgw_state = 1;
     PgwState pgw_state = 2;
 }
+
+message SpgwImsiMap {
+    map<uint64, uint64> imsi_teid5_map = 1;
+}

--- a/lte/gateway/c/oai/tasks/grpc_service/spgw_service_handler.c
+++ b/lte/gateway/c/oai/tasks/grpc_service/spgw_service_handler.c
@@ -20,6 +20,7 @@
  */
 #include <string.h>
 #include <sys/types.h>
+#include <conversions.h>
 
 #include "common_types.h"
 #include "intertask_interface.h"
@@ -35,15 +36,21 @@ int send_activate_bearer_request_itti(
   MessageDef *message_p = itti_alloc_new_message(
     TASK_GRPC_SERVICE, PGW_NW_INITIATED_ACTIVATE_BEARER_REQ);
   message_p->ittiMsg.pgw_nw_init_actv_bearer_request = *itti_msg;
+
+  IMSI_STRING_TO_IMSI64((char*) itti_msg->imsi, &message_p->ittiMsgHeader.imsi);
+
   return itti_send_msg_to_task(TASK_PGW_APP, INSTANCE_DEFAULT, message_p);
 }
 
 int send_deactivate_bearer_request_itti(
-  itti_pgw_nw_init_deactv_bearer_request_t *itti_msg)
+  itti_pgw_nw_init_deactv_bearer_request_t* itti_msg)
 {
   OAILOG_DEBUG(LOG_SPGW_APP, "Sending pgw_nw_init_deactv_bearer_request\n");
-  MessageDef *message_p = itti_alloc_new_message(
+  MessageDef* message_p = itti_alloc_new_message(
     TASK_GRPC_SERVICE, PGW_NW_INITIATED_DEACTIVATE_BEARER_REQ);
   message_p->ittiMsg.pgw_nw_init_deactv_bearer_request = *itti_msg;
+
+  IMSI_STRING_TO_IMSI64((char*) itti_msg->imsi, &message_p->ittiMsgHeader.imsi);
+
   return itti_send_msg_to_task(TASK_PGW_APP, INSTANCE_DEFAULT, message_p);
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -185,6 +185,8 @@ int send_modify_bearer_req(mme_ue_s1ap_id_t ue_id, ebi_t ebi)
     sizeof(s11_modify_bearer_request->indication_flags));
   s11_modify_bearer_request->rat_type = RAT_EUTRAN;
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_INFO(
     LOG_MME_APP,
     "Sending S11_MODIFY_BEARER_REQUEST to SGW for ue" MME_UE_S1AP_ID_FMT "\n",
@@ -250,6 +252,8 @@ int _send_pcrf_bearer_actv_rsp(
   s11_nw_init_actv_bearer_rsp->bearer_contexts.bearer_contexts[msg_bearer_index]
     .s1u_sgw_fteid = bc->s_gw_fteid_s1u;
   s11_nw_init_actv_bearer_rsp->bearer_contexts.num_bearer_context++;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
 
   OAILOG_INFO(
     LOG_MME_APP,
@@ -1301,6 +1305,9 @@ void mme_app_handle_initial_context_setup_rsp(mme_app_desc_t *mme_app_desc_p,
    * S11 stack specific parameter. Not used in standalone epc mode
    */
   s11_modify_bearer_request->trxn = NULL;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_INFO(
     TASK_MME_APP, "Sending S11 MODIFY BEARER REQ to SPGW for ue_id = (%d), teid = (%u)\n",
     initial_ctxt_setup_rsp_pP->ue_id, s11_modify_bearer_request->teid);
@@ -2090,6 +2097,8 @@ int mme_app_send_s11_suspend_notification(
   */
   suspend_notification_p->lbi = ue_context_pP->pdn_contexts[pdn_index]->default_ebi;
 
+  message_p->ittiMsgHeader.imsi = ue_context_pP->emm_context._imsi64;
+
   OAILOG_INFO(
     LOG_MME_APP,
     "Send Suspend Notification for IMSI = " IMSI_64_FMT "\n",
@@ -2758,6 +2767,8 @@ void send_delete_dedicated_bearer_rsp(
   s11_deact_ded_bearer_rsp->imsi = ue_context_p->emm_context._imsi64;
   s11_deact_ded_bearer_rsp->s_gw_teid_s11_s4 = s_gw_teid_s11_s4;
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_INFO(
     LOG_MME_APP,
     " Sending nw_initiated_deactv_bearer_rsp to SGW with %d bearers\n",
@@ -3063,6 +3074,9 @@ void mme_app_handle_path_switch_request(mme_app_desc_t *mme_app_desc_p,
    * S11 stack specific parameter. Not used in standalone epc mode
    */
   s11_modify_bearer_request->trxn = NULL;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   OAILOG_DEBUG(
     LOG_MME_APP,
     "MME_APP send S11_MODIFY_BEARER_REQUEST to teid %u \n",

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
@@ -96,6 +96,8 @@ void mme_app_send_delete_session_request(
     ue_context_p->pdn_contexts[cid]->s_gw_address_s11_s4.address.ipv4_address;
   mme_config_unlock(&mme_config);
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   itti_send_msg_to_task(TASK_SPGW, INSTANCE_DEFAULT, message_p);
   increment_counter("mme_spgw_delete_session_req", 1, NO_LABELS);
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -148,6 +148,8 @@ int mme_app_send_s11_release_access_bearers_req(
 
   release_access_bearers_request_p->originating_node = NODE_TYPE_MME;
 
+  message_p->ittiMsgHeader.imsi = ue_mm_context->emm_context._imsi64;
+
   rc = itti_send_msg_to_task(TASK_SPGW, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
@@ -229,6 +231,8 @@ int mme_app_send_s11_create_session_req(
     (char*) (&session_request_p->imsi.digit),
     ue_mm_context->emm_context._imsi.length);
   session_request_p->imsi.length = ue_mm_context->emm_context._imsi.length;
+
+  message_p->ittiMsgHeader.imsi = ue_mm_context->emm_context._imsi64;
 
   /*
    * Copy the MSISDN

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_procedures.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_procedures.c
@@ -134,6 +134,8 @@ void mme_app_s11_procedure_create_bearer_send_response(
     itti_alloc_new_message(TASK_MME_APP, S11_CREATE_BEARER_RESPONSE);
   AssertFatal(message_p, "itti_alloc_new_message Failed");
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
+
   itti_s11_create_bearer_response_t *s11_create_bearer_response =
     &message_p->ittiMsg.s11_create_bearer_response;
   s11_create_bearer_response->local_teid = ue_context_p->mme_teid_s11;

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -446,14 +446,11 @@ uint32_t pgw_handle_nw_initiated_bearer_actv_req(
 {
   OAILOG_FUNC_IN(LOG_PGW_APP);
   MessageDef *message_p = NULL;
-  uint32_t i = 0;
   uint32_t rc = RETURNok;
   hash_table_ts_t *hashtblP = NULL;
-  uint32_t num_elements = 0;
   s_plus_p_gw_eps_bearer_context_information_t *spgw_ctxt_p = NULL;
-  hash_node_t *node = NULL;
   itti_s5_nw_init_actv_bearer_request_t *itti_s5_actv_bearer_req = NULL;
-  bool is_imsi_found = false;
+  bool is_teid_found = false;
   bool is_lbi_found = false;
 
   OAILOG_INFO(
@@ -496,47 +493,37 @@ uint32_t pgw_handle_nw_initiated_bearer_actv_req(
     OAILOG_FUNC_RETURN(LOG_PGW_APP, RETURNerror);
   }
 
-  // TODO: Get S11 MME TEID from SPGW UE ID map
-  // Fetch S11 MME TEID using IMSI and LBI
-  while ((num_elements < hashtblP->num_elements) && (i < hashtblP->size)) {
-    pthread_mutex_lock(&hashtblP->lock_nodes[i]);
-    if (hashtblP->nodes[i] != NULL) {
-      node = hashtblP->nodes[i];
+  spgw_imsi_map_t* imsi_map = get_spgw_imsi_map();
+  uint64_t local_teid;
+  hashtable_uint64_ts_get(
+    imsi_map->imsi_teid5_htbl, (const hash_key_t) imsi64, &local_teid);
+  OAILOG_DEBUG(
+    LOG_SPGW_APP,
+    "Got imsi" IMSI_64_FMT " with local_teid %lu",
+    imsi64,
+    local_teid);
+
+  hashtable_ts_get(
+    hashtblP, (const hash_key_t) local_teid, (void**) &spgw_ctxt_p);
+  if (spgw_ctxt_p != NULL) {
+    is_teid_found = true;
+    if (
+      spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection
+        .default_bearer == bearer_req_p->lbi) {
+      is_lbi_found = true;
+      itti_s5_actv_bearer_req->lbi = bearer_req_p->lbi;
+      itti_s5_actv_bearer_req->mme_teid_S11 =
+        spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
+      itti_s5_actv_bearer_req->s_gw_teid_S11_S4 =
+        spgw_ctxt_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4;
     }
-    pthread_mutex_unlock(&hashtblP->lock_nodes[i]);
-    while (node) {
-      num_elements++;
-      hashtable_ts_get(
-        hashtblP, (const hash_key_t) node->key, (void **) &spgw_ctxt_p);
-      if (spgw_ctxt_p != NULL) {
-        if (!strncmp(
-          (const char *)
-          spgw_ctxt_p->sgw_eps_bearer_context_information.imsi.digit,
-          (const char *) bearer_req_p->imsi,
-          strlen((const char *) bearer_req_p->imsi))) {
-          is_imsi_found = true;
-          if (
-            spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection
-              .default_bearer == bearer_req_p->lbi) {
-            is_lbi_found = true;
-            itti_s5_actv_bearer_req->lbi = bearer_req_p->lbi;
-            itti_s5_actv_bearer_req->mme_teid_S11 =
-              spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
-            itti_s5_actv_bearer_req->s_gw_teid_S11_S4 =
-              spgw_ctxt_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4;
-            break;
-          }
-        }
-      }
-      node = node->next;
-    }
-    i++;
   }
-  if ((!is_imsi_found) || (!is_lbi_found)) {
+
+  if ((!is_teid_found) || (!is_lbi_found)) {
     OAILOG_INFO(
       LOG_PGW_APP,
-      "is_imsi_found (%d), is_lbi_found (%d)\n",
-      is_imsi_found, is_lbi_found);
+      "is_teid_found (%d), is_lbi_found (%d)\n",
+      is_teid_found, is_lbi_found);
     OAILOG_ERROR(
       LOG_PGW_APP,
       "Sending dedicated_bearer_actv_rsp with REQUEST_REJECTED "
@@ -574,15 +561,12 @@ uint32_t pgw_handle_nw_initiated_bearer_deactv_req(
   uint32_t rc = RETURNok;
   OAILOG_FUNC_IN(LOG_PGW_APP);
   MessageDef *message_p = NULL;
-  uint32_t i = 0;
   uint32_t itrn = 0;
   hash_table_ts_t *hashtblP = NULL;
-  uint32_t num_elements = 0;
   s_plus_p_gw_eps_bearer_context_information_t *spgw_ctxt_p = NULL;
-  hash_node_t *node = NULL;
   itti_s5_nw_init_deactv_bearer_request_t *itti_s5_deactv_ded_bearer_req = NULL;
   bool is_lbi_found = false;
-  bool is_imsi_found = false;
+  bool is_teid_found = false;
   bool is_ebi_found = false;
   ebi_t ebi_to_be_deactivated[BEARERS_PER_UE] = {0};
   uint32_t no_of_bearers_to_be_deact = 0;
@@ -600,52 +584,43 @@ uint32_t pgw_handle_nw_initiated_bearer_deactv_req(
     OAILOG_FUNC_RETURN(LOG_PGW_APP, RETURNerror);
   }
 
-  // TODO: Get S11 MME TEID from SPGW UE ID map
+  spgw_imsi_map_t* imsi_map = get_spgw_imsi_map();
+  uint64_t local_teid;
+  hashtable_uint64_ts_get(
+    imsi_map->imsi_teid5_htbl, (const hash_key_t) imsi64, &local_teid);
+  OAILOG_DEBUG(
+    LOG_SPGW_APP, "Got imsi" IMSI_64_FMT " with teid5 %lu", imsi64, local_teid);
+  hashtable_ts_get(
+    hashtblP, (const hash_key_t) local_teid, (void**) &spgw_ctxt_p);
+
   // Check if valid LBI and EBI recvd
   /* For multi PDN, same IMSI can have multiple sessions, which means there
    * will be multiple entries for different sessions with the same IMSI. Hence
    * even though IMSI is found search the entire list for the LBI
    */
-  while ((num_elements < hashtblP->num_elements) && (i < hashtblP->size) &&
-         (!is_lbi_found)) {
-    pthread_mutex_lock(&hashtblP->lock_nodes[i]);
-    if (hashtblP->nodes[i] != NULL) {
-      node = hashtblP->nodes[i];
-      spgw_ctxt_p = node->data;
-      num_elements++;
-      if (spgw_ctxt_p != NULL) {
-        if (!strcmp(
-          (const char *)
-          spgw_ctxt_p->sgw_eps_bearer_context_information.imsi.digit,
-          (const char *) bearer_req_p->imsi)) {
-          is_imsi_found = true;
-          s11_mme_teid =
-            spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
-          if ((bearer_req_p->lbi != 0) &&
-            (bearer_req_p->lbi ==
-            spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection
-              .default_bearer)) {
-            is_lbi_found = true;
-            // Check if the received EBI is valid
-            for (itrn = 0; itrn < bearer_req_p->no_of_bearers; itrn ++) {
-              if(sgw_cm_get_eps_bearer_entry(
-                &spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection,
-                bearer_req_p->ebi[itrn])) {
-                is_ebi_found = true;
-                ebi_to_be_deactivated[no_of_bearers_to_be_deact] =
-                  bearer_req_p->ebi[itrn];
-                no_of_bearers_to_be_deact++;
-              } else {
-                invalid_bearer_id[no_of_bearers_rej] = bearer_req_p->ebi[itrn];
-                no_of_bearers_rej++;
-              }
-            }
-          }
+  if (spgw_ctxt_p != NULL) {
+    is_teid_found = true;
+    s11_mme_teid = spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
+    if (
+      (bearer_req_p->lbi != 0) &&
+      (bearer_req_p->lbi == spgw_ctxt_p->sgw_eps_bearer_context_information
+                              .pdn_connection.default_bearer)) {
+      is_lbi_found = true;
+      // Check if the received EBI is valid
+      for (itrn = 0; itrn < bearer_req_p->no_of_bearers; itrn++) {
+        if (sgw_cm_get_eps_bearer_entry(
+              &spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection,
+              bearer_req_p->ebi[itrn])) {
+          is_ebi_found = true;
+          ebi_to_be_deactivated[no_of_bearers_to_be_deact] =
+            bearer_req_p->ebi[itrn];
+          no_of_bearers_to_be_deact++;
+        } else {
+          invalid_bearer_id[no_of_bearers_rej] = bearer_req_p->ebi[itrn];
+          no_of_bearers_rej++;
         }
       }
     }
-    pthread_mutex_unlock(&hashtblP->lock_nodes[i]);
-    i++;
   }
 
   /* Send reject to NW if we did not find ebi/lbi/imsi.
@@ -654,12 +629,12 @@ uint32_t pgw_handle_nw_initiated_bearer_deactv_req(
    * Proceed with deactivation by sending s5_nw_init_deactv_bearer_request to
    * SGW for valid EBIs
    */
-  if ((!is_ebi_found) || (!is_lbi_found) || (!is_imsi_found) ||
+  if ((!is_ebi_found) || (!is_lbi_found) || (!is_teid_found) ||
     (no_of_bearers_rej > 0)) {
     OAILOG_INFO(
       LOG_PGW_APP,
       "is_imsi_found (%d), is_lbi_found (%d), is_ebi_found (%d) \n",
-      is_imsi_found, is_lbi_found, is_ebi_found);
+      is_teid_found, is_lbi_found, is_ebi_found);
     OAILOG_ERROR(
       LOG_PGW_APP,
       "Sending dedicated bearer deactivation reject to NW\n");

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.h
@@ -34,15 +34,18 @@
 
 int pgw_handle_create_bearer_request(
   spgw_state_t *spgw_state,
-  const itti_s5_create_bearer_request_t *const bearer_req_p);
+  const itti_s5_create_bearer_request_t *const bearer_req_p,
+  imsi64_t imsi64);
 uint32_t pgw_handle_nw_init_activate_bearer_rsp(
   const itti_s5_nw_init_actv_bearer_rsp_t *const act_ded_bearer_rsp);
 uint32_t pgw_handle_nw_initiated_bearer_actv_req(
   spgw_state_t *spgw_state,
-  const itti_pgw_nw_init_actv_bearer_request_t *const bearer_req_p);
+  const itti_pgw_nw_init_actv_bearer_request_t *const bearer_req_p,
+  imsi64_t imsi64);
 uint32_t pgw_handle_nw_init_deactivate_bearer_rsp(
   const itti_s5_nw_init_deactv_bearer_rsp_t *const deact_ded_bearer_rsp);
 uint32_t pgw_handle_nw_initiated_bearer_deactv_req(
   spgw_state_t *spgw_state,
-  const itti_pgw_nw_init_deactv_bearer_request_t *const bearer_req_p);
+  const itti_pgw_nw_init_deactv_bearer_request_t *const bearer_req_p,
+  imsi64_t imsi64);
 #endif /* FILE_PGW_HANDLERS_SEEN */

--- a/lte/gateway/c/oai/tasks/sgw/pgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_task.c
@@ -59,6 +59,12 @@ static void *pgw_intertask_interface(void *args_p)
 
     itti_receive_msg(TASK_PGW_APP, &received_message_p);
 
+    imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+    OAILOG_DEBUG(
+      LOG_PGW_APP,
+      "Received message with imsi: " IMSI_64_FMT,
+      imsi64);
+
     if (ITTI_MSG_ID(received_message_p) != TERMINATE_MESSAGE) {
       spgw_state_p = get_spgw_state(false);
       AssertFatal(
@@ -69,18 +75,21 @@ static void *pgw_intertask_interface(void *args_p)
       case PGW_NW_INITIATED_ACTIVATE_BEARER_REQ: {
         pgw_handle_nw_initiated_bearer_actv_req(
           spgw_state_p,
-          &received_message_p->ittiMsg.pgw_nw_init_actv_bearer_request);
+          &received_message_p->ittiMsg.pgw_nw_init_actv_bearer_request,
+          imsi64);
       } break;
 
       case PGW_NW_INITIATED_DEACTIVATE_BEARER_REQ: {
         pgw_handle_nw_initiated_bearer_deactv_req(
           spgw_state_p,
-          &received_message_p->ittiMsg.pgw_nw_init_deactv_bearer_request);
+          &received_message_p->ittiMsg.pgw_nw_init_deactv_bearer_request,
+          imsi64);
       } break;
 
       case S5_CREATE_BEARER_REQUEST: {
         pgw_handle_create_bearer_request(
-          spgw_state_p, &received_message_p->ittiMsg.s5_create_bearer_request);
+          spgw_state_p, &received_message_p->ittiMsg.s5_create_bearer_request,
+          imsi64);
       } break;
 
       case S5_NW_INITIATED_ACTIVATE_BEARER_RESP: {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_context_manager.c
@@ -218,6 +218,7 @@ mme_sgw_tunnel_t *sgw_cm_create_s11_tunnel(
    * * * * If collision_p is not NULL (0), it means tunnel is already present.
    */
   hashtable_ts_insert(state->sgw_state.s11teid2mme, local_teid, new_tunnel);
+
   return new_tunnel;
 }
 

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -143,6 +143,18 @@ int sgw_handle_create_session_request(
     session_req_pP->sender_fteid_for_cp.teid,
     sgw_get_new_S11_tunnel_id(state));
 
+  spgw_imsi_map_t* imsi_map = get_spgw_imsi_map();
+  hashtable_uint64_ts_insert(
+    imsi_map->imsi_teid5_htbl,
+    (uint64_t) imsi64,
+    (const hash_key_t) new_endpoint_p->local_teid);
+
+  OAILOG_INFO(
+    LOG_SPGW_APP,
+    "Putting imsi" IMSI_64_FMT " with teid5 %u",
+    imsi64,
+    new_endpoint_p->local_teid);
+
   if (new_endpoint_p == NULL) {
     OAILOG_ERROR(
       LOG_SPGW_APP,

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.h
@@ -38,7 +38,8 @@
 
 int sgw_handle_create_session_request(
   spgw_state_t *state,
-  const itti_s11_create_session_request_t *const session_req_p);
+  const itti_s11_create_session_request_t *const session_req_p,
+  imsi64_t imsi64);
 int sgw_handle_sgi_endpoint_created(
   spgw_state_t *state,
   itti_sgi_create_end_point_response_t *const resp_p);
@@ -55,7 +56,8 @@ int sgw_handle_gtpv1uDeleteTunnelResp(
   const Gtpv1uDeleteTunnelResp *const endpoint_deleted_p);
 int sgw_handle_modify_bearer_request(
   spgw_state_t *state,
-  const itti_s11_modify_bearer_request_t *const modify_bearer_p);
+  const itti_s11_modify_bearer_request_t *const modify_bearer_p,
+  imsi64_t imsi64);
 int sgw_handle_delete_session_request(
   spgw_state_t *state,
   const itti_s11_delete_session_request_t *const delete_session_p);
@@ -65,7 +67,8 @@ int sgw_handle_release_access_bearers_request(
     *const release_access_bearers_req_pP);
 int sgw_handle_s5_create_bearer_response(
   spgw_state_t *state,
-  const itti_s5_create_bearer_response_t *const bearer_resp_p);
+  const itti_s5_create_bearer_response_t *const bearer_resp_p,
+  imsi64_t imsi64);
 int sgw_handle_suspend_notification(
   spgw_state_t *state,
   const itti_s11_suspend_notification_t *const suspend_notification_pP);
@@ -78,14 +81,16 @@ int sgw_handle_nw_initiated_actv_bearer_req(
   const itti_s5_nw_init_actv_bearer_request_t *const itti_s5_actv_bearer_req);
 int sgw_handle_nw_initiated_actv_bearer_rsp(
   spgw_state_t *state,
-  const itti_s11_nw_init_actv_bearer_rsp_t *const s11_actv_bearer_rsp);
+  const itti_s11_nw_init_actv_bearer_rsp_t *const s11_actv_bearer_rsp,
+  imsi64_t imsi64);
 uint32_t sgw_handle_nw_initiated_deactv_bearer_req(
   const itti_s5_nw_init_deactv_bearer_request_t
-    *const itti_s5_deactiv_ded_bearer_req);
+    *const itti_s5_deactiv_ded_bearer_req, imsi64_t imsi64);
 int sgw_handle_nw_initiated_deactv_bearer_rsp(
   spgw_state_t *state,
   const itti_s11_nw_init_deactv_bearer_rsp_t
-    *const s11_pcrf_ded_bearer_deactv_rsp);
+    *const s11_pcrf_ded_bearer_deactv_rsp,
+    imsi64_t imsi64);
 bool is_enb_ip_address_same(const fteid_t *fte_p, ip_address_t *ip_p);
 int send_activate_dedicated_bearer_rsp_to_pgw(
   spgw_state_t* state,
@@ -93,5 +98,6 @@ int send_activate_dedicated_bearer_rsp_to_pgw(
   teid_t s_gw_teid_S11_S4,
   ebi_t ebi,
   teid_t enb_u_teid,
-  teid_t sgw_u_teid);
+  teid_t sgw_u_teid,
+  imsi64_t imsi64);
 #endif /* FILE_SGW_HANDLERS_SEEN */

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -216,6 +216,7 @@ static void* sgw_intertask_interface(void* args_p)
     }
 
     put_spgw_state();
+    put_spgw_imsi_map();
 
     itti_free_msg_content(received_message_p);
     itti_free(ITTI_MSG_ORIGIN_ID(received_message_p), received_message_p);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -66,6 +66,12 @@ static void* sgw_intertask_interface(void* args_p)
     MessageDef* received_message_p = NULL;
     itti_receive_msg(TASK_SPGW_APP, &received_message_p);
 
+    imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+    OAILOG_DEBUG(
+      LOG_SPGW_APP,
+      "Received message with imsi: " IMSI_64_FMT,
+      imsi64);
+
     spgw_state_p = get_spgw_state(false);
 
     switch (ITTI_MSG_ID(received_message_p)) {
@@ -100,7 +106,8 @@ static void* sgw_intertask_interface(void* args_p)
          */
         sgw_handle_create_session_request(
           spgw_state_p,
-          &received_message_p->ittiMsg.s11_create_session_request);
+          &received_message_p->ittiMsg.s11_create_session_request,
+          imsi64);
       } break;
 
       case S11_DELETE_SESSION_REQUEST: {
@@ -111,7 +118,8 @@ static void* sgw_intertask_interface(void* args_p)
 
       case S11_MODIFY_BEARER_REQUEST: {
         sgw_handle_modify_bearer_request(
-          spgw_state_p, &received_message_p->ittiMsg.s11_modify_bearer_request);
+          spgw_state_p, &received_message_p->ittiMsg.s11_modify_bearer_request,
+          imsi64);
       } break;
 
       case S11_RELEASE_ACCESS_BEARERS_REQUEST: {
@@ -144,7 +152,8 @@ static void* sgw_intertask_interface(void* args_p)
 
       case S5_CREATE_BEARER_RESPONSE: {
         sgw_handle_s5_create_bearer_response(
-          spgw_state_p, &received_message_p->ittiMsg.s5_create_bearer_response);
+          spgw_state_p, &received_message_p->ittiMsg.s5_create_bearer_response,
+          imsi64);
       } break;
 
       case S5_NW_INITIATED_ACTIVATE_BEARER_REQ: {
@@ -162,7 +171,8 @@ static void* sgw_intertask_interface(void* args_p)
               .s_gw_teid_S11_S4, /*SGW C-plane teid to fetch spgw context*/
             0 /*EBI*/,
             0 /*enb teid*/,
-            0 /*sgw teid*/);
+            0 /*sgw teid*/,
+            imsi64);
         }
       } break;
 
@@ -170,20 +180,23 @@ static void* sgw_intertask_interface(void* args_p)
         //Handle Dedicated bearer Activation Rsp from MME
         sgw_handle_nw_initiated_actv_bearer_rsp(
           spgw_state_p,
-          &received_message_p->ittiMsg.s11_nw_init_actv_bearer_rsp);
+          &received_message_p->ittiMsg.s11_nw_init_actv_bearer_rsp,
+          imsi64);
       } break;
 
       case S5_NW_INITIATED_DEACTIVATE_BEARER_REQ: {
         //Handle Dedicated bearer Deactivation Req from PGW
         sgw_handle_nw_initiated_deactv_bearer_req(
-          &received_message_p->ittiMsg.s5_nw_init_deactv_bearer_request);
+          &received_message_p->ittiMsg.s5_nw_init_deactv_bearer_request,
+          imsi64);
       } break;
 
       case S11_NW_INITIATED_DEACTIVATE_BEARER_RESP: {
         //Handle Dedicated bearer deactivation Rsp from MME
         sgw_handle_nw_initiated_deactv_bearer_rsp(
           spgw_state_p,
-          &received_message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp);
+          &received_message_p->ittiMsg.s11_nw_init_deactv_bearer_rsp,
+          imsi64);
       } break;
 
       case TERMINATE_MESSAGE: {

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -54,6 +54,14 @@ void put_spgw_state()
   SpgwStateManager::getInstance().write_state_to_db();
 }
 
+void put_spgw_imsi_map() {
+  SpgwStateManager::getInstance().put_spgw_imsi_map();
+}
+
+spgw_imsi_map_t* get_spgw_imsi_map() {
+  return SpgwStateManager::getInstance().get_spgw_imsi_map();
+}
+
 void sgw_free_s11_bearer_context_information(
   s_plus_p_gw_eps_bearer_context_information_t** context_p)
 {

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.h
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.h
@@ -61,6 +61,10 @@ typedef struct spgw_state_s {
   pgw_state_t pgw_state;
 } spgw_state_t;
 
+typedef struct spgw_imsi_map_s {
+  hash_table_uint64_ts_t* imsi_teid5_htbl; // imsi => teid5
+} spgw_imsi_map_t;
+
 // Initializes SGW state struct when task process starts.
 int spgw_state_init(bool persist_state, const spgw_config_t* spgw_config_p);
 // Function that frees spgw_state.
@@ -69,6 +73,9 @@ void spgw_state_exit(void);
 spgw_state_t *get_spgw_state(bool read_from_db);
 // Function that writes the spgw_state struct into db.
 void put_spgw_state(void);
+
+void put_spgw_imsi_map(void);
+spgw_imsi_map_t* get_spgw_imsi_map(void);
 
 /**
  * Callback function for s11_bearer_context_information hashtable freefunc

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -36,6 +36,7 @@ using magma::lte::gateway::spgw::SgwPdnConnection;
 using magma::lte::gateway::spgw::SgwState;
 using magma::lte::gateway::spgw::SpgwState;
 using magma::lte::gateway::spgw::TrafficFlowTemplate;
+using magma::lte::gateway::spgw::SpgwImsiMap;
 
 namespace magma {
 namespace lte {
@@ -59,6 +60,25 @@ void SpgwStateConverter::proto_to_state(
 {
   sgw_proto_to_state(proto.sgw_state(), &spgw_state->sgw_state);
   pgw_proto_to_state(proto.pgw_state(), &spgw_state->pgw_state);
+}
+
+void SpgwStateConverter::spgw_imsi_map_to_proto(
+  const spgw_imsi_map_t* spgw_imsi_map,
+  SpgwImsiMap* spgw_imsi_proto)
+{
+  hashtable_uint64_ts_to_proto(
+    spgw_imsi_map->imsi_teid5_htbl,
+    spgw_imsi_proto->mutable_imsi_teid5_map());
+}
+
+void SpgwStateConverter::proto_to_spgw_imsi_map(
+  const SpgwImsiMap& spgw_imsi_proto,
+  spgw_imsi_map_t* spgw_imsi_map)
+{
+  if(!spgw_imsi_proto.imsi_teid5_map().empty()) {
+    proto_to_hashtable_uint64_ts(
+      spgw_imsi_proto.imsi_teid5_map(), spgw_imsi_map->imsi_teid5_htbl);
+  }
 }
 
 /**********************************************************/

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.h
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.h
@@ -69,6 +69,22 @@ class SpgwStateConverter : StateConverter {
     const gateway::spgw::SpgwState& proto,
     spgw_state_t* spgw_state);
 
+  /**
+   * @param spgw_imsi_map spgw_imsi_map_t struct
+   * @param spgw_imsi_proto SpgwImsiMap protobuf
+   */
+  static void spgw_imsi_map_to_proto(
+    const spgw_imsi_map_t* spgw_imsi_map,
+    gateway::spgw::SpgwImsiMap* spgw_imsi_proto);
+
+  /**
+   * @param spgw_imsi_proto SpgwImsiMap protobuf
+   * @param spgw_imsi_map spgw_imsi_map_t struct
+   */
+  static void proto_to_spgw_imsi_map(
+    const gateway::spgw::SpgwImsiMap& spgw_imsi_proto,
+    spgw_imsi_map_t* spgw_imsi_map);
+
  private:
   SpgwStateConverter();
   ~SpgwStateConverter();
@@ -78,8 +94,9 @@ class SpgwStateConverter : StateConverter {
    * @param sgw_state sgw state struct
    * @param proto object to write to
    */
-  static void sgw_state_to_proto(const sgw_state_t* sgw_state,
-                                 gateway::spgw::SgwState* proto);
+  static void sgw_state_to_proto(
+    const sgw_state_t* sgw_state,
+    gateway::spgw::SgwState* proto);
 
   /**
    * Converts SGW proto to stater
@@ -87,16 +104,17 @@ class SpgwStateConverter : StateConverter {
    * @param sgw_state sgw state struct to write to
    */
   static void sgw_proto_to_state(
-    const gateway::spgw::SgwState &proto,
-    sgw_state_t *sgw_state);
+    const gateway::spgw::SgwState& proto,
+    sgw_state_t* sgw_state);
 
   /**
    * Converts PGW state to proto, memory is owned by the caller
    * @param pgw_state pgw state struct
    * @param proto object to write to
    */
-  static void pgw_state_to_proto(const pgw_state_t* pgw_state,
-                                 gateway::spgw::PgwState* proto);
+  static void pgw_state_to_proto(
+    const pgw_state_t* pgw_state,
+    gateway::spgw::PgwState* proto);
 
   /**
    * Converts PGW proto to state
@@ -104,8 +122,8 @@ class SpgwStateConverter : StateConverter {
    * @param pgw_state pgw state struct
    */
   static void pgw_proto_to_state(
-    const gateway::spgw::PgwState &proto,
-    pgw_state_t *pgw_state);
+    const gateway::spgw::PgwState& proto,
+    pgw_state_t* pgw_state);
 
   /**
    * Converts s11teid_mme hashtable object to proto, memory owned by the caller
@@ -113,9 +131,9 @@ class SpgwStateConverter : StateConverter {
    * @param proto_map Map protobuf object to write to
    */
   static void s11teid_mme_ht_to_proto(
-      hash_table_ts_t* state_map,
-      google::protobuf::Map<unsigned int, gateway::spgw::MmeSgwTunnel>*
-          proto_map);
+    hash_table_ts_t* state_map,
+    google::protobuf::Map<unsigned int, gateway::spgw::MmeSgwTunnel>*
+      proto_map);
 
   /**
    * Converts s11bearer_context hashtable object to proto,
@@ -124,17 +142,18 @@ class SpgwStateConverter : StateConverter {
    * @param proto_map Map protobuf object to write to
    */
   static void s11bearer_context_ht_to_proto(
-      hash_table_ts_t* state_map,
-      google::protobuf::Map<unsigned int, gateway::spgw::S11BearerContext>*
-          proto_map);
+    hash_table_ts_t* state_map,
+    google::protobuf::Map<unsigned int, gateway::spgw::S11BearerContext>*
+      proto_map);
 
   /**
    * Converts mme sgw tunnel struct to proto, memory is owned by the caller
    * @param tunnel
    * @param proto
    */
-  static void mme_sgw_tunnel_to_proto(const mme_sgw_tunnel_t* tunnel,
-                                      gateway::spgw::MmeSgwTunnel* proto);
+  static void mme_sgw_tunnel_to_proto(
+    const mme_sgw_tunnel_t* tunnel,
+    gateway::spgw::MmeSgwTunnel* proto);
 
   /**
    * Converts mme proto to sgw tunnel struct
@@ -142,8 +161,8 @@ class SpgwStateConverter : StateConverter {
    * @param tunnel
    */
   static void proto_to_mme_sgw_tunnel(
-      const gateway::spgw::MmeSgwTunnel &proto,
-      mme_sgw_tunnel_t *tunnel);
+    const gateway::spgw::MmeSgwTunnel& proto,
+    mme_sgw_tunnel_t* tunnel);
 
   /**
    * Converts spgw bearer context struct to proto, memory is owned by the caller
@@ -151,8 +170,8 @@ class SpgwStateConverter : StateConverter {
    * @param spgw_bearer_proto
    */
   static void spgw_bearer_context_to_proto(
-      const s_plus_p_gw_eps_bearer_context_information_t* spgw_bearer_state,
-      gateway::spgw::S11BearerContext* spgw_bearer_proto);
+    const s_plus_p_gw_eps_bearer_context_information_t* spgw_bearer_state,
+    gateway::spgw::S11BearerContext* spgw_bearer_proto);
 
   /**
    * Converts proto to spgw bearer context struct
@@ -160,17 +179,17 @@ class SpgwStateConverter : StateConverter {
    * @param spgw_bearer_state
    */
   static void proto_to_spgw_bearer_context(
-      const gateway::spgw::S11BearerContext &spgw_bearer_proto,
-      s_plus_p_gw_eps_bearer_context_information_t *spgw_bearer_state);
+    const gateway::spgw::S11BearerContext& spgw_bearer_proto,
+    s_plus_p_gw_eps_bearer_context_information_t* spgw_bearer_state);
 
   /**
    * Converts sgw eps bearer struct to proto, memory is owned by the caller
    * @param eps_bearer
    * @param eps_bearer_proto
    */
-  static void
-  sgw_eps_bearer_to_proto(const sgw_eps_bearer_ctxt_t* eps_bearer,
-                          gateway::spgw::SgwEpsBearerContext* eps_bearer_proto);
+  static void sgw_eps_bearer_to_proto(
+    const sgw_eps_bearer_ctxt_t* eps_bearer,
+    gateway::spgw::SgwEpsBearerContext* eps_bearer_proto);
 
   /**
    * Converts proto to sgw eps bearer struct to proto
@@ -178,17 +197,17 @@ class SpgwStateConverter : StateConverter {
    * @param eps_bearer
    */
   static void proto_to_sgw_eps_bearer(
-      const gateway::spgw::SgwEpsBearerContext &eps_bearer_proto,
-      sgw_eps_bearer_ctxt_t *eps_bearer);
+    const gateway::spgw::SgwEpsBearerContext& eps_bearer_proto,
+    sgw_eps_bearer_ctxt_t* eps_bearer);
 
   /**
    * Converts sgw pdn connection struct to proto, memory is owned by the caller
    * @param state_pdn
    * @param proto_pdn
    */
-  static void
-  sgw_pdn_connection_to_proto(const sgw_pdn_connection_t* state_pdn,
-                              gateway::spgw::SgwPdnConnection* proto_pdn);
+  static void sgw_pdn_connection_to_proto(
+    const sgw_pdn_connection_t* state_pdn,
+    gateway::spgw::SgwPdnConnection* proto_pdn);
 
   /**
    * Converts proto to sgw pdn connection struct
@@ -196,8 +215,8 @@ class SpgwStateConverter : StateConverter {
    * @param state_pdn
    */
   static void proto_to_sgw_pdn_connection(
-      const gateway::spgw::SgwPdnConnection &proto,
-      sgw_pdn_connection_t *state_pdn);
+    const gateway::spgw::SgwPdnConnection& proto,
+    sgw_pdn_connection_t* state_pdn);
 
   /**
    * Converts itti_s11_create_session_request struct to proto, memory is
@@ -206,8 +225,8 @@ class SpgwStateConverter : StateConverter {
    * @param proto
    */
   static void sgw_create_session_message_to_proto(
-      const itti_s11_create_session_request_t* session_request,
-      gateway::spgw::CreateSessionMessage* proto);
+    const itti_s11_create_session_request_t* session_request,
+    gateway::spgw::CreateSessionMessage* proto);
 
   /**
    * Converts proto to itti_s11_create_session_request struct
@@ -215,8 +234,8 @@ class SpgwStateConverter : StateConverter {
    * @param session_request
    */
   static void proto_to_sgw_create_session_message(
-      const gateway::spgw::CreateSessionMessage &proto,
-      itti_s11_create_session_request_t *session_request);
+    const gateway::spgw::CreateSessionMessage& proto,
+    itti_s11_create_session_request_t* session_request);
 
   /**
    * Converts sgw pending procedures entries list to proto, memory is
@@ -225,9 +244,9 @@ class SpgwStateConverter : StateConverter {
    * @param proto
    */
   static void sgw_pending_procedures_to_proto(
-      const sgw_eps_bearer_context_information_t::pending_procedures_s*
+    const sgw_eps_bearer_context_information_t::pending_procedures_s*
       procedures,
-      gateway::spgw::SgwEpsBearerContextInfo* proto);
+    gateway::spgw::SgwEpsBearerContextInfo* proto);
 
   /**
    * Converts proto to sgw pending procedures entries list
@@ -235,8 +254,8 @@ class SpgwStateConverter : StateConverter {
    * @param procedures LIST entries of bearer pending procedures
    */
   static void proto_to_sgw_pending_procedures(
-      const gateway::spgw::SgwEpsBearerContextInfo &proto,
-      sgw_eps_bearer_context_information_t::pending_procedures_s *procedures);
+    const gateway::spgw::SgwEpsBearerContextInfo& proto,
+    sgw_eps_bearer_context_information_t::pending_procedures_s* procedures);
 
   /**
    * Inserts new procedure struct to eps bearer pending procedures list
@@ -244,9 +263,9 @@ class SpgwStateConverter : StateConverter {
    * @param pending_procedures entries list to insert new proc
    */
   static void insert_proc_into_sgw_pending_procedures(
-      const gateway::spgw::PgwCbrProcedure &proto,
-      sgw_eps_bearer_context_information_t::pending_procedures_s
-      *pending_procedures);
+    const gateway::spgw::PgwCbrProcedure& proto,
+    sgw_eps_bearer_context_information_t::pending_procedures_s*
+      pending_procedures);
 
   /**
    * Converts traffic flow template struct to proto, memory is owned by the
@@ -254,9 +273,9 @@ class SpgwStateConverter : StateConverter {
    * @param tft_state
    * @param tft_proto
    */
-  static void
-  traffic_flow_template_to_proto(const traffic_flow_template_t* tft_state,
-                                 gateway::spgw::TrafficFlowTemplate* tft_proto);
+  static void traffic_flow_template_to_proto(
+    const traffic_flow_template_t* tft_state,
+    gateway::spgw::TrafficFlowTemplate* tft_proto);
 
   /**
    * Converts proto to traffic flow template struct
@@ -264,17 +283,17 @@ class SpgwStateConverter : StateConverter {
    * @param tft_state
    */
   static void proto_to_traffic_flow_template(
-      const gateway::spgw::TrafficFlowTemplate &tft_proto,
-      traffic_flow_template_t *tft_state);
+    const gateway::spgw::TrafficFlowTemplate& tft_proto,
+    traffic_flow_template_t* tft_state);
 
   /**
    * Converts eps bearer QOS struct to proto, memory is owned by the caller
    * @param eps_bearer_qos_state
    * @param eps_bearer_qos_proto
    */
-  static void
-  eps_bearer_qos_to_proto(const bearer_qos_t* eps_bearer_qos_state,
-                          gateway::spgw::BearerQos* eps_bearer_qos_proto);
+  static void eps_bearer_qos_to_proto(
+    const bearer_qos_t* eps_bearer_qos_state,
+    gateway::spgw::BearerQos* eps_bearer_qos_proto);
 
   /**
    * Converts proto to eps bearer QOS struct
@@ -282,16 +301,17 @@ class SpgwStateConverter : StateConverter {
    * @param eps_bearer_qos_state
    */
   static void proto_to_eps_bearer_qos(
-      const gateway::spgw::BearerQos &eps_bearer_qos_proto,
-      bearer_qos_t *eps_bearer_qos_state);
+    const gateway::spgw::BearerQos& eps_bearer_qos_proto,
+    bearer_qos_t* eps_bearer_qos_state);
 
   /**
    * Converts gtpv1u_data struct to proto, memory is owned by the caller
    * @param gtp_data
    * @param gtp_proto
    */
-  static void gtpv1u_data_to_proto(const gtpv1u_data_t* gtp_data,
-                                   gateway::spgw::GTPV1uData* gtp_proto);
+  static void gtpv1u_data_to_proto(
+    const gtpv1u_data_t* gtp_data,
+    gateway::spgw::GTPV1uData* gtp_proto);
 
   /**
    * Converts proto to gtpv1u_data struct
@@ -299,16 +319,17 @@ class SpgwStateConverter : StateConverter {
    * @param gtp_data
    */
   static void proto_to_gtpv1u_data(
-      const gateway::spgw::GTPV1uData &gtp_proto,
-      gtpv1u_data_t *gtp_data);
+    const gateway::spgw::GTPV1uData& gtp_proto,
+    gtpv1u_data_t* gtp_data);
 
   /**
    * Converts port range struct to proto, memory is owned by the caller
    * @param port_range
    * @param port_range_proto
    */
-  static void port_range_to_proto(const port_range_t* port_range,
-                                  PortRange* port_range_proto);
+  static void port_range_to_proto(
+    const port_range_t* port_range,
+    PortRange* port_range_proto);
 
   /**
    * Converts proto to port range struct
@@ -316,17 +337,17 @@ class SpgwStateConverter : StateConverter {
    * @param port_range
    */
   static void proto_to_port_range(
-      const PortRange &port_range_proto,
-      port_range_t *port_range);
+    const PortRange& port_range_proto,
+    port_range_t* port_range);
 
   /**
    * Converts packet filter struct to proto, memory is owned by the caller
    * @param packet_filter
    * @param packet_filter_proto
    */
-  static void
-  packet_filter_to_proto(const packet_filter_t* packet_filter,
-                         gateway::spgw::PacketFilter* packet_filter_proto);
+  static void packet_filter_to_proto(
+    const packet_filter_t* packet_filter,
+    gateway::spgw::PacketFilter* packet_filter_proto);
 
   /**
    * Converts proto to packet filter struct
@@ -334,8 +355,8 @@ class SpgwStateConverter : StateConverter {
    * @param packet_filter
    */
   static void proto_to_packet_filter(
-      const gateway::spgw::PacketFilter &packet_filter_proto,
-      packet_filter_t *packet_filter);
+    const gateway::spgw::PacketFilter& packet_filter_proto,
+    packet_filter_t* packet_filter);
 
   /**
    * Converts pcc_rules hashtable to proto
@@ -343,16 +364,17 @@ class SpgwStateConverter : StateConverter {
    * @param proto_map
    */
   static void pcc_rule_ht_to_proto(
-      hash_table_ts_t* state_map,
-      google::protobuf::Map<unsigned int, gateway::spgw::PccRule>* proto_map);
+    hash_table_ts_t* state_map,
+    google::protobuf::Map<unsigned int, gateway::spgw::PccRule>* proto_map);
 
   /**
    * Converts pcc rule object to proto, memory is owned by the caller
    * @param pcc_rule_state
    * @param proto
    */
-  static void pcc_rule_to_proto(const pcc_rule_t* pcc_rule_state,
-                                gateway::spgw::PccRule* proto);
+  static void pcc_rule_to_proto(
+    const pcc_rule_t* pcc_rule_state,
+    gateway::spgw::PccRule* proto);
 
   /**
    * Converts proto to pcc rule object to proto
@@ -360,8 +382,8 @@ class SpgwStateConverter : StateConverter {
    * @param pcc_rule_state
    */
   static void proto_to_pcc_rule(
-    const gateway::spgw::PccRule &proto,
-    pcc_rule_t *pcc_rule_state);
+    const gateway::spgw::PccRule& proto,
+    pcc_rule_t* pcc_rule_state);
 };
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.h
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.h
@@ -32,9 +32,9 @@ constexpr char SGW_S11_TEID_MME_HT_NAME[] = "sgw_s11_teid2mme_htbl";
 constexpr char S11_BEARER_CONTEXT_INFO_HT_NAME[] =
   "s11_bearer_context_information_htbl";
 constexpr char SPGW_STATE_TABLE_NAME[] = "spgw_state";
+constexpr char SPGW_IMSI_MAP_TABLE_NAME[] = "spgw_imsi_map";
+constexpr char SPGW_TEID5_IMSI_HT_NAME[] = "SPGW_TEID5_IMSI_HTBL";
 } // namespace
-
-using magma::lte::gateway::spgw::SpgwState;
 
 namespace magma {
 namespace lte {
@@ -45,7 +45,7 @@ namespace lte {
  * freeing state structs, and writing / reading state to db.
  */
 class SpgwStateManager :
-  public StateManager<spgw_state_t, SpgwState, SpgwStateConverter> {
+ public StateManager<spgw_state_t, gateway::spgw::SpgwState, SpgwStateConverter> {
  public:
   /**
    * Returns an instance of SpgwStateManager, guaranteed to be thread safe and
@@ -73,6 +73,23 @@ class SpgwStateManager :
    */
   void free_state() override;
 
+  /**
+   * Allocates spgw_imsi_map_t
+   */
+  void create_spgw_imsi_map();
+  /**
+   * Converts spgw_imsi_map to protobuf and saves into redis.
+   */
+  void put_spgw_imsi_map();
+  /**
+   * Frees spgw_imsi_map htbls
+   */
+  void free_spgw_imsi_map();
+  /**
+   * @return spgw_imsi_map pointer
+   */
+  spgw_imsi_map_t* get_spgw_imsi_map();
+
  private:
   SpgwStateManager();
   ~SpgwStateManager();
@@ -84,6 +101,7 @@ class SpgwStateManager :
   void create_state() override;
 
   const spgw_config_t* config_;
+  spgw_imsi_map_t* imsi_map_;
 };
 
 } // namespace lte


### PR DESCRIPTION
Summary:
- Adding SPGW imsi to local tunnel id hashtable
- Persisting and obtaining map with protobuf to redis
- Updating NW initiated dedicated bearer PGW handlers to retrieve local tunnel id using IMSI, instead of iterating all hashtable this allows to get SGW context using SPGW imsi map
- Reformatting SPGW state converter with clangd rules

Differential Revision: D19647375

