### PR TITLE
Save monitoring_quota_state as part of sessiond and update state on session creation and termination

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -64,6 +64,11 @@ static bool parse_apn(
   std::string& mac_addr,
   std::string& name);
 
+static SubscriberQuotaUpdate make_subscriber_quota_update(
+  const std::string& imsi,
+  const std::string& ue_mac_addr,
+  const SubscriberQuotaUpdate_Type state);
+
 LocalEnforcer::LocalEnforcer(
   std::shared_ptr<SessionReporter> reporter,
   std::shared_ptr<StaticRuleStore> rule_store,
@@ -227,6 +232,21 @@ void LocalEnforcer::terminate_service(
                    << "Radius ID: " << session->get_radius_session_id()
                    << ", IMSI: " << imsi;
       aaa_client_->terminate_session(session->get_radius_session_id(), imsi);
+
+      MLOG(MDEBUG) << "Deleting UE MAC flow for subscriber " << imsi;
+      SubscriberID sid;
+      sid.set_id(imsi);
+      bool delete_ue_mac_flow_success = pipelined_client_->delete_ue_mac_flow(
+          sid, session->get_mac_addr());
+      if (!delete_ue_mac_flow_success) {
+        MLOG(MERROR) << "Failed to delete UE MAC flow for subscriber " << imsi;
+      }
+      MLOG(MDEBUG) << "Setting subscriber quota state as TERMINATE "
+                   << "for subscriber " << imsi;
+      session->set_monitoring_quota_state(
+        SubscriberQuotaUpdate_Type_TERMINATE);
+      report_subscriber_state_to_pipelined(
+        imsi, session->get_mac_addr(), SubscriberQuotaUpdate_Type_TERMINATE);
     }
 
     std::string session_id = session->get_session_id();
@@ -684,13 +704,35 @@ bool LocalEnforcer::init_session_credit(
         apn_mac_addr = "";
         apn_name = cfg.apn;
     }
+    auto ue_mac_addr = session_state->get_mac_addr();
     bool add_ue_mac_flow_success = pipelined_client_->add_ue_mac_flow(
-      sid, session_state->get_mac_addr(), cfg.msisdn, apn_mac_addr, apn_name);
+      sid, ue_mac_addr, cfg.msisdn, apn_mac_addr, apn_name);
     if (!add_ue_mac_flow_success) {
       MLOG(MERROR) << "Failed to add UE MAC flow for subscriber " << imsi;
     }
+    MLOG(MDEBUG) << "Setting subscriber quota state as TERMINATE "
+                 << "for subscriber " << imsi;
+    session_state->set_monitoring_quota_state(
+      SubscriberQuotaUpdate_Type_VALID_QUOTA);
+    report_subscriber_state_to_pipelined(
+      imsi, ue_mac_addr, SubscriberQuotaUpdate_Type_VALID_QUOTA);
   }
   return rule_update_success;
+}
+
+void LocalEnforcer::report_subscriber_state_to_pipelined(
+  const std::string& imsi,
+  const std::string& ue_mac_addr,
+  const SubscriberQuotaUpdate_Type state)
+{
+  auto update = make_subscriber_quota_update(imsi, ue_mac_addr, state);
+  bool add_subscriber_quota_state_success =
+  pipelined_client_->update_subscriber_quota_state(
+    std::vector<SubscriberQuotaUpdate>{update});
+  if (!add_subscriber_quota_state_success) {
+    MLOG(MERROR) << "Failed to update subscriber's quota state to " << state
+                 << " for subscriber " << imsi;
+  }
 }
 
 void LocalEnforcer::complete_termination(
@@ -869,6 +911,8 @@ void LocalEnforcer::update_session_credits_and_rules(
   update_monitoring_credits_and_rules(response, subscribers_to_terminate);
 
   terminate_multiple_services(subscribers_to_terminate);
+  // todo update monitoring quota if all monitoring rules are gone OR
+  // subscriber is terminated
 }
 
 // terminate_subscriber (for externally triggered EndSession)
@@ -913,6 +957,9 @@ void LocalEnforcer::terminate_subscriber(
         if (!delete_ue_mac_flow_success) {
           MLOG(MERROR) << "Failed to delete UE MAC flow for subscriber " << imsi;
         }
+        session->set_monitoring_quota_state(SubscriberQuotaUpdate_Type_TERMINATE);
+        report_subscriber_state_to_pipelined(
+          imsi, session->get_mac_addr(), SubscriberQuotaUpdate_Type_TERMINATE);
       }
 
       session->start_termination(on_termination_callback);
@@ -1089,6 +1136,7 @@ void LocalEnforcer::init_policy_reauth_for_session(
       request.imsi(), ip_addr, rules_to_activate.static_rules,
       rules_to_activate.dynamic_rules);
   }
