### PR TITLE
Update config on session recycling

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1606,6 +1606,19 @@ bool LocalEnforcer::session_with_same_config_exists(
   return false;
 }
 
+void LocalEnforcer::handle_cwf_roaming(
+  const std::string& imsi, const magma::SessionState::Config& config)
+{
+  auto it = session_map_.find(imsi);
+  if (it != session_map_.end()) {
+    for (const auto &session : it->second) {
+      session->set_config(config);
+      // TODO Check for event triggers and send updates to the core if needed
+      // TODO Update APN information to pipelined
+    }
+  }
+}
+
 static void handle_command_level_result_code(
   const std::string& imsi,
   const uint32_t result_code,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -214,6 +214,13 @@ class LocalEnforcer {
     std::string* core_session_id) const;
 
   /**
+   * Set session config for the IMSI.
+   * Should be only used for WIFI as it will apply it to all sessions with the
+   * IMSI
+   */
+  void handle_cwf_roaming(const std::string& imsi, const magma::SessionState::Config& config);
+
+  /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or
    * just continue
    */

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -234,6 +234,9 @@ void LocalSessionManagerHandlerImpl::CreateSession(
       if (is_wifi) {
         MLOG(MINFO) << "Found a session with the same IMSI " << imsi
                     << " and RAT Type is WLAN, not creating a new session";
+        // Wifi only supports one session per subscriber, so update the config
+        // here
+        enforcer_->handle_cwf_roaming(imsi, cfg);
       } else {
         MLOG(MINFO) << "Found completely duplicated session with IMSI " << imsi
                     << " and APN " << request->apn()

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -428,6 +428,10 @@ std::string SessionState::get_apn() const
   return config_.apn;
 }
 
+void SessionState::set_config(const Config& config) {
+  config_ = config;
+}
+
 bool SessionState::is_radius_cwf_session() const
 {
   return (config_.rat_type == RATType::TGPP_WLAN);

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -203,6 +203,8 @@ class SessionState {
     const magma::lte::TgppContext& tgpp_context,
     SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
+  void set_config(const Config& config);
+
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 
   void set_subscriber_quota_state(

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -97,11 +97,15 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     request.set_hardware_addr(hardware_addr_bytes);
     request.set_msisdn(msisdn);
     request.set_radius_session_id(radius_session_id);
+    request.set_apn("apn2"); // Update APN
 
     // Ensure session is not reported as its a duplicate
     EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
     session_manager->CreateSession(&create_context, &request, [this](
             grpc::Status status, LocalCreateSessionResponse response_out) {});
+    // Assert the internal session config is updated to the new one
+    EXPECT_FALSE(local_enforcer->session_with_apn_exists("IMSI1", "apn1"));
+    EXPECT_TRUE(local_enforcer->session_with_apn_exists("IMSI1", "apn2"));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary:
* When we recycle session for sessiond, we need to make sure we update the existing config with the new one in the request.
* Will add the stateless sessiond part next

Some notes for the future
* There are some Event Triggers that we should be watching out for here.
   * TimeZone Change: If the new AP is in a different timezone, we have to notify the core. We don't have a way of supporting this right now as the LocalCreateSessionRequest doesn't include any timezone info. (We need this for the TimeZone AVP later on, so we can support this change)
   * IP CAN CHANGE: If the UE ipv4 changes, we need to notify the PCRF/OCS.
* We will also need to add a call to pipelined to update the APN info.

Reviewed By: koolzz

Differential Revision: D20748599

