### PR TITLE
Multiple diameter (integ_test) (1/3) - main.go mockPCRF and mockOCS to support multiple configurations

### DIFF
--- a/cwf/gateway/docker/docker-compose.multi-session_proxy.yml
+++ b/cwf/gateway/docker/docker-compose.multi-session_proxy.yml
@@ -1,0 +1,40 @@
+version: "3.7"
+
+# Standard logging for each service
+x-logging: &logging_anchor
+  driver: "json-file"
+  options:
+    max-size: "10mb"
+    max-file: "10"
+
+# Standard volumes mounted
+x-standard-volumes: &volumes_anchor
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - /etc/snowflake:/etc/snowflake
+
+x-generic-service: &service
+  volumes: *volumes_anchor
+  logging: *logging_anchor
+  restart: always
+  network_mode: host
+
+x-feg-goservice: &feggoservice
+  <<: *service
+  image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+
+services:
+  pcrf2:
+    <<: *feggoservice
+    container_name: pcrf2
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/pcrf -logtostderr=true -v=0 -servernumber=2
+
+  ocs2:
+    <<: *feggoservice
+    container_name: ocs2
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/ocs -logtostderr=true -v=0 -servernumber=2
+

--- a/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
+++ b/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
@@ -136,6 +136,20 @@
        "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
        "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
        "disableDestHost": false
+      },
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50013",
+       "retransmits": 0,
+       "watchdogInterval": 0,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50014",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
       }
     ]
    },
@@ -148,6 +162,20 @@
        "watchdogInterval": 0,
        "retryCount": 0,
        "localAddress": "127.0.0.1:50002",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "sdp1c.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
