### PR TITLE
Add v2 analytics support (#2130)

### DIFF
--- a/feg/radius/src/loader/static_loader.go
+++ b/feg/radius/src/loader/static_loader.go
@@ -24,6 +24,7 @@ import (
 	modeap "fbc/cwf/radius/modules/eap"
 	modlbserve "fbc/cwf/radius/modules/lbserve"
 	modmagmaacct "fbc/cwf/radius/modules/magmaacct"
+	ofpanalytics "fbc/cwf/radius/modules/ofpanalytics"
 	modproxy "fbc/cwf/radius/modules/proxy"
 	modloopback "fbc/cwf/radius/modules/testloopback"
 	testsessionstorage "fbc/cwf/radius/modules/testsessionstorage"
@@ -58,6 +59,7 @@ var CWFModuleMap = ModuleNameMap{
 	"eap":                func() modules.Module { return NewModule(modeap.Init, modeap.Handle) },
 	"lbserve":            func() modules.Module { return NewModule(modlbserve.Init, modlbserve.Handle) },
 	"proxy":              func() modules.Module { return NewModule(modproxy.Init, modproxy.Handle) },
+	"ofpanalytics":       func() modules.Module { return NewModule(ofpanalytics.Init, ofpanalytics.Handle) },
 	"xwfv3":              func() modules.Module { return NewModule(modxwfv3.Init, modxwfv3.Handle) },
 	"testloopback":       func() modules.Module { return NewModule(modloopback.Init, modloopback.Handle) },
 	"coafixedip":         func() modules.Module { return NewModule(modcoafixed.Init, modcoafixed.Handle) },

--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -1,0 +1,150 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package ofpanalytics
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fbc/cwf/radius/modules"
+	"fbc/lib/go/radius"
+	"fbc/lib/go/radius/rfc2865"
+	"fmt"
+	"github.com/mitchellh/mapstructure"
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"net/http"
+	"strings"
+	"time"
+)
+
+type (
+	Config struct {
+		URI         string
+		AccessToken string
+		DryRun      bool
+	}
+
+	moduleContext struct {
+		URI         string
+		AccessToken string
+		HTTPClient  *http.Client
+	}
+
+	EndpointResponse struct {
+		Auth []string `json:"config:Auth-Type,omitempty"`
+	}
+)
+
+var (
+	defaultTimeout   = 5 * time.Second
+	acceptCode       = "254"
+	rejectCode       = "5"
+	analyticsVersion = "v1.1"
+)
+
+// Init module interface implementation
+func Init(logger *zap.Logger, config modules.ModuleConfig) (modules.Context, error) {
+	var mCtx moduleContext
+	var cfg Config
+
+	err := mapstructure.Decode(config, &cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	if cfg.URI == "" {
+		return nil, errors.New("OFPAnalytics module cannot be initialized with an empty URI value")
+	}
+	if cfg.AccessToken == "" {
+		return nil, errors.New("OFPAnalytics module cannot be initialized with an empty access token value")
+	}
+
+	mCtx.URI = cfg.URI
+	mCtx.AccessToken = cfg.AccessToken
+	mCtx.HTTPClient = &http.Client{
+		Timeout: defaultTimeout,
+	}
+	// For DryRun we're going to allow connection to an unauthenticated end
+	if cfg.DryRun {
+		mCtx.HTTPClient.Transport = &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+	}
+
+	logger.Info("OFPAnalytics module initialized successfully")
+	return mCtx, nil
+}
+
+// Normalizing fields
+func normalize(radiusAvp string) string {
+	var replacer = strings.NewReplacer("-", ":")
+	return strings.ToLower(replacer.Replace(radiusAvp))
+}
+
+// Handle module interface implementation
+func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ modules.Middleware) (*modules.Response, error) {
+	ctx, ok := m.(moduleContext)
+	if !ok {
+		return nil, fmt.Errorf("unable to obtain context")
+	}
+
+	// Currently only handling authorization requests - we have roadmap tasks to support full v2 integration T64414814
+	// When we'll have v2 support we can remove the hand crafted json packet
+	jsonPacket := map[string]map[string]interface{}{
+		"NAS-IP-Address":     {"type": "string", "value": []string{rfc2865.NASIPAddress_Get(r.Packet).String()}},
+		"Called-Station-Id":  {"type": "string", "value": []string{normalize(rfc2865.CalledStationID_GetString(r.Packet))}},
+		"Calling-Station-Id": {"type": "string", "value": []string{normalize(rfc2865.CallingStationID_GetString(r.Packet))}},
+		"NAS-Identifier":     {"type": "string", "value": []string{rfc2865.NASIdentifier_GetString(r.Packet)}},
+		"XWF-C-Version":      {"type": "string", "value": []string{analyticsVersion}},
+	}
+
+	encodedMsg, err := json.Marshal(jsonPacket)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to marshal radius packet")
+	}
+	req, err := http.NewRequest(http.MethodPost, ctx.URI, bytes.NewReader(encodedMsg))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("Authorization", "Bearer "+ctx.AccessToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := ctx.HTTPClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "error sending response to endpoint")
+	}
+	defer resp.Body.Close()
+	rc.Logger.Debug("got response", zap.String("status", resp.Status),
+		zap.String("msg", string(encodedMsg)), zap.String("url", resp.Request.URL.String()),
+		zap.Any("request", r.Packet.Attributes))
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("error processing message by endpoint. Response status %d", resp.StatusCode)
+	}
+	var endPointResponse EndpointResponse
+	if err := json.NewDecoder(resp.Body).Decode(&endPointResponse); err != nil {
+		return nil, errors.Wrap(err, "unable to decode endpoint response")
+	}
+
+	if len(endPointResponse.Auth) == 0 {
+		return nil, fmt.Errorf("malformed auth response: no acceptance code")
+	}
+	var p *radius.Packet
+	switch endPointResponse.Auth[0] {
+	case acceptCode:
+		p = r.Response(radius.CodeAccessAccept)
+	case rejectCode:
+		p = r.Response(radius.CodeAccessReject)
+	}
+
+	response := &modules.Response{
+		Code:       p.Code,
+		Attributes: p.Attributes,
+	}
+	return response, nil
+}

