### PR TITLE
Clean up all integration tests

### DIFF
--- a/cwf/gateway/integ_tests/enforcement_test.go
+++ b/cwf/gateway/integ_tests/enforcement_test.go
@@ -41,7 +41,7 @@ const (
 // - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
 func TestUsageReportEnforcement(t *testing.T) {
 	fmt.Println("\nRunning TestUsageReportEnforcement...")
-	tr := NewTestRunner()
+	tr := NewTestRunner(t)
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
 	assert.NoError(t, usePCRFMockDriver())
@@ -84,7 +84,7 @@ func TestUsageReportEnforcement(t *testing.T) {
 	// On unexpected requests, just return the default update answer
 	assert.NoError(t, setPCRFExpectations(expectations, updateAnswer1))
 
-	tr.AuthenticateAndAssertSuccess(t, imsi)
+	tr.AuthenticateAndAssertSuccess(imsi)
 
 	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("500K")}}
 	_, err = tr.GenULTraffic(req)
@@ -145,7 +145,7 @@ func TestUsageReportEnforcement(t *testing.T) {
 func TestMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	fmt.Println("\nRunning TestMidSessionRuleRemovalWithCCA_U...")
 
-	tr := NewTestRunner()
+	tr := NewTestRunner(t)
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
 	assert.NoError(t, usePCRFMockDriver())
@@ -188,7 +188,7 @@ func TestMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	// On unexpected requests, just return some quota
 	assert.NoError(t, setPCRFExpectations(expectations, defaultUpdateAnswer))
 
-	tr.AuthenticateAndAssertSuccess(t, imsi)
+	tr.AuthenticateAndAssertSuccess(imsi)
 
 	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "250K"}}
 	_, err = tr.GenULTraffic(req)

--- a/cwf/gateway/integ_tests/ocs_credit_exhaustion_test.go
+++ b/cwf/gateway/integ_tests/ocs_credit_exhaustion_test.go
@@ -29,7 +29,7 @@ const (
 )
 
 func ocsCreditExhaustionTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwfprotos.UEConfig) {
-	tr := NewTestRunner()
+	tr := NewTestRunner(t)
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
 
@@ -63,10 +63,11 @@ func ocsCreditExhaustionTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwf
 	err = ruleManager.AddStaticPassAllToDB("static-pass-all-ocs2", "", 1, models.PolicyRuleConfigTrackingTypeONLYOCS, 10)
 	assert.NoError(t, err)
 
+	tr.WaitForPoliciesToSync()
+
 	// Apply a dynamic rule that points to the static rules above
 	err = ruleManager.AddRulesToPCRF(ue.Imsi, []string{"static-pass-all-ocs1", "static-pass-all-ocs2"}, nil)
 	assert.NoError(t, err)
-
 	return tr, ruleManager, ues[0]
 }
 
@@ -74,6 +75,12 @@ func TestAuthenticateOcsCreditExhaustedWithCRRU(t *testing.T) {
 	fmt.Println("\nRunning TestAuthenticateOcsCreditExhaustedWithCRRU...")
 
 	tr, ruleManager, ue := ocsCreditExhaustionTestSetup(t)
+	defer func() {
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
 	setCreditOnOCS(
 		&fegprotos.CreditInfo{
 			Imsi:        ue.Imsi,
@@ -83,22 +90,20 @@ func TestAuthenticateOcsCreditExhaustedWithCRRU(t *testing.T) {
 		},
 	)
 
-	// Wait for rules propagation
-	time.Sleep(2 * time.Second)
-	tr.AuthenticateAndAssertSuccess(t, ue.GetImsi())
+	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
 
 	// we need to generate over 80% of the quota to trigger a CCR update
 	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("5M")}}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
-	time.Sleep(3 * time.Second)
+	tr.WaitForEnforcementStatsToSync()
 
 	// we need to generate over 100% of the quota to trigger a session termination
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
-
-	// Wait for traffic to go through
-	time.Sleep(5 * time.Second)
+	tr.WaitForEnforcementStatsToSync()
+	// Wait for session termination
+	time.Sleep(3 * time.Second)
 
 	// Check that UE mac flow is removed
 	recordsBySubID, err := tr.GetPolicyUsage()
@@ -109,16 +114,18 @@ func TestAuthenticateOcsCreditExhaustedWithCRRU(t *testing.T) {
 	// trigger disconnection
 	_, err = tr.Disconnect(ue.GetImsi())
 	assert.NoError(t, err)
-
-	// Clear hss, ocs, and pcrf
-	assert.NoError(t, ruleManager.RemoveInstalledRules())
-	assert.NoError(t, tr.CleanUp())
 }
 
 func TestAuthenticateOcsCreditExhaustedWithoutCRRU(t *testing.T) {
 	fmt.Println("\nRunning TestAuthenticateOcsCreditExhaustedWithoutCCRU...")
 
 	tr, ruleManager, ue := ocsCreditExhaustionTestSetup(t)
+	defer func() {
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
 	setCreditOnOCS(
 		&fegprotos.CreditInfo{
 			Imsi:        ue.Imsi,
@@ -127,17 +134,15 @@ func TestAuthenticateOcsCreditExhaustedWithoutCRRU(t *testing.T) {
 			UnitType:    fegprotos.CreditInfo_Bytes,
 		},
 	)
-
-	// Wait for rules propagation
-	time.Sleep(2 * time.Second)
-	tr.AuthenticateAndAssertSuccess(t, ue.GetImsi())
+	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
 
 	// we need to generate over 100% of the quota to trigger a session termination
-	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("5M")}}
+	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: "5M"}}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
+	tr.WaitForEnforcementStatsToSync()
 
