### PR TITLE
Make eventd synchronize time using NTP before startup

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # - updated vbguest-tool
     magma.vm.box = "fbcmagma/magma_dev"
     magma.vm.hostname = "magma-dev"
-    magma.vm.box_version = "1.0.1581412195"
+    magma.vm.box_version = "1.0.1581548158"
     magma.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
@@ -10,6 +10,7 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
+ExecStartPre=/usr/sbin/ntpdate 1.ntp.vip.facebook.com
 ExecStart=/usr/bin/env python3 -m magma.eventd.main
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -15,6 +15,7 @@
     - magmad
     - mobilityd
     - dnsd
+    - eventd
     # Magma OAI services
     - mme
     # Magma third-party services
@@ -149,6 +150,8 @@
       - redis-server
       - python-redis
       - magma-cpp-redis
+      # Time synchronization with NTP for eventd
+      - ntpdate
   retries: 5
   when: preburn
 

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -107,6 +107,7 @@ MAGMA_DEPS=(
     "libdouble-conversion-dev" # required for folly
     "libboost-chrono-dev" # required for folly
     "td-agent-bit >= 1.3.2" # fluent-bit
+    "ntpdate" # required for eventd time synchronization
     )
 
 # OAI runtime dependencies


### PR DESCRIPTION
Summary:
- This allows for accurate logging when we send messages to fluentbit
- The facebook SNTP server is called

Reviewed By: xjtian

Differential Revision: D19861324

