### PR TITLE
Convert Enforcement Uplink Test to use expectation based PCRF

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -30,6 +30,7 @@ replace (
 require (
 	fbc/cwf/radius v0.0.0
 	fbc/lib/go/radius v0.0.0-00010101000000-000000000000
+	github.com/fiorix/go-diameter/v4 v4.0.1-0.20200120193412-55a1c21738f9
 	github.com/go-openapi/swag v0.18.0
 	github.com/go-redis/redis v6.15.5+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b

--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestAuthenticate(t *testing.T) {
-	fmt.Printf("Running TestAuthenticate...\n")
+	fmt.Printf("\nRunning TestAuthenticate...\n")
 	tr := NewTestRunner()
 	ues, err := tr.ConfigUEs(3)
 	assert.NoError(t, err)

--- a/cwf/gateway/integ_tests/auth_ul_test.go
+++ b/cwf/gateway/integ_tests/auth_ul_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestAuthenticateUplinkTraffic(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateUplinkTraffic...\n")
+	fmt.Printf("\nRunning TestAuthenticateUplinkTraffic...\n")
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)

--- a/cwf/gateway/integ_tests/enforcement_test.go
+++ b/cwf/gateway/integ_tests/enforcement_test.go
@@ -17,11 +17,12 @@ import (
 
 	"fbc/lib/go/radius/rfc2869"
 	cwfprotos "magma/cwf/cloud/go/protos"
+	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/eap"
 	"magma/lte/cloud/go/plugin/models"
-
 	lteProtos "magma/lte/cloud/go/protos"
 
+	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
@@ -34,25 +35,42 @@ const (
 )
 
 func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateUplinkTrafficWithEnforcement...\n")
+	fmt.Printf("\nRunning TestAuthenticateUplinkTrafficWithEnforcement...\n")
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
+	assert.NoError(t, usePCRFMockDriver())
 
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
 	imsi := ues[0].GetImsi()
 
-	// setup policy rules & monitor
-	// 1. Install a usage monitor
-	// 2. Install a static rule that passes all traffic tied to the usage monitor above
-	// 3. Install a dynamic rule that points to the static rule above
-	err = ruleManager.AddUsageMonitor(imsi, "mkey1", 1000*KiloBytes, 250*KiloBytes)
+	err = ruleManager.AddStaticPassAllToDB("ul-enforcement-static-pass-all", "mkey1", 0, models.PolicyRuleTrackingTypeONLYPCRF, 3)
 	assert.NoError(t, err)
-	err = ruleManager.AddStaticPassAllToDB("static-pass-all", "mkey1", 0, models.PolicyRuleTrackingTypeONLYPCRF, 3)
-	assert.NoError(t, err)
-	err = ruleManager.AddRulesToPCRF(imsi, []string{"static-pass-all"}, nil)
-	assert.NoError(t, err)
+
+	usageMonitorInfo := []*protos.UsageMonitoringInformation{
+		{
+			MonitoringLevel: protos.MonitoringLevel_RuleLevel,
+			MonitoringKey:   []byte("mkey1"),
+			Octets:          &protos.Octets{TotalOctets: 250 * KiloBytes},
+		},
+	}
+
+	initRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGxCCAnswer(diam.Success).
+		SetStaticRuleInstalls([]string{"ul-enforcement-static-pass-all"}, []string{}).
+		SetUsageMonitorInfos(usageMonitorInfo)
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	// We expect an update request with some usage update (probably around 80-100% of the given quota)
+	updateRequest1 := protos.NewGxCCRequest(imsi, protos.CCRequestType_UPDATE, 2).
+		SetUsageMonitorReports(usageMonitorInfo).
+		SetUsageReportDelta(250 * KiloBytes * 0.2)
+	updateAnswer1 := protos.NewGxCCAnswer(diam.Success).SetUsageMonitorInfos(usageMonitorInfo)
+	updateExpectation1 := protos.NewGxCreditControlExpectation().Expect(updateRequest1).Return(updateAnswer1)
+	expectations := []*protos.GxCreditControlExpectation{initExpectation, updateExpectation1}
+	// On unexpected requests, just return the default update answer
+	assert.NoError(t, setPCRFExpectations(expectations, updateAnswer1))
 
 	// wait for the rules to be synced into sessiond
 	time.Sleep(1 * time.Second)
@@ -64,7 +82,6 @@ func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
 	assert.NotNil(t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
 	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
 
-	// TODO assert CCR-I
 	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("500K")}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -76,14 +93,44 @@ func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
 	// amount of data was passed through
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
-	record := recordsBySubID["IMSI"+imsi]["static-pass-all"]
+	record := recordsBySubID["IMSI"+imsi]["ul-enforcement-static-pass-all"]
 	assert.NotNil(t, record, fmt.Sprintf("No policy usage record for imsi: %v", imsi))
-	// We should not be seeing > 1024k data here
-	assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
-	assert.True(t, record.BytesTx <= uint64(500*KiloBytes+Buffer), fmt.Sprintf("policy usage: %v", record))
-	// TODO Talk to PCRF and verify appropriate CCRs propagate up
+	if record != nil {
+		// We should not be seeing > 1024k data here
+		assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
+		assert.True(t, record.BytesTx <= uint64(500*KiloBytes+Buffer), fmt.Sprintf("policy usage: %v", record))
+	}
+
+	// Assert that reasonable CCR-I and at least one CCR-U were sent up to the PCRF
+	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult := []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+		{ExpectationIndex: 1, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+
+	// When we initiate a UE disconnect, we expect a terminate request to go up
+	terminateRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_TERMINATION, 3)
+	terminateAnswer := protos.NewGxCCAnswer(diam.Success)
+	terminateExpectation := protos.NewGxCreditControlExpectation().Expect(terminateRequest).Return(terminateAnswer)
+	expectations = []*protos.GxCreditControlExpectation{terminateExpectation}
+	assert.NoError(t, setPCRFExpectations(expectations, nil))
+
 	_, err = tr.Disconnect(imsi)
 	assert.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	// Assert that we saw a Terminate request
+	resultByIndex, errByIndex, err = getAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult = []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+	assert.NoError(t, clearPCRFMockDriver())
 
 	// Clear hss, ocs, and pcrf
 	assert.NoError(t, ruleManager.RemoveInstalledRules())
@@ -91,7 +138,7 @@ func TestAuthenticateUplinkTrafficWithEnforcement(t *testing.T) {
 }
 
 func TestAuthenticateUplinkTrafficWithQosEnforcement(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateUplinkTrafficWithQosEnforcement...\n")
+	fmt.Printf("\nRunning TestAuthenticateUplinkTrafficWithQosEnforcement...\n")
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
@@ -166,7 +213,6 @@ func TestAuthenticateUplinkTrafficWithQosEnforcement(t *testing.T) {
 	_, err = tr.Disconnect(imsi)
 	assert.NoError(t, err)
 	time.Sleep(3 * time.Second)
-
 	// Clear hss, ocs, and pcrf
 	assert.NoError(t, ruleManager.RemoveInstalledRules())
 	assert.NoError(t, tr.CleanUp())
@@ -175,7 +221,7 @@ func TestAuthenticateUplinkTrafficWithQosEnforcement(t *testing.T) {
 }
 
 func testAuthenticateDownlinkTrafficWithQosEnforcement(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateDownlinkTrafficWithQosEnforcement...\n")
+	fmt.Printf("\nRunning TestAuthenticateDownlinkTrafficWithQosEnforcement...\n")
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
@@ -246,4 +292,5 @@ func testAuthenticateDownlinkTrafficWithQosEnforcement(t *testing.T) {
 	// Clear hss, ocs, and pcrf
 	assert.NoError(t, ruleManager.RemoveInstalledRules())
 	assert.NoError(t, tr.CleanUp())
+	clearPCRFMockDriver()
 }

--- a/cwf/gateway/integ_tests/ocs_credit_exhausted1_test.go
+++ b/cwf/gateway/integ_tests/ocs_credit_exhausted1_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 func TestAuthenticateOcsCreditExhaustedWithCRRU(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateOcsCreditExhaustedWithCRRU...\n")
+	fmt.Printf("\nRunning TestAuthenticateOcsCreditExhaustedWithCRRU...\n")
 
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()

--- a/cwf/gateway/integ_tests/ocs_credit_exhausted2_test.go
+++ b/cwf/gateway/integ_tests/ocs_credit_exhausted2_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestAuthenticateOcsCreditExhaustedWithoutCRRU(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateOcsCreditExhaustedWithoutCCRU...\n")
+	fmt.Printf("\nRunning TestAuthenticateOcsCreditExhaustedWithoutCCRU...\n")
 
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -189,6 +189,52 @@ func setNewOCSConfig(ocsConfig *fegprotos.OCSConfig) error {
 	return err
 }
 
+func usePCRFMockDriver() error {
+	cli, err := getPCRFClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.SetPCRFConfigs(context.Background(), &fegprotos.PCRFConfigs{UseMockDriver: true})
+	return err
+}
+
+func clearPCRFMockDriver() error {
+	cli, err := getPCRFClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.SetPCRFConfigs(context.Background(), &fegprotos.PCRFConfigs{UseMockDriver: false})
+	return err
+}
+
+func setPCRFExpectations(expectations []*fegprotos.GxCreditControlExpectation, defaultAnswer *fegprotos.GxCreditControlAnswer) error {
+	cli, err := getPCRFClient()
+	if err != nil {
+		return err
+	}
+	request := &fegprotos.GxCreditControlExpectations{
+		Expectations: expectations,
+		GxDefaultCca: defaultAnswer,
+	}
+	if defaultAnswer != nil {
+		request.UnexpectedRequestBehavior = fegprotos.UnexpectedRequestBehavior_CONTINUE_WITH_DEFAULT_ANSWER
+	}
+	_, err = cli.SetExpectations(context.Background(), request)
+	return err
+}
+
+func getAssertExpectationsResult() ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
+	cli, err := getPCRFClient()
+	if err != nil {
+		return nil, nil, nil
+	}
+	res, err := cli.AssertExpectations(context.Background(), &protos.Void{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return res.Results, res.Errors, nil
+}
+
 // addSubscriber tries to add this subscriber to the OCS server.
 // Input: The subscriber data which will be added.
 func addSubscriberToOCS(sub *lteprotos.SubscriberID) error {

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -267,7 +267,3 @@ func makeSubscriber(imsi string, key []byte, opc []byte, seq uint64) *lteprotos.
 		},
 	}
 }
-
-func makeDynamicRuleIDFromIMSI(imsi string) string {
-	return "dynrule1-" + imsi
-}


### PR DESCRIPTION
Summary:
- Add Gx Expectations for CCR-I, one CCR-U with usage report and assert that the expectations are met
- Add Gx Expectations for CCR-T and trigger a UE disconnect. Assert that the expectations are met.
- I added a new line infront of the prints for each test so that the test logs are a bit more readable

Differential Revision: D20427365

