### PR TITLE
Session Manager's SessionMap ownership changed from LocalEnforcer to global

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -16,6 +16,7 @@
 #include "LocalEnforcer.h"
 #include "SessionReporter.h"
 #include "SessionID.h"
+#include "SessionStore.h"
 
 using grpc::Server;
 using grpc::ServerContext;
@@ -65,7 +66,8 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   LocalSessionManagerHandlerImpl(
     std::shared_ptr<LocalEnforcer> monitor,
     SessionReporter* reporter,
-    std::shared_ptr<AsyncDirectorydClient> directoryd_client);
+    std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+    SessionMap& session_map);
   ~LocalSessionManagerHandlerImpl() {}
   /**
    * Report flow stats from pipelined and track the usage per rule
@@ -93,6 +95,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
     std::function<void(Status, LocalEndSessionResponse)> response_callback);
 
  private:
+  SessionMap& session_map_;
   std::shared_ptr<LocalEnforcer> enforcer_;
   SessionReporter* reporter_;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -21,10 +21,12 @@ const uint RestartHandler::rpc_retry_interval_s_ = 5;
 RestartHandler::RestartHandler(
   std::shared_ptr<AsyncDirectorydClient> directoryd_client,
   std::shared_ptr<LocalEnforcer> enforcer,
-  SessionReporter* reporter):
+  SessionReporter* reporter,
+  SessionMap& session_map):
   directoryd_client_(directoryd_client),
   enforcer_(enforcer),
-  reporter_(reporter)
+  reporter_(reporter),
+  session_map_(session_map)
 {
 }
 
@@ -112,7 +114,7 @@ void RestartHandler::terminate_previous_session(
           return;
         }
         // Don't delete subscriber from directoryD if IMSI is known
-        if (enforcer_->session_with_imsi_exists(response.sid())) {
+        if (enforcer_->session_with_imsi_exists(session_map_, response.sid())) {
           MLOG(MINFO) << "Not cleaning up previous session after restart "
                       << "for subscriber " << response.sid()
                       << ", session id: " << response.session_id()

--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -25,7 +25,8 @@ class RestartHandler {
   RestartHandler(
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
     std::shared_ptr<LocalEnforcer> enforcer,
-    SessionReporter* reporter);
+    SessionReporter* reporter,
+    SessionMap& session_map);
 
   /**
    * Cleanup previous sessions stored in directoryD
@@ -42,6 +43,7 @@ class RestartHandler {
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
   SessionReporter* reporter_;
   std::unordered_map<std::string, std::string> sessions_to_terminate_;
+  SessionMap& session_map_;
   static const uint max_cleanup_retries_;
   static const uint rpc_retry_interval_s_;
 };

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -17,8 +17,10 @@ using grpc::Status;
 namespace magma {
 
 SessionProxyResponderHandlerImpl::SessionProxyResponderHandlerImpl(
-  std::shared_ptr<LocalEnforcer> enforcer):
-  enforcer_(enforcer)
+  std::shared_ptr<LocalEnforcer> enforcer,
+  SessionMap& session_map):
+  enforcer_(enforcer),
+  session_map_(session_map)
 {
 }
 
@@ -30,7 +32,7 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
   auto &request_cpy = *request;
   enforcer_->get_event_base().runInEventBaseThread(
     [this, request_cpy, response_callback]() {
-      auto result = enforcer_->init_charging_reauth(request_cpy);
+      auto result = enforcer_->init_charging_reauth(session_map_, request_cpy);
       ChargingReAuthAnswer ans;
       ans.set_result(result);
       response_callback(Status::OK, ans);
@@ -46,7 +48,7 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
   enforcer_->get_event_base().runInEventBaseThread(
     [this, request_cpy, response_callback]() {
       PolicyReAuthAnswer ans;
-      enforcer_->init_policy_reauth(request_cpy, ans);
+      enforcer_->init_policy_reauth(session_map_, request_cpy, ans);
       response_callback(Status::OK, ans);
     });
 }

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
@@ -14,6 +14,7 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 
 #include "LocalEnforcer.h"
+#include "SessionStore.h"
 
 using grpc::Server;
 using grpc::ServerContext;
@@ -46,7 +47,9 @@ class SessionProxyResponderHandler {
  */
 class SessionProxyResponderHandlerImpl : public SessionProxyResponderHandler {
  public:
-  SessionProxyResponderHandlerImpl(std::shared_ptr<LocalEnforcer> monitor);
+  SessionProxyResponderHandlerImpl(
+    std::shared_ptr<LocalEnforcer> monitor,
+    SessionMap& session_map);
 
   ~SessionProxyResponderHandlerImpl() {}
 
@@ -68,6 +71,7 @@ class SessionProxyResponderHandlerImpl : public SessionProxyResponderHandler {
     std::function<void(Status, PolicyReAuthAnswer)> response_callback);
 
  private:
+   SessionMap& session_map_;
    std::shared_ptr<LocalEnforcer> enforcer_;
 };
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -82,16 +82,16 @@ class SessionState {
   StoredSessionState marshal();
 
   /**
-   * new_report sets the state of terminating session to aggregating, to tell if
+   * notify_new_report_for_sessions sets the state of terminating session to aggregating, to tell if
    * flows for the terminating session is in the latest report.
    * Should be called before add_used_credit.
    */
   void new_report();
 
   /**
-   * finish_report updates the state of aggregating session not included report
+   * notify_finish_report_for_sessions updates the state of aggregating session not included report
    * to specify its flows are deleted and termination can be completed.
-   * Should be called after new_report and add_used_credit.
+   * Should be called after notify_new_report_for_sessions and add_used_credit.
    */
   void finish_report();
 
@@ -264,11 +264,11 @@ class SessionState {
    *       V                   V
    * SESSION_TERMINATING_FLOW_ACTIVE <----------
    *       |                                   |
-   *       | (new_report)                      | (add_used_credit)
+   *       | (notify_new_report_for_sessions)  | (add_used_credit)
    *       V                                   |
    * SESSION_TERMINATING_AGGREGATING_STATS -----
    *       |
-   *       | (finish_report)
+   *       | (notify_finish_report_for_sessions)
    *       V
    * SESSION_TERMINATING_FLOW_DELETED
    *       |

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -53,6 +53,7 @@ class LocalEnforcerTest : public ::testing::Test {
       aaa_client, 0, 0);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
+    session_map = SessionMap{};
   }
 
   virtual void TearDown()
@@ -94,7 +95,7 @@ class LocalEnforcerTest : public ::testing::Test {
   {
     for (auto &volume_pair : volumes) {
       auto volume_out =
-        local_enforcer->get_charging_credit(imsi, volume_pair.first, bucket);
+        local_enforcer->get_charging_credit(session_map, imsi, volume_pair.first, bucket);
       EXPECT_EQ(volume_out, volume_pair.second);
     }
   }
@@ -106,7 +107,7 @@ class LocalEnforcerTest : public ::testing::Test {
   {
     for (auto &volume_pair : volumes) {
       auto volume_out =
-        local_enforcer->get_monitor_credit(imsi, volume_pair.first, bucket);
+        local_enforcer->get_monitor_credit(session_map, imsi, volume_pair.first, bucket);
       EXPECT_EQ(volume_out, volume_pair.second);
     }
   }
@@ -120,6 +121,7 @@ class LocalEnforcerTest : public ::testing::Test {
   std::shared_ptr<MockEventdClient> eventd_client;
   std::shared_ptr<MockSpgwServiceClient> spgw_client;
   std::shared_ptr<MockAAAClient> aaa_client;
+  SessionMap session_map;
   folly::EventBase *evb;
 };
 
@@ -214,10 +216,10 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit)
   test_cwf_cfg.mac_addr = "00:00:00:00:00:00";
   test_cwf_cfg.radius_session_id = "1234567";
 
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 1024);
 }
 
 TEST_F(LocalEnforcerTest, test_init_session_credit)
