### PR TITLE
Add secrets subchart to FeG helmchart to allow persistent gwinfo

### DIFF
--- a/feg/gateway/helm/feg/README.md
+++ b/feg/gateway/helm/feg/README.md
@@ -67,12 +67,12 @@ The following table list the configurable parameters of the orchestrator chart a
 
 | Parameter        | Description     | Default   |
 | ---              | ---             | ---       |
-| `manifests.configmap_bin` | Enable feg configmap bin. | `True` |
 | `manifests.configmap_env` | Enable feg configmap env. | `True` |
-| `manifests.secrets` | Enable feg secrets. | `True` |
 | `manifests.deployment` | Enable feg deployment. | `True` |
 | `manifests.service` | Enable feg service. | `True` |
 | `manifests.rbac` | Enable feg rbac. | `True` |
+| `secrets.create` | Enable feg secret creation | `False` |
+| `secret.gwinfo`   | Secret name containing feg gwinfo | `feg-secrets-gwinfo` |
 | `feg.type` | Gateway type agrument. | `feg` |
 | `feg.image.docker_registry` | FeG docker registry host. | `docker.io` |
 | `feg.image.tag` | FeG docker images tag. | `latest` |
@@ -117,15 +117,43 @@ The following table list the configurable parameters of the orchestrator chart a
 
 ## Installation steps
 
-1. Install FeG 
+1. Create persistent gateway info (optional)
+
+    If you want your gateway pod to have the same gwinfo on pod 
+    recreation, first follow the steps below.
+    
+    #### Creating Gateway Info
+    If creating a gateway for the first time, you'll need to create a snowflake
+    and challenge key before installing the gateway. To do so:
+
+    ```
+    $ docker login <DOCKER REGISTRY>
+    $ docker pull <DOCKER REGISTRY>/gateway_python:<IMAGE_VERSION>
+    $ docker run -d <DOCKER_REGISTRY>/gateway_python:<IMAGE_VERSION> python3.5 -m magma.magmad.main
+
+    This will output a container ID such as
+    f3bc383a95db16f2e448fdf67cac133a5f9019375720b59477aebc96bacd05a9
+
+    Run the following, substituting your container ID:
+    $ docker cp <container ID>:/etc/snowflake charts/secrets/.secrets
+    $ docker cp <container ID>:/var/opt/magma/certs/gw_challenge.key /charts/secrets/.secrets 
+    ```
+   
+    If you're instead upgrading your gateway to have persistent gwinfo,
+    copy the `etc/snowflake` and `/var/opt/magma/certs/gw_challenge.key` from 
+    your gateway to `charts/secrets/.secrets` of where this chart is stored.
+
+    Ensure that `secrets.create` is set to true in your vals.yaml override
+
+2. Install FeG 
 
 	helm upgrade --install feg --namespace magma orc8r --values=vals.yaml
 
-2. Register the gateway with the orchestrator
+3. Register the gateway with the orchestrator
 
-login to feg VM and execute below command
+    Login to the Feg VM and execute below command:
 
-```shell
+    ```shell
    
    a. Get IP of FeG VM:
    
@@ -147,8 +175,8 @@ login to feg VM and execute below command
       -----------
       MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2lAV8Dj1ZQEeQlJ/M9/iYXmiVLC7l5QU7IvrNe+lLsu2MuGz4hjNwFPLmG      /x055Zqzh++8LsXQSKJ0mgV9AUB87xyFGt1wGjvaUa8Jea1ZMRMd1lJ+IsKA606HeaQfVq
 
-```
+    ```
 
-3. Login to NMS Dahsboard and register New Gateway
+4. Login to NMS Dahsboard and register New Gateway
 
 

--- a/feg/gateway/helm/feg/charts/secrets/.helmignore
+++ b/feg/gateway/helm/feg/charts/secrets/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/feg/gateway/helm/feg/charts/secrets/Chart.yaml
+++ b/feg/gateway/helm/feg/charts/secrets/Chart.yaml
@@ -5,13 +5,15 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-apiVersion: "1.0"
-description: Magma Federated Gateway
-name: feg
-version: 0.1.5
-home: https://github.com/facebookincubator/magma
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart to create magma feg gateway secrets
+name: secrets
+version: 0.1.0
+engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma
 keywords:
   - magma
   - feg
+  - secrets

--- a/feg/gateway/helm/feg/charts/secrets/README.md
+++ b/feg/gateway/helm/feg/charts/secrets/README.md
@@ -1,0 +1,63 @@
+# FeG Secrets
+
+Feg Secrets is used to apply a set of secrets for a federated gateway. These 
+secrets provide permanent gateway identification so that gateway pods will be 
+recreated with the same hwid and challenge key.
+
+## TL;DR;
+
+```bash
+# Copy secrets into subchart root
+$ mkdir charts/secrets/.secrets && \
+    cp -r <secrets>/* charts/secrets/.secrets/
+$ ls charts/secrets/.secrets
+snowflake gw_challenge.key
+
+# Apply secrets
+helm template charts/secrets \
+    --name <feg release name> \
+    --namespace magma | kubectl -n magma apply -f -
+```
+
+## Overview
+
+This chart installs a secret that serves as identifiers for the gateway. 
+The secrets are expected to be provided as files and placed under
+secrets subchart root.
+```bash
+$ ls charts/secrets/.secrets
+snowflake  gw_challenge.key
+$ pwd
+magma/feg/gateway/helm/feg
+```
+
+## Creating Gateway Info
+If creating a gateway for the first time, you'll need to create a snowflake
+and challenge key before installing the gateway. To do so:
+
+```
+$ docker login <DOCKER REGISTRY>
+$ docker pull <DOCKER REGISTRY>/gateway_python:<IMAGE_VERSION>
+$ docker run -d <DOCKER_REGISTRY>/gateway_python:<IMAGE_VERSION> python3.5 -m magma.magmad.main
+
+This will output a container ID such as
+f3bc383a95db16f2e448fdf67cac133a5f9019375720b59477aebc96bacd05a9
+
+Run the following, substituting your container ID here
+$ docker cp <container ID>:/etc/snowflake charts/secrets/.secrets
+$ docker cp <container ID>:/var/opt/magma/certs/gw_challenge.key /charts/secrets/.secrets
+```
+
+Otherwise if redeploying a gateway with permanent gwinfo, copy the existing 
+snowflake from `etc/snowflake` and challenge key at 
+`/var/opt/magma/certs/gw_challenge.key`
+
+## Configuration
+
+The following table lists the configurable secret locations and 
+their default values.
+
+| Parameter        | Description     | Default   |
+| ---              | ---             | ---       |
+| `create` | Set to ``true`` to create feg secrets. | `false` |
+| `secret.gwinfo` | Root relative secrets directory. | `.secrets` |

