### PR TITLE
Modify and re-enable tests for SessionProxyResponderHandler

### DIFF
--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(SESSIOND_TEST_LIB
 
 target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
-foreach(session_test session_credit local_enforcer cloud_reporter async_service
+foreach(session_test session_credit local_enforcer cloud_reporter
         session_manager_handler sessiond_integ session_state credit_pool
         session_store store_client stored_state)
   add_executable(${session_test}_test test_${session_test}.cpp)

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -14,7 +14,7 @@ target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
 foreach(session_test session_credit local_enforcer cloud_reporter
         session_manager_handler sessiond_integ session_state credit_pool
-        session_store store_client stored_state)
+        session_store store_client stored_state proxy_responder_handler)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)


### PR DESCRIPTION
Summary: `test_proxy_responder_handler` was not enabled to run automatically. Fixing and re-enabling the test.

Differential Revision: D20974510

