### PR TITLE
Modify MockDriver's DoesMatch's interface to return a custom error

### DIFF
--- a/feg/gateway/services/testcore/mock_driver/mock_driver.go
+++ b/feg/gateway/services/testcore/mock_driver/mock_driver.go
@@ -9,13 +9,11 @@
 package mock_driver
 
 import (
-	"fmt"
-
 	"magma/feg/cloud/go/protos"
 )
 
 type Expectation interface {
-	DoesMatch(interface{}) bool
+	DoesMatch(interface{}) error
 	GetAnswer() interface{}
 }
 
@@ -60,10 +58,10 @@ func (e *MockDriver) GetAnswerFromExpectations(message interface{}) interface{} 
 		return e.getAnswerForUnexpectedMessage()
 	}
 	expectation := e.expectations[e.expectationIndex]
-	doesMatch := expectation.DoesMatch(message)
-	if !doesMatch {
-		err := &protos.ErrorByIndex{Index: int32(e.expectationIndex), Error: fmt.Sprintf("Expected: %v, Received: %v", expectation, message)}
-		e.errorMessages = append(e.errorMessages, err)
+	err := expectation.DoesMatch(message)
+	if err != nil {
+		errByIndex := &protos.ErrorByIndex{Index: int32(e.expectationIndex), Error: err.Error()}
+		e.errorMessages = append(e.errorMessages, errByIndex)
 		return e.getAnswerForUnexpectedMessage()
 	}
 

--- a/feg/gateway/services/testcore/mock_driver/mock_driver_test.go
+++ b/feg/gateway/services/testcore/mock_driver/mock_driver_test.go
@@ -9,6 +9,7 @@
 package mock_driver_test
 
 import (
+	"fmt"
 	"testing"
 
 	"magma/feg/cloud/go/protos"
@@ -22,12 +23,15 @@ type TestExpectation struct {
 	answer  string
 }
 
-func (t TestExpectation) DoesMatch(iReq interface{}) bool {
+func (t TestExpectation) DoesMatch(iReq interface{}) error {
 	request, ok := iReq.(string)
 	if !ok {
-		return false
+		return fmt.Errorf("request is not of type string")
 	}
-	return request == t.request
+	if request != t.request {
+		return fmt.Errorf("Expected: %v, Received: %v", t.request, request)
+	}
+	return nil
 }
 
 func (t TestExpectation) GetAnswer() interface{} {
@@ -103,8 +107,8 @@ func TestSomeExpectationsNotMet(t *testing.T) {
 	}
 	assert.ElementsMatch(t, expectedResult, result)
 	expectedErrors := []*protos.ErrorByIndex{
-		{Index: 1, Error: "Expected: {req2 ans2}, Received: bad-req2-1"},
-		{Index: 1, Error: "Expected: {req2 ans2}, Received: bad-req2-2"},
+		{Index: 1, Error: "Expected: req2, Received: bad-req2-1"},
+		{Index: 1, Error: "Expected: req2, Received: bad-req2-2"},
 	}
 	assert.ElementsMatch(t, expectedErrors, errs)
 }


### PR DESCRIPTION
Summary: Modifying the interface a bit so that we delegate the construction of error messages to the client

Differential Revision: D20422965

