### PR TITLE
Remove v0 metricsd handlers

### DIFF
--- a/orc8r/cloud/go/services/metricsd/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/metricsd/obsidian/handlers/handlers.go
@@ -35,9 +35,6 @@ func GetObsidianHandlers(configMap *config.ConfigMap) []obsidian.Handler {
 	client, err := promAPI.NewClient(promAPI.Config{Address: configMap.GetRequiredStringParam(confignames.PrometheusQueryAddress)})
 	if err != nil {
 		ret = append(ret,
-			obsidian.Handler{Path: promH.QueryURL, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-			obsidian.Handler{Path: promH.QueryRangeURL, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
-
 			// V1
 			obsidian.Handler{Path: promH.QueryV1URL, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
 			obsidian.Handler{Path: promH.QueryRangeV1URL, Methods: obsidian.GET, HandlerFunc: getInitErrorHandler(err)},
@@ -50,9 +47,6 @@ func GetObsidianHandlers(configMap *config.ConfigMap) []obsidian.Handler {
 	} else {
 		pAPI := v1.NewAPI(client)
 		ret = append(ret,
-			obsidian.Handler{Path: promH.QueryURL, Methods: obsidian.GET, HandlerFunc: promH.GetPrometheusQueryHandler(pAPI)},
-			obsidian.Handler{Path: promH.QueryRangeURL, Methods: obsidian.GET, HandlerFunc: promH.GetPrometheusQueryRangeHandler(pAPI)},
-
 			// V1
 			obsidian.Handler{Path: promH.QueryV1URL, Methods: obsidian.GET, HandlerFunc: promH.GetPrometheusQueryHandler(pAPI)},
 			obsidian.Handler{Path: promH.QueryRangeV1URL, Methods: obsidian.GET, HandlerFunc: promH.GetPrometheusQueryRangeHandler(pAPI)},
@@ -67,22 +61,6 @@ func GetObsidianHandlers(configMap *config.ConfigMap) []obsidian.Handler {
 	alertmanagerConfigServiceURL := configMap.GetRequiredStringParam(confignames.AlertmanagerConfigServiceURL)
 	prometheusConfigServiceURL := configMap.GetRequiredStringParam(confignames.PrometheusConfigServiceURL)
 	alertmanagerURL := configMap.GetRequiredStringParam(confignames.AlertmanagerApiURL)
-	ret = append(ret,
-		obsidian.Handler{Path: promH.AlertConfigURL, Methods: obsidian.POST, HandlerFunc: promH.GetConfigurePrometheusAlertHandler(prometheusConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertConfigURL, Methods: obsidian.GET, HandlerFunc: promH.GetRetrieveAlertRuleHandler(prometheusConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertConfigURL, Methods: obsidian.DELETE, HandlerFunc: promH.GetDeleteAlertRuleHandler(prometheusConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertUpdateURL, Methods: obsidian.PUT, HandlerFunc: promH.GetUpdateAlertRuleHandler(prometheusConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertBulkUpdateURL, Methods: obsidian.PUT, HandlerFunc: promH.GetBulkUpdateAlertHandler(prometheusConfigServiceURL)},
-
-		obsidian.Handler{Path: promH.FiringAlertURL, Methods: obsidian.GET, HandlerFunc: promH.GetViewFiringAlertHandler(alertmanagerURL)},
-		obsidian.Handler{Path: promH.AlertReceiverConfigURL, Methods: obsidian.POST, HandlerFunc: promH.GetConfigureAlertReceiverHandler(alertmanagerConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertReceiverConfigURL, Methods: obsidian.GET, HandlerFunc: promH.GetRetrieveAlertReceiverHandler(alertmanagerConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertReceiverConfigURL, Methods: obsidian.DELETE, HandlerFunc: promH.GetDeleteAlertReceiverHandler(alertmanagerConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertReceiverUpdateURL, Methods: obsidian.PUT, HandlerFunc: promH.GetUpdateAlertReceiverHandler(alertmanagerConfigServiceURL)},
-
-		obsidian.Handler{Path: promH.AlertReceiverConfigURL + "/route", Methods: obsidian.GET, HandlerFunc: promH.GetRetrieveAlertRouteHandler(alertmanagerConfigServiceURL)},
-		obsidian.Handler{Path: promH.AlertReceiverConfigURL + "/route", Methods: obsidian.POST, HandlerFunc: promH.GetUpdateAlertRouteHandler(alertmanagerConfigServiceURL)},
-	)
 
 	// V1
 	ret = append(ret,

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/alert_config_handler.go
@@ -32,19 +32,12 @@ const (
 	AlertNameQueryParam = "alert_name"
 	AlertNamePathParam  = "alert_name"
 
-	AlertConfigURL         = PrometheusRoot + obsidian.UrlSep + alertConfigPart
-	AlertUpdateURL         = AlertConfigURL + obsidian.UrlSep + ":" + AlertNamePathParam
-	AlertReceiverConfigURL = PrometheusRoot + obsidian.UrlSep + alertReceiverPart
-	AlertReceiverUpdateURL = AlertReceiverConfigURL + obsidian.UrlSep + ":" + ReceiverNamePathParam
-	AlertBulkUpdateURL     = AlertConfigURL + "/bulk"
-
 	AlertConfigV1URL         = PrometheusV1Root + obsidian.UrlSep + alertConfigPart
 	AlertUpdateV1URL         = AlertConfigV1URL + obsidian.UrlSep + ":" + AlertNamePathParam
 	AlertReceiverConfigV1URL = PrometheusV1Root + obsidian.UrlSep + alertReceiverPart
 	AlertReceiverUpdateV1URL = AlertReceiverConfigV1URL + obsidian.UrlSep + ":" + ReceiverNamePathParam
 	AlertBulkUpdateV1URL     = AlertConfigV1URL + "/bulk"
 
-	FiringAlertURL   = obsidian.NetworksRoot + obsidian.UrlSep + ":network_id" + obsidian.UrlSep + "alerts"
 	FiringAlertV1URL = handlers.ManageNetworkPath + obsidian.UrlSep + "alerts"
 
 	AlertSilencerV1URL = FiringAlertV1URL + obsidian.UrlSep + "silence"

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -35,11 +35,7 @@ const (
 	seriesPart     = "series"
 	paramMatch     = "match"
 
-	PrometheusRoot   = obsidian.NetworksRoot + obsidian.UrlSep + ":network_id" + obsidian.UrlSep + "prometheus"
 	PrometheusV1Root = handlers.ManageNetworkPath + obsidian.UrlSep + "prometheus"
-
-	QueryURL      = PrometheusRoot + obsidian.UrlSep + queryPart
-	QueryRangeURL = PrometheusRoot + obsidian.UrlSep + queryRangePart
 
 	QueryV1URL      = PrometheusV1Root + obsidian.UrlSep + queryPart
 	QueryRangeV1URL = PrometheusV1Root + obsidian.UrlSep + queryRangePart


### PR DESCRIPTION
Summary: v0 paths are not used anymore, so we can safely remove them.

Differential Revision: D20004915

