### PR TITLE
adding workflows container

### DIFF
--- a/symphony/app/fbcnms-projects/platform-server/src/app.js
+++ b/symphony/app/fbcnms-projects/platform-server/src/app.js
@@ -128,13 +128,19 @@ app.use('/user', require('@fbcnms/auth/express').unprotectedUserRoutes());
 
 app.use(configureAccess({loginUrl: '/user/login'}));
 
-// All /graph, /store and /webhooks endpoints don't use CORS and are JSON (no form),
-// so no CSRF is needed
+// All /graph, /workflows, /store and /webhooks endpoints don't use CORS and
+// are JSON (no form), so no CSRF is needed
 app.use(
   '/graph',
   passport.authenticate(['basic_local', 'session'], {session: false}),
   access(USER),
   require('./graph/routes'),
+);
+app.use(
+  '/workflows',
+  passport.authenticate(['basic_local', 'session'], {session: false}),
+  access(USER),
+  require('./workflows/routes'),
 );
 app.use(
   '/store',

--- a/symphony/app/fbcnms-projects/platform-server/src/config.js
+++ b/symphony/app/fbcnms-projects/platform-server/src/config.js
@@ -19,6 +19,7 @@ const LOG_LEVEL = getValidLogLevel(process.env.LOG_LEVEL);
 const MAPBOX_ACCESS_TOKEN = process.env.MAPBOX_ACCESS_TOKEN || '';
 
 const GRAPH_HOST = process.env.GRAPH_HOST || 'graph';
+const WORKFLOWS_HOST = process.env.GRAPH_HOST || 'workflows';
 const STORE_HOST = process.env.STORE_HOST || 'store';
 const DOCS_HOST = process.env.DOCS_HOST || 'docs';
 const ID_HOST = process.env.ID_HOST || 'id';
@@ -26,6 +27,7 @@ const ID_HOST = process.env.ID_HOST || 'id';
 module.exports = {
   DEV_MODE,
   GRAPH_HOST,
+  WORKFLOWS_HOST,
   LOG_FORMAT,
   LOG_LEVEL,
   MAPBOX_ACCESS_TOKEN,

--- a/symphony/app/fbcnms-projects/platform-server/src/workflows/routes.js
+++ b/symphony/app/fbcnms-projects/platform-server/src/workflows/routes.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+const express = require('express');
+const querystring = require('querystring');
+const proxy = require('http-proxy-middleware');
+const {WORKFLOWS_HOST} = require('../config');
+import {accessRoleToString} from '@fbcnms/auth/roles';
+import {oidcAccessToken} from '@fbcnms/auth/oidc/middleware';
+import type {ClientRequest} from 'http';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+
+const router = express.Router();
+
+router.use(
+  '/',
+  proxy({
+    // hostname to the target server
+    target: 'http://' + WORKFLOWS_HOST,
+
+    // enable websocket proxying
+    ws: true,
+
+    // rewrite paths
+    pathRewrite: (path: string): string => path.replace(/^\/workflows/, ''),
+
+    // subscribe to http-proxy's proxyReq event
+    onProxyReq: (proxyReq: ClientRequest, req: FBCNMSRequest): void => {
+      if (req.user.organization) {
+        proxyReq.setHeader('x-auth-organization', req.user.organization);
+      }
+      proxyReq.setHeader('x-auth-user-email', req.user.email);
+      proxyReq.setHeader('x-auth-user-role', accessRoleToString(req.user.role));
+
+      const accessToken = oidcAccessToken(req);
+      if (accessToken != null) {
+        proxyReq.setHeader('authorization', 'Bearer ' + accessToken);
+      }
+
+      if (!req.body || !Object.keys(req.body).length) {
+        return;
+      }
+
+      const writeBody = (body: string) => {
+        proxyReq.setHeader(
+          'Content-Length',
+          Buffer.byteLength(body).toString(),
+        );
+        proxyReq.write(body);
+        proxyReq.end();
+      };
+
+      const contentType = proxyReq.getHeader('Content-Type');
+      if (contentType.includes('application/json')) {
+        writeBody(JSON.stringify(req.body));
+      } else if (contentType.includes('application/x-www-form-urlencoded')) {
+        writeBody(querystring.stringify(req.body));
+      }
+    },
+  }),
+);
+
+module.exports = router;

--- a/symphony/app/fbcnms-projects/workflows/Dockerfile
+++ b/symphony/app/fbcnms-projects/workflows/Dockerfile
@@ -1,0 +1,32 @@
+FROM node:12
+
+EXPOSE 8080
+
+# # Copy the app
+# WORKDIR /app
+# COPY package.json ./src/ ./
+
+# # Install shared dependencies
+# COPY fbcnms-packages fbcnms-packages
+# RUN yarn install --frozen-lockfile && yarn cache clean
+
+# RUN yarn install
+# CMD yarn start
+
+# Create app directory
+WORKDIR /app
+
+# Copy package dependencies
+COPY package.json yarn.lock babel.config.js ./
+COPY fbcnms-projects/workflows/package.json fbcnms-projects/workflows/
+
+# Install shared dependencies
+COPY fbcnms-packages fbcnms-packages
+RUN yarn install --frozen-lockfile && yarn cache clean
+
+# Copy app source
+WORKDIR /app/fbcnms-projects/workflows
+COPY fbcnms-projects/workflows .
+
+# Start app
+CMD yarn start

--- a/symphony/app/fbcnms-projects/workflows/package.json
+++ b/symphony/app/fbcnms-projects/workflows/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "workflows",
+  "version": "1.0.0",
+  "main": "index.js",
+  "author": "Ken Garber <kengarber@fb.com>",
+  "license": "MIT",
+  "dependencies": {
+    "express": "^4.17.1",
+    "@fbcnms/babel-register": "^0.1.0"
+  },
+  "scripts": {
+    "start": "node -r @fbcnms/babel-register src/index.js"
+  }
+}

--- a/symphony/app/fbcnms-projects/workflows/src/index.js
+++ b/symphony/app/fbcnms-projects/workflows/src/index.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+'use strict';
+
+import ExpressApplication from 'express';
+
+const app = ExpressApplication();
+
+app.get('/', (req, res) => {
+  res.send('hello world');
+});
+
+app.get('/echo/:str', (req, res) => {
+  res.send(req.params.str);
+});
+
+app.listen(80);

--- a/symphony/integration/docker-compose.workflows.yaml
+++ b/symphony/integration/docker-compose.workflows.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2004-present Facebook All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: "3.7"
+
+services:
+  workflows:
+    build:
+      context: ${XPLAT_FBC_DIR}
+      dockerfile: fbcnms-projects/workflows/Dockerfile
+    networks:
+      - private
+    restart: on-failure
+
+networks:
+  public:
+  private:
+    internal: true


### PR DESCRIPTION
Summary: This adds a simple container to the local symphony deployment, and sets up a platform-server to proxy requests to /workflows to the container. I closely followed the example of the "graph" container. This will allow independent workflow development without interfering with anything inventory related.

Differential Revision: D20831913

Test Plan:

To run the workflow server separately:
```
cd fbcnms-projects/workflows
yarn install
yarn start
```
You can make a request to "http://localhost/" to get a "hello world" message, or "http://localhost/echo/xyz" to get an echo response of "xyz".

You can launch symphony and then the workflow container as such:
```
# build symphony
docker-compose build
# build the workflows container
docker-compose -f docker-compose.workflows.yaml build
# start symphony
docker-compose up -d
# start the workflows container
docker-compose -f docker-compose.workflows.yaml up -d
```
Now you can curl "https://fb-test.localhost/workflows/" for the hello world message, or hit "https://fb-test.localhost/workflows/echo/test123" for an echo response of test123.
