### PR TITLE
Exact match for UE Paging

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -28,275 +28,216 @@ using namespace fluid_msg;
 namespace openflow {
 
 ControllerEvent::ControllerEvent(
-  fluid_base::OFConnection *ofconn,
-  const ControllerEventType type):
-  ofconn_(ofconn),
-  type_(type)
-{
-}
+    fluid_base::OFConnection* ofconn, const ControllerEventType type)
+    : ofconn_(ofconn), type_(type) {}
 
-const ControllerEventType ControllerEvent::get_type() const
-{
+const ControllerEventType ControllerEvent::get_type() const {
   return type_;
 }
 
-fluid_base::OFConnection *ControllerEvent::get_connection() const
-{
+fluid_base::OFConnection* ControllerEvent::get_connection() const {
   return ofconn_;
 }
 
 DataEvent::DataEvent(
-  fluid_base::OFConnection *ofconn,
-  fluid_base::OFHandler &ofhandler,
-  const void *data,
-  const size_t len,
-  const ControllerEventType type):
-  ControllerEvent(ofconn, type),
-  ofhandler_(ofhandler),
-  data_(static_cast<const uint8_t *>(data)),
-  len_(len)
-{
+    fluid_base::OFConnection* ofconn, fluid_base::OFHandler& ofhandler,
+    const void* data, const size_t len, const ControllerEventType type)
+    : ControllerEvent(ofconn, type),
+      ofhandler_(ofhandler),
+      data_(static_cast<const uint8_t*>(data)),
+      len_(len) {}
+
+DataEvent::~DataEvent() {
+  ofhandler_.free_data(const_cast<uint8_t*>(data_));
 }
 
-DataEvent::~DataEvent()
-{
-  ofhandler_.free_data(const_cast<uint8_t *>(data_));
-}
-
-const uint8_t *DataEvent::get_data() const
-{
+const uint8_t* DataEvent::get_data() const {
   return data_;
 }
 
-const size_t DataEvent::get_length() const
-{
+const size_t DataEvent::get_length() const {
   return len_;
 }
 
 PacketInEvent::PacketInEvent(
-  fluid_base::OFConnection *ofconn,
-  fluid_base::OFHandler &ofhandler,
-  const void *data,
-  const size_t len):
-  DataEvent(ofconn, ofhandler, data, len, EVENT_PACKET_IN)
-{
-}
+    fluid_base::OFConnection* ofconn, fluid_base::OFHandler& ofhandler,
+    const void* data, const size_t len)
+    : DataEvent(ofconn, ofhandler, data, len, EVENT_PACKET_IN) {}
 
 SwitchUpEvent::SwitchUpEvent(
-  fluid_base::OFConnection *ofconn,
-  fluid_base::OFHandler &ofhandler,
-  const void *data,
-  const size_t len):
-  DataEvent(ofconn, ofhandler, data, len, EVENT_SWITCH_UP)
-{
-}
+    fluid_base::OFConnection* ofconn, fluid_base::OFHandler& ofhandler,
+    const void* data, const size_t len)
+    : DataEvent(ofconn, ofhandler, data, len, EVENT_SWITCH_UP) {}
 
-SwitchDownEvent::SwitchDownEvent(fluid_base::OFConnection *ofconn):
-  ControllerEvent(ofconn, EVENT_SWITCH_DOWN)
-{
-}
+SwitchDownEvent::SwitchDownEvent(fluid_base::OFConnection* ofconn)
+    : ControllerEvent(ofconn, EVENT_SWITCH_DOWN) {}
 
 ErrorEvent::ErrorEvent(
-  fluid_base::OFConnection *ofconn,
-  const struct ofp_error_msg *error_msg):
-  error_type_(ntohs(error_msg->type)),
-  error_code_(ntohs(error_msg->code)),
-  ControllerEvent(ofconn, EVENT_ERROR)
-{
-}
+    fluid_base::OFConnection* ofconn, const struct ofp_error_msg* error_msg)
+    : error_type_(ntohs(error_msg->type)),
+      error_code_(ntohs(error_msg->code)),
+      ControllerEvent(ofconn, EVENT_ERROR) {}
 
-const uint16_t ErrorEvent::get_error_type() const
-{
+const uint16_t ErrorEvent::get_error_type() const {
   return error_type_;
 }
 
-const uint16_t ErrorEvent::get_error_code() const
-{
+const uint16_t ErrorEvent::get_error_code() const {
   return error_code_;
 }
 
-ExternalEvent::ExternalEvent(const ControllerEventType type):
-  ControllerEvent(NULL, type)
-{
-}
+ExternalEvent::ExternalEvent(const ControllerEventType type)
+    : ControllerEvent(NULL, type) {}
 
-void ExternalEvent::set_of_connection(fluid_base::OFConnection *ofconn)
-{
+void ExternalEvent::set_of_connection(fluid_base::OFConnection* ofconn) {
   ofconn_ = ofconn;
 }
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip,
-    const struct in_addr enb_ip,
-    const uint32_t in_tei,
-    const uint32_t out_tei,
-    const char *imsi):
-  ue_ip_(ue_ip),
-  enb_ip_(enb_ip),
-  in_tei_(in_tei),
-  out_tei_(out_tei),
-  imsi_(imsi),
-  dl_flow_valid_(false),
-  dl_flow_(),
-  dl_flow_precedence_(DEFAULT_PRECEDENCE),
-  ExternalEvent(EVENT_ADD_GTP_TUNNEL)
-{
-}
+    const struct in_addr ue_ip, const struct in_addr enb_ip,
+    const uint32_t in_tei, const uint32_t out_tei, const char* imsi)
+    : ue_ip_(ue_ip),
+      enb_ip_(enb_ip),
+      in_tei_(in_tei),
+      out_tei_(out_tei),
+      imsi_(imsi),
+      dl_flow_valid_(false),
+      dl_flow_(),
+      dl_flow_precedence_(DEFAULT_PRECEDENCE),
+      ExternalEvent(EVENT_ADD_GTP_TUNNEL) {}
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip,
-    const struct in_addr enb_ip,
-    const uint32_t in_tei,
-    const uint32_t out_tei,
-    const char *imsi,
-    const struct ipv4flow_dl *dl_flow,
-    const uint32_t dl_flow_precedence):
-  ue_ip_(ue_ip),
-  enb_ip_(enb_ip),
-  in_tei_(in_tei),
-  out_tei_(out_tei),
-  imsi_(imsi),
-  dl_flow_valid_(true),
-  dl_flow_(*dl_flow),
-  dl_flow_precedence_(dl_flow_precedence),
-  ExternalEvent(EVENT_ADD_GTP_TUNNEL)
-{
-}
+    const struct in_addr ue_ip, const struct in_addr enb_ip,
+    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+    const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence)
+    : ue_ip_(ue_ip),
+      enb_ip_(enb_ip),
+      in_tei_(in_tei),
+      out_tei_(out_tei),
+      imsi_(imsi),
+      dl_flow_valid_(true),
+      dl_flow_(*dl_flow),
+      dl_flow_precedence_(dl_flow_precedence),
+      ExternalEvent(EVENT_ADD_GTP_TUNNEL) {}
 
