### PR TITLE
marshal/unmarshal for SessionState uses request_number

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -53,13 +53,15 @@ StoredSessionState SessionState::marshal()
   marshaled.core_session_id = core_session_id_;
   marshaled.subscriber_quota_state = subscriber_quota_state_;
   marshaled.tgpp_context = tgpp_context_;
+  marshaled.request_number = request_number_;
+
   return marshaled;
 }
 
 SessionState::SessionState(
   const StoredSessionState &marshaled,
   StaticRuleStore &rule_store):
-  request_number_(2),
+  request_number_(marshaled.request_number),
   curr_state_(SESSION_ACTIVE),
   session_rules_(marshaled.rules, rule_store),
   charging_pool_(std::move(*ChargingCreditPool::unmarshal(marshaled.charging_pool))),

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -122,6 +122,7 @@ struct StoredSessionState {
   std::string core_session_id;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
   magma::lte::TgppContext tgpp_context;
+  uint32_t request_number;
 };
 
 }; // namespace magma


### PR DESCRIPTION
Summary: Required for SessionStore to work in a later diff.

Reviewed By: themarwhal

Differential Revision: D19963898

