### PR TITLE
Enumerated type should not be defined as uint32.

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/definitions.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/definitions.go
@@ -122,7 +122,7 @@ type QosInformation struct {
 	MaxReqBwDL       *uint32 `avp:"Max-Requested-Bandwidth-DL"`
 	GbrDL            *uint32 `avp:"Guaranteed-Bitrate-DL"`
 	GbrUL            *uint32 `avp:"Guaranteed-Bitrate-UL"`
-	Qci              *uint32 `avp:"QoS-Class-Identifier"`
+	Qci              *int32  `avp:"QoS-Class-Identifier"`
 }
 
 // RuleInstallAVP represents a policy rule to install. It can hold one of

--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go
@@ -71,7 +71,7 @@ func (q *QosInformation) ToProto() *protos.FlowQos {
 			MaxReqBwDl: swag.Uint32Value(q.MaxReqBwDL),
 			GbrUl:      swag.Uint32Value(q.GbrUL),
 			GbrDl:      swag.Uint32Value(q.GbrDL),
-			Qci:        protos.FlowQos_Qci(swag.Uint32Value(q.Qci)),
+			Qci:        protos.FlowQos_Qci(swag.Int32Value(q.Qci)),
 		}
 	}
 	return qos

--- a/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/model_conversion_test.go
@@ -31,7 +31,7 @@ func TestReAuthRequest_ToProto(t *testing.T) {
 	bearerID := "bearer1"
 	var ratingGroup uint32 = 42
 	var totalOctets uint64 = 2048
-	var qci uint32 = 1
+	var qci int32 = 1
 	var monitoringLevel gx.MonitoringLevel = gx.SessionLevel
 	currentTime := time.Now()
 	protoTimestamp, err := ptypes.TimestampProto(currentTime)


### PR DESCRIPTION
Summary: QCI AVP is defined of type Enumerated in Diameter Gx interface as well as in policydb.proto file and not as unsigned integer. This change makes it consistent similar to the usage in "S6a_definitions.go". This will also rule out this type discrepancy as the potential cause of RAR decoding of non-zero QCI values as QCI_0.

Reviewed By: uri200

Differential Revision: D20454022

