### PR TITLE
Don't add to network wide rules if it already is in there

### DIFF
--- a/lte/cloud/go/plugin/handlers/handlers.go
+++ b/lte/cloud/go/plugin/handlers/handlers.go
@@ -809,10 +809,28 @@ func addToNetworkSubscriberConfig(networkID, ruleName, baseName string) error {
 		return fmt.Errorf("Unable to convert config")
 	}
 	if len(ruleName) != 0 {
-		subscriberConfig.NetworkWideRuleNames = append(subscriberConfig.NetworkWideRuleNames, ruleName)
+		ruleAlreadyExists := false
+		for _, existing := range subscriberConfig.NetworkWideRuleNames {
+			if existing == ruleName {
+				ruleAlreadyExists = true
+				break
+			}
+		}
+		if !ruleAlreadyExists {
+			subscriberConfig.NetworkWideRuleNames = append(subscriberConfig.NetworkWideRuleNames, ruleName)
+		}
 	}
 	if len(baseName) != 0 {
-		subscriberConfig.NetworkWideBaseNames = append(subscriberConfig.NetworkWideBaseNames, ltemodels.BaseName(baseName))
+		bnAlreadyExists := false
+		for _, existing := range subscriberConfig.NetworkWideBaseNames {
+			if existing == ltemodels.BaseName(baseName){
+				bnAlreadyExists = true
+				break
+			}
+		}
+		if !bnAlreadyExists {
+			subscriberConfig.NetworkWideBaseNames = append(subscriberConfig.NetworkWideBaseNames, ltemodels.BaseName(baseName))
+		}
 	}
 	return configurator.UpdateNetworkConfig(networkID, lte.NetworkSubscriberConfigType, subscriberConfig)
 }

--- a/lte/cloud/go/plugin/handlers/handlers_test.go
+++ b/lte/cloud/go/plugin/handlers/handlers_test.go
@@ -937,7 +937,31 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
+	// posting twice shouldn't affect anything
 	tc = tests.Test{
+		Method:         "POST",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/rule_names/%s", testURLRoot, "n1", "rule4"),
+		Payload:        tests.JSONMarshaler(newSubscriberConfig),
+		ParamNames:     []string{"network_id", "rule_id"},
+		ParamValues:    []string{"n1", "rule4"},
+		Handler:        postRuleName,
+		ExpectedStatus: 201,
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            fmt.Sprintf("%s/%s/subscriber_config/base_names/%s", testURLRoot, "n1", "base4"),
+		Payload:        tests.JSONMarshaler(newSubscriberConfig),
+		ParamNames:     []string{"network_id", "base_name"},
+		ParamValues:    []string{"n1", "base4"},
+		Handler:        postBaseName,
+		ExpectedStatus: 201,
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+		tc = tests.Test{
 		Method:         "POST",
 		URL:            fmt.Sprintf("%s/%s/subscriber_config/base_names/%s", testURLRoot, "n1", "base4"),
 		Payload:        tests.JSONMarshaler(newSubscriberConfig),


### PR DESCRIPTION
Summary: POST handler for `network_subscriber_config`'s `rule_names` incorrectly added rule names even if you previously added it before

Differential Revision: D20287075

