### PR TITLE
Disable ovs in band mode

### DIFF
--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -104,6 +104,7 @@ services:
       sh -c "set bridge cwag_br0 protocols=protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true &&
         /usr/bin/ovs-vsctl set-controller cwag_br0 tcp:127.0.0.1:6633 &&
         /usr/bin/ovs-vsctl set-fail-mode cwag_br0 secure &&
+        /usr/bin/ovs-vsctl set bridge cwag_br0 other-config:disable-in-band=true &&
         python3 -m magma.pipelined.main"
 
   policydb:

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -345,6 +345,10 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             self._ue_mac_app.delete_ue_mac_flow,
             request.sid.id, request.mac_addr)
 
+        if self._service_manager.is_app_enabled(CheckQuotaController.APP_NAME):
+            self._loop.call_soon_threadsafe(
+                self._check_quota_app.remove_subscriber_flow, request.sid.id)
+
         if self._service_manager.is_app_enabled(IPFIXController.APP_NAME):
             # Delete trace flow
             self._loop.call_soon_threadsafe(


### PR DESCRIPTION
Summary:
This was causing a bunch of issues with our check quota fake ip routing, as ovs would hijack our fake arp and broadcast it to all ports(due to a higher kernel level priority rule).

*This was painfull to debug.*

Reviewed By: themarwhal

Differential Revision: D20195640

