### PR TITLE
Update bootstrap manager state call on scheduled check

### DIFF
--- a/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
+++ b/orc8r/gateway/python/magma/magmad/bootstrap_manager.py
@@ -99,7 +99,7 @@ class BootstrapManager(SDWatchdogTask):
         elif self._state == BootstrapState.SCHEDULED_BOOTSTRAP:
             await self._bootstrap_now()
         elif self._state == BootstrapState.SCHEDULED_CHECK:
-            await self._bootstrap_now()
+            await self._bootstrap_check()
         elif self._state == BootstrapState.IDLE:
             pass
 


### PR DESCRIPTION
Summary:
- Bootstrap manager SCHEDULED_CHECK state is calling `bootstrap_now()` which is restarting control_proxy every scheduled period (1 hour)

```
magma@magma:~$ sudo journalctl -u magma@magmad | grep 'Socket closed'
Apr 08 00:24:10 magma magmad[17837]: ERROR:root:[SyncRPC] Transient gRPC error, retrying: Socket closed
Apr 08 01:24:42 magma magmad[26675]: ERROR:root:[SyncRPC] Transient gRPC error, retrying: Socket closed
Apr 08 02:24:51 magma magmad[26675]: ERROR:root:[SyncRPC] Transient gRPC error, retrying: Socket closed
Apr 08 03:25:00 magma magmad[26675]: ERROR:root:[SyncRPC] Transient gRPC error, retrying: Socket closed
Apr 08 04:25:09 magma magmad[26675]: ERROR:root:[SyncRPC] Transient gRPC error, retrying: Socket closed
Apr 08 05:25:18 magma magmad[26675]: ERROR:root:[SyncRPC] Transient gRPC error, retrying: Socket closed
```

Differential Revision: D20931261

