### PR TITLE
Fix ASR bug by adding sessionID to CreateSessionResponse (#2024)

### DIFF
--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -136,6 +136,7 @@ func (srv *CentralSessionController) CreateSession(
 		DynamicRules:  dynamicRuleInstalls,
 		UsageMonitors: usageMonitors,
 		TgppCtx:       &protos.TgppContext{GxDestHost: gxOriginHost, GyDestHost: gyOriginHost},
+		SessionId:     request.SessionId,
 	}, nil
 }
 
@@ -167,6 +168,7 @@ func (srv *CentralSessionController) handleUseGyForAuthOnly(
 		DynamicRules:  dynamicRuleInstalls,
 		UsageMonitors: getUsageMonitorsFromCCA_I(imsi, gyOriginHost, gyCCAInit.SessionID, gxCCAInit),
 		TgppCtx:       &protos.TgppContext{GxDestHost: gxOriginHost, GyDestHost: gyCCAInit.OriginHost},
+		SessionId:     pReq.SessionId,
 	}, nil
 }
 


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2024

Currently the AAA server sets AcctSessionID to
the CreateSessionResponse's sessionID. When receiving an ASR
the AAA server doesn't check if ASR SessionID == AcctSessionID
if either the ASR SessionID or AcctSessionID is empty. As a result,
any ASR will terminate a current session, even if that session isn't
the one the ASR was intended for.

To fix this, we set SessionID in Session Proxy to ensure
that the AAA server's acct session ID is not empty.

Reviewed By: themarwhal, uri200

Differential Revision: D20435932

