### PR TITLE
Delete bearer on core initiated session terminate

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -24,16 +24,16 @@
 
 namespace {
 
-std::chrono::milliseconds time_difference_from_now(
-    const google::protobuf::Timestamp& timestamp) {
+std::chrono::milliseconds
+time_difference_from_now(const google::protobuf::Timestamp &timestamp) {
   auto rule_time_sec =
       google::protobuf::util::TimeUtil::TimestampToSeconds(timestamp);
-  auto now   = time(NULL);
+  auto now = time(NULL);
   auto delta = std::max(rule_time_sec - now, 0L);
   std::chrono::seconds sec(delta);
   return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
 }
-}  // namespace
+} // namespace
 
 namespace magma {
 
@@ -45,26 +45,28 @@ using google::protobuf::util::TimeUtil;
 // We will treat rule install/uninstall failures as all-or-nothing - that is,
 // if we get a bad response from the pipelined client, we'll mark all the rules
 // as failed in the response
-static void mark_rule_failures(
-    const bool activate_success, const bool deactivate_success,
-    const PolicyReAuthRequest& request, PolicyReAuthAnswer& answer_out);
+static void mark_rule_failures(const bool activate_success,
+                               const bool deactivate_success,
+                               const PolicyReAuthRequest &request,
+                               PolicyReAuthAnswer &answer_out);
 // For command level result codes, we will mark the subscriber to be terminated
 // if the result code indicates a permanent failure.
 static void handle_command_level_result_code(
-    const std::string& imsi, const uint32_t result_code,
-    std::unordered_set<std::string>& subscribers_to_terminate);
-static bool isValidMacAddress(const char* mac);
-static int get_apn_split_locaion(const std::string& apn);
-static bool parse_apn(
-    const std::string& apn, std::string& mac_addr, std::string& name);
+    const std::string &imsi, const uint32_t result_code,
+    std::unordered_set<std::string> &subscribers_to_terminate);
+static bool isValidMacAddress(const char *mac);
+static int get_apn_split_locaion(const std::string &apn);
+static bool parse_apn(const std::string &apn, std::string &mac_addr,
+                      std::string &name);
 
