### PR TITLE
Add single post/delete for network wide rule and base name

### DIFF
--- a/cwf/cloud/go/plugin/handlers/handlers.go
+++ b/cwf/cloud/go/plugin/handlers/handlers.go
@@ -16,6 +16,7 @@ import (
 	"magma/cwf/cloud/go/cwf"
 	cwfModels "magma/cwf/cloud/go/plugin/models"
 	fegModels "magma/feg/cloud/go/plugin/models"
+	lteHandlers "magma/lte/cloud/go/plugin/handlers"
 	lteModels "magma/lte/cloud/go/plugin/models"
 	merrors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/models"
@@ -45,6 +46,8 @@ const (
 	ManageNetworkSubscriberPath  = ManageNetworkPath + obsidian.UrlSep + "subscriber_config"
 	ManageNetworkBaseNamesPath   = ManageNetworkSubscriberPath + obsidian.UrlSep + "base_names"
 	ManageNetworkRuleNamesPath   = ManageNetworkSubscriberPath + obsidian.UrlSep + "rule_names"
+	ManageNetworkBaseNamePath    = ManageNetworkBaseNamesPath + obsidian.UrlSep + ":base_name"
+	ManageNetworkRuleNamePath    = ManageNetworkRuleNamesPath + obsidian.UrlSep + ":rule_id"
 
 	Gateways                     = "gateways"
 	ListGatewaysPath             = ManageNetworkPath + obsidian.UrlSep + Gateways
@@ -72,6 +75,11 @@ func GetHandlers() []obsidian.Handler {
 
 		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: handlers.GetStateHandler},
 		{Path: SubscriberDirectoryRecordPath, Methods: obsidian.GET, HandlerFunc: getSubscriberDirectoryHandler},
+
+		{Path: ManageNetworkBaseNamePath, Methods: obsidian.POST, HandlerFunc: lteHandlers.AddNetworkWideSubscriberBaseName},
+		{Path: ManageNetworkRuleNamePath, Methods: obsidian.POST, HandlerFunc: lteHandlers.AddNetworkWideSubscriberRuleName},
+		{Path: ManageNetworkBaseNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberRuleName},
+		{Path: ManageNetworkRuleNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberBaseName},
 	}
 
 	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListNetworksPath, ManageNetworkPath, cwf.CwfNetworkType, &cwfModels.CwfNetwork{})...)

--- a/cwf/cloud/go/plugin/models/swagger.v1.yml
+++ b/cwf/cloud/go/plugin/models/swagger.v1.yml
@@ -293,6 +293,32 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /cwf/{network_id}/subscriber_config/rule_names/{rule_id}:
+    post:
+      summary: Add a network-wide rule name
+      tags:
+        - Carrier Wifi Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './lte-swagger.yml#/parameters/rule_id'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide rule name
+      tags:
+        - Carrier Wifi Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './lte-swagger.yml#/parameters/rule_id'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /cwf/{network_id}/subscriber_config/base_names:
     get:
       summary: Get network-wide base names
@@ -319,6 +345,32 @@ paths:
           required: true
           schema:
             $ref: './lte-swagger.yml#/definitions/base_names'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
+  /cwf/{network_id}/subscriber_config/base_names/{base_name}:
+    post:
+      summary: Add a network-wide base name
+      tags:
+        - Carrier Wifi Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref:  './lte-swagger.yml#/parameters/base_name'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide base name
+      tags:
+        - Carrier Wifi Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref:  './lte-swagger.yml#/parameters/base_name'
       responses:
         '204':
           description: Success

