### PR TITLE
Fix clang-format file to position braces and parameters correctly

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,7 +40,7 @@ SortIncludes: false
 
 # alignment
 AlignAfterOpenBracket: AlwaysBreak
-AlignConsecutiveAssignments: false
+AlignConsecutiveAssignments: true
 AlignConsecutiveDeclarations: false
 AlignEscapedNewlines: Right
 AlignOperands: true
@@ -52,8 +52,6 @@ PointerAlignment: Left
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AlwaysBreakAfterReturnType: None
-BinPackArguments: false
-BinPackParameters: false
 IndentWrappedFunctionNames: false
 
 # template style
@@ -68,26 +66,24 @@ KeepEmptyLinesAtTheStartOfBlocks: false
 
 # break style
 BreakBeforeBinaryOperators: None
-BreakBeforeBraces: WebKit
+BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: false
 BreakStringLiterals: true
 CompactNamespaces: false
-ContinuationIndentWidth: 2
+ContinuationIndentWidth: 4
 MaxEmptyLinesToKeep: 1
-ReflowComments: false
+ReflowComments: true
 
 # spacing style
 UseTab: Never
 SpaceAfterCStyleCast: true
 SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCpp11BracedList: true
-SpaceBeforeCtorInitializerColon: false
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
+SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
 SpacesInCStyleCastParentheses: false
 SpacesInContainerLiterals: false
@@ -95,20 +91,13 @@ SpacesInParentheses: false
 SpacesInSquareBrackets: false
 
 # class style
-BreakConstructorInitializers: AfterColon
-BreakInheritanceList: AfterColon
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
-ConstructorInitializerIndentWidth: 2
+ConstructorInitializerIndentWidth: 4
 
 # case statements
-AllowShortCaseLabelsOnASingleLine: true
 IndentCaseLabels: true
-
-# if statements
-AllowShortIfStatementsOnASingleLine: true
-
-# loop statements
-AllowShortLoopsOnASingleLine: true
 
 # cpp
 Cpp11BracedListStyle: true

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
@@ -23,7 +23,8 @@
   OpenAirInterface Tech : openair_tech@eurecom.fr
   OpenAirInterface Dev  : openair4g-devel@eurecom.fr
 
-  Address      : Eurecom, Compus SophiaTech 450, route des chappes, 06451 Biot, France.
+  Address      : Eurecom, Compus SophiaTech 450, route des chappes, 06451 Biot,
+ France.
 
  *******************************************************************************/
 
@@ -58,41 +59,38 @@
 
 //------------------------------------------------------------------------------
 void mme_app_send_delete_session_request(
-  struct ue_mm_context_s* const ue_context_p,
-  const ebi_t ebi,
-  const pdn_cid_t cid)
-{
+    struct ue_mm_context_s* const ue_context_p, const ebi_t ebi,
+    const pdn_cid_t cid) {
   MessageDef* message_p = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);
   message_p = itti_alloc_new_message(TASK_MME_APP, S11_DELETE_SESSION_REQUEST);
   if (message_p == NULL) {
     OAILOG_ERROR(
-      LOG_MME_APP,
-      "Failed to allocate new ITTI message for S11 Delete Session Request "
-      "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT " and LBI: %u\n",
-      ue_context_p->mme_ue_s1ap_id,
-      ebi);
+        LOG_MME_APP,
+        "Failed to allocate new ITTI message for S11 Delete Session Request "
+        "for MME UE S1AP Id: " MME_UE_S1AP_ID_FMT " and LBI: %u\n",
+        ue_context_p->mme_ue_s1ap_id, ebi);
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
   S11_DELETE_SESSION_REQUEST(message_p).local_teid = ue_context_p->mme_teid_s11;
   S11_DELETE_SESSION_REQUEST(message_p).teid =
-    ue_context_p->pdn_contexts[cid]->s_gw_teid_s11_s4;
-  S11_DELETE_SESSION_REQUEST(message_p).lbi = ebi; //default bearer
+      ue_context_p->pdn_contexts[cid]->s_gw_teid_s11_s4;
+  S11_DELETE_SESSION_REQUEST(message_p).lbi = ebi;  // default bearer
 
   /* clang-format off */
   OAI_GCC_DIAG_OFF(pointer-to-int-cast);
   /* clang-format on */
   S11_DELETE_SESSION_REQUEST(message_p).sender_fteid_for_cp.teid =
