### PR TITLE
Multiple diameter (integ_test) (2/3) - Add second scenario for integ_test for OCS2 and PCRF2

### DIFF
--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -75,6 +75,8 @@ services:
     depends_on:
       - pcrf
       - ocs
+      - pcrf2
+      - ocs2
     environment:
       MAGMA_PRINT_GRPC_PAYLOAD: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/session_proxy -logtostderr=true -v=2
@@ -93,6 +95,16 @@ services:
     <<: *feggoservice
     container_name: ocs
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/ocs -logtostderr=true -v=0
+
+  pcrf2:
+    <<: *feggoservice
+    container_name: pcrf2
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/pcrf -logtostderr=true -v=0 -servernumber=2
+
+  ocs2:
+    <<: *feggoservice
+    container_name: ocs2
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/ocs -logtostderr=true -v=0 -servernumber=2
 
   redis:
     <<: *pyservice

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -32,6 +32,7 @@ class SubTests(Enum):
     AUTH = "authenticate"
     GX = "gx"
     GY = "gy"
+    MULTISESSIONPROXY = "multi_session_proxy"
 
     @staticmethod
     def list():
@@ -77,7 +78,7 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
     if not skip_unit_tests:
         execute(_run_unit_tests)
 
-    execute(_set_cwag_configs)
+    execute(_set_cwag_configs, "gateway.mconfig")
     cwag_host_to_mac = execute(_get_br_mac, CWAG_BR_NAME)
     host = env.hosts[0]
     cwag_br_mac = cwag_host_to_mac[host]
@@ -90,6 +91,8 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
         if not no_build:
             execute(_build_gateway)
     execute(_run_gateway)
+    # Stop not necessary services for this test case
+    execute(_stop_docker_services, ["pcrf2", "ocs2"])
 
     # Setup the trfserver: use the provided trfserver if given, else default to the
     # vagrant machine
@@ -121,7 +124,7 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
         ansible_setup(gateway_host, "cwag", "cwag_dev.yml")
     execute(_set_cwag_networking, cwag_test_br_mac)
 
-    # Start tests
+    # Start main tests - except for multi session proxy
     if not test_host:
         # No, definitely do NOT destroy this VM
         vagrant_setup("cwag_test", False)
@@ -129,7 +132,38 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
         ansible_setup(test_host, "cwag_test", "cwag_test.yml")
     execute(_start_ue_simulator)
     execute(_set_cwag_test_networking, cwag_br_mac)
-    execute(_run_integ_tests, test_host, trf_host, tests_to_run, test_re)
+
+    if tests_to_run.value not in [SubTests.MULTISESSIONPROXY.value]:
+        execute(_run_integ_tests, test_host, trf_host, tests_to_run, test_re)
+
+    # Setup environment and run test for multi service proxy if required
+    if tests_to_run.value in [SubTests.MULTISESSIONPROXY.value, SubTests.ALL.value]:
+
+        # CWAG VM
+        if not gateway_host:
+            vagrant_setup("cwag", False)
+        else:
+            ansible_setup(gateway_host, "cwag", "cwag_dev.yml")
+        # copy new config and restart the impacted services
+        execute(_set_cwag_configs, "gateway.mconfig.multi_session_proxy")
+        execute(_restart_docker_services, ["session_proxy", "pcrf", "ocs",
+                                           "pcrf2", "ocs2"])
+
+        # CWAG_TEST VM
+        if not test_host:
+            vagrant_setup("cwag_test", False)
+        else:
+            ansible_setup(test_host, "cwag_test", "cwag_test.yml")
+        execute(
+            _run_integ_tests, test_host, trf_host, SubTests.MULTISESSIONPROXY, test_re
+        )
+
+    # If we got here means everything work well!!
+    if not test_host and not trf_host:
+        # Clean up only for now when running locally
+        execute(_clean_up)
+    print('Integration Test Passed for "{}"!'.format(tests_to_run.value))
+    sys.exit(0)
 
 
 def transfer_service_logs(services="sessiond session_proxy"):
@@ -158,13 +192,13 @@ def _transfer_docker_images():
         run('docker load -i %s.tar' % image)
 
 
-def _set_cwag_configs():
+def _set_cwag_configs(configfile):
     """ Set the necessary config overrides """
 
     with cd(CWAG_INTEG_ROOT):
         sudo('mkdir -p /var/opt/magma')
         sudo('mkdir -p /var/opt/magma/configs')
-        sudo('cp gateway.mconfig /var/opt/magma/configs/')
+        sudo("cp {} /var/opt/magma/configs/gateway.mconfig".format(configfile))
 
 
 def _set_cwag_networking(mac):
@@ -223,6 +257,30 @@ def _run_gateway():
              ' up -d ')
 
 
