### PR TITLE
Clean up Mock-PCRF

### DIFF
--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -26,6 +26,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf h1:eg0MeVzsP1G42dRafH3vf+al2vQIJU0YHX+1Tw87oco=
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v0.0.0-20180507225419-00862f899353/go.mod h1:ZRmQr0FajVIyZ4ZzBYKG5P3ZqPz9IHG41ZoMu1ADI3k=
 github.com/aws/aws-sdk-go v1.19.6/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
@@ -76,6 +77,7 @@ github.com/facebookgo/clock v0.0.0-20150410010913-600d898af40a/go.mod h1:7Ga40eg
 github.com/facebookincubator/ent v0.0.0-20191128071424-29c7b0a0d805 h1:Gqrw3IfjWQ1afKMX8OuKq3vTnjhccK0Apllv8qrLdfI=
 github.com/facebookincubator/ent v0.0.0-20191128071424-29c7b0a0d805/go.mod h1:3CGvz1m+D78JUti7JFkY6AkKj88McWuT80UcamLqEJQ=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fiorix/go-diameter/v4 v4.0.1-0.20200120193412-55a1c21738f9 h1:6UPuzuDfCBakYddEJ5FslPAHxC+wdXUjK7JgcZw0i8o=
 github.com/fiorix/go-diameter/v4 v4.0.1-0.20200120193412-55a1c21738f9/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -99,6 +101,7 @@ github.com/go-openapi/errors v0.17.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQH
 github.com/go-openapi/errors v0.17.2/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
 github.com/go-openapi/errors v0.18.0 h1:+RnmJ5MQccF7jwWAoMzwOpzJEspZ18ZIWfg9Z2eiXq8=
 github.com/go-openapi/errors v0.18.0/go.mod h1:LcZQpmvG4wyF5j4IhA73wkLFQg+QJXOQHVjmcZxhka0=
+github.com/go-openapi/errors v0.19.2 h1:a2kIyV3w+OS3S97zxUndRVD46+FhGOUBDFY7nmu4CsY=
 github.com/go-openapi/errors v0.19.2/go.mod h1:qX0BLWsyaKfvhluLejVpVNwNRdXZhEbTA4kxxpKBC94=
 github.com/go-openapi/inflect v0.18.0/go.mod h1:lHpZVlpIQqLyKwJ4N+YSc9hchQy/i12fJykb83CRBH4=
 github.com/go-openapi/jsonpointer v0.17.0/go.mod h1:cOnomiV+CVVwFLk0A/MExoFMjwdsUdVpsRhURCKh+3M=
@@ -124,6 +127,7 @@ github.com/go-openapi/strfmt v0.17.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pL
 github.com/go-openapi/strfmt v0.17.2/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
 github.com/go-openapi/strfmt v0.18.0 h1:FqqmmVCKn3di+ilU/+1m957T1CnMz3IteVUcV3aGXWA=
 github.com/go-openapi/strfmt v0.18.0/go.mod h1:P82hnJI0CXkErkXi8IKjPbNBM6lV6+5pLP5l494TcyU=
+github.com/go-openapi/strfmt v0.19.4 h1:eRvaqAhpL0IL6Trh5fDsGnGhiXndzHFuA05w6sXH6/g=
 github.com/go-openapi/strfmt v0.19.4/go.mod h1:eftuHTlB/dI8Uq8JJOyRlieZf+WkkxUuk0dgdHXr2Qk=
 github.com/go-openapi/swag v0.17.0/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
 github.com/go-openapi/swag v0.17.2/go.mod h1:AByQ+nYG6gQg71GINrmuDXCPWdL640yX49/kXLo40Tg=
@@ -138,6 +142,7 @@ github.com/go-redis/redis v6.15.5+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8w
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1-0.20190510102335-877a9775f068 h1:q2kwd9Bcgl2QpSi/Wjcx9jzwyICt3EWTP5to43QhwaA=
 github.com/go-sql-driver/mysql v1.4.1-0.20190510102335-877a9775f068/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-swagger/go-swagger v0.18.0/go.mod h1:fOcXeMI1KPNv3uk4u7cR4VSyq0NyrYx4SS1/ajuTWDg=
 github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013/go.mod h1:b65mBPzqzZWxOZGxSWrqs4GInLIn+u99Q9q7p+GKni0=
