### PR TITLE
Add network_id gating for /events

### DIFF
--- a/orc8r/cloud/go/services/eventd/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/eventd/models/swagger.v1.yml
@@ -15,12 +15,13 @@ info:
 basePath: /magma/v1
 
 paths:
-  /events/{stream_name}:
+  /events/{network_id}/{stream_name}:
     get:
       summary: Query events logged by services
       tags:
         - Events
       parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
         - name: stream_name
           in: path
           description: The user-specified string to categorize events

--- a/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers_test.go
+++ b/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers_test.go
@@ -48,10 +48,12 @@ var (
 				StreamName: "streamOne",
 				EventType:  "an_event",
 				HardwareID: "hardware-2",
+				NetworkID:  "test_network",
 				Tag:        "critical",
 			},
 			expected: elastic.NewBoolQuery().
 				Filter(elastic.NewTermQuery("stream_name.keyword", "streamOne")).
+				Filter(elastic.NewTermQuery("network_id.keyword", "test_network")).
 				Filter(elastic.NewTermQuery("event_type.keyword", "an_event")).
 				Filter(elastic.NewTermQuery("hw_id.keyword", "hardware-2")).
 				Filter(elastic.NewTermQuery("event_tag.keyword", "critical")),
@@ -60,19 +62,23 @@ var (
 			name: "partial query params",
 			params: eventQueryParams{
 				StreamName: "streamTwo",
+				NetworkID:  "test_network_two",
 				EventType:  "an_event",
 			},
 			expected: elastic.NewBoolQuery().
 				Filter(elastic.NewTermQuery("stream_name.keyword", "streamTwo")).
+				Filter(elastic.NewTermQuery("network_id.keyword", "test_network_two")).
 				Filter(elastic.NewTermQuery("event_type.keyword", "an_event")),
 		},
 		{
-			name: "only StreamName",
+			name: "only required Path params",
 			params: eventQueryParams{
 				StreamName: "streamThree",
+				NetworkID:  "test_network_three",
 			},
 			expected: elastic.NewBoolQuery().
-				Filter(elastic.NewTermQuery("stream_name.keyword", "streamThree")),
+				Filter(elastic.NewTermQuery("stream_name.keyword", "streamThree")).
+				Filter(elastic.NewTermQuery("network_id.keyword", "test_network_three")),
 		},
 	}
 
@@ -84,33 +90,33 @@ var (
 			expectedParams: eventQueryParams{},
 		},
 		{
-			name:        "only stream_name",
-			urlString:   "",
-			paramNames:  []string{"stream_name"},
-			paramValues: []string{"streamOne"},
-			expectedParams: eventQueryParams{
-				StreamName: "streamOne",
-			},
+			name:         "only stream_name",
+			urlString:    "",
+			paramNames:   []string{"stream_name"},
+			paramValues:  []string{"streamOne"},
+			expectsError: true,
 		},
 		{
 			name:         "excess path params",
 			urlString:    "",
-			paramNames:   []string{"stream_name", "bad_param"},
-			paramValues:  []string{"streamOne", "bad_value"},
+			paramNames:   []string{"stream_name", "network_id", "bad_param"},
+			paramValues:  []string{"streamOne", "nw1", "bad_value"},
 			expectsError: false,
 			expectedParams: eventQueryParams{
 				StreamName: "streamOne",
+				NetworkID:  "nw1",
 			},
 		},
 		{
 			name:        "all query params",
 			urlString:   "?event_type=mock_subscriber_event&hardware_id=123&tag=critical",
-			paramNames:  []string{"stream_name"},
-			paramValues: []string{"streamOne"},
+			paramNames:  []string{"stream_name", "network_id"},
+			paramValues: []string{"streamOne", "nw1"},
 			expectedParams: eventQueryParams{
 				StreamName: "streamOne",
 				EventType:  "mock_subscriber_event",
 				HardwareID: "123",
+				NetworkID:  "nw1",
 				Tag:        "critical",
 			},
 		},
@@ -166,6 +172,12 @@ var (
 	}
 )
 
+func TestEventsPath(t *testing.T) {
+	assert.Equal(t,
+		"/magma/v1/events/:network_id/:stream_name",
+		EventsPath)
+}
+
 func TestElasticBoolQuery(t *testing.T) {
 	for _, test := range elasticCases {
 		t.Run(test.name, func(t *testing.T) {
@@ -199,8 +211,8 @@ func runQueryParamTestCase(t *testing.T, tc queryParamTestCase) {
 		assert.Error(t, err)
 	} else {
 		assert.NoError(t, err)
+		assert.Equal(t, tc.expectedParams, params)
 	}
-	assert.Equal(t, tc.expectedParams, params)
 }
 
 func TestGetEventMap(t *testing.T) {


### PR DESCRIPTION
Summary:
- This allows clients to only see the events that they emit
- This is a pre-requisite to exposing events on the NMS

Reviewed By: andreilee

Differential Revision: D20446989

