### PR TITLE
Add local health service to CWAG

### DIFF
--- a/cwf/gateway/configs/service_registry.yml
+++ b/cwf/gateway/configs/service_registry.yml
@@ -49,6 +49,9 @@ services:
   eap_aka:
     ip_address: 127.0.0.1
     port: 9123
+  health:
+    ip_address: 127.0.0.1
+    port: 9107
   redis:
     ip_address: 127.0.0.1
     port: 6380

--- a/cwf/gateway/docker/docker-compose.override.yml
+++ b/cwf/gateway/docker/docker-compose.override.yml
@@ -13,6 +13,11 @@ services:
       - controller.magma.test:10.0.2.2
       - bootstrapper-controller.magma.test:10.0.2.2
 
+  health:
+    build:
+      context: ${BUILD_CONTEXT}
+      dockerfile: cwf/gateway/docker/go/Dockerfile
+
   magmad:
     build:
       context: ${BUILD_CONTEXT} # TODO: Move feg/gateway/docker/python to magma/orc8r/gateway/docker

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -71,6 +71,16 @@ services:
       USE_REMOTE_SWX_PROXY: 1 # Relay to FeG
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
 
+  health:
+    <<: *feggoservice
+    image: ${DOCKER_REGISTRY}cwag_go:${IMAGE_VERSION}
+    container_name: health
+    # Needed in order to enable/disable ICMP
+    privileged: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
+
   magmad:
     <<: *pyservice
     container_name: magmad

--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -108,10 +108,10 @@ RUN make -C $MAGMA_ROOT/cwf/gateway build
 # -----------------------------------------------------------------------------
 # Production image
 # -----------------------------------------------------------------------------
-FROM ubuntu:xenial AS uesim
+FROM ubuntu:xenial AS cwag_go
 
 # Install envdir.
