### PR TITLE
Bug fix for recycled sessions the sessiond.

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -833,7 +833,7 @@ bool LocalEnforcer::init_session_credit(
     std::string apn_mac_addr;
     std::string apn_name;
     if (!parse_apn(cfg.apn, apn_mac_addr, apn_name)) {
-        MLOG(MWARNING) << "Failed mac/name parsiong for apn " << cfg.apn;
+        MLOG(MWARNING) << "Failed mac/name parsing for apn " << cfg.apn;
         apn_mac_addr = "";
         apn_name = cfg.apn;
     }
@@ -1658,16 +1658,45 @@ bool LocalEnforcer::session_with_imsi_exists(
 }
 
 bool LocalEnforcer::session_with_apn_exists(
-  SessionMap& session_map,
-  const std::string& imsi,
-  const std::string& apn) const
-{
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& apn) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     if (session->get_apn() == apn) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool LocalEnforcer::is_session_active(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& core_session_id) const {
+  auto it = session_map.find(imsi);
+  if (it == session_map.end()) {
+    return false;
+  }
+  for (const auto& session : it->second) {
+    if (session->get_core_session_id() == core_session_id) {
+      return session->is_active();
+    }
+  }
+  return false;
+}
+
+bool LocalEnforcer::has_active_session(
+    SessionMap& session_map, const std::string& imsi,
+    std::string* core_session_id) const {
+  auto it = session_map.find(imsi);
+  if (it == session_map.end()) {
+    return false;
+  }
+  for (const auto& session : it->second) {
+    if (session->is_active()) {
+      *core_session_id = session->get_core_session_id();
       return true;
     }
   }

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -203,6 +203,16 @@ class LocalEnforcer {
     const std::string& imsi,
     const std::string& apn) const;
 
+  bool is_session_active(
+    SessionMap& session_map,
+    const std::string& imsi,
+    const std::string& core_session_id) const;
+
+  bool has_active_session(
+    SessionMap& session_map,
+    const std::string& imsi,
+    std::string* core_session_id) const;
+
   bool session_with_same_config_exists(
     SessionMap& session_map,
     const std::string& imsi,

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -209,13 +209,12 @@ static CreateSessionRequest copy_session_info2create_req(
 }
 
 void LocalSessionManagerHandlerImpl::CreateSession(
-  ServerContext* context,
-  const LocalCreateSessionRequest* request,
-  std::function<void(Status, LocalCreateSessionResponse)> response_callback)
-{
-  auto &request_cpy = *request;
-  enforcer_->get_event_base().runInEventBaseThread(
-      [this, context, response_callback, request_cpy]() {
+    ServerContext* context, const LocalCreateSessionRequest* request,
+    std::function<void(Status, LocalCreateSessionResponse)> response_callback) {
+  auto& request_cpy = *request;
+  enforcer_->get_event_base().runInEventBaseThread([this, context,
+                                                    response_callback,
+                                                    request_cpy]() {
     auto imsi     = request_cpy.sid().id();
     auto sid      = id_gen_.gen_session_id(imsi);
     auto mac_addr = convert_mac_addr_to_str(request_cpy.hardware_addr());
@@ -246,17 +245,31 @@ void LocalSessionManagerHandlerImpl::CreateSession(
     auto session_map = get_sessions_for_creation(request_cpy);
     if (enforcer_->session_with_imsi_exists(session_map, imsi)) {
       std::string core_sid;
-      bool same_config = enforcer_->session_with_same_config_exists(
-          session_map, imsi, cfg, &core_sid);
-      bool is_wifi = request_cpy.rat_type() == RATType::TGPP_WLAN;
-      if (same_config || is_wifi) {
+
+      // For LTE case, load session if and only if the configuration exactly
+      // matches. For CWF use case, we can recycle any active session
+      bool same_config = false;
+      bool is_active   = false;
+      bool is_wifi     = request_cpy.rat_type() == RATType::TGPP_WLAN;
+      if (is_wifi) {
+        is_active = enforcer_->has_active_session(session_map, imsi, &core_sid);
+      } else {
+        same_config = enforcer_->session_with_same_config_exists(
+            session_map, imsi, cfg, &core_sid);
+        is_active = enforcer_->is_session_active(session_map, imsi, core_sid);
+      }
+      // To recycle the session, it has to be active (i.e., not in transition
+      // for termination), it should have the exact same configuration or it
+      // should be CWF use case.
+      if ((same_config || is_wifi) && is_active) {
         Status status;
         if (is_wifi) {
-          MLOG(MINFO) << "Found a session with the same IMSI " << imsi
+          MLOG(MINFO) << "Found an active session with the same IMSI " << imsi
                       << " and RAT Type is WLAN, not creating a new session";
           // Wifi only supports one session per subscriber, so update the config
           // here
-          SessionUpdate session_update = SessionStore::get_default_session_update(session_map);
+          SessionUpdate session_update =
+              SessionStore::get_default_session_update(session_map);
           enforcer_->handle_cwf_roaming(session_map, imsi, cfg, session_update);
           if (session_store_.update_sessions(session_update)) {
             MLOG(MINFO) << "Successfully updated session " << sid
@@ -288,29 +301,33 @@ void LocalSessionManagerHandlerImpl::CreateSession(
         // No new session created
         return;
       }
-      if (enforcer_->session_with_apn_exists(
+
+      if (!enforcer_->session_with_apn_exists(
               session_map, imsi, request_cpy.apn())) {
         MLOG(MINFO) << "Found session with the same IMSI " << imsi
+                    << " but different APN " << request_cpy.apn()
+                    << ", will request a new session from PCRF/PCF";
+      } else if (is_active) {
+        MLOG(MINFO) << "Found an active session with the same IMSI " << imsi
                     << " and APN " << request_cpy.apn()
                     << ", but different configuration."
-                    << " Ending the existing session";
+                    << " Ending the existing session, "
+                    << "will request a new session from PCRF/PCF";
         LocalEndSessionRequest end_session_req;
         end_session_req.mutable_sid()->CopyFrom(request_cpy.sid());
         end_session_req.set_apn(request_cpy.apn());
         end_session(
-            session_map,
-            end_session_req,
+            session_map, end_session_req,
             [&](grpc::Status status, LocalEndSessionResponse response) {});
       } else {
-        MLOG(MINFO) << "Found session with the same IMSI " << imsi
-                    << " but different APN " << request_cpy.apn()
+        MLOG(MINFO) << "Found a session in termination with the same IMSI "
+                    << imsi << " and same APN " << request_cpy.apn()
                     << ", will request a new session from PCRF/PCF";
       }
     }
     send_create_session(
-        session_map,
-        copy_session_info2create_req(request_cpy, sid), imsi, sid, cfg,
-        response_callback);
+        session_map, copy_session_info2create_req(request_cpy, sid), imsi, sid,
+        cfg, response_callback);
   });
 }
 
@@ -449,7 +466,7 @@ void LocalSessionManagerHandlerImpl::end_session(
           "occurred to the session first.");
       response_callback(status, LocalEndSessionResponse());
     }
-  } catch (const SessionNotFound &ex) {
+  } catch (const SessionNotFound& ex) {
     MLOG(MERROR) << "Failed to find session to terminate for subscriber "
                  << request.sid().id();
     Status status(grpc::FAILED_PRECONDITION, "Session not found");

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -672,4 +672,7 @@ uint32_t SessionState::get_credit_key_count()
   return charging_pool_.get_credit_key_count() + monitor_pool_.get_credit_key_count();
 }
 
+bool SessionState::is_active() {
+  return (curr_state_ == SESSION_ACTIVE);
+}
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -269,6 +269,7 @@ class SessionState {
   DynamicRuleStore& get_dynamic_rules();
 
   uint32_t total_monitored_rules_count();
+  bool is_active();
 
   uint32_t get_credit_key_count();
 

--- a/lte/gateway/python/magma/policydb/servicers/session_servicer.py
+++ b/lte/gateway/python/magma/policydb/servicers/session_servicer.py
@@ -71,6 +71,7 @@ class SessionRpcServicer(CentralSessionControllerServicer):
             credits=self._get_credits(imsi),
             static_rules=self._get_rules_for_imsi(imsi),
             dynamic_rules=self._get_default_dynamic_rules(imsi),
+            session_id=request.session_id,
         )
 
     def UpdateSession(


### PR DESCRIPTION
Summary: Sessiond recycles sessions if a session exists with the right WLAN RAT type or exact configuration. When the session is in a transitional state to terminate, it creates a bug where session is deleted while MME thinks that the session still exists. This change does not recycle sessions in transitional state.

Differential Revision: D20787659

