### PR TITLE
Add basic events for magmad

### DIFF
--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -20,3 +20,15 @@ event_registry:
   session_terminated:
     module: lte
     filename: session_manager_events.v1.yml
+  deleted_stored_mconfig:
+     module: orc8r
+     filename: magmad_events.v1.yml
+  updated_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  processed_updates:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  restarted_services:
+    module: orc8r
+    filename: magmad_events.v1.yml

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -75,14 +75,14 @@ class MagmaService(Service303Servicer):
         # Load the managed config if present
         self._mconfig = empty_mconfig
         self._mconfig_metadata = None
-        self._mconfig_manager = get_mconfig_manager()
+        self._mconfig_manager = get_mconfig_manager(loop)
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self._loop = loop
         self.reload_mconfig()
 
         self._state = ServiceInfo.STARTING
         self._health = ServiceInfo.APP_UNHEALTHY
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        self._loop = loop
         self._start_time = int(time.time())
         self._register_signal_handlers()
 
@@ -189,7 +189,7 @@ class MagmaService(Service303Servicer):
         """
         try:
             # reload mconfig manager in case feature flag for streaming changed
-            self._mconfig_manager = get_mconfig_manager()
+            self._mconfig_manager = get_mconfig_manager(self._loop)
             self._mconfig = self._mconfig_manager.load_service_mconfig(
                 self._name,
                 self._mconfig,

--- a/orc8r/gateway/python/magma/configuration/events.py
+++ b/orc8r/gateway/python/magma/configuration/events.py
@@ -1,0 +1,39 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+import snowflake
+from asyncio.events import AbstractEventLoop
+
+from magma.eventd.eventd_client import log_event
+from orc8r.protos.eventd_pb2 import Event
+
+
+def deleted_stored_mconfig(loop: AbstractEventLoop):
+    loop.run_until_complete(
+        log_event(
+            Event(
+                stream_name="magmad",
+                event_type="deleted_stored_mconfig",
+                tag=snowflake.snowflake(),
+                value="{}",
+            )
+        )
+    )
+
+
+def updated_stored_mconfig(loop: AbstractEventLoop):
+    loop.run_until_complete(
+        log_event(
+            Event(
+                stream_name="magmad",
+                event_type="updated_stored_mconfig",
+                tag=snowflake.snowflake(),
+                value="{}",
+            )
+        )
+    )

--- a/orc8r/gateway/python/magma/configuration/mconfig_managers.py
+++ b/orc8r/gateway/python/magma/configuration/mconfig_managers.py
@@ -6,12 +6,14 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
+import asyncio
 import contextlib
 import json
-from typing import Any, Generic, TypeVar
-
 import abc
 import os
+from typing import Any, Generic, TypeVar
+
+import magma.configuration.events as magma_configuration_events
 from google.protobuf import json_format
 from magma.common import serialization_utils
 from magma.configuration.exceptions import LoadConfigError
@@ -26,36 +28,39 @@ MCONFIG_OVERRIDE_DIR = '/var/opt/magma/configs'
 DEFAULT_MCONFIG_DIR = os.environ.get('MAGMA_CONFIG_LOCATION', MCONFIG_DIR)
 
 
-def get_mconfig_manager():
+def get_mconfig_manager(loop=None):
     """
     Get the mconfig manager implementation that the system is configured to
     use.
 
     Returns: MconfigManager implementation
     """
+    if loop is None:
+        loop = asyncio.get_event_loop()
     # This is stubbed out after deleting the streamed mconfig manager
-    return MconfigManagerImpl()
+    return MconfigManagerImpl(loop)
 
 
-def load_service_mconfig(service: str, mconfig_struct: Any) -> Any:
+def load_service_mconfig(service: str, mconfig_struct: Any, loop=None) -> Any:
     """
     Utility function to load the mconfig for a specific service using the
     configured mconfig manager.
     """
-    return get_mconfig_manager().load_service_mconfig(service, mconfig_struct)
+    return get_mconfig_manager(loop).load_service_mconfig(service, mconfig_struct)
 
 
-def load_service_mconfig_as_json(service_name: str) -> Any:
+def load_service_mconfig_as_json(service_name: str, loop=None) -> Any:
     """
     Loads the managed configuration from its json file stored on disk.
 
     Args:
         service_name (str): name of the service to load the config for
