### PR TITLE
Round 2: add Python protobuf typings for code completion via mypy-protobuf.

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -23,7 +23,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # - updated vbguest-tool
     magma.vm.box = "fbcmagma/magma_dev"
     magma.vm.hostname = "magma-dev"
-    magma.vm.box_version = "1.0.1581548158"
+    magma.vm.box_version = "1.0.1586316960"
     magma.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -85,6 +85,10 @@ setup(
         "strict-rfc3339>=0.7",
         "rfc3987>=1.3.0",
         "jsonpointer>=1.13",
-        "webcolors>=1.11.1"
-    ]
+        "webcolors>=1.11.1",
+    ],
+    extras_require={
+        'dev': [
+        ],
+    },
 )

--- a/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
@@ -9,7 +9,7 @@
 ##################################
 # Set up dev environment variables
 ##################################
-#
+
 - name: Set Python environment variables
   lineinfile:
     dest: /etc/environment
@@ -98,3 +98,13 @@
     name: setuptools
     state: forcereinstall
     executable: pip3
+
+###########################
+# Install dev dependencies
+###########################
+
+- name: Install mypy-protobuf
+  pip:
+    name: mypy-protobuf
+    executable: pip3
+  when: preburn

--- a/protos/gen_protos.py
+++ b/protos/gen_protos.py
@@ -6,13 +6,15 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
-import sys
-
 import os
+import shutil
+import sys
+from typing import Iterable, List
+
 from grpc.tools import protoc
 
 
-def find_all_proto_files_in_dir(input_dir):
+def find_all_proto_files_in_dir(input_dir: str) -> List[str]:
     """
     Returns a list of filenames of .proto files in the given directory
 
@@ -38,7 +40,12 @@ def find_all_proto_files_in_dir(input_dir):
     return proto_files
 
 
-def gen_bindings(input_dir, include_paths, proto_path, output_dir):
+def gen_bindings(
+        input_dir: str,
+        include_paths: Iterable[str],
+        proto_path: str,
+        output_dir: str,
+) -> None:
     """
     Generates python and Go bindings for all .proto files in input dir
        @input_dir - input directory with .proto files to generate code for
@@ -46,12 +53,20 @@ def gen_bindings(input_dir, include_paths, proto_path, output_dir):
        @output_dir - output directory to put generated code in
     """
     protofiles = find_all_proto_files_in_dir(input_dir)
+
+    inouts = [
+        '--proto_path=' + proto_path,
+        '--python_out=' + output_dir,
+        '--grpc_python_out=' + output_dir,
+    ]
+    # Only run mypy (dev dependency) when the protoc-consumed executable exists
+    if shutil.which('protoc-gen-mypy') is not None:
+        inouts.append('--mypy_out=' + output_dir)
+
     protoc.main(
         ('',) +
         tuple('-I' + path for path in include_paths) +
-        ('--proto_path=' + proto_path,
-         '--python_out=' + output_dir,
-         '--grpc_python_out=' + output_dir) +
+        tuple(inouts) +
         tuple(f for f in protofiles),
     )
 


### PR DESCRIPTION
Summary:
Supersedes D20854672, which was unlanded.

## Implementation
Preburn mypy-protobuf pip-install to python_dev VM image, and update agw Vagrantfile to point to new image.

## Rationale
The Python-generated proto code sucks in terms of developer ergonomics because it generates an ~opaque metaclass, instead of generating the classes directly as in e.g. Go. This precludes straightforward code completion, makes reading through code impossible, and I personally always struggle with the documentation for the Python generated code.

This diff solves one of those three gripes--we now have access to intelligent code completion for Python protobuf code. The mypy-protobuf [0] package is installed via pip, and outputs `.pyi` files in the same directory as our generated Python proto code.

## Consumption
IntelliJ automatically consumes these `.pyi` files and provides completion based off them--it may need an `Invalidate Caches / Restart` run first, though.

{F233195190}

[0] https://github.com/dropbox/mypy-protobuf

Differential Revision: D20911265

