### PR TITLE
Make all redis clients use address configured in redis.yml

### DIFF
--- a/cwf/gateway/configs/redis.yml
+++ b/cwf/gateway/configs/redis.yml
@@ -8,6 +8,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 port: 6380
+bind: 127.0.0.1
 redis_loglevel: notice
 dir: /var/opt/magma
 # How frequently to save/dump to disk.

--- a/cwf/gateway/configs/service_registry.yml
+++ b/cwf/gateway/configs/service_registry.yml
@@ -52,9 +52,6 @@ services:
   health:
     ip_address: 127.0.0.1
     port: 9107
-  redis:
-    ip_address: 127.0.0.1
-    port: 6380
   radiusd:
     ip_address: 127.0.0.1
     port: 9115

--- a/feg/gateway/configs/redis.yml
+++ b/feg/gateway/configs/redis.yml
@@ -8,6 +8,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 port: 6380
+bind: 127.0.0.1
 redis_loglevel: notice
 dir: /var/opt/magma
 # How frequently to save/dump to disk.

--- a/feg/gateway/configs/service_registry.yml
+++ b/feg/gateway/configs/service_registry.yml
@@ -45,9 +45,6 @@ services:
   radiusd:
     ip_address: 127.0.0.1
     port: 9115
-  redis:
-    ip_address: 127.0.0.1
-    port: 6380
 
   # Development/Test Services
   mock_ocs:

--- a/feg/gateway/object_store/redis.go
+++ b/feg/gateway/object_store/redis.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 
 	"magma/feg/gateway/registry"
+	"magma/orc8r/lib/go/service/config"
 
 	"github.com/go-redis/redis"
 )
@@ -34,13 +35,21 @@ type RedisClientImpl struct {
 // NewRedisClient gets the redis configuration from the service config and returns
 // a new client or an error if something went wrong
 func NewRedisClient() (RedisClient, error) {
-	address, err := registry.GetServiceAddress(registry.REDIS)
+	redisConfig, err := config.GetServiceConfig("", registry.REDIS)
+	if err != nil {
+		return nil, err
+	}
+	bindAddr, err := redisConfig.GetStringParam("bind")
+	if err != nil {
+		bindAddr = "127.0.0.1"
+	}
+	port, err := redisConfig.GetIntParam("port")
 	if err != nil {
 		return nil, err
 	}
 	return &RedisClientImpl{
 		RawClient: redis.NewClient(&redis.Options{
-			Addr: fmt.Sprintf(address),
+			Addr: fmt.Sprintf("%s:%d", bindAddr, port),
 		}),
 	}, nil
 }

--- a/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.cpp
@@ -42,14 +42,15 @@ RedisClient::RedisClient():
   db_client_(std::make_unique<cpp_redis::client>()),
   is_connected_(false)
 {
-  init_db_connection(LOCALHOST);
+  init_db_connection();
 }
 
-void RedisClient::init_db_connection(const std::string& addr)
+void RedisClient::init_db_connection()
 {
   magma::ServiceConfigLoader loader;
 
   auto config = loader.load_service_config("redis");
+  auto addr = config["bind"].as<std::string>();
   auto port = config["port"].as<uint32_t>();
 
   // Make connection to db

--- a/lte/gateway/c/oai/common/redis_utils/redis_client.h
+++ b/lte/gateway/c/oai/common/redis_utils/redis_client.h
@@ -26,10 +26,6 @@
 #include <cpp_redis/cpp_redis>
 #include <google/protobuf/message.h>
 
-namespace {
-constexpr char LOCALHOST[] = "127.0.0.1";
-}
-
 namespace magma {
 namespace lte {
 
@@ -39,11 +35,10 @@ class RedisClient {
   ~RedisClient() = default;
 
   /**
-   * Initializes a connection to redis datastore.
-   * @param addr IP address on which redis db is running
+   * Initializes a connection to the redis datastore configured in redis.yml
    * @return response code of success / error with db connection
    */
-  void init_db_connection(const std::string& addr);
+  void init_db_connection();
 
   /**
    * Converts protobuf Message and parses it to string

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -27,9 +27,10 @@ bool RedisStoreClient::try_redis_connect()
   ServiceConfigLoader loader;
   auto config = loader.load_service_config("redis");
   auto port = config["port"].as<uint32_t>();
+  auto addr = config["bind"].as<std::string>();
   try {
     client_->connect(
-        "127.0.0.1",
+        addr,
         port,
         [](
             const std::string& host,

--- a/lte/gateway/configs/redis.yml
+++ b/lte/gateway/configs/redis.yml
@@ -8,6 +8,7 @@
 # of patent rights can be found in the PATENTS file in the same directory.
 
 port: 6380
+bind: 127.0.0.1
 redis_loglevel: notice
 dir: /var/opt/magma
 # How frequently to save/dump to disk.

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -19,9 +19,10 @@ bool try_redis_connect(cpp_redis::client& client)
   ServiceConfigLoader loader;
   auto config = loader.load_service_config("redis");
   auto port = config["port"].as<uint32_t>();
+  auto addr = config["bind"].as<std::string>();
   try {
     client.connect(
-      "127.0.0.1",
+      addr,
       port,
       [](
         const std::string& host,

--- a/orc8r/gateway/python/magma/common/redis/client.py
+++ b/orc8r/gateway/python/magma/common/redis/client.py
@@ -16,4 +16,5 @@ def get_default_client():
     Return a default redis client using the configured port in redis.yml
     """
     redis_port = get_service_config_value('redis', 'port', 6379)
-    return redis.Redis(host='localhost', port=redis_port)
+    redis_addr = get_service_config_value('redis', 'bind', 'localhost')
+    return redis.Redis(host=redis_addr, port=redis_port)


### PR DESCRIPTION
Summary:
For CWF we need the ability to read from a remote redis server.
Currently, all redis clients in the magma codebase use localhost without
any available configuration. This diff adds a `bind` field (following
redis notation) to allow that field to be changed.

Reviewed By: koolzz

Differential Revision: D20866248

