### PR TITLE
Remove rules from DB after each test run

### DIFF
--- a/cwf/gateway/integ_tests/rule_manager.go
+++ b/cwf/gateway/integ_tests/rule_manager.go
@@ -128,13 +128,9 @@ func (manager *RuleManager) RemoveInstalledRules() error {
 		if err != nil {
 			return err
 		}
-		for _, ruleID := range ruleIDs {
-			manager.policyDBWrapper.policyMap.Delete(ruleID)
-		}
 	}
-	for _, baseNameRecord := range manager.baseNameMappings {
-		manager.policyDBWrapper.baseNameMap.Delete(baseNameRecord.Name)
-	}
+	manager.policyDBWrapper.policyMap.DeleteAll()
+	manager.policyDBWrapper.baseNameMap.DeleteAll()
 	return nil
 }
 

--- a/feg/gateway/object_store/object_store.go
+++ b/feg/gateway/object_store/object_store.go
@@ -18,6 +18,7 @@ type ObjectMap interface {
 	Delete(key string) error
 	Get(key string) (interface{}, error)
 	GetAll() (map[string]interface{}, error)
+	DeleteAll() error
 }
 
 // Serializer turns an object into a string
@@ -87,4 +88,18 @@ func (rm *RedisMap) GetAll() (map[string]interface{}, error) {
 		}
 	}
 	return returnVals, nil
+}
+
+func (rm *RedisMap) DeleteAll() error {
+	valMap, err := rm.client.HGetAll(rm.hash)
+	if err != nil {
+		return err
+	}
+	for key := range valMap {
+		err = rm.Delete(key)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/feg/gateway/policydb/policydb_test.go
+++ b/feg/gateway/policydb/policydb_test.go
@@ -138,6 +138,17 @@ func (os *mockObjectStore) GetAll() (map[string]interface{}, error) {
 	return returnVals, nil
 }
 
+func (os *mockObjectStore) DeleteAll() error {
+	valsByKey, err := os.GetAll()
+	if err != nil {
+		return err
+	}
+	for key := range valsByKey {
+		os.Delete(key)
+	}
+	return nil
+}
+
 func initOnce(t *testing.T) {
 	streamer_test_init.StartTestService(t)
 }


### PR DESCRIPTION
Summary: We were not properly removing rules from the policy DB store after each test run

Reviewed By: karthiksubraveti

Differential Revision: D20931187