@@ -234,10 +236,10 @@ TEST_F(LocalEnforcerTest, test_init_session_credit)
       testing::_, testing::_, CheckCount(0), CheckCount(0)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 1024);
 }
 
 TEST_F(LocalEnforcerTest, test_single_record)
@@ -246,19 +248,19 @@ TEST_F(LocalEnforcerTest, test_single_record)
   CreateSessionResponse response;
   create_credit_update_response(
     "IMSI1", 1, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   insert_static_rule(1, "", "rule1");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 16, 32, record_list->Add());
 
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_RX), 16);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_TX), 32);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX), 16);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX), 32);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 1024);
 }
 
 TEST_F(LocalEnforcerTest, test_aggregate_records)
@@ -268,7 +270,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records)
     "IMSI1", 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
     "IMSI1", 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
@@ -279,12 +281,12 @@ TEST_F(LocalEnforcerTest, test_aggregate_records)
   create_rule_record("IMSI1", "rule2", 5, 15, record_list->Add());
   create_rule_record("IMSI1", "rule3", 100, 150, record_list->Add());
 
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_RX), 15);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_TX), 35);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 2, USED_RX), 100);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 2, USED_TX), 150);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX), 15);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX), 35);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 2, USED_RX), 100);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 2, USED_TX), 150);
 }
 
 TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination)
