### PR TITLE
Add secrets subchart to allow gwinfo to be mounted as secrets

### DIFF
--- a/cwf/gateway/helm/cwf/README.md
+++ b/cwf/gateway/helm/cwf/README.md
@@ -65,13 +65,13 @@ The following table list the configurable parameters of the orchestrator chart a
 
 | Parameter        | Description     | Default   |
 | ---              | ---             | ---       |
-| `manifests.configmap_bin` | Enable cwf configmap bin. | `True` |
 | `manifests.configmap_env` | Enable cwf configmap env. | `True` |
-| `manifests.secrets` | Enable cwf secrets. | `True` |
 | `manifests.deployment` | Enable cwf deployment. | `True` |
 | `manifests.service` | Enable cwf service. | `True` |
 | `manifests.rbac` | Enable cwf rbac. | `True` |
-| `cwf.type` | Gateway type agrument. | `cwf` |
+| `secrets.create` | Enable cwf secret creation | `False` |
+| `secret.gwinfo`   | Secret name containing cwf gwinfo | `cwf-secrets-gwinfo`
+| `cwf.type` | Gateway type argument. | `cwf` |
 | `cwf.image.docker_registry` | CWF docker registry host. | `docker.io` |
 | `cwf.image.tag` | CWF docker images tag. | `latest` |
 | `cwf.image.username` | Docker registry username. | `` |
@@ -103,15 +103,43 @@ The following table list the configurable parameters of the orchestrator chart a
 
 ## Installation steps
 
-1. Install CWF
+1. Create persistent gateway info (optional)
 
-	helm upgrade --install cwf --namespace magma ./cwf --values=vals.yaml
+    If you want your gateway pod to have the same gwinfo on pod 
+    recreation, first follow the steps below.
+    
+    #### Creating Gateway Info
+    If creating a gateway for the first time, you'll need to create a snowflake
+    and challenge key before installing the gateway. To do so:
 
-2. Register the gateway with the orchestrator
+    ```
+    $ docker login <DOCKER REGISTRY>
+    $ docker pull <DOCKER REGISTRY>/gateway_python:<IMAGE_VERSION>
+    $ docker run -d <DOCKER_REGISTRY>/gateway_python:<IMAGE_VERSION> python3.5 -m magma.magmad.main
 
-login to cwf VM and execute below command
+    This will output a container ID such as
+    f3bc383a95db16f2e448fdf67cac133a5f9019375720b59477aebc96bacd05a9
 
-```shell
+    Run the following, substituting your container ID:
+    $ docker cp <container ID>:/etc/snowflake charts/secrets/.secrets
+    $ docker cp <container ID>:/var/opt/magma/certs/gw_challenge.key /charts/secrets/.secrets 
+    ```
+   
+    If you're instead upgrading your gateway to have persistent gwinfo,
+    copy the `etc/snowflake` and `/var/opt/magma/certs/gw_challenge.key` from 
+    your gateway to `charts/secrets/.secrets` of where this chart is stored.
+
+    Ensure that `secrets.create` is set to true in your vals.yaml override
+
+2. Install CWF
+
+	`helm upgrade --install cwf --namespace magma ./cwf --values=vals.yaml`
+
+3. Register the gateway with the orchestrator
+
+    Login to the CWF VM and execute the commands below:
+
+   ```shell
    
    a. Get IP of CWF VM:
    
@@ -132,9 +160,8 @@ login to cwf VM and execute below command
       Challenge Key:
       -----------
       MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2lAV8Dj1ZQEeQlJ/M9/iYXmiVLC7l5QU7IvrNe+lLsu2MuGz4hjNwFPLmG      /x055Zqzh++8LsXQSKJ0mgV9AUB87xyFGt1wGjvaUa8Jea1ZMRMd1lJ+IsKA606HeaQfVq
+   ```
 
-```
-
-3. Login to NMS Dahsboard and register New Gateway
+4. Login to NMS Dahsboard and register New Gateway
 
 

--- a/cwf/gateway/helm/cwf/charts/secrets/.helmignore
+++ b/cwf/gateway/helm/cwf/charts/secrets/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/cwf/gateway/helm/cwf/charts/secrets/Chart.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/Chart.yaml
@@ -5,13 +5,15 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-apiVersion: "1.0"
-description: Magma Carrier Gateway
-name: cwf
-version: 0.1.6
-home: https://github.com/facebookincubator/magma
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart to create magma cwf gateway secrets
+name: secrets
+version: 0.1.0
+engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma
 keywords:
   - magma
   - cwf
+  - secrets

