### PR TITLE
Fixing Allocate IP procedure with IPv4andIPv6 PDN type

### DIFF
--- a/lte/gateway/c/oai/lib/rpc_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/rpc_client/MobilityClientAPI.cpp
@@ -221,6 +221,7 @@ static itti_sgi_create_end_point_response_t handle_allocate_ipv4_address_status(
       "result",
       "success");
     sgi_create_endpoint_resp.paa.ipv4_address = inaddr;
+    sgi_create_endpoint_resp.paa.pdn_type = IPv4;
     OAILOG_DEBUG(
       LOG_UTIL,
       "Allocated IPv4 address for imsi <%s>, apn <%s>\n",

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -89,6 +89,14 @@ static int32_t _spgw_build_and_send_s11_deactivate_bearer_req(
   bool delete_default_bearer,
   teid_t mme_teid_S11);
 
+static void _spgw_handle_s5_response_with_error(
+  spgw_state_t* spgw_state,
+  s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
+  teid_t context_teid,
+  ebi_t eps_bearer_id,
+  itti_sgi_create_end_point_response_t* sgi_create_endpoint_resp,
+  s5_create_session_response_t* s5_response);
+
 //--------------------------------------------------------------------------------
 
 void handle_s5_create_session_request(
@@ -118,7 +126,13 @@ void handle_s5_create_session_request(
       "teid" TEID_FMT "\n",
       context_teid);
     sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_CONTEXT_NOT_FOUND;
-    goto err;
+    _spgw_handle_s5_response_with_error(
+      spgw_state,
+      new_bearer_ctxt_info_p,
+      context_teid,
+      eps_bearer_id,
+      &sgi_create_endpoint_resp,
+      &s5_response);
   }
 
   // PCO processing
@@ -136,7 +150,13 @@ void handle_s5_create_session_request(
       "context_id: " TEID_FMT "\n",
       context_teid);
     sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_FAILED_TO_PROCESS_PCO;
-    goto err;
+    _spgw_handle_s5_response_with_error(
+      spgw_state,
+      new_bearer_ctxt_info_p,
+      context_teid,
+      eps_bearer_id,
+      &sgi_create_endpoint_resp,
+      &s5_response);
   }
   copy_protocol_configuration_options(&sgi_create_endpoint_resp.pco, &pco_resp);
   clear_protocol_configuration_options(&pco_resp);
@@ -218,13 +238,31 @@ void handle_s5_create_session_request(
         0, "BAD paa.pdn_type %d", sgi_create_endpoint_resp.paa.pdn_type);
       break;
   }
-err:
-  s5_response.context_teid = context_teid;
-  s5_response.eps_bearer_id = eps_bearer_id;
-  s5_response.sgi_create_endpoint_resp = sgi_create_endpoint_resp;
-  s5_response.failure_cause = S5_OK;
 }
 