@@ -294,7 +296,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination)
     "IMSI1", 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
     "IMSI1", 2, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
@@ -302,8 +304,8 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination)
 
   std::promise<void> termination_promise;
   auto future = termination_promise.get_future();
-  local_enforcer->terminate_subscriber(
-    "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest req) {
+  local_enforcer->terminate_subscriber(session_map,
+                                       "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest req) {
       termination_promise.set_value();
 
       EXPECT_EQ(req.credit_usages_size(), 2);
@@ -318,7 +320,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination)
   create_rule_record("IMSI1", "rule2", 5, 15, record_list->Add());
   create_rule_record("IMSI1", "rule3", 100, 150, record_list->Add());
 
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   // Termination should not have been completed since we are still aggregating
   // the records.
@@ -327,7 +329,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination)
 
   RuleRecordTable empty_table;
 
-  local_enforcer->aggregate_records(empty_table);
+  local_enforcer->aggregate_records(session_map, empty_table);
 
   status = future.wait_for(std::chrono::seconds(0));
   EXPECT_EQ(status, std::future_status::ready);
@@ -338,27 +340,27 @@ TEST_F(LocalEnforcerTest, test_collect_updates)
   CreateSessionResponse response;
   create_credit_update_response(
     "IMSI1", 1, 3072, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
   insert_static_rule(1, "", "rule1");
 
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto empty_update = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto empty_update = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
   EXPECT_EQ(empty_update.updates_size(), 0);
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
 
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
   actions.clear();
-  auto session_update = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto session_update = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
   EXPECT_EQ(session_update.updates_size(), 1);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, REPORTING_RX), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, REPORTING_RX), 1024);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, REPORTING_TX), 2048);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, REPORTING_TX), 2048);
 }
 
 TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules)
@@ -368,17 +370,17 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules)
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
   create_credit_update_response("IMSI1", 1, 2048, credits->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 2048);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 2048);
 
   insert_static_rule(1, "1", "rule1");
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 1024, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   UpdateSessionResponse update_response;
   auto credit_updates_response = update_response.mutable_responses();
@@ -397,9 +399,9 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules)
     time(NULL),
     monitor_updates_response->Add());
   EXPECT_CALL(*reporter, report_updates(_, _)).Times(1);
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 2072);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 2072);
 }
 
 TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure)
@@ -415,7 +417,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure)
     MonitoringLevel::PCC_RULE_LEVEL,
     1024,
     monitor_updates->Add());
-  local_enforcer->init_session_credit("IMSI1", "1", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1", test_cfg, response);
   assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
   assert_charging_credit("IMSI1", ALLOWED_TOTAL, {});
 
@@ -423,7 +425,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure)
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
   assert_monitor_credit("IMSI1", USED_RX, {{"1", 10}});
   assert_monitor_credit("IMSI1", USED_TX, {{"1", 20}});
 
@@ -446,7 +448,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure)
     deactivate_flows_for_rules("IMSI1", std::vector<std::string>{"rule1"}, CheckCount(0)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 
   // expect no update to credit
   assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
@@ -463,12 +465,12 @@ TEST_F(LocalEnforcerTest, test_terminate_credit)
   CreateSessionResponse response2;
   create_credit_update_response(
     "IMSI2", 1, 4096, response2.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
-  local_enforcer->init_session_credit("IMSI2", "4321", test_cfg, response2);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI2", "4321", test_cfg, response2);
 
   std::promise<void> termination_promise;
-  local_enforcer->terminate_subscriber(
-    "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest req) {
+  local_enforcer->terminate_subscriber(session_map,
+                                       "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest req) {
       termination_promise.set_value();
 
       EXPECT_EQ(req.credit_usages_size(), 2);
@@ -482,8 +484,8 @@ TEST_F(LocalEnforcerTest, test_terminate_credit)
   EXPECT_EQ(status, std::future_status::ready);
 
   // No longer in system
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 0);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 2, ALLOWED_TOTAL), 0);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 0);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 2, ALLOWED_TOTAL), 0);
 }
 
 TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting)