--- a/feg/gateway/helm/feg/charts/secrets/templates/_helpers.tpl
+++ b/feg/gateway/helm/feg/charts/secrets/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Copyright (c) 2018-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+*/}}
+{{- define "labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: helm
+app.kubernetes.io/part-of: magma
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/feg/gateway/helm/feg/charts/secrets/templates/gwinfo.secret.yaml
+++ b/feg/gateway/helm/feg/charts/secrets/templates/gwinfo.secret.yaml
@@ -1,0 +1,18 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+{{- if .Values.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-gwinfo
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ tuple . "feg" "gateway" | include "labels" | indent 4 }}
+data:
+{{- (.Files.Glob (print .Values.secret.gwinfo "/*")).AsSecrets | nindent 2 }}
+{{- end }}

--- a/feg/gateway/helm/feg/charts/secrets/values.yaml
+++ b/feg/gateway/helm/feg/charts/secrets/values.yaml
@@ -5,13 +5,13 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-apiVersion: "1.0"
-description: Magma Federated Gateway
-name: feg
-version: 0.1.5
-home: https://github.com/facebookincubator/magma
-sources:
-  - https://github.com/facebookincubator/magma
-keywords:
-  - magma
-  - feg
+# Create feg gateway secrets
+create: true
+
+# Define which secrets should be mounted by pods.
+secret:
+   # directory holding orc8r cert secrets (needed to get rootCA.pem)
+  certs: orc8r-secrets-certs
+  # directory holding gateway's hwid (snowflake) and challenge key
+  gwinfo: .secrets
+

--- a/feg/gateway/helm/feg/requirements.yaml
+++ b/feg/gateway/helm/feg/requirements.yaml
@@ -5,13 +5,8 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-apiVersion: "1.0"
-description: Magma Federated Gateway
-name: feg
-version: 0.1.5
-home: https://github.com/facebookincubator/magma
-sources:
-  - https://github.com/facebookincubator/magma
-keywords:
-  - magma
-  - feg
+dependencies:
+  - name: secrets
+    version: 0.1.0
+    repository: ""
+    condition: secrets.create

--- a/feg/gateway/helm/feg/templates/deployment.yaml
+++ b/feg/gateway/helm/feg/templates/deployment.yaml
@@ -168,6 +168,16 @@ spec:
           tty: true
           stdin: true
           volumeMounts:
+            {{- if .Values.secret.gwinfo }}
+            - name: hwid
+              mountPath: /etc/snowflake
+              subPath: snowflake
+            {{- end }}
+            {{- if .Values.secret.gwinfo }}
+            - name: gw-challenge-key
+              mountPath: /var/opt/magma/certs/gw_challenge.key
+              subPath: gw_challenge.key
+            {{- end }}
             - name: feg-env
               mountPath: /opt/magma
             - name: orc8r-secrets-certs
@@ -178,6 +188,18 @@ spec:
               mountPath: /var/opt/magma/configs
             {{- end }}
       volumes:
+        {{- if .Values.secret.gwinfo }}
+        - name: hwid
+          secret:
+            secretName: {{ required "secret.gwinfo must be provided" .Values.secret.gwinfo }}
+            defaultMode: 0755
+        {{- end}}
+        {{- if .Values.secret.gwinfo }}
+        - name: gw-challenge-key
+          secret:
+            secretName: {{ required "secret.gwinfo must be provided" .Values.secret.gwinfo }}
+            defaultMode: 0755
+        {{- end }}
         - name: feg-env
           configMap:
             name: {{ $envAll.Release.Name}}-env

--- a/feg/gateway/helm/feg/values.yaml
+++ b/feg/gateway/helm/feg/values.yaml
@@ -17,9 +17,14 @@ release_group: null
 imagePullSecrets: []
 # - name: orc8r-secrets-registry
 
+# secrets sub-chart configuration.
+secrets:
+  create: false
+
 # Define which secrets should be mounted by pods.
 secret:
   certs: orc8r-secrets-certs
+  gwinfo: feg-secrets-gwinfo
 
 ## Key Values for docker inside VM
 feg:


### PR DESCRIPTION
Summary:
This diff matches a previous diff enabling the same functionality
for the cwf helm chart. Here we are able to create a snowflake and gw_challenge.key
as a secret. This ensures that when a pod is recreated it will be able to continue
to function with the Orchestrator.

Reviewed By: xjtian

Differential Revision: D20966558

