### PR TITLE
Fix for the duplicated CalledStationId seen on Gx

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -239,10 +239,6 @@ func (gxClient *GxClient) createCreditControlMessage(
 		m.NewAVP(avp.FramedIPv6Prefix, avp.Mbit, 0, datatype.OctetString(Ipv6PrefixFromMAC(request.HardwareAddr)))
 	}
 
-	if len(request.Apn) > 0 {
-		m.NewAVP(avp.CalledStationID, avp.Mbit, 0, datatype.UTF8String(request.Apn))
-	}
-
 	apn := datatype.UTF8String(request.Apn)
 	if globalConfig != nil && len(globalConfig.PCFROverwriteApn) > 0 {
 		apn = datatype.UTF8String(globalConfig.PCFROverwriteApn)


### PR DESCRIPTION
Summary: Bug found on GX client that was pushing avp.CalledStationID two times

Differential Revision: D20499635

