### PR TITLE
Add/remove helper functions to clean up `init_session_credit`

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -576,27 +576,91 @@ static bool contains_credit(const GrantedUnits& gsu)
          (gsu.rx().is_valid() && gsu.rx().volume() > 0);
 }
 
+bool LocalEnforcer::handle_session_init_rule_updates(
+  const std::string& imsi,
+  SessionState& session_state,
+  const CreateSessionResponse& response,
+  std::unordered_set<uint32_t>& charging_credits_received)
+{
+  auto ip_addr = session_state.get_subscriber_ip_addr();
+
+  RulesToProcess rules_to_activate;
+  RulesToProcess rules_to_deactivate;
+
+  process_create_session_response(
+    response,
+    charging_credits_received,
+    imsi,
+    ip_addr,
+    rules_to_activate,
+    rules_to_deactivate);
+
+  // activate_flows_for_rules() should be called even if there is no rule to
+  // activate, because pipelined activates a "drop all packet" rule
+  // when no rule is provided as the parameter
+  for (const auto &static_rule : rules_to_activate.static_rules) {
+    session_state.activate_static_rule(static_rule);
+  }
+  for (const auto &policy_rule : rules_to_activate.dynamic_rules) {
+    session_state.insert_dynamic_rule(policy_rule);
+  }
+  bool activate_success = pipelined_client_->activate_flows_for_rules(
+    imsi,
+    ip_addr,
+    rules_to_activate.static_rules,
+    rules_to_activate.dynamic_rules);
+
+  // deactivate_flows_for_rules() should not be called when there is no rule
+  // to deactivate, because pipelined deactivates all rules
+  // when no rule is provided as the parameter
+  bool deactivate_success = true;
+  if (rules_to_process_is_not_empty(rules_to_deactivate)) {
+    for (const auto &static_rule : rules_to_deactivate.static_rules) {
+      if (!session_state.deactivate_static_rule(static_rule))
+        MLOG(MWARNING) << "Could not find rule " << static_rule  << "for IMSI "
+                       << imsi << " during static rule removal";
+
+    }
+    for (const auto &policy_rule : rules_to_deactivate.dynamic_rules) {
+      PolicyRule rule_dont_care;
+      session_state.remove_dynamic_rule(policy_rule.id(), &rule_dont_care);
+    }
+    deactivate_success = pipelined_client_->deactivate_flows_for_rules(
+      imsi,
+      rules_to_deactivate.static_rules,
+      rules_to_deactivate.dynamic_rules);
+  }
+
+  return activate_success && deactivate_success;
+}
+
 bool LocalEnforcer::init_session_credit(
   const std::string& imsi,
   const std::string& session_id,
   const SessionState::Config& cfg,
   const CreateSessionResponse& response)
 {
-  std::unordered_set<uint32_t> successful_credits;
   auto session_state = new SessionState(imsi, session_id,
     response.session_id(), cfg, *rule_store_, response.tgpp_ctx());
+
+  std::unordered_set<uint32_t> charging_credits_received;
   for (const auto &credit : response.credits()) {
     session_state->get_charging_pool().receive_credit(credit);
     if (credit.success() && contains_credit(credit.credit().granted_units())) {
-      successful_credits.insert(credit.charging_key());
+      charging_credits_received.insert(credit.charging_key());
     }
   }
+  // We don't have to check 'success' field for monitors because command level
+  // errors are handled in session proxy
   for (const auto &monitor : response.usage_monitors()) {
     if (revalidation_required(monitor.event_triggers())) {
       schedule_revalidation(monitor.revalidation_time());
     }
     session_state->get_monitor_pool().receive_credit(monitor);
   }
+
+  auto rule_update_success = handle_session_init_rule_updates(
+    imsi, *session_state, response, charging_credits_received);
 
   auto it = session_map_.find(imsi);
   if (it == session_map_.end()) {
@@ -605,7 +669,8 @@ bool LocalEnforcer::init_session_credit(
                  << " with session ID " << session_id;
     session_map_[imsi] = std::vector<std::unique_ptr<SessionState>>();
   }
-  session_map_[imsi].push_back(std::move(std::unique_ptr<SessionState>(session_state)));
+  session_map_[imsi].push_back(
+    std::move(std::unique_ptr<SessionState>(session_state)));
 
   if (session_state->is_radius_cwf_session()) {
     MLOG(MDEBUG) << "Adding UE MAC flow for subscriber " << imsi;
@@ -624,57 +689,7 @@ bool LocalEnforcer::init_session_credit(
       MLOG(MERROR) << "Failed to add UE MAC flow for subscriber " << imsi;
     }
   }
-
-  auto ip_addr = session_state->get_subscriber_ip_addr();
-
-  RulesToProcess rules_to_activate;
-  RulesToProcess rules_to_deactivate;
-
-  process_create_session_response(
-    response,
-    successful_credits,
-    imsi,
-    ip_addr,
-    rules_to_activate,
-    rules_to_deactivate);
-
-  // activate_flows_for_rules() should be called even if there is no rule to
-  // activate, because pipelined activates a "drop all packet" rule
-  // when no rule is provided as the parameter
-  for (const auto &static_rule : rules_to_activate.static_rules) {
-    session_state->activate_static_rule(static_rule);
-  }
-  for (const auto &policy_rule : rules_to_activate.dynamic_rules) {
-    session_state->insert_dynamic_rule(policy_rule);
-  }
-  bool activate_success = pipelined_client_->activate_flows_for_rules(
-    imsi,
-    ip_addr,
-    rules_to_activate.static_rules,
-    rules_to_activate.dynamic_rules);
-
-  // deactivate_flows_for_rules() should not be called when there is no rule
-  // to deactivate, because pipelined deactivates all rules
-  // when no rule is provided as the parameter
-  bool deactivate_success = true;
-  if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    for (const auto &static_rule : rules_to_deactivate.static_rules) {
-      if (!session_state->deactivate_static_rule(static_rule))
-        MLOG(MWARNING) << "Could not find rule " << static_rule  << "for IMSI "
-                       << imsi << " during static rule removal";
-
-    }
-    for (const auto &policy_rule : rules_to_deactivate.dynamic_rules) {
-      PolicyRule rule_dont_care;
-      session_state->remove_dynamic_rule(policy_rule.id(), &rule_dont_care);
-    }
-    deactivate_success = pipelined_client_->deactivate_flows_for_rules(
-      imsi,
-      rules_to_deactivate.static_rules,
-      rules_to_deactivate.dynamic_rules);
-  }
-
-  return activate_success && deactivate_success;
+  return rule_update_success;
 }
 
 void LocalEnforcer::complete_termination(
@@ -1030,23 +1045,37 @@ void LocalEnforcer::init_policy_reauth_for_session(
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
 
-  get_rules_from_policy_reauth_request(
-    request, session, rules_to_activate, rules_to_deactivate);
+  MLOG(MDEBUG) << "Processing policy reauth for subscriber " << request.imsi();
+  if (revalidation_required(request.event_triggers())) {
+    schedule_revalidation(request.revalidation_time());
+  }
+
+  std::string imsi = request.imsi();
+
+  process_rules_to_remove(
+    imsi,
+    session,
+    request.rules_to_remove(),
+    rules_to_deactivate);
+
+  process_rules_to_install(
+    imsi,
+    session,
+    request.rules_to_install(),
+    request.dynamic_rules_to_install(),
+    rules_to_activate,
+    rules_to_deactivate);
 
   auto ip_addr = session->get_subscriber_ip_addr();
   if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    if (!pipelined_client_->deactivate_flows_for_rules(
+    deactivate_success = pipelined_client_->deactivate_flows_for_rules(
       request.imsi(), rules_to_deactivate.static_rules,
-      rules_to_deactivate.dynamic_rules)) {
-      deactivate_success = false;
-    }
+      rules_to_deactivate.dynamic_rules);
   }
   if (rules_to_process_is_not_empty(rules_to_activate)) {
-    if (!pipelined_client_->activate_flows_for_rules(
+    activate_success = pipelined_client_->activate_flows_for_rules(
       request.imsi(), ip_addr, rules_to_activate.static_rules,
-      rules_to_activate.dynamic_rules)) {
-      activate_success = false;
-    }
+      rules_to_activate.dynamic_rules);
   }
 
   create_bearer(
@@ -1164,34 +1193,6 @@ void LocalEnforcer::process_rules_to_install(
       rules_to_deactivate.dynamic_rules.push_back(dynamic_rule.policy_rule());
     }
   }
-}
-
-void LocalEnforcer::get_rules_from_policy_reauth_request(
-  const PolicyReAuthRequest& request,
-  const std::unique_ptr<SessionState>& session,
-  RulesToProcess& rules_to_activate,
-  RulesToProcess& rules_to_deactivate)
-{
-  MLOG(MDEBUG) << "Processing policy reauth for subscriber " << request.imsi();
-  if (revalidation_required(request.event_triggers())) {
-    schedule_revalidation(request.revalidation_time());
-  }
-
-  std::string imsi = request.imsi();
-
-  process_rules_to_remove(
-    imsi,
-    session,
-    request.rules_to_remove(),
-    rules_to_deactivate);
-
-  process_rules_to_install(
-    imsi,
-    session,
-    request.rules_to_install(),
-    request.dynamic_rules_to_install(),
-    rules_to_activate,
-    rules_to_deactivate);
 }
 
 bool LocalEnforcer::revalidation_required(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -93,6 +93,16 @@ class LocalEnforcer {
   UpdateSessionRequest collect_updates();
 
   /**
+   * Perform any rule installs/removals that need to be executed given a
+   * CreateSessionResponse. 
+   */
+  bool handle_session_init_rule_updates(
+    const std::string& imsi,
+    SessionState& session_state,
+    const CreateSessionResponse& response,
+    std::unordered_set<uint32_t>& charging_credits_received);
+
+  /**
    * Initialize credit received from the cloud in the system. This adds all the
    * charging keys to the credit manager for tracking
    * @param credit_response - message from cloud containing initial credits
@@ -194,7 +204,7 @@ class LocalEnforcer {
   /**
    * Process the create session response to get rules to activate/deactivate
    * instantly and schedule rules with activation/deactivation time info
-   * to activate/deactivate later.
+   * to activate/deactivate later. No state change is made.
    */
   void process_create_session_response(
     const CreateSessionResponse& response,
@@ -223,7 +233,8 @@ class LocalEnforcer {
 
   /**
    * Process the list of rule names given and fill in rules_to_deactivate by
-   * determining whether each one is dynamic or static.
+   * determining whether each one is dynamic or static. Modifies session state.
+   * TODO separate out logic that modifies state vs logic that does not.
    */
   void process_rules_to_remove(
     const std::string& imsi,
@@ -245,7 +256,8 @@ class LocalEnforcer {
 
   /**
    * Process protobuf StaticRuleInstalls and DynamicRuleInstalls to fill in
-   * rules_to_activate and rules_to_deactivate.
+   * rules_to_activate and rules_to_deactivate. Modifies session state.
+   * TODO separate out logic that modifies state vs logic that does not.
    */
   void process_rules_to_install(
     const std::string& imsi,
@@ -254,20 +266,6 @@ class LocalEnforcer {
       static_rules_to_install,
     const google::protobuf::RepeatedPtrField<magma::lte::DynamicRuleInstall>
       dynamic_rules_to_install,
-    RulesToProcess& rules_to_activate,
-    RulesToProcess& rules_to_deactivate);
-
-  /**
-   * Process the policy reauth request to get rules to activate/deactivate
-   * instantly and schedule rules with activation/deactivation time info
-   * to activate/deactivate later.
-   * Policy reauth request also specifies a flat list of rule IDs to remove.
-   * Rules need to be deactivated are categorized as either staic or dynamic
-   * rule and put in the vector.
-   */
-  void get_rules_from_policy_reauth_request(
-    const PolicyReAuthRequest& request,
-    const std::unique_ptr<SessionState>& session,
     RulesToProcess& rules_to_activate,
     RulesToProcess& rules_to_deactivate);
 


### PR DESCRIPTION
Summary:
Making a helper function `handle_session_init_rule_updates` to move all of rule install/removal related logic into this one. Motivation is to make `init_session_credit` a bit easier on the eyes.

Move the logic of `get_rules_from_policy_reauth_request` into the parent function. Since the function doesn't do much, it's probably better to keep it in the parent function so that the logic is not as fragmented.

Differential Revision: D19750624

