### PR TITLE
Provide an option to collapse AAA Service and EAP AKA Service into a single AAA Service binary

### DIFF
--- a/feg/gateway/Makefile
+++ b/feg/gateway/Makefile
@@ -17,6 +17,7 @@ install:
 
 test:
 	go test ./...
+	go test -tags link_local_service magma/feg/gateway/services/eap/... magma/feg/gateway/services/aaa/...
 
 buildenv: stop
 	PROTO_LIST="orc8r_protos feg_protos lte_protos" $(MAKE) -C $(MAGMA_ROOT)/orc8r/gateway/python $@

--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
@@ -110,7 +110,7 @@ func TestEAPPeerNak(t *testing.T) {
 	failureEAP := []byte{4, 237, 0, 4}
 	akaPrimeIdentity := eap.NewPacket(
 		eap.ResponseCode, 236,
-		append([]byte{eap_client.EapMethodIdentity}, []byte("6001010000000091@wlan.mnc001.mcc001.3gppnetwork.org")...))
+		append([]byte{eap.MethodIdentity}, []byte("6001010000000091@wlan.mnc001.mcc001.3gppnetwork.org")...))
 	permIdReq := []byte{0x01, 237, 0x00, 0x0c, 0x17, 0x05, 0x00, 0x00, 0x0a, 0x01, 0x00, 0x00}
 	akaPrimeNak := []byte{0x02, 237, 0x00, 0x06, 0x03, 50}
 	akaAkaPrimeNak := []byte{0x02, 236, 0x00, 0x07, 0x03, 50, 23}

