### PR TITLE
Fix camel case function name to be snake case

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -53,7 +53,7 @@ static void mark_rule_failures(
 static void handle_command_level_result_code(
     const std::string& imsi, const uint32_t result_code,
     std::unordered_set<std::string>& subscribers_to_terminate);
-static bool isValidMacAddress(const char* mac);
+static bool is_valid_mac_address(const char* mac);
 static int get_apn_split_locaion(const std::string& apn);
 static bool parse_apn(
     const std::string& apn, std::string& mac_addr, std::string& name);
@@ -1685,7 +1685,7 @@ static void mark_rule_failures(
   }
 }
 
-static bool isValidMacAddress(const char* mac) {
+static bool is_valid_mac_address(const char* mac) {
   int i = 0;
   int s = 0;
 
@@ -1717,7 +1717,7 @@ static bool parse_apn(
     return false;
   }
   auto mac = apn.substr(0, split_location);
-  if (!isValidMacAddress(mac.c_str())) {
+  if (!is_valid_mac_address(mac.c_str())) {
     return false;
   }
   mac_addr = mac;


### PR DESCRIPTION
Summary: isValidMacAddress -> is_valid_mac_address

Reviewed By: andreilee

Differential Revision: D21072697

