### PR TITLE
Making monitord dynamic service on magmad

### DIFF
--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -23,7 +23,6 @@ magma_services:
   - dnsd
   - policydb
   - state
-  - monitord
 
 # List of services that don't provide service303 interface
 non_service303_services:
@@ -36,6 +35,7 @@ non_service303_services:
 registered_dynamic_services:
   - redirectd
   - td-agent-bit
+  - monitord
 
 # A list of group of services which are linked together in systemd
 linked_services:
@@ -44,7 +44,6 @@ linked_services:
     - pipelined
     - mobilityd
     - sessiond
-    - monitord
 
 # list of services that are required to have meta before checking in
 # (meta = data gathered via MagmaService.register_get_status_callback())


### PR DESCRIPTION
Summary:
- Adding monitord to list of registered dynamic services, so it can be easier to enable / disable service on AGW magmad configs.
- Removing monitord from linked services as restart of this service could trigger restart other linked services.

Differential Revision: D21006196

