### PR TITLE
Adding metrics, unit tests to monitord

### DIFF
--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -16,6 +16,7 @@ TESTS=magma/tests \
       magma/pipelined/openflow/tests \
       magma/pkt_tester/tests \
       magma/redirectd/tests \
-      magma/subscriberdb/tests
+      magma/subscriberdb/tests \
+      magma/monitord/tests
 
 SUDO_TESTS=magma/pipelined/tests

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -9,6 +9,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
+from magma.configuration import load_service_config
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.icmp_state import serialize_subscriber_states
 
@@ -18,8 +19,9 @@ def main():
     service = MagmaService('monitord', mconfigs_pb2.MonitorD())
 
     # Monitoring thread loop
+    mtr_interface = load_service_config("monitord")["mtr_interface"]
     icmp_monitor = ICMPMonitoring(service.mconfig.polling_interval,
-                                  service.loop)
+                                  service.loop, mtr_interface)
     icmp_monitor.start()
 
     # Register a callback function for GetOperationalStates

--- a/lte/gateway/python/magma/monitord/metrics.py
+++ b/lte/gateway/python/magma/monitord/metrics.py
@@ -1,0 +1,13 @@
+#  Copyright (c) Facebook, Inc. and its affiliates.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from prometheus_client import Histogram
+
+SUBSCRIBER_ICMP_LATENCY_MS = Histogram('subscriber_icmp_latency_ms',
+                                  'Reported latency for subscriber '
+                                  'in milliseconds',
+                                  ['imsi'],
+                                  buckets=[50, 100, 200, 500, 1000, 2000])

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+
+import asyncio
+import unittest
+
+from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
+from magma.monitord.icmp_monitoring import ICMPMonitoring
+from magma.subscriberdb.sid import SIDUtils
+
+
+class ICMPMonitoringTests(unittest.TestCase):
+    """
+    Test class for the ICMPMonitor class
+    """
+
+    def _add_test_subscriber(self, imsi):
+        ip = IPAddress(version=IPAddress.IPV4, address=b'127.0.0.1')
+        sid = SIDUtils.to_pb(imsi)
+        self.subscribers.entries.add(sid=sid, ip=ip, apn='test_apn')
+
+    async def _ping_local(self):
+        return await self._monitor._ping_subscribers(["127.0.0.1"],
+                                                     self.subscribers.entries)
+
+    def setUp(self):
+        """
+        Creates and sets up ICMP monitor
+        """
+        self.loop = asyncio.get_event_loop()
+        self.subscribers = SubscriberIPTable()
+        self._monitor = ICMPMonitoring(polling_interval=5,
+                                       service_loop=self.loop,
+                                       mtr_interface="test")
+
+    def test_ping_subscriber_saves_response(self):
+        imsi = 'IMSI00000000001'
+        self._add_test_subscriber(imsi)
+        self.loop.run_until_complete(self._ping_local())
+        sub_states = self._monitor.get_subscriber_state()
+        self.loop.close()
+        self.assertTrue(imsi in sub_states)

--- a/lte/gateway/python/magma/monitord/tests/test_metrics.py
+++ b/lte/gateway/python/magma/monitord/tests/test_metrics.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+
+from magma.common import metrics_export
+from magma.monitord.metrics import SUBSCRIBER_ICMP_LATENCY_MS
+
+
+class MetricTests(unittest.TestCase):
+    """
+    Tests for the Service303 metrics interface
+    """
+    def test_metrics_defined(self):
+        """ Test that all metrics are defined in proto enum """
+        SUBSCRIBER_ICMP_LATENCY_MS.labels('IMSI00000001').observe(10.33)
+
+        metrics_protos = list(metrics_export.get_metrics())
+        for metrics_proto in metrics_protos:
+            if metrics_proto.name == "subscriber_latency_ms":
+                metric = metrics_proto.metric[0]
+                self.assertEqual(metric.histogram.sample_sum, 10.33)
+                self.assertEqual(metric.label[0].value, 'IMSI00000001')


### PR DESCRIPTION
Summary:
- Adding SUBSCRIBER_ICMP_LATENCY_MS to monitord metrics
- Adding unit tests

Differential Revision: D20614889

