### PR TITLE
Add subscriber quota states to pipelined setup

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -141,6 +141,7 @@ bool LocalEnforcer::setup(
   std::function<void(Status status, SetupFlowsResult)> callback)
 {
   std::vector<SessionState::SessionInfo> session_infos;
+  std::vector<SubscriberQuotaUpdate> quota_updates;
   std::vector<std::string> msisdns;
   std::vector<std::string> ue_mac_addrs;
   std::vector<std::string> apn_mac_addrs;
@@ -168,12 +169,17 @@ bool LocalEnforcer::setup(
       apn_names.push_back(apn_name);
       if (session->is_radius_cwf_session()) {
         cwf = true;
+        SubscriberQuotaUpdate update = make_subscriber_quota_update(
+            session_info.imsi,
+            ue_mac_addr,
+            session->get_subscriber_quota_state());
+        quota_updates.push_back(update);
       }
     }
   }
   if (cwf){
-    return pipelined_client_->setup_cwf(session_infos, ue_mac_addrs, msisdns,
-        apn_mac_addrs, apn_names, epoch, callback);
+    return pipelined_client_->setup_cwf(session_infos, quota_updates,
+        ue_mac_addrs, msisdns, apn_mac_addrs, apn_names, epoch, callback);
   } else {
     return pipelined_client_->setup_lte(session_infos, epoch, callback);
   }

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -156,6 +156,7 @@ AsyncPipelinedClient::AsyncPipelinedClient():
 
 bool AsyncPipelinedClient::setup_cwf(
    const std::vector<SessionState::SessionInfo>& infos,
+   const std::vector<SubscriberQuotaUpdate>& quota_updates,
    const std::vector<std::string> ue_mac_addrs,
    const std::vector<std::string> msisdns,
    const std::vector<std::string> apn_mac_addrs,
@@ -169,6 +170,8 @@ bool AsyncPipelinedClient::setup_cwf(
   SetupUEMacRequest setup_ue_mac_req = create_setup_ue_mac_req(infos,
     ue_mac_addrs, msisdns, apn_mac_addrs, apn_names, epoch);
   setup_ue_mac_rpc(setup_ue_mac_req, callback);
+
+  update_subscriber_quota_state(quota_updates);
   return true;
 }
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -37,6 +37,7 @@ class PipelinedClient {
    */
   virtual bool setup_cwf(
     const std::vector<SessionState::SessionInfo>& infos,
+    const std::vector<SubscriberQuotaUpdate>& quota_updates,
     const std::vector<std::string> ue_mac_addrs,
     const std::vector<std::string> msisdns,
     const std::vector<std::string> apn_mac_addrs,
@@ -124,6 +125,7 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    */
   bool setup_cwf(
     const std::vector<SessionState::SessionInfo>& infos,
+    const std::vector<SubscriberQuotaUpdate>& quota_updates,
     const std::vector<std::string> ue_mac_addrs,
     const std::vector<std::string> msisdns,
     const std::vector<std::string> apn_mac_addrs,

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -264,6 +264,11 @@ void SessionState::mark_as_awaiting_termination()
   curr_state_ = SESSION_TERMINATION_SCHEDULED;
 }
 
+SubscriberQuotaUpdate_Type SessionState::get_subscriber_quota_state() const
+{
+  return subscriber_quota_state_;
+}
+
 void SessionState::complete_termination()
 {
   if (curr_state_ == SESSION_TERMINATED) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -164,6 +164,8 @@ class SessionState {
 
   uint32_t get_qci() const;
 
+  SubscriberQuotaUpdate_Type get_subscriber_quota_state() const;
+
   bool is_radius_cwf_session() const;
 
   bool is_same_config(const Config& new_config) const;

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -64,7 +64,7 @@ class MockPipelinedClient : public PipelinedClient {
  public:
   MockPipelinedClient()
   {
-    ON_CALL(*this, setup_cwf(_,_,_,_,_,_,_)).WillByDefault(Return(true));
+    ON_CALL(*this, setup_cwf(_,_,_,_,_,_,_,_)).WillByDefault(Return(true));
     ON_CALL(*this, setup_lte(_,_,_)).WillByDefault(Return(true));
     ON_CALL(*this, deactivate_all_flows(_)).WillByDefault(Return(true));
     ON_CALL(*this, deactivate_flows_for_rules(_, _, _))
@@ -77,9 +77,10 @@ class MockPipelinedClient : public PipelinedClient {
       .WillByDefault(Return(true));
   }
 
-  MOCK_METHOD7(setup_cwf,
+  MOCK_METHOD8(setup_cwf,
     bool(
       const std::vector<SessionState::SessionInfo>& infos,
+      const std::vector<SubscriberQuotaUpdate>& quota_updates,
       const std::vector<std::string> ue_mac_addrs,
       const std::vector<std::string> msisdns,
       const std::vector<std::string> apn_mac_addrs,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1171,8 +1171,8 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup)
   EXPECT_CALL(
     *pipelined_client,
     setup_cwf(CheckSessionInfos(imsi_list, ip_address_list, static_rule_list,
-      dynamic_rule_list), ue_mac_addrs, msisdns, apn_mac_addrs, apn_names,
-      testing::_, testing::_))
+      dynamic_rule_list), testing::_, ue_mac_addrs, msisdns, apn_mac_addrs,
+      apn_names, testing::_, testing::_))
     .Times(1)
     .WillOnce(testing::Return(true));
 


### PR DESCRIPTION
Summary: Send subscriber quota states as part of setup_cwf

Reviewed By: koolzz

Differential Revision: D20193443

