### PR TITLE
LocalEnforcer accepts SessionUpdate argument but doesn't do anything with it

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -41,7 +41,8 @@ class SessionNotFound : public std::exception {
 class LocalEnforcer {
  public:
 
-  static SessionMap UNUSED_SESSION_MAP;
+  static SessionUpdate UNUSED_SESSION_UPDATE;
+  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 
   LocalEnforcer();
 
@@ -83,7 +84,8 @@ class LocalEnforcer {
    */
   void aggregate_records(
     SessionMap& session_map,
-    const RuleRecordTable& records);
+    const RuleRecordTable& records,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * reset_updates resets all of the charging keys being updated in
@@ -105,9 +107,10 @@ class LocalEnforcer {
    * @param force_update force updates if revalidation timer expires
    */
   UpdateSessionRequest collect_updates(
-      SessionMap& session_map,
-      std::vector<std::unique_ptr<ServiceAction>>& actions,
-      const bool force_update = false) const;
+    SessionMap& session_map,
+    std::vector<std::unique_ptr<ServiceAction>>& actions,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE,
+    const bool force_update = false) const;
 
   /**
    * Perform any rule installs/removals that need to be executed given a
@@ -140,7 +143,8 @@ class LocalEnforcer {
    */
   void update_session_credits_and_rules(
     SessionMap& session_map,
-    const UpdateSessionResponse& response);
+    const UpdateSessionResponse& response,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Starts the termination process for the session. When termination completes,
@@ -153,7 +157,8 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::string& apn,
-    std::function<void(SessionTerminateRequest)> on_termination_callback);
+    std::function<void(SessionTerminateRequest)> on_termination_callback,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   uint64_t get_charging_credit(
     SessionMap& session_map,
@@ -173,7 +178,8 @@ class LocalEnforcer {
    */
   ChargingReAuthAnswer::Result init_charging_reauth(
     SessionMap& session_map,
-    ChargingReAuthRequest request);
+    ChargingReAuthRequest request,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Handles the equivalent of a RAR.
@@ -189,7 +195,8 @@ class LocalEnforcer {
   void init_policy_reauth(
     SessionMap& session_map,
     PolicyReAuthRequest request,
-    PolicyReAuthAnswer& answer_out);
+    PolicyReAuthAnswer& answer_out,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   bool session_with_imsi_exists(
     SessionMap& session_map,
@@ -212,7 +219,8 @@ class LocalEnforcer {
    */
   void execute_actions(
     SessionMap& session_map,
-    const std::vector<std::unique_ptr<ServiceAction>>& actions);
+    const std::vector<std::unique_ptr<ServiceAction>>& actions,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
@@ -248,7 +256,9 @@ class LocalEnforcer {
    * report is finished. For sessions that are terminating, complete the
    * termination if the session is not included in the report.
    */
-  void notify_finish_report_for_sessions(SessionMap& session_map);
+  void notify_finish_report_for_sessions(
+    SessionMap& session_map,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Process the create session response to get rules to activate/deactivate
@@ -271,7 +281,8 @@ class LocalEnforcer {
   void update_charging_credits(
     SessionMap& session_map,
     const UpdateSessionResponse& response,
-    std::unordered_set<std::string>& subscribers_to_terminate);
+    std::unordered_set<std::string>& subscribers_to_terminate,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Processes the monitoring component of UpdateSessionResponse.
@@ -283,7 +294,8 @@ class LocalEnforcer {
   void update_monitoring_credits_and_rules(
     SessionMap& session_map,
     const UpdateSessionResponse& response,
-    std::unordered_set<std::string>& subscribers_to_terminate);
+    std::unordered_set<std::string>& subscribers_to_terminate,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Process the list of rule names given and fill in rules_to_deactivate by
@@ -334,7 +346,8 @@ class LocalEnforcer {
     const PolicyReAuthRequest& request,
     const std::unique_ptr<SessionState>& session,
     bool& activate_success,
-    bool& deactivate_success);
+    bool& deactivate_success,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Completes the session termination and executes the callback function
@@ -350,7 +363,8 @@ class LocalEnforcer {
   void complete_termination(
     SessionMap& session_map,
     const std::string& imsi,
-    const std::string& session_id);
+    const std::string& session_id,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   void schedule_static_rule_activation(
     SessionMap& session_map,
@@ -380,7 +394,8 @@ class LocalEnforcer {
    */
   void receive_monitoring_credit_from_rar(
     const PolicyReAuthRequest& request,
-    const std::unique_ptr<SessionState>& session);
+    const std::unique_ptr<SessionState>& session,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Send bearer creation request through the PGW client if rules were
@@ -404,7 +419,8 @@ class LocalEnforcer {
 
   void check_usage_for_reporting(
     SessionMap& session_map,
-    const bool force_update = false);
+    const bool force_update = false,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
     * Deactivate rules for certain IMSI.
@@ -414,7 +430,8 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::vector<std::string>& rule_ids,
-    const std::vector<PolicyRule>& dynamic_rules);
+    const std::vector<PolicyRule>& dynamic_rules,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
 
   /**
@@ -423,7 +440,8 @@ class LocalEnforcer {
     */
   void terminate_multiple_services(
     SessionMap& session_map,
-    const std::unordered_set<std::string>& imsis);
+    const std::unordered_set<std::string>& imsis,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
     * Install flow for redirection through pipelined

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -106,7 +106,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   static const std::string hex_digit_;
 
  private:
-  void check_usage_for_reporting();
+  void check_usage_for_reporting(SessionUpdate& session_update);
   bool is_pipelined_restarted();
   bool restart_pipelined(const std::uint64_t& epoch);
 

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -32,9 +32,11 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
   auto &request_cpy = *request;
   enforcer_->get_event_base().runInEventBaseThread(
     [this, request_cpy, response_callback]() {
-      auto result = enforcer_->init_charging_reauth(session_map_, request_cpy);
+      SessionUpdate update = SessionStore::get_default_session_update(session_map_);
+      auto result = enforcer_->init_charging_reauth(session_map_, request_cpy, update);
       ChargingReAuthAnswer ans;
       ans.set_result(result);
+      // TODO: write the update back into the SessionStore
       response_callback(Status::OK, ans);
     });
 }
@@ -48,7 +50,9 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
   enforcer_->get_event_base().runInEventBaseThread(
     [this, request_cpy, response_callback]() {
       PolicyReAuthAnswer ans;
-      enforcer_->init_policy_reauth(session_map_, request_cpy, ans);
+      SessionUpdate update = SessionStore::get_default_session_update(session_map_);
+      enforcer_->init_policy_reauth(session_map_, request_cpy, ans, update);
+      // TODO: write the update back into the SessionStore
       response_callback(Status::OK, ans);
     });
 }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -144,5 +144,16 @@ bool SessionStore::merge_into_session(
   return true;
 }
 
+SessionUpdate SessionStore::get_default_session_update(SessionMap& session_map)
+{
+  SessionUpdate update = {};
+  for (const auto &session_pair : session_map) {
+    for (const auto &session : session_pair.second) {
+      update[session_pair.first][session->get_session_id()] = get_default_update_criteria();
+    }
+  }
+  return update;
+}
+
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -24,7 +24,6 @@ namespace lte {
 typedef std::
   unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>
     SessionMap;
-typedef std::function<void(SessionMap)> CallBackOnAccess;
 // Value int represents the request numbers needed for requests to PCRF
 typedef std::unordered_map<std::string, int> SessionRead;
 typedef std::unordered_map<
@@ -47,6 +46,8 @@ typedef std::unordered_map<
  */
 class SessionStore {
  public:
+  static SessionUpdate get_default_session_update(SessionMap& session_map);
+
   SessionStore(std::shared_ptr<StaticRuleStore> rule_store);
 
   /**
@@ -79,6 +80,7 @@ class SessionStore {
    * @return true if successful, otherwise the update to storage is discarded.
    */
   bool update_sessions(const SessionUpdate& update_criteria);
+
 
  private:
   static bool merge_into_session(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -135,6 +135,7 @@ struct SessionCreditUpdateCriteria {
 };
 
 struct SessionStateUpdateCriteria {
+  bool is_session_ended;
   std::vector<std::string> static_rules_to_install;
   std::vector<std::string> static_rules_to_uninstall;
   std::vector<PolicyRule> dynamic_rules_to_install;

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -197,6 +197,8 @@ class SessionStoreTest : public ::testing::Test {
  * 7) Commit updates to SessionStore
  * 8) Read in session for IMSI1 again, and check that the update was successful
  * 9) Check request numbers again
+ * 10) Delete the session for IMSI1
+ * 11) Verify IMSI1 no longer has any sessions
  */
 TEST_F(SessionStoreTest, test_read_and_write)
 {
@@ -285,6 +287,18 @@ TEST_F(SessionStoreTest, test_read_and_write)
   // This request number should increment in storage every time a read is done.
   // The incremented value is set by the read request to the storage interface.
   EXPECT_EQ(session_map[imsi].front()->get_request_number(), 7);
+
+  // 10) Delete sessions for IMSI1
+  update_req = SessionUpdate{};
+  update_criteria = SessionStateUpdateCriteria{};
+  update_criteria.is_session_ended = true;
+  update_req[imsi][sid] = update_criteria;
+  session_store->update_sessions(update_req);
+
+  // 11) Verify that IMSI1 no longer has a session
+  session_map = session_store->read_sessions(read_req);
+  EXPECT_EQ(session_map.size(), 1);
+  EXPECT_EQ(session_map[imsi].size(), 0);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary:
This revision is part of a series of changes to allow `session_manager` to become stateless, reading from `SessionStore`, and writing `UpdateCriteria` back to the store after updates are made

## Changes
- Function signature changes to methods of `LocalEnforcer` to accept `SessionUpdate` or `SessionStateUpdateCriteria`, as part of a refactor to have `session_manager` use the `SessionStore`
- SessionStore has a new static method `get_default_session_update(..)` to be used to build a `SessionUpdate` to be passed into the `LocalEnforcer`, before committing the update back to `SessionStore`

Reviewed By: themarwhal

Differential Revision: D20570888

