### PR TITLE
Fix linux-headers installation

### DIFF
--- a/cwf/gateway/deploy/roles/ovs/files/install_ovs.sh
+++ b/cwf/gateway/deploy/roles/ovs/files/install_ovs.sh
@@ -8,13 +8,13 @@ apt-get -y install automake
 apt-get -y install gcc
 apt-get -y install libtool
 apt-get -y libcap-ng-dev
-apt-get -y install linux-headers-"$(uname -r)"
+apt-get -y install linux-headers-generic
 apt-get -y update
 git clone https://github.com/openvswitch/ovs.git
 cd ovs/ || exit
 git checkout v2.12.0
 git apply /tmp/0001-Add-custom-IPDR-fields-for-IPFIX-export.patch
 ./boot.sh
-./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-linux=/lib/modules/"$(uname -r)"/build
+./configure --prefix=/usr --localstatedir=/var --sysconfdir=/etc --with-linux="$(ls -d /lib/modules/* | tail -1)/build"
 make
 make install


### PR DESCRIPTION
When I'm building the cwf using these commands in (non-ubuntu) OS, but I'm getting issue with installing the `linux-headers` which is called by the `install_ovs.sh` script:

```bash
$ cat /etc/os-release | grep PRETTY_NAME
PRETTY_NAME="Fedora 31 (Thirty One)"

$ uname -a
Linux peru.xvx.cz 5.5.8-200.fc31.x86_64 #1 SMP Thu Mar 5 21:28:03 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ cd magma/cwf/gateway/docker
$ docker-compose build
...
...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package linux-headers-5.5.8-200.fc31.x86_64
E: Couldn't find any package by glob 'linux-headers-5.5.8-200.fc31.x86_64'                                                                                                                   
E: Couldn't find any package by regex 'linux-headers-5.5.8-200.fc31.x86_64' 
...
...
checking whether gcc accepts -Wno-unused... yes
checking whether gcc accepts -Wno-unused-parameter... yes
checking target hint for cgcc... x86_64
checking vector options for cgcc... -D__MMX__=1 -D__SSE2_MATH__=1 -D__SSE_MATH__=1 -D__SSE2__=1 -D__SSE__=1
checking for Linux build directory... no
configure: error: source dir /lib/modules/5.5.8-200.fc31.x86_64/build doesn't exist
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target 'install'.  Stop.
ERROR: Service 'pipelined' failed to build: The command '/bin/sh -c bash /tmp/install_ovs.sh' returned a non-zero code: 2
```

The reason is - `uname -r` is giving me `5.5.8-200.fc31.x86_64` on my Fedora build server therefore I can not build `cwf` because it's expecting to run `docker-compose` on Ubuntu  - that's why I proposing the change which removes this dependency.