+void _spgw_handle_s5_response_with_error(
+  spgw_state_t* spgw_state,
+  s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
+  teid_t context_teid,
+  ebi_t eps_bearer_id,
+  itti_sgi_create_end_point_response_t* sgi_create_endpoint_resp,
+  s5_create_session_response_t* s5_response)
+{
+  s5_response->context_teid = context_teid;
+  s5_response->eps_bearer_id = eps_bearer_id;
+  s5_response->sgi_create_endpoint_resp = (*sgi_create_endpoint_resp);
+  s5_response->failure_cause = S5_OK;
+
+  OAILOG_DEBUG(
+    LOG_PGW_APP,
+    "Sending S5 Create Session Response to SGW: with context teid, " TEID_FMT
+    "EPS Bearer Id = %u\n",
+    s5_response->context_teid,
+    s5_response->eps_bearer_id);
+  handle_s5_create_session_response(
+    spgw_state, new_bearer_ctxt_info_p, (*s5_response));
+  OAILOG_FUNC_OUT(LOG_PGW_APP);
+}
 
 /*
  * Handle NW initiated Dedicated Bearer Activation from SPGW service

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -26,7 +26,8 @@ s1aptests/test_attach_service.py \
 s1aptests/test_attach_detach_service.py \
 s1aptests/test_attach_service_ue_radio_capability.py \
 s1aptests/test_attach_service_multi_ue.py \
-s1aptests/test_attach_ipv4v6_pdn_type.py \
+s1aptests/test_attach_ipv4orv6_pdn_type.py \
+s1aptests/test_attach_ipv4andv6_pdn_type.py \
 s1aptests/test_service_info.py \
 s1aptests/test_attach_detach_with_ovs.py \
 s1aptests/test_resync.py \

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4andv6_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4andv6_pdn_type.py
@@ -8,13 +8,12 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 
 
-import unittest
-
 import s1ap_types
 import s1ap_wrapper
+import unittest
 
 
-class TestAttachIpv4v6PdnType(unittest.TestCase):
+class TestAttachIpv4andIPv6PdnType(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
 
@@ -22,29 +21,28 @@ class TestAttachIpv4v6PdnType(unittest.TestCase):
         self._s1ap_wrapper.cleanup()
 
     def test_attach_ipv4v6_pdn_type(self):
-        """ Test Attach for the UEs that are dual IP stack IPv4v6
+        """ Test Attach for the UEs that are dual IP stack IPv4IPv6
             capable """
         # Ground work.
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
 
-        # Trigger Attach Request with PDN_Type = IPv4v6
+        # Trigger Attach Request with PDN_Type = IPv4andv6
         attach_req = s1ap_types.ueAttachRequest_t()
         sec_ctxt = s1ap_types.TFW_CREATE_NEW_SECURITY_CONTEXT
         id_type = s1ap_types.TFW_MID_TYPE_IMSI
         eps_type = s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH
         pdn_type = s1ap_types.pdn_Type()
         pdn_type.pres = True
-        # Set PDN TYPE to IPv4V6 i.e. 3. IPV4 is equal to 1
-        # IPV6 is equal to 2 in value
-        pdn_type.pdn_type = 3
+        # Set PDN TYPE to IPv4andIPv6
+        pdn_type.pdn_type = 2
         attach_req.ue_Id = req.ue_id
         attach_req.mIdType = id_type
         attach_req.epsAttachType = eps_type
         attach_req.useOldSecCtxt = sec_ctxt
         attach_req.pdnType_pr = pdn_type
 
-        print("********Triggering Attach Request with PND Type IPv4v6 test")
+        print("********Triggering Attach Request with PDN Type IPv4andIPv6 test")
 
         self._s1ap_wrapper._s1_util.issue_cmd(
             s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4orv6_pdn_type.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ipv4orv6_pdn_type.py
@@ -1,0 +1,111 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+
+import s1ap_types
+import s1ap_wrapper
+import unittest
+
+
+class TestAttachIpv4orv6PdnType(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_ipv4orv6_pdn_type(self):
+        """ Test Attach for the UEs that are dual IP stack IPv4v6
+            capable """
+        # Ground work.
+        self._s1ap_wrapper.configUEDevice(1)
+        req = self._s1ap_wrapper.ue_req
+
+        # Trigger Attach Request with PDN_Type = IPv4v6
+        attach_req = s1ap_types.ueAttachRequest_t()
+        sec_ctxt = s1ap_types.TFW_CREATE_NEW_SECURITY_CONTEXT
+        id_type = s1ap_types.TFW_MID_TYPE_IMSI
+        eps_type = s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH
+        pdn_type = s1ap_types.pdn_Type()
+        pdn_type.pres = True
+        # IPV4orIPv6 is equal to 3 in value
+        pdn_type.pdn_type = 3
+        attach_req.ue_Id = req.ue_id
+        attach_req.mIdType = id_type
+        attach_req.epsAttachType = eps_type
+        attach_req.useOldSecCtxt = sec_ctxt
+        attach_req.pdnType_pr = pdn_type
+
+        print("********Triggering Attach Request with PND Type IPv4v6 test")
+
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+        )
+
+        # Trigger Authentication Response
+        auth_res = s1ap_types.ueAuthResp_t()
+        auth_res.ue_Id = req.ue_id
+        sqnRecvd = s1ap_types.ueSqnRcvd_t()
+        sqnRecvd.pres = 0
+        auth_res.sqnRcvd = sqnRecvd
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+        )
+
+        # Trigger Security Mode Complete
+        sec_mode_complete = s1ap_types.ueSecModeComplete_t()
+        sec_mode_complete.ue_Id = req.ue_id
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+        )
+
+        # Trigger Attach Complete
+        attach_complete = s1ap_types.ueAttachComplete_t()
+        attach_complete.ue_Id = req.ue_id
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+        )
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("************************* Running UE detach")
+        # Now detach the UE
+        detach_req = s1ap_types.uedetachReq_t()
+        detach_req.ue_Id = req.ue_id
+        detach_req.ueDetType = (
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
+        )
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+        )
+        # Wait for UE context release command
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
- With changes from AllocateIP using MobilityClientAPI, IPv4andIPv6 PDN type case was missing PDN type update, this diff fixes this case.
- Using handler function for response error instead of goto statements
- Adding and updating pdn type ipv4ipv6 integ test cases

Differential Revision: D20651104

