### PR TITLE
Modify omnipresent rule test to use expectation based PCRF

### DIFF
--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -14,67 +14,110 @@ import (
 	"time"
 
 	cwfprotos "magma/cwf/cloud/go/protos"
+	"magma/feg/cloud/go/protos"
 	"magma/lte/cloud/go/plugin/models"
 
+	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAuthenticateUplinkTrafficWithOmniRules(t *testing.T) {
-	fmt.Println("Running TestAuthenticateUplinkTrafficWithOmniRules...")
-
+// - Insert two static rules into the DB. (static-block-all and omni-pass-all)
+// - The omnipresent rule, with higher priority than the block all, will be set
+//   as omnipresent/network-wide.
+// - Set an expectation for a CCR-I to be sent up to PCRF, to which it will
+//   respond with a rule install (static-block-all).
+//   Generate traffic and assert the CCR-I is received.
+//   Assert that the traffic goes through. This means the network wide rules
+//   gets installed properly.
+// - Trigger a Gx RAR with a rule removal for the block all rule. Assert the
+//   answer is successful. Since the only rule with a usage monitor is removed,
+//   the session will terminate. Assert that policy usage is empty.
+func TestOmnipresentRules(t *testing.T) {
+	fmt.Println("\nRunning TestOmnipresentRules...")
 	tr := NewTestRunner()
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
+	assert.NoError(t, usePCRFMockDriver())
+	defer func() {
+		// Delete omni rules
+		assert.NoError(t, ruleManager.RemoveOmniPresentRulesFromDB("omni"))
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearPCRFMockDriver())
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
 
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
-
 	imsi := ues[0].GetImsi()
+
 	// Set a block all rule to be installed by the PCRF
 	err = ruleManager.AddStaticRuleToDB(getStaticDenyAll("static-block-all", "mkey1", 0, models.PolicyRuleConfigTrackingTypeONLYPCRF, 30))
 	assert.NoError(t, err)
-	err = ruleManager.AddRulesToPCRF(imsi, []string{"static-block-all"}, nil)
-	assert.NoError(t, err)
-
 	// Override with an omni pass all static rule with a higher priority
 	err = ruleManager.AddStaticPassAllToDB("omni-pass-all-1", "", 0, models.PolicyRuleTrackingTypeNOTRACKING, 20)
 	assert.NoError(t, err)
 	// Apply a network wide rule that points to the static rule above
 	err = ruleManager.AddOmniPresentRulesToDB("omni", []string{"omni-pass-all-1"}, []string{""})
 	assert.NoError(t, err)
+	// wait for the rules to be synced into sessiond
+	time.Sleep(1 * time.Second)
 
-	// Wait for rules propagation
-	time.Sleep(2 * time.Second)
+	usageMonitorInfo := []*protos.UsageMonitoringInformation{
+		{
+			MonitoringLevel: protos.MonitoringLevel_RuleLevel,
+			MonitoringKey:   []byte("mkey1"),
+			Octets:          &protos.Octets{TotalOctets: 1 * MegaBytes},
+		},
+	}
+	initRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGxCCAnswer(diam.Success).
+		SetStaticRuleInstalls([]string{"static-block-all"}, []string{}).
+		SetUsageMonitorInfos(usageMonitorInfo)
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+	expectations := []*protos.GxCreditControlExpectation{initExpectation}
+	assert.NoError(t, setPCRFExpectations(expectations, nil)) // we don't expect any update requests
+
 	tr.AuthenticateAndAssertSuccess(t, imsi)
 
 	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("200k")}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
+	// Wait for enforcement stats to sync
+	time.Sleep(3 * time.Second)
 
-	// Wait for traffic to go through
-	time.Sleep(6 * time.Second)
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
-
 	omniRecord := recordsBySubID["IMSI"+imsi]["omni-pass-all-1"]
 	blockAllRecord := recordsBySubID["IMSI"+imsi]["static-block-all"]
 	assert.NotNil(t, omniRecord, fmt.Sprintf("No policy usage omniRecord for imsi: %v", imsi))
 	assert.NotNil(t, blockAllRecord, fmt.Sprintf("Block all record was not installed for imsi %v", imsi))
 
 	assert.True(t, omniRecord.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", omniRecord.RuleId))
-	assert.True(t, omniRecord.BytesTx <= uint64(200*KiloBytes+Buffer), fmt.Sprintf("policy usage: %v", omniRecord))
 	assert.Equal(t, uint64(0x0), blockAllRecord.BytesTx)
 
-	// Disconnect
-	_, err = tr.Disconnect(imsi)
+	// Trigger a ReAuth with rule removals of monitored rules
+	target := &protos.PolicyReAuthTarget{
+		Imsi: imsi,
+		RulesToRemove: &protos.RuleRemovals{
+			RuleNames: []string{"static-block-all"},
+		},
+	}
+	fmt.Printf("Sending a ReAuthRequest with target %v\n", target)
+	raa, err := sendPolicyReAuthRequest(target)
+
 	assert.NoError(t, err)
+	// Wait for RAR to be processed
+	time.Sleep(3 * time.Second)
+	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
 
-	// Delete omni rules
-	assert.NoError(t, ruleManager.RemoveOmniPresentRulesFromDB("omni"))
+	// With all monitored rules gone, the session should terminate
+	recordsBySubID, err = tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	assert.Empty(t, recordsBySubID)
 
-	// Clear hss, ocs, and pcrf
-	assert.NoError(t, ruleManager.RemoveInstalledRules())
-	assert.NoError(t, tr.CleanUp())
+	// Wait for session termination to complete
+	time.Sleep(4 * time.Second)
 }

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -169,35 +169,6 @@ func addPCRFUsageMonitors(monitorInfo *fegprotos.UsageMonitorConfiguration) erro
 	return err
 }
 
-/**  ========== OCS Helpers ========== **/
-// getOCSClient is a utility function to an RPC connection to a
-// remote OCS service.
-func getOCSClient() (*ocsClient, error) {
-	var conn *grpc.ClientConn
-	var err error
-	conn, err = registry.GetConnection(MockOCSRemote)
-	if err != nil {
-		errMsg := fmt.Sprintf("PCRF client initialization error: %s", err)
-		glog.Error(errMsg)
-		return nil, errors.New(errMsg)
-	}
-	return &ocsClient{
-		fegprotos.NewMockOCSClient(conn),
-		conn,
-	}, err
-}
-
-// setNewOCSConfig tries to override the default ocs settings
-// Input: ocsConfig data
-func setNewOCSConfig(ocsConfig *fegprotos.OCSConfig) error {
-	cli, err := getOCSClient()
-	if err != nil {
-		return err
-	}
-	_, err = cli.SetOCSSettings(context.Background(), ocsConfig)
-	return err
-}
-
 func usePCRFMockDriver() error {
 	cli, err := getPCRFClient()
 	if err != nil {
@@ -242,6 +213,35 @@ func getAssertExpectationsResult() ([]*fegprotos.ExpectationResult, []*fegprotos
 		return nil, nil, err
 	}
 	return res.Results, res.Errors, nil
+}
+
+/**  ========== OCS Helpers ========== **/
+// getOCSClient is a utility function to an RPC connection to a
+// remote OCS service.
+func getOCSClient() (*ocsClient, error) {
+	var conn *grpc.ClientConn
+	var err error
+	conn, err = registry.GetConnection(MockOCSRemote)
+	if err != nil {
+		errMsg := fmt.Sprintf("PCRF client initialization error: %s", err)
+		glog.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	return &ocsClient{
+		fegprotos.NewMockOCSClient(conn),
+		conn,
+	}, err
+}
+
+// setNewOCSConfig tries to override the default ocs settings
+// Input: ocsConfig data
+func setNewOCSConfig(ocsConfig *fegprotos.OCSConfig) error {
+	cli, err := getOCSClient()
+	if err != nil {
+		return err
+	}
+	_, err = cli.SetOCSSettings(context.Background(), ocsConfig)
+	return err
 }
 
 // addSubscriber tries to add this subscriber to the OCS server.


### PR DESCRIPTION
Summary:
- Modify omnipresent rule test to use expectation based PCRF

Test Summary
- Insert two static rules into the DB. (static-block-all and omni-pass-all)
- The omnipresent rule, with higher priority than the block all, will be set as omnipresent/network-wide.
- Set an expectation for a CCR-I to be sent up to PCRF, to which it will respond with a rule install (static-block-all). Generate traffic and assert the CCR-I is received. Assert that the traffic goes through. This means the network wide rules gets installed properly.
- Trigger a Gx RAR with a rule removal for the block all rule. Assert the
  answer is successful. Since the only rule with a usage monitor is removed,
  the session will terminate. Assert that policy usage is empty.

Differential Revision: D20606884

