### PR TITLE
Add StoreClient interface for marshaling & serializing into storage

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -114,6 +114,9 @@ add_library(SESSION_MANAGER
     SessionStore.h
     MemorySessionStore.cpp
     MemorySessionStore.h
+    MemoryStoreClient.cpp
+    MemoryStoreClient.h
+    StoreClient.h
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )

--- a/lte/gateway/c/session_manager/MemoryStoreClient.cpp
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.cpp
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "SessionState.h"
+#include "MemoryStoreClient.h"
+#include "magma_logging.h"
+
+namespace magma {
+namespace lte {
+
+MemoryStoreClient::MemoryStoreClient(
+  std::shared_ptr<StaticRuleStore> rule_store):
+  session_map_({}),
+  rule_store_(rule_store) {}
+
+SessionMap MemoryStoreClient::read_sessions(std::vector<std::string> subscriber_ids)
+{
+  auto session_map = SessionMap{};
+  for (const auto& subscriber_id : subscriber_ids) {
+    auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+    if (session_map_.find(subscriber_id) != session_map_.end()) {
+      for (auto& stored_session : session_map_[subscriber_id]) {
+        auto session = SessionState::unmarshal(stored_session, *rule_store_);
+        sessions.push_back(std::move(session));
+      }
+    }
+    session_map[subscriber_id] = std::move(sessions);
+  }
+  return session_map;
+}
+
+bool MemoryStoreClient::write_sessions(SessionMap session_map)
+{
+  for (auto& it : session_map) {
+    auto sessions = std::vector<StoredSessionState>{};
+    for (auto const& session : it.second) {
+      auto stored_session = session->marshal();
+      sessions.push_back(stored_session);
+    }
+    session_map_[it.first] = std::move(sessions);
+  }
+  return true;
+}
+
+} // namespace lte
+} // namespace magma

--- a/lte/gateway/c/session_manager/MemoryStoreClient.h
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.h
@@ -1,0 +1,43 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include <memory>
+
+#include <lte/protos/session_manager.grpc.pb.h>
+
+#include "StoreClient.h"
+#include "StoredState.h"
+
+namespace magma {
+namespace lte {
+
+/**
+ * Non-persistent StoreClient used as intermediate stage in development
+ */
+class MemoryStoreClient final : public StoreClient {
+ public:
+  MemoryStoreClient(std::shared_ptr<StaticRuleStore> rule_store);
+  MemoryStoreClient(MemoryStoreClient const&) = delete;
+  MemoryStoreClient(MemoryStoreClient&&) = default;
+
+  SessionMap read_sessions(std::vector<std::string> subscriber_ids);
+
+  bool write_sessions(SessionMap session_map);
+
+ private:
+  ~MemoryStoreClient() = default;
+
+ private:
+  std::unordered_map<std::string, std::vector<StoredSessionState>> session_map_;
+  std::shared_ptr<StaticRuleStore> rule_store_;
+};
+
+} // namespace lte
+} // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -53,13 +53,15 @@ StoredSessionState SessionState::marshal()
   marshaled.core_session_id = core_session_id_;
   marshaled.subscriber_quota_state = subscriber_quota_state_;
   marshaled.tgpp_context = tgpp_context_;
+  marshaled.request_number = request_number_;
+
   return marshaled;
 }
 
 SessionState::SessionState(
   const StoredSessionState &marshaled,
   StaticRuleStore &rule_store):
-  request_number_(2),
+  request_number_(marshaled.request_number),
   curr_state_(SESSION_ACTIVE),
   session_rules_(marshaled.rules, rule_store),
   charging_pool_(std::move(*ChargingCreditPool::unmarshal(marshaled.charging_pool))),

--- a/lte/gateway/c/session_manager/StoreClient.h
+++ b/lte/gateway/c/session_manager/StoreClient.h
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include <memory>
+
+#include <lte/protos/session_manager.grpc.pb.h>
+
+#include "SessionState.h"
+
+namespace magma {
+namespace lte {
+
+typedef std::unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>> SessionMap;
+
+/**
+ * StoreClient is responsible for reading/writing sessions to/from storage.
+ */
+class StoreClient {
+ public:
+  /**
+   * Directly read the subscriber's sessions from storage
+   *
+   * If one or more of the subscribers have no sessions, empty entries will be
+   * returned.
+   * @param subscriber_ids typically in IMSI
+   * @return All sessions for the subscribers
+   */
+  virtual SessionMap read_sessions(std::vector<std::string> subscriber_ids) = 0;
+
+  /**
+   * Directly write the subscriber sessions into storage, overwriting previous
+   * values.
+   *
+   * @param sessions Sessions to write into storage
+   * @return True if writes have completed successfully for all sessions.
+   */
+  virtual bool write_sessions(SessionMap sessions) = 0;
+};
+
+} // namespace lte
+} // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -125,4 +125,25 @@ struct StoredSessionState {
   uint32_t request_number;
 };
 
