### PR TITLE
Split LocalEnforcer's collect_updates into pure/non-pure functions

### DIFF
--- a/lte/gateway/c/session_manager/CreditPool.cpp
+++ b/lte/gateway/c/session_manager/CreditPool.cpp
@@ -74,7 +74,7 @@ static void populate_output_actions(
   KeyType key,
   SessionRules *session_rules,
   std::unique_ptr<ServiceAction> &action,
-  std::vector<std::unique_ptr<ServiceAction>> *actions_out)
+  std::vector<std::unique_ptr<ServiceAction>> *actions_out) // const
 {
   action->set_imsi(imsi);
   action->set_ip_addr(ip_addr);
@@ -87,7 +87,7 @@ void ChargingCreditPool::get_updates(
   std::string ip_addr,
   SessionRules *session_rules,
   std::vector<CreditUsage> *updates_out,
-  std::vector<std::unique_ptr<ServiceAction>> *actions_out)
+  std::vector<std::unique_ptr<ServiceAction>> *actions_out) const
 {
   for (auto &credit_pair : credit_map_) {
     auto &credit = *(credit_pair.second);
@@ -123,7 +123,7 @@ void ChargingCreditPool::get_updates(
 }
 
 bool ChargingCreditPool::get_termination_updates(
-  SessionTerminateRequest *termination_out)
+  SessionTerminateRequest *termination_out) const
 {
   for (auto &credit_pair : credit_map_) {
     termination_out->mutable_credit_usages()->Add()->CopyFrom(
@@ -236,7 +236,7 @@ bool ChargingCreditPool::receive_credit(const CreditUpdateResponse &update)
   return true;
 }
 
-uint64_t ChargingCreditPool::get_credit(const CreditKey &key, Bucket bucket)
+uint64_t ChargingCreditPool::get_credit(const CreditKey &key, Bucket bucket) const
 {
   auto it = credit_map_.find(key);
   if (it == credit_map_.end()) {
@@ -341,7 +341,7 @@ void UsageMonitoringCreditPool::get_updates(
   std::string ip_addr,
   SessionRules *session_rules,
   std::vector<UsageMonitorUpdate> *updates_out,
-  std::vector<std::unique_ptr<ServiceAction>> *actions_out)
+  std::vector<std::unique_ptr<ServiceAction>> *actions_out) const
 {
   for (auto &monitor_pair : monitor_map_) {
     auto &credit = monitor_pair.second->credit;
@@ -370,7 +370,7 @@ void UsageMonitoringCreditPool::get_updates(
 }
 
 bool UsageMonitoringCreditPool::get_termination_updates(
-  SessionTerminateRequest *termination_out)
+  SessionTerminateRequest *termination_out) const
 {
   for (auto &credit_pair : monitor_map_) {
     termination_out->mutable_monitor_usages()->Add()->CopyFrom(
@@ -460,7 +460,7 @@ bool UsageMonitoringCreditPool::receive_credit(
 
 uint64_t UsageMonitoringCreditPool::get_credit(
   const std::string &key,
-  Bucket bucket)
+  Bucket bucket) const
 {
   auto it = monitor_map_.find(key);
   if (it == monitor_map_.end()) {

--- a/lte/gateway/c/session_manager/CreditPool.h
+++ b/lte/gateway/c/session_manager/CreditPool.h
@@ -46,14 +46,14 @@ class CreditPool {
     std::string ip_addr,
     SessionRules *session_rules,
     std::vector<UpdateRequestType> *updates_out,
-    std::vector<std::unique_ptr<ServiceAction>> *actions_out) = 0;
+    std::vector<std::unique_ptr<ServiceAction>> *actions_out) const = 0;
 
   /**
    * get_termination_updates gets updates from all credits in the pool at the
    * time of termination
    */
   virtual bool get_termination_updates(
-    SessionTerminateRequest *termination_out) = 0;
+    SessionTerminateRequest *termination_out) const = 0;
 
   /**
    * receive_credit adds allowed credit from the cloud
@@ -63,7 +63,7 @@ class CreditPool {
   /**
    * get_credit is a helper function to return the bytes in a credit bucket
    */
-  virtual uint64_t get_credit(const KeyType &key, Bucket bucket) = 0;
+  virtual uint64_t get_credit(const KeyType &key, Bucket bucket) const = 0;
 };
 
 /**
@@ -86,14 +86,14 @@ class ChargingCreditPool :
     std::string ip_addr,
     SessionRules *session_rules,
     std::vector<CreditUsage> *updates_out,
-    std::vector<std::unique_ptr<ServiceAction>> *actions_out) override;
+    std::vector<std::unique_ptr<ServiceAction>> *actions_out) const override;
 
   bool get_termination_updates(
-    SessionTerminateRequest *termination_out) override;
+    SessionTerminateRequest *termination_out) const override;
 
   bool receive_credit(const CreditUpdateResponse &update) override;
 
-  uint64_t get_credit(const CreditKey &key, Bucket bucket) override;
+  uint64_t get_credit(const CreditKey &key, Bucket bucket) const override;
 
   ChargingReAuthAnswer::Result reauth_key(const CreditKey &charging_key);
 
@@ -134,14 +134,14 @@ class UsageMonitoringCreditPool :
     std::string ip_addr,
     SessionRules *session_rules,
     std::vector<UsageMonitorUpdate> *updates_out,
-    std::vector<std::unique_ptr<ServiceAction>> *actions_out) override;
+    std::vector<std::unique_ptr<ServiceAction>> *actions_out) const override;
 
   bool get_termination_updates(
-    SessionTerminateRequest *termination_out) override;
+    SessionTerminateRequest *termination_out) const override;
 
   bool receive_credit(const UsageMonitoringUpdateResponse &update) override;
 
-  uint64_t get_credit(const std::string &key, Bucket bucket) override;
+  uint64_t get_credit(const std::string &key, Bucket bucket) const override;
 
   std::unique_ptr<std::string> get_session_level_key();
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -300,16 +300,15 @@ void LocalEnforcer::install_redirect_flow(
 );
 }
 
-UpdateSessionRequest LocalEnforcer::collect_updates()
+UpdateSessionRequest LocalEnforcer::collect_updates(
+  std::vector<std::unique_ptr<ServiceAction>>& actions) const
 {
   UpdateSessionRequest request;
-  std::vector<std::unique_ptr<ServiceAction>> actions;
   for (const auto &session_pair : session_map_) {
     for (const auto &session : session_pair.second) {
       session->get_updates(request, &actions);
     }
   }
-  execute_actions(actions);
   return request;
 }
 
@@ -1243,7 +1242,9 @@ void LocalEnforcer::create_bearer(
 
 void LocalEnforcer::check_usage_for_reporting()
 {
-  auto request = collect_updates();
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto request = collect_updates(actions);
+  execute_actions(actions);
   if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
     return; // nothing to report
   }

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -90,7 +90,7 @@ class LocalEnforcer {
    * and apply actions to the services if need be
    * @param updates_out (out) - vector to add usage updates to, if they exist
    */
-  UpdateSessionRequest collect_updates();
+  UpdateSessionRequest collect_updates(std::vector<std::unique_ptr<ServiceAction>>& actions) const;
 
   /**
    * Perform any rule installs/removals that need to be executed given a
@@ -168,6 +168,13 @@ class LocalEnforcer {
 
   std::string *duplicate_session_id(
     const std::string& imsi, const magma::SessionState::Config& config);
+
+  /**
+   * Execute actions on subscriber's service, eg. terminate, redirect data, or
+   * just continue
+   */
+  void execute_actions(
+    const std::vector<std::unique_ptr<ServiceAction>>& actions);
 
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
@@ -341,9 +348,6 @@ class LocalEnforcer {
     const google::protobuf::Timestamp& revalidation_time);
 
   void check_usage_for_reporting();
-
-  void execute_actions(
-    const std::vector<std::unique_ptr<ServiceAction>>& actions);
 
   /**
     * Deactivate rules for certain IMSI.

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -58,7 +58,9 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
 
 void LocalSessionManagerHandlerImpl::check_usage_for_reporting()
 {
-  auto request = enforcer_->collect_updates();
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto request = enforcer_->collect_updates(actions);
+  enforcer_->execute_actions(actions);
   if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
     return; // nothing to report
   }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -207,10 +207,24 @@ class SessionState {
   std::function<void(SessionTerminateRequest)> on_termination_callback_;
 
  private:
+  /**
+   * For this session, add the CreditUsageUpdate to the UpdateSessionRequest.
+   * Also
+   *
+   * @param update_request_out Modified with added CreditUsageUpdate
+   * @param actions_out Modified with additional actions to take on session
+   */
   void get_updates_from_charging_pool(
     UpdateSessionRequest& update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out);
 
+  /**
+   * For this session, add the UsageMonitoringUpdateRequest to the
+   * UpdateSessionRequest.
+   *
+   * @param update_request_out Modified with added UsdageMonitoringUpdateRequest
+   * @param actions_out Modified with additional actions to take on session.
+   */
   void get_updates_from_monitor_pool(
     UpdateSessionRequest& update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out);

--- a/lte/protos/session_manager.proto
+++ b/lte/protos/session_manager.proto
@@ -16,7 +16,7 @@ package magma.lte;
 option go_package = "magma/lte/cloud/go/protos";
 
 message RuleRecord {
-  string sid = 1; // System Identification Number
+  string sid = 1; // Session ID - specified as IMSI
   string rule_id = 2;
   uint64 bytes_tx = 3;
   uint64 bytes_rx = 4;


### PR DESCRIPTION
Summary:
(Refactor only)

## Changes
- `LocalEnforcer`: Move `execute_actions()` call out of  `collect_updates()` to split into pure/non-pure functions
- Document functions of `SessionState`
- `CreditPool` mark pure-functions with `const`

Reviewed By: themarwhal

Differential Revision: D19738986

