### PR TITLE
Missing PTP_Status will not raise error in outputting status

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -254,7 +254,10 @@ def get_enb_status(enodeb: EnodebAcsStateMachine) -> EnodebStatus:
         rf_tx_desired = False
     mme_connected = _parse_param_as_bool(enodeb, ParameterName.MME_STATUS)
     gps_connected = _get_gps_status_as_bool(enodeb)
-    ptp_connected = _parse_param_as_bool(enodeb, ParameterName.PTP_STATUS)
+    try:
+        ptp_connected = _parse_param_as_bool(enodeb, ParameterName.PTP_STATUS)
+    except ConfigurationError:
+        ptp_connected = False
 
     return EnodebStatus(enodeb_configured=enodeb_configured,
                         gps_latitude=gps_lat,


### PR DESCRIPTION
Summary: Baicells QAFA does not have the PTP_STATUS parameter, so when eNB status is routinely retrieved, it fails for QAFA devices.

Reviewed By: themarwhal

Differential Revision: D20295482

