### PR TITLE
Reduce Usage/Quota logging

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -43,7 +43,9 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
   std::function<void(Status, Void)> response_callback)
 {
   auto &request_cpy = *request;
-  MLOG(MDEBUG) << "Aggregating " << request_cpy.records_size() << " records";
+  if (request_cpy.records_size() > 0) {
+    MLOG(MDEBUG) << "Aggregating " << request_cpy.records_size() << " records";
+  }
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     enforcer_->aggregate_records(session_map_, request_cpy);
     check_usage_for_reporting();

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -143,8 +143,8 @@ void SessionCredit::add_used_credit(uint64_t used_tx, uint64_t used_rx, SessionC
   uc.bucket_deltas[USED_TX] += used_tx;
   uc.bucket_deltas[USED_RX] += used_rx;
 
+  log_quota_and_usage();
   if (should_deactivate_service()) {
-    MLOG(MDEBUG) << "Quota exhausted. Deactivating service";
     service_state_ = SERVICE_NEEDS_DEACTIVATION;
     uc.service_state = SERVICE_NEEDS_DEACTIVATION;
   }
@@ -200,17 +200,10 @@ void SessionCredit::receive_credit(
   update_criteria.bucket_deltas[ALLOWED_TOTAL] += total_volume;
   update_criteria.bucket_deltas[ALLOWED_TX] += tx_volume;
   update_criteria.bucket_deltas[ALLOWED_RX] += rx_volume;
-  MLOG(MDEBUG) << "Total amount received since start of session is "
-               << " total=" << buckets_[ALLOWED_TOTAL]
-               << " tx=" << buckets_[ALLOWED_TX]
-               << " rx=" << buckets_[ALLOWED_RX];
+
   // transfer reporting usage to reported
   buckets_[REPORTED_RX] += buckets_[REPORTING_RX];
   buckets_[REPORTED_TX] += buckets_[REPORTING_TX];
-  MLOG(MDEBUG) << "Total amount reported since start of session is "
-               << " total=" << buckets_[REPORTED_RX] + buckets_[REPORTED_TX]
-               << " rx=" << buckets_[REPORTED_RX]
-               << " tx=" << buckets_[REPORTED_TX];
 
   // Set the usage_reporting_limit so that we never report more than grant
   // we've received.
@@ -221,7 +214,7 @@ void SessionCredit::receive_credit(
     usage_reporting_limit_ = buckets_[ALLOWED_TOTAL] - reported_sum;
   } else if (usage_reporting_limit_ != 0) {
     MLOG(MINFO) << "We have reported data usage for all credit received, the "
-                 << "upper limit for reporting is now 0.";
+                 << "upper limit for reporting is now 0";
     usage_reporting_limit_ = 0;
     update_criteria.usage_reporting_limit = usage_reporting_limit_;
   }
@@ -241,6 +234,20 @@ void SessionCredit::receive_credit(
     MLOG(MDEBUG) << "Quota available. Activating service";
     service_state_ = SERVICE_NEEDS_ACTIVATION;
   }
+  log_quota_and_usage();
+}
+
+void SessionCredit::log_quota_and_usage() {
+   auto reported_sum = buckets_[REPORTED_TX] + buckets_[REPORTED_RX];
+   MLOG(MDEBUG) << "===> Used     Tx: " << buckets_[USED_TX]
+               << " Rx: " << buckets_[USED_RX]
+               << " Total: " << buckets_[USED_TX] + buckets_[USED_RX];
+   MLOG(MDEBUG) << "===> Allowed  Tx:  " << buckets_[ALLOWED_TX]
+               << " Rx: " << buckets_[ALLOWED_RX]
+               << " Total: " << buckets_[ALLOWED_TOTAL];
+   MLOG(MDEBUG) << "===> Reported Tx: " << buckets_[REPORTED_TX]
+               << " Rx: " << buckets_[REPORTED_RX]
+               << " Total: " << buckets_[REPORTED_RX] + buckets_[REPORTED_TX];
 }
 
 bool SessionCredit::is_quota_exhausted(
@@ -277,11 +284,6 @@ bool SessionCredit::is_quota_exhausted(
                            (buckets_[ALLOWED_RX] - buckets_[REPORTED_RX]) *
                              usage_reporting_threshold);
 
-   MLOG(MDEBUG) << " Is Quota exhausted?"
-               << "\n Total used: " << buckets_[USED_TX] + buckets_[USED_RX]
-               << "\n Allowed total: " << buckets_[ALLOWED_TOTAL]
-               << "\n Reported total: " << total_reported_usage;
-
   bool is_exhausted = false;
   if (total_usage_since_report >= total_usage_reporting_threshold) {
     is_exhausted = true;
@@ -295,7 +297,7 @@ bool SessionCredit::is_quota_exhausted(
     is_exhausted = true;
   }
   if (is_exhausted) {
-    MLOG(MDEBUG) << " YES Quota exhausted ";
+    MLOG(MDEBUG) << " Quota exhausted ";
   }
   return is_exhausted;
 }
@@ -315,6 +317,8 @@ bool SessionCredit::should_deactivate_service()
   }
   if (is_final_grant_ && is_quota_exhausted()) {
     // If we've exhausted the last grant, we should terminate
+    MLOG(MINFO) << "Terminating service because we have exhausted the given "
+                << "quota and it is the final grant";
     return true;
   }
   if (is_quota_exhausted(1, SessionCredit::EXTRA_QUOTA_MARGIN)) {

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -258,6 +258,8 @@ class SessionCredit {
   bool is_quota_exhausted(
     float usage_reporting_threshold = 1, uint64_t extra_quota_margin = 0);
 
+  void log_quota_and_usage();
+
   bool should_deactivate_service();
 
   bool validity_timer_expired();

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -56,7 +56,6 @@ bool do_loop(
     return false;
   }
   processor(rules);
-  MLOG(MDEBUG) << rules.size() << " rules synced";
   return true;
 }
 


### PR DESCRIPTION
Summary:
* Reducing the number of times we print usage/quota
* Remove redundant information
* Log all tx/rx/total

Roughly the same code path from running the integration test

## Before
```
I0331 02:20:29.452762     1 SessionState.cpp:175] Updating used monitoring credit for Rule=static-pass-all-ocs1 Monitoring Key=mkey-ocs
I0331 02:20:29.452788     1 SessionState.cpp:168] Updating used charging credit for Rule=static-pass-all-ocs2 Rating Group=1 Service Identifier=0
I0331 02:20:29.452800     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 0
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:29.452805     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 0
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:29.452828     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 0
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:29.452833     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 0
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:29.452838     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 0
 Allowed total: 102400
 Reported total: 0
I0331 02:20:30.451344     6 PolicyLoader.cpp:59] 2 rules synced
I0331 02:20:30.453472    19 LocalSessionManagerHandler.cpp:46] Aggregating 2 records
I0331 02:20:30.453629     1 SessionState.cpp:175] Updating used monitoring credit for Rule=static-pass-all-ocs1 Monitoring Key=mkey-ocs
I0331 02:20:30.453653     1 LocalEnforcer.cpp:205] Subscriber IMSI946374708316738 used 74 tx bytes and 60 rx bytes for rule static-pass-all-ocs2
I0331 02:20:30.453661     1 SessionState.cpp:168] Updating used charging credit for Rule=static-pass-all-ocs2 Rating Group=1 Service Identifier=0
I0331 02:20:30.453670     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 134
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:30.453673     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 134
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:30.453697     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 134
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:30.453702     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 134
 Allowed total: 5242880
 Reported total: 0
I0331 02:20:30.453707     1 SessionCredit.cpp:280]  Is Quota exhausted?
 Total used: 0
 Allowed total: 102400
 Reported total: 0
```
## After

```
I0331 02:20:29.452788     1 SessionState.cpp:168] Updating used charging credit for Rule=static-pass-all-ocs2 Rating Group=1 Service Identifier=0
I0331 02:13:56.054370     1 SessionCredit.cpp:242] ===> Used Tx: 0 Rx: 0 Total: 0
I0331 02:13:56.054448     1 SessionCredit.cpp:245] ===> Allowed Tx: 0 Rx: 0 Total: 5242880
I0331 02:13:56.054522     1 SessionCredit.cpp:248] ===> Reported Tx: 0 Rx: 0 Total: 0
I0331 02:13:56.054728     1 SessionState.cpp:175] Updating used monitoring credit for Rule=static-pass-all-ocs1 Monitoring Key=mkey-ocs
I0331 02:13:56.054993     1 SessionCredit.cpp:242] ===> Used Tx: 0 Rx: 0 Total: 0
I0331 02:13:56.055733     1 SessionCredit.cpp:245] ===> Allowed Tx: 0 Rx: 0 Total: 10240
I0331 02:13:56.055918     1 SessionCredit.cpp:248] ===> Reported Tx: 0 Rx: 0 Total: 0
I0331 02:13:57.057580    19 LocalSessionManagerHandler.cpp:46] Aggregating 2 records
I0331 02:13:57.057714     1 LocalEnforcer.cpp:205] Subscriber IMSI161688146749619 used 807 tx bytes and 434 rx bytes for rule static-pass-all-ocs2
I0331 02:13:57.057747     1 SessionState.cpp:168] Updating used charging credit for Rule=static-pass-all-ocs2 Rating Group=1 Service Identifier=0
I0331 02:13:57.057768     1 SessionCredit.cpp:242] ===> Used Tx: 807 Rx: 434 Total: 1241
I0331 02:13:57.057781     1 SessionCredit.cpp:245] ===> Allowed Tx: 0 Rx: 0 Total: 5242880
I0331 02:13:57.057799     1 SessionCredit.cpp:248] ===> Reported Tx: 0 Rx: 0 Total: 0
I0331 02:13:57.057816     1 SessionState.cpp:175] Updating used monitoring credit for Rule=static-pass-all-ocs1 Monitoring Key=mkey-ocs
I0331 02:13:57.057832     1 SessionCredit.cpp:242] ===> Used Tx: 0 Rx: 0 Total: 0
I0331 02:13:57.057888     1 SessionCredit.cpp:245] ===> Allowed Tx: 0 Rx: 0 Total: 10240
I0331 02:13:57.057960     1 SessionCredit.cpp:248] ===> Reported Tx: 0 Rx: 0 Total: 0
```

Differential Revision: D20757651

