### PR TITLE
Add reindex job queue for cross-controller coordination.

### DIFF
--- a/orc8r/cloud/go/services/state/indexer/indexer.go
+++ b/orc8r/cloud/go/services/state/indexer/indexer.go
@@ -35,6 +35,7 @@ type Indexer interface {
 
 	// GetVersion returns the current version for the indexer.
 	// Incrementing the version in a release will result in a reindex.
+	// An indexer's version is required to be non-decreasing across successive releases.
 	GetVersion() Version
 
 	// GetSubscriptions defines the composite keys this indexer is interested in.

--- a/orc8r/cloud/go/services/state/indexer/registry.go
+++ b/orc8r/cloud/go/services/state/indexer/registry.go
@@ -94,9 +94,19 @@ func unregisterUnsafe(indexers []Indexer) {
 	}
 }
 
-// SetIndexerUnsafeForTest sets an indexer in the registry for testing purposes.
-// It acquires no locks and will overwrite any existing indexer with the same indexer ID.
-func SetIndexerUnsafeForTest(t *testing.T, idx Indexer) {
+// DeregisterAllForTest deregisters all previously-registered indexers.
+// This should only be called by test code.
+func DeregisterAllForTest(t *testing.T) {
+	if t == nil {
+		panic("for tests only")
+	}
+	registry.indexers = map[string]Indexer{}
+}
+
+// RegisterForTest sets an indexer in the registry.
+// Overwrites any existing indexer with the same indexer ID.
+// This should only be called by test code.
+func RegisterForTest(t *testing.T, idx Indexer) {
 	if t == nil {
 		panic("for tests only")
 	}

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue.go
@@ -1,0 +1,107 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package reindex
+
+import (
+	"magma/orc8r/cloud/go/services/state/indexer"
+)
+
+// status of a reindex job
+type Status string
+
+const (
+	// StatusAvailable indicates the job is not in progress and has not been successfully completed.
+	// Available jobs will be considered "errored" when attempts >= max attempts.
+	StatusAvailable Status = "available"
+	// StatusInProgress indicates a job is being processed.
+	// In-progress jobs can be claimed by a new caller if last_status_change is more than defaultTimeout ago.
+	StatusInProgress Status = "in_progress"
+	// StatusComplete indicates a job has been completed successfully.
+	StatusComplete Status = "complete"
+
+	// DefaultMaxAttempts is the default max number of attempts at a reindex job before it's considered failed.
+	DefaultMaxAttempts = 3
+)
+
+// Job required to carry out a reindex job.
+type Job struct {
+	Idx  indexer.Indexer
+	From indexer.Version
+	To   indexer.Version
+}
+
+// JobInfo provides information about a job's progress.
+type JobInfo struct {
+	Status   Status
+	Attempts uint
+}
+
+// JobQueue is a static, unordered job queue containing state indexers.
+// State indexers are added to the queue for reindexing at initialization, and removed from the queue after the reindex is complete.
+// ClaimAvailableJob should be polled periodically, as jobs may become available at any time.
+type JobQueue interface {
+	// Initialize the queue. Call before other methods.
+	Initialize() error
+
+	// PopulateJobs populates the queue with the necessary jobs read from the indexer registry.
+	// Returns true if job queue was updated with new jobs.
+	PopulateJobs() (bool, error)
+
+	// ClaimAvailableJob claims the returned indexer, to safely perform reindexing operations.
+	// Returns nil if no job available.
+	ClaimAvailableJob() (*Job, error)
+
+	// CompleteJob indicates completion of the reindexing operation and returns ownership of the job to the queue.
+	CompleteJob(job *Job, withErr error) error
+
+	// GetAllErrors returns all job errors, keyed by indexer ID.
+	// A job only returns an error when its been attempted at least the max number of attempts.
+	GetAllErrors() (map[string]string, error)
+
+	// GetAllJobInfo provides information about job progress, keyed by indexer ID.
+	GetAllJobInfo() (map[string]JobInfo, error)
+}
+
+func GetError(queue JobQueue, indexerID string) (string, error) {
+	errs, err := queue.GetAllErrors()
+	if err != nil {
+		return "", err
+	}
+	errVal, ok := errs[indexerID]
+	if !ok {
+		return "", nil
+	}
+	return errVal, nil
+}
+
+// GetStatus returns the job status of the job for a particular reindex job.
+func GetStatus(queue JobQueue, indexerID string) (Status, error) {
+	statuses, err := GetAllStatuses(queue)
+	if err != nil {
+		return "", err
+	}
+	status, ok := statuses[indexerID]
+	if !ok {
+		return "", nil
+	}
+	return status, nil
+}
+
+// GetAllStatuses returns all job statuses, keyed by indexer ID.
+func GetAllStatuses(queue JobQueue) (map[string]Status, error) {
+	infos, err := queue.GetAllJobInfo()
+	if err != nil {
+		return nil, err
+	}
+	statuses := map[string]Status{}
+	for id, info := range infos {
+		statuses[id] = info.Status
+	}
+	return statuses, nil
+}

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
@@ -1,0 +1,701 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package reindex
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/services/state/indexer"
+	"magma/orc8r/cloud/go/sqorc"
+	merrors "magma/orc8r/lib/go/errors"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/golang/glog"
+	errors2 "github.com/pkg/errors"
+)
+
+const (
+	// queueTableName is the name of the SQL table acting as the reindex job queue.
+	queueTableName = "reindex_job_queue"
+	// versionTableName is the name of the SQL table acting as the source of truth for indexer versions.
+	versionTableName = "indexer_versions"
+
+	// Columns of queue table
+	idCol         = "indexer_id"
+	fromCol       = "from_version"
+	toCol         = "to_version"
+	statusCol     = "status"
+	lastChangeCol = "last_status_change"
+	attemptsCol   = "attempts"
+	errorCol      = "error"
+
+	// Columns of indexer versions table
+	idColVersions      = "indexer_id"
+	actualColVersions  = "version_actual"
+	desiredColVersions = "version_desired"
+
+	// defaultTimeout after which reindex jobs are considered failed.
+	defaultTimeout = 5 * time.Minute
+)
+
+var (
+	// testHookPopulateStart is an empty hook function which tests can use to coordinate job populations.
+	testHookPopulateStart = func() {}
+)
+
+// indexerVersions represents the discrepancy between an indexer's versions -- desired vs. actual.
+type indexerVersions struct {
+	desired indexer.Version
+	actual  indexer.Version
+}
+
+// newIndexerVersions returns a new indexer versions view.
+// First checks the indexer versions fit in an indexer.Version.
+func newIndexerVersions(indexerID string, actualVersion, desiredVersion int64) (*indexerVersions, error) {
+	td, ta := indexer.Version(desiredVersion), indexer.Version(actualVersion)
+	if int64(td) < desiredVersion || int64(ta) < actualVersion {
+		return nil, fmt.Errorf(
+			"found versions for indexer %s are too large, %v or %v doesn't fit in %T",
+			indexerID, desiredVersion, actualVersion, indexer.Version(0),
+		)
+	}
+	v := &indexerVersions{
+		desired: td,
+		actual:  ta,
+	}
+	return v, nil
+}
+
+// reindexJob is the internal representation of a reindex job.
+type reindexJob struct {
+	// Indexer-relevant
+	id   string
+	from indexer.Version
+	to   indexer.Version
+	// Job-relevant
+	status     Status
+	attempts   uint
+	error      string
+	lastChange time.Time
+}
+
+func (j *reindexJob) isSameVersions(job *reindexJob) bool {
+	return j.from == job.from && j.to == job.to
+}
+
+// sqlJobQueue wraps a Postgres/Maria table to provide a job queue for reindex jobs.
+//
+// sqlJobQueue stores the "actual" versions of state indexers, compares to the desired versions
+// denoted in each registered indexer, then creates reindex jobs based on those discrepancies.
+//
+// Note that the version is only "actual" with quotes since indexers may only be in-transition to
+// their denoted version, but, if so, a relevant reindex job will be present in the reindex job queue.
+//
+// Job queue columns:
+//	- indexer_id 			-- ID of indexer needing a reindex
+//	- status 				-- available, in_progress, complete, or error
+//	- last_status_change	-- Unix time since last update to status
+//	- attempts 				-- number of attempts at completing the reindex
+//	- error 				-- non-empty string if the reindex job was completed with err
+// Indexer versions columns:
+//	- indexer_id			-- ID of an indexer
+//	- version_desired		-- most-recently-updated desired indexer version
+//	- version_actual		-- actual version of the indexer
+//
+// Notes:
+//	- Reindex jobs are assumed to take less than 5 minutes (defaultTimeout) to complete. For jobs that
+//	  happen to take longer, multiple controller instances may try to complete the job concurrently,
+//	  under the assumption that previous jobs failed. Individual indexers should handle this gracefully.
+//	  Last writer wins for storing error strings.
+//	- As with other SQL usages in magma, multiple concurrent calls to Initialize can cause a race condition in Postgres's
+//	  DDL table creation, which will return an error.
+//	- Indexer versions (uint32) are stored in Postgres/Maria default integer types (int32). While this isn't expected to
+//	  be an issue, future updates to this type should consider the possibility of a sufficiently-large version being misinterpreted
+//	  by a SQL WHERE clause.
+type sqlJobQueue struct {
+	maxAttempts int
+	db          *sql.DB
+	builder     sqorc.StatementBuilder
+}
+
+// NewSQLJobQueue returns a new SQL-backed implementation of an unordered job queue.
+// The job queue is safe for use across goroutines and processes.
+//
+// maxAttempts is the max number of times to attempt reindexing the indexer.
+//
+// Populating the job queue is an exactly-once operation. We handle this in two parts
+//	- Populate <= 1 time
+//		- The job queue jobs are written as part of a tx that checks the "stored"
+//		  indexer versions, and these stored versions are updated the the "desired" versions during the same tx,
+//		  ensuring no more than one controller instance will write to the job queue per code push.
+//		- There is a small race condition where multiple callers may both log that they successfully updated the job queue,
+//		  but this is inconsequential since the condition (a) requires near-simultaneous calls and (b) actually results in the
+//		  exact same jobs being written.
+//	- Populate >= 1 time
+//		- This work is best suited for a future where we have a message broker in the orc8r,
+//		  so for now each controller warning-logs either success or failure to write to the job queue, and manual
+//		  inspection of the logs would be required (thankfully, we also have tests to ensure this doesn't happen in the expected case).
+//
+// Only provides Postgres/Maria support due to use of the non-standard "FOR UPDATE SKIP LOCKED" clause.
+func NewSQLJobQueue(maxAttempts int, db *sql.DB, builder sqorc.StatementBuilder) JobQueue {
+	return &sqlJobQueue{maxAttempts: maxAttempts, db: db, builder: builder}
+}
+
+func (s *sqlJobQueue) Initialize() error {
+	err := s.initVersionTable()
+	if err != nil {
+		return err
+	}
+	err = s.initQueueTable()
+	return err
+}
+
+// PopulateJobs tries to add necessary reindex jobs to the job queue.
+//
+// The population is performed atomically, so max 1 controller instance will be successful per push with indexer version updates.
+// However, verifying that at least 1 controller instance was successful is left to manual inspection of the logs.
+//
+// The tx spans two tables--reindex_job_queue and indexer_versions. If anything fails during the tx, log the error and assume
+// it was due to serializing the update with other controller instances.
+func (s *sqlJobQueue) PopulateJobs() (bool, error) {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+
+		versions, err := s.getComposedVersions(tx)
+		if err != nil {
+			return false, err
+		}
+
+		// Test hook after first db call so the tx has "officially" started by acquiring some locks
+		testHookPopulateStart()
+
+		jobs := getRequiredJobs(versions)
+		if len(jobs) == 0 {
+			glog.Info("All desired and actual indexer versions equal, not populating job queue")
+			return false, nil
+		}
+		err = s.addJobs(tx, jobs)
+		if err != nil {
+			return false, err
+		}
+
+		err = s.overwriteAllIndexerDesiredVersions(tx, versions)
+		if err != nil {
+			return false, err
+		}
+
+		return true, nil
+	}
+	ret, err := sqorc.ExecInTx(s.db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, txFn)
+	if err != nil {
+		glog.Warningf("Failed to populate reindex job queue; ignore if another controller instance succeeded: %s", err)
+		return false, nil
+	}
+	updated := ret.(bool)
+
+	if updated {
+		// Info-level so can compare that at least one controller writes to the job queue
+		glog.Info("Succeeded in updating reindex job queue and overwriting new indexer versions")
+	}
+
+	return updated, nil
+}
+
+func (s *sqlJobQueue) ClaimAvailableJob() (*Job, error) {
+	reindexJob, err := s.claimAvailableJob()
+	if err == merrors.ErrNotFound {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	idx, err := indexer.GetIndexer(reindexJob.id)
+	if err != nil {
+		return nil, err
+	}
+
+	job := &Job{
+		Idx:  idx,
+		From: reindexJob.from,
+		To:   reindexJob.to,
+	}
+
+	return job, nil
+}
+
+func (s *sqlJobQueue) CompleteJob(job *Job, withErr error) error {
+	if job == nil {
+		return errors.New("job cannot be nil")
+	}
+
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		var errVal string
+		var statusVal Status
+
+		switch withErr {
+		case nil:
+			errVal = ""
+			statusVal = StatusComplete
+		default:
+			errVal = withErr.Error()
+			statusVal = StatusAvailable
+		}
+
+		// Only update indexer actual versions on successful job completion
+		if withErr == nil {
+			err := s.updateIndexerActualVersion(tx, job.Idx.GetID(), job.To)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		_, err := s.builder.Update(queueTableName).
+			Set(statusCol, statusVal).
+			Set(errorCol, errVal).
+			Where(squirrel.Eq{idCol: job.Idx.GetID()}).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return nil, errors2.Wrap(err, "update reindex job completed")
+		}
+
+		return nil, nil
+	}
+
+	_, err := sqorc.ExecInTx(s.db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, txFn)
+	return err
+}
+
+func (s *sqlJobQueue) GetAllErrors() (map[string]string, error) {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		now := clock.Now()
+		timeoutThreshold := now.Add(-defaultTimeout)
+
+		rows, err := s.selectAll().
+			From(queueTableName).
+			Where(
+				squirrel.And{
+					// Attempts >= max
+					squirrel.GtOrEq{attemptsCol: s.maxAttempts},
+					// Available || in_progress+timeout
+					squirrel.Or{
+						squirrel.Eq{statusCol: StatusAvailable},
+						squirrel.And{
+							squirrel.Eq{statusCol: StatusInProgress},
+							squirrel.Lt{lastChangeCol: timeoutThreshold.Unix()},
+						},
+					},
+				},
+			).
+			RunWith(tx).
+			Query()
+		if err != nil {
+			return nil, errors2.Wrap(err, "select all job errors")
+		}
+		defer sqorc.CloseRowsLogOnError(rows, "GetAllErrors")
+
+		jobs, err := scanJobs(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		return jobs, nil
+	}
+
+	txRet, err := sqorc.ExecInTx(s.db, nil, nil, txFn)
+	if err != nil {
+		return nil, err
+	}
+	jobs := txRet.(map[string]*reindexJob)
+
+	ret := map[string]string{}
+	for id, job := range jobs {
+		ret[id] = job.error
+	}
+
+	return ret, nil
+}
+
+func (s *sqlJobQueue) GetAllJobInfo() (map[string]JobInfo, error) {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		rows, err := s.selectAll().From(queueTableName).RunWith(tx).Query()
+		if err != nil {
+			return nil, errors2.Wrap(err, "select all job infos")
+		}
+		defer sqorc.CloseRowsLogOnError(rows, "GetAllJobInfo")
+
+		jobs, err := scanJobs(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		return jobs, nil
+	}
+
+	txRet, err := sqorc.ExecInTx(s.db, nil, nil, txFn)
+	if err != nil {
+		return nil, err
+	}
+	jobs := txRet.(map[string]*reindexJob)
+
+	infos := map[string]JobInfo{}
+	for id, job := range jobs {
+		infos[id] = JobInfo{Status: job.status, Attempts: job.attempts}
+	}
+
+	return infos, nil
+}
+
+func (s *sqlJobQueue) initQueueTable() error {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		_, err := s.builder.CreateTable(queueTableName).
+			IfNotExists().
+			Column(idCol).Type(sqorc.ColumnTypeText).NotNull().PrimaryKey().EndColumn().
+			Column(fromCol).Type(sqorc.ColumnTypeInt).NotNull().EndColumn().
+			Column(toCol).Type(sqorc.ColumnTypeInt).NotNull().EndColumn().
+			Column(statusCol).Type(sqorc.ColumnTypeText).Default(fmt.Sprintf("'%s'", StatusAvailable)).NotNull().EndColumn().
+			Column(lastChangeCol).Type(sqorc.ColumnTypeInt).NotNull().EndColumn().
+			Column(attemptsCol).Type(sqorc.ColumnTypeInt).Default(0).NotNull().EndColumn().
+			Column(errorCol).Type(sqorc.ColumnTypeText).Default("''").NotNull().EndColumn().
+			RunWith(tx).
+			Exec()
+		return nil, errors2.Wrap(err, "initialize job queue table")
+	}
+	_, err := sqorc.ExecInTx(s.db, &sql.TxOptions{Isolation: sql.LevelRepeatableRead}, nil, txFn)
+	return err
+}
+
+// addJobs adds reindex jobs to the table.
+func (s *sqlJobQueue) addJobs(tx *sql.Tx, newJobs []*reindexJob) error {
+	oldJobs, err := s.getExistingIncompleteJobs(tx)
+	if err != nil {
+		return err
+	}
+
+	// Venn diagram of indexer IDs in old and new jobs
+	// old_only:	indexer ID only present in old jobs -- existing job uncomplete, but no new job needed
+	// new_only:	indexer ID only present in new jobs -- existing job not found, and new job needed
+	// both:		indexer ID present in both old and new jobs -- existing job uncomplete, and new job also needed
+	// {    old_only    [    both    }    new_only    ]
+
+	insertJobs := map[string]*reindexJob{}
+
+	// Include all new jobs -- on conflict with an old job, log and replace with new job
+	for _, job := range newJobs {
+		if prev, exists := oldJobs[job.id]; exists && !job.isSameVersions(prev) {
+			glog.Warningf("Replacing existing reindex job %+v with %+v", prev, job)
+		}
+		insertJobs[job.id] = job
+	}
+
+	// Include remaining old jobs -- add back all incomplete old jobs that haven't been superseded by a new job
+	for _, job := range oldJobs {
+		if _, hasNewerVersion := insertJobs[job.id]; !hasNewerVersion {
+			insertJobs[job.id] = job
+		}
+	}
+
+	// Clear job queue
+	_, err = s.builder.Delete(queueTableName).RunWith(tx).Exec()
+	if err != nil {
+		return errors2.Wrap(err, "add reindex jobs, delete existing table contents")
+	}
+
+	// Insert new jobs
+	now := clock.Now()
+	builder := s.builder.Insert(queueTableName).Columns(idCol, fromCol, toCol, lastChangeCol)
+	for _, job := range insertJobs {
+		builder = builder.Values(job.id, job.from, job.to, now.Unix())
+	}
+
+	_, err = builder.RunWith(tx).Exec()
+	if err != nil {
+		return errors2.Wrap(err, "add reindex jobs, insert new jobs")
+	}
+
+	return nil
+}
+
+// getExistingIncompleteJobs returns a map {indexer ID -> reindex job} for incomplete jobs currently stored in the table.
+func (s *sqlJobQueue) getExistingIncompleteJobs(tx *sql.Tx) (map[string]*reindexJob, error) {
+	rows, err := s.selectAll().
+		From(queueTableName).
+		Where(squirrel.NotEq{statusCol: StatusComplete}).
+		RunWith(tx).
+		Query()
+	if err != nil {
+		return nil, errors2.Wrap(err, "select existing incomplete jobs")
+	}
+	defer sqorc.CloseRowsLogOnError(rows, "getExistingIncompleteJobs")
+
+	jobs, err := scanJobs(rows)
+	if err != nil {
+		return nil, err
+	}
+
+	return jobs, nil
+}
+
+// If no job available, returns ErrNotFound from magma/orc8r/lib/go/errors.
+func (s *sqlJobQueue) claimAvailableJob() (*reindexJob, error) {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		now := clock.Now()
+		timeoutThreshold := now.Add(-defaultTimeout)
+
+		rows, err := s.selectAll().
+			From(queueTableName).
+			Where(
+				squirrel.And{
+					// Hasn't been claimed/attempted too many times
+					squirrel.Lt{attemptsCol: s.maxAttempts},
+					// Is available
+					squirrel.Or{
+						// Normal case: job is available
+						squirrel.Eq{statusCol: StatusAvailable},
+						// Timeout case: claim job that has been "executing" for too long
+						squirrel.And{
+							squirrel.Eq{statusCol: StatusInProgress},
+							squirrel.Lt{lastChangeCol: timeoutThreshold.Unix()},
+						},
+					},
+				},
+			).
+			Limit(1).
+			Suffix("FOR UPDATE SKIP LOCKED").
+			RunWith(tx).
+			Query()
+
+		if err != nil {
+			return nil, errors2.Wrap(err, "claim available job, select available job")
+		}
+		defer sqorc.CloseRowsLogOnError(rows, "ClaimAvailableJob")
+
+		job, err := scanJob(rows)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set job status to in_progress
+		_, err = s.builder.Update(queueTableName).
+			Set(statusCol, StatusInProgress).
+			Set(lastChangeCol, now.Unix()).
+			Set(attemptsCol, job.attempts+1).
+			Where(squirrel.Eq{idCol: job.id}).
+			RunWith(tx).
+			Exec()
+		if err != nil {
+			return nil, errors2.Wrap(err, "claim available job, update job status")
+		}
+
+		return job, nil
+	}
+
+	ret, err := sqorc.ExecInTx(s.db, nil, nil, txFn)
+	if err != nil {
+		return nil, err
+	}
+	job := ret.(*reindexJob)
+
+	return job, nil
+}
+
+// getComposedVersions returns the full understanding of desired and actual versions.
+// Determining whether an indexer needs to be reindexed depends on three recorded version infos per indexer
+//	- new_desired	-- desired version from indexer registry
+//	- old_desired	-- desired version from existing reindex jobs
+//	- actual		-- actual version updated upon successful reindex job completion
+func (s *sqlJobQueue) getComposedVersions(tx *sql.Tx) (map[string]*indexerVersions, error) {
+	newVersions := indexer.GetAllIndexerVersionsByID()
+	oldVersions, err := s.getAllIndexerVersions(tx)
+	if err != nil {
+		return nil, err
+	}
+	return getComposedVersionsImpl(newVersions, oldVersions), nil
+}
+
+// Keep impl separate as pure function for easy testing
+func getComposedVersionsImpl(newVersions map[string]indexer.Version, oldVersions map[string]*indexerVersions) map[string]*indexerVersions {
+	versions := map[string]*indexerVersions{}
+
+	// Insert all old versions -- old_desired and actual values
+	for id, version := range oldVersions {
+		versions[id] = version
+	}
+
+	// Insert all new versions -- new_desired overwrites any existing old_desired
+	for id, newDesired := range newVersions {
+		if _, present := versions[id]; present {
+			versions[id].desired = newDesired
+			continue
+		}
+		versions[id] = &indexerVersions{desired: newDesired, actual: 0}
+	}
+
+	return versions
+}
+
+// getRequiredJobs returns slice of reindex jobs to run.
+func getRequiredJobs(versions map[string]*indexerVersions) []*reindexJob {
+	var jobs []*reindexJob
+
+	// Include only jobs where desired != actual
+	for id, version := range versions {
+		if version.desired == version.actual {
+			continue
+		}
+		job := &reindexJob{
+			id:   id,
+			from: version.actual,
+			to:   version.desired,
+		}
+		jobs = append(jobs, job)
+	}
+
+	return jobs
+}
+
+func (s *sqlJobQueue) selectAll() squirrel.SelectBuilder {
+	return s.builder.Select(idCol, fromCol, toCol, statusCol, attemptsCol, errorCol, lastChangeCol)
+}
+
+// If no job available, returns ErrNotFound from magma/orc8r/lib/go/errors.
+func scanJob(rows *sql.Rows) (*reindexJob, error) {
+	jobs, err := scanJobs(rows)
+	if err != nil {
+		return nil, err
+	}
+	if len(jobs) == 0 {
+		return nil, merrors.ErrNotFound
+	}
+
+	// Return one job
+	for _, job := range jobs {
+		return job, nil
+	}
+	return nil, errors.New("err returning one job") // to appease compiler
+}
+
+// Returns map of indexer ID to reindex job.
+func scanJobs(rows *sql.Rows) (map[string]*reindexJob, error) {
+	var err error
+	jobs := map[string]*reindexJob{}
+
+	for rows.Next() {
+		job := &reindexJob{}
+		var lastChangeVal int64
+		err = rows.Scan(&job.id, &job.from, &job.to, &job.status, &job.attempts, &job.error, &lastChangeVal)
+		if err != nil {
+			return nil, errors2.Wrap(err, "scan job, SQL row scan error")
+		}
+		job.lastChange = time.Unix(lastChangeVal, 0)
+
+		jobs[job.id] = job
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors2.Wrap(err, "scan job, SQL rows error")
+	}
+
+	return jobs, nil
+}
+
+// Initialize the versioner.
+func (s *sqlJobQueue) initVersionTable() error {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		_, err := s.builder.CreateTable(versionTableName).
+			IfNotExists().
+			Column(idColVersions).Type(sqorc.ColumnTypeText).NotNull().PrimaryKey().EndColumn().
+			Column(actualColVersions).Type(sqorc.ColumnTypeInt).Default(0).NotNull().EndColumn().
+			Column(desiredColVersions).Type(sqorc.ColumnTypeInt).NotNull().EndColumn().
+			RunWith(tx).
+			Exec()
+		return nil, errors2.Wrap(err, "initialize indexer versions table")
+	}
+
+	_, err := sqorc.ExecInTx(s.db, &sql.TxOptions{Isolation: sql.LevelRepeatableRead}, nil, txFn)
+	return err
+}
+
+// getAllIndexerVersions returns a map of all stored indexer IDs to their desired and actual versions.
+func (s *sqlJobQueue) getAllIndexerVersions(tx *sql.Tx) (map[string]*indexerVersions, error) {
+	ret := map[string]*indexerVersions{}
+
+	rows, err := s.builder.Select(idColVersions, actualColVersions, desiredColVersions).
+		From(versionTableName).
+		RunWith(tx).
+		Query()
+	if err != nil {
+		return nil, errors2.Wrap(err, "get all indexer versions, select existing versions")
+	}
+
+	defer sqorc.CloseRowsLogOnError(rows, "GetAllIndexerVersions")
+
+	var idVal string
+	var actualVal, desiredVal int64 // int64 is driver's default int type, though these cols are actually int32 storing a uint32
+	for rows.Next() {
+		err = rows.Scan(&idVal, &actualVal, &desiredVal)
+		if err != nil {
+			return ret, errors2.Wrap(err, "get all indexer versions, SQL row scan error")
+		}
+
+		versions, err := newIndexerVersions(idVal, actualVal, desiredVal)
+		if err != nil {
+			return nil, err
+		}
+
+		ret[idVal] = versions
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return ret, errors2.Wrap(err, "get all indexer versions, SQL rows error")
+	}
+
+	return ret, nil
+}
+
+// overwriteAllIndexerDesiredVersions clears all stored indexer IDs then writes the passed ID to versions map.
+func (s *sqlJobQueue) overwriteAllIndexerDesiredVersions(tx *sql.Tx, versions map[string]*indexerVersions) error {
+	// Clear existing rows
+	_, err := s.builder.Delete(versionTableName).RunWith(tx).Exec()
+	if err != nil {
+		return errors2.Wrap(err, "overwrite all indexer versions, delete existing versions")
+	}
+
+	// Insert new rows
+	builder := s.builder.Insert(versionTableName).Columns(idColVersions, actualColVersions, desiredColVersions)
+	for id, version := range versions {
+		builder = builder.Values(id, version.actual, version.desired)
+	}
+	_, err = builder.RunWith(tx).Exec()
+	if err != nil {
+		return errors2.Wrap(err, "overwrite all indexer desired versions, insert new versions")
+	}
+
+	return nil
+}
+
+// updateIndexerActualVersion updates the actual version of an indexer.
+func (s *sqlJobQueue) updateIndexerActualVersion(tx *sql.Tx, indexerID string, version indexer.Version) error {
+	_, err := s.builder.Update(versionTableName).
+		Set(actualColVersions, version).
+		Where(squirrel.Eq{idColVersions: indexerID}).
+		RunWith(tx).
+		Exec()
+
+	if err != nil {
+		return errors2.Wrap(err, "update indexer actual versions")
+	}
+
+	return nil
+}

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql_test.go
@@ -1,0 +1,400 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+// NOTE: to run these tests outside the testing environment, e.g. from IntelliJ, ensure
+// Postgres container is running, and use the DATABASE_SOURCE environment variable
+// to target localhost and non-standard port.
+// Example: `host=localhost port=5433 dbname=magma_test user=magma_test password=magma_test sslmode=disable`.
+
+package reindex
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/services/state/indexer"
+	"magma/orc8r/cloud/go/sqorc"
+	"magma/orc8r/lib/go/definitions"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestGetComposedVersions(t *testing.T) {
+	type testCase struct {
+		new      map[string]indexer.Version
+		old      map[string]*indexerVersions
+		expected map[string]*indexerVersions
+	}
+	runCase := func(c testCase) {
+		recvd := getComposedVersionsImpl(c.new, c.old)
+		assert.Equal(t, c.expected, recvd)
+	}
+
+	noNewNoJobs := testCase{
+		new: map[string]indexer.Version{},
+		old: map[string]*indexerVersions{
+			id0: {desired: version0a, actual: version0},
+			id1: {desired: version1, actual: version1},
+		},
+		expected: map[string]*indexerVersions{
+			id0: {desired: version0a, actual: version0},
+			id1: {desired: version1, actual: version1},
+		},
+	}
+
+	noOldVersion := testCase{
+		new: map[string]indexer.Version{
+			id0: version0,
+		},
+		old: map[string]*indexerVersions{
+			id1: {desired: version1, actual: version1},
+		},
+		expected: map[string]*indexerVersions{
+			id0: {desired: version0, actual: zero},
+			id1: {desired: version1, actual: version1},
+		},
+	}
+
+	newVersionUnfinishedReindex := testCase{
+		new: map[string]indexer.Version{
+			id0: version0b,
+		},
+		old: map[string]*indexerVersions{
+			id0: {desired: version0a, actual: version0},
+			id1: {desired: version1, actual: version1},
+		},
+		expected: map[string]*indexerVersions{
+			id0: {desired: version0b, actual: version0},
+			id1: {desired: version1, actual: version1},
+		},
+	}
+
+	newVersionFinishedReindex := testCase{
+		new: map[string]indexer.Version{
+			id0: version0a,
+		},
+		old: map[string]*indexerVersions{
+			id0: {desired: version0, actual: version0},
+			id1: {desired: version1, actual: version1},
+		},
+		expected: map[string]*indexerVersions{
+			id0: {desired: version0a, actual: version0},
+			id1: {desired: version1, actual: version1},
+		},
+	}
+
+	runCase(noNewNoJobs)
+	runCase(noOldVersion)
+	runCase(newVersionUnfinishedReindex)
+	runCase(newVersionFinishedReindex)
+}
+
+func TestSQLReindexJobQueue_PopulateJobs(t *testing.T) {
+	queue := initQueueTest(t)
+
+	ch := make(chan interface{})
+	defer close(ch)
+	wg := sync.WaitGroup{}
+
+	// tx0 -- will be held up by the test hook, eventually fail to commit
+	testHookPopulateStart = func() {
+		ch <- nil
+		ch <- nil
+	}
+	wg.Add(1)
+	go func() {
+		populated, err := queue.PopulateJobs()
+		assert.NoError(t, err)
+		assert.False(t, populated)
+		wg.Done()
+	}()
+
+	select {
+	// tx0 has begun
+	case <-ch:
+	// Prevent test hanging
+	case <-time.After(15 * time.Second):
+		t.Fatal("PopulateJobs failed to start transaction")
+		return
+	}
+
+	// tx1 -- will begin after tx0 has begun, but tx1 will move first and commit its update
+	testHookPopulateStart = func() {}
+	populated, err := queue.PopulateJobs()
+	assert.NoError(t, err)
+	assert.True(t, populated)
+
+	<-ch // tx0 can continue, will fail
+	wg.Wait()
+
+	// All jobs are available
+	statuses, err := GetAllStatuses(queue)
+	assert.NoError(t, err)
+	for _, st := range statuses {
+		assert.Equal(t, StatusAvailable, st)
+	}
+}
+
+func TestSQLJobQueue_ClaimAvailableReindexJob(t *testing.T) {
+	queue := initQueueTest(t)
+
+	populated, err := queue.PopulateJobs()
+	assert.NoError(t, err)
+	assert.True(t, populated)
+
+	// Claim all idxs
+	jobX, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	jobY, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	jobZ, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+
+	// No jobs left
+	j, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+
+	// All jobs are in_progress
+	statuses, err := GetAllStatuses(queue)
+	assert.NoError(t, err)
+	for _, st := range statuses {
+		assert.Equal(t, StatusInProgress, st)
+	}
+
+	// Extract jobs/indexers to properly keep track by number
+	jobs := map[string]*Job{}
+	jobs[jobX.Idx.GetID()] = jobX
+	jobs[jobY.Idx.GetID()] = jobY
+	jobs[jobZ.Idx.GetID()] = jobZ
+	job0, job1, job2 := jobs[id0], jobs[id1], jobs[id2]
+	idx0, idx1, idx2 := job0.Idx, job1.Idx, job2.Idx
+
+	// Got correct from/to versions
+	assert.Equal(t, zero, job0.From)
+	assert.Equal(t, zero, job1.From)
+	assert.Equal(t, zero, job2.From)
+	assert.Equal(t, version0, job0.To)
+	assert.Equal(t, version1, job1.To)
+	assert.Equal(t, version2, job2.To)
+
+	// Successfully complete idx0
+	err = queue.CompleteJob(job0, nil)
+	assert.NoError(t, err)
+	status, err := GetStatus(queue, job0.Idx.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, StatusComplete, status)
+
+	// Fail to complete idx1 => retry=1, no error saved
+	err = queue.CompleteJob(job1, someErr)
+	assert.NoError(t, err)
+	errVal, err := GetError(queue, idx1.GetID())
+	assert.NoError(t, err)
+	assert.Empty(t, errVal)
+
+	// Claim new idx -- should be idx1 again
+	job1a, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	idx1a := job1a.Idx
+	assert.Equal(t, idx1.GetID(), idx1a.GetID())
+	assert.Equal(t, zero, job1a.From)
+	assert.Equal(t, version1, job1a.To)
+
+	// Still no errors saved
+	errs, err := queue.GetAllErrors()
+	assert.NoError(t, err)
+	assert.Empty(t, errVal)
+
+	// Fail to complete idx1 (aka idx1a) again => retry=2, error now saved
+	err = queue.CompleteJob(job1a, someErr)
+	assert.NoError(t, err)
+	status, err = GetStatus(queue, job1a.Idx.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, StatusAvailable, status)
+	errVal, err = GetError(queue, idx1a.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, someErr.Error(), errVal)
+
+	// Can't claim idx1 again -- no idxs left
+	j, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+
+	// Get all errors -- should just be for idx1
+	errs, err = queue.GetAllErrors()
+	assert.NoError(t, err)
+	assert.Contains(t, errs, idx1.GetID())
+	assert.Equal(t, someErr.Error(), errs[idx1.GetID()])
+
+	// Fail idx2, then claim but allow to time out -- should result in an err
+	err = queue.CompleteJob(job2, someErr)
+	assert.NoError(t, err)
+	errVal, err = GetError(queue, idx0.GetID())
+	assert.NoError(t, err)
+	assert.Empty(t, errVal)
+	job2a, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	idx2a := job2a.Idx
+	assert.Equal(t, idx2.GetID(), idx2a.GetID())
+
+	errVal, err = GetError(queue, idx2a.GetID())
+	assert.NoError(t, err)
+	assert.Empty(t, errVal)
+	clock.SetAndFreezeClock(t, time.Now().Add(10*time.Minute))
+	defer clock.UnfreezeClock(t)
+	errVal, err = GetError(queue, idx2a.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, someErr.Error(), errVal)
+
+	// Complete idx2 -- unspecified behavior but gracefully handle a job taking longer than default timeout
+	err = queue.CompleteJob(job2a, nil)
+	assert.NoError(t, err)
+	errVal, err = GetError(queue, idx0.GetID())
+	assert.NoError(t, err)
+	assert.Empty(t, errVal)
+	status, err = GetStatus(queue, job2a.Idx.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, StatusComplete, status)
+}
+
+// Update indexer version, repopulate should add new job
+func TestSQLJobQueue_RepopulateNewJobs(t *testing.T) {
+	queue := initQueueTest(t)
+
+	// Empty to start
+	j, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+
+	// Populate indexers
+	populated, err := queue.PopulateJobs()
+	assert.NoError(t, err)
+	assert.True(t, populated)
+
+	// Claim all idxs
+	jobX, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	jobY, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	jobZ, err := queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	// No jobs left
+	j, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+	// Extract jobs/indexers to properly keep track by number
+	jobs := map[string]*Job{}
+	jobs[jobX.Idx.GetID()] = jobX
+	jobs[jobY.Idx.GetID()] = jobY
+	jobs[jobZ.Idx.GetID()] = jobZ
+	job0, job1, job2 := jobs[id0], jobs[id1], jobs[id2]
+
+	// Complete all idxs
+	// Complete with success idx0, idx2
+	err = queue.CompleteJob(job0, nil)
+	assert.NoError(t, err)
+	err = queue.CompleteJob(job2, nil)
+	assert.NoError(t, err)
+	// Complete with fail idx1
+	err = queue.CompleteJob(job1, someErr)
+	assert.NoError(t, err)
+	_, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	err = queue.CompleteJob(job1, someErr)
+	assert.NoError(t, err)
+	errVal, err := GetError(queue, job1.Idx.GetID())
+	assert.NoError(t, err)
+	assert.Equal(t, someErr.Error(), errVal)
+	// No jobs left
+	j, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+
+	// Update version of indexer 0 -- previously succeeded
+	indexer.RegisterForTest(t, indexer0a)
+	updated, err := queue.PopulateJobs()
+	assert.NoError(t, err)
+	assert.True(t, updated)
+	// Update version of indexer 1 -- previously failed
+	indexer.RegisterForTest(t, indexer1a)
+	updated, err = queue.PopulateJobs()
+	assert.NoError(t, err)
+	assert.True(t, updated)
+
+	// Claim jobs -- idx0 and idx1 should both be present, across repopulations
+	jobZ, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	jobY, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	// No jobs remaining
+	j, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+
+	// Extract jobs/indexers to properly keep track by number
+	jobs = map[string]*Job{}
+	jobs[jobZ.Idx.GetID()] = jobZ
+	jobs[jobY.Idx.GetID()] = jobY
+	job0, job1 = jobs[id0], jobs[id1]
+	idx0, idx1 := job0.Idx, job1.Idx
+
+	// Check idx0 version -- previously succeeded
+	assert.Equal(t, indexer0a.GetID(), idx0.GetID())
+	assert.Equal(t, version0, job0.From)
+	assert.Equal(t, version0a, job0.To)
+	// Check idx1 version -- previously failed
+	assert.Equal(t, indexer1a.GetID(), idx1.GetID())
+	assert.Equal(t, zero, job1.From)
+	assert.Equal(t, version1a, job1.To)
+
+	// Complete job for indexer 0
+	err = queue.CompleteJob(job0, nil)
+	assert.NoError(t, err)
+	// Complete job for indexer 1
+	err = queue.CompleteJob(job1, nil)
+	assert.NoError(t, err)
+
+	// No jobs remaining
+	j, err = queue.ClaimAvailableJob()
+	assert.NoError(t, err)
+	assert.Nil(t, j)
+
+	// All jobs succeeded
+	statuses, err := GetAllStatuses(queue)
+	assert.NoError(t, err)
+	for _, st := range statuses {
+		assert.Equal(t, StatusComplete, st)
+	}
+}
+
+func initQueueTest(t *testing.T) JobQueue {
+	// Uncomment below to view reindex queue logs during test
+	//_ = flag.Set("alsologtostderr", "true")
+
+	indexer.DeregisterAllForTest(t)
+	err := indexer.RegisterAll(indexer0, indexer1, indexer2)
+	assert.NoError(t, err)
+
+	sqlDriver := definitions.GetEnvWithDefault("SQL_DRIVER", "postgres")
+	databaseSource := definitions.GetEnvWithDefault("DATABASE_SOURCE", connectionStringPostgres)
+	db, err := sqorc.Open(sqlDriver, databaseSource)
+	assert.NoError(t, err)
+
+	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", queueTableName))
+	assert.NoError(t, err)
+	_, err = db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %s", versionTableName))
+	assert.NoError(t, err)
+
+	queue := NewSQLJobQueue(maxAttempts, db, sqorc.GetSqlBuilder())
+	err = queue.Initialize()
+	assert.NoError(t, err)
+	return queue
+}