-	// Wait for traffic to go through
+	// Wait for session termination to go through
 	time.Sleep(5 * time.Second)
 
 	// Check that UE mac flow is removed
@@ -149,8 +154,4 @@ func TestAuthenticateOcsCreditExhaustedWithoutCRRU(t *testing.T) {
 	// trigger disconnection
 	_, err = tr.Disconnect(ue.GetImsi())
 	assert.NoError(t, err)
-
-	// Clear hss, ocs, and pcrf
-	assert.NoError(t, ruleManager.RemoveInstalledRules())
-	assert.NoError(t, tr.CleanUp())
 }

--- a/cwf/gateway/integ_tests/ocs_reauth_test.go
+++ b/cwf/gateway/integ_tests/ocs_reauth_test.go
@@ -10,14 +10,11 @@ package integ_tests
 
 import (
 	"fmt"
-	"reflect"
 	"testing"
 	"time"
 
-	"fbc/lib/go/radius/rfc2869"
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
-	"magma/feg/gateway/services/eap"
 	"magma/lte/cloud/go/plugin/models"
 
 	"github.com/fiorix/go-diameter/v4/diam"
@@ -34,9 +31,14 @@ const (
 func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 	fmt.Println("\nRunning TestAuthenticateUplinkWithOcsChargingReAuth...")
 
-	tr := NewTestRunner()
+	tr := NewTestRunner(t)
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
+	defer func() {
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
 
 	ues, err := tr.ConfigUEs(1)
 	assert.NoError(t, err)
@@ -69,20 +71,13 @@ func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 	ratingGroup := uint32(1)
 	err = ruleManager.AddStaticPassAllToDB("static-pass-all-ocs2", "", ratingGroup, models.PolicyRuleConfigTrackingTypeONLYOCS, 10)
 	assert.NoError(t, err)
+	tr.WaitForPoliciesToSync()
 
 	// Apply a dynamic rule that points to the static rules above
 	err = ruleManager.AddRulesToPCRF(imsi, []string{"static-pass-all-ocs1", "static-pass-all-ocs2"}, nil)
 	assert.NoError(t, err)
 
-	// Wait for rules propagation
-	time.Sleep(2 * time.Second)
-	radiusP, err := tr.Authenticate(imsi)
-	assert.NoError(t, err)
-
-	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(t, eapMessage)
-	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode))
-	time.Sleep(2 * time.Second)
+	tr.AuthenticateAndAssertSuccess(imsi)
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
@@ -90,9 +85,7 @@ func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 		Volume: &wrappers.StringValue{Value: "4.5M"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
-
-	// Wait for traffic to go through
-	time.Sleep(3 * time.Second)
+	tr.WaitForEnforcementStatsToSync()
 
 	// Check that UE mac flow is installed and traffic is less than the quota
 	recordsBySubID, err := tr.GetPolicyUsage()
@@ -115,9 +108,7 @@ func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 
 	// Send ReAuth Request to update quota
 	raa, err := sendChargingReAuthRequest(imsi, ratingGroup)
-
-	// Wait for RAR to be processed
-	time.Sleep(2 * time.Second)
+	tr.WaitForReAuthToProcess()
 
 	// Check ReAuth success
 	assert.NoError(t, err)
@@ -128,9 +119,7 @@ func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "5M"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
-
-	// Wait for traffic to go through
-	time.Sleep(10 * time.Second)
+	tr.WaitForEnforcementStatsToSync()
 
 	// Check that initial quota was exceeded
 	recordsBySubID, err = tr.GetPolicyUsage()
@@ -143,11 +132,6 @@ func TestAuthenticateUplinkWithOCSChargingReAuth(t *testing.T) {
 	// trigger disconnection
 	_, err = tr.Disconnect(imsi)
 	assert.NoError(t, err)
-	time.Sleep(3 * time.Second)
-
-	// Clear hss, ocs, and pcrf
-	assert.NoError(t, ruleManager.RemoveInstalledRules())
-	assert.NoError(t, tr.CleanUp())
 	fmt.Println("wait for flows to get deactivated")
 	time.Sleep(3 * time.Second)
 }

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -14,6 +14,7 @@ import (
 	"reflect"
 	"strconv"
 	"testing"
+	"time"
 
 	"fbc/lib/go/radius"
 	"fbc/lib/go/radius/rfc2869"
@@ -218,6 +219,18 @@ func (tr *TestRunner) GetPolicyUsage() (RecordByIMSI, error) {
 		recordsBySubID[record.Sid][record.RuleId] = record
 	}
 	return recordsBySubID, nil
+}
+
+func (tr *TestRunner) WaitForEnforcementStatsToSync() {
+	// TODO load this value from pipelined.yml
+	enforcementPollPeriod := 1 * time.Second
+	time.Sleep(3 * enforcementPollPeriod)
+}
+
+func (tr *TestRunner) WaitForPoliciesToSync() {
+	// TODO load this value from sessiond.yml (rule_update_interval_sec)
+	ruleUpdatePeriod := 1 * time.Second
+	time.Sleep(2 * ruleUpdatePeriod)
 }
 
 // getRandomIMSI makes a random 15-digit IMSI that is not added to the UESim or HSS.

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -49,6 +49,7 @@ const (
 )
 
 type TestRunner struct {
+	t     *testing.T
 	imsis map[string]bool
 }
 
@@ -57,9 +58,9 @@ type RecordByIMSI map[string]map[string]*lteprotos.RuleRecord
 
 // NewTestRunner initializes a new TestRunner by making a UESim client and
 // and setting the next IMSI.
-func NewTestRunner() *TestRunner {
+func NewTestRunner(t *testing.T) *TestRunner {
 	fmt.Println("************************* TestRunner setup")
-	testRunner := &TestRunner{}
+	testRunner := &TestRunner{t: t}
 
 	testRunner.imsis = make(map[string]bool)
 	fmt.Printf("Adding Mock HSS service at %s:%d\n", CwagIP, HSSPort)
@@ -78,14 +79,14 @@ func NewTestRunner() *TestRunner {
 
 // ConfigUEs creates and adds the specified number of UEs and Subscribers
 // to the UE Simulator and the HSS.
-func (testRunner *TestRunner) ConfigUEs(numUEs int) ([]*cwfprotos.UEConfig, error) {
+func (tr *TestRunner) ConfigUEs(numUEs int) ([]*cwfprotos.UEConfig, error) {
 	fmt.Printf("************************* Configuring %d UE(s)\n", numUEs)
 	ues := make([]*cwfprotos.UEConfig, 0)
 	for i := 0; i < numUEs; i++ {
 		imsi := ""
 		for {
 			imsi = getRandomIMSI()
-			_, present := testRunner.imsis[imsi]
+			_, present := tr.imsis[imsi]
 			if !present {
 				break
 			}
@@ -119,7 +120,7 @@ func (testRunner *TestRunner) ConfigUEs(numUEs int) ([]*cwfprotos.UEConfig, erro
 		ues = append(ues, ue)
 		fmt.Printf("Added UE to Simulator, HSS, PCRF, and OCS:\n"+
 			"\tIMSI: %s\tKey: %x\tOpc: %x\tSeq: %d\n", imsi, key, opc, seq)
-		testRunner.imsis[imsi] = true
+		tr.imsis[imsi] = true
 	}
 	fmt.Println("Successfully configured UE(s)")
 	return ues, nil
@@ -127,7 +128,7 @@ func (testRunner *TestRunner) ConfigUEs(numUEs int) ([]*cwfprotos.UEConfig, erro
 
 // Authenticate simulates an authentication between the UE with the specified
 // IMSI and the HSS, and returns the resulting Radius packet.
-func (testRunner *TestRunner) Authenticate(imsi string) (*radius.Packet, error) {
+func (tr *TestRunner) Authenticate(imsi string) (*radius.Packet, error) {
 	fmt.Printf("************************* Authenticating UE with IMSI: %s\n", imsi)
 	res, err := uesim.Authenticate(&cwfprotos.AuthenticateRequest{Imsi: imsi})
 	if err != nil {
@@ -141,22 +142,31 @@ func (testRunner *TestRunner) Authenticate(imsi string) (*radius.Packet, error) 
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}
-	fmt.Printf("Finished Authenticating UE. Resulting RADIUS Packet: %d\n", radiusP)
+	tr.t.Logf("Finished Authenticating UE. Resulting RADIUS Packet: %d\n", radiusP)
 	return radiusP, nil
 }
 
-func (testRunner *TestRunner) AuthenticateAndAssertSuccess(t *testing.T, imsi string) {
-	radiusP, err := testRunner.Authenticate(imsi)
-	assert.NoError(t, err)
+func (tr *TestRunner) AuthenticateAndAssertSuccess(imsi string) {
+	radiusP, err := tr.Authenticate(imsi)
+	assert.NoError(tr.t, err)
 
 	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
-	assert.NotNil(t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
-	assert.True(t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
+	assert.NotNil(tr.t, eapMessage, fmt.Sprintf("EAP Message from authentication is nil"))
+	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.SuccessCode), fmt.Sprintf("UE Authentication did not return success"))
+}
+
+func (tr *TestRunner) AuthenticateAndAssertFail(imsi string) {
+	radiusP, err := tr.Authenticate(imsi)
+	assert.NoError(tr.t, err)
+
+	eapMessage := radiusP.Attributes.Get(rfc2869.EAPMessage_Type)
+	assert.NotNil(tr.t, eapMessage)
+	assert.True(tr.t, reflect.DeepEqual(int(eapMessage[0]), eap.FailureCode))
 }
 
 // Authenticate simulates an authentication between the UE with the specified
 // IMSI and the HSS, and returns the resulting Radius packet.
-func (testRunner *TestRunner) Disconnect(imsi string) (*radius.Packet, error) {
+func (tr *TestRunner) Disconnect(imsi string) (*radius.Packet, error) {
 	fmt.Printf("************************* Sending a disconnect request UE with IMSI: %s\n", imsi)
 	res, err := uesim.Disconnect(&cwfprotos.DisconnectRequest{Imsi: imsi})
 	if err != nil {
@@ -169,22 +179,22 @@ func (testRunner *TestRunner) Disconnect(imsi string) (*radius.Packet, error) {
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}
-	fmt.Printf("Finished Discconnecting UE. Resulting RADIUS Packet: %d\n", radiusP)
+	tr.t.Logf("Finished Discconnecting UE. Resulting RADIUS Packet: %d\n", radiusP)
 	return radiusP, nil
 }
 
 // GenULTraffic simulates the UE sending traffic through the CWAG to the Internet
 // by running an iperf3 client on the UE simulator and an iperf3 server on the
 // Magma traffic server.
-func (testRunner *TestRunner) GenULTraffic(req *cwfprotos.GenTrafficRequest) (*cwfprotos.GenTrafficResponse, error) {
+func (tr *TestRunner) GenULTraffic(req *cwfprotos.GenTrafficRequest) (*cwfprotos.GenTrafficResponse, error) {
 	fmt.Printf("************************* Generating Traffic for UE with Req: %v\n", req)
 	return uesim.GenTraffic(req)
 }
 
 // Remove subscribers, rules, flows, and monitors to clean up the state for
 // consecutive test runs
-func (testRunner *TestRunner) CleanUp() error {
-	for imsi, _ := range testRunner.imsis {
+func (tr *TestRunner) CleanUp() error {
+	for imsi, _ := range tr.imsis {
 		err := deleteSubscribersFromHSS(imsi)
 		if err != nil {
 			return err
@@ -211,7 +221,7 @@ func (tr *TestRunner) GetPolicyUsage() (RecordByIMSI, error) {
 		return recordsBySubID, err
 	}
 	for _, record := range table.Records {
-		fmt.Printf("Record %v", record)
+		fmt.Printf("Record %v\n", record)
 		_, exists := recordsBySubID[record.Sid]
 		if !exists {
 			recordsBySubID[record.Sid] = map[string]*lteprotos.RuleRecord{}
@@ -231,6 +241,11 @@ func (tr *TestRunner) WaitForPoliciesToSync() {
 	// TODO load this value from sessiond.yml (rule_update_interval_sec)
 	ruleUpdatePeriod := 1 * time.Second
 	time.Sleep(2 * ruleUpdatePeriod)
+}
+
+func (tr *TestRunner) WaitForReAuthToProcess() {
+	// Todo figure out the best way to figure out when RAR is processed
+	time.Sleep(3 * time.Second)
 }
 
 // getRandomIMSI makes a random 15-digit IMSI that is not added to the UESim or HSS.


### PR DESCRIPTION
Summary:
* Add test description to `auth_test.go` and `auth_ul_test.go`
* Consolidate cleaning into a defer function
* Use `tr.WaitForPoliciesToSync()` instead of sleep for waiting for policies to sync up to sessiond
* Use `tr.WaitFortr.WaitForEnforcementStatsToSync()` instead of sleep for waiting for enforcement stats to sync
    * Note these functions above uses sleeps to sync. But I want to keep the number of seconds consistent. I will eventually load these values from the config so that they're consistent with the configs
* Use `tr.WaitForReAuthToProcess()` for after generating traffic to wait for updates from pipelined.
    * For this one, I'll brainstorm the best way to figure out when ReAuth has processed. Once sessiond states are stored in Redis, maybe we can use that to look into ReAuth states...

Differential Revision: D20653942

