### PR TITLE
[bug fix][mme] Fix for handling nw initiated detach

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -2902,11 +2902,10 @@ void mme_app_handle_nw_init_bearer_deactv_req(
   pdn_context_t* pdn_context = ue_context_p->pdn_contexts[cid];
 
   /* If delete_default_bearer is set and this is the only active PDN,
-  *  Send Detach Request to UE
-  */
-  if (
-    (nw_init_bearer_deactv_req_p->delete_default_bearer) &&
-    (ue_context_p->nb_active_pdn_contexts == 1)) {
+   *  Send Detach Request to UE
+   */
+  if ((nw_init_bearer_deactv_req_p->delete_default_bearer) &&
+      (ue_context_p->emm_context.esm_ctx.n_pdns == 1)) {
     OAILOG_INFO_UE(
       LOG_MME_APP,
       ue_context_p->emm_context._imsi64,

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
@@ -201,7 +201,7 @@ int mme_app_handle_nw_initiated_detach_request(
   emm_cn_nw_initiated_detach.ue_id       = ue_id;
   emm_cn_nw_initiated_detach.detach_type = detach_type;
 
-  OAILOG_FUNC_RETURN(
-      LOG_MME_APP,
-      nas_proc_nw_initiated_detach_ue_request(&emm_cn_nw_initiated_detach));
+  int ret =
+      nas_proc_nw_initiated_detach_ue_request(&emm_cn_nw_initiated_detach);
+  OAILOG_FUNC_RETURN(LOG_MME_APP, ret);
 }


### PR DESCRIPTION
Summary:
This PR has fix for sending network initiated detach request to UE when session manager/SPGW has triggered deletion of the last PDN

Test Plan:
1. Verified S1 SIM sanity
2. Executed newly added S1 SIM TC - test_attach_detach_nw_triggered_delete_last_pdn.py(PR- #1525)