### PR TITLE
Add Mock Driven PCRF in MockPCRF

### DIFF
--- a/feg/cloud/go/protos/mock_core_conversions.go
+++ b/feg/cloud/go/protos/mock_core_conversions.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package protos
+
+func NewGxCreditControlExpectation() *GxCreditControlExpectation {
+	return &GxCreditControlExpectation{}
+}
+
+func (m *GxCreditControlExpectation) Expect(ccr *GxCreditControlRequest) *GxCreditControlExpectation {
+	m.ExpectedRequest = ccr
+	return m
+}
+
+func (m *GxCreditControlExpectation) Return(cca *GxCreditControlAnswer) *GxCreditControlExpectation {
+	m.Answer = cca
+	return m
+}
+
+func NewGxCCRequest(imsi string, requestType CCRequestType, requestNumber uint32) *GxCreditControlRequest {
+	return &GxCreditControlRequest{Imsi: imsi, RequestType: requestType, RequestNumber: requestNumber}
+}
+
+func NewGxCCAnswer(resultCode uint32) *GxCreditControlAnswer {
+	return &GxCreditControlAnswer{ResultCode: resultCode}
+}
+
+func (m *GxCreditControlAnswer) SetUsageMonitorInfos(monitors []*UsageMonitoringInformation) *GxCreditControlAnswer {
+	m.UsageMonitoringInfos = monitors
+	return m
+}
+
+func (m *GxCreditControlAnswer) SetStaticRuleInstalls(ruleIDs, baseNames []string) *GxCreditControlAnswer {
+	if m.RuleInstalls == nil {
+		m.RuleInstalls = &RuleInstalls{}
+	}
+	m.RuleInstalls.RuleNames = ruleIDs
+	m.RuleInstalls.RuleBaseNames = baseNames
+	return m
+}
+
+func (m *GxCreditControlAnswer) SetDynamicRuleInstalls(rules []*RuleDefinition) *GxCreditControlAnswer {
+	if m.RuleInstalls == nil {
+		m.RuleInstalls = &RuleInstalls{}
+	}
+	m.RuleInstalls.RuleDefinitions = rules
+	return m
+}
+
+func (m *GxCreditControlRequest) SetUsageMonitorReports(reports []*UsageMonitoringInformation) *GxCreditControlRequest {
+	m.UsageMonitoringReports = reports
+	return m
+}
+
+func (m *GxCreditControlRequest) SetUsageReportDelta(delta uint64) *GxCreditControlRequest {
+	m.UsageReportDelta = delta
+	return m
+}

--- a/feg/gateway/services/testcore/mock_driver/mock_driver.go
+++ b/feg/gateway/services/testcore/mock_driver/mock_driver.go
@@ -54,7 +54,7 @@ func (e *MockDriver) GetAnswerFromExpectations(message interface{}) interface{} 
 	if !e.expectationsSet {
 		return nil
 	}
