### PR TITLE
Adding IMSI to S1AP task ITTI messages

### DIFF
--- a/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
+++ b/lte/gateway/c/oai/lib/s6a_proxy/s6a_client_api.cpp
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <string>
 #include <iostream>
+#include <conversions.h>
 
 #include "s6a_client_api.h"
 #include "S6aClient.h"
@@ -104,6 +105,8 @@ static void _s6a_handle_authentication_info_ans(
     itti_msg->result.present = S6A_RESULT_BASE;
     itti_msg->result.choice.base = DIAMETER_UNABLE_TO_COMPLY;
   }
+
+  IMSI_STRING_TO_IMSI64((char*) imsi.c_str(), &message_p->ittiMsgHeader.imsi);
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   return;
 }
@@ -165,6 +168,7 @@ static void _s6a_handle_update_location_ans(
   }
   std::cout << "[INFO] sent itti S6A-LOCATION-UPDATE_ANSWER for IMSI: " << imsi
                   << std::endl;
+  IMSI_STRING_TO_IMSI64((char*) imsi.c_str(), &message_p->ittiMsgHeader.imsi);
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   return;
 }

--- a/lte/gateway/c/oai/protos/s1ap_state.proto
+++ b/lte/gateway/c/oai/protos/s1ap_state.proto
@@ -41,3 +41,8 @@ message S1apState {
   map<uint32, uint32> mmeid2associd = 2; // mmeueid -> ue associd
   uint32 num_enbs = 3;
 }
+
+message S1apImsiMap {
+  map<uint64, uint64> mme_ue_id_imsi_map = 1; // mme_s1ap_ue_id => IMSI64
+  map<uint64, uint64> enb_ue_id_mme_ue_id_map = 2; // enb_s1ap_ue_id => mme_s1ap_ue_id
+}

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -497,6 +497,7 @@ void mme_app_handle_conn_est_cnf(nas_establish_rsp_t* const nas_conn_est_cnf_p)
     "security_capabilities_integrity_algorithms  0x%04X\n",
     establishment_cnf_p->ue_security_capabilities_integrity_algorithms);
 
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   /*
@@ -837,6 +838,7 @@ void mme_app_handle_erab_setup_req(
 
     s1ap_e_rab_setup_req->e_rab_to_be_setup_list.item[0].nas_pdu = nas_msg;
 
+    message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
     itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
   } else {
     OAILOG_DEBUG(
@@ -1309,8 +1311,10 @@ void mme_app_handle_initial_context_setup_rsp(mme_app_desc_t *mme_app_desc_p,
   message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
 
   OAILOG_INFO(
-    TASK_MME_APP, "Sending S11 MODIFY BEARER REQ to SPGW for ue_id = (%d), teid = (%u)\n",
-    initial_ctxt_setup_rsp_pP->ue_id, s11_modify_bearer_request->teid);
+    LOG_MME_APP,
+    "Sending S11 MODIFY BEARER REQ to SPGW for ue_id = (%d), teid = (%u)\n",
+    initial_ctxt_setup_rsp_pP->ue_id,
+    s11_modify_bearer_request->teid);
   itti_send_msg_to_task(TASK_SPGW, INSTANCE_DEFAULT, message_p);
   /*
    * During Service request procedure,after initial context setup response
@@ -1608,6 +1612,8 @@ void mme_app_handle_e_rab_setup_rsp(
         bc->bearer_state = BEARER_STATE_NULL;
       }
     }
+
+    message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
     itti_send_msg_to_task(TASK_S11, INSTANCE_DEFAULT, message_p);
   } else {
     // not send S11 response
@@ -1958,6 +1964,7 @@ int mme_app_paging_request_helper(
       &tai_list->partial_tai_list[tai_list_idx],
       tai_list->partial_tai_list[tai_list_idx].numberofelements);
   }
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   rc = itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   if (!set_timer) {
@@ -2621,6 +2628,8 @@ void mme_app_handle_modify_ue_ambr_request(mme_app_desc_t *mme_app_desc_p,
       modify_ue_ambr_request_p->ue_ambr.br_ul;
     S1AP_UE_CONTEXT_MODIFICATION_REQUEST(message_p).ue_ambr.br_dl =
       modify_ue_ambr_request_p->ue_ambr.br_dl;
+
+    message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
     itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
     OAILOG_DEBUG(
       LOG_MME_APP,
@@ -3172,6 +3181,8 @@ void mme_app_handle_erab_rel_cmd(
     "and EBI %u \n",
     ue_id,
     ebi);
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   OAILOG_FUNC_OUT(LOG_MME_APP);
@@ -3270,6 +3281,8 @@ void mme_app_handle_path_switch_req_ack(
     LOG_MME_APP,
     "MME_APP send PATH_SWITCH_REQUEST_ACK to S1AP for ue_id %d \n",
     ue_context_p->mme_ue_s1ap_id);
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   OAILOG_FUNC_OUT(LOG_MME_APP);
@@ -3297,6 +3310,7 @@ void mme_app_handle_path_switch_req_failure(
     LOG_MME_APP,
     "MME_APP send PATH_SWITCH_REQUEST_FAILURE to S1AP for ue_id %d \n",
     ue_context_p->mme_ue_s1ap_id);
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
 
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -413,6 +413,7 @@ struct ue_mm_context_s *mme_ue_context_exists_s11_teid(
   hashtable_rc_t h_rc = HASH_TABLE_OK;
   uint64_t mme_ue_s1ap_id64 = 0;
 
+  // TODO: Update once SPGW is indexed by IMSI
   h_rc = hashtable_uint64_ts_get(
     mme_ue_context_p->tun11_ue_context_htbl,
     (const hash_key_t) teid,
@@ -479,7 +480,6 @@ void mme_ue_context_update_coll_keys(
   const guti_t* const guti_p) //  never NULL, if none put &ue_context_p->guti
 {
   hashtable_rc_t h_rc = HASH_TABLE_OK;
-
   OAILOG_FUNC_IN(LOG_MME_APP);
 
   OAILOG_TRACE(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -98,6 +98,8 @@ void mme_app_itti_ue_context_release(
   S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).enb_ue_s1ap_id =
     ue_context_p->enb_ue_s1ap_id;
   S1AP_UE_CONTEXT_RELEASE_COMMAND(message_p).cause = cause;
+
+  message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
   itti_send_msg_to_task(TASK_S1AP, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }
@@ -487,6 +489,8 @@ void nas_itti_sgsap_uplink_unitdata(
     SGSAP_UPLINK_UNITDATA(message_p).presencemask |=
       UPLINK_UNITDATA_ECGI_PARAMETER_PRESENT;
   }
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   if (itti_send_msg_to_task(TASK_SGS, INSTANCE_DEFAULT, message_p)
     != RETURNok) {
     OAILOG_ERROR(
@@ -535,6 +539,8 @@ void mme_app_itti_sgsap_tmsi_reallocation_comp(
   memcpy(SGSAP_TMSI_REALLOC_COMP(message_p).imsi, imsi, imsi_len);
   SGSAP_TMSI_REALLOC_COMP(message_p).imsi[imsi_len] = '\0';
   SGSAP_TMSI_REALLOC_COMP(message_p).imsi_length = imsi_len;
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   if (itti_send_msg_to_task(TASK_SGS, INSTANCE_DEFAULT, message_p)
     != RETURNok) {
     OAILOG_ERROR(
@@ -582,6 +588,8 @@ void mme_app_itti_sgsap_ue_activity_ind(
   memcpy(SGSAP_UE_ACTIVITY_IND(message_p).imsi, imsi, imsi_len);
   SGSAP_UE_ACTIVITY_IND(message_p).imsi[imsi_len] = '\0';
   SGSAP_UE_ACTIVITY_IND(message_p).imsi_length = imsi_len;
+
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   if (itti_send_msg_to_task(TASK_SGS, INSTANCE_DEFAULT, message_p)
     != RETURNok) {
     OAILOG_ERROR(

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -87,6 +87,11 @@ void *mme_app_thread(void *args)
      */
     itti_receive_msg(TASK_MME_APP, &received_message_p);
     DevAssert(received_message_p);
