### PR TITLE
Fixing retrieval of spgw bearer context info on actv/deactv bearer handlers

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -481,29 +481,24 @@ uint32_t pgw_handle_nw_initiated_bearer_actv_req(
     OAILOG_FUNC_RETURN(LOG_PGW_APP, RETURNerror);
   }
 
-  spgw_imsi_map_t* imsi_map = get_spgw_imsi_map();
-  uint64_t local_teid;
-  hashtable_uint64_ts_get(
-    imsi_map->imsi_teid5_htbl, (const hash_key_t) imsi64, &local_teid);
-  OAILOG_DEBUG(
-    LOG_SPGW_APP,
-    "Got imsi" IMSI_64_FMT " with local_teid %lu",
-    imsi64,
-    local_teid);
-
-  hashtable_ts_get(
-    hashtblP, (const hash_key_t) local_teid, (void**) &spgw_ctxt_p);
-  if (spgw_ctxt_p != NULL) {
-    is_teid_found = true;
-    if (
-      spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection
-        .default_bearer == bearer_req_p->lbi) {
-      is_lbi_found = true;
-      itti_s5_actv_bearer_req->lbi = bearer_req_p->lbi;
-      itti_s5_actv_bearer_req->mme_teid_S11 =
-        spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
-      itti_s5_actv_bearer_req->s_gw_teid_S11_S4 =
-        spgw_ctxt_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4;
+  hashtable_key_array_t* spgw_context_keys = hashtable_ts_get_keys(hashtblP);
+  for (int i = 0; i < spgw_context_keys->num_keys; i++) {
+    hashtable_ts_get(
+      hashtblP,
+      (const hash_key_t) spgw_context_keys->keys[i],
+      (void**) &spgw_ctxt_p);
+    if (spgw_ctxt_p != NULL) {
+      is_teid_found = true;
+      if (
+        spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection
+          .default_bearer == bearer_req_p->lbi) {
+        is_lbi_found = true;
+        itti_s5_actv_bearer_req->lbi = bearer_req_p->lbi;
+        itti_s5_actv_bearer_req->mme_teid_S11 =
+          spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
+        itti_s5_actv_bearer_req->s_gw_teid_S11_S4 =
+          spgw_ctxt_p->sgw_eps_bearer_context_information.s_gw_teid_S11_S4;
+      }
     }
   }
 
@@ -572,40 +567,39 @@ uint32_t pgw_handle_nw_initiated_bearer_deactv_req(
     OAILOG_FUNC_RETURN(LOG_PGW_APP, RETURNerror);
   }
 
-  spgw_imsi_map_t* imsi_map = get_spgw_imsi_map();
-  uint64_t local_teid;
-  hashtable_uint64_ts_get(
-    imsi_map->imsi_teid5_htbl, (const hash_key_t) imsi64, &local_teid);
-  OAILOG_DEBUG(
-    LOG_SPGW_APP, "Got imsi" IMSI_64_FMT " with teid5 %lu", imsi64, local_teid);
-  hashtable_ts_get(
-    hashtblP, (const hash_key_t) local_teid, (void**) &spgw_ctxt_p);
-
   // Check if valid LBI and EBI recvd
   /* For multi PDN, same IMSI can have multiple sessions, which means there
    * will be multiple entries for different sessions with the same IMSI. Hence
    * even though IMSI is found search the entire list for the LBI
    */
-  if (spgw_ctxt_p != NULL) {
-    is_teid_found = true;
-    s11_mme_teid = spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
-    if (
-      (bearer_req_p->lbi != 0) &&
-      (bearer_req_p->lbi == spgw_ctxt_p->sgw_eps_bearer_context_information
-                              .pdn_connection.default_bearer)) {
-      is_lbi_found = true;
-      // Check if the received EBI is valid
-      for (itrn = 0; itrn < bearer_req_p->no_of_bearers; itrn++) {
-        if (sgw_cm_get_eps_bearer_entry(
-              &spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection,
-              bearer_req_p->ebi[itrn])) {
-          is_ebi_found = true;
-          ebi_to_be_deactivated[no_of_bearers_to_be_deact] =
-            bearer_req_p->ebi[itrn];
-          no_of_bearers_to_be_deact++;
-        } else {
-          invalid_bearer_id[no_of_bearers_rej] = bearer_req_p->ebi[itrn];
-          no_of_bearers_rej++;
+  hashtable_key_array_t* spgw_context_keys = hashtable_ts_get_keys(hashtblP);
+  for (int i = 0; i < spgw_context_keys->num_keys; i++) {
+    hashtable_ts_get(
+      hashtblP,
+      (const hash_key_t) spgw_context_keys->keys[i],
+      (void**) &spgw_ctxt_p);
+    if (spgw_ctxt_p != NULL) {
+      is_teid_found = true;
+      s11_mme_teid =
+        spgw_ctxt_p->sgw_eps_bearer_context_information.mme_teid_S11;
+      if (
+        (bearer_req_p->lbi != 0) &&
+        (bearer_req_p->lbi == spgw_ctxt_p->sgw_eps_bearer_context_information
+                                .pdn_connection.default_bearer)) {
+        is_lbi_found = true;
+        // Check if the received EBI is valid
+        for (itrn = 0; itrn < bearer_req_p->no_of_bearers; itrn++) {
+          if (sgw_cm_get_eps_bearer_entry(
+                &spgw_ctxt_p->sgw_eps_bearer_context_information.pdn_connection,
+                bearer_req_p->ebi[itrn])) {
+            is_ebi_found = true;
+            ebi_to_be_deactivated[no_of_bearers_to_be_deact] =
+              bearer_req_p->ebi[itrn];
+            no_of_bearers_to_be_deact++;
+          } else {
+            invalid_bearer_id[no_of_bearers_rej] = bearer_req_p->ebi[itrn];
+            no_of_bearers_rej++;
+          }
         }
       }
     }

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -76,6 +76,7 @@ s1aptests/test_attach_detach_secondary_pdn_no_disconnect.py \
 s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_looped.py \
 s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_multi_ue.py \
 s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer.py \
+s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py \
 s1aptests/test_attach_detach_disconnect_default_pdn.py \
 s1aptests/test_attach_detach_max_pdns.py \
 s1aptests/test_attach_detach_multiple_secondary_pdn.py \


### PR DESCRIPTION
Summary:
On PGW handling of NW initiated activate / deactivate bearer requests, with updates of usages of SPGW IMSI => Tunnel ID map,
as there can be multiple entries with the same IMSI for multiple PDN connections,
the retrieval of SPGW UE context info state by IMSI is not sufficient as it will always return the last inserted entry,
which causes a bug. This diff fixes it.

- On `pgw_handle_nw_initiated_bearer_deactv_req`, it now traverses entire map to match by IMSI + EPS Bearer LBI.

Reviewed By: ulaskozat

Differential Revision: D20100843

