### PR TITLE
Fix pipelined setup failure

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/base.py
+++ b/lte/gateway/python/magma/pipelined/app/base.py
@@ -125,7 +125,7 @@ class MagmaController(app_manager.RyuApp):
 
         if self.init_finished:
             self.logger.warning('Controller already initialized, ignoring')
-            return SetupFlowsResult.FAILURE
+            return SetupFlowsResult.SUCCESS
 
         return SetupFlowsResult.SUCCESS
 

--- a/lte/gateway/python/magma/pipelined/app/check_quota.py
+++ b/lte/gateway/python/magma/pipelined/app/check_quota.py
@@ -87,7 +87,7 @@ class CheckQuotaController(MagmaController):
         self._install_default_flows(self._datapath)
         self.update_subscriber_quota_state(quota_updates)
 
-        return SetupFlowsResult.SUCCESS
+        return SetupFlowsResult(result=SetupFlowsResult.SUCCESS)
 
     def initialize_on_connect(self, datapath: Datapath):
         self._datapath = datapath

--- a/lte/gateway/python/magma/pipelined/app/ue_mac.py
+++ b/lte/gateway/python/magma/pipelined/app/ue_mac.py
@@ -73,7 +73,7 @@ class UEMacAddressController(MagmaController):
                 self.arp_contoller = self.arpd_controller_fut.result()
             self.arp_contoller.handle_restart(ue_requests)
 
-        return SetupFlowsResult.SUCCESS
+        return SetupFlowsResult(result=SetupFlowsResult.SUCCESS)
 
     def delete_all_flows(self, datapath):
         flows.delete_all_flows_from_table(datapath, self.tbl_num)

--- a/lte/gateway/python/magma/pipelined/directoryd_client.py
+++ b/lte/gateway/python/magma/pipelined/directoryd_client.py
@@ -11,6 +11,7 @@ import logging
 from ryu.lib import hub
 
 from magma.common.service_registry import ServiceRegistry
+from orc8r.protos.common_pb2 import Void
 from orc8r.protos.directoryd_pb2 import UpdateRecordRequest, \
     GetDirectoryFieldRequest
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
@@ -88,7 +89,7 @@ def get_all_records(retries: int = 3, sleep_time: float = 0.1) -> [dict]:
     client = GatewayDirectoryServiceStub(chan)
     for _ in range(0, retries):
         try:
-            res = client.GetAllDirectoryRecords(DEFAULT_GRPC_TIMEOUT)
+            res = client.GetAllDirectoryRecords(Void(), DEFAULT_GRPC_TIMEOUT)
             if res.records is not None:
                 return res.records
             hub.sleep(sleep_time)

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -376,6 +376,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         if ret != SetupFlowsResult.SUCCESS:
             return SetupFlowsResult(result=ret)
 
+        fut = Future()
+        self._loop.call_soon_threadsafe(self._setup_quota,
+                                        request, fut)
+        return fut.result()
+
     def _setup_quota(self, request: SetupQuotaRequest,
                      fut: 'Future(SetupFlowsResult)'
                      ) -> SetupFlowsResult:


### PR DESCRIPTION
Summary: Some grpc returns were getting the enum and not the whole message so they were failing

Reviewed By: themarwhal

Differential Revision: D20347187

