### PR TITLE
Specify bravado-core version in orc8r setup.py

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -81,7 +81,7 @@ setup(
         # force same requests version as lte/gateway/python/setup.py
         'requests==2.22.0',
         'jsonpickle',
-        'bravado-core==5',
-        'jsonschema==3',
+        'bravado-core==5.16.1',
+        'jsonschema==3.2.0',
     ]
 )


### PR DESCRIPTION
Summary:
- Only specifying the major version for `bravado-core` causes `AttributeError: module 'jsonschema._validators' has no attribute 'type_draft4'` on `test_type_checking (eventd.tests.event_validation_tests.EventValidationTests)`
- `jsonschema` is also locked as a dependency for a validation error

Reviewed By: tmdzk

Differential Revision: D20261378

