### PR TITLE
Update gateway_go image to build radius binary

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -29,7 +29,6 @@ CWF_IMAGES = [
     'cwag_go'
     'gateway_go',
     'gateway_python',
-    'gateway_radius',
     'gateway_sessiond',
     'gateway_pipelined',
 ]

--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -26,6 +26,7 @@ STACKS = [
 ]
 
 CWF_IMAGES = [
+    'cwag_go'
     'gateway_go',
     'gateway_python',
     'gateway_radius',

--- a/cwf/gateway/docker/docker-compose.override.yml
+++ b/cwf/gateway/docker/docker-compose.override.yml
@@ -31,17 +31,7 @@ services:
       context: ${BUILD_CONTEXT}
       dockerfile: cwf/gateway/docker/python/Dockerfile
 
-  radius:
-    build:
-      context: ${BUILD_CONTEXT}
-      dockerfile: feg/gateway/docker/radius/Dockerfile
-
   sessiond:
     build:
       context: ${BUILD_CONTEXT}
       dockerfile: cwf/gateway/docker/c/Dockerfile
-
-  uesim:
-    build:
-      context: ${BUILD_CONTEXT}
-      dockerfile: cwf/gateway/docker/go/Dockerfile

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -158,7 +158,7 @@ services:
     command: python3 -m magma.redirectd.main
 
   radius:
-    image: ${DOCKER_REGISTRY}gateway_radius:${IMAGE_VERSION}
+    image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
     container_name: radius
     logging: *logging_anchor
     environment:
@@ -179,6 +179,9 @@ services:
       retries: 3
     network_mode: host
     restart: always
+    command: >
+      /bin/bash -c "envsubst < /etc/magma/templates/radius.conf.template > /var/opt/magma/tmp/radius.config.json &&
+             envdir /var/opt/magma/envdir /var/opt/magma/bin/radius -config /var/opt/magma/tmp/radius.config.json"
 
   radiusd:
     <<: *feggoservice

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -65,6 +65,10 @@ ENV GOPROXY https://proxy.golang.org
 
 RUN printenv > /etc/environment
 
+COPY feg/radius/lib/go/ /radius/lib/go
+COPY feg/radius/src/go.* /radius/src/
+WORKDIR /radius/src
+RUN go mod download
 
 # Copy just the go.mod and go.sum files to download the golang deps.
 # This step allows us to cache the downloads, and prevents reaching out to
@@ -104,6 +108,9 @@ FROM base as builder
 # RUN make -C $MAGMA_ROOT/feg/gateway gen
 RUN make -C $MAGMA_ROOT/feg/gateway build
 
+WORKDIR $MAGMA_ROOT/feg/radius/src
+RUN ./run.sh build
+
 # -----------------------------------------------------------------------------
 # Go-cache base image
 # -----------------------------------------------------------------------------
@@ -116,15 +123,18 @@ COPY --from=builder /root/.cache /root/.cache
 FROM ubuntu:xenial AS gateway_go
 
 # Install envdir.
-RUN apt-get -y update && apt-get -y install daemontools netcat
+RUN apt-get -y update && apt-get -y install daemontools netcat gettext musl
 
+ENV MAGMA_ROOT /magma
 # Copy the build artifacts.
 COPY --from=builder /var/opt/magma/bin /var/opt/magma/bin
+COPY --from=builder $MAGMA_ROOT/feg/radius/src/radius /var/opt/magma/bin/radius
+COPY --from=builder $MAGMA_ROOT/feg/radius/src/config/samples/radius.cwf.config.json.template /etc/magma/templates/radius.conf.template
 
 # Copy the configs.
 COPY feg/gateway/configs /etc/magma
 
 # Create empty envdir directory
 RUN mkdir -p /var/opt/magma/envdir
-
 RUN mkdir -p /var/opt/magma/configs
+RUN mkdir -p /var/opt/magma/tmp


### PR DESCRIPTION
Summary:
This diff updates the dockerfile at magma/feg/gateway/docker/go
to include building the radius binary. Since the radius server is in
golang this is an easy inclusion. This gives us:

1. Less images to build and publish for the CWAG
2. Closer to all bionic base images for the CWAG
3. Closer to a magma style of running for radius (binary, template, configs locations)

The radius dockerfile will be deleted in a later diff.

Reviewed By: themarwhal

Differential Revision: D21049108