-const struct in_addr &AddGTPTunnelEvent::get_ue_ip() const
-{
+const struct in_addr& AddGTPTunnelEvent::get_ue_ip() const {
   return ue_ip_;
 }
 
-const struct in_addr &AddGTPTunnelEvent::get_enb_ip() const
-{
+const struct in_addr& AddGTPTunnelEvent::get_enb_ip() const {
   return enb_ip_;
 }
 
-const uint32_t AddGTPTunnelEvent::get_in_tei() const
-{
+const uint32_t AddGTPTunnelEvent::get_in_tei() const {
   return in_tei_;
 }
 
-const uint32_t AddGTPTunnelEvent::get_out_tei() const
-{
+const uint32_t AddGTPTunnelEvent::get_out_tei() const {
   return out_tei_;
 }
 
-const std::string &AddGTPTunnelEvent::get_imsi() const
-{
+const std::string& AddGTPTunnelEvent::get_imsi() const {
   return imsi_;
 }
 
-const bool AddGTPTunnelEvent::is_dl_flow_valid() const
-{
+const bool AddGTPTunnelEvent::is_dl_flow_valid() const {
   return dl_flow_valid_;
 }
 
-const struct ipv4flow_dl &AddGTPTunnelEvent::get_dl_flow() const
-{
+const struct ipv4flow_dl& AddGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 
-const uint32_t AddGTPTunnelEvent::get_dl_flow_precedence() const
-{
+const uint32_t AddGTPTunnelEvent::get_dl_flow_precedence() const {
   return dl_flow_precedence_;
 }
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-    const struct in_addr ue_ip,
-    const uint32_t in_tei,
-    const struct ipv4flow_dl *dl_flow):
-  ue_ip_(ue_ip),
-  in_tei_(in_tei),
-  dl_flow_valid_(true),
-  dl_flow_(*dl_flow),
-  ExternalEvent(EVENT_DELETE_GTP_TUNNEL)
-{
-}
+    const struct in_addr ue_ip, const uint32_t in_tei,
+    const struct ipv4flow_dl* dl_flow)
+    : ue_ip_(ue_ip),
+      in_tei_(in_tei),
+      dl_flow_valid_(true),
+      dl_flow_(*dl_flow),
+      ExternalEvent(EVENT_DELETE_GTP_TUNNEL) {}
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-    const struct in_addr ue_ip,
-    const uint32_t in_tei):
-  ue_ip_(ue_ip),
-  in_tei_(in_tei),
-  dl_flow_valid_(false),
-  dl_flow_(),
-  ExternalEvent(EVENT_DELETE_GTP_TUNNEL)
-{
-}
+    const struct in_addr ue_ip, const uint32_t in_tei)
+    : ue_ip_(ue_ip),
+      in_tei_(in_tei),
+      dl_flow_valid_(false),
+      dl_flow_(),
+      ExternalEvent(EVENT_DELETE_GTP_TUNNEL) {}
 
-const struct in_addr &DeleteGTPTunnelEvent::get_ue_ip() const
-{
+const struct in_addr& DeleteGTPTunnelEvent::get_ue_ip() const {
   return ue_ip_;
 }
 
-const uint32_t DeleteGTPTunnelEvent::get_in_tei() const
-{
+const uint32_t DeleteGTPTunnelEvent::get_in_tei() const {
   return in_tei_;
 }
 
-const bool DeleteGTPTunnelEvent::is_dl_flow_valid() const
-{
+const bool DeleteGTPTunnelEvent::is_dl_flow_valid() const {
   return dl_flow_valid_;
 }
 
-const struct ipv4flow_dl &DeleteGTPTunnelEvent::get_dl_flow() const
-{
+const struct ipv4flow_dl& DeleteGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
-    const struct in_addr ue_ip,
-    const uint32_t in_tei,
-    const ControllerEventType event_type,
-    const struct ipv4flow_dl *dl_flow,
-    const uint32_t dl_flow_precedence):
-  ue_ip_(ue_ip),
-  in_tei_(in_tei),
-  dl_flow_valid_(true),
-  dl_flow_(*dl_flow),
-  dl_flow_precedence_(dl_flow_precedence),
-  ExternalEvent(event_type)
-{
-}
+    const struct in_addr ue_ip, const uint32_t in_tei,
+    const ControllerEventType event_type, const struct ipv4flow_dl* dl_flow,
+    const uint32_t dl_flow_precedence)
+    : ue_ip_(ue_ip),
+      in_tei_(in_tei),
+      dl_flow_valid_(true),
+      dl_flow_(*dl_flow),
+      dl_flow_precedence_(dl_flow_precedence),
+      ExternalEvent(event_type) {}
 
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
-    const struct in_addr ue_ip,
-    const uint32_t in_tei,
-    const ControllerEventType event_type):
-  ue_ip_(ue_ip),
-  in_tei_(in_tei),
-  dl_flow_valid_(false),
-  dl_flow_(),
-  dl_flow_precedence_(DEFAULT_PRECEDENCE),
-  ExternalEvent(event_type)
-{
-}
+    const struct in_addr ue_ip, const uint32_t in_tei,
+    const ControllerEventType event_type)
+    : ue_ip_(ue_ip),
+      in_tei_(in_tei),
+      dl_flow_valid_(false),
+      dl_flow_(),
+      dl_flow_precedence_(DEFAULT_PRECEDENCE),
+      ExternalEvent(event_type) {}
 
-const struct in_addr &HandleDataOnGTPTunnelEvent::get_ue_ip() const
-{
+const struct in_addr& HandleDataOnGTPTunnelEvent::get_ue_ip() const {
   return ue_ip_;
 }
 
-const uint32_t HandleDataOnGTPTunnelEvent::get_in_tei() const
-{
+const uint32_t HandleDataOnGTPTunnelEvent::get_in_tei() const {
   return in_tei_;
 }
 
-const bool HandleDataOnGTPTunnelEvent::is_dl_flow_valid() const
-{
+const bool HandleDataOnGTPTunnelEvent::is_dl_flow_valid() const {
   return dl_flow_valid_;
 }
 
-const struct ipv4flow_dl &HandleDataOnGTPTunnelEvent::get_dl_flow() const
-{
+const struct ipv4flow_dl& HandleDataOnGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 
-const uint32_t HandleDataOnGTPTunnelEvent::get_dl_flow_precedence() const
-{
+const uint32_t HandleDataOnGTPTunnelEvent::get_dl_flow_precedence() const {
   return dl_flow_precedence_;
 }
 
-} // namespace openflow
+AddPagingRuleEvent::AddPagingRuleEvent(const struct in_addr ue_ip)
+    : ue_ip_(ue_ip), ExternalEvent(EVENT_ADD_PAGING_RULE) {}
+
+const struct in_addr& AddPagingRuleEvent::get_ue_ip() const {
+  return ue_ip_;
+}
+
+DeletePagingRuleEvent::DeletePagingRuleEvent(const struct in_addr ue_ip)
+    : ue_ip_(ue_ip), ExternalEvent(EVENT_DELETE_PAGING_RULE) {}
+
+const struct in_addr& DeletePagingRuleEvent::get_ue_ip() const {
+  return ue_ip_;
+}
+
+}  // namespace openflow

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -39,6 +39,8 @@ enum ControllerEventType {
   EVENT_DELETE_GTP_TUNNEL,
   EVENT_DISCARD_DATA_ON_GTP_TUNNEL,
   EVENT_FORWARD_DATA_ON_GTP_TUNNEL,
+  EVENT_ADD_PAGING_RULE,
+  EVENT_DELETE_PAGING_RULE,
 };
 
 /**
@@ -247,4 +249,32 @@ class HandleDataOnGTPTunnelEvent : public ExternalEvent {
   const uint32_t dl_flow_precedence_;
 };
 
-} // namespace openflow
+/*
+ * Event triggered by SPGW to support UE paging when
+ * S1 is released (i.e., UE is in IDLE mode)
+ */
+class AddPagingRuleEvent : public ExternalEvent {
+ public:
+  AddPagingRuleEvent(const struct in_addr ue_ip);
+
+  const struct in_addr& get_ue_ip() const;
+
+ private:
+  const struct in_addr ue_ip_;
+};
+
+/*
+ * Event triggered by SPGW to stop UE paging when
+ * UE is detached
+ */
+class DeletePagingRuleEvent : public ExternalEvent {
+ public:
+  DeletePagingRuleEvent(const struct in_addr ue_ip);
+
+  const struct in_addr& get_ue_ip() const;
+
+ private:
+  const struct in_addr ue_ip_;
+};
+
+}  // namespace openflow

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -47,6 +47,8 @@ int start_of_controller(bool persist_state)
   ctrl.register_for_event(&base_app, openflow::EVENT_ERROR);
   ctrl.register_for_event(&paging_app, openflow::EVENT_PACKET_IN);
   ctrl.register_for_event(&paging_app, openflow::EVENT_SWITCH_UP);
+  ctrl.register_for_event(&paging_app, openflow::EVENT_ADD_PAGING_RULE);
+  ctrl.register_for_event(&paging_app, openflow::EVENT_DELETE_PAGING_RULE);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_ADD_GTP_TUNNEL);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_DELETE_GTP_TUNNEL);
   ctrl.register_for_event(&gtp_app, openflow::EVENT_DISCARD_DATA_ON_GTP_TUNNEL);
@@ -145,5 +147,17 @@ int openflow_controller_forward_data_on_tunnel(
       ue, i_tei, openflow::EVENT_FORWARD_DATA_ON_GTP_TUNNEL);
     ctrl.inject_external_event(gtp_tunnel, external_event_callback);
   }
+  return 0;
+}
+
+int openflow_controller_add_paging_rule(struct in_addr ue_ip) {
+  auto paging_event = std::make_shared<openflow::AddPagingRuleEvent>(ue_ip);
+  ctrl.inject_external_event(paging_event, external_event_callback);
+  return 0;
+}
+
+int openflow_controller_delete_paging_rule(struct in_addr ue_ip) {
+  auto paging_event = std::make_shared<openflow::DeletePagingRuleEvent>(ue_ip);
+  ctrl.inject_external_event(paging_event, external_event_callback);
   return 0;
 }

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
@@ -58,6 +58,10 @@ int openflow_controller_forward_data_on_tunnel(
   struct ipv4flow_dl *flow_dl,
   uint32_t flow_precedence_dl);
 
+int openflow_controller_add_paging_rule(struct in_addr ue_ip);
+
+int openflow_controller_delete_paging_rule(struct in_addr ue_ip);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/lib/openflow/controller/PagingApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/PagingApplication.cpp
@@ -55,7 +55,13 @@ void PagingApplication::event_callback(
     handle_paging_message(
       ev.get_connection(), static_cast<uint8_t *>(ofpi.data()), messenger);
   } else if (ev.get_type() == EVENT_SWITCH_UP) {
-    install_default_flow(ev.get_connection(), messenger);
+    // install_default_flow(ev.get_connection(), messenger);
+  } else if (ev.get_type() == EVENT_ADD_PAGING_RULE) {
+    auto add_paging_rule_event = static_cast<const AddPagingRuleEvent&>(ev);
+    add_paging_flow(add_paging_rule_event, messenger);
+  } else if (ev.get_type() == EVENT_DELETE_PAGING_RULE) {
+    auto delete_paging_rule_event = static_cast<const DeletePagingRuleEvent&>(ev);
+    delete_paging_flow(delete_paging_rule_event, messenger);
   }
 }
 
@@ -130,6 +136,72 @@ void PagingApplication::install_default_flow(
 
   messenger.send_of_msg(fm, ofconn);
   OAILOG_DEBUG(LOG_GTPV1U, "Default paging flow added\n");
+}
+
+void PagingApplication::add_paging_flow(
+    const AddPagingRuleEvent& ev, const OpenflowMessenger& messenger)
+{
+  of13::FlowMod fm =
+    messenger.create_default_flow_mod(0, of13::OFPFC_ADD, MID_PRIORITY);
+  // IP eth type
+  of13::EthType type_match(IP_ETH_TYPE);
+  fm.add_oxm_field(type_match);
+
+  // Match on UE IP addr
+  const struct in_addr& ue_ip = ev.get_ue_ip();
+  of13::IPv4Dst ip_match(ue_ip.s_addr);
+  fm.add_oxm_field(ip_match);
+
+  // Output to controller
+  of13::OutputAction act(of13::OFPP_CONTROLLER, of13::OFPCML_NO_BUFFER);
+  of13::ApplyActions inst;
+  inst.add_action(act);
+  fm.add_instruction(inst);
+
+  messenger.send_of_msg(fm, ev.get_connection());
+  // Convert to string for logging
+  char ip_str[INET_ADDRSTRLEN];
+  inet_ntop(AF_INET, &(ue_ip.s_addr), ip_str, INET_ADDRSTRLEN);
+  OAILOG_INFO(
+    LOG_GTPV1U,
+    "Added paging flow rule for UE IP %s\n",
+    ip_str);
+}
+
+void PagingApplication::delete_paging_flow(
+    const DeletePagingRuleEvent& ev, const OpenflowMessenger& messenger)
+{
+  of13::FlowMod fm =
+    messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
+
+  // IP eth type
+  of13::EthType type_match(IP_ETH_TYPE);
+  fm.add_oxm_field(type_match);
+
+  // match all ports and groups
+  fm.out_port(of13::OFPP_ANY);
+  fm.out_group(of13::OFPG_ANY);
+
+  // Match on UE IP addr
+  const struct in_addr& ue_ip = ev.get_ue_ip();
+  of13::IPv4Dst ip_match(ue_ip.s_addr);
+  fm.add_oxm_field(ip_match);
+
+  // Output to controller 
+  // (This has actually no effect on deletion, but included
+  // for symmetry purposes wrt add_paging_flow)
+  of13::OutputAction act(of13::OFPP_CONTROLLER, of13::OFPCML_NO_BUFFER);
+  of13::ApplyActions inst;
+  inst.add_action(act);
+  fm.add_instruction(inst);
+
+  messenger.send_of_msg(fm, ev.get_connection());
+  // Convert to string for logging
+  char *ip_str = inet_ntoa(ue_ip);
+  OAILOG_INFO(
+    LOG_GTPV1U,
+    "Deleted paging flow rule for UE IP %s\n",
+    ip_str);
 }
 
 } // namespace openflow

