### PR TITLE
Add read_sessions_for_reporting method to Session Manager's SessionStore

### DIFF
--- a/lte/gateway/c/session_manager/CreditPool.cpp
+++ b/lte/gateway/c/session_manager/CreditPool.cpp
@@ -359,6 +359,11 @@ void ChargingCreditPool::merge_credit_update(
   }
 }
 
+uint32_t ChargingCreditPool::get_credit_key_count() const
+{
+  return credit_map_.size();
+}
+
 ChargingReAuthAnswer::Result ChargingCreditPool::reauth_key(
   const CreditKey &charging_key,
   SessionStateUpdateCriteria& update_criteria)
@@ -698,6 +703,11 @@ void UsageMonitoringCreditPool::merge_credit_update(
     it->second->credit.add_credit(
       credit_update.bucket_deltas.find(bucket)->second, bucket);
   }
+}
+
+uint32_t UsageMonitoringCreditPool::get_credit_key_count() const
+{
+  return monitor_map_.size();
 }
 
 std::unique_ptr<std::string> UsageMonitoringCreditPool::get_session_level_key()

--- a/lte/gateway/c/session_manager/CreditPool.h
+++ b/lte/gateway/c/session_manager/CreditPool.h
@@ -86,6 +86,8 @@ class CreditPool {
   virtual void merge_credit_update(
     const KeyType &key,
     const SessionCreditUpdateCriteria &credit_update) = 0;
+
+  virtual uint32_t get_credit_key_count() const = 0;
 };
 
 /**
@@ -146,6 +148,8 @@ class ChargingCreditPool :
   void merge_credit_update(
     const CreditKey &key,
     const SessionCreditUpdateCriteria &credit_update) override;
+
+  uint32_t get_credit_key_count() const override;
 
   ChargingReAuthAnswer::Result reauth_key(
     const CreditKey &charging_key,
@@ -249,6 +253,8 @@ class UsageMonitoringCreditPool :
   void merge_credit_update(
     const std::string &key,
     const SessionCreditUpdateCriteria &credit_update) override;
+
+  uint32_t get_credit_key_count() const override;
 
   std::unique_ptr<std::string> get_session_level_key();
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -158,7 +158,7 @@ class LocalEnforcer {
     const std::string& imsi,
     const std::string& apn,
     std::function<void(SessionTerminateRequest)> on_termination_callback,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   uint64_t get_charging_credit(
     SessionMap& session_map,
@@ -419,8 +419,8 @@ class LocalEnforcer {
 
   void check_usage_for_reporting(
     SessionMap& session_map,
-    const bool force_update = false,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE,
+    const bool force_update = false);
 
   /**
     * Deactivate rules for certain IMSI.

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -41,7 +41,8 @@ class SessionNotFound : public std::exception {
 class LocalEnforcer {
  public:
 
-  static SessionMap UNUSED_SESSION_MAP;
+  static SessionUpdate UNUSED_SESSION_UPDATE;
+  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 
   LocalEnforcer();
 
@@ -83,7 +84,8 @@ class LocalEnforcer {
    */
   void aggregate_records(
     SessionMap& session_map,
-    const RuleRecordTable& records);
+    const RuleRecordTable& records,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * reset_updates resets all of the charging keys being updated in
@@ -105,9 +107,10 @@ class LocalEnforcer {
    * @param force_update force updates if revalidation timer expires
    */
   UpdateSessionRequest collect_updates(
-      SessionMap& session_map,
-      std::vector<std::unique_ptr<ServiceAction>>& actions,
-      const bool force_update = false) const;
+    SessionMap& session_map,
+    std::vector<std::unique_ptr<ServiceAction>>& actions,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE,
+    const bool force_update = false) const;
 
   /**
    * Perform any rule installs/removals that need to be executed given a
@@ -140,7 +143,8 @@ class LocalEnforcer {
    */
   void update_session_credits_and_rules(
     SessionMap& session_map,
-    const UpdateSessionResponse& response);
+    const UpdateSessionResponse& response,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Starts the termination process for the session. When termination completes,
@@ -153,7 +157,8 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::string& apn,
-    std::function<void(SessionTerminateRequest)> on_termination_callback);
+    std::function<void(SessionTerminateRequest)> on_termination_callback,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   uint64_t get_charging_credit(
     SessionMap& session_map,
@@ -173,7 +178,8 @@ class LocalEnforcer {
    */
   ChargingReAuthAnswer::Result init_charging_reauth(
     SessionMap& session_map,
-    ChargingReAuthRequest request);
+    ChargingReAuthRequest request,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Handles the equivalent of a RAR.
@@ -189,7 +195,8 @@ class LocalEnforcer {
   void init_policy_reauth(
     SessionMap& session_map,
     PolicyReAuthRequest request,
-    PolicyReAuthAnswer& answer_out);
+    PolicyReAuthAnswer& answer_out,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   bool session_with_imsi_exists(
     SessionMap& session_map,
@@ -212,7 +219,8 @@ class LocalEnforcer {
    */
   void execute_actions(
     SessionMap& session_map,
-    const std::vector<std::unique_ptr<ServiceAction>>& actions);
+    const std::vector<std::unique_ptr<ServiceAction>>& actions,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
@@ -248,7 +256,9 @@ class LocalEnforcer {
    * report is finished. For sessions that are terminating, complete the
    * termination if the session is not included in the report.
    */
-  void notify_finish_report_for_sessions(SessionMap& session_map);
+  void notify_finish_report_for_sessions(
+    SessionMap& session_map,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Process the create session response to get rules to activate/deactivate
@@ -271,7 +281,8 @@ class LocalEnforcer {
   void update_charging_credits(
     SessionMap& session_map,
     const UpdateSessionResponse& response,
-    std::unordered_set<std::string>& subscribers_to_terminate);
+    std::unordered_set<std::string>& subscribers_to_terminate,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Processes the monitoring component of UpdateSessionResponse.
@@ -283,7 +294,8 @@ class LocalEnforcer {
   void update_monitoring_credits_and_rules(
     SessionMap& session_map,
     const UpdateSessionResponse& response,
-    std::unordered_set<std::string>& subscribers_to_terminate);
+    std::unordered_set<std::string>& subscribers_to_terminate,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Process the list of rule names given and fill in rules_to_deactivate by
@@ -334,7 +346,8 @@ class LocalEnforcer {
     const PolicyReAuthRequest& request,
     const std::unique_ptr<SessionState>& session,
     bool& activate_success,
-    bool& deactivate_success);
+    bool& deactivate_success,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Completes the session termination and executes the callback function
@@ -350,7 +363,8 @@ class LocalEnforcer {
   void complete_termination(
     SessionMap& session_map,
     const std::string& imsi,
-    const std::string& session_id);
+    const std::string& session_id,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   void schedule_static_rule_activation(
     SessionMap& session_map,
@@ -380,7 +394,8 @@ class LocalEnforcer {
    */
   void receive_monitoring_credit_from_rar(
     const PolicyReAuthRequest& request,
-    const std::unique_ptr<SessionState>& session);
+    const std::unique_ptr<SessionState>& session,
+    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
   /**
    * Send bearer creation request through the PGW client if rules were
@@ -404,7 +419,8 @@ class LocalEnforcer {
 
   void check_usage_for_reporting(
     SessionMap& session_map,
-    const bool force_update = false);
+    const bool force_update = false,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
     * Deactivate rules for certain IMSI.
@@ -414,7 +430,8 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::vector<std::string>& rule_ids,
-    const std::vector<PolicyRule>& dynamic_rules);
+    const std::vector<PolicyRule>& dynamic_rules,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
 
   /**
@@ -423,7 +440,8 @@ class LocalEnforcer {
     */
   void terminate_multiple_services(
     SessionMap& session_map,
-    const std::unordered_set<std::string>& imsis);
+    const std::unordered_set<std::string>& imsis,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
     * Install flow for redirection through pipelined

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -106,7 +106,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   static const std::string hex_digit_;
 
  private:
-  void check_usage_for_reporting();
+  void check_usage_for_reporting(SessionUpdate& session_update);
   bool is_pipelined_restarted();
   bool restart_pipelined(const std::uint64_t& epoch);
 

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -32,9 +32,11 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
   auto &request_cpy = *request;
   enforcer_->get_event_base().runInEventBaseThread(
     [this, request_cpy, response_callback]() {
-      auto result = enforcer_->init_charging_reauth(session_map_, request_cpy);
+      SessionUpdate update = SessionStore::get_default_session_update(session_map_);
+      auto result = enforcer_->init_charging_reauth(session_map_, request_cpy, update);
       ChargingReAuthAnswer ans;
       ans.set_result(result);
+      // TODO: write the update back into the SessionStore
       response_callback(Status::OK, ans);
     });
 }
@@ -48,7 +50,9 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
   enforcer_->get_event_base().runInEventBaseThread(
     [this, request_cpy, response_callback]() {
       PolicyReAuthAnswer ans;
-      enforcer_->init_policy_reauth(session_map_, request_cpy, ans);
+      SessionUpdate update = SessionStore::get_default_session_update(session_map_);
+      enforcer_->init_policy_reauth(session_map_, request_cpy, ans, update);
+      // TODO: write the update back into the SessionStore
       response_callback(Status::OK, ans);
     });
 }

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -583,4 +583,9 @@ uint32_t SessionState::total_monitored_rules_count()
   return monitored_dynamic_rules + monitored_static_rules;
 }
 
+uint32_t SessionState::get_credit_key_count()
+{
+  return charging_pool_.get_credit_key_count() + monitor_pool_.get_credit_key_count();
+}
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -249,6 +249,8 @@ class SessionState {
 
   uint32_t total_monitored_rules_count();
 
+  uint32_t get_credit_key_count();
+
  private:
   /**
    * State transitions of a session:

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -144,5 +144,16 @@ bool SessionStore::merge_into_session(
   return true;
 }
 
+SessionUpdate SessionStore::get_default_session_update(SessionMap& session_map)
+{
+  SessionUpdate update = {};
+  for (const auto &session_pair : session_map) {
+    for (const auto &session : session_pair.second) {
+      update[session_pair.first][session->get_session_id()] = get_default_update_criteria();
+    }
+  }
+  return update;
+}
+
 } // namespace lte
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -22,18 +22,17 @@ SessionStore::SessionStore(std::shared_ptr<StaticRuleStore> rule_store):
 
 SessionMap SessionStore::read_sessions(const SessionRead& req)
 {
-  // First allocate some request numbers
-  auto subscriber_ids = std::vector<std::string> {};
-  for (const auto& it : req) {
-    subscriber_ids.push_back(it.first);
-  }
-  auto session_map = store_client_.read_sessions(subscriber_ids);
-  auto session_map_2 = store_client_.read_sessions(subscriber_ids);
+  return store_client_.read_sessions(req);
+}
 
+SessionMap SessionStore::read_sessions_for_reporting(const SessionRead& req)
+{
+  auto session_map = store_client_.read_sessions(req);
+  auto session_map_2 = store_client_.read_sessions(req);
   // For all sessions of the subscriber, increment the request numbers
-  for (const auto& it : req) {
-    for (auto& session : session_map_2[it.first]) {
-      session->increment_request_number(it.second);
+  for (const std::string& imsi : req) {
+    for (auto& session : session_map_2[imsi]) {
+      session->increment_request_number(session->get_credit_key_count());
     }
   }
   store_client_.write_sessions(std::move(session_map_2));

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -25,7 +25,7 @@ typedef std::
   unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>
     SessionMap;
 // Value int represents the request numbers needed for requests to PCRF
-typedef std::unordered_map<std::string, int> SessionRead;
+typedef std::vector<std::string> SessionRead;
 typedef std::unordered_map<
   std::string,
   std::unordered_map<std::string, SessionStateUpdateCriteria>>
@@ -51,8 +51,18 @@ class SessionStore {
   SessionStore(std::shared_ptr<StaticRuleStore> rule_store);
 
   /**
-   * Read the last written values for the rqeuested sessions through the
+   * Read the last written values for the requested sessions through the
    * storage interface.
+   * @param req
+   * @return Last written values for requested sessions. Returns an empty vector
+   *         for subscribers that do not have active sessions.
+   */
+  SessionMap read_sessions(const SessionRead& req);
+
+  /**
+   * Read the last written values for the requested sessions through the
+   * storage interface. This also modifies the request_numbers stored before
+   * returning the SessionMap to the caller.
    * NOTE: It is assumed that the correct number of request_numbers are
    *       reserved on each read_sessions call. If more requests are made to
    *       the OCS/PCRF than are requested, this can cause undefined behavior.
@@ -60,7 +70,7 @@ class SessionStore {
    * @return Last written values for requested sessions. Returns an empty vector
    *         for subscribers that do not have active sessions.
    */
-  SessionMap read_sessions(const SessionRead& req);
+  SessionMap read_sessions_for_reporting(const SessionRead& req);
 
   /**
    * Create sessions for a subscriber. Redundant creations will fail.

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -24,7 +24,6 @@ namespace lte {
 typedef std::
   unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>
     SessionMap;
-typedef std::function<void(SessionMap)> CallBackOnAccess;
 // Value int represents the request numbers needed for requests to PCRF
 typedef std::unordered_map<std::string, int> SessionRead;
 typedef std::unordered_map<
@@ -47,6 +46,8 @@ typedef std::unordered_map<
  */
 class SessionStore {
  public:
+  static SessionUpdate get_default_session_update(SessionMap& session_map);
+
   SessionStore(std::shared_ptr<StaticRuleStore> rule_store);
 
   /**
@@ -79,6 +80,7 @@ class SessionStore {
    * @return true if successful, otherwise the update to storage is discarded.
    */
   bool update_sessions(const SessionUpdate& update_criteria);
+
 
  private:
   static bool merge_into_session(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -135,6 +135,7 @@ struct SessionCreditUpdateCriteria {
 };
 
 struct SessionStateUpdateCriteria {
+  bool is_session_ended;
   std::vector<std::string> static_rules_to_install;
   std::vector<std::string> static_rules_to_uninstall;
   std::vector<PolicyRule> dynamic_rules_to_install;

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -197,6 +197,8 @@ class SessionStoreTest : public ::testing::Test {
  * 7) Commit updates to SessionStore
  * 8) Read in session for IMSI1 again, and check that the update was successful
  * 9) Check request numbers again
+ * 10) Delete the session for IMSI1
+ * 11) Verify IMSI1 no longer has any sessions
  */
 TEST_F(SessionStoreTest, test_read_and_write)
 {
@@ -285,6 +287,18 @@ TEST_F(SessionStoreTest, test_read_and_write)
   // This request number should increment in storage every time a read is done.
   // The incremented value is set by the read request to the storage interface.
   EXPECT_EQ(session_map[imsi].front()->get_request_number(), 7);
+
+  // 10) Delete sessions for IMSI1
+  update_req = SessionUpdate{};
+  update_criteria = SessionStateUpdateCriteria{};
+  update_criteria.is_session_ended = true;
+  update_req[imsi][sid] = update_criteria;
+  session_store->update_sessions(update_req);
+
+  // 11) Verify that IMSI1 no longer has a session
+  session_map = session_store->read_sessions(read_req);
+  EXPECT_EQ(session_map.size(), 1);
+  EXPECT_EQ(session_map[imsi].size(), 0);
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary:
## Changes
- `SessionStore` interface changed to add various methods for reading sessions: `read_session` and `read_sessions_for_reporting`, the latter of which is required to read the gRPC request to correctly update the request numbers

Reviewed By: xjtian

Differential Revision: D20615451