+      },
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50011",
+       "retransmits": 0,
+       "watchdogInterval": 0,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50012",
        "productName": "magma",
        "realm": "magma.svc.cluster.local",
        "host": "feg.magma.svc.cluster.local",

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -36,11 +36,15 @@ const (
 	MockHSSRemote   = "HSS_REMOTE"
 	MockPCRFRemote  = "PCRF_REMOTE"
 	MockOCSRemote   = "OCS_REMOTE"
+	MockPCRFRemote2 = "PCRF_REMOTE2"
+	MockOCSRemote2  = "OCS_REMOTE2"
 	PipelinedRemote = "pipelined.local"
 	RedisRemote     = "REDIS"
 	CwagIP          = "192.168.70.101"
 	OCSPort         = 9201
 	PCRFPort        = 9202
+	OCSPort2        = 9205
+	PCRFPort2       = 9206
 	HSSPort         = 9204
 	PipelinedPort   = 8443
 	RedisPort       = 6380
@@ -75,6 +79,17 @@ func NewTestRunner(t *testing.T) *TestRunner {
 	registry.AddService(RedisRemote, CwagIP, RedisPort)
 
 	return testRunner
+}
+
+// NewTestRunnerWithTwoPCRFandOCS does the same as NewTestRunner but it inclides 2 PCRF and 2 OCS
+// Used in scenarios that run 2 PCRFs and 2 OCSs
+func NewTestRunnerWithTwoPCRFandOCS(t *testing.T) *TestRunner {
+	tr :=NewTestRunner(t)
+	fmt.Printf("Adding second Mock PCRF service at %s:%d\n", CwagIP, PCRFPort2)
+	registry.AddService(MockPCRFRemote2, CwagIP, PCRFPort2)
+	fmt.Printf("Adding second OCS service at %s:%d\n", CwagIP, OCSPort2)
+	registry.AddService(MockOCSRemote2, CwagIP, OCSPort2)
+	return tr
 }
 
 // ConfigUEs creates and adds the specified number of UEs and Subscribers

--- a/feg/gateway/registry/local_registry.go
+++ b/feg/gateway/registry/local_registry.go
@@ -36,7 +36,9 @@ const (
 	REDIS         = "REDIS"
 	MOCK_VLR      = "MOCK_VLR"
 	MOCK_OCS      = "MOCK_OCS"
+	MOCK_OCS2     = "MOCK_OCS2"
 	MOCK_PCRF     = "MOCK_PCRF"
+	MOCK_PCRF2    = "MOCK_PCRF2"
 	MOCK_HSS      = "HSS"
 
 	SESSION_MANAGER = "SESSIOND"
@@ -86,6 +88,8 @@ func init() {
 
 	addLocalService(MOCK_OCS, 9201)
 	addLocalService(MOCK_PCRF, 9202)
+	addLocalService(MOCK_OCS2, 9205)
+	addLocalService(MOCK_PCRF2, 9206)
 	addLocalService(MOCK_VLR, 9203)
 	addLocalService(MOCK_HSS, 9204)
 

--- a/feg/gateway/services/testcore/ocs/main.go
+++ b/feg/gateway/services/testcore/ocs/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	"magma/feg/cloud/go/protos"
@@ -27,19 +28,36 @@ const (
 	ValidityTime  = 60   // in second
 )
 
+var (
+	serverNumber int
+)
+
 func init() {
-	flag.Parse()
+	flag.IntVar(&serverNumber, "servernumber", 1, "Number of the server. Will use Gy[servernumber-1] configuration")
 }
 
 func main() {
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_OCS)
-	if err != nil {
-		log.Fatalf("Error creating mock OCS service: %s", err)
-	}
+	flag.Parse()
 
-	// TODO: support multiple connections
-	gyCliConf := gy.GetGyClientConfiguration()[0]
-	gyServConf := gy.GetOCSConfiguration()[0]
+	serverIdx := serverNumber - 1
+	log.Print("------ Reading Gy configuration a couple of times ------")
+	// Get the server N from the list of configured servers. This is normally 0, unless multiple GX connections are configured
+	gyConfigs := gy.GetGyClientConfiguration()
+	if serverIdx >= len(gyConfigs) {
+		log.Fatalf("ServerIndex value (%d) is bigger than the amout Gy servers configured (%d)", serverIdx, len(gyConfigs))
+		return
+	}
+	gyCliConf := gyConfigs[serverIdx]
+	gyServConf := gy.GetOCSConfiguration()[serverIdx]
+	log.Print("------ Done reading Gy configuration  ------")
+	log.Printf("Mock OCS using Gy server configured at index %d with adderess %s", serverIdx, gyServConf.Addr)
+
+	serviceName := registry.MOCK_OCS
+	if serverIdx > 0 {
+		serviceName = fmt.Sprintf("%s%d", serviceName, serverNumber)
+		log.Printf("OCS serviceName renamed to: %s", serviceName)
+
+	}
 
 	diamServer := mock_ocs.NewOCSDiamServer(
 		gyCliConf,
@@ -52,20 +70,25 @@ func main() {
 		},
 	)
 
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
+	if err != nil {
+		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
+	}
+
 	lis, err := diamServer.StartListener()
 	if err != nil {
-		log.Fatalf("Unable to start listener for mock OCS: %s", err)
+		log.Fatalf("Unable to start listener for mock %s: %s", serviceName, err)
 	}
 
 	protos.RegisterMockOCSServer(srv.GrpcServer, diamServer)
 
 	go func() {
-		glog.V(2).Infof("Starting mock OCS server at %s", lis.Addr().String())
+		glog.V(2).Infof("Starting mock %s server at %s", serviceName, lis.Addr().String())
 		glog.Errorf(diamServer.Start(lis).Error()) // blocks
 	}()
 
 	err = srv.Run()
 	if err != nil {
-		log.Fatalf("Error running mock OCS service: %s", err)
+		log.Fatalf("Error running mock %s service: %s", serviceName, err)
 	}
 }


### PR DESCRIPTION
Summary: Modified main.go at mockPCRF and mockOCS to support configuring multiple gx and gy connections

Differential Revision: D21094833

