### PR TITLE
create Network Hub tab with create service page

### DIFF
--- a/symphony/app/fbcnms-packages/fbcnms-types/tabs.js
+++ b/symphony/app/fbcnms-packages/fbcnms-types/tabs.js
@@ -8,7 +8,13 @@
  * @format
  */
 
-export type Tab = 'automation' | 'admin' | 'inventory' | 'nms' | 'workorders';
+export type Tab =
+  | 'automation'
+  | 'admin'
+  | 'inventory'
+  | 'nms'
+  | 'workorders'
+  | 'hub';
 
 export const TABS: {[string]: Tab} = Object.freeze({
   admin: 'admin',
@@ -16,6 +22,7 @@ export const TABS: {[string]: Tab} = Object.freeze({
   inventory: 'inventory',
   nms: 'nms',
   workorders: 'workorders',
+  hub: 'hub',
 });
 
 export function coerceToTab(tab: string): Tab {

--- a/symphony/app/fbcnms-projects/hub/app/components/Main.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/Main.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import AppContent from '@fbcnms/ui/components/layout/AppContent';
+import AppContext, {AppContextProvider} from '@fbcnms/ui/context/AppContext';
+import AppSideBar from '@fbcnms/ui/components/layout/AppSideBar';
+import ApplicationMain from '@fbcnms/ui/components/ApplicationMain';
+import Button from '@fbcnms/ui/components/design-system/Button';
+import NavListItem from '@fbcnms/ui/components/NavListItem';
+import React, {useContext} from 'react';
+import RouterIcon from '@material-ui/icons/Router';
+import Text from '@fbcnms/ui/components/design-system/Text';
+import TextInput from '@fbcnms/ui/components/design-system/Input/TextInput';
+import nullthrows from '@fbcnms/util/nullthrows';
+import {Redirect, Route, Switch} from 'react-router-dom';
+import {getProjectLinks} from '@fbcnms/magmalte/app/common/projects';
+import {makeStyles} from '@material-ui/styles';
+import {shouldShowSettings} from '@fbcnms/magmalte/app/components/Settings';
+import {useRelativeUrl} from '@fbcnms/ui/hooks/useRouter';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  paper: {
+    margin: theme.spacing(3),
+  },
+}));
+
+function NavBarItems() {
+  return [
+    <NavListItem
+      key={1}
+      label="Services"
+      path="/hub/services"
+      icon={<RouterIcon />}
+      onClick={() => {}}
+    />,
+  ];
+}
+
+function CreateServiceForm() {
+  const classes = useStyles();
+  return (
+    <div className={classes.paper}>
+      <div className={classes.header}>
+        <Text variant="h5">Create a Service</Text>
+      </div>
+      <br />
+      <Text>Service Name</Text>
+      <TextInput />
+      <br />
+      <Button>Create Service</Button>
+    </div>
+  );
+}
+
+function Main() {
+  const {user, tabs, ssoEnabled} = useContext(AppContext);
+  const classes = useStyles();
+  return (
+    <div className={classes.root}>
+      <AppSideBar
+        mainItems={<NavBarItems />}
+        secondaryItems={[]}
+        projects={getProjectLinks(tabs, user)}
+        showSettings={shouldShowSettings({
+          isSuperUser: user.isSuperUser,
+          ssoEnabled,
+        })}
+        user={nullthrows(user)}
+      />
+      <AppContent>
+        <CreateServiceForm />
+      </AppContent>
+    </div>
+  );
+}
+
+export default () => {
+  const relativeUrl = useRelativeUrl();
+  return (
+    <ApplicationMain>
+      <AppContextProvider>
+        <Switch>
+          <Redirect exact from="/hub" to={relativeUrl('/services')} />
+          <Route path="/hub/services" component={Main} />
+        </Switch>
+      </AppContextProvider>
+    </ApplicationMain>
+  );
+};

--- a/symphony/app/fbcnms-projects/hub/app/main.js
+++ b/symphony/app/fbcnms-projects/hub/app/main.js
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+'use strict';
+
+import '@fbcnms/babel-register/polyfill';
+
+import Main from './components/Main';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import nullthrows from '@fbcnms/util/nullthrows';
+import {BrowserRouter} from 'react-router-dom';
+
+ReactDOM.render(
+  <BrowserRouter>
+    <Main />
+  </BrowserRouter>,
+  nullthrows(document.getElementById('root')),
+);

--- a/symphony/app/fbcnms-projects/hub/package.json
+++ b/symphony/app/fbcnms-projects/hub/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@fbcnms/hub",
+  "private": true,
+  "version": "0.1.0",
+  "dependencies": {
+    "@fbcnms/ui": "^0.1.0",
+    "classnames": "^2.2.5"
+  },
+  "devDependencies": {
+    "@fbcnms/test": "^0.1.0",
+    "@testing-library/react": "^9.4.0",
+    "@testing-library/react-hooks": "^3.2.1",
+    "jest": "^24.9.0",
+    "jest-dom": "^3.1.3"
+  }
+}

--- a/symphony/app/fbcnms-projects/inventory/Dockerfile
+++ b/symphony/app/fbcnms-projects/inventory/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json babel.config.js /app/
 COPY fbcnms-packages /app/fbcnms-packages
 COPY fbcnms-projects/inventory /app/fbcnms-projects/inventory
 COPY fbcnms-projects/magmalte /app/fbcnms-projects/magmalte
+COPY fbcnms-projects/hub /app/fbcnms-projects/hub
 
 # Build static files
 WORKDIR /app/fbcnms-projects/inventory

