### PR TITLE
Fixing update of mme_ue_s1ap_id => IMSI on s1ap handlers

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -631,10 +631,7 @@ void s1ap_remove_ue(s1ap_state_t* state, ue_description_t* ue_ref)
   hashtable_ts_free(&enb_ref->ue_coll, ue_ref->enb_ue_s1ap_id);
   hashtable_ts_free(&state->mmeid2associd, mme_ue_s1ap_id);
 
-  s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
-  hashtable_uint64_ts_remove(
-    imsi_map->mme_ue_id_imsi_htbl,
-    (const hash_key_t) mme_ue_s1ap_id);
+
 
   if (!enb_ref->nb_ue_associated) {
     if (enb_ref->s1_state == S1AP_RESETING) {


### PR DESCRIPTION
Summary:
- During updates of D19793320, on `s1ap_mme_handle_path_switch_request` mme_ue_s1ap_id was getting removed after being freed by function call to `s1ap_remove_ue`, this fixes it by removing removal of ue id on `s1ap_remove_ue` function.
- For `s1ap_mme_handle_path_switch_request`, as ue_id will remain the same, the update of ue_id => IMSI is removed.

Differential Revision: D20823560

