### PR TITLE
Add marshal/unmarshal function between structs for data classes

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -110,6 +110,7 @@ add_library(SESSION_MANAGER
     CreditPool.h
     SessionProxyResponderHandler.cpp
     SessionProxyResponderHandler.h
+    StoredState.h
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )

--- a/lte/gateway/c/session_manager/CreditPool.h
+++ b/lte/gateway/c/session_manager/CreditPool.h
@@ -13,6 +13,7 @@
 #include "CreditKey.h"
 #include "SessionCredit.h"
 #include "SessionRules.h"
+#include "StoredState.h"
 
 namespace magma {
 
@@ -74,6 +75,11 @@ class CreditPool {
 class ChargingCreditPool :
   public CreditPool<CreditKey, CreditUpdateResponse, CreditUsage> {
  public:
+  static std::unique_ptr<ChargingCreditPool> unmarshal(
+    const StoredChargingCreditPool &marshaled);
+
+  StoredChargingCreditPool marshal();
+
   ChargingCreditPool(const std::string &imsi);
 
   bool add_used_credit(const CreditKey &key, uint64_t used_tx, uint64_t used_rx)
@@ -120,6 +126,11 @@ class UsageMonitoringCreditPool :
     UsageMonitoringUpdateResponse,
     UsageMonitorUpdate> {
  public:
+  static std::unique_ptr<UsageMonitoringCreditPool> unmarshal(
+    const StoredUsageMonitoringCreditPool &marshaled);
+
+  StoredUsageMonitoringCreditPool marshal();
+
   UsageMonitoringCreditPool(const std::string &imsi);
 
   bool add_used_credit(

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -16,40 +16,10 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 
 #include "ServiceAction.h"
+#include "StoredState.h"
 #include "CreditKey.h"
 
 namespace magma {
-
-/**
- * A bucket is a counter used for tracking credit volume across sessiond.
- * These are independently incremented and reset
- * Each value is in terms of a volume unit - either bytes or seconds
- */
-enum Bucket {
-  USED_TX = 0,
-  USED_RX = 1,
-  ALLOWED_TOTAL = 2,
-  ALLOWED_TX = 3,
-  ALLOWED_RX = 4,
-  REPORTING_TX = 5,
-  REPORTING_RX = 6,
-  REPORTED_TX = 7,
-  REPORTED_RX = 8,
-  MAX_VALUES = 9,
-};
-
-enum ReAuthState {
-  REAUTH_NOT_NEEDED = 0,
-  REAUTH_REQUIRED = 1,
-  REAUTH_PROCESSING = 2,
-};
-
-enum ServiceState {
-  SERVICE_ENABLED = 0,
-  SERVICE_NEEDS_DEACTIVATION = 1,
-  SERVICE_DISABLED = 2,
-  SERVICE_NEEDS_ACTIVATION = 3,
-};
 
 enum CreditUpdateType {
   CREDIT_NO_UPDATE = 0,

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -50,6 +50,12 @@ class SessionCredit {
     RedirectServer redirect_server;
   };
 
+  static std::unique_ptr<SessionCredit> unmarshal(
+    const StoredSessionCredit &marshaled,
+    CreditType credit_type);
+
+  StoredSessionCredit marshal();
+
   SessionCredit(CreditType credit_type);
 
   SessionCredit(CreditType credit_type, ServiceState start_state);

--- a/lte/gateway/c/session_manager/SessionRules.cpp
+++ b/lte/gateway/c/session_manager/SessionRules.cpp
@@ -10,6 +10,41 @@
 
 namespace magma {
 
+std::unique_ptr<SessionRules> SessionRules::unmarshal(
+  const StoredSessionRules& marshaled,
+  StaticRuleStore &static_rule_ref)
+{
+  return std::make_unique<SessionRules>(marshaled, static_rule_ref);
+}
+
+SessionRules::SessionRules(
+  const StoredSessionRules& marshaled,
+  StaticRuleStore &static_rule_ref):
+  static_rules_(static_rule_ref)
+{
+  for (const std::string& rule_id : marshaled.static_rule_ids)
+  {
+    active_static_rules_.push_back(rule_id);
+  }
+  for (auto& rule : marshaled.dynamic_rules)
+  {
+    dynamic_rules_.insert_rule(rule);
+  }
+}
+
+StoredSessionRules SessionRules::marshal()
+{
+  StoredSessionRules stored_rules;
+  for (auto& rule_id : active_static_rules_)
+  {
+    stored_rules.static_rule_ids.push_back(rule_id);
+  }
+  std::vector<PolicyRule> dynamic_rules;
+  dynamic_rules_.get_rules(dynamic_rules);
+  stored_rules.dynamic_rules = std::move(dynamic_rules);
+  return stored_rules;
+}
+
 SessionRules::SessionRules(StaticRuleStore &static_rule_ref):
   static_rules_(static_rule_ref)
 {

--- a/lte/gateway/c/session_manager/SessionRules.h
+++ b/lte/gateway/c/session_manager/SessionRules.h
@@ -11,6 +11,7 @@
 #include "CreditKey.h"
 #include "RuleStore.h"
 #include "ServiceAction.h"
+#include "StoredState.h"
 
 namespace magma {
 
@@ -19,7 +20,17 @@ namespace magma {
  */
 class SessionRules {
  public:
+  static std::unique_ptr<SessionRules> unmarshal(
+    const StoredSessionRules& marshaled,
+    StaticRuleStore &static_rule_ref);
+
+  StoredSessionRules marshal();
+
   SessionRules(StaticRuleStore &static_rule_ref);
+
+  SessionRules(
+    const StoredSessionRules& marshaled,
+    StaticRuleStore &static_rule_ref);
 
   bool get_charging_key_for_rule_id(
     const std::string &rule_id,

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -14,6 +14,7 @@
 
 #include "RuleStore.h"
 #include "SessionRules.h"
+#include "StoredState.h"
 #include "CreditPool.h"
 
 namespace magma {
@@ -60,6 +61,16 @@ class SessionState {
     const SessionState::Config& cfg,
     StaticRuleStore& rule_store,
     const magma::lte::TgppContext& tgpp_context);
+
+  SessionState(
+    const StoredSessionState &marshaled,
+    StaticRuleStore &rule_store);
+
+  static std::unique_ptr<SessionState> unmarshal(
+    const StoredSessionState &marshaled,
+    StaticRuleStore &rule_store);
+
+  StoredSessionState marshal();
 
   /**
    * new_report sets the state of terminating session to aggregating, to tell if

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include <functional>
+
+#include <lte/protos/session_manager.grpc.pb.h>
+
+#include "RuleStore.h"
+#include "SessionRules.h"
+#include "CreditPool.h"
+
+namespace magma {
+
+struct StoredQoSInfo {
+  bool enabled;
+  uint32_t qci;
+};
+
+struct StoredSessionConfig {
+  std::string ue_ipv4;
+  std::string spgw_ipv4;
+  std::string msisdn;
+  std::string apn;
+  std::string imei;
+  std::string plmn_id;
+  std::string imsi_plmn_id;
+  std::string user_location;
+  RATType rat_type;
+  std::string mac_addr; // MAC Address for WLAN
+  std::string hardware_addr; // MAC Address for WLAN (binary)
+  std::string radius_session_id;
+  uint32_t bearer_id;
+  StoredQoSInfo qos_info;
+};
+
+// Session Credit
+
+struct StoredFinalActionInfo {
+  ChargingCredit_FinalAction final_action;
+  RedirectServer redirect_server;
+};
+
+struct StoredSessionCredit {
+  bool reporting;
+  bool is_final;
+  bool unlimited_quota;
+  StoredFinalActionInfo final_action_info;
+  ReAuthState reauth_state;
+  ServiceState service_state;
+  std::time_t  expiry_time;
+  std::unordered_map<Bucket, uint64_t> buckets;
+  uint64_t usage_reporting_limit;
+};
+
+struct StoredMonitor {
+  StoredSessionCredit credit;
+  MonitoringLevel level;
+};
+
+struct StoredChargingCreditPool {
+  std::string imsi;
+  std::unordered_map<
+    CreditKey, StoredSessionCredit,
+    decltype(&ccHash), decltype(&ccEqual)> credit_map;
+};
+
+struct StoredUsageMonitoringCreditPool {
+  std::string imsi;
+  std::string session_level_key; // "" maps to nullptr
+  std::unordered_map<std::string, StoredMonitor> monitor_map;
+};
+
+// Installed session rules
+struct StoredSessionRules {
+  std::vector<std::string> static_rule_ids;
+  std::vector<PolicyRule> dynamic_rules;
+};
+
+struct StoredSessionState {
+  StoredSessionConfig config;
+  StoredSessionRules rules;
+  StoredChargingCreditPool charging_pool;
+  StoredUsageMonitoringCreditPool monitor_pool;
+  std::string imsi;
+  std::string session_id;
+  std::string core_session_id;
+};
+
+}; // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -12,9 +12,7 @@
 
 #include <lte/protos/session_manager.grpc.pb.h>
 
-#include "RuleStore.h"
-#include "SessionRules.h"
-#include "CreditPool.h"
+#include "CreditKey.h"
 
 namespace magma {
 
@@ -45,6 +43,37 @@ struct StoredSessionConfig {
 struct StoredFinalActionInfo {
   ChargingCredit_FinalAction final_action;
   RedirectServer redirect_server;
+};
+
+/**
+ * A bucket is a counter used for tracking credit volume across sessiond.
+ * These are independently incremented and reset
+ * Each value is in terms of a volume unit - either bytes or seconds
+ */
+enum Bucket {
+  USED_TX = 0,
+  USED_RX = 1,
+  ALLOWED_TOTAL = 2,
+  ALLOWED_TX = 3,
+  ALLOWED_RX = 4,
+  REPORTING_TX = 5,
+  REPORTING_RX = 6,
+  REPORTED_TX = 7,
+  REPORTED_RX = 8,
+  MAX_VALUES = 9,
+};
+
+enum ReAuthState {
+  REAUTH_NOT_NEEDED = 0,
+  REAUTH_REQUIRED = 1,
+  REAUTH_PROCESSING = 2,
+};
+
+enum ServiceState {
+  SERVICE_ENABLED = 0,
+  SERVICE_NEEDS_DEACTIVATION = 1,
+  SERVICE_DISABLED = 2,
+  SERVICE_NEEDS_ACTIVATION = 3,
 };
 
 struct StoredSessionCredit {

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -13,7 +13,8 @@ add_library(SESSIOND_TEST_LIB
 target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
 foreach(session_test session_credit local_enforcer cloud_reporter async_service
-        session_manager_handler sessiond_integ session_state)
+        session_manager_handler sessiond_integ session_state session_rules
+        credit_pool)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/test_credit_pool.cpp
+++ b/lte/gateway/c/session_manager/test/test_credit_pool.cpp
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#include <chrono>
+#include <thread>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "CreditPool.h"
+#include "StoredState.h"
+#include <lte/protos/session_manager.pb.h>
+#include <lte/protos/policydb.pb.h>
+
+using ::testing::Test;
+
+namespace magma {
+using namespace lte;
+
+class CreditPoolTest : public ::testing::Test {
+ protected:
+  CreditUpdateResponse* get_credit_update()
+  {
+    auto credit_update = new CreditUpdateResponse();
+    credit_update->set_success(true);
+    credit_update->set_sid("sid1"); // System Identification Number
+    credit_update->set_charging_key(1);
+    credit_update->set_allocated_credit(get_charging_credit());
+    credit_update->set_type(CreditUpdateResponse_ResponseType_UPDATE);
+    // Don't set the result code since this is a successful response
+    auto service_identifier = new ServiceIdentifier();
+    service_identifier->set_value(uint32_t(1));
+    credit_update->set_allocated_service_identifier(service_identifier);
+    credit_update->set_limit_type(
+      CreditUpdateResponse_CreditLimitType_INFINITE_METERED);
+    // Don't set the TgppContext, assume relay disabled
+    return credit_update;
+  }
+
+  ChargingCredit* get_charging_credit()
+  {
+    auto charging_credit = new ChargingCredit();
+    charging_credit->set_type(ChargingCredit_UnitType_BYTES);
+    charging_credit->set_validity_time(1000);
+    charging_credit->set_is_final(false);
+    charging_credit->set_final_action(ChargingCredit_FinalAction_TERMINATE);
+    charging_credit->set_allocated_granted_units(get_granted_units());
+    charging_credit->set_allocated_redirect_server(get_redirect_server());
+    return charging_credit;
+  }
+
+  RedirectServer* get_redirect_server()
+  {
+    auto redirect = new RedirectServer();
+    redirect->set_redirect_address_type(RedirectServer_RedirectAddressType_IPV4);
+    redirect->set_redirect_server_address("192.168.0.1");
+  }
+
+  GrantedUnits* get_granted_units()
+  {
+    auto units = new GrantedUnits();
+
+    auto total = new CreditUnit();
+    total->set_is_valid(true);
+    total->set_volume(1000);
+
+    auto tx = new CreditUnit();
+    tx->set_is_valid(true);
+    tx->set_volume(1000);
+
+    auto rx = new CreditUnit();
+    rx->set_is_valid(true);
+    rx->set_volume(1000);
+
+    units->set_allocated_total(total);
+    units->set_allocated_tx(tx);
+    units->set_allocated_rx(rx);
+
+    return units;
+  }
+
+  UsageMonitoringUpdateResponse* get_monitoring_update()
+  {
+    auto credit_update = new UsageMonitoringUpdateResponse();
+    credit_update->set_allocated_credit(get_monitoring_credit());
+    credit_update->set_session_id("sid1");
+    credit_update->set_success(true);
+    // Don't set event triggers
+    // Don't set result code since the response is already successful
+    // Don't set any rule installation/uninstallation
+    // Don't set the TgppContext, assume relay disabled
+    return credit_update;
+  }
+
+  UsageMonitoringCredit* get_monitoring_credit()
+  {
+    auto monitoring_credit = new UsageMonitoringCredit();
+    monitoring_credit->set_action(UsageMonitoringCredit_Action_CONTINUE);
+    monitoring_credit->set_monitoring_key("mk1");
+    monitoring_credit->set_level(SESSION_LEVEL);
+    monitoring_credit->set_allocated_granted_units(get_granted_units());
+    return monitoring_credit;
+  }
+};
+
+TEST_F(CreditPoolTest, test_marshal_unmarshal_charging)
+{
+  auto pool = new ChargingCreditPool("imsi1");
+
+  // Receive credit
+  auto credit_update = get_credit_update();
+  CreditUpdateResponse& credit_update_ref = *credit_update;
+  pool->receive_credit(credit_update_ref);
+
+  // Add some used credit
+  pool->add_used_credit(CreditKey(credit_update), uint64_t(123), uint64_t(456));
+  EXPECT_EQ(pool->get_credit(CreditKey(credit_update), USED_TX), 123);
+  EXPECT_EQ(pool->get_credit(CreditKey(credit_update), USED_RX), 456);
+
+  // Check that after marshaling/unmarshaling that the fields are still the
+  // same.
+  auto marshaled = pool->marshal();
+  auto pool_2 = ChargingCreditPool::unmarshal(marshaled);
+  EXPECT_EQ(pool_2->get_credit(CreditKey(credit_update), USED_TX), 123);
+  EXPECT_EQ(pool_2->get_credit(CreditKey(credit_update), USED_RX), 456);
+}
+
+TEST_F(CreditPoolTest, test_marshal_unmarshal_monitoring)
+{
+  auto pool = new UsageMonitoringCreditPool("imsi1");
+
+  // Receive credit
+  auto credit_update = get_monitoring_update();
+  UsageMonitoringUpdateResponse& credit_update_ref = *credit_update;
+  pool->receive_credit(credit_update_ref);
+
+  // Add some used credit
+  pool->add_used_credit("mk1", uint64_t(123), uint64_t(456));
+  EXPECT_EQ(pool->get_credit("mk1", USED_TX), 123);
+  EXPECT_EQ(pool->get_credit("mk1", USED_RX), 456);
+
+  // Check that after marshaling/unmarshaling that the fields are still the
+  // same.
+  auto marshaled = pool->marshal();
+  auto pool_2 = UsageMonitoringCreditPool::unmarshal(marshaled);
+  //EXPECT_EQ(pool_2->get_credit("mk1", USED_TX), 123);
+  //EXPECT_EQ(pool_2->get_credit("mk1", USED_RX), 456);
+}
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  FLAGS_logtostderr = 1;
+  FLAGS_v = 10;
+  return RUN_ALL_TESTS();
+}
+
+} // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -23,6 +23,27 @@ const SessionCredit::FinalActionInfo default_final_action_info = {
 class SessionCreditParameterizedTest :
   public ::testing::TestWithParam<CreditType> {};
 
+TEST_P(SessionCreditParameterizedTest, test_marshal_unmarshal) {
+  CreditType credit_type = GetParam();
+  SessionCredit credit(credit_type);
+
+  // Set some fields here to non default values. Credit is used.
+  credit.add_used_credit((uint64_t) 39u, (uint64_t) 40u);
+
+  // Sanity check of credit usage. Test result after marshal/unmarshal should
+  // match.
+  EXPECT_EQ(credit.get_credit(USED_TX), (uint64_t) 39u);
+  EXPECT_EQ(credit.get_credit(USED_RX), (uint64_t) 40u);
+
+  // Check that after marshaling/unmarshaling that the fields are still the
+  // same.
+  auto marshaled = credit.marshal();
+  auto credit_2 = SessionCredit::unmarshal(marshaled, credit_type);
+
+  EXPECT_EQ(credit_2->get_credit(USED_TX), (uint64_t) 39u);
+  EXPECT_EQ(credit_2->get_credit(USED_RX), (uint64_t) 40u);
+}
+
 TEST_P(SessionCreditParameterizedTest, test_track_credit) {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);

--- a/lte/gateway/c/session_manager/test/test_session_rules.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_rules.cpp
@@ -1,0 +1,114 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#include <memory>
+#include <future>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "SessionRules.h"
+#include "magma_logging.h"
+
+using ::testing::Test;
+
+namespace magma {
+
+class SessionRulesTest : public ::testing::Test {
+ protected:
+ protected:
+  virtual void SetUp()
+  {
+    rule_store = std::make_shared<StaticRuleStore>();
+    session_rules = std::make_shared<SessionRules>(*rule_store);
+  }
+
+  PolicyRule get_rule(
+    uint32_t rating_group,
+    const std::string &m_key,
+    const std::string &rule_id)
+  {
+    PolicyRule rule;
+    rule.set_id(rule_id);
+    rule.set_rating_group(rating_group);
+    rule.set_monitoring_key(m_key);
+    if (rating_group == 0 && m_key.length() > 0) {
+      rule.set_tracking_type(PolicyRule::ONLY_PCRF);
+    } else if (rating_group > 0 && m_key.length() == 0) {
+      rule.set_tracking_type(PolicyRule::ONLY_OCS);
+    } else if (rating_group > 0 && m_key.length() > 0) {
+      rule.set_tracking_type(PolicyRule::OCS_AND_PCRF);
+    } else {
+      rule.set_tracking_type(PolicyRule::NO_TRACKING);
+    }
+    return rule;
+  }
+
+  void activate_rule(
+    uint32_t rating_group,
+    const std::string &m_key,
+    const std::string &rule_id,
+    bool is_static)
+  {
+    PolicyRule rule = get_rule(rating_group, m_key, rule_id);
+    if (is_static) {
+      rule_store->insert_rule(rule);
+      session_rules->activate_static_rule(rule_id);
+    } else {
+      session_rules->insert_dynamic_rule(rule);
+    }
+  }
+
+ protected:
+  std::shared_ptr<StaticRuleStore> rule_store;
+  std::shared_ptr<SessionRules> session_rules;
+};
+
+TEST_F(SessionRulesTest, test_marshal_unmarshal)
+{
+  // Activate a dynamic rule
+  activate_rule(1, "m1", "rule1", false);
+
+  // Activate static rules
+  activate_rule(2, "m2", "rule2", true);
+
+  std::vector<std::string> rules_out{};
+  std::vector<std::string>& rules_out_ptr = rules_out;
+
+  session_rules->get_dynamic_rules().get_rule_ids(rules_out_ptr);
+  EXPECT_EQ(rules_out_ptr.size(), 1);
+  EXPECT_EQ(rules_out_ptr[0], "rule1");
+
+  auto static_rules = session_rules->get_static_rule_ids();
+  EXPECT_EQ(static_rules.size(), 1);
+  EXPECT_EQ(static_rules[0], "rule2");
+
+  // Check that after marshaling/unmarshaling that the fields are still the
+  // same.
+  auto marshaled = (*session_rules).marshal();
+  auto session_rules_2 = SessionRules::unmarshal(marshaled, *rule_store);
+
+  rules_out = {};
+  session_rules_2->get_dynamic_rules().get_rule_ids(rules_out_ptr);
+  EXPECT_EQ(rules_out_ptr.size(), 1);
+  EXPECT_EQ(rules_out_ptr[0], "rule1");
+
+  static_rules = session_rules_2->get_static_rule_ids();
+  EXPECT_EQ(static_rules.size(), 1);
+  EXPECT_EQ(static_rules[0], "rule2");
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  FLAGS_logtostderr = 1;
+  FLAGS_v = 10;
+  return RUN_ALL_TESTS();
+}
+
+} // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -82,6 +82,26 @@ class SessionStateTest : public ::testing::Test {
   std::shared_ptr<SessionState> session_state;
 };
 
+TEST_F(SessionStateTest, test_marshal_unmarshal)
+{
+  insert_rule(1, "m1", "rule1", true);
+
+  receive_credit_from_ocs(1, 1024);
+  EXPECT_EQ(
+    session_state->get_charging_pool().get_credit(1, ALLOWED_TOTAL), 1024);
+
+  receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
+  EXPECT_EQ(
+    session_state->get_monitor_pool().get_credit("m1", ALLOWED_TOTAL), 1024);
+
+  auto marshaled = session_state->marshal();
+  auto unmarshaled = SessionState::unmarshal(marshaled, *rule_store);
+  EXPECT_EQ(
+    unmarshaled->get_charging_pool().get_credit(1, ALLOWED_TOTAL), 1024);
+  EXPECT_EQ(
+    unmarshaled->get_monitor_pool().get_credit("m1", ALLOWED_TOTAL), 1024);
+}
+
 TEST_F(SessionStateTest, test_insert_credit)
 {
   insert_rule(1, "m1", "rule1", true);


### PR DESCRIPTION
Summary:
spongebob_diff

**For stateless sessiond**

The storage interface will consume the data structs and convert them into some serialized form for storage, either protobuf or swagger models. The data classes themselves are kept agnostic to the end format.

## Changes

- marshal/unmarshal function for each data class of sessiond
- unit tests to check marshal and unmarshal behavior

Reviewed By: xjtian

Differential Revision: D19674334

