### PR TITLE
Open FluentBit TCP input for event logging

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -235,3 +235,57 @@
     M2_HOME: "{{ mvn_dir }}"
     CODEGEN_ROOT: "{{ codegen_root }}"
   when: preburn
+
+###############################################
+# Download and build swagger-codegen
+###############################################
+
+- name: Clone swagger-codegen repo
+  become: yes
+  git:
+    repo: 'https://github.com/swagger-api/swagger-codegen'
+    dest: /home/{{ ansible_user }}/codegen
+    version: v2.2.3
+    force: yes
+  when: preburn
+
+- name: Setup build requirements for python sdk
+  become: yes
+  apt:
+    pkg: openjdk-8-jdk
+    state: present
+    update_cache: yes
+  when: preburn
+
+- name: Download maven
+  get_url:
+    url: "http://mirrors.ibiblio.org/apache/maven/maven-3/{{ mvn_version }}/binaries/apache-maven-{{ mvn_version }}-bin.tar.gz"
+    dest: "{{ mvn_dir }}-bin.tar.gz"
+    checksum: "sha1:{{ mvn_sha1 }}"
+  when: preburn
+
+- name: Unarchive maven
+  unarchive:
+    src: "{{ mvn_dir }}-bin.tar.gz"
+    dest: /var/tmp
+    remote_src: yes
+  when: preburn
+
+- name: Upload script to build swagger-codegen
+  become: yes
+  copy:
+    src: build_swagger_codegen.sh
+    dest: /home/{{ ansible_user }}/build_swagger_codegen.sh
+    mode: 0755
+  when: preburn
+
+- name: Build swagger code-gen
+  become: yes
+  #  no_log: True
+  command: "/home/{{ ansible_user }}/build_swagger_codegen.sh"
+  args:
+    creates: "{{ swagger_codegen_jar }}"
+  environment:
+    M2_HOME: "{{ mvn_dir }}"
+    CODEGEN_ROOT: "{{ codegen_root }}"
+  when: preburn

--- a/lte/gateway/python/Makefile
+++ b/lte/gateway/python/Makefile
@@ -11,7 +11,7 @@ define setup_rules
 endef
 _ := $(foreach python_src, $(PYTHON_SRCS), $(eval $(call setup_rules,$(python_src))))
 
-buildenv: setupenv protos $(BUILD_LIST)
+buildenv: setupenv protos swagger $(BUILD_LIST)
 $(BUILD_LIST): %_build:
 	make -C $* install_egg
 

--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -6,6 +6,7 @@
 #
 PYTHON_SRCS=$(MAGMA_ROOT)/lte/gateway/python $(MAGMA_ROOT)/orc8r/gateway/python
 PROTO_LIST:=orc8r_protos lte_protos feg_protos
+SWAGGER_LIST:=orc8r_swagger_specs
 
 # Path to the test files
 TESTS=magma/tests \

--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -43,6 +43,13 @@
     Port     5140
     Mode     tcp
 
+[INPUT]
+    Name        tcp
+    Listen      0.0.0.0
+    Port        5170
+    Format      json
+    Tag event_log
+
 {% for t,f in files %}
 [INPUT]
     Name tail
@@ -86,4 +93,7 @@
     tls.crt_file {{ certfile }}
     tls.key_file {{ keyfile }}
 
+[OUTPUT]
+    Name        stdout
+    Match       event_log
 

--- a/orc8r/swagger/swagger_eventd.v1.yml
+++ b/orc8r/swagger/swagger_eventd.v1.yml
@@ -1,0 +1,21 @@
+---
+swagger: '2.0'
+
+info:
+  title: Event definitions
+  description: These are the definitions for events allowed to be forwarded to orchestrator
+  version: 1.0.0
+
+definitions:
+  mock_subscriber_event:
+    type: object
+    description: A mock event for testing
+    properties:
+      foo:
+        type: string
+      bar:
+        type: integer
+      baz:
+        type: array
+        items:
+          type: integer


### PR DESCRIPTION
Summary:
The eventd service will now be able to use TCP to send logs to FluentBit.
To properly test local data collection, the logs tagged as event_logs will be output to stdout (to syslog)

Reviewed By: xjtian

Differential Revision: D19802124

