### PR TITLE
fix routing for symphony-hub UI

### DIFF
--- a/symphony/app/fbcnms-projects/hub/app/components/Main.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/Main.js
@@ -94,8 +94,9 @@ export default () => {
     <ApplicationMain>
       <AppContextProvider>
         <Switch>
+          <Route path={relativeUrl('/services')} component={Main} />
+          <Redirect exact from="/" to={relativeUrl('/hub')} />
           <Redirect exact from="/hub" to={relativeUrl('/services')} />
-          <Route path="/hub/services" component={Main} />
         </Switch>
       </AppContextProvider>
     </ApplicationMain>

--- a/symphony/app/fbcnms-projects/platform-server/src/main/routes.js
+++ b/symphony/app/fbcnms-projects/platform-server/src/main/routes.js
@@ -72,6 +72,7 @@ router.use(
 router.get('/admin*', access(AccessRoles.SUPERUSER), handleReact('admin'));
 router.get('/automation*', access(AccessRoles.USER), handleReact('automation'));
 router.get('/inventory*', access(AccessRoles.USER), handleReact('inventory'));
+router.get('/hub*', access(AccessRoles.USER), handleReact('inventory'));
 router.get('/workorders*', access(AccessRoles.USER), handleReact('workorders'));
 router.get('/id*', access(AccessRoles.USER), handleReact('id'));
 router.use(


### PR DESCRIPTION
Summary: Previously navigating to fb-test.localhost/hub/services wouldn't work - only navigating to that page via the UI would work. This is because I didn't modify the platform-server. I've fixed that in this diff.

Reviewed By: dlvhdr

Differential Revision: D20815828

