### PR TITLE
Add idle timer for DPI flows

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -79,6 +79,7 @@ dpi:
   enabled: true
   mon_port: mon1
   mon_port_number: 32769
+  idle_timeout: 5
 
 # Interface to address L2 traffic to and answer ARP for UE subnet
 virtual_interface: cwag_br0

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -77,6 +77,7 @@ dpi:
   enabled: false
   mon_port: mon1
   mon_port_number: 32769
+  idle_timeout: 5
 
 # Interface to address L2 traffic to and answer ARP for UE subnet
 virtual_interface: cwag_br0

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -74,6 +74,7 @@ dpi:
   enabled: false
   mon_port: mon1
   mon_port_number: 32769
+  idle_timeout: 5
 
 # Interface to address L2 traffic to and answer ARP for UE subnet
 virtual_interface: gtp_br0

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -65,6 +65,7 @@ dpi:
   enabled: false
   mon_port: mon1
   mon_port_number: 32769
+  idle_timeout: 5
 
 # Enable polling mobilityd to identify which subscriber sessions need to be
 # terminated. If disabling this, make sure to set a valid idle_timeout for

--- a/lte/gateway/python/magma/pipelined/app/dpi.py
+++ b/lte/gateway/python/magma/pipelined/app/dpi.py
@@ -51,6 +51,7 @@ class DPIController(MagmaController):
         self._dpi_enabled = kwargs['config']['dpi']['enabled']
         self._mon_port = kwargs['config']['dpi']['mon_port']
         self._mon_port_number = kwargs['config']['dpi']['mon_port_number']
+        self._idle_timeout = kwargs['config']['dpi']['idle_timeout']
         self._bridge_name = kwargs['config']['bridge_name']
         if self._dpi_enabled:
             self._create_monitor_port()
@@ -134,9 +135,8 @@ class DPIController(MagmaController):
         actions = [parser.OFPActionOutput(self._mon_port_number),
                    parser.NXActionRegLoad2(dst=DPI_REG, value=app_id)]
         flows.add_resubmit_next_service_flow(self._datapath, self.tbl_num,
-                                             match, actions,
-                                             priority=flows.DEFAULT_PRIORITY,
-                                             resubmit_table=self.next_table)
+            match, actions, priority=flows.DEFAULT_PRIORITY,
+            resubmit_table=self.next_table, idle_timeout=self._idle_timeout)
 
     def remove_classify_flow(self, match):
         try:

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -36,7 +36,7 @@ class IPFIXController(MagmaController):
         [('enabled', bool), ('collector_ip', str), ('collector_port', int),
          ('probability', int), ('collector_set_id', int),
          ('obs_domain_id', int), ('obs_point_id', int), ('cache_timeout', int),
-         ('gtp_port', int)],
+         ('sampling_port', int)],
     )
 
     def __init__(self, *args, **kwargs):
@@ -54,23 +54,32 @@ class IPFIXController(MagmaController):
         if 'ipfix' not in config_dict or not config_dict['ipfix']['enabled']:
             return self.IPFIXConfig(enabled=False, probability=0,
                 collector_ip='', collector_port=0, collector_set_id=0,
-                obs_domain_id=0, obs_point_id=0, cache_timeout=0, gtp_port=0)
+                obs_domain_id=0, obs_point_id=0, cache_timeout=0,
+                sampling_port=0)
+        collector_ip = mconfig.ipdr_export_dst.ip
+        collector_port = mconfig.ipdr_export_dst.port
         if not mconfig.ipdr_export_dst.ip:
-            self.logger.error("IPDR enabled byt ipdr dst ip not provided")
-            return self.IPFIXConfig(enabled=False, probability=0,
-                collector_ip='', collector_port=0, collector_set_id=0,
-                obs_domain_id=0, obs_point_id=0, cache_timeout=0, gtp_port=0)
+            if 'collector_ip' in config_dict['ipfix']:
+                self.logger.error("Missing IPDR dest IP, using val from .yml")
+                collector_ip = config_dict['ipfix']['collector_ip']
+                collector_port = config_dict['ipfix']['collector_port']
+            else:
+                self.logger.error("Missing mconfig IPDR dest IP")
+                return self.IPFIXConfig(enabled=False, probability=0,
+                    collector_ip='', collector_port=0, collector_set_id=0,
+                    obs_domain_id=0, obs_point_id=0, cache_timeout=0,
+                    sampling_port=0)
 
         return self.IPFIXConfig(
             enabled=config_dict['ipfix']['enabled'],
-            collector_ip=mconfig.ipdr_export_dst.ip,
-            collector_port=mconfig.ipdr_export_dst.port,
+            collector_ip=collector_ip,
+            collector_port=collector_port,
             probability=config_dict['ipfix']['probability'],
             collector_set_id=config_dict['ipfix']['collector_set_id'],
             obs_domain_id=config_dict['ipfix']['obs_domain_id'],
             obs_point_id=config_dict['ipfix']['obs_point_id'],
             cache_timeout=config_dict['ipfix']['cache_timeout'],
-            gtp_port=config_dict['ovs_gtp_port_number']
+            sampling_port=config_dict['ovs_uplink_port_name']
         )
 
     def initialize_on_connect(self, datapath: Datapath):
