### PR TITLE
add react-relay to hub ui

### DIFF
--- a/symphony/app/fbcnms-projects/hub/app/common/RelayEnvironment.js
+++ b/symphony/app/fbcnms-projects/hub/app/common/RelayEnvironment.js
@@ -1,0 +1,36 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import type {StoreUpdater as RelayStoreUpdater} from 'relay-runtime';
+
+import axios from 'axios';
+import {Environment, Network, RecordSource, Store} from 'relay-runtime';
+
+// TODO: create a proxy using platform-server to the hub
+
+function fetchQuery(operation, variables) {
+  return axios
+    .post('http://localhost:4000/query', {
+      query: operation.text,
+      variables,
+    })
+    .then(response => {
+      return response.data;
+    });
+}
+
+const RelayEnvironment = new Environment({
+  network: Network.create(fetchQuery),
+  store: new Store(new RecordSource()),
+});
+
+export default RelayEnvironment;
+
+export type StoreUpdater = RelayStoreUpdater;

--- a/symphony/app/fbcnms-projects/hub/app/components/HubVersion.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/HubVersion.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import * as React from 'react';
+import RelayEnvironment from '../common/RelayEnvironment';
+import Text from '@fbcnms/ui/components/design-system/Text';
+import type {HubVersionQueryResponse} from './__generated__/HubVersionQuery.graphql';
+// flowlint untyped-import:warn
+import {QueryRenderer, graphql} from 'react-relay';
+
+const HubVersionQuery = graphql`
+  query HubVersionQuery {
+    version {
+      string
+    }
+  }
+`;
+
+function HubVersion() {
+  return (
+    <QueryRenderer
+      environment={RelayEnvironment}
+      query={HubVersionQuery}
+      variables={{}}
+      render={({
+        error,
+        props,
+      }: {
+        error?: Error,
+        props?: HubVersionQueryResponse,
+      }) => {
+        if (error) {
+          return <Text>Couldn't load hub version!</Text>;
+        }
+        if (!props) {
+          return <Text>Loading hub version...</Text>;
+        }
+        return <Text>Hub version: {props.version.string}</Text>;
+      }}
+    />
+  );
+}
+
+export default HubVersion;

--- a/symphony/app/fbcnms-projects/hub/app/components/Main.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/Main.js
@@ -13,6 +13,7 @@ import AppContext, {AppContextProvider} from '@fbcnms/ui/context/AppContext';
 import AppSideBar from '@fbcnms/ui/components/layout/AppSideBar';
 import ApplicationMain from '@fbcnms/ui/components/ApplicationMain';
 import Button from '@fbcnms/ui/components/design-system/Button';
+import HubVersion from './HubVersion';
 import NavListItem from '@fbcnms/ui/components/NavListItem';
 import React, {useContext} from 'react';
 import RouterIcon from '@material-ui/icons/Router';
@@ -57,6 +58,8 @@ function CreateServiceForm() {
       <div className={classes.header}>
         <Text variant="h5">Create a Service</Text>
       </div>
+      <br />
+      <HubVersion />
       <br />
       <Text>Service Name</Text>
       <TextInput />

--- a/symphony/app/fbcnms-projects/hub/app/components/__generated__/HubVersionQuery.graphql.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/__generated__/HubVersionQuery.graphql.js
@@ -1,0 +1,87 @@
+/**
+ * @generated
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ **/
+
+ /**
+ * @flow
+ * @relayHash 4e95ef44d950f97aaf5bb7c64b9a4fef
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest } from 'relay-runtime';
+export type HubVersionQueryVariables = {||};
+export type HubVersionQueryResponse = {|
+  +version: {|
+    +string: string
+  |}
+|};
+export type HubVersionQuery = {|
+  variables: HubVersionQueryVariables,
+  response: HubVersionQueryResponse,
+|};
+*/
+
+
+/*
+query HubVersionQuery {
+  version {
+    string
+  }
+}
+*/
+
+const node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "kind": "LinkedField",
+    "alias": null,
+    "name": "version",
+    "storageKey": null,
+    "args": null,
+    "concreteType": "Version",
+    "plural": false,
+    "selections": [
+      {
+        "kind": "ScalarField",
+        "alias": null,
+        "name": "string",
+        "args": null,
+        "storageKey": null
+      }
+    ]
+  }
+];
+return {
+  "kind": "Request",
+  "fragment": {
+    "kind": "Fragment",
+    "name": "HubVersionQuery",
+    "type": "Query",
+    "metadata": null,
+    "argumentDefinitions": [],
+    "selections": (v0/*: any*/)
+  },
+  "operation": {
+    "kind": "Operation",
+    "name": "HubVersionQuery",
+    "argumentDefinitions": [],
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "operationKind": "query",
+    "name": "HubVersionQuery",
+    "id": null,
+    "text": "query HubVersionQuery {\n  version {\n    string\n  }\n}\n",
+    "metadata": {}
+  }
+};
+})();
+// prettier-ignore
+(node/*: any*/).hash = '34ebb96a32faf7bffcb55abca095e681';
+module.exports = node;

