### PR TITLE
Add UE identifier to OAI logging

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -551,10 +551,6 @@ void log_configure(const log_config_t *const config)
     (MIN_LOG_LEVEL <= config->spgw_app_log_level))
     g_oai_log.log_level[LOG_SPGW_APP] = config->spgw_app_log_level;
   if (
-    (MAX_LOG_LEVEL > config->pgw_app_log_level) &&
-    (MIN_LOG_LEVEL <= config->pgw_app_log_level))
-    g_oai_log.log_level[LOG_PGW_APP] = config->pgw_app_log_level;
-  if (
     (MAX_LOG_LEVEL > config->s11_log_level) &&
     (MIN_LOG_LEVEL <= config->s11_log_level))
     g_oai_log.log_level[LOG_S11] = config->s11_log_level;
@@ -740,10 +736,6 @@ int log_init(
     &g_oai_log.log_proto2str[LOG_SPGW_APP][0],
     LOG_MAX_PROTO_NAME_LENGTH,
     "SPGW-APP");
-  snprintf(
-    &g_oai_log.log_proto2str[LOG_PGW_APP][0],
-    LOG_MAX_PROTO_NAME_LENGTH,
-    "PGW-APP");
   snprintf(
     &g_oai_log.log_proto2str[LOG_S11][0], LOG_MAX_PROTO_NAME_LENGTH, "S11");
   snprintf(

--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -87,6 +87,11 @@
 #define LOG_FUNC_INDENT_SPACES 3
 #define LOG_LEVEL_NAME_MAX_LENGTH 10
 
+#define LOG_CTXT_INFO_FMT                                                      \
+  "%06" PRIu64 " %s %08lX %-*.*s %-*.*s %-*.*s:%04u   %*s"
+#define LOG_CTXT_INFO_ID_FMT                                                   \
+  "%06" PRIu64 " %s %08lX %-*.*s %-*.*s %-*.*s:%04u   [%lu]%*s"
+
 #define LOG_MAGMA_REPO_ROOT "/oai/"
 //-------------------------------
 
@@ -169,15 +174,6 @@ typedef struct oai_log_s {
 static oai_log_t g_oai_log = {
   0}; /*!< \brief  logging utility internal variables global var definition*/
 
-void log_message_int(
-  log_thread_ctxt_t *const thread_ctxtP,
-  const log_level_t log_levelP,
-  const log_proto_t protoP,
-  void **contextP, // Out parameter
-  const char *const source_fileP,
-  const unsigned int line_numP,
-  const char *format,
-  va_list args);
 static void log_connect_to_server(void);
 static void log_message_finish_sync(log_queue_item_t *messageP);
 
@@ -1539,6 +1535,41 @@ void log_message(
   }
 }
 
+void log_message_prefix_id(
+  const log_level_t log_levelP,
+  const log_proto_t protoP,
+  const char* const source_fileP,
+  const unsigned int line_numP,
+  uint64_t prefix_id,
+  char* format, ...) {
+  va_list args;
+  void* new_item_p                                 = NULL;
+  log_queue_item_t* new_item_p_sync                = NULL;
+  struct shared_log_queue_item_s* new_item_p_async = NULL;
+
+  va_start(args, format);
+  log_message_int_prefix_id(log_levelP, protoP, &new_item_p,
+      source_fileP, line_numP, prefix_id, format, args);
+  va_end(args);
+
+  if (new_item_p == NULL) {
+    return;
+  }
+  if (g_oai_log.is_async) {
+    new_item_p_async = (struct shared_log_queue_item_s*) new_item_p;
+    if (g_oai_log.is_ansi_codes) {
+      bformata(new_item_p_async->bstr, "%s", ANSI_COLOR_RESET);
+    }
+    _LOG_ASYNC(new_item_p_async);
+  } else {
+    new_item_p_sync = (log_queue_item_t*) new_item_p;
+    if (g_oai_log.is_ansi_codes) {
+      bformata(new_item_p_sync->bstr, "%s", ANSI_COLOR_RESET);
+    }
+    _LOG(new_item_p_sync);
+  }
+}
+
 void log_message_int(
   log_thread_ctxt_t *const thread_ctxtP,
   const log_level_t log_levelP,
@@ -1574,24 +1605,9 @@ void log_message_int(
     MIN((strlen(short_source_fileP) - LOG_DISPLAYED_FILENAME_MAX_LENGTH), (0));
   if (!(g_oai_log.is_async)) {
     sync_context_p = (log_queue_item_t **) contextP;
-    rv = bformata(
-      (*sync_context_p)->bstr,
-      "%06" PRIu64 " %s %08lX %-*.*s %-*.*s %-*.*s:%04u   %*s",
-      __sync_fetch_and_add(&g_oai_log.log_message_number, 1),
-      log_get_readable_cur_time(&cur_time),
-      thread_ctxt->tid,
-      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
-      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
-      &g_oai_log.log_level2str[log_levelP][0],
-      LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
-      LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
-      &g_oai_log.log_proto2str[protoP][0],
-      LOG_DISPLAYED_FILENAME_MAX_LENGTH,
-      LOG_DISPLAYED_FILENAME_MAX_LENGTH,
-      &short_source_fileP[filename_length],
-      line_numP,
-      thread_ctxt->indent,
-      " ");
+    rv = append_log_ctx_info(
+        (*sync_context_p)->bstr, &log_levelP, &protoP, line_numP,
+        filename_length, thread_ctxt, &cur_time, short_source_fileP);
     if (BSTR_ERR == rv) {
       OAI_FPRINTF_ERR(
         "Error while logging LOG message : %s",
@@ -1608,24 +1624,9 @@ void log_message_int(
     }
   } else {
     async_context_p = (shared_log_queue_item_t **) contextP;
-    rv = bformata(
-      (*async_context_p)->bstr,
-      "%06" PRIu64 " %s %08lX %-*.*s %-*.*s %-*.*s:%04u   %*s",
-      __sync_fetch_and_add(&g_oai_log.log_message_number, 1),
-      log_get_readable_cur_time(&cur_time),
-      thread_ctxt->tid,
-      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
-      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
-      &g_oai_log.log_level2str[log_levelP][0],
-      LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
-      LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
-      &g_oai_log.log_proto2str[protoP][0],
-      LOG_DISPLAYED_FILENAME_MAX_LENGTH,
-      LOG_DISPLAYED_FILENAME_MAX_LENGTH,
-      &short_source_fileP[filename_length],
-      line_numP,
-      thread_ctxt->indent,
-      " ");
+    rv = append_log_ctx_info(
+        (*async_context_p)->bstr, &log_levelP, &protoP, line_numP,
+        filename_length, thread_ctxt, &cur_time, short_source_fileP);
     if (BSTR_ERR == rv) {
       OAI_FPRINTF_ERR(
         "Error while logging LOG message : %s",
@@ -1650,6 +1651,134 @@ error_event:
   } else {
     _LOG_FREE_ITEM_ASYNC(*async_context_p);
   }
+}
+
+void log_message_int_prefix_id(
+    const log_level_t log_levelP,
+    const log_proto_t protoP,
+    void **contextP, // Out parameter
+    const char *const source_fileP,
+    const unsigned int line_numP,
+    const uint64_t prefix_id,
+    const char *format,
+    va_list args)
+{
+  int rv = 0;
+  size_t filename_length = 0;
+  log_thread_ctxt_t *thread_ctxt = NULL;
+  log_queue_item_t **sync_context_p = NULL;
+  shared_log_queue_item_t **async_context_p = NULL;
+  if (!log_is_enabled(log_levelP, protoP)) {
+    return;
+  }
+  get_thread_context(&thread_ctxt);
+
+  assert(thread_ctxt != NULL);
+  *contextP = _LOG_GET_ITEM();
+  time_t cur_time;
+
+  // get the short file name to use for printing in log
+  const char *const short_source_fileP = get_short_file_name(source_fileP);
+
+  filename_length =
+      MIN((strlen(short_source_fileP) - LOG_DISPLAYED_FILENAME_MAX_LENGTH), (0));
+  if (!(g_oai_log.is_async)) {
+    sync_context_p = (log_queue_item_t **) contextP;
+    rv = append_log_ctx_info_prefix_id(prefix_id,
+        (*sync_context_p)->bstr, &log_levelP, &protoP, line_numP,
+        filename_length, thread_ctxt, &cur_time, short_source_fileP);
+    if (BSTR_ERR == rv) {
+      OAI_FPRINTF_ERR(
+          "Error while logging LOG message : %s",
+          &g_oai_log.log_proto2str[protoP][0]);
+      goto error_event;
+    }
+    rv = bvcformata((*sync_context_p)->bstr, 4096, format, args); // big number
+    (*sync_context_p)->log_level = g_oai_log.log_level2syslog[log_levelP];
+    if (BSTR_ERR == rv) {
+      OAI_FPRINTF_ERR(
+          "Error while logging LOG message : %s",
+          &g_oai_log.log_proto2str[protoP][0]);
+      goto error_event;
+    }
+  } else {
+    async_context_p = (shared_log_queue_item_t **) contextP;
+    rv = append_log_ctx_info_prefix_id(prefix_id,
+        (*async_context_p)->bstr, &log_levelP, &protoP, line_numP,
+        filename_length, thread_ctxt, &cur_time, short_source_fileP);
+    if (BSTR_ERR == rv) {
+      OAI_FPRINTF_ERR(
+          "Error while logging LOG message : %s",
+          &g_oai_log.log_proto2str[protoP][0]);
+      goto error_event;
+    }
+    rv = bvcformata((*async_context_p)->bstr, 4096, format, args); // big number
+    (*async_context_p)->u_app_log.log.log_level =
+        g_oai_log.log_level2syslog[log_levelP];
+    if (BSTR_ERR == rv) {
+      OAI_FPRINTF_ERR(
+          "Error while logging LOG message : %s",
+          &g_oai_log.log_proto2str[protoP][0]);
+      goto error_event;
+    }
+  }
+  return;
+
+  error_event:
+  if (!(g_oai_log.is_async)) {
+    _LOG_FREE_ITEM(sync_context_p);
+  } else {
+    _LOG_FREE_ITEM_ASYNC(*async_context_p);
+  }
+}
+
+int append_log_ctx_info(
+    bstring bstr,
+    const log_level_t* log_levelP,
+    const log_proto_t* protoP,
+    const unsigned int line_numP,
+    size_t filename_length,
+    const log_thread_ctxt_t* thread_ctxt,
+    time_t* cur_time,
+    const char* short_source_fileP) {
+  int rv;
+  rv = bformata(
+      bstr, LOG_CTXT_INFO_FMT,
+      __sync_fetch_and_add(&g_oai_log.log_message_number, 1),
+      log_get_readable_cur_time(cur_time), thread_ctxt->tid,
+      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
+      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
+      &g_oai_log.log_level2str[(*log_levelP)][0],
+      LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH, LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
+      &g_oai_log.log_proto2str[(*protoP)][0], LOG_DISPLAYED_FILENAME_MAX_LENGTH,
+      LOG_DISPLAYED_FILENAME_MAX_LENGTH, &short_source_fileP[filename_length],
+      line_numP, thread_ctxt->indent, " ");
+  return rv;
+}
+
+int append_log_ctx_info_prefix_id(
+    const uint64_t prefix_id,
+    bstring bstr,
+    const log_level_t* log_levelP,
+    const log_proto_t* protoP,
+    const unsigned int line_numP,
+    size_t filename_length,
+    const log_thread_ctxt_t* thread_ctxt,
+    time_t* cur_time,
+    const char* short_source_fileP) {
+  int rv;
+  rv = bformata(
+      bstr, LOG_CTXT_INFO_ID_FMT,
+      __sync_fetch_and_add(&g_oai_log.log_message_number, 1),
+      log_get_readable_cur_time(cur_time), thread_ctxt->tid,
+      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
+      LOG_DISPLAYED_LOG_LEVEL_NAME_MAX_LENGTH,
+      &g_oai_log.log_level2str[(*log_levelP)][0],
+      LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH, LOG_DISPLAYED_PROTO_NAME_MAX_LENGTH,
+      &g_oai_log.log_proto2str[(*protoP)][0], LOG_DISPLAYED_FILENAME_MAX_LENGTH,
+      LOG_DISPLAYED_FILENAME_MAX_LENGTH, &short_source_fileP[filename_length],
+      line_numP, prefix_id, thread_ctxt->indent, " ");
+  return rv;
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -120,7 +120,6 @@ extern int fd_g_debug_lvl;
 #define LOG_CONFIG_STRING_SECU_LOG_LEVEL "SECU_LOG_LEVEL"
 #define LOG_CONFIG_STRING_SCTP_LOG_LEVEL "SCTP_LOG_LEVEL"
 #define LOG_CONFIG_STRING_SPGW_APP_LOG_LEVEL "SPGW_APP_LOG_LEVEL"
-#define LOG_CONFIG_STRING_PGW_APP_LOG_LEVEL "PGW_APP_LOG_LEVEL"
 #define LOG_CONFIG_STRING_OUTPUT_SYSLOG "SYSLOG"
 #define LOG_CONFIG_STRING_OUTPUT_THREAD_SAFE "THREAD_SAFE"
 #define LOG_CONFIG_STRING_UDP_LOG_LEVEL "UDP_LOG_LEVEL"
@@ -153,7 +152,6 @@ typedef enum {
   LOG_NAS_EMM,
   LOG_NAS_ESM,
   LOG_SPGW_APP,
-  LOG_PGW_APP,
   LOG_S11,
   LOG_S6A,
   LOG_SECU,
@@ -221,8 +219,6 @@ typedef struct log_config_s {
     mme_app_log_level; /*!< \brief MME-APP ITTI task log level starting from OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */
   log_level_t
     spgw_app_log_level; /*!< \brief SP-GW ITTI task log level starting from OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */
-  log_level_t
-    pgw_app_log_level; /*!< \brief PGW ITTI task log level starting from OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */
   log_level_t
     s11_log_level; /*!< \brief S11 ITTI task log level starting from OAILOG_LEVEL_EMERGENCY up to MAX_LOG_LEVEL (no log) */
   log_level_t

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -336,6 +336,47 @@ void log_message(
   const char *format,
   ...) __attribute__((format(printf, 6, 7)));
 
+void log_message_prefix_id(
+    log_level_t log_levelP,
+    log_proto_t protoP,
+    const char* source_fileP,
+    unsigned int line_numP,
+    uint64_t prefix_id,
+    char* format, ...)
+    __attribute__((format(printf, 6, 7)));
+
+void log_message_int(
+    log_thread_ctxt_t *const thread_ctxtP,
+    const log_level_t log_levelP,
+    const log_proto_t protoP,
+    void **contextP, // Out parameter
+    const char *const source_fileP,
+    const unsigned int line_numP,
+    const char *format,
+    va_list args);
+
+void log_message_int_prefix_id(
+    const log_level_t log_levelP,
+    const log_proto_t protoP,
+    void **contextP, // Out parameter
+    const char *const source_fileP,
+    const unsigned int line_numP,
+    const uint64_t prefix_id,
+    const char *format,
+    va_list args);
+
+int append_log_ctx_info(
+    bstring bstr, const log_level_t* log_levelP, const log_proto_t* protoP,
+    const unsigned int line_numP, size_t filename_length,
+    const log_thread_ctxt_t* thread_ctxt, time_t* cur_time,
+    const char* short_source_fileP);
+
+int append_log_ctx_info_prefix_id(
+    const uint64_t prefix_id, bstring bstr, const log_level_t* log_levelP, const log_proto_t* protoP,
+    const unsigned int line_numP, size_t filename_length,
+    const log_thread_ctxt_t* thread_ctxt, time_t* cur_time,
+    const char* short_source_fileP);
+
 const char *const get_short_file_name(
   const char *const source_file_nameP);
 
@@ -427,6 +468,11 @@ const char *const get_short_file_name(
     log_message(                                                               \
       NULL, OAILOG_LEVEL_DEBUG, pRoTo, __FILE__, __LINE__, ##__VA_ARGS__);     \
   } while (0) /*!< \brief debug informations */
+#define OAILOG_DEBUG_UE(pRoTo, ue_id, ...)                                     \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_DEBUG, pRoTo, __FILE__, __LINE__, ue_id, ##__VA_ARGS__);  \
+  } while (0) /*!< \brief debug informations */
 #if TRACE_IS_ON
 #define OAILOG_EXTERNAL(lOgLeVeL, pRoTo, ...)                                  \
   do {                                                                         \
@@ -436,7 +482,12 @@ const char *const get_short_file_name(
   do {                                                                         \
     log_message(                                                               \
       NULL, OAILOG_LEVEL_TRACE, pRoTo, __FILE__, __LINE__, ##__VA_ARGS__);     \
-  } while (0) /*!< \brief most detailled informations, struct dumps */
+  } while (0) /*!< \brief most detailed information, struct dumps */
+#define OAILOG_TRACE_UE(pRoTo, ue_id, ...)                                     \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_TRACE, pRoTo, __FILE__, __LINE__, ue_id, ##__VA_ARGS__);  \
+  } while (0) /*!< \brief most detailed information, struct dumps */
 #define OAILOG_FUNC_IN(pRoTo)                                                  \
   do {                                                                         \
     log_func(true, pRoTo, __FILE__, __LINE__, __FUNCTION__);                   \
@@ -511,4 +562,37 @@ const char *const get_short_file_name(
     fflush(stderr);                                                            \
   } while (0)
 #endif
+
+#define OAILOG_ALERT_UE(pRoTo, ue_id, ...)                                     \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_ALERT, pRoTo, __FILE__, __LINE__, ue_id, ##__VA_ARGS__);  \
+  } while (0) /*!< \brief action must be taken immediately */
+#define OAILOG_CRITICAL_UE(pRoTo, ue_id, ...)                                  \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_CRITICAL, pRoTo, __FILE__, __LINE__, ue_id,               \
+        ##__VA_ARGS__);                                                        \
+  } while (0) /*!< \brief critical conditions */
+#define OAILOG_ERROR_UE(pRoTo, ue_id, ...)                                     \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_ERROR, pRoTo, __FILE__, __LINE__, ue_id, ##__VA_ARGS__);  \
+  } while (0) /*!< \brief error conditions */
+#define OAILOG_WARNING_UE(pRoTo, ue_id, ...)                                   \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_WARNING, pRoTo, __FILE__, __LINE__, ue_id,                \
+        ##__VA_ARGS__);                                                        \
+  } while (0) /*!< \brief warning conditions */
+#define OAILOG_NOTICE_UE(pRoTo, ue_id, ...)                                    \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_NOTICE, pRoTo, __FILE__, __LINE__, ue_id, ##__VA_ARGS__); \
+  } while (0) /*!< \brief normal but significant condition */
+#define OAILOG_INFO_UE(pRoTo, ue_id, ...)                                      \
+  do {                                                                         \
+    log_message_prefix_id(                                                     \
+        OAILOG_LEVEL_INFO, pRoTo, __FILE__, __LINE__, ue_id, ##__VA_ARGS__);   \
+  } while (0) /*!< \brief informational */
 #endif /* FILE_LOG_SEEN */

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -149,7 +149,7 @@ static char _convert_digit_to_char(char digit)
     return digit;
   } else {
     OAILOG_ERROR(
-      LOG_PGW_APP,
+      LOG_SPGW_APP,
       "The input value for digit is not in a valid range: "
       "Session request would likely be rejected on Gx or Gy interface\n");
     return '0';

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -91,8 +91,6 @@ void *mme_app_thread(void *args)
     }
 
     imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
-    OAILOG_DEBUG(
-      LOG_MME_APP, "Received message with imsi: " IMSI_64_FMT, imsi64);
 
     OAILOG_DEBUG(LOG_MME_APP, "Getting mme_nas_state");
     mme_app_desc_p = get_mme_nas_state(false);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_config.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_config.c
@@ -144,7 +144,6 @@ void log_config_init(log_config_t *log_conf)
   log_conf->util_log_level = MAX_LOG_LEVEL;
   log_conf->itti_log_level = MAX_LOG_LEVEL;
   log_conf->spgw_app_log_level = MAX_LOG_LEVEL;
-  log_conf->pgw_app_log_level = MAX_LOG_LEVEL;
   log_conf->asn1_verbosity_level = 0;
 }
 
@@ -442,11 +441,6 @@ int mme_config_parse_file(mme_config_t *config_pP)
         config_pP->log_config.spgw_app_log_level =
           OAILOG_LEVEL_STR2INT(astring);
 
-      if (config_setting_lookup_string(
-            setting,
-            LOG_CONFIG_STRING_PGW_APP_LOG_LEVEL,
-            (const char **) &astring))
-        config_pP->log_config.pgw_app_log_level = OAILOG_LEVEL_STR2INT(astring);
 #else
       if (config_setting_lookup_string(
             setting,
@@ -1541,10 +1535,6 @@ void mme_config_display(mme_config_t *config_pP)
     LOG_CONFIG,
     "    SPGW_APP log level....: %s\n",
     OAILOG_LEVEL_INT2STR(config_pP->log_config.spgw_app_log_level));
-  OAILOG_INFO(
-    LOG_CONFIG,
-    "    PGW_APP log level....: %s\n",
-    OAILOG_LEVEL_INT2STR(config_pP->log_config.pgw_app_log_level));
   OAILOG_INFO(
     LOG_CONFIG,
     "    S11 log level........: %s\n",

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -105,7 +105,7 @@ void handle_s5_create_session_request(
   teid_t context_teid,
   ebi_t eps_bearer_id)
 {
-  OAILOG_FUNC_IN(LOG_PGW_APP);
+  OAILOG_FUNC_IN(LOG_SPGW_APP);
   itti_sgi_create_end_point_response_t sgi_create_endpoint_resp = {0};
   s5_create_session_response_t s5_response = {0};
   struct in_addr inaddr;
@@ -113,7 +113,7 @@ void handle_s5_create_session_request(
   char *apn = NULL;
 
   OAILOG_DEBUG(
-    LOG_PGW_APP,
+    LOG_SPGW_APP,
     "Handle s5_create_session_request, for context sgw s11 teid, " TEID_FMT
     "EPS bearer id %u\n",
     context_teid,
@@ -121,7 +121,7 @@ void handle_s5_create_session_request(
 
   if (!new_bearer_ctxt_info_p) {
     OAILOG_ERROR(
-      LOG_PGW_APP,
+      LOG_SPGW_APP,
       "Failed to fetch sgw bearer context from the received context "
       "teid" TEID_FMT "\n",
       context_teid);
@@ -145,7 +145,7 @@ void handle_s5_create_session_request(
 
   if (pgw_process_pco_request(pco_req, &pco_resp, &pco_ids) != RETURNok) {
     OAILOG_ERROR(
-      LOG_PGW_APP,
+      LOG_SPGW_APP,
       "Error in processing PCO in create session request for "
       "context_id: " TEID_FMT "\n",
       context_teid);
@@ -215,7 +215,7 @@ void handle_s5_create_session_request(
     case IPv6:
       increment_counter(
         "ue_pdn_connection", 1, 2, "pdn_type", "ipv6", "result", "failure");
-      OAILOG_ERROR(LOG_PGW_APP, "IPV6 PDN type NOT Supported\n");
+      OAILOG_ERROR(LOG_SPGW_APP, "IPV6 PDN type NOT Supported\n");
       sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SERVICE_NOT_SUPPORTED;
       break;
 
@@ -254,14 +254,14 @@ void _spgw_handle_s5_response_with_error(
   s5_response->failure_cause = S5_OK;
 
   OAILOG_DEBUG(
-    LOG_PGW_APP,
+    LOG_SPGW_APP,
     "Sending S5 Create Session Response to SGW: with context teid, " TEID_FMT
     "EPS Bearer Id = %u\n",
     s5_response->context_teid,
     s5_response->eps_bearer_id);
   handle_s5_create_session_response(
     spgw_state, new_bearer_ctxt_info_p, (*s5_response));
-  OAILOG_FUNC_OUT(LOG_PGW_APP);
+  OAILOG_FUNC_OUT(LOG_SPGW_APP);
 }
 
 /*
@@ -273,7 +273,7 @@ int spgw_handle_nw_initiated_bearer_actv_req(
   imsi64_t imsi64,
   gtpv2c_cause_value_t* failed_cause)
 {
-  OAILOG_FUNC_IN(LOG_PGW_APP);
+  OAILOG_FUNC_IN(LOG_SPGW_APP);
   uint32_t i = 0;
   int rc = RETURNok;
   hash_table_ts_t* hashtblP = NULL;
@@ -545,7 +545,7 @@ int spgw_send_nw_init_activate_bearer_rsp(
   imsi64_t imsi64,
   uint8_t eps_bearer_id)
 {
-  OAILOG_FUNC_IN(LOG_PGW_APP);
+  OAILOG_FUNC_IN(LOG_SPGW_APP);
   uint32_t rc = RETURNok;
 
   OAILOG_INFO(

--- a/lte/gateway/c/oai/tasks/sgw/pgw_pco.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_pco.c
@@ -50,7 +50,7 @@ int pgw_pco_push_protocol_or_container_id(
     PCO_UNSPEC_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID <=
     pco->num_protocol_or_container_id) {
     OAILOG_ERROR(
-      LOG_PGW_APP,
+      LOG_SPGW_APP,
       "Invalid num_protocol_or_container_id :%d within pco \n",
       pco->num_protocol_or_container_id);
     return RETURNerror;
@@ -339,7 +339,7 @@ int pgw_process_pco_request(
   protocol_configuration_options_t *pco_resp,
   protocol_configuration_options_ids_t *const pco_ids)
 {
-  OAILOG_FUNC_IN(LOG_PGW_APP);
+  OAILOG_FUNC_IN(LOG_SPGW_APP);
   uint32_t rc = RETURNok;
   memset(pco_ids, 0, sizeof *pco_ids);
 

--- a/lte/gateway/c/oai/tasks/sgw/sgw_task.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_task.c
@@ -67,11 +67,6 @@ static void* sgw_intertask_interface(void* args_p)
     itti_receive_msg(TASK_SPGW_APP, &received_message_p);
 
     imsi64_t imsi64 = itti_get_associated_imsi(received_message_p);
-    OAILOG_DEBUG(
-      LOG_SPGW_APP,
-      "Received message with imsi: " IMSI_64_FMT,
-      imsi64);
-
     spgw_state_t* spgw_state = get_spgw_state(false);
 
     switch (ITTI_MSG_ID(received_message_p)) {

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -215,7 +215,6 @@ MME :
         SCTP_LOG_LEVEL     = "ERROR";
         GTPV1U_LOG_LEVEL   = "{{ oai_log_level }}";
         SPGW_APP_LOG_LEVEL = "{{ oai_log_level }}";
-        PGW_APP_LOG_LEVEL  = "{{ oai_log_level }}";
         UDP_LOG_LEVEL      = "{{ oai_log_level }}";
         S1AP_LOG_LEVEL     = "{{ oai_log_level }}";
         NAS_LOG_LEVEL      = "{{ oai_log_level }}";


### PR DESCRIPTION
Summary:
- With the updates to ITTI messaging to include IMSI on header, we can then retrieve it and have an easier method to include it on logging on MME.
- Adding macros that receive parameter `ue_id` to prefix it into the message to log.

Differential Revision: D20761081