+        loop (asyncio.AbstractEventLoop): an event loop to run async tasks on
 
     Returns: Loaded config value for the service as parsed json struct, not
     protobuf message struct
     """
-    return get_mconfig_manager().load_service_mconfig_as_json(service_name)
+    return get_mconfig_manager(loop).load_service_mconfig_as_json(service_name)
 
 
 class MconfigManager(Generic[T]):
@@ -138,6 +143,10 @@ class MconfigManagerImpl(MconfigManager[GatewayConfigs]):
     MCONFIG_FILE_NAME = 'gateway.mconfig'
     MCONFIG_PATH = os.path.join(MCONFIG_OVERRIDE_DIR, MCONFIG_FILE_NAME)
 
+    def __init__(self, loop: asyncio.AbstractEventLoop):
+        self._loop = loop
+
+
     def load_mconfig(self) -> GatewayConfigs:
         cfg_file_name = self._get_mconfig_file_path()
         try:
@@ -203,11 +212,13 @@ class MconfigManagerImpl(MconfigManager[GatewayConfigs]):
     def delete_stored_mconfig(self):
         with contextlib.suppress(FileNotFoundError):
             os.remove(self.MCONFIG_PATH)
+        magma_configuration_events.deleted_stored_mconfig(self._loop)
 
     def update_stored_mconfig(self, updated_value: str) -> GatewayConfigs:
         serialization_utils.write_to_file_atomically(
             self.MCONFIG_PATH, updated_value,
         )
+        magma_configuration_events.updated_stored_mconfig(self._loop)
 
     def _get_mconfig_file_path(self):
         if os.path.isfile(self.MCONFIG_PATH):

--- a/orc8r/gateway/python/magma/configuration/tests/mconfig_manager_impl_tests.py
+++ b/orc8r/gateway/python/magma/configuration/tests/mconfig_manager_impl_tests.py
@@ -6,7 +6,7 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
-
+import asyncio
 import unittest
 from unittest import mock
 
@@ -18,6 +18,9 @@ from orc8r.protos.mconfig import mconfigs_pb2
 
 
 class MconfigManagerImplTest(unittest.TestCase):
+    def setUp(self) -> None:
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
     @mock.patch('magma.configuration.service_configs.load_service_config')
     def test_load_mconfig(self, get_service_config_value_mock):
         # Fixture mconfig has 1 unrecognized service, 1 unregistered type
@@ -54,6 +57,6 @@ class MconfigManagerImplTest(unittest.TestCase):
         }
 
         with mock.patch('builtins.open', mock.mock_open(read_data=fixture)):
-            manager = mconfig_managers.MconfigManagerImpl()
+            manager = mconfig_managers.MconfigManagerImpl(asyncio.get_event_loop())
             with self.assertRaises(LoadConfigError):
                 manager.load_mconfig()

--- a/orc8r/gateway/python/magma/eventd/eventd_client.py
+++ b/orc8r/gateway/python/magma/eventd/eventd_client.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+import logging
+
+import grpc
+from google.protobuf.json_format import MessageToDict
+from magma.common.service_registry import ServiceRegistry
+from orc8r.protos.eventd_pb2 import Event
+from orc8r.protos.eventd_pb2_grpc import EventServiceStub
+
+
+EVENTD_SERVICE_NAME = "eventd"
+DEFAULT_GRPC_TIMEOUT = 10
+IPV4_ADDR_KEY = "ipv4_addr"
+
+
+async def log_event(event: Event) -> None:
+    """
+    Make RPC call to 'LogEvent' method of local eventD service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(
+            EVENTD_SERVICE_NAME, ServiceRegistry.LOCAL
+        )
+    except ValueError:
+        logging.error("Cant get RPC channel to %s", EVENTD_SERVICE_NAME)
+        return
+    client = EventServiceStub(chan)
+    try:
+        # Location will be filled in by directory service
+        client.LogEvent(event, DEFAULT_GRPC_TIMEOUT)
+    except grpc.RpcError as err:
+        logging.error(
+            "LogEvent error for event: %s, [%s] %s",
+            MessageToDict(event),
+            err.code(),
+            err.details(),
+        )

