### PR TITLE
Add Activation/Deactivation time to Mock PCRF

### DIFF
--- a/feg/cloud/go/protos/mock_core_conversions.go
+++ b/feg/cloud/go/protos/mock_core_conversions.go
@@ -8,6 +8,8 @@
 
 package protos
 
+import "github.com/golang/protobuf/ptypes/timestamp"
+
 func NewGxCreditControlExpectation() *GxCreditControlExpectation {
 	return &GxCreditControlExpectation{}
 }
@@ -36,18 +38,26 @@ func (m *GxCreditControlAnswer) SetUsageMonitorInfos(monitors []*UsageMonitoring
 }
 
 func (m *GxCreditControlAnswer) SetStaticRuleInstalls(ruleIDs, baseNames []string) *GxCreditControlAnswer {
-	if m.RuleInstalls == nil {
-		m.RuleInstalls = &RuleInstalls{}
-	}
+	m.initializeRuleInstallsIfNil()
 	m.RuleInstalls.RuleNames = ruleIDs
 	m.RuleInstalls.RuleBaseNames = baseNames
 	return m
 }
 
+func (m *GxCreditControlAnswer) SetRuleActivationTime(activationTime *timestamp.Timestamp) *GxCreditControlAnswer {
+	m.initializeRuleInstallsIfNil()
+	m.RuleInstalls.ActivationTime = activationTime
+	return m
+}
+
+func (m *GxCreditControlAnswer) SetRuleDeactivationTime(deactivationTime *timestamp.Timestamp) *GxCreditControlAnswer {
+	m.initializeRuleInstallsIfNil()
+	m.RuleInstalls.DeactivationTime = deactivationTime
+	return m
+}
+
 func (m *GxCreditControlAnswer) SetDynamicRuleInstalls(rules []*RuleDefinition) *GxCreditControlAnswer {
-	if m.RuleInstalls == nil {
-		m.RuleInstalls = &RuleInstalls{}
-	}
+	m.initializeRuleInstallsIfNil()
 	m.RuleInstalls.RuleDefinitions = rules
 	return m
 }
@@ -69,4 +79,10 @@ func (m *GxCreditControlRequest) SetUsageMonitorReports(reports []*UsageMonitori
 func (m *GxCreditControlRequest) SetUsageReportDelta(delta uint64) *GxCreditControlRequest {
 	m.UsageReportDelta = delta
 	return m
+}
+
+func (m *GxCreditControlAnswer) initializeRuleInstallsIfNil() {
+	if m.RuleInstalls == nil {
+		m.RuleInstalls = &RuleInstalls{}
+	}
 }

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
@@ -99,7 +99,7 @@ func getCCRHandler(srv *PCRFDiamServer) diam.HandlerFunc {
 		avps := []*diam.AVP{}
 		if credit_control.CreditRequestType(ccr.RequestType) == credit_control.CRTInit {
 			// Install all rules attached to the subscriber for the initial answer
-			ruleInstalls := toRuleInstallAVPs(account.RuleNames, account.RuleBaseNames, account.RuleDefinitions)
+			ruleInstalls := toRuleInstallAVPs(account.RuleNames, account.RuleBaseNames, account.RuleDefinitions, nil, nil)
 			// Install all monitors attached to the subscriber for the initial answer
 			usageMonitors := toUsageMonitorAVPs(account.UsageMonitors)
 			avps = append(ruleInstalls, usageMonitors...)

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/mock.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/mock.go
@@ -62,7 +62,10 @@ func (answer GxAnswer) toAVPs() ([]*diam.AVP, uint32) {
 		ruleInstallAVPs := toRuleInstallAVPs(
 			answer.RuleInstalls.GetRuleNames(),
 			answer.RuleInstalls.GetRuleBaseNames(),
-			answer.RuleInstalls.GetRuleDefinitions())
+			answer.RuleInstalls.GetRuleDefinitions(),
+			answer.RuleInstalls.ActivationTime,
+			answer.RuleInstalls.DeactivationTime,
+		)
 		avps = append(avps, ruleInstallAVPs...)
 	}
 	ruleRemovals := answer.GetRuleRemovals()

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/mock_driven_pcrf_test.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/mock_driven_pcrf_test.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"log"
 	"testing"
+	"time"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/go-openapi/swag"
+	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -61,9 +63,17 @@ func TestPCRFExpectations(t *testing.T) {
 			},
 		},
 	}
