### PR TITLE
Terminate session on monitoring quota exhaustion on RAR/CCA-U

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -31,3 +31,8 @@ session_force_termination_timeout_ms: 5000
 
 # Set to true to enable sessiond support of carrier wifi
 support_carrier_wifi: true
+
+# CWF only
+# Number of ms before sessiond terminates a session when it is started without
+# quota.
+cwf_quota_exhaustion_termination_on_init_ms: 30000

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -48,6 +48,8 @@ require (
 	magma/feg/gateway v0.0.0-00010101000000-000000000000
 	magma/lte/cloud/go v0.0.0
 	magma/orc8r/cloud/go v0.0.0
+	magma/orc8r/lib/go v0.0.0
+	magma/orc8r/lib/go/protos v0.0.0
 )
 
 go 1.13

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -153,6 +153,7 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.0-20160529050041-d9eb7a3d35ec/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -308,6 +309,7 @@ github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4 h1:gQz4mCbXsO+nc9n1hCxHcGA3Zx3Eo+UHZoInFGUIXNM=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181119215939-b36ad289a3ea/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -408,6 +410,7 @@ golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191007182048-72f939374954 h1:JGZucVF/L/TotR719NbujzadOZ2AgnYlqphQGHDCKaU=
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -478,6 +481,7 @@ google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.24.0/go.mod h1:XDChyiUovWa60DnaeDeZmSW86xtLtjtZbwvSiRnRtcA=
 google.golang.org/grpc v1.25.0 h1:ItERT+UbGdX+s4u+nQNlVM/Q7cbmf7icKfvzbWqVtq0=
 google.golang.org/grpc v1.25.0/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
