### PR TITLE
Add installed base names to the list of things RuleManager keeps track of

### DIFF
--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -42,7 +42,7 @@ func TestAuthenticateUplinkTrafficWithOmniRules(t *testing.T) {
 	err = ruleManager.AddStaticPassAllToDB("omni-pass-all-1", "", 0, models.PolicyRuleTrackingTypeNOTRACKING, 20)
 	assert.NoError(t, err)
 	// Apply a network wide rule that points to the static rule above
-	err = ruleManager.AddOmniPresentRulesToDB("onmi", []string{"omni-pass-all-1"}, []string{""})
+	err = ruleManager.AddOmniPresentRulesToDB("omni", []string{"omni-pass-all-1"}, []string{""})
 	assert.NoError(t, err)
 
 	// Wait for rules propagation


### PR DESCRIPTION
Summary:
- RuleManager should store basename -> rule associations
- Several functions had the err case and success case flipped so fixing that here.

Differential Revision: D20544936

