### PR TITLE
fix orc8r terraform variables file and readme

### DIFF
--- a/orc8r/cloud/deploy/terraform/README.md
+++ b/orc8r/cloud/deploy/terraform/README.md
@@ -13,5 +13,4 @@ section of the docs: https://facebookincubator.github.io/magma.
 | region | The AWS region to provision the resources in | string | "eu-west-1" | no |
 | vpc_name | The name of the provisioned VPC | string | "orc8r-vpc" | no |
 | cluster_name | The name of the provisioned EKS cluster | string | "orc8r" | no |
-| map_users | Additional IAM users to add to the aws-auth configmap | list(map(string)) | [] | no |
-| map_users_count | How many users are in map_users | string | 0 | no
+| map_users | Additional IAM users to add to the aws-auth configmap | list(map(string)) | [] | no 

--- a/orc8r/cloud/deploy/terraform/variables.tf
+++ b/orc8r/cloud/deploy/terraform/variables.tf
@@ -22,30 +22,30 @@ variable "cluster_name" {
 
 variable "db_password" {
   description = "Password for the DB user. You should put this value into a file NOT checked into source control!"
-  type        = "string"
+  type        = string
 }
 
 variable "nms_db_password" {
   description = "Password for the NMS DB user. You should put this value into a file NOT checked into source control!"
-  type        = "string"
+  type        = string
 }
 
 variable "key_name" {
   description = "Name of the EC2 Keypair to use for SSH access to nodes"
-  type        = "string"
+  type        = string
 }
 
 variable "map_users" {
   description = "Additional IAM users to add to the aws-auth configmap"
-  type        = "list"
+  type        = list
   default     = []
 
   # For e.g.:
   # [
   #   {
-  #     user_arn = "arn:aws:iam::66666666666:user/user1"
+  #     userarn = "arn:aws:iam::66666666666:user/user1"
   #     username = "user1"
-  #     group    = "system:masters"
+  #     groups    = ["system:masters"]
   #   },
   # ]
 }


### PR DESCRIPTION
Terraform variables definition file and readme seems to be a bit outdated according to warnings and issues been found during the test deployment.
 - Variable type definition should be defined without double quotes
 - **user_arn** was renamed into **userarn** in new aws module
 - **map_users_count** is not declared in the config file but present in the readme
 - **group** key is renamed in to **groups**