### PR TITLE
Multiple diameter (integ_test) (3/3) - service_wrapper.go support to select of different OCS and PCRF on

### DIFF
--- a/cwf/gateway/docker/docker-compose.multi-session_proxy.yml
+++ b/cwf/gateway/docker/docker-compose.multi-session_proxy.yml
@@ -1,0 +1,40 @@
+version: "3.7"
+
+# Standard logging for each service
+x-logging: &logging_anchor
+  driver: "json-file"
+  options:
+    max-size: "10mb"
+    max-file: "10"
+
+# Standard volumes mounted
+x-standard-volumes: &volumes_anchor
+  - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
+  - ${CERTS_VOLUME}:/var/opt/magma/certs
+  - ${CONFIGS_OVERRIDE_VOLUME}:/var/opt/magma/configs
+  - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
+  - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
+  - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+  - /etc/snowflake:/etc/snowflake
+
+x-generic-service: &service
+  volumes: *volumes_anchor
+  logging: *logging_anchor
+  restart: always
+  network_mode: host
+
+x-feg-goservice: &feggoservice
+  <<: *service
+  image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+
+services:
+  pcrf2:
+    <<: *feggoservice
+    container_name: pcrf2
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/pcrf -logtostderr=true -v=0 -servernumber=2
+
+  ocs2:
+    <<: *feggoservice
+    container_name: ocs2
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/ocs -logtostderr=true -v=0 -servernumber=2
+

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -485,6 +485,7 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20191007182048-72f939374954/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -516,6 +517,7 @@ golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339 h1:zSqWKgm/o7HAnlAzBQ+aetp9f
 golang.org/x/sys v0.0.0-20191025090151-53bf42e6b339/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170810154203-b19bf474d317/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/cwf/gateway/integ_tests/Makefile
+++ b/cwf/gateway/integ_tests/Makefile
@@ -11,10 +11,13 @@ MANDATORY_TESTS=Test
 AUTH=Authenticate
 GX=Gx
 GY=Gy
+MULTISP=MultiSessionProxy
 
 define execute_test
  	echo "Running test: $(1)"
-	go test -run $(1)
+ 	# tag  main_iontegration prevents running multi_session_proxy tests.
+ 	# multi_session_proxy_must be run excusively from multi_session_proxy target
+	go test -tags main_integration -run $(1)
 endef
 
 integ_test:
@@ -35,3 +38,8 @@ gx:
 gy:
 	echo "Running Auth+Gy Tests..."
 	$(foreach test,$(GY),$(call execute_test,$(test));)
+
+multi_session_proxy:
+	echo "Running Multi Session Proxy Tests..."
+	go test -run $(MULTISP)
+

--- a/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
+++ b/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
@@ -136,6 +136,20 @@
        "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
        "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
        "disableDestHost": false
+      },
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50013",
+       "retransmits": 0,
+       "watchdogInterval": 0,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50014",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
       }
     ]
    },
@@ -148,6 +162,20 @@
        "watchdogInterval": 0,
        "retryCount": 0,
        "localAddress": "127.0.0.1:50002",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "sdp1c.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
+      },
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50011",
+       "retransmits": 0,
+       "watchdogInterval": 0,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50012",
        "productName": "magma",
        "realm": "magma.svc.cluster.local",
        "host": "feg.magma.svc.cluster.local",

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -25,10 +25,10 @@ import (
 
 func gxReAuthTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwfprotos.UEConfig) {
 	tr := NewTestRunner(t)
-	ruleManager, err := NewRuleManager()
+	ruleManager, err := NewRuleManager(MockPCRFRemote)
 	assert.NoError(t, err)
 
-	ues, err := tr.ConfigUEs(1)
+	ues, err := tr.ConfigUEs(1, MockPCRFRemote, MockOCSRemote)
 	assert.NoError(t, err)
 	ue := ues[0]
 
@@ -96,7 +96,7 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 		RuleNames:     []string{"static-pass-all-raa2"},
 		RuleBaseNames: []string{"base-raa1"},
 	}
