### PR TITLE
Fix flaky test for TAU (periodic inactive)

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_tau_periodic_inactive.py
@@ -82,6 +82,8 @@ class TestTauPeriodicInactive(unittest.TestCase):
             self.assertEqual(
                 response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
 
+        # Delay to ensure that last TAU finishes up
+        time.sleep(0.5)
         print("************************* Running UE detach (switch-off) for ",
               "UE id ", ue_id)
         # Now detach the UE


### PR DESCRIPTION
Summary: The last TAU cycle does not finish up before detach operation occasionally. Placed an extra sleep before detach request to mitigate the flakiness.

Differential Revision: D20997792

