### PR TITLE
Test Rule removal mid session through a CCA-U

### DIFF
--- a/cwf/gateway/integ_tests/Makefile
+++ b/cwf/gateway/integ_tests/Makefile
@@ -6,7 +6,7 @@ endif
 export MAGMA_ROOT
 
 # Integration tests to run (Tests with a prefix name TestAuthenticate)  
-MANDATORY_TESTS=TestAuthenticate
+MANDATORY_TESTS=Test
 
 define execute_test
  	echo "Running test: $(1)"

--- a/cwf/gateway/integ_tests/Makefile
+++ b/cwf/gateway/integ_tests/Makefile
@@ -5,7 +5,7 @@ MAGMA_ROOT = /home/$USER/magma
 endif
 export MAGMA_ROOT
 
-# Integration tests to run (Tests with a prefix name TestAuthenticate)  
+# Integration tests to run (Tests with a prefix name Test)
 MANDATORY_TESTS=Test
 
 define execute_test

--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"fbc/lib/go/radius/rfc2869"
 	"magma/feg/cloud/go/protos"
@@ -28,14 +29,10 @@ func TestAuthenticateMultipleUEs(t *testing.T) {
 	assert.NoError(t, err)
 
 	for _, ue := range ues {
-		radiusP, err := tr.Authenticate(ue.GetImsi())
-		assert.NoError(t, err)
-
-		eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-		assert.NotNil(t, eapMessage)
-		assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
+		tr.AuthenticateAndAssertSuccess(t, ue.GetImsi())
+		tr.Disconnect(ue.GetImsi())
 	}
-
+	time.Sleep(1 * time.Second)
 	// Clear hss, ocs, and pcrf
 	assert.NoError(t, tr.CleanUp())
 }
@@ -45,7 +42,7 @@ func TestAuthenticateFail(t *testing.T) {
 	tr := NewTestRunner()
 	assert.NoError(t, usePCRFMockDriver())
 
-	ues, err := tr.ConfigUEs(2)
+	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
 
 	// Test Authentication Fail

--- a/cwf/gateway/integ_tests/enforcement_test.go
+++ b/cwf/gateway/integ_tests/enforcement_test.go
@@ -125,8 +125,132 @@ func TestBasicUplinkTrafficWithEnforcement(t *testing.T) {
 
 	// Clear hss, ocs, and pcrf
 	assert.NoError(t, clearPCRFMockDriver())
+	assert.NoError(t, ruleManager.RemoveInstalledRules())
+	assert.NoError(t, tr.CleanUp())
+}
+
+// - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
+//   respond with a rule install (static-pass-all-1).
+//   Generate traffic and assert the CCR-I is received.
+// - Set an expectation for a CCR-U to be sent up to PCRF, to which it will
+//   respond with a rule removal (static-pass-all-1) and rule install (static-pass-all-2).
+//   Generate traffic and assert the CCR-U is received.
+// - Generate traffic to put traffic through the newly installed rule.
+//   Assert that there's > 0 data usage in the rule.
+func TestMidSessionRuleRemovalWithCCA_U(t *testing.T) {
+	fmt.Println("\nRunning TestMidSessionRuleRemovalWithCCA_U...")
+
+	tr := NewTestRunner()
+	ruleManager, err := NewRuleManager()
+	assert.NoError(t, err)
+	assert.NoError(t, usePCRFMockDriver())
+
+	ues, err := tr.ConfigUEs(1)
+	assert.NoError(t, err)
+	imsi := ues[0].GetImsi()
+
+	err = ruleManager.AddStaticPassAllToDB("static-pass-all-1", "mkey1", 0, models.PolicyRuleTrackingTypeONLYPCRF, 100)
+	assert.NoError(t, err)
+	err = ruleManager.AddStaticPassAllToDB("static-pass-all-2", "mkey2", 0, models.PolicyRuleTrackingTypeONLYPCRF, 10)
+	assert.NoError(t, err)
+
+	usageMonitorInfo := []*protos.UsageMonitoringInformation{
+		{
+			MonitoringLevel: protos.MonitoringLevel_RuleLevel,
+			MonitoringKey:   []byte("mkey1"),
+			Octets:          &protos.Octets{TotalOctets: 250 * KiloBytes},
+		},
+	}
+
+	initRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGxCCAnswer(diam.Success).
+		SetStaticRuleInstalls([]string{"static-pass-all-1"}, []string{}).
+		SetUsageMonitorInfos(usageMonitorInfo)
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+	// Remove the high priority Rule
+	defaultUpdateAnswer := protos.NewGxCCAnswer(diam.Success).SetUsageMonitorInfos(usageMonitorInfo)
+	expectations := []*protos.GxCreditControlExpectation{initExpectation}
+	// On unexpected requests, just return some quota
+	assert.NoError(t, setPCRFExpectations(expectations, defaultUpdateAnswer))
+
+	// wait for the rules to be synced into sessiond
+	time.Sleep(1 * time.Second)
+
+	tr.AuthenticateAndAssertSuccess(t, imsi)
+
+	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "250K"}}
+	_, err = tr.GenULTraffic(req)
+	assert.NoError(t, err)
+
+	// Wait for some traffic to go through
+	time.Sleep(1 * time.Second)
+
+	// Assert that enforcement_stats rules are properly installed and the right
+	// amount of data was passed through
+	recordsBySubID, err := tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	record1 := recordsBySubID["IMSI"+imsi]["static-pass-all-1"]
+	if record1 != nil {
+		assert.True(t, record1.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record1.RuleId))
+	}
+	assert.NotNil(t, record1, fmt.Sprintf("No policy usage record for imsi: %v rule=static-pass-all-1", imsi))
+
+	// Assert that a CCR-I was sent up to the PCRF
+	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult := []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+
+	updateRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_UPDATE, 2).
+		SetUsageMonitorReports(usageMonitorInfo).
+		SetUsageReportDelta(250 * KiloBytes * 0.5)
+	updateAnswer := protos.NewGxCCAnswer(diam.Success).SetUsageMonitorInfos(usageMonitorInfo).
+		SetStaticRuleInstalls([]string{"static-pass-all-2"}, []string{}).
+		SetStaticRuleRemovals([]string{"static-pass-all-1"})
+	updateExpectation := protos.NewGxCreditControlExpectation().Expect(updateRequest).Return(updateAnswer)
+	expectations = []*protos.GxCreditControlExpectation{updateExpectation}
+	// On unexpected requests, just return some quota
+	assert.NoError(t, setPCRFExpectations(expectations, defaultUpdateAnswer))
+
+	fmt.Println("Generating traffic again to trigger a CCR/A-U so that 'static-pass-all-1' gets removed")
+	// Generate traffic to trigger the CCR-U so that the rule removal/install happens
+	_, err = tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	time.Sleep(3 * time.Second)
+
+	fmt.Println("Generating traffic again to put data through static-pass-all-2")
+	_, err = tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	// Wait for some traffic to go through
+	time.Sleep(1 * time.Second)
+
+	// Assert that we sent back a CCA-Update with RuleRemovals
+	resultByIndex, errByIndex, err = getAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult = []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+
+	recordsBySubID, err = tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	record2 := recordsBySubID["IMSI"+imsi]["static-pass-all-2"]
+	assert.NotNil(t, record1, fmt.Sprintf("No policy usage record for imsi: %v rule=static-pass-all-2", imsi))
+	if record2 != nil {
+		// This rule should have passed some traffic
+		assert.True(t, record2.BytesTx > 0, fmt.Sprintf("%s did not pass any data", record2.RuleId))
+	}
+
+	_, err = tr.Disconnect(imsi)
+	assert.NoError(t, err)
+	time.Sleep(3 * time.Second)
 
 	// Clear hss, ocs, and pcrf