-	if len(e.expectations) == 0 {
+	if len(e.expectations) == 0 || e.expectationIndex >= len(e.expectations) {
 		return e.getAnswerForUnexpectedMessage()
 	}
 	expectation := e.expectations[e.expectationIndex]

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
@@ -70,9 +70,23 @@ func getCCRHandler(srv *PCRFDiamServer) diam.HandlerFunc {
 			sendAnswer(ccr, c, m, diam.AuthenticationRejected)
 			return
 		}
+
+		if srv.serviceConfig.UseMockDriver {
+			srv.mockDriverLock.Lock()
+			iAnswer := srv.mockDriver.GetAnswerFromExpectations(ccr)
+			srv.mockDriverLock.Unlock()
+			if iAnswer == nil {
+				sendAnswer(ccr, c, m, diam.UnableToComply)
+				return
+			}
+			avps, resultCode := iAnswer.(GxAnswer).toAVPs()
+			sendAnswer(ccr, c, m, resultCode, avps...)
+			return
+		}
+
 		account, found := srv.subscribers[imsi]
 		if !found {
-			glog.Error("IMSI not found in subscribers")
+			glog.Errorf("IMSI %v not found in subscribers", imsi)
 			sendAnswer(ccr, c, m, diam.AuthenticationRejected)
 			return
 		}

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/mock.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/mock.go
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package mock_pcrf
+
+import (
+	"fmt"
+
+	"magma/feg/cloud/go/protos"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/golang/glog"
+)
+
+type GxExpectation struct {
+	*protos.GxCreditControlExpectation
+}
+
+type GxAnswer struct {
+	*protos.GxCreditControlAnswer
+}
+
+type requestPK struct {
+	imsi        string
+	requestType protos.CCRequestType
+}
+
+func (r requestPK) String() string {
+	return fmt.Sprintf("Imsi: %v, Type: %v", r.imsi, r.requestType)
+}
+
+func (e GxExpectation) GetAnswer() interface{} {
+	return GxAnswer{e.Answer}
+}
+
+func (e GxExpectation) DoesMatch(message interface{}) error {
+	expected := e.ExpectedRequest
+	ccr := message.(ccrMessage)
+	expectedPK := requestPK{imsi: expected.Imsi, requestType: expected.RequestType}
+	actualImsi, _ := ccr.GetIMSI()
+	actualPK := requestPK{imsi: actualImsi, requestType: protos.CCRequestType(ccr.RequestType)}
+	// For better readability of errors, we will check for the IMSI and the request type first.
+	if expectedPK != actualPK {
+		return fmt.Errorf("Expected: %v, Received: %v", expectedPK, actualPK)
+	}
+	expectedUsageReports := expected.GetUsageMonitoringReports()
+	if !compareUsageMonitorsAgainstExpected(ccr.UsageMonitors, expectedUsageReports, expected.GetUsageReportDelta()) {
+		return fmt.Errorf("For Request=%v, Expected: %v, Received: %v", actualPK, expectedUsageReports, ccr.UsageMonitors)
+	}
+	return nil
+}
+
+func (answer GxAnswer) toAVPs() ([]*diam.AVP, uint32) {
+	avps := []*diam.AVP{}
+	ruleInstalls := answer.GetRuleInstalls()
+	if ruleInstalls != nil {
+		ruleInstallAVPs := toRuleInstallAVPs(
+			answer.RuleInstalls.GetRuleNames(),
+			answer.RuleInstalls.GetRuleBaseNames(),
+			answer.RuleInstalls.GetRuleDefinitions())
+		avps = append(avps, ruleInstallAVPs...)
+	}
+	ruleRemovals := answer.GetRuleRemovals()
+	if ruleRemovals != nil {
+		ruleRemovalAVPs := toRuleRemovalAVPs(
+			ruleRemovals.GetRuleNames(),
+			ruleRemovals.GetRuleBaseNames())
+		avps = append(avps, ruleRemovalAVPs...)
+	}
+	monitorInstalls := answer.GetUsageMonitoringInfos()
+	if monitorInstalls != nil {
+		for _, monitor := range monitorInstalls {
+			octets := monitor.GetOctets()
+			if octets == nil {
+				glog.Errorf("Monitor Octets is nil, skipping.")
+				continue
+			}
+			avps = append(avps, toUsageMonitoringInfoAVP(string(monitor.MonitoringKey), octets, monitor.MonitoringLevel))
+		}
+	}
+	return avps, answer.GetResultCode()
+}
+
+func (usageMonitor *usageMonitorRequestAVP) toProtosUsageMonitorInfo() *protos.UsageMonitoringInformation {
+	return &protos.UsageMonitoringInformation{
+		MonitoringKey:   []byte(usageMonitor.MonitoringKey),
+		MonitoringLevel: protos.MonitoringLevel(usageMonitor.Level),
+		Octets: &protos.Octets{
+			TotalOctets:  usageMonitor.UsedServiceUnit.TotalOctets,
+			InputOctets:  usageMonitor.UsedServiceUnit.InputOctets,
+			OutputOctets: usageMonitor.UsedServiceUnit.OutputOctets,
+		},
+	}
+}
+
+func compareUsageMonitorsAgainstExpected(actual []*usageMonitorRequestAVP, expected []*protos.UsageMonitoringInformation, delta uint64) bool {
+	if expected == nil {
+		return true
+	}
+	actualMonitorByKey := toUsageMonitorByMkey(actual)
+	expectedMonitorByKey := toProtosMonitorByKey(expected)
+	for mKey, expectedMonitor := range expectedMonitorByKey {
+		actualMonitor, exists := actualMonitorByKey[mKey]
+		if !exists {
+			return false
+		}
+		if protos.MonitoringLevel(actualMonitor.Level) != expectedMonitor.MonitoringLevel {
+			return false
+		}
+		if !equalWithinDelta(actualMonitor.UsedServiceUnit.TotalOctets, expectedMonitor.GetOctets().GetTotalOctets(), delta) {
+			return false
+		}
+	}
+	return true
+}
+
+func toProtosMonitorByKey(monitors []*protos.UsageMonitoringInformation) map[string]*protos.UsageMonitoringInformation {
+	result := map[string]*protos.UsageMonitoringInformation{}
+	for _, monitor := range monitors {
+		result[string(monitor.MonitoringKey)] = monitor
+	}
+	return result
+}
+
+func equalWithinDelta(a, b, delta uint64) bool {
+	if b >= a && b-a <= delta {
+		return true
+	}
+	if a >= b && a-b <= delta {
+		return true
+	}
+	return false
+}

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/mock_driven_pcrf_test.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/mock_driven_pcrf_test.go
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package mock_pcrf_test
+
+import (
+	"context"
+	"log"
+	"testing"
+	"time"
+
+	fegprotos "magma/feg/cloud/go/protos"
+	"magma/feg/gateway/diameter"
+	"magma/feg/gateway/services/eap/test"
+	"magma/feg/gateway/services/session_proxy/credit_control"
+	"magma/feg/gateway/services/session_proxy/credit_control/gx"
+	"magma/feg/gateway/services/testcore/pcrf/mock_pcrf"
+	lteprotos "magma/lte/cloud/go/protos"
+	orcprotos "magma/orc8r/lib/go/protos"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/go-openapi/swag"
+	"github.com/stretchr/testify/assert"
+)
+
+func startServerWithExpectations(
+	client *diameter.DiameterClientConfig,
+	server *diameter.DiameterServerConfig,
+	expectations []*fegprotos.GxCreditControlExpectation,
+	failureBehavior fegprotos.UnexpectedRequestBehavior,
+	defaultCCA *fegprotos.GxCreditControlAnswer,
+) *mock_pcrf.PCRFDiamServer {
+	serverStarted := make(chan struct{})
+	pcrf := mock_pcrf.NewPCRFDiamServer(
+		client,
+		&mock_pcrf.PCRFConfig{ServerConfig: server},
+	)
+	go func() {
+		log.Printf("Starting server")
+		ctx := context.Background()
+		pcrf.SetPCRFConfigs(ctx, &fegprotos.PCRFConfigs{UseMockDriver: true})
+		pcrf.SetExpectations(ctx, &fegprotos.GxCreditControlExpectations{
+			Expectations:              expectations,
+			UnexpectedRequestBehavior: failureBehavior,
+			GxDefaultCca:              defaultCCA,
+		})
+
+		serverStarted <- struct{}{}
+		lis, err := pcrf.StartListener()
+		if err != nil {
+			log.Fatalf("Could not start listener for PCRF, %s", err.Error())
+		}
+		server.Addr = lis.Addr().String()
+		err = pcrf.Start(lis)
+		if err != nil {
+			log.Fatalf("Could not start test PCRF server, %s", err.Error())
+			return
+		}
+	}()
+	<-serverStarted
+	time.Sleep(time.Millisecond)
+	return pcrf
+}
+
+// TestGxClient tests CCR init and terminate messages using a fake PCRF
+func TestPCRFExpectations(t *testing.T) {
+	serverConfig := diameter.DiameterServerConfig{DiameterServerConnConfig: diameter.DiameterServerConnConfig{
+		Addr:     "127.0.0.1:3898",
+		Protocol: "tcp"},
+	}
+	serverConfig1 := serverConfig
+	serverConfig2 := serverConfig
+	clientConfig := getClientConfig()
+
+	// E/A that should be met
+	expectedInitReq := fegprotos.NewGxCCRequest(test.IMSI1, fegprotos.CCRequestType_INITIAL, 1)
+	usageMonitoringQuotaGrant := []*fegprotos.UsageMonitoringInformation{
+		{
+			MonitoringLevel: fegprotos.MonitoringLevel_RuleLevel,
+			MonitoringKey:   []byte("mkey1"),
+			Octets:          &fegprotos.Octets{TotalOctets: 1024},
+		},
+	}
+	dynamicRulesToInstall := []*fegprotos.RuleDefinition{
+		{
+			RuleName:         "rule1",
+			RatingGroup:      9,
+			Precedence:       10,
+			MonitoringKey:    "m1",
+			FlowDescriptions: []string{"permit out ip from any to any", "permit in ip from any to any"},
+			RedirectInformation: &lteprotos.RedirectInformation{
+				Support:     lteprotos.RedirectInformation_ENABLED,
+				AddressType: lteprotos.RedirectInformation_IPv4,
+			},
+			QosInformation: &lteprotos.FlowQos{
+				MaxReqBwDl: 15,
+				MaxReqBwUl: 30,
+			},
+		},
+	}
+	expectedInitAns := fegprotos.NewGxCCAnswer(diam.Success).
+		SetStaticRuleInstalls([]string{"rule1", "rule2"}, []string{"base1", "base2"}).
+		SetDynamicRuleInstalls(dynamicRulesToInstall).
+		SetUsageMonitorInfos(usageMonitoringQuotaGrant)
+	expectedInit := fegprotos.NewGxCreditControlExpectation().Expect(expectedInitReq).Return(expectedInitAns)
+
+	// Update Request
+	expectedUpdateReq := fegprotos.NewGxCCRequest(test.IMSI1, fegprotos.CCRequestType_UPDATE, 2).
+		SetUsageMonitorReports(usageMonitoringQuotaGrant).
+		SetUsageReportDelta(100)
+	expectedUpdateAns := fegprotos.NewGxCCAnswer(diam.Success).
+		SetUsageMonitorInfos(usageMonitoringQuotaGrant)
+	expectedUpdate := fegprotos.NewGxCreditControlExpectation().Expect(expectedUpdateReq).Return(expectedUpdateAns)
+
+	// E/A that will not be met
+	expectedReqNotMet := fegprotos.NewGxCCRequest(test.IMSI1, fegprotos.CCRequestType_UPDATE, 3)
+	answerNotMet := fegprotos.NewGxCCAnswer(diam.UnableToComply)
+	expectationNotMet := fegprotos.NewGxCreditControlExpectation().Expect(expectedReqNotMet).Return(answerNotMet)
+
+	defaultCCA := &fegprotos.GxCreditControlAnswer{
+		ResultCode: 2001,
+	}
+	pcrf := startServerWithExpectations(
+		clientConfig, &serverConfig1,
+		[]*fegprotos.GxCreditControlExpectation{expectedInit, expectedUpdate, expectationNotMet},
+		fegprotos.UnexpectedRequestBehavior_CONTINUE_WITH_DEFAULT_ANSWER,
+		defaultCCA)
+
+	gxClient := gx.NewGxClient(clientConfig, &serverConfig2, getMockReAuthHandler(), nil, nil)
+
+	// send init
+	ccrInit := &gx.CreditControlRequest{
+		SessionID:     "1",
+		Type:          credit_control.CRTInit,
+		IMSI:          test.IMSI1,
+		RequestNumber: 1,
+		IPAddr:        "192.168.1.1",
+		SpgwIPV4:      "10.10.10.10",
+	}
+	done := make(chan interface{}, 1000)
+
+	assert.NoError(t, gxClient.SendCreditControlRequest(&serverConfig, done, ccrInit))
+	actualAnswer := gx.GetAnswer(done)
+	assertCCAIsEqualToExpectedAnswer(t, actualAnswer, expectedInitAns)
+
+	ccrUpdate := &gx.CreditControlRequest{
+		SessionID:     "1",
+		Type:          credit_control.CRTUpdate,
+		IMSI:          test.IMSI1,
+		RequestNumber: 2,
+		IPAddr:        "192.168.1.1",
+		SpgwIPV4:      "10.10.10.10",
+		UsageReports: []*gx.UsageReport{
+			{
+				MonitoringKey: []byte("mkey1"),
+				Level:         gx.RuleLevel,
+				TotalOctets:   950,
+			},
+		},
+	}
+	done = make(chan interface{}, 1000)
+	assert.NoError(t, gxClient.SendCreditControlRequest(&serverConfig, done, ccrUpdate))
+	actualAnswer = gx.GetAnswer(done)
+	assertCCAIsEqualToExpectedAnswer(t, actualAnswer, expectedUpdateAns)
+
+	// send an unexpected request
+	ccrUpdateUnexpected := &gx.CreditControlRequest{
+		SessionID:     "2",
+		Type:          credit_control.CRTTerminate,
+		IMSI:          test.IMSI2,
+		RequestNumber: 3,
+		IPAddr:        "192.168.1.1",
+		SpgwIPV4:      "10.10.10.10",
+	}
+	done = make(chan interface{}, 1000)
+
+	assert.NoError(t, gxClient.SendCreditControlRequest(&serverConfig, done, ccrUpdateUnexpected))
+	unexpectedAnswer := gx.GetAnswer(done)
+	assertCCAIsEqualToExpectedAnswer(t, unexpectedAnswer, defaultCCA)
+
+	// should complain about an unexpected request
+	res, err := pcrf.AssertExpectations(context.Background(), &orcprotos.Void{})
+	assert.Nil(t, err)
+
+	expectedResult := []*fegprotos.ExpectationResult{
+		{
+			ExpectationMet:   true,
+			ExpectationIndex: 0,
+		},
+		{
+			ExpectationMet:   true,
+			ExpectationIndex: 1,
+		},
+		{
+			ExpectationMet:   false,
+			ExpectationIndex: 2,
+		},
+	}
+	assert.ElementsMatch(t, expectedResult, res.Results)
+	expectedErrors := []*fegprotos.ErrorByIndex{
+		{
+			Index: 2,
+			Error: "Expected: Imsi: 001010000000055, Type: UPDATE, " +
+				"Received: Imsi: 001010000000043, Type: TERMINATION",
+		},
+	}
+	assert.ElementsMatch(t, expectedErrors, res.Errors)
+}
+
+func assertCCAIsEqualToExpectedAnswer(t *testing.T, actual *gx.CreditControlAnswer, expectation *fegprotos.GxCreditControlAnswer) {
+	ruleNames, ruleBaseNames, ruleDefinitions := getRuleInstallsFromCCA(actual)
+	assert.ElementsMatch(t, expectation.GetRuleInstalls().GetRuleNames(), ruleNames)
+	assert.ElementsMatch(t, expectation.GetRuleInstalls().GetRuleBaseNames(), ruleBaseNames)
+	assert.ElementsMatch(t, expectation.GetRuleInstalls().GetRuleDefinitions(), ruleDefinitions)
+	usageMonitors := getUsageMonitorsFromCCA(actual)
+	assert.ElementsMatch(t, expectation.GetUsageMonitoringInfos(), usageMonitors)
+}
+
+func getRuleInstallsFromCCA(cca *gx.CreditControlAnswer) ([]string, []string, []*fegprotos.RuleDefinition) {
+	var ruleNames []string
+	var ruleBaseNames []string
+	var ruleDefinitions []*fegprotos.RuleDefinition
+	for _, installRule := range cca.RuleInstallAVP {
+		ruleNames = append(ruleNames, installRule.RuleNames...)
+		ruleBaseNames = append(ruleBaseNames, installRule.RuleBaseNames...)
+		ruleDefinitions = append(ruleDefinitions, toProtosRuleDefinitions(installRule.RuleDefinitions)...)
+	}
+	return ruleNames, ruleBaseNames, ruleDefinitions
+}
+
+func toProtosRuleDefinitions(gxRuleDfs []*gx.RuleDefinition) []*fegprotos.RuleDefinition {
+	ruleDefs := []*fegprotos.RuleDefinition{}
+	for _, ruleDef := range gxRuleDfs {
+		ruleDefs = append(ruleDefs, &fegprotos.RuleDefinition{
+			RuleName:            ruleDef.RuleName,
+			RatingGroup:         swag.Uint32Value(ruleDef.RatingGroup),
+			Precedence:          ruleDef.Precedence,
+			MonitoringKey:       string(ruleDef.MonitoringKey),
+			FlowDescriptions:    ruleDef.FlowDescriptions,
+			RedirectInformation: ruleDef.RedirectInformation.ToProto(),
+			QosInformation:      ruleDef.Qos.ToProto(),
+		})
+	}
+	return ruleDefs
+}
+
+func getUsageMonitorsFromCCA(cca *gx.CreditControlAnswer) []*fegprotos.UsageMonitoringInformation {
+	monitors := []*fegprotos.UsageMonitoringInformation{}
+	for _, usageMonitor := range cca.UsageMonitors {
+		monitors = append(monitors, &fegprotos.UsageMonitoringInformation{
+			MonitoringKey:   usageMonitor.MonitoringKey,
+			MonitoringLevel: fegprotos.MonitoringLevel(usageMonitor.Level),
+			Octets:          grantedServiceUnitToOctet(usageMonitor.GrantedServiceUnit),
+		})
+	}
+	return monitors
+}
+
+func grantedServiceUnitToOctet(gsu *credit_control.GrantedServiceUnit) *fegprotos.Octets {
+	return &fegprotos.Octets{
+		TotalOctets:  swag.Uint64Value(gsu.TotalOctets),
+		InputOctets:  swag.Uint64Value(gsu.InputOctets),
+		OutputOctets: swag.Uint64Value(gsu.OutputOctets),
+	}
+}
+
+func getClientConfig() *diameter.DiameterClientConfig {
+	return &diameter.DiameterClientConfig{
+		Host:        "test.test.com",
+		Realm:       "test.com",
+		ProductName: "gx_test",
+		AppID:       diam.GX_CHARGING_CONTROL_APP_ID,
+	}
+}
+
+func getMockReAuthHandler() gx.ReAuthHandler {
+	return func(request *gx.ReAuthRequest) *gx.ReAuthAnswer {
+		return &gx.ReAuthAnswer{
+			SessionID:  request.SessionID,
+			ResultCode: diam.Success,
+		}
+	}
+}


### PR DESCRIPTION
Summary:
- `mock_core_conversions.go` Some conversion functions to make defining expectations a bit easier
- `mock_driver.go` quick bug fix to not get an out of bounds exception
- `mock.go` A whole bunch of functions to compare CCR messages to protos.GxCreditControlRequest, and convert protos.GxCreditControlAnswer to AVPs.

Differential Revision: D20451841

