### PR TITLE
Save gx/gy destination hosts in SessionState

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -583,8 +583,8 @@ bool LocalEnforcer::init_session_credit(
   const CreateSessionResponse& response)
 {
   std::unordered_set<uint32_t> successful_credits;
-  auto session_state = new SessionState(
-    imsi, session_id, response.session_id(), cfg, *rule_store_);
+  auto session_state = new SessionState(imsi, session_id,
+    response.session_id(), cfg, *rule_store_, response.tgpp_ctx());
   for (const auto &credit : response.credits()) {
     session_state->get_charging_pool().receive_credit(credit);
     if (credit.success() && contains_credit(credit.credit().granted_units())) {
@@ -756,6 +756,7 @@ void LocalEnforcer::update_charging_credits(
     }
     for (const auto &session : it->second) {
       session->get_charging_pool().receive_credit(credit_update_resp);
+      session->set_tgpp_context(credit_update_resp.tgpp_ctx());
     }
   }
 }
@@ -787,6 +788,7 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
 
     for (const auto &session : it->second) {
       session->get_monitor_pool().receive_credit(usage_monitor_resp);
+      session->set_tgpp_context(usage_monitor_resp.tgpp_ctx());
 
       RulesToProcess rules_to_activate;
       RulesToProcess rules_to_deactivate;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -20,7 +20,8 @@ SessionState::SessionState(
   const std::string& session_id,
   const std::string& core_session_id,
   const SessionState::Config& cfg,
-  StaticRuleStore& rule_store):
+  StaticRuleStore& rule_store,
+  const magma::lte::TgppContext& tgpp_context):
   imsi_(imsi),
   session_id_(session_id),
   core_session_id_(core_session_id),
@@ -30,7 +31,8 @@ SessionState::SessionState(
   curr_state_(SESSION_ACTIVE),
   session_rules_(rule_store),
   charging_pool_(imsi),
-  monitor_pool_(imsi)
+  monitor_pool_(imsi),
+  tgpp_context_(tgpp_context)
 {
 }
 
@@ -101,6 +103,7 @@ void SessionState::get_updates_from_charging_pool(
     new_req->set_user_location(config_.user_location);
     new_req->set_hardware_addr(config_.hardware_addr);
     new_req->set_rat_type(config_.rat_type);
+    fill_protos_tgpp_context(new_req->mutable_tgpp_ctx());
     new_req->mutable_usage()->CopyFrom(update);
     request_number_++;
   }
@@ -122,6 +125,7 @@ void SessionState::get_updates_from_monitor_pool(
     new_req->set_ue_ipv4(config_.ue_ipv4);
     new_req->set_hardware_addr(config_.hardware_addr);
     new_req->set_rat_type(config_.rat_type);
+    fill_protos_tgpp_context(new_req->mutable_tgpp_ctx());
     new_req->mutable_update()->CopyFrom(update);
     request_number_++;
   }
@@ -177,6 +181,7 @@ void SessionState::complete_termination()
   termination.set_user_location(config_.user_location);
   termination.set_hardware_addr(config_.hardware_addr);
   termination.set_rat_type(config_.rat_type);
+  fill_protos_tgpp_context(termination.mutable_tgpp_ctx());
   monitor_pool_.get_termination_updates(&termination);
   charging_pool_.get_termination_updates(&termination);
   try {
@@ -291,6 +296,16 @@ uint32_t SessionState::get_bearer_id()
 bool SessionState::qos_enabled()
 {
   return config_.qos_info.enabled;
+}
+
+void SessionState::set_tgpp_context(const magma::lte::TgppContext& tgpp_context)
+{
+  tgpp_context_ = tgpp_context;
+}
+
+void SessionState::fill_protos_tgpp_context(
+  magma::lte::TgppContext* tgpp_context) {
+  *tgpp_context = tgpp_context_;
 }
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -58,7 +58,8 @@ class SessionState {
     const std::string& session_id,
     const std::string& core_session_id,
     const SessionState::Config& cfg,
-    StaticRuleStore& rule_store);
+    StaticRuleStore& rule_store,
+    const magma::lte::TgppContext& tgpp_context);
 
   /**
    * new_report sets the state of terminating session to aggregating, to tell if
@@ -160,6 +161,10 @@ class SessionState {
 
   bool qos_enabled();
 
+  void set_tgpp_context(const magma::lte::TgppContext& tgpp_context);
+
+  void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context);
+
  private:
   /**
    * State transitions of a session:
@@ -198,6 +203,7 @@ class SessionState {
   SessionRules session_rules_;
   SessionState::State curr_state_;
   SessionState::Config config_;
+  magma::lte::TgppContext tgpp_context_;
   std::function<void(SessionTerminateRequest)> on_termination_callback_;
 
  private:

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -156,4 +156,13 @@ void create_policy_reauth_request(
   }
 }
 
+void create_tgpp_context(
+  const std::string& gx_dest_host,
+  const std::string& gy_dest_host,
+  TgppContext* context)
+{
+  context->set_gx_dest_host(gx_dest_host);
+  context->set_gy_dest_host(gy_dest_host);
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -76,4 +76,8 @@ void create_policy_reauth_request(
   const std::vector<UsageMonitoringCredit> &usage_monitoring_credits,
   PolicyReAuthRequest *request);
 
+void create_tgpp_context(
+  const std::string& gx_dest_host,
+  const std::string& gy_dest_host,
+  TgppContext* context);
 } // namespace magma


### PR DESCRIPTION
Summary:
## What's Changed
- sessiond now stores `monitoring_dest_host` and `charging_dest_host` as part of session state.
- the destination hosts (for both gx and gy) received from CreateSession is used for the following Update and Terminate session requests.
- with every credit update or monitoring update, we update the corresponding host in the message
- With every update/termination request, we send up both the gy and gx hosts as part of the request.

Reviewed By: emakeev

Differential Revision: D19657659