--- a/orc8r/cloud/go/services/state/indexer/reindex/test_utils.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/test_utils.go
@@ -1,0 +1,56 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+package reindex
+
+import (
+	"errors"
+
+	"magma/orc8r/cloud/go/services/state/indexer"
+)
+
+const (
+	connectionStringPostgres = "dbname=magma_test user=magma_test password=magma_test host=postgres_test sslmode=disable"
+
+	maxAttempts = 2
+
+	nid0 = "some_networkid_0"
+	nid1 = "some_networkid_1"
+	nid2 = "some_networkid_2"
+
+	hwid0 = "some_hwid_0"
+	hwid1 = "some_hwid_1"
+	hwid2 = "some_hwid_2"
+
+	id0 = "some_indexerid_0"
+	id1 = "some_indexerid_1"
+	id2 = "some_indexerid_2"
+	id3 = "some_indexerid_3"
+
+	zero      indexer.Version = 0
+	version0  indexer.Version = 100
+	version0a indexer.Version = 1000
+	version0b indexer.Version = 10000
+	version1  indexer.Version = 200
+	version1a indexer.Version = 2000
+	version2  indexer.Version = 300
+	version3  indexer.Version = 400
+)
+
+var (
+	someErr  = errors.New("some_error")
+	someErr1 = errors.New("some_error_1")
+	someErr2 = errors.New("some_error_2")
+	someErr3 = errors.New("some_error_3")
+
+	indexer0  = indexer.NewTestIndexer(id0, version0)
+	indexer0a = indexer.NewTestIndexer(id0, version0a)
+	indexer1  = indexer.NewTestIndexer(id1, version1)
+	indexer1a = indexer.NewTestIndexer(id1, version1a)
+	indexer2  = indexer.NewTestIndexer(id2, version2)
+)


### PR DESCRIPTION
Summary:
Unordered job queue for implemented using the `FOR UPDATE SKIP LOCKED` clause available in Postgres and Maria.

## Cross-controller coordination

Populating the job queue is an exactly-once operation. We handle this in two parts

- <= 1 -- the job queue jobs are written as part of a tx that checks the "stored" indexer versions, and these stored versions are updated the the "desired" versions during the same tx, ensuring no more than one controller instance will write to the job queue per code push
- >= 1 -- this work is best suited for a future where we have a message broker in the orc8r, so for now each controller warning-logs either success or failure to write to the job queue, and manual inspection of the logs would be required (thankfully, we also have tests to ensure this doesn't happen in the expected case)

Differential Revision: D20242297