@@ -493,7 +495,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting)
     "IMSI1", 1, 3072, response.mutable_credits()->Add());
   create_credit_update_response(
     "IMSI1", 2, 2048, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(2, "", "rule2");
 
@@ -501,19 +503,19 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting)
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   // Collect updates to put key 1 into reporting state
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto usage_updates = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto usage_updates = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, REPORTING_RX), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, REPORTING_RX), 1024);
 
   // Collecting terminations should key 1 anyways during reporting
   std::promise<void> termination_promise;
-  local_enforcer->terminate_subscriber(
-    "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest term_req) {
+  local_enforcer->terminate_subscriber(session_map,
+                                       "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest term_req) {
       termination_promise.set_value();
 
       EXPECT_EQ(term_req.credit_usages_size(), 2);
@@ -535,7 +537,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling)
   CreateSessionResponse response;
   create_credit_update_response(
     "IMSI1", 1, true, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
 
@@ -544,7 +546,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling)
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
   create_rule_record("IMSI1", "rule2", 1024, 2048, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   EXPECT_CALL(
     *pipelined_client,
@@ -553,8 +555,8 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling)
     .WillOnce(testing::Return(true));
   // call collect_updates to trigger actions
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto usage_updates = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto usage_updates = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling)
@@ -578,7 +580,7 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling)
   test_cwf_cfg.mac_addr = "00:00:00:00:00:00";
   test_cwf_cfg.radius_session_id = "1234567";
 
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
 
@@ -587,7 +589,7 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling)
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
   create_rule_record("IMSI1", "rule2", 1024, 2048, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   EXPECT_CALL(
     *pipelined_client,
@@ -602,8 +604,8 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling)
     .WillOnce(testing::Return(true));
   // call collect_updates to trigger actions
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto usage_updates = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto usage_updates = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
 }
 
 TEST_F(LocalEnforcerTest, test_all)
@@ -617,16 +619,16 @@ TEST_F(LocalEnforcerTest, test_all)
   CreateSessionResponse response;
   create_credit_update_response(
     "IMSI1", 1, 1024, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
   CreateSessionResponse response2;
   create_credit_update_response(
     "IMSI2", 2, 2048, response2.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI2", "4321", test_cfg, response2);
+  local_enforcer->init_session_credit(session_map, "IMSI2", "4321", test_cfg, response2);
 
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 1024);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI2", 2, ALLOWED_TOTAL), 2048);
+    local_enforcer->get_charging_credit(session_map, "IMSI2", 2, ALLOWED_TOTAL), 2048);
 
   // receive usages from pipelined
   RuleRecordTable table;
@@ -634,40 +636,40 @@ TEST_F(LocalEnforcerTest, test_all)
   create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
   create_rule_record("IMSI1", "rule2", 5, 15, record_list->Add());
   create_rule_record("IMSI2", "rule3", 1024, 1024, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_RX), 15);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_TX), 35);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI2", 2, USED_RX), 1024);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI2", 2, USED_TX), 1024);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX), 15);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX), 35);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI2", 2, USED_RX), 1024);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI2", 2, USED_TX), 1024);
 
   // Collect updates for reporting
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto session_update = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto session_update = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
   EXPECT_EQ(session_update.updates_size(), 1);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI2", 2, REPORTING_RX), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTING_RX), 1024);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI2", 2, REPORTING_TX), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTING_TX), 1024);
 
   // Add updated credit from cloud
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
   create_credit_update_response("IMSI2", 2, 4096, updates->Add());
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI2", 2, ALLOWED_TOTAL), 6144);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI2", 2, REPORTING_TX), 0);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI2", 2, REPORTING_RX), 0);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI2", 2, REPORTED_TX), 1024);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI2", 2, REPORTED_RX), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI2", 2, ALLOWED_TOTAL), 6144);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTING_TX), 0);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTING_RX), 0);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTED_TX), 1024);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTED_RX), 1024);
 
   // Terminate IMSI1
   std::promise<void> termination_promise;