+
+    imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+    OAILOG_DEBUG(
+      LOG_MME_APP, "Received message with imsi: " IMSI_64_FMT, imsi64);
+
     OAILOG_DEBUG(LOG_MME_APP, "Getting mme_nas_state");
     mme_app_desc_p = get_locked_mme_nas_state(false);
 
@@ -149,11 +154,10 @@ void *mme_app_thread(void *args)
             TASK_MME_APP, "S11 MODIFY BEARER RESPONSE local S11 teid = " TEID_FMT"\n",
             received_message_p->ittiMsg.s11_modify_bearer_response.teid);
 
-          if (ue_context_p->path_switch_req != true) {
+          if (!ue_context_p->path_switch_req) {
             /* Updating statistics */
             update_mme_app_stats_s1u_bearer_add();
-          }
-          if (ue_context_p->path_switch_req == true) {
+          } else {
             mme_app_handle_path_switch_req_ack(
               &received_message_p->ittiMsg.s11_modify_bearer_response,
               ue_context_p);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_transport.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_transport.c
@@ -85,6 +85,7 @@ int mme_app_handle_nas_dl_req(
   S1AP_NAS_DL_DATA_REQ(message_p).nas_msg = bstrcpy(nas_msg);
   bdestroy_wrapper(&nas_msg);
 
+  message_p->ittiMsgHeader.imsi = ue_context->emm_context._imsi64;
   /*
    * Store the S1AP NAS DL DATA REQ in case of IMSI or combined EPS/IMSI detach in sgs context
    * and send it after recieving the SGS IMSI Detach Ack from SGS task.

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -132,6 +132,8 @@ void* s1ap_mme_thread(__attribute__((unused)) void* args)
      */
     itti_receive_msg(TASK_S1AP, &received_message_p);
 
+    imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
+
     state = get_s1ap_state(false);
     AssertFatal(state != NULL, "failed to retrieve s1ap state (was null)");
 
@@ -212,7 +214,8 @@ void* s1ap_mme_thread(__attribute__((unused)) void* args)
           state,
           S1AP_NAS_DL_DATA_REQ(received_message_p).enb_ue_s1ap_id,
           S1AP_NAS_DL_DATA_REQ(received_message_p).mme_ue_s1ap_id,
-          &S1AP_NAS_DL_DATA_REQ(received_message_p).nas_msg);
+          &S1AP_NAS_DL_DATA_REQ(received_message_p).nas_msg,
+          imsi64);
       } break;
 
       case S1AP_E_RAB_SETUP_REQ: {
@@ -223,50 +226,62 @@ void* s1ap_mme_thread(__attribute__((unused)) void* args)
       // From MME_APP task
       case S1AP_UE_CONTEXT_RELEASE_COMMAND: {
         s1ap_handle_ue_context_release_command(
-          state, &received_message_p->ittiMsg.s1ap_ue_context_release_command);
+          state,
+          &received_message_p->ittiMsg.s1ap_ue_context_release_command,
+          imsi64);
       } break;
 
       case MME_APP_CONNECTION_ESTABLISHMENT_CNF: {
         s1ap_handle_conn_est_cnf(
-          state, &MME_APP_CONNECTION_ESTABLISHMENT_CNF(received_message_p));
+          state,
+          &MME_APP_CONNECTION_ESTABLISHMENT_CNF(received_message_p));
       } break;
 
       case MME_APP_S1AP_MME_UE_ID_NOTIFICATION: {
         s1ap_handle_mme_ue_id_notification(
-          state, &MME_APP_S1AP_MME_UE_ID_NOTIFICATION(received_message_p));
+          state,
+          &MME_APP_S1AP_MME_UE_ID_NOTIFICATION(received_message_p));
       } break;
 
       case S1AP_ENB_INITIATED_RESET_ACK: {
         s1ap_handle_enb_initiated_reset_ack(
-          &S1AP_ENB_INITIATED_RESET_ACK(received_message_p));
+          &S1AP_ENB_INITIATED_RESET_ACK(received_message_p), imsi64);
       } break;
 
       case S1AP_PAGING_REQUEST: {
         if (
           s1ap_handle_paging_request(
-            state, &S1AP_PAGING_REQUEST(received_message_p)) != RETURNok) {
+            state, &S1AP_PAGING_REQUEST(received_message_p), imsi64) !=
+          RETURNok) {
           OAILOG_ERROR(LOG_S1AP, "Failed to send paging message\n");
         }
       } break;
 
       case S1AP_UE_CONTEXT_MODIFICATION_REQUEST: {
         s1ap_handle_ue_context_mod_req(
-          state, &received_message_p->ittiMsg.s1ap_ue_context_mod_request);
+          state,
+          &received_message_p->ittiMsg.s1ap_ue_context_mod_request,
+          imsi64);
       } break;
 
       case S1AP_E_RAB_REL_CMD: {
         s1ap_generate_s1ap_e_rab_rel_cmd(
-          state, &S1AP_E_RAB_REL_CMD(received_message_p));
+          state,
+          &S1AP_E_RAB_REL_CMD(received_message_p));
       } break;
 
       case S1AP_PATH_SWITCH_REQUEST_ACK: {
         s1ap_handle_path_switch_req_ack(
-          state, &received_message_p->ittiMsg.s1ap_path_switch_request_ack);
+          state,
+          &received_message_p->ittiMsg.s1ap_path_switch_request_ack,
+          imsi64);
       } break;
 
       case S1AP_PATH_SWITCH_REQUEST_FAILURE: {
         s1ap_handle_path_switch_req_failure(
-          state, &received_message_p->ittiMsg.s1ap_path_switch_request_failure);
+          state,
+          &received_message_p->ittiMsg.s1ap_path_switch_request_failure,
+          imsi64);
       } break;
 
       case TIMER_HAS_EXPIRED: {
@@ -349,6 +364,7 @@ void* s1ap_mme_thread(__attribute__((unused)) void* args)
 
       case TERMINATE_MESSAGE: {
         put_s1ap_state();
+        put_s1ap_imsi_map();
         s1ap_mme_exit();
         itti_free_msg_content(received_message_p);
         itti_free(ITTI_MSG_ORIGIN_ID(received_message_p), received_message_p);
@@ -366,6 +382,7 @@ void* s1ap_mme_thread(__attribute__((unused)) void* args)
     }
 
     put_s1ap_state();
+    put_s1ap_imsi_map();
 
     itti_free_msg_content(received_message_p);
     itti_free(ITTI_MSG_ORIGIN_ID(received_message_p), received_message_p);
@@ -580,6 +597,7 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref)
   if (ue_ref == NULL) return;
 
   mme_ue_s1ap_id_t mme_ue_s1ap_id = ue_ref->mme_ue_s1ap_id;
