### PR TITLE
Add SESSION_TERMINATION_SCHEDULED state

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -184,10 +184,16 @@ class SessionState {
  private:
   /**
    * State transitions of a session:
-   * SESSION_ACTIVE
-   *       |
-   *       | (start_termination)
-   *       V
+   * SESSION_ACTIVE  ---------
+   *       |                  \
+   *       |                   \
+   *       |                    \
+   *       |                     \
+   *       | (start_termination)  SESSION_TERMINATION_SCHEDULED
+   *       |                      /
+   *       |                     /
+   *       |                    /
+   *       V                   V
    * SESSION_TERMINATING_FLOW_ACTIVE <----------
    *       |                                   |
    *       | (new_report)                      | (add_used_credit)
@@ -207,7 +213,9 @@ class SessionState {
     SESSION_TERMINATING_FLOW_ACTIVE = 1,
     SESSION_TERMINATING_AGGREGATING_STATS = 2,
     SESSION_TERMINATING_FLOW_DELETED = 3,
-    SESSION_TERMINATED = 4
+    SESSION_TERMINATED = 4,
+    // TODO All sessions in this state should be terminated on sessiond restart
+    SESSION_TERMINATION_SCHEDULED = 5
   };
 
   std::string imsi_;


### PR DESCRIPTION
Summary: Add a new state. This will be used when a session exhausts quota and is awaiting termination. If sessiond restarts before the scheduled termination happens, we will terminate it when sessiond starts again.

Differential Revision: D19893316

