### PR TITLE
Implement CWAG health interfaces with specific health implementations

### DIFF
--- a/cwf/gateway/configs/service_registry.yml
+++ b/cwf/gateway/configs/service_registry.yml
@@ -9,6 +9,9 @@ services:
   # Example service name that contains dash: hello-world-blah
   # As we use "-" in nghttpx config to connect service name and hostname,
   # "-" is used as a delimiter in dispatcher to parse out service names.
+
+  # IMPORTANT: If you change a port in this file, ensure that the health checks
+  # at magma/cwf/gateway/docker/docker-compose.yml are updated.
   subscriberdb:
     ip_address: 127.0.0.1
     port: 50051
@@ -22,15 +25,23 @@ services:
   mobilityd:
     ip_address: 127.0.0.1
     port: 60051
+  # If modifying the port, ensure the healthcheck at
+  # magma/cwf/gateway/docker/docker-compose.yml is updated
   pipelined:
     ip_address: 127.0.0.1
     port: 50063
+  # If modifying the port, ensure the healthcheck at
+  # magma/cwf/gateway/docker/docker-compose.yml is updated
   sessiond:
     ip_address: 127.0.0.1
     port: 50065
+  # If modifying the port, ensure the healthcheck at
+  # magma/cwf/gateway/docker/docker-compose.yml is updated
   directoryd:
     ip_address: 127.0.0.1
     port: 50067
+  # If modifying the port, ensure the healthcheck at
+  # magma/cwf/gateway/docker/docker-compose.yml is updated
   policydb:
     ip_address: 127.0.0.1
     port: 50068
@@ -40,12 +51,16 @@ services:
   state:
     ip_address: 127.0.0.1
     port: 50074
+  # If modifying the port, ensure the healthcheck at
+  # magma/cwf/gateway/docker/docker-compose.yml is updated
   aaa_server:
     ip_address: 127.0.0.1
     port: 9109
   abort_session_service:
     ip_address: 127.0.0.1
     port: 9109
+  # If modifying the port, ensure the healthcheck at
+  # magma/cwf/gateway/docker/docker-compose.yml is updated
   eap_aka:
     ip_address: 127.0.0.1
     port: 9123

--- a/cwf/gateway/docker/c/Dockerfile
+++ b/cwf/gateway/docker/c/Dockerfile
@@ -102,7 +102,8 @@ RUN apt-get -y update && apt-get -y install \
   magma-cpp-redis \
   grpc-dev \
   protobuf-compiler \
-  libprotoc-dev
+  libprotoc-dev \
+  netcat
 
 # Copy the build artifacts.
 COPY --from=builder /build/c/session_manager/sessiond /usr/local/bin/sessiond

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -48,6 +48,10 @@ services:
     container_name: aaa_server
     environment:
       USE_REMOTE_SWX_PROXY: 1 # Relay to FeG
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","9109"]
+      timeout: "4s"
+      retries: 3
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/aaa_server -logtostderr=true -v=0
 
   control_proxy:
@@ -62,6 +66,10 @@ services:
     container_name: directoryd
     depends_on:
       - redis
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","50067"]
+      timeout: "4s"
+      retries: 3
     command: python3.5 -m magma.directoryd.main
 
   eap_aka:
@@ -69,6 +77,10 @@ services:
     container_name: eap_aka
     environment:
       USE_REMOTE_SWX_PROXY: 1 # Relay to FeG
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","9123"]
+      timeout: "4s"
+      retries: 3
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
 
   health:
@@ -78,6 +90,12 @@ services:
     # Needed in order to enable/disable ICMP
     privileged: true
     volumes:
+      - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+      - ${CERTS_VOLUME}:/var/opt/magma/certs
+      - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
+      - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+      - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+      - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
       - /var/run/docker.sock:/var/run/docker.sock
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
 
