### PR TITLE
Conductor metrics collection

### DIFF
--- a/symphony/integration/docker-compose.conductor.frinx.yaml
+++ b/symphony/integration/docker-compose.conductor.frinx.yaml
@@ -43,9 +43,11 @@ services:
       retries: 1
 
   conductor-server:
+    build:
+      context: ${FBCODE_FBC_DIR}/symphony/integration/workflows/conductor
     environment:
       - CONFIG_PROP=config.properties
-    image: frinx/fm-conductor-server:latest
+      - LOG4J_PROP=log4j-fluentd-appender.properties
     container_name: conductor-server
     links:
       - elasticsearch:es

--- a/symphony/integration/docker-compose.prometheus.yaml
+++ b/symphony/integration/docker-compose.prometheus.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2004-present Facebook All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+version: "3.7"
+
+services:
+  prometheus:
+    build:
+      context: ${FBCODE_FBC_DIR}/symphony/integration/prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--storage.tsdb.path=/prometheus'
+      - '--web.console.libraries=/usr/share/prometheus/console_libraries'
+      - '--web.console.templates=/usr/share/prometheus/consoles'
+    ports:
+      - 9090:9090
+    restart: always
+    networks:
+      - private
+      - public
+
+  grafana:
+    image: grafana/grafana
+    user: "104"
+    depends_on:
+      - prometheus
+    ports:
+      - 3000:3000
+    networks:
+      - private
+      - public
+    restart: always
+
+networks:
+  public:
+  private:
+    internal: true

--- a/symphony/integration/docker-compose.yaml
+++ b/symphony/integration/docker-compose.yaml
@@ -137,7 +137,7 @@ services:
     networks:
       - private
     volumes:
-      - ${PWD}/fluentd/fluent.conf:/fluentd/etc/fluent.conf:ro
+      - ${PWD}/fluentd/:/fluentd/etc/:ro
     restart: on-failure
 
   nginx:

--- a/symphony/integration/fluentd/fluent.conf
+++ b/symphony/integration/fluentd/fluent.conf
@@ -23,6 +23,8 @@
   </metric>
 </filter>
 
+@include fluent_conductor.conf
+
 <match **>
   @type stdout
 </match>

--- a/symphony/integration/fluentd/fluent_conductor.conf
+++ b/symphony/integration/fluentd/fluent_conductor.conf
@@ -1,0 +1,50 @@
+; syslog is used for conductor metrics streaming
+<source>
+  @type syslog
+  port 5170
+  bind 0.0.0.0
+  tag conductor
+    <parse>
+     ; only allow TIMER metrics of workflow execution and extract tenant ID
+      @type regexp
+      expression /^.*type=TIMER, name=workflow_execution.class-WorkflowMonitor.+workflowName-(?<tenant>.*)_(?<workflow>.+), count=(?<count>\d+), min=(?<min>[\d.]+), max=(?<max>[\d.]+), mean=(?<mean>[\d.]+).*$/
+      types count:integer,min:float,max:float,mean:float
+    </parse>
+</source>
+
+<filter conductor.local1.info>
+    @type prometheus
+    <metric>
+      name conductor_workflow_count
+      type gauge
+      desc The total number of executed workflows
+      key count
+      <labels>
+        workflow ${workflow}
+        tenant ${tenant}
+        user ${email}
+      </labels>
+    </metric>
+    <metric>
+      name conductor_workflow_max_duration
+      type gauge
+      desc Max duration in millis for a workflow
+      key max
+      <labels>
+        workflow ${workflow}
+        tenant ${tenant}
+        user ${email}
+      </labels>
+    </metric>
+    <metric>
+      name conductor_workflow_mean_duration
+      type gauge
+      desc Mean duration in millis for a workflow
+      key mean
+      <labels>
+        workflow ${workflow}
+        tenant ${tenant}
+        user ${email}
+      </labels>
+    </metric>
+</filter>

--- a/symphony/integration/prometheus/Dockerfile
+++ b/symphony/integration/prometheus/Dockerfile
@@ -1,0 +1,9 @@
+# Copyright (c) 2004-present Facebook All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Extend base fluentd image
+FROM prom/prometheus
+
+# Copy config files
+COPY prometheus.yaml /etc/prometheus/prometheus.yml

