### PR TITLE
Make monitord use ping_interface_async

### DIFF
--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -16,6 +16,7 @@ TESTS=magma/tests \
       magma/pipelined/openflow/tests \
       magma/pkt_tester/tests \
       magma/redirectd/tests \
-      magma/subscriberdb/tests
+      magma/subscriberdb/tests \
+      magma/monitord/tests
 
 SUDO_TESTS=magma/pipelined/tests

--- a/lte/gateway/python/magma/monitord/icmp_monitoring.py
+++ b/lte/gateway/python/magma/monitord/icmp_monitoring.py
@@ -82,7 +82,7 @@ class ICMPMonitoring(Job):
         ping_params = [
             ping.PingInterfaceCommandParams(host, NUM_PACKETS, self._MTR_PORT,
                                             TIMEOUT_SECS) for host in hosts]
-        ping_results = await ping.ping_async(ping_params, self._loop)
+        ping_results = await ping.ping_interface_async(ping_params, self._loop)
         ping_results_list = list(ping_results)
         for sub, result in zip(subscribers, ping_results_list):
             sid = "IMSI%s" % sub.sid.id

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -9,6 +9,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 from lte.protos.mconfig import mconfigs_pb2
 from magma.common.service import MagmaService
+from magma.configuration import load_service_config
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.monitord.icmp_state import serialize_subscriber_states
 
@@ -18,8 +19,9 @@ def main():
     service = MagmaService('monitord', mconfigs_pb2.MonitorD())
 
     # Monitoring thread loop
+    mtr_interface = load_service_config("monitord")["mtr_interface"]
     icmp_monitor = ICMPMonitoring(service.mconfig.polling_interval,
-                                  service.loop)
+                                  service.loop, mtr_interface)
     icmp_monitor.start()
 
     # Register a callback function for GetOperationalStates

--- a/lte/gateway/python/magma/monitord/metrics.py
+++ b/lte/gateway/python/magma/monitord/metrics.py
@@ -1,0 +1,13 @@
+#  Copyright (c) Facebook, Inc. and its affiliates.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree.
+
+from prometheus_client import Histogram
+
+SUBSCRIBER_ICMP_LATENCY_MS = Histogram('subscriber_icmp_latency_ms',
+                                  'Reported latency for subscriber '
+                                  'in milliseconds',
+                                  ['imsi'],
+                                  buckets=[50, 100, 200, 500, 1000, 2000])

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -15,6 +15,7 @@ from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
 from magma.monitord.icmp_monitoring import ICMPMonitoring
 from magma.subscriberdb.sid import SIDUtils
 
+LOCALHOST = '127.0.0.1'
 
 class ICMPMonitoringTests(unittest.TestCase):
     """
@@ -27,7 +28,7 @@ class ICMPMonitoringTests(unittest.TestCase):
         self.subscribers.entries.add(sid=sid, ip=ip, apn='test_apn')
 
     async def _ping_local(self):
-        return await self._monitor._ping_subscribers(["127.0.0.1"],
+        return await self._monitor._ping_subscribers([LOCALHOST],
                                                      self.subscribers.entries)
 
     def setUp(self):
@@ -38,7 +39,7 @@ class ICMPMonitoringTests(unittest.TestCase):
         self.subscribers = SubscriberIPTable()
         self._monitor = ICMPMonitoring(polling_interval=5,
                                        service_loop=self.loop,
-                                       mtr_interface="test")
+                                       mtr_interface=LOCALHOST)
 
     def test_ping_subscriber_saves_response(self):
         imsi = 'IMSI00000000001'

--- a/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
+++ b/lte/gateway/python/magma/monitord/tests/test_icmp_monitor.py
@@ -1,0 +1,49 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+
+import asyncio
+import unittest
+
+from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
+from magma.monitord.icmp_monitoring import ICMPMonitoring
+from magma.subscriberdb.sid import SIDUtils
+
+
+class ICMPMonitoringTests(unittest.TestCase):
+    """
+    Test class for the ICMPMonitor class
+    """
+
+    def _add_test_subscriber(self, imsi):
+        ip = IPAddress(version=IPAddress.IPV4, address=b'127.0.0.1')
+        sid = SIDUtils.to_pb(imsi)
+        self.subscribers.entries.add(sid=sid, ip=ip, apn='test_apn')
+
+    async def _ping_local(self):
+        return await self._monitor._ping_subscribers(["127.0.0.1"],
+                                                     self.subscribers.entries)
+
+    def setUp(self):
+        """
+        Creates and sets up ICMP monitor
+        """
+        self.loop = asyncio.get_event_loop()
+        self.subscribers = SubscriberIPTable()
+        self._monitor = ICMPMonitoring(polling_interval=5,
+                                       service_loop=self.loop,
+                                       mtr_interface="test")
+
+    def test_ping_subscriber_saves_response(self):
+        imsi = 'IMSI00000000001'
+        self._add_test_subscriber(imsi)
+        self.loop.run_until_complete(self._ping_local())
+        sub_states = self._monitor.get_subscriber_state()
+        self.loop.close()
+        self.assertTrue(imsi in sub_states)

--- a/lte/gateway/python/magma/monitord/tests/test_metrics.py
+++ b/lte/gateway/python/magma/monitord/tests/test_metrics.py
@@ -1,0 +1,29 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+
+from magma.common import metrics_export
+from magma.monitord.metrics import SUBSCRIBER_ICMP_LATENCY_MS
+
+
+class MetricTests(unittest.TestCase):
+    """
+    Tests for the Service303 metrics interface
+    """
+    def test_metrics_defined(self):
+        """ Test that all metrics are defined in proto enum """
+        SUBSCRIBER_ICMP_LATENCY_MS.labels('IMSI00000001').observe(10.33)
+
+        metrics_protos = list(metrics_export.get_metrics())
+        for metrics_proto in metrics_protos:
+            if metrics_proto.name == "subscriber_latency_ms":
+                metric = metrics_proto.metric[0]
+                self.assertEqual(metric.histogram.sample_sum, 10.33)
+                self.assertEqual(metric.label[0].value, 'IMSI00000001')

--- a/orc8r/gateway/python/magma/magmad/check/network_check/ping.py
+++ b/orc8r/gateway/python/magma/magmad/check/network_check/ping.py
@@ -87,6 +87,26 @@ def ping_async(ping_params, loop=None):
     )
 
 
+@asyncio.coroutine
+def ping_interface_async(ping_params, loop=None):
+    """
+    Execute ping commands asynchronously through specified interface.
+
+    Args:
+        ping_params ([PingCommandParams]): params for the pings to execute
+        loop: asyncio event loop (optional)
+
+    Returns:
+        [PingCommandResult]: stats from the executed ping commands
+    """
+    return subprocess_workflow.exec_and_parse_subprocesses_async(
+        ping_params,
+        _get_ping_command_interface_args_list,
+        parse_ping_output,
+        loop,
+    )
+
+
 def _get_ping_command_args_list(ping_param):
     return [
         'ping', ping_param.host_or_ip,


### PR DESCRIPTION
Summary: - Adding ping_interface_async to send ICMP ping through specified interface, specifying mtr0 as defined monitoring port

Reviewed By: koolzz

Differential Revision: D20680063