+  // todo update monitoring quota if all monitoring rules are gone
 
   create_bearer(
     activate_success, session, request, rules_to_activate.dynamic_rules);
@@ -1282,7 +1330,7 @@ void LocalEnforcer::check_usage_for_reporting()
     });
 }
 
-bool LocalEnforcer::is_imsi_duplicate(const std::string& imsi)
+bool LocalEnforcer::is_imsi_duplicate(const std::string& imsi) const
 {
   auto it = session_map_.find(imsi);
   if (it == session_map_.end()) {
@@ -1291,7 +1339,8 @@ bool LocalEnforcer::is_imsi_duplicate(const std::string& imsi)
   return true;
 }
 
-bool LocalEnforcer::is_apn_duplicate(const std::string& imsi, const std::string& apn)
+bool LocalEnforcer::is_apn_duplicate(
+  const std::string& imsi, const std::string& apn) const
 {
   auto it = session_map_.find(imsi);
   if (it == session_map_.end()) {
@@ -1305,8 +1354,8 @@ bool LocalEnforcer::is_apn_duplicate(const std::string& imsi, const std::string&
   return false;
 }
 
-std::string *LocalEnforcer::duplicate_session_id(
-  const std::string& imsi, const magma::SessionState::Config& config)
+std::string* LocalEnforcer::duplicate_session_id(
+  const std::string& imsi, const magma::SessionState::Config& config) const
 {
   auto it = session_map_.find(imsi);
   if (it != session_map_.end()) {
@@ -1407,5 +1456,18 @@ static bool parse_apn(
   // Allow empty name, spec is unclear on this
   name = apn.substr(split_location + 1, apn.size());
   return true;
+}
+
+static SubscriberQuotaUpdate make_subscriber_quota_update(
+  const std::string& imsi,
+  const std::string& ue_mac_addr,
+  const SubscriberQuotaUpdate_Type state)
+{
+  SubscriberQuotaUpdate update;
+  auto sid = update.mutable_sid();
+  sid->set_id(imsi);
+  update.set_mac_addr(ue_mac_addr);
+  update.set_update_type(state);
+  return update;
 }
 } // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -163,11 +163,11 @@ class LocalEnforcer {
     PolicyReAuthRequest request,
     PolicyReAuthAnswer& answer_out);
 
-  bool is_imsi_duplicate(const std::string& imsi);
-  bool is_apn_duplicate(const std::string& imsi, const std::string& apn);
+  bool is_imsi_duplicate(const std::string& imsi) const;
+  bool is_apn_duplicate(const std::string& imsi, const std::string& apn) const;
 
-  std::string *duplicate_session_id(
-    const std::string& imsi, const magma::SessionState::Config& config);
+  std::string* duplicate_session_id(
+    const std::string& imsi, const magma::SessionState::Config& config) const;
 
   /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or
@@ -372,6 +372,11 @@ class LocalEnforcer {
   void install_redirect_flow(const std::unique_ptr<ServiceAction>& action);
 
   bool rules_to_process_is_not_empty(const RulesToProcess& rules_to_process);
+
+  void report_subscriber_state_to_pipelined(
+    const std::string& imsi,
+    const std::string& ue_mac_addr,
+    const SubscriberQuotaUpdate_Type state);
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -17,48 +17,48 @@ using grpc::Status;
 namespace { // anonymous
 
 magma::DeactivateFlowsRequest create_deactivate_req(
-  const std::string &imsi,
-  const std::vector<std::string> &rule_ids,
-  const std::vector<magma::PolicyRule> &dynamic_rules)
+  const std::string& imsi,
+  const std::vector<std::string>& rule_ids,
+  const std::vector<magma::PolicyRule>& dynamic_rules)
 {
   magma::DeactivateFlowsRequest req;
   req.mutable_sid()->set_id(imsi);
   auto ids = req.mutable_rule_ids();
-  for (const auto &id : rule_ids) {
+  for (const auto& id : rule_ids) {
     ids->Add()->assign(id);
   }
-  for (const auto &rule : dynamic_rules) {
+  for (const auto& rule : dynamic_rules) {
     ids->Add()->assign(rule.id());
   }
   return req;
 }
 
 magma::ActivateFlowsRequest create_activate_req(
-  const std::string &imsi,
-  const std::string &ip_addr,
-  const std::vector<std::string> &static_rules,
-  const std::vector<magma::PolicyRule> &dynamic_rules)
+  const std::string& imsi,
+  const std::string& ip_addr,
+  const std::vector<std::string>& static_rules,
+  const std::vector<magma::PolicyRule>& dynamic_rules)
 {
   magma::ActivateFlowsRequest req;
   req.mutable_sid()->set_id(imsi);
   req.set_ip_addr(ip_addr);
   auto ids = req.mutable_rule_ids();
-  for (const auto &id : static_rules) {
+  for (const auto& id : static_rules) {
     ids->Add()->assign(id);
   }
   auto mut_dyn_rules = req.mutable_dynamic_rules();
-  for (const auto &dyn_rule : dynamic_rules) {
+  for (const auto& dyn_rule : dynamic_rules) {
     mut_dyn_rules->Add()->CopyFrom(dyn_rule);
   }
   return req;
 }
 
 magma::UEMacFlowRequest create_add_ue_mac_flow_req(
-  const magma::SubscriberID &sid,
-  const std::string &ue_mac_addr,
-  const std::string &msisdn,
-  const std::string &ap_mac_addr,
-  const std::string &ap_name)
+  const magma::SubscriberID& sid,
+  const std::string& ue_mac_addr,
+  const std::string& msisdn,
+  const std::string& ap_mac_addr,
+  const std::string& ap_name)
 {
   magma::UEMacFlowRequest req;
   req.mutable_sid()->CopyFrom(sid);
@@ -80,8 +80,8 @@ magma::UEMacFlowRequest create_delete_ue_mac_flow_req(
 }
 
 magma::SetupFlowsRequest create_setup_flows_req(
-  const std::vector<magma::SessionState::SessionInfo> &infos,
-  const std::uint64_t &epoch)
+  const std::vector<magma::SessionState::SessionInfo>& infos,
+  const std::uint64_t& epoch)
 {
   magma::SetupFlowsRequest req;
   std::vector<magma::ActivateFlowsRequest> activation_reqs;
@@ -92,12 +92,24 @@ magma::SetupFlowsRequest create_setup_flows_req(
     activation_reqs.push_back(activate_req);
   }
   auto mut_requests = req.mutable_requests();
-  for (const auto &act_req : activation_reqs) {
+  for (const auto& act_req : activation_reqs) {
     mut_requests->Add()->CopyFrom(act_req);
   }
   req.set_epoch(epoch);
   return req;
 }
+
+magma::UpdateSubscriberQuotaStateRequest create_subscriber_quota_state_req(
+  const std::vector<magma::SubscriberQuotaUpdate>& updates)
+{
+  magma::UpdateSubscriberQuotaStateRequest req;
+  auto p_updates = req.mutable_updates();
+  for (const auto& update : updates) {
+    p_updates->Add()->CopyFrom(update);
+  }
+  return req;
+}
+
 
 } // namespace
 
@@ -117,8 +129,8 @@ AsyncPipelinedClient::AsyncPipelinedClient():
 }
 
 bool AsyncPipelinedClient::setup(
-   const std::vector<SessionState::SessionInfo> &infos,
-   const std::uint64_t &epoch,
+   const std::vector<SessionState::SessionInfo>& infos,
+   const std::uint64_t& epoch,
    std::function<void(Status status, SetupFlowsResult)> callback)
 {
   SetupFlowsRequest setup_req = create_setup_flows_req(infos, epoch);
@@ -126,7 +138,7 @@ bool AsyncPipelinedClient::setup(
   return true;
 }
 
-bool AsyncPipelinedClient::deactivate_all_flows(const std::string &imsi)
+bool AsyncPipelinedClient::deactivate_all_flows(const std::string& imsi)
 {
   DeactivateFlowsRequest req;
   req.mutable_sid()->set_id(imsi);
@@ -141,9 +153,9 @@ bool AsyncPipelinedClient::deactivate_all_flows(const std::string &imsi)
 }
 
 bool AsyncPipelinedClient::deactivate_flows_for_rules(
-  const std::string &imsi,
-  const std::vector<std::string> &rule_ids,
-  const std::vector<PolicyRule> &dynamic_rules)
+  const std::string& imsi,
+  const std::vector<std::string>& rule_ids,
+  const std::vector<PolicyRule>& dynamic_rules)
 {
   auto req = create_deactivate_req(imsi, rule_ids, dynamic_rules);
   MLOG(MDEBUG) << "Deactivating " << rule_ids.size() << " static rules and "
@@ -159,10 +171,10 @@ bool AsyncPipelinedClient::deactivate_flows_for_rules(
 }
 
 bool AsyncPipelinedClient::activate_flows_for_rules(
-  const std::string &imsi,
-  const std::string &ip_addr,
-  const std::vector<std::string> &static_rules,
-  const std::vector<PolicyRule> &dynamic_rules)
+  const std::string& imsi,
+  const std::string& ip_addr,
+  const std::vector<std::string>& static_rules,
+  const std::vector<PolicyRule>& dynamic_rules)
 {
   MLOG(MDEBUG) << "Activating " << static_rules.size() << " static rules and "
                << dynamic_rules.size() << " dynamic rules for subscriber "
@@ -191,11 +203,11 @@ bool AsyncPipelinedClient::activate_flows_for_rules(
 }
 
 bool AsyncPipelinedClient::add_ue_mac_flow(
-    const SubscriberID &sid,
-    const std::string &ue_mac_addr,
-    const std::string &msisdn,
-    const std::string &ap_mac_addr,
-    const std::string &ap_name)
+    const SubscriberID& sid,
+    const std::string& ue_mac_addr,
+    const std::string& msisdn,
+    const std::string& ap_mac_addr,
+    const std::string& ap_name)
 {
   auto req = create_add_ue_mac_flow_req(sid, ue_mac_addr, msisdn, ap_mac_addr,
     ap_name);
@@ -222,8 +234,21 @@ bool AsyncPipelinedClient::delete_ue_mac_flow(
   return true;
 }
 
+bool AsyncPipelinedClient::update_subscriber_quota_state(
+    const std::vector<SubscriberQuotaUpdate>& updates)
+{
+  auto req = create_subscriber_quota_state_req(updates);
+  update_subscriber_quota_state_rpc(req,
+    [](Status status, FlowResponse resp) {
+      if (!status.ok()) {
+        MLOG(MERROR) << "Could send quota update " << status.error_message();
+      }
+  });
+  return true;
+}
+
 void AsyncPipelinedClient::setup_flows_rpc(
-  const SetupFlowsRequest &request,
+  const SetupFlowsRequest& request,
   std::function<void(Status, SetupFlowsResult)> callback)
 {
   auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
@@ -233,7 +258,7 @@ void AsyncPipelinedClient::setup_flows_rpc(
 }
 
 void AsyncPipelinedClient::deactivate_flows_rpc(
-  const DeactivateFlowsRequest &request,
+  const DeactivateFlowsRequest& request,
   std::function<void(Status, DeactivateFlowsResult)> callback)
 {
   auto local_resp = new AsyncLocalResponse<DeactivateFlowsResult>(
@@ -243,7 +268,7 @@ void AsyncPipelinedClient::deactivate_flows_rpc(
 }
 
 void AsyncPipelinedClient::activate_flows_rpc(
-  const ActivateFlowsRequest &request,
+  const ActivateFlowsRequest& request,
   std::function<void(Status, ActivateFlowsResult)> callback)
 {
   auto local_resp = new AsyncLocalResponse<ActivateFlowsResult>(
@@ -253,7 +278,7 @@ void AsyncPipelinedClient::activate_flows_rpc(
 }
 
 void AsyncPipelinedClient::add_ue_mac_flow_rpc(
-    const UEMacFlowRequest &request,
+    const UEMacFlowRequest& request,
     std::function<void(Status, FlowResponse)> callback)
 {
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
@@ -270,6 +295,17 @@ void AsyncPipelinedClient::delete_ue_mac_flow_rpc(
     std::move(callback), RESPONSE_TIMEOUT);
   local_resp->set_response_reader(std::move(
     stub_->AsyncDeleteUEMacFlow(local_resp->get_context(), request, &queue_)));
+}
+
+void AsyncPipelinedClient::update_subscriber_quota_state_rpc(
+    const UpdateSubscriberQuotaStateRequest& request,
+    std::function<void(Status, FlowResponse)> callback)
+{
+  auto local_resp = new AsyncLocalResponse<FlowResponse>(
+    std::move(callback), RESPONSE_TIMEOUT);
+  local_resp->set_response_reader(std::move(
+    stub_->AsyncUpdateSubscriberQuotaState(
+      local_resp->get_context(), request, &queue_)));
 }
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -13,6 +13,7 @@
 
 #include <lte/protos/policydb.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
+#include <lte/protos/pipelined.pb.h>
 #include <lte/protos/subscriberdb.pb.h>
 
 #include "GRPCReceiver.h"
@@ -35,8 +36,8 @@ class PipelinedClient {
    * @return true if the operation was successful
    */
   virtual bool setup(
-    const std::vector<SessionState::SessionInfo> &infos,
-    const std::uint64_t &epoch,
+    const std::vector<SessionState::SessionInfo>& infos,
+    const std::uint64_t& epoch,
     std::function<void(Status status, SetupFlowsResult)> callback) = 0;
 
   /**
@@ -44,7 +45,7 @@ class PipelinedClient {
    * @param imsi - UE to delete all policy flows for
    * @return true if the operation was successful
    */
-  virtual bool deactivate_all_flows(const std::string &imsi) = 0;
+  virtual bool deactivate_all_flows(const std::string& imsi) = 0;
 
   /**
    * Deactivate all flows for the specified rules
@@ -53,18 +54,18 @@ class PipelinedClient {
    * @return true if the operation was successful
    */
   virtual bool deactivate_flows_for_rules(
-    const std::string &imsi,
-    const std::vector<std::string> &rule_ids,
-    const std::vector<PolicyRule> &dynamic_rules) = 0;
+    const std::string& imsi,
+    const std::vector<std::string>& rule_ids,
+    const std::vector<PolicyRule>& dynamic_rules) = 0;
 
   /**
    * Activate all rules for the specified rules, using a normal vector
    */
   virtual bool activate_flows_for_rules(
-    const std::string &imsi,
-    const std::string &ip_addr,
-    const std::vector<std::string> &static_rules,
-    const std::vector<PolicyRule> &dynamic_rules) = 0;
+    const std::string& imsi,
+    const std::string& ip_addr,
+    const std::vector<std::string>& static_rules,
+    const std::vector<PolicyRule>& dynamic_rules) = 0;
 
   /**
    * Send the MAC address of UE and the subscriberID
@@ -84,6 +85,12 @@ class PipelinedClient {
   virtual bool delete_ue_mac_flow(
     const SubscriberID &sid,
     const std::string &ue_mac_addr) = 0;
+
+  /**
+   * Propagate whether a subscriber has quota / no quota / or terminated
+   */
+  virtual bool update_subscriber_quota_state(
+    const std::vector<SubscriberQuotaUpdate>& updates) = 0;
 };
 
 /**
@@ -102,8 +109,8 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * @return true if the operation was successful
    */
   bool setup(
-    const std::vector<SessionState::SessionInfo> &infos,
-    const std::uint64_t &epoch,
+    const std::vector<SessionState::SessionInfo>& infos,
+    const std::uint64_t& epoch,
     std::function<void(Status status, SetupFlowsResult)> callback);
 
   /**
@@ -111,7 +118,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * @param imsi - UE to delete all policy flows for
    * @return true if the operation was successful
    */
-  bool deactivate_all_flows(const std::string &imsi);
+  bool deactivate_all_flows(const std::string& imsi);
 
   /**
    * Deactivate all flows related to a specific charging key
@@ -120,25 +127,35 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * @return true if the operation was successful
    */
   bool deactivate_flows_for_rules(
-    const std::string &imsi,
-    const std::vector<std::string> &rule_ids,
-    const std::vector<PolicyRule> &dynamic_rules);
+    const std::string& imsi,
+    const std::vector<std::string>& rule_ids,
+    const std::vector<PolicyRule>& dynamic_rules);
 
   /**
    * Activate all rules for the specified rules, using a normal vector
    */
   bool activate_flows_for_rules(
-    const std::string &imsi,
-    const std::string &ip_addr,
-    const std::vector<std::string> &static_rules,
-    const std::vector<PolicyRule> &dynamic_rules);
+    const std::string& imsi,
+    const std::string& ip_addr,
+    const std::vector<std::string>& static_rules,
+    const std::vector<PolicyRule>& dynamic_rules);
 
+  /**
+   * Send the MAC address of UE and the subscriberID
+   * for pipelined to add a flow for the subscriber by matching the MAC
+   */
   bool add_ue_mac_flow(
-    const SubscriberID &sid,
-    const std::string &ue_mac_addr,
-    const std::string &msisdn,
-    const std::string &ap_mac_addr,
-    const std::string &ap_name);
+    const SubscriberID& sid,
+    const std::string& ue_mac_addr,
+    const std::string& msisdn,
+    const std::string& ap_mac_addr,
+    const std::string& ap_name);
+
+  /**
+   * Propagate whether a subscriber has quota / no quota / or terminated
+   */
+  bool update_subscriber_quota_state(
+    const std::vector<SubscriberQuotaUpdate>& updates);
 
   bool delete_ue_mac_flow(
     const SubscriberID &sid,
@@ -150,19 +167,23 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
 
  private:
   void setup_flows_rpc(
-    const SetupFlowsRequest &request,
+    const SetupFlowsRequest& request,
     std::function<void(Status, SetupFlowsResult)> callback);
 
   void deactivate_flows_rpc(
-    const DeactivateFlowsRequest &request,
+    const DeactivateFlowsRequest& request,
     std::function<void(Status, DeactivateFlowsResult)> callback);
 
   void activate_flows_rpc(
-    const ActivateFlowsRequest &request,
+    const ActivateFlowsRequest& request,
     std::function<void(Status, ActivateFlowsResult)> callback);
 
   void add_ue_mac_flow_rpc(
-    const UEMacFlowRequest &request,
+    const UEMacFlowRequest& request,
+    std::function<void(Status, FlowResponse)> callback);
+
+  void update_subscriber_quota_state_rpc(
+    const UpdateSubscriberQuotaStateRequest& request,
     std::function<void(Status, FlowResponse)> callback);
 
   void delete_ue_mac_flow_rpc(

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -155,6 +155,12 @@ void SessionState::add_used_credit(
   }
 }
 
+void SessionState::set_monitoring_quota_state(
+    const magma::lte::SubscriberQuotaUpdate_Type state)
+{
+  monitoring_quota_state_ = state;
+}
+
 void SessionState::get_updates_from_charging_pool(
   UpdateSessionRequest& update_request_out,
   std::vector<std::unique_ptr<ServiceAction>>* actions_out)

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -176,6 +176,9 @@ class SessionState {
 
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context);
 
+  void set_monitoring_quota_state(
+    const magma::lte::SubscriberQuotaUpdate_Type state);
+
  private:
   /**
    * State transitions of a session:
@@ -214,6 +217,9 @@ class SessionState {
   SessionRules session_rules_;
   SessionState::State curr_state_;
   SessionState::Config config_;
+  // Used to keep track of whether there are monitoring quotas.
+  // (only used for CWF at the moment)
+  magma::lte::SubscriberQuotaUpdate_Type monitoring_quota_state_;
   magma::lte::TgppContext tgpp_context_;
   std::function<void(SessionTerminateRequest)> on_termination_callback_;
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -14,6 +14,7 @@
 
 #include <lte/protos/policydb.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
+#include <lte/protos/pipelined.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
 
 #include <folly/io/async/EventBase.h>
@@ -71,27 +72,29 @@ class MockPipelinedClient : public PipelinedClient {
       .WillByDefault(Return(true));
     ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _)).WillByDefault(Return(true));
     ON_CALL(*this, delete_ue_mac_flow(_, _)).WillByDefault(Return(true));
+    ON_CALL(*this, update_subscriber_quota_state(_))
+      .WillByDefault(Return(true));
   }
 
   MOCK_METHOD3(setup,
     bool(
-      const std::vector<SessionState::SessionInfo> &infos,
-      const std::uint64_t &epoch,
+      const std::vector<SessionState::SessionInfo>& infos,
+      const std::uint64_t& epoch,
       std::function<void(Status status, SetupFlowsResult)> callback));
-  MOCK_METHOD1(deactivate_all_flows, bool(const std::string &imsi));
+  MOCK_METHOD1(deactivate_all_flows, bool(const std::string& imsi));
   MOCK_METHOD3(
     deactivate_flows_for_rules,
     bool(
-      const std::string &imsi,
-      const std::vector<std::string> &rule_ids,
-      const std::vector<PolicyRule> &dynamic_rules));
+      const std::string& imsi,
+      const std::vector<std::string>& rule_ids,
+      const std::vector<PolicyRule>& dynamic_rules));
   MOCK_METHOD4(
     activate_flows_for_rules,
     bool(
-      const std::string &imsi,
-      const std::string &ip_addr,
-      const std::vector<std::string> &static_rules,
-      const std::vector<PolicyRule> &dynamic_rules));
+      const std::string& imsi,
+      const std::string& ip_addr,
+      const std::vector<std::string>& static_rules,
+      const std::vector<PolicyRule>& dynamic_rules));
   MOCK_METHOD5(
     add_ue_mac_flow,
     bool(
@@ -105,6 +108,9 @@ class MockPipelinedClient : public PipelinedClient {
     bool(
       const SubscriberID &sid,
       const std::string &ue_mac_addr));
+  MOCK_METHOD1(
+    update_subscriber_quota_state,
+    bool(const std::vector<SubscriberQuotaUpdate>& updates));
 };
 
 class MockDirectorydClient : public AsyncDirectorydClient {
@@ -151,10 +157,10 @@ class MockCallback {
  public:
   MOCK_METHOD2(
     update_callback,
-    void(Status status, const UpdateSessionResponse &));
+    void(Status status, const UpdateSessionResponse& ));
   MOCK_METHOD2(
     create_callback,
-    void(Status status, const CreateSessionResponse &));
+    void(Status status, const CreateSessionResponse& ));
 };
 
 /**
@@ -191,19 +197,19 @@ class MockSessionReporter : public SessionReporter {
     MOCK_METHOD2(
       report_updates,
       void(
-        const UpdateSessionRequest &,
+        const UpdateSessionRequest& ,
         std::function<void(grpc::Status, UpdateSessionResponse)>));
 
     MOCK_METHOD2(
       report_create_session,
       void(
-        const CreateSessionRequest &,
+        const CreateSessionRequest& ,
         std::function<void(Status, CreateSessionResponse)>));
 
     MOCK_METHOD2(
       report_terminate_session,
       void(
-        const SessionTerminateRequest &,
+        const SessionTerminateRequest& ,
         std::function<void(Status, SessionTerminateResponse)>));
 
 };
@@ -218,8 +224,8 @@ class MockAAAClient : public aaa::AAAClient {
   MOCK_METHOD2(
     terminate_session,
     bool(
-      const std::string &radius_session_id,
-      const std::string &imsi));
+      const std::string& radius_session_id,
+      const std::string& imsi));
 };
 
 class MockSpgwServiceClient : public SpgwServiceClient {
@@ -235,17 +241,17 @@ class MockSpgwServiceClient : public SpgwServiceClient {
     MOCK_METHOD4(
       delete_dedicated_bearer,
       bool(
-        const std::string &,
-        const std::string &,
+        const std::string& ,
+        const std::string& ,
         const uint32_t,
-        const std::vector<uint32_t> &));
+        const std::vector<uint32_t>& ));
     MOCK_METHOD4(
       create_dedicated_bearer,
       bool(
-        const std::string &,
-        const std::string &,
+        const std::string& ,
+        const std::string& ,
         const uint32_t,
-        const std::vector<PolicyRule> &));
+        const std::vector<PolicyRule>& ));
 };
 
 } // namespace magma


### PR DESCRIPTION
Summary:
## Monitoring Quota Exhaustion setup for Session Init/Terminate
- When a session is started, we will propagate to pipelined that the subscriber has valid quota. (`SubscriberQuotaUpdate_Type_VALID_QUOTA`) (There's an edge case here where a session could be started with no monitoring quota, in which case I think the session is started without any rule installs/0 GSUs. I have to double check on exactly what this might look like. I will handle this in a later diff. )
- When a session termination is started, we will propagate to pipelined that the subscriber is terminated. (`SubscriberQuotaUpdate_Type_TERMINATE`)

## Next Step
- For each SessionUpdate response and RAR, we should check if there are any existing monitoring rules installed in the session. If there isn't any, we should mark the subscriber as out of quota. (`SubscriberQuotaUpdate_Type_NO_QUOTA`)
- For session init, check for edge case where session create succeeds for users with out of quota

Reviewed By: xjtian

Differential Revision: D19774197