+	assert.NoError(t, clearPCRFMockDriver())
 	assert.NoError(t, ruleManager.RemoveInstalledRules())
 	assert.NoError(t, tr.CleanUp())
 }

--- a/cwf/gateway/integ_tests/ocs_credit_exhaustion_test.go
+++ b/cwf/gateway/integ_tests/ocs_credit_exhaustion_test.go
@@ -10,14 +10,11 @@ package integ_tests
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
-	"fbc/lib/go/radius/rfc2869"
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
-	"magma/feg/gateway/services/eap"
 	"magma/lte/cloud/go/plugin/models"
 
 	"github.com/go-openapi/swag"
@@ -88,17 +85,11 @@ func TestAuthenticateOcsCreditExhaustedWithCRRU(t *testing.T) {
 
 	// Wait for rules propagation
 	time.Sleep(2 * time.Second)
-	radiusP, err := tr.Authenticate(ue.GetImsi())
-	assert.NoError(t, err)
-
-	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(t, eapMessage)
-	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
-	time.Sleep(2 * time.Second)
+	tr.AuthenticateAndAssertSuccess(t, ue.GetImsi())
 
 	// we need to generate over 80% of the quota to trigger a CCR update
 	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("5M")}}
-	_, err = tr.GenULTraffic(req)
+	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	time.Sleep(3 * time.Second)
 
@@ -139,17 +130,11 @@ func TestAuthenticateOcsCreditExhaustedWithoutCRRU(t *testing.T) {
 
 	// Wait for rules propagation
 	time.Sleep(2 * time.Second)
-	radiusP, err := tr.Authenticate(ue.GetImsi())
-	assert.NoError(t, err)
-
-	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(t, eapMessage)
-	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
-	time.Sleep(2 * time.Second)
+	tr.AuthenticateAndAssertSuccess(t, ue.GetImsi())
 
 	// we need to generate over 100% of the quota to trigger a session termination
 	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("5M")}}
-	_, err = tr.GenULTraffic(req)
+	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
 	// Wait for traffic to go through

--- a/cwf/gateway/integ_tests/ocs_reauth_test.go
+++ b/cwf/gateway/integ_tests/ocs_reauth_test.go
@@ -32,7 +32,7 @@ const (
 )
 
 func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
