### PR TITLE
Disable Rest Ryu service for xwfm

### DIFF
--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -29,7 +29,6 @@ log_level: INFO
 static_services: [
   'tunnel_learn',
   'vlan_learn',
-  'ryu_rest_service',
   'startup_flows',
 ]
 


### PR DESCRIPTION
Summary: Disable Rest Ryu service for xwfm

Reviewed By: xjtian

Differential Revision: D20593292