--- a/lte/gateway/c/oai/lib/openflow/controller/PagingApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/PagingApplication.h
@@ -30,7 +30,7 @@ class PagingApplication : public Application {
  private:
   static const int MID_PRIORITY = 5;
   // TODO: move to config file
-  static const int CLAMPING_TIMEOUT = 30; // seconds
+  static const int CLAMPING_TIMEOUT = 30;  // seconds
   /**
    * Main callback event required by inherited Application class. Whenever
    * the controller gets an event like packet in or switch up, it will pass
@@ -39,8 +39,7 @@ class PagingApplication : public Application {
    * @param ev (in) - pointer to some subclass of ControllerEvent that occurred
    */
   virtual void event_callback(
-    const ControllerEvent &ev,
-    const OpenflowMessenger &messenger);
+      const ControllerEvent& ev, const OpenflowMessenger& messenger);
 
   /**
    * Handles downlink data intended for a UE in idle mode, then forwards the
@@ -51,17 +50,28 @@ class PagingApplication : public Application {
    * @param data (in) - the ethernet packet received by the switch
    */
   void handle_paging_message(
-    fluid_base::OFConnection *ofconn,
-    uint8_t *data,
-    const OpenflowMessenger &messenger);
+      fluid_base::OFConnection* ofconn, uint8_t* data,
+      const OpenflowMessenger& messenger);
 
   /**
    * Creates the default paging flow, which sends a packet intended for an
    * idle UE to this application
    */
   void install_default_flow(
-    fluid_base::OFConnection *ofconn,
-    const OpenflowMessenger &messenger);
+      fluid_base::OFConnection* ofconn, const OpenflowMessenger& messenger);
+
+  /**
+   * Creates exact paging flow, which sends a packet intended for an
+   * idle UE to this application
+   */
+  void add_paging_flow(
+      const AddPagingRuleEvent& ev, const OpenflowMessenger& messenger);
+
+  /**
+   * Removes exact paging flow rule to stop paging UE
+   */
+  void delete_paging_flow(
+      const DeletePagingRuleEvent& ev, const OpenflowMessenger& messenger);
 };
 