-	fmt.Printf("Running TestAuthenticateUplinkWithOcsChargingReAuth...\n")
+	fmt.Println("\nRunning TestAuthenticateUplinkWithOcsChargingReAuth...")
 
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()
@@ -149,5 +149,5 @@ func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 	assert.NoError(t, ruleManager.RemoveInstalledRules())
 	assert.NoError(t, tr.CleanUp())
 	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(10 * time.Second)
+	time.Sleep(3 * time.Second)
 }

--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -10,13 +10,10 @@ package integ_tests
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
-	"fbc/lib/go/radius/rfc2869"
 	cwfprotos "magma/cwf/cloud/go/protos"
-	"magma/feg/gateway/services/eap"
 	"magma/lte/cloud/go/plugin/models"
 
 	"github.com/go-openapi/swag"
@@ -34,11 +31,11 @@ func TestAuthenticateUplinkTrafficWithOmniRules(t *testing.T) {
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
 
-	ue := ues[0]
+	imsi := ues[0].GetImsi()
 	// Set a block all rule to be installed by the PCRF
 	err = ruleManager.AddStaticRuleToDB(getStaticDenyAll("static-block-all", "mkey1", 0, models.PolicyRuleConfigTrackingTypeONLYPCRF, 30))
 	assert.NoError(t, err)
-	err = ruleManager.AddRulesToPCRF(ue.Imsi, []string{"static-block-all"}, nil)
+	err = ruleManager.AddRulesToPCRF(imsi, []string{"static-block-all"}, nil)
 	assert.NoError(t, err)
 
 	// Override with an omni pass all static rule with a higher priority
@@ -50,14 +47,9 @@ func TestAuthenticateUplinkTrafficWithOmniRules(t *testing.T) {
 
 	// Wait for rules propagation
 	time.Sleep(2 * time.Second)
-	radiusP, err := tr.Authenticate(ue.GetImsi())
-	assert.NoError(t, err)
+	tr.AuthenticateAndAssertSuccess(t, imsi)
 
-	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(t, eapMessage)
-	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
-
-	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("200k")}}
+	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("200k")}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
@@ -66,15 +58,15 @@ func TestAuthenticateUplinkTrafficWithOmniRules(t *testing.T) {
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
 
-	omniRecord := recordsBySubID["IMSI"+ue.GetImsi()]["omni-pass-all-1"]
-	blockAllRecord := recordsBySubID["IMSI"+ue.GetImsi()]["static-block-all"]
-	assert.NotNil(t, omniRecord, fmt.Sprintf("No policy usage omniRecord for imsi: %v", ue.GetImsi()))
-	assert.NotNil(t, blockAllRecord, fmt.Sprintf("Block all record was not installed for imsi %v", ue.GetImsi()))
+	omniRecord := recordsBySubID["IMSI"+imsi]["omni-pass-all-1"]
+	blockAllRecord := recordsBySubID["IMSI"+imsi]["static-block-all"]
+	assert.NotNil(t, omniRecord, fmt.Sprintf("No policy usage omniRecord for imsi: %v", imsi))
+	assert.NotNil(t, blockAllRecord, fmt.Sprintf("Block all record was not installed for imsi %v", imsi))
 
 	assert.True(t, omniRecord.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", omniRecord.RuleId))
 	assert.True(t, omniRecord.BytesTx <= uint64(200*KiloBytes+Buffer), fmt.Sprintf("policy usage: %v", omniRecord))
 	assert.Equal(t, uint64(0x0), blockAllRecord.BytesTx)
-	_, err = tr.Disconnect(ue.GetImsi())
+	_, err = tr.Disconnect(imsi)
 	assert.NoError(t, err)
 
 	// Clear hss, ocs, and pcrf

--- a/feg/cloud/go/protos/mock_core_conversions.go
+++ b/feg/cloud/go/protos/mock_core_conversions.go
@@ -52,6 +52,14 @@ func (m *GxCreditControlAnswer) SetDynamicRuleInstalls(rules []*RuleDefinition) 
 	return m
 }
 
+func (m *GxCreditControlAnswer) SetStaticRuleRemovals(rulesIDs []string) *GxCreditControlAnswer {
+	if m.RuleRemovals == nil {
+		m.RuleRemovals = &RuleRemovals{}
+	}
+	m.RuleRemovals.RuleNames = rulesIDs
+	return m
+}
+
 func (m *GxCreditControlRequest) SetUsageMonitorReports(reports []*UsageMonitoringInformation) *GxCreditControlRequest {
 	m.UsageMonitoringReports = reports
 	return m


### PR DESCRIPTION
Summary:
- Set an expectation for a  CCR-I to be sent up to PCRF, to which it will respond with a rule install (static-pass-all-1). Generate traffic and assert the CCR-I is received.
- Set an expectation for a CCR-U to be sent up to PCRF, to which it will respond with a rule removal (static-pass-all-1) and rule install (static-pass-all-2). Generate traffic and assert the CCR-U is received.
- Generate traffic to put traffic through the newly installed rule. Assert that there's > 0 data usage in the rule.

Differential Revision: D20541324

