### PR TITLE
Wait 1s before shutdown of grpc completion_queue in tests to wait out race condition

### DIFF
--- a/lte/gateway/c/session_manager/test/test_async_service.cpp
+++ b/lte/gateway/c/session_manager/test/test_async_service.cpp
@@ -58,6 +58,12 @@ class AsyncServiceTest : public ::testing::Test {
 
   virtual void TearDown()
   {
+    // TODO: things are getting scheduled on the completion queue after
+    //       it is shutdown. Need to make it impossible to do so, but
+    //       until then, this wait is needed to make sure everything that
+    //       is going to be scheduled, is scheduled, before shutdown
+    //       is initiated.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1001));
     magma_service->Stop();
     async_service->stop();
   }


### PR DESCRIPTION
Summary:
`test_async_service` has been failing due to a race condition, usually with the error:
```
completion_queue.cc:512]    assertion failed: cq_event_queue_num_items(&cqd->queue) == 0
```

The working theory here is that the completion queue is getting modified after shutdown, probably since something is still running in the EventBase thread.

Added a 1s wait after calls to handlers of `session_manager` before shutdown of completion queues.

Reviewed By: uri200

Differential Revision: D20897396

