### PR TITLE
Adjust log levels

### DIFF
--- a/lte/gateway/c/session_manager/CreditPool.cpp
+++ b/lte/gateway/c/session_manager/CreditPool.cpp
@@ -248,7 +248,7 @@ bool ChargingCreditPool::init_new_credit(
                  << " and charging key " << update.charging_key();
     return false;
   }
-  MLOG(MDEBUG) << "Initialized a charging credit for imsi" << imsi_
+  MLOG(MINFO) << "Initialized a charging credit for imsi " << imsi_
                << " and charging key " << update.charging_key();
   // unless defined, volume is defined as the maximum possible value
   // uint64_t default_volume = std::numeric_limits<uint64_t>::max();

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -208,7 +208,8 @@ void LocalEnforcer::aggregate_records(
       continue;
     }
     if (record.bytes_tx() > 0 || record.bytes_rx() > 0) {
-      MLOG(MDEBUG) << "Subscriber " << record.sid() << " used "
+      MLOG(MINFO) << "";
+      MLOG(MINFO) << "Subscriber " << record.sid() << " used "
                    << record.bytes_tx() << " tx bytes and " << record.bytes_rx()
                    << " rx bytes for rule " << record.rule_id();
     }
@@ -244,8 +245,8 @@ void LocalEnforcer::execute_actions(
     } else if (action_p->get_type() == REDIRECT) {
       install_redirect_flow(action_p);
     } else if (action_p->get_type() == RESTRICT_ACCESS) {
-      MLOG(MDEBUG) << "RESTRICT_ACCESS mode is unsupported"
-                   << ", will just terminate the service.";
+      MLOG(MWARNING) << "RESTRICT_ACCESS mode is unsupported"
+                     << ", will just terminate the service.";
       terminate_service(
         session_map,
         action_p->get_imsi(),

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -45,7 +45,9 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
   std::function<void(Status, Void)> response_callback)
 {
   auto &request_cpy = *request;
-  MLOG(MDEBUG) << "Aggregating " << request_cpy.records_size() << " records";
+  if (request_cpy.records_size() > 0) {
+    MLOG(MDEBUG) << "\nAggregating " << request_cpy.records_size() << " records";
+  }
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = get_sessions_for_reporting(request_cpy);
     SessionUpdate update = SessionStore::get_default_session_update(session_map);

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -46,7 +46,7 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
 {
   auto &request_cpy = *request;
   if (request_cpy.records_size() > 0) {
-    MLOG(MDEBUG) << "\nAggregating " << request_cpy.records_size() << " records";
+    MLOG(MDEBUG) << "Aggregating " << request_cpy.records_size() << " records";
   }
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = get_sessions_for_reporting(request_cpy);
@@ -56,7 +56,7 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
   });
   reported_epoch_ = request_cpy.epoch();
   if (is_pipelined_restarted()) {
-    MLOG(MDEBUG) << "Pipelined has been restarted, attempting to sync flows";
+    MLOG(MINFO) << "Pipelined has been restarted, attempting to sync flows";
     restart_pipelined(reported_epoch_);
     // Set the current epoch right away to prevent double setup call requests
     current_epoch_ = reported_epoch_;
@@ -80,7 +80,7 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
     }
     return; // nothing to report
   }
-  MLOG(MDEBUG) << "Sending " << request.updates_size()
+  MLOG(MINFO) << "Sending " << request.updates_size()
                << " charging updates and " << request.usage_monitors_size()
                << " monitor updates to OCS and PCRF";
 
@@ -97,7 +97,6 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
         MLOG(MERROR) << "Update of size " << request.updates_size()
                      << " to OCS failed entirely: " << status.error_message();
       } else {
-        MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
         enforcer_->update_session_credits_and_rules(*session_map_ptr, response, session_update);
         session_store_.update_sessions(session_update);
       }
@@ -330,7 +329,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
         bool success = enforcer_->init_session_credit(
           *session_map_ptr, imsi, sid, cfg, response);
         if (!success) {
-          MLOG(MERROR) << "Failed to init session in for IMSI " << imsi;
+          MLOG(MERROR) << "Failed to initialize session for IMSI " << imsi;
           status =
             Status(
               grpc::FAILED_PRECONDITION, "Failed to initialize session");

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -258,6 +258,8 @@ class SessionCredit {
   bool is_quota_exhausted(
     float usage_reporting_threshold = 1, uint64_t extra_quota_margin = 0);
 
+  void log_quota_and_usage();
+
   bool should_deactivate_service();
 
   bool validity_timer_expired();

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -190,14 +190,14 @@ void SessionState::add_used_credit(
 
   CreditKey charging_key;
   if (get_charging_key_for_rule_id(rule_id, &charging_key)) {
-    MLOG(MDEBUG) << "Updating used charging credit for Rule=" << rule_id
+    MLOG(MINFO) << "Updating used charging credit for Rule=" << rule_id
                  << " Rating Group=" << charging_key.rating_group
                  << " Service Identifier=" << charging_key.service_identifier;
     charging_pool_.add_used_credit(charging_key, used_tx, used_rx, update_criteria);
   }
   std::string monitoring_key;
   if (get_monitoring_key_for_rule_id(rule_id, &monitoring_key)) {
-    MLOG(MDEBUG) << "Updating used monitoring credit for Rule=" << rule_id
+    MLOG(MINFO) << "Updating used monitoring credit for Rule=" << rule_id
                  << " Monitoring Key=" << monitoring_key;
     monitor_pool_.add_used_credit(monitoring_key, used_tx, used_rx, update_criteria);
   }

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -55,6 +55,9 @@ bool do_loop(
     MLOG(MERROR) << "Failed to get rules from map because map error " << result;
     return false;
   }
+  if (rules.size() > 0) {
+    MLOG(MDEBUG) << rules.size() << " rules synced";
+  }
   processor(rules);
   return true;
 }

--- a/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
+++ b/orc8r/gateway/c/common/policydb/PolicyLoader.cpp
@@ -56,7 +56,6 @@ bool do_loop(
     return false;
   }
   processor(rules);
-  MLOG(MDEBUG) << rules.size() << " rules synced";
   return true;
 }
 


### PR DESCRIPTION
Summary:
- Any events like subscriber receiving credit or using data is upgraded to INFO from DEBUG
- Data usage logs for debugging are left at debug
- Defined a helper to print final unit action as a string

Reviewed By: andreilee

Differential Revision: D20773204

