### PR TITLE
Move parse IMSI from sessionId to a centralized location

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/handlers.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/handlers.go
@@ -20,6 +20,7 @@ import (
 	"magma/feg/gateway/services/session_proxy/metrics"
 	"magma/feg/gateway/services/session_proxy/relay"
 	"magma/gateway/service_registry"
+	"magma/lte/cloud/go/protos"
 )
 
 // ccaHandler parses a CCADiameterMessage received over Gx and returns the
@@ -57,7 +58,7 @@ type PolicyReAuthHandler func(request *PolicyReAuthRequest) *PolicyReAuthAnswer
 func GetGxReAuthHandler(cloudRegistry service_registry.GatewayRegistry, policyDBClient policydb.PolicyDBClient) PolicyReAuthHandler {
 	return func(request *PolicyReAuthRequest) *PolicyReAuthAnswer {
 		sid := diameter.DecodeSessionID(request.SessionID)
-		imsi, err := relay.GetIMSIFromSessionID(sid)
+		imsi, err := protos.ParseIMSIfromSessionIdWithPrefix(sid)
 		if err != nil {
 			glog.Errorf("Error retrieving IMSI from session ID %s: %s", request.SessionID, err)
 			return &PolicyReAuthAnswer{

--- a/feg/gateway/services/session_proxy/credit_control/gy/handlers.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/handlers.go
@@ -25,7 +25,7 @@ import (
 func GetGyReAuthHandler(cloudRegistry service_registry.GatewayRegistry) ChargingReAuthHandler {
 	return ChargingReAuthHandler(func(request *ChargingReAuthRequest) *ChargingReAuthAnswer {
 		sid := diameter.DecodeSessionID(request.SessionID)
-		imsi, err := relay.GetIMSIFromSessionID(sid)
+		imsi, err := protos.ParseIMSIfromSessionIdWithPrefix(sid)
 		if err != nil {
 			glog.Errorf("Error retreiving IMSI from Session ID %s: %s", request.SessionID, err)
 			return &ChargingReAuthAnswer{

--- a/feg/gateway/services/session_proxy/servicers/multiple_session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/multiple_session_controller.go
@@ -161,7 +161,7 @@ func (srv *CentralSessionControllers) TerminateSession(
 	if request == nil || len(request.GetSessionId()) == 0 {
 		return nil, fmt.Errorf("Could not terminate session")
 	}
-	imsi, err := parseImsiFromSessionId(request.GetSessionId())
+	imsi, err := protos.ParseIMSIfromSessionIdNoPrefix(request.GetSessionId())
 	if err != nil {
 		return nil, err
 	}
@@ -268,7 +268,7 @@ func getUpdateSessionRequestPerController(
 
 // getControllerFromSessionId provides the controllerId on a given SessionID (note session ID contains the IMSI)
 func getControllerFromSessionId(controllers []*CentralSessionController, sessionId string) (*CentralSessionController, error) {
-	imsiStr, err := parseImsiFromSessionId(sessionId)
+	imsiStr, err := protos.ParseIMSIfromSessionIdNoPrefix(sessionId)
 	if err != nil {
 		glog.Error(err)
 		return nil, err
@@ -291,17 +291,6 @@ func getControllerFromImsi(imsi string, controllers []*CentralSessionController)
 		return nil, err
 	}
 	return controllers[index], nil
-}
-
-// parseImsiFromSessionId extracts IMSI from a sessionId. SessionId format is is considered
-// to be IMMSIxxxxxx-1234, where xxxxx is the imsi to be extracted
-func parseImsiFromSessionId(sessionId string) (string, error) {
-	sessionId = strings.TrimPrefix(sessionId, "IMSI")
-	data := strings.Split(sessionId, "-")
-	if len(data) != 2 {
-		return "", fmt.Errorf("Couldn't parse Subscrier ID from sessionID. Format should be IMISxxxxx-RandomNumber")
-	}
-	return data[0], nil
 }
 
 // GetControllerIndexFromImsi describes how we allocate the subscriber on the controllers

--- a/lte/cloud/go/protos/sid.go
+++ b/lte/cloud/go/protos/sid.go
@@ -47,3 +47,23 @@ func SidFromString(sid string) *SubscriberID {
 	}
 	return nil
 }
+
+// ParseIMSIfromSessionIdNoPrefix extracts IMSI from a sessionId and returns only the IMSI without prefix
+// SessionId format is is considered to be IMMSIxxxxxx-1234, where xxxxx is the imsi to be extracted
+// ie:  IMSI123456789012345-54321   ->  123456789012345
+func ParseIMSIfromSessionIdNoPrefix(sessionId string) (string, error) {
+	sessionId = strings.TrimPrefix(sessionId, "IMSI")
+	return ParseIMSIfromSessionIdWithPrefix(sessionId)
+}
+
+// ParseIMSIfromSessionIdWithPrefix extracts IMSI from a sessionId and returns the IMSI with prefix
+// SessionId format is is considered to be IMMSIxxxxxx-1234, where xxxxx is the imsi to be extracted
+// ie:  IMSI123456789012345-54321   ->  IMSI123456789012345
+func ParseIMSIfromSessionIdWithPrefix(sessionId string) (string, error) {
+	data := strings.Split(sessionId, "-")
+	if len(data) != 2 {
+		return "", fmt.Errorf("Session ID %s does not match format 'IMSI-RandNum'", sessionId)
+	}
+	return data[0], nil
+
+}

--- a/lte/cloud/go/protos/sid_test.go
+++ b/lte/cloud/go/protos/sid_test.go
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 package protos_test
 
 import (
+	"fmt"
 	"testing"
 
 	"magma/lte/cloud/go/protos"
@@ -31,4 +32,20 @@ func TestSidString(t *testing.T) {
 	pb := protos.SubscriberID{Id: "12345"}
 	out := protos.SidString(&pb)
 	assert.Equal(t, out, str)
+}
+
+func TestParseImsiFromSessionId(t *testing.T) {
+	randomSid := "99999"
+	IMSI := "123456789"
+	prefixedIMSI := fmt.Sprintf("IMSI%s", IMSI)
+	magmaSid := fmt.Sprintf("%s-%s", prefixedIMSI, randomSid)
+
+	resultIMSINoprefix, err := protos.ParseIMSIfromSessionIdNoPrefix(magmaSid)
+	assert.NoError(t, err)
+	assert.Equal(t, resultIMSINoprefix, IMSI)
+
+	resultIMSIWithprefix, err := protos.ParseIMSIfromSessionIdWithPrefix(magmaSid)
+	assert.NoError(t, err)
+	assert.Equal(t, resultIMSIWithprefix, prefixedIMSI)
+
 }


### PR DESCRIPTION
Summary:
In order not to have defined in different places how to parse IMSI from sessionID we will
add the code to feg protos package.

Since sometimes engineers need different output format for the IMSI depending on where they are
using the value, We have created 2 different functions to parse the imsi from sessionID. One returns
the plain IMSI (only numbers in string format), the other return imsi number plus the prefix IMSI
(this is the sessiond imsi format)

Differential Revision: D20778557

