### PR TITLE
[Bug fix][mme] Fixed seg fault seen during deletion on dedicated bearer

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_ebr_context.c
@@ -394,6 +394,13 @@ ebi_t esm_ebr_context_release(
           /* Delete only dedicated bearer. Default bearer will be deleted
            * outside this function
            */
+          /* If ue_mm_context->bearer_contexts[idx] is NULL, move to
+           * the next index
+           */
+          if (!ue_mm_context->bearer_contexts[idx]) {
+            continue;
+          }
+
           if (
             ue_mm_context->bearer_contexts[idx]->ebi ==
             ue_mm_context->pdn_contexts[*pid]->default_ebi) {


### PR DESCRIPTION
Summary:
This PR provides a fix for the segmentation fault seen during deletion of dedicated bearer when multiple RARs are sent from the test script

Test Plan:
1. Executed multiple RAR TC
2. Executed sanity