-  local_enforcer->terminate_subscriber(
-    "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest term_req) {
+  local_enforcer->terminate_subscriber(session_map,
+                                       "IMSI1", "IMS", [&termination_promise](SessionTerminateRequest term_req) {
       termination_promise.set_value();
 
       EXPECT_EQ(term_req.sid(), "IMSI1");
@@ -683,19 +685,19 @@ TEST_F(LocalEnforcerTest, test_re_auth)
 {
   insert_static_rule(1, "", "rule1");
   CreateSessionResponse response;
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   ChargingReAuthRequest reauth;
   reauth.set_sid("IMSI1");
   reauth.set_session_id("1234");
   reauth.set_charging_key(1);
   reauth.set_type(ChargingReAuthRequest::SINGLE_SERVICE);
-  auto result = local_enforcer->init_charging_reauth(reauth);
+  auto result = local_enforcer->init_charging_reauth(session_map, reauth);
   EXPECT_EQ(result, ChargingReAuthAnswer::UPDATE_INITIATED);
 
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto update_req = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto update_req = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
   EXPECT_EQ(update_req.updates_size(), 1);
   EXPECT_EQ(update_req.updates(0).sid(), "IMSI1");
   EXPECT_EQ(update_req.updates(0).usage().type(), CreditUsage::REAUTH_REQUIRED);
@@ -704,7 +706,7 @@ TEST_F(LocalEnforcerTest, test_re_auth)
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
   create_credit_update_response("IMSI1", 1, 4096, updates->Add());
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 
   // when next update is collected, this should trigger an action to activate
   // the flow in pipelined
@@ -714,8 +716,8 @@ TEST_F(LocalEnforcerTest, test_re_auth)
     .Times(1)
     .WillOnce(testing::Return(true));
   actions.clear();
-  local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
 }
 
 TEST_F(LocalEnforcerTest, test_dynamic_rules)
@@ -728,7 +730,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules)
   policy_rule->set_id("rule1");
   policy_rule->set_rating_group(1);
   policy_rule->set_tracking_type(PolicyRule::ONLY_OCS);
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   insert_static_rule(1, "", "rule2");
   RuleRecordTable table;
@@ -736,12 +738,12 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules)
   create_rule_record("IMSI1", "rule1", 16, 32, record_list->Add());
   create_rule_record("IMSI1", "rule2", 8, 8, record_list->Add());
 
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_RX), 24);
-  EXPECT_EQ(local_enforcer->get_charging_credit("IMSI1", 1, USED_TX), 40);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX), 24);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX), 40);
   EXPECT_EQ(
-    local_enforcer->get_charging_credit("IMSI1", 1, ALLOWED_TOTAL), 1024);
+    local_enforcer->get_charging_credit(session_map, "IMSI1", 1, ALLOWED_TOTAL), 1024);
 }
 
 TEST_F(LocalEnforcerTest, test_dynamic_rule_actions)
@@ -763,13 +765,13 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions)
       testing::_, testing::_, CheckCount(0), CheckCount(1)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
   create_rule_record("IMSI1", "rule2", 1024, 2048, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   EXPECT_CALL(
     *pipelined_client,
@@ -777,8 +779,8 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions)
     .Times(1)
     .WillOnce(testing::Return(true));
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto usage_updates = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto usage_updates = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
 }
 
 TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time)
@@ -856,7 +858,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time)
       testing::_, testing::_, CheckCount(0), CheckCount(1)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 }
 
 TEST_F(LocalEnforcerTest, test_usage_monitors)
@@ -892,7 +894,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
     MonitoringLevel::SESSION_LEVEL,
     2128,
     response.mutable_usage_monitors()->Add());
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
   assert_charging_credit("IMSI1", ALLOWED_TOTAL, {{1, 1024}, {2, 1024}});
   assert_monitor_credit(
     "IMSI1", ALLOWED_TOTAL, {{"1", 1024}, {"3", 2048}, {"4", 2128}});
