### PR TITLE
Fix of a fix [orc8r] Fix missing .deb - bad filename generated by fpm for python webcolors 1.11.0

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -100,7 +100,7 @@ setup(
         'six>=1.12.0',
         'eventlet>=0.24',
         'h2>=3.2.0',
-        'hpack>=3.0',
+        'hpack>=3.0'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Summary:
Fixing a bug on the previous diff

{emoji:1f605}

Differential Revision: D20936163

