### PR TITLE
Implement a proxy to simulate the orchestrator for integ tests

### DIFF
--- a/cwf/gateway/docker/.env
+++ b/cwf/gateway/docker/.env
@@ -13,6 +13,7 @@ IMAGE_VERSION=latest
 
 BUILD_CONTEXT=../../..
 
+CERTS_PATH=../../../.cache/test_certs/
 ROOTCA_PATH=../../../.cache/test_certs/rootCA.pem
 CONTROL_PROXY_PATH=../configs/control_proxy.yml
 CONFIGS_TEMPLATES_PATH=../../../orc8r/gateway/configs/templates

--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -61,6 +61,9 @@ services:
   sessiond:
     volumes:
       - ../integ_tests/sessiond.yml:/etc/magma/sessiond.yml
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
 
   swx_proxy:
     <<: *feggoservice
@@ -103,8 +106,38 @@ services:
       /bin/bash -c "/usr/bin/redis-server /var/opt/magma/redis.conf --daemonize no &&
              /usr/bin/redis-cli shutdown"
 
+  control_proxy:
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
+    command: >
+      sh -c "mkdir -p /usr/share/ca-certificates/extra/ &&
+             cp -f /var/opt/magma/certs/rootCA.pem /usr/share/ca-certificates/extra/ &&
+             echo \"extra/rootCA.pem\" >> /etc/ca-certificates.conf && update-ca-certificates &&
+             /usr/local/bin/generate_nghttpx_config.py &&
+            /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf /var/opt/magma/certs/controller.key /var/opt/magma/certs/controller.crt"
+
+  magmad:
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
+
   uesim:
     <<: *service
     container_name: uesim
     image: ${DOCKER_REGISTRY}uesim:${IMAGE_VERSION}
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/uesim -logtostderr=true -v=0
+
+  ingress:
+    <<: *service
+    container_name: ingress
+    image: nginx:latest
+    extra_hosts:
+      - controller.magma.test:127.0.0.1
+      - bootstrapper-controller.magma.test:127.0.0.1
+      - session-proxy.magma.test:127.0.0.1
+      - sessiond.magma.test:127.0.0.1
+    volumes:
+      - ../integ_tests/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${CERTS_PATH}/:/etc/nginx/certs/
+    command: /usr/sbin/nginx -g "daemon off;"

--- a/cwf/gateway/integ_tests/nginx.conf
+++ b/cwf/gateway/integ_tests/nginx.conf
@@ -1,0 +1,52 @@
+user root;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+  worker_connections 768;
+  #multi_accept on;
+}
+
+http {
+  server {
+    error_log  /var/log/nginx/error.log info;
+    access_log /var/log/nginx/access.log;
+
+    listen              9443 ssl http2;
+    server_name         controller.magma.test;
+    root                /var/www;
+
+    ssl_certificate     /etc/nginx/certs/controller.crt;
+    ssl_certificate_key /etc/nginx/certs/controller.key;
+
+
+    location /magma.lte.SessionProxyResponder/ {
+      grpc_pass grpc://session-proxy.magma.test:50065;
+      http2_push_preload on;
+    }
+
+    location /magma.lte.CentralSessionController/ {
+      grpc_pass grpc://sessiond.magma.test:9097;
+      http2_push_preload on;
+    }
+
+    location /magma.orc8r.Streamer/ {
+      grpc_set_header Content-Type "application/gprc";
+      http2_push_preload on;
+      return 404;
+    }
+
+    location /magma.orc8r.MetricsController/ {
+      grpc_set_header Content-Type "application/gprc";
+      http2_push_preload on;
+      return 404;
+    }
+
+    location /magma.orc8r.StateService/ {
+      grpc_set_header Content-Type application/gprc;
+      http2_push_preload on;
+      return 404;
+    }
+  }
+}

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -31,11 +31,3 @@ session_force_termination_timeout_ms: 5000
 
 # Set to true to enable sessiond support of carrier wifi
 support_carrier_wifi: true
-
-# For Testing
-# Set to use a locally running session proxy instance. If
-# use_local_session_proxy is set to true sessiond will use 127.0.0.1:<port> as
-# the address for the session proxy service.
-# Note: these flags are only relevant when relay is turned on
-use_local_session_proxy: true
-local_session_proxy_port: 9097

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -55,26 +55,11 @@ static magma::mconfig::SessionD load_mconfig()
   return mconfig;
 }
 
-static const std::shared_ptr<grpc::Channel> get_local_controller(
-  const YAML::Node &config)
-{
- auto port = config["local_session_proxy_port"].as<std::string>();
- auto addr = "127.0.0.1:" + port;
- MLOG(MINFO) << "Using local address " << addr << " for controller";
- return grpc::CreateCustomChannel(
-   addr, grpc::InsecureChannelCredentials(), grpc::ChannelArguments {});
-}
-
 static const std::shared_ptr<grpc::Channel> get_controller_channel(
   const YAML::Node &config, const bool relay_enabled)
 {
   if (relay_enabled) {
     MLOG(MINFO) << "Using proxied sessiond controller";
-    if (config["use_local_session_proxy"].IsDefined() &&
-      config["use_local_session_proxy"].as<bool>()) {
-      // Use a locally running SessionProxy. (Used for testing)
-      return get_local_controller(config);
-    }
     return magma::ServiceRegistrySingleton::Instance()->GetGrpcChannel(
       SESSION_PROXY_SERVICE, magma::ServiceRegistrySingleton::CLOUD);
   } else {


### PR DESCRIPTION
Summary:
1/ Rework the integration tests to connect ocs to sessiond for reauth tests
2/ Remove integ specific code from sessiond

Reviewed By: themarwhal

Differential Revision: D20335465