-	raa, err := sendPolicyReAuthRequest(
+	raa, err := sendPolicyReAuthRequest(MockPCRFRemote,
 		&fegprotos.PolicyReAuthTarget{Imsi: imsi, RulesToRemove: rulesRemoval},
 	)
 	assert.NoError(t, err)
@@ -169,7 +169,7 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 		RuleNames:     []string{"static-pass-all-raa1", "static-pass-all-raa2"},
 		RuleBaseNames: []string{"base-raa1"},
 	}
-	raa, err := sendPolicyReAuthRequest(
+	raa, err := sendPolicyReAuthRequest(MockPCRFRemote,
 		&fegprotos.PolicyReAuthTarget{Imsi: imsi, RulesToRemove: rulesRemoval},
 	)
 	assert.NoError(t, err)
@@ -258,7 +258,7 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 	ruleInstall := &fegprotos.RuleInstalls{
 		RuleDefinitions: ruleDefinition,
 	}
-	raa, err := sendPolicyReAuthRequest(
+	raa, err := sendPolicyReAuthRequest(MockPCRFRemote,
 		&fegprotos.PolicyReAuthTarget{
 			Imsi:                 imsi,
 			RulesToInstall:       ruleInstall,
@@ -363,7 +363,7 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 	ruleInstall := &fegprotos.RuleInstalls{
 		RuleDefinitions: ruleDefinition,
 	}
-	raa, err := sendPolicyReAuthRequest(
+	raa, err := sendPolicyReAuthRequest(MockPCRFRemote,
 		&fegprotos.PolicyReAuthTarget{
 			Imsi:                 imsi,
 			RulesToInstall:       ruleInstall,
@@ -446,7 +446,7 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 			Octets:          &fegprotos.Octets{TotalOctets: 250 * KiloBytes},
 		},
 	}
-	raa, err := sendPolicyReAuthRequest(
+	raa, err := sendPolicyReAuthRequest(MockPCRFRemote,
 		&fegprotos.PolicyReAuthTarget{
 			Imsi:                 imsi,
 			UsageMonitoringInfos: usageMonitoring,

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -30,12 +30,12 @@ const (
 
 func ocsCreditExhaustionTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwfprotos.UEConfig) {
 	tr := NewTestRunner(t)
-	ruleManager, err := NewRuleManager()
+	ruleManager, err := NewRuleManager(MockPCRFRemote)
 	assert.NoError(t, err)
 
-	ues, err := tr.ConfigUEs(1)
+	ues, err := tr.ConfigUEs(1, MockPCRFRemote, MockOCSRemote)
 	assert.NoError(t, err)
-	setNewOCSConfig(
+	setNewOCSConfig(MockOCSRemote,
 		&fegprotos.OCSConfig{
 			MaxUsageOctets: &fegprotos.Octets{TotalOctets: MaxUsageBytes},
 			MaxUsageTime:   MaxUsageTime,
@@ -44,7 +44,7 @@ func ocsCreditExhaustionTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwf
 	)
 
 	ue := ues[0]
-	setCreditOnOCS(
+	setCreditOnOCS(MockOCSRemote,
 		&fegprotos.CreditInfo{
 			Imsi:        ue.Imsi,
 			ChargingKey: 1,
@@ -81,7 +81,7 @@ func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 		assert.NoError(t, tr.CleanUp())
 	}()
 
-	setCreditOnOCS(
+	setCreditOnOCS(MockOCSRemote,
 		&fegprotos.CreditInfo{
 			Imsi:        ue.Imsi,
 			ChargingKey: 1,
@@ -126,7 +126,7 @@ func TestGyCreditExhaustionWithoutCRRU(t *testing.T) {
 		assert.NoError(t, tr.CleanUp())
 	}()
 
-	setCreditOnOCS(
+	setCreditOnOCS(MockOCSRemote,
 		&fegprotos.CreditInfo{
 			Imsi:        ue.Imsi,
 			ChargingKey: 1,

--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -37,19 +37,19 @@ import (
 func TestOmnipresentRules(t *testing.T) {
 	fmt.Println("\nRunning TestOmnipresentRules...")
 	tr := NewTestRunner(t)
-	ruleManager, err := NewRuleManager()
+	ruleManager, err := NewRuleManager(MockPCRFRemote)
 	assert.NoError(t, err)
-	assert.NoError(t, usePCRFMockDriver())
+	assert.NoError(t, usePCRFMockDriver(MockPCRFRemote))
 	defer func() {
 		// Delete omni rules
 		assert.NoError(t, ruleManager.RemoveOmniPresentRulesFromDB("omni"))
 		// Clear hss, ocs, and pcrf
-		assert.NoError(t, clearPCRFMockDriver())
+		assert.NoError(t, clearPCRFMockDriver(MockPCRFRemote))
 		assert.NoError(t, ruleManager.RemoveInstalledRules())
 		assert.NoError(t, tr.CleanUp())
 	}()
 
-	ues, err := tr.ConfigUEs(1)
+	ues, err := tr.ConfigUEs(1, MockPCRFRemote, MockOCSRemote)
 	assert.NoError(t, err)
 	imsi := ues[0].GetImsi()
 
@@ -77,7 +77,7 @@ func TestOmnipresentRules(t *testing.T) {
 		SetUsageMonitorInfos(usageMonitorInfo)
 	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
 	expectations := []*protos.GxCreditControlExpectation{initExpectation}
-	assert.NoError(t, setPCRFExpectations(expectations, nil)) // we don't expect any update requests
+	assert.NoError(t, setPCRFExpectations(MockPCRFRemote, expectations, nil)) // we don't expect any update requests
 
 	tr.AuthenticateAndAssertSuccess(imsi)
 
@@ -104,7 +104,7 @@ func TestOmnipresentRules(t *testing.T) {
 		},
 	}
 	fmt.Printf("Sending a ReAuthRequest with target %v\n", target)
-	raa, err := sendPolicyReAuthRequest(target)
+	raa, err := sendPolicyReAuthRequest(MockPCRFRemote, target)
 
 	assert.NoError(t, err)
 	// Wait for RAR to be processed

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -36,11 +36,15 @@ const (
 	MockHSSRemote   = "HSS_REMOTE"
 	MockPCRFRemote  = "PCRF_REMOTE"
 	MockOCSRemote   = "OCS_REMOTE"
+	MockPCRFRemote2 = "PCRF_REMOTE2"
+	MockOCSRemote2  = "OCS_REMOTE2"
 	PipelinedRemote = "pipelined.local"
 	RedisRemote     = "REDIS"
 	CwagIP          = "192.168.70.101"
 	OCSPort         = 9201
 	PCRFPort        = 9202
+	OCSPort2        = 9205
+	PCRFPort2       = 9206
 	HSSPort         = 9204
 	PipelinedPort   = 8443
 	RedisPort       = 6380
@@ -75,6 +79,17 @@ func NewTestRunner(t *testing.T) *TestRunner {
 	registry.AddService(RedisRemote, CwagIP, RedisPort)
 
 	return testRunner
+}
+
+// NewTestRunnerWithTwoPCRFandOCS does the same as NewTestRunner but it inclides 2 PCRF and 2 OCS
+// Used in scenarios that run 2 PCRFs and 2 OCSs
+func NewTestRunnerWithTwoPCRFandOCS(t *testing.T) *TestRunner {
+	tr :=NewTestRunner(t)
+	fmt.Printf("Adding second Mock PCRF service at %s:%d\n", CwagIP, PCRFPort2)
+	registry.AddService(MockPCRFRemote2, CwagIP, PCRFPort2)
+	fmt.Printf("Adding second OCS service at %s:%d\n", CwagIP, OCSPort2)
+	registry.AddService(MockOCSRemote2, CwagIP, OCSPort2)
+	return tr
 }
 
 // ConfigUEs creates and adds the specified number of UEs and Subscribers

--- a/feg/gateway/registry/local_registry.go
+++ b/feg/gateway/registry/local_registry.go
@@ -36,7 +36,9 @@ const (
 	REDIS         = "REDIS"
 	MOCK_VLR      = "MOCK_VLR"
 	MOCK_OCS      = "MOCK_OCS"
+	MOCK_OCS2     = "MOCK_OCS2"
 	MOCK_PCRF     = "MOCK_PCRF"
+	MOCK_PCRF2    = "MOCK_PCRF2"
 	MOCK_HSS      = "HSS"
 
 	SESSION_MANAGER = "SESSIOND"
@@ -86,6 +88,8 @@ func init() {
 
 	addLocalService(MOCK_OCS, 9201)
 	addLocalService(MOCK_PCRF, 9202)
+	addLocalService(MOCK_OCS2, 9205)
+	addLocalService(MOCK_PCRF2, 9206)
 	addLocalService(MOCK_VLR, 9203)
 	addLocalService(MOCK_HSS, 9204)
 

--- a/feg/gateway/services/testcore/ocs/main.go
+++ b/feg/gateway/services/testcore/ocs/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 
 	"magma/feg/cloud/go/protos"
@@ -27,19 +28,36 @@ const (
 	ValidityTime  = 60   // in second
 )
 
+var (
+	serverNumber int
+)
+
 func init() {
-	flag.Parse()
+	flag.IntVar(&serverNumber, "servernumber", 1, "Number of the server. Will use Gy[servernumber-1] configuration")
 }
 
 func main() {
-	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.MOCK_OCS)
-	if err != nil {
-		log.Fatalf("Error creating mock OCS service: %s", err)
-	}
+	flag.Parse()
 
-	// TODO: support multiple connections
-	gyCliConf := gy.GetGyClientConfiguration()[0]
-	gyServConf := gy.GetOCSConfiguration()[0]
+	serverIdx := serverNumber - 1
+	log.Print("------ Reading Gy configuration a couple of times ------")
+	// Get the server N from the list of configured servers. This is normally 0, unless multiple GX connections are configured
+	gyConfigs := gy.GetGyClientConfiguration()
+	if serverIdx >= len(gyConfigs) {
+		log.Fatalf("ServerIndex value (%d) is bigger than the amout Gy servers configured (%d)", serverIdx, len(gyConfigs))
+		return
+	}
+	gyCliConf := gyConfigs[serverIdx]
+	gyServConf := gy.GetOCSConfiguration()[serverIdx]
+	log.Print("------ Done reading Gy configuration  ------")
+	log.Printf("Mock OCS using Gy server configured at index %d with adderess %s", serverIdx, gyServConf.Addr)
+
+	serviceName := registry.MOCK_OCS
+	if serverIdx > 0 {
+		serviceName = fmt.Sprintf("%s%d", serviceName, serverNumber)
+		log.Printf("OCS serviceName renamed to: %s", serviceName)
+
+	}
 
 	diamServer := mock_ocs.NewOCSDiamServer(
 		gyCliConf,
@@ -52,20 +70,25 @@ func main() {
 		},
 	)
 
+	srv, err := service.NewServiceWithOptions(registry.ModuleName, serviceName)
+	if err != nil {
+		log.Fatalf("Error creating mock %s service: %s", serviceName, err)
+	}
+
 	lis, err := diamServer.StartListener()
 	if err != nil {
-		log.Fatalf("Unable to start listener for mock OCS: %s", err)
+		log.Fatalf("Unable to start listener for mock %s: %s", serviceName, err)
 	}
 
 	protos.RegisterMockOCSServer(srv.GrpcServer, diamServer)
 
 	go func() {
-		glog.V(2).Infof("Starting mock OCS server at %s", lis.Addr().String())
+		glog.V(2).Infof("Starting mock %s server at %s", serviceName, lis.Addr().String())
 		glog.Errorf(diamServer.Start(lis).Error()) // blocks
 	}()
 
 	err = srv.Run()
 	if err != nil {
-		log.Fatalf("Error running mock OCS service: %s", err)
+		log.Fatalf("Error running mock %s service: %s", serviceName, err)
 	}
 }


### PR DESCRIPTION
Summary: Modify service_wrapper.go and any other files to support selection of OCS/PCRF instance on integ_test

Differential Revision: D21094931

