### PR TITLE
Fix racy FeG unit test

### DIFF
--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/mock_driven_pcrf_test.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/mock_driven_pcrf_test.go
@@ -83,8 +83,9 @@ func TestPCRFExpectations(t *testing.T) {
 	defaultCCA := &fegprotos.GxCreditControlAnswer{
 		ResultCode: 2001,
 	}
+	serverConifgForPCRF := serverConfig
 	pcrf := startServerWithExpectations(
-		clientConfig, &serverConfig,
+		clientConfig, &serverConifgForPCRF,
 		[]*fegprotos.GxCreditControlExpectation{expectedInit, expectedUpdate, expectationNotMet},
 		fegprotos.UnexpectedRequestBehavior_CONTINUE_WITH_DEFAULT_ANSWER,
 		defaultCCA)


### PR DESCRIPTION
Summary: Circle Ci is occasionally failing because of raciness?

Differential Revision: D20484068

