### PR TITLE
Session Manager's SessionState class accepts UpdateCriteria structs in its methods

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -108,6 +108,7 @@ add_library(SESSION_MANAGER
     CreditPool.h
     SessionProxyResponderHandler.cpp
     SessionProxyResponderHandler.h
+    StoredState.cpp
     StoredState.h
     SessionStore.cpp
     SessionStore.h

--- a/lte/gateway/c/session_manager/CreditPool.h
+++ b/lte/gateway/c/session_manager/CreditPool.h
@@ -30,14 +30,19 @@ class CreditPool {
   /**
    * add_used_credit adds usage to a specific credit
    */
-  virtual bool
-  add_used_credit(const KeyType &key, uint64_t used_tx, uint64_t used_rx) = 0;
+  virtual bool add_used_credit(
+    const KeyType &key,
+    uint64_t used_tx,
+    uint64_t used_rx,
+    SessionStateUpdateCriteria& update_criteria) = 0;
 
   /**
    * reset_reporting_credit resets the credit state machine by clearing any
    * credit that was in the reporting state
    */
-  virtual bool reset_reporting_credit(const KeyType &key) = 0;
+  virtual bool reset_reporting_credit(
+    const KeyType &key,
+    SessionStateUpdateCriteria& update_criteria) = 0;
 
   /**
    * get_updates gets any usage updates required by the credits in the pool
@@ -48,7 +53,8 @@ class CreditPool {
     StaticRuleStore &static_rules,
     DynamicRuleStore *dynamic_rules,
     std::vector<UpdateRequestType> *updates_out,
-    std::vector<std::unique_ptr<ServiceAction>> *actions_out) const = 0;
+    std::vector<std::unique_ptr<ServiceAction>> *actions_out,
+    SessionStateUpdateCriteria& update_criteria) = 0;
 
   /**
    * get_termination_updates gets updates from all credits in the pool at the
@@ -60,12 +66,18 @@ class CreditPool {
   /**
    * receive_credit adds allowed credit from the cloud
    */
-  virtual bool receive_credit(const UpdateResponseType &update) = 0;
+  virtual bool receive_credit(
+    const UpdateResponseType &update,
+    SessionStateUpdateCriteria& update_criteria) = 0;
 
   /**
    * get_credit is a helper function to return the bytes in a credit bucket
    */
   virtual uint64_t get_credit(const KeyType &key, Bucket bucket) const = 0;
+
+  virtual SessionCreditUpdateCriteria* get_credit_update(
+    const KeyType &key,
+    SessionStateUpdateCriteria& update_criteria) = 0;
 
   /**
    * Updates either the Monitor or SessionCredit using the update criteria
@@ -83,6 +95,8 @@ class CreditPool {
 class ChargingCreditPool :
   public CreditPool<CreditKey, CreditUpdateResponse, CreditUsage> {
  public:
+  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
+
   static std::unique_ptr<ChargingCreditPool> unmarshal(
     const StoredChargingCreditPool &marshaled);
 
@@ -90,10 +104,15 @@ class ChargingCreditPool :
 
   ChargingCreditPool(const std::string &imsi);
 
-  bool add_used_credit(const CreditKey &key, uint64_t used_tx, uint64_t used_rx)
-    override;
+  bool add_used_credit(
+    const CreditKey &key,
+    uint64_t used_tx,
+    uint64_t used_rx,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
-  bool reset_reporting_credit(const CreditKey &key) override;
+  bool reset_reporting_credit(
+    const CreditKey &key,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   void get_updates(
     std::string imsi,
@@ -101,24 +120,37 @@ class ChargingCreditPool :
     StaticRuleStore &static_rules,
     DynamicRuleStore *dynamic_rules,
     std::vector<CreditUsage> *updates_out,
-    std::vector<std::unique_ptr<ServiceAction>> *actions_out) const override;
+    std::vector<std::unique_ptr<ServiceAction>> *actions_out,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   bool get_termination_updates(
     SessionTerminateRequest *termination_out) const override;
 
-  bool receive_credit(const CreditUpdateResponse &update) override;
+  bool receive_credit(
+    const CreditUpdateResponse &update,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   uint64_t get_credit(const CreditKey &key, Bucket bucket) const override;
 
-  void add_credit(const CreditKey &key, std::unique_ptr<SessionCredit> credit);
+  void add_credit(
+    const CreditKey &key,
+    std::unique_ptr<SessionCredit> credit,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+
+  SessionCreditUpdateCriteria* get_credit_update(
+    const CreditKey &key,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   void merge_credit_update(
     const CreditKey &key,
     const SessionCreditUpdateCriteria &credit_update) override;
 
-  ChargingReAuthAnswer::Result reauth_key(const CreditKey &charging_key);
+  ChargingReAuthAnswer::Result reauth_key(
+    const CreditKey &charging_key,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
-  ChargingReAuthAnswer::Result reauth_all();
+  ChargingReAuthAnswer::Result reauth_all(
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
  private:
   std::unordered_map<
@@ -127,7 +159,9 @@ class ChargingCreditPool :
   std::string imsi_;
 
  private:
-  bool init_new_credit(const CreditUpdateResponse &update);
+  bool init_new_credit(
+    const CreditUpdateResponse &update,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   void populate_output_actions(
     std::string imsi,
@@ -150,12 +184,17 @@ class UsageMonitoringCreditPool :
     UsageMonitoringUpdateResponse,
     UsageMonitorUpdate> {
  public:
+  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
+
   struct Monitor {
     SessionCredit credit;
     MonitoringLevel level;
 
     Monitor(): credit(CreditType::MONITORING) {}
   };
+
+  static StoredMonitor marshal_monitor(
+    std::unique_ptr<UsageMonitoringCreditPool::Monitor> &monitor);
 
   static std::unique_ptr<Monitor> unmarshal_monitor(
     const StoredMonitor &marshaled);
@@ -170,9 +209,12 @@ class UsageMonitoringCreditPool :
   bool add_used_credit(
     const std::string &key,
     uint64_t used_tx,
-    uint64_t used_rx) override;
+    uint64_t used_rx,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
-  bool reset_reporting_credit(const std::string &key) override;
+  bool reset_reporting_credit(
+    const std::string &key,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   void get_updates(
     std::string imsi,
@@ -180,18 +222,26 @@ class UsageMonitoringCreditPool :
     StaticRuleStore &static_rules,
     DynamicRuleStore *dynamic_rules,
     std::vector<UsageMonitorUpdate> *updates_out,
-    std::vector<std::unique_ptr<ServiceAction>> *actions_out) const override;
+    std::vector<std::unique_ptr<ServiceAction>> *actions_out,
+    SessionStateUpdateCriteria& _ = UNUSED_UPDATE_CRITERIA) override;
 
   bool get_termination_updates(
     SessionTerminateRequest *termination_out) const override;
 
-  bool receive_credit(const UsageMonitoringUpdateResponse &update) override;
+  bool receive_credit(
+    const UsageMonitoringUpdateResponse &update,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   uint64_t get_credit(const std::string &key, Bucket bucket) const override;
 
   void add_monitor(
     const std::string &key,
-    std::unique_ptr<UsageMonitoringCreditPool::Monitor> monitor);
+    std::unique_ptr<UsageMonitoringCreditPool::Monitor> monitor,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+
+  SessionCreditUpdateCriteria* get_credit_update(
+    const std::string &key,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
 
   void merge_credit_update(
     const std::string &key,
@@ -206,8 +256,12 @@ class UsageMonitoringCreditPool :
   std::unique_ptr<std::string> session_level_key_;
 
  private:
-  void update_session_level_key(const UsageMonitoringUpdateResponse &update);
-  bool init_new_credit(const UsageMonitoringUpdateResponse &update);
+  void update_session_level_key(
+    const UsageMonitoringUpdateResponse &update,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+  bool init_new_credit(
+    const UsageMonitoringUpdateResponse &update,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
   void populate_output_actions(
     std::string imsi,
     std::string ip_addr,

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -40,6 +40,8 @@ enum CreditType {
  */
 class SessionCredit {
  public:
+  static SessionCreditUpdateCriteria UNUSED_UPDATE_CRITERIA;
+
   struct Usage {
     uint64_t bytes_tx;
     uint64_t bytes_rx;
@@ -56,6 +58,8 @@ class SessionCredit {
 
   StoredSessionCredit marshal();
 
+  SessionCreditUpdateCriteria get_update_criteria();
+
   SessionCredit(CreditType credit_type);
 
   SessionCredit(CreditType credit_type, ServiceState start_state);
@@ -69,19 +73,24 @@ class SessionCredit {
    * add_used_credit increments USED_TX and USED_RX
    * as being recently updated
    */
-  void add_used_credit(uint64_t used_tx, uint64_t used_rx);
+  void add_used_credit(
+    uint64_t used_tx,
+    uint64_t used_rx,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * reset_reporting_credit resets the REPORTING_* to 0
    * Also marks the session as not in reporting.
    */
-  void reset_reporting_credit();
+  void reset_reporting_credit(SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Credit update has failed to the OCS, so mark this credit as failed so it
    * can be cut off accordingly
    */
-  void mark_failure(uint32_t code = 0);
+  void mark_failure(
+    uint32_t code = 0,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
   /**
    * receive_credit increments ALLOWED* and moves the REPORTING_* credit to
    * the REPORTED_* credit
@@ -92,7 +101,8 @@ class SessionCredit {
     uint64_t rx_volume,
     uint32_t validity_time,
     bool is_final_grant,
-    FinalActionInfo final_action_info);
+    FinalActionInfo final_action_info,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * get_update_type returns the type of update required for the credit. If no
@@ -106,13 +116,15 @@ class SessionCredit {
    * one if no update exists. Check has_update before calling.
    * This method also sets the REPORTING_* credit buckets
    */
-  SessionCredit::Usage get_usage_for_reporting(bool is_termination);
+  SessionCredit::Usage get_usage_for_reporting(
+    bool is_termination,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * get_action returns the action to take on the credit based on the last
    * update. If no action needs to take place, CONTINUE_SERVICE is returned.
    */
-  ServiceActionType get_action();
+  ServiceActionType get_action(SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Returns true if either of REPORTING_* buckets are more than 0
@@ -128,7 +140,7 @@ class SessionCredit {
    * Mark the credit to be in the REAUTH_REQUIRED state. The next time
    * get_update is called, this credit will report its usage.
    */
-  void reauth();
+  void reauth(SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Returns
@@ -140,28 +152,36 @@ class SessionCredit {
    * NOTE: Use only for merging updates into SessionStore
    * @param is_final_grant
    */
-  void set_is_final_grant(bool is_final_grant);
+  void set_is_final_grant(
+    bool is_final_grant,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Set ReAuthState.
    * NOTE: Use only for merging updates into SessionStore
    * @param reauth_state
    */
-  void set_reauth(ReAuthState reauth_state);
+  void set_reauth(
+    ReAuthState reauth_state,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Set ServiceState.
    * NOTE: Use only for merging updates into SessionStore
    * @param service_state
    */
-  void set_service_state(ServiceState service_state);
+  void set_service_state(
+    ServiceState service_state,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Set expiry time of SessionCredit
    * NOTE: Use only for merging updates into SessionStore
    * @param expiry_time
    */
-  void set_expiry_time(std::time_t expiry_time);
+  void set_expiry_time(
+    std::time_t expiry_time,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Add credit to the specified bucket. This does not necessarily correspond
@@ -170,7 +190,10 @@ class SessionCredit {
    * @param credit
    * @param bucket
    */
-  void add_credit(uint64_t credit, Bucket bucket);
+  void add_credit(
+    uint64_t credit,
+    Bucket bucket,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * A threshold represented as a ratio for triggering usage update before
@@ -239,7 +262,9 @@ class SessionCredit {
 
   bool validity_timer_expired();
 
-  void set_expiry_time(uint32_t validity_time);
+  void set_expiry_time(
+    uint32_t validity_time,
+    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   bool is_reauth_required();
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -15,6 +15,8 @@
 
 namespace magma {
 
+SessionStateUpdateCriteria SessionState::UNUSED_UPDATE_CRITERIA = get_default_update_criteria();
+
 std::unique_ptr<SessionState> SessionState::unmarshal(
   const StoredSessionState &marshaled, StaticRuleStore &rule_store)
 {
@@ -148,7 +150,8 @@ void SessionState::finish_report()
 void SessionState::add_used_credit(
   const std::string& rule_id,
   uint64_t used_tx,
-  uint64_t used_rx)
+  uint64_t used_rx,
+  SessionStateUpdateCriteria& update_criteria)
 {
   if (curr_state_ == SESSION_TERMINATING_AGGREGATING_STATS) {
     curr_state_ = SESSION_TERMINATING_FLOW_ACTIVE;
@@ -159,25 +162,27 @@ void SessionState::add_used_credit(
     MLOG(MDEBUG) << "Updating used charging credit for Rule=" << rule_id
                  << " Rating Group=" << charging_key.rating_group
                  << " Service Identifier=" << charging_key.service_identifier;
-    charging_pool_.add_used_credit(charging_key, used_tx, used_rx);
+    charging_pool_.add_used_credit(charging_key, used_tx, used_rx, update_criteria);
   }
   std::string monitoring_key;
   if (get_monitoring_key_for_rule_id(rule_id, &monitoring_key)) {
     MLOG(MDEBUG) << "Updating used monitoring credit for Rule=" << rule_id
                  << " Monitoring Key=" << monitoring_key;
-    monitor_pool_.add_used_credit(monitoring_key, used_tx, used_rx);
+    monitor_pool_.add_used_credit(monitoring_key, used_tx, used_rx, update_criteria);
   }
   auto session_level_key_p = monitor_pool_.get_session_level_key();
   if (
     session_level_key_p != nullptr && monitoring_key != *session_level_key_p) {
     // Update session level key if its different
-    monitor_pool_.add_used_credit(*session_level_key_p, used_tx, used_rx);
+    monitor_pool_.add_used_credit(*session_level_key_p, used_tx, used_rx, update_criteria);
   }
 }
 
 void SessionState::set_subscriber_quota_state(
-    const magma::lte::SubscriberQuotaUpdate_Type state)
+    const magma::lte::SubscriberQuotaUpdate_Type state,
+    SessionStateUpdateCriteria& update_criteria)
 {
+  update_criteria.updated_subscriber_quota_state = state;
   subscriber_quota_state_ = state;
 }
 
@@ -188,12 +193,13 @@ bool SessionState::active_monitored_rules_exist()
 
 void SessionState::get_updates_from_charging_pool(
   UpdateSessionRequest& update_request_out,
-  std::vector<std::unique_ptr<ServiceAction>>* actions_out)
+  std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+  SessionStateUpdateCriteria& update_criteria)
 {
   // charging updates
   std::vector<CreditUsage> charging_updates;
   charging_pool_.get_updates(
-    imsi_, config_.ue_ipv4, static_rules_, &dynamic_rules_, &charging_updates, actions_out);
+    imsi_, config_.ue_ipv4, static_rules_, &dynamic_rules_, &charging_updates, actions_out, update_criteria);
   for (const auto& update : charging_updates) {
     auto new_req = update_request_out.mutable_updates()->Add();
     new_req->set_session_id(session_id_);
@@ -217,12 +223,13 @@ void SessionState::get_updates_from_charging_pool(
 
 void SessionState::get_updates_from_monitor_pool(
   UpdateSessionRequest& update_request_out,
-  std::vector<std::unique_ptr<ServiceAction>>* actions_out)
+  std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+  SessionStateUpdateCriteria& update_criteria)
 {
   // monitor updates
   std::vector<UsageMonitorUpdate> monitor_updates;
   monitor_pool_.get_updates(
-    imsi_, config_.ue_ipv4, static_rules_, &dynamic_rules_, &monitor_updates, actions_out);
+    imsi_, config_.ue_ipv4, static_rules_, &dynamic_rules_, &monitor_updates, actions_out, update_criteria);
   for (const auto& update : monitor_updates) {
     auto new_req = update_request_out.mutable_usage_monitors()->Add();
     new_req->set_session_id(session_id_);
@@ -239,16 +246,18 @@ void SessionState::get_updates_from_monitor_pool(
 
 void SessionState::get_updates(
   UpdateSessionRequest& update_request_out,
-  std::vector<std::unique_ptr<ServiceAction>>* actions_out)
+  std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+  SessionStateUpdateCriteria& update_criteria)
 {
   if (curr_state_ != SESSION_ACTIVE) return;
 
-  get_updates_from_charging_pool(update_request_out, actions_out);
-  get_updates_from_monitor_pool(update_request_out, actions_out);
+  get_updates_from_charging_pool(update_request_out, actions_out, update_criteria);
+  get_updates_from_monitor_pool(update_request_out, actions_out, update_criteria);
 }
 
 void SessionState::start_termination(
-  std::function<void(SessionTerminateRequest)> on_termination_callback)
+  std::function<void(SessionTerminateRequest)> on_termination_callback,
+  SessionStateUpdateCriteria& update_criteria)
 {
   curr_state_ = SESSION_TERMINATING_FLOW_ACTIVE;
   on_termination_callback_ = on_termination_callback;
@@ -259,7 +268,8 @@ bool SessionState::can_complete_termination() const
   return curr_state_ == SESSION_TERMINATING_FLOW_DELETED;
 }
 
-void SessionState::mark_as_awaiting_termination()
+void SessionState::mark_as_awaiting_termination(
+  SessionStateUpdateCriteria& update_criteria)
 {
   curr_state_ = SESSION_TERMINATION_SCHEDULED;
 }
@@ -269,7 +279,8 @@ SubscriberQuotaUpdate_Type SessionState::get_subscriber_quota_state() const
   return subscriber_quota_state_;
 }
 
-void SessionState::complete_termination()
+void SessionState::complete_termination(
+  SessionStateUpdateCriteria& update_criteria)
 {
   if (curr_state_ == SESSION_TERMINATED) {
     // session is already terminated. Do nothing.
@@ -397,8 +408,11 @@ bool SessionState::qos_enabled() const
   return config_.qos_info.enabled;
 }
 
-void SessionState::set_tgpp_context(const magma::lte::TgppContext& tgpp_context)
+void SessionState::set_tgpp_context(
+  const magma::lte::TgppContext& tgpp_context,
+  SessionStateUpdateCriteria& update_criteria)
 {
+  update_criteria.updated_tgpp_context = tgpp_context;
   tgpp_context_ = tgpp_context;
 }
 
@@ -452,30 +466,41 @@ bool SessionState::is_static_rule_installed(const std::string& rule_id)
     rule_id) != active_static_rules_.end();
 }
 
-void SessionState::insert_dynamic_rule(const PolicyRule& rule)
+void SessionState::insert_dynamic_rule(
+  const PolicyRule& rule,
+  SessionStateUpdateCriteria& update_criteria)
 {
+  update_criteria.dynamic_rules_to_install.push_back(rule);
   dynamic_rules_.insert_rule(rule);
 }
 
-void SessionState::activate_static_rule(const std::string& rule_id)
+void SessionState::activate_static_rule(
+  const std::string& rule_id,
+  SessionStateUpdateCriteria& update_criteria)
 {
+  update_criteria.static_rules_to_install.push_back(rule_id);
   active_static_rules_.push_back(rule_id);
 }
 
 bool SessionState::remove_dynamic_rule(
   const std::string& rule_id,
-  PolicyRule *rule_out)
+  PolicyRule *rule_out,
+  SessionStateUpdateCriteria& update_criteria)
 {
+  update_criteria.dynamic_rules_to_uninstall.push_back(rule_id);
   return dynamic_rules_.remove_rule(rule_id, rule_out);
 }
 
-bool SessionState::deactivate_static_rule(const std::string& rule_id)
+bool SessionState::deactivate_static_rule(
+  const std::string& rule_id,
+  SessionStateUpdateCriteria& update_criteria)
 {
   auto it = std::find(active_static_rules_.begin(), active_static_rules_.end(),
                       rule_id);
   if (it == active_static_rules_.end()) {
     return false;
   }
+  update_criteria.static_rules_to_uninstall.push_back(rule_id);
   active_static_rules_.erase(it);
   return true;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -24,6 +24,8 @@ namespace magma {
  */
 class SessionState {
  public:
+  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
+
   struct QoSInfo {
     bool enabled;
     uint32_t qci;
@@ -91,7 +93,8 @@ class SessionState {
   void add_used_credit(
     const std::string& rule_id,
     uint64_t used_tx,
-    uint64_t used_rx);
+    uint64_t used_rx,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * get_updates collects updates and adds them to a UpdateSessionRequest
@@ -102,7 +105,8 @@ class SessionState {
    */
   void get_updates(
     UpdateSessionRequest& update_request_out,
-    std::vector<std::unique_ptr<ServiceAction>>* actions_out);
+    std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * start_termination starts the termination process for the session.
@@ -113,13 +117,15 @@ class SessionState {
    * termination
    */
   void start_termination(
-    std::function<void(SessionTerminateRequest)> on_termination_callback);
+    std::function<void(SessionTerminateRequest)> on_termination_callback,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * mark_as_awaiting_termination transitions the session state from
    * SESSION_ACTIVE to SESSION_TERMINATION_SCHEDULED
    */
-  void mark_as_awaiting_termination();
+  void mark_as_awaiting_termination(
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * can_complete_termination returns whether the termination for the session
@@ -138,7 +144,8 @@ class SessionState {
    * termination, this function should only be called when
    * can_complete_termination returns true.
    */
-  void complete_termination();
+  void complete_termination(
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   ChargingCreditPool& get_charging_pool();
 
@@ -174,12 +181,15 @@ class SessionState {
 
   bool qos_enabled() const;
 
-  void set_tgpp_context(const magma::lte::TgppContext& tgpp_context);
+  void set_tgpp_context(
+    const magma::lte::TgppContext& tgpp_context,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 
   void set_subscriber_quota_state(
-    const magma::lte::SubscriberQuotaUpdate_Type state);
+    const magma::lte::SubscriberQuotaUpdate_Type state,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   bool active_monitored_rules_exist();
 
@@ -200,13 +210,22 @@ class SessionState {
 
   bool is_static_rule_installed(const std::string& rule_id);
 
-  void insert_dynamic_rule(const PolicyRule& rule);
+  void insert_dynamic_rule(
+    const PolicyRule& rule,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
-  void activate_static_rule(const std::string& rule_id);
+  void activate_static_rule(
+    const std::string& rule_id,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
-  bool remove_dynamic_rule(const std::string& rule_id, PolicyRule *rule_out);
+  bool remove_dynamic_rule(
+    const std::string& rule_id,
+    PolicyRule *rule_out,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
-  bool deactivate_static_rule(const std::string& rule_id);
+  bool deactivate_static_rule(
+    const std::string& rule_id,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   DynamicRuleStore& get_dynamic_rules();
 
@@ -280,7 +299,8 @@ class SessionState {
    */
   void get_updates_from_charging_pool(
     UpdateSessionRequest& update_request_out,
-    std::vector<std::unique_ptr<ServiceAction>>* actions_out);
+    std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * For this session, add the UsageMonitoringUpdateRequest to the
@@ -291,7 +311,8 @@ class SessionState {
    */
   void get_updates_from_monitor_pool(
     UpdateSessionRequest& update_request_out,
-    std::vector<std::unique_ptr<ServiceAction>>* actions_out);
+    std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "CreditKey.h"
+#include "StoredState.h"
+
+namespace magma {
+
+SessionStateUpdateCriteria get_default_update_criteria()
+{
+  SessionStateUpdateCriteria uc {};
+  uc.charging_credit_to_install = std::unordered_map<
+    CreditKey,
+    StoredSessionCredit,
+    decltype(&ccHash),
+    decltype(&ccEqual)>(4, &ccHash, &ccEqual);
+  uc.charging_credit_map = std::unordered_map<
+    CreditKey,
+    SessionCreditUpdateCriteria,
+    decltype(&ccHash),
+    decltype(&ccEqual)>(4, &ccHash, &ccEqual);
+  return uc;
+}
+
+}; // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -148,6 +148,7 @@ struct SessionStateUpdateCriteria {
   std::unordered_map<std::string, StoredMonitor> monitor_credit_to_install;
   std::unordered_map<std::string, SessionCreditUpdateCriteria> monitor_credit_map;
   TgppContext updated_tgpp_context;
+  magma::lte::SubscriberQuotaUpdate_Type updated_subscriber_quota_state;
 };
 
 SessionStateUpdateCriteria get_default_update_criteria();

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -12,6 +12,7 @@
 
 #include <lte/protos/session_manager.grpc.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
+#include <lte/protos/session_manager.grpc.pb.h>
 
 #include "CreditKey.h"
 
@@ -124,10 +125,13 @@ struct StoredSessionState {
 
 struct SessionCreditUpdateCriteria {
   bool is_final;
+  bool reporting;
   ReAuthState reauth_state;
   ServiceState service_state;
   std::time_t  expiry_time;
+  // Do not mark REPORTING buckets, but do mark REPORTED
   std::unordered_map<Bucket, uint64_t> bucket_deltas;
+  uint64_t usage_reporting_limit;
 };
 
 struct SessionStateUpdateCriteria {
@@ -143,5 +147,9 @@ struct SessionStateUpdateCriteria {
     decltype(&ccHash), decltype(&ccEqual)> charging_credit_map;
   std::unordered_map<std::string, StoredMonitor> monitor_credit_to_install;
   std::unordered_map<std::string, SessionCreditUpdateCriteria> monitor_credit_map;
+  TgppContext updated_tgpp_context;
 };
-}; // namespace magma
+
+SessionStateUpdateCriteria get_default_update_criteria();
+
+} // namespace magma

--- a/lte/gateway/c/session_manager/test/test_credit_pool.cpp
+++ b/lte/gateway/c/session_manager/test/test_credit_pool.cpp
@@ -111,14 +111,17 @@ class CreditPoolTest : public ::testing::Test {
 TEST_F(CreditPoolTest, test_marshal_unmarshal_charging)
 {
   auto pool = new ChargingCreditPool("imsi1");
+  auto uc = get_default_update_criteria();
 
   // Receive credit
   auto credit_update = get_credit_update();
   CreditUpdateResponse& credit_update_ref = *credit_update;
-  pool->receive_credit(credit_update_ref);
+  pool->receive_credit(credit_update_ref, uc);
 
   // Add some used credit
-  pool->add_used_credit(CreditKey(credit_update), uint64_t(123), uint64_t(456));
+  EXPECT_EQ(uc.charging_credit_map.size(), 0);
+  pool->add_used_credit(CreditKey(credit_update), uint64_t(123), uint64_t(456), uc);
+  EXPECT_EQ(uc.charging_credit_map.size(), 1);
   EXPECT_EQ(pool->get_credit(CreditKey(credit_update), USED_TX), 123);
   EXPECT_EQ(pool->get_credit(CreditKey(credit_update), USED_RX), 456);
 
@@ -133,23 +136,28 @@ TEST_F(CreditPoolTest, test_marshal_unmarshal_charging)
 TEST_F(CreditPoolTest, test_marshal_unmarshal_monitoring)
 {
   auto pool = new UsageMonitoringCreditPool("imsi1");
+  auto uc = get_default_update_criteria();
 
   // Receive credit
   auto credit_update = get_monitoring_update();
   UsageMonitoringUpdateResponse& credit_update_ref = *credit_update;
-  pool->receive_credit(credit_update_ref);
+  pool->receive_credit(credit_update_ref, uc);
 
   // Add some used credit
-  pool->add_used_credit("mk1", uint64_t(123), uint64_t(456));
+  EXPECT_EQ(uc.monitor_credit_map.size(), 0);
+  pool->add_used_credit("mk1", uint64_t(123), uint64_t(456), uc);
+  EXPECT_EQ(uc.monitor_credit_map.size(), 1);
   EXPECT_EQ(pool->get_credit("mk1", USED_TX), 123);
   EXPECT_EQ(pool->get_credit("mk1", USED_RX), 456);
+  EXPECT_EQ(uc.monitor_credit_map["mk1"].bucket_deltas[USED_TX], 123);
+  EXPECT_EQ(uc.monitor_credit_map["mk1"].bucket_deltas[USED_RX], 456);
 
   // Check that after marshaling/unmarshaling that the fields are still the
   // same.
   auto marshaled = pool->marshal();
   auto pool_2 = UsageMonitoringCreditPool::unmarshal(marshaled);
-  //EXPECT_EQ(pool_2->get_credit("mk1", USED_TX), 123);
-  //EXPECT_EQ(pool_2->get_credit("mk1", USED_RX), 456);
+  EXPECT_EQ(pool_2->get_credit("mk1", USED_TX), 123);
+  EXPECT_EQ(pool_2->get_credit("mk1", USED_RX), 456);
 }
 
 int main(int argc, char** argv)

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -26,14 +26,19 @@ class SessionCreditParameterizedTest :
 TEST_P(SessionCreditParameterizedTest, test_marshal_unmarshal) {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   // Set some fields here to non default values. Credit is used.
-  credit.add_used_credit((uint64_t) 39u, (uint64_t) 40u);
+  credit.add_used_credit((uint64_t) 39u, (uint64_t) 40u, uc);
 
   // Sanity check of credit usage. Test result after marshal/unmarshal should
   // match.
   EXPECT_EQ(credit.get_credit(USED_TX), (uint64_t) 39u);
   EXPECT_EQ(credit.get_credit(USED_RX), (uint64_t) 40u);
+
+  // Check that the update criteria also includes the changes
+  EXPECT_EQ(uc.bucket_deltas[USED_TX], (uint64_t) 39u);
+  EXPECT_EQ(uc.bucket_deltas[USED_RX], (uint64_t) 40u);
 
   // Check that after marshaling/unmarshaling that the fields are still the
   // same.
@@ -47,45 +52,61 @@ TEST_P(SessionCreditParameterizedTest, test_marshal_unmarshal) {
 TEST_P(SessionCreditParameterizedTest, test_track_credit) {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 3600, false,
-    default_final_action_info);
+    default_final_action_info, uc);
 
   EXPECT_EQ(1024, credit.get_credit(ALLOWED_TOTAL));
   EXPECT_EQ(0, credit.get_credit(USED_TX));
+
+  // Check that the update criteria also includes the changes
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_TOTAL], 1024);
+  EXPECT_EQ(uc.bucket_deltas[USED_TX], 0);
 }
 
 TEST_P(SessionCreditParameterizedTest, test_add_received_credit)
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(10, 20);
+    default_final_action_info, uc);
+  credit.add_used_credit(10, 20, uc);
   EXPECT_EQ(credit.get_credit(USED_TX), 10);
   EXPECT_EQ(credit.get_credit(USED_RX), 20);
-  credit.add_used_credit(30, 40);
+  EXPECT_EQ(uc.bucket_deltas[USED_TX], 10);
+  EXPECT_EQ(uc.bucket_deltas[USED_RX], 20);
+  credit.add_used_credit(30, 40, uc);
   EXPECT_EQ(credit.get_credit(USED_TX), 40);
   EXPECT_EQ(credit.get_credit(USED_RX), 60);
+  EXPECT_EQ(uc.bucket_deltas[USED_TX], 40);
+  EXPECT_EQ(uc.bucket_deltas[USED_RX], 60);
 }
 
 TEST_P(SessionCreditParameterizedTest, test_collect_updates)
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(500, 524);
+    default_final_action_info, uc);
+  credit.add_used_credit(500, 524, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_QUOTA_EXHAUSTED);
-  auto update = credit.get_usage_for_reporting(false);
+  auto update = credit.get_usage_for_reporting(false, uc);
   EXPECT_EQ(update.bytes_tx, 500);
   EXPECT_EQ(update.bytes_rx, 524);
 
   EXPECT_TRUE(credit.is_reporting());
+  EXPECT_TRUE(uc.reporting);
   EXPECT_EQ(credit.get_credit(REPORTING_TX), 500);
   EXPECT_EQ(credit.get_credit(REPORTING_RX), 524);
+  // Only track how much has been reported. The currently reporting amount
+  // should be held in memory only.
+  EXPECT_EQ(uc.bucket_deltas[REPORTING_TX], 0);
+  EXPECT_EQ(uc.bucket_deltas[REPORTING_RX], 0);
 }
 
 /*
@@ -97,32 +118,39 @@ TEST_P(SessionCreditParameterizedTest,
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1000, HIGH_CREDIT, HIGH_CREDIT, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(300, 500);
+    default_final_action_info, uc);
+  credit.add_used_credit(300, 500, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_QUOTA_EXHAUSTED);
-  auto update = credit.get_usage_for_reporting(false);
+  auto update = credit.get_usage_for_reporting(false, uc);
   EXPECT_EQ(update.bytes_tx, 300);
   EXPECT_EQ(update.bytes_rx, 500);
 
   EXPECT_TRUE(credit.is_reporting());
+  EXPECT_TRUE(uc.reporting);
   EXPECT_EQ(credit.get_credit(REPORTING_TX), 300);
   EXPECT_EQ(credit.get_credit(REPORTING_RX), 500);
+  // Only track how much has been reported. The currently reporting amount
+  // should be held in memory only.
+  EXPECT_EQ(uc.bucket_deltas[REPORTING_TX], 0);
+  EXPECT_EQ(uc.bucket_deltas[REPORTING_RX], 0);
 }
 
 TEST_P(SessionCreditParameterizedTest, test_collect_updates_timer_expiries)
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 1, false,
-    default_final_action_info);
-  credit.add_used_credit(20, 30);
+    default_final_action_info, uc);
+  credit.add_used_credit(20, 30, uc);
 
   std::this_thread::sleep_for(std::chrono::milliseconds(1001));
   EXPECT_EQ(credit.get_update_type(), CREDIT_VALIDITY_TIMER_EXPIRED);
-  auto update = credit.get_usage_for_reporting(false);
+  auto update = credit.get_usage_for_reporting(false, uc);
   EXPECT_EQ(update.bytes_tx, 20);
   EXPECT_EQ(update.bytes_rx, 30);
 }
@@ -131,10 +159,11 @@ TEST_P(SessionCreditParameterizedTest, test_collect_updates_none_available)
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1000, HIGH_CREDIT, HIGH_CREDIT, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(400, 399);
+    default_final_action_info, uc);
+  credit.add_used_credit(400, 399, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_NO_UPDATE);
 }
 
@@ -146,46 +175,53 @@ TEST_P(SessionCreditParameterizedTest, test_collect_updates_when_overusing)
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   credit.receive_credit(1000, HIGH_CREDIT, HIGH_CREDIT, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(510, 500);
+    default_final_action_info, uc);
+  credit.add_used_credit(510, 500, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_QUOTA_EXHAUSTED);
-  auto update = credit.get_usage_for_reporting(false);
+  auto update = credit.get_usage_for_reporting(false, uc);
   EXPECT_EQ(update.bytes_tx, 510);
   EXPECT_EQ(update.bytes_rx, 490);
 
   EXPECT_TRUE(credit.is_reporting());
+  EXPECT_TRUE(uc.reporting);
   EXPECT_EQ(credit.get_credit(REPORTING_TX), 510);
   EXPECT_EQ(credit.get_credit(REPORTING_RX), 490);
+  // Only track how much has been reported. The currently reporting amount
+  // should be held in memory only.
+  EXPECT_EQ(uc.bucket_deltas[REPORTING_TX], 0);
+  EXPECT_EQ(uc.bucket_deltas[REPORTING_RX], 0);
 }
 
 TEST_P(SessionCreditParameterizedTest, test_add_rx_tx_credit)
 {
   CreditType credit_type = GetParam();
   SessionCredit credit(credit_type);
+  SessionCreditUpdateCriteria uc{};
 
   // receive tx
   credit.receive_credit(1000, 1000, 0, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(1000, 0);
+    default_final_action_info, uc);
+  credit.add_used_credit(1000, 0, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_QUOTA_EXHAUSTED);
-  auto update = credit.get_usage_for_reporting(false);
+  auto update = credit.get_usage_for_reporting(false, uc);
   EXPECT_EQ(update.bytes_tx, 1000);
   EXPECT_EQ(update.bytes_rx, 0);
 
   // receive rx
   credit.receive_credit(1000, 0, 1000, 3600, false,
-    default_final_action_info);
-  credit.add_used_credit(0, 1000);
+    default_final_action_info, uc);
+  credit.add_used_credit(0, 1000, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_QUOTA_EXHAUSTED);
-  auto update2 = credit.get_usage_for_reporting(false);
+  auto update2 = credit.get_usage_for_reporting(false, uc);
   EXPECT_EQ(update2.bytes_tx, 0);
   EXPECT_EQ(update2.bytes_rx, 1000);
 
   // receive rx, tx, but no usage
   credit.receive_credit(2000, 1000, 1000, 3600, false,
-    default_final_action_info);
+    default_final_action_info, uc);
   EXPECT_EQ(credit.get_update_type(), CREDIT_NO_UPDATE);
 }
 
@@ -198,20 +234,22 @@ TEST(test_get_action_for_charging, test_session_credit)
 {
   // Test Charging Credit
   SessionCredit charging_credit(CreditType::CHARGING);
+  SessionCreditUpdateCriteria uc{};
   charging_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, false,
-    default_final_action_info);
-  charging_credit.add_used_credit(1024, 0);
-  auto cont_action = charging_credit.get_action();
+    default_final_action_info, uc);
+  charging_credit.add_used_credit(1024, 0, uc);
+  auto cont_action = charging_credit.get_action(uc);
   EXPECT_EQ(cont_action, CONTINUE_SERVICE);
+  EXPECT_EQ(uc.service_state, CONTINUE_SERVICE);
   charging_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, true,
-    default_final_action_info);
-  charging_credit.add_used_credit(2048, 0);
-  charging_credit.add_used_credit(30, 20);
-  auto term_action = charging_credit.get_action();
+    default_final_action_info, uc);
+  charging_credit.add_used_credit(2048, 0, uc);
+  charging_credit.add_used_credit(30, 20, uc);
+  auto term_action = charging_credit.get_action(uc);
   EXPECT_EQ(term_action, TERMINATE_SERVICE);
 
   // Termination action only returned once
-  auto repeated_action = charging_credit.get_action();
+  auto repeated_action = charging_credit.get_action(uc);
   EXPECT_EQ(repeated_action, CONTINUE_SERVICE);
 }
 
@@ -219,35 +257,38 @@ TEST(test_get_action_for_monitoring, test_session_credit)
 {
   // Monitoring Credit should never return TERMINATE_SERVICE
   SessionCredit monitoring_credit(CreditType::MONITORING);
+  SessionCreditUpdateCriteria uc{};
   monitoring_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, false,
-    default_final_action_info);
-  monitoring_credit.add_used_credit(1024, 0);
-  auto cont_action = monitoring_credit.get_action();
+    default_final_action_info, uc);
+  monitoring_credit.add_used_credit(1024, 0, uc);
+  auto cont_action = monitoring_credit.get_action(uc);
   EXPECT_EQ(cont_action, CONTINUE_SERVICE);
   monitoring_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, true,
-    default_final_action_info);
-  monitoring_credit.add_used_credit(2048, 0);
-  monitoring_credit.add_used_credit(30, 20);
-  auto term_action = monitoring_credit.get_action();
+    default_final_action_info, uc);
+  monitoring_credit.add_used_credit(2048, 0, uc);
+  monitoring_credit.add_used_credit(30, 20, uc);
+  auto term_action = monitoring_credit.get_action(uc);
   EXPECT_EQ(term_action, CONTINUE_SERVICE);
 }
 
 TEST(test_last_grant_exhausted_for_charging, test_session_credit)
 {
   SessionCredit charging_credit(CreditType::CHARGING);
+  SessionCreditUpdateCriteria uc{};
   charging_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, true,
-    default_final_action_info);
-  charging_credit.add_used_credit(1024, 0);
-  EXPECT_EQ(charging_credit.get_action(), TERMINATE_SERVICE);
+    default_final_action_info, uc);
+  charging_credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(charging_credit.get_action(uc), TERMINATE_SERVICE);
 }
 
 TEST(test_last_grant_exhausted_for_monitoring, test_session_credit)
 {
   SessionCredit monitoring_credit(CreditType::MONITORING);
+  SessionCreditUpdateCriteria uc{};
   monitoring_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, true,
-    default_final_action_info);
-  monitoring_credit.add_used_credit(1024, 0);
-  EXPECT_EQ(monitoring_credit.get_action(), CONTINUE_SERVICE);
+    default_final_action_info, uc);
+  monitoring_credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(monitoring_credit.get_action(uc), CONTINUE_SERVICE);
 }
 
 TEST(test_final_unit_action_restrict_access, test_session_credit)
@@ -256,10 +297,11 @@ TEST(test_final_unit_action_restrict_access, test_session_credit)
   final_action_info.final_action = ChargingCredit_FinalAction_RESTRICT_ACCESS;
 
   SessionCredit charging_credit(CreditType::CHARGING);
+  SessionCreditUpdateCriteria uc{};
   charging_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, true,
-    final_action_info);
-  charging_credit.add_used_credit(1024, 0);
-  EXPECT_EQ(charging_credit.get_action(), RESTRICT_ACCESS);
+    final_action_info, uc);
+  charging_credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(charging_credit.get_action(uc), RESTRICT_ACCESS);
 }
 
 TEST(test_final_unit_action_redirect, test_session_credit)
@@ -268,38 +310,41 @@ TEST(test_final_unit_action_redirect, test_session_credit)
   final_action_info.final_action = ChargingCredit_FinalAction_REDIRECT;
 
   SessionCredit charging_credit(CreditType::CHARGING);
+  SessionCreditUpdateCriteria uc{};
   charging_credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, true,
-    final_action_info);
-  charging_credit.add_used_credit(1024, 0);
-  EXPECT_EQ(charging_credit.get_action(), REDIRECT);
+    final_action_info, uc);
+  charging_credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(charging_credit.get_action(uc), REDIRECT);
 }
 
 TEST(test_tolerance_quota_exhausted, test_session_credit)
 {
   SessionCredit credit(CreditType::CHARGING);
+  SessionCreditUpdateCriteria uc{};
   credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, false,
-    default_final_action_info);
+    default_final_action_info, uc);
   // continue the service when there was still available tolerance quota
-  credit.add_used_credit(1024, 0);
-  EXPECT_EQ(credit.get_action(), CONTINUE_SERVICE);
+  credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(credit.get_action(uc), CONTINUE_SERVICE);
   // terminate the service when granted quota and tolerance quota are exhausted
-  credit.add_used_credit(1024, 0);
-  EXPECT_EQ(credit.get_action(), TERMINATE_SERVICE);
+  credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(credit.get_action(uc), TERMINATE_SERVICE);
 }
 
 TEST(test_failures, test_session_credit)
 {
   SessionCredit credit(CreditType::CHARGING);
+  SessionCreditUpdateCriteria uc{};
   credit.receive_credit(1024, HIGH_CREDIT, HIGH_CREDIT, 0, false,
-    default_final_action_info);
-  credit.add_used_credit(1024, 0);
-  EXPECT_EQ(credit.get_action(), CONTINUE_SERVICE);
-  credit.mark_failure();
-  EXPECT_EQ(credit.get_action(), CONTINUE_SERVICE);
+    default_final_action_info, uc);
+  credit.add_used_credit(1024, 0, uc);
+  EXPECT_EQ(credit.get_action(uc), CONTINUE_SERVICE);
+  credit.mark_failure(0, uc);
+  EXPECT_EQ(credit.get_action(uc), CONTINUE_SERVICE);
   // extra tolerance quota are exhausted
-  credit.add_used_credit(1024, 0);
-  credit.mark_failure();
-  EXPECT_EQ(credit.get_action(), TERMINATE_SERVICE);
+  credit.add_used_credit(1024, 0, uc);
+  credit.mark_failure(0, uc);
+  EXPECT_EQ(credit.get_action(uc), TERMINATE_SERVICE);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary:
This revision adds the optional argument of `SessionStateUpdateCriteria` to methods of `SessionState` which modify its state. The plan here is to first get all classes accepting `UpdateCriteria` and modifying it successfully, before requiring its usage, and using the `SessionStore` instead of the sessions held only in memory of `sessiond`

## Changes
- `SessionState` now accepts `SessionStateUpdateCriteria` argument optionally for all methods which modify state
- Changes to `test_session_state.cpp` so that all test cases check that `SessionStateUpdateCriteria` is modified correctly

Reviewed By: themarwhal

Differential Revision: D20312660