@@ -112,6 +130,10 @@ services:
       - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
       - /etc/snowflake:/etc/snowflake
       - /var/run/openvswitch:/var/run/openvswitch
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","50063"]
+      timeout: "4s"
+      retries: 3
     command: >
       sh -c "set bridge cwag_br0 protocols=protocols=OpenFlow10,OpenFlow13,OpenFlow14 other-config:disable-in-band=true &&
         /usr/bin/ovs-vsctl set-controller cwag_br0 tcp:127.0.0.1:6633 &&
@@ -122,6 +144,10 @@ services:
   policydb:
     <<: *ltepyservice
     container_name: policydb
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","50068"]
+      timeout: "4s"
+      retries: 3
     depends_on:
       - redis
     command: python3 -m magma.policydb.main
@@ -145,6 +171,10 @@ services:
       - AAA_ENDPOINT=127.0.0.1:9109
       - ANALYTICS_GRAPHQL_TOKEN=${ANALYTICS_GRAPHQL_TOKEN}
       - ANALYTICS_GRAPHQL_ENDPOINT=${ANALYTICS_GRAPHQL_ENDPOINT}
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","9108"]
+      timeout: "4s"
+      retries: 3
     network_mode: host
     restart: always
 
@@ -164,6 +194,10 @@ services:
   sessiond:
     <<: *ltecservice
     container_name: sessiond
+    healthcheck:
+      test: ["CMD", "nc", "-zv", "localhost","50065"]
+      timeout: "4s"
+      retries: 3
     depends_on:
       - directoryd
     command: /usr/local/bin/sessiond

--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -67,7 +67,8 @@ RUN apt-get -y update && apt-get -y install \
     gcc \
     libtool \
     libcap-ng-dev \
-    linux-headers-generic
+    linux-headers-generic \
+    netcat
     
 RUN pip3 install \
     Cython \

--- a/cwf/gateway/services/gateway_health/health/gre_probe/gre_probe.go
+++ b/cwf/gateway/services/gateway_health/health/gre_probe/gre_probe.go
@@ -14,9 +14,14 @@ type GREProbe interface {
 	// Start begins the probe of the GRE endpoint(s).
 	Start() error
 
-	// GetStatus fetches the status of the GRE probe. The values returned are
-	// slices of reachable and unreachable endpoint IPs.
-	GetStatus() ([]string, []string)
+	// GetStatus fetches the status of the GRE probe. The GREProbeStatus
+	// returned contains slices of reachable and unreachable endpoint IPs.
+	GetStatus() *GREProbeStatus
+}
+
+type GREProbeStatus struct {
+	Reachable   []string
+	Unreachable []string
 }
 
 type GREEndpointStatus uint
@@ -32,6 +37,9 @@ func (d *DummyGREProbe) Start() error {
 	return nil
 }
 