--- a/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
+++ b/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 
 from jsonschema import ValidationError
 
-from ..rpc_servicer import EventDRpcServicer
+from magma.eventd.rpc_servicer import EventDRpcServicer
 from magma.common.service import MagmaService
 
 
@@ -29,7 +29,8 @@ class EventValidationTests(TestCase):
             'tcp_timeout': '',
             'event_registry': {
                 'simple_event': test_events_location,
-                'array_and_object_event': test_events_location
+                'array_and_object_event': test_events_location,
+                'null_event': test_events_location,
             },
         }
         servicer = EventDRpcServicer(config)
@@ -67,6 +68,9 @@ class EventValidationTests(TestCase):
         # Does not error when the fields are equivalent
         self.validate_event(json.dumps({'foo': 'asdf', 'bar': 123}),
                             'simple_event')
+
+        # Does not error when event has no fields
+        self.validate_event(json.dumps({}), 'null_event')
 
     def test_type_checking(self):
         # Does not error when the types match

--- a/orc8r/gateway/python/magma/magmad/config_manager.py
+++ b/orc8r/gateway/python/magma/magmad/config_manager.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 from typing import Any, List
 
+import magma.magmad.events as magmad_events
 from magma.common.service import MagmaService
 from magma.common.streamer import StreamerClient
 from magma.configuration.mconfig_managers import MconfigManager, \
@@ -117,3 +118,5 @@ class ConfigManager(StreamerClient.Callback):
             )
 
         self._mconfig = mconfig
+
+        magmad_events.processed_updates(self._loop, updates)

--- a/orc8r/gateway/python/magma/magmad/events.py
+++ b/orc8r/gateway/python/magma/magmad/events.py
@@ -1,0 +1,47 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+import json
+import snowflake
+from asyncio.events import AbstractEventLoop
+
+from google.protobuf.json_format import MessageToDict
+from magma.eventd.eventd_client import log_event
+from orc8r.protos.eventd_pb2 import Event
+from orc8r.swagger.models.processed_updates import ProcessedUpdates
+from orc8r.swagger.models.restarted_services import RestartedServices
+
+
+def processed_updates(loop: AbstractEventLoop, updates):
+    # Convert updates to dicts for JSON serializability
+    dict_updates = [MessageToDict(u) for u in updates]
+    loop.run_until_complete(
+        log_event(
+            Event(
+                stream_name="magmad",
+                event_type="processed_updates",
+                tag=snowflake.snowflake(),
+                value=json.dumps(ProcessedUpdates(updates=dict_updates).to_dict()),
+            )
+        )
+    )
+
+
+def restarted_services(loop: AbstractEventLoop, services):
+    # Convert to a list for JSON serializability
+    services = list(services)
+    loop.run_until_complete(
+        log_event(
+            Event(
+                stream_name="magmad",
+                event_type="restarted_services",
+                tag=snowflake.snowflake(),
+                value=json.dumps(RestartedServices(services=services).to_dict()),
+            )
+        )
+    )

--- a/orc8r/gateway/python/magma/magmad/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/magmad/rpc_servicer.py
@@ -151,7 +151,8 @@ class MagmadRpcServicer(magmad_pb2_grpc.MagmadServicer):
         """
         Get gateway hardware ID
         """