@@ -156,18 +165,17 @@ class IPFIXController(MagmaController):
             apn_name (string): AP name
         """
         imsi_hex = hex(encode_imsi(imsi))
-        apn_name = apn_name.replace(' ', '_')
         action_str = (
             'ovs-ofctl add-flow {} "table={},priority={},metadata={},'
             'actions=sample(probability={},collector_set_id={},'
             'obs_domain_id={},obs_point_id={},apn_mac_addr={},msisdn={},'
-            'apn_name={}),resubmit(,{})"'
+            'apn_name=\\\"{}\\\", sampling_port={}),resubmit(,{})"'
         ).format(
             self._bridge_name, self.tbl_num, flows.UE_FLOW_PRIORITY, imsi_hex,
             self.ipfix_config.probability, self.ipfix_config.collector_set_id,
             self.ipfix_config.obs_domain_id, self.ipfix_config.obs_point_id,
             apn_mac_addr.replace("-", ":"), msisdn, apn_name,
-            self.next_main_table
+            self.ipfix_config.sampling_port, self.next_main_table
         )
         try:
             subprocess.Popen(action_str, shell=True).wait()

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_add_app_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_add_app_rules.snapshot
@@ -1,5 +1,5 @@
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=10,tcp,reg1=0x1,nw_src=1.2.3.0/24,nw_dst=45.10.0.0/24,tp_src=51115,tp_dst=80 actions=output:32769,set_field:0xa->reg10,resubmit(,egress(main_table)),set_field:0->reg0
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=10,tcp,reg1=0x1,nw_src=6.2.3.0/24,nw_dst=1.10.0.0/24,tp_src=222,tp_dst=111 actions=output:32769,set_field:0x5->reg10,resubmit(,egress(main_table)),set_field:0->reg0
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=10,udp,reg1=0x1,nw_src=15.22.32.0/24,nw_dst=22.2.2.24,tp_src=111,tp_dst=222 actions=output:32769,set_field:0x20->reg10,resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,tcp,reg1=0x1,nw_src=1.2.3.0/24,nw_dst=45.10.0.0/24,tp_src=51115,tp_dst=80 actions=output:32769,set_field:0xa->reg10,resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,tcp,reg1=0x1,nw_src=6.2.3.0/24,nw_dst=1.10.0.0/24,tp_src=222,tp_dst=111 actions=output:32769,set_field:0x5->reg10,resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,udp,reg1=0x1,nw_src=15.22.32.0/24,nw_dst=22.2.2.24,tp_src=111,tp_dst=222 actions=output:32769,set_field:0x20->reg10,resubmit(,egress(main_table)),set_field:0->reg0
  cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,egress(main_table)),set_field:0->reg0
  cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_remove_app_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_remove_app_rules.snapshot
@@ -1,4 +1,4 @@
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=10,tcp,reg1=0x1,nw_src=6.2.3.0/24,nw_dst=1.10.0.0/24,tp_src=222,tp_dst=111 actions=output:32769,set_field:0x5->reg10,resubmit(,egress(main_table)),set_field:0->reg0
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=10,udp,reg1=0x1,nw_src=15.22.32.0/24,nw_dst=22.2.2.24,tp_src=111,tp_dst=222 actions=output:32769,set_field:0x20->reg10,resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,tcp,reg1=0x1,nw_src=6.2.3.0/24,nw_dst=1.10.0.0/24,tp_src=222,tp_dst=111 actions=output:32769,set_field:0x5->reg10,resubmit(,egress(main_table)),set_field:0->reg0
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,udp,reg1=0x1,nw_src=15.22.32.0/24,nw_dst=22.2.2.24,tp_src=111,tp_dst=222 actions=output:32769,set_field:0x20->reg10,resubmit(,egress(main_table)),set_field:0->reg0
  cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,egress(main_table)),set_field:0->reg0
  cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/test_dpi.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_dpi.py
@@ -72,6 +72,7 @@ class DPITest(unittest.TestCase):
                     'enabled': False,
                     'mon_port': 'mon1',
                     'mon_port_number': 32769,
+                    'idle_timeout': 42,
                 },
             },
             mconfig=None,

--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -73,6 +73,7 @@ dpi:
   enabled: false
   mon_port: mon1
   mon_port_number: 32769
+  idle_timeout: 5
 
 # Interface to address L2 traffic to and answer ARP for UE subnet
 virtual_interface: cwag_br0


### PR DESCRIPTION
Summary: DPI engine doesn't always terminate the flows(this might be due to our service implementation), this fix resolves this problem for now and connections shoudn't be idle for this time anwyways, so should be safe

Reviewed By: themarwhal

Differential Revision: D20551235