-    (teid_t) ue_context_p;
+      (teid_t) ue_context_p;
   OAI_GCC_DIAG_ON(pointer - to - int - cast);
   S11_DELETE_SESSION_REQUEST(message_p).sender_fteid_for_cp.interface_type =
-    S11_MME_GTP_C;
+      S11_MME_GTP_C;
   mme_config_read_lock(&mme_config);
   S11_DELETE_SESSION_REQUEST(message_p).sender_fteid_for_cp.ipv4_address =
-    mme_config.ipv4.s11;
+      mme_config.ipv4.s11;
   mme_config_unlock(&mme_config);
   S11_DELETE_SESSION_REQUEST(message_p).sender_fteid_for_cp.ipv4 = 1;
-  S11_DELETE_SESSION_REQUEST(message_p).indication_flags.oi = 1;
+  S11_DELETE_SESSION_REQUEST(message_p).indication_flags.oi      = 1;
 
   /*
    * S11 stack specific parameter. Not used in standalone epc mode
@@ -100,7 +98,7 @@ void mme_app_send_delete_session_request(
   S11_DELETE_SESSION_REQUEST(message_p).trxn = NULL;
   mme_config_read_lock(&mme_config);
   S11_DELETE_SESSION_REQUEST(message_p).peer_ip =
-    ue_context_p->pdn_contexts[cid]->s_gw_address_s11_s4.address.ipv4_address;
+      ue_context_p->pdn_contexts[cid]->s_gw_address_s11_s4.address.ipv4_address;
   mme_config_unlock(&mme_config);
 
   message_p->ittiMsgHeader.imsi = ue_context_p->emm_context._imsi64;
@@ -111,23 +109,21 @@ void mme_app_send_delete_session_request(
 }
 
 //------------------------------------------------------------------------------
-void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id)
-{
+void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id) {
   struct ue_mm_context_s* ue_context_p = NULL;
   OAILOG_FUNC_IN(LOG_MME_APP);
-
   OAILOG_INFO(
-    LOG_MME_APP,
-    "Handle Detach Req at MME app for ue-id: " MME_UE_S1AP_ID_FMT "\n",
-    ue_id);
+      LOG_MME_APP,
+      "Handle Detach Req at MME app for ue-id: " MME_UE_S1AP_ID_FMT "\n",
+      ue_id);
   ue_context_p = mme_ue_context_exists_mme_ue_s1ap_id(ue_id);
   if (ue_context_p == NULL) {
     OAILOG_ERROR(
-      LOG_MME_APP, "UE context doesn't exist -> Nothing to do :-) \n");
+        LOG_MME_APP, "UE context doesn't exist -> Nothing to do :-) \n");
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
-  if (
-    (!ue_context_p->mme_teid_s11) && (!ue_context_p->nb_active_pdn_contexts)) {
+  if ((!ue_context_p->mme_teid_s11) &&
+      (!ue_context_p->nb_active_pdn_contexts)) {
     /* No Session.
      * If UE is already in idle state, skip asking eNB to release UE context and
      * just clean up locally.
@@ -141,14 +137,13 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id)
       ue_context_p->ue_context_rel_cause = S1AP_IMPLICIT_CONTEXT_RELEASE;
       // Notify S1AP to release S1AP UE context locally.
       mme_app_itti_ue_context_release(
-        ue_context_p, ue_context_p->ue_context_rel_cause);
+          ue_context_p, ue_context_p->ue_context_rel_cause);
       // Free MME UE Context
       mme_notify_ue_context_released(
-        &mme_app_desc_p->mme_ue_contexts, ue_context_p);
+          &mme_app_desc_p->mme_ue_contexts, ue_context_p);
       // Send PUR,before removal of ue contexts
-      if (
-        (ue_context_p->send_ue_purge_request == true) &&
-        (ue_context_p->hss_initiated_detach == false)) {
+      if ((ue_context_p->send_ue_purge_request == true) &&
+          (ue_context_p->hss_initiated_detach == false)) {
         mme_app_send_s6a_purge_ue_req(mme_app_desc_p, ue_context_p);
       }
       mme_remove_ue_context(&mme_app_desc_p->mme_ue_contexts, ue_context_p);
@@ -158,18 +153,17 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id)
       }
       // Notify S1AP to send UE Context Release Command to eNB.
       mme_app_itti_ue_context_release(
-        ue_context_p, ue_context_p->ue_context_rel_cause);
+          ue_context_p, ue_context_p->ue_context_rel_cause);
       if (ue_context_p->ue_context_rel_cause == S1AP_SCTP_SHUTDOWN_OR_RESET) {
         // Just cleanup the MME APP state associated with s1.
         mme_ue_context_update_ue_sig_connection_state(
-          &mme_app_desc_p->mme_ue_contexts, ue_context_p, ECM_IDLE);
+            &mme_app_desc_p->mme_ue_contexts, ue_context_p, ECM_IDLE);
         // Free MME UE Context
         mme_notify_ue_context_released(
-          &mme_app_desc_p->mme_ue_contexts, ue_context_p);
+            &mme_app_desc_p->mme_ue_contexts, ue_context_p);
         // Send PUR,before removal of ue contexts
-        if (
-          (ue_context_p->send_ue_purge_request == true) &&
-          (ue_context_p->hss_initiated_detach == false)) {
+        if ((ue_context_p->send_ue_purge_request == true) &&
+            (ue_context_p->hss_initiated_detach == false)) {
           mme_app_send_s6a_purge_ue_req(mme_app_desc_p, ue_context_p);
         }
         mme_remove_ue_context(&mme_app_desc_p->mme_ue_contexts, ue_context_p);
@@ -182,7 +176,7 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id)
       if (ue_context_p->pdn_contexts[i]) {
         // Send a DELETE_SESSION_REQUEST message to the SGW
         mme_app_send_delete_session_request(
-          ue_context_p, ue_context_p->pdn_contexts[i]->default_ebi, i);
+            ue_context_p, ue_context_p->pdn_contexts[i]->default_ebi, i);
       }
     }
   }
@@ -198,18 +192,16 @@ void mme_app_handle_detach_req(const mme_ue_s1ap_id_t ue_id)
  ** Outputs:                                                                **
  **          Return:    RETURNok, RETURNerror                               **
  **                                                                         **
-******************************************************************************/
+ ******************************************************************************/
 int mme_app_handle_nw_initiated_detach_request(
-  mme_ue_s1ap_id_t ue_id,
-  uint8_t detach_type)
-{
+    mme_ue_s1ap_id_t ue_id, uint8_t detach_type) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   emm_cn_nw_initiated_detach_ue_t emm_cn_nw_initiated_detach = {0};
 