--- a/symphony/app/fbcnms-projects/inventory/Dockerfile.dev
+++ b/symphony/app/fbcnms-projects/inventory/Dockerfile.dev
@@ -10,6 +10,7 @@ WORKDIR /app
 COPY package.json yarn.lock babel.config.js ./
 COPY fbcnms-projects/inventory/package.json fbcnms-projects/inventory/
 COPY fbcnms-projects/magmalte/package.json fbcnms-projects/magmalte/
+COPY fbcnms-projects/hub/package.json fbcnms-projects/hub/
 
 # Install shared dependencies
 COPY fbcnms-packages fbcnms-packages
@@ -19,6 +20,7 @@ RUN yarn install --frozen-lockfile && yarn cache clean
 WORKDIR /app/fbcnms-projects/inventory
 COPY fbcnms-projects/inventory .
 COPY fbcnms-projects/magmalte /app/fbcnms-projects/magmalte
+COPY fbcnms-projects/hub /app/fbcnms-projects/hub
 
 # Start app
 CMD yarn dev

--- a/symphony/app/fbcnms-projects/inventory/app/components/Main.js
+++ b/symphony/app/fbcnms-projects/inventory/app/components/Main.js
@@ -11,6 +11,7 @@
 import Admin from './admin/Admin';
 import Automation from './automation/Automation';
 import FilesUploadContextProvider from './context/FilesUploadContextProvider';
+import Hub from '@fbcnms/hub/app/components/Main';
 import IDToolMain from './id/IDToolMain';
 import Inventory from './Inventory';
 import MagmaMain from '@fbcnms/magmalte/app/components/Main';
@@ -24,6 +25,7 @@ export default () => (
   <FilesUploadContextProvider>
     <Switch>
       <Route path="/nms" component={MagmaMain} />
+      <Route path="/hub" component={Hub} />
       <Route path="/inventory" component={Inventory} />
       <Route path="/workorders" component={WorkOrdersMain} />
       <Route path="/admin" component={Admin} />

--- a/symphony/app/fbcnms-projects/inventory/config/webpack.config.js
+++ b/symphony/app/fbcnms-projects/inventory/config/webpack.config.js
@@ -15,7 +15,7 @@ const paths = require('fbcnms-webpack-config/paths');
 
 module.exports = webpackConfig.createDevWebpackConfig({
   projectName: 'inventory',
-  extraPaths: [paths.resolveApp('../magmalte')],
+  extraPaths: [paths.resolveApp('../magmalte'), paths.resolveApp('../hub')],
   entry: {
     master: [paths.resolveApp('app/master.js')],
     onboarding: [paths.resolveApp('app/onboarding.js')],

--- a/symphony/app/fbcnms-projects/inventory/config/webpack.production.config.js
+++ b/symphony/app/fbcnms-projects/inventory/config/webpack.production.config.js
@@ -16,7 +16,7 @@ const paths = require('fbcnms-webpack-config/paths');
 module.exports = webpackConfig.createProductionWebpackConfig({
   projectName: 'inventory',
   devtool: 'source-map',
-  extraPaths: [paths.resolveApp('../magmalte')],
+  extraPaths: [paths.resolveApp('../magmalte'), paths.resolveApp('../hub')],
   entry: {
     master: [paths.resolveApp('app/master.js')],
     onboarding: [paths.resolveApp('app/onboarding.js')],

--- a/symphony/app/fbcnms-projects/magmalte/app/common/projects.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/common/projects.js
@@ -36,6 +36,12 @@ const allTabs: $ReadOnlyArray<ProjectLink> = [
     secondary: 'Automation Management',
     url: '/automation',
   },
+  {
+    id: 'hub',
+    name: 'Hub',
+    secondary: 'Network Hub',
+    url: '/hub',
+  },
 ];
 
 const ADMIN: ProjectLink = {

--- a/symphony/app/fbcnms-projects/platform-server/Dockerfile.prod
+++ b/symphony/app/fbcnms-projects/platform-server/Dockerfile.prod
@@ -13,6 +13,7 @@ COPY package.json yarn.lock babel.config.js /app/
 COPY fbcnms-packages /app/fbcnms-packages
 COPY fbcnms-projects/inventory /app/fbcnms-projects/inventory
 COPY fbcnms-projects/magmalte /app/fbcnms-projects/magmalte
+COPY fbcnms-projects/hub /app/fbcnms-projects/hub
 
 # build static files to /app/fbcnms-projects/inventory/static
 WORKDIR /app/fbcnms-projects/inventory

--- a/symphony/integration/docker-compose.override.yaml
+++ b/symphony/integration/docker-compose.override.yaml
@@ -29,6 +29,7 @@ services:
       - ${XPLAT_FBC_DIR}/fbcnms-projects/inventory/app:/app/fbcnms-projects/inventory/app:delegated
       - ${XPLAT_FBC_DIR}/fbcnms-projects/inventory/scripts:/app/fbcnms-projects/inventory/scripts:delegated
       - ${XPLAT_FBC_DIR}/fbcnms-projects/magmalte/app:/app/fbcnms-projects/magmalte/app:delegated
+      - ${XPLAT_FBC_DIR}/fbcnms-projects/hub/app:/app/fbcnms-projects/hub/app:delegated
 
   store:
     environment:


### PR DESCRIPTION
Summary: Create a new "Network Hub" tab in the Inventory Symphony project. Create a simple form for the "create service" page. This is a placeholder, and later the form will include more options and actually do stuff. This is fine to include in Symphony now because we need to explicitly enable the tab for a tenant to see it, so it won't interfere with current tenants.

Differential Revision: D20522835

