### PR TITLE
Change naming for /events <-> ES interaction

### DIFF
--- a/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers.go
+++ b/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers.go
@@ -22,14 +22,18 @@ import (
 )
 
 const (
-	Events               = "events"
-	EventsPath           = obsidian.V1Root + Events + obsidian.UrlSep + ":" + pathParamStreamName
+	Events     = "events"
+	EventsPath = obsidian.V1Root + Events + obsidian.UrlSep + ":" + pathParamStreamName
+
 	pathParamStreamName  = "stream_name"
 	queryParamEventType  = "event_type"
 	queryParamHardwareID = "hardware_id"
 	queryParamTag        = "tag"
-	defaultQuerySize     = 50
-	timestamp            = "timestamp"
+
+	defaultQuerySize        = 50
+	timestamp               = "timestamp"
+	elasticFilterEventTag   = "event_tag"
+	elasticFilterHardwareID = "hw_id.keyword" // Uses the ES "keyword" type for exact match
 )
 
 // Returns a Hander that uses the provided elastic client
@@ -149,10 +153,10 @@ func (b *eventQueryParams) ToElasticBoolQuery() *elastic.BoolQuery {
 		query.Filter(elastic.NewTermQuery(queryParamEventType, b.EventType))
 	}
 	if len(b.HardwareID) > 0 {
-		query.Filter(elastic.NewTermQuery(queryParamHardwareID, b.HardwareID))
+		query.Filter(elastic.NewTermQuery(elasticFilterHardwareID, b.HardwareID))
 	}
 	if len(b.Tag) > 0 {
-		query.Filter(elastic.NewTermQuery(queryParamTag, b.Tag))
+		query.Filter(elastic.NewTermQuery(elasticFilterEventTag, b.Tag))
 	}
 	return query
 }

--- a/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers_test.go
+++ b/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers_test.go
@@ -53,8 +53,8 @@ var (
 			expected: elastic.NewBoolQuery().
 				Filter(elastic.NewTermQuery("stream_name", "streamOne")).
 				Filter(elastic.NewTermQuery("event_type", "an_event")).
-				Filter(elastic.NewTermQuery("hardware_id", "hardware-2")).
-				Filter(elastic.NewTermQuery("tag", "critical")),
+				Filter(elastic.NewTermQuery("hw_id.keyword", "hardware-2")).
+				Filter(elastic.NewTermQuery("event_tag", "critical")),
 		},
 		{
 			name: "partial query params",

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -116,8 +116,6 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
             return
 
         try:
-            # TODO use a different name, tag doesn't work because of fluentbit
-            # using the "tag" field.
             with closing(socket.create_connection(
                     ('localhost', self.fluent_bit_port),
                     timeout=self.tcp_timeout)) as sock:
@@ -125,7 +123,8 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
                 sock.sendall(json.dumps({
                     'stream_name': request.stream_name,
                     'event_type': request.event_type,
-                    'tag': request.tag,
+                    # We use event_tag as fluentd uses the "tag" field
+                    'event_tag': request.tag,
                     'value': request.value
                 }).encode('utf-8'))
         except socket.error as e:


### PR DESCRIPTION
Summary:
- All the tags in ES are of the form "eventd" due to fluent-bit tagging them
	- Unfortunately fluent-bit uses the "tag" field in the json abjects that it forwards, so we use the name event_tag instead
- All the hardware IDs in ES use the key "hw_id", not "hardware_id"
- ES doesn't match `hw_id` as a term, so the `keyword` type must be used to prevent matching with individual tokens (hyhen is a valid separator to ES)

Reviewed By: xjtian

Differential Revision: D20164464

