### PR TITLE
Removing PGW app entry from OAI logging config

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -551,10 +551,6 @@ void log_configure(const log_config_t *const config)
     (MIN_LOG_LEVEL <= config->spgw_app_log_level))
     g_oai_log.log_level[LOG_SPGW_APP] = config->spgw_app_log_level;
   if (
-    (MAX_LOG_LEVEL > config->pgw_app_log_level) &&
-    (MIN_LOG_LEVEL <= config->pgw_app_log_level))
-    g_oai_log.log_level[LOG_PGW_APP] = config->pgw_app_log_level;
-  if (
     (MAX_LOG_LEVEL > config->s11_log_level) &&
     (MIN_LOG_LEVEL <= config->s11_log_level))
     g_oai_log.log_level[LOG_S11] = config->s11_log_level;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -144,7 +144,6 @@ void log_config_init(log_config_t *log_conf)
   log_conf->util_log_level = MAX_LOG_LEVEL;
   log_conf->itti_log_level = MAX_LOG_LEVEL;
   log_conf->spgw_app_log_level = MAX_LOG_LEVEL;
-  log_conf->pgw_app_log_level = MAX_LOG_LEVEL;
   log_conf->asn1_verbosity_level = 0;
 }
 
@@ -442,11 +441,6 @@ int mme_config_parse_file(mme_config_t *config_pP)
         config_pP->log_config.spgw_app_log_level =
           OAILOG_LEVEL_STR2INT(astring);
 
-      if (config_setting_lookup_string(
-            setting,
-            LOG_CONFIG_STRING_PGW_APP_LOG_LEVEL,
-            (const char **) &astring))
-        config_pP->log_config.pgw_app_log_level = OAILOG_LEVEL_STR2INT(astring);
 #else
       if (config_setting_lookup_string(
             setting,
@@ -1541,10 +1535,6 @@ void mme_config_display(mme_config_t *config_pP)
     LOG_CONFIG,
     "    SPGW_APP log level....: %s\n",
     OAILOG_LEVEL_INT2STR(config_pP->log_config.spgw_app_log_level));
-  OAILOG_INFO(
-    LOG_CONFIG,
-    "    PGW_APP log level....: %s\n",
-    OAILOG_LEVEL_INT2STR(config_pP->log_config.pgw_app_log_level));
   OAILOG_INFO(
     LOG_CONFIG,
     "    S11 log level........: %s\n",

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -215,7 +215,6 @@ MME :
         SCTP_LOG_LEVEL     = "ERROR";
         GTPV1U_LOG_LEVEL   = "{{ oai_log_level }}";
         SPGW_APP_LOG_LEVEL = "{{ oai_log_level }}";
-        PGW_APP_LOG_LEVEL  = "{{ oai_log_level }}";
         UDP_LOG_LEVEL      = "{{ oai_log_level }}";
         S1AP_LOG_LEVEL     = "{{ oai_log_level }}";
         NAS_LOG_LEVEL      = "{{ oai_log_level }}";


### PR DESCRIPTION
Summary: - With PGW app being merged into SPGW task, we can clean up log config entry on mme_config for PGW.

Differential Revision: D20746160