-        return magmad_pb2.GetGatewayIdResponse(gateway_id=snowflake.snowflake())
+        return magmad_pb2.GetGatewayIdResponse(
+            gateway_id=snowflake.snowflake())
 
     def GenericCommand(self, request, context):
         """

--- a/orc8r/gateway/python/magma/magmad/service_manager.py
+++ b/orc8r/gateway/python/magma/magmad/service_manager.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import List, Tuple
 
 from magma.magmad.service_poller import ServicePoller
+import magma.magmad.events as magmad_events
 
 
 class ServiceState(Enum):
@@ -51,6 +52,7 @@ class ServiceManager(object):
             services: List[str],
             init_system,
             service_poller: ServicePoller,
+            loop: asyncio.AbstractEventLoop,
             registered_dynamic_services: List[str] = None,
             dynamic_services: List[str] = None,
     ):
@@ -60,6 +62,7 @@ class ServiceManager(object):
             dynamic_services = []
         self._services = services
         self._service_poller = service_poller
+        self._loop = loop
         self._registered_dynamic_services = registered_dynamic_services
 
         init_system_spec = self._get_init_system_spec(init_system)
@@ -105,6 +108,8 @@ class ServiceManager(object):
         await asyncio.gather(
             *[self._service_control[s].restart_process() for s in services]
         )
+        magmad_events.restarted_services(self._loop, services)
+
 
     async def update_dynamic_services(self, dynamic_services: List[str]):
         """

--- a/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/config_manager_tests.py
@@ -7,7 +7,6 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 import asyncio
-from collections import namedtuple
 from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
@@ -17,12 +16,14 @@ from magma.configuration.mconfig_managers import MconfigManagerImpl
 from magma.magmad.config_manager import CONFIG_STREAM_NAME, ConfigManager
 from orc8r.protos.mconfig.mconfigs_pb2 import MagmaD, MetricsD
 from orc8r.protos.mconfig_pb2 import GatewayConfigs
+from orc8r.protos.streamer_pb2 import DataUpdate
 
 
 class ConfigManagerTest(TestCase):
     """
     Tests for the config manager class
     """
+
     @patch('magma.configuration.service_configs.load_service_config')
     def test_update(self, config_mock):
         """
@@ -31,7 +32,6 @@ class ConfigManagerTest(TestCase):
         # Set up fixture data
         # Update will simulate gateway moving from
         # test_mconfig -> updated_mconfig
-        TestUpdate = namedtuple('TestUpdate', ['value', 'key'])
         test_mconfig = GatewayConfigs()
         updated_mconfig = GatewayConfigs()
 
@@ -58,7 +58,7 @@ class ConfigManagerTest(TestCase):
 
         service_manager_mock = MagicMock()
         magmad_service_mock = MagicMock()
-        mconfig_manager_mock = MconfigManagerImpl()
+        mconfig_manager_mock = MconfigManagerImpl(MagicMock())
 
         load_mock = patch.object(
             mconfig_manager_mock,
@@ -72,9 +72,13 @@ class ConfigManagerTest(TestCase):
             service_manager_mock,
             'restart_services', MagicMock(wraps=_mock_restart_services),
         )
+        processed_updates_mock = patch('magma.magmad.events.processed_updates',
+                                       MagicMock())
 
-        with load_mock as loader, update_mock as updater, \
-                restart_service_mock as restarter:
+        with load_mock as loader,\
+                update_mock as updater, \
+                restart_service_mock as restarter,\
+                processed_updates_mock as processed_updates:
             loop = asyncio.new_event_loop()
             config_manager = ConfigManager(
                 ['magmad', 'metricsd'], service_manager_mock,
@@ -94,11 +98,9 @@ class ConfigManagerTest(TestCase):
             # Verify that config update restarts all services
             update_str = MessageToJson(updated_mconfig)
             updates = [
-                TestUpdate(value='', key='some key'),
-                TestUpdate(
-                    value=update_str.encode('utf-8'),
-                    key='last key',
-                ),
+                DataUpdate(value=''.encode('utf-8'), key='some key'),
+                DataUpdate(value=update_str.encode('utf-8'),
+                    key='last key'),
             ]
             config_manager.process_update(CONFIG_STREAM_NAME, updates, False)
 
@@ -106,3 +108,4 @@ class ConfigManagerTest(TestCase):
             loader.assert_called_once_with()
             restarter.assert_called_once_with(['metricsd'])
             updater.assert_called_once_with(update_str)
+            processed_updates.assert_called_once_with(loop, updates)

--- a/orc8r/gateway/python/magma/magmad/tests/service_manager_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/service_manager_tests.py
@@ -78,7 +78,7 @@ class ServiceManagerSystemdTest(TestCase):
         verify functionality beyond the tests above
         """
         mgr = ServiceManager(['dummy1', 'dummy2'], init_system='systemd',
-                             service_poller=MagicMock())
+                             service_poller=MagicMock(), loop=MagicMock())
 
         self._loop.run_until_complete(mgr.start_services())
         self.subprocess_mock.return_value = b'active\n'
