### PR TITLE
Fix missing .deb - bad filename generated by fpm for python webcolors 1.11.0

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -101,7 +101,6 @@ setup(
         'eventlet>=0.24',
         'h2>=3.2.0',
         'hpack>=3.0',
-        'webcolors>=1.11.0'
     ],
     extras_require={
         'dev': [

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -85,6 +85,6 @@ setup(
         "strict-rfc3339>=0.7",
         "rfc3987>=1.3.0",
         "jsonpointer>=1.13",
-        "webcolors>=1.11.0"
+        "webcolors>=1.11.1"
     ]
 )


### PR DESCRIPTION
Summary:
```pydep``` script uses  ```fpm``` command to generate the .deb files. For some reason when generating the deb for webcolors version 1.11.0 the comes wrong:

```python3-webcolors_1.11_all.deb```
instead of
```python3-webcolors_1.11.0_all.deb```

That prevents the auto update of magma on AGW.

Since the issue is on fpm, which is a third party command, we can only bypass the issue. For that reason I am changing the version from ```1.11.0``` to ```1.11.1```

An issue on fpm github team will be open to warn about this.

Note this dependency it is not needed at AGW level, that is why I am removing it form there.

Differential Revision: D20934226