-RUN apt-get -y update && apt-get -y install daemontools
+RUN apt-get -y update && apt-get -y install daemontools curl iptables
 
 # Copy the build artifacts.
 COPY --from=builder /var/opt/magma/bin /var/opt/magma/bin

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -32,13 +32,20 @@ replace (
 require (
 	fbc/cwf/radius v0.0.0
 	fbc/lib/go/radius v0.0.0-00010101000000-000000000000
+	github.com/coreos/go-iptables v0.4.5
+	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/docker v1.13.1
+	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/fiorix/go-diameter/v4 v4.0.1-0.20200120193412-55a1c21738f9
 	github.com/go-openapi/swag v0.18.0
 	github.com/go-redis/redis v6.15.5+incompatible
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.3
 	github.com/google/go-cmp v0.3.1 // indirect
+	github.com/opencontainers/go-digest v1.0.0-rc1 // indirect
 	github.com/pkg/errors v0.8.1
+	github.com/shirou/gopsutil v2.18.10+incompatible
+	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
 	github.com/stretchr/testify v1.4.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
@@ -47,6 +54,7 @@ require (
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
+	magma/feg/cloud/go v0.0.0
 	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000
 	magma/gateway v0.0.0

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -60,6 +60,8 @@ github.com/cockroachdb/cockroach-go v0.0.0-20181001143604-e0a95dfd547c/go.mod h1
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
+github.com/coreos/go-iptables v0.4.5 h1:DpHb9vJrZQEFMcVLFKAAGMUVX0XoRC0ptCthinRYm38=
+github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142 h1:3jFq2xL4ZajGK4aZY8jz+DAF0FHjI51BXjjSwCzS1Dk=
 github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -70,6 +72,13 @@ github.com/dgrijalva/jwt-go v0.0.0-20161101193935-9ed569b5d1ac/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v1.13.1 h1:IkZjBSIc8hBjLpqeAbeE5mca5mNgeatLHBy3GO78BWo=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
+github.com/docker/go-units v0.3.3 h1:Xk8S3Xj5sLGlG5g67hJmYMmUgXv5N4PhkjJHHqrwnTk=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/donovanhide/eventsource v0.0.0-20171031113327-3ed64d21fb0b/go.mod h1:56wL82FO0bfMU5RvfXoIwSOP2ggqqxT+tAfNEIyxuHw=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
@@ -307,6 +316,8 @@ github.com/onsi/gomega v1.4.1/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.5.0 h1:izbySO9zDPmjJ8rDjLvkA2zJHIo+HkYXHnf7eN7SSyo=
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
+github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20170113013457-1de4cc2120e7/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.1/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -377,6 +388,7 @@ github.com/sasha-s/go-deadlock v0.0.0-20161201235124-341000892f3d/go.mod h1:StQn
 github.com/satori/go.uuid v0.0.0-20160603004225-b111a074d5ef/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
+github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
@@ -389,6 +401,8 @@ github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h
 github.com/smartystreets/goconvey v0.0.0-20180222194500-ef6db91d284a/go.mod h1:XDJAKZRPZ1CvBcN2aX5YOUTYGHki24fSF0Iv48Ibg0s=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c h1:gqEdF4VwBu3lTKGHS9rXE9x1/pEaSwCXRLOZRF6qtlw=
+github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c/go.mod h1:eMyUVp6f/5jnzM+3zahzl7q6UXLbgSc3MKg/+ow9QW0=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=

--- a/cwf/gateway/registry/local_registry.go
+++ b/cwf/gateway/registry/local_registry.go
@@ -17,8 +17,9 @@ import (
 const (
 	ModuleName = "cwf"
 
-	UeSim   = "UESIM"
-	Radiusd = "RADIUSD"
+	GatewayHealth = "HEALTH"
+	UeSim         = "UESIM"
+	Radiusd       = "RADIUSD"
 )
 
 // Add a new service.
@@ -44,5 +45,6 @@ func addLocalService(serviceType string, port int) {
 
 func init() {
 	addLocalService(UeSim, 10101)
+	addLocalService(GatewayHealth, 9107)
 	addLocalService(Radiusd, 10102)
 }

--- a/cwf/gateway/services/gateway_health/gateway_health/main.go
+++ b/cwf/gateway/services/gateway_health/gateway_health/main.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package main
+
+import (
+	"flag"
+	"os"
+	"strings"
+	"time"
+
+	"magma/cwf/gateway/registry"
+	"magma/cwf/gateway/services/gateway_health/health/gre_probe"
+	"magma/cwf/gateway/services/gateway_health/health/service_health"
+	"magma/cwf/gateway/services/gateway_health/health/system_health"
+	"magma/cwf/gateway/services/gateway_health/servicers"
+	"magma/feg/cloud/go/protos"
+	"magma/orc8r/lib/go/service"
+
+	"github.com/golang/glog"
+)
+
+func init() {
+	flag.Parse()
+}
+
+const (
+	defaultMemUtilPct       = 0.75
+	defaultCpuUtilPct       = 0.75
+	defaultGREProbeInterval = 10 * time.Second
+)
+
+func main() {
+	// Create the service
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.GatewayHealth)
+	if err != nil {
+		glog.Fatalf("Error creating %s service: %s", registry.GatewayHealth, err)
+	}
+	//TODO: Update with mconfig values
+	endpointStr := os.Getenv("GRE_ENDPOINTS")
+	greEndpoints := strings.Split(endpointStr, ",")
+	probe := &gre_probe.DummyGREProbe{}
+	systemHealth := &system_health.DummySystemStatsProvider{}
+	serviceHealth := &service_health.DummyServiceHealthProvider{}
+	cfg := &servicers.HealthConfig{
+		GrePeers:      greEndpoints,
+		MaxCpuUtilPct: defaultMemUtilPct,
+		MaxMemUtilPct: defaultCpuUtilPct,
+	}
+	servicer := servicers.NewGatewayHealthServicer(cfg, probe, serviceHealth, systemHealth)
+	protos.RegisterServiceHealthServer(srv.GrpcServer, servicer)
+
+	// Start GRE probe
+	err = probe.Start()
+	if err != nil {
+		glog.Fatalf("Error running GRE health probe: %s", err)
+	}
+	// Run the service
+	err = srv.Run()
+	if err != nil {
+		glog.Fatalf("Error running %s service: %s", registry.GatewayHealth, err)
+	}
+}

--- a/cwf/gateway/services/gateway_health/health/gre_probe/gre_probe.go
+++ b/cwf/gateway/services/gateway_health/health/gre_probe/gre_probe.go
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package gre_probe
+
+// GREProbe defines an interface to begin a probe of GRE endpoints
+// and fetch that status at a later point.
+type GREProbe interface {
+	// Start begins the probe of the GRE endpoint(s).
+	Start() error
+
+	// GetStatus fetches the status of the GRE probe. The values returned are
+	// slices of reachable and unreachable endpoint IPs.
+	GetStatus() ([]string, []string)
+}
+
+type GREEndpointStatus uint
+
+const (
+	EndpointReachable   GREEndpointStatus = 0
+	EndpointUnreachable GREEndpointStatus = 1
+)
+
+type DummyGREProbe struct{}
+
+func (d *DummyGREProbe) Start() error {
+	return nil
+}
+
+func (d *DummyGREProbe) GetStatus() ([]string, []string) {
+	return []string{}, []string{}
+}

--- a/cwf/gateway/services/gateway_health/health/service_health/service_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/service_health.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package service_health
+
+// ServiceHealth defines an interface to fetch unhealthy services and enable
+// functionality necessary for promotion/demotions of the gateway.
+type ServiceHealth interface {
+	// GetUnhealthyServices return a list of services found to be in an
+	// unhealthy state.
+	GetUnhealthyServices() ([]string, error)
+
+	// Enable allows the enabling of service level functionality for the
+	// provided service. It is up to implementors to determine
+	// the specific functionality.
+	Enable(service string) error
+}
+
+type DummyServiceHealthProvider struct {
+}
+
+func (d *DummyServiceHealthProvider) GetUnhealthyServices() ([]string, error) {
+	return []string{}, nil
+}
+
+func (d *DummyServiceHealthProvider) Enable(service string) error {
+	return nil
+}

--- a/cwf/gateway/services/gateway_health/health/system_health/system_health.go
+++ b/cwf/gateway/services/gateway_health/health/system_health/system_health.go
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package system_health
+
+// SystemHealth defines an interface to fetch system health and enable/disable
+// functionality necessary for promotion/demotion from failovers
+type SystemHealth interface {
+	// GetSystemStats provides system level health stats
+	GetSystemStats() (*SystemStats, error)
+
+	// Disable allows the disabling of system level functionality. It is
+	// up to implementors to determine specific functionality.
+	Disable() error
+
+	// Enable allows the enabling of system level functionality. It is
+	// up to implementors to determine specific functionality.
+	Enable() error
+}
+
+type SystemStats struct {
+	CpuUtilPct float64
+	MemUtilPct float64
+}
+
+type DummySystemStatsProvider struct{}
+
+func (d *DummySystemStatsProvider) GetSystemStats() (*SystemStats, error) {
+	return &SystemStats{MemUtilPct: 0.1, CpuUtilPct: 0.1}, nil
+}
+
+func (d *DummySystemStatsProvider) Enable() error {
+	return nil
+}
+
+func (d *DummySystemStatsProvider) Disable() error {
+	return nil
+}

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer.go
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package servicers
+
+import (
+	"context"
+	"fmt"
+
+	"magma/cwf/gateway/services/gateway_health/health/gre_probe"
+	"magma/cwf/gateway/services/gateway_health/health/service_health"
+	"magma/cwf/gateway/services/gateway_health/health/system_health"
+	"magma/feg/cloud/go/protos"
+	orcprotos "magma/orc8r/lib/go/protos"
+
+	"github.com/golang/glog"
+)
+
+type GatewayHealthServicer struct {
+	config        *HealthConfig
+	greProbe      gre_probe.GREProbe
+	serviceHealth service_health.ServiceHealth
+	systemHealth  system_health.SystemHealth
+}
+
+type HealthConfig struct {
+	GrePeers      []string
+	MaxCpuUtilPct float64
+	MaxMemUtilPct float64
+}
+
+const (
+	sessiondServiceName = "sessiond"
+)
+
+// NewGatewayHealthServicer constructs a GatewayHealthServicer.
+func NewGatewayHealthServicer(cfg *HealthConfig, greProbe gre_probe.GREProbe, serviceHealth service_health.ServiceHealth, systemHealth system_health.SystemHealth) *GatewayHealthServicer {
+	return &GatewayHealthServicer{
+		config:        cfg,
+		greProbe:      greProbe,
+		systemHealth:  systemHealth,
+		serviceHealth: serviceHealth,
+	}
+}
+
+// Disable adds a drop rule for ICMP on eth1 of the gateway. This is used to ensure that
+// the standby gateway is perceived as being down by the AP/WLC.
+func (s *GatewayHealthServicer) Disable(ctx context.Context, req *protos.DisableMessage) (*orcprotos.Void, error) {
+	ret := &orcprotos.Void{}
+	return ret, s.systemHealth.Disable()
+}
+
+// Enable ensures ICMP is enabled on eth1, then restarts sessiond to trigger
+// initialization of the gateway.
+func (s *GatewayHealthServicer) Enable(ctx context.Context, req *orcprotos.Void) (*orcprotos.Void, error) {
+	ret := &orcprotos.Void{}
+	err := s.systemHealth.Enable()
+	if err != nil {
+		return ret, err
+	}
+	err = s.serviceHealth.Enable(sessiondServiceName)
+	return ret, err
+}
+
+// GetHealthStatus retrieves a health status object which contains the current
+// health of the gateway.
+func (s *GatewayHealthServicer) GetHealthStatus(ctx context.Context, req *orcprotos.Void) (*protos.HealthStatus, error) {
+	greHealth := s.getGREHealth()
+	systemHealth := s.getSystemHealth()
+	serviceHealth := s.getServiceHealth()
+	return s.composeAggregateHealth(greHealth, systemHealth, serviceHealth), nil
+
+}
+
+func (s *GatewayHealthServicer) getGREHealth() *protos.HealthStatus {
+	reachable, unreachable := s.greProbe.GetStatus()
+	glog.V(1).Infof("reachable GRE endpoints: %v; unreachable GRE endpoints: %v", reachable, unreachable)
+	// Current approach is to be conservative for GRE health. As long as we have
+	// a reachable peer, determine to be healthy
+	if len(reachable) == 0 && len(unreachable) > 0 {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_UNHEALTHY,
+			HealthMessage: fmt.Sprintf("All GRE peers are detected as unreachable; unreachable: %v", unreachable),
+		}
+	}
+	return &protos.HealthStatus{
+		Health:        protos.HealthStatus_HEALTHY,
+		HealthMessage: fmt.Sprintf("At least 1 configured GRE peers is reachable; reachable: %v, unreachable: %v", reachable, unreachable),
+	}
+}
+
+func (s *GatewayHealthServicer) getSystemHealth() *protos.HealthStatus {
+	stats, err := s.systemHealth.GetSystemStats()
+	if err != nil {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_UNHEALTHY,
+			HealthMessage: fmt.Sprintf("could not fetch system metrics"),
+		}
+	}
+	glog.V(1).Infof("system stats: cpuUtilPct: %f, memUtilPct: %f", stats.CpuUtilPct, stats.MemUtilPct)
+	if stats.CpuUtilPct > s.config.MaxCpuUtilPct {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_UNHEALTHY,
+			HealthMessage: fmt.Sprintf("current cpuUtilPct execeeds threshold: %f > %f", stats.CpuUtilPct, s.config.MaxCpuUtilPct),
+		}
+	}
+	if stats.MemUtilPct > s.config.MaxMemUtilPct {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_UNHEALTHY,
+			HealthMessage: fmt.Sprintf("current memUtilPct execeeds threshold: %f > %f", stats.MemUtilPct, s.config.MaxMemUtilPct),
+		}
+	}
+	return &protos.HealthStatus{
+		Health:        protos.HealthStatus_HEALTHY,
+		HealthMessage: "All metrics appear healthy",
+	}
+}
+
+func (s *GatewayHealthServicer) getServiceHealth() *protos.HealthStatus {
+	unhealthyServices, err := s.serviceHealth.GetUnhealthyServices()
+	if err != nil {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_UNHEALTHY,
+			HealthMessage: err.Error(),
+		}
+	}
+	glog.V(1).Infof("unhealthy services: %v", unhealthyServices)
+	if len(unhealthyServices) > 0 {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_UNHEALTHY,
+			HealthMessage: fmt.Sprintf("The following services were unhealthy: %v", unhealthyServices),
+		}
+	}
+	return &protos.HealthStatus{
+		Health:        protos.HealthStatus_HEALTHY,
+		HealthMessage: fmt.Sprintf("All services appear healthy"),
+	}
+}
+
+func (s *GatewayHealthServicer) composeAggregateHealth(
+	greHealth *protos.HealthStatus,
+	systemHealth *protos.HealthStatus,
+	serviceHealth *protos.HealthStatus,
+) *protos.HealthStatus {
+	isGatewayHealthy := greHealth.Health == protos.HealthStatus_HEALTHY && serviceHealth.Health == protos.HealthStatus_HEALTHY &&
+		systemHealth.Health == protos.HealthStatus_HEALTHY
+	if isGatewayHealthy {
+		return &protos.HealthStatus{
+			Health:        protos.HealthStatus_HEALTHY,
+			HealthMessage: "gateway status appears healthy",
+		}
+	}
+	healthMsg := ""
+	if greHealth.Health == protos.HealthStatus_UNHEALTHY {
+		healthMsg = fmt.Sprintf("GRE status: %s; ", greHealth.HealthMessage)
+	}
+	if systemHealth.Health == protos.HealthStatus_UNHEALTHY {
+		healthMsg = fmt.Sprintf("%sSystem status: %s; ", healthMsg, systemHealth.HealthMessage)
+	}
+	if serviceHealth.Health == protos.HealthStatus_UNHEALTHY {
+		healthMsg = fmt.Sprintf("%sService status: %s", healthMsg, serviceHealth.HealthMessage)
+	}
+	return &protos.HealthStatus{
+		Health:        protos.HealthStatus_UNHEALTHY,
+		HealthMessage: healthMsg,
+	}
+}

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package servicers
+
+import (
+	"context"
+	"testing"
+
+	"magma/cwf/gateway/services/gateway_health/health/system_health"
+	"magma/feg/cloud/go/protos"
+	orc8rprotos "magma/orc8r/lib/go/protos"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestGetHealthStatus(t *testing.T) {
+	mockService := &mockServiceHealth{}
+	mockSystem := &mockSystemHealth{}
+	mockGREProbe := &mockGREProbe{}
+	req := &orc8rprotos.Void{}
+	hc := &HealthConfig{
+		GrePeers:      []string{"127.0.0.1"},
+		MaxCpuUtilPct: 0.75,
+		MaxMemUtilPct: 0.75,
+	}
+	servicer := NewGatewayHealthServicer(hc, mockGREProbe, mockService, mockSystem)
+	expectedStatus := &protos.HealthStatus{
+		Health:        protos.HealthStatus_HEALTHY,
+		HealthMessage: "gateway status appears healthy",
+	}
+	// Simulate healthy status
+	mockGREProbe.On("GetStatus").Return([]string{"127.0.0.1"}, []string{}, nil).Once()
+	mockSystem.On("GetSystemStats").Return(&system_health.SystemStats{CpuUtilPct: 0.1, MemUtilPct: 0.1}, nil).Once()
+	mockService.On("GetUnhealthyServices").Return([]string{}, nil).Once()
+	health, err := servicer.GetHealthStatus(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStatus, health)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
+
+	// Simulate successful enable
+	mockSystem.On("Enable").Return(nil)
+	mockService.On("Enable", "sessiond").Return(nil)
+	_, err = servicer.Enable(context.Background(), req)
+	assert.NoError(t, err)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
+
+	// Simulate GRE unhealthy
+	expectedStatus.Health = protos.HealthStatus_UNHEALTHY
+	expectedStatus.HealthMessage = "GRE status: All GRE peers are detected as unreachable; unreachable: [127.0.0.1]; "
+	mockGREProbe.On("GetStatus").Return([]string{}, []string{"127.0.0.1"}, nil).Once()
+	mockSystem.On("GetSystemStats").Return(&system_health.SystemStats{CpuUtilPct: 0.1, MemUtilPct: 0.1}, nil).Once()
+	mockService.On("GetUnhealthyServices").Return([]string{}, nil).Once()
+	health, err = servicer.GetHealthStatus(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStatus, health)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
+
+	// Simulate successful disable
+	disableReq := &protos.DisableMessage{}
+	mockSystem.On("Disable").Return(nil)
+	_, err = servicer.Disable(context.Background(), disableReq)
+	assert.NoError(t, err)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
+
+	// Simulate unhealthy system status
+	mockGREProbe.On("GetStatus").Return([]string{"127.0.0.1"}, []string{}, nil).Once()
+	mockSystem.On("GetSystemStats").Return(&system_health.SystemStats{CpuUtilPct: 0.99, MemUtilPct: 0.5}, nil).Once()
+	mockService.On("GetUnhealthyServices").Return([]string{}, nil).Once()
+	expectedStatus.Health = protos.HealthStatus_UNHEALTHY
+	expectedStatus.HealthMessage = "System status: current cpuUtilPct execeeds threshold: 0.990000 > 0.750000; "
+	health, err = servicer.GetHealthStatus(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStatus, health)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
+
+	// Simulate unhealthy services and GRE
+	mockGREProbe.On("GetStatus").Return([]string{}, []string{"127.0.0.1"}, nil).Once()
+	mockSystem.On("GetSystemStats").Return(&system_health.SystemStats{CpuUtilPct: 0.1, MemUtilPct: 0.1}, nil).Once()
+	mockService.On("GetUnhealthyServices").Return([]string{"sessiond"}, nil).Once()
+	expectedStatus.Health = protos.HealthStatus_UNHEALTHY
+	expectedStatus.HealthMessage = "GRE status: All GRE peers are detected as unreachable; unreachable: [127.0.0.1]; Service status: The following services were unhealthy: [sessiond]"
+	health, err = servicer.GetHealthStatus(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStatus, health)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
+}
+
+func assertMocks(t *testing.T, probe *mockGREProbe, systemHealth *mockSystemHealth, serviceHealth *mockServiceHealth) {
+	probe.AssertExpectations(t)
+	systemHealth.AssertExpectations(t)
+	serviceHealth.AssertExpectations(t)
+}
+
+type mockServiceHealth struct {
+	mock.Mock
+}
+
+func (m *mockServiceHealth) GetUnhealthyServices() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *mockServiceHealth) Enable(service string) error {
+	args := m.Called(service)
+	return args.Error(0)
+}
+
+type mockSystemHealth struct {
+	mock.Mock
+}
+
+func (m *mockSystemHealth) GetSystemStats() (*system_health.SystemStats, error) {
+	args := m.Called()
+	return args.Get(0).(*system_health.SystemStats), args.Error(1)
+}
+
+func (m *mockSystemHealth) Enable() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockSystemHealth) Disable() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+type mockGREProbe struct {
+	mock.Mock
+}
+
+func (m *mockGREProbe) Start() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+func (m *mockGREProbe) GetStatus() ([]string, []string) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Get(1).([]string)
+}


### PR DESCRIPTION
Summary:
This diff adds a health service to the CWAG.
This service will be called by the operator to give
status and implement any actions necessary for maintaining
an active/standby configuration for CWF.

A stack diff will implement the health interfaces provided.

Reviewed By: xjtian

Differential Revision: D20822202