-static SubscriberQuotaUpdate make_subscriber_quota_update(
-    const std::string& imsi, const std::string& ue_mac_addr,
-    const SubscriberQuotaUpdate_Type state);
+static SubscriberQuotaUpdate
+make_subscriber_quota_update(const std::string &imsi,
+                             const std::string &ue_mac_addr,
+                             const SubscriberQuotaUpdate_Type state);
 
 LocalEnforcer::LocalEnforcer(
     std::shared_ptr<SessionReporter> reporter,
-    std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
+    std::shared_ptr<StaticRuleStore> rule_store, SessionStore &session_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
     std::shared_ptr<AsyncEventdClient> eventd_client,
@@ -72,34 +74,30 @@ LocalEnforcer::LocalEnforcer(
     std::shared_ptr<aaa::AAAClient> aaa_client,
     long session_force_termination_timeout_ms,
     long quota_exhaustion_termination_on_init_ms)
-    : reporter_(reporter),
-      rule_store_(rule_store),
-      session_store_(session_store),
-      pipelined_client_(pipelined_client),
-      directoryd_client_(directoryd_client),
-      eventd_client_(eventd_client),
-      spgw_client_(spgw_client),
-      aaa_client_(aaa_client),
+    : reporter_(reporter), rule_store_(rule_store),
+      session_store_(session_store), pipelined_client_(pipelined_client),
+      directoryd_client_(directoryd_client), eventd_client_(eventd_client),
+      spgw_client_(spgw_client), aaa_client_(aaa_client),
       session_force_termination_timeout_ms_(
           session_force_termination_timeout_ms),
       quota_exhaustion_termination_on_init_ms_(
           quota_exhaustion_termination_on_init_ms) {}
 
-void LocalEnforcer::notify_new_report_for_sessions(SessionMap& session_map) {
-  for (const auto& session_pair : session_map) {
-    for (const auto& session : session_pair.second) {
+void LocalEnforcer::notify_new_report_for_sessions(SessionMap &session_map) {
+  for (const auto &session_pair : session_map) {
+    for (const auto &session : session_pair.second) {
       session->new_report();
     }
   }
 }
 
 void LocalEnforcer::notify_finish_report_for_sessions(
-    SessionMap& session_map, SessionUpdate& session_update) {
+    SessionMap &session_map, SessionUpdate &session_update) {
   // Iterate through sessions and notify that report has finished. Terminate any
   // sessions that can be terminated.
   std::vector<std::pair<std::string, std::string>> imsi_to_terminate;
-  for (const auto& session_pair : session_map) {
-    for (const auto& session : session_pair.second) {
+  for (const auto &session_pair : session_map) {
+    for (const auto &session : session_pair.second) {
       session->finish_report();
       if (session->can_complete_termination()) {
         imsi_to_terminate.push_back(
@@ -107,33 +105,24 @@ void LocalEnforcer::notify_finish_report_for_sessions(
       }
     }
   }
-  for (const auto& imsi_sid_pair : imsi_to_terminate) {
-    SessionStateUpdateCriteria& update_criteria =
+  for (const auto &imsi_sid_pair : imsi_to_terminate) {
+    SessionStateUpdateCriteria &update_criteria =
         session_update[imsi_sid_pair.first][imsi_sid_pair.second];
-    complete_termination(
-        session_map, imsi_sid_pair.first, imsi_sid_pair.second,
-        update_criteria);
+    complete_termination(session_map, imsi_sid_pair.first, imsi_sid_pair.second,
+                         update_criteria);
   }
 }
 
-void LocalEnforcer::start() {
-  evb_->loopForever();
-}
+void LocalEnforcer::start() { evb_->loopForever(); }
 
-void LocalEnforcer::attachEventBase(folly::EventBase* evb) {
-  evb_ = evb;
-}
+void LocalEnforcer::attachEventBase(folly::EventBase *evb) { evb_ = evb; }
 
-void LocalEnforcer::stop() {
-  evb_->terminateLoopSoon();
-}
+void LocalEnforcer::stop() { evb_->terminateLoopSoon(); }
 
-folly::EventBase& LocalEnforcer::get_event_base() {
-  return *evb_;
-}
+folly::EventBase &LocalEnforcer::get_event_base() { return *evb_; }
 
 bool LocalEnforcer::setup(
-    SessionMap& session_map, const std::uint64_t& epoch,
+    SessionMap &session_map, const std::uint64_t &epoch,
     std::function<void(Status status, SetupFlowsResult)> callback) {
   std::vector<SessionState::SessionInfo> session_infos;
   std::vector<SubscriberQuotaUpdate> quota_updates;
@@ -143,7 +132,7 @@ bool LocalEnforcer::setup(
   std::vector<std::string> apn_names;
   auto cwf = false;
   for (auto it = session_map.begin(); it != session_map.end(); it++) {
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       SessionState::SessionInfo session_info;
       session->get_session_info(session_info);
       session_infos.push_back(session_info);
@@ -157,33 +146,33 @@ bool LocalEnforcer::setup(
       if (!parse_apn(apn, apn_mac_addr, apn_name)) {
         MLOG(MWARNING) << "Failed mac/name parsiong for apn " << apn;
         apn_mac_addr = "";
-        apn_name     = apn;
+        apn_name = apn;
       }
       apn_mac_addrs.push_back(apn_mac_addr);
       apn_names.push_back(apn_name);
       if (session->is_radius_cwf_session()) {
-        cwf                          = true;
-        SubscriberQuotaUpdate update = make_subscriber_quota_update(
-            session_info.imsi, ue_mac_addr,
-            session->get_subscriber_quota_state());
+        cwf = true;
+        SubscriberQuotaUpdate update =
+            make_subscriber_quota_update(session_info.imsi, ue_mac_addr,
+                                         session->get_subscriber_quota_state());
         quota_updates.push_back(update);
       }
     }
   }
   if (cwf) {
-    return pipelined_client_->setup_cwf(
-        session_infos, quota_updates, ue_mac_addrs, msisdns, apn_mac_addrs,
-        apn_names, epoch, callback);
+    return pipelined_client_->setup_cwf(session_infos, quota_updates,
+                                        ue_mac_addrs, msisdns, apn_mac_addrs,
+                                        apn_names, epoch, callback);
   } else {
     return pipelined_client_->setup_lte(session_infos, epoch, callback);
   }
 }
 
-void LocalEnforcer::aggregate_records(
-    SessionMap& session_map, const RuleRecordTable& records,
-    SessionUpdate& session_update) {
-  notify_new_report_for_sessions(session_map);  // unmark all credits
-  for (const RuleRecord& record : records.records()) {
+void LocalEnforcer::aggregate_records(SessionMap &session_map,
+                                      const RuleRecordTable &records,
+                                      SessionUpdate &session_update) {
+  notify_new_report_for_sessions(session_map); // unmark all credits
+  for (const RuleRecord &record : records.records()) {
     auto it = session_map.find(record.sid());
     if (it == session_map.end()) {
       MLOG(MERROR) << "Could not find session for IMSI " << record.sid()
@@ -197,25 +186,25 @@ void LocalEnforcer::aggregate_records(
                   << " rx bytes for rule " << record.rule_id();
     }
     // Update sessions
-    for (const auto& session : it->second) {
-      SessionStateUpdateCriteria& uc =
+    for (const auto &session : it->second) {
+      SessionStateUpdateCriteria &uc =
           session_update[record.sid()][session->get_session_id()];
-      session->add_used_credit(
-          record.rule_id(), record.bytes_tx(), record.bytes_rx(), uc);
+      session->add_used_credit(record.rule_id(), record.bytes_tx(),
+                               record.bytes_rx(), uc);
     }
   }
   notify_finish_report_for_sessions(session_map, session_update);
 }
 
 void LocalEnforcer::execute_actions(
-    SessionMap& session_map,
-    const std::vector<std::unique_ptr<ServiceAction>>& actions,
-    SessionUpdate& session_update) {
-  for (const auto& action_p : actions) {
+    SessionMap &session_map,
+    const std::vector<std::unique_ptr<ServiceAction>> &actions,
+    SessionUpdate &session_update) {
+  for (const auto &action_p : actions) {
     if (action_p->get_type() == TERMINATE_SERVICE) {
-      terminate_service(
-          session_map, action_p->get_imsi(), action_p->get_rule_ids(),
-          action_p->get_rule_definitions(), session_update);
+      terminate_service(session_map, action_p->get_imsi(),
+                        action_p->get_rule_ids(),
+                        action_p->get_rule_definitions(), session_update);
     } else if (action_p->get_type() == ACTIVATE_SERVICE) {
       pipelined_client_->activate_flows_for_rules(
           action_p->get_imsi(), action_p->get_ip_addr(),
@@ -225,15 +214,15 @@ void LocalEnforcer::execute_actions(
     } else if (action_p->get_type() == RESTRICT_ACCESS) {
       MLOG(MWARNING) << "RESTRICT_ACCESS mode is unsupported"
                      << ", will just terminate the service.";
-      terminate_service(
-          session_map, action_p->get_imsi(), action_p->get_rule_ids(),
-          action_p->get_rule_definitions(), session_update);
+      terminate_service(session_map, action_p->get_imsi(),
+                        action_p->get_rule_ids(),
+                        action_p->get_rule_definitions(), session_update);
     }
   }
 }
 
 void LocalEnforcer::set_termination_callback(
-    SessionMap& session_map, const std::string& imsi, const std::string& apn,
+    SessionMap &session_map, const std::string &imsi, const std::string &apn,
     std::function<void(SessionTerminateRequest)> on_termination_callback) {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
@@ -241,7 +230,7 @@ void LocalEnforcer::set_termination_callback(
                  << " during termination";
     throw SessionNotFound();
   }
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     session->set_termination_callback(on_termination_callback);
   }
 }
@@ -249,10 +238,10 @@ void LocalEnforcer::set_termination_callback(
 // Terminates sessions that correspond to the given IMSI.
 // (For session termination triggered by sessiond)
 void LocalEnforcer::terminate_service(
-    SessionMap& session_map, const std::string& imsi,
-    const std::vector<std::string>& rule_ids,
-    const std::vector<PolicyRule>& dynamic_rules,
-    SessionUpdate& session_update) {
+    SessionMap &session_map, const std::string &imsi,
+    const std::vector<std::string> &rule_ids,
+    const std::vector<PolicyRule> &dynamic_rules,
+    SessionUpdate &session_update) {
   pipelined_client_->deactivate_flows_for_rules(imsi, rule_ids, dynamic_rules);
 
   auto it = session_map.find(imsi);
@@ -262,32 +251,38 @@ void LocalEnforcer::terminate_service(
     return;
   }
 
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     auto update_criteria = session_update[imsi][session->get_session_id()];
 
     session->start_termination(update_criteria);
 
     // tell AAA service to terminate radius session if necessary
     if (session->is_radius_cwf_session()) {
+      auto radius_session_id = session->get_radius_session_id();
       MLOG(MDEBUG) << "Asking AAA service to terminate session with "
-                   << "Radius ID: " << session->get_radius_session_id()
-                   << ", IMSI: " << imsi;
-      aaa_client_->terminate_session(session->get_radius_session_id(), imsi);
+                   << "Radius ID: " << radius_session_id << ", IMSI: " << imsi;
+      aaa_client_->terminate_session(radius_session_id, imsi);
 
       MLOG(MDEBUG) << "Deleting UE MAC flow for subscriber " << imsi;
+      auto mac_addr = session->get_mac_addr();
       SubscriberID sid;
       sid.set_id(imsi);
       bool delete_ue_mac_flow_success =
-          pipelined_client_->delete_ue_mac_flow(sid, session->get_mac_addr());
+          pipelined_client_->delete_ue_mac_flow(sid, mac_addr);
       if (!delete_ue_mac_flow_success) {
         MLOG(MERROR) << "Failed to delete UE MAC flow for subscriber " << imsi;
       }
       MLOG(MDEBUG) << "Setting subscriber quota state as TERMINATE "
                    << "for subscriber " << imsi;
-      session->set_subscriber_quota_state(
-          SubscriberQuotaUpdate_Type_TERMINATE, update_criteria);
+      session->set_subscriber_quota_state(SubscriberQuotaUpdate_Type_TERMINATE,
+                                          update_criteria);
       report_subscriber_state_to_pipelined(
-          imsi, session->get_mac_addr(), SubscriberQuotaUpdate_Type_TERMINATE);
+          imsi, mac_addr, SubscriberQuotaUpdate_Type_TERMINATE);
+    } else {
+      // Deleting the PDN session by triggering network issued default bearer
+      // deactivation
+      spgw_client_->delete_default_bearer(
+          imsi, session->get_subscriber_ip_addr(), session->get_bearer_id());
     }
 
     std::string session_id = session->get_session_id();
@@ -298,15 +293,15 @@ void LocalEnforcer::terminate_service(
     evb_->runAfterDelay(
         [this, imsi, session_id] {
           MLOG(MDEBUG) << "Forced service termination for IMSI " << imsi;
-          SessionRead req  = {imsi};
+          SessionRead req = {imsi};
           auto session_map = session_store_.read_sessions_for_deletion(req);
           auto session_update =
               SessionStore::get_default_session_update(session_map);
           if (session_update[imsi].find(session_id) !=
               session_update[imsi].end()) {
-            auto& update_criteria = session_update[imsi][session_id];
-            complete_termination(
-                session_map, imsi, session_id, update_criteria);
+            auto &update_criteria = session_update[imsi][session_id];
+            complete_termination(session_map, imsi, session_id,
+                                 update_criteria);
             bool end_success = session_store_.update_sessions(session_update);
             if (end_success) {
               MLOG(MDEBUG) << "Ended session " << imsi
@@ -327,28 +322,28 @@ void LocalEnforcer::terminate_service(
 }
 
 // TODO: make session_manager.proto and policydb.proto to use common field
-static RedirectInformation_AddressType address_type_converter(
-    RedirectServer_RedirectAddressType address_type) {
+static RedirectInformation_AddressType
+address_type_converter(RedirectServer_RedirectAddressType address_type) {
   switch (address_type) {
-    case RedirectServer_RedirectAddressType_IPV4:
-      return RedirectInformation_AddressType_IPv4;
-    case RedirectServer_RedirectAddressType_IPV6:
-      return RedirectInformation_AddressType_IPv6;
-    case RedirectServer_RedirectAddressType_URL:
-      return RedirectInformation_AddressType_URL;
-    case RedirectServer_RedirectAddressType_SIP_URI:
-      return RedirectInformation_AddressType_SIP_URI;
+  case RedirectServer_RedirectAddressType_IPV4:
+    return RedirectInformation_AddressType_IPv4;
+  case RedirectServer_RedirectAddressType_IPV6:
+    return RedirectInformation_AddressType_IPv6;
+  case RedirectServer_RedirectAddressType_URL:
+    return RedirectInformation_AddressType_URL;
+  case RedirectServer_RedirectAddressType_SIP_URI:
+    return RedirectInformation_AddressType_SIP_URI;
   }
 }
 
-static PolicyRule create_redirect_rule(
-    const std::unique_ptr<ServiceAction>& action) {
+static PolicyRule
+create_redirect_rule(const std::unique_ptr<ServiceAction> &action) {
   PolicyRule redirect_rule;
   redirect_rule.set_id("redirect");
   redirect_rule.set_priority(LocalEnforcer::REDIRECT_FLOW_PRIORITY);
   action->get_credit_key().set_rule(&redirect_rule);
 
-  RedirectInformation* redirect_info = redirect_rule.mutable_redirect();
+  RedirectInformation *redirect_info = redirect_rule.mutable_redirect();
   redirect_info->set_support(RedirectInformation_Support_ENABLED);
 
   auto redirect_server = action->get_redirect_server();
@@ -360,14 +355,14 @@ static PolicyRule create_redirect_rule(
 }
 
 void LocalEnforcer::install_redirect_flow(
-    const std::unique_ptr<ServiceAction>& action) {
+    const std::unique_ptr<ServiceAction> &action) {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules{create_redirect_rule(action)};
-  const std::string& imsi = action->get_imsi();
+  const std::string &imsi = action->get_imsi();
 
   auto request = directoryd_client_->get_directoryd_ip_field(
-      imsi, [this, imsi, static_rules, dynamic_rules](
-                Status status, DirectoryField resp) {
+      imsi, [this, imsi, static_rules, dynamic_rules](Status status,
+                                                      DirectoryField resp) {
         if (!status.ok()) {
           MLOG(MERROR) << "Could not fetch subscriber " << imsi << "ip, "
                        << "redirection fails, error: "
@@ -380,14 +375,14 @@ void LocalEnforcer::install_redirect_flow(
 }
 
 UpdateSessionRequest LocalEnforcer::collect_updates(
-    SessionMap& session_map,
-    std::vector<std::unique_ptr<ServiceAction>>& actions,
-    SessionUpdate& session_update, const bool force_update) const {
+    SessionMap &session_map,
+    std::vector<std::unique_ptr<ServiceAction>> &actions,
+    SessionUpdate &session_update, const bool force_update) const {
   UpdateSessionRequest request;
-  for (const auto& session_pair : session_map) {
-    for (const auto& session : session_pair.second) {
-      std::string imsi     = session_pair.first;
-      std::string sid      = session->get_session_id();
+  for (const auto &session_pair : session_map) {
+    for (const auto &session : session_pair.second) {
+      std::string imsi = session_pair.first;
+      std::string sid = session->get_session_id();
       auto update_criteria = session_update[imsi][sid];
       session->get_updates(request, &actions, update_criteria, force_update);
     }
@@ -395,9 +390,9 @@ UpdateSessionRequest LocalEnforcer::collect_updates(
   return request;
 }
 
-void LocalEnforcer::reset_updates(
-    SessionMap& session_map, const UpdateSessionRequest& failed_request) {
-  for (const auto& update : failed_request.updates()) {
+void LocalEnforcer::reset_updates(SessionMap &session_map,
+                                  const UpdateSessionRequest &failed_request) {
+  for (const auto &update : failed_request.updates()) {
     auto it = session_map.find(update.sid());
     if (it == session_map.end()) {
       MLOG(MERROR) << "Could not reset credit for IMSI " << update.sid()
@@ -405,7 +400,7 @@ void LocalEnforcer::reset_updates(
       return;
     }
 
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       // When updates are reset, they aren't written back into SessionStore,
       // so we can just put in a default UpdateCriteria
       auto uc = get_default_update_criteria();
@@ -413,7 +408,7 @@ void LocalEnforcer::reset_updates(
           CreditKey(update.usage()), uc);
     }
   }
-  for (const auto& update : failed_request.usage_monitors()) {
+  for (const auto &update : failed_request.usage_monitors()) {
     auto it = session_map.find(update.sid());
     if (it == session_map.end()) {
       MLOG(MERROR) << "Could not reset credit for IMSI " << update.sid()
@@ -421,7 +416,7 @@ void LocalEnforcer::reset_updates(
       return;
     }
 
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       // When updates are reset, they aren't written back into SessionStore,
       // so we can just put in a default UpdateCriteria
       auto uc = get_default_update_criteria();
@@ -437,9 +432,9 @@ void LocalEnforcer::reset_updates(
  * If a rule has a monitoring key, it is not required that a usage monitor is
  * installed with quota
  */
-static bool should_activate(
-    const PolicyRule& rule,
-    const std::unordered_set<uint32_t>& successful_credits) {
+static bool
+should_activate(const PolicyRule &rule,
+                const std::unordered_set<uint32_t> &successful_credits) {
   if (rule.tracking_type() == PolicyRule::ONLY_OCS ||
       rule.tracking_type() == PolicyRule::OCS_AND_PCRF) {
     const bool exists = successful_credits.count(rule.rating_group()) > 0;
@@ -451,29 +446,29 @@ static bool should_activate(
     }
   }
   switch (rule.tracking_type()) {
-    case PolicyRule::ONLY_PCRF:
-      MLOG(MINFO) << "Activating Gx tracked rule " << rule.id()
-                  << " with monitoring key " << rule.monitoring_key();
-      break;
-    case PolicyRule::ONLY_OCS:
-      MLOG(MINFO) << "Activating Gy tracked rule " << rule.id()
-                  << " with rating group " << rule.rating_group();
-      break;
-    case PolicyRule::OCS_AND_PCRF:
-      MLOG(MINFO) << "Activating Gx+Gy tracked rule " << rule.id()
-                  << " with monitoring key " << rule.monitoring_key()
-                  << " with rating group " << rule.rating_group();
-      break;
-    case PolicyRule::NO_TRACKING:
-      MLOG(MINFO) << "Activating untracked rule " << rule.id();
-      break;
+  case PolicyRule::ONLY_PCRF:
+    MLOG(MINFO) << "Activating Gx tracked rule " << rule.id()
+                << " with monitoring key " << rule.monitoring_key();
+    break;
+  case PolicyRule::ONLY_OCS:
+    MLOG(MINFO) << "Activating Gy tracked rule " << rule.id()
+                << " with rating group " << rule.rating_group();
+    break;
+  case PolicyRule::OCS_AND_PCRF:
+    MLOG(MINFO) << "Activating Gx+Gy tracked rule " << rule.id()
+                << " with monitoring key " << rule.monitoring_key()
+                << " with rating group " << rule.rating_group();
+    break;
+  case PolicyRule::NO_TRACKING:
+    MLOG(MINFO) << "Activating untracked rule " << rule.id();
+    break;
   }
   return true;
 }
 
 void LocalEnforcer::schedule_static_rule_activation(
-    const std::string& imsi, const std::string& ip_addr,
-    const StaticRuleInstall& static_rule) {
+    const std::string &imsi, const std::string &ip_addr,
+    const StaticRuleInstall &static_rule) {
   std::vector<std::string> static_rules{static_rule.rule_id()};
   std::vector<PolicyRule> dynamic_rules;
 
@@ -495,9 +490,9 @@ void LocalEnforcer::schedule_static_rule_activation(
                            << "during installation of static rule "
                            << static_rule.rule_id();
           } else {
-            for (const auto& session : it->second) {
+            for (const auto &session : it->second) {
               if (session->get_subscriber_ip_addr() == ip_addr) {
-                auto& uc = session_update[imsi][session->get_session_id()];
+                auto &uc = session_update[imsi][session->get_session_id()];
                 session->activate_static_rule(static_rule.rule_id(), uc);
               }
             }
@@ -510,8 +505,8 @@ void LocalEnforcer::schedule_static_rule_activation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_activation(
-    const std::string& imsi, const std::string& ip_addr,
-    const DynamicRuleInstall& dynamic_rule) {
+    const std::string &imsi, const std::string &ip_addr,
+    const DynamicRuleInstall &dynamic_rule) {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules{dynamic_rule.policy_rule()};
 
@@ -533,9 +528,9 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
                            << "during installation of dynamic rule "
                            << dynamic_rule.policy_rule().id();
           } else {
-            for (const auto& session : it->second) {
+            for (const auto &session : it->second) {
               if (session->get_subscriber_ip_addr() == ip_addr) {
-                auto& uc = session_update[imsi][session->get_session_id()];
+                auto &uc = session_update[imsi][session->get_session_id()];
                 session->insert_dynamic_rule(dynamic_rule.policy_rule(), uc);
               }
             }
@@ -548,7 +543,7 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
 }
 
 void LocalEnforcer::schedule_static_rule_deactivation(
-    const std::string& imsi, const StaticRuleInstall& static_rule) {
+    const std::string &imsi, const StaticRuleInstall &static_rule) {
   std::vector<std::string> static_rules{static_rule.rule_id()};
   std::vector<PolicyRule> dynamic_rules;
 
@@ -562,20 +557,20 @@ void LocalEnforcer::schedule_static_rule_deactivation(
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto session_update =
               session_store_.get_default_session_update(session_map);
-          pipelined_client_->deactivate_flows_for_rules(
-              imsi, static_rules, dynamic_rules);
+          pipelined_client_->deactivate_flows_for_rules(imsi, static_rules,
+                                                        dynamic_rules);
           auto it = session_map.find(imsi);
           if (it == session_map.end()) {
             MLOG(MWARNING) << "Could not find session for IMSI " << imsi
                            << "during removal of static rule "
                            << static_rule.rule_id();
           } else {
-            for (const auto& session : it->second) {
-              auto& uc = session_update[imsi][session->get_session_id()];
+            for (const auto &session : it->second) {
+              auto &uc = session_update[imsi][session->get_session_id()];
               if (!session->deactivate_static_rule(static_rule.rule_id(), uc))
-                MLOG(MWARNING)
-                    << "Could not find rule " << static_rule.rule_id()
-                    << "for IMSI " << imsi << " during static rule removal";
+                MLOG(MWARNING) << "Could not find rule "
+                               << static_rule.rule_id() << "for IMSI " << imsi
+                               << " during static rule removal";
             }
             auto update_success =
                 session_store_.update_sessions(session_update);
@@ -586,7 +581,7 @@ void LocalEnforcer::schedule_static_rule_deactivation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_deactivation(
-    const std::string& imsi, const DynamicRuleInstall& dynamic_rule) {
+    const std::string &imsi, const DynamicRuleInstall &dynamic_rule) {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules{dynamic_rule.policy_rule()};
 
@@ -600,8 +595,8 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto session_update =
               session_store_.get_default_session_update(session_map);
-          pipelined_client_->deactivate_flows_for_rules(
-              imsi, static_rules, dynamic_rules);
+          pipelined_client_->deactivate_flows_for_rules(imsi, static_rules,
+                                                        dynamic_rules);
           auto it = session_map.find(imsi);
           if (it == session_map.end()) {
             MLOG(MWARNING) << "Could not find session for IMSI " << imsi
@@ -609,10 +604,10 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
                            << dynamic_rule.policy_rule().id();
           } else {
             PolicyRule rule_dont_care;
-            for (const auto& session : it->second) {
-              auto& uc = session_update[imsi][session->get_session_id()];
-              session->remove_dynamic_rule(
-                  dynamic_rule.policy_rule().id(), &rule_dont_care, uc);
+            for (const auto &session : it->second) {
+              auto &uc = session_update[imsi][session->get_session_id()];
+              session->remove_dynamic_rule(dynamic_rule.policy_rule().id(),
+                                           &rule_dont_care, uc);
             }
             auto update_success =
                 session_store_.update_sessions(session_update);
@@ -623,12 +618,12 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
 }
 
 void LocalEnforcer::process_create_session_response(
-    SessionMap& session_map, const CreateSessionResponse& response,
-    const std::unordered_set<uint32_t>& successful_credits,
-    const std::string& imsi, const std::string& ip_addr,
-    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate) {
+    SessionMap &session_map, const CreateSessionResponse &response,
+    const std::unordered_set<uint32_t> &successful_credits,
+    const std::string &imsi, const std::string &ip_addr,
+    RulesToProcess &rules_to_activate, RulesToProcess &rules_to_deactivate) {
   std::time_t current_time = time(NULL);
-  for (const auto& static_rule : response.static_rules()) {
+  for (const auto &static_rule : response.static_rules()) {
     auto id = static_rule.rule_id();
     PolicyRule rule;
     if (!rule_store_->get_rule(id, &rule)) {
@@ -661,7 +656,7 @@ void LocalEnforcer::process_create_session_response(
     }
   }
 
-  for (const auto& dynamic_rule : response.dynamic_rules()) {
+  for (const auto &dynamic_rule : response.dynamic_rules()) {
     if (should_activate(dynamic_rule.policy_rule(), successful_credits)) {
       auto activation_time =
           TimeUtil::TimestampToSeconds(dynamic_rule.activation_time());
@@ -682,24 +677,24 @@ void LocalEnforcer::process_create_session_response(
 }
 
 // return true if any credit unit is valid and has non-zero volume
-static bool contains_credit(const GrantedUnits& gsu) {
+static bool contains_credit(const GrantedUnits &gsu) {
   return (gsu.total().is_valid() && gsu.total().volume() > 0) ||
          (gsu.tx().is_valid() && gsu.tx().volume() > 0) ||
          (gsu.rx().is_valid() && gsu.rx().volume() > 0);
 }
 
 bool LocalEnforcer::handle_session_init_rule_updates(
-    SessionMap& session_map, const std::string& imsi,
-    SessionState& session_state, const CreateSessionResponse& response,
-    std::unordered_set<uint32_t>& charging_credits_received) {
+    SessionMap &session_map, const std::string &imsi,
+    SessionState &session_state, const CreateSessionResponse &response,
+    std::unordered_set<uint32_t> &charging_credits_received) {
   auto ip_addr = session_state.get_subscriber_ip_addr();
 
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
 
-  process_create_session_response(
-      session_map, response, charging_credits_received, imsi, ip_addr,
-      rules_to_activate, rules_to_deactivate);
+  process_create_session_response(session_map, response,
+                                  charging_credits_received, imsi, ip_addr,
+                                  rules_to_activate, rules_to_deactivate);
 
   // activate_flows_for_rules() should be called even if there is no rule to
   // activate, because pipelined activates a "drop all packet" rule
@@ -707,10 +702,10 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   // Can use a default UpdateCriteria since SessionStore's create and update
   // methods are separate.
   auto uc = get_default_update_criteria();
-  for (const auto& static_rule : rules_to_activate.static_rules) {
+  for (const auto &static_rule : rules_to_activate.static_rules) {
     session_state.activate_static_rule(static_rule, uc);
   }
-  for (const auto& policy_rule : rules_to_activate.dynamic_rules) {
+  for (const auto &policy_rule : rules_to_activate.dynamic_rules) {
     session_state.insert_dynamic_rule(policy_rule, uc);
   }
   bool activate_success = pipelined_client_->activate_flows_for_rules(
@@ -722,12 +717,12 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   // when no rule is provided as the parameter
   bool deactivate_success = true;
   if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    for (const auto& static_rule : rules_to_deactivate.static_rules) {
+    for (const auto &static_rule : rules_to_deactivate.static_rules) {
       if (!session_state.deactivate_static_rule(static_rule, uc))
         MLOG(MWARNING) << "Could not find rule " << static_rule << "for IMSI "
                        << imsi << " during static rule removal";
     }
-    for (const auto& policy_rule : rules_to_deactivate.dynamic_rules) {
+    for (const auto &policy_rule : rules_to_deactivate.dynamic_rules) {
       PolicyRule rule_dont_care;
       session_state.remove_dynamic_rule(policy_rule.id(), &rule_dont_care, uc);
     }
@@ -739,16 +734,16 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   return activate_success && deactivate_success;
 }
 
-bool LocalEnforcer::init_session_credit(
-    SessionMap& session_map, const std::string& imsi,
-    const std::string& session_id, const SessionConfig& cfg,
-    const CreateSessionResponse& response) {
-  auto session_state = new SessionState(
-      imsi, session_id, response.session_id(), cfg, *rule_store_,
-      response.tgpp_ctx());
+bool LocalEnforcer::init_session_credit(SessionMap &session_map,
+                                        const std::string &imsi,
+                                        const std::string &session_id,
+                                        const SessionConfig &cfg,
+                                        const CreateSessionResponse &response) {
+  auto session_state = new SessionState(imsi, session_id, response.session_id(),
+                                        cfg, *rule_store_, response.tgpp_ctx());
 
   std::unordered_set<uint32_t> charging_credits_received;
-  for (const auto& credit : response.credits()) {
+  for (const auto &credit : response.credits()) {
     auto uc = get_default_update_criteria();
     session_state->get_charging_pool().receive_credit(credit, uc);
     if (credit.success() && contains_credit(credit.credit().granted_units())) {
@@ -757,7 +752,7 @@ bool LocalEnforcer::init_session_credit(
   }
   // We don't have to check 'success' field for monitors because command level
   // errors are handled in session proxy
-  for (const auto& monitor : response.usage_monitors()) {
+  for (const auto &monitor : response.usage_monitors()) {
     if (revalidation_required(monitor.event_triggers())) {
       schedule_revalidation(session_map, monitor.revalidation_time());
     }
@@ -777,17 +772,17 @@ bool LocalEnforcer::init_session_credit(
     if (!parse_apn(cfg.apn, apn_mac_addr, apn_name)) {
       MLOG(MWARNING) << "Failed mac/name parsing for apn " << cfg.apn;
       apn_mac_addr = "";
-      apn_name     = cfg.apn;
+      apn_name = cfg.apn;
     }
-    auto ue_mac_addr             = session_state->get_mac_addr();
+    auto ue_mac_addr = session_state->get_mac_addr();
     bool add_ue_mac_flow_success = pipelined_client_->add_ue_mac_flow(
         sid, ue_mac_addr, cfg.msisdn, apn_mac_addr, apn_name);
     if (!add_ue_mac_flow_success) {
       MLOG(MERROR) << "Failed to add UE MAC flow for subscriber " << imsi;
     }
 
-    handle_session_init_subscriber_quota_state(
-        session_map, imsi, *session_state);
+    handle_session_init_subscriber_quota_state(session_map, imsi,
+                                               *session_state);
   }
 
   auto it = session_map.find(imsi);
@@ -808,8 +803,8 @@ bool LocalEnforcer::init_session_credit(
 }
 
 void LocalEnforcer::handle_session_init_subscriber_quota_state(
-    SessionMap& session_map, const std::string& imsi,
-    SessionState& session_state) {
+    SessionMap &session_map, const std::string &imsi,
+    SessionState &session_state) {
   auto ue_mac_addr = session_state.get_mac_addr();
   // This method only used for session creation and not updates, so
   // UpdateCriteria is unused.
@@ -825,10 +820,10 @@ void LocalEnforcer::handle_session_init_subscriber_quota_state(
   }
   MLOG(MDEBUG) << "No monitoring rules are installed, setting subscriber "
                << "quota state as NO_QUOTA for subscriber " << imsi;
-  session_state.set_subscriber_quota_state(
-      SubscriberQuotaUpdate_Type_NO_QUOTA, uc);
-  report_subscriber_state_to_pipelined(
-      imsi, ue_mac_addr, SubscriberQuotaUpdate_Type_NO_QUOTA);
+  session_state.set_subscriber_quota_state(SubscriberQuotaUpdate_Type_NO_QUOTA,
+                                           uc);
+  report_subscriber_state_to_pipelined(imsi, ue_mac_addr,
+                                       SubscriberQuotaUpdate_Type_NO_QUOTA);
 
   // Schedule a session termination for a configured number of seconds after
   // session create
@@ -840,23 +835,22 @@ void LocalEnforcer::handle_session_init_subscriber_quota_state(
       [this, imsi] {
         MLOG(MDEBUG) << "Starting termination due to quota exhaustion for"
                      << " IMSI " << imsi;
-        SessionRead req  = {imsi};
+        SessionRead req = {imsi};
         auto session_map = session_store_.read_sessions_for_deletion(req);
-        auto it          = session_map.find(imsi);
+        auto it = session_map.find(imsi);
         if (it == session_map.end()) {
           MLOG(MDEBUG) << "Session for IMSI " << imsi << " not found";
           return;
         }
         SessionUpdate session_update =
             SessionStore::get_default_session_update(session_map);
-        for (const auto& session : it->second) {
+        for (const auto &session : it->second) {
           RulesToProcess rules;
           populate_rules_from_session_to_remove(imsi, session, rules);
           // terminate_service will properly propagate subscriber quota state
           // as terminated
-          terminate_service(
-              session_map, imsi, rules.static_rules, rules.dynamic_rules,
-              session_update);
+          terminate_service(session_map, imsi, rules.static_rules,
+                            rules.dynamic_rules, session_update);
         }
         bool end_success = session_store_.update_sessions(session_update);
         if (end_success) {
@@ -870,7 +864,7 @@ void LocalEnforcer::handle_session_init_subscriber_quota_state(
 }
 
 void LocalEnforcer::report_subscriber_state_to_pipelined(
-    const std::string& imsi, const std::string& ue_mac_addr,
+    const std::string &imsi, const std::string &ue_mac_addr,
     const SubscriberQuotaUpdate_Type state) {
   auto update = make_subscriber_quota_update(imsi, ue_mac_addr, state);
   bool add_subscriber_quota_state_success =
@@ -883,9 +877,9 @@ void LocalEnforcer::report_subscriber_state_to_pipelined(
 }
 
 void LocalEnforcer::complete_termination(
-    SessionMap& session_map, const std::string& imsi,
-    const std::string& session_id,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionMap &session_map, const std::string &imsi,
+    const std::string &session_id,
+    SessionStateUpdateCriteria &update_criteria) {
   // If the session cannot be found in session_map, or a new session has
   // already begun, do nothing.
   auto it = session_map.find(imsi);
@@ -924,39 +918,38 @@ void LocalEnforcer::complete_termination(
 }
 
 bool LocalEnforcer::rules_to_process_is_not_empty(
-    const RulesToProcess& rules_to_process) {
+    const RulesToProcess &rules_to_process) {
   return rules_to_process.static_rules.size() > 0 ||
          rules_to_process.dynamic_rules.size() > 0;
 }
 
 void LocalEnforcer::terminate_multiple_services(
-    SessionMap& session_map, const std::unordered_set<std::string>& imsis,
-    SessionUpdate& session_update) {
-  for (const auto& imsi : imsis) {
+    SessionMap &session_map, const std::unordered_set<std::string> &imsis,
+    SessionUpdate &session_update) {
+  for (const auto &imsi : imsis) {
     auto it = session_map.find(imsi);
     if (it == session_map.end()) {
       continue;
     }
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       RulesToProcess rules;
       populate_rules_from_session_to_remove(imsi, session, rules);
-      terminate_service(
-          session_map, imsi, rules.static_rules, rules.dynamic_rules,
-          session_update);
+      terminate_service(session_map, imsi, rules.static_rules,
+                        rules.dynamic_rules, session_update);
     }
   }
 }
 
 void LocalEnforcer::update_charging_credits(
-    SessionMap& session_map, const UpdateSessionResponse& response,
-    std::unordered_set<std::string>& subscribers_to_terminate,
-    SessionUpdate& session_update) {
-  for (const auto& credit_update_resp : response.responses()) {
-    const std::string& imsi = credit_update_resp.sid();
+    SessionMap &session_map, const UpdateSessionResponse &response,
+    std::unordered_set<std::string> &subscribers_to_terminate,
+    SessionUpdate &session_update) {
+  for (const auto &credit_update_resp : response.responses()) {
+    const std::string &imsi = credit_update_resp.sid();
 
     if (!credit_update_resp.success()) {
-      handle_command_level_result_code(
-          imsi, credit_update_resp.result_code(), subscribers_to_terminate);
+      handle_command_level_result_code(imsi, credit_update_resp.result_code(),
+                                       subscribers_to_terminate);
       continue;
     }
 
@@ -966,26 +959,26 @@ void LocalEnforcer::update_charging_credits(
                    << credit_update_resp.sid() << " during update";
       continue;
     }
-    for (const auto& session : it->second) {
-      std::string sid                             = session->get_session_id();
-      SessionStateUpdateCriteria& update_criteria = session_update[imsi][sid];
-      session->get_charging_pool().receive_credit(
-          credit_update_resp, update_criteria);
+    for (const auto &session : it->second) {
+      std::string sid = session->get_session_id();
+      SessionStateUpdateCriteria &update_criteria = session_update[imsi][sid];
+      session->get_charging_pool().receive_credit(credit_update_resp,
+                                                  update_criteria);
       session->set_tgpp_context(credit_update_resp.tgpp_ctx(), update_criteria);
     }
   }
 }
 
 void LocalEnforcer::update_monitoring_credits_and_rules(
-    SessionMap& session_map, const UpdateSessionResponse& response,
-    std::unordered_set<std::string>& subscribers_to_terminate,
-    SessionUpdate& session_update) {
-  for (const auto& usage_monitor_resp : response.usage_monitor_responses()) {
-    const std::string& imsi = usage_monitor_resp.sid();
+    SessionMap &session_map, const UpdateSessionResponse &response,
+    std::unordered_set<std::string> &subscribers_to_terminate,
+    SessionUpdate &session_update) {
+  for (const auto &usage_monitor_resp : response.usage_monitor_responses()) {
+    const std::string &imsi = usage_monitor_resp.sid();
 
     if (!usage_monitor_resp.success()) {
-      handle_command_level_result_code(
-          imsi, usage_monitor_resp.result_code(), subscribers_to_terminate);
+      handle_command_level_result_code(imsi, usage_monitor_resp.result_code(),
+                                       subscribers_to_terminate);
       continue;
     }
 
@@ -997,32 +990,32 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
     }
 
     if (revalidation_required(usage_monitor_resp.event_triggers())) {
-      schedule_revalidation(
-          session_map, usage_monitor_resp.revalidation_time());
+      schedule_revalidation(session_map,
+                            usage_monitor_resp.revalidation_time());
     }
 
-    for (const auto& session : it->second) {
-      auto& update_criteria = session_update[imsi][session->get_session_id()];
-      session->get_monitor_pool().receive_credit(
-          usage_monitor_resp, update_criteria);
+    for (const auto &session : it->second) {
+      auto &update_criteria = session_update[imsi][session->get_session_id()];
+      session->get_monitor_pool().receive_credit(usage_monitor_resp,
+                                                 update_criteria);
       session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), update_criteria);
 
       RulesToProcess rules_to_activate;
       RulesToProcess rules_to_deactivate;
 
-      process_rules_to_remove(
-          imsi, session, usage_monitor_resp.rules_to_remove(),
-          rules_to_deactivate, update_criteria);
+      process_rules_to_remove(imsi, session,
+                              usage_monitor_resp.rules_to_remove(),
+                              rules_to_deactivate, update_criteria);
 
-      process_rules_to_install(
-          session_map, imsi, session,
-          usage_monitor_resp.static_rules_to_install(),
-          usage_monitor_resp.dynamic_rules_to_install(), rules_to_activate,
-          rules_to_deactivate, update_criteria);
+      process_rules_to_install(session_map, imsi, session,
+                               usage_monitor_resp.static_rules_to_install(),
+                               usage_monitor_resp.dynamic_rules_to_install(),
+                               rules_to_activate, rules_to_deactivate,
+                               update_criteria);
 
-      auto ip_addr            = session->get_subscriber_ip_addr();
+      auto ip_addr = session->get_subscriber_ip_addr();
       bool deactivate_success = true;
-      bool activate_success   = true;
+      bool activate_success = true;
 
       if (rules_to_process_is_not_empty(rules_to_deactivate)) {
         // TODO: modify the SessionUpdate
@@ -1061,27 +1054,28 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
 }
 
 void LocalEnforcer::update_session_credits_and_rules(
-    SessionMap& session_map, const UpdateSessionResponse& response,
-    SessionUpdate& session_update) {
+    SessionMap &session_map, const UpdateSessionResponse &response,
+    SessionUpdate &session_update) {
   // These subscribers will include any subscriber that received a permanent
   // diameter error code. Additionally, it will also include CWF sessions that
   // have run out of monitoring quota.
   std::unordered_set<std::string> subscribers_to_terminate;
 
-  update_charging_credits(
-      session_map, response, subscribers_to_terminate, session_update);
-  update_monitoring_credits_and_rules(
-      session_map, response, subscribers_to_terminate, session_update);
+  update_charging_credits(session_map, response, subscribers_to_terminate,
+                          session_update);
+  update_monitoring_credits_and_rules(session_map, response,
+                                      subscribers_to_terminate, session_update);
 
-  terminate_multiple_services(
-      session_map, subscribers_to_terminate, session_update);
+  terminate_multiple_services(session_map, subscribers_to_terminate,
+                              session_update);
 }
 
 // terminate_subscriber (for externally triggered EndSession)
 // terminates the session that is associated with the given imsi and apn
-void LocalEnforcer::terminate_subscriber(
-    SessionMap& session_map, const std::string& imsi, const std::string& apn,
-    SessionUpdate& session_update) {
+void LocalEnforcer::terminate_subscriber(SessionMap &session_map,
+                                         const std::string &imsi,
+                                         const std::string &apn,
+                                         SessionUpdate &session_update) {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     MLOG(MERROR) << "Could not find session for IMSI " << imsi
@@ -1089,19 +1083,19 @@ void LocalEnforcer::terminate_subscriber(
     throw SessionNotFound();
   }
 
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     if (session->get_apn() == apn) {
-      SessionStateUpdateCriteria& update_criteria =
+      SessionStateUpdateCriteria &update_criteria =
           session_update[imsi][session->get_session_id()];
       RulesToProcess rules_to_deactivate;
       // The assumption here is that
       // mutually exclusive rule names are used for different apns
       populate_rules_from_session_to_remove(imsi, session, rules_to_deactivate);
       bool deactivate_success = true;
-      for (const std::string& static_rule : rules_to_deactivate.static_rules) {
+      for (const std::string &static_rule : rules_to_deactivate.static_rules) {
         update_criteria.static_rules_to_uninstall.insert(static_rule);
       }
-      for (const PolicyRule& dynamic_rule : rules_to_deactivate.dynamic_rules) {
+      for (const PolicyRule &dynamic_rule : rules_to_deactivate.dynamic_rules) {
         update_criteria.dynamic_rules_to_uninstall.insert(dynamic_rule.id());
       }
       deactivate_success = pipelined_client_->deactivate_flows_for_rules(
@@ -1137,15 +1131,15 @@ void LocalEnforcer::terminate_subscriber(
       // force terminate the session.
       evb_->runAfterDelay(
           [this, imsi, session_id] {
-            SessionRead req  = {imsi};
+            SessionRead req = {imsi};
             auto session_map = session_store_.read_sessions_for_deletion(req);
             auto session_update =
                 SessionStore::get_default_session_update(session_map);
-            SessionStateUpdateCriteria& update_criteria =
+            SessionStateUpdateCriteria &update_criteria =
                 session_update[imsi][session_id];
             MLOG(MDEBUG) << "Completing forced termination for IMSI " << imsi;
-            complete_termination(
-                session_map, imsi, session_id, update_criteria);
+            complete_termination(session_map, imsi, session_id,
+                                 update_criteria);
 
             bool end_success = session_store_.update_sessions(session_update);
             if (end_success) {
@@ -1162,14 +1156,15 @@ void LocalEnforcer::terminate_subscriber(
   }
 }
 
-uint64_t LocalEnforcer::get_charging_credit(
-    SessionMap& session_map, const std::string& imsi,
-    const CreditKey& charging_key, Bucket bucket) const {
+uint64_t LocalEnforcer::get_charging_credit(SessionMap &session_map,
+                                            const std::string &imsi,
+                                            const CreditKey &charging_key,
+                                            Bucket bucket) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return 0;
   }
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     uint64_t credit =
         session->get_charging_pool().get_credit(charging_key, bucket);
     if (credit > 0) {
@@ -1179,14 +1174,15 @@ uint64_t LocalEnforcer::get_charging_credit(
   return 0;
 }
 
-uint64_t LocalEnforcer::get_monitor_credit(
-    SessionMap& session_map, const std::string& imsi, const std::string& mkey,
-    Bucket bucket) const {
+uint64_t LocalEnforcer::get_monitor_credit(SessionMap &session_map,
+                                           const std::string &imsi,
+                                           const std::string &mkey,
+                                           Bucket bucket) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return 0;
   }
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     uint64_t credit = session->get_monitor_pool().get_credit(mkey, bucket);
     if (credit > 0) {
       return credit;
@@ -1195,25 +1191,26 @@ uint64_t LocalEnforcer::get_monitor_credit(
   return 0;
 }
 
-ChargingReAuthAnswer::Result LocalEnforcer::init_charging_reauth(
-    SessionMap& session_map, ChargingReAuthRequest request,
-    SessionUpdate& session_update) {
+ChargingReAuthAnswer::Result
+LocalEnforcer::init_charging_reauth(SessionMap &session_map,
+                                    ChargingReAuthRequest request,
+                                    SessionUpdate &session_update) {
   auto it = session_map.find(request.sid());
   if (it == session_map.end()) {
     MLOG(MERROR) << "Could not find session for subscriber " << request.sid()
                  << " during reauth";
     return ChargingReAuthAnswer::SESSION_NOT_FOUND;
   }
-  SessionStateUpdateCriteria& update_criteria =
+  SessionStateUpdateCriteria &update_criteria =
       session_update[request.sid()][request.session_id()];
   if (request.type() == ChargingReAuthRequest::SINGLE_SERVICE) {
     MLOG(MDEBUG) << "Initiating reauth of key " << request.charging_key()
                  << " for subscriber " << request.sid() << " for session "
                  << request.session_id();
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       if (session->get_session_id() == request.session_id()) {
-        return session->get_charging_pool().reauth_key(
-            CreditKey(request), update_criteria);
+        return session->get_charging_pool().reauth_key(CreditKey(request),
+                                                       update_criteria);
       }
     }
     MLOG(MERROR) << "Could not find session for subscriber " << request.sid()
@@ -1222,7 +1219,7 @@ ChargingReAuthAnswer::Result LocalEnforcer::init_charging_reauth(
   }
   MLOG(MDEBUG) << "Initiating reauth of all keys for subscriber "
                << request.sid() << " for session" << request.session_id();
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     if (session->get_session_id() == request.session_id()) {
       return session->get_charging_pool().reauth_all(update_criteria);
     }
@@ -1233,9 +1230,10 @@ ChargingReAuthAnswer::Result LocalEnforcer::init_charging_reauth(
   return ChargingReAuthAnswer::SESSION_NOT_FOUND;
 }
 
-void LocalEnforcer::init_policy_reauth(
-    SessionMap& session_map, PolicyReAuthRequest request,
-    PolicyReAuthAnswer& answer_out, SessionUpdate& session_update) {
+void LocalEnforcer::init_policy_reauth(SessionMap &session_map,
+                                       PolicyReAuthRequest request,
+                                       PolicyReAuthAnswer &answer_out,
+                                       SessionUpdate &session_update) {
   auto it = session_map.find(request.imsi());
   if (it == session_map.end()) {
     MLOG(MERROR) << "Could not find session for subscriber " << request.imsi()
@@ -1245,17 +1243,17 @@ void LocalEnforcer::init_policy_reauth(
   }
 
   bool deactivate_success = true;
-  bool activate_success   = true;
+  bool activate_success = true;
   // For empty session_id, apply changes to all sessions of subscriber
   // Changes are applied on a best-effort basis, so failures for one session
   // won't stop changes from being applied for subsequent sessions.
   if (request.session_id() == "") {
-    bool all_activated   = true;
+    bool all_activated = true;
     bool all_deactivated = true;
-    for (const auto& session : it->second) {
-      init_policy_reauth_for_session(
-          session_map, request, session, activate_success, deactivate_success,
-          session_update);
+    for (const auto &session : it->second) {
+      init_policy_reauth_for_session(session_map, request, session,
+                                     activate_success, deactivate_success,
+                                     session_update);
       all_activated &= activate_success;
       all_deactivated &= deactivate_success;
     }
@@ -1263,12 +1261,12 @@ void LocalEnforcer::init_policy_reauth(
     mark_rule_failures(all_activated, all_deactivated, request, answer_out);
   } else {
     bool session_id_valid = false;
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       if (session->get_session_id() == request.session_id()) {
         session_id_valid = true;
-        init_policy_reauth_for_session(
-            session_map, request, session, activate_success, deactivate_success,
-            session_update);
+        init_policy_reauth_for_session(session_map, request, session,
+                                       activate_success, deactivate_success,
+                                       session_update);
       }
     }
     if (!session_id_valid) {
@@ -1278,21 +1276,21 @@ void LocalEnforcer::init_policy_reauth(
       answer_out.set_result(ReAuthResult::SESSION_NOT_FOUND);
       return;
     }
-    mark_rule_failures(
-        activate_success, deactivate_success, request, answer_out);
+    mark_rule_failures(activate_success, deactivate_success, request,
+                       answer_out);
   }
   answer_out.set_result(ReAuthResult::UPDATE_INITIATED);
 }
 
 void LocalEnforcer::init_policy_reauth_for_session(
-    SessionMap& session_map, const PolicyReAuthRequest& request,
-    const std::unique_ptr<SessionState>& session, bool& activate_success,
-    bool& deactivate_success, SessionUpdate& session_update) {
+    SessionMap &session_map, const PolicyReAuthRequest &request,
+    const std::unique_ptr<SessionState> &session, bool &activate_success,
+    bool &deactivate_success, SessionUpdate &session_update) {
   std::string imsi = request.imsi();
-  SessionStateUpdateCriteria& update_criteria =
+  SessionStateUpdateCriteria &update_criteria =
       session_update[imsi][session->get_session_id()];
 
-  activate_success   = true;
+  activate_success = true;
   deactivate_success = true;
   receive_monitoring_credit_from_rar(request, session, update_criteria);
 
@@ -1304,9 +1302,8 @@ void LocalEnforcer::init_policy_reauth_for_session(
     schedule_revalidation(session_map, request.revalidation_time());
   }
 
-  process_rules_to_remove(
-      imsi, session, request.rules_to_remove(), rules_to_deactivate,
-      update_criteria);
+  process_rules_to_remove(imsi, session, request.rules_to_remove(),
+                          rules_to_deactivate, update_criteria);
 
   process_rules_to_install(
       session_map, imsi, session, request.rules_to_install(),
@@ -1315,10 +1312,10 @@ void LocalEnforcer::init_policy_reauth_for_session(
 
   auto ip_addr = session->get_subscriber_ip_addr();
   if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    for (const std::string& static_rule : rules_to_deactivate.static_rules) {
+    for (const std::string &static_rule : rules_to_deactivate.static_rules) {
       update_criteria.static_rules_to_uninstall.insert(static_rule);
     }
-    for (const PolicyRule& dynamic_rule : rules_to_deactivate.dynamic_rules) {
+    for (const PolicyRule &dynamic_rule : rules_to_deactivate.dynamic_rules) {
       update_criteria.dynamic_rules_to_uninstall.insert(dynamic_rule.id());
     }
     deactivate_success = pipelined_client_->deactivate_flows_for_rules(
@@ -1326,10 +1323,10 @@ void LocalEnforcer::init_policy_reauth_for_session(
         rules_to_deactivate.dynamic_rules);
   }
   if (rules_to_process_is_not_empty(rules_to_activate)) {
-    for (const std::string& static_rule : rules_to_activate.static_rules) {
+    for (const std::string &static_rule : rules_to_activate.static_rules) {
       update_criteria.static_rules_to_install.insert(static_rule);
     }
-    for (const PolicyRule& dynamic_rule : rules_to_activate.dynamic_rules) {
+    for (const PolicyRule &dynamic_rule : rules_to_activate.dynamic_rules) {
       if (!session->is_dynamic_rule_installed(dynamic_rule.id())) {
         update_criteria.dynamic_rules_to_install.push_back(dynamic_rule);
       }
@@ -1344,42 +1341,41 @@ void LocalEnforcer::init_policy_reauth_for_session(
       !session->active_monitored_rules_exist()) {
     RulesToProcess rules;
     populate_rules_from_session_to_remove(imsi, session, rules);
-    terminate_service(
-        session_map, imsi, rules.static_rules, rules.dynamic_rules,
-        session_update);
+    terminate_service(session_map, imsi, rules.static_rules,
+                      rules.dynamic_rules, session_update);
     return;
   }
   if (!session->is_radius_cwf_session()) {
-    create_bearer(
-        activate_success, session, request, rules_to_activate.dynamic_rules);
+    create_bearer(activate_success, session, request,
+                  rules_to_activate.dynamic_rules);
   }
 }
 
 void LocalEnforcer::receive_monitoring_credit_from_rar(
-    const PolicyReAuthRequest& request,
-    const std::unique_ptr<SessionState>& session,
-    SessionStateUpdateCriteria& update_criteria) {
+    const PolicyReAuthRequest &request,
+    const std::unique_ptr<SessionState> &session,
+    SessionStateUpdateCriteria &update_criteria) {
   UsageMonitoringUpdateResponse monitoring_credit;
   monitoring_credit.set_session_id(request.session_id());
   monitoring_credit.set_sid("IMSI" + request.session_id());
   monitoring_credit.set_success(true);
-  UsageMonitoringCredit* credit = monitoring_credit.mutable_credit();
+  UsageMonitoringCredit *credit = monitoring_credit.mutable_credit();
 
-  for (const auto& usage_monitoring_credit :
+  for (const auto &usage_monitoring_credit :
        request.usage_monitoring_credits()) {
     credit->CopyFrom(usage_monitoring_credit);
-    session->get_monitor_pool().receive_credit(
-        monitoring_credit, update_criteria);
+    session->get_monitor_pool().receive_credit(monitoring_credit,
+                                               update_criteria);
   }
 }
 
 void LocalEnforcer::process_rules_to_remove(
-    const std::string& imsi, const std::unique_ptr<SessionState>& session,
+    const std::string &imsi, const std::unique_ptr<SessionState> &session,
     const google::protobuf::RepeatedPtrField<std::basic_string<char>>
         rules_to_remove,
-    RulesToProcess& rules_to_deactivate,
-    SessionStateUpdateCriteria& update_criteria) {
-  for (const auto& rule_id : rules_to_remove) {
+    RulesToProcess &rules_to_deactivate,
+    SessionStateUpdateCriteria &update_criteria) {
+  for (const auto &rule_id : rules_to_remove) {
     // Try to remove as dynamic rule first
     PolicyRule dy_rule;
     bool is_dynamic =
@@ -1396,30 +1392,30 @@ void LocalEnforcer::process_rules_to_remove(
 }
 
 void LocalEnforcer::populate_rules_from_session_to_remove(
-    const std::string& imsi, const std::unique_ptr<SessionState>& session,
-    RulesToProcess& rules_to_deactivate) {
+    const std::string &imsi, const std::unique_ptr<SessionState> &session,
+    RulesToProcess &rules_to_deactivate) {
   SessionState::SessionInfo info;
   session->get_session_info(info);
-  for (const auto& policyrule : info.dynamic_rules) {
+  for (const auto &policyrule : info.dynamic_rules) {
     rules_to_deactivate.dynamic_rules.push_back(policyrule);
   }
-  for (const auto& staticrule : info.static_rules) {
+  for (const auto &staticrule : info.static_rules) {
     rules_to_deactivate.static_rules.push_back(staticrule);
   }
 }
 
 void LocalEnforcer::process_rules_to_install(
-    SessionMap& session_map, const std::string& imsi,
-    const std::unique_ptr<SessionState>& session,
+    SessionMap &session_map, const std::string &imsi,
+    const std::unique_ptr<SessionState> &session,
     const google::protobuf::RepeatedPtrField<magma::lte::StaticRuleInstall>
         static_rules_to_install,
     const google::protobuf::RepeatedPtrField<magma::lte::DynamicRuleInstall>
         dynamic_rules_to_install,
-    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-    SessionStateUpdateCriteria& update_criteria) {
+    RulesToProcess &rules_to_activate, RulesToProcess &rules_to_deactivate,
+    SessionStateUpdateCriteria &update_criteria) {
   std::time_t current_time = time(NULL);
-  auto ip_addr             = session->get_subscriber_ip_addr();
-  for (const auto& static_rule : static_rules_to_install) {
+  auto ip_addr = session->get_subscriber_ip_addr();
+  for (const auto &static_rule : static_rules_to_install) {
     auto activation_time =
         TimeUtil::TimestampToSeconds(static_rule.activation_time());
     if (activation_time > current_time) {
@@ -1434,15 +1430,15 @@ void LocalEnforcer::process_rules_to_install(
     if (deactivation_time > current_time) {
       schedule_static_rule_deactivation(imsi, static_rule);
     } else if (deactivation_time > 0) {
-      if (!session->deactivate_static_rule(
-              static_rule.rule_id(), update_criteria))
+      if (!session->deactivate_static_rule(static_rule.rule_id(),
+                                           update_criteria))
         MLOG(MWARNING) << "Could not find rule " << static_rule.rule_id()
                        << "for IMSI " << imsi << " during static rule removal";
       rules_to_deactivate.static_rules.push_back(static_rule.rule_id());
     }
   }
 
-  for (const auto& dynamic_rule : dynamic_rules_to_install) {
+  for (const auto &dynamic_rule : dynamic_rules_to_install) {
     auto activation_time =
         TimeUtil::TimestampToSeconds(dynamic_rule.activation_time());
     if (activation_time > current_time) {
@@ -1458,25 +1454,25 @@ void LocalEnforcer::process_rules_to_install(
       schedule_dynamic_rule_deactivation(imsi, dynamic_rule);
     } else if (deactivation_time > 0) {
       PolicyRule rule_dont_care;
-      session->remove_dynamic_rule(
-          dynamic_rule.policy_rule().id(), &rule_dont_care, update_criteria);
+      session->remove_dynamic_rule(dynamic_rule.policy_rule().id(),
+                                   &rule_dont_care, update_criteria);
       rules_to_deactivate.dynamic_rules.push_back(dynamic_rule.policy_rule());
     }
   }
 }
 
 bool LocalEnforcer::revalidation_required(
-    const google::protobuf::RepeatedField<int>& event_triggers) {
-  auto it = std::find(
-      event_triggers.begin(), event_triggers.end(), REVALIDATION_TIMEOUT);
+    const google::protobuf::RepeatedField<int> &event_triggers) {
+  auto it = std::find(event_triggers.begin(), event_triggers.end(),
+                      REVALIDATION_TIMEOUT);
   return it != event_triggers.end();
 }
 
 void LocalEnforcer::schedule_revalidation(
-    SessionMap& session_map,
-    const google::protobuf::Timestamp& revalidation_time) {
+    SessionMap &session_map,
+    const google::protobuf::Timestamp &revalidation_time) {
   SessionRead req;
-  for (const auto& it : session_map) {
+  for (const auto &it : session_map) {
     req.insert(it.first);
   }
   auto delta = time_difference_from_now(revalidation_time);
@@ -1494,9 +1490,9 @@ void LocalEnforcer::schedule_revalidation(
 }
 
 void LocalEnforcer::create_bearer(
-    const bool activate_success, const std::unique_ptr<SessionState>& session,
-    const PolicyReAuthRequest& request,
-    const std::vector<PolicyRule>& dynamic_rules) {
+    const bool activate_success, const std::unique_ptr<SessionState> &session,
+    const PolicyReAuthRequest &request,
+    const std::vector<PolicyRule> &dynamic_rules) {
   if (!activate_success || !session->qos_enabled() || !request.has_qos_info()) {
     MLOG(MDEBUG) << "Not creating bearer";
     return;
@@ -1512,57 +1508,55 @@ void LocalEnforcer::create_bearer(
   return;
 }
 
-void LocalEnforcer::check_usage_for_reporting(
-    SessionMap& session_map, SessionUpdate& session_update,
-    const bool force_update) {
+void LocalEnforcer::check_usage_for_reporting(SessionMap &session_map,
+                                              SessionUpdate &session_update,
+                                              const bool force_update) {
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto request =
       collect_updates(session_map, actions, session_update, force_update);
   execute_actions(session_map, actions, session_update);
   if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
-    return;  // nothing to report
+    return; // nothing to report
   }
   MLOG(MDEBUG) << "Sending " << request.updates_size()
                << " charging updates and " << request.usage_monitors_size()
                << " monitor updates to OCS and PCRF";
 
   // report to cloud
-  (*reporter_)
-      .report_updates(
-          request,
-          [this, request,
-           session_map_ptr =
-               std::make_shared<SessionMap>(std::move(session_map)),
-           &session_update](Status status, UpdateSessionResponse response) {
-            if (!status.ok()) {
-              MLOG(MERROR) << "Update of size " << request.updates_size()
-                           << " to OCS and PCRF failed entirely: "
-                           << status.error_message();
-            } else {
-              MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
-              update_session_credits_and_rules(
-                  *session_map_ptr, response, session_update);
-              session_store_.update_sessions(session_update);
-            }
-          });
+  (*reporter_).report_updates(request, [
+    this, request,
+    session_map_ptr = std::make_shared<SessionMap>(std::move(session_map)),
+    &session_update
+  ](Status status, UpdateSessionResponse response) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Update of size " << request.updates_size()
+                   << " to OCS and PCRF failed entirely: "
+                   << status.error_message();
+    } else {
+      MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
+      update_session_credits_and_rules(*session_map_ptr, response,
+                                       session_update);
+      session_store_.update_sessions(session_update);
+    }
+  });
 }
 
-bool LocalEnforcer::session_with_imsi_exists(
-    SessionMap& session_map, const std::string& imsi) const {
+bool LocalEnforcer::session_with_imsi_exists(SessionMap &session_map,
+                                             const std::string &imsi) const {
   if (session_map.find(imsi) != session_map.end()) {
     return session_map[imsi].size() > 0;
   }
   return false;
 }
 
-bool LocalEnforcer::session_with_apn_exists(
-    SessionMap& session_map, const std::string& imsi,
-    const std::string& apn) const {
+bool LocalEnforcer::session_with_apn_exists(SessionMap &session_map,
+                                            const std::string &imsi,
+                                            const std::string &apn) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     if (session->get_apn() == apn) {
       return true;
     }
@@ -1571,13 +1565,13 @@ bool LocalEnforcer::session_with_apn_exists(
 }
 
 bool LocalEnforcer::is_session_active(
-    SessionMap& session_map, const std::string& imsi,
-    const std::string& core_session_id) const {
+    SessionMap &session_map, const std::string &imsi,
+    const std::string &core_session_id) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     if (session->get_core_session_id() == core_session_id) {
       return session->is_active();
     }
@@ -1585,14 +1579,14 @@ bool LocalEnforcer::is_session_active(
   return false;
 }
 
-bool LocalEnforcer::has_active_session(
-    SessionMap& session_map, const std::string& imsi,
-    std::string* core_session_id) const {
+bool LocalEnforcer::has_active_session(SessionMap &session_map,
+                                       const std::string &imsi,
+                                       std::string *core_session_id) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto& session : it->second) {
+  for (const auto &session : it->second) {
     if (session->is_active()) {
       *core_session_id = session->get_core_session_id();
       return true;
@@ -1602,11 +1596,11 @@ bool LocalEnforcer::has_active_session(
 }
 
 bool LocalEnforcer::session_with_same_config_exists(
-    SessionMap& session_map, const std::string& imsi,
-    const SessionConfig& config, std::string* core_session_id) const {
+    SessionMap &session_map, const std::string &imsi,
+    const SessionConfig &config, std::string *core_session_id) const {
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
-    for (const auto& session : it->second) {
+    for (const auto &session : it->second) {
       if (session->is_same_config(config)) {
         *core_session_id = session->get_core_session_id();
         return true;
@@ -1616,16 +1610,17 @@ bool LocalEnforcer::session_with_same_config_exists(
   return false;
 }
 
-void LocalEnforcer::handle_cwf_roaming(
-    SessionMap& session_map, const std::string& imsi,
-    const SessionConfig& config, SessionUpdate& session_update) {
+void LocalEnforcer::handle_cwf_roaming(SessionMap &session_map,
+                                       const std::string &imsi,
+                                       const SessionConfig &config,
+                                       SessionUpdate &session_update) {
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
-    for (const auto& session : it->second) {
-      auto& update_criteria = session_update[imsi][session->get_session_id()];
+    for (const auto &session : it->second) {
+      auto &update_criteria = session_update[imsi][session->get_session_id()];
       session->set_config(config);
       update_criteria.is_config_updated = true;
-      update_criteria.updated_config    = session->marshal_config();
+      update_criteria.updated_config = session->marshal_config();
       // TODO Check for event triggers and send updates to the core if needed
       MLOG(MDEBUG) << "Updating IPFIX flow for subscriber " << imsi;
       SubscriberID sid;
@@ -1635,9 +1630,9 @@ void LocalEnforcer::handle_cwf_roaming(
       if (!parse_apn(config.apn, apn_mac_addr, apn_name)) {
         MLOG(MWARNING) << "Failed mac/name parsiong for apn " << config.apn;
         apn_mac_addr = "";
-        apn_name     = config.apn;
+        apn_name = config.apn;
       }
-      auto ue_mac_addr             = session->get_mac_addr();
+      auto ue_mac_addr = session->get_mac_addr();
       bool add_ue_mac_flow_success = pipelined_client_->update_ipfix_flow(
           sid, ue_mac_addr, config.msisdn, apn_mac_addr, apn_name);
       if (!add_ue_mac_flow_success) {
@@ -1648,8 +1643,8 @@ void LocalEnforcer::handle_cwf_roaming(
 }
 
 static void handle_command_level_result_code(
-    const std::string& imsi, const uint32_t result_code,
-    std::unordered_set<std::string>& subscribers_to_terminate) {
+    const std::string &imsi, const uint32_t result_code,
+    std::unordered_set<std::string> &subscribers_to_terminate) {
   const bool is_permanent_failure =
       DiameterCodeHandler::is_permanent_failure(result_code);
   if (is_permanent_failure) {
@@ -1664,12 +1659,13 @@ static void handle_command_level_result_code(
   }
 }
 
-static void mark_rule_failures(
-    const bool activate_success, const bool deactivate_success,
-    const PolicyReAuthRequest& request, PolicyReAuthAnswer& answer_out) {
+static void mark_rule_failures(const bool activate_success,
+                               const bool deactivate_success,
+                               const PolicyReAuthRequest &request,
+                               PolicyReAuthAnswer &answer_out) {
   auto failed_rules = *answer_out.mutable_failed_rules();
   if (!deactivate_success) {
-    for (const std::string& rule_id : request.rules_to_remove()) {
+    for (const std::string &rule_id : request.rules_to_remove()) {
       failed_rules[rule_id] = PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
     }
   }
@@ -1677,7 +1673,7 @@ static void mark_rule_failures(
     for (const StaticRuleInstall rule : request.rules_to_install()) {
       failed_rules[rule.rule_id()] = PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
     }
-    for (const DynamicRuleInstall& d_rule :
+    for (const DynamicRuleInstall &d_rule :
          request.dynamic_rules_to_install()) {
       failed_rules[d_rule.policy_rule().id()] =
           PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
@@ -1685,7 +1681,7 @@ static void mark_rule_failures(
   }
 }
 
-static bool isValidMacAddress(const char* mac) {
+static bool isValidMacAddress(const char *mac) {
   int i = 0;
   int s = 0;
 
@@ -1705,8 +1701,8 @@ static bool isValidMacAddress(const char* mac) {
   return (i == 12 && s == 5);
 }
 
-static bool parse_apn(
-    const std::string& apn, std::string& mac_addr, std::string& name) {
+static bool parse_apn(const std::string &apn, std::string &mac_addr,
+                      std::string &name) {
   // Format is mac:name, if format check fails return failure
   // Format example - 1C-B9-C4-36-04-F0:Wifi-Offload-hotspot20
   if (apn.empty()) {
@@ -1726,9 +1722,10 @@ static bool parse_apn(
   return true;
 }
 
-static SubscriberQuotaUpdate make_subscriber_quota_update(
-    const std::string& imsi, const std::string& ue_mac_addr,
-    const SubscriberQuotaUpdate_Type state) {
+static SubscriberQuotaUpdate
+make_subscriber_quota_update(const std::string &imsi,
+                             const std::string &ue_mac_addr,
+                             const SubscriberQuotaUpdate_Type state) {
   SubscriberQuotaUpdate update;
   auto sid = update.mutable_sid();
   sid->set_id(imsi);
@@ -1736,4 +1733,4 @@ static SubscriberQuotaUpdate make_subscriber_quota_update(
   update.set_update_type(state);
   return update;
 }
-}  // namespace magma
+} // namespace magma

--- a/lte/gateway/c/session_manager/SpgwServiceClient.cpp
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.cpp
@@ -16,16 +16,15 @@ using grpc::Status;
 
 namespace { // anonymous
 
-magma::DeleteBearerRequest create_delete_bearer_req(
-  const std::string &imsi,
-  const std::string &apn_ip_addr,
-  const uint32_t link_bearer_id,
-  const std::vector<uint32_t> &eps_bearer_ids)
-{
+magma::DeleteBearerRequest
+create_delete_bearer_req(const std::string &imsi,
+                         const std::string &apn_ip_addr,
+                         const uint32_t linked_bearer_id,
+                         const std::vector<uint32_t> &eps_bearer_ids) {
   magma::DeleteBearerRequest req;
   req.mutable_sid()->set_id(imsi);
   req.set_ip_addr(apn_ip_addr);
-  req.set_link_bearer_id(link_bearer_id);
+  req.set_link_bearer_id(linked_bearer_id);
 
   auto ebis = req.mutable_eps_bearer_ids();
   for (const auto &eps_bearer_id : eps_bearer_ids) {
@@ -35,16 +34,14 @@ magma::DeleteBearerRequest create_delete_bearer_req(
   return req;
 }
 
-magma::CreateBearerRequest create_add_bearer_req(
-  const std::string &imsi,
-  const std::string &apn_ip_addr,
-  const uint32_t link_bearer_id,
-  const std::vector<magma::PolicyRule> &flows)
-{
+magma::CreateBearerRequest
+create_add_bearer_req(const std::string &imsi, const std::string &apn_ip_addr,
+                      const uint32_t linked_bearer_id,
+                      const std::vector<magma::PolicyRule> &flows) {
   magma::CreateBearerRequest req;
   req.mutable_sid()->set_id(imsi);
   req.set_ip_addr(apn_ip_addr);
-  req.set_link_bearer_id(link_bearer_id);
+  req.set_link_bearer_id(linked_bearer_id);
 
   auto req_policy_rules = req.mutable_policy_rules();
   for (const auto &flow : flows) {
@@ -59,73 +56,82 @@ magma::CreateBearerRequest create_add_bearer_req(
 namespace magma {
 
 AsyncSpgwServiceClient::AsyncSpgwServiceClient(
-  std::shared_ptr<grpc::Channel> channel):
-  stub_(SpgwService::NewStub(channel))
-{
-}
+    std::shared_ptr<grpc::Channel> channel)
+    : stub_(SpgwService::NewStub(channel)) {}
 
-AsyncSpgwServiceClient::AsyncSpgwServiceClient():
-  AsyncSpgwServiceClient(ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-    "spgw_service",
-    ServiceRegistrySingleton::LOCAL))
-{
+AsyncSpgwServiceClient::AsyncSpgwServiceClient()
+    : AsyncSpgwServiceClient(
+          ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+              "spgw_service", ServiceRegistrySingleton::LOCAL)) {}
+
+bool AsyncSpgwServiceClient::delete_default_bearer(
+    const std::string &imsi, const std::string &apn_ip_addr,
+    const uint32_t linked_bearer_id) {
+  MLOG(MINFO) << "Deleting default bearer and corresponding PDN session for"
+              << " IMSI: " << imsi << " APN IP addr " << apn_ip_addr
+              << " Bearer ID " << linked_bearer_id;
+  std::vector<uint32_t> eps_bearer_ids = {linked_bearer_id};
+  return delete_bearer(imsi, apn_ip_addr, linked_bearer_id, eps_bearer_ids);
 }
 
 bool AsyncSpgwServiceClient::delete_dedicated_bearer(
-  const std::string &imsi,
-  const std::string &apn_ip_addr,
-  const uint32_t link_bearer_id,
-  const std::vector<uint32_t> &eps_bearer_ids)
-{
-  auto req =
-    create_delete_bearer_req(imsi, apn_ip_addr, link_bearer_id, eps_bearer_ids);
-  MLOG(MDEBUG) << "deleting dedicated bearer " << imsi << apn_ip_addr;
-  delete_dedicated_bearer_rpc(
-    req, [imsi, apn_ip_addr](Status status, DeleteBearerResult resp) {
-      if (!status.ok()) {
-        MLOG(MERROR) << "Could not delete dedicated bearer" << imsi
-                     << apn_ip_addr << ": " << status.error_message();
-      }
-    });
-  return true;
+    const std::string &imsi, const std::string &apn_ip_addr,
+    const uint32_t linked_bearer_id,
+    const std::vector<uint32_t> &eps_bearer_ids) {
+  MLOG(MINFO) << "Deleting dedicated bearer IMSI: " << imsi << " APN IP addr "
+              << apn_ip_addr << " Bearer ID " << linked_bearer_id;
+  return delete_bearer(imsi, apn_ip_addr, linked_bearer_id, eps_bearer_ids);
 }
 
 bool AsyncSpgwServiceClient::create_dedicated_bearer(
-  const std::string &imsi,
-  const std::string &apn_ip_addr,
-  const uint32_t link_bearer_id,
-  const std::vector<PolicyRule> &flows)
-{
-  auto req = create_add_bearer_req(imsi, apn_ip_addr, link_bearer_id, flows);
-  MLOG(MDEBUG) << "creating dedicated bearer " << imsi << apn_ip_addr;
+    const std::string &imsi, const std::string &apn_ip_addr,
+    const uint32_t linked_bearer_id, const std::vector<PolicyRule> &flows) {
+  auto req = create_add_bearer_req(imsi, apn_ip_addr, linked_bearer_id, flows);
+  MLOG(MINFO) << "creating dedicated bearer " << imsi << apn_ip_addr;
   create_dedicated_bearer_rpc(
-    req, [imsi, apn_ip_addr](Status status, CreateBearerResult resp) {
-      if (!status.ok()) {
-        MLOG(MERROR) << "Could not create dedicated bearer" << imsi
-                     << apn_ip_addr << ": " << status.error_message();
-      }
-    });
+      req, [imsi, apn_ip_addr](Status status, CreateBearerResult resp) {
+        if (!status.ok()) {
+          MLOG(MERROR) << "Could not create dedicated bearer" << imsi
+                       << apn_ip_addr << ": " << status.error_message();
+        }
+      });
   return true;
 }
 
-void AsyncSpgwServiceClient::delete_dedicated_bearer_rpc(
-  const DeleteBearerRequest &request,
-  std::function<void(Status, DeleteBearerResult)> callback)
-{
+// delete_bearer creates the DeleteBearerRequest and logs the error
+bool AsyncSpgwServiceClient::delete_bearer(
+    const std::string &imsi, const std::string &apn_ip_addr,
+    const uint32_t linked_bearer_id,
+    const std::vector<uint32_t> &eps_bearer_ids) {
+  auto req = create_delete_bearer_req(imsi, apn_ip_addr, linked_bearer_id,
+                                      eps_bearer_ids);
+  delete_bearer_rpc(
+      req, [imsi, apn_ip_addr](Status status, DeleteBearerResult resp) {
+        if (!status.ok()) {
+          // only log error for now
+          MLOG(MERROR) << "Could not delete bearer" << imsi << apn_ip_addr
+                       << ": " << status.error_message();
+        }
+      });
+  return true;
+}
+
+void AsyncSpgwServiceClient::delete_bearer_rpc(
+    const DeleteBearerRequest &request,
+    std::function<void(Status, DeleteBearerResult)> callback) {
   auto local_resp = new AsyncLocalResponse<DeleteBearerResult>(
-    std::move(callback), RESPONSE_TIMEOUT);
+      std::move(callback), RESPONSE_TIMEOUT);
   local_resp->set_response_reader(std::move(
-    stub_->AsyncDeleteBearer(local_resp->get_context(), request, &queue_)));
+      stub_->AsyncDeleteBearer(local_resp->get_context(), request, &queue_)));
 }
 
 void AsyncSpgwServiceClient::create_dedicated_bearer_rpc(
-  const CreateBearerRequest &request,
-  std::function<void(Status, CreateBearerResult)> callback)
-{
+    const CreateBearerRequest &request,
+    std::function<void(Status, CreateBearerResult)> callback) {
   auto local_resp = new AsyncLocalResponse<CreateBearerResult>(
-    std::move(callback), RESPONSE_TIMEOUT);
+      std::move(callback), RESPONSE_TIMEOUT);
   local_resp->set_response_reader(std::move(
-    stub_->AsyncCreateBearer(local_resp->get_context(), request, &queue_)));
+      stub_->AsyncCreateBearer(local_resp->get_context(), request, &queue_)));
 }
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SpgwServiceClient.h
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.h
@@ -25,34 +25,45 @@ using namespace lte;
  * create/delete to PGW
  */
 class SpgwServiceClient {
- public:
+public:
+  /**
+   * Delete a default bearer (all session bearers)
+   * @param imsi - msi to identify a UE
+   * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
+   * @param linked_bearer_id - identifier for link bearer
+   * @return true if the operation was successful
+   */
+  virtual bool delete_default_bearer(const std::string &imsi,
+                                     const std::string &apn_ip_addr,
+                                     const uint32_t linked_bearer_id) = 0;
+
   /**
    * Delete a dedicated bearer
    * @param imsi - msi to identify a UE
    * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param link_bearer_id - id for identifying link bearer
+   * @param linked_bearer_id - identifier for link bearer
    * @param eps_bearer_ids - ids of bearers to delete
    * @return true if the operation was successful
    */
-  virtual bool delete_dedicated_bearer(
-    const std::string &imsi,
-    const std::string &apn_ip_addr,
-    const uint32_t link_bearer_id,
-    const std::vector<uint32_t> &eps_bearer_ids) = 0;
+  virtual bool
+  delete_dedicated_bearer(const std::string &imsi,
+                          const std::string &apn_ip_addr,
+                          const uint32_t linked_bearer_id,
+                          const std::vector<uint32_t> &eps_bearer_ids) = 0;
 
   /**
    * Create a dedicated bearer
    * @param imsi - msi to identify a UE
    * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param link_bearer_id - id for identifying link bearer
+   * @param linked_bearer_id - identifier for link bearer
    * @param flows - flow information required for a dedicated bearer
    * @return true if the operation was successful
    */
-  virtual bool create_dedicated_bearer(
-    const std::string &imsi,
-    const std::string &apn_ip_addr,
-    const uint32_t link_bearer_id,
-    const std::vector<PolicyRule> &flows) = 0;
+  virtual bool
+  create_dedicated_bearer(const std::string &imsi,
+                          const std::string &apn_ip_addr,
+                          const uint32_t linked_bearer_id,
+                          const std::vector<PolicyRule> &flows) = 0;
 };
 
 /**
@@ -60,51 +71,63 @@ class SpgwServiceClient {
  * asynchronously to PGW.
  */
 class AsyncSpgwServiceClient : public GRPCReceiver, public SpgwServiceClient {
- public:
+public:
   AsyncSpgwServiceClient();
 
   AsyncSpgwServiceClient(std::shared_ptr<grpc::Channel> pgw_channel);
+  /**
+   * Delete a default bearer (all session bearers)
+   * @param imsi - msi to identify a UE
+   * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
+   * @param linked_bearer_id - identifier for link bearer
+   * @return true if the operation was successful
+   */
+  bool delete_default_bearer(const std::string &imsi,
+                             const std::string &apn_ip_addr,
+                             const uint32_t linked_bearer_id);
 
   /**
    * Delete a dedicated bearer
    * @param imsi - msi to identify a UE
    * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param link_bearer_id - id for identifying link bearer
+   * @param linked_bearer_id - identifier for link bearer
    * @param flows - flow information required for a dedicated bearer
    * @return true if the operation was successful
    */
-  bool delete_dedicated_bearer(
-    const std::string &imsi,
-    const std::string &apn_ip_addr,
-    const uint32_t link_bearer_id,
-    const std::vector<uint32_t> &eps_bearer_ids);
+  bool delete_dedicated_bearer(const std::string &imsi,
+                               const std::string &apn_ip_addr,
+                               const uint32_t linked_bearer_id,
+                               const std::vector<uint32_t> &eps_bearer_ids);
 
   /**
    * Create a dedicated bearer
    * @param imsi - msi to identify a UE
    * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param link_bearer_id - id for identifying link bearer
+   * @param linked_bearer_id - identifier for link bearer
    * @param flows - flow information required for a dedicated bearer
    * @return true if the operation was successful
    */
-  bool create_dedicated_bearer(
-    const std::string &imsi,
-    const std::string &apn_ip_addr,
-    const uint32_t link_bearer_id,
-    const std::vector<PolicyRule> &flows);
+  bool create_dedicated_bearer(const std::string &imsi,
+                               const std::string &apn_ip_addr,
+                               const uint32_t linked_bearer_id,
+                               const std::vector<PolicyRule> &flows);
 
- private:
+private:
   static const uint32_t RESPONSE_TIMEOUT = 6; // seconds
   std::unique_ptr<SpgwService::Stub> stub_;
 
- private:
-  void delete_dedicated_bearer_rpc(
-    const DeleteBearerRequest &request,
-    std::function<void(Status, DeleteBearerResult)> callback);
+private:
+  bool delete_bearer(const std::string &imsi, const std::string &apn_ip_addr,
+                     const uint32_t linked_bearer_id,
+                     const std::vector<uint32_t> &eps_bearer_ids);
+
+  void
+  delete_bearer_rpc(const DeleteBearerRequest &request,
+                    std::function<void(Status, DeleteBearerResult)> callback);
 
   void create_dedicated_bearer_rpc(
-    const CreateBearerRequest &request,
-    std::function<void(Status, CreateBearerResult)> callback);
+      const CreateBearerRequest &request,
+      std::function<void(Status, CreateBearerResult)> callback);
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -8,22 +8,22 @@
  */
 #pragma once
 
+#include <gmock/gmock.h>
 #include <grpc++/grpc++.h>
 #include <gtest/gtest.h>
-#include <gmock/gmock.h>
 
-#include <lte/protos/policydb.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
 #include <lte/protos/pipelined.pb.h>
+#include <lte/protos/policydb.pb.h>
 #include <lte/protos/session_manager.grpc.pb.h>
 #include <orc8r/protos/eventd.pb.h>
 
 #include <folly/io/async/EventBase.h>
 
-#include "SessionReporter.h"
 #include "LocalSessionManagerHandler.h"
 #include "PipelinedClient.h"
 #include "RuleStore.h"
+#include "SessionReporter.h"
 #include "SessionState.h"
 #include "SpgwServiceClient.h"
 
@@ -36,255 +36,189 @@ namespace magma {
  * Mock handler to mock actual request handling and just test server
  */
 class MockPipelined final : public Pipelined::Service {
- public:
-  MockPipelined(): Pipelined::Service()
-  {
+public:
+  MockPipelined() : Pipelined::Service() {
     ON_CALL(*this, AddRule(_, _, _)).WillByDefault(Return(Status::OK));
     ON_CALL(*this, ActivateFlows(_, _, _)).WillByDefault(Return(Status::OK));
     ON_CALL(*this, DeactivateFlows(_, _, _)).WillByDefault(Return(Status::OK));
   }
 
-  MOCK_METHOD3(
-    AddRule,
-    Status(grpc::ServerContext *, const PolicyRule *, Void *));
-  MOCK_METHOD3(
-    ActivateFlows,
-    Status(
-      grpc::ServerContext *,
-      const ActivateFlowsRequest *,
-      ActivateFlowsResult *));
-  MOCK_METHOD3(
-    DeactivateFlows,
-    Status(
-      grpc::ServerContext *,
-      const DeactivateFlowsRequest *,
-      DeactivateFlowsResult *));
+  MOCK_METHOD3(AddRule,
+               Status(grpc::ServerContext *, const PolicyRule *, Void *));
+  MOCK_METHOD3(ActivateFlows,
+               Status(grpc::ServerContext *, const ActivateFlowsRequest *,
+                      ActivateFlowsResult *));
+  MOCK_METHOD3(DeactivateFlows,
+               Status(grpc::ServerContext *, const DeactivateFlowsRequest *,
+                      DeactivateFlowsResult *));
 };
 
 class MockPipelinedClient : public PipelinedClient {
- public:
-  MockPipelinedClient()
-  {
-    ON_CALL(*this, setup_cwf(_,_,_,_,_,_,_,_)).WillByDefault(Return(true));
-    ON_CALL(*this, setup_lte(_,_,_)).WillByDefault(Return(true));
+public:
+  MockPipelinedClient() {
+    ON_CALL(*this, setup_cwf(_, _, _, _, _, _, _, _))
+        .WillByDefault(Return(true));
+    ON_CALL(*this, setup_lte(_, _, _)).WillByDefault(Return(true));
     ON_CALL(*this, deactivate_all_flows(_)).WillByDefault(Return(true));
     ON_CALL(*this, deactivate_flows_for_rules(_, _, _))
-      .WillByDefault(Return(true));
+        .WillByDefault(Return(true));
     ON_CALL(*this, activate_flows_for_rules(_, _, _, _))
-      .WillByDefault(Return(true));
+        .WillByDefault(Return(true));
     ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _)).WillByDefault(Return(true));
     ON_CALL(*this, delete_ue_mac_flow(_, _)).WillByDefault(Return(true));
-    ON_CALL(*this, update_ipfix_flow(_, _, _, _, _)).WillByDefault(Return(true));
+    ON_CALL(*this, update_ipfix_flow(_, _, _, _, _))
+        .WillByDefault(Return(true));
     ON_CALL(*this, update_subscriber_quota_state(_))
-      .WillByDefault(Return(true));
+        .WillByDefault(Return(true));
   }
 
-  MOCK_METHOD8(setup_cwf,
-    bool(
-      const std::vector<SessionState::SessionInfo>& infos,
-      const std::vector<SubscriberQuotaUpdate>& quota_updates,
-      const std::vector<std::string> ue_mac_addrs,
-      const std::vector<std::string> msisdns,
-      const std::vector<std::string> apn_mac_addrs,
-      const std::vector<std::string> apn_names,
-      const std::uint64_t& epoch,
-      std::function<void(Status status, SetupFlowsResult)> callback));
-  MOCK_METHOD3(setup_lte,
-    bool(
-      const std::vector<SessionState::SessionInfo>& infos,
-      const std::uint64_t& epoch,
-      std::function<void(Status status, SetupFlowsResult)> callback));
-  MOCK_METHOD1(deactivate_all_flows, bool(const std::string& imsi));
+  MOCK_METHOD8(
+      setup_cwf,
+      bool(const std::vector<SessionState::SessionInfo> &infos,
+           const std::vector<SubscriberQuotaUpdate> &quota_updates,
+           const std::vector<std::string> ue_mac_addrs,
+           const std::vector<std::string> msisdns,
+           const std::vector<std::string> apn_mac_addrs,
+           const std::vector<std::string> apn_names, const std::uint64_t &epoch,
+           std::function<void(Status status, SetupFlowsResult)> callback));
   MOCK_METHOD3(
-    deactivate_flows_for_rules,
-    bool(
-      const std::string& imsi,
-      const std::vector<std::string>& rule_ids,
-      const std::vector<PolicyRule>& dynamic_rules));
-  MOCK_METHOD4(
-    activate_flows_for_rules,
-    bool(
-      const std::string& imsi,
-      const std::string& ip_addr,
-      const std::vector<std::string>& static_rules,
-      const std::vector<PolicyRule>& dynamic_rules));
-  MOCK_METHOD5(
-    add_ue_mac_flow,
-    bool(
-      const SubscriberID &sid,
-      const std::string &ue_mac_addr,
-      const std::string &msisdn,
-      const std::string &ap_mac_addr,
-      const std::string &ap_name));
-  MOCK_METHOD2(
-    delete_ue_mac_flow,
-    bool(
-      const SubscriberID &sid,
-      const std::string &ue_mac_addr));
-  MOCK_METHOD5(
-    update_ipfix_flow,
-    bool(
-      const SubscriberID &sid,
-      const std::string &ue_mac_addr,
-      const std::string &msisdn,
-      const std::string &ap_mac_addr,
-      const std::string &ap_name));
-  MOCK_METHOD1(
-    update_subscriber_quota_state,
-    bool(const std::vector<SubscriberQuotaUpdate>& updates));
+      setup_lte,
+      bool(const std::vector<SessionState::SessionInfo> &infos,
+           const std::uint64_t &epoch,
+           std::function<void(Status status, SetupFlowsResult)> callback));
+  MOCK_METHOD1(deactivate_all_flows, bool(const std::string &imsi));
+  MOCK_METHOD3(deactivate_flows_for_rules,
+               bool(const std::string &imsi,
+                    const std::vector<std::string> &rule_ids,
+                    const std::vector<PolicyRule> &dynamic_rules));
+  MOCK_METHOD4(activate_flows_for_rules,
+               bool(const std::string &imsi, const std::string &ip_addr,
+                    const std::vector<std::string> &static_rules,
+                    const std::vector<PolicyRule> &dynamic_rules));
+  MOCK_METHOD5(add_ue_mac_flow,
+               bool(const SubscriberID &sid, const std::string &ue_mac_addr,
+                    const std::string &msisdn, const std::string &ap_mac_addr,
+                    const std::string &ap_name));
+  MOCK_METHOD2(delete_ue_mac_flow,
+               bool(const SubscriberID &sid, const std::string &ue_mac_addr));
+  MOCK_METHOD5(update_ipfix_flow,
+               bool(const SubscriberID &sid, const std::string &ue_mac_addr,
+                    const std::string &msisdn, const std::string &ap_mac_addr,
+                    const std::string &ap_name));
+  MOCK_METHOD1(update_subscriber_quota_state,
+               bool(const std::vector<SubscriberQuotaUpdate> &updates));
 };
 
 class MockDirectorydClient : public AsyncDirectorydClient {
- public:
-  MockDirectorydClient()
-  {
-    ON_CALL(*this, get_directoryd_ip_field(_,_)).WillByDefault(Return(true));
+public:
+  MockDirectorydClient() {
+    ON_CALL(*this, get_directoryd_ip_field(_, _)).WillByDefault(Return(true));
   }
 
-  MOCK_METHOD2(get_directoryd_ip_field,
-    bool(
-      const std::string& imsi,
-      std::function<void(Status status, DirectoryField)> callback));
+  MOCK_METHOD2(
+      get_directoryd_ip_field,
+      bool(const std::string &imsi,
+           std::function<void(Status status, DirectoryField)> callback));
 };
 
 class MockEventdClient : public AsyncEventdClient {
- public:
-  MockEventdClient()
-  {
-  }
+public:
+  MockEventdClient() {}
 
   MOCK_METHOD2(log_event,
-    void(
-      const Event& request,
-      std::function<void(Status status, Void)> callback));
+               void(const Event &request,
+                    std::function<void(Status status, Void)> callback));
 };
 
 /**
  * Mock handler to mock actual request handling and just test server
  */
 class MockCentralController final : public CentralSessionController::Service {
- public:
-  MOCK_METHOD3(
-    CreateSession,
-    Status(
-      grpc::ServerContext *,
-      const CreateSessionRequest *,
-      CreateSessionResponse *));
+public:
+  MOCK_METHOD3(CreateSession,
+               Status(grpc::ServerContext *, const CreateSessionRequest *,
+                      CreateSessionResponse *));
 
-  MOCK_METHOD3(
-    UpdateSession,
-    Status(
-      grpc::ServerContext *,
-      const UpdateSessionRequest *,
-      UpdateSessionResponse *));
+  MOCK_METHOD3(UpdateSession,
+               Status(grpc::ServerContext *, const UpdateSessionRequest *,
+                      UpdateSessionResponse *));
 
-  MOCK_METHOD3(
-    TerminateSession,
-    Status(
-      grpc::ServerContext *,
-      const SessionTerminateRequest *,
-      SessionTerminateResponse *));
+  MOCK_METHOD3(TerminateSession,
+               Status(grpc::ServerContext *, const SessionTerminateRequest *,
+                      SessionTerminateResponse *));
 };
 
 class MockCallback {
- public:
-  MOCK_METHOD2(
-    update_callback,
-    void(Status status, const UpdateSessionResponse& ));
-  MOCK_METHOD2(
-    create_callback,
-    void(Status status, const CreateSessionResponse& ));
+public:
+  MOCK_METHOD2(update_callback,
+               void(Status status, const UpdateSessionResponse &));
+  MOCK_METHOD2(create_callback,
+               void(Status status, const CreateSessionResponse &));
 };
 
 /**
  * Mock handler to mock actual request handling and just test server
  */
 class MockSessionHandler final : public LocalSessionManagerHandler {
- public:
+public:
   ~MockSessionHandler() {}
 
-  MOCK_METHOD3(
-    ReportRuleStats,
-    void(
-      grpc::ServerContext *,
-      const RuleRecordTable *,
-      std::function<void(Status, Void)>));
+  MOCK_METHOD3(ReportRuleStats,
+               void(grpc::ServerContext *, const RuleRecordTable *,
+                    std::function<void(Status, Void)>));
 
-  MOCK_METHOD3(
-    CreateSession,
-    void(
-      grpc::ServerContext *,
-      const LocalCreateSessionRequest *,
-      std::function<void(Status, LocalCreateSessionResponse)>));
+  MOCK_METHOD3(CreateSession,
+               void(grpc::ServerContext *, const LocalCreateSessionRequest *,
+                    std::function<void(Status, LocalCreateSessionResponse)>));
 
-  MOCK_METHOD3(
-    EndSession,
-    void(
-      grpc::ServerContext *,
-      const LocalEndSessionRequest *,
-      std::function<void(Status, LocalEndSessionResponse)>));
+  MOCK_METHOD3(EndSession,
+               void(grpc::ServerContext *, const LocalEndSessionRequest *,
+                    std::function<void(Status, LocalEndSessionResponse)>));
 };
 
 class MockSessionReporter : public SessionReporter {
-  public:
-    MOCK_METHOD2(
-      report_updates,
-      void(
-        const UpdateSessionRequest& ,
-        std::function<void(grpc::Status, UpdateSessionResponse)>));
+public:
+  MOCK_METHOD2(report_updates,
+               void(const UpdateSessionRequest &,
+                    std::function<void(grpc::Status, UpdateSessionResponse)>));
 
-    MOCK_METHOD2(
-      report_create_session,
-      void(
-        const CreateSessionRequest& ,
-        std::function<void(Status, CreateSessionResponse)>));
+  MOCK_METHOD2(report_create_session,
+               void(const CreateSessionRequest &,
+                    std::function<void(Status, CreateSessionResponse)>));
 
-    MOCK_METHOD2(
-      report_terminate_session,
-      void(
-        const SessionTerminateRequest& ,
-        std::function<void(Status, SessionTerminateResponse)>));
-
+  MOCK_METHOD2(report_terminate_session,
+               void(const SessionTerminateRequest &,
+                    std::function<void(Status, SessionTerminateResponse)>));
 };
 
 class MockAAAClient : public aaa::AAAClient {
- public:
-  MockAAAClient()
-  {
+public:
+  MockAAAClient() {
     ON_CALL(*this, terminate_session(_, _)).WillByDefault(Return(true));
   }
 
-  MOCK_METHOD2(
-    terminate_session,
-    bool(
-      const std::string& radius_session_id,
-      const std::string& imsi));
+  MOCK_METHOD2(terminate_session, bool(const std::string &radius_session_id,
+                                       const std::string &imsi));
 };
 
 class MockSpgwServiceClient : public SpgwServiceClient {
-  public:
-    MockSpgwServiceClient()
-    {
-      ON_CALL(*this, delete_dedicated_bearer(_, _, _, _))
+public:
+  MockSpgwServiceClient() {
+    ON_CALL(*this, delete_default_bearer(_, _, _)).WillByDefault(Return(true));
+    ON_CALL(*this, delete_dedicated_bearer(_, _, _, _))
         .WillByDefault(Return(true));
-      ON_CALL(*this, create_dedicated_bearer(_, _, _, _))
+    ON_CALL(*this, create_dedicated_bearer(_, _, _, _))
         .WillByDefault(Return(true));
-    }
+  }
+  MOCK_METHOD3(delete_default_bearer,
+               bool(const std::string &, const std::string &, const uint32_t));
 
-    MOCK_METHOD4(
-      delete_dedicated_bearer,
-      bool(
-        const std::string& ,
-        const std::string& ,
-        const uint32_t,
-        const std::vector<uint32_t>& ));
-    MOCK_METHOD4(
-      create_dedicated_bearer,
-      bool(
-        const std::string& ,
-        const std::string& ,
-        const uint32_t,
-        const std::vector<PolicyRule>& ));
+  MOCK_METHOD4(delete_dedicated_bearer,
+               bool(const std::string &, const std::string &, const uint32_t,
+                    const std::vector<uint32_t> &));
+  MOCK_METHOD4(create_dedicated_bearer,
+               bool(const std::string &, const std::string &, const uint32_t,
+                    const std::vector<PolicyRule> &));
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -609,6 +609,11 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
               deactivate_flows_for_rules(testing::_, testing::_, testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
+  // Since this is a termination triggered by SessionD/Core (quota exhaustion
+  // + FUA-Terminate), we expect MME to be notified to delete the bearer
+  // created on session creation
+  EXPECT_CALL(*spgw_client,
+              delete_default_bearer("IMSI1", testing::_, testing::_));
   // call collect_updates to trigger actions
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto usage_updates =


### PR DESCRIPTION
Summary:
- When session terminate is triggered by the core, (quota exhaustion + FUA terminate), we need to delete the default bearer + PDN session previously created in the MME.

- Minor change to rename `link_bearer_id` -> `linked_bearer_id`

- clang formatting on touched files

Reviewed By: ulaskozat

Differential Revision: D21051228

