### PR TITLE
Missing dependency preventing AGW to update

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -100,7 +100,8 @@ setup(
         'six>=1.12.0',
         'eventlet>=0.24',
         'h2>=3.2.0',
-        'hpack>=3.0'
+        'hpack>=3.0',
+        'webcolors>=1.11.0'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Summary:
When trying to update TeraVM AGW to the latest version we get.

```
The following packages have unmet dependencies:
 magma : Depends: python3-webcolors (>= 1.11.0) but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
```

It looks like the package ```webcolors``` was recent actually and is not on our repository

Differential Revision: D20911177

