### PR TITLE
Session Manager's SessionStore supports deletion of sessions

### DIFF
--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -135,6 +135,7 @@ struct SessionCreditUpdateCriteria {
 };
 
 struct SessionStateUpdateCriteria {
+  bool is_session_ended;
   std::vector<std::string> static_rules_to_install;
   std::vector<std::string> static_rules_to_uninstall;
   std::vector<PolicyRule> dynamic_rules_to_install;

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -197,6 +197,8 @@ class SessionStoreTest : public ::testing::Test {
  * 7) Commit updates to SessionStore
  * 8) Read in session for IMSI1 again, and check that the update was successful
  * 9) Check request numbers again
+ * 10) Delete the session for IMSI1
+ * 11) Verify IMSI1 no longer has any sessions
  */
 TEST_F(SessionStoreTest, test_read_and_write)
 {
@@ -285,6 +287,18 @@ TEST_F(SessionStoreTest, test_read_and_write)
   // This request number should increment in storage every time a read is done.
   // The incremented value is set by the read request to the storage interface.
   EXPECT_EQ(session_map[imsi].front()->get_request_number(), 7);
+
+  // 10) Delete sessions for IMSI1
+  update_req = SessionUpdate{};
+  update_criteria = SessionStateUpdateCriteria{};
+  update_criteria.is_session_ended = true;
+  update_req[imsi][sid] = update_criteria;
+  session_store->update_sessions(update_req);
+
+  // 11) Verify that IMSI1 no longer has a session
+  session_map = session_store->read_sessions(read_req);
+  EXPECT_EQ(session_map.size(), 1);
+  EXPECT_EQ(session_map[imsi].size(), 0);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary: This revision adds supports deletion of sessions to the `SessionStore` interface. Of note is the grouping of the deletion functionality into the `update_session` method. The reason for this is that each method of the interface is intended to appear atomic to the rest of the `sessiond` service, and as updates & deletions are done at the same time when credit usage is reported, then it makes sense to group this together.

Reviewed By: themarwhal

Differential Revision: D20501223