+  enb_ue_s1ap_id_t enb_ue_s1ap_id = ue_ref->enb_ue_s1ap_id;
   enb_ref = ue_ref->enb;
   /*
    * Updating number of UE
@@ -613,6 +631,16 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref)
   ue_ref->s1_ue_state = S1AP_UE_INVALID_STATE;
   hashtable_ts_free(&enb_ref->ue_coll, ue_ref->enb_ue_s1ap_id);
   hashtable_ts_free(&state->mmeid2associd, mme_ue_s1ap_id);
+
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_remove(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) mme_ue_s1ap_id);
+  hashtable_uint64_ts_remove(
+    imsi_map->enb_s1ap_mme_ue_id_htbl,
+    (const hash_key_t) enb_ue_s1ap_id);
+
+
   if (!enb_ref->nb_ue_associated) {
     if (enb_ref->s1_state == S1AP_RESETING) {
       OAILOG_INFO(LOG_S1AP, "Moving eNB state to S1AP_INIT \n");

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.h
@@ -66,7 +66,7 @@ void s1ap_dump_ue(const ue_description_t *const ue_ref);
 /** \brief Allocate and add to the list a new eNB descriptor
  * @returns Reference to the new eNB element in list
  **/
-enb_description_t *s1ap_new_enb(s1ap_state_t *state);
+enb_description_t *s1ap_new_enb(s1ap_state_t* state);
 
 /** \brief Allocate and add to the right eNB list a new UE descriptor
  * \param sctp_assoc_id association ID over SCTP

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -116,7 +116,8 @@ static int s1ap_generate_s1_setup_response(
 static int s1ap_mme_generate_ue_context_release_command(
   s1ap_state_t *state,
   ue_description_t *ue_ref_p,
-  enum s1cause);
+  enum s1cause,
+  imsi64_t imsi64);
 
 static bool is_all_erabId_same(
   S1ap_PathSwitchRequestIEs_t *pathSwitchRequest_p);
@@ -467,6 +468,7 @@ int s1ap_mme_handle_s1_setup_request(
       S1ap_Cause_PR_misc,
       S1ap_CauseMisc_control_processing_overload,
       S1ap_TimeToWait_v20s);
+
     increment_counter(
       "s1_setup",
       1,
@@ -495,6 +497,7 @@ int s1ap_mme_handle_s1_setup_request(
       S1ap_Cause_PR_misc,
       S1ap_CauseMisc_unknown_PLMN,
       S1ap_TimeToWait_v20s);
+
     increment_counter(
       "s1_setup", 1, 2, "result", "failure", "cause", "plmnid_or_tac_mismatch");
     OAILOG_FUNC_RETURN(LOG_S1AP, rc);
@@ -660,6 +663,7 @@ int s1ap_mme_handle_ue_cap_indication(
   ue_description_t *ue_ref_p = NULL;
   S1ap_UECapabilityInfoIndicationIEs_t *ue_cap_p = NULL;
   int rc = RETURNok;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   DevAssert(message != NULL);
@@ -674,6 +678,12 @@ int s1ap_mme_handle_ue_cap_indication(
       (uint32_t) ue_cap_p->mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+
+  s1ap_imsi_map_t* s1ap_imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    s1ap_imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) ue_cap_p->mme_ue_s1ap_id,
+    &imsi64);
 
   if (ue_ref_p->enb_ue_s1ap_id != ue_cap_p->eNB_UE_S1AP_ID) {
     OAILOG_DEBUG(
@@ -722,6 +732,8 @@ int s1ap_mme_handle_ue_cap_indication(
       ue_cap_ind_p->radio_capabilities,
       ue_cap_p->ueRadioCapability.buf,
       ue_cap_ind_p->radio_capabilities_length);
+
+    message_p->ittiMsgHeader.imsi = imsi64;
     rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
     OAILOG_FUNC_RETURN(LOG_S1AP, rc);
   }
@@ -745,6 +757,7 @@ int s1ap_mme_handle_initial_context_setup_response(
   ue_description_t *ue_ref_p = NULL;
   MessageDef *message_p = NULL;
   int rc = RETURNok;
+  imsi64_t imsi64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   initialContextSetupResponseIEs_p =
@@ -762,6 +775,12 @@ int s1ap_mme_handle_initial_context_setup_response(
       (uint32_t) initialContextSetupResponseIEs_p->mme_ue_s1ap_id);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+
+  s1ap_imsi_map_t* s1ap_imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    s1ap_imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) initialContextSetupResponseIEs_p->mme_ue_s1ap_id,
+    &imsi64);
 
   if (
     ue_ref_p->enb_ue_s1ap_id !=
@@ -812,6 +831,7 @@ int s1ap_mme_handle_initial_context_setup_response(
         eRABSetupItemCtxtSURes_p->transportLayerAddress.size);
   }
   // TODO num items
+  message_p->ittiMsgHeader.imsi = imsi64;
   rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
@@ -830,6 +850,7 @@ int s1ap_mme_handle_ue_context_release_request(
   long cause_value;
   enum s1cause s1_release_cause = S1AP_RADIO_EUTRAN_GENERATED_REASON;
   int rc = RETURNok;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   ueContextReleaseRequest_p = &message->msg.s1ap_UEContextReleaseRequestIEs;
@@ -939,6 +960,12 @@ int s1ap_mme_handle_ue_context_release_request(
        * Send a UE context Release Command to eNB after releasing S1-U bearer tunnel mapping for all the
        * bearers.
        */
+      s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+      hashtable_uint64_ts_get(
+        imsi_map->mme_ue_id_imsi_htbl,
+        (const hash_key_t) ueContextReleaseRequest_p->mme_ue_s1ap_id,
+        &imsi64);
+
       message_p =
         itti_alloc_new_message(TASK_S1AP, S1AP_UE_CONTEXT_RELEASE_REQ);
       AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