+google.golang.org/grpc v1.27.1 h1:zvIju4sqAGvwKspUQOhwnpcqSbzi7/H6QomNNjTL4sk=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/DATA-DOG/go-sqlmock.v1 v1.3.0/go.mod h1:OdE7CF6DbADk7lN8LIKRzRJTTZXIjtWgA5THM5lhBAw=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
@@ -493,6 +497,7 @@ gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/cwf/gateway/integ_tests/auth_ul_test.go
+++ b/cwf/gateway/integ_tests/auth_ul_test.go
@@ -16,6 +16,7 @@ import (
 	"fbc/lib/go/radius/rfc2869"
 	"magma/feg/gateway/services/eap"
 
+	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -38,7 +39,7 @@ func TestAuthenticateUplinkTraffic(t *testing.T) {
 	assert.NotNil(t, eapMessage)
 	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
 
-	err = tr.GenULTraffic(ue.GetImsi(), nil)
+	err = tr.GenULTraffic(ue.GetImsi(), swag.String("100K"))
 	assert.NoError(t, err)
 
 	// Clear hss, ocs, and pcrf

--- a/cwf/gateway/integ_tests/enforcement_test.go
+++ b/cwf/gateway/integ_tests/enforcement_test.go
@@ -43,7 +43,7 @@ func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
 	// 3. Install a dynamic rule that points to the static rule above
 	err = ruleManager.AddUsageMonitor(imsi, "mkey1", 1000*KiloBytes, 250*KiloBytes)
 	assert.NoError(t, err)
-	err = ruleManager.AddStaticPassAll("static-pass-all", "mkey1", models.PolicyRuleTrackingTypeONLYPCRF)
+	err = ruleManager.AddStaticPassAll("static-pass-all", "mkey1", models.PolicyRuleTrackingTypeONLYPCRF, 3)
 	assert.NoError(t, err)
 	err = ruleManager.AddDynamicRules(imsi, []string{"static-pass-all"}, nil)
 	assert.NoError(t, err)
@@ -69,9 +69,8 @@ func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
 	// amount of data was passed through
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
-	record := recordsBySubID["IMSI"+imsi]
+	record := recordsBySubID["IMSI"+imsi]["static-pass-all"]
 	assert.NotNil(t, record, fmt.Sprintf("No policy usage record for imsi: %v", imsi))
-	assert.Equal(t, "static-pass-all", record.RuleId)
 	// We should not be seeing > 1024k data here
 	assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
 	assert.True(t, record.BytesTx <= uint64(500*KiloBytes+Buffer), fmt.Sprintf("policy usage: %v", record))

--- a/cwf/gateway/integ_tests/rule_manager.go
+++ b/cwf/gateway/integ_tests/rule_manager.go
@@ -48,9 +48,9 @@ func NewRuleManager() (*RuleManager, error) {
 
 // AddStaticPassAll adds a static rule that passes all traffic to policyDB
 // storage
-func (manager *RuleManager) AddStaticPassAll(ruleID string, monitoringKey string, trackingType string) error {
+func (manager *RuleManager) AddStaticPassAll(ruleID string, monitoringKey string, trackingType string, priority uint32) error {
 	fmt.Printf("************************* Adding a Pass-All static rule: %s\n", ruleID)
-	staticPassAll := getStaticPassAll(ruleID, monitoringKey, trackingType)
+	staticPassAll := getStaticPassAll(ruleID, monitoringKey, trackingType, priority)
 	return manager.insertStaticRuleIntoRedis(staticPassAll)
 }
 

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -18,8 +18,8 @@ import (
 	"magma/feg/gateway/policydb"
 	"magma/feg/gateway/services/testcore/hss"
 	lteprotos "magma/lte/cloud/go/protos"
-	"magma/orc8r/lib/go/protos"
 	registryTestUtils "magma/orc8r/cloud/go/test_utils"
+	"magma/orc8r/lib/go/protos"
 
 	"github.com/go-redis/redis"
 	"github.com/golang/glog"

--- a/cwf/gateway/integ_tests/static_rules.go
+++ b/cwf/gateway/integ_tests/static_rules.go
@@ -15,7 +15,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-func getStaticPassAll(ruleID string, monitoringKey string, trackingType string) *protos.PolicyRule {
+func getStaticPassAll(ruleID string, monitoringKey string, trackingType string, priority uint32) *protos.PolicyRule {
 	rule := &models.PolicyRuleConfig{
 		FlowList: []*models.FlowDescription{
 			{
@@ -38,8 +38,40 @@ func getStaticPassAll(ruleID string, monitoringKey string, trackingType string) 
 			},
 		},
 		MonitoringKey: monitoringKey,
-		Priority:      swag.Uint32(3),
+		Priority:      swag.Uint32(priority),
 		TrackingType:  trackingType,
+		RatingGroup:   0,
+	}
+
+	return rule.ToProto(ruleID)
+}
+
+func getStaticDenyAll(ruleID string, monitoringKey string, trackingType string, priority uint32) *protos.PolicyRule {
+	rule := &models.PolicyRuleConfig{
+		FlowList: []*models.FlowDescription{
+			{
+				Action: swag.String("DENY"),
+				Match: &models.FlowMatch{
+					Direction: swag.String("UPLINK"),
+					IPProto:   swag.String("IPPROTO_IP"),
+					IPV4Dst:   "0.0.0.0/0",
+					IPV4Src:   "0.0.0.0/0",
+				},
+			},
+			{
+				Action: swag.String("DENY"),
+				Match: &models.FlowMatch{
+					Direction: swag.String("DOWNLINK"),
+					IPProto:   swag.String("IPPROTO_IP"),
+					IPV4Dst:   "0.0.0.0/0",
+					IPV4Src:   "0.0.0.0/0",
+				},
+			},
+		},
+		MonitoringKey: monitoringKey,
+		Priority:      swag.Uint32(priority),
+		TrackingType:  trackingType,
+		RatingGroup:   0,
 	}
 
 	return rule.ToProto(ruleID)

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -15,8 +15,8 @@ import (
 	"fbc/lib/go/radius"
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/orc8r/cloud/go/blobstore"
-	"magma/orc8r/lib/go/protos"
 	"magma/orc8r/cloud/go/storage"
+	"magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
 	"github.com/pkg/errors"

--- a/cwf/gateway/tools/uesim_cli/main.go
+++ b/cwf/gateway/tools/uesim_cli/main.go
@@ -27,8 +27,8 @@ import (
 	"magma/cwf/gateway/services/uesim"
 	"magma/feg/gateway/services/eap"
 	"magma/lte/cloud/go/crypto"
-	"magma/orc8r/lib/go/service/config"
 	"magma/orc8r/cloud/go/tools/commands"
+	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
 )

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -76,14 +76,16 @@ LocalEnforcer::LocalEnforcer(
   std::shared_ptr<AsyncDirectorydClient> directoryd_client,
   std::shared_ptr<SpgwServiceClient> spgw_client,
   std::shared_ptr<aaa::AAAClient> aaa_client,
-  long session_force_termination_timeout_ms):
+  long session_force_termination_timeout_ms,
+  long quota_exhaustion_termination_on_init_ms):
   reporter_(reporter),
   rule_store_(rule_store),
   pipelined_client_(pipelined_client),
   directoryd_client_(directoryd_client),
   spgw_client_(spgw_client),
   aaa_client_(aaa_client),
-  session_force_termination_timeout_ms_(session_force_termination_timeout_ms)
+  session_force_termination_timeout_ms_(session_force_termination_timeout_ms),
+  quota_exhaustion_termination_on_init_ms_(quota_exhaustion_termination_on_init_ms)
 {
 }
 
@@ -243,7 +245,7 @@ void LocalEnforcer::terminate_service(
       }
       MLOG(MDEBUG) << "Setting subscriber quota state as TERMINATE "
                    << "for subscriber " << imsi;
-      session->set_monitoring_quota_state(
+      session->set_subscriber_quota_state(
         SubscriberQuotaUpdate_Type_TERMINATE);
       report_subscriber_state_to_pipelined(
         imsi, session->get_mac_addr(), SubscriberQuotaUpdate_Type_TERMINATE);
@@ -683,16 +685,6 @@ bool LocalEnforcer::init_session_credit(
   auto rule_update_success = handle_session_init_rule_updates(
     imsi, *session_state, response, charging_credits_received);
 
-  auto it = session_map_.find(imsi);
-  if (it == session_map_.end()) {
-    // First time a session is created for IMSI
-    MLOG(MDEBUG) << "First session for IMSI " << imsi
-                 << " with session ID " << session_id;
-    session_map_[imsi] = std::vector<std::unique_ptr<SessionState>>();
-  }
-  session_map_[imsi].push_back(
-    std::move(std::unique_ptr<SessionState>(session_state)));
-
   if (session_state->is_radius_cwf_session()) {
     MLOG(MDEBUG) << "Adding UE MAC flow for subscriber " << imsi;
     SubscriberID sid;
@@ -710,14 +702,67 @@ bool LocalEnforcer::init_session_credit(
     if (!add_ue_mac_flow_success) {
       MLOG(MERROR) << "Failed to add UE MAC flow for subscriber " << imsi;
     }
+
+    handle_session_init_subscriber_quota_state(imsi, *session_state);
+  }
+
+  auto it = session_map_.find(imsi);
+  if (it == session_map_.end()) {
+    // First time a session is created for IMSI
+    MLOG(MDEBUG) << "First session for IMSI " << imsi
+                 << " with session ID " << session_id;
+    session_map_[imsi] = std::vector<std::unique_ptr<SessionState>>();
+  }
+  session_map_[imsi].push_back(
+    std::move(std::unique_ptr<SessionState>(session_state)));
+  return rule_update_success;
+}
+
+void LocalEnforcer::handle_session_init_subscriber_quota_state(
+  const std::string& imsi,
+  SessionState& session_state)
+{
+  auto ue_mac_addr = session_state.get_mac_addr();
+  if (session_state.active_monitored_rules_exist()) {
     MLOG(MDEBUG) << "Setting subscriber quota state as VALID "
-                 << "for subscriber " << imsi;
-    session_state->set_monitoring_quota_state(
+             << "for subscriber " << imsi;
+    session_state.set_subscriber_quota_state(
       SubscriberQuotaUpdate_Type_VALID_QUOTA);
     report_subscriber_state_to_pipelined(
       imsi, ue_mac_addr, SubscriberQuotaUpdate_Type_VALID_QUOTA);
+    return;
   }
-  return rule_update_success;
+  MLOG(MDEBUG) << "No monitoring rules are installed, setting subscriber "
+               << "quota state as NO_QUOTA for subscriber " << imsi;
+  session_state.set_subscriber_quota_state(
+    SubscriberQuotaUpdate_Type_NO_QUOTA);
+  report_subscriber_state_to_pipelined(
+    imsi, ue_mac_addr, SubscriberQuotaUpdate_Type_NO_QUOTA);
+
+  // Schedule a session termination for a configured number of seconds after
+  // session create
+  session_state.mark_as_awaiting_termination();
+  MLOG(MDEBUG) << "Scheduling session for subscriber " << imsi
+               << "to be terminated in "
+               << quota_exhaustion_termination_on_init_ms_ << " ms";
+  evb_->runAfterDelay(
+    [this, imsi] {
+      MLOG(MDEBUG) << "Starting termination due to quota exhaustion for"
+                   << " IMSI " << imsi;
+      auto it = session_map_.find(imsi);
+      if (it == session_map_.end()) {
+          MLOG(MDEBUG) << "Session for IMSI " << imsi << " not found";
+          return;
+      }
+      for (const auto &session : it->second) {
+        RulesToProcess rules;
+        populate_rules_from_session_to_remove(imsi, session, rules);
+        // terminate_service will properly propagate subscriber quota state
+        // as terminated
+        terminate_service(imsi, rules.static_rules, rules.dynamic_rules);
+      }
+    },
+    quota_exhaustion_termination_on_init_ms_);
 }
 
 void LocalEnforcer::report_subscriber_state_to_pipelined(
@@ -911,8 +956,6 @@ void LocalEnforcer::update_session_credits_and_rules(
   update_monitoring_credits_and_rules(response, subscribers_to_terminate);
 
   terminate_multiple_services(subscribers_to_terminate);
-  // todo update monitoring quota if all monitoring rules are gone OR
-  // subscriber is terminated
 }
 
 // terminate_subscriber (for externally triggered EndSession)
@@ -957,7 +1000,7 @@ void LocalEnforcer::terminate_subscriber(
         if (!delete_ue_mac_flow_success) {
           MLOG(MERROR) << "Failed to delete UE MAC flow for subscriber " << imsi;
         }
-        session->set_monitoring_quota_state(SubscriberQuotaUpdate_Type_TERMINATE);
+        session->set_subscriber_quota_state(SubscriberQuotaUpdate_Type_TERMINATE);
         report_subscriber_state_to_pipelined(
           imsi, session->get_mac_addr(), SubscriberQuotaUpdate_Type_TERMINATE);
       }

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -156,6 +156,8 @@ class LocalEnforcer {
    * For the matching session ID, activate and/or deactivate the specified
    * rules.
    * Afterwards, a bearer is created.
+   * If a session is CWF and out of monitoring quota, it will trigger a session
+   * terminate
    *
    * NOTE: If an empty session ID is specified, apply changes to all matching
    * sessions with the specified IMSI.
@@ -237,6 +239,8 @@ class LocalEnforcer {
    * Processes the monitoring component of UpdateSessionResponse.
    * Updates moniroting credits according to the response and updates rules
    * that are installed for this session.
+   * If a session is CWF and out of monitoring quota, it will trigger a session
+   * terminate
    */
   void update_monitoring_credits_and_rules(
     const UpdateSessionResponse& response,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -46,7 +46,8 @@ class LocalEnforcer {
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
     std::shared_ptr<SpgwServiceClient> spgw_client,
     std::shared_ptr<aaa::AAAClient> aaa_client,
-    long session_force_termination_timeout_ms);
+    long session_force_termination_timeout_ms,
+    long quota_exhaustion_termination_on_init_ms);
 
   void attachEventBase(folly::EventBase *evb);
 
@@ -193,6 +194,9 @@ class LocalEnforcer {
                      std::vector<std::unique_ptr<SessionState>>> session_map_;
   folly::EventBase* evb_;
   long session_force_termination_timeout_ms_;
+  // [CWF-ONLY] This configures how long we should wait before terminating a
+  // session after it is created without any monitoring quota
+  long quota_exhaustion_termination_on_init_ms_;
 
  private:
   /**
@@ -377,6 +381,17 @@ class LocalEnforcer {
     const std::string& imsi,
     const std::string& ue_mac_addr,
     const SubscriberQuotaUpdate_Type state);
+
+  /**
+   * [CWF-ONLY]
+   * If the session has active monitored rules attached to it, then propagate
+   * to pipelined that the subscriber has valid quota.
+   * Otherwise, mark the subscriber as out of quota to pipelined, and schedule
+   * the session to be terminated in a configured amount of time.
+   */
+  void handle_session_init_subscriber_quota_state(
+    const std::string& imsi,
+    SessionState& session_state);
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -260,10 +260,11 @@ bool SessionCredit::quota_exhausted(
 
 bool SessionCredit::should_deactivate_service()
 {
-  return credit_type_ == CreditType::CHARGING && !unlimited_quota_ &&
-    SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED &&
-    ((no_more_grant() && quota_exhausted()) ||
-      quota_exhausted(1, SessionCredit::EXTRA_QUOTA_MARGIN));
+  return credit_type_ == CreditType::CHARGING &&
+         !unlimited_quota_ &&
+         SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED &&
+         ((no_more_grant() && quota_exhausted()) ||
+           quota_exhausted(1, SessionCredit::EXTRA_QUOTA_MARGIN));
 }
 
 bool SessionCredit::validity_timer_expired()

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -155,10 +155,10 @@ void SessionState::add_used_credit(
   }
 }
 
-void SessionState::set_monitoring_quota_state(
+void SessionState::set_subscriber_quota_state(
     const magma::lte::SubscriberQuotaUpdate_Type state)
 {
-  monitoring_quota_state_ = state;
+  subscriber_quota_state_ = state;
 }
 
 bool SessionState::active_monitored_rules_exist()
@@ -237,6 +237,11 @@ void SessionState::start_termination(
 bool SessionState::can_complete_termination() const
 {
   return curr_state_ == SESSION_TERMINATING_FLOW_DELETED;
+}
+
+void SessionState::mark_as_awaiting_termination()
+{
+  curr_state_ = SESSION_TERMINATION_SCHEDULED;
 }
 
 void SessionState::complete_termination()

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -117,6 +117,12 @@ class SessionState {
     std::function<void(SessionTerminateRequest)> on_termination_callback);
 
   /**
+   * mark_as_awaiting_termination transitions the session state from
+   * SESSION_ACTIVE to SESSION_TERMINATION_SCHEDULED
+   */
+  void mark_as_awaiting_termination();
+
+  /**
    * can_complete_termination returns whether the termination for the session
    * can be completed.
    * For this to be true, start_termination needs to be called for the session,
@@ -177,7 +183,7 @@ class SessionState {
 
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 
-  void set_monitoring_quota_state(
+  void set_subscriber_quota_state(
     const magma::lte::SubscriberQuotaUpdate_Type state);
 
   bool active_monitored_rules_exist();
@@ -228,9 +234,9 @@ class SessionState {
   SessionRules session_rules_;
   SessionState::State curr_state_;
   SessionState::Config config_;
-  // Used to keep track of whether there are monitoring quotas.
+  // Used to keep track of whether the subscriber has valid quota.
   // (only used for CWF at the moment)
-  magma::lte::SubscriberQuotaUpdate_Type monitoring_quota_state_;
+  magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state_;
   magma::lte::TgppContext tgpp_context_;
   std::function<void(SessionTerminateRequest)> on_termination_callback_;
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -177,4 +177,25 @@ void create_subscriber_quota_update(
   update->set_update_type(state);
 }
 
+void create_cwf_session_create_response(
+  const std::string& imsi,
+  const std::string& monitoring_key,
+  std::vector<std::string>& static_rules,
+  CreateSessionResponse* response)
+{
+  create_monitor_update_response(
+    imsi,
+    monitoring_key,
+    MonitoringLevel::PCC_RULE_LEVEL,
+    2048,
+    response->mutable_usage_monitors()->Add());
+
+  for (auto& rule_id : static_rules) {
+    // insert into create session response
+    StaticRuleInstall rule_install;
+    rule_install.set_rule_id(rule_id);
+    response->mutable_static_rules()->Add()->CopyFrom(rule_install);
+  }
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -165,4 +165,16 @@ void create_tgpp_context(
   context->set_gy_dest_host(gy_dest_host);
 }
 
+void create_subscriber_quota_update(
+  const std::string& imsi,
+  const std::string& ue_mac_addr,
+  const SubscriberQuotaUpdate_Type state,
+  SubscriberQuotaUpdate* update)
+{
+  auto sid = update->mutable_sid();
+  sid->set_id(imsi);
+  update->set_mac_addr(ue_mac_addr);
+  update->set_update_type(state);
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <lte/protos/session_manager.grpc.pb.h>
+#include <lte/protos/pipelined.grpc.pb.h>
 
 namespace magma {
 using namespace lte;
@@ -80,4 +81,10 @@ void create_tgpp_context(
   const std::string& gx_dest_host,
   const std::string& gy_dest_host,
   TgppContext* context);
+
+void create_subscriber_quota_update(
+  const std::string& imsi,
+  const std::string& ue_mac_addr,
+  const SubscriberQuotaUpdate_Type state,
+  SubscriberQuotaUpdate* update);
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -87,4 +87,10 @@ void create_subscriber_quota_update(
   const std::string& ue_mac_addr,
   const SubscriberQuotaUpdate_Type state,
   SubscriberQuotaUpdate* update);
+
+void create_cwf_session_create_response(
+  const std::string& imsi,
+  const std::string& monitoring_key,
+  std::vector<std::string>& static_rules,
+  CreateSessionResponse* response);
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -49,7 +49,7 @@ class LocalEnforcerTest : public ::testing::Test {
     aaa_client = std::make_shared<MockAAAClient>();
     local_enforcer = std::make_unique<LocalEnforcer>(
       reporter, rule_store, pipelined_client, directoryd_client, spgw_client,
-      aaa_client, 0);
+      aaa_client, 0, 0);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
   }
@@ -160,6 +160,20 @@ MATCHER_P4(CheckSessionInfos, imsi_list, ip_address_list, static_rule_lists,
       if (infos[i].dynamic_rules[r_index].id() !=
           dynamic_rule_ids_lists[i][r_index])
         return false;
+    }
+  }
+  return true;
+}
+
+MATCHER_P2(CheckQuotaUpdateState, size, expected_states, "")
+{
+  auto updates = static_cast<const std::vector<SubscriberQuotaUpdate>>(arg);
+  if (updates.size() != size) {
+    return false;
+  }
+  for (int i = 0; i < updates.size(); i++) {
+    if (updates[i].update_type() != expected_states[i]) {
+      return false;
     }
   }
   return true;
@@ -537,9 +551,19 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling)
 
 TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling)
 {
-  CreateSessionResponse response;
+    CreateSessionResponse response;
   create_credit_update_response(
     "IMSI1", 1, true, 1024, response.mutable_credits()->Add());
+  auto monitors = response.mutable_usage_monitors();
+  auto monitor = monitors->Add();
+  create_monitor_update_response(
+    "IMSI1", "m1", MonitoringLevel::PCC_RULE_LEVEL,
+    1024, monitor);
+  StaticRuleInstall static_rule_install;
+  static_rule_install.set_rule_id("rule3");
+  response.mutable_static_rules()->Add()->CopyFrom(static_rule_install);
+
+  insert_static_rule(0, "m1", "rule3");
 
   SessionState::Config test_cwf_cfg;
   test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
@@ -1184,6 +1208,67 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing)
   test_cwf_cfg.apn = "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay";
   test_cwf_cfg.msisdn = "msisdn_test";
 
+  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+}
+
+TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota)
+{
+  insert_static_rule(1, "m1", "static_1");
+
+  SessionState::Config test_cwf_cfg;
+  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+
+  CreateSessionResponse response;
+  auto monitors = response.mutable_usage_monitors();
+  create_monitor_update_response(
+    "IMSI1",
+    "m1",
+    MonitoringLevel::PCC_RULE_LEVEL,
+    2048,
+    monitors->Add());
+
+  // No rule installs -> No monitoring quota
+  std::vector<SubscriberQuotaUpdate_Type> expected_states
+    {SubscriberQuotaUpdate_Type_NO_QUOTA};
+  EXPECT_CALL(
+    *pipelined_client,
+    update_subscriber_quota_state(
+      CheckQuotaUpdateState(1, expected_states)))
+    .Times(1)
+    .WillOnce(testing::Return(true));
+  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+}
+
+TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota)
+{
+  insert_static_rule(0, "m1", "static_1");
+
+  SessionState::Config test_cwf_cfg;
+  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+
+  CreateSessionResponse response;
+  auto monitors = response.mutable_usage_monitors();
+  auto monitor = monitors->Add();
+  create_monitor_update_response(
+    "IMSI1",
+    "m1",
+    MonitoringLevel::PCC_RULE_LEVEL,
+    2048,
+    monitor);
+
+  StaticRuleInstall static_rule_install;
+  static_rule_install.set_rule_id("static_1");
+  auto res_rules_to_install = response.mutable_static_rules()->Add();
+  res_rules_to_install->CopyFrom(static_rule_install);
+
+  std::vector<SubscriberQuotaUpdate_Type> expected_states
+    {SubscriberQuotaUpdate_Type_VALID_QUOTA};
+  EXPECT_CALL(
+    *pipelined_client,
+    update_subscriber_quota_state(
+      CheckQuotaUpdateState(1, expected_states)))
+    .Times(1)
+    .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
 }
 

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -43,6 +43,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
                 directoryd_client,
                 spgw_client,
                 aaa_client,
+                0,
                 0);
         evb = folly::EventBaseManager::get()->getEventBase();
         local_enforcer->attachEventBase(evb);

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -61,7 +61,8 @@ class SessiondTest : public ::testing::Test {
       directoryd_client,
       spgw_client,
       nullptr,
-      SESSION_TERMINATION_TIMEOUT_MS);
+      SESSION_TERMINATION_TIMEOUT_MS,
+      0);
 
     local_service =
       std::make_shared<service303::MagmaService>("sessiond", "1.0");

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -31,3 +31,8 @@ session_force_termination_timeout_ms: 5000
 
 # Set to true to enable sessiond support of carrier wifi
 support_carrier_wifi: false
+
+# CWF only
+# Number of ms before sessiond terminates a session when it is started without
+# quota.
+cwf_quota_exhaustion_termination_on_init_ms: 30000


### PR DESCRIPTION
Summary:
# Connection Steering Feature Summary
CWAG will host a flask server to indicate whether the subscriber has quota or not.

If a subscriber tries to connect without any quota, the subscriber will stay connected for 30 seconds (configurable) but without any access to data. During this time, curling the flask server  should indicate that the subscriber is out of quota.
Once the 30 seconds passes, the subscriber will get disconnected.

If a subscriber runs out of quota mid-session, the subscriber will be disconnected immediately.

# Implementation Details
Currently, the way we configure policies for the CWF case is that only WLAN rules are monitored and tracked by the PCRF. This means that whenever a CWF session no longer has monitoring rules, the subscriber is out of quota.

# What's changed in this diff
This diff implements the case where a subscriber runs out of quota mid-session. In this case, sessiond will receive a CCA-Update or a RAR with rule removals for the monitored rules. In this case we terminate the session.

Reviewed By: mpgermano

Differential Revision: D19841921