--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_linked_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_linked_auth_test.go
@@ -1,0 +1,85 @@
+//
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// +build link_local_service
+
+// Package eap_router_test implements eap router unit tests
+package main_test
+
+import (
+	"reflect"
+	"testing"
+
+	cp "magma/feg/cloud/go/protos"
+	"magma/feg/gateway/registry"
+	aaa_client "magma/feg/gateway/services/aaa/client"
+	"magma/feg/gateway/services/aaa/protos"
+	"magma/feg/gateway/services/eap"
+	eap_client "magma/feg/gateway/services/eap/client"
+	_ "magma/feg/gateway/services/eap/providers/aka/servicers/handlers"
+	eap_test "magma/feg/gateway/services/eap/test"
+	"magma/orc8r/cloud/go/test_utils"
+)
+
+// TestEapAkaConcurent tests EAP AKA Provider
+func TestLinkedEapAkaConcurent(t *testing.T) {
+	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
+	var service eap_test.SwxProxy
+	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
+	go srv.RunTest(lis)
+
+	rtrSrv, rtrLis := test_utils.NewTestService(t, registry.ModuleName, registry.AAA_SERVER)
+	protos.RegisterAuthenticatorServer(rtrSrv.GrpcServer, &testAuthenticator{supportedMethods: eap_client.SupportedTypes()})
+	go rtrSrv.RunTest(rtrLis)
+
+	client := &testEapServiceClient{}
+	done := make(chan error)
+	go eap_test.Auth(t, client, eap_test.IMSI1, 50, done)
+	go eap_test.Auth(t, client, eap_test.IMSI2, 47, done)
+	eap_test.Auth(t, client, eap_test.IMSI1, 43, nil)
+	<-done
+	<-done // wait for test 1 & 2 to complete
+}
+
+func TestLinkedEAPPeerNak(t *testing.T) {
+	failureEAP := []byte{4, 237, 0, 4}
+	akaPrimeIdentity := eap.NewPacket(
+		eap.ResponseCode, 236,
+		append([]byte{eap.MethodIdentity}, []byte("6001010000000091@wlan.mnc001.mcc001.3gppnetwork.org")...))
+	permIdReq := []byte{0x01, 237, 0x00, 0x0c, 0x17, 0x05, 0x00, 0x00, 0x0a, 0x01, 0x00, 0x00}
+	akaPrimeNak := []byte{0x02, 237, 0x00, 0x06, 0x03, 50}
+	akaAkaPrimeNak := []byte{0x02, 236, 0x00, 0x07, 0x03, 50, 23}
+
+	rtrSrv, rtrLis := test_utils.NewTestService(t, registry.ModuleName, registry.AAA_SERVER)
+	protos.RegisterAuthenticatorServer(rtrSrv.GrpcServer, &testAuthenticator{supportedMethods: eap_client.SupportedTypes()})
+	go rtrSrv.RunTest(rtrLis)
+
+	eapCtx := &protos.Context{SessionId: eap.CreateSessionId()}
+
+	peap, err := aaa_client.HandleIdentity(&protos.EapIdentity{Payload: akaPrimeIdentity, Ctx: eapCtx, Method: 23})
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	if !reflect.DeepEqual([]byte(peap.GetPayload()), permIdReq) {
+		t.Fatalf("Unexpected Identity Responsen\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), permIdReq)
+	}
+	peap, err = aaa_client.Handle(&protos.Eap{Payload: akaPrimeNak, Ctx: peap.Ctx})
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	if !reflect.DeepEqual([]byte(peap.GetPayload()), failureEAP) {
+		t.Fatalf("Unexpected AKA' Nak Response\n\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), failureEAP)
+	}
+	peap, err = aaa_client.Handle(&protos.Eap{Payload: akaAkaPrimeNak, Ctx: eapCtx})
+	if err != nil {
+		t.Fatalf("Unexpected Error: %v", err)
+	}
+	if !reflect.DeepEqual([]byte(peap.GetPayload()), permIdReq) {
+		t.Fatalf("Unexpected AKA['] Nak Response\n\tReceived: %.3v\n\tExpected: %.3v", peap.GetPayload(), permIdReq)
+	}
+}

--- a/feg/gateway/services/eap/client/client_api_test.go
+++ b/feg/gateway/services/eap/client/client_api_test.go
@@ -20,8 +20,10 @@ import (
 	"magma/feg/gateway/services/eap/client"
 	eapp "magma/feg/gateway/services/eap/protos"
 	"magma/feg/gateway/services/eap/providers/aka"
+	aka_provider "magma/feg/gateway/services/eap/providers/aka/provider"
 	"magma/feg/gateway/services/eap/providers/aka/servicers"
 	_ "magma/feg/gateway/services/eap/providers/aka/servicers/handlers"
+	eap_registry "magma/feg/gateway/services/eap/providers/registry"
 	eap_test "magma/feg/gateway/services/eap/test"
 	"magma/orc8r/cloud/go/test_utils"
 )
@@ -64,6 +66,8 @@ func TestEAPClientApi(t *testing.T) {
 		t.Fatalf("failed to create EAP AKA Service: %v", err)
 		return
 	}
+	eap_registry.Register(aka_provider.NewServiced(servicer)) // register aka provider for linked local service
+
 	eapp.RegisterEapServiceServer(eapSrv.GrpcServer, servicer)
 	go eapSrv.RunTest(eapLis)
 
@@ -132,7 +136,7 @@ func TestEAPClientApi(t *testing.T) {
 			peap.GetPayload(), []byte(eap_test.SuccessEAP))
 	}
 
-	time.Sleep(servicer.SessionAuthenticatedTimeout() + time.Millisecond*10)
+	time.Sleep(servicer.SessionAuthenticatedTimeout() + time.Millisecond*100)
 
 	eapCtx = peap.GetCtx()
 	peap, err = client.Handle(&protos.Eap{Payload: tst.EapChallengeResp, Ctx: eapCtx})

--- a/feg/gateway/services/eap/eap_router/eap_router_test.go
+++ b/feg/gateway/services/eap/eap_router/eap_router_test.go
@@ -124,7 +124,7 @@ func TestEAPPeerNak(t *testing.T) {
 	failureEAP := []byte{4, 237, 0, 4}
 	akaPrimeIdentity := eap.NewPacket(
 		eap.ResponseCode, 236,
-		append([]byte{eap_client.EapMethodIdentity}, []byte("6001010000000091@wlan.mnc001.mcc001.3gppnetwork.org")...))
+		append([]byte{eap.MethodIdentity}, []byte("6001010000000091@wlan.mnc001.mcc001.3gppnetwork.org")...))
 	permIdReq := []byte{0x01, 237, 0x00, 0x0c, 0x17, 0x05, 0x00, 0x00, 0x0a, 0x01, 0x00, 0x00}
 	akaPrimeNak := []byte{0x02, 237, 0x00, 0x06, 0x03, 50}
 	akaAkaPrimeNak := []byte{0x02, 236, 0x00, 0x07, 0x03, 50, 23}

--- a/feg/gateway/services/eap/header.go
+++ b/feg/gateway/services/eap/header.go
@@ -12,6 +12,8 @@ LICENSE file in the root directory of this source tree.
 //
 package eap
 
+import "magma/feg/gateway/services/aaa/protos"
+
 const (
 	// EAP Message Payload Offsets
 	EapMsgCode int = iota
@@ -38,4 +40,11 @@ const (
 	ResponseCode  = 2
 	SuccessCode   = 3
 	FailureCode   = 4
+)
+
+const (
+	// EAP Related Consts
+	MethodIdentity = uint8(protos.EapType_Identity)
+	MethodNak      = uint8(protos.EapType_Legacy_Nak)
+	CodeResponse   = uint8(protos.EapCode_Response)
 )

--- a/feg/gateway/services/eap/providers/aka/definitions.go
+++ b/feg/gateway/services/eap/providers/aka/definitions.go
@@ -20,6 +20,8 @@ import (
 const (
 	TYPE           = uint8(protos.EapType_AKA)
 	MIN_PACKET_LEN = eap.EapSubtype
+
+	EapAkaServiceName = "eap_aka"
 )
 
 const (

--- a/feg/gateway/services/eap/providers/aka/eap_aka/main.go
+++ b/feg/gateway/services/eap/providers/aka/eap_aka/main.go
@@ -16,13 +16,12 @@ import (
 	"magma/feg/cloud/go/protos/mconfig"
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/eap/protos"
+	"magma/feg/gateway/services/eap/providers/aka"
 	"magma/feg/gateway/services/eap/providers/aka/servicers"
 	_ "magma/feg/gateway/services/eap/providers/aka/servicers/handlers"
 	managed_configs "magma/gateway/mconfig"
 	"magma/orc8r/lib/go/service"
 )
-
-const EapAkaServiceName = "eap_aka"
 
 func init() {
 	flag.Parse()
@@ -36,7 +35,7 @@ func main() {
 	}
 
 	akaConfigs := &mconfig.EapAkaConfig{}
-	err = managed_configs.GetServiceConfigs(EapAkaServiceName, akaConfigs)
+	err = managed_configs.GetServiceConfigs(aka.EapAkaServiceName, akaConfigs)
 	if err != nil {
 		log.Printf("Error getting EAP AKA service configs: %s", err)
 		akaConfigs = nil

--- a/feg/gateway/services/eap/providers/aka/provider/client_api.go
+++ b/feg/gateway/services/eap/providers/aka/provider/client_api.go
@@ -1,17 +1,22 @@
-/*
-Copyright (c) Facebook, Inc. and its affiliates.
-All rights reserved.
+//
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
 
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
-*/
+// +build !link_local_service
 
 // Package aka implements EAP-AKA provider
-package aka
+package provider
 
 import (
 	"errors"
 	"fmt"
+
+	"magma/feg/gateway/services/eap/providers"
+	"magma/feg/gateway/services/eap/providers/aka/servicers"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
@@ -20,15 +25,7 @@ import (
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/aaa/protos"
 	eapp "magma/feg/gateway/services/eap/protos"
-	"magma/feg/gateway/services/eap/providers"
 )
-
-// AKA Provider Implementation
-type providerImpl struct{} // singleton for now
-
-func New() providers.Method {
-	return providerImpl{}
-}
 
 // Wrapper to provide a wrapper for GRPC Client to extend it with Cleanup
 // functionality
@@ -57,18 +54,9 @@ func getAKAClient() (*akaClient, error) {
 	}, err
 }
 
-// String returns EAP AKA Provider name/info
-func (providerImpl) String() string {
-	return "<Magma EAP-AKA Method Provider>"
-}
-
-// EAPType returns EAP AKA Type - 23
-func (providerImpl) EAPType() uint8 {
-	return TYPE
-}
-
 // Handle handles passed EAP-AKA payload & returns corresponding result
-func (providerImpl) Handle(msg *protos.Eap) (*protos.Eap, error) {
+// this Handle implementation is using GRPC based AKA provider service
+func (*providerImpl) Handle(msg *protos.Eap) (*protos.Eap, error) {
 	if msg == nil {
 		return nil, errors.New("Invalid EAP AKA Message")
 	}
@@ -77,4 +65,8 @@ func (providerImpl) Handle(msg *protos.Eap) (*protos.Eap, error) {
 		return nil, err
 	}
 	return cli.Handle(context.Background(), msg)
+}
+
+func NewServiced(_ *servicers.EapAkaSrv) providers.Method {
+	return New()
 }

--- a/feg/gateway/services/eap/providers/aka/provider/linked_client_api.go
+++ b/feg/gateway/services/eap/providers/aka/provider/linked_client_api.go
@@ -1,0 +1,58 @@
+//
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// +build link_local_service
+
+// package aka implements EAP-AKA provider
+package provider
+
+import (
+	"errors"
+	"log"
+
+	"magma/feg/cloud/go/protos/mconfig"
+	"magma/feg/gateway/services/aaa/protos"
+	"magma/feg/gateway/services/eap/providers"
+	"magma/feg/gateway/services/eap/providers/aka"
+	"magma/feg/gateway/services/eap/providers/aka/servicers"
+	managed_configs "magma/gateway/mconfig"
+)
+
+func NewServiced(srvsr *servicers.EapAkaSrv) providers.Method {
+	return &providerImpl{EapAkaSrv: srvsr}
+}
+
+// Handle handles passed EAP-AKA payload & returns corresponding result
+// this Handle implementation is using GRPC based AKA provider service
+func (prov *providerImpl) Handle(msg *protos.Eap) (*protos.Eap, error) {
+	if msg == nil {
+		return nil, errors.New("Invalid EAP AKA Message")
+	}
+	prov.RLock()
+	if prov.EapAkaSrv == nil {
+		// servicer is not initialized, relock, recheck, create
+		prov.RUnlock()
+		prov.Lock()
+		if prov.EapAkaSrv == nil {
+			akaConfigs := &mconfig.EapAkaConfig{}
+			err := managed_configs.GetServiceConfigs(aka.EapAkaServiceName, akaConfigs)
+			if err != nil {
+				log.Printf("Error getting EAP AKA service configs: %s", err)
+				akaConfigs = nil
+			}
+			prov.EapAkaSrv, err = servicers.NewEapAkaService(akaConfigs)
+			if err != nil || prov.EapAkaSrv == nil {
+				log.Fatalf("failed to create EAP AKA Service: %v", err) // should never happen
+			}
+		}
+		prov.Unlock()
+		prov.RLock()
+	}
+	defer prov.RUnlock()
+	return prov.EapAkaSrv.HandleImpl(msg)
+}

--- a/feg/gateway/services/eap/providers/aka/provider/provider.go
+++ b/feg/gateway/services/eap/providers/aka/provider/provider.go
@@ -1,0 +1,38 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// Package aka implements EAP-AKA provider
+package provider
+
+import (
+	"sync"
+
+	"magma/feg/gateway/services/eap/providers"
+	"magma/feg/gateway/services/eap/providers/aka"
+	"magma/feg/gateway/services/eap/providers/aka/servicers"
+)
+
+// AKA Provider Implementation
+type providerImpl struct {
+	sync.RWMutex
+	*servicers.EapAkaSrv
+}
+
+func New() providers.Method {
+	return &providerImpl{}
+}
+
+// String returns EAP AKA Provider name/info
+func (*providerImpl) String() string {
+	return "<Magma EAP-AKA Method Provider>"
+}
+
+// EAPType returns EAP AKA Type - 23
+func (*providerImpl) EAPType() uint8 {
+	return aka.TYPE
+}

--- a/feg/gateway/services/eap/providers/aka/servicers/rpc.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/rpc.go
@@ -17,13 +17,17 @@ import (
 
 	"magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/eap"
-	"magma/feg/gateway/services/eap/client"
 	"magma/feg/gateway/services/eap/providers/aka"
 	"magma/feg/gateway/services/eap/providers/aka/metrics"
 )
 
 // Handle implements AKA handler RPC
-func (s *EapAkaSrv) Handle(ctx context.Context, req *protos.Eap) (*protos.Eap, error) {
+func (s *EapAkaSrv) Handle(_ context.Context, req *protos.Eap) (*protos.Eap, error) {
+	return s.HandleImpl(req)
+}
+
+// Handle implements AKA handler API
+func (s *EapAkaSrv) HandleImpl(req *protos.Eap) (*protos.Eap, error) {
 	failure := true
 	metrics.Requests.Inc()
 	defer func() {
@@ -50,7 +54,7 @@ func (s *EapAkaSrv) Handle(ctx context.Context, req *protos.Eap) (*protos.Eap, e
 	}
 	identifier := p.Identifier()
 	method := p.Type()
-	if method == client.EapMethodIdentity {
+	if method == eap.MethodIdentity {
 		return &protos.Eap{Payload: aka.NewIdentityReq(identifier+1, aka.AT_PERMANENT_ID_REQ), Ctx: eapCtx}, nil
 	}
 	if method != aka.TYPE {

--- a/feg/gateway/services/eap/providers/registry/providers.go
+++ b/feg/gateway/services/eap/providers/registry/providers.go
@@ -10,9 +10,9 @@ LICENSE file in the root directory of this source tree.
 package registry
 
 import (
-	"magma/feg/gateway/services/eap/providers/aka"
+	aka_provider "magma/feg/gateway/services/eap/providers/aka/provider"
 )
 
 func init() {
-	Register(aka.New())
+	Register(aka_provider.New())
 }


### PR DESCRIPTION
Summary: Use Golang build tags to select the single/multiple service option

Differential Revision: D20785009

