### PR TITLE
Convert SessionID back to AGW form for ASR (#2113)

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/asr.go
+++ b/feg/gateway/services/session_proxy/credit_control/asr.go
@@ -60,7 +60,7 @@ func (h *asrHandler) ServeDIAM(conn diam.Conn, m *diam.Message) {
 
 		res, err := client.AbortSession(context.Background(), &protos.AbortSessionRequest{
 			UserName:  imsi,
-			SessionId: asr.SessionID,
+			SessionId: diameter.DecodeSessionID(asr.SessionID),
 		})
 		if err != nil {
 			glog.Errorf("Error relaying ASR to gateway: %s", err)

--- a/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_client.go
+++ b/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_client.go
@@ -132,6 +132,7 @@ func (c *SyncRpcClient) Run() {
 			continue
 		} else {
 			currentBackoffInterval = MinRetryInterval // reset backoff interval
+			log.Printf("[SyncRpc] successfully connected to cloud '%s' service", definitions.DispatcherServiceName)
 		}
 
 		// this should simply wait here for requests and process responses


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2113

Convert SessionID back to AGW form for ASR

Reviewed By: karthiksubraveti

Differential Revision: D20665294

