### PR TITLE
Fix Pylint error from D19443825

### DIFF
--- a/lte/gateway/python/integ_tests/common/subscriber_db_client.py
+++ b/lte/gateway/python/integ_tests/common/subscriber_db_client.py
@@ -195,6 +195,8 @@ class SubscriberDbGrpc(SubscriberDbClient):
     def config_apn_details(self, imsi, apn_list):
         sid = SIDUtils.to_pb(imsi)
         update_sub = self._get_apn_data(sid, apn_list)
+        fields = update_sub.mask.paths
+        fields.append('non_3gpp')
         SubscriberDbGrpc._try_to_call(
             lambda: self._subscriber_stub.UpdateSubscriber(update_sub)
         )

--- a/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/rpc_servicer.py
@@ -11,13 +11,10 @@ import logging
 
 import grpc
 from lte.protos import subscriberdb_pb2, subscriberdb_pb2_grpc
-
 from magma.common.rpc_utils import return_void
 from magma.subscriberdb.sid import SIDUtils
-from .store.base import (
-    DuplicateSubscriberError,
-    SubscriberNotFoundError,
-)
+
+from .store.base import DuplicateSubscriberError, SubscriberNotFoundError
 
 
 class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
@@ -47,7 +44,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         try:
             self._store.add_subscriber(request)
         except DuplicateSubscriberError:
-            context.set_details('Duplicate subscriber: %s' % sid)
+            context.set_details("Duplicate subscriber: %s" % sid)
             context.set_code(grpc.StatusCode.ALREADY_EXISTS)
 
     @return_void
@@ -66,10 +63,12 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         """
         sid = SIDUtils.to_str(request.data.sid)
         try:
-            with self._store.edit_subscriber(sid, request) as subs:
-                request.mask.MergeMessage(request.data, subs)
+            with self._store.edit_subscriber(sid) as subs:
+                request.mask.MergeMessage(
+                    request.data, subs, replace_message_field=True
+                )
         except SubscriberNotFoundError:
-            context.set_details('Subscriber not found: %s' % sid)
+            context.set_details("Subscriber not found: %s" % sid)
             context.set_code(grpc.StatusCode.NOT_FOUND)
 
     def GetSubscriberData(self, request, context):
@@ -80,7 +79,7 @@ class SubscriberDBRpcServicer(subscriberdb_pb2_grpc.SubscriberDBServicer):
         try:
             return self._store.get_subscriber_data(sid)
         except SubscriberNotFoundError:
-            context.set_details('Subscriber not found: %s' % sid)
+            context.set_details("Subscriber not found: %s" % sid)
             context.set_code(grpc.StatusCode.NOT_FOUND)
             return subscriberdb_pb2.SubscriberData()
 

--- a/lte/gateway/python/magma/subscriberdb/store/sqlite.py
+++ b/lte/gateway/python/magma/subscriberdb/store/sqlite.py
@@ -70,8 +70,7 @@ class SqliteStore(BaseStore):
         self._on_ready.add_subscriber(subscriber_data)
 
     @contextmanager
-    # pylint: disable=W0221
-    def edit_subscriber(self, subscriber_id, request=None):
+    def edit_subscriber(self, subscriber_id):
         """
         Context manager to modify the subscriber data.
         """
@@ -85,15 +84,6 @@ class SqliteStore(BaseStore):
                 raise SubscriberNotFoundError(subscriber_id)
             subscriber_data = SubscriberData()
             subscriber_data.ParseFromString(row[0])
-            # Manually update APN config as MergeMessage() does not work on
-            # repeated field
-            if request and request.data.non_3gpp.apn_config:
-                # Delete the existing APN config/s in the subscriberdb and add
-                # new APN config received
-                del subscriber_data.non_3gpp.apn_config[:]
-                for apn in request.data.non_3gpp.apn_config:
-                    apn_config = subscriber_data.non_3gpp.apn_config.add()
-                    self._update_apn(apn_config, apn)
             yield subscriber_data
             data_str = subscriber_data.SerializeToString()
             self.conn.execute(

--- a/lte/gateway/python/scripts/subscriber_cli.py
+++ b/lte/gateway/python/scripts/subscriber_cli.py
@@ -115,6 +115,7 @@ def update_subscriber(client, args):
             )
             apn_config.ambr.max_bandwidth_ul = int(apn_dict[ul])
             apn_config.ambr.max_bandwidth_dl = int(apn_dict[dl])
+        fields.append('non_3gpp')
 
     client.UpdateSubscriber(update)
 


### PR DESCRIPTION
Summary: Pylint error was complaining about the inherited class not following the base class function signature in CLI support for APN configurations. The function signature is reverted back to what the base class expects and the rest of the code is modified accordingly.

Differential Revision: D20479120