@@ -951,6 +978,8 @@ int s1ap_mme_handle_ue_context_release_request(
       S1AP_UE_CONTEXT_RELEASE_REQ(message_p).relCause = s1_release_cause;
       S1AP_UE_CONTEXT_RELEASE_REQ(message_p).cause =
         ueContextReleaseRequest_p->cause;
+
+      message_p->ittiMsgHeader.imsi = imsi64;
       rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
       OAILOG_FUNC_RETURN(LOG_S1AP, rc);
     } else {
@@ -972,7 +1001,8 @@ int s1ap_mme_handle_ue_context_release_request(
 static int s1ap_mme_generate_ue_context_release_command(
   s1ap_state_t *state,
   ue_description_t *ue_ref_p,
-  enum s1cause cause)
+  enum s1cause cause,
+  imsi64_t imsi64)
 {
   uint8_t *buffer = NULL;
   uint32_t length = 0;
@@ -1051,7 +1081,7 @@ static int s1ap_mme_generate_ue_context_release_command(
   // Start timer to track UE context release complete from eNB
 
   // We can safely remove UE context now, no need for timer
-  s1ap_mme_release_ue_context(state, ue_ref_p);
+  s1ap_mme_release_ue_context(state, ue_ref_p, imsi64);
 
   free_s1ap_uecontextreleasecommand(ueContextReleaseCommandIEs_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
@@ -1062,7 +1092,8 @@ static int s1ap_mme_generate_ue_context_release_command(
 //------------------------------------------------------------------------------
 static int s1ap_mme_generate_ue_context_modification(
   ue_description_t *ue_ref_p,
-  const itti_s1ap_ue_context_mod_req_t *const ue_context_mod_req_pP)
+  const itti_s1ap_ue_context_mod_req_t *const ue_context_mod_req_pP,
+  imsi64_t imsi64)
 {
   uint8_t *buffer = NULL;
   uint32_t length = 0;
@@ -1153,11 +1184,12 @@ static int s1ap_mme_generate_ue_context_modification(
 
 //------------------------------------------------------------------------------
 int s1ap_handle_ue_context_release_command(
-  s1ap_state_t *state,
-  const itti_s1ap_ue_context_release_command_t
-    *const ue_context_release_command_pP)
+  s1ap_state_t* state,
+  const itti_s1ap_ue_context_release_command_t* const
+    ue_context_release_command_pP,
+  imsi64_t imsi64)
 {
-  ue_description_t *ue_ref_p = NULL;
+  ue_description_t* ue_ref_p = NULL;
   int rc = RETURNok;
 
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -1184,7 +1216,7 @@ int s1ap_handle_ue_context_release_command(
       s1ap_remove_ue(state, ue_ref_p);
     } else {
       rc = s1ap_mme_generate_ue_context_release_command(
-        state, ue_ref_p, ue_context_release_command_pP->cause);
+        state, ue_ref_p, ue_context_release_command_pP->cause, imsi64);
     }
   }
 
@@ -1196,7 +1228,8 @@ int s1ap_handle_ue_context_release_command(
 //------------------------------------------------------------------------------
 int s1ap_handle_ue_context_mod_req(
   s1ap_state_t *state,
-  const itti_s1ap_ue_context_mod_req_t *const ue_context_mod_req_pP)
+  const itti_s1ap_ue_context_mod_req_t *const ue_context_mod_req_pP,
+  imsi64_t imsi64)
 {
   ue_description_t *ue_ref_p = NULL;
   int rc = RETURNok;
@@ -1214,7 +1247,7 @@ int s1ap_handle_ue_context_mod_req(
     rc = RETURNok;
   } else {
     rc = s1ap_mme_generate_ue_context_modification(
-      ue_ref_p, ue_context_mod_req_pP);
+      ue_ref_p, ue_context_mod_req_pP, imsi64);
   }
 
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
@@ -1274,6 +1307,7 @@ int s1ap_mme_handle_initial_context_setup_failure(
   S1ap_Cause_PR cause_type;
   long cause_value;
   int rc = RETURNok;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   initialContextSetupFailureIEs_p =
@@ -1308,6 +1342,13 @@ int s1ap_mme_handle_initial_context_setup_failure(
         initialContextSetupFailureIEs_p->eNB_UE_S1AP_ID & ENB_UE_S1AP_ID_MASK));
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) initialContextSetupFailureIEs_p->mme_ue_s1ap_id,
+    &imsi64);
+
   // Pass this message to MME APP for necessary handling
   // Log the Cause Type and Cause value
   cause_type = initialContextSetupFailureIEs_p->cause.present;
@@ -1374,6 +1415,8 @@ int s1ap_mme_handle_initial_context_setup_failure(
     sizeof(itti_mme_app_initial_context_setup_failure_t));
   MME_APP_INITIAL_CONTEXT_SETUP_FAILURE(message_p).mme_ue_s1ap_id =
     ue_ref_p->mme_ue_s1ap_id;
+
+  message_p->ittiMsgHeader.imsi = imsi64;
   rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
@@ -1388,6 +1431,7 @@ int s1ap_mme_handle_ue_context_modification_response(
   ue_description_t *ue_ref_p = NULL;
   MessageDef *message_p = NULL;
   int rc = RETURNok;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   ueContextModification_p = &message->msg.s1ap_UEContextModificationResponseIEs;
@@ -1416,6 +1460,13 @@ int s1ap_mme_handle_ue_context_modification_response(
        * Send a UE context Release Command to eNB after releasing S1-U bearer tunnel mapping for all the
        * bearers.
        */
+
+      s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+      hashtable_uint64_ts_get(
+        imsi_map->mme_ue_id_imsi_htbl,
+        (const hash_key_t) ueContextModification_p->mme_ue_s1ap_id,
+        &imsi64);
+
       message_p = itti_alloc_new_message(
         TASK_S1AP, S1AP_UE_CONTEXT_MODIFICATION_RESPONSE);
       AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
@@ -1427,6 +1478,8 @@ int s1ap_mme_handle_ue_context_modification_response(
         ue_ref_p->mme_ue_s1ap_id;
       S1AP_UE_CONTEXT_MODIFICATION_RESPONSE(message_p).enb_ue_s1ap_id =
         ue_ref_p->enb_ue_s1ap_id;
+
+      message_p->ittiMsgHeader.imsi = imsi64;
       rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
       OAILOG_FUNC_RETURN(LOG_S1AP, rc);
     } else {
@@ -1457,6 +1510,7 @@ int s1ap_mme_handle_ue_context_modification_failure(
   int rc = RETURNok;
   S1ap_Cause_PR cause_type;
   int64_t cause_value;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   ueContextModification_p = &message->msg.s1ap_UEContextModificationFailureIEs;
@@ -1480,6 +1534,13 @@ int s1ap_mme_handle_ue_context_modification_failure(
     if (
       ue_ref_p->enb_ue_s1ap_id ==
       (ueContextModification_p->eNB_UE_S1AP_ID & ENB_UE_S1AP_ID_MASK)) {
+
+      s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+      hashtable_uint64_ts_get(
+        imsi_map->mme_ue_id_imsi_htbl,
+        (const hash_key_t) ueContextModification_p->mme_ue_s1ap_id,
+        &imsi64);
+
       // Pass this message to MME APP for necessary handling
       // Log the Cause Type and Cause value
       cause_type = ueContextModification_p->cause.present;
@@ -1548,6 +1609,8 @@ int s1ap_mme_handle_ue_context_modification_failure(
       S1AP_UE_CONTEXT_MODIFICATION_FAILURE(message_p).enb_ue_s1ap_id =
         ue_ref_p->enb_ue_s1ap_id;
       S1AP_UE_CONTEXT_MODIFICATION_FAILURE(message_p).cause = cause_value;
+
+      message_p->ittiMsgHeader.imsi = imsi64;
       rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
       OAILOG_FUNC_RETURN(LOG_S1AP, rc);
     } else {
@@ -1589,6 +1652,8 @@ int s1ap_mme_handle_path_switch_request(
   uint32_t num_erab = 0;
   uint16_t index = 0;
   itti_s1ap_path_switch_request_failure_t path_switch_req_failure = {0};
+  imsi64_t imsi64 = INVALID_IMSI64;
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
 
   OAILOG_FUNC_IN(LOG_S1AP);
 
@@ -1620,7 +1685,7 @@ int s1ap_mme_handle_path_switch_request(
     path_switch_req_failure.mme_ue_s1ap_id =
       pathSwitchRequest_p->sourceMME_UE_S1AP_ID;
     path_switch_req_failure.enb_ue_s1ap_id = enb_ue_s1ap_id;
-    s1ap_handle_path_switch_req_failure(state, &path_switch_req_failure);
+    s1ap_handle_path_switch_req_failure(state, &path_switch_req_failure, imsi64);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
 
@@ -1682,6 +1747,15 @@ int s1ap_mme_handle_path_switch_request(
       &state->mmeid2associd,
       (const hash_key_t) new_ue_ref_p->mme_ue_s1ap_id,
       (void *) (uintptr_t) assoc_id);
+
+    // Update mme_ue_s1ap => IMSI mapping
+    hashtable_uint64_ts_remove(
+      imsi_map->mme_ue_id_imsi_htbl,
+      (const hash_key_t) ue_ref_p->mme_ue_s1ap_id);
+    hashtable_uint64_ts_insert(
+      imsi_map->mme_ue_id_imsi_htbl,
+      (const hash_key_t) new_ue_ref_p->mme_ue_s1ap_id,
+      imsi64);
     OAILOG_DEBUG(
       LOG_S1AP,
       "Associated sctp_assoc_id %d, enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT
@@ -1741,7 +1815,8 @@ int s1ap_mme_handle_path_switch_request(
     &ecgi,
     &tai,
     encryption_algorithm_capabilitie,
-    integrity_algorithm_capabilities);
+    integrity_algorithm_capabilities,
+    imsi64);
 
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
@@ -1762,6 +1837,7 @@ static bool s1ap_send_enb_deregistered_ind(
 {
   arg_s1ap_send_enb_dereg_ind_t *arg = (arg_s1ap_send_enb_dereg_ind_t *) argP;
   ue_description_t *ue_ref_p = (ue_description_t *) dataP;
+  imsi64_t imsi64 = INVALID_IMSI64;
   /*
    * Ask for a release of each UE context associated to the eNB
    */
@@ -1774,6 +1850,12 @@ static bool s1ap_send_enb_deregistered_ind(
       // Send deregistered ind for this also and let MMEAPP find the context using enb_ue_s1ap_id_key
       OAILOG_WARNING(LOG_S1AP, "UE with invalid MME s1ap id found");
     }
+
+    s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+    hashtable_uint64_ts_get(
+      imsi_map->mme_ue_id_imsi_htbl,
+      (const hash_key_t) ue_ref_p->mme_ue_s1ap_id,
+      &imsi64);
 
     AssertFatal(
       arg->current_ue_index < S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE,
@@ -1788,6 +1870,8 @@ static bool s1ap_send_enb_deregistered_ind(
     if (arg->current_ue_index == 0 && arg->handled_ues > 0) {
       S1AP_ENB_DEREGISTERED_IND(arg->message_p).nb_ue_to_deregister =
         S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE;
+
+      arg->message_p->ittiMsgHeader.imsi = imsi64;
       itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, arg->message_p);
       arg->message_p = NULL;
     }
@@ -1912,6 +1996,7 @@ int s1ap_handle_sctp_disconnection(
       0;
   }
   S1AP_ENB_DEREGISTERED_IND(message_p).enb_id = enb_association->enb_id;
+
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   message_p = NULL;
 
@@ -2042,6 +2127,7 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
   OAILOG_FUNC_IN(LOG_S1AP);
   DevAssert(ue_ref_p != NULL);
   ue_ref_p->s1ap_ue_context_rel_timer.id = S1AP_TIMER_INACTIVE_ID;
+  imsi64_t imsi64 = INVALID_IMSI64;
   OAILOG_DEBUG(
     LOG_S1AP,
     "Expired- UE Context Release Timer for UE id  %d \n",
@@ -2058,6 +2144,14 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
     sizeof(itti_s1ap_ue_context_release_complete_t));
   S1AP_UE_CONTEXT_RELEASE_COMPLETE(message_p).mme_ue_s1ap_id =
     ue_ref_p->mme_ue_s1ap_id;
+
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) ue_ref_p->mme_ue_s1ap_id,
+    &imsi64);
+
+  message_p->ittiMsgHeader.imsi = imsi64;
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   DevAssert(ue_ref_p->s1_ue_state == S1AP_UE_WAITING_CRR);
   OAILOG_DEBUG(
@@ -2065,13 +2159,18 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
     "Removed S1AP UE " MME_UE_S1AP_ID_FMT "\n",
     (uint32_t) ue_ref_p->mme_ue_s1ap_id);
   s1ap_remove_ue(state, ue_ref_p);
+
+  hashtable_uint64_ts_remove(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) ue_ref_p->mme_ue_s1ap_id);
   OAILOG_FUNC_OUT(LOG_S1AP);
 }
 
 //------------------------------------------------------------------------------
 void s1ap_mme_release_ue_context(
   s1ap_state_t *state,
-  ue_description_t *ue_ref_p)
+  ue_description_t *ue_ref_p,
+  imsi64_t imsi64)
 {
   MessageDef *message_p = NULL;
   OAILOG_FUNC_IN(LOG_S1AP);
@@ -2092,12 +2191,15 @@ void s1ap_mme_release_ue_context(
     sizeof(itti_s1ap_ue_context_release_complete_t));
   S1AP_UE_CONTEXT_RELEASE_COMPLETE(message_p).mme_ue_s1ap_id =
     ue_ref_p->mme_ue_s1ap_id;
+
+  message_p->ittiMsgHeader.imsi = imsi64;
   itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   DevAssert(ue_ref_p->s1_ue_state == S1AP_UE_WAITING_CRR);
   OAILOG_DEBUG(
     LOG_S1AP,
     "Removed S1AP UE " MME_UE_S1AP_ID_FMT "\n",
     (uint32_t) ue_ref_p->mme_ue_s1ap_id);
+
   s1ap_remove_ue(state, ue_ref_p);
   OAILOG_FUNC_OUT(LOG_S1AP);
 }
@@ -2128,6 +2230,7 @@ int s1ap_mme_handle_erab_setup_response(
   ue_description_t *ue_ref_p = NULL;
   MessageDef *message_p = NULL;
   int rc = RETURNok;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   s1ap_E_RABSetupResponseIEs_p = &message->msg.s1ap_E_RABSetupResponseIEs;
 
@@ -2152,6 +2255,12 @@ int s1ap_mme_handle_erab_setup_response(
       (enb_ue_s1ap_id_t) s1ap_E_RABSetupResponseIEs_p->eNB_UE_S1AP_ID);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) ue_ref_p->mme_ue_s1ap_id,
+    &imsi64);
 
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_SETUP_RSP);
   AssertFatal(message_p != NULL, "itti_alloc_new_message Failed");
@@ -2203,6 +2312,7 @@ int s1ap_mme_handle_erab_setup_response(
     }
   }
 
+  message_p->ittiMsgHeader.imsi = imsi64;
   rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
@@ -2235,6 +2345,7 @@ int s1ap_mme_handle_enb_reset(
   int rc = RETURNok;
   mme_ue_s1ap_id_t mme_ue_s1ap_id;
   enb_ue_s1ap_id_t enb_ue_s1ap_id;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
 
@@ -2352,6 +2463,11 @@ int s1ap_mme_handle_enb_reset(
         if (s1_sig_conn_id_p->mME_UE_S1AP_ID != NULL) {
           mme_ue_s1ap_id =
             (mme_ue_s1ap_id_t) * (s1_sig_conn_id_p->mME_UE_S1AP_ID);
+          s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+          hashtable_uint64_ts_get(
+            imsi_map->mme_ue_id_imsi_htbl,
+            (const hash_key_t) mme_ue_s1ap_id,
+            &imsi64);
           if (
             (ue_ref_p = s1ap_state_get_ue_mmeid(state, mme_ue_s1ap_id)) !=
             NULL) {
@@ -2425,12 +2541,14 @@ int s1ap_mme_handle_enb_reset(
       }
   }
 
+  msg->ittiMsgHeader.imsi = imsi64;
   rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, msg);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }
 //------------------------------------------------------------------------------
 int s1ap_handle_enb_initiated_reset_ack(
-  const itti_s1ap_enb_initiated_reset_ack_t *const enb_reset_ack_p)
+  const itti_s1ap_enb_initiated_reset_ack_t *const enb_reset_ack_p,
+  imsi64_t imsi64)
 {
   uint8_t *buffer = NULL;
   uint32_t length = 0;
@@ -2486,6 +2604,7 @@ int s1ap_handle_enb_initiated_reset_ack(
     enb_reset_ack_p->sctp_assoc_id,
     enb_reset_ack_p->sctp_stream_id,
     INVALID_MME_UE_S1AP_ID);
+
   free_wrapper((void **) &(enb_reset_ack_p->ue_to_reset_list));
   increment_counter("s1_reset_from_enb", 1, 1, "action", "reset_ack_sent");
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
@@ -2519,21 +2638,19 @@ void s1ap_enb_assoc_clean_up_timer_expiry(
 
 int s1ap_handle_paging_request(
   s1ap_state_t *state,
-  const itti_s1ap_paging_request_t *paging_request)
+  const itti_s1ap_paging_request_t *paging_request,
+  imsi64_t imsi64)
 {
   OAILOG_FUNC_IN(LOG_S1AP);
   DevAssert(paging_request != NULL);
   // ue_description_t* ue_ref_p = NULL;
   S1ap_PagingIEs_t *paging_message = NULL;
   s1ap_message message = {0};
-  imsi64_t imsi64;
   int rc = RETURNok;
   uint8_t num_of_tac = 0;
   uint16_t tai_list_count = paging_request->tai_list_count;
   bool is_tai_found = false;
   uint32_t idx = 0;
-
-  IMSI_STRING_TO_IMSI64((char *) paging_request->imsi, &imsi64);
   paging_message = &message.msg.s1ap_PagingIEs;
 
   paging_message->presenceMask = 0;   // no optional fields
@@ -2801,8 +2918,9 @@ static bool is_all_erabId_same(
 }
 //------------------------------------------------------------------------------
 int s1ap_handle_path_switch_req_ack(
-  s1ap_state_t *state,
-  const itti_s1ap_path_switch_request_ack_t *path_switch_req_ack_p)
+  s1ap_state_t* state,
+  const itti_s1ap_path_switch_request_ack_t* path_switch_req_ack_p,
+  imsi64_t imsi64)
 {
   OAILOG_FUNC_IN(LOG_S1AP);
 
@@ -2864,7 +2982,8 @@ int s1ap_handle_path_switch_req_ack(
 //------------------------------------------------------------------------------
 int s1ap_handle_path_switch_req_failure(
   s1ap_state_t *state,
-  const itti_s1ap_path_switch_request_failure_t *path_switch_req_failure_p)
+  const itti_s1ap_path_switch_request_failure_t *path_switch_req_failure_p,
+  imsi64_t imsi64)
 {
   OAILOG_FUNC_IN(LOG_S1AP);
 
@@ -2952,6 +3071,7 @@ int s1ap_mme_handle_erab_rel_response(
   ue_description_t *ue_ref_p = NULL;
   MessageDef *message_p = NULL;
   int rc = RETURNok;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   s1ap_E_RABReleaseResponseIEs_p = &message->msg.s1ap_E_RABReleaseResponseIEs;
 
@@ -2977,6 +3097,12 @@ int s1ap_mme_handle_erab_rel_response(
       (enb_ue_s1ap_id_t) s1ap_E_RABReleaseResponseIEs_p->eNB_UE_S1AP_ID);
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) s1ap_E_RABReleaseResponseIEs_p->mme_ue_s1ap_id,
+    &imsi64);
 
   message_p = itti_alloc_new_message(TASK_S1AP, S1AP_E_RAB_REL_RSP);
   if (message_p == NULL) {
@@ -3023,6 +3149,7 @@ int s1ap_mme_handle_erab_rel_response(
         1;
     }
   }
+  message_p->ittiMsgHeader.imsi = imsi64;
   rc = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   OAILOG_FUNC_RETURN(LOG_S1AP, rc);
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.h
@@ -84,9 +84,10 @@ int s1ap_mme_handle_ue_context_release_request(
   struct s1ap_message_s *message_p);
 
 int s1ap_handle_ue_context_release_command(
-  s1ap_state_t *state,
-  const itti_s1ap_ue_context_release_command_t
-    *const ue_context_release_command_pP);
+  s1ap_state_t* state,
+  const itti_s1ap_ue_context_release_command_t* const
+    ue_context_release_command_pP,
+  imsi64_t imsi64);
 
 int s1ap_mme_handle_ue_context_release_complete(
   s1ap_state_t *state,
@@ -96,7 +97,8 @@ int s1ap_mme_handle_ue_context_release_complete(
 
 int s1ap_handle_ue_context_mod_req(
   s1ap_state_t *state,
-  const itti_s1ap_ue_context_mod_req_t *const ue_context_mod_req_pP);
+  const itti_s1ap_ue_context_mod_req_t *const ue_context_mod_req_pP,
+  imsi64_t imsi64);
 
 int s1ap_mme_handle_initial_context_setup_failure(
   s1ap_state_t *state,
@@ -148,7 +150,8 @@ void s1ap_mme_handle_ue_context_rel_comp_timer_expiry(
 
 void s1ap_mme_release_ue_context(
   s1ap_state_t *state,
-  ue_description_t *ue_ref_p);
+  ue_description_t *ue_ref_p,
+  imsi64_t imsi64);
 
 int s1ap_mme_handle_error_ind_message(
   s1ap_state_t *state,
@@ -163,7 +166,8 @@ int s1ap_mme_handle_enb_reset(
   struct s1ap_message_s *message);
 
 int s1ap_handle_enb_initiated_reset_ack(
-  const itti_s1ap_enb_initiated_reset_ack_t *const enb_reset_ack_p);
+  const itti_s1ap_enb_initiated_reset_ack_t *const enb_reset_ack_p,
+  imsi64_t imsi64);
 
 void s1ap_enb_assoc_clean_up_timer_expiry(
   s1ap_state_t *state,
@@ -171,7 +175,8 @@ void s1ap_enb_assoc_clean_up_timer_expiry(
 
 int s1ap_handle_paging_request(
   s1ap_state_t* state,
-  const itti_s1ap_paging_request_t* paging_request);
+  const itti_s1ap_paging_request_t* paging_request,
+  imsi64_t imsi64);
 
 int s1ap_mme_handle_ue_context_modification_response(
   s1ap_state_t *state,
@@ -199,10 +204,12 @@ int s1ap_mme_handle_enb_configuration_transfer(
 
 int s1ap_handle_path_switch_req_ack(
   s1ap_state_t *state,
-  const itti_s1ap_path_switch_request_ack_t *path_switch_req_ack_p);
+  const itti_s1ap_path_switch_request_ack_t *path_switch_req_ack_p,
+  imsi64_t imsi64);
 
 int s1ap_handle_path_switch_req_failure(
   s1ap_state_t *state,
-  const itti_s1ap_path_switch_request_failure_t *path_switch_req_failure_p);
+  const itti_s1ap_path_switch_request_failure_t *path_switch_req_failure_p,
+  imsi64_t imsi64);
 
 #endif /* FILE_S1AP_MME_HANDLERS_SEEN */

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_itti_messaging.h
@@ -79,7 +79,8 @@ void s1ap_mme_itti_nas_non_delivery_ind(
   const mme_ue_s1ap_id_t ue_id,
   uint8_t *const nas_msg,
   const size_t nas_msg_length,
-  const S1ap_Cause_t *const cause);
+  const S1ap_Cause_t *const cause,
+  imsi64_t imsi64);
 
 int s1ap_mme_itti_s1ap_path_switch_request(
   const sctp_assoc_id_t assoc_id,
@@ -91,6 +92,7 @@ int s1ap_mme_itti_s1ap_path_switch_request(
   const ecgi_t const *ecgi,
   const tai_t const *tai,
   const uint16_t encryption_algorithm_capabilitie,
-  const uint16_t integrity_algorithm_capabilities);
+  const uint16_t integrity_algorithm_capabilities,
+  imsi64_t imsi64);
 
 #endif /* FILE_S1AP_MME_ITTI_MESSAGING_SEEN */

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -340,6 +340,7 @@ int s1ap_mme_handle_nas_non_delivery(
 {
   S1ap_NASNonDeliveryIndication_IEs_t *nasNonDeliveryIndication_p = NULL;
   ue_description_t *ue_ref = NULL;
+  imsi64_t imsi64 = INVALID_IMSI64;
 
   OAILOG_FUNC_IN(LOG_S1AP);
   increment_counter("nas_non_delivery_indication_received", 1, NO_LABELS);
@@ -381,12 +382,20 @@ int s1ap_mme_handle_nas_non_delivery(
       "S1AP_UE_CONNECTED\n");
     OAILOG_FUNC_RETURN(LOG_S1AP, RETURNerror);
   }
+
+  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+  hashtable_uint64_ts_get(
+    imsi_map->mme_ue_id_imsi_htbl,
+    (const hash_key_t) nasNonDeliveryIndication_p->mme_ue_s1ap_id,
+    &imsi64);
+
   //TODO: forward NAS PDU to NAS
   s1ap_mme_itti_nas_non_delivery_ind(
     nasNonDeliveryIndication_p->mme_ue_s1ap_id,
     nasNonDeliveryIndication_p->nas_pdu.buf,
     nasNonDeliveryIndication_p->nas_pdu.size,
-    &nasNonDeliveryIndication_p->cause);
+    &nasNonDeliveryIndication_p->cause,
+    imsi64);
   OAILOG_FUNC_RETURN(LOG_S1AP, RETURNok);
 }
 
@@ -395,7 +404,8 @@ int s1ap_generate_downlink_nas_transport(
   s1ap_state_t *state,
   const enb_ue_s1ap_id_t enb_ue_s1ap_id,
   const mme_ue_s1ap_id_t ue_id,
-  STOLEN_REF bstring *payload)
+  STOLEN_REF bstring *payload,
+  const imsi64_t imsi64)
 {
   ue_description_t *ue_ref = NULL;
   uint8_t *buffer_p = NULL;
@@ -440,6 +450,16 @@ int s1ap_generate_downlink_nas_transport(
      * We have fount the UE in the list.
      * * * * Create new IE list message and encode it.
      */
+    s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+    hashtable_uint64_ts_insert(
+      imsi_map->enb_s1ap_mme_ue_id_htbl,
+      (const hash_key_t) enb_ue_s1ap_id,
+      ue_id);
+    hashtable_uint64_ts_insert(
+      imsi_map->mme_ue_id_imsi_htbl,
+      (const hash_key_t) ue_id,
+      imsi64);
+
     S1ap_DownlinkNASTransportIEs_t *downlinkNasTransport = NULL;
     s1ap_message message = {0};
 
@@ -936,6 +956,12 @@ void s1ap_handle_mme_ue_id_notification(
         &state->mmeid2associd,
         (const hash_key_t) mme_ue_s1ap_id,
         (void *) (uintptr_t) sctp_assoc_id);
+
+      s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
+      hashtable_uint64_ts_insert(
+        imsi_map->enb_s1ap_mme_ue_id_htbl,
+        (const hash_key_t) enb_ue_s1ap_id,
+        mme_ue_s1ap_id);
       OAILOG_DEBUG(
         LOG_S1AP,
         "Associated  sctp_assoc_id %d, enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.h
@@ -84,7 +84,8 @@ int s1ap_generate_downlink_nas_transport(
   s1ap_state_t *state,
   const enb_ue_s1ap_id_t enb_ue_s1ap_id,
   const mme_ue_s1ap_id_t ue_id,
-  STOLEN_REF bstring *payload);
+  STOLEN_REF bstring *payload,
+  imsi64_t imsi64);
 
 void s1ap_handle_mme_ue_id_notification(
   s1ap_state_t *state,
@@ -97,4 +98,5 @@ int s1ap_generate_s1ap_e_rab_setup_req(
 int s1ap_generate_s1ap_e_rab_rel_cmd(
   s1ap_state_t *state,
   itti_s1ap_e_rab_rel_cmd_t *const e_rab_rel_cmd);
+
 #endif /* FILE_S1AP_MME_NAS_PROCEDURES_SEEN */

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -97,6 +97,14 @@ ue_description_t* s1ap_state_get_ue_mmeid(
   return ue;
 }
 
+void put_s1ap_imsi_map() {
+  S1apStateManager::getInstance().put_s1ap_imsi_map();
+}
+
+s1ap_imsi_map_t* get_s1ap_imsi_map() {
+  return S1apStateManager::getInstance().get_s1ap_imsi_map();
+}
+
 bool s1ap_ue_compare_by_mme_ue_id_cb(
   __attribute__((unused)) const hash_key_t keyP,
   void* const elementP,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.h
@@ -49,6 +49,15 @@ ue_description_t* s1ap_state_get_ue_mmeid(
   s1ap_state_t* state,
   mme_ue_s1ap_id_t mme_ue_s1ap_id);
 
+/**
+ * Converts s1ap_imsi_map to protobuf and saves it into data store
+ */
+void put_s1ap_imsi_map(void);
+/**
+ * @return s1ap_imsi_map_t pointer
+ */
+s1ap_imsi_map_t * get_s1ap_imsi_map(void);
+
 bool s1ap_enb_find_ue_by_mme_ue_id_cb(
   __attribute__((unused)) hash_key_t keyP,
   void* elementP,

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.cpp
@@ -183,5 +183,28 @@ void S1apStateConverter::proto_to_ue(
   ue->s1ap_ue_context_rel_timer.sec = proto.s1ap_ue_context_rel_timer().sec();
 }
 
+void S1apStateConverter::s1ap_imsi_map_to_proto(
+  const s1ap_imsi_map_t* s1ap_imsi_map,
+  gateway::s1ap::S1apImsiMap* s1ap_imsi_proto)
+{
+  hashtable_uint64_ts_to_proto(
+    s1ap_imsi_map->enb_s1ap_mme_ue_id_htbl,
+    s1ap_imsi_proto->mutable_enb_ue_id_mme_ue_id_map());
+  hashtable_uint64_ts_to_proto(
+    s1ap_imsi_map->mme_ue_id_imsi_htbl,
+    s1ap_imsi_proto->mutable_mme_ue_id_imsi_map());
+}
+void S1apStateConverter::proto_to_s1ap_imsi_map(
+  const gateway::s1ap::S1apImsiMap& s1ap_imsi_proto,
+  s1ap_imsi_map_t* s1ap_imsi_map)
+{
+  proto_to_hashtable_uint64_ts(
+    s1ap_imsi_proto.mme_ue_id_imsi_map(),
+    s1ap_imsi_map->mme_ue_id_imsi_htbl);
+  proto_to_hashtable_uint64_ts(
+    s1ap_imsi_proto.enb_ue_id_mme_ue_id_map(),
+    s1ap_imsi_map->enb_s1ap_mme_ue_id_htbl);
+}
+
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_converter.h
@@ -54,6 +54,20 @@ class S1apStateConverter : StateConverter {
     const gateway::s1ap::S1apState& proto,
     s1ap_state_t* state);
 
+  /**
+   * Serializes s1ap_imsi_map_t to S1apImsiMap proto
+   */
+  static void s1ap_imsi_map_to_proto(
+    const s1ap_imsi_map_t* s1ap_imsi_map,
+    gateway::s1ap::S1apImsiMap* s1ap_imsi_proto);
+
+  /**
+   * Deserializes s1ap_imsi_map_t from S1apImsiMap proto
+   */
+  static void proto_to_s1ap_imsi_map(
+    const gateway::s1ap::S1apImsiMap& s1ap_imsi_proto,
+    s1ap_imsi_map_t* s1ap_imsi_map);
+
   static void enb_to_proto(
     enb_description_t* enb,
     gateway::s1ap::EnbDescription* proto);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -22,8 +22,9 @@
 #include "s1ap_state_manager.h"
 
 namespace {
-constexpr char s1ap_enb_coll[] = "s1ap_eNB_coll";
-constexpr char s1ap_mme_id2assoc_id_coll[] = "s1ap_mme_id2assoc_id_coll";
+constexpr char S1AP_ENB_COLL[] = "s1ap_eNB_coll";
+constexpr char S1AP_MME_ID2ASSOC_ID_COLL[] = "s1ap_mme_id2assoc_id_coll";
+constexpr char S1AP_IMSI_MAP_TABLE_NAME[] = "s1ap_imsi_map";
 } // namespace
 
 namespace magma {
@@ -65,12 +66,12 @@ void S1apStateManager::create_state()
 
   state_cache_p = (s1ap_state_t*) calloc(1, sizeof(s1ap_state_t));
 
-  ht_name = bfromcstr(s1ap_enb_coll);
+  ht_name = bfromcstr(S1AP_ENB_COLL);
   hashtable_ts_init(
     &state_cache_p->enbs, max_enbs_, nullptr, free_wrapper, ht_name);
   bdestroy(ht_name);
 
-  ht_name = bfromcstr(s1ap_mme_id2assoc_id_coll);
+  ht_name = bfromcstr(S1AP_MME_ID2ASSOC_ID_COLL);
   hashtable_ts_init(
     &state_cache_p->mmeid2associd,
     max_ues_,
@@ -80,6 +81,8 @@ void S1apStateManager::create_state()
   bdestroy(ht_name);
 
   state_cache_p->num_enbs = 0;
+
+  create_s1ap_imsi_map();
 }
 
 void S1apStateManager::free_state()
@@ -122,6 +125,44 @@ void S1apStateManager::free_state()
     OAI_FPRINTF_ERR("An error occured while destroying assoc_id hash table");
   }
   free_wrapper((void**) &state_cache_p);
+
+  clear_s1ap_imsi_map();
+}
+
+void S1apStateManager::create_s1ap_imsi_map()
+{
+  s1ap_imsi_map_ = (s1ap_imsi_map_t*) calloc(1, sizeof(s1ap_imsi_map_t));
+
+  s1ap_imsi_map_->enb_s1ap_mme_ue_id_htbl =
+    hashtable_uint64_ts_create(max_ues_, nullptr, nullptr);
+  s1ap_imsi_map_->mme_ue_id_imsi_htbl =
+    hashtable_uint64_ts_create(max_ues_, nullptr, nullptr);
+
+  gateway::s1ap::S1apImsiMap imsi_proto = gateway::s1ap::S1apImsiMap();
+  redis_client->read_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);
+
+  S1apStateConverter::proto_to_s1ap_imsi_map(imsi_proto, s1ap_imsi_map_);
+}
+
+void S1apStateManager::clear_s1ap_imsi_map() {
+  if(!s1ap_imsi_map_) {
+    return;
+  }
+  hashtable_uint64_ts_destroy(s1ap_imsi_map_->enb_s1ap_mme_ue_id_htbl);
+  hashtable_uint64_ts_destroy(s1ap_imsi_map_->mme_ue_id_imsi_htbl);
+
+  free_wrapper((void **) &s1ap_imsi_map_);
+}
+
+s1ap_imsi_map_t* S1apStateManager::get_s1ap_imsi_map()
+{
+  return s1ap_imsi_map_;
+}
+
+void S1apStateManager::put_s1ap_imsi_map() {
+  gateway::s1ap::S1apImsiMap imsi_proto = gateway::s1ap::S1apImsiMap();
+  S1apStateConverter::s1ap_imsi_map_to_proto(s1ap_imsi_map_, &imsi_proto);
+  redis_client->write_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);
 }
 
 } // namespace lte

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
@@ -74,6 +74,16 @@ class S1apStateManager :
    */
   void free_state() override;
 
+  /**
+   * Serializes s1ap_imsi_map to proto and saves it into data store
+   */
+  void put_s1ap_imsi_map();
+
+  /**
+   * Returns a pointer to s1ap_imsi_map
+   */
+  s1ap_imsi_map_t* get_s1ap_imsi_map();
+
  private:
   S1apStateManager();
   ~S1apStateManager();
@@ -83,8 +93,12 @@ class S1apStateManager :
    */
   void create_state() override;
 
+  void create_s1ap_imsi_map();
+  void clear_s1ap_imsi_map();
+
   uint32_t max_ues_;
   uint32_t max_enbs_;
+  s1ap_imsi_map_t* s1ap_imsi_map_;
 };
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_types.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_types.h
@@ -42,6 +42,11 @@ typedef struct s1ap_state_s {
   uint32_t num_enbs;
 } s1ap_state_t;
 
+typedef struct s1ap_imsi_map_s {
+  hash_table_uint64_ts_t* enb_s1ap_mme_ue_id_htbl;
+  hash_table_uint64_ts_t* mme_ue_id_imsi_htbl;
+} s1ap_imsi_map_t;
+
 enum s1_timer_class_s {
   S1AP_INVALID_TIMER_CLASS,
   S1AP_ENB_TIMER,

--- a/lte/gateway/c/oai/tasks/s6a/s6a_cancel_loc.c
+++ b/lte/gateway/c/oai/tasks/s6a/s6a_cancel_loc.c
@@ -27,6 +27,7 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <conversions.h>
 
 #include "assertions.h"
 #include "intertask_interface.h"
@@ -144,6 +145,9 @@ int s6a_clr_cb(
       s6a_cancel_location_req_p->imsi_length = imsi_len;
       s6a_cancel_location_req_p->cancellation_type = SUBSCRIPTION_WITHDRAWL;
       s6a_cancel_location_req_p->msg_cla_p = msg_p;
+      IMSI_STRING_TO_IMSI64(
+        (char*) s6a_cancel_location_req_p->imsi,
+        &message_p->ittiMsgHeader.imsi);
       itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
       OAILOG_DEBUG(
         LOG_S6A, "Sending S6A_CANCEL_LOCATION_REQ to task MME_APP\n");

--- a/lte/gateway/c/oai/tasks/sgw/sgw_paging.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_paging.c
@@ -24,6 +24,7 @@
 #include <netinet/in.h>
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <conversions.h>
 
 #include "intertask_interface.h"
 #include "log.h"
@@ -54,6 +55,7 @@ int sgw_send_paging_request(const struct in_addr *dest_ip)
   paging_request_p->imsi = strdup(imsi);
   free(imsi);
 
+  IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   ret = itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, message_p);
   return ret;
 }


### PR DESCRIPTION
Summary:
This diff:

   - Adds IMSI on ITTI messages being sent by S1AP task to other tasks
    - Updates S1AP task IMSI map with new UE IDs or changes to UE IDs
    - Uses added IMSI map to retrieve IMSI on messages exchanged between S1AP and SCTP tasks

Differential Revision: D19793320