+// Update Criteria
+
+struct SessionCreditUpdateCriteria {
+  bool reporting;
+  bool is_final;
+  ReAuthState reauth_state;
+  ServiceState service_state;
+  std::time_t  expiry_time;
+  std::unordered_map<Bucket, uint64_t> bucket_deltas;
+};
+
+struct SessionStateUpdateCriteria {
+  std::vector<std::string> static_rules_to_install;
+  std::vector<std::string> static_rules_to_uninstall;
+  std::vector<PolicyRule> dynamic_rules_to_install;
+  std::vector<std::string> dynamic_rules_to_uninstall;
+  std::unordered_map<
+    CreditKey, SessionCreditUpdateCriteria,
+    decltype(&ccHash), decltype(&ccEqual)> charging_credit_map;
+  std::unordered_map<std::string, SessionCreditUpdateCriteria> monitor_credit_map;
+};
 }; // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -122,6 +122,7 @@ struct StoredSessionState {
   std::string core_session_id;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
   magma::lte::TgppContext tgpp_context;
+  uint32_t request_number;
 };
 
 }; // namespace magma

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
 foreach(session_test session_credit local_enforcer cloud_reporter async_service
         session_manager_handler sessiond_integ session_state session_rules
-        credit_pool session_store)
+        credit_pool session_store store_client)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <memory>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "RuleStore.h"
+#include "SessionID.h"
+#include "SessionState.h"
+#include "MemoryStoreClient.h"
+#include "magma_logging.h"
+
+using ::testing::Test;
+
+namespace magma {
+
+class StoreClientTest : public ::testing::Test {
+ protected:
+  SessionIDGenerator id_gen_;
+};
+
+/**
+ * End to end test of the MemoryStoreClient.
+ * 1) Create MemoryStoreClient
+ * 2) Read in sessions for subscribers IMSI1 and IMSI2
+ * 3) Create bare-bones session for IMSI1 and IMSI2
+ * 4) Write and commit session state for IMSI1 and IMSI2
+ * 5) Read for subscribers IMSI1 and IMSI2
+ * 6) Verify that state was written for IMSI1/IMSI2 and has been retrieved.
+ */
+TEST_F(StoreClientTest, test_read_and_write)
+{
+  std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
+  std::string imsi = "IMSI1";
+  std::string imsi2 = "IMSI2";
+  std::string msisdn = "5100001234";
+  std::string radius_session_id =
+    "AA-AA-AA-AA-AA-AA:TESTAP__"
+    "0F-10-2E-12-3A-55";
+  auto sid = id_gen_.gen_session_id(imsi);
+  auto sid2 = id_gen_.gen_session_id(imsi2);
+  std::string core_session_id = "asdf";
+  SessionState::Config cfg = {.ue_ipv4 = "",
+    .spgw_ipv4 = "",
+    .msisdn = msisdn,
+    .apn = "",
+    .imei = "",
+    .plmn_id = "",
+    .imsi_plmn_id = "",
+    .user_location = "",
+    .rat_type = RATType::TGPP_WLAN,
+    .mac_addr = "0f:10:2e:12:3a:55",
+    .hardware_addr = hardware_addr_bytes,
+    .radius_session_id = radius_session_id};
+  auto rule_store = std::make_shared<StaticRuleStore>();
+  auto tgpp_context = TgppContext{};
+
+  auto store_client = new MemoryStoreClient(rule_store);
+
+  // Emulate CreateSession, which needs to create a new session for a subscriber
+  std::vector<std::string> requested_ids{imsi, imsi2};
+  auto session_map = store_client->read_sessions(requested_ids);
+
+  auto session = std::make_unique<SessionState>(imsi, sid, core_session_id, cfg, *rule_store, tgpp_context);
+  auto session2 = std::make_unique<SessionState>(imsi2, sid2, core_session_id, cfg, *rule_store, tgpp_context);
+  EXPECT_EQ(session->get_session_id(), sid);
+  EXPECT_EQ(session2->get_session_id(), sid2);
+
+  EXPECT_EQ(session_map.size(), 2);
+  EXPECT_EQ(session_map[imsi].size(), 0);
+  session_map[imsi].push_back(std::move(session));
+  EXPECT_EQ(session_map[imsi].size(), 1);
+
+  // Since the grant was not given with R/W permission for subscriber IMSI2,
+  // The session for IMSI2 should not be saved into the store
+  session_map[imsi2] = std::vector<std::unique_ptr<SessionState>>();
+  session_map[imsi2].push_back(std::move(session2));
+  EXPECT_EQ(session_map.size(), 2);
+  EXPECT_EQ(session_map[imsi2].size(), 1);
+
+  // And now commit back to storage (memory actually, but later persistent)
+  store_client->write_sessions(std::move(session_map));
+
+  // Try to do a read to make sure that things are the same
+  auto session_map_2 = store_client->read_sessions(requested_ids);
+  EXPECT_EQ(session_map_2.size(), 2);
+  EXPECT_EQ(session_map_2[imsi].size(), 1);
+  EXPECT_EQ(session_map_2[imsi].front()->get_session_id(), sid);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+} // namespace magma


### PR DESCRIPTION
Summary:
## Changes
- Addition of StoreClient for abstracting away storage of sessiond state
- Addition of MemoryStoreClient to be used during development to verify that things work before switching to use of Redis

Reviewed By: xjtian

Differential Revision: D19963896

