### PR TITLE
Fix flaky pipelined uint tests by properly waiting for snapshots

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_two_policies.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_subscriber_two_policies.snapshot
@@ -1,6 +1,6 @@
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_src=192.168.128.74 actions=load:0x5f04fb434e009->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=mme(main_table), n_packets=1, n_bytes=34, priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x5f04fb434e009->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x3, table=enforcement(main_table), n_packets=1, n_bytes=34, priority=65533,ip,reg1=0x10,metadata=0x5f04fb434e009,nw_src=15.0.0.0/24 actions=note:b'match'
+ cookie=0x0, table=mme(main_table), n_packets=42, n_bytes=1428, priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x5f04fb434e009->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
+ cookie=0x3, table=enforcement(main_table), n_packets=42, n_bytes=1428, priority=65533,ip,reg1=0x10,metadata=0x5f04fb434e009,nw_src=15.0.0.0/24 actions=note:b'match'
  cookie=0x4, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=65533,tcp,reg1=0x1,metadata=0x5f04fb434e009 actions=note:b'no_match',set_field:0x4->reg2,set_field:0->reg4,resubmit(,enforcement_stats(main_table))
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=1,metadata=0x5f04fb434e009 actions=drop
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_two_subscribers.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement.EnforcementTableTest.test_two_subscribers.snapshot
@@ -1,9 +1,9 @@
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_src=192.168.128.5 actions=load:0x5f04fb4bc8239->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_src=192.168.128.100 actions=load:0x19e809e4df0089->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=29, n_bytes=986, priority=65535,ip,nw_dst=192.168.128.5 actions=load:0x5f04fb4bc8239->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x0, table=mme(main_table), n_packets=1, n_bytes=54, priority=65535,ip,nw_dst=192.168.128.100 actions=load:0x19e809e4df0089->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
+ cookie=0x0, table=mme(main_table), n_packets=18, n_bytes=972, priority=65535,ip,nw_dst=192.168.128.100 actions=load:0x19e809e4df0089->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x5, table=enforcement(main_table), n_packets=29, n_bytes=986, priority=65533,ip,reg1=0x10,metadata=0x5f04fb4bc8239,nw_src=8.8.8.0/24 actions=note:b't'
- cookie=0x6, table=enforcement(main_table), n_packets=1, n_bytes=54, priority=65533,tcp,reg1=0x10,metadata=0x19e809e4df0089 actions=note:b'qqq'
+ cookie=0x6, table=enforcement(main_table), n_packets=18, n_bytes=972, priority=65533,tcp,reg1=0x10,metadata=0x19e809e4df0089 actions=note:b'qqq'
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=1,metadata=0x5f04fb4bc8239 actions=drop
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=1,metadata=0x19e809e4df0089 actions=drop
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement_stats.EnforcementStatsTest.test_rule_deactivation.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement_stats.EnforcementStatsTest.test_rule_deactivation.snapshot
@@ -1,6 +1,5 @@
  cookie=0x0, table=mme(main_table), n_packets=4096, n_bytes=139264, priority=65535,ip,nw_src=192.168.128.74 actions=load:0x7594587a06d->OXM_OF_METADATA[],load:0x1->NXM_NX_REG1[],resubmit(,enforcement(main_table))
  cookie=0x0, table=mme(main_table), n_packets=0, n_bytes=0, priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x7594587a06d->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,enforcement(main_table))
- cookie=0x1, table=enforcement(main_table), n_packets=128, n_bytes=4352, priority=65532,ip,reg1=0x1,metadata=0x7594587a06d,nw_dst=45.10.0.0/25 actions=note:b'rule1',set_field:0x1->reg2,set_field:0x1->reg4,resubmit(,enforcement_stats(main_table))
  cookie=0x0, table=enforcement(main_table), n_packets=3968, n_bytes=134912, priority=1,metadata=0x7594587a06d actions=drop
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0
  cookie=0x0, table=enforcement(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x1 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0


### PR DESCRIPTION
Summary: before we weren't doing any waiting when getting ofctl snapshots, this diff adds a wait function that resolves a few realted issues

Differential Revision: D20961889

