### PR TITLE
Fix flaky integration test

### DIFF
--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -162,7 +162,7 @@ func (srv *UESimServer) GenTraffic(ctx context.Context, req *cwfprotos.GenTraffi
 	}
 	var cmd *exec.Cmd
 
-	argList := []string{"--json", "--get-server-output", "-c", trafficSrvIP, "-M", trafficMSS}
+	argList := []string{"--json", "-c", trafficSrvIP, "-M", trafficMSS}
 	if req.Volume != nil {
 		argList = append(argList, []string{"-n", req.Volume.Value}...)
 	}


### PR DESCRIPTION
Summary:
TestQosDowngrade test can be flaky because it depends on when CCA update kicks in. Removed an additional test and increased the threshold at which CCA can kick in. Also i found that adding the additional --get-server-output seems to be causing the iperf to get stuck. Not entirely sure why it is happening. Running tcpdump on both ends seem to reveal that the towards the end when server sends a large packet that never reaches iperf client. For now we don't use this functionality, hence i disabled it. I ran it couple of times after disabling --get-server-output and iperf client wasn't getting stuck.

Attaching the dump here in case anyone is interested in taking a look
P128986301: https://our.intern.facebook.com/intern/paste/P128986301/
P128986304: https://our.intern.facebook.com/intern/paste/P128986304/

Reviewed By: themarwhal

Differential Revision: D21017650

