### PR TITLE
Only log new state assignments if it's different from the current state

### DIFF
--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -466,9 +466,11 @@ void SessionCredit::set_reauth(
   ReAuthState new_reauth_state,
   SessionCreditUpdateCriteria& update_criteria)
 {
-  MLOG(MDEBUG) << "ReAuth state change from "
-               << reauth_state_to_str(reauth_state_)
-               << " to " << reauth_state_to_str(new_reauth_state);
+  if (reauth_state_ != new_reauth_state) {
+    MLOG(MDEBUG) << "ReAuth state change from "
+                 << reauth_state_to_str(reauth_state_)
+                 << " to " << reauth_state_to_str(new_reauth_state);
+  }
   reauth_state_ = new_reauth_state;
   update_criteria.reauth_state = new_reauth_state;
 }
@@ -477,9 +479,11 @@ void SessionCredit::set_service_state(
   ServiceState new_service_state,
   SessionCreditUpdateCriteria& update_criteria)
 {
-  MLOG(MDEBUG) << "Service state change from "
-               << service_state_to_str(service_state_)
-               << " to " << service_state_to_str(new_service_state);
+  if (service_state_ != new_service_state) {
+    MLOG(MDEBUG) << "Service state change from "
+                 << service_state_to_str(service_state_)
+                 << " to " << service_state_to_str(new_service_state);
+  }
   service_state_ = new_service_state;
   update_criteria.service_state = new_service_state;
 }


### PR DESCRIPTION
Summary:
Only log states when they change...
Want to reduce logs like
```
I0410 16:04:50.560730     1 SessionCredit.cpp:469] ReAuth state change from REAUTH_NOT_NEEDED to REAUTH_NOT_NEEDED
I0410 16:04:50.560909     1 SessionCredit.cpp:480] Service state change from SERVICE_ENABLED to SERVICE_ENABLED
```

Differential Revision: D20964934

