### PR TITLE
Add dialect option for sequelize orm

### DIFF
--- a/symphony/app/fbcnms-packages/fbcnms-sequelize-models/index.js
+++ b/symphony/app/fbcnms-packages/fbcnms-sequelize-models/index.js
@@ -42,7 +42,10 @@ export const User = db.User;
 export const FeatureFlag = db.FeatureFlag;
 
 export function jsonArrayContains(column: string, value: string) {
-  if (sequelize.getDialect() === 'mysql') {
+  if (
+    sequelize.getDialect() === 'mysql' ||
+    sequelize.getDialect() === 'mariadb'
+  ) {
     return Sequelize.fn('JSON_CONTAINS', Sequelize.col(column), `"${value}"`);
   } else {
     // sqlite

--- a/symphony/app/fbcnms-packages/fbcnms-sequelize-models/sequelizeConfig.js
+++ b/symphony/app/fbcnms-packages/fbcnms-sequelize-models/sequelizeConfig.js
@@ -16,6 +16,7 @@ const MYSQL_PORT = parseInt(process.env.MYSQL_PORT || '3306');
 const MYSQL_USER = process.env.MYSQL_USER || 'root';
 const MYSQL_PASS = process.env.MYSQL_PASS || '';
 const MYSQL_DB = process.env.MYSQL_DB || 'cxl';
+const SEQUELIZE_DIALECT = process.env.SEQUELIZE_DIALECT || 'mysql';
 
 const logger = require('@fbcnms/logging').getLogger(module);
 
@@ -33,7 +34,7 @@ const config: {[string]: Options} = {
     database: MYSQL_DB,
     host: MYSQL_HOST,
     port: MYSQL_PORT,
-    dialect: 'mysql',
+    dialect: SEQUELIZE_DIALECT,
     logging: (msg: string) => logger.debug(msg),
   },
   production: {
@@ -42,7 +43,7 @@ const config: {[string]: Options} = {
     database: MYSQL_DB,
     host: MYSQL_HOST,
     port: MYSQL_PORT,
-    dialect: 'mysql',
+    dialect: SEQUELIZE_DIALECT,
     logging: (msg: string) => logger.debug(msg),
   },
 };

--- a/symphony/app/fbcnms-projects/magmalte/docker-compose.yml
+++ b/symphony/app/fbcnms-projects/magmalte/docker-compose.yml
@@ -3,10 +3,10 @@
 version: '3.6'
 
 services:
-  mysql:
-    image: mysql:5
+  mariadb:
+    image: mariadb:10.4.12
     volumes:
-      - mysql:/var/lib/mysql
+      - mariadb:/var/lib/mysql
     environment:
       MYSQL_ROOT_PASSWORD: 12345
       MYSQL_DATABASE: nms
@@ -29,14 +29,14 @@ services:
     build:
       context: ../..
       dockerfile: fbcnms-projects/magmalte/Dockerfile
-    command: "/usr/local/bin/wait-for-it.sh -s -t 30 mysql:3306 -- yarn run start:dev"
+    command: "/usr/local/bin/wait-for-it.sh -s -t 30 mariadb:3306 -- yarn run start:dev"
     volumes:
       - ../../fbcnms-packages:/usr/src/fbcnms-packages
       - ../../fbcnms-projects/magmalte/app:/usr/src/fbcnms-projects/magmalte/app
       - ../../fbcnms-projects/magmalte/scripts:/usr/src/fbcnms-projects/magmalte/scripts
       - ../../fbcnms-projects/magmalte/server:/usr/src/fbcnms-projects/magmalte/server
     depends_on:
-      - mysql
+      - mariadb
     networks:
       - default
       - orc8r_default
@@ -48,11 +48,12 @@ services:
       API_HOST: ${API_HOST:-proxy:9443}
       PORT: 8081
       HOST: 0.0.0.0
-      MYSQL_HOST: mysql
+      MYSQL_HOST: mariadb
       MYSQL_DB: nms
       MYSQL_USER: nms
       MYSQL_PASS: password
       MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
+      SEQUELIZE_DIALECT: mariadb
     healthcheck:
       test: curl -If localhost:8081/healthz
     restart: on-failure
@@ -71,4 +72,4 @@ networks:
     external: true
 
 volumes:
-  mysql:
+  mariadb:

--- a/symphony/app/fbcnms-projects/magmalte/package.json
+++ b/symphony/app/fbcnms-projects/magmalte/package.json
@@ -29,6 +29,7 @@
     "dotenv": "^6.0.0",
     "lodash": "^4.17.11",
     "mapbox-gl": "^0.53.0",
+    "mariadb": "^2.3.1",
     "pug": "^2.0.3",
     "react-chartjs-2": "^2.7.4",
     "react-json-tree": "^0.11.2",

--- a/symphony/app/yarn.lock
+++ b/symphony/app/yarn.lock
@@ -2558,7 +2558,7 @@
   resolved "https://registry.yarnpkg.com/@types/events/-/events-3.0.0.tgz#2862f3f58a9a7f7c3e78d79f130dd4d71c25c2a7"
   integrity sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==
 
-"@types/geojson@*":
+"@types/geojson@*", "@types/geojson@^7946.0.7":
   version "7946.0.7"
   resolved "https://registry.yarnpkg.com/@types/geojson/-/geojson-7946.0.7.tgz#c8fa532b60a0042219cdf173ca21a975ef0666ad"
   integrity sha512-wE2v81i4C4Ol09RtsWFAqg3BUitWbHSpSlIo+bNdsCJijO9sjme+zm+73ZMCa/qMC8UEERxzGbvmr1cffo2SiQ==
@@ -2633,6 +2633,11 @@
   version "13.1.8"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.8.tgz#1d590429fe8187a02707720ecf38a6fe46ce294b"
   integrity sha512-6XzyyNM9EKQW4HKuzbo/CkOIjn/evtCmsU+MUM1xDfJ+3/rNjBttM1NgN7AOQvN6tP1Sl1D1PIKMreTArnxM9A==
+
+"@types/node@>=8.0.0":
+  version "13.11.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.11.1.tgz#49a2a83df9d26daacead30d0ccc8762b128d53c7"
+  integrity sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g==
 
 "@types/node@^10.1.0":
   version "10.14.17"
@@ -9002,6 +9007,13 @@ iconv-lite@^0.5.0:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+iconv-lite@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.5.1.tgz#b2425d3c7b18f7219f2ca663d103bddb91718d64"
+  integrity sha512-ONHr16SQvKZNSqjQT9gy5z24Jw+uqfO02/ngBSBoqChZ+W8qXX7GPRa1RoUnzGADw8K63R1BXUMzarCVQBpY8Q==
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
+
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz#06ea6f83679a7749e386cfe1fe812ae5db223ded"
@@ -11153,6 +11165,18 @@ mapbox-gl@^0.53.0:
     tinyqueue "^2.0.0"
     vt-pbf "^3.1.1"
 
+mariadb@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/mariadb/-/mariadb-2.3.1.tgz#bbc05c82aa4bf3fe58e54b1735e94a3a43fa4bff"
+  integrity sha512-suv+ygoiS+tQSKmxgzJsGV9R+USN8g6Ql+GuMo9k7alD6FxOT/lwebLHy63/7yPZfVtlyAitK1tPd7ZoFhN/Sg==
+  dependencies:
+    "@types/geojson" "^7946.0.7"
+    "@types/node" ">=8.0.0"
+    denque "^1.4.1"
+    iconv-lite "^0.5.1"
+    long "^4.0.0"
+    moment-timezone "^0.5.27"
+
 markdown-to-jsx@^6.9.1, markdown-to-jsx@^6.9.3:
   version "6.10.3"
   resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz#7f0946684acd321125ff2de7fd258a9b9c7c40b7"
@@ -11518,6 +11542,13 @@ moment-timezone@^0.5.21:
   version "0.5.27"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.27.tgz#73adec8139b6fe30452e78f210f27b1f346b8877"
   integrity sha512-EIKQs7h5sAsjhPCqN6ggx6cEbs94GK050254TIJySD1bzoM5JTYDwAU1IoVOeTOL6Gm27kYJ51/uuvq1kIlrbw==
+  dependencies:
+    moment ">= 2.9.0"
+
+moment-timezone@^0.5.27:
+  version "0.5.28"
+  resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
+  integrity sha512-TDJkZvAyKIVWg5EtVqRzU97w0Rb0YVbfpqyjgu6GwXCAohVRqwZjf4fOzDE6p1Ch98Sro/8hQQi65WDXW5STPw==
   dependencies:
     moment ">= 2.9.0"
 


### PR DESCRIPTION
Summary:
To more align with Magma technical requirements, we need to support mariadb rather than just mysql.

Sequelize added support for mariadb dialect in v5, and this diff just adds support to choose the dialect as an envioronment variable. Additionally, we now use a mariadb image in the development docker-compose file.

Differential Revision: D21077649

