### PR TITLE
Add AuthenticateFail test

### DIFF
--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -77,7 +77,7 @@ services:
       - ocs
     environment:
       MAGMA_PRINT_GRPC_PAYLOAD: 0
-    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=0
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=2
 
   hss:
     <<: *feggoservice

--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -14,12 +14,14 @@ import (
 	"testing"
 
 	"fbc/lib/go/radius/rfc2869"
+	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/eap"
 
+	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAuthenticate(t *testing.T) {
+func TestAuthenticateMultipleUEs(t *testing.T) {
 	fmt.Printf("\nRunning TestAuthenticate...\n")
 	tr := NewTestRunner()
 	ues, err := tr.ConfigUEs(3)
@@ -35,5 +37,45 @@ func TestAuthenticate(t *testing.T) {
 	}
 
 	// Clear hss, ocs, and pcrf
+	assert.NoError(t, tr.CleanUp())
+}
+
+func TestAuthenticateFail(t *testing.T) {
+	fmt.Printf("\nRunning TestAuthenticateFail...\n")
+	tr := NewTestRunner()
+	assert.NoError(t, usePCRFMockDriver())
+
+	ues, err := tr.ConfigUEs(2)
+	assert.NoError(t, err)
+
+	// Test Authentication Fail
+	imsiFail := ues[0].GetImsi()
+	initRequest := protos.NewGxCCRequest(imsiFail, protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGxCCAnswer(diam.AuthenticationRejected).
+		SetDynamicRuleInstalls([]*protos.RuleDefinition{getDynamicPassAll("dynamic-pass-all", "mkey1", 100)})
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	defaultAnswer := protos.NewGxCCAnswer(diam.AuthenticationRejected)
+	assert.NoError(t, setPCRFExpectations([]*protos.GxCreditControlExpectation{initExpectation}, defaultAnswer))
+
+	radiusP, err := tr.Authenticate(imsiFail)
+	assert.NoError(t, err)
+
+	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
+	assert.NotNil(t, eapMessage)
+	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.FailureCode))
+
+	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult := []*protos.ExpectationResult{{ExpectationIndex: 0, ExpectationMet: true}}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+	// Since CCR/A-I failed, there should be no rules installed
+	recordsBySubID, err := tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	assert.Empty(t, recordsBySubID["IMSI"+imsiFail])
+
+	// Clear hss, ocs, and pcrf
+	assert.NoError(t, clearPCRFMockDriver())
 	assert.NoError(t, tr.CleanUp())
 }

--- a/cwf/gateway/integ_tests/auth_ul_test.go
+++ b/cwf/gateway/integ_tests/auth_ul_test.go
@@ -12,12 +12,14 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"fbc/lib/go/radius/rfc2869"
 	cwfprotos "magma/cwf/cloud/go/protos"
+	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/services/eap"
 
-	"github.com/go-openapi/swag"
+	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,27 +27,51 @@ import (
 func TestAuthenticateUplinkTraffic(t *testing.T) {
 	fmt.Printf("\nRunning TestAuthenticateUplinkTraffic...\n")
 	tr := NewTestRunner()
-	ruleManager, err := NewRuleManager()
-	assert.NoError(t, err)
+	assert.NoError(t, usePCRFMockDriver())
 
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
 
-	ue := ues[0]
-	err = ruleManager.AddDynamicPassAllToPCRF(ue.GetImsi(), "dynamic-pass-all", "mkey1")
-	assert.NoError(t, err)
-	radiusP, err := tr.Authenticate(ue.GetImsi())
+	imsi := ues[0].GetImsi()
+	usageMonitorInfo := []*protos.UsageMonitoringInformation{
+		{
+			MonitoringLevel: protos.MonitoringLevel_RuleLevel,
+			MonitoringKey:   []byte("mkey1"),
+			Octets:          &protos.Octets{TotalOctets: 250 * KiloBytes},
+		},
+	}
+	initRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGxCCAnswer(diam.Success).
+		SetDynamicRuleInstalls([]*protos.RuleDefinition{getDynamicPassAll("dynamic-pass-all", "mkey1", 100)}).
+		SetUsageMonitorInfos(usageMonitorInfo)
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+	// return success with credit on unexpected requests
+	defaultAnswer := protos.NewGxCCAnswer(2001).SetUsageMonitorInfos(usageMonitorInfo)
+	assert.NoError(t, setPCRFExpectations([]*protos.GxCreditControlExpectation{initExpectation}, defaultAnswer))
+
+	radiusP, err := tr.Authenticate(imsi)
 	assert.NoError(t, err)
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
 	assert.NotNil(t, eapMessage)
 	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
 
-	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("100K")}}
+	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "100K"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
+	time.Sleep(3 * time.Second)
+
+	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult := []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+	assert.NoError(t, clearPCRFMockDriver())
+
 	// Clear hss, ocs, and pcrf
-	assert.NoError(t, ruleManager.RemoveInstalledRules())
+	assert.NoError(t, clearPCRFMockDriver())
 	assert.NoError(t, tr.CleanUp())
 }

--- a/cwf/gateway/integ_tests/dynamic_rules.go
+++ b/cwf/gateway/integ_tests/dynamic_rules.go
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package integ_tests
+
+import "magma/feg/cloud/go/protos"
+
+func getDynamicPassAll(ruleID, monitoringKey string, precedence uint32) *protos.RuleDefinition {
+	return &protos.RuleDefinition{
+		RuleName:         ruleID,
+		Precedence:       precedence,
+		FlowDescriptions: []string{"permit out ip from any to any", "permit in ip from any to any"},
+		MonitoringKey:    monitoringKey,
+	}
+}

--- a/cwf/gateway/integ_tests/rule_manager.go
+++ b/cwf/gateway/integ_tests/rule_manager.go
@@ -153,12 +153,7 @@ func getAccountRulesWithDynamicPassAll(imsi, ruleID, monitoringKey string) *fegP
 		StaticRuleNames:     []string{},
 		StaticRuleBaseNames: []string{},
 		DynamicRuleDefinitions: []*fegProtos.RuleDefinition{
-			{
-				RuleName:         ruleID,
-				Precedence:       100,
-				FlowDescriptions: []string{"permit out ip from any to any", "permit in ip from any to any"},
-				MonitoringKey:    monitoringKey,
-			},
+			getDynamicPassAll(ruleID, monitoringKey, 100),
 		},
 	}
 }


### PR DESCRIPTION
Summary:
- Add a AuthenticateFail test that tests the scenario where the PCRF rejects the CCR-I
- Convert AuthenticateULTraffic to use expectation based PCRF

Differential Revision: D20499071

