### PR TITLE
Some lint fixes in sessiond

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -583,8 +583,10 @@ bool LocalEnforcer::init_session_credit(
   const CreateSessionResponse& response)
 {
   std::unordered_set<uint32_t> successful_credits;
+  auto tgpp_ctx = response.tgpp_ctx();
   auto session_state = new SessionState(
-    imsi, session_id, response.session_id(), cfg, *rule_store_);
+    imsi, session_id, response.session_id(), cfg, *rule_store_,
+    tgpp_ctx.gx_dest_host(), tgpp_ctx.gy_dest_host());
   for (const auto &credit : response.credits()) {
     session_state->get_charging_pool().receive_credit(credit);
     if (credit.success() && contains_credit(credit.credit().granted_units())) {
@@ -756,6 +758,8 @@ void LocalEnforcer::update_charging_credits(
     }
     for (const auto &session : it->second) {
       session->get_charging_pool().receive_credit(credit_update_resp);
+      session->set_charging_dest_host(
+        credit_update_resp.tgpp_ctx().gy_dest_host());
     }
   }
 }
@@ -787,6 +791,8 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
 
     for (const auto &session : it->second) {
       session->get_monitor_pool().receive_credit(usage_monitor_resp);
+      session->set_monitoring_dest_host(
+        usage_monitor_resp.tgpp_ctx().gx_dest_host());
 
       RulesToProcess rules_to_activate;
       RulesToProcess rules_to_deactivate;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -257,8 +257,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
       if (status.ok()) {
         bool success = enforcer_->init_session_credit(imsi, sid, cfg, response);
         if (!success) {
-          MLOG(MERROR) << "Failed to init session in Usage Monitor "
-                       << "for IMSI " << imsi;
+          MLOG(MERROR) << "Failed to init session in for IMSI " << imsi;
           status =
             Status(
               grpc::FAILED_PRECONDITION, "Failed to initialize session");

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -62,30 +62,31 @@ void SessionReporterImpl::report_updates(
   const UpdateSessionRequest& request,
   ReporterCallbackFn<UpdateSessionResponse> callback)
 {
-  auto cloud_response = new AsyncEvbResponse<UpdateSessionResponse>(
+  auto controller_response = new AsyncEvbResponse<UpdateSessionResponse>(
     base_, callback, RESPONSE_TIMEOUT);
-  cloud_response->set_response_reader(std::move(stub_->AsyncUpdateSession(
-    cloud_response->get_context(), request, &queue_)));
+  controller_response->set_response_reader(std::move(stub_->AsyncUpdateSession(
+    controller_response->get_context(), request, &queue_)));
 }
 
 void SessionReporterImpl::report_create_session(
   const CreateSessionRequest& request,
   ReporterCallbackFn<CreateSessionResponse> callback)
 {
-  auto cloud_response = new AsyncEvbResponse<CreateSessionResponse>(
+  auto controller_response = new AsyncEvbResponse<CreateSessionResponse>(
     base_, callback, RESPONSE_TIMEOUT);
-  cloud_response->set_response_reader(std::move(stub_->AsyncCreateSession(
-    cloud_response->get_context(), request, &queue_)));
+  controller_response->set_response_reader(std::move(stub_->AsyncCreateSession(
+    controller_response->get_context(), request, &queue_)));
 }
 
 void SessionReporterImpl::report_terminate_session(
   const SessionTerminateRequest& request,
   ReporterCallbackFn<SessionTerminateResponse> callback)
 {
-  auto cloud_response = new AsyncEvbResponse<SessionTerminateResponse>(
+  auto controller_response = new AsyncEvbResponse<SessionTerminateResponse>(
     base_, callback, RESPONSE_TIMEOUT);
-  cloud_response->set_response_reader(std::move(stub_->AsyncTerminateSession(
-    cloud_response->get_context(), request, &queue_)));
+  controller_response->set_response_reader(
+    std::move(stub_->AsyncTerminateSession(controller_response->get_context(),
+      request, &queue_)));
 }
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -58,7 +58,9 @@ class SessionState {
     const std::string& session_id,
     const std::string& core_session_id,
     const SessionState::Config& cfg,
-    StaticRuleStore& rule_store);
+    StaticRuleStore& rule_store,
+    const std::string& monitoring_dest_host,
+    const std::string& charging_dest_host);
 
   /**
    * new_report sets the state of terminating session to aggregating, to tell if
@@ -160,6 +162,12 @@ class SessionState {
 
   bool qos_enabled();
 
+  void set_charging_dest_host(const std::string& host);
+
+  void set_monitoring_dest_host(const std::string& host);
+
+  void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context);
+
  private:
   /**
    * State transitions of a session:
@@ -198,6 +206,8 @@ class SessionState {
   SessionRules session_rules_;
   SessionState::State curr_state_;
   SessionState::Config config_;
+  std::string monitoring_dest_host_;
+  std::string charging_dest_host_;
   std::function<void(SessionTerminateRequest)> on_termination_callback_;
 
  private:

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -12,11 +12,11 @@
 namespace magma {
 
 void create_rule_record(
-  const std::string &imsi,
-  const std::string &rule_id,
+  const std::string& imsi,
+  const std::string& rule_id,
   uint64_t bytes_rx,
   uint64_t bytes_tx,
-  RuleRecord *rule_record)
+  RuleRecord* rule_record)
 {
   rule_record->set_sid(imsi);
   rule_record->set_rule_id(rule_id);
@@ -27,7 +27,7 @@ void create_rule_record(
 void create_charging_credit(
   uint64_t volume,
   bool is_final,
-  ChargingCredit *credit)
+  ChargingCredit* credit)
 {
   credit->mutable_granted_units()->mutable_total()->set_volume(volume);
   credit->mutable_granted_units()->mutable_total()->set_is_valid(true);
@@ -37,20 +37,20 @@ void create_charging_credit(
 
 // defaults to not final credit
 void create_credit_update_response(
-  const std::string &imsi,
+  const std::string& imsi,
   uint32_t charging_key,
   uint64_t volume,
-  CreditUpdateResponse *response)
+  CreditUpdateResponse* response)
 {
   create_credit_update_response(imsi, charging_key, volume, false, response);
 }
 
 void create_credit_update_response(
-  const std::string &imsi,
+  const std::string& imsi,
   uint32_t charging_key,
   uint64_t volume,
   bool is_final,
-  CreditUpdateResponse *response)
+  CreditUpdateResponse* response)
 {
   create_charging_credit(volume, is_final, response->mutable_credit());
   response->set_success(true);
@@ -60,12 +60,12 @@ void create_credit_update_response(
 }
 
 void create_usage_update(
-  const std::string &imsi,
+  const std::string& imsi,
   uint32_t charging_key,
   uint64_t bytes_rx,
   uint64_t bytes_tx,
   CreditUsage::UpdateType type,
-  CreditUsageUpdate *update)
+  CreditUsageUpdate* update)
 {
   auto usage = update->mutable_usage();
   update->set_sid(imsi);
@@ -76,10 +76,10 @@ void create_usage_update(
 }
 
 void create_monitor_credit(
-  const std::string &m_key,
+  const std::string& m_key,
   MonitoringLevel level,
   uint64_t volume,
-  UsageMonitoringCredit *credit)
+  UsageMonitoringCredit* credit)
 {
   if (volume == 0) {
     credit->set_action(UsageMonitoringCredit::DISABLE);
@@ -93,11 +93,11 @@ void create_monitor_credit(
 }
 
 void create_monitor_update_response(
-  const std::string &imsi,
-  const std::string &m_key,
+  const std::string& imsi,
+  const std::string& m_key,
   MonitoringLevel level,
   uint64_t volume,
-  UsageMonitoringUpdateResponse *response)
+  UsageMonitoringUpdateResponse* response)
 {
   std::vector<EventTrigger> event_triggers;
   create_monitor_update_response(
@@ -105,53 +105,53 @@ void create_monitor_update_response(
 }
 
 void create_monitor_update_response(
-  const std::string &imsi,
-  const std::string &m_key,
+  const std::string& imsi,
+  const std::string& m_key,
   MonitoringLevel level,
   uint64_t volume,
-  const std::vector<EventTrigger> &event_triggers,
+  const std::vector<EventTrigger>& event_triggers,
   const uint64_t revalidation_time_unix_ts,
-  UsageMonitoringUpdateResponse *response)
+  UsageMonitoringUpdateResponse* response)
 {
   create_monitor_credit(m_key, level, volume, response->mutable_credit());
   response->set_success(true);
   response->set_sid(imsi);
-  for (const auto &event_trigger : event_triggers) {
+  for (const auto& event_trigger : event_triggers) {
     response->add_event_triggers(event_trigger);
   }
   response->mutable_revalidation_time()->set_seconds(revalidation_time_unix_ts);
 }
 
 void create_policy_reauth_request(
-  const std::string &session_id,
-  const std::string &imsi,
-  const std::vector<std::string> &rules_to_remove,
-  const std::vector<StaticRuleInstall> &rules_to_install,
-  const std::vector<DynamicRuleInstall> &dynamic_rules_to_install,
-  const std::vector<EventTrigger> &event_triggers,
+  const std::string& session_id,
+  const std::string& imsi,
+  const std::vector<std::string>& rules_to_remove,
+  const std::vector<StaticRuleInstall>& rules_to_install,
+  const std::vector<DynamicRuleInstall>& dynamic_rules_to_install,
+  const std::vector<EventTrigger>& event_triggers,
   const uint64_t revalidation_time_unix_ts,
-  const std::vector<UsageMonitoringCredit> &usage_monitoring_credits,
-  PolicyReAuthRequest *request)
+  const std::vector<UsageMonitoringCredit>& usage_monitoring_credits,
+  PolicyReAuthRequest* request)
 {
   request->set_session_id(session_id);
   request->set_imsi(imsi);
-  for (const auto &rule_id : rules_to_remove) {
+  for (const auto& rule_id : rules_to_remove) {
     request->add_rules_to_remove(rule_id);
   }
   auto req_rules_to_install = request->mutable_rules_to_install();
-  for (const auto &static_rule_to_install : rules_to_install) {
+  for (const auto& static_rule_to_install : rules_to_install) {
     req_rules_to_install->Add()->CopyFrom(static_rule_to_install);
   }
   auto req_dynamic_rules_to_install = request->mutable_dynamic_rules_to_install();
-  for (const auto &dynamic_rule_to_install : dynamic_rules_to_install) {
+  for (const auto& dynamic_rule_to_install : dynamic_rules_to_install) {
     req_dynamic_rules_to_install->Add()->CopyFrom(dynamic_rule_to_install);
   }
-  for (const auto &event_trigger : event_triggers) {
+  for (const auto& event_trigger : event_triggers) {
     request->add_event_triggers(event_trigger);
   }
   request->mutable_revalidation_time()->set_seconds(revalidation_time_unix_ts);
   auto req_credits = request->mutable_usage_monitoring_credits();
-  for (const auto &credit : usage_monitoring_credits) {
+  for (const auto& credit : usage_monitoring_credits) {
     req_credits->Add()->CopyFrom(credit);
   }
 }

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -14,66 +14,66 @@ namespace magma {
 using namespace lte;
 
 void create_rule_record(
-  const std::string &imsi,
-  const std::string &rule_id,
+  const std::string& imsi,
+  const std::string& rule_id,
   uint64_t bytes_rx,
   uint64_t bytes_tx,
-  RuleRecord *rule_record);
+  RuleRecord* rule_record);
 
-void create_charging_credit(uint64_t volume, ChargingCredit *credit);
+void create_charging_credit(uint64_t volume, ChargingCredit* credit);
 
 void create_credit_update_response(
-  const std::string &imsi,
+  const std::string& imsi,
   uint32_t charging_key,
   uint64_t volume,
-  CreditUpdateResponse *response);
+  CreditUpdateResponse* response);
 
 void create_credit_update_response(
-  const std::string &imsi,
+  const std::string& imsi,
   uint32_t charging_key,
   uint64_t volume,
   bool is_final,
-  CreditUpdateResponse *response);
+  CreditUpdateResponse* response);
 
 void create_monitor_credit(
-  const std::string &m_key,
+  const std::string& m_key,
   MonitoringLevel level,
   uint64_t volume,
-  UsageMonitoringCredit *response);
+  UsageMonitoringCredit* response);
 
 void create_monitor_update_response(
-  const std::string &imsi,
-  const std::string &m_key,
+  const std::string& imsi,
+  const std::string& m_key,
   MonitoringLevel level,
   uint64_t volume,
-  UsageMonitoringUpdateResponse *response);
+  UsageMonitoringUpdateResponse* response);
 
 void create_monitor_update_response(
-  const std::string &imsi,
-  const std::string &m_key,
+  const std::string& imsi,
+  const std::string& m_key,
   MonitoringLevel level,
   uint64_t volume,
-  const std::vector<EventTrigger> &event_triggers,
+  const std::vector<EventTrigger>& event_triggers,
   const uint64_t revalidation_time_unix_ts,
-  UsageMonitoringUpdateResponse *response);
+  UsageMonitoringUpdateResponse* response);
 
 void create_usage_update(
-  const std::string &imsi,
+  const std::string& imsi,
   uint32_t charging_key,
   uint64_t bytes_rx,
   uint64_t bytes_tx,
   CreditUsage::UpdateType type,
-  CreditUsageUpdate *update);
+  CreditUsageUpdate* update);
 
 void create_policy_reauth_request(
-  const std::string &session_id,
-  const std::string &imsi,
-  const std::vector<std::string> &rules_to_remove,
-  const std::vector<StaticRuleInstall> &rules_to_install,
-  const std::vector<DynamicRuleInstall> &dynamic_rules_to_install,
-  const std::vector<EventTrigger> &event_triggers,
+  const std::string& session_id,
+  const std::string& imsi,
+  const std::vector<std::string>& rules_to_remove,
+  const std::vector<StaticRuleInstall>& rules_to_install,
+  const std::vector<DynamicRuleInstall>& dynamic_rules_to_install,
+  const std::vector<EventTrigger>& event_triggers,
   const uint64_t revalidation_time_unix_ts,
-  const std::vector<UsageMonitoringCredit> &usage_monitoring_credits,
-  PolicyReAuthRequest *request);
+  const std::vector<UsageMonitoringCredit>& usage_monitoring_credits,
+  PolicyReAuthRequest* request);
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -35,8 +35,8 @@ class SessionStateTest : public ::testing::Test {
 
   void insert_rule(
     uint32_t rating_group,
-    const std::string &m_key,
-    const std::string &rule_id,
+    const std::string& m_key,
+    const std::string& rule_id,
     bool is_static)
   {
     PolicyRule rule;
@@ -67,7 +67,7 @@ class SessionStateTest : public ::testing::Test {
   }
 
   void receive_credit_from_pcrf(
-    const std::string &mkey,
+    const std::string& mkey,
     uint64_t volume,
     MonitoringLevel level)
   {
@@ -217,7 +217,7 @@ TEST_F(SessionStateTest, test_session_level_key)
   session_state->get_updates(update, &actions);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.usage_monitors_size(), 1);
-  auto &single_update = update.usage_monitors(0).update();
+  auto& single_update = update.usage_monitors(0).update();
   EXPECT_EQ(single_update.level(), MonitoringLevel::SESSION_LEVEL);
   EXPECT_EQ(single_update.bytes_rx(), 3000);
   EXPECT_EQ(single_update.bytes_tx(), 5000);
@@ -252,7 +252,7 @@ TEST_F(SessionStateTest, test_reauth_key)
   UpdateSessionRequest reauth_update;
   session_state->get_updates(reauth_update, &actions);
   EXPECT_EQ(reauth_update.updates_size(), 1);
-  auto &usage = reauth_update.updates(0).usage();
+  auto& usage = reauth_update.updates(0).usage();
   EXPECT_EQ(usage.bytes_tx(), 2);
   EXPECT_EQ(usage.bytes_rx(), 1);
 }
@@ -267,7 +267,7 @@ TEST_F(SessionStateTest, test_reauth_new_key)
   std::vector<std::unique_ptr<ServiceAction>> actions;
   session_state->get_updates(reauth_update, &actions);
   EXPECT_EQ(reauth_update.updates_size(), 1);
-  auto &usage = reauth_update.updates(0).usage();
+  auto& usage = reauth_update.updates(0).usage();
   EXPECT_EQ(usage.charging_key(), 1);
   EXPECT_EQ(usage.bytes_tx(), 0);
   EXPECT_EQ(usage.bytes_rx(), 0);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -29,7 +29,8 @@ class SessionStateTest : public ::testing::Test {
   {
     rule_store = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
-      "imsi", "session", "", test_sstate_cfg, *rule_store);
+      "imsi", "session", "", test_sstate_cfg,
+      *rule_store, "gx.dest.com", "gy.dest.com");
   }
 
   void insert_rule(
@@ -298,6 +299,30 @@ TEST_F(SessionStateTest, test_reauth_all)
   // All charging keys are reporting, no update needed
   reauth_res = session_state->get_charging_pool().reauth_all();
   EXPECT_EQ(reauth_res, ChargingReAuthAnswer::UPDATE_NOT_NEEDED);
+}
+
+TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update)
+{
+  receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
+  receive_credit_from_ocs(1, 1024);
+  insert_rule(1, "m1", "rule1", true);
+  session_state->add_used_credit("rule1", 1024, 0);
+
+  EXPECT_EQ(
+    session_state->get_monitor_pool().get_credit("m1", ALLOWED_TOTAL), 1024);
+  EXPECT_EQ(
+    session_state->get_charging_pool().get_credit(1, ALLOWED_TOTAL), 1024);
+
+  UpdateSessionRequest update;
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  session_state->get_updates(update,& actions);
+  EXPECT_EQ(actions.size(), 0);
+  EXPECT_EQ(update.updates_size(), 1);
+  EXPECT_EQ(update.updates().Get(0).tgpp_ctx().gx_dest_host(), "gx.dest.com");
+  EXPECT_EQ(update.updates().Get(0).tgpp_ctx().gy_dest_host(), "gy.dest.com");
+  EXPECT_EQ(update.usage_monitors_size(), 1);
+  EXPECT_EQ(update.usage_monitors().Get(0).tgpp_ctx().gx_dest_host(), "gx.dest.com");
+  EXPECT_EQ(update.usage_monitors().Get(0).tgpp_ctx().gy_dest_host(), "gy.dest.com");
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary:
Some lint/format things I noticed while modifying SessionState. Mostly pointer and reference placements.

removing cloud references from SessionReporter because we have a local pcrf/ocs now.

Differential Revision: D19654924

