### PR TITLE
restrict magma network requests when no organization

### DIFF
--- a/symphony/app/fbcnms-packages/fbcnms-auth/__tests__/express-test.js
+++ b/symphony/app/fbcnms-packages/fbcnms-auth/__tests__/express-test.js
@@ -336,6 +336,12 @@ describe('magma api proxy tests', () => {
     nock('https://' + API_HOST)
       .get('/magma/v1/networks')
       .reply(200, new Buffer(JSON.stringify(allNetworks), 'utf8'));
+    nock('https://' + API_HOST)
+      .get('/magma/v1/networks/network1')
+      .reply(200);
+    nock('https://' + API_HOST)
+      .get('/magma/v1/networks/network2')
+      .reply(200);
   });
 
   afterEach(async () => {
@@ -343,7 +349,7 @@ describe('magma api proxy tests', () => {
     nock.cleanAll();
   });
 
-  describe('get networks no organization', () => {
+  describe('get all networks no organization', () => {
     it('as normal user, can only see own networks', async () => {
       const app = getApp('', 'valid@123.com');
       await request(app)
@@ -365,6 +371,27 @@ describe('magma api proxy tests', () => {
             allNetworks,
           ),
         );
+    });
+  });
+
+  describe('get one network no organization', () => {
+    it('as normal user, can only get own networks', async () => {
+      const app = getApp('', 'valid@123.com');
+      await request(app)
+        .get('/nms/apicontroller/magma/v1/networks/network1')
+        .expect(200);
+      await request(app)
+        .get('/nms/apicontroller/magma/v1/networks/network2')
+        .expect(404);
+    });
+    it('as super user, can get all networks', async () => {
+      const app = getApp('', 'superuser@123.com');
+      await request(app)
+        .get('/nms/apicontroller/magma/v1/networks/network1')
+        .expect(200);
+      await request(app)
+        .get('/nms/apicontroller/magma/v1/networks/network2')
+        .expect(200);
     });
   });
 });

--- a/symphony/app/fbcnms-packages/fbcnms-platform-server/apicontroller/__tests__/proxy-test.js
+++ b/symphony/app/fbcnms-packages/fbcnms-platform-server/apicontroller/__tests__/proxy-test.js
@@ -88,6 +88,18 @@ describe('Proxy test', () => {
       expect(isAllowed).toBe(true);
     });
 
+    it('allows superuser access no org', async () => {
+      const req = {
+        params,
+        user: {
+          isSuperUser: true,
+          networkIDs: [],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(true);
+    });
+
     it('disallows superuser access to non-org network', async () => {
       const req = {
         params,
@@ -118,6 +130,18 @@ describe('Proxy test', () => {
       expect(isAllowed).toBe(true);
     });
 
+    it('allows user with access to network no org', async () => {
+      const req = {
+        params,
+        user: {
+          isSuperUser: false,
+          networkIDs: ['test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(true);
+    });
+
     it('disallows user with access to network but not org', async () => {
       const req = {
         params,
@@ -139,6 +163,18 @@ describe('Proxy test', () => {
         organization: () => ({
           networkIDs: ['test', 'not-test'],
         }),
+        user: {
+          isSuperUser: false,
+          networkIDs: ['not-test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(false);
+    });
+
+    it('disallows user without access to network no org', async () => {
+      const req = {
+        params,
         user: {
           isSuperUser: false,
           networkIDs: ['not-test'],

--- a/symphony/app/fbcnms-packages/fbcnms-platform-server/apicontroller/routes.js
+++ b/symphony/app/fbcnms-packages/fbcnms-platform-server/apicontroller/routes.js
@@ -47,21 +47,18 @@ const PROXY_OPTIONS = {
 };
 
 export async function networkIdFilter(req: FBCNMSRequest): Promise<boolean> {
-  // If not using organizations, always allow
-  if (!req.organization) {
-    return true;
-  }
+  if (req.organization) {
+    const organization = await req.organization();
 
-  const organization = await req.organization();
-
-  // If the request isn't an organization network, block
-  // the request
-  const isOrganizationAllowed = containsNetworkID(
-    organization.networkIDs,
-    req.params.networkID,
-  );
-  if (!isOrganizationAllowed) {
-    return false;
+    // If the request isn't an organization network, block
+    // the request
+    const isOrganizationAllowed = containsNetworkID(
+      organization.networkIDs,
+      req.params.networkID,
+    );
+    if (!isOrganizationAllowed) {
+      return false;
+    }
   }
 
   // super users on standalone deployments


### PR DESCRIPTION
Summary: Partner reported that after they've pulled v1, users could still access networks they didn't have access to through the url.  Turns out we weren't properly restricting `networks/:networkID` magma requests when there is no organization. This fixes that.

Reviewed By: rckclmbr

Differential Revision: D19866952