@@ -904,7 +906,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
   create_rule_record("IMSI1", "ocs_rule", 5, 15, record_list->Add());
   create_rule_record("IMSI1", "pcrf_only", 1024, 1024, record_list->Add());
   create_rule_record("IMSI1", "pcrf_split", 10, 20, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   assert_charging_credit("IMSI1", USED_RX, {{1, 10}, {2, 5}});
   assert_charging_credit("IMSI1", USED_TX, {{1, 20}, {2, 15}});
@@ -915,8 +917,8 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
 
   // Collect updates, should only have mkeys 3 and 4
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto session_update = local_enforcer->collect_updates(actions);
-  local_enforcer->execute_actions(actions);
+  auto session_update = local_enforcer->collect_updates(session_map, actions);
+  local_enforcer->execute_actions(session_map, actions);
   EXPECT_EQ(session_update.usage_monitors_size(), 2);
   for (const auto &monitor : session_update.usage_monitors()) {
     EXPECT_EQ(monitor.sid(), "IMSI1");
@@ -950,7 +952,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
     monitor_updates->Add());
   create_monitor_update_response(
     "IMSI1", "4", MonitoringLevel::SESSION_LEVEL, 2048, monitor_updates->Add());
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
   assert_monitor_credit("IMSI1", REPORTING_RX, {{"3", 0}, {"4", 0}});
   assert_monitor_credit("IMSI1", REPORTING_TX, {{"3", 0}, {"4", 0}});
   assert_monitor_credit("IMSI1", REPORTED_RX, {{"3", 1024}, {"4", 1049}});
@@ -975,7 +977,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
       std::vector<std::string>{"pcrf_only"}, CheckCount(0)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 
   // Test rule installation in usage monitor response for CCA-Update
   update_response.Clear();
@@ -1000,7 +1002,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors)
       std::vector<std::string>{"pcrf_only"}, CheckCount(0)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 }
 
 TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer)
@@ -1016,7 +1018,7 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer)
 
   CreateSessionResponse response;
   local_enforcer->init_session_credit(
-    "IMSI1", "1234", test_volte_cfg, response);
+    session_map, "IMSI1", "1234", test_volte_cfg, response);
 
   PolicyReAuthRequest rar;
   std::vector<std::string> rules_to_remove;
@@ -1044,7 +1046,7 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer)
   .WillOnce(testing::Return(true));
 
   PolicyReAuthAnswer raa;
-  local_enforcer->init_policy_reauth(rar, raa);
+  local_enforcer->init_policy_reauth(session_map, rar, raa);
   EXPECT_EQ(raa.result(), ReAuthResult::UPDATE_INITIATED);
 }
 
@@ -1068,14 +1070,14 @@ TEST_F(LocalEnforcerTest, test_rar_session_not_found)
     usage_monitoring_credits,
     &rar);
   PolicyReAuthAnswer raa;
-  local_enforcer->init_policy_reauth(rar, raa);
+  local_enforcer->init_policy_reauth(session_map, rar, raa);
   EXPECT_EQ(raa.result(), ReAuthResult::SESSION_NOT_FOUND);
 
   // verify session validity passing in a valid IMSI (IMSI1)
   // and an invalid session-id (session1)
   CreateSessionResponse response;
-  local_enforcer->init_session_credit("IMSI1", "session0", test_cfg, response);
-  local_enforcer->init_policy_reauth(rar, raa);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "session0", test_cfg, response);
+  local_enforcer->init_policy_reauth(session_map, rar, raa);
   EXPECT_EQ(raa.result(), ReAuthResult::SESSION_NOT_FOUND);
 }
 
@@ -1085,13 +1087,13 @@ TEST_F(LocalEnforcerTest, test_rar_revalidation_timer)
   CreateSessionResponse response;
   create_credit_update_response(
     "IMSI1", 1, 3072, response.mutable_credits()->Add());
-  local_enforcer->init_session_credit("IMSI1", "session1", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "session1", test_cfg, response);
   insert_static_rule(1, "", "rule1");
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
-  local_enforcer->aggregate_records(table);
+  local_enforcer->aggregate_records(session_map, table);
 
   // only RAR with REVALIDATION_TIMEOUT as one of the event triggers
   // will initiate an update
@@ -1114,11 +1116,11 @@ TEST_F(LocalEnforcerTest, test_rar_revalidation_timer)
     usage_monitoring_credits,
     &rar);
   PolicyReAuthAnswer raa;
-  local_enforcer->init_policy_reauth(rar, raa);
+  local_enforcer->init_policy_reauth(session_map, rar, raa);
   EXPECT_EQ(raa.result(), ReAuthResult::UPDATE_INITIATED);
 
   rar.add_event_triggers(EventTrigger::REVALIDATION_TIMEOUT);
-  local_enforcer->init_policy_reauth(rar, raa);
+  local_enforcer->init_policy_reauth(session_map, rar, raa);
   EXPECT_EQ(raa.result(), ReAuthResult::UPDATE_INITIATED);
 }
 