+def _restart_docker_services(services):
+    with cd(CWAG_ROOT + "/docker"):
+        sudo(
+            " docker-compose"
+            " -f docker-compose.yml"
+            " -f docker-compose.override.yml"
+            " -f docker-compose.nginx.yml"
+            " -f docker-compose.integ-test.yml"
+            " restart {}".format(" ".join(services))
+        )
+
+
+def _stop_docker_services(services):
+    with cd(CWAG_ROOT + "/docker"):
+        sudo(
+            " docker-compose"
+            " -f docker-compose.yml"
+            " -f docker-compose.override.yml"
+            " -f docker-compose.nginx.yml"
+            " -f docker-compose.integ-test.yml"
+            " stop {}".format(" ".join(services))
+        )
+
+
 def _start_ue_simulator():
     """ Starts the UE Sim Service """
     with cd(CWAG_ROOT + '/services/uesim/uesim'):
@@ -236,7 +294,6 @@ def _start_trfserver():
 
 def _run_unit_tests():
     """ Run the cwag unit tests """
-
     with cd(CWAG_ROOT):
         run('make test')
 
@@ -249,21 +306,18 @@ def _run_integ_tests(test_host, trf_host, tests_to_run: SubTests, testRe=None):
         else:
             command = "make " + str(tests_to_run.value)
         result = run(command, warn_only=True)
-    if not test_host and not trf_host:
-        # Clean up only for now when running locally
-        execute(_clean_up)
-    if result.return_code == 0:
-        print("Integration Test Passed!")
-        sys.exit(0)
-    else:
+    if result.return_code != 0:
+        if not test_host and not trf_host:
+            # Clean up only for now when running locally
+            execute(_clean_up)
         print("Integration Test returned ", result.return_code)
         sys.exit(result.return_code)
+
 
 def _clean_up():
     # already in cwag test vm at this point
     # Kill uesim service
     run('pkill go', warn_only=True)
-
     with lcd(LTE_AGW_ROOT):
         vagrant_setup("magma_trfserver", False)
         run('pkill iperf3 > /dev/null &', pty=False, warn_only=True)

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -485,6 +485,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -516,6 +517,7 @@ golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339 h1:zSqWKgm/o7HAnlAzBQ+aetp9f
 golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170810154203-b19bf474d317/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/cwf/gateway/integ_tests/Makefile
+++ b/cwf/gateway/integ_tests/Makefile
@@ -11,10 +11,13 @@ MANDATORY_TESTS=Test
 AUTH=Authenticate
 GX=Gx
 GY=Gy
+MULTISP=MultiSessionProxy
 
 define execute_test
  	echo "Running test: $(1)"
-	go test -run $(1)
+ 	# tag  main_iontegration prevents running multi_session_proxy tests.
+ 	# multi_session_proxy_must be run excusively from multi_session_proxy target
+	go test -tags main_integration -run $(1)
 endef
 
 integ_test:
@@ -35,3 +38,8 @@ gx:
 gy:
 	echo "Running Auth+Gy Tests..."
 	$(foreach test,$(GY),$(call execute_test,$(test));)
+
+multi_session_proxy:
+	echo "Running Multi Session Proxy Tests..."
+	go test -run $(MULTISP)
+

--- a/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
+++ b/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
@@ -136,6 +136,20 @@
        "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
        "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
        "disableDestHost": false
+      },
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50013",
+       "retransmits": 0,
+       "watchdogInterval": 0,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50014",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
       }
     ]
    },
@@ -148,6 +162,20 @@
        "watchdogInterval": 0,
        "retryCount": 0,
        "localAddress": "127.0.0.1:50002",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "sdp1c.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
