### PR TITLE
Move Wifi check in create_bearer to the caller of the func

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1363,9 +1363,10 @@ void LocalEnforcer::init_policy_reauth_for_session(
       session_map, imsi, rules.static_rules, rules.dynamic_rules, session_update);
     return;
   }
-
-  create_bearer(
-    activate_success, session, request, rules_to_activate.dynamic_rules);
+  if (!session->is_radius_cwf_session()) {
+    create_bearer(
+      activate_success, session, request, rules_to_activate.dynamic_rules);
+  }
 }
 
 void LocalEnforcer::receive_monitoring_credit_from_rar(
@@ -1514,8 +1515,7 @@ void LocalEnforcer::create_bearer(
   const PolicyReAuthRequest& request,
   const std::vector<PolicyRule>& dynamic_rules)
 {
-  if (!activate_success || session->is_radius_cwf_session() ||
-    !session->qos_enabled() || !request.has_qos_info()) {
+  if (!activate_success || !session->qos_enabled() || !request.has_qos_info()) {
     MLOG(MDEBUG) << "Not creating bearer";
     return;
   }

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1607,10 +1607,12 @@ bool LocalEnforcer::session_with_same_config_exists(
 }
 
 void LocalEnforcer::handle_cwf_roaming(
-  const std::string& imsi, const magma::SessionState::Config& config)
+  SessionMap& session_map,
+  const std::string& imsi,
+  const magma::SessionState::Config& config)
 {
-  auto it = session_map_.find(imsi);
-  if (it != session_map_.end()) {
+  auto it = session_map.find(imsi);
+  if (it != session_map.end()) {
     for (const auto &session : it->second) {
       session->set_config(config);
       // TODO Check for event triggers and send updates to the core if needed

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -218,7 +218,7 @@ class LocalEnforcer {
    * Should be only used for WIFI as it will apply it to all sessions with the
    * IMSI
    */
-  void handle_cwf_roaming(const std::string& imsi, const magma::SessionState::Config& config);
+  void handle_cwf_roaming(SessionMap& session_map, const std::string& imsi, const magma::SessionState::Config& config);
 
   /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -236,7 +236,7 @@ void LocalSessionManagerHandlerImpl::CreateSession(
                     << " and RAT Type is WLAN, not creating a new session";
         // Wifi only supports one session per subscriber, so update the config
         // here
-        enforcer_->handle_cwf_roaming(imsi, cfg);
+        enforcer_->handle_cwf_roaming(session_map_, imsi, cfg);
       } else {
         MLOG(MINFO) << "Found completely duplicated session with IMSI " << imsi
                     << " and APN " << request->apn()

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -104,8 +104,8 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     session_manager->CreateSession(&create_context, &request, [this](
             grpc::Status status, LocalCreateSessionResponse response_out) {});
     // Assert the internal session config is updated to the new one
-    EXPECT_FALSE(local_enforcer->session_with_apn_exists("IMSI1", "apn1"));
-    EXPECT_TRUE(local_enforcer->session_with_apn_exists("IMSI1", "apn2"));
+    EXPECT_FALSE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn1"));
+    EXPECT_TRUE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn2"));
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Summary: - i think it's more clear this way that we do not create bearer for Wifi

Reviewed By: ulaskozat

Differential Revision: D20777286

