### PR TITLE
Session recycling for WiFi should update the config

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1429,16 +1429,12 @@ void LocalEnforcer::check_usage_for_reporting()
     });
 }
 
-bool LocalEnforcer::is_imsi_duplicate(const std::string& imsi) const
+bool LocalEnforcer::session_with_imsi_exists(const std::string& imsi) const
 {
-  auto it = session_map_.find(imsi);
-  if (it == session_map_.end()) {
-    return false;
-  }
-  return true;
+  return session_map_.find(imsi) != session_map_.end();
 }
 
-bool LocalEnforcer::is_apn_duplicate(
+bool LocalEnforcer::session_with_apn_exists(
   const std::string& imsi, const std::string& apn) const
 {
   auto it = session_map_.find(imsi);
@@ -1453,18 +1449,31 @@ bool LocalEnforcer::is_apn_duplicate(
   return false;
 }
 
-std::string* LocalEnforcer::duplicate_session_id(
-  const std::string& imsi, const magma::SessionState::Config& config) const
+bool LocalEnforcer::session_with_same_config_exists(
+  const std::string& imsi, const magma::SessionState::Config& config,
+  std::string* core_session_id) const
 {
   auto it = session_map_.find(imsi);
   if (it != session_map_.end()) {
     for (const auto &session : it->second) {
       if (session->is_same_config(config)) {
-        return new std::string(session->get_core_session_id());
+        *core_session_id = session->get_core_session_id();
+        return true;
       }
     }
   }
-  return nullptr;
+  return false;
+}
+
+void LocalEnforcer::set_cwf_session_config(
+  const std::string& imsi, const magma::SessionState::Config& config)
+{
+  auto it = session_map_.find(imsi);
+  if (it != session_map_.end()) {
+    for (const auto &session : it->second) {
+      session->set_config(config);
+    }
+  }
 }
 
 static void handle_command_level_result_code(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -167,11 +167,20 @@ class LocalEnforcer {
     PolicyReAuthRequest request,
     PolicyReAuthAnswer& answer_out);
 
-  bool is_imsi_duplicate(const std::string& imsi) const;
-  bool is_apn_duplicate(const std::string& imsi, const std::string& apn) const;
+  bool session_with_imsi_exists(const std::string& imsi) const;
+  bool session_with_apn_exists(const std::string& imsi, const std::string& apn) const;
 
-  std::string* duplicate_session_id(
-    const std::string& imsi, const magma::SessionState::Config& config) const;
+  bool session_with_same_config_exists(
+    const std::string& imsi,
+    const magma::SessionState::Config& config,
+    std::string* core_session_id) const;
+
+  /**
+   * Set session config for the IMSI.
+   * Should be only used for WIFI as it will apply it to all sessions with the
+   * IMSI
+   */
+  void set_cwf_session_config(const std::string& imsi, const magma::SessionState::Config& config);
 
   /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -201,25 +201,28 @@ void LocalSessionManagerHandlerImpl::CreateSession(
   }
   cfg.qos_info = qos_info;
 
-  if (enforcer_->is_imsi_duplicate(imsi)) {
-    std::string * core_sid = enforcer_->duplicate_session_id(imsi, cfg);
-    if ((core_sid != nullptr) || (request->rat_type() == RATType::TGPP_WLAN)){
-      if (request->rat_type() == RATType::TGPP_WLAN) {
+  if (enforcer_->session_with_imsi_exists(imsi)) {
+    std::string core_sid;
+    bool same_config = enforcer_->session_with_same_config_exists(imsi, cfg, &core_sid);
+    bool is_wifi = request->rat_type() == RATType::TGPP_WLAN;
+    if (same_config || is_wifi){
+      if (is_wifi) {
         MLOG(MINFO) << "Found a session with the same IMSI " << imsi
-                  << " and RAT Type is WLAN, not creating session";
+                    << " and RAT Type is WLAN, not creating a new session";
+        // Wifi only supports one session per subscriber, so update the config
+        // here
+        enforcer_->set_cwf_session_config(imsi, cfg);
       } else {
-      MLOG(MINFO) << "Found completely duplicated session with IMSI " << imsi
-                  << " and APN " << request->apn()
-                  << ", not creating session";
+        MLOG(MINFO) << "Found completely duplicated session with IMSI " << imsi
+                    << " and APN " << request->apn()
+                    << ", not creating session";
       }
       enforcer_->get_event_base().runInEventBaseThread(
           [response_callback, core_sid]() {
             try {
               LocalCreateSessionResponse resp;
-              resp.set_session_id(*core_sid);
-              delete core_sid;
-              response_callback(
-                grpc::Status::OK, resp);
+              resp.set_session_id(core_sid);
+              response_callback(grpc::Status::OK, resp);
             } catch (...) {
                 std::exception_ptr ep = std::current_exception();
                 MLOG(MERROR) << "CreateSession response_callback exception: "
@@ -228,9 +231,10 @@ void LocalSessionManagerHandlerImpl::CreateSession(
             }
           }
       );
+      // No new session created
       return;
     }
-    if (enforcer_->is_apn_duplicate(imsi, request->apn())) {
+    if (enforcer_->session_with_apn_exists(imsi, request->apn())) {
       MLOG(MINFO) << "Found session with the same IMSI " << imsi
                   << " and APN " << request->apn()
                   << ", but different configuration."

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -112,7 +112,7 @@ void RestartHandler::terminate_previous_session(
           return;
         }
         // Don't delete subscriber from directoryD if IMSI is known
-        if (enforcer_->is_imsi_duplicate(response.sid())) {
+        if (enforcer_->session_with_imsi_exists(response.sid())) {
           MLOG(MINFO) << "Not cleaning up previous session after restart "
                       << "for subscriber " << response.sid()
                       << ", session id: " << response.session_id()

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -360,6 +360,10 @@ std::string SessionState::get_apn() const
   return config_.apn;
 }
 
+void SessionState::set_config(const Config& config) {
+  config_ = config;
+}
+
 bool SessionState::is_radius_cwf_session() const
 {
   return (config_.rat_type == RATType::TGPP_WLAN);

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -174,6 +174,8 @@ class SessionState {
 
   bool qos_enabled() const;
 
+  void set_config(const Config& config);
+
   void set_tgpp_context(const magma::lte::TgppContext& tgpp_context);
 
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -72,7 +72,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     SessionState::Config cfg = {.ue_ipv4 = "",
             .spgw_ipv4 = "",
             .msisdn = msisdn,
-            .apn = "",
+            .apn = "apn1",
             .imei = "",
             .plmn_id = "",
             .imsi_plmn_id = "",
@@ -90,11 +90,15 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     request.set_hardware_addr(hardware_addr_bytes);
     request.set_msisdn(msisdn);
     request.set_radius_session_id(radius_session_id);
+    request.set_apn("apn2"); // Update APN
 
     // Ensure session is not reported as its a duplicate
     EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
     session_manager->CreateSession(&create_context, &request, [this](
             grpc::Status status, LocalCreateSessionResponse response_out) {});
+    // Assert the internal session config is updated to the new one
+    EXPECT_FALSE(local_enforcer->session_with_apn_exists("IMSI1", "apn1"));
+    EXPECT_TRUE(local_enforcer->session_with_apn_exists("IMSI1", "apn2"));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary:
When a WIFI session creation requested AND the IMSI already has a session, we recycle the existing session. We should override the existing session config with the new config.
Ex. If the user switches AP, that will trigger a new CreateSession and our current implementation will recycle the old session. But since the old config still points to the previous AP, when the old AP gets around to sending a Terminate Request, the session incorrectly gets terminated.

This should fix that problem, as `terminate_subscriber` in local enforcer only terminates the subscriber that matches the given APN and IMSI.

Reviewed By: emakeev

Differential Revision: D20267498