--- a/cwf/gateway/helm/cwf/charts/secrets/README.md
+++ b/cwf/gateway/helm/cwf/charts/secrets/README.md
@@ -1,0 +1,63 @@
+# Cwf Secrets
+
+Cwf Secrets is used to apply a set of secrets for a cwf gateway. These secrets
+provide permanent gateway identification so that gateway pods will be recreated
+with the same hwid and challenge key.
+
+## TL;DR;
+
+```bash
+# Copy secrets into subchart root
+$ mkdir charts/secrets/.secrets && \
+    cp -r <secrets>/* charts/secrets/.secrets/
+$ ls charts/secrets/.secrets
+snowflake gw_challenge.key
+
+# Apply secrets
+helm template charts/secrets \
+    --name <cwf release name> \
+    --namespace magma | kubectl -n magma apply -f -
+```
+
+## Overview
+
+This chart installs a secret that serves as identifiers for the gateway. 
+The secrets are expected to be provided as files and placed under
+secrets subchart root.
+```bash
+$ ls charts/secrets/.secrets
+snowflake  gw_challenge.key
+$ pwd
+magma/cwf/gateway/helm/cwf
+```
+
+## Creating Gateway Info
+If creating a gateway for the first time, you'll need to create a snowflake
+and challenge key before installing the gateway. To do so:
+
+```
+$ docker login <DOCKER REGISTRY>
+$ docker pull <DOCKER REGISTRY>/gateway_python:<IMAGE_VERSION>
+$ docker run -d <DOCKER_REGISTRY>/gateway_python:<IMAGE_VERSION> python3.5 -m magma.magmad.main
+
+This will output a container ID such as
+f3bc383a95db16f2e448fdf67cac133a5f9019375720b59477aebc96bacd05a9
+
+Run the following, substituting your container ID here
+$ docker cp <container ID>:/etc/snowflake charts/secrets/.secrets
+$ docker cp <container ID>:/var/opt/magma/certs/gw_challenge.key /charts/secrets/.secrets
+```
+
+Otherwise if redploying a gateway with permanent gwinfo, copy the existing 
+snowflake from `etc/snowflake` and challenge key at 
+`/var/opt/magma/certs/gw_challenge.key`
+
+## Configuration
+
+The following table lists the configurable secret locations, 
+docker credentials and their default values.
+
+| Parameter        | Description     | Default   |
+| ---              | ---             | ---       |
+| `create` | Set to ``true`` to create cwf secrets. | `false` |
+| `secret.gwinfo` | Root relative secrets directory. | `.secrets` |

--- a/cwf/gateway/helm/cwf/charts/secrets/templates/_helpers.tpl
+++ b/cwf/gateway/helm/cwf/charts/secrets/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
+{{- define "labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: helm
+app.kubernetes.io/part-of: magma
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/cwf/gateway/helm/cwf/charts/secrets/templates/gwinfo.secret.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/templates/gwinfo.secret.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+{{- if .Values.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-gwinfo
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ tuple . "cwf" "gateway" | include "labels" | indent 4 }}
+data:
+{{- (.Files.Glob (print .Values.secret.gwinfo "/*")).AsSecrets | nindent 2 }}
+{{- end }}

--- a/cwf/gateway/helm/cwf/charts/secrets/values.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/values.yaml
@@ -5,13 +5,13 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-apiVersion: "1.0"
-description: Magma Carrier Gateway
-name: cwf
-version: 0.1.6
-home: https://github.com/facebookincubator/magma
-sources:
-  - https://github.com/facebookincubator/magma
-keywords:
-  - magma
-  - cwf
+# Create cwf gateway secrets
+create: true
+
+# Define which secrets should be mounted by pods.
+secret:
+   # directory holding orc8r cert secrets (needed to get rootCA.pem)
+  certs: orc8r-secrets-certs
+  # directory holding gateway's hwid (snowflake) and challenge key
+  gwinfo: .secrets
+

--- a/cwf/gateway/helm/cwf/requirements.yaml
+++ b/cwf/gateway/helm/cwf/requirements.yaml
@@ -5,13 +5,8 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-apiVersion: "1.0"
-description: Magma Carrier Gateway
-name: cwf
-version: 0.1.6
-home: https://github.com/facebookincubator/magma
-sources:
-  - https://github.com/facebookincubator/magma
-keywords:
-  - magma
-  - cwf
+dependencies:
+  - name: secrets
+    version: 0.1.0
+    repository: ""
+    condition: secrets.create

--- a/cwf/gateway/helm/cwf/templates/deployment.yaml
+++ b/cwf/gateway/helm/cwf/templates/deployment.yaml
@@ -168,6 +168,16 @@ spec:
           tty: true
           stdin: true
           volumeMounts:
+            {{- if .Values.secret.gwinfo }}
+            - name: hwid
+              mountPath: /etc/snowflake
+              subPath: snowflake
+            {{- end }}
+            {{- if .Values.secret.gwinfo }}
+            - name: gw-challenge-key
+              mountPath: /var/opt/magma/certs/gw_challenge.key
+              subPath: gw_challenge.key
+            {{- end }}
             - name: cwf-env
               mountPath: /opt/magma
             - name: orc8r-secrets-certs
@@ -178,6 +188,18 @@ spec:
               mountPath: /var/opt/magma/configs
             {{- end }}
       volumes:
+        {{- if .Values.secret.gwinfo }}
+        - name: hwid
+          secret:
+            secretName: {{ required "secret.gwinfo must be provided" .Values.secret.gwinfo }}
+            defaultMode: 0755
+        {{- end}}
+        {{- if .Values.secret.gwinfo }}
+        - name: gw-challenge-key
+          secret:
+            secretName: {{ required "secret.gwinfo must be provided" .Values.secret.gwinfo }}
+            defaultMode: 0755
+        {{- end }}
         - name: cwf-env
           configMap:
             name: {{ $envAll.Release.Name}}-env

--- a/cwf/gateway/helm/cwf/values.yaml
+++ b/cwf/gateway/helm/cwf/values.yaml
@@ -17,9 +17,14 @@ release_group: null
 imagePullSecrets: []
 # - name: orc8r-secrets-registry
 
+# secrets sub-chart configuration.
+secrets:
+  create: false
+
 # Define which secrets should be mounted by pods.
 secret:
   certs: orc8r-secrets-certs
+  gwinfo: cwf-secrets-gwinfo
 
 ## Key Values for docker inside VM
 cwf:
@@ -124,6 +129,4 @@ manifests:
   deployment: true
   service: true
   configmap_env: true
-  configmap_bin: true
-  secrets: true
   rbac: true


### PR DESCRIPTION
Summary:
This diff adds a secrets subchart to the cwf helm chart. This allows
us to provide persistent gwinfo as a secret which will be mounted on pod recreation.
This ensure that when a pod is recreated, it'll continue to operate correctly
with the orchestrator.

Secrets can either be created independently or created as part of the helm
installation.

Reviewed By: xjtian

Differential Revision: D20906236

