### PR TITLE
Adding IMSI to MME task ITTI messages

### DIFF
--- a/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <string>
 #include <iostream>
+#include <conversions.h>
 
 #include "s6a_client_api.h"
 #include "S6aClient.h"
@@ -104,6 +105,8 @@ static void _s6a_handle_authentication_info_ans(
     itti_msg->result.present = S6A_RESULT_BASE;
     itti_msg->result.choice.base = DIAMETER_UNABLE_TO_COMPLY;
   }
+
+  IMSI_STRING_TO_IMSI64((char*) imsi.c_str(), &message_p->ittiMsgHeader.imsi);
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   return;
 }
@@ -165,6 +168,7 @@ static void _s6a_handle_update_location_ans(
   }
   std::cout << "[INFO] sent itti S6A-LOCATION-UPDATE_ANSWER for IMSI: " << imsi
                   << std::endl;
+  IMSI_STRING_TO_IMSI64((char*) imsi.c_str(), &message_p->ittiMsgHeader.imsi);
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   return;
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -497,6 +497,7 @@ void mme_app_handle_conn_est_cnf(nas_establish_rsp_t* const nas_conn_est_cnf_p)
     "security_capabilities_integrity_algorithms  0x%04X\n",
     establishment_cnf_p->ue_security_capabilities_integrity_algorithms);
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   /*
@@ -837,6 +838,7 @@ void mme_app_handle_erab_setup_req(
 
     s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0].nas_pdu = nas_msg;
 
+    message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
     itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
   } else {
     OAILOG_DEBUG(
@@ -1309,8 +1311,10 @@ void mme_app_handle_initial_context_setup_rsp(mme_app_desc_t *mme_app_desc_p,
   message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
 
   OAILOG_INFO(
-    TASK_MME_APP, "Sending S11 MODIFY BEARER REQ to SPGW for ue_id = (%d), teid = (%u)\n",
-    initial_ctxt_setup_rsp_pP->ue_id, s11_modify_bearer_request->teid);
+    LOG_MME_APP,
+    "Sending S11 MODIFY BEARER REQ to SPGW for ue_id = (%d), teid = (%u)\n",
+    initial_ctxt_setup_rsp_pP->ue_id,
+    s11_modify_bearer_request->teid);
   itti_send_msg_to_task(TASK_SPGW, INSTANCE_DEFAULT, message_p);
   /*
    * During Service request procedure,after initial context setup response
@@ -1608,6 +1612,8 @@ void mme_app_handle_e_rab_setup_rsp(
         bc->bearer_state = BEARER_STATE_NULL;
       }
     }
+
+    message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
     itti_send_msg_to_task(TASK_S11, INSTANCE_DEFAULT, message_p);
   } else {
     // not send S11 response
@@ -1958,6 +1964,7 @@ int mme_app_paging_request_helper(
       &tai_list->partial_tai_list[tai_list_idx],
       tai_list->partial_tai_list[tai_list_idx].numberofelements);
   }
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   rc = itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   if (!set_timer) {
@@ -2621,6 +2628,8 @@ void mme_app_handle_modify_ue_ambr_request(mme_app_desc_t *mme_app_desc_p,
       modify_ue_ambr_request_p->ue_ambr.br_ul;
     S1AP_UE_CONTEXT_MODIFICATION_REQUEST(message_p).ue_ambr.br_dl =
       modify_ue_ambr_request_p->ue_ambr.br_dl;
+
+    message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
     itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
     OAILOG_DEBUG(
       LOG_MME_APP,
@@ -3172,6 +3181,8 @@ void mme_app_handle_erab_rel_cmd(
     "and EBI %u \n",
     ue_id,
     ebi);
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   OAILOG_FUNC_OUT(LOG_MME_APP);
@@ -3270,6 +3281,8 @@ void mme_app_handle_path_switch_req_ack(
     LOG_MME_APP,
     "MME_APP send PATH_SWITCH_REQUEST_ACK to S1AP for ue_id %d \n",
     ue_context_p->mme_ue_s1ap_id);
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   OAILOG_FUNC_OUT(LOG_MME_APP);
@@ -3297,6 +3310,7 @@ void mme_app_handle_path_switch_req_failure(
     LOG_MME_APP,
     "MME_APP send PATH_SWITCH_REQUEST_FAILURE to S1AP for ue_id %d \n",
     ue_context_p->mme_ue_s1ap_id);
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -413,6 +413,7 @@ struct ue_mm_context_s *mme_ue_context_exists_s11_teid(
   hashtable_rc_t h_rc = HASH_TABLE_OK;
   uint64_t mme_ue_s1ap_id64 = 0;
 
+  // TODO: Update once SPGW is indexed by IMSI
   h_rc = hashtable_uint64_ts_get(
     mme_ue_context_p->tun11_ue_context_htbl,
     (const hash_key_t) teid,
@@ -479,7 +480,6 @@ void mme_ue_context_update_coll_keys(
   const guti_t* const guti_p) //  never NULL, if none put &ue_context_p->guti
 {
   hashtable_rc_t h_rc = HASH_TABLE_OK;
-
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   OAILOG_TRACE(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -98,6 +98,8 @@ void mme_app_itti_ue_context_release(
   S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).enb_ue_s1ap_id =
     ue_context_p->enb_ue_s1ap_id;
   S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).cause = cause;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }
@@ -487,6 +489,8 @@ void nas_itti_sgsap_uplink_unitdata(
     SGSAP_UPLINK_UNITDATA(message_p).presencemask |=
       UPLINK_UNITDATA_ECGI_PARAMETER_PRESENT;
   }
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   if (itti_send_msg_to_task(TASK_SGS, INSTANCE_DEFAULT, message_p)
     != RETURNok) {
     OAILOG_ERROR(
@@ -535,6 +539,8 @@ void mme_app_itti_sgsap_tmsi_reallocation_comp(
   memcpy(SGSAP_TMSI_REALLOC_COMP(message_p).imsi, imsi, imsi_len);
   SGSAP_TMSI_REALLOC_COMP(message_p).imsi[imsi_len] = '\0';
   SGSAP_TMSI_REALLOC_COMP(message_p).imsi_length = imsi_len;
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   if (itti_send_msg_to_task(TASK_SGS, INSTANCE_DEFAULT, message_p)
     != RETURNok) {
     OAILOG_ERROR(
@@ -582,6 +588,8 @@ void mme_app_itti_sgsap_ue_activity_ind(
   memcpy(SGSAP_UE_ACTIVITY_IND(message_p).imsi, imsi, imsi_len);
   SGSAP_UE_ACTIVITY_IND(message_p).imsi[imsi_len] = '\0';
   SGSAP_UE_ACTIVITY_IND(message_p).imsi_length = imsi_len;
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   if (itti_send_msg_to_task(TASK_SGS, INSTANCE_DEFAULT, message_p)
     != RETURNok) {
     OAILOG_ERROR(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -87,6 +87,11 @@ void *mme_app_thread(void *args)
      */
     itti_receive_msg(TASK_MME_APP, &received_message_p);
     DevAssert(received_message_p);