@@ -100,7 +100,7 @@ class ServiceManagerSystemdTest(TestCase):
         verify functionality beyond the tests above
         """
         mgr = ServiceManager(
-            ['dummy1', 'dummy2'], 'systemd', MagicMock(), ['redirectd'], []
+            ['dummy1', 'dummy2'], 'systemd', MagicMock(), MagicMock(), ['redirectd'], []
         )
 
         self.subprocess_mock.return_value = b'inactive\n'
@@ -196,7 +196,7 @@ class ServiceManagerRunitTest(TestCase):
             return
 
         mgr = ServiceManager(['dummy1', 'dummy2'], init_system='runit',
-                             service_poller=MagicMock())
+                             service_poller=MagicMock(), loop=MagicMock())
 
         mgr.start_services()
         self.subprocess_mock.return_value = (
@@ -227,7 +227,7 @@ class ServiceManagerRunitTest(TestCase):
             return
 
         mgr = ServiceManager(
-            ['dummy1', 'dummy2'], 'runit', MagicMock(), ['redirectd'], []
+            ['dummy1', 'dummy2'], 'runit', MagicMock(), MagicMock(), ['redirectd'], []
         )
 
         self.subprocess_mock.return_value = (
@@ -321,7 +321,7 @@ class ServiceManagerDockerTest(TestCase):
         verify functionality beyond the tests above
         """
         mgr = ServiceManager(['dummy1', 'dummy2'], init_system='docker',
-                             service_poller=MagicMock())
+                             service_poller=MagicMock(), loop=MagicMock())
 
         try:
             self._loop.run_until_complete(mgr.start_services())

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -26,6 +26,7 @@ setup(
         'magma.configuration',
         'magma.directoryd',
         'magma.magmad',
+        'magma.magmad.events',
         'magma.magmad.generic_command',
         'magma.magmad.check',
         'magma.magmad.check.kernel_check',

--- a/orc8r/swagger/magmad_events.v1.yml
+++ b/orc8r/swagger/magmad_events.v1.yml
@@ -1,0 +1,37 @@
+---
+swagger: '2.0'
+
+info:
+  title: Magmad events
+  description: These denote events that happen within Magmad on the AGW
+  version: 1.0.0
+
+definitions:
+  deleted_stored_mconfig:
+    type: object
+    description: The stored mconfig was deleted
+  updated_stored_mconfig:
+    type: object
+    description: The stored mconfig was updated
+  processed_updates:
+    type: object
+    description: Stream updates were successfully processed
+    properties:
+      updates:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            value:
+              type: string
+              format: byte
+  restarted_services:
+    type: object
+    description: Services were restarted
+    properties:
+      services:
+        type: array
+        items:
+          type: string

--- a/orc8r/swagger/test_event_definitions.yml
+++ b/orc8r/swagger/test_event_definitions.yml
@@ -30,3 +30,6 @@ definitions:
         type: object
         additionalProperties:
           type: integer
+  null_event:
+    type: object
+    description: An event with no properties


### PR DESCRIPTION
Summary:
- 4 Events are sent for config updates and service restarts
- Python client_api added
- eventd TARGETS added

Reviewed By: xjtian

Differential Revision: D20352586

