### PR TITLE
Remove default UpdateCriteria arguments in session_manager

### DIFF
--- a/lte/gateway/c/session_manager/CreditPool.h
+++ b/lte/gateway/c/session_manager/CreditPool.h
@@ -62,7 +62,8 @@ class CreditPool {
    * time of termination
    */
   virtual bool get_termination_updates(
-    SessionTerminateRequest *termination_out) const = 0;
+    SessionTerminateRequest *termination_out,
+    SessionStateUpdateCriteria& update_criteria) = 0;
 
   /**
    * receive_credit adds allowed credit from the cloud
@@ -85,7 +86,7 @@ class CreditPool {
    */
   virtual void merge_credit_update(
     const KeyType &key,
-    const SessionCreditUpdateCriteria &credit_update) = 0;
+    SessionCreditUpdateCriteria &credit_update) = 0;
 
   virtual uint32_t get_credit_key_count() const = 0;
 };
@@ -98,8 +99,6 @@ class CreditPool {
 class ChargingCreditPool :
   public CreditPool<CreditKey, CreditUpdateResponse, CreditUsage> {
  public:
-  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
-
   static std::unique_ptr<ChargingCreditPool> unmarshal(
     const StoredChargingCreditPool &marshaled);
 
@@ -111,11 +110,11 @@ class ChargingCreditPool :
     const CreditKey &key,
     uint64_t used_tx,
     uint64_t used_rx,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   bool reset_reporting_credit(
     const CreditKey &key,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   void get_updates(
     std::string imsi,
@@ -124,39 +123,40 @@ class ChargingCreditPool :
     DynamicRuleStore *dynamic_rules,
     std::vector<CreditUsage> *updates_out,
     std::vector<std::unique_ptr<ServiceAction>> *actions_out,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA,
+    SessionStateUpdateCriteria& update_criteria,
     const bool force_update = false) override;
 
   bool get_termination_updates(
-    SessionTerminateRequest *termination_out) const override;
+    SessionTerminateRequest *termination_out,
+    SessionStateUpdateCriteria& update_criteria) override;
 
   bool receive_credit(
     const CreditUpdateResponse &update,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   uint64_t get_credit(const CreditKey &key, Bucket bucket) const override;
 
   void add_credit(
     const CreditKey &key,
     std::unique_ptr<SessionCredit> credit,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   SessionCreditUpdateCriteria* get_credit_update(
     const CreditKey &key,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   void merge_credit_update(
     const CreditKey &key,
-    const SessionCreditUpdateCriteria &credit_update) override;
+    SessionCreditUpdateCriteria &credit_update) override;
 
   uint32_t get_credit_key_count() const override;
 
   ChargingReAuthAnswer::Result reauth_key(
     const CreditKey &charging_key,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   ChargingReAuthAnswer::Result reauth_all(
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
  private:
   std::unordered_map<
@@ -167,7 +167,7 @@ class ChargingCreditPool :
  private:
   bool init_new_credit(
     const CreditUpdateResponse &update,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   void populate_output_actions(
     std::string imsi,
@@ -190,8 +190,6 @@ class UsageMonitoringCreditPool :
     UsageMonitoringUpdateResponse,
     UsageMonitorUpdate> {
  public:
-  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
-
   struct Monitor {
     SessionCredit credit;
     MonitoringLevel level;
@@ -216,11 +214,11 @@ class UsageMonitoringCreditPool :
     const std::string &key,
     uint64_t used_tx,
     uint64_t used_rx,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   bool reset_reporting_credit(
     const std::string &key,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   void get_updates(
     std::string imsi,
@@ -229,30 +227,31 @@ class UsageMonitoringCreditPool :
     DynamicRuleStore *dynamic_rules,
     std::vector<UsageMonitorUpdate> *updates_out,
     std::vector<std::unique_ptr<ServiceAction>> *actions_out,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA,
+    SessionStateUpdateCriteria& update_criteria,
     const bool force_update = false) override;
 
   bool get_termination_updates(
-    SessionTerminateRequest *termination_out) const override;
+    SessionTerminateRequest *termination_out,
+    SessionStateUpdateCriteria& update_criteria) override;
 
   bool receive_credit(
     const UsageMonitoringUpdateResponse &update,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   uint64_t get_credit(const std::string &key, Bucket bucket) const override;
 
   void add_monitor(
     const std::string &key,
     std::unique_ptr<UsageMonitoringCreditPool::Monitor> monitor,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   SessionCreditUpdateCriteria* get_credit_update(
     const std::string &key,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA) override;
+    SessionStateUpdateCriteria& update_criteria) override;
 
   void merge_credit_update(
     const std::string &key,
-    const SessionCreditUpdateCriteria &credit_update) override;
+    SessionCreditUpdateCriteria &credit_update) override;
 
   uint32_t get_credit_key_count() const override;
 
@@ -267,10 +266,10 @@ class UsageMonitoringCreditPool :
  private:
   void update_session_level_key(
     const UsageMonitoringUpdateResponse &update,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
   bool init_new_credit(
     const UsageMonitoringUpdateResponse &update,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
   void populate_output_actions(
     std::string imsi,
     std::string ip_addr,

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1639,12 +1639,16 @@ bool LocalEnforcer::session_with_same_config_exists(
 void LocalEnforcer::handle_cwf_roaming(
   SessionMap& session_map,
   const std::string& imsi,
-  const magma::SessionState::Config& config)
+  const magma::SessionState::Config& config,
+  SessionUpdate& session_update)
 {
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
     for (const auto &session : it->second) {
+      auto& update_criteria = session_update[imsi][session->get_session_id()];
       session->set_config(config);
+      update_criteria.is_config_updated = true;
+      update_criteria.updated_config = session->marshal_config();
       // TODO Check for event triggers and send updates to the core if needed
       MLOG(MDEBUG) << "Updating IPFIX flow for subscriber " << imsi;
       SubscriberID sid;

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -49,6 +49,7 @@ class LocalEnforcer {
   LocalEnforcer(
     std::shared_ptr<SessionReporter> reporter,
     std::shared_ptr<StaticRuleStore> rule_store,
+    SessionStore& session_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
     std::shared_ptr<AsyncEventdClient> eventd_client,
@@ -157,7 +158,6 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::string& apn,
-    std::function<void(SessionTerminateRequest)> on_termination_callback,
     SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   uint64_t get_charging_credit(
@@ -229,6 +229,12 @@ class LocalEnforcer {
     const std::vector<std::unique_ptr<ServiceAction>>& actions,
     SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
+  void set_termination_callback(
+    SessionMap& session_map,
+    const std::string& imsi,
+    const std::string& apn,
+    std::function<void(SessionTerminateRequest)> on_termination_callback);
+
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
  private:
@@ -245,6 +251,7 @@ class LocalEnforcer {
   std::shared_ptr<aaa::AAAClient> aaa_client_;
   std::unordered_map<std::string,
                      std::vector<std::unique_ptr<SessionState>>> session_map_;
+  SessionStore& session_store_;
   folly::EventBase* evb_;
   long session_force_termination_timeout_ms_;
   // [CWF-ONLY] This configures how long we should wait before terminating a

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -218,7 +218,11 @@ class LocalEnforcer {
    * Should be only used for WIFI as it will apply it to all sessions with the
    * IMSI
    */
-  void handle_cwf_roaming(SessionMap& session_map, const std::string& imsi, const magma::SessionState::Config& config);
+  void handle_cwf_roaming(
+    SessionMap& session_map,
+    const std::string& imsi,
+    const magma::SessionState::Config& config,
+    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
 
   /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -40,10 +40,6 @@ class SessionNotFound : public std::exception {
  */
 class LocalEnforcer {
  public:
-
-  static SessionUpdate UNUSED_SESSION_UPDATE;
-  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
-
   LocalEnforcer();
 
   LocalEnforcer(
@@ -86,7 +82,7 @@ class LocalEnforcer {
   void aggregate_records(
     SessionMap& session_map,
     const RuleRecordTable& records,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * reset_updates resets all of the charging keys being updated in
@@ -110,7 +106,7 @@ class LocalEnforcer {
   UpdateSessionRequest collect_updates(
     SessionMap& session_map,
     std::vector<std::unique_ptr<ServiceAction>>& actions,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE,
+    SessionUpdate& session_update,
     const bool force_update = false) const;
 
   /**
@@ -145,7 +141,7 @@ class LocalEnforcer {
   void update_session_credits_and_rules(
     SessionMap& session_map,
     const UpdateSessionResponse& response,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Starts the termination process for the session. When termination completes,
@@ -158,7 +154,7 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::string& apn,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   uint64_t get_charging_credit(
     SessionMap& session_map,
@@ -179,7 +175,7 @@ class LocalEnforcer {
   ChargingReAuthAnswer::Result init_charging_reauth(
     SessionMap& session_map,
     ChargingReAuthRequest request,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Handles the equivalent of a RAR.
@@ -196,7 +192,7 @@ class LocalEnforcer {
     SessionMap& session_map,
     PolicyReAuthRequest request,
     PolicyReAuthAnswer& answer_out,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   bool session_with_imsi_exists(
     SessionMap& session_map,
@@ -222,7 +218,7 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const magma::SessionState::Config& config,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Execute actions on subscriber's service, eg. terminate, redirect data, or
@@ -231,7 +227,7 @@ class LocalEnforcer {
   void execute_actions(
     SessionMap& session_map,
     const std::vector<std::unique_ptr<ServiceAction>>& actions,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   void set_termination_callback(
     SessionMap& session_map,
@@ -276,7 +272,7 @@ class LocalEnforcer {
    */
   void notify_finish_report_for_sessions(
     SessionMap& session_map,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Process the create session response to get rules to activate/deactivate
@@ -300,7 +296,7 @@ class LocalEnforcer {
     SessionMap& session_map,
     const UpdateSessionResponse& response,
     std::unordered_set<std::string>& subscribers_to_terminate,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Processes the monitoring component of UpdateSessionResponse.
@@ -313,7 +309,7 @@ class LocalEnforcer {
     SessionMap& session_map,
     const UpdateSessionResponse& response,
     std::unordered_set<std::string>& subscribers_to_terminate,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Process the list of rule names given and fill in rules_to_deactivate by
@@ -325,7 +321,8 @@ class LocalEnforcer {
     const std::unique_ptr<SessionState>& session,
     const google::protobuf::RepeatedPtrField<std::basic_string<char>>
       rules_to_remove,
-    RulesToProcess& rules_to_deactivate);
+    RulesToProcess& rules_to_deactivate,
+    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * Populate existing rules from a specific session;
@@ -352,7 +349,8 @@ class LocalEnforcer {
     const google::protobuf::RepeatedPtrField<magma::lte::DynamicRuleInstall>
       dynamic_rules_to_install,
     RulesToProcess& rules_to_activate,
-    RulesToProcess& rules_to_deactivate);
+    RulesToProcess& rules_to_deactivate,
+    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * For the matching session ID, activate and/or deactivate the specified
@@ -365,7 +363,7 @@ class LocalEnforcer {
     const std::unique_ptr<SessionState>& session,
     bool& activate_success,
     bool& deactivate_success,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
    * Completes the session termination and executes the callback function
@@ -382,7 +380,7 @@ class LocalEnforcer {
     SessionMap& session_map,
     const std::string& imsi,
     const std::string& session_id,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   void schedule_static_rule_activation(
     SessionMap& session_map,
@@ -413,7 +411,7 @@ class LocalEnforcer {
   void receive_monitoring_credit_from_rar(
     const PolicyReAuthRequest& request,
     const std::unique_ptr<SessionState>& session,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * Send bearer creation request through the PGW client if rules were
@@ -437,7 +435,7 @@ class LocalEnforcer {
 
   void check_usage_for_reporting(
     SessionMap& session_map,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE,
+    SessionUpdate& session_update,
     const bool force_update = false);
 
   /**
@@ -449,7 +447,7 @@ class LocalEnforcer {
     const std::string& imsi,
     const std::vector<std::string>& rule_ids,
     const std::vector<PolicyRule>& dynamic_rules,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
 
   /**
@@ -459,7 +457,7 @@ class LocalEnforcer {
   void terminate_multiple_services(
     SessionMap& session_map,
     const std::unordered_set<std::string>& imsis,
-    SessionUpdate& session_update = UNUSED_SESSION_UPDATE);
+    SessionUpdate& session_update);
 
   /**
     * Install flow for redirection through pipelined

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -84,8 +84,6 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(SessionUpdate& se
       } else {
         MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
         enforcer_->update_session_credits_and_rules(session_map_, response, session_update);
-        // Check if we need to report more updates
-        check_usage_for_reporting(session_update);
       }
     });
 }

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -108,11 +108,13 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   static const std::string hex_digit_;
 
  private:
-  void check_usage_for_reporting(SessionUpdate& session_update);
+  void check_usage_for_reporting(
+      SessionMap session_map, SessionUpdate& session_update);
   bool is_pipelined_restarted();
   bool restart_pipelined(const std::uint64_t& epoch);
 
   void end_session(
+      SessionMap& session_map,
     const LocalEndSessionRequest& request,
     std::function<void(Status, LocalEndSessionResponse)> response_callback);
 
@@ -122,7 +124,13 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
     const std::string& imsi,
     const std::string& session_id);
 
+  /**
+   * Send session creation request to the CentralSessionController.
+   * If it is successful, create a session in session_map, and respond to
+   * gRPC caller.
+   */
   void send_create_session(
+    SessionMap& session_map,
     const CreateSessionRequest& request,
     const std::string& imsi,
     const std::string& sid,

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -112,6 +112,10 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   bool is_pipelined_restarted();
   bool restart_pipelined(const std::uint64_t& epoch);
 
+  void end_session(
+    const LocalEndSessionRequest& request,
+    std::function<void(Status, LocalEndSessionResponse)> response_callback);
+
   std::string convert_mac_addr_to_str(const std::string& mac_addr);
 
   void add_session_to_directory_record(

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -15,7 +15,6 @@
 
 namespace magma {
 
-SessionCreditUpdateCriteria SessionCredit::UNUSED_UPDATE_CRITERIA{};
 float SessionCredit::USAGE_REPORTING_THRESHOLD = 0.8;
 uint64_t SessionCredit::EXTRA_QUOTA_MARGIN = 1024;
 bool SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
@@ -226,8 +225,8 @@ void SessionCredit::receive_credit(
     update_criteria.usage_reporting_limit = usage_reporting_limit_;
   }
 
-  set_expiry_time(validity_time);
-  reset_reporting_credit();
+  set_expiry_time(validity_time, update_criteria);
+  reset_reporting_credit(update_criteria);
 
   is_final_grant_ = is_final_grant;
   final_action_info_ = final_action_info;

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -456,6 +456,10 @@ void SessionCredit::set_is_final_grant(
   update_criteria.is_final = is_final_grant;
 }
 
+ReAuthState SessionCredit::get_reauth() {
+  return reauth_state_;
+}
+
 void SessionCredit::set_reauth(
   ReAuthState reauth_state,
   SessionCreditUpdateCriteria& update_criteria) {

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -156,6 +156,8 @@ class SessionCredit {
     bool is_final_grant,
     SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
 
+  ReAuthState get_reauth();
+
   /**
    * Set ReAuthState.
    * NOTE: Use only for merging updates into SessionStore

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -40,8 +40,6 @@ enum CreditType {
  */
 class SessionCredit {
  public:
-  static SessionCreditUpdateCriteria UNUSED_UPDATE_CRITERIA;
-
   struct Usage {
     uint64_t bytes_tx;
     uint64_t bytes_rx;
@@ -76,21 +74,21 @@ class SessionCredit {
   void add_used_credit(
     uint64_t used_tx,
     uint64_t used_rx,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * reset_reporting_credit resets the REPORTING_* to 0
    * Also marks the session as not in reporting.
    */
-  void reset_reporting_credit(SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+  void reset_reporting_credit(SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Credit update has failed to the OCS, so mark this credit as failed so it
    * can be cut off accordingly
    */
   void mark_failure(
-    uint32_t code = 0,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    uint32_t code,
+    SessionCreditUpdateCriteria& update_criteria);
   /**
    * receive_credit increments ALLOWED* and moves the REPORTING_* credit to
    * the REPORTED_* credit
@@ -102,7 +100,7 @@ class SessionCredit {
     uint32_t validity_time,
     bool is_final_grant,
     FinalActionInfo final_action_info,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * get_update_type returns the type of update required for the credit. If no
@@ -118,13 +116,13 @@ class SessionCredit {
    */
   SessionCredit::Usage get_usage_for_reporting(
     bool is_termination,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * get_action returns the action to take on the credit based on the last
    * update. If no action needs to take place, CONTINUE_SERVICE is returned.
    */
-  ServiceActionType get_action(SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+  ServiceActionType get_action(SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Returns true if either of REPORTING_* buckets are more than 0
@@ -140,7 +138,7 @@ class SessionCredit {
    * Mark the credit to be in the REAUTH_REQUIRED state. The next time
    * get_update is called, this credit will report its usage.
    */
-  void reauth(SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+  void reauth(SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Returns
@@ -154,7 +152,7 @@ class SessionCredit {
    */
   void set_is_final_grant(
     bool is_final_grant,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   ReAuthState get_reauth();
 
@@ -165,7 +163,7 @@ class SessionCredit {
    */
   void set_reauth(
     ReAuthState reauth_state,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Set ServiceState.
@@ -174,7 +172,7 @@ class SessionCredit {
    */
   void set_service_state(
     ServiceState service_state,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Set expiry time of SessionCredit
@@ -183,7 +181,7 @@ class SessionCredit {
    */
   void set_expiry_time(
     std::time_t expiry_time,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Add credit to the specified bucket. This does not necessarily correspond
@@ -195,7 +193,7 @@ class SessionCredit {
   void add_credit(
     uint64_t credit,
     Bucket bucket,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * A threshold represented as a ratio for triggering usage update before
@@ -266,7 +264,7 @@ class SessionCredit {
 
   void set_expiry_time(
     uint32_t validity_time,
-    SessionCreditUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionCreditUpdateCriteria& update_criteria);
 
   bool is_reauth_required();
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -26,8 +26,6 @@ namespace magma {
  */
 class SessionState {
  public:
-  static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
-
   struct QoSInfo {
     bool enabled;
     uint32_t qci;
@@ -107,7 +105,7 @@ class SessionState {
     const std::string& rule_id,
     uint64_t used_tx,
     uint64_t used_rx,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * get_updates collects updates and adds them to a UpdateSessionRequest
@@ -120,7 +118,7 @@ class SessionState {
   void get_updates(
     UpdateSessionRequest& update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA,
+    SessionStateUpdateCriteria& update_criteria,
     const bool force_update = false);
 
   /**
@@ -133,7 +131,7 @@ class SessionState {
    * termination
    */
   void start_termination(
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   void set_termination_callback(
     std::function<void(SessionTerminateRequest)> on_termination_callback);
@@ -143,7 +141,7 @@ class SessionState {
    * SESSION_ACTIVE to SESSION_TERMINATION_SCHEDULED
    */
   void mark_as_awaiting_termination(
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * can_complete_termination returns whether the termination for the session
@@ -163,7 +161,7 @@ class SessionState {
    * can_complete_termination returns true.
    */
   void complete_termination(
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * complete_termination collects final usages for all credits into a
@@ -176,7 +174,7 @@ class SessionState {
    */
   void complete_termination(
     SessionReporter& reporter,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   ChargingCreditPool& get_charging_pool();
 
@@ -222,7 +220,7 @@ class SessionState {
 
   void set_tgpp_context(
     const magma::lte::TgppContext& tgpp_context,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   void set_config(const Config& config);
 
@@ -230,7 +228,7 @@ class SessionState {
 
   void set_subscriber_quota_state(
     const magma::lte::SubscriberQuotaUpdate_Type state,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   bool active_monitored_rules_exist();
 
@@ -253,20 +251,20 @@ class SessionState {
 
   void insert_dynamic_rule(
     const PolicyRule& rule,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   void activate_static_rule(
     const std::string& rule_id,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   bool remove_dynamic_rule(
     const std::string& rule_id,
     PolicyRule *rule_out,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   bool deactivate_static_rule(
     const std::string& rule_id,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA);
+    SessionStateUpdateCriteria& update_criteria);
 
   DynamicRuleStore& get_dynamic_rules();
 
@@ -344,7 +342,7 @@ class SessionState {
   void get_updates_from_charging_pool(
     UpdateSessionRequest& update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA,
+    SessionStateUpdateCriteria& update_criteria,
     const bool force_update = false);
 
   /**
@@ -358,7 +356,7 @@ class SessionState {
   void get_updates_from_monitor_pool(
     UpdateSessionRequest& update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-    SessionStateUpdateCriteria& update_criteria = UNUSED_UPDATE_CRITERIA,
+    SessionStateUpdateCriteria& update_criteria,
     const bool force_update = false);
 };
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -82,6 +82,10 @@ class SessionState {
 
   StoredSessionState marshal();
 
+  StoredSessionConfig marshal_config();
+
+  void unmarshal_config(const StoredSessionConfig& marshaled);
+
   /**
    * notify_new_report_for_sessions sets the state of terminating session to aggregating, to tell if
    * flows for the terminating session is in the latest report.

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -39,6 +39,20 @@ SessionMap SessionStore::read_sessions_for_reporting(const SessionRead& req)
   return session_map;
 }
 
+SessionMap SessionStore::read_sessions_for_deletion(const SessionRead& req)
+{
+  auto session_map = store_client_.read_sessions(req);
+  auto session_map_2 = store_client_.read_sessions(req);
+  // For all sessions of the subscriber, increment the request numbers
+  for (const std::string& imsi : req) {
+    for (auto& session : session_map_2[imsi]) {
+      session->increment_request_number(1);
+    }
+  }
+  store_client_.write_sessions(std::move(session_map_2));
+  return session_map;
+}
+
 bool SessionStore::create_sessions(
   const std::string& subscriber_id,
   std::vector<std::unique_ptr<SessionState>> sessions)

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -106,17 +106,18 @@ bool SessionStore::merge_into_session(
   }
 
   // Static rules
+  auto uc = get_default_update_criteria();
   for (const auto& rule_id : update_criteria.static_rules_to_install) {
     if (session->is_static_rule_installed(rule_id)) {
       return false;
     }
-    session->activate_static_rule(rule_id);
+    session->activate_static_rule(rule_id, uc);
   }
   for (const auto& rule_id : update_criteria.static_rules_to_uninstall) {
     if (!session->is_static_rule_installed(rule_id)) {
       return false;
     }
-    session->deactivate_static_rule(rule_id);
+    session->deactivate_static_rule(rule_id, uc);
   }
 
   // Dynamic rules
@@ -124,14 +125,14 @@ bool SessionStore::merge_into_session(
     if (session->is_dynamic_rule_installed(rule.id())) {
       return false;
     }
-    session->insert_dynamic_rule(rule);
+    session->insert_dynamic_rule(rule, uc);
   }
   PolicyRule* _ = {};
   for (const auto& rule_id : update_criteria.dynamic_rules_to_uninstall) {
     if (!session->is_dynamic_rule_installed(rule_id)) {
       return false;
     }
-    session->remove_dynamic_rule(rule_id, _);
+    session->remove_dynamic_rule(rule_id, _, uc);
   }
 
   // Charging credit
@@ -143,8 +144,9 @@ bool SessionStore::merge_into_session(
   for (const auto& it : update_criteria.charging_credit_to_install) {
     auto key = it.first;
     auto stored_credit = it.second;
+    auto uc = get_default_update_criteria();
     session->get_charging_pool().add_credit(
-      key, SessionCredit::unmarshal(stored_credit, CHARGING));
+      key, SessionCredit::unmarshal(stored_credit, CHARGING), uc);
   }
 
   // Monitoring credit
@@ -156,8 +158,9 @@ bool SessionStore::merge_into_session(
   for (const auto& it : update_criteria.monitor_credit_to_install) {
     auto key = it.first;
     auto stored_monitor = it.second;
+    auto uc = get_default_update_criteria();
     session->get_monitor_pool().add_monitor(
-      key, UsageMonitoringCreditPool::unmarshal_monitor(stored_monitor));
+      key, UsageMonitoringCreditPool::unmarshal_monitor(stored_monitor), uc);
   }
   return true;
 }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -100,6 +100,11 @@ bool SessionStore::merge_into_session(
   std::unique_ptr<SessionState>& session,
   const SessionStateUpdateCriteria& update_criteria)
 {
+  // Config
+  if (update_criteria.is_config_updated) {
+    session->unmarshal_config(update_criteria.updated_config);
+  }
+
   // Static rules
   for (const auto& rule_id : update_criteria.static_rules_to_install) {
     if (session->is_static_rule_installed(rule_id)) {

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -73,6 +73,22 @@ class SessionStore {
   SessionMap read_sessions_for_reporting(const SessionRead& req);
 
   /**
+   * Read the last written values for the requested sessions through the
+   * storage interface. This also modifies the request_numbers stored before
+   * returning the SessionMap to the caller, incremented by one for each
+   * session.
+   * NOTE: It is assumed that the correct number of request_numbers are
+   *       reserved on each read_sessions call. If more requests are made to
+   *       the OCS/PCRF than are requested, this can cause undefined behavior.
+   * NOTE: Here, it is expected that the caller will use one additional
+   *       request_number for each session.
+   * @param req
+   * @return Last written values for requested sessions. Returns an empty vector
+   *         for subscribers that do not have active sessions.
+   */
+  SessionMap read_sessions_for_deletion(const SessionRead& req);
+
+  /**
    * Create sessions for a subscriber. Redundant creations will fail.
    * @param subscriber_id
    * @param sessions

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -15,6 +15,7 @@ namespace magma {
 SessionStateUpdateCriteria get_default_update_criteria()
 {
   SessionStateUpdateCriteria uc {};
+  uc.is_config_updated = false;
   uc.charging_credit_to_install = std::unordered_map<
     CreditKey,
     StoredSessionCredit,

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -136,6 +136,8 @@ struct SessionCreditUpdateCriteria {
 
 struct SessionStateUpdateCriteria {
   bool is_session_ended;
+  bool is_config_updated;
+  StoredSessionConfig updated_config;
   std::vector<std::string> static_rules_to_install;
   std::vector<std::string> static_rules_to_uninstall;
   std::vector<PolicyRule> dynamic_rules_to_install;

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -217,6 +217,7 @@ int main(int argc, char *argv[])
   auto monitor = std::make_shared<magma::LocalEnforcer>(
     reporter,
     rule_store,
+    *session_store,
     pipelined_client,
     directoryd_client,
     eventd_client,

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <memory>
+
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+#include <folly/io/async/EventBaseManager.h>
+
+#include "MagmaService.h"
+#include "LocalEnforcer.h"
+#include "ProtobufCreators.h"
+#include "RuleStore.h"
+#include "SessionID.h"
+#include "ServiceRegistrySingleton.h"
+#include "SessiondMocks.h"
+#include "SessionProxyResponderHandler.h"
+#include "SessionState.h"
+#include "SessionStore.h"
+#include "StoredState.h"
+#include "magma_logging.h"
+
+using ::testing::Test;
+
+namespace magma {
+
+class SessionProxyResponderHandlerTest : public ::testing::Test {
+ protected:
+  virtual void SetUp()
+  {
+    imsi = "IMSI1";
+    imsi2 = "IMSI2";
+    sid = id_gen_.gen_session_id(imsi);
+    sid2 = id_gen_.gen_session_id(imsi2);
+    sid3 = id_gen_.gen_session_id(imsi2);
+    monitoring_key = "mk1";
+    monitoring_key2 = "mk2";
+    rule_id_1 = "test_rule_1";
+    rule_id_2 = "test_rule_2";
+    rule_id_3 = "test_rule_3";
+    dynamic_rule_id_1 = "dynamic_rule_1";
+    dynamic_rule_id_2 = "dynamic_rule_2";
+
+    reporter = std::make_shared<MockSessionReporter>();
+    auto rule_store = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(rule_store);
+    pipelined_client = std::make_shared<MockPipelinedClient>();
+    auto directoryd_client = std::make_shared<MockDirectorydClient>();
+    auto eventd_client = std::make_shared<MockEventdClient>();
+    auto spgw_client = std::make_shared<MockSpgwServiceClient>();
+    auto aaa_client = std::make_shared<MockAAAClient>();
+    local_enforcer = std::make_shared<LocalEnforcer>(
+      reporter,
+      rule_store,
+      pipelined_client,
+      directoryd_client,
+      eventd_client,
+      spgw_client,
+      aaa_client,
+      0,
+      0);
+    evb = folly::EventBaseManager::get()->getEventBase();
+    session_map = SessionMap{};
+
+    proxy_responder = std::make_shared<SessionProxyResponderHandlerImpl>(
+      local_enforcer, session_map, *session_store);
+
+    local_enforcer->attachEventBase(evb);
+  }
+
+  std::unique_ptr<SessionState> get_session(
+    std::string session_id,
+    std::shared_ptr<StaticRuleStore> rule_store)
+  {
+    std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
+    std::string msisdn = "5100001234";
+    std::string radius_session_id =
+      "AA-AA-AA-AA-AA-AA:TESTAP__"
+      "0F-10-2E-12-3A-55";
+    std::string core_session_id = "asdf";
+    SessionState::Config cfg = {.ue_ipv4 = "",
+      .spgw_ipv4 = "",
+      .msisdn = msisdn,
+      .apn = "",
+      .imei = "",
+      .plmn_id = "",
+      .imsi_plmn_id = "",
+      .user_location = "",
+      .rat_type = RATType::TGPP_WLAN,
+      .mac_addr = "0f:10:2e:12:3a:55",
+      .hardware_addr = hardware_addr_bytes,
+      .radius_session_id = radius_session_id};
+    auto tgpp_context = TgppContext{};
+    auto session = std::make_unique<SessionState>(
+      imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);
+    return std::move(session);
+  }
+
+  UsageMonitoringUpdateResponse* get_monitoring_update()
+  {
+    auto units = new GrantedUnits();
+    auto total = new CreditUnit();
+    total->set_is_valid(true);
+    total->set_volume(1000);
+    auto tx = new CreditUnit();
+    tx->set_is_valid(true);
+    tx->set_volume(1000);
+    auto rx = new CreditUnit();
+    rx->set_is_valid(true);
+    rx->set_volume(1000);
+    units->set_allocated_total(total);
+    units->set_allocated_tx(tx);
+    units->set_allocated_rx(rx);
+
+    auto monitoring_credit = new UsageMonitoringCredit();
+    monitoring_credit->set_action(UsageMonitoringCredit_Action_CONTINUE);
+    monitoring_credit->set_monitoring_key(monitoring_key);
+    monitoring_credit->set_level(SESSION_LEVEL);
+    monitoring_credit->set_allocated_granted_units(units);
+
+    auto credit_update = new UsageMonitoringUpdateResponse();
+    credit_update->set_allocated_credit(monitoring_credit);
+    credit_update->set_session_id("sid1");
+    credit_update->set_success(true);
+    // Don't set event triggers
+    // Don't set result code since the response is already successful
+    // Don't set any rule installation/uninstallation
+    // Don't set the TgppContext, assume relay disabled
+    return credit_update;
+  }
+
+  PolicyReAuthRequest* get_policy_reauth_request()
+  {
+//    message PolicyReAuthRequest {
+//      // NOTE: if no session_id is specified, apply to all sessions for the IMSI
+//      string session_id = 1;
+//      string imsi = 2;
+//      repeated string rules_to_remove = 3;
+//      repeated StaticRuleInstall rules_to_install = 6;
+//      repeated DynamicRuleInstall dynamic_rules_to_install = 7;
+//      repeated EventTrigger event_triggers = 8;
+//      google.protobuf.Timestamp revalidation_time = 9;
+//      repeated UsageMonitoringCredit usage_monitoring_credits = 10;
+//      QoSInformation qos_info = 11;
+//    }
+    auto request = new PolicyReAuthRequest();
+    request->set_session_id("");
+    request->set_imsi("IMSI1");
+
+    auto static_rule = new StaticRuleInstall();
+    static_rule->set_rule_id("static_1");
+    request->mutable_rules_to_install()->AddAllocated(static_rule);
+    return request;
+  }
+
+ protected:
+  std::string imsi;
+  std::string imsi2;
+  std::string sid;
+  std::string sid2;
+  std::string sid3;
+  std::string monitoring_key;
+  std::string monitoring_key2;
+  std::string rule_id_1;
+  std::string rule_id_2;
+  std::string rule_id_3;
+  std::string dynamic_rule_id_1;
+  std::string dynamic_rule_id_2;
+
+  std::shared_ptr<MockPipelinedClient> pipelined_client;
+  std::shared_ptr<SessionProxyResponderHandlerImpl> proxy_responder;
+  std::shared_ptr<MockSessionReporter> reporter;
+  std::shared_ptr <LocalEnforcer> local_enforcer;
+  SessionIDGenerator id_gen_;
+  folly::EventBase *evb;
+  SessionMap session_map;
+  std::shared_ptr<SessionStore> session_store;
+  std::shared_ptr<StaticRuleStore> rule_store;
+};
+
+TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth)
+{
+  // 1) Create SessionStore
+  auto rule_store = std::make_shared<StaticRuleStore>();
+
+  // 2) Create bare-bones session for IMSI1
+  auto session = get_session(sid, rule_store);
+  session->activate_static_rule(rule_id_3);
+  EXPECT_EQ(session->get_session_id(), sid);
+  EXPECT_EQ(session->get_request_number(), 2);
+  EXPECT_EQ(session->is_static_rule_installed(rule_id_3),true);
+
+  auto credit_update = get_monitoring_update();
+  UsageMonitoringUpdateResponse& credit_update_ref = *credit_update;
+  session->get_monitor_pool().receive_credit(credit_update_ref);
+
+  // Add some used credit
+  session->get_monitor_pool().add_used_credit(monitoring_key, uint64_t(111), uint64_t(333));
+  EXPECT_EQ(session->get_monitor_pool().get_credit(monitoring_key, USED_TX), 111);
+  EXPECT_EQ(session->get_monitor_pool().get_credit(monitoring_key, USED_RX), 333);
+
+  // 3) Commit session for IMSI1 into SessionStore
+  auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+  EXPECT_EQ(sessions.size(), 0);
+  sessions.push_back(std::move(session));
+  EXPECT_EQ(sessions.size(), 1);
+  session_store->create_sessions(imsi, std::move(sessions));
+
+  // Just verify some things about the session before doing PolicyReAuth
+  SessionRead read_req = {};
+  read_req.insert(imsi);
+  auto session_map = session_store->read_sessions(read_req);
+  EXPECT_EQ(session_map.size(), 1);
+  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[imsi].front()->get_request_number(), 2);
+  EXPECT_EQ(session_map[imsi].front()->is_static_rule_installed("static_1"), false);
+
+  // 4) Now call PolicyReAuth
+  auto request = get_policy_reauth_request();
+  grpc::ServerContext create_context;
+  EXPECT_CALL(*pipelined_client, activate_flows_for_rules(_, _, _, _)).Times(1);
+  proxy_responder->PolicyReAuth(&create_context, request, [this](
+    grpc::Status status, PolicyReAuthAnswer response_out) {});
+
+  // run LocalEnforcer's init_policy_reauth which was scheduled by
+  // proxy_responder
+  evb->loopOnce();
+
+  // 5) Read the session back from SessionStore and verify that the update
+  //    was done correctly to what's stored.
+  session_map = session_store->read_sessions(read_req);
+  EXPECT_EQ(session_map.size(), 1);
+  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[imsi].front()->get_request_number(), 2);
+  EXPECT_EQ(session_map[imsi].front()->is_static_rule_installed("static_1"), true);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+} // namespace magma

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -58,6 +58,7 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     local_enforcer = std::make_shared<LocalEnforcer>(
       reporter,
       rule_store,
+      *session_store,
       pipelined_client,
       directoryd_client,
       eventd_client,

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -20,6 +20,8 @@
 #include "ServiceRegistrySingleton.h"
 #include "SessiondMocks.h"
 #include "SessionStore.h"
+#include "SessionState.h"
+#include "StoredState.h"
 #include "magma_logging.h"
 
 
@@ -28,43 +30,67 @@ using ::testing::Test;
 namespace magma {
 
 class SessionManagerHandlerTest : public ::testing::Test {
-  protected:
-  protected:
-    virtual void SetUp() {
-        reporter = std::make_shared<MockSessionReporter>();
-        auto rule_store = std::make_shared<StaticRuleStore>();
-        auto session_store = new SessionStore(rule_store);
-        auto pipelined_client = std::make_shared<MockPipelinedClient>();
-        auto directoryd_client = std::make_shared<MockDirectorydClient>();
-        auto eventd_client = std::make_shared<MockEventdClient>();
-        auto spgw_client = std::make_shared<MockSpgwServiceClient>();
-        auto aaa_client = std::make_shared<MockAAAClient>();
-        local_enforcer = std::make_shared<LocalEnforcer>(
-                reporter,
-                rule_store,
-                pipelined_client,
-                directoryd_client,
-                eventd_client,
-                spgw_client,
-                aaa_client,
-                0,
-                0);
-        evb = folly::EventBaseManager::get()->getEventBase();
-        local_enforcer->attachEventBase(evb);
-      session_map = SessionMap{};
+ protected:
+  virtual void SetUp() {
+    monitoring_key = "mk1";
 
-      session_manager = std::make_shared<LocalSessionManagerHandlerImpl>(
-        local_enforcer, reporter.get(), directoryd_client, session_map, *session_store);
-    }
+    reporter = std::make_shared<MockSessionReporter>();
+    rule_store = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(rule_store);
+    pipelined_client = std::make_shared<MockPipelinedClient>();
+    auto directoryd_client = std::make_shared<MockDirectorydClient>();
+    auto eventd_client = std::make_shared<MockEventdClient>();
+    auto spgw_client = std::make_shared<MockSpgwServiceClient>();
+    auto aaa_client = std::make_shared<MockAAAClient>();
+    local_enforcer = std::make_shared<LocalEnforcer>(
+            reporter,
+            rule_store,
+            pipelined_client,
+            directoryd_client,
+            eventd_client,
+            spgw_client,
+            aaa_client,
+            0,
+            0);
+    evb = folly::EventBaseManager::get()->getEventBase();
+    local_enforcer->attachEventBase(evb);
+    session_map = SessionMap{};
 
-  protected:
-    std::shared_ptr<LocalSessionManagerHandlerImpl> session_manager;
-    std::shared_ptr<MockSessionReporter> reporter;
-    std::shared_ptr <LocalEnforcer> local_enforcer;
-    SessionIDGenerator id_gen_;
-    folly::EventBase *evb;
-    SessionMap session_map;
+    session_manager = std::make_shared<LocalSessionManagerHandlerImpl>(
+      local_enforcer, reporter.get(), directoryd_client, session_map, *session_store);
+  }
+
+  void insert_static_rule(
+    std::shared_ptr<StaticRuleStore> rule_store,
+    uint32_t charging_key,
+    const std::string &rule_id)
+  {
+    PolicyRule rule;
+    rule.set_id(rule_id);
+    rule.set_rating_group(charging_key);
+    rule.set_tracking_type(PolicyRule::ONLY_OCS);
+    rule_store->insert_rule(rule);
+  }
+
+ protected:
+  std::string monitoring_key;
+
+  std::shared_ptr<SessionStore> session_store;
+  std::shared_ptr<StaticRuleStore> rule_store;
+  std::shared_ptr<LocalSessionManagerHandlerImpl> session_manager;
+  std::shared_ptr<MockSessionReporter> reporter;
+  std::shared_ptr<MockPipelinedClient> pipelined_client;
+  std::shared_ptr <LocalEnforcer> local_enforcer;
+  SessionIDGenerator id_gen_;
+  folly::EventBase *evb;
+  SessionMap session_map;
 };
+
+MATCHER_P(CheckCreateSession, imsi, "")
+{
+  auto sid = static_cast<const CreateSessionRequest *>(arg);
+  return sid->subscriber().id() == imsi;
+}
 
 TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
 {
@@ -84,7 +110,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
             .plmn_id = "",
             .imsi_plmn_id = "",
             .user_location = "",
-            .rat_type = RATType::TGPP_WLAN,
+            .rat_type = RATType::TGPP_LTE,
             .mac_addr = "0f:10:2e:12:3a:55",
             .hardware_addr = hardware_addr_bytes,
             .radius_session_id = radius_session_id};
@@ -99,19 +125,155 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     request.set_radius_session_id(radius_session_id);
     request.set_apn("apn2"); // Update APN
 
-    // Ensure session is not reported as its a duplicate
+  // Ensure session is not reported as its a duplicate
     EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
     session_manager->CreateSession(&create_context, &request, [this](
             grpc::Status status, LocalCreateSessionResponse response_out) {});
+
+    // Run session creation in the EventBase loop
+    // It needs to loop twice here.
     evb->loopOnce();
+    evb->loopOnce();
+    evb->loopOnce();
+
     // Assert the internal session config is updated to the new one
     EXPECT_FALSE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn1"));
     EXPECT_TRUE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn2"));
 }
 
+TEST_F(SessionManagerHandlerTest, test_create_session)
+{
+  // 1) Create the session
+  LocalCreateSessionRequest request;
+  std::string hardware_addr_bytes = {0x0f,0x10,0x2e,0x12,0x3a,0x55};
+  std::string imsi = "IMSI1";
+  std::string msisdn = "5100001234";
+  std::string radius_session_id = "AA-AA-AA-AA-AA-AA:TESTAP__"
+                                  "0F-10-2E-12-3A-55";
+
+  grpc::ServerContext server_context;
+  request.mutable_sid()->set_id(imsi);
+  request.set_rat_type(RATType::TGPP_LTE);
+  request.set_hardware_addr(hardware_addr_bytes);
+  request.set_msisdn(msisdn);
+  request.set_radius_session_id(radius_session_id);
+
+  CreateSessionResponse create_response;
+  create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
+      "rule1");
+  create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
+      "rule2");
+  create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
+      "rule3");
+  create_credit_update_response(
+      "IMSI1", 1, 1536, create_response.mutable_credits()->Add());
+  create_credit_update_response(
+      "IMSI1", 2, 1024, create_response.mutable_credits()->Add());
+
+  // Ensure session is not reported as its a duplicate
+  EXPECT_CALL(*reporter, report_create_session(_, _)).Times(1);
+  session_manager->CreateSession(&server_context, &request, [this](
+      grpc::Status status, LocalCreateSessionResponse response_out) {});
+
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+  evb->loopOnce();
+  evb->loopOnce();
+}
+
+TEST_F(SessionManagerHandlerTest, test_report_rule_stats)
+{
+  // 1) Insert the entry for a rule
+  insert_static_rule(rule_store, 1, "rule1");
+
+  // 2) Create a session
+  CreateSessionResponse response;
+  response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  create_credit_update_response(
+      "IMSI1", 1, 1025, response.mutable_credits()->Add());
+  std::string hardware_addr_bytes = {0x0f,0x10,0x2e,0x12,0x3a,0x55};
+  std::string imsi = "IMSI1";
+  std::string msisdn = "5100001234";
+  std::string radius_session_id = "AA-AA-AA-AA-AA-AA:TESTAP__"
+                                  "0F-10-2E-12-3A-55";
+  auto sid = id_gen_.gen_session_id(imsi);
+  SessionState::Config cfg = {.ue_ipv4 = "",
+      .spgw_ipv4 = "",
+      .msisdn = msisdn,
+      .apn = "apn1",
+      .imei = "",
+      .plmn_id = "",
+      .imsi_plmn_id = "",
+      .user_location = "",
+      .rat_type = RATType::TGPP_LTE,
+      .mac_addr = "0f:10:2e:12:3a:55",
+      .hardware_addr = hardware_addr_bytes,
+      .radius_session_id = radius_session_id};
+
+  local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
+
+  // 2) ReportRuleStats
+  grpc::ServerContext server_context;
+  RuleRecordTable table;
+  auto record_list = table.mutable_records();
+  create_rule_record("IMSI1", "rule1", 512, 512, record_list->Add());
+
+  EXPECT_CALL(*reporter, report_updates(_, _)).Times(1);
+  session_manager->ReportRuleStats(&server_context, &table, [this](
+      grpc::Status status, orc8r::Void response_out) {});
+  evb->loopOnce();
+  evb->loopOnce();
+}
+
+TEST_F(SessionManagerHandlerTest, test_end_session) {
+  // 1) Insert the entry for a rule
+  insert_static_rule(rule_store, 1, "rule1");
+
+  // 2) Create a session
+  CreateSessionResponse response;
+  response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  create_credit_update_response(
+      "IMSI1", 1, 1025, response.mutable_credits()->Add());
+  std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
+  std::string imsi                = "IMSI1";
+  std::string msisdn              = "5100001234";
+  std::string radius_session_id =
+      "AA-AA-AA-AA-AA-AA:TESTAP__"
+      "0F-10-2E-12-3A-55";
+  auto sid                 = id_gen_.gen_session_id(imsi);
+  SessionState::Config cfg = {.ue_ipv4           = "",
+                              .spgw_ipv4         = "",
+                              .msisdn            = msisdn,
+                              .apn               = "apn1",
+                              .imei              = "",
+                              .plmn_id           = "",
+                              .imsi_plmn_id      = "",
+                              .user_location     = "",
+                              .rat_type          = RATType::TGPP_LTE,
+                              .mac_addr          = "0f:10:2e:12:3a:55",
+                              .hardware_addr     = hardware_addr_bytes,
+                              .radius_session_id = radius_session_id};
+
+  local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
+
+  // 3) EndSession
+  EXPECT_EQ(session_map["IMSI1"].size(), 1);
+  LocalEndSessionRequest end_request;
+  end_request.mutable_sid()->set_id("IMSI1");
+  end_request.set_apn("apn1");
+  EXPECT_CALL(*reporter, report_terminate_session(_, _)).Times(1);
+  grpc::ServerContext server_context;
+  session_manager->EndSession(&server_context, &end_request,
+      [this] (grpc::Status status, LocalEndSessionResponse response_out) {});
+  evb->loopOnce();
+  std::this_thread::sleep_for(std::chrono::milliseconds(5000));
+  evb->loopOnce();
+  EXPECT_EQ(session_map["IMSI1"].size(), 0);
+}
+
 int main(int argc, char **argv)
 {
-    ::testing::InitGoogleTest(&argc, argv);
+  ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
 

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -144,8 +144,8 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     // Assert the internal session config is updated to the new one
     req = {"IMSI1"};
     session_map = session_store->read_sessions(req);
-//    EXPECT_FALSE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn1"));
-//    EXPECT_TRUE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn2"));
+    EXPECT_FALSE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn1"));
+    EXPECT_TRUE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn2"));
 }
 
 TEST_F(SessionManagerHandlerTest, test_create_session)

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -103,6 +103,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg)
     EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
     session_manager->CreateSession(&create_context, &request, [this](
             grpc::Status status, LocalCreateSessionResponse response_out) {});
+    evb->loopOnce();
     // Assert the internal session config is updated to the new one
     EXPECT_FALSE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn1"));
     EXPECT_TRUE(local_enforcer->session_with_apn_exists(session_map, "IMSI1", "apn2"));

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -233,7 +233,8 @@ TEST_F(SessionStateTest, test_insert_credit)
 TEST_F(SessionStateTest, test_termination)
 {
   std::promise<void> termination_promise;
-  session_state->start_termination(
+  session_state->start_termination();
+  session_state->set_termination_callback(
     [&termination_promise](SessionTerminateRequest term_req) {
       termination_promise.set_value();
     });
@@ -253,7 +254,7 @@ TEST_F(SessionStateTest, test_can_complete_termination)
 
   EXPECT_EQ(session_state->can_complete_termination(), false);
 
-  session_state->start_termination([](SessionTerminateRequest term_req) {});
+  session_state->start_termination();
   EXPECT_EQ(session_state->can_complete_termination(), false);
 
   // If the rule is still being reported, termination should not be completed.

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -213,17 +213,18 @@ TEST_F(SessionStoreTest, test_read_and_write)
 
   // 2) Create bare-bones session for IMSI1
   auto session = get_session(sid, rule_store);
-  session->activate_static_rule(rule_id_3);
+  auto uc = get_default_update_criteria();
+  session->activate_static_rule(rule_id_3, uc);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session->get_request_number(), 2);
   EXPECT_EQ(session->is_static_rule_installed(rule_id_3),true);
 
   auto credit_update = get_monitoring_update();
   UsageMonitoringUpdateResponse& credit_update_ref = *credit_update;
-  session->get_monitor_pool().receive_credit(credit_update_ref);
+  session->get_monitor_pool().receive_credit(credit_update_ref, uc);
 
   // Add some used credit
-  session->get_monitor_pool().add_used_credit(monitoring_key, uint64_t(111), uint64_t(333));
+  session->get_monitor_pool().add_used_credit(monitoring_key, uint64_t(111), uint64_t(333), uc);
   EXPECT_EQ(session->get_monitor_pool().get_credit(monitoring_key, USED_TX), 111);
   EXPECT_EQ(session->get_monitor_pool().get_credit(monitoring_key, USED_RX), 333);
 
@@ -273,7 +274,7 @@ TEST_F(SessionStoreTest, test_read_and_write)
 
   // Check for installation of new monitoring credit
   session_map[imsi].front()->get_monitor_pool().add_monitor(monitoring_key2,
-    UsageMonitoringCreditPool::unmarshal_monitor(update_criteria.monitor_credit_to_install[monitoring_key2]));
+    UsageMonitoringCreditPool::unmarshal_monitor(update_criteria.monitor_credit_to_install[monitoring_key2]), uc);
   EXPECT_EQ(session_map[imsi].front()->get_monitor_pool().get_credit(monitoring_key2, USED_TX), 100);
   EXPECT_EQ(session_map[imsi].front()->get_monitor_pool().get_credit(monitoring_key2, USED_RX), 200);
 

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -69,12 +69,13 @@ TEST_F(StoreClientTest, test_read_and_write)
   std::set<std::string> requested_ids{imsi, imsi2};
   auto session_map = store_client->read_sessions(requested_ids);
 
+  auto uc = get_default_update_criteria();
   auto session = std::make_unique<SessionState>(imsi, sid, core_session_id, cfg, *rule_store, tgpp_context);
   auto session2 = std::make_unique<SessionState>(imsi2, sid2, core_session_id, cfg, *rule_store, tgpp_context);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 
-  session->activate_static_rule("rule1");
+  session->activate_static_rule("rule1", uc);
   EXPECT_EQ(session->is_static_rule_installed("rule1"), true);
 
   EXPECT_EQ(session_map.size(), 2);

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -100,6 +100,22 @@ TEST_F(StoreClientTest, test_read_and_write)
   EXPECT_EQ(session_map_2[imsi].front()->is_static_rule_installed("rule1"), true);
 }
 
+TEST_F(StoreClientTest, test_lambdas)
+{
+  auto sm = std::make_unique<int>(1);
+
+  std::function<void(std::unique_ptr<int>&)> callback2 = [](std::unique_ptr<int>& inp) {
+    EXPECT_EQ(*inp, 2);
+  };
+
+  std::function<void()> callback = [=, shared = std::make_shared<decltype(sm)>(std::move(sm))]() mutable {
+    EXPECT_EQ(**shared, 1);
+    **shared = 2;
+    callback2(*shared);
+  };
+  callback();
+}
+
 int main(int argc, char **argv)
 {
   ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Summary:
## Changes
- Remove default arguments of methods of CreditPool which should no longer be used.
- Remove default arguments for LocalEnforcer
- Remove default arguments for SessionState
- Remove default arguments for SessionCredit

Reviewed By: ulaskozat

Differential Revision: D20784350

