### PR TITLE
Implement Cloud Connection cache & prevent potential connections leakage (#2174)

### DIFF
--- a/feg/gateway/registry/registry_test.go
+++ b/feg/gateway/registry/registry_test.go
@@ -10,8 +10,9 @@ package registry_test
 
 import (
 	"fmt"
-	"log"
 	"net"
+	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -50,22 +51,24 @@ func TestCloudConnection(t *testing.T) {
 	reg := service_registry.Get()
 	reg.AddService(platform_registry.ServiceLocation{Name: registry.CONTROL_PROXY, Host: "127.0.0.1", Port: 50053})
 
-	lis, err := net.Listen("tcp", ":44444")
+	lis, err := net.Listen("tcp", "127.0.0.1:")
 	assert.NoError(t, err)
 
 	grpcServer := grpc.NewServer()
 	protos.RegisterHelloServer(grpcServer, &helloServer{})
-	serverStarted := make(chan struct{})
+	serverStarted := make(chan struct{}, 2)
+	localPort, _ := strconv.Atoi(strings.Split(lis.Addr().String(), ":")[1])
+
 	go func() {
-		log.Printf("Starting server")
+		t.Logf("Starting server on addr: %s, port: %d", lis.Addr(), localPort)
 		serverStarted <- struct{}{}
 		grpcServer.Serve(lis)
 	}()
 	<-serverStarted
-	time.Sleep(time.Millisecond)
+	time.Sleep(time.Millisecond * 7)
 
 	configMap := config.NewConfigMap(map[interface{}]interface{}{
-		"local_port": 44444, "cloud_address": "controller.magma.test",
+		"local_port": localPort, "cloud_address": "controller.magma.test",
 		"cloud_port": 443})
 
 	conn, err := reg.GetCloudConnectionFromServiceConfig(configMap, "hello")
@@ -75,4 +78,70 @@ func TestCloudConnection(t *testing.T) {
 	reply, err := client.SayHello(context.Background(), &protos.HelloRequest{Greeting: "hi"})
 	assert.NoError(t, err)
 	assert.Equal(t, "hello-controller.magma.test", reply.Greeting)
+
+	assert.NoError(t, conn.Close())
+
+	conn, err = reg.GetSharedCloudConnectionFromServiceConfig(configMap, "hello")
+	assert.NoError(t, err)
+	client = protos.NewHelloClient(conn)
+
+	reply, err = client.SayHello(context.Background(), &protos.HelloRequest{Greeting: "hi"})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello-controller.magma.test", reply.Greeting)
+
+	conn1, err := reg.GetSharedCloudConnectionFromServiceConfig(configMap, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, conn, conn1)
+
+	grpcServer.Stop() // kill previous server & all existing connections
+
+	// Start new Hello service & make sure all tests pass without errors &
+	// the cached cloud connection is automatically recreated
+	lis, err = net.Listen("tcp", "127.0.0.1:")
+	assert.NoError(t, err)
+	localPort, _ = strconv.Atoi(strings.Split(lis.Addr().String(), ":")[1])
+	grpcServer = grpc.NewServer()
+	protos.RegisterHelloServer(grpcServer, &helloServer{})
+	go func() {
+		t.Logf("Starting second server on addr: %s, port: %d", lis.Addr(), localPort)
+		serverStarted <- struct{}{}
+		grpcServer.Serve(lis)
+	}()
+	<-serverStarted
+	time.Sleep(time.Millisecond * 7)
+
+	configMap = config.NewConfigMap(map[interface{}]interface{}{
+		"local_port": localPort, "cloud_address": "controller.magma.test",
+		"cloud_port": 443})
+	conn, err = reg.GetSharedCloudConnectionFromServiceConfig(configMap, "hello")
+	assert.NoError(t, err)
+	assert.NotEqual(t, conn, conn1)
+
+	client = protos.NewHelloClient(conn)
+	reply, err = client.SayHello(context.Background(), &protos.HelloRequest{Greeting: "hi"})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello-controller.magma.test", reply.Greeting)
+
+	conn1, err = reg.GetSharedCloudConnectionFromServiceConfig(configMap, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, conn, conn1)
+
+	client = protos.NewHelloClient(conn1)
+	reply, err = client.SayHello(context.Background(), &protos.HelloRequest{Greeting: "hi"})
+	assert.NoError(t, err)
+	assert.Equal(t, "hello-controller.magma.test", reply.Greeting)
+
+	reg.CleanupSharedCloudConnection("hello")
+	platform_registry.SetSharedCloudConnectionTTL(time.Millisecond * 100)
+
+	conn, err = reg.GetSharedCloudConnectionFromServiceConfig(configMap, "hello")
+	assert.NoError(t, err)
+	assert.NotEqual(t, conn, conn1)
+
+	time.Sleep(time.Millisecond * 101)
+	conn1, err = reg.GetSharedCloudConnectionFromServiceConfig(configMap, "hello")
+	assert.NoError(t, err)
+	assert.NotEqual(t, conn1, conn)
+
+	platform_registry.SetSharedCloudConnectionTTL(platform_registry.DefaultSharedCloudConnectionTTL)
 }

--- a/orc8r/gateway/go/service_registry/registry.go
+++ b/orc8r/gateway/go/service_registry/registry.go
@@ -34,14 +34,24 @@ type GatewayRegistry interface {
 	// GetCloudConnectionFromServiceConfig returns a connection to the cloud
 	// using a specific control_proxy service config map. This map must contain the cloud_address
 	// and local_port params
-	// Input: serviceConfig - ConfigMap containing cloud_address and local_port
-	//        and optional proxy_cloud_connections, cloud_port, rootca_cert, gateway_cert/key fields if direct
-	//        cloud connection is needed
+	// Input: serviceConfig - ConfigMap containing cloud_address and local_port and optional proxy_cloud_connections,
+	// 		  cloud_port, rootca_cert, gateway_cert/key fields if direct cloud connection is needed
 	//        service - name of cloud service to connect to
-	//
-	// Output: *grpc.ClientConn with connection to cloud service
-	//         error if it exists
+	// Output: *grpc.ClientConn with connection to cloud service error if it exists
 	GetCloudConnectionFromServiceConfig(controlProxyConfig *config.ConfigMap, service string) (*grpc.ClientConn, error)
+	// GetSharedCloudConnection returns a new GRPC service connection to the service in the cloud for a gateway
+	// either directly or via control proxy
+	// GetSharedCloudConnection will return an existing cached cloud connection if it's available and healthy,
+	// if not - it'll try to create, cache and return a new cloud connection
+	GetSharedCloudConnection(service string) (*grpc.ClientConn, error)
+	// GetSharedCloudConnectionFromServiceConfig returns a connection to the cloud
+	// using a specific control_proxy service config map. This map must contain the cloud_address
+	// and local_port params
+	// GetSharedCloudConnectionFromServiceConfig will return an existing cached cloud connection if it's available and
+	// healthy, if not - it'll try to create, cache and return a new cloud connection
+	GetSharedCloudConnectionFromServiceConfig(controlProxyConfig *config.ConfigMap, service string) (*grpc.ClientConn, error)
+	// GetClientConnection provides a gRPC connection to a service on the address addr.
+	CleanupSharedCloudConnection(service string) bool
 
 	// GetConnection provides a gRPC connection to a service in the registry.
 	GetConnection(service string) (*grpc.ClientConn, error)

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -28,17 +28,25 @@ type ServiceLocation struct {
 	ProxyAliases map[string]int
 }
 
+type cloudConnection struct {
+	*grpc.ClientConn
+	expiration time.Time
+}
 type ServiceRegistry struct {
 	sync.RWMutex
 	ServiceConnections map[string]*grpc.ClientConn
 	ServiceLocations   map[string]ServiceLocation
+
+	cloudConnMu      sync.RWMutex
+	cloudConnections map[string]cloudConnection
 }
 
 // New creates and returns a new registry
 func New() *ServiceRegistry {
 	return &ServiceRegistry{
 		ServiceConnections: map[string]*grpc.ClientConn{},
-		ServiceLocations:   map[string]ServiceLocation{}}
+		ServiceLocations:   map[string]ServiceLocation{},
+		cloudConnections:   map[string]cloudConnection{}}
 }
 
 // String implements ServiceLocation stringer interface

--- a/orc8r/lib/go/registry/shared_cloud_conn.go
+++ b/orc8r/lib/go/registry/shared_cloud_conn.go
@@ -1,0 +1,170 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// package registry provides Registry interface for Go based gateways
+// as well as cloud connection routines
+package registry
+
+import (
+	"fmt"
+	"log"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+
+	"magma/orc8r/lib/go/service/config"
+)
+
+// DefaultSharedCloudConnectionTTL - default duration to reuse the same connection
+const DefaultSharedCloudConnectionTTL = time.Hour * 4
+
+// sharedCloudConnectionTTL - default duration to reuse the same connection the TTL should be a fraction of gateway
+// certificate renewal period to make sure, the connection is not reused past the certificate expiration
+var sharedCloudConnectionTTL = DefaultSharedCloudConnectionTTL
+
+// GetSharedCloudConnection returns a new GRPC service connection to the service in the cloud for a gateway
+// either directly or via control proxy
+// GetSharedCloudConnection will return an existing cached cloud connection if it's available and healthy,
+// if not - it'll try to create, cache and return a new cloud connection
+// Input: service - name of cloud service to connect to
+//
+// Output: *grpc.ClientConn with connection to cloud service
+//         error if it exists
+func (registry *ServiceRegistry) GetSharedCloudConnection(service string) (*grpc.ClientConn, error) {
+	cpc, ok := controlProxyConfig.Load().(*config.ConfigMap)
+	if (!ok) || cpc == nil {
+		var err error
+		// moduleName is "" since all feg configs lie in /etc/magma/configs without a module name
+		cpc, err = config.GetServiceConfig("", "control_proxy")
+		if err != nil {
+			return nil, err
+		}
+		controlProxyConfig.Store(cpc)
+	}
+	return registry.GetSharedCloudConnectionFromServiceConfig(cpc, service)
+}
+
+// GetSharedCloudConnectionFromServiceConfig returns a connection to the cloud
+// using a specific control_proxy service config map. This map must contain the cloud_address
+// and local_port params
+// GetSharedCloudConnectionFromServiceConfig will return an existing cached cloud connection if it's available and
+// healthy, if not - it'll try to create, cache and return a new cloud connection
+// Input:  serviceConfig - ConfigMap containing cloud_address and local_port
+//         and optional proxy_cloud_connections, cloud_port, rootca_cert, gateway_cert/key fields if direct
+//         cloud connection is needed
+//         service - name of cloud service to connect to
+//
+// Output: *grpc.ClientConn with connection to cloud service
+//         error if it exists
+// Note:   controlProxyConfig differences are ignored in cached connection mapping,
+//         if an update to ConfigMap is required - use CleanupSharedCloudConnection() to flush the service conn cache
+func (registry *ServiceRegistry) GetSharedCloudConnectionFromServiceConfig(
+	controlProxyConfig *config.ConfigMap, service string) (*grpc.ClientConn, error) {
+
+	// First try to get an existing connection with reader lock
+	registry.cloudConnMu.RLock()
+	conn, connExists := registry.cloudConnections[service]
+	registry.cloudConnMu.RUnlock()
+
+	timeNow := time.Now()
+	if connExists && (conn.ClientConn != nil) {
+		if conn.GetState() == connectivity.Ready && conn.expiration.After(timeNow) {
+			return conn.ClientConn, nil // cached connection is good & current - return it
+		}
+	}
+
+	// Attempt to connect outside of the lock
+	grpcConn, connectErr := registry.GetCloudConnectionFromServiceConfig(controlProxyConfig, service)
+	if connectErr != nil || grpcConn == nil || grpcConn.GetState() != connectivity.Ready {
+		connectErr = fmt.Errorf("cloud service '%s' connection error: %v", service, connectErr)
+	}
+
+	newConnectionTTL := GetSharedCloudConnectionTTL()
+
+	// GRPC connection is successfully established, update the cache
+	registry.cloudConnMu.Lock() // LOCK
+
+	// check if another thread already created/updated the shared connection for the service
+	conn, connExists = registry.cloudConnections[service]
+	if connExists && conn.ClientConn != nil {
+		if connState := conn.GetState(); connState == connectivity.Ready {
+			if conn.expiration.After(timeNow) {
+				// another thread already created/updated the shared connection for the service,
+				// return it & close just created grpcConn, it's no longer needed
+				registry.cloudConnMu.Unlock() // UNLOCK
+
+				if connectErr == nil {
+					grpcConn.Close()
+				}
+				return conn.ClientConn, nil
+			} else {
+				if connectErr != nil {
+					// we failed to create a new cloud connection, better to use expired but otherwise valid
+					// connection and retry later then fail the call
+					registry.cloudConnMu.Unlock() // UNLOCK
+
+					log.Printf(
+						"failed to create a new service '%s' cloud connection: %v; using expired",
+						service, connectErr)
+					return conn.ClientConn, nil
+				}
+				// connection is expired, but is still valid, give existing users time to complete
+				// and defer + delay connection close call
+				defer func() {
+					go func() {
+						time.Sleep(time.Second * grpcMaxDelaySec)
+						conn.Close()
+					}()
+				}()
+				log.Printf("service '%s' cloud connection is expired, will reconnect", service)
+			}
+		} else { // if connState := conn.GetState(); connState == connectivity.Ready ... else
+			// connection is already broken, close on return without delay
+			defer conn.Close()
+			log.Printf("unhealthy state '%s' of service '%s' cloud connection", connState, service)
+		}
+	}
+	if connectErr == nil {
+		registry.cloudConnections[service] =
+			cloudConnection{ClientConn: grpcConn, expiration: timeNow.Add(newConnectionTTL)}
+	} else {
+		delete(registry.cloudConnections, service)
+	}
+
+	registry.cloudConnMu.Unlock() // UNLOCK
+
+	return grpcConn, connectErr
+}
+
+// CleanupSharedCloudConnection removes cached cloud connection for the service from cache and closes it
+// Returns true if connection was cached
+func (registry *ServiceRegistry) CleanupSharedCloudConnection(service string) bool {
+	registry.cloudConnMu.Lock()
+	conn, ok := registry.cloudConnections[service]
+	if ok {
+		delete(registry.cloudConnections, service)
+		if ok = conn.ClientConn != nil; ok {
+			defer conn.ClientConn.Close()
+		}
+	}
+	registry.cloudConnMu.Unlock()
+	return ok
+}
+
+// SetSharedCloudConnectionTTL atomically sets Shared Cloud Connection TTL
+// Note: the new TTL will apply only to newly created connections,
+// existing cached connections will not be affected
+func SetSharedCloudConnectionTTL(ttl time.Duration) {
+	atomic.StoreInt64((*int64)(&sharedCloudConnectionTTL), int64(ttl))
+}
+
+// GetSharedCloudConnectionTTL atomically gets and returns current Shared Cloud Connection TTL value
+func GetSharedCloudConnectionTTL() time.Duration {
+	return time.Duration(atomic.LoadInt64((*int64)(&sharedCloudConnectionTTL)))
+}


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2174

Implement Cloud Connection cache & prevent potential connections leakage.
Many Magma services are using CreateCloudConnection() to RPC  a cloud service. Some call the function per every RPC and never close the connection, some create & close connection with every RPC call.
We need to reuse connection to 1) prevent connection leakage from services which never clean up and 2) prevent running out of FDs due to high calls rate even for services which clean up the connection.

Reviewed By: uri200

Differential Revision: D20828530