-func (d *DummyGREProbe) GetStatus() ([]string, []string) {
-	return []string{}, []string{}
+func (d *DummyGREProbe) GetStatus() *GREProbeStatus {
+	return &GREProbeStatus{
+		Reachable:   []string{},
+		Unreachable: []string{},
+	}
 }

--- a/cwf/gateway/services/gateway_health/health/gre_probe/icmp_probe.go
+++ b/cwf/gateway/services/gateway_health/health/gre_probe/icmp_probe.go
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package gre_probe
+
+import (
+	"sync"
+	"time"
+
+	"magma/cwf/cloud/go/protos/mconfig"
+
+	"github.com/sparrc/go-ping"
+)
+
+// ICMPProbe implements the GRE probe interface
+// using ICMP over GRE.
+type ICMPProbe struct {
+	Endpoints []*mconfig.CwfGatewayHealthConfigGrePeer
+	Interval  time.Duration
+	PktCount  int
+
+	// Maps endpoints IPs to their current GREEndpointStatus
+	endpointStatus map[string]GREEndpointStatus
+	sync.RWMutex   // R/W lock synchronizing map endpoint status access
+}
+
+const (
+	defaultPingTimeout = 5 * time.Second
+)
+
+// NewICMPProbe create a new ICMPProbe with the provided endpoints and
+// probe interval.
+func NewICMPProbe(endpoints []*mconfig.CwfGatewayHealthConfigGrePeer, interval uint32, pktCount int) *ICMPProbe {
+	return &ICMPProbe{
+		Endpoints:      endpoints,
+		Interval:       time.Duration(interval) * time.Second,
+		PktCount:       pktCount,
+		endpointStatus: map[string]GREEndpointStatus{},
+	}
+}
+
+// Start begins the ICMP probes of the ICMPProbe's endpoints.
+func (i *ICMPProbe) Start() error {
+	var pingers []*ping.Pinger
+	for _, endpoint := range i.Endpoints {
+		p, err := ping.NewPinger(endpoint.Ip)
+		if err != nil {
+			return err
+		}
+		// Need privileged mode to work with docker
+		p.SetPrivileged(true)
+		pingers = append(pingers, p)
+	}
+	startProbe := func() {
+		for {
+			time.Sleep(i.Interval)
+			i.executeProbe(pingers)
+		}
+	}
+
+	go startProbe()
+	return nil
+}
+
+// GetStatus returns the current GREEndpointStatus of each endpoint.
+func (i *ICMPProbe) GetStatus() *GREProbeStatus {
+	var reachable []string
+	var unreachable []string
+	i.RLock()
+	defer i.RUnlock()
+	for ip, status := range i.endpointStatus {
+		if status == EndpointUnreachable {
+			unreachable = append(unreachable, ip)
+		} else if status == EndpointReachable {
+			reachable = append(reachable, ip)
+		}
+	}
+	return &GREProbeStatus{
+		Reachable:   reachable,
+		Unreachable: unreachable,
+	}
+}
+
+func (i *ICMPProbe) executeProbe(pingers []*ping.Pinger) {
+	for _, pinger := range pingers {
+		pinger.Count = i.PktCount
+		pinger.Timeout = defaultPingTimeout
+		// reduce frequency of updates by only updating on finish
+		pinger.OnFinish = func(stats *ping.Statistics) {
+			i.Lock()
+			defer i.Unlock()
+			if stats.PacketsRecv == 0 {
+				i.endpointStatus[stats.Addr] = EndpointUnreachable
+			} else {
+				i.endpointStatus[stats.Addr] = EndpointReachable
+			}
+		}
+		pinger.Run()
+	}
+}

--- a/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package service_health
+
+import (
+	"context"
+	"time"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/filters"
+	"github.com/docker/docker/client"
+)
+
+const (
+	dockerRequestTimeout = 3 * time.Second
+)
+
+// DockerServiceHealthProvider provides service health for
+// docker containers through docker's API.
+type DockerServiceHealthProvider struct {
+	dockerClient *client.Client
+}
+
+// NewDockerServiceHealthProvider creates a new DockerServiceHealthProvider
+// with an initialized docker client.
+func NewDockerServiceHealthProvider() (*DockerServiceHealthProvider, error) {
+	dockercli, err := client.NewEnvClient()
+	if err != nil {
+		return nil, err
+	}
+	return &DockerServiceHealthProvider{
+		dockerClient: dockercli,
+	}, nil
+}
+
+// GetUnhealthyServices returns all docker services failing their health checks.
+func (d *DockerServiceHealthProvider) GetUnhealthyServices() ([]string, error) {
+	filter := filters.NewArgs()
+	filter.Add("health", types.Unhealthy)
+	unhealthyFilter := types.ContainerListOptions{
+		Filters: filter,
+	}
+	unhealthyContainers, err := d.dockerClient.ContainerList(context.Background(), unhealthyFilter)
+	if err != nil {
+		return []string{}, err
+	}
+	var unhealthyServices []string
+	for _, container := range unhealthyContainers {
+		if len(container.Names) == 0 {
+			continue
+		}
+		unhealthyServices = append(unhealthyServices, container.Names[0])
+	}
+	return unhealthyServices, nil
+}
+
+// Enable restarts the service provided
+func (d *DockerServiceHealthProvider) Enable(service string) error {
+	sessiondID, err := d.getContainerID(service)
+	if err != nil {
+		return err
+	}
+	timeout := dockerRequestTimeout
+	return d.dockerClient.ContainerRestart(context.Background(), sessiondID, &timeout)
+}
+
+func (d *DockerServiceHealthProvider) getContainerID(serviceName string) (string, error) {
+	filter := filters.NewArgs()
+	filter.Add("name", serviceName)
+	sessiondContainerFilter := types.ContainerListOptions{
+		Filters: filter,
+	}
+	containers, err := d.dockerClient.ContainerList(context.Background(), sessiondContainerFilter)
+	if err != nil || len(containers) == 0 {
+		return "", err
+	}
+	return containers[0].ID, nil
+}

--- a/cwf/gateway/services/gateway_health/health/service_health/service_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/service_health.go
@@ -20,14 +20,3 @@ type ServiceHealth interface {
 	// the specific functionality.
 	Enable(service string) error
 }
-
-type DummyServiceHealthProvider struct {
-}
-
-func (d *DummyServiceHealthProvider) GetUnhealthyServices() ([]string, error) {
-	return []string{}, nil
-}
-
-func (d *DummyServiceHealthProvider) Enable(service string) error {
-	return nil
-}

--- a/cwf/gateway/services/gateway_health/health/system_health/system_health.go
+++ b/cwf/gateway/services/gateway_health/health/system_health/system_health.go
@@ -8,6 +8,15 @@
 
 package system_health
 
+import (
+	"fmt"
+
+	"github.com/coreos/go-iptables/iptables"
+	"github.com/golang/glog"
+	"github.com/shirou/gopsutil/cpu"
+	"github.com/shirou/gopsutil/mem"
+)
+
 // SystemHealth defines an interface to fetch system health and enable/disable
 // functionality necessary for promotion/demotion from failovers
 type SystemHealth interface {
@@ -23,21 +32,98 @@ type SystemHealth interface {
 	Enable() error
 }
 
+const (
+	filterTable = "filter"
+	inputChain  = "INPUT"
+)
+
+// SystemsStats define the metrics this provider will collect.
 type SystemStats struct {
-	CpuUtilPct float64
-	MemUtilPct float64
+	CpuUtilPct float32
+	MemUtilPct float32
 }
 
-type DummySystemStatsProvider struct{}
-
-func (d *DummySystemStatsProvider) GetSystemStats() (*SystemStats, error) {
-	return &SystemStats{MemUtilPct: 0.1, CpuUtilPct: 0.1}, nil
+// CWAGSystemHealthProvider defines a system health provider.
+type CWAGSystemHealthProvider struct {
+	iptables      *iptables.IPTables
+	icmpInterface string
 }
 
-func (d *DummySystemStatsProvider) Enable() error {
+// NewCWAGSystemHealthProvider creates a new CWAGSystemHealthProvider with
+// initialized iptables.
+func NewCWAGSystemHealthProvider(eth string) (*CWAGSystemHealthProvider, error) {
+	ipt, err := iptables.New()
+	if err != nil {
+		return nil, err
+	}
+	return &CWAGSystemHealthProvider{
+		iptables:      ipt,
+		icmpInterface: eth,
+	}, nil
+}
+
+// GetSystemStats collects and return the stats defined in SystemStats.
+func (c *CWAGSystemHealthProvider) GetSystemStats() (*SystemStats, error) {
+	stats := &SystemStats{}
+	cpuUtilPctArray, cpuErr := cpu.Percent(0, false)
+	if cpuErr == nil && len(cpuUtilPctArray) == 1 {
+		stats.CpuUtilPct = float32(cpuUtilPctArray[0]) / 100
+	}
+	virtualMem, vmErr := mem.VirtualMemory()
+	if vmErr == nil {
+		stats.MemUtilPct = float32(virtualMem.UsedPercent) / 100
+	}
+	if cpuErr != nil || vmErr != nil {
+		return stats, fmt.Errorf("Error collecting system stats; CPU Result: %v, MEM Result: %v,", cpuErr, vmErr)
+	}
+	return stats, nil
+}
+
+// Enable removes the ICMP DROP rule from iptables for the configured interface.
+// If the iptables rule doesn't exist, Enable has no effect.
+func (c *CWAGSystemHealthProvider) Enable() error {
+	exists, err := c.doesICMPDropExist()
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+	icmpDropCmd := c.getICMPDropCmd()
+	err = c.iptables.Delete(filterTable, inputChain, icmpDropCmd...)
+	if err != nil {
+		glog.Errorf("Unable to remove ICMP DROP rule from iptables for %s", c.icmpInterface)
+		return err
+	}
+	glog.Infof("Successfully removed iptables ICMP DROP for %s", c.icmpInterface)
 	return nil
 }
 
-func (d *DummySystemStatsProvider) Disable() error {
+// Disable adds an ICMP DROP rule from iptables for the configured interface.
+// If the iptables rule already exists, Disable has no effect.
+func (c *CWAGSystemHealthProvider) Disable() error {
+	exists, err := c.doesICMPDropExist()
+	if err != nil {
+		return err
+	}
+	if exists {
+		return nil
+	}
+	icmpDropCmd := c.getICMPDropCmd()
+	err = c.iptables.Append(filterTable, inputChain, icmpDropCmd...)
+	if err != nil {
+		glog.Errorf("Error adding iptables ICMP DROP rule for %s", c.icmpInterface)
+		return err
+	}
+	glog.Infof("Successfully added iptables ICMP DROP for %s", c.icmpInterface)
 	return nil
+}
+
+func (c *CWAGSystemHealthProvider) doesICMPDropExist() (bool, error) {
+	icmpDropCmd := c.getICMPDropCmd()
+	return c.iptables.Exists(filterTable, inputChain, icmpDropCmd...)
+}
+
+func (c *CWAGSystemHealthProvider) getICMPDropCmd() []string {
+	return []string{"-i", c.icmpInterface, "--proto", "icmp", "-j", "DROP"}
 }

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -116,7 +116,7 @@ COPY --from=builder /root/.cache /root/.cache
 FROM ubuntu:xenial AS gateway_go
 
 # Install envdir.
-RUN apt-get -y update && apt-get -y install daemontools
+RUN apt-get -y update && apt-get -y install daemontools netcat
 
 # Copy the build artifacts.
 COPY --from=builder /var/opt/magma/bin /var/opt/magma/bin

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -70,7 +70,8 @@ RUN apt-get -y update && apt-get -y install \
   python3-pip \
   python3.5-dev \
   redis-server \
-  git
+  git \
+  netcat
 
 # Install docker.
 RUN curl -sSL https://get.docker.com/ > /tmp/get_docker.sh && \

--- a/feg/gateway/docker/radius/Dockerfile
+++ b/feg/gateway/docker/radius/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:alpine as builder
-RUN apk add git gcc musl-dev bash protobuf
+RUN apk add git gcc musl-dev bash protobuf netcat-openbsd
 
 RUN go get -d -u github.com/golang/protobuf/protoc-gen-go
 RUN git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout v1.2.0


### PR DESCRIPTION
Summary:
This diff implements the interfaces defined in the previous diff.
For GRE we use an ICMP probe that determines unhealthy if all endpoints are
unreachable. For service status, we utilize docker's health check to ensure
that every critical service (those that have checks), are healthy. For system
stats we use psutil to fetch memory and cpu.

For disable - we utilize iptables to block ping on eth1. This ensures that
the AP/WLC will detect the primary tunnel as down and use the secondary tunnel
(the newly promoted active).

For enable - we remove the icmp drop rule and then restart sessiond. This
will kick of the initialization sequence to get the gateway in a ready state.

Reviewed By: uri200

Differential Revision: D20829622

