### PR TITLE
Fix failing s6a application unit tests

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/s6a_application_tests.py
+++ b/lte/gateway/python/magma/subscriberdb/tests/protocols/diameter/s6a_application_tests.py
@@ -286,7 +286,7 @@ class S6AApplicationTests(unittest.TestCase):
 
         # Response result
         msg.append_avp(avp.AVP('Result-Code',
-            avp.ResultCode.DIAMETER_AUTHORIZATION_REJECTED))
+            avp.ResultCode.DIAMETER_ERROR_USER_UNKNOWN))
         # Encode response into buffer
         resp_buf = bytearray(msg.length)
         msg.encode(resp_buf, 0)


### PR DESCRIPTION
Summary:
A recent diff updated the s6a application to use the
DIAMETER_ERROR_USER_UNKNOWN response for an unknown user. This
diff updates the associated unit tests, which was failing.

Reviewed By: themarwhal

Differential Revision: D20776145