--- a/feg/cloud/go/plugin/handlers/handlers.go
+++ b/feg/cloud/go/plugin/handlers/handlers.go
@@ -15,6 +15,7 @@ import (
 	"magma/feg/cloud/go/feg"
 	fegModels "magma/feg/cloud/go/plugin/models"
 	"magma/feg/cloud/go/services/health"
+	lteHandlers "magma/lte/cloud/go/plugin/handlers"
 	lteModels "magma/lte/cloud/go/plugin/models"
 	merrors "magma/orc8r/cloud/go/errors"
 	"magma/orc8r/cloud/go/obsidian"
@@ -37,6 +38,8 @@ const (
 	ManageFegNetworkBaseNamesPath  = ManageFegNetworkSubscriberPath + obsidian.UrlSep + "base_names"
 	ManageFegNetworkRuleNamesPath  = ManageFegNetworkSubscriberPath + obsidian.UrlSep + "rule_names"
 	ManageNetworkClusterStatusPath = ManageFegNetworkPath + obsidian.UrlSep + "cluster_status"
+	ManageFegNetworkBaseNamePath   = ManageFegNetworkBaseNamesPath + obsidian.UrlSep + ":base_name"
+	ManageFegNetworkRuleNamePath   = ManageFegNetworkRuleNamesPath + obsidian.UrlSep + ":rule_id"
 
 	Gateways                      = "gateways"
 	ListGatewaysPath              = ManageFegNetworkPath + obsidian.UrlSep + Gateways
@@ -52,6 +55,8 @@ const (
 	ManageFegLteNetworkSubscriberPath = ManageFegLteNetworkPath + obsidian.UrlSep + "subscriber_config"
 	ManageFegLteNetworkBaseNamesPath  = ManageFegLteNetworkSubscriberPath + obsidian.UrlSep + "base_names"
 	ManageFegLteNetworkRuleNamesPath  = ManageFegLteNetworkSubscriberPath + obsidian.UrlSep + "rule_names"
+	ManageFegLteNetworkBaseNamePath   = ManageFegLteNetworkBaseNamesPath + obsidian.UrlSep + ":base_name"
+	ManageFegLteNetworkRuleNamePath   = ManageFegLteNetworkRuleNamesPath + obsidian.UrlSep + ":rule_id"
 )
 
 func GetHandlers() []obsidian.Handler {
@@ -65,6 +70,15 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: handlers.GetStateHandler},
 		{Path: ManageNetworkClusterStatusPath, Methods: obsidian.GET, HandlerFunc: getClusterStatusHandler},
 		{Path: ManageGatewayHealthStatusPath, Methods: obsidian.GET, HandlerFunc: getHealthStatusHandler},
+
+		{Path: ManageFegNetworkBaseNamePath, Methods: obsidian.POST, HandlerFunc: lteHandlers.AddNetworkWideSubscriberBaseName},
+		{Path: ManageFegNetworkRuleNamePath, Methods: obsidian.POST, HandlerFunc: lteHandlers.AddNetworkWideSubscriberRuleName},
+		{Path: ManageFegNetworkBaseNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberRuleName},
+		{Path: ManageFegNetworkRuleNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberBaseName},
+		{Path: ManageFegLteNetworkBaseNamePath, Methods: obsidian.POST, HandlerFunc: lteHandlers.AddNetworkWideSubscriberBaseName},
+		{Path: ManageFegLteNetworkRuleNamePath, Methods: obsidian.POST, HandlerFunc: lteHandlers.AddNetworkWideSubscriberRuleName},
+		{Path: ManageFegLteNetworkBaseNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberRuleName},
+		{Path: ManageFegLteNetworkRuleNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberBaseName},
 	}
 
 	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegNetworksPath, ManageFegNetworkPath, feg.FederationNetworkType, &fegModels.FegNetwork{})...)

--- a/feg/cloud/go/plugin/models/swagger.v1.yml
+++ b/feg/cloud/go/plugin/models/swagger.v1.yml
@@ -235,6 +235,32 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /feg/{network_id}/subscriber_config/rule_names/{rule_id}:
+    post:
+      summary: Add a network-wide rule name
+      tags:
+         - Federation Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './lte-swagger.yml#/parameters/rule_id'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide rule name
+      tags:
+         - Federation Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './lte-swagger.yml#/parameters/rule_id'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /feg/{network_id}/subscriber_config/base_names:
     get:
       summary: Get network-wide base names
@@ -261,6 +287,32 @@ paths:
           required: true
           schema:
             $ref: './lte-swagger.yml#/definitions/base_names'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
+  /feg/{network_id}/subscriber_config/base_names/{base_name}:
+    post:
+      summary: Add a network-wide base name
+      tags:
+         - Federation Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref:  './lte-swagger.yml#/parameters/base_name'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide base name
+      tags:
+         - Federation Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref:  './lte-swagger.yml#/parameters/base_name'
       responses:
         '204':
           description: Success
@@ -626,6 +678,32 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /feg_lte/{network_id}/subscriber_config/rule_names/{rule_id}:
+    post:
+      summary: Add a network-wide rule name
+      tags:
+        - Federated LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './lte-swagger.yml#/parameters/rule_id'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide rule name
+      tags:
+        - Federated LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: './lte-swagger.yml#/parameters/rule_id'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /feg_lte/{network_id}/subscriber_config/base_names:
     get:
       summary: Get network-wide base names
