### PR TITLE
Remove local SessionMap from SessionProxyResponderHandler

### DIFF
--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -18,10 +18,8 @@ namespace magma {
 
 SessionProxyResponderHandlerImpl::SessionProxyResponderHandlerImpl(
   std::shared_ptr<LocalEnforcer> enforcer,
-  SessionMap& session_map,
   SessionStore& session_store):
   enforcer_(enforcer),
-  session_map_(session_map),
   session_store_(session_store)
 {
 }

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
@@ -49,7 +49,6 @@ class SessionProxyResponderHandlerImpl : public SessionProxyResponderHandler {
  public:
   SessionProxyResponderHandlerImpl(
     std::shared_ptr<LocalEnforcer> monitor,
-    SessionMap& session_map,
     SessionStore& session_store);
 
   ~SessionProxyResponderHandlerImpl() {}
@@ -72,7 +71,6 @@ class SessionProxyResponderHandlerImpl : public SessionProxyResponderHandler {
     std::function<void(Status, PolicyReAuthAnswer)> response_callback);
 
  private:
-   SessionMap& session_map_;
    SessionStore& session_store_;
    std::shared_ptr<LocalEnforcer> enforcer_;
 

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -249,7 +249,7 @@ int main(int argc, char *argv[])
   auto local_handler = std::make_unique<magma::LocalSessionManagerHandlerImpl>(
     monitor, reporter.get(), directoryd_client, session_map, *session_store);
   auto proxy_handler =std::make_unique<magma::SessionProxyResponderHandlerImpl>(
-    monitor, session_map, *session_store);
+    monitor, *session_store);
 
   auto restart_handler = std::make_shared<magma::sessiond::RestartHandler>(
       directoryd_client, monitor, reporter.get(), session_map);

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -70,7 +70,7 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     session_map = SessionMap{};
 
     proxy_responder = std::make_shared<SessionProxyResponderHandlerImpl>(
-      local_enforcer, session_map, *session_store);
+      local_enforcer, *session_store);
 
     local_enforcer->attachEventBase(evb);
   }

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -80,7 +80,7 @@ class SessiondTest : public ::testing::Test {
     proxy_responder = std::make_shared<SessionProxyResponderAsyncService>(
       local_service->GetNewCompletionQueue(),
       std::make_unique<SessionProxyResponderHandlerImpl>(
-        monitor, session_map, *session_store));
+        monitor, *session_store));
 
     local_service->AddServiceToServer(session_manager.get());
     local_service->AddServiceToServer(proxy_responder.get());


### PR DESCRIPTION
Summary: SessionMap was unused in SessionProxyResponderHandler

Differential Revision: D20973032