--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics_test.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+package ofpanalytics
+
+import (
+	"encoding/json"
+	"fbc/cwf/radius/modules"
+	"fbc/lib/go/radius"
+	"fbc/lib/go/radius/rfc2865"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+var (
+	AccessToken      = "123"
+	SecretCode       = []byte{0x01, 0x02, 0x03, 0x4, 0x05, 0x06}
+	NASIPAddress     = "1.1.1.1"
+	NASIdentifier    = "1C:B9:C4:3C:C1:80"
+	CalledStationID  = "1C-B9-C4-3C-C1-80:Globe Express Wi-Fi by Facebook"
+	CallingStationID = "1C-B9-C4-3C-C1-81"
+)
+
+func MiddlewareSink(t *testing.T) modules.Middleware {
+	return func(c *modules.RequestContext, r *radius.Request) (*modules.Response, error) {
+		require.Fail(t, "Should never be called (ofpanalytics module should not call next())")
+		return nil, nil
+	}
+}
+
+func CreateAuthRequest() *radius.Request {
+
+	packet := radius.New(radius.CodeAccessRequest, SecretCode)
+	req := &radius.Request{}
+	rfc2865.NASIPAddress_Add(packet, net.ParseIP(NASIPAddress))
+	rfc2865.NASIdentifier_AddString(packet, NASIdentifier)
+	rfc2865.CalledStationID_AddString(packet, CalledStationID)
+	rfc2865.CallingStationID_AddString(packet, CallingStationID)
+	req.Packet = packet
+
+	return req
+}
+
+func TestV2(t *testing.T) {
+	cases := []struct {
+		authCode      string
+		radiusResCode radius.Code
+		name          string
+	}{
+		{
+			authCode:      acceptCode,
+			radiusResCode: radius.CodeAccessAccept,
+			name:          "accept",
+		},
+		{
+			authCode:      rejectCode,
+			radiusResCode: radius.CodeAccessReject,
+			name:          "reject",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create test server
+			ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Returning radius auth response
+				jsonPacket, _ := json.Marshal(map[string][]string{
+					"config:Auth-Type": []string{tc.authCode},
+				})
+				w.Write(jsonPacket)
+			}))
+			defer ts.Close()
+
+			logger, _ := zap.NewDevelopment()
+			mCtx, err := Init(logger, modules.ModuleConfig{
+				"URI":         ts.URL,
+				"AccessToken": AccessToken,
+				"DryRun":      true,
+			})
+			require.Nil(t, err)
+
+			req := CreateAuthRequest()
+			res, err := Handle(mCtx, &modules.RequestContext{
+				RequestID:      0,
+				Logger:         logger,
+				SessionStorage: nil,
+			}, req, MiddlewareSink(t))
+			require.NoError(t, err)
+
+			require.Equal(t, tc.radiusResCode, res.Code)
+
+		})
+	}
+}


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2130

In order to support express wifi analytics using the magma box, we're adding a module for the go radius server

Differential Revision: D20723932