@@ -205,6 +210,7 @@ github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKe
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v0.0.0-20170331210902-15e594fc09f1/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
+github.com/ishidawataru/sctp v0.0.0-20190922091402-408ec287e38c h1:PwVcPU2rqkJIG0Lz/UGbGcbfi/HhEbOIId+w4xkbGHQ=
 github.com/ishidawataru/sctp v0.0.0-20190922091402-408ec287e38c/go.mod h1:co9pwDoBCm1kGxawmb4sPq0cSIOOWNPT4KnHotMP1Zg=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
@@ -377,6 +383,7 @@ github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/gopher-lua v0.0.0-20190514113301-1cd887cd7036/go.mod h1:gqRgreBUhTSL0GeU64rtZ3Uq3wtjOa/TB2YfrtkCbVQ=
+go.mongodb.org/mongo-driver v1.0.3 h1:GKoji1ld3tw2aC+GX1wbr/J2fX13yNacEYoJ8Nhr0yU=
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package mock_pcrf
+
+import (
+	"errors"
+	"fmt"
+
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/services/session_proxy/credit_control"
+	"magma/feg/gateway/services/session_proxy/credit_control/gx"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/golang/glog"
+)
+
+type ccrMessage struct {
+	SessionID        datatype.UTF8String       `avp:"Session-Id"`
+	OriginHost       datatype.DiameterIdentity `avp:"Origin-Host"`
+	OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
+	DestinationRealm datatype.DiameterIdentity `avp:"Destination-Realm"`
+	DestinationHost  datatype.DiameterIdentity `avp:"Destination-Host"`
+	RequestType      datatype.Enumerated       `avp:"CC-Request-Type"`
+	RequestNumber    datatype.Unsigned32       `avp:"CC-Request-Number"`
+	SubscriptionIDs  []*subscriptionIDDiam     `avp:"Subscription-Id"`
+	IPAddr           datatype.OctetString      `avp:"Framed-IP-Address"`
+	UsageMonitors    []*usageMonitorRequestAVP `avp:"Usage-Monitoring-Information"`
+}
+
+type subscriptionIDDiam struct {
+	IDType credit_control.SubscriptionIDType `avp:"Subscription-Id-Type"`
+	IDData string                            `avp:"Subscription-Id-Data"`
+}
+
+type usageMonitorRequestAVP struct {
+	MonitoringKey   string             `avp:"Monitoring-Key"`
+	UsedServiceUnit usedServiceUnitAVP `avp:"Used-Service-Unit"`
+	Level           gx.MonitoringLevel `avp:"Usage-Monitoring-Level"`
+}
+
+type usedServiceUnitAVP struct {
+	InputOctets  uint64 `avp:"CC-Input-Octets"`
+	OutputOctets uint64 `avp:"CC-Output-Octets"`
+	TotalOctets  uint64 `avp:"CC-Total-Octets"`
+}
+
+// getCCRHandler returns a handler to be called when the server receives a CCR
+func getCCRHandler(srv *PCRFDiamServer) diam.HandlerFunc {
+	return func(c diam.Conn, m *diam.Message) {
+		glog.V(2).Infof("Received CCR from %s\n", c.RemoteAddr())
+		var ccr ccrMessage
+		if err := m.Unmarshal(&ccr); err != nil {
+			glog.Errorf("Failed to unmarshal CCR %s", err)
+			return
+		}
+		imsi, err := getIMSI(ccr)
+		if err != nil {
+			glog.Errorf("Could not parse CCR: %s", err.Error())
+			sendAnswer(ccr, c, m, diam.AuthenticationRejected)
+			return
+		}
+		account, found := srv.subscribers[imsi]
+		if !found {
+			glog.Error("IMSI not found in subscribers")
+			sendAnswer(ccr, c, m, diam.AuthenticationRejected)
+			return
+		}
+
+		avps := []*diam.AVP{}
+		if credit_control.CreditRequestType(ccr.RequestType) == credit_control.CRTInit {
+			// Install all rules attached to the subscriber for the initial answer
+			ruleInstalls := toRuleInstallAVPs(account.RuleNames, account.RuleBaseNames, account.RuleDefinitions)
+			// Install all monitors attached to the subscriber for the initial answer
+			usageMonitors := toUsageMonitoringInfoAVPs(account.UsageMonitors)
+			avps = append(ruleInstalls, usageMonitors...)
+		} else {
+			// Update the subscriber state with the usage updates in CCR-U/T
+			creditByMkey, err := updateSubscriberAccountWithUsageUpdates(account, ccr.UsageMonitors)
+			if err != nil {
+				glog.Errorf("Failed to update quota: %v", err)
+			}
+			avps = toUsageMonitoringInfoAVPs(creditByMkey)
+		}
+		sendAnswer(ccr, c, m, diam.Success, avps...)
+	}
+}
+
+// sendAnswer sends a CCA to the connection given
+func sendAnswer(
+	ccr ccrMessage,
+	conn diam.Conn,
+	message *diam.Message,
+	statusCode uint32,
+	additionalAVPs ...*diam.AVP,
+) {
+	a := message.Answer(statusCode)
+	a.NewAVP(avp.OriginHost, avp.Mbit, 0, ccr.DestinationHost)
+	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, ccr.DestinationRealm)
+	a.NewAVP(avp.DestinationRealm, avp.Mbit, 0, ccr.OriginRealm)
+	a.NewAVP(avp.DestinationHost, avp.Mbit, 0, ccr.OriginHost)
+	a.NewAVP(avp.CCRequestType, avp.Mbit, 0, ccr.RequestType)
+	a.NewAVP(avp.CCRequestNumber, avp.Mbit, 0, ccr.RequestNumber)
+	for _, avp := range additionalAVPs {
+		a.InsertAVP(avp)
+	}
+	// SessionID must be the first AVP
+	a.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, ccr.SessionID))
+
+	_, err := a.WriteTo(conn)
+	if err != nil {
+		glog.V(2).Infof("Failed to write message to %s: %s\n%s\n",
+			conn.RemoteAddr(), err, a)
+		return
+	}
+	glog.V(2).Infof("Sent CCA to %s:\n", conn.RemoteAddr())
+}
+
+func getIMSI(message ccrMessage) (string, error) {
+	for _, subID := range message.SubscriptionIDs {
+		if subID.IDType == credit_control.EndUserIMSI {
+			return subID.IDData, nil
+		}
+	}
+	return "", errors.New("Could not obtain IMSI from CCR message")
+}
+
+func updateSubscriberAccountWithUsageUpdates(account *subscriberAccount, monitorUpdates []*usageMonitorRequestAVP) (creditByMkey, error) {
+	credits := make(creditByMkey, len(monitorUpdates))
+	for _, update := range monitorUpdates {
+		monitorCredit, ok := account.UsageMonitors[update.MonitoringKey]
+		if !ok {
+			return credits, fmt.Errorf("Unknown monitoring key %s", update.MonitoringKey)
+		}
+		monitorCredit.Volume -= update.UsedServiceUnit.TotalOctets
+		if monitorCredit.Volume < 0 {
+			monitorCredit.Volume = 0
+		}
+		credits[update.MonitoringKey] = monitorCredit
+	}
+	return credits, nil
+}
+
+func getQuotaGrant(monitorCredit *protos.UsageMonitorCredit) uint64 {
+	// get the min of return bytes or the total volume
+	if monitorCredit.ReturnBytes > monitorCredit.Volume {
+		return monitorCredit.Volume
+	}
+	return monitorCredit.ReturnBytes
+}

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/conversions.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/conversions.go
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package mock_pcrf
+
+import (
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/diameter"
+	lteprotos "magma/lte/cloud/go/protos"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+)
+
+func toStaticRuleNameInstallAVP(ruleName string) *diam.AVP {
+	return diam.NewAVP(avp.ChargingRuleInstall, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.ChargingRuleName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(ruleName)),
+		},
+	})
+}
+
+func toStaticBaseNameInstallAVP(baseName string) *diam.AVP {
+	return diam.NewAVP(avp.ChargingRuleInstall, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.ChargingRuleBaseName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.UTF8String(baseName)),
+		},
+	})
+}
+
+func toDynamicRuleInstallAVP(rule *protos.RuleDefinition) *diam.AVP {
+	installAVPs := []*diam.AVP{
+		diam.NewAVP(avp.ChargingRuleName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(rule.RuleName)),
+		diam.NewAVP(avp.Precedence, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(rule.Precedence)),
+	}
+	if rule.RatingGroup != 0 {
+		installAVPs = append(installAVPs, diam.NewAVP(avp.RatingGroup, avp.Mbit, 0, datatype.Unsigned32(rule.RatingGroup)))
+	}
+	if rule.MonitoringKey != "" {
+		installAVPs = append(
+			installAVPs,
+			diam.NewAVP(avp.MonitoringKey, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(rule.MonitoringKey)),
+		)
+	}
+	if rule.QosInformation != nil && (rule.QosInformation.MaxReqBwUl != 0 || rule.QosInformation.MaxReqBwDl != 0) {
+		installAVPs = append(installAVPs, toQosAVP(rule.QosInformation))
+	}
+	for _, flowDescription := range rule.FlowDescriptions {
+		installAVPs = append(
+			installAVPs,
+			diam.NewAVP(avp.FlowDescription, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.IPFilterRule(flowDescription)),
+		)
+	}
+	if rule.RedirectInformation != nil {
+		installAVPs = append(
+			installAVPs,
+			diam.NewAVP(avp.RedirectInformation, avp.Mbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+				AVP: toRedirectionAVP(rule.RedirectInformation),
+			}),
+		)
+	}
+	return diam.NewAVP(avp.ChargingRuleInstall, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.ChargingRuleDefinition, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+				AVP: installAVPs,
+			}),
+		},
+	})
+}
+
+func toQosAVP(qos *lteprotos.FlowQos) *diam.AVP {
+	qosAVPs := []*diam.AVP{}
+	if qos.MaxReqBwUl != 0 {
+		qosAVPs = append(
+			qosAVPs,
+			diam.NewAVP(avp.MaxRequestedBandwidthUL, avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(qos.MaxReqBwUl)),
+		)
+	}
+	if qos.MaxReqBwDl != 0 {
+		qosAVPs = append(
+			qosAVPs,
+			diam.NewAVP(avp.MaxRequestedBandwidthDL, avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(qos.MaxReqBwDl)),
+		)
+	}
+	return diam.NewAVP(avp.QoSInformation, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{AVP: qosAVPs})
+}
+
+func toRedirectionAVP(redirection *lteprotos.RedirectInformation) []*diam.AVP {
+	return []*diam.AVP{
+		diam.NewAVP(avp.RedirectSupport, avp.Mbit, diameter.Vendor3GPP, datatype.Enumerated(redirection.Support)),
+		diam.NewAVP(avp.RedirectAddressType, avp.Mbit, 0, datatype.Enumerated(redirection.AddressType)),
+		diam.NewAVP(avp.RedirectServerAddress, avp.Mbit, 0, datatype.UTF8String(redirection.ServerAddress)),
+	}
+}
+
+func toUsageMonitoringInfoAVP(monitoringKey string, quotaGrant uint64, level protos.UsageMonitorCredit_MonitoringLevel) *diam.AVP {
+	return diam.NewAVP(avp.UsageMonitoringInformation, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+		AVP: []*diam.AVP{
+			diam.NewAVP(avp.MonitoringKey, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(monitoringKey)),
+			diam.NewAVP(avp.GrantedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{
+				AVP: []*diam.AVP{
+					diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant)),
+				},
+			}),
+			diam.NewAVP(avp.UsageMonitoringLevel, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Enumerated(level)),
+		},
+	})
+}
+
+func toRuleInstallAVPs(
+	ruleNames []string,
+	ruleBaseNames []string,
+	ruleDefs []*protos.RuleDefinition,
+) []*diam.AVP {
+	avps := make([]*diam.AVP, 0, len(ruleNames)+len(ruleBaseNames)+len(ruleDefs))
+	for _, ruleName := range ruleNames {
+		avps = append(avps, toStaticRuleNameInstallAVP(ruleName))
+	}
+
+	for _, baseName := range ruleBaseNames {
+		avps = append(avps, toStaticBaseNameInstallAVP(baseName))
+	}
+
+	for _, rule := range ruleDefs {
+		avps = append(avps, toDynamicRuleInstallAVP(rule))
+	}
+	return avps
+}
+
+func toUsageMonitoringInfoAVPs(monitors map[string]*protos.UsageMonitorCredit) []*diam.AVP {
+	avps := make([]*diam.AVP, 0, len(monitors))
+	for key, monitor := range monitors {
+		avps = append(avps, toUsageMonitoringInfoAVP(key, getQuotaGrant(monitor), monitor.MonitoringLevel))
+	}
+	return avps
+}

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -17,13 +17,10 @@ import (
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
-	"magma/feg/gateway/services/session_proxy/credit_control"
-	"magma/feg/gateway/services/session_proxy/credit_control/gx"
 	lteprotos "magma/lte/cloud/go/protos"
 	orcprotos "magma/orc8r/lib/go/protos"
 
 	"github.com/fiorix/go-diameter/v4/diam"
-	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/golang/glog"
@@ -35,11 +32,13 @@ type PCRFConfig struct {
 	ServerConfig *diameter.DiameterServerConfig
 }
 
+type creditByMkey map[string]*protos.UsageMonitorCredit
+
 type subscriberAccount struct {
 	RuleNames       []string
 	RuleBaseNames   []string
 	RuleDefinitions []*protos.RuleDefinition
-	UsageMonitors   map[string]*protos.UsageMonitorCredit
+	UsageMonitors   creditByMkey
 }
 
 // PCRFDiamServer wraps an PCRF storing subscribers and their rules
@@ -47,36 +46,6 @@ type PCRFDiamServer struct {
 	diameterSettings *diameter.DiameterClientConfig
 	pcrfConfig       *PCRFConfig
 	subscribers      map[string]*subscriberAccount // map of imsi to to rules
-}
-
-type ccrMessage struct {
-	SessionID        datatype.UTF8String       `avp:"Session-Id"`
-	OriginHost       datatype.DiameterIdentity `avp:"Origin-Host"`
-	OriginRealm      datatype.DiameterIdentity `avp:"Origin-Realm"`
-	DestinationRealm datatype.DiameterIdentity `avp:"Destination-Realm"`
-	DestinationHost  datatype.DiameterIdentity `avp:"Destination-Host"`
-	RequestType      datatype.Enumerated       `avp:"CC-Request-Type"`
-	RequestNumber    datatype.Unsigned32       `avp:"CC-Request-Number"`
-	SubscriptionIDs  []*subscriptionIDDiam     `avp:"Subscription-Id"`
-	IPAddr           datatype.OctetString      `avp:"Framed-IP-Address"`
-	UsageMonitors    []*usageMonitorRequestAVP `avp:"Usage-Monitoring-Information"`
-}
-
-type subscriptionIDDiam struct {
-	IDType credit_control.SubscriptionIDType `avp:"Subscription-Id-Type"`
-	IDData string                            `avp:"Subscription-Id-Data"`
-}
-
-type usageMonitorRequestAVP struct {
-	MonitoringKey   string             `avp:"Monitoring-Key"`
-	UsedServiceUnit usedServiceUnitAVP `avp:"Used-Service-Unit"`
-	Level           gx.MonitoringLevel `avp:"Usage-Monitoring-Level"`
-}
-
-type usedServiceUnitAVP struct {
-	InputOctets  uint64 `avp:"CC-Input-Octets"`
-	OutputOctets uint64 `avp:"CC-Output-Octets"`
-	TotalOctets  uint64 `avp:"CC-Total-Octets"`
 }
 
 // NewPCRFDiamServer initializes an PCRF with an empty rule map
@@ -173,7 +142,7 @@ func (srv *PCRFDiamServer) CreateAccount(
 ) (*orcprotos.Void, error) {
 	srv.subscribers[subscriberID.Id] = &subscriberAccount{
 		RuleNames:     []string{},
-		UsageMonitors: make(map[string]*protos.UsageMonitorCredit),
+		UsageMonitors: make(creditByMkey),
 	}
 	glog.V(2).Infof("New account %s added", subscriberID.Id)
 	return &orcprotos.Void{}, nil
@@ -207,7 +176,7 @@ func (srv *PCRFDiamServer) SetUsageMonitors(
 	if !ok {
 		return nil, fmt.Errorf("Could not find imsi %s", usageMonitorInfo.Imsi)
 	}
-	account.UsageMonitors = make(map[string]*protos.UsageMonitorCredit)
+	account.UsageMonitors = make(creditByMkey)
 	for _, monitor := range usageMonitorInfo.UsageMonitorCredits {
 		account.UsageMonitors[monitor.MonitoringKey] = monitor
 	}
@@ -257,230 +226,4 @@ func (srv *PCRFDiamServer) ClearSubscribers(ctx context.Context, void *orcprotos
 	srv.subscribers = map[string]*subscriberAccount{}
 	glog.V(2).Info("All accounts deleted.")
 	return &orcprotos.Void{}, nil
-}
-
-// getCCRHandler returns a handler to be called when the server receives a CCR
-func getCCRHandler(srv *PCRFDiamServer) diam.HandlerFunc {
-	return func(c diam.Conn, m *diam.Message) {
-		glog.V(2).Infof("Received CCR from %s\n", c.RemoteAddr())
-		var ccr ccrMessage
-		if err := m.Unmarshal(&ccr); err != nil {
-			glog.Errorf("Failed to unmarshal CCR %s", err)
-			return
-		}
-		imsi, err := getIMSI(ccr)
-		if err != nil {
-			glog.Errorf("Could not parse CCR: %s", err.Error())
-			sendAnswer(ccr, c, m, diam.AuthenticationRejected)
-			return
-		}
-		account, found := srv.subscribers[imsi]
-		if !found {
-			glog.Error("IMSI not found in subscribers")
-			sendAnswer(ccr, c, m, diam.AuthenticationRejected)
-			return
-		}
-
-		if credit_control.CreditRequestType(ccr.RequestType) == credit_control.CRTInit {
-			ruleInstalls := getRuleInstallAVPs(account.RuleNames, account.RuleBaseNames, account.RuleDefinitions)
-			usageMonitors := getInitialUsageMonitoringAVPs(account.UsageMonitors)
-			avps := append(ruleInstalls, usageMonitors...)
-			sendAnswer(ccr, c, m, diam.Success, avps...)
-			return
-		}
-
-		returnAVPs, err := getUsageMonitorUpdates(account, ccr.UsageMonitors)
-		if err != nil {
-			sendAnswer(ccr, c, m, diam.InvalidAVPValue)
-			return
-		}
-		sendAnswer(ccr, c, m, diam.Success, returnAVPs...)
-	}
-}
-
-func shouldReturnRules(requestType credit_control.CreditRequestType) bool {
-	return requestType == credit_control.CRTInit
-}
-
-// getIMSI finds the account IMSI in a CCR message
-func getIMSI(message ccrMessage) (string, error) {
-	for _, subID := range message.SubscriptionIDs {
-		if subID.IDType == credit_control.EndUserIMSI {
-			return subID.IDData, nil
-		}
-	}
-	return "", errors.New("Could not obtain IMSI from CCR message")
-}
-
-func getRuleInstallAVPs(
-	ruleNames []string,
-	ruleBaseNames []string,
-	ruleDefs []*protos.RuleDefinition,
-) []*diam.AVP {
-	avps := make([]*diam.AVP, 0, len(ruleNames)+len(ruleBaseNames)+len(ruleDefs))
-	for _, rule := range ruleNames {
-		avps = append(avps, diam.NewAVP(avp.ChargingRuleInstall, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-			AVP: []*diam.AVP{
-				diam.NewAVP(avp.ChargingRuleName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(rule)),
-			},
-		}))
-	}
-
-	for _, rule := range ruleBaseNames {
-		avps = append(avps, diam.NewAVP(avp.ChargingRuleInstall, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-			AVP: []*diam.AVP{
-				diam.NewAVP(avp.ChargingRuleBaseName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.UTF8String(rule)),
-			},
-		}))
-	}
-
-	for _, rule := range ruleDefs {
-		avps = append(avps, getRuleDefinitionAVP(rule))
-	}
-
-	return avps
-}
-
-func getInitialUsageMonitoringAVPs(monitors map[string]*protos.UsageMonitorCredit) []*diam.AVP {
-	avps := make([]*diam.AVP, 0, len(monitors))
-	for key, monitor := range monitors {
-		avps = append(avps, getUsageMonitoringResponseAVP(key, monitor.ReturnBytes, monitor.MonitoringLevel))
-	}
-	return avps
-}
-
-func getUsageMonitorUpdates(account *subscriberAccount, monitorUpdates []*usageMonitorRequestAVP) ([]*diam.AVP, error) {
-	avps := make([]*diam.AVP, 0, len(monitorUpdates))
-	for _, update := range monitorUpdates {
-		monitorCredit, ok := account.UsageMonitors[update.MonitoringKey]
-		if !ok {
-			return []*diam.AVP{}, fmt.Errorf("unknown monitoring key %s", update.MonitoringKey)
-		}
-		returnBytes := decrementUsageAndGetReturnBytes(monitorCredit, update.UsedServiceUnit.TotalOctets)
-		avps = append(avps, getUsageMonitoringResponseAVP(monitorCredit.MonitoringKey, returnBytes, monitorCredit.MonitoringLevel))
-	}
-	return avps, nil
-}
-
-func getUsageMonitoringResponseAVP(monitoringKey string, returnBytes uint64, level protos.UsageMonitorCredit_MonitoringLevel) *diam.AVP {
-	return diam.NewAVP(avp.UsageMonitoringInformation, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-		AVP: []*diam.AVP{
-			diam.NewAVP(avp.MonitoringKey, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(monitoringKey)),
-			diam.NewAVP(avp.GrantedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{
-				AVP: []*diam.AVP{
-					diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(returnBytes)),
-				},
-			}),
-			diam.NewAVP(avp.UsageMonitoringLevel, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Enumerated(level)),
-		},
-	})
-}
-
-func decrementUsageAndGetReturnBytes(monitorCredit *protos.UsageMonitorCredit, usedVolume uint64) uint64 {
-	monitorCredit.Volume -= usedVolume
-	if monitorCredit.Volume < 0 {
-		monitorCredit.Volume = 0
-	}
-	if monitorCredit.ReturnBytes > monitorCredit.Volume {
-		return monitorCredit.Volume
-	}
-	return monitorCredit.ReturnBytes
-}
-
-func getQosAVP(qos *lteprotos.FlowQos) *diam.AVP {
-	qosAVPs := []*diam.AVP{}
-	if qos.MaxReqBwUl != 0 {
-		qosAVPs = append(
-			qosAVPs,
-			diam.NewAVP(avp.MaxRequestedBandwidthUL, avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(qos.MaxReqBwUl)),
-		)
-	}
-	if qos.MaxReqBwDl != 0 {
-		qosAVPs = append(
-			qosAVPs,
-			diam.NewAVP(avp.MaxRequestedBandwidthDL, avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(qos.MaxReqBwDl)),
-		)
-	}
-	return diam.NewAVP(avp.QoSInformation, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-		AVP: qosAVPs,
-	})
-}
-
-func getRuleDefinitionAVP(rule *protos.RuleDefinition) *diam.AVP {
-	installAVPs := []*diam.AVP{
-		diam.NewAVP(avp.ChargingRuleName, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(rule.RuleName)),
-		diam.NewAVP(avp.Precedence, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(rule.Precedence)),
-	}
-	if rule.RatingGroup != 0 {
-		installAVPs = append(installAVPs, diam.NewAVP(avp.RatingGroup, avp.Mbit, 0, datatype.Unsigned32(rule.RatingGroup)))
-	}
-	if rule.MonitoringKey != "" {
-		installAVPs = append(
-			installAVPs,
-			diam.NewAVP(avp.MonitoringKey, avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(rule.MonitoringKey)),
-		)
-	}
-	if rule.QosInformation != nil && (rule.QosInformation.MaxReqBwUl != 0 || rule.QosInformation.MaxReqBwDl != 0) {
-		installAVPs = append(
-			installAVPs,
-			getQosAVP(rule.QosInformation),
-		)
-	}
-	for _, flowDescription := range rule.FlowDescriptions {
-		installAVPs = append(
-			installAVPs,
-			diam.NewAVP(avp.FlowDescription, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.IPFilterRule(flowDescription)),
-		)
-	}
-	if rule.RedirectInformation != nil {
-		RedirectInformation := []*diam.AVP{
-			diam.NewAVP(avp.RedirectSupport, avp.Mbit, diameter.Vendor3GPP, datatype.Enumerated(rule.RedirectInformation.Support)),
-			diam.NewAVP(avp.RedirectAddressType, avp.Mbit, 0, datatype.Enumerated(rule.RedirectInformation.AddressType)),
-			diam.NewAVP(avp.RedirectServerAddress, avp.Mbit, 0, datatype.UTF8String(rule.RedirectInformation.ServerAddress)),
-		}
-		installAVPs = append(
-			installAVPs,
-			diam.NewAVP(avp.RedirectInformation, avp.Mbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-				AVP: RedirectInformation,
-			}),
-		)
-	}
-	return diam.NewAVP(avp.ChargingRuleInstall, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-		AVP: []*diam.AVP{
-			diam.NewAVP(avp.ChargingRuleDefinition, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
-				AVP: installAVPs,
-			}),
-		},
-	})
-}
-
-// sendAnswer sends a CCA to the connection given
-func sendAnswer(
-	ccr ccrMessage,
-	conn diam.Conn,
-	message *diam.Message,
-	statusCode uint32,
-	additionalAVPs ...*diam.AVP,
-) {
-	a := message.Answer(statusCode)
-	a.NewAVP(avp.OriginHost, avp.Mbit, 0, ccr.DestinationHost)
-	a.NewAVP(avp.OriginRealm, avp.Mbit, 0, ccr.DestinationRealm)
-	a.NewAVP(avp.DestinationRealm, avp.Mbit, 0, ccr.OriginRealm)
-	a.NewAVP(avp.DestinationHost, avp.Mbit, 0, ccr.OriginHost)
-	a.NewAVP(avp.CCRequestType, avp.Mbit, 0, ccr.RequestType)
-	a.NewAVP(avp.CCRequestNumber, avp.Mbit, 0, ccr.RequestNumber)
-	a.NewAVP(avp.SessionID, avp.Mbit, 0, ccr.SessionID)
-	for _, avp := range additionalAVPs {
-		a.InsertAVP(avp)
-	}
-	// SessionID must be the first AVP
-	a.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, ccr.SessionID))
-
-	_, err := a.WriteTo(conn)
-	if err != nil {
-		glog.V(2).Infof("Failed to write message to %s: %s\n%s\n",
-			conn.RemoteAddr(), err, a)
-		return
-	}
-	glog.V(2).Infof("Sent CCA to %s:\n", conn.RemoteAddr())
 }


### PR DESCRIPTION
Summary:
No logic change here.
Move all AVP conversion related functions into `conversion.go`
Separate out the RPC interface functions from CCR handling functions. (`mock_pcrf.go` and `ccr_handlers.go`).

Reviewed By: xjtian

Differential Revision: D20010822

