### PR TITLE
Print ReAuth Result Code in Int not Uint32

### DIFF
--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -414,7 +414,7 @@ func TestGxQosDowngradeWithReAuth(t *testing.T) {
 
 	// Check ReAuth success
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
+	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -104,7 +104,7 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 
 	// Check ReAuth success
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
+	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Check that UE flows were deleted for rule 2 and 3
 	recordsBySubID, err = tr.GetPolicyUsage()
@@ -177,7 +177,7 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 
 	// Check ReAuth success
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
+	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Check that all UE mac flows are deleted
 	recordsBySubID, err = tr.GetPolicyUsage()
@@ -270,7 +270,7 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 
 	// Check ReAuth success
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
+	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Generate more traffic
 	_, err = tr.GenULTraffic(req)
@@ -376,7 +376,7 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 
 	// Check ReAuth success
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
+	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Generate more traffic
 	_, err = tr.GenULTraffic(req)
@@ -457,7 +457,7 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 
 	// Check ReAuth success
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.Success), raa.ResultCode)
+	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Generate more traffic
 	_, err = tr.GenULTraffic(req)

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -113,7 +113,7 @@ func TestGyReAuth(t *testing.T) {
 	// Check ReAuth success
 	assert.NoError(t, err)
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
-	assert.Equal(t, uint32(diam.LimitedSuccess), raa.ResultCode)
+	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
 	// Generate over 7M of data to check that initial quota was updated
 	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "5M"}}


### PR DESCRIPTION
Summary:
From
```
[vagrant@127.0.0.1:2202] out:         	Error:      	Not equal:
[vagrant@127.0.0.1:2202] out:         	            	expected: 0x7d1
[vagrant@127.0.0.1:2202] out:         	            	actual  : 0xbba
[vagrant@127.0.0.1:2202] out:         	Test:
```
To
```
[vagrant@127.0.0.1:2202] out:         	Error:      	Not equal:
[vagrant@127.0.0.1:2202] out:         	            	expected: 2001
[vagrant@127.0.0.1:2202] out:         	            	actual  : 3002
[vagrant@127.0.0.1:2202] out:         	Test:
```

Differential Revision: D20844170