-  emm_cn_nw_initiated_detach.ue_id = ue_id;
+  emm_cn_nw_initiated_detach.ue_id       = ue_id;
   emm_cn_nw_initiated_detach.detach_type = detach_type;
 
   OAILOG_FUNC_RETURN(
-    LOG_MME_APP,
-    nas_proc_nw_initiated_detach_ue_request(&emm_cn_nw_initiated_detach));
+      LOG_MME_APP,
+      nas_proc_nw_initiated_detach_ue_request(&emm_cn_nw_initiated_detach));
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -31,16 +31,16 @@ extern "C" {
 
 namespace {
 constexpr char MME_NAS_STATE_KEY[] = "mme_nas_state";
-const int NUM_MAX_UE_HTBL_LISTS = 6;
+const int NUM_MAX_UE_HTBL_LISTS    = 6;
 constexpr char UE_ID_UE_CTXT_TABLE_NAME[] =
-  "mme_app_mme_ue_s1ap_id_ue_context_htbl";
+    "mme_app_mme_ue_s1ap_id_ue_context_htbl";
 constexpr char IMSI_UE_ID_TABLE_NAME[] = "mme_app_imsi_ue_context_htbl";
-constexpr char TUN_UE_ID_TABLE_NAME[] = "mme_app_tun11_ue_context_htbl";
+constexpr char TUN_UE_ID_TABLE_NAME[]  = "mme_app_tun11_ue_context_htbl";
 constexpr char GUTI_UE_ID_TABLE_NAME[] = "mme_app_tun11_ue_context_htbl";
 constexpr char ENB_UE_ID_MME_UE_ID_TABLE_NAME[] =
-  "mme_app_enb_ue_s1ap_id_ue_context_htbl";
+    "mme_app_enb_ue_s1ap_id_ue_context_htbl";
 constexpr char MME_TASK_NAME[] = "MME";
-} // namespace
+}  // namespace
 
 namespace magma {
 namespace lte {
@@ -49,33 +49,27 @@ namespace lte {
  * Getter function for singleton instance of the MmeNasStateManager class,
  * guaranteed to be thread-safe and initialized only once
  */
-MmeNasStateManager& MmeNasStateManager::getInstance()
-{
+MmeNasStateManager& MmeNasStateManager::getInstance() {
   static MmeNasStateManager instance;
   return instance;
 }
 
 // Constructor for MME NAS state object
-MmeNasStateManager::MmeNasStateManager():
-  max_ue_htbl_lists_(NUM_MAX_UE_HTBL_LISTS),
-  mme_statistic_timer_(10)
-{
-}
+MmeNasStateManager::MmeNasStateManager()
+    : max_ue_htbl_lists_(NUM_MAX_UE_HTBL_LISTS), mme_statistic_timer_(10) {}
 
 // Destructor for MME NAS state object
-MmeNasStateManager::~MmeNasStateManager()
-{
+MmeNasStateManager::~MmeNasStateManager() {
   free_state();
 }
 
-int MmeNasStateManager::initialize_state(const mme_config_t* mme_config_p)
-{
+int MmeNasStateManager::initialize_state(const mme_config_t* mme_config_p) {
   persist_state_enabled = mme_config_p->use_stateless;
-  max_ue_htbl_lists_ = mme_config_p->max_ues;
-  mme_statistic_timer_ = mme_config_p->mme_statistic_timer;
-  log_task = LOG_MME_APP;
-  task_name = MME_TASK_NAME;
-  table_key = MME_NAS_STATE_KEY;
+  max_ue_htbl_lists_    = mme_config_p->max_ues;
+  mme_statistic_timer_  = mme_config_p->mme_statistic_timer;
+  log_task              = LOG_MME_APP;
+  task_name             = MME_TASK_NAME;
+  table_key             = MME_NAS_STATE_KEY;
 
   // Allocate the local mme state
   create_state();
@@ -93,14 +87,12 @@ int MmeNasStateManager::initialize_state(const mme_config_t* mme_config_p)
  * data store when initialize_state is called and get_state just returns the
  * pointer to that structure.
  */
-mme_app_desc_t* MmeNasStateManager::get_state(bool read_from_db)
-{
+mme_app_desc_t* MmeNasStateManager::get_state(bool read_from_db) {
   AssertFatal(
-    is_initialized,
-    "Calling get_state without initializing state manager");
+      is_initialized, "Calling get_state without initializing state manager");
   AssertFatal(state_cache_p, "mme_nas_state is NULL");
   OAILOG_DEBUG(
-    LOG_MME_APP, "Inside get_state with read_from_db %d", read_from_db);
+      LOG_MME_APP, "Inside get_state with read_from_db %d", read_from_db);
 
   state_dirty = true;
   if (persist_state_enabled && read_from_db) {
@@ -120,8 +112,7 @@ mme_app_desc_t* MmeNasStateManager::get_state(bool read_from_db)
 
 // This is a helper function for debugging. If the state manager needs to clear
 // the state in the data store, it can call this function to delete the key.
-void MmeNasStateManager::clear_db_state()
-{
+void MmeNasStateManager::clear_db_state() {
   OAILOG_DEBUG(LOG_MME_APP, "Clearing state in data store");
   std::vector<std::string> keys_to_del;
   keys_to_del.emplace_back(MME_NAS_STATE_KEY);
@@ -133,62 +124,53 @@ void MmeNasStateManager::clear_db_state()
 }
 
 // Initialize state that is non-persistent, e.g. timers
-void MmeNasStateManager::mme_nas_state_init_local_state()
-{
+void MmeNasStateManager::mme_nas_state_init_local_state() {
   // create statistic timer locally
   state_cache_p->statistic_timer_period = mme_statistic_timer_;
 
   // Request for periodic timer to print statistics in debug mode
-  if (
-    timer_setup(
-      mme_statistic_timer_,
-      0,
-      TASK_MME_APP,
-      INSTANCE_DEFAULT,
-      TIMER_PERIODIC,
-      nullptr,
-      0,
-      &(state_cache_p->statistic_timer_id)) < 0) {
+  if (timer_setup(
+          mme_statistic_timer_, 0, TASK_MME_APP, INSTANCE_DEFAULT,
+          TIMER_PERIODIC, nullptr, 0,
+          &(state_cache_p->statistic_timer_id)) < 0) {
     OAILOG_ERROR(
-      LOG_MME_APP,
-      "Failed to request new timer for statistics with %ds "
-      "of periocidity\n",
-      mme_statistic_timer_);
+        LOG_MME_APP,
+        "Failed to request new timer for statistics with %ds "
+        "of periocidity\n",
+        mme_statistic_timer_);
     state_cache_p->statistic_timer_id = 0;
   }
 }
 
 // Create the hashtables for MME NAS state
-void MmeNasStateManager::create_hashtables()
-{
+void MmeNasStateManager::create_hashtables() {
   bstring b = bfromcstr(IMSI_UE_ID_TABLE_NAME);
   state_cache_p->mme_ue_contexts.imsi_mme_ue_id_htbl =
-    hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
+      hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
   btrunc(b, 0);
   bassigncstr(b, TUN_UE_ID_TABLE_NAME);
   state_cache_p->mme_ue_contexts.tun11_ue_context_htbl =
-    hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
+      hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
   AssertFatal(
-    sizeof(uintptr_t) >= sizeof(uint64_t),
-    "Problem with mme_ue_s1ap_id_ue_context_htbl in MME_APP");
+      sizeof(uintptr_t) >= sizeof(uint64_t),
+      "Problem with mme_ue_s1ap_id_ue_context_htbl in MME_APP");
   btrunc(b, 0);
   bassigncstr(b, UE_ID_UE_CTXT_TABLE_NAME);
   state_imsi_ht = hashtable_ts_create(
-    max_ue_htbl_lists_, nullptr, mme_app_state_free_ue_context, b);
+      max_ue_htbl_lists_, nullptr, mme_app_state_free_ue_context, b);
   btrunc(b, 0);
   bassigncstr(b, ENB_UE_ID_MME_UE_ID_TABLE_NAME);
   state_cache_p->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl =
-    hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
+      hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, b);
   btrunc(b, 0);
   bassigncstr(b, GUTI_UE_ID_TABLE_NAME);
   state_cache_p->mme_ue_contexts.guti_ue_context_htbl =
-    obj_hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, nullptr, b);
+      obj_hashtable_uint64_ts_create(max_ue_htbl_lists_, nullptr, nullptr, b);
   bdestroy_wrapper(&b);
 }
 
 // Initialize memory for MME state before reading from data-store
-void MmeNasStateManager::create_state()
-{
+void MmeNasStateManager::create_state() {
   state_cache_p = (mme_app_desc_t*) calloc(1, sizeof(mme_app_desc_t));
   if (!state_cache_p) {
     return;
@@ -201,26 +183,24 @@ void MmeNasStateManager::create_state()
 }
 
 // Delete the hashtables for MME NAS state
-void MmeNasStateManager::clear_mme_nas_hashtables()
-{
+void MmeNasStateManager::clear_mme_nas_hashtables() {
   if (!state_cache_p) {
     return;
   }
 
   hashtable_ts_destroy(state_imsi_ht);
   hashtable_uint64_ts_destroy(
-    state_cache_p->mme_ue_contexts.imsi_mme_ue_id_htbl);
+      state_cache_p->mme_ue_contexts.imsi_mme_ue_id_htbl);
   hashtable_uint64_ts_destroy(
-    state_cache_p->mme_ue_contexts.tun11_ue_context_htbl);
+      state_cache_p->mme_ue_contexts.tun11_ue_context_htbl);
   hashtable_uint64_ts_destroy(
-    state_cache_p->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl);
+      state_cache_p->mme_ue_contexts.enb_ue_s1ap_id_ue_context_htbl);
   obj_hashtable_uint64_ts_destroy(
-    state_cache_p->mme_ue_contexts.guti_ue_context_htbl);
+      state_cache_p->mme_ue_contexts.guti_ue_context_htbl);
 }
 
 // Free the memory allocated to state pointer
-void MmeNasStateManager::free_state()
-{
+void MmeNasStateManager::free_state() {
   if (!state_cache_p) {
     return;
   }
@@ -230,30 +210,29 @@ void MmeNasStateManager::free_state()
   state_cache_p = nullptr;
 }
 
-int MmeNasStateManager::read_ue_state_from_db()
-{
+int MmeNasStateManager::read_ue_state_from_db() {
   if (persist_state_enabled) {
     auto keys = redis_client->get_keys("IMSI*" + task_name + "*");
     for (const auto& key : keys) {
       OAILOG_DEBUG(log_task, "Reading UE state from db for %s", key.c_str());
       UeContext ue_proto = UeContext();
       auto* ue_context =
-        (ue_mm_context_t*) (calloc(1, sizeof(ue_mm_context_t)));
+          (ue_mm_context_t*) (calloc(1, sizeof(ue_mm_context_t)));
       if (redis_client->read_proto(key.c_str(), ue_proto) != RETURNok) {
         return RETURNerror;
       }
       MmeNasStateConverter::proto_to_ue(ue_proto, ue_context);
 
       hashtable_ts_insert(
-        state_imsi_ht, ue_context->mme_ue_s1ap_id, (void*) ue_context);
+          state_imsi_ht, ue_context->mme_ue_s1ap_id, (void*) ue_context);
       OAILOG_DEBUG(
-        log_task,
-        "Inserted UE state with key mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT,
-        ue_context->mme_ue_s1ap_id);
+          log_task,
+          "Inserted UE state with key mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT,
+          ue_context->mme_ue_s1ap_id);
     }
   }
   return RETURNok;
 }
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.h
@@ -37,13 +37,9 @@ namespace lte {
  * and freeing state structs, and writing/reading state to db.
  */
 
-class MmeNasStateManager :
-  public StateManager<
-    mme_app_desc_t,
-    ue_mm_context_t,
-    MmeNasState,
-    UeContext,
-    MmeNasStateConverter> {
+class MmeNasStateManager : public StateManager<
+                               mme_app_desc_t, ue_mm_context_t, MmeNasState,
+                               UeContext, MmeNasStateConverter> {
  public:
   /**
    * Returns an instance of MmeNasStateManager, guaranteed to be thread safe and
@@ -55,16 +51,16 @@ class MmeNasStateManager :
   int initialize_state(const mme_config_t* mme_config_p);
 
   /**
-    * Retrieve the state pointer from state manager. The read_from_db flag is a
-    * debug flag; if set to true, the state is loaded from the data store on
-    * every get.
-    */
+   * Retrieve the state pointer from state manager. The read_from_db flag is a
+   * debug flag; if set to true, the state is loaded from the data store on
+   * every get.
+   */
   mme_app_desc_t* get_state(bool read_from_db) override;
 
   /**
-    * Release the memory for MME NAS state and destroy the read-write lock. This
-    * is only called when task terminates
-    */
+   * Release the memory for MME NAS state and destroy the read-write lock. This
+   * is only called when task terminates
+   */
 
   void free_state() override;
 
@@ -106,5 +102,5 @@ class MmeNasStateManager :
   // Clean-up the in-memory hashtables
   void clear_mme_nas_hashtables();
 };
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma


### PR DESCRIPTION
Summary:
We would like to follow the prevalent C++ style guidelines in our C/C++ code
formatting. This change fixes the clang-format style file as follows:
- In class/funtion definitions, put opening brace on the same line as the
  function/class name
- In function declarations/definitions/calls pack the parameter/arguments in as
  few lines as possible
- In class definitions, break line before the colon if the inheritance list
  doesn't fit in one line
- In constructor initialization, break line before the colon if the initializers
  don't fit in one line
- Other minor horizontal whitespace fixes
This is a preview diff to highlight the changes. Future diffs will apply the
format to entire oai/ directory.

Differential Revision: D20499279