+
+    imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+    OAILOG_DEBUG(
+      LOG_MME_APP, "Received message with imsi: " IMSI_64_FMT, imsi64);
+
     OAILOG_DEBUG(LOG_MME_APP, "Getting mme_nas_state");
     mme_app_desc_p = get_locked_mme_nas_state(false);
 
@@ -149,11 +154,10 @@ void *mme_app_thread(void *args)
             TASK_MME_APP, "S11 MODIFY BEARER RESPONSE local S11 teid = " TEID_FMT"\n",
             received_message_p->ittiMsg.s11_modify_bearer_response.teid);
 
-          if (ue_context_p->path_switch_req != true) {
+          if (!ue_context_p->path_switch_req) {
             /* Updating statistics */
             update_mme_app_stats_s1u_bearer_add();
-          }
-          if (ue_context_p->path_switch_req == true) {
+          } else {
             mme_app_handle_path_switch_req_ack(
               &received_message_p->ittiMsg.s11_modify_bearer_response,
               ue_context_p);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_transport.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_transport.c
@@ -85,6 +85,7 @@ int mme_app_handle_nas_dl_req(
   S1AP_NAS_DL_DATA_REQ(message_p).nas_msg = bstrcpy(nas_msg);
   bdestroy_wrapper(&nas_msg);
 
+  message_p->ittiMsgHeader.imsi = ue_context->emm_context._imsi64;
   /*
    * Store the S1AP NAS DL DATA REQ in case of IMSI or combined EPS/IMSI detach in sgs context
    * and send it after recieving the SGS IMSI Detach Ack from SGS task.

--- a/lte/gateway/c/oai/tasks/s6a/s6a_cancel_loc.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_cancel_loc.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <conversions.h>
 
 #include "assertions.h"
 #include "intertask_interface.h"
@@ -144,6 +145,9 @@ int s6a_clr_cb(
       s6a_cancel_location_req_p->imsi_length = imsi_len;
       s6a_cancel_location_req_p->cancellation_type = SUBSCRIPTION_WITHDRAWL;
       s6a_cancel_location_req_p->msg_cla_p = msg_p;
+      IMSI_STRING_TO_IMSI64(
+        (char*) s6a_cancel_location_req_p->imsi,
+        &message_p->ittiMsgHeader.imsi);
       itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
       OAILOG_DEBUG(
         LOG_S6A, "Sending S6A_CANCEL_LOCATION_REQ to task MME_APP\n");

--- a/lte/gateway/c/oai/tasks/sgw/sgw_paging.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_paging.c
@@ -24,6 +24,7 @@
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <conversions.h>
 
 #include "intertask_interface.h"
 #include "log.h"
@@ -54,6 +55,7 @@ int sgw_send_paging_request(const struct in_addr *dest_ip)
   paging_request_p->imsi = strdup(imsi);
   free(imsi);
 
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   ret = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   return ret;
 }


### PR DESCRIPTION
Summary:
This diff:

- Adds IMSI on ITTI messages being sent by MME task to other tasks
- Updates IMSI map with new UE IDs or changes to UE IDs
- Adds logging on MME task to show retrieved IMSI from ITTI message

Differential Revision: D19764493

