### PR TITLE
Downgrade jsonschema to 3.1.0

### DIFF
--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -82,6 +82,6 @@ setup(
         'requests==2.22.0',
         'jsonpickle',
         'bravado-core==5.16.1',
-        'jsonschema==3.2.0',
+        'jsonschema==3.1.0',
     ]
 )


### PR DESCRIPTION
Summary: - jsonschema 3.2.0 uses `from importlib import metadata` which is only available on python 3.8.

Reviewed By: andreilee

Differential Revision: D20391595

