### PR TITLE
Mark class methods as const (#1918)

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -234,7 +234,7 @@ void SessionState::start_termination(
   on_termination_callback_ = on_termination_callback;
 }
 
-bool SessionState::can_complete_termination()
+bool SessionState::can_complete_termination() const
 {
   return curr_state_ == SESSION_TERMINATING_FLOW_DELETED;
 }
@@ -311,7 +311,7 @@ UsageMonitoringCreditPool& SessionState::get_monitor_pool()
   return monitor_pool_;
 }
 
-bool SessionState::is_same_config(const Config& new_config)
+bool SessionState::is_same_config(const Config& new_config) const
 {
   return config_.ue_ipv4.compare(new_config.ue_ipv4) == 0 &&
          config_.spgw_ipv4.compare(new_config.spgw_ipv4) == 0 &&
@@ -327,32 +327,32 @@ bool SessionState::is_same_config(const Config& new_config)
          config_.bearer_id == new_config.bearer_id;
 }
 
-std::string SessionState::get_session_id()
+std::string SessionState::get_session_id() const
 {
   return session_id_;
 }
 
-std::string SessionState::get_subscriber_ip_addr()
+std::string SessionState::get_subscriber_ip_addr() const
 {
   return config_.ue_ipv4;
 }
 
-std::string SessionState::get_mac_addr()
+std::string SessionState::get_mac_addr() const
 {
   return config_.mac_addr;
 }
 
-std::string SessionState::get_apn()
+std::string SessionState::get_apn() const
 {
   return config_.apn;
 }
 
-bool SessionState::is_radius_cwf_session()
+bool SessionState::is_radius_cwf_session() const
 {
   return (config_.rat_type == RATType::TGPP_WLAN);
 }
 
-std::string SessionState::get_radius_session_id()
+std::string SessionState::get_radius_session_id() const
 {
   return config_.radius_session_id;
 }
@@ -365,7 +365,7 @@ void SessionState::get_session_info(SessionState::SessionInfo& info)
   info.static_rules = session_rules_.get_static_rule_ids();
 }
 
-uint32_t SessionState::get_qci()
+uint32_t SessionState::get_qci() const
 {
   if (!config_.qos_info.enabled) {
     MLOG(MWARNING) << "QoS is not enabled.";
@@ -374,12 +374,12 @@ uint32_t SessionState::get_qci()
   return config_.qos_info.qci;
 }
 
-uint32_t SessionState::get_bearer_id()
+uint32_t SessionState::get_bearer_id() const
 {
   return config_.bearer_id;
 }
 
-bool SessionState::qos_enabled()
+bool SessionState::qos_enabled() const
 {
   return config_.qos_info.enabled;
 }
@@ -390,7 +390,8 @@ void SessionState::set_tgpp_context(const magma::lte::TgppContext& tgpp_context)
 }
 
 void SessionState::fill_protos_tgpp_context(
-  magma::lte::TgppContext* tgpp_context) {
+  magma::lte::TgppContext* tgpp_context) const
+{
   *tgpp_context = tgpp_context_;
 }
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -97,6 +97,7 @@ class SessionState {
   /**
    * get_updates collects updates and adds them to a UpdateSessionRequest
    * for reporting.
+   * Only updates request number
    * @param update_request (out) - request to add new updates to
    * @param actions (out) - actions to take on services
    */
@@ -121,7 +122,7 @@ class SessionState {
    * For this to be true, start_termination needs to be called for the session,
    * and the flows for the session needs to be deleted.
    */
-  bool can_complete_termination();
+  bool can_complete_termination() const;
 
   /**
    * complete_termination collects final usages for all credits into a
@@ -146,35 +147,35 @@ class SessionState {
 
   UsageMonitoringCreditPool& get_monitor_pool();
 
-  std::string get_session_id();
+  std::string get_session_id() const;
 
-  std::string get_subscriber_ip_addr();
+  std::string get_subscriber_ip_addr() const;
 
-  std::string get_mac_addr();
+  std::string get_mac_addr() const;
 
-  std::string get_hardware_addr() { return config_.hardware_addr; }
+  std::string get_hardware_addr() const { return config_.hardware_addr; }
 
-  std::string get_radius_session_id();
+  std::string get_radius_session_id() const;
 
-  std::string get_apn();
+  std::string get_apn() const;
 
   std::string get_core_session_id() const { return core_session_id_; };
 
-  uint32_t get_bearer_id();
+  uint32_t get_bearer_id() const;
 
-  uint32_t get_qci();
+  uint32_t get_qci() const;
 
-  bool is_radius_cwf_session();
+  bool is_radius_cwf_session() const;
 
-  bool is_same_config(const Config& new_config);
+  bool is_same_config(const Config& new_config) const;
 
   void get_session_info(SessionState::SessionInfo& info);
 
-  bool qos_enabled();
+  bool qos_enabled() const;
 
   void set_tgpp_context(const magma::lte::TgppContext& tgpp_context);
 
-  void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context);
+  void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 
   void set_monitoring_quota_state(
     const magma::lte::SubscriberQuotaUpdate_Type state);


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/1918

Adding some `const` specifiers to certain methods to make the effect of things easier to understand at a glance

Reviewed By: themarwhal

Differential Revision: D19873076

