### PR TITLE
Forward eventd events to a dedicated ES index

### DIFF
--- a/orc8r/cloud/docker/fluentd/conf/fluent.conf
+++ b/orc8r/cloud/docker/fluentd/conf/fluent.conf
@@ -37,6 +37,23 @@
   </parse>
 </filter>
 
+<match eventd>
+  @type copy
+  <store>
+    @type elasticsearch
+    host elasticsearch
+    port 9200
+    logstash_format true
+    logstash_prefix eventd
+    include_tag_key true
+    tag_key tag
+    flush_interval 1s
+  </store>
+  <store>
+    @type stdout
+  </store>
+</match>
+
 <match *.**>
   @type copy
   <store>

--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -48,7 +48,7 @@
     Listen      0.0.0.0
     Port        5170
     Format      json
-    Tag event_log
+    Tag eventd
 
 {% for t,f in files %}
 [INPUT]
@@ -95,5 +95,5 @@
 
 [OUTPUT]
     Name        stdout
-    Match       event_log
+    Match       eventd
 


### PR DESCRIPTION
Summary: - This forwards the TCP logs tagged as eventd to a dedicated ES index

Reviewed By: xjtian

Differential Revision: D19871320