@@ -658,7 +736,31 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
-
+  /feg_lte/{network_id}/subscriber_config/base_names/{base_name}:
+    post:
+      summary: Add a network-wide base name
+      tags:
+        - Federated LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref:  './lte-swagger.yml#/parameters/base_name'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide base name
+      tags:
+        - Federated LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref:  './lte-swagger.yml#/parameters/base_name'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 definitions:
   feg_network:
     type: object

--- a/lte/cloud/go/plugin/handlers/handlers_test.go
+++ b/lte/cloud/go/plugin/handlers/handlers_test.go
@@ -793,7 +793,7 @@ func Test_GetNetworkSubscriberConfigHandlers(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 }
 
-func Test_PutNetworkSubscriberConfigHandlers(t *testing.T) {
+func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	_ = plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{})
 	test_init.StartTestService(t)
@@ -807,22 +807,50 @@ func Test_PutNetworkSubscriberConfigHandlers(t *testing.T) {
 	putSubscriberConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config", obsidian.PUT).HandlerFunc
 	putRuleNames := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config/rule_names", obsidian.PUT).HandlerFunc
 	putBaseNames := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config/base_names", obsidian.PUT).HandlerFunc
+	postRuleName := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config/rule_names/:rule_id", obsidian.POST).HandlerFunc
+	postBaseName := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config/base_names/:base_name", obsidian.POST).HandlerFunc
+	deleteRuleName := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config/rule_names/:rule_id", obsidian.DELETE).HandlerFunc
+	deleteBaseName := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/lte/:network_id/subscriber_config/base_names/:base_name", obsidian.DELETE).HandlerFunc
 
 	subscriberConfig := &lteModels.NetworkSubscriberConfig{
 		NetworkWideBaseNames: []lteModels.BaseName{"base1"},
 		NetworkWideRuleNames: []string{"rule1"},
 	}
 
-	// 404
+	// non-existent network id
 	tc := tests.Test{
+		Method:         "PUT",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/base_names/", testURLRoot, "n32"),
+		Payload:        tests.JSONMarshaler(subscriberConfig.NetworkWideBaseNames),
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n32"},
+		Handler:        putBaseNames,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/rule_names/", testURLRoot, "n32"),
+		Payload:        tests.JSONMarshaler(subscriberConfig.NetworkWideRuleNames),
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n32"},
+		Handler:        putRuleNames,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// add to non existent config
+	tc = tests.Test{
 		Method:         "PUT",
 		URL:            fmt.Sprintf("%s/%s/subscriber_config/base_names/", testURLRoot, "n1"),
 		Payload:        tests.JSONMarshaler(subscriberConfig.NetworkWideBaseNames),
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
 		Handler:        putBaseNames,
-		ExpectedStatus: 400,
-		ExpectedError:  "No Subscriber Config registered for this network",
+		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
 	tc = tests.Test{
@@ -832,12 +860,12 @@ func Test_PutNetworkSubscriberConfigHandlers(t *testing.T) {
 		ParamNames:     []string{"network_id"},
 		ParamValues:    []string{"n1"},
 		Handler:        putRuleNames,
-		ExpectedStatus: 400,
-		ExpectedError:  "No Subscriber Config registered for this network",
+		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-
-	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, subscriberConfig))
+	iSubscriberConfig, err := configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	assert.NoError(t, err)
+	assert.Equal(t, subscriberConfig, iSubscriberConfig.(*lteModels.NetworkSubscriberConfig))
 
 	newRuleNames := []string{"rule2"}
 	// happy case
@@ -867,7 +895,7 @@ func Test_PutNetworkSubscriberConfigHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	iSubscriberConfig, err := configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
 	assert.NoError(t, err)
 	actualSubscriberConfig := iSubscriberConfig.(*lteModels.NetworkSubscriberConfig)
 
@@ -895,6 +923,72 @@ func Test_PutNetworkSubscriberConfigHandlers(t *testing.T) {
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*lteModels.NetworkSubscriberConfig)
 
+	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
+
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/rule_names/%s", testURLRoot, "n1", "rule4"),
+		Payload:        tests.JSONMarshaler(newSubscriberConfig),
+		ParamNames:     []string{"network_id", "rule_id"},
+		ParamValues:    []string{"n1", "rule4"},
+		Handler:        postRuleName,
+		ExpectedStatus: 201,
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/base_names/%s", testURLRoot, "n1", "base4"),
+		Payload:        tests.JSONMarshaler(newSubscriberConfig),
+		ParamNames:     []string{"network_id", "base_name"},
+		ParamValues:    []string{"n1", "base4"},
+		Handler:        postBaseName,
+		ExpectedStatus: 201,
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	newSubscriberConfig = &lteModels.NetworkSubscriberConfig{
+		NetworkWideBaseNames: []lteModels.BaseName{"base3", "base4"},
+		NetworkWideRuleNames: []string{"rule3", "rule4"},
+	}
+	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	assert.NoError(t, err)
+	actualSubscriberConfig = iSubscriberConfig.(*lteModels.NetworkSubscriberConfig)
+	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
+
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/rule_names/%s", testURLRoot, "n1", "rule4"),
+		Payload:        tests.JSONMarshaler(newSubscriberConfig),
+		ParamNames:     []string{"network_id", "rule_id"},
+		ParamValues:    []string{"n1", "rule4"},
+		Handler:        deleteRuleName,
+		ExpectedStatus: 204,
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/base_names/%s", testURLRoot, "n1", "base4"),
+		Payload:        tests.JSONMarshaler(newSubscriberConfig),
+		ParamNames:     []string{"network_id", "base_name"},
+		ParamValues:    []string{"n1", "base4"},
+		Handler:        deleteBaseName,
+		ExpectedStatus: 204,
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	newSubscriberConfig = &lteModels.NetworkSubscriberConfig{
+		NetworkWideBaseNames: []lteModels.BaseName{"base3"},
+		NetworkWideRuleNames: []string{"rule3"},
+	}
+	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	assert.NoError(t, err)
+	actualSubscriberConfig = iSubscriberConfig.(*lteModels.NetworkSubscriberConfig)
 	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
 }
 

--- a/lte/cloud/go/plugin/models/conversion.go
+++ b/lte/cloud/go/plugin/models/conversion.go
@@ -159,7 +159,8 @@ func (m *RuleNames) GetFromNetwork(network configurator.Network) interface{} {
 func (m *RuleNames) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
 	iNetworkSubscriberConfig := orc8rModels.GetNetworkConfig(network, lte.NetworkSubscriberConfigType)
 	if iNetworkSubscriberConfig == nil {
-		return configurator.NetworkUpdateCriteria{}, fmt.Errorf("No Subscriber Config registered for this network")
+		// allow update even not previously defined
+		iNetworkSubscriberConfig = &NetworkSubscriberConfig{}
 	}
 	iNetworkSubscriberConfig.(*NetworkSubscriberConfig).NetworkWideRuleNames = *m
 	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.NetworkSubscriberConfigType, iNetworkSubscriberConfig), nil
@@ -176,7 +177,8 @@ func (m *BaseNames) GetFromNetwork(network configurator.Network) interface{} {
 func (m *BaseNames) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
 	iNetworkSubscriberConfig := orc8rModels.GetNetworkConfig(network, lte.NetworkSubscriberConfigType)
 	if iNetworkSubscriberConfig == nil {
-		return configurator.NetworkUpdateCriteria{}, fmt.Errorf("No Subscriber Config registered for this network")
+		// allow update even not previously defined
+		iNetworkSubscriberConfig = &NetworkSubscriberConfig{}
 	}
 	iNetworkSubscriberConfig.(*NetworkSubscriberConfig).NetworkWideBaseNames = *m
 	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.NetworkSubscriberConfigType, iNetworkSubscriberConfig), nil

--- a/lte/cloud/go/plugin/models/swagger.v1.yml
+++ b/lte/cloud/go/plugin/models/swagger.v1.yml
@@ -427,6 +427,32 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /lte/{network_id}/subscriber_config/rule_names/{rule_id}:
+    post:
+      summary: Add a network-wide rule name
+      tags:
+        - LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/rule_id'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide rule name
+      tags:
+        - LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/rule_id'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /lte/{network_id}/subscriber_config/base_names:
     get:
       summary: Get network-wide base names
@@ -453,6 +479,32 @@ paths:
           required: true
           schema:
             $ref: '#/definitions/base_names'
+      responses:
+        '204':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
+  /lte/{network_id}/subscriber_config/base_names/{base_name}:
+    post:
+      summary: Add a network-wide base name
+      tags:
+        - LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/base_name'
+      responses:
+        '201':
+          description: Success
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+    delete:
+      summary: Add a network-wide base name
+      tags:
+        - LTE Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/base_name'
       responses:
         '204':
           description: Success


### PR DESCRIPTION
Summary:
- Added POST and DELETE methods for single rule/basename update for whether it is network wide or not.
- also unit tests for new endpoints

It will be good to have these endpoints so that in the NMS we can have a checkbox/boolean to indicate whether a rule is network wide or not.

Differential Revision: D19670730

