### PR TITLE
Store tgpp_context and quota_state as part of session state

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -51,7 +51,8 @@ StoredSessionState SessionState::marshal()
   marshaled.imsi = imsi_;
   marshaled.session_id = session_id_;
   marshaled.core_session_id = core_session_id_;
-
+  marshaled.subscriber_quota_state = subscriber_quota_state_;
+  marshaled.tgpp_context = tgpp_context_;
   return marshaled;
 }
 
@@ -88,6 +89,8 @@ SessionState::Config cfg{};
   imsi_ = marshaled.imsi;
   session_id_ = marshaled.session_id;
   core_session_id_ = marshaled.core_session_id;
+  subscriber_quota_state_ = marshaled.subscriber_quota_state;
+  tgpp_context_ = marshaled.tgpp_context;
 }
 
 SessionState::SessionState(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -11,11 +11,11 @@
 #include <functional>
 
 #include <lte/protos/session_manager.grpc.pb.h>
+#include <lte/protos/pipelined.grpc.pb.h>
 
 #include "CreditKey.h"
 
 namespace magma {
-
 struct StoredQoSInfo {
   bool enabled;
   uint32_t qci;
@@ -120,6 +120,8 @@ struct StoredSessionState {
   std::string imsi;
   std::string session_id;
   std::string core_session_id;
+  magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
+  magma::lte::TgppContext tgpp_context;
 };
 
 }; // namespace magma


### PR DESCRIPTION
Summary: These recently added fields in session state should be stored as well.

Reviewed By: koolzz

Differential Revision: D19905948