--- a/symphony/app/fbcnms-projects/hub/package.json
+++ b/symphony/app/fbcnms-projects/hub/package.json
@@ -2,11 +2,18 @@
   "name": "@fbcnms/hub",
   "private": true,
   "version": "0.1.0",
+  "scripts": {
+    "relay": "fbcnms-relay-compiler --src ./app --schema ./resources/schema.graphql"
+  },
   "dependencies": {
     "@fbcnms/ui": "^0.1.0",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-relay": "0.0.0-experimental-5f1cb628"
   },
   "devDependencies": {
+    "@fbcnms/relay": "^0.1.0",
     "@fbcnms/test": "^0.1.0",
     "@testing-library/react": "^9.4.0",
     "@testing-library/react-hooks": "^3.2.1",

--- a/symphony/app/fbcnms-projects/hub/resources/readme.md
+++ b/symphony/app/fbcnms-projects/hub/resources/readme.md
@@ -1,0 +1,1 @@
+Since we're using federation we don't have a single schema file. Later we can concatenate all schema files, but to make life easier, for now we're downloading the stitched schema from the federated server and placing it here.

--- a/symphony/app/fbcnms-projects/hub/resources/schema.graphql
+++ b/symphony/app/fbcnms-projects/hub/resources/schema.graphql
@@ -1,0 +1,98 @@
+input AtrinetService {
+  serviceGlobalSettings: ServiceGlobalSettings!
+  customer: String!
+  operatorName: String!
+  modelName: String!
+  sites: [Site!]!
+}
+
+scalar Map
+
+type Mutation {
+  createService(serviceRequest: NetworkServiceRequest): String!
+  deleteService(service: NetworkServiceInput): String!
+}
+
+type NetworkDevice {
+  ID: Int!
+  Name: String!
+  DeviceType: String!
+  Host: String!
+  AccessMethod: String!
+}
+
+input NetworkDeviceInput {
+  ID: Int!
+  Name: String!
+  DeviceType: String!
+  Host: String!
+  AccessMethod: String!
+}
+
+type NetworkService {
+  ID: Int!
+  ExternalID: Int!
+  Name: String!
+  Model: NetworkServiceModel!
+  Devices: [NetworkDevice!]!
+  AdditionalParams: Map!
+  Status: String!
+}
+
+input NetworkServiceInput {
+  ID: Int!
+  ExternalID: Int!
+  Name: String!
+  Model: NetworkServiceModelInput!
+  Devices: [NetworkDeviceInput!]!
+  AdditionalParams: Map!
+  Status: String!
+}
+
+type NetworkServiceModel {
+  Name: String!
+}
+
+input NetworkServiceModelInput {
+  Name: String!
+}
+
+input NetworkServiceRequest {
+  Name: String!
+  Model: NetworkServiceModelInput!
+  Devices: [NetworkDeviceInput!]!
+  AdditionalParams: Map!
+}
+
+type Query {
+  version: Version!
+  getServiceStatus(serviceID: Int!): String!
+}
+
+input ServiceGlobalSettings {
+  name: String!
+  rollbackPolicy: String!
+  mode: String!
+}
+
+input Site {
+  siteNumber: Int!
+  siteModelName: String!
+  deviceName: String!
+  deviceId: Int!
+  parameters: Map
+  userPort: UserPort!
+  accessMethod: String!
+}
+
+input UserPort {
+  id: Int!
+  name: String!
+}
+
+type Version {
+  major: Int!
+  minor: Int!
+  patch: Int!
+  string: String!
+}


### PR DESCRIPTION
Summary:
Add react-relay to the hub ui page and execute a simple "get version" query against the hub graph server.

For now the hub graph server is on localhost, eventually it will be deployed in the cluster and I'll change the code to reflect that.

Since we're using federation I've chosen to copy over the schema from introspecting the federated server. One option we discussed is concatenating the schema files but this ends up being pretty hard since they're not all in the same folder - there are different schema folder / files for every service that is being federated. Later we'll make a more robust solution for this.

Reviewed By: dlvhdr

Differential Revision: D20850294

