### PR TITLE
Run clang on read_all_sessions files

### DIFF
--- a/lte/gateway/c/session_manager/MemoryStoreClient.cpp
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.cpp
@@ -15,12 +15,11 @@ namespace magma {
 namespace lte {
 
 MemoryStoreClient::MemoryStoreClient(
-  std::shared_ptr<StaticRuleStore> rule_store):
-  session_map_({}),
-  rule_store_(rule_store) {}
+    std::shared_ptr<StaticRuleStore> rule_store)
+    : session_map_({}), rule_store_(rule_store) {}
 
-SessionMap MemoryStoreClient::read_sessions(std::set<std::string> subscriber_ids)
-{
+SessionMap MemoryStoreClient::read_sessions(
+    std::set<std::string> subscriber_ids) {
   auto session_map = SessionMap{};
   for (const auto& subscriber_id : subscriber_ids) {
     auto sessions = std::vector<std::unique_ptr<SessionState>>{};
@@ -48,8 +47,7 @@ SessionMap MemoryStoreClient::read_all_sessions() {
   return session_map;
 }
 
-bool MemoryStoreClient::write_sessions(SessionMap session_map)
-{
+bool MemoryStoreClient::write_sessions(SessionMap session_map) {
   for (auto& it : session_map) {
     auto sessions = std::vector<StoredSessionState>{};
     for (auto const& session : it.second) {
@@ -61,5 +59,5 @@ bool MemoryStoreClient::write_sessions(SessionMap session_map)
   return true;
 }
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/MemoryStoreClient.cpp
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.cpp
@@ -35,6 +35,19 @@ SessionMap MemoryStoreClient::read_sessions(std::set<std::string> subscriber_ids
   return session_map;
 }
 
+SessionMap MemoryStoreClient::read_all_sessions() {
+  auto session_map = SessionMap{};
+  for (auto& it : session_map_) {
+    auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+    for (auto& stored_session : it.second) {
+      auto session = SessionState::unmarshal(stored_session, *rule_store_);
+      sessions.push_back(std::move(session));
+    }
+    session_map[it.first] = std::move(sessions);
+  }
+  return session_map;
+}
+
 bool MemoryStoreClient::write_sessions(SessionMap session_map)
 {
   for (auto& it : session_map) {

--- a/lte/gateway/c/session_manager/MemoryStoreClient.h
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.h
@@ -30,6 +30,8 @@ class MemoryStoreClient final : public StoreClient {
 
   SessionMap read_sessions(std::set<std::string> subscriber_ids);
 
+  SessionMap read_all_sessions();
+
   bool write_sessions(SessionMap session_map);
 
  private:

--- a/lte/gateway/c/session_manager/MemoryStoreClient.h
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.h
@@ -25,8 +25,8 @@ class MemoryStoreClient final : public StoreClient {
  public:
   MemoryStoreClient(std::shared_ptr<StaticRuleStore> rule_store);
   MemoryStoreClient(MemoryStoreClient const&) = delete;
-  MemoryStoreClient(MemoryStoreClient&&) = default;
-  ~MemoryStoreClient() = default;
+  MemoryStoreClient(MemoryStoreClient&&)      = default;
+  ~MemoryStoreClient()                        = default;
 
   SessionMap read_sessions(std::set<std::string> subscriber_ids);
 
@@ -39,5 +39,5 @@ class MemoryStoreClient final : public StoreClient {
   std::shared_ptr<StaticRuleStore> rule_store_;
 };
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -15,27 +15,20 @@ namespace magma {
 namespace lte {
 
 RedisStoreClient::RedisStoreClient(
-    std::shared_ptr<cpp_redis::client> client,
-    const std::string& redis_table,
-    std::shared_ptr<StaticRuleStore> rule_store):
-    client_(client),
-    redis_table_(redis_table),
-    rule_store_(rule_store) {}
+    std::shared_ptr<cpp_redis::client> client, const std::string& redis_table,
+    std::shared_ptr<StaticRuleStore> rule_store)
+    : client_(client), redis_table_(redis_table), rule_store_(rule_store) {}
 
-bool RedisStoreClient::try_redis_connect()
-{
+bool RedisStoreClient::try_redis_connect() {
   ServiceConfigLoader loader;
   auto config = loader.load_service_config("redis");
-  auto port = config["port"].as<uint32_t>();
-  auto addr = config["bind"].as<std::string>();
+  auto port   = config["port"].as<uint32_t>();
+  auto addr   = config["bind"].as<std::string>();
   try {
     client_->connect(
-        addr,
-        port,
-        [](
-            const std::string& host,
-            std::size_t port,
-            cpp_redis::client::connect_state status) {
+        addr, port,
+        [](const std::string& host, std::size_t port,
+           cpp_redis::client::connect_state status) {
           if (status == cpp_redis::client::connect_state::dropped) {
             MLOG(MERROR) << "Client disconnected from " << host << ":" << port;
           }
@@ -47,8 +40,8 @@ bool RedisStoreClient::try_redis_connect()
   }
 }
 
-SessionMap RedisStoreClient::read_sessions(std::set<std::string> subscriber_ids)
-{
+SessionMap RedisStoreClient::read_sessions(
+    std::set<std::string> subscriber_ids) {
   // The approach here is made assuming that the SessionStore only has one
   // call being processed at a time, and that the writes it makes are done
   // atomically. Based on that, reads can be done without using Redis
@@ -108,9 +101,7 @@ SessionMap RedisStoreClient::read_all_sessions() {
   return session_map;
 }
 
-
-bool RedisStoreClient::write_sessions(SessionMap session_map)
-{
+bool RedisStoreClient::write_sessions(SessionMap session_map) {
   // Writes should happen via a transaction, otherwise the state inside in
   // Redis may not be recoverable or consistent.
   // For reference, see https://redis.io/topics/transactions
@@ -146,8 +137,7 @@ bool RedisStoreClient::write_sessions(SessionMap session_map)
 }
 
 std::string RedisStoreClient::serialize_session_vec(
-  std::vector<std::unique_ptr<SessionState>>& session_vec)
-{
+    std::vector<std::unique_ptr<SessionState>>& session_vec) {
   folly::dynamic marshaled = folly::dynamic::array;
   for (auto& session_ptr : session_vec) {
     auto stored_session = session_ptr->marshal();
@@ -157,18 +147,18 @@ std::string RedisStoreClient::serialize_session_vec(
   return serialized;
 }
 
-std::vector<std::unique_ptr<SessionState>> RedisStoreClient::deserialize_session_vec(
-  std::string serialized)
-{
+std::vector<std::unique_ptr<SessionState>>
+RedisStoreClient::deserialize_session_vec(std::string serialized) {
   auto folly_serialized    = folly::StringPiece(serialized);
   folly::dynamic marshaled = folly::parseJson(folly_serialized);
   std::vector<std::unique_ptr<SessionState>> session_vec;
   for (auto& it : marshaled) {
     auto stored_session = deserialize_stored_session(it.getString());
-    session_vec.push_back(SessionState::unmarshal(stored_session, *rule_store_));
+    session_vec.push_back(
+        SessionState::unmarshal(stored_session, *rule_store_));
   }
   return session_vec;
 }
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -32,13 +32,12 @@ class RedisReadFailed : public std::exception {
 class RedisStoreClient final : public StoreClient {
  public:
   RedisStoreClient(
-      std::shared_ptr<cpp_redis::client> client,
-      const std::string& redis_table,
+      std::shared_ptr<cpp_redis::client> client, const std::string& redis_table,
       std::shared_ptr<StaticRuleStore> rule_store);
 
   RedisStoreClient(RedisStoreClient const&) = delete;
-  RedisStoreClient(RedisStoreClient&&) = default;
-  ~RedisStoreClient() = default;
+  RedisStoreClient(RedisStoreClient&&)      = default;
+  ~RedisStoreClient()                       = default;
 
   bool try_redis_connect();
 
@@ -61,5 +60,5 @@ class RedisStoreClient final : public StoreClient {
       std::string serialized);
 };
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -44,6 +44,8 @@ class RedisStoreClient final : public StoreClient {
 
   SessionMap read_sessions(std::set<std::string> subscriber_ids);
 
+  SessionMap read_all_sessions();
+
   bool write_sessions(SessionMap session_map);
 
  private:

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -32,6 +32,10 @@ SessionMap SessionStore::read_sessions(const SessionRead& req)
   return store_client_->read_sessions(req);
 }
 
+SessionMap SessionStore::read_all_sessions() {
+  return store_client_->read_all_sessions();
+}
+
 SessionMap SessionStore::read_sessions_for_reporting(const SessionRead& req)
 {
   auto session_map = store_client_->read_sessions(req);

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -15,20 +15,16 @@
 namespace magma {
 namespace lte {
 
-SessionStore::SessionStore(std::shared_ptr<StaticRuleStore> rule_store):
-    rule_store_(rule_store), store_client_(std::make_shared<MemoryStoreClient>(rule_store))
-{
-}
+SessionStore::SessionStore(std::shared_ptr<StaticRuleStore> rule_store)
+    : rule_store_(rule_store),
+      store_client_(std::make_shared<MemoryStoreClient>(rule_store)) {}
 
 SessionStore::SessionStore(
-  std::shared_ptr<StaticRuleStore> rule_store,
-  std::shared_ptr<RedisStoreClient> store_client):
-  rule_store_(rule_store), store_client_(store_client)
-{
-}
+    std::shared_ptr<StaticRuleStore> rule_store,
+    std::shared_ptr<RedisStoreClient> store_client)
+    : rule_store_(rule_store), store_client_(store_client) {}
 
-SessionMap SessionStore::read_sessions(const SessionRead& req)
-{
+SessionMap SessionStore::read_sessions(const SessionRead& req) {
   return store_client_->read_sessions(req);
 }
 
@@ -36,9 +32,8 @@ SessionMap SessionStore::read_all_sessions() {
   return store_client_->read_all_sessions();
 }
 
-SessionMap SessionStore::read_sessions_for_reporting(const SessionRead& req)
-{
-  auto session_map = store_client_->read_sessions(req);
+SessionMap SessionStore::read_sessions_for_reporting(const SessionRead& req) {
+  auto session_map   = store_client_->read_sessions(req);
   auto session_map_2 = store_client_->read_sessions(req);
   // For all sessions of the subscriber, increment the request numbers
   for (const std::string& imsi : req) {
@@ -50,9 +45,8 @@ SessionMap SessionStore::read_sessions_for_reporting(const SessionRead& req)
   return session_map;
 }
 
-SessionMap SessionStore::read_sessions_for_deletion(const SessionRead& req)
-{
-  auto session_map = store_client_->read_sessions(req);
+SessionMap SessionStore::read_sessions_for_deletion(const SessionRead& req) {
+  auto session_map   = store_client_->read_sessions(req);
   auto session_map_2 = store_client_->read_sessions(req);
   // For all sessions of the subscriber, increment the request numbers
   for (const std::string& imsi : req) {
@@ -65,20 +59,18 @@ SessionMap SessionStore::read_sessions_for_deletion(const SessionRead& req)
 }
 
 bool SessionStore::create_sessions(
-  const std::string& subscriber_id,
-  std::vector<std::unique_ptr<SessionState>> sessions)
-{
-  auto session_map = SessionMap {};
+    const std::string& subscriber_id,
+    std::vector<std::unique_ptr<SessionState>> sessions) {
+  auto session_map           = SessionMap{};
   session_map[subscriber_id] = std::move(sessions);
   store_client_->write_sessions(std::move(session_map));
   return true;
 }
 
-bool SessionStore::update_sessions(const SessionUpdate& update_criteria)
-{
+bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
   MLOG(MERROR) << "Running update_sessions";
   // Read the current state
-  auto subscriber_ids = std::set<std::string> {};
+  auto subscriber_ids = std::set<std::string>{};
   for (const auto& it : update_criteria) {
     subscriber_ids.insert(it.first);
   }
@@ -87,8 +79,7 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria)
   // Now attempt to modify the state
   for (auto& it : session_map) {
     auto it2 = it.second.begin();
-    while (it2 != it.second.end())
-    {
+    while (it2 != it.second.end()) {
       auto updates = update_criteria.find(it.first)->second;
       if (updates.find((*it2)->get_session_id()) != updates.end()) {
         auto update = updates[(*it2)->get_session_id()];
@@ -109,9 +100,8 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria)
 }
 
 bool SessionStore::merge_into_session(
-  std::unique_ptr<SessionState>& session,
-  const SessionStateUpdateCriteria& update_criteria)
-{
+    std::unique_ptr<SessionState>& session,
+    const SessionStateUpdateCriteria& update_criteria) {
   // Config
   if (update_criteria.is_config_updated) {
     session->unmarshal_config(update_criteria.updated_config);
@@ -122,8 +112,8 @@ bool SessionStore::merge_into_session(
   for (const auto& rule_id : update_criteria.static_rules_to_install) {
     if (session->is_static_rule_installed(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
-                   << " because static rule already installed: "
-                   << rule_id << std::endl;
+                   << " because static rule already installed: " << rule_id
+                   << std::endl;
       return false;
     }
     session->activate_static_rule(rule_id, uc);
@@ -131,8 +121,8 @@ bool SessionStore::merge_into_session(
   for (const auto& rule_id : update_criteria.static_rules_to_uninstall) {
     if (!session->is_static_rule_installed(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
-                   << " because static rule already uninstalled: "
-                   << rule_id << std::endl;
+                   << " because static rule already uninstalled: " << rule_id
+                   << std::endl;
       return false;
     }
     session->deactivate_static_rule(rule_id, uc);
@@ -142,8 +132,8 @@ bool SessionStore::merge_into_session(
   for (const auto& rule : update_criteria.dynamic_rules_to_install) {
     if (session->is_dynamic_rule_installed(rule.id())) {
       MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
-                   << " because dynamic rule already installed: "
-                   << rule.id() << std::endl;
+                   << " because dynamic rule already installed: " << rule.id()
+                   << std::endl;
       return false;
     }
     session->insert_dynamic_rule(rule, uc);
@@ -152,8 +142,8 @@ bool SessionStore::merge_into_session(
   for (const auto& rule_id : update_criteria.dynamic_rules_to_uninstall) {
     if (!session->is_dynamic_rule_installed(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
-                   << " because dynamic rule already uninstalled: "
-                   << rule_id << std::endl;
+                   << " because dynamic rule already uninstalled: " << rule_id
+                   << std::endl;
       return false;
     }
     session->remove_dynamic_rule(rule_id, _, uc);
@@ -161,44 +151,45 @@ bool SessionStore::merge_into_session(
 
   // Charging credit
   for (const auto& it : update_criteria.charging_credit_map) {
-    auto key = it.first;
+    auto key           = it.first;
     auto credit_update = it.second;
     session->get_charging_pool().merge_credit_update(key, credit_update);
   }
   for (const auto& it : update_criteria.charging_credit_to_install) {
-    auto key = it.first;
+    auto key           = it.first;
     auto stored_credit = it.second;
-    auto uc = get_default_update_criteria();
+    auto uc            = get_default_update_criteria();
     session->get_charging_pool().add_credit(
-      key, SessionCredit::unmarshal(stored_credit, CHARGING), uc);
+        key, SessionCredit::unmarshal(stored_credit, CHARGING), uc);
   }
 
   // Monitoring credit
   for (const auto& it : update_criteria.monitor_credit_map) {
-    auto key = it.first;
+    auto key           = it.first;
     auto credit_update = it.second;
     session->get_monitor_pool().merge_credit_update(key, credit_update);
   }
   for (const auto& it : update_criteria.monitor_credit_to_install) {
-    auto key = it.first;
+    auto key            = it.first;
     auto stored_monitor = it.second;
-    auto uc = get_default_update_criteria();
+    auto uc             = get_default_update_criteria();
     session->get_monitor_pool().add_monitor(
-      key, UsageMonitoringCreditPool::unmarshal_monitor(stored_monitor), uc);
+        key, UsageMonitoringCreditPool::unmarshal_monitor(stored_monitor), uc);
   }
   return true;
 }
 
-SessionUpdate SessionStore::get_default_session_update(SessionMap& session_map)
-{
+SessionUpdate SessionStore::get_default_session_update(
+    SessionMap& session_map) {
   SessionUpdate update = {};
-  for (const auto &session_pair : session_map) {
-    for (const auto &session : session_pair.second) {
-      update[session_pair.first][session->get_session_id()] = get_default_update_criteria();
+  for (const auto& session_pair : session_map) {
+    for (const auto& session : session_pair.second) {
+      update[session_pair.first][session->get_session_id()] =
+          get_default_update_criteria();
     }
   }
   return update;
 }
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -22,15 +22,14 @@
 namespace magma {
 namespace lte {
 
-typedef std::
-  unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>
+typedef std::unordered_map<
+    std::string, std::vector<std::unique_ptr<SessionState>>>
     SessionMap;
 // Value int represents the request numbers needed for requests to PCRF
 typedef std::set<std::string> SessionRead;
 typedef std::unordered_map<
-  std::string,
-  std::unordered_map<std::string, SessionStateUpdateCriteria>>
-  SessionUpdate;
+    std::string, std::unordered_map<std::string, SessionStateUpdateCriteria>>
+    SessionUpdate;
 
 /**
  * SessionStore acts as a broker to storage of sessiond state.
@@ -52,8 +51,8 @@ class SessionStore {
   SessionStore(std::shared_ptr<StaticRuleStore> rule_store);
 
   SessionStore(
-    std::shared_ptr<StaticRuleStore> rule_store,
-    std::shared_ptr<RedisStoreClient> store_client);
+      std::shared_ptr<StaticRuleStore> rule_store,
+      std::shared_ptr<RedisStoreClient> store_client);
 
   /**
    * Read the last written values for the requested sessions through the
@@ -108,8 +107,8 @@ class SessionStore {
    * @return true if successful, otherwise the update to storage is discarded.
    */
   bool create_sessions(
-    const std::string& subscriber_id,
-    std::vector<std::unique_ptr<SessionState>> sessions);
+      const std::string& subscriber_id,
+      std::vector<std::unique_ptr<SessionState>> sessions);
 
   /**
    * Attempt to update sessions with update criteria. If any update to any of
@@ -120,16 +119,15 @@ class SessionStore {
    */
   bool update_sessions(const SessionUpdate& update_criteria);
 
-
  private:
   static bool merge_into_session(
-    std::unique_ptr<SessionState>& session,
-    const SessionStateUpdateCriteria& update_criteria);
+      std::unique_ptr<SessionState>& session,
+      const SessionStateUpdateCriteria& update_criteria);
 
  private:
   std::shared_ptr<StoreClient> store_client_;
   std::shared_ptr<StaticRuleStore> rule_store_;
 };
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -65,6 +65,14 @@ class SessionStore {
   SessionMap read_sessions(const SessionRead& req);
 
   /**
+   * Read the last written values for all existing sessions through the
+   * storage interface.
+   * @return Last written values for all sessions. Returns an empty vector
+   *         for subscribers that do not have active sessions.
+   */
+  SessionMap read_all_sessions();
+
+  /**
    * Read the last written values for the requested sessions through the
    * storage interface. This also modifies the request_numbers stored before
    * returning the SessionMap to the caller.

--- a/lte/gateway/c/session_manager/StoreClient.h
+++ b/lte/gateway/c/session_manager/StoreClient.h
@@ -17,7 +17,9 @@
 namespace magma {
 namespace lte {
 
-typedef std::unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>> SessionMap;
+typedef std::unordered_map<
+    std::string, std::vector<std::unique_ptr<SessionState>>>
+    SessionMap;
 
 /**
  * StoreClient is responsible for reading/writing sessions to/from storage.
@@ -53,5 +55,5 @@ class StoreClient {
   virtual bool write_sessions(SessionMap sessions) = 0;
 };
 
-} // namespace lte
-} // namespace magma
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/StoreClient.h
+++ b/lte/gateway/c/session_manager/StoreClient.h
@@ -35,6 +35,15 @@ class StoreClient {
   virtual SessionMap read_sessions(std::set<std::string> subscriber_ids) = 0;
 
   /**
+   * Directly read all subscriber sessions from storage
+   *
+   * If one or more of the subscribers have no sessions, empty entries will be
+   * returned.
+   * @return All sessions for the subscribers
+   */
+  virtual SessionMap read_all_sessions() = 0;
+
+  /**
    * Directly write the subscriber sessions into storage, overwriting previous
    * values.
    *

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -36,32 +36,33 @@ class StoreClientTest : public ::testing::Test {
  * 5) Read for subscribers IMSI1 and IMSI2
  * 6) Verify that state was written for IMSI1/IMSI2 and has been retrieved.
  */
-TEST_F(StoreClientTest, test_read_and_write)
-{
+TEST_F(StoreClientTest, test_read_and_write) {
   std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  std::string imsi = "IMSI1";
-  std::string imsi2 = "IMSI2";
-  std::string msisdn = "5100001234";
+  std::string imsi                = "IMSI1";
+  std::string imsi2               = "IMSI2";
+  std::string imsi3               = "IMSI3";
+  std::string msisdn              = "5100001234";
   std::string radius_session_id =
-    "AA-AA-AA-AA-AA-AA:TESTAP__"
-    "0F-10-2E-12-3A-55";
-  auto sid = id_gen_.gen_session_id(imsi);
-  auto sid2 = id_gen_.gen_session_id(imsi2);
+      "AA-AA-AA-AA-AA-AA:TESTAP__"
+      "0F-10-2E-12-3A-55";
+  auto sid                    = id_gen_.gen_session_id(imsi);
+  auto sid2                   = id_gen_.gen_session_id(imsi2);
+  auto sid3                   = id_gen_.gen_session_id(imsi3);
   std::string core_session_id = "asdf";
-  SessionState::Config cfg = {.ue_ipv4 = "",
-    .spgw_ipv4 = "",
-    .msisdn = msisdn,
-    .apn = "",
-    .imei = "",
-    .plmn_id = "",
-    .imsi_plmn_id = "",
-    .user_location = "",
-    .rat_type = RATType::TGPP_WLAN,
-    .mac_addr = "0f:10:2e:12:3a:55",
-    .hardware_addr = hardware_addr_bytes,
-    .radius_session_id = radius_session_id};
-  auto rule_store = std::make_shared<StaticRuleStore>();
-  auto tgpp_context = TgppContext{};
+  SessionState::Config cfg    = {.ue_ipv4           = "",
+                              .spgw_ipv4         = "",
+                              .msisdn            = msisdn,
+                              .apn               = "",
+                              .imei              = "",
+                              .plmn_id           = "",
+                              .imsi_plmn_id      = "",
+                              .user_location     = "",
+                              .rat_type          = RATType::TGPP_WLAN,
+                              .mac_addr          = "0f:10:2e:12:3a:55",
+                              .hardware_addr     = hardware_addr_bytes,
+                              .radius_session_id = radius_session_id};
+  auto rule_store             = std::make_shared<StaticRuleStore>();
+  auto tgpp_context           = TgppContext{};
 
   auto store_client = new MemoryStoreClient(rule_store);
 
@@ -69,9 +70,13 @@ TEST_F(StoreClientTest, test_read_and_write)
   std::set<std::string> requested_ids{imsi, imsi2};
   auto session_map = store_client->read_sessions(requested_ids);
 
-  auto uc = get_default_update_criteria();
-  auto session = std::make_unique<SessionState>(imsi, sid, core_session_id, cfg, *rule_store, tgpp_context);
-  auto session2 = std::make_unique<SessionState>(imsi2, sid2, core_session_id, cfg, *rule_store, tgpp_context);
+  auto uc      = get_default_update_criteria();
+  auto session = std::make_unique<SessionState>(
+      imsi, sid, core_session_id, cfg, *rule_store, tgpp_context);
+  auto session2 = std::make_unique<SessionState>(
+      imsi2, sid2, core_session_id, cfg, *rule_store, tgpp_context);
+  auto session3 = std::make_unique<SessionState>(
+      imsi3, sid3, core_session_id, cfg, *rule_store, tgpp_context);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 
@@ -98,29 +103,44 @@ TEST_F(StoreClientTest, test_read_and_write)
   EXPECT_EQ(session_map_2.size(), 2);
   EXPECT_EQ(session_map_2[imsi].size(), 1);
   EXPECT_EQ(session_map_2[imsi].front()->get_session_id(), sid);
-  EXPECT_EQ(session_map_2[imsi].front()->is_static_rule_installed("rule1"), true);
+  EXPECT_EQ(
+      session_map_2[imsi].front()->is_static_rule_installed("rule1"), true);
+
+  // Now create a third session
+  std::set<std::string> requested_imsi3{imsi3};
+  auto session_map_3 = store_client->read_sessions(requested_imsi3);
+  EXPECT_EQ(session_map_3.size(), 1);
+  session_map_3[imsi3].push_back(std::move(session3));
+  EXPECT_EQ(session_map_3[imsi3].size(), 1);
+  store_client->write_sessions(std::move(session_map_3));
+
+  // Get all sessions
+  auto all_sessions = store_client->read_all_sessions();
+  EXPECT_EQ(all_sessions.size(), 3);
+  EXPECT_EQ(all_sessions[imsi].size(), 1);
+  EXPECT_EQ(all_sessions[imsi].front()->get_session_id(), sid);
+  EXPECT_EQ(all_sessions[imsi3].size(), 1);
+  EXPECT_EQ(all_sessions[imsi3].front()->get_session_id(), sid3);
 }
 
-TEST_F(StoreClientTest, test_lambdas)
-{
+TEST_F(StoreClientTest, test_lambdas) {
   auto sm = std::make_unique<int>(1);
 
-  std::function<void(std::unique_ptr<int>&)> callback2 = [](std::unique_ptr<int>& inp) {
-    EXPECT_EQ(*inp, 2);
-  };
+  std::function<void(std::unique_ptr<int>&)> callback2 =
+      [](std::unique_ptr<int>& inp) { EXPECT_EQ(*inp, 2); };
 
-  std::function<void()> callback = [=, shared = std::make_shared<decltype(sm)>(std::move(sm))]() mutable {
-    EXPECT_EQ(**shared, 1);
-    **shared = 2;
-    callback2(*shared);
-  };
+  std::function<void()> callback =
+      [=, shared = std::make_shared<decltype(sm)>(std::move(sm))]() mutable {
+        EXPECT_EQ(**shared, 1);
+        **shared = 2;
+        callback2(*shared);
+      };
   callback();
 }
 
-int main(int argc, char **argv)
-{
+int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }
 
-} // namespace magma
+}  // namespace magma


### PR DESCRIPTION
Summary:
This diff runs clang format on all files modified
in the diff that implements `read_all_sessions` for sessiond
storage.

Reviewed By: themarwhal

Differential Revision: D20973018

