### PR TITLE
Fix li_mirror controller deploy/init for cwf

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -34,6 +34,7 @@ static_services: [
   'tunnel_learn',
   'vlan_learn',
   'ipfix',
+  'li_mirror',
   'ryu_rest_service',
   'startup_flows',
 #  'packet_tracer',
@@ -101,7 +102,7 @@ ipfix:
 
 # Configuration for LI mirroring
 li_local_iface: li_port
-li_mirror_all: true
+li_mirror_all: false
 li_dst_iface: eth4
 
 # Interface to NAT traffic to

--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -93,7 +93,7 @@ allow_unknown_arps: False
 # Configuration for IPFIX sampling
 ipfix:
   enabled: true
-  probability: 30000
+  probability: 650
   collector_set_id: 1
   cache_timeout: 60
   obs_domain_id: 1

--- a/cwf/gateway/deploy/roles/cwag/files/setup_li_mirror_br.sh
+++ b/cwf/gateway/deploy/roles/cwag/files/setup_li_mirror_br.sh
@@ -7,12 +7,12 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+sudo ovs-vsctl --may-exist add-port cwag_br0 li_port -- set Interface li_port type=internal
+sudo ifconfig li_port up
+
 # LI might not be enabled for all setups
 if [ -d "/sys/class/net/eth4" ]
 then
-  sudo ovs-vsctl --may-exist add-port cwag_br0 li_port -- set Interface li_port type=internal
-  sudo ifconfig li_port up
-
   sudo ovs-vsctl --may-exist add-port cwag_br0 eth4
 
   # Setup tc rules to mirror traffic to li mirror bridge

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -33,6 +33,7 @@ static_services: [
   'access_control',
   'tunnel_learn',
   'vlan_learn',
+  'li_mirror',
   'startup_flows',
   'ryu_rest_service',
 ]
@@ -114,6 +115,11 @@ clean_restart: true
 quota_check_ip: '192.0.0.1'
 has_quota_port: 51115
 no_quota_port: 51125
+
+# Configuration for LI mirroring
+li_local_iface: li_port
+li_mirror_all: false
+li_dst_iface: eth4
 
 # Configuration for IPFIX sampling
 ipfix:

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -118,7 +118,7 @@ no_quota_port: 51125
 # Configuration for IPFIX sampling
 ipfix:
   enabled: false
-  probability: 30000
+  probability: 650
   collector_set_id: 1
   cache_timeout: 60
   obs_domain_id: 1

--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -89,7 +89,7 @@ ipfix:
   enabled: true
   collector_ip: '10.22.20.116'
   collector_port: 4740
-  probability: 30000
+  probability: 650
   collector_set_id: 1
   obs_domain_id: 1
   obs_point_id: 1


### PR DESCRIPTION
Summary: Always run li_mirror but don't mirror all traffic by default

Reviewed By: mpgermano

Differential Revision: D20939426