--- a/symphony/integration/workflows/conductor/Dockerfile
+++ b/symphony/integration/workflows/conductor/Dockerfile
@@ -1,0 +1,10 @@
+# Copyright (c) 2004-present Facebook All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# Extend base fluentd image
+FROM frinx/fm-conductor-server:latest
+
+# Copy config files
+COPY config.properties /app/config/config.properties
+COPY log4j-fluentd-appender.properties /app/config/log4j-fluentd-appender.properties

--- a/symphony/integration/workflows/conductor/config.properties
+++ b/symphony/integration/workflows/conductor/config.properties
@@ -1,0 +1,61 @@
+# Servers.
+conductor.jetty.server.enabled=true
+conductor.grpc.server.enabled=false
+
+# Database persistence model.  Possible values are memory, redis, and dynomite.
+# If ommitted, the persistence used is memory
+#
+# memory : The data is stored in memory and lost when the server dies.  Useful for testing or demo
+# redis : non-Dynomite based redis instance
+# dynomite : Dynomite cluster.  Use this for HA configuration.
+
+db=dynomite
+
+# Dynomite Cluster details.
+# format is host:port:rack separated by semicolon
+workflow.dynomite.cluster.hosts=dyno1:8102:us-east-1c
+
+# Dynomite cluster name
+workflow.dynomite.cluster.name=dyno1
+workflow.dynomite.connection.maxConnsPerHost=30
+
+# Namespace for the keys stored in Dynomite/Redis
+workflow.namespace.prefix=conductor
+
+# Namespace prefix for the dyno queues
+workflow.namespace.queue.prefix=conductor_queues
+
+# No. of threads allocated to dyno-queues (optional)
+queues.dynomite.threads=10
+
+# Non-quorum port used to connect to local redis.  Used by dyno-queues.
+# When using redis directly, set this to the same port as redis server
+# For Dynomite, this is 22122 by default or the local redis-server port used by Dynomite.
+queues.dynomite.nonQuorum.port=22122
+
+# Elastic search instance type. Possible values are memory and external.
+# If not specified, the instance type will be embedded in memory
+#
+# memory: The instance is created in memory and lost when the server dies. Useful for development and testing.
+# external: Elastic search instance runs outside of the server. Data is persisted and does not get lost when
+#           the server dies. Useful for more stable environments like staging or production.
+workflow.elasticsearch.instanceType=EXTERNAL
+
+# Transport address to elasticsearch
+workflow.elasticsearch.url=es:9300
+
+# Name of the elasticsearch cluster
+workflow.elasticsearch.index.name=conductor
+
+# Set elasticsearch version
+workflow.elasticsearch.version=6
+
+# Additional modules (optional)
+# conductor.additional.modules=class_extending_com.google.inject.AbstractModule
+
+# Additional modules for metrics collection (optional)
+conductor.additional.modules=com.netflix.conductor.contribs.metrics.MetricsRegistryModule,com.netflix.conductor.contribs.metrics.LoggingMetricsModule
+com.netflix.conductor.contribs.metrics.LoggingMetricsModule.reportPeriodSeconds=15
+
+# Load sample kitchen sink workflow
+loadSample=false

--- a/symphony/integration/workflows/conductor/log4j-fluentd-appender.properties
+++ b/symphony/integration/workflows/conductor/log4j-fluentd-appender.properties
@@ -1,0 +1,39 @@
+#
+# Copyright 2017 Netflix, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO,console,file
+
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{ISO8601} %5p [%t] (%C) - %m%n
+
+log4j.appender.file=org.apache.log4j.RollingFileAppender
+log4j.appender.file.File=/app/logs/conductor.log
+log4j.appender.file.MaxFileSize=10MB
+log4j.appender.file.MaxBackupIndex=10
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{ISO8601} %5p [%t] (%C) - %m%n
+
+# Syslog based appender streaming metrics into fluentd
+log4j.appender.server=org.apache.log4j.net.SyslogAppender
+log4j.appender.server.syslogHost=fluentd:5170
+log4j.appender.server.facility=LOCAL1
+log4j.appender.server.layout=org.apache.log4j.PatternLayout
+log4j.appender.server.layout.ConversionPattern=%d{ISO8601} %5p [%t] (%C) - %m%n
+
+log4j.logger.ConductorMetrics=INFO,console,server
+log4j.additivity.ConductorMetrics=false
+


### PR DESCRIPTION
conductor now pushes metrics into fluentD
fluentD processes the metrics and exposes them for prometheus
prometheus already collects metrics from fluentD

* add prometheus and grafana compose file for local deployment

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>