### PR TITLE
Use public NTP server for eventd

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_eventd.service
@@ -10,7 +10,7 @@ Description=Magma eventd service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStartPre=/usr/sbin/ntpdate 1.ntp.vip.facebook.com
+ExecStartPre=/usr/sbin/ntpdate pool.ntp.org
 ExecStart=/usr/bin/env python3 -m magma.eventd.main
 ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py eventd
 StandardOutput=syslog


### PR DESCRIPTION
Summary:
- The FB NTP server is not accessible on external networks
- This uses pool.ntp.org, which will get the closest NTP server and sync the time
- Fixes #1230

Reviewed By: andreilee

Differential Revision: D20006251