@@ -1145,7 +1147,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup)
   test_cwf_cfg1.radius_session_id = "5555";
   test_cwf_cfg1.apn = "01-a1-20-c2-0f-bb:CWC_OFFLOAD";
   test_cwf_cfg1.msisdn = "msisdn1";
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg1, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg1, response);
 
   CreateSessionResponse response2;
   create_credit_update_response(
@@ -1162,7 +1164,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup)
   test_cwf_cfg2.radius_session_id = "5555";
   test_cwf_cfg2.apn = "03-21-00-02-00-20:Magma";
   test_cwf_cfg2.msisdn = "msisdn2";
-  local_enforcer->init_session_credit("IMSI2", "12345", test_cwf_cfg2, response2);
+  local_enforcer->init_session_credit(session_map, "IMSI2", "12345", test_cwf_cfg2, response2);
 
   std::vector<std::string> imsi_list = {"IMSI2", "IMSI1"};
   std::vector<std::string> ip_address_list = {"127.0.0.1", "127.0.0.1"};
@@ -1184,7 +1186,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup)
     .Times(1)
     .WillOnce(testing::Return(true));
 
-    local_enforcer->setup(epoch,
+    local_enforcer->setup(session_map, epoch,
       [](Status status, SetupFlowsResult resp) {});
 }
 
@@ -1204,7 +1206,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup)
   policy_rule->set_tracking_type(PolicyRule::ONLY_OCS);
   auto static_rule = response.mutable_static_rules()->Add();
   static_rule->set_rule_id("rule2");
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg, response);
 
   CreateSessionResponse response2;
   create_credit_update_response(
@@ -1214,7 +1216,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup)
   policy_rule2->set_id("rule22");
   policy_rule2->set_rating_group(1);
   policy_rule2->set_tracking_type(PolicyRule::ONLY_OCS);
-  local_enforcer->init_session_credit("IMSI2", "12345", test_cfg, response2);
+  local_enforcer->init_session_credit(session_map, "IMSI2", "12345", test_cfg, response2);
 
   std::vector<std::string> imsi_list = {"IMSI2", "IMSI1"};
   std::vector<std::string> ip_address_list = {"127.0.0.1", "127.0.0.1"};
@@ -1235,7 +1237,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup)
     .Times(1)
     .WillOnce(testing::Return(true));
 
-    local_enforcer->setup(epoch,
+    local_enforcer->setup(session_map, epoch,
       [](Status status, SetupFlowsResult resp) {});
 }
 
@@ -1261,7 +1263,7 @@ TEST_F(LocalEnforcerTest, test_valid_apn_parsing)
   test_cwf_cfg.apn = "03-21-00-02-00-20:Magma";
   test_cwf_cfg.msisdn = "msisdn";
 
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 }
 
 TEST_F(LocalEnforcerTest, test_invalid_apn_parsing)
@@ -1288,7 +1290,7 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing)
   test_cwf_cfg.apn = "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay";
   test_cwf_cfg.msisdn = "msisdn_test";
 
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota)
@@ -1308,7 +1310,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota)
     update_subscriber_quota_state(CheckQuotaUpdateState(1, expected_states)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota)
@@ -1333,7 +1335,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota)
     update_subscriber_quota_state(CheckQuotaUpdateState(1, expected_states)))
     .Times(1)
     .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update)
@@ -1347,7 +1349,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update)
   test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
   CreateSessionResponse response;
   create_cwf_session_create_response("IMSI1", "m1", static_rules, &response);
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 
   // remove only static_2, should not change anything in terms of quota since
   // static_1 is still active
@@ -1361,7 +1363,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update)
     2048,
     monitor);
   monitor->add_rules_to_remove("static_2");
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 
 
   // send an update response with rule removals for "static_1" to indicate
@@ -1384,7 +1386,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update)
     .Times(1)
     .WillOnce(testing::Return(true));
 
-  local_enforcer->update_session_credits_and_rules(update_response);
+  local_enforcer->update_session_credits_and_rules(session_map, update_response);
 }
 
 TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar)
@@ -1397,7 +1399,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar)
   test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
   CreateSessionResponse response;
   create_cwf_session_create_response("IMSI1", "m1", static_rules, &response);
-  local_enforcer->init_session_credit("IMSI1", "1234", test_cwf_cfg, response);
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cwf_cfg, response);
 
   // send a policy reauth request with rule removals for "static_1" to indicate
   // total monitoring quota exhaustion
