### PR TITLE
Health] Update failover functions to disable/enable radius service

### DIFF
--- a/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
@@ -70,6 +70,16 @@ func (d *DockerServiceHealthProvider) Enable(service string) error {
 	return d.dockerClient.ContainerRestart(context.Background(), sessiondID, &timeout)
 }
 
+// Disable stops the service provided
+func (d *DockerServiceHealthProvider) Disable(service string) error {
+	sessiondID, err := d.getContainerID(service)
+	if err != nil {
+		return err
+	}
+	timeout := dockerRequestTimeout
+	return d.dockerClient.ContainerStop(context.Background(), sessiondID, &timeout)
+}
+
 func (d *DockerServiceHealthProvider) getContainerID(serviceName string) (string, error) {
 	filter := filters.NewArgs()
 	filter.Add("name", serviceName)

--- a/cwf/gateway/services/gateway_health/health/service_health/service_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/service_health.go
@@ -19,4 +19,9 @@ type ServiceHealth interface {
 	// provided service. It is up to implementors to determine
 	// the specific functionality.
 	Enable(service string) error
+
+	// Disable allows the disabling of service level functionality for the
+	// provided service. It is up to implementors to determine
+	// the specific functionality.
+	Disable(service string) error
 }

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
@@ -58,6 +58,7 @@ func TestGetHealthStatus(t *testing.T) {
 
 	// Simulate successful enable
 	mockSystem.On("Enable").Return(nil)
+	mockService.On("Enable", "radius").Return(nil)
 	mockService.On("Enable", "sessiond").Return(nil)
 	_, err = servicer.Enable(context.Background(), req)
 	assert.NoError(t, err)
@@ -77,6 +78,7 @@ func TestGetHealthStatus(t *testing.T) {
 	// Simulate successful disable
 	disableReq := &protos.DisableMessage{}
 	mockSystem.On("Disable").Return(nil)
+	mockService.On("Disable", "radius").Return(nil)
 	_, err = servicer.Disable(context.Background(), disableReq)
 	assert.NoError(t, err)
 	assertMocks(t, mockGREProbe, mockSystem, mockService)
@@ -120,6 +122,11 @@ func (m *mockServiceHealth) GetUnhealthyServices() ([]string, error) {
 }
 
 func (m *mockServiceHealth) Enable(service string) error {
+	args := m.Called(service)
+	return args.Error(0)
+}
+
+func (m *mockServiceHealth) Disable(service string) error {
 	args := m.Called(service)
 	return args.Error(0)
 }


### PR DESCRIPTION
Summary:
The WLC we use in the lab detects GRE health and RADIUS/AAA server health seperately.
Therefore, we need to disable the RADIUS server in order for control-plane traffic to failover
when the CWAGs failover.

Reviewed By: themarwhal

Differential Revision: D21008654

