### PR TITLE
Change default value for extra_quota_margin to 1024

### DIFF
--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -17,7 +17,7 @@ rule_update_inteval_sec: 1
 usage_reporting_threshold: 0.8
 
 # Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 0
+extra_quota_margin: 1024
 
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -17,7 +17,7 @@ rule_update_inteval_sec: 1
 usage_reporting_threshold: 0.8
 
 # Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 0
+extra_quota_margin: 1024
 
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -218,6 +218,14 @@ class SessionCredit {
   CreditType credit_type_;
 
  private:
+  /**
+   * quota_exhausted checks whether usage reported from pipelined since the
+   * last SessionUpdate exceeds the quota received from the reporter.
+   * We mark quota as exhausted if usage_reporting_threshold * available quota
+   * is reached. (so the default is 100% of quota)
+   * We will also add a extra_quota_margin on to the available quota if it is
+   * specified.
+   */
   bool quota_exhausted(
     float usage_reporting_threshold = 1, uint64_t extra_quota_margin = 0);
 

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -17,7 +17,7 @@ rule_update_inteval_sec: 1
 usage_reporting_threshold: 0.8
 
 # Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 0
+extra_quota_margin: 1024
 
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -17,7 +17,7 @@ rule_update_inteval_sec: 15
 usage_reporting_threshold: 0.8
 
 # Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 0
+extra_quota_margin: 1024
 
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.


### PR DESCRIPTION
Summary:
There's a sessiond config called `extra_quota_margin` that affects when session's get terminated.
The basic idea is that even if we've used up the charging quota and it is not the final grant, if it's excessively above the quota limit, we will terminate the service.
This was added to tackle the case where the UpdateRequest to the reporter (FeG, or PolicyDB) failed. If the GRPC call fails permanently, we would eventually want to terminate the service.

The issue here was the default value in the sessiond config was set to 0. Which meant that if pipelined reports > 100% of the charging quota grant, we would always terminate the session.

I'm not sure if I like this solution because you can always find a data rate at which the session will always get terminated even if there's no failure. Maybe we can keep track of the number of failed grpc calls and terminate at a threshold.

But in the meantime, I'll change the sessiond logic to take the max of (config value, default=1024bytes).

Differential Revision: D20110872