@@ -1415,7 +1417,7 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar)
     .WillOnce(testing::Return(true));
 
   PolicyReAuthAnswer answer;
-  local_enforcer->init_policy_reauth(request, answer);
+  local_enforcer->init_policy_reauth(session_map, request, answer);
 }
 
 int main(int argc, char **argv)

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -19,6 +19,7 @@
 #include "RuleStore.h"
 #include "ServiceRegistrySingleton.h"
 #include "SessiondMocks.h"
+#include "SessionStore.h"
 #include "magma_logging.h"
 
 
@@ -49,8 +50,9 @@ class SessionManagerHandlerTest : public ::testing::Test {
                 0);
         evb = folly::EventBaseManager::get()->getEventBase();
         local_enforcer->attachEventBase(evb);
-        session_manager = std::make_shared<LocalSessionManagerHandlerImpl>(
-                local_enforcer, reporter.get(), directoryd_client);
+      session_map = SessionMap{};
+      session_manager = std::make_shared<LocalSessionManagerHandlerImpl>(
+                local_enforcer, reporter.get(), directoryd_client, session_map);
     }
 
   protected:
@@ -59,6 +61,7 @@ class SessionManagerHandlerTest : public ::testing::Test {
     std::shared_ptr <LocalEnforcer> local_enforcer;
     SessionIDGenerator id_gen_;
     folly::EventBase *evb;
+    SessionMap session_map;
 };
 
 TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
@@ -84,7 +87,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
             .hardware_addr = hardware_addr_bytes,
             .radius_session_id = radius_session_id};
 
-    local_enforcer->init_session_credit(imsi, sid, cfg, response);
+    local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
 
     grpc::ServerContext create_context;
     request.mutable_sid()->set_id("IMSI1");

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -65,17 +65,18 @@ class SessiondTest : public ::testing::Test {
       nullptr,
       SESSION_TERMINATION_TIMEOUT_MS,
       0);
+    session_map = SessionMap{};
 
     local_service =
       std::make_shared<service303::MagmaService>("sessiond", "1.0");
     session_manager = std::make_shared<LocalSessionManagerAsyncService>(
       local_service->GetNewCompletionQueue(),
       std::make_unique<LocalSessionManagerHandlerImpl>(
-        monitor, reporter.get(), directoryd_client));
+        monitor, reporter.get(), directoryd_client, session_map));
 
     proxy_responder = std::make_shared<SessionProxyResponderAsyncService>(
       local_service->GetNewCompletionQueue(),
-      std::make_unique<SessionProxyResponderHandlerImpl>(monitor));
+      std::make_unique<SessionProxyResponderHandlerImpl>(monitor, session_map));
 
     local_service->AddServiceToServer(session_manager.get());
     local_service->AddServiceToServer(proxy_responder.get());
@@ -158,6 +159,7 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<AsyncDirectorydClient> directoryd_client;
   std::shared_ptr<AsyncEventdClient> eventd_client;
   std::shared_ptr<AsyncSpgwServiceClient> spgw_client;
+  SessionMap session_map;
 };
 
 MATCHER_P(CheckCreateSession, imsi, "")


### PR DESCRIPTION
Summary:
This large revision is a refactor as a stepping stone towards the `LocalEnforcer` using the storage interface, `SessionStore`, rather than its privately held `session_map_` field. For now, the `session_map` will be passed around as a reference, and owned by the service as a whole, rather than just the `LocalEnforcer`. No functional difference is created with this diff.

Afterwards, it is intended that the two handlers will only be responsible for receiving incoming gRPC requests, and handing them off to `LocalEnforcer`, which will make reads from the `SessionStore`, and then make updates as necessary back to the `SessionStore` interface. Under this new model, concurrently handled gRPC requests will be handled with two separate `SessionMap` structs that are passed around, one for each gRPC request. Though they may be out of sync with each other, potential issues are resolved at the `SessionStore` level, as `SessionStateUpdateCriteria` is checked for validity before updating storage. If an update is invalid, then the gRPC request is deemed to be out of date, and should fail.

## Changes
- `LocalEnforcer` no longer owns a `SessionMap` field
- `SessionMap` is owned by the main thread and references are passed around
- `LocalSessionManagerHandler` and `SessionProxyResponderHandler` both own references to the `SessionMap`
- Updates to unit tests to reflect these changes

Reviewed By: themarwhal

Differential Revision: D20437075