+      },
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50011",
+       "retransmits": 0,
+       "watchdogInterval": 0,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50012",
        "productName": "magma",
        "realm": "magma.svc.cluster.local",
        "host": "feg.magma.svc.cluster.local",

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -36,11 +36,15 @@ const (
 	MockHSSRemote   = "HSS_REMOTE"
 	MockPCRFRemote  = "PCRF_REMOTE"
 	MockOCSRemote   = "OCS_REMOTE"
+	MockPCRFRemote2 = "PCRF_REMOTE2"
+	MockOCSRemote2  = "OCS_REMOTE2"
 	PipelinedRemote = "pipelined.local"
 	RedisRemote     = "REDIS"
 	CwagIP          = "192.168.70.101"
 	OCSPort         = 9201
 	PCRFPort        = 9202
+	OCSPort2        = 9205
+	PCRFPort2       = 9206
 	HSSPort         = 9204
 	PipelinedPort   = 8443
 	RedisPort       = 6380
@@ -75,6 +79,17 @@ func NewTestRunner(t *testing.T) *TestRunner {
 	registry.AddService(RedisRemote, CwagIP, RedisPort)
 
 	return testRunner
+}
+
+// NewTestRunnerWithTwoPCRFandOCS does the same as NewTestRunner but it inclides 2 PCRF and 2 OCS
+// Used in scenarios that run 2 PCRFs and 2 OCSs
+func NewTestRunnerWithTwoPCRFandOCS(t *testing.T) *TestRunner {
+	tr := NewTestRunner(t)
+	fmt.Printf("Adding second Mock PCRF service at %s:%d\n", CwagIP, PCRFPort2)
+	registry.AddService(MockPCRFRemote2, CwagIP, PCRFPort2)
+	fmt.Printf("Adding second OCS service at %s:%d\n", CwagIP, OCSPort2)
+	registry.AddService(MockOCSRemote2, CwagIP, OCSPort2)
+	return tr
 }
 
 // ConfigUEs creates and adds the specified number of UEs and Subscribers

--- a/feg/gateway/registry/local_registry.go
+++ b/feg/gateway/registry/local_registry.go
@@ -36,7 +36,9 @@ const (
 	REDIS         = "REDIS"
 	MOCK_VLR      = "MOCK_VLR"
 	MOCK_OCS      = "MOCK_OCS"
+	MOCK_OCS2     = "MOCK_OCS2"
 	MOCK_PCRF     = "MOCK_PCRF"
+	MOCK_PCRF2    = "MOCK_PCRF2"
 	MOCK_HSS      = "HSS"
 
 	SESSION_MANAGER = "SESSIOND"
@@ -86,6 +88,8 @@ func init() {
 
 	addLocalService(MOCK_OCS, 9201)
 	addLocalService(MOCK_PCRF, 9202)
+	addLocalService(MOCK_OCS2, 9205)
+	addLocalService(MOCK_PCRF2, 9206)
 	addLocalService(MOCK_VLR, 9203)
 	addLocalService(MOCK_HSS, 9204)
 

--- a/feg/gateway/services/testcore/pcrf/main.go
+++ b/feg/gateway/services/testcore/pcrf/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	"magma/feg/cloud/go/protos"
@@ -21,39 +22,60 @@ import (
 	"github.com/golang/glog"
 )
 
+var (
+	serverNumber int
+)
+
 func init() {
-	flag.Parse()
+	flag.IntVar(&serverNumber, "servernumber", 1, "Number of the server. Will use Gx[servernumber-1] configuration")
 }
 
 func main() {
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_PCRF)
-	if err != nil {
-		log.Fatalf("Error creating mock PCRF service: %s", err)
-	}
+	flag.Parse()
 
-	// TODO: support multiple connections
-	gxCliConf := gx.GetGxClientConfiguration()[0]
-	gxServConf := gx.GetPCRFConfiguration()[0]
+	serverIdx := serverNumber - 1
+	log.Print("------ Reading Gx configuration a couple of times ------")
+	// Get the server N from the list of configured servers. This is normally 0, unless multiple GX connections are configured
+	gxConfigs := gx.GetGxClientConfiguration()
+	if serverIdx >= len(gxConfigs) {
+		log.Fatalf("ServerIndex value (%d) is bigger than the amount Gx servers configured (%d)", serverIdx, len(gxConfigs))
+		return
+	}
+	gxCliConf := gxConfigs[serverIdx]
+	gxServConf := gx.GetPCRFConfiguration()[serverIdx]
+	log.Print("------ Done reading Gy configuration  ------")
+	log.Printf("Mock PCRF using Gx server configured at index %d with adderess %s", serverIdx, gxServConf.Addr)
+
+	serviceName := registry.MOCK_PCRF
+	if serverIdx > 0 {
+		serviceName = fmt.Sprintf("%s%d", serviceName, serverNumber)
+		log.Printf("PCRF serviceName renamed to: %s", serviceName)
+	}
 
 	pcrfServer := mock_pcrf.NewPCRFDiamServer(
 		gxCliConf,
 		&mock_pcrf.PCRFConfig{ServerConfig: gxServConf},
 	)
 
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
+	if err != nil {
+		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
+	}
+
 	lis, err := pcrfServer.StartListener()
 	if err != nil {
-		log.Fatalf("Unable to start listener for mock PCRF: %s", err)
+		log.Fatalf("Unable to start listener for mock %s: %s", serviceName, err)
 	}
 
 	protos.RegisterMockPCRFServer(srv.GrpcServer, pcrfServer)
 
 	go func() {
-		glog.V(2).Infof("Starting mock PCRF server at %s", lis.Addr().String())
+		glog.V(2).Infof("Starting mock %s server at %s", serviceName, lis.Addr().String())
 		glog.Errorf(pcrfServer.Start(lis).Error()) // blocks
 	}()
 
 	err = srv.Run()
 	if err != nil {
-		log.Fatalf("Error running mock PCRF service: %s", err)
+		log.Fatalf("Error running mock %s service: %s", serviceName, err)
 	}
 }


### PR DESCRIPTION
Summary:
Added a second scenario to fab file to be able to run MultiSessionProxy tests.

Modified makefile:
- To prevent MultiSessionProxy when ```make integ_test``` is run we will use golang build tags: MultiSessionProxy tests files will include ```//build !main_integration``` at the top of the file that will prevent its execution when ```make integ_test``` is called.
- To run MultiSessionProxy tests we will have to call ```make multi_session_proxy``` (fab file will take care of set up the right environment for that that)

Modified fab file:
- Added new scenario after the main integ_test is done
- Modified ```_run_integ_tests``` not to clean up in case of success (```clean_up``` will be run at the very end, if we get there)
- Added conditions to run the test by name: MultiSessionProxy will be executed with proper scenario if we run```fab integ_test``` or ```fab integ_test:test_to_run=multi_session_proxy```

Differential Revision: D21094862

