### PR TITLE
Fix AGW installation by removing custom patch

### DIFF
--- a/lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml
@@ -12,4 +12,3 @@ patches:
   - "0002-userspace-Add-L3-tunnel-type-GTP.patch"
   - "0003-Build-symbols-for-gtp-vport-linux-4.9-module-require.patch"
   - "0004-Linux-compat-fixes.patch"
-  - "0005-Add-custom-ipfix-fields.patch"


### PR DESCRIPTION
This commit a440c1f3346326aa703b6201f344a7bccfba973c
breaks AGW installation, because it added line 0005-Add-custom-ipfix-fields.patch
in lte/gateway/deploy/roles/ovs_prepare/vars/all.yaml. Meanwhile this
patch doesn't exist in third_party/gtp_ovs/ovs/2.8.1 and third_party/gtp_ovs/ovs/2.9.6
where ansible trying to find it in this scenario lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml