### PR TITLE
Adding IMSI map to S1AP task

### DIFF
--- a/lte/gateway/c/oai/include/mme_app_state.h
+++ b/lte/gateway/c/oai/include/mme_app_state.h
@@ -64,6 +64,16 @@ void put_mme_nas_state(mme_app_desc_t** task_state_ptr);
 */
 void clear_mme_nas_state(void);
 
+/**
+ * Converts mme_imsi_map to protobuf and saves it into data store
+ */
+void put_mme_imsi_map(void);
+
+/**
+ * @return mme_imsi_map_t pointer
+ */
+mme_imsi_map_t* get_mme_imsi_map(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/oai/include/mme_app_ue_context.h
@@ -486,6 +486,11 @@ typedef struct mme_ue_context_s {
   obj_hash_table_uint64_t *guti_ue_context_htbl; // data is mme_ue_s1ap_id_t
 } mme_ue_context_t;
 
+typedef struct mme_imsi_map_s {
+  hash_table_uint64_ts_t *enb_s1ap_mme_ue_id_htbl;
+  hash_table_uint64_ts_t *mme_ue_s1ap_imsi_htbl;
+} mme_imsi_map_t;
+
 /** \brief Retrieve an UE context by selecting the provided IMSI
  * \param imsi Imsi to find in UE map
  * @returns an UE context matching the IMSI or NULL if the context doesn't exists

--- a/lte/gateway/c/oai/protos/mme_nas_state.proto
+++ b/lte/gateway/c/oai/protos/mme_nas_state.proto
@@ -159,3 +159,8 @@ message MmeNasState {
   uint32 nb_s1u_bearers = 6;
   uint64 statistic_timer_id = 7;
 }
+
+message MmeImsiMap {
+  map<uint64, uint64> mme_ue_id_imsi_map = 1; // mme_s1ap_ue_id => IMSI64
+  map<uint64, uint64> enb_ue_id_mme_ue_id_map = 2; // enb_s1ap_ue_id => mme_s1ap_ue_id
+}

--- a/lte/gateway/c/oai/protos/s1ap_state.proto
+++ b/lte/gateway/c/oai/protos/s1ap_state.proto
@@ -41,3 +41,8 @@ message S1apState {
   map<uint32, uint32> mmeid2associd = 2; // mmeueid -> ue associd
   uint32 num_enbs = 3;
 }
+
+message S1apImsiMap {
+  map<uint64, uint64> mme_ue_id_imsi_map = 1; // mme_s1ap_ue_id => IMSI64
+  map<uint64, uint64> enb_ue_id_mme_ue_id_map = 2; // enb_s1ap_ue_id => mme_s1ap_ue_id
+}

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -438,6 +438,8 @@ void *mme_app_thread(void *args)
     }
 
     put_mme_nas_state(&mme_app_desc_p);
+    put_mme_imsi_map();
+
     itti_free_msg_content(received_message_p);
     itti_free(ITTI_MSG_ORIGIN_ID(received_message_p), received_message_p);
     received_message_p = NULL;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state.cpp
@@ -81,3 +81,12 @@ void clear_mme_nas_state()
   magma::lte::MmeNasStateManager::getInstance().free_state();
 }
 
+void put_mme_imsi_map(void)
+{
+  magma::lte::MmeNasStateManager::getInstance().put_mme_imsi_map();
+}
+
+mme_imsi_map_t* get_mme_imsi_map(void)
+{
+  return magma::lte::MmeNasStateManager::getInstance().get_mme_imsi_map();
+}

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -792,5 +792,26 @@ void MmeNasStateConverter::proto_to_state(
     mme_ue_ctxts_proto.guti_ue_id_htbl(),
     mme_ue_ctxt_state->guti_ue_context_htbl);*/
 }
+
+void MmeNasStateConverter::proto_to_mme_imsi_map(
+  const MmeImsiMap& mme_imsi_proto,
+  mme_imsi_map_t* mme_imsi_map)
+{
+  proto_to_hashtable_uint64_ts(
+    mme_imsi_proto.enb_ue_id_mme_ue_id_map(), mme_imsi_map->enb_s1ap_mme_ue_id_htbl);
+  proto_to_hashtable_uint64_ts(
+    mme_imsi_proto.mme_ue_id_imsi_map(), mme_imsi_map->mme_ue_s1ap_imsi_htbl);
+}
+
+void MmeNasStateConverter::mme_imsi_map_to_proto(
+  const mme_imsi_map_t* mme_imsi_map,
+  MmeImsiMap* mme_imsi_proto)
+{
+  hashtable_uint64_ts_to_proto(
+    mme_imsi_map->enb_s1ap_mme_ue_id_htbl, mme_imsi_proto->mutable_enb_ue_id_mme_ue_id_map());
+  hashtable_uint64_ts_to_proto(
+    mme_imsi_map->mme_ue_s1ap_imsi_htbl, mme_imsi_proto->mutable_mme_ue_id_imsi_map());
+}
+
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.h
@@ -58,6 +58,16 @@ class MmeNasStateConverter : public StateConverter {
     const MmeNasState& state_proto,
     mme_app_desc_t* mme_nas_state_p);
 
+  // Serialize mme_imsi_map_to to MmeImsiMap proto
+  static void mme_imsi_map_to_proto(
+    const mme_imsi_map_t* mme_imsi_map,
+    MmeImsiMap* mme_imsi_proto);
+
+  // Deserialize mme_imsi_map_to from MmeImsiMap proto
+  static void proto_to_mme_imsi_map(
+    const MmeImsiMap& mme_imsi_proto,
+    mme_imsi_map_t* mme_imsi_map);
+
  private:
   /***********************************************************
     *                 Hashtable <-> Proto

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.h
@@ -31,6 +31,10 @@ extern "C" {
 #include "mme_app_state_converter.h"
 #include "ServiceConfigLoader.h"
 
+namespace {
+constexpr char MME_IMSI_MAP_TABLE_NAME[] = "mme_imsi_map";
+}
+
 namespace magma {
 namespace lte {
 /**
@@ -79,6 +83,16 @@ class MmeNasStateManager :
   void free_state() override;
 
   /**
+   * Serializes mme_imsi_map into proto and writes it into data store
+   */
+  void put_mme_imsi_map();
+  /**
+   * Returns a pointer to mme_imsi_map
+   * @return mme_imsi_map_t pointer
+   */
+  mme_imsi_map_t* get_mme_imsi_map();
+
+  /**
    * Copy constructor and assignment operator are marked as deleted functions.
    * Making them public for better debugging/logging.
    */
@@ -100,6 +114,7 @@ class MmeNasStateManager :
   int max_ue_htbl_lists_;
   uint32_t mme_statistic_timer_;
   bool mme_nas_state_dirty_; // TODO: convert this to version numbers
+  mme_imsi_map_t* mme_imsi_map_;
 
   // Initialize state that is non-persistent, e.g. mutex locks and timers
   void mme_nas_state_init_local_state();
@@ -122,6 +137,11 @@ class MmeNasStateManager :
    * task terminates
    */
   void create_state() override;
+
+  // Allocates mme_imsi_map_t and hashtables
+  void create_mme_imsi_map();
+  // Cleans up mme_imsi_map_t and hashtables
+  void clear_mme_imsi_map();
 
   // Clean-up the in-memory hashtables
   void clear_mme_nas_hashtables();

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -97,6 +97,14 @@ ue_description_t* s1ap_state_get_ue_mmeid(
   return ue;
 }
 
+void put_s1ap_imsi_map() {
+  S1apStateManager::getInstance().put_s1ap_imsi_map();
+}
+
+s1ap_imsi_map_t* get_s1ap_imsi_map() {
+  return S1apStateManager::getInstance().get_s1ap_imsi_map();
+}
+
 bool s1ap_ue_compare_by_mme_ue_id_cb(
   __attribute__((unused)) const hash_key_t keyP,
   void* const elementP,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.h
@@ -49,6 +49,15 @@ ue_description_t* s1ap_state_get_ue_mmeid(
   s1ap_state_t* state,
   mme_ue_s1ap_id_t mme_ue_s1ap_id);
 
+/**
+ * Converts s1ap_imsi_map to protobuf and saves it into data store
+ */
+void put_s1ap_imsi_map(void);
+/**
+ * @return s1ap_imsi_map_t pointer
+ */
+s1ap_imsi_map_t * get_s1ap_imsi_map(void);
+
 bool s1ap_enb_find_ue_by_mme_ue_id_cb(
   __attribute__((unused)) hash_key_t keyP,
   void* elementP,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.cpp
@@ -183,5 +183,28 @@ void S1apStateConverter::proto_to_ue(
   ue->s1ap_ue_context_rel_timer.sec = proto.s1ap_ue_context_rel_timer().sec();
 }
 
+void S1apStateConverter::s1ap_imsi_map_to_proto(
+  const s1ap_imsi_map_t* s1ap_imsi_map,
+  gateway::s1ap::S1apImsiMap* s1ap_imsi_proto)
+{
+  hashtable_uint64_ts_to_proto(
+    s1ap_imsi_map->enb_s1ap_mme_ue_id_htbl,
+    s1ap_imsi_proto->mutable_enb_ue_id_mme_ue_id_map());
+  hashtable_uint64_ts_to_proto(
+    s1ap_imsi_map->mme_ue_id_imsi_htbl,
+    s1ap_imsi_proto->mutable_mme_ue_id_imsi_map());
+}
+void S1apStateConverter::proto_to_s1ap_imsi_map(
+  const gateway::s1ap::S1apImsiMap& s1ap_imsi_proto,
+  s1ap_imsi_map_t* s1ap_imsi_map)
+{
+  proto_to_hashtable_uint64_ts(
+    s1ap_imsi_proto.mme_ue_id_imsi_map(),
+    s1ap_imsi_map->mme_ue_id_imsi_htbl);
+  proto_to_hashtable_uint64_ts(
+    s1ap_imsi_proto.enb_ue_id_mme_ue_id_map(),
+    s1ap_imsi_map->enb_s1ap_mme_ue_id_htbl);
+}
+
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.h
@@ -54,6 +54,20 @@ class S1apStateConverter : StateConverter {
     const gateway::s1ap::S1apState& proto,
     s1ap_state_t* state);
 
+  /**
+   * Serializes s1ap_imsi_map_t to S1apImsiMap proto
+   */
+  static void s1ap_imsi_map_to_proto(
+    const s1ap_imsi_map_t* s1ap_imsi_map,
+    gateway::s1ap::S1apImsiMap* s1ap_imsi_proto);
+
+  /**
+   * Deserializes s1ap_imsi_map_t from S1apImsiMap proto
+   */
+  static void proto_to_s1ap_imsi_map(
+    const gateway::s1ap::S1apImsiMap& s1ap_imsi_proto,
+    s1ap_imsi_map_t* s1ap_imsi_map);
+
   static void enb_to_proto(
     enb_description_t* enb,
     gateway::s1ap::EnbDescription* proto);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
@@ -74,6 +74,15 @@ class S1apStateManager :
    */
   void free_state() override;
 
+  /**
+   * Serializes s1ap_imsi_map to proto and saves it into data store
+   */
+  void put_s1ap_imsi_map();
+  /**
+   * Returns a pointer to s1ap_imsi_map
+   */
+  s1ap_imsi_map_t* get_s1ap_imsi_map();
+
  private:
   S1apStateManager();
   ~S1apStateManager();
@@ -83,8 +92,12 @@ class S1apStateManager :
    */
   void create_state() override;
 
+  void create_s1ap_imsi_map();
+  void clear_s1ap_imsi_map();
+
   uint32_t max_ues_;
   uint32_t max_enbs_;
+  s1ap_imsi_map_t* s1ap_imsi_map_;
 };
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_types.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_types.h
@@ -42,6 +42,11 @@ typedef struct s1ap_state_s {
   uint32_t num_enbs;
 } s1ap_state_t;
 
+typedef struct s1ap_imsi_map_s {
+  hash_table_uint64_ts_t* enb_s1ap_mme_ue_id_htbl;
+  hash_table_uint64_ts_t* mme_ue_id_imsi_htbl;
+} s1ap_imsi_map_t;
+
 enum s1_timer_class_s {
   S1AP_INVALID_TIMER_CLASS,
   S1AP_ENB_TIMER,


### PR DESCRIPTION
Summary:
This diff:

- Adds IMSI hashtable structs to S1AP task
- Adds proto representation of s1ap_imsi_map for serializing/deserializing

For introducing a consistent way to retrieve IMSI on ITTI messages, MME tasks rely on different UE identifiers that are mapped to IMSI, this map will allow the tasks to save and retrieve IMSI through the ITTI messages.

Differential Revision: D19793319

