### PR TITLE
Adding ovs_mtr_port_number config to spgw.yml and pipelined.yml

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -40,7 +40,8 @@ int start_of_controller(bool persist_state)
   static openflow::BaseApplication base_app(persist_state);
   static openflow::GTPApplication gtp_app(
     std::string(bdata(spgw_config.sgw_config.ovs_config.uplink_mac)),
-    spgw_config.sgw_config.ovs_config.gtp_port_num);
+    spgw_config.sgw_config.ovs_config.gtp_port_num,
+    spgw_config.sgw_config.ovs_config.mtr_port_num);
   // Base app registers first, because it deletes/creates default flow
   ctrl.register_for_event(&base_app, openflow::EVENT_SWITCH_UP);
   ctrl.register_for_event(&base_app, openflow::EVENT_ERROR);

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -40,9 +40,11 @@ const std::string GTPApplication::GTP_PORT_MAC = "02:00:00:00:00:01";
 
 GTPApplication::GTPApplication(
   const std::string &uplink_mac,
-  uint32_t gtp_port_num):
+  uint32_t gtp_port_num,
+  uint32_t mtr_port_num):
   uplink_mac_(uplink_mac),
-  gtp_port_num_(gtp_port_num)
+  gtp_port_num_(gtp_port_num),
+  mtr_port_num_(mtr_port_num)
 {
 }
 

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -33,7 +33,10 @@ namespace openflow {
  */
 class GTPApplication : public Application {
  public:
-  GTPApplication(const std::string &uplink_mac, uint32_t gtp_port_num);
+  GTPApplication(
+    const std::string& uplink_mac,
+    uint32_t gtp_port_num,
+    uint32_t mtr_port_num);
 
  private:
   /**
@@ -123,6 +126,7 @@ class GTPApplication : public Application {
 
   const std::string uplink_mac_;
   const uint32_t gtp_port_num_;
+  const uint32_t mtr_port_num_;
   /* cookie is added to identify the rules enforced for the flow controller
    * Initialising with 1
    */

--- a/lte/gateway/c/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_config.c
@@ -339,6 +339,7 @@ int sgw_config_parse_file(sgw_config_t *config_pP)
     }
     char *ovs_bridge_name = NULL;
     libconfig_int gtp_port_num = 0;
+    libconfig_int mtr_port_num = 0;
     libconfig_int uplink_port_num = 0;
     char *uplink_mac = NULL;
     if (
@@ -355,9 +356,12 @@ int sgw_config_parse_file(sgw_config_t *config_pP)
       config_setting_lookup_string(
         ovs_settings,
         SGW_CONFIG_STRING_OVS_UPLINK_MAC,
-        (const char **) &uplink_mac)) {
+        (const char**) &uplink_mac) &&
+      config_setting_lookup_int(
+        ovs_settings, SGW_CONFIG_STRING_OVS_MTR_PORT_NUM, &mtr_port_num)) {
       config_pP->ovs_config.bridge_name = bfromcstr(ovs_bridge_name);
       config_pP->ovs_config.gtp_port_num = gtp_port_num;
+      config_pP->ovs_config.mtr_port_num = mtr_port_num;
       config_pP->ovs_config.uplink_port_num = uplink_port_num;
       config_pP->ovs_config.uplink_mac = bfromcstr(uplink_mac);
     } else {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_config.h
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_config.h
@@ -55,6 +55,7 @@
 #define SGW_CONFIG_STRING_SGW_IPV4_ADDRESS_FOR_S11 "SGW_IPV4_ADDRESS_FOR_S11"
 #define SGW_CONFIG_STRING_OVS_BRIDGE_NAME "BRIDGE_NAME"
 #define SGW_CONFIG_STRING_OVS_GTP_PORT_NUM "GTP_PORT_NUM"
+#define SGW_CONFIG_STRING_OVS_MTR_PORT_NUM "MTR_PORT_NUM"
 #define SGW_CONFIG_STRING_OVS_UPLINK_PORT_NUM "UPLINK_PORT_NUM"
 #define SGW_CONFIG_STRING_OVS_UPLINK_MAC "UPLINK_MAC"
 
@@ -64,6 +65,7 @@
 typedef struct ovs_config_s {
   bstring bridge_name;
   int gtp_port_num;
+  int mtr_port_num;
   int uplink_port_num;
   bstring uplink_mac;
 } ovs_config_t;

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -112,3 +112,5 @@ clean_restart: true
 # This is duplicated from spgw.yml - if you change the value here,
 # also change it there
 ovs_gtp_port_number: 32768
+# Internal port for monitoring service
+ovs_mtr_port_number: 15577

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -110,3 +110,5 @@ clean_restart: true
 # This is duplicated from spgw.yml - if you change the value here,
 # also change it there
 ovs_gtp_port_number: 32768
+# Internal port for monitoring service
+ovs_mtr_port_number: 15577

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -25,3 +25,5 @@ ovs_uplink_port_number: 65534
 # These is duplicated into pipelined.yml - if you change the value here,
 # also change it there
 ovs_gtp_port_number: 32768
+# Internal port for monitoring service
+ovs_mtr_port_number: 15577

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -35,6 +35,7 @@ S-GW :
     {
       BRIDGE_NAME                          = "{{ ovs_bridge_name }}";
       GTP_PORT_NUM                         = {{ ovs_gtp_port_number }};
+      MTR_PORT_NUM                         = {{ ovs_mtr_port_number }};
       UPLINK_PORT_NUM                      = {{ ovs_uplink_port_number }};
       UPLINK_MAC                           = "{{ ovs_uplink_mac }}";
     };

--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -7,7 +7,7 @@ iface gtp_br0 inet static
     up iptables -t mangle -A FORWARD -i gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
     up iptables -t mangle -A FORWARD -o gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
     ovs_type OVSBridge
-    ovs_ports gtp0 cpe_port
+    ovs_ports gtp0 mtr0
 
 # Add GTP vport to gtp_br0 as port 32768
 allow-gtp_br0 gtp0
@@ -17,9 +17,10 @@ iface gtp0 inet manual
     ovs_tunnel_type gtp
     ovs_tunnel_options ofport_request=32768 options:remote_ip=flow options:key=flow
 
-allow-gtp_br0 cpe_port
-iface cpe_port inet static
+allow-gtp_br0 mtr0
+iface mtr0 inet static
     address 10.0.2.10
     netmask 255.255.255.0
     ovs_bridge gtp_br0
     ovs_type OVSIntPort
+    ovs_extra set interface ${IFACE} ofport_request=15577

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -231,5 +231,5 @@
   shell: ifup {{ item }}
   with_items:
     - eth0
-    - cpe_port
+    - mtr0
   when: full_provision

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -94,8 +94,8 @@
   shell: ifup gtp_br0
   become: yes
 
-- name: Bring up cpe_port
-  shell: ifup cpe_port
+- name: Bring up mtr0
+  shell: ifup mtr0
   become: yes
 
 - name: Start service magma@magmad.

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -12,9 +12,8 @@ and the config/mconfig for the service.
 """
 
 import logging
-import socket
-
 import os
+import socket
 from create_oai_certs import generate_mme_certs
 from generate_service_config import generate_template_config
 from lte.protos.mconfig.mconfigs_pb2 import MME
@@ -138,6 +137,7 @@ def _get_context():
     for key in (
         "ovs_bridge_name",
         "ovs_gtp_port_number",
+        "ovs_mtr_port_number",
         "ovs_uplink_port_number",
         "ovs_uplink_mac",
     ):


### PR DESCRIPTION
Summary:
For CPE monitoring service, we are introducing an OVS internal port `mtr_port` for which we will setup flow rules to accomplish ICMP ping routing from the AGW to the CPE and back.

This diff:
- Adds mtr_port_number config parameter to pipelined.yml, pipelined.yml_prod, spgw.yml
- Adds mtr_port_number entry to spgw.conf.template
- Adds implementation to parse port number inside spgw_config
- Updates GTPApplication to take mtr_port as parameter
- Renames cpe_port interface to mtr_port

Reviewed By: koolzz

Differential Revision: D20271205

