### PR TITLE
Fix gateways statuses #1158

### DIFF
--- a/symphony/app/fbcnms-packages/fbcnms-ui/components/icons/DeviceStatusCircle.js
+++ b/symphony/app/fbcnms-packages/fbcnms-ui/components/icons/DeviceStatusCircle.js
@@ -13,6 +13,7 @@ import {makeStyles} from '@material-ui/styles';
 
 type Props = {
   isGrey: boolean,
+  isYellow: boolean,
   isActive: boolean,
 };
 
@@ -35,6 +36,10 @@ export default function DeviceStatusCircle(props: Props) {
   if (props.isGrey) {
     return (
       <span className={classes.status} style={{backgroundColor: '#bec3c8'}} />
+    );
+  } else if (props.isYellow) {
+    return (
+      <span className={classes.status} style={{backgroundColor: '#f5e945'}} />
     );
   } else if (props.isActive) {
     return (

--- a/symphony/app/fbcnms-projects/magmalte/app/components/Gateways.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/components/Gateways.js
@@ -294,8 +294,16 @@ function GatewayRowItem(props: Props) {
     <TableRow>
       <TableCell>
         <DeviceStatusCircle
-          isGrey={!gateway.enodebRFTXOn}
-          isActive={gateway.enodebRFTXOn === gateway.enodebRFTXEnabled}
+          isGrey={gateway.isBackhaulDown}
+          isYellow={
+              !gateway.enodebRFTXEnabled && 
+              (!gateway.enodebRFTXOn ||
+              !gateway.mmeConnected)
+          }
+          isActive={
+              gateway.enodebRFTXOn === gateway.enodebRFTXEnabled &&
+              gateway.mmeConnected
+          }
         />
         {gateway.name}
       </TableCell>


### PR DESCRIPTION
Show green circle for gateway when the enodeB is connected and MME is
connected.
Show yellow circle when RF transmit is disabled, if the enodeB is
disconnected or if the MME is disconnected - this indicates a fault with
the radio configuration which will not impact the site (since transmit
is disabled)
Show gray circle  when backhaul is down.
Show red circle in any other scenario when RF is enabled.