+	activationTime := time.Now().Round(1 * time.Second)
+	pActivationTime, err := ptypes.TimestampProto(activationTime)
+	assert.NoError(t, err)
+	deactivationTime := time.Now().Round(1 * time.Second).Add(5 * time.Second)
+	pDeactivationTime, err := ptypes.TimestampProto(deactivationTime)
+	assert.NoError(t, err)
 	expectedInitAns := fegprotos.NewGxCCAnswer(diam.Success).
 		SetStaticRuleInstalls([]string{"rule1", "rule2"}, []string{"base1", "base2"}).
 		SetDynamicRuleInstalls(dynamicRulesToInstall).
+		SetRuleActivationTime(pActivationTime).
+		SetRuleDeactivationTime(pDeactivationTime).
 		SetUsageMonitorInfos(usageMonitoringQuotaGrant)
 	expectedInit := fegprotos.NewGxCreditControlExpectation().Expect(expectedInitReq).Return(expectedInitAns)
 
@@ -213,6 +223,7 @@ func assertCCAIsEqualToExpectedAnswer(t *testing.T, actual *gx.CreditControlAnsw
 	assert.ElementsMatch(t, expectation.GetRuleInstalls().GetRuleNames(), ruleNames)
 	assert.ElementsMatch(t, expectation.GetRuleInstalls().GetRuleBaseNames(), ruleBaseNames)
 	assert.ElementsMatch(t, expectation.GetRuleInstalls().GetRuleDefinitions(), ruleDefinitions)
+	assertRuleInstallTimeStampsMatch(t, expectation.GetRuleInstalls(), actual.RuleInstallAVP)
 	usageMonitors := getUsageMonitorsFromCCA(actual)
 	assert.ElementsMatch(t, expectation.GetUsageMonitoringInfos(), usageMonitors)
 }
@@ -227,6 +238,20 @@ func getRuleInstallsFromCCA(cca *gx.CreditControlAnswer) ([]string, []string, []
 		ruleDefinitions = append(ruleDefinitions, toProtosRuleDefinitions(installRule.RuleDefinitions)...)
 	}
 	return ruleNames, ruleBaseNames, ruleDefinitions
+}
+
+func assertRuleInstallTimeStampsMatch(t *testing.T, expected *fegprotos.RuleInstalls, actual []*gx.RuleInstallAVP) {
+	expectedActivationTime, _ := ptypes.Timestamp(expected.GetActivationTime())
+	expectedDeactivationTime, _ := ptypes.Timestamp(expected.GetDeactivationTime())
+
+	for _, ruleInstall := range actual {
+		if expected.GetActivationTime() != nil {
+			assert.True(t, expectedActivationTime.Equal(*ruleInstall.RuleActivationTime))
+		}
+		if expected.GetDeactivationTime() != nil {
+			assert.True(t, expectedDeactivationTime.Equal(*ruleInstall.RuleDeactivationTime))
+		}
+	}
 }
 
 func toProtosRuleDefinitions(gxRuleDfs []*gx.RuleDefinition) []*fegprotos.RuleDefinition {

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -329,7 +329,8 @@ func sendRAR(state *SubscriberSessionState, target *protos.PolicyReAuthTarget, c
 				ruleInstalls.GetRuleNames(),
 				ruleInstalls.GetRuleBaseNames(),
 				ruleInstalls.GetRuleDefinitions(),
-			)...,
+				nil,
+				nil)...,
 		)
 	}
 	// Construct AVPs for Rules to Remove


### PR DESCRIPTION
Summary:
Modifying MockPCRF conversion code to include activation/deactivation time.
Added a basic unit test to make sure the diameter AVPs get translated to the Gx CCA model properly

Differential Revision: D20635227

