### PR TITLE
SessionState exposes new methods for checking if rules are installed

### DIFF
--- a/lte/gateway/c/session_manager/SessionRules.cpp
+++ b/lte/gateway/c/session_manager/SessionRules.cpp
@@ -77,6 +77,20 @@ bool SessionRules::get_monitoring_key_for_rule_id(
   return false;
 }
 
+bool SessionRules::is_dynamic_rule_installed(const std::string& rule_id)
+{
+  auto _ = new PolicyRule();
+  return dynamic_rules_.get_rule(rule_id, _);
+}
+
+bool SessionRules::is_static_rule_installed(const std::string& rule_id)
+{
+  return std::find(
+    active_static_rules_.begin(),
+    active_static_rules_.end(),
+    rule_id) != active_static_rules_.end();
+}
+
 void SessionRules::insert_dynamic_rule(const PolicyRule& rule)
 {
   dynamic_rules_.insert_rule(rule);

--- a/lte/gateway/c/session_manager/SessionRules.h
+++ b/lte/gateway/c/session_manager/SessionRules.h
@@ -40,6 +40,10 @@ class SessionRules {
     const std::string& rule_id,
     std::string* monitoring_key);
 
+  bool is_dynamic_rule_installed(const std::string& rule_id);
+
+  bool is_static_rule_installed(const std::string& rule_id);
+
   void insert_dynamic_rule(const PolicyRule& rule);
 
   void activate_static_rule(const std::string& rule_id);

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -289,6 +289,16 @@ void SessionState::complete_termination()
   }
 }
 
+bool SessionState::is_dynamic_rule_installed(const std::string& rule_id)
+{
+  return session_rules_.is_dynamic_rule_installed(rule_id);
+}
+
+bool SessionState::is_static_rule_installed(const std::string& rule_id)
+{
+  return session_rules_.is_static_rule_installed(rule_id);
+}
+
 void SessionState::insert_dynamic_rule(const PolicyRule& dynamic_rule)
 {
   session_rules_.insert_dynamic_rule(dynamic_rule);
@@ -403,6 +413,14 @@ void SessionState::fill_protos_tgpp_context(
   magma::lte::TgppContext* tgpp_context) const
 {
   *tgpp_context = tgpp_context_;
+}
+
+uint32_t SessionState::get_request_number() {
+  return request_number_;
+}
+
+void SessionState::increment_request_number(uint32_t incr) {
+  request_number_ += incr;
 }
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -141,6 +141,10 @@ class SessionState {
    */
   void complete_termination();
 
+  bool is_dynamic_rule_installed(const std::string& rule_id);
+
+  bool is_static_rule_installed(const std::string& rule_id);
+
   void insert_dynamic_rule(const PolicyRule& dynamic_rule);
 
   void activate_static_rule(const std::string& rule_id);
@@ -187,6 +191,10 @@ class SessionState {
     const magma::lte::SubscriberQuotaUpdate_Type state);
 
   bool active_monitored_rules_exist();
+
+  uint32_t get_request_number();
+
+  void increment_request_number(uint32_t incr);
 
  private:
   /**

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -96,6 +96,7 @@ class SessionStateTest : public ::testing::Test {
 TEST_F(SessionStateTest, test_marshal_unmarshal)
 {
   insert_rule(1, "m1", "rule1", STATIC);
+  EXPECT_EQ(session_state->is_static_rule_installed("rule1"), true);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
 
   receive_credit_from_ocs(1, 1024);
@@ -112,6 +113,7 @@ TEST_F(SessionStateTest, test_marshal_unmarshal)
     unmarshaled->get_charging_pool().get_credit(1, ALLOWED_TOTAL), 1024);
   EXPECT_EQ(
     unmarshaled->get_monitor_pool().get_credit("m1", ALLOWED_TOTAL), 1024);
+  EXPECT_EQ(unmarshaled->is_static_rule_installed("rule1"), true);
 }
 
 TEST_F(SessionStateTest, test_insert_credit)


### PR DESCRIPTION
Summary:
Adding convenience methods to SessionState that will allow SessionStore to work with UpdateCriteria.

## Changes
- Added `is_static_rule_installed` and `is_dynamic_rule_installed`
- Added getter and setter for `request_number` of `SessionState`

Reviewed By: themarwhal

Differential Revision: D20087549

