### PR TITLE
symphony/storybook: pin node version to 13.8

### DIFF
--- a/symphony/app/fbcnms-projects/storybook/Dockerfile
+++ b/symphony/app/fbcnms-projects/storybook/Dockerfile
@@ -1,4 +1,4 @@
-FROM node AS builder
+FROM node:13.8 AS builder
 
 WORKDIR /src/
 


### PR DESCRIPTION
Summary:
Using latest node image produces the following error during docker build:
```
info => Loading manager config..
info => Loading presets
info => Loading custom manager config.
info => Compiling manager..
ERR! => Failed to build the manager
ERR! ./.storybook/addons.js
ERR! Module build failed (from /src/node_modules/babel-loader/lib/index.js):
ERR! Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main resolved in /src/node_modules/babel/helper-compilation-targets/package.json
ERR!     at applyExports (internal/modules/cjs/loader.js:524:9)
ERR!     at resolveExports (internal/modules/cjs/loader.js:541:12)
ERR!     at Function.Module._findPath (internal/modules/cjs/loader.js:661:22)
ERR!     at Function.Module._resolveFilename (internal/modules/cjs/loader.js:963:27)
ERR!     at Function.Module._load (internal/modules/cjs/loader.js:859:27)
ERR!     at Module.require (internal/modules/cjs/loader.js:1036:19)
ERR!     at require (internal/modules/cjs/helpers.js:72:18)
ERR!     at Object.<anonymous> (/src/node_modules/babel/preset-env/lib/debug.js:8:33)
ERR!     at Module._compile (internal/modules/cjs/loader.js:1147:30)
ERR!     at Object.Module._extensions..js (internal/modules/cjs/loader.js:1167:10)
ERR!     at Module.load (internal/modules/cjs/loader.js:996:32)
ERR!     at Function.Module._load (internal/modules/cjs/loader.js:896:14)
ERR!     at Module.require (internal/modules/cjs/loader.js:1036:19)
ERR!     at require (internal/modules/cjs/helpers.js:72:18)
ERR!     at Object.<anonymous> (/src/node_modules/babel/preset-env/lib/index.js:11:14)
ERR!     at Module._compile (internal/modules/cjs/loader.js:1147:30)
ERR!  @ multi /src/node_modules/storybook/core/dist/server/common/polyfills.js /src/node_modules/storybook/core/dist/client/manager/index.js ./.storybook/addons.js main[2]
(node:30) UnhandledPromiseRejectionWarning: [object Object]
(node:30) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 2)
(node:30) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
The command '/bin/sh -c rm -rf storybook-static && yarn build-storybook -s public' returned a non-zero code: 1
```

Differential Revision: D20335389