-} // namespace openflow
+}  // namespace openflow

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -100,6 +100,16 @@ int openflow_forward_data_on_tunnel(
     ue, i_tei, flow_dl, flow_precedence_dl);
 }
 
+int openflow_add_paging_rule(struct in_addr ue)
+{
+  return openflow_controller_add_paging_rule(ue);
+}
+
+int openflow_delete_paging_rule(struct in_addr ue)
+{
+  return openflow_controller_delete_paging_rule(ue);
+}
+
 static const struct gtp_tunnel_ops openflow_ops = {
   .init = openflow_init,
   .uninit = openflow_uninit,
@@ -108,6 +118,8 @@ static const struct gtp_tunnel_ops openflow_ops = {
   .del_tunnel = openflow_del_tunnel,
   .discard_data_on_tunnel = openflow_discard_data_on_tunnel,
   .forward_data_on_tunnel = openflow_forward_data_on_tunnel,
+  .add_paging_rule = openflow_add_paging_rule,
+  .delete_paging_rule = openflow_delete_paging_rule,
 };
 
 const struct gtp_tunnel_ops *gtp_tunnel_ops_init_openflow(void)

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -70,7 +70,7 @@ struct ipv4flow_dl {
 };
 
 /*
- * This structure defines the management hooks for GTP tunnels.
+ * This structure defines the management hooks for GTP tunnels and paging support.
  * The following hooks can be defined; unless noted otherwise, they are
  * optional and can be filled with a null pointer.
  *
@@ -115,6 +115,9 @@ struct ipv4flow_dl {
  *         @i_tei: RX GTP Tunnel ID
  *         @flow_dl: Downlink flow rule
  *         @flow_precedence_dl: Downlink flow rule precedence
+ *
+ * int (*add_paging_rule)(struct in_addr ue);
+ *        @ue: UE IP address
  */
 struct gtp_tunnel_ops {
   int (*init)(
@@ -143,6 +146,8 @@ struct gtp_tunnel_ops {
     uint32_t i_tei,
     struct ipv4flow_dl* flow_dl,
     uint32_t flow_precedence_dl);
+  int (*add_paging_rule)(struct in_addr ue);
+  int (*delete_paging_rule)(struct in_addr ue);
 };
 
 #if ENABLE_OPENFLOW

--- a/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_paging_request.py
@@ -27,7 +27,7 @@ class TestPagingRequest(unittest.TestCase):
         """ Multi Enb Multi UE attach detach """
         # column is a enb parameter,  row is a number of enbs
         # column description: 1.Cell Id, 2.Tac, 3.EnbType, 4.PLMN Id 5. PLMN length
-        enb_list = [(1, 1, 1, "001010", 6)]
+        enb_list = [(1, 1, 1, "00101", 5)]
 
         self._s1ap_wrapper.multiEnbConfig(len(enb_list), enb_list)
 


### PR DESCRIPTION
Summary: The existing paging mechanism install a default paging rule for the UE address pool. Thus, any DL traffic that pass through NAT is able to reach the paging app for a UE even when the UE is not attached to the network anymore. The current diff provides paging support only for the idle mode UEs.

Reviewed By: pshelar

Differential Revision: D20911578

