### PR TITLE
Decompose LocalSessionManagerHandler's method CreateSession

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -22,18 +22,22 @@ const std::string LocalSessionManagerHandlerImpl::hex_digit_ =
     "0123456789abcdef";
 
 LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
-    std::shared_ptr<LocalEnforcer> enforcer, SessionReporter *reporter,
+    std::shared_ptr<LocalEnforcer> enforcer, SessionReporter* reporter,
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
-    SessionStore &session_store)
-    : enforcer_(enforcer), session_store_(session_store), reporter_(reporter),
+    SessionStore& session_store)
+    : enforcer_(enforcer),
+      session_store_(session_store),
+      reporter_(reporter),
       directoryd_client_(directoryd_client),
 
-      current_epoch_(0), reported_epoch_(0), retry_timeout_(1) {}
+      current_epoch_(0),
+      reported_epoch_(0),
+      retry_timeout_(1) {}
 
 void LocalSessionManagerHandlerImpl::ReportRuleStats(
-    ServerContext *context, const RuleRecordTable *request,
+    ServerContext* context, const RuleRecordTable* request,
     std::function<void(Status, Void)> response_callback) {
-  auto &request_cpy = *request;
+  auto& request_cpy = *request;
   if (request_cpy.records_size() > 0) {
     MLOG(MDEBUG) << "Aggregating " << request_cpy.records_size() << " records";
 
@@ -56,7 +60,7 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
 }
 
 void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
-    SessionMap session_map, SessionUpdate &session_update) {
+    SessionMap session_map, SessionUpdate& session_update) {
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto request =
       enforcer_->collect_updates(session_map, actions, session_update);
@@ -68,7 +72,7 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
     } else {
       MLOG(MERROR) << "Failed in updating session after no reporting";
     }
-    return; // nothing to report
+    return;  // nothing to report
   }
   MLOG(MINFO) << "Sending " << request.updates_size()
               << " charging updates and " << request.usage_monitors_size()
@@ -81,20 +85,21 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
   //       the session_map is used.
   //       Check
   //       https://stackoverflow.com/questions/25421346/how-to-create-an-stdfunction-from-a-move-capturing-lambda-expression
-  reporter_->report_updates(request, [
-    this, request,
-    session_map_ptr = std::make_shared<SessionMap>(std::move(session_map)),
-    session_update = std::move(session_update)
-  ](Status status, UpdateSessionResponse response) mutable {
-    if (!status.ok()) {
-      MLOG(MERROR) << "Update of size " << request.updates_size()
-                   << " to OCS failed entirely: " << status.error_message();
-    } else {
-      enforcer_->update_session_credits_and_rules(*session_map_ptr, response,
-                                                  session_update);
-      session_store_.update_sessions(session_update);
-    }
-  });
+  reporter_->report_updates(
+      request,
+      [this, request,
+       session_map_ptr = std::make_shared<SessionMap>(std::move(session_map)),
+       session_update  = std::move(session_update)](
+          Status status, UpdateSessionResponse response) mutable {
+        if (!status.ok()) {
+          MLOG(MERROR) << "Update of size " << request.updates_size()
+                       << " to OCS failed entirely: " << status.error_message();
+        } else {
+          enforcer_->update_session_credits_and_rules(
+              *session_map_ptr, response, session_update);
+          session_store_.update_sessions(session_update);
+        }
+      });
 }
 
 bool LocalSessionManagerHandlerImpl::is_pipelined_restarted() {
@@ -106,7 +111,7 @@ bool LocalSessionManagerHandlerImpl::is_pipelined_restarted() {
 }
 
 void LocalSessionManagerHandlerImpl::handle_setup_callback(
-    const std::uint64_t &epoch, Status status, SetupFlowsResult resp) {
+    const std::uint64_t& epoch, Status status, SetupFlowsResult resp) {
   using namespace std::placeholders;
   if (!status.ok()) {
     MLOG(MERROR) << "Could not setup pipelined, rpc failed with: "
@@ -150,21 +155,21 @@ void LocalSessionManagerHandlerImpl::handle_setup_callback(
 }
 
 bool LocalSessionManagerHandlerImpl::restart_pipelined(
-    const std::uint64_t &epoch) {
+    const std::uint64_t& epoch) {
   using namespace std::placeholders;
   enforcer_->get_event_base().runInEventBaseThread([this, epoch]() {
     auto session_map = session_store_.read_all_sessions();
     enforcer_->setup(
         session_map, epoch,
-        std::bind(&LocalSessionManagerHandlerImpl::handle_setup_callback, this,
-                  epoch, _1, _2));
+        std::bind(
+            &LocalSessionManagerHandlerImpl::handle_setup_callback, this, epoch,
+            _1, _2));
   });
   return true;
 }
 
-static CreateSessionRequest
-copy_session_info2create_req(const LocalCreateSessionRequest &request,
-                             const std::string &sid) {
+static CreateSessionRequest copy_session_info2create_req(
+    const LocalCreateSessionRequest& request, const std::string& sid) {
   CreateSessionRequest create_request;
 
   create_request.mutable_subscriber()->CopyFrom(request.sid());
@@ -187,31 +192,31 @@ copy_session_info2create_req(const LocalCreateSessionRequest &request,
 }
 
 void LocalSessionManagerHandlerImpl::CreateSession(
-    ServerContext *context, const LocalCreateSessionRequest *request,
+    ServerContext* context, const LocalCreateSessionRequest* request,
     std::function<void(Status, LocalCreateSessionResponse)> response_callback) {
-  auto &request_cpy = *request;
+  auto& request_cpy = *request;
   enforcer_->get_event_base().runInEventBaseThread([this, context,
                                                     response_callback,
                                                     request_cpy]() {
-    auto imsi = request_cpy.sid().id();
-    auto sid = id_gen_.gen_session_id(imsi);
+    auto imsi     = request_cpy.sid().id();
+    auto sid      = id_gen_.gen_session_id(imsi);
     auto mac_addr = convert_mac_addr_to_str(request_cpy.hardware_addr());
     MLOG(MDEBUG) << "PLMN_ID: " << request_cpy.plmn_id()
                  << " IMSI_PLMN_ID: " << request_cpy.imsi_plmn_id();
 
-    SessionConfig cfg = {.ue_ipv4 = request_cpy.ue_ipv4(),
-                         .spgw_ipv4 = request_cpy.spgw_ipv4(),
-                         .msisdn = request_cpy.msisdn(),
-                         .apn = request_cpy.apn(),
-                         .imei = request_cpy.imei(),
-                         .plmn_id = request_cpy.plmn_id(),
-                         .imsi_plmn_id = request_cpy.imsi_plmn_id(),
-                         .user_location = request_cpy.user_location(),
-                         .rat_type = request_cpy.rat_type(),
-                         .mac_addr = mac_addr,
-                         .hardware_addr = request_cpy.hardware_addr(),
+    SessionConfig cfg = {.ue_ipv4           = request_cpy.ue_ipv4(),
+                         .spgw_ipv4         = request_cpy.spgw_ipv4(),
+                         .msisdn            = request_cpy.msisdn(),
+                         .apn               = request_cpy.apn(),
+                         .imei              = request_cpy.imei(),
+                         .plmn_id           = request_cpy.plmn_id(),
+                         .imsi_plmn_id      = request_cpy.imsi_plmn_id(),
+                         .user_location     = request_cpy.user_location(),
+                         .rat_type          = request_cpy.rat_type(),
+                         .mac_addr          = mac_addr,
+                         .hardware_addr     = request_cpy.hardware_addr(),
                          .radius_session_id = request_cpy.radius_session_id(),
-                         .bearer_id = request_cpy.bearer_id()};
+                         .bearer_id         = request_cpy.bearer_id()};
 
     QoSInfo qos_info = {.enabled = request_cpy.has_qos_info()};
     if (request_cpy.has_qos_info()) {
@@ -226,8 +231,8 @@ void LocalSessionManagerHandlerImpl::CreateSession(
       // For LTE case, load session if and only if the configuration exactly
       // matches. For CWF use case, we can recycle any active session
       bool same_config = false;
-      bool is_active = false;
-      bool is_wifi = request_cpy.rat_type() == RATType::TGPP_WLAN;
+      bool is_active   = false;
+      bool is_wifi     = request_cpy.rat_type() == RATType::TGPP_WLAN;
       if (is_wifi) {
         is_active = enforcer_->has_active_session(session_map, imsi, &core_sid);
       } else {
@@ -279,8 +284,8 @@ void LocalSessionManagerHandlerImpl::CreateSession(
         return;
       }
 
-      if (!enforcer_->session_with_apn_exists(session_map, imsi,
-                                              request_cpy.apn())) {
+      if (!enforcer_->session_with_apn_exists(
+              session_map, imsi, request_cpy.apn())) {
         MLOG(MINFO) << "Found session with the same IMSI " << imsi
                     << " but different APN " << request_cpy.apn()
                     << ", will request a new session from PCRF/PCF";
@@ -302,61 +307,63 @@ void LocalSessionManagerHandlerImpl::CreateSession(
                     << ", will request a new session from PCRF/PCF";
       }
     }
-    send_create_session(session_map,
-                        copy_session_info2create_req(request_cpy, sid), imsi,
-                        sid, cfg, response_callback);
+    send_create_session(
+        session_map, copy_session_info2create_req(request_cpy, sid), imsi, sid,
+        cfg, response_callback);
   });
 }
 
 void LocalSessionManagerHandlerImpl::send_create_session(
-    SessionMap &session_map, const CreateSessionRequest &request,
-    const std::string &imsi, const std::string &sid, const SessionConfig &cfg,
+    SessionMap& session_map, const CreateSessionRequest& request,
+    const std::string& imsi, const std::string& sid, const SessionConfig& cfg,
     std::function<void(grpc::Status, LocalCreateSessionResponse)>
         response_callback) {
-  reporter_->report_create_session(request, [
-    this, imsi, sid, cfg, response_callback,
-    session_map_ptr = std::make_shared<SessionMap>(std::move(session_map))
-  ](Status status, CreateSessionResponse response) mutable {
-    if (status.ok()) {
-      bool success = enforcer_->init_session_credit(*session_map_ptr, imsi, sid,
-                                                    cfg, response);
-      if (!success) {
-        MLOG(MERROR) << "Failed to initialize session for IMSI " << imsi;
-        status =
-            Status(grpc::FAILED_PRECONDITION, "Failed to initialize session");
-      } else {
-        bool write_success = session_store_.create_sessions(
-            imsi, std::move((*session_map_ptr)[imsi]));
-        if (write_success) {
-          MLOG(MINFO) << "Successfully initialized new session " << sid
-                      << " in sessiond for subscriber " << imsi
-                      << " with default bearer id " << cfg.bearer_id;
-          add_session_to_directory_record(imsi, sid);
+  reporter_->report_create_session(
+      request,
+      [this, imsi, sid, cfg, response_callback,
+       session_map_ptr = std::make_shared<SessionMap>(std::move(session_map))](
+          Status status, CreateSessionResponse response) mutable {
+        if (status.ok()) {
+          bool success = enforcer_->init_session_credit(
+              *session_map_ptr, imsi, sid, cfg, response);
+          if (!success) {
+            MLOG(MERROR) << "Failed to initialize session for IMSI " << imsi;
+            status = Status(
+                grpc::FAILED_PRECONDITION, "Failed to initialize session");
+          } else {
+            bool write_success = session_store_.create_sessions(
+                imsi, std::move((*session_map_ptr)[imsi]));
+            if (write_success) {
+              MLOG(MINFO) << "Successfully initialized new session " << sid
+                          << " in sessiond for subscriber " << imsi
+                          << " with default bearer id " << cfg.bearer_id;
+              add_session_to_directory_record(imsi, sid);
+            } else {
+              MLOG(MINFO) << "Failed to initialize new session " << sid
+                          << " in sessiond for subscriber " << imsi
+                          << " with default bearer id " << cfg.bearer_id
+                          << " due to failure writing to SessionStore."
+                          << " An earlier update may have invalidated it.";
+              status = Status(
+                  grpc::ABORTED,
+                  "Failed to write session to sessiond storage.");
+            }
+          }
         } else {
-          MLOG(MINFO) << "Failed to initialize new session " << sid
-                      << " in sessiond for subscriber " << imsi
-                      << " with default bearer id " << cfg.bearer_id
-                      << " due to failure writing to SessionStore."
-                      << " An earlier update may have invalidated it.";
-          status = Status(grpc::ABORTED,
-                          "Failed to write session to sessiond storage.");
+          MLOG(MERROR) << "Failed to initialize session in SessionProxy "
+                       << "for IMSI " << imsi << ": " << status.error_message();
         }
-      }
-    } else {
-      MLOG(MERROR) << "Failed to initialize session in SessionProxy "
-                   << "for IMSI " << imsi << ": " << status.error_message();
-    }
-    LocalCreateSessionResponse resp;
-    resp.set_session_id(response.session_id());
-    response_callback(status, resp);
-  });
+        LocalCreateSessionResponse resp;
+        resp.set_session_id(response.session_id());
+        response_callback(status, resp);
+      });
 }
 
 void LocalSessionManagerHandlerImpl::add_session_to_directory_record(
-    const std::string &imsi, const std::string &session_id) {
+    const std::string& imsi, const std::string& session_id) {
   UpdateRecordRequest request;
   request.set_id(imsi);
-  auto update_fields = request.mutable_fields();
+  auto update_fields         = request.mutable_fields();
   std::string session_id_key = "session_id";
   update_fields->insert({session_id_key, session_id});
   directoryd_client_->update_directoryd_record(
@@ -370,7 +377,7 @@ void LocalSessionManagerHandlerImpl::add_session_to_directory_record(
 }
 
 std::string LocalSessionManagerHandlerImpl::convert_mac_addr_to_str(
-    const std::string &mac_addr) {
+    const std::string& mac_addr) {
   std::string res;
   auto l = mac_addr.length();
   if (l == 0) {
@@ -400,36 +407,36 @@ std::string LocalSessionManagerHandlerImpl::convert_mac_addr_to_str(
  *    termination succeeds or not
  */
 void LocalSessionManagerHandlerImpl::EndSession(
-    ServerContext *context, const LocalEndSessionRequest *request,
+    ServerContext* context, const LocalEndSessionRequest* request,
     std::function<void(Status, LocalEndSessionResponse)> response_callback) {
-  auto &request_cpy = *request;
+  auto& request_cpy = *request;
   enforcer_->get_event_base().runInEventBaseThread(
-      [ this, request_cpy = std::move(request_cpy), response_callback ]() {
+      [this, request_cpy = std::move(request_cpy), response_callback]() {
         auto session_map = get_sessions_for_deletion(request_cpy);
         end_session(session_map, request_cpy, response_callback);
       });
 }
 
 void LocalSessionManagerHandlerImpl::end_session(
-    SessionMap &session_map, const LocalEndSessionRequest &request,
+    SessionMap& session_map, const LocalEndSessionRequest& request,
     std::function<void(Status, LocalEndSessionResponse)> response_callback) {
   try {
     auto reporter = reporter_;
-    auto update = SessionStore::get_default_session_update(session_map);
-    enforcer_->terminate_subscriber(session_map, request.sid().id(),
-                                    request.apn(), update);
+    auto update   = SessionStore::get_default_session_update(session_map);
+    enforcer_->terminate_subscriber(
+        session_map, request.sid().id(), request.apn(), update);
 
     bool update_success = session_store_.update_sessions(update);
     if (update_success) {
       response_callback(Status::OK, LocalEndSessionResponse());
     } else {
-      auto status =
-          Status(grpc::ABORTED,
-                 "EndSession no longer valid due to another update that "
-                 "occurred to the session first.");
+      auto status = Status(
+          grpc::ABORTED,
+          "EndSession no longer valid due to another update that "
+          "occurred to the session first.");
       response_callback(status, LocalEndSessionResponse());
     }
-  } catch (const SessionNotFound &ex) {
+  } catch (const SessionNotFound& ex) {
     MLOG(MERROR) << "Failed to find session to terminate for subscriber "
                  << request.sid().id();
     Status status(grpc::FAILED_PRECONDITION, "Session not found");
@@ -438,26 +445,26 @@ void LocalSessionManagerHandlerImpl::end_session(
 }
 
 SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_creation(
-    const LocalCreateSessionRequest &request) {
+    const LocalCreateSessionRequest& request) {
   SessionRead req = {request.sid().id()};
   return session_store_.read_sessions(req);
 }
 
 SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_reporting(
-    const RuleRecordTable &records) {
+    const RuleRecordTable& records) {
   SessionRead req = {};
-  for (const RuleRecord &record : records.records()) {
+  for (const RuleRecord& record : records.records()) {
     req.insert(record.sid());
   }
   return session_store_.read_sessions_for_reporting(req);
 }
 
 SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_deletion(
-    const LocalEndSessionRequest &request) {
+    const LocalEndSessionRequest& request) {
   // Request numbers are not incremented here, but rather in the 5s delayed
   // callback when reporting is done.
   SessionRead req = {request.sid().id()};
   return session_store_.read_sessions(req);
 }
 
-} // namespace magma
+}  // namespace magma

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -26,33 +26,32 @@ namespace magma {
 using namespace orc8r;
 
 class LocalSessionManagerHandler {
-public:
+ public:
   virtual ~LocalSessionManagerHandler() {}
 
   /**
    * Report flow stats from pipelined and track the usage per rule
    */
-  virtual void
-  ReportRuleStats(ServerContext *context, const RuleRecordTable *request,
-                  std::function<void(Status, Void)> response_callback) = 0;
+  virtual void ReportRuleStats(
+      ServerContext* context, const RuleRecordTable* request,
+      std::function<void(Status, Void)> response_callback) = 0;
 
   /**
    * Create a new session, initializing credit monitoring and requesting credit
    * from the cloud
    */
-  virtual void
-  CreateSession(ServerContext *context,
-                const LocalCreateSessionRequest *request,
-                std::function<void(Status, LocalCreateSessionResponse)>
-                    response_callback) = 0;
+  virtual void CreateSession(
+      ServerContext* context, const LocalCreateSessionRequest* request,
+      std::function<void(Status, LocalCreateSessionResponse)>
+          response_callback) = 0;
 
   /**
    * Terminate a session, untracking credit and terminating in the cloud
    */
-  virtual void EndSession(ServerContext *context,
-                          const LocalEndSessionRequest *request,
-                          std::function<void(Status, LocalEndSessionResponse)>
-                              response_callback) = 0;
+  virtual void EndSession(
+      ServerContext* context, const LocalEndSessionRequest* request,
+      std::function<void(Status, LocalEndSessionResponse)>
+          response_callback) = 0;
 };
 
 /**
@@ -61,38 +60,39 @@ public:
  * and report to the cloud, respectively
  */
 class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
-public:
+ public:
   LocalSessionManagerHandlerImpl(
-      std::shared_ptr<LocalEnforcer> monitor, SessionReporter *reporter,
+      std::shared_ptr<LocalEnforcer> monitor, SessionReporter* reporter,
       std::shared_ptr<AsyncDirectorydClient> directoryd_client,
-      SessionStore &session_store);
+      SessionStore& session_store);
   ~LocalSessionManagerHandlerImpl() {}
   /**
    * Report flow stats from pipelined and track the usage per rule
    */
-  void ReportRuleStats(ServerContext *context, const RuleRecordTable *request,
-                       std::function<void(Status, Void)> response_callback);
+  void ReportRuleStats(
+      ServerContext* context, const RuleRecordTable* request,
+      std::function<void(Status, Void)> response_callback);
 
   /**
    * Create a new session, initializing credit monitoring and requesting credit
    * from the cloud
    */
-  void CreateSession(ServerContext *context,
-                     const LocalCreateSessionRequest *request,
-                     std::function<void(Status, LocalCreateSessionResponse)>
-                         response_callback);
+  void CreateSession(
+      ServerContext* context, const LocalCreateSessionRequest* request,
+      std::function<void(Status, LocalCreateSessionResponse)>
+          response_callback);
 
   /**
    * Terminate a session, untracking credit and terminating in the cloud
    */
   void EndSession(
-      ServerContext *context, const LocalEndSessionRequest *request,
+      ServerContext* context, const LocalEndSessionRequest* request,
       std::function<void(Status, LocalEndSessionResponse)> response_callback);
 
-private:
-  SessionStore &session_store_;
+ private:
+  SessionStore& session_store_;
   std::shared_ptr<LocalEnforcer> enforcer_;
-  SessionReporter *reporter_;
+  SessionReporter* reporter_;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
   SessionIDGenerator id_gen_;
   uint64_t current_epoch_;
@@ -100,20 +100,20 @@ private:
   std::chrono::seconds retry_timeout_;
   static const std::string hex_digit_;
 
-private:
-  void check_usage_for_reporting(SessionMap session_map,
-                                 SessionUpdate &session_update);
+ private:
+  void check_usage_for_reporting(
+      SessionMap session_map, SessionUpdate& session_update);
   bool is_pipelined_restarted();
-  bool restart_pipelined(const std::uint64_t &epoch);
+  bool restart_pipelined(const std::uint64_t& epoch);
 
   void end_session(
-      SessionMap &session_map, const LocalEndSessionRequest &request,
+      SessionMap& session_map, const LocalEndSessionRequest& request,
       std::function<void(Status, LocalEndSessionResponse)> response_callback);
 
-  std::string convert_mac_addr_to_str(const std::string &mac_addr);
+  std::string convert_mac_addr_to_str(const std::string& mac_addr);
 
-  void add_session_to_directory_record(const std::string &imsi,
-                                       const std::string &session_id);
+  void add_session_to_directory_record(
+      const std::string& imsi, const std::string& session_id);
 
   /**
    * Send session creation request to the CentralSessionController.
@@ -121,13 +121,13 @@ private:
    * gRPC caller.
    */
   void send_create_session(
-      SessionMap &session_map, const CreateSessionRequest &request,
-      const std::string &imsi, const std::string &sid, const SessionConfig &cfg,
+      SessionMap& session_map, const CreateSessionRequest& request,
+      const std::string& imsi, const std::string& sid, const SessionConfig& cfg,
       std::function<void(grpc::Status, LocalCreateSessionResponse)>
           response_callback);
 
-  void handle_setup_callback(const std::uint64_t &epoch, Status status,
-                             SetupFlowsResult resp);
+  void handle_setup_callback(
+      const std::uint64_t& epoch, Status status, SetupFlowsResult resp);
 
   /**
    * Get the most recently written state of sessions for Creation
@@ -136,8 +136,8 @@ private:
    * NOTE: Call only from the main EventBase thread, otherwise there will
    *       be undefined behavior.
    */
-  SessionMap
-  get_sessions_for_creation(const LocalCreateSessionRequest &request);
+  SessionMap get_sessions_for_creation(
+      const LocalCreateSessionRequest& request);
 
   /**
    * Get the most recently written state of sessions for reporting usage.
@@ -146,7 +146,7 @@ private:
    * NOTE: Call only from the main EventBase thread, otherwise there will
    *       be undefined behavior.
    */
-  SessionMap get_sessions_for_reporting(const RuleRecordTable &request);
+  SessionMap get_sessions_for_reporting(const RuleRecordTable& request);
 
   /**
    * Get the most recently written state of the session that is to be deleted.
@@ -155,7 +155,7 @@ private:
    * NOTE: Call only from the main EventBase thread, otherwise there will
    *       be undefined behavior.
    */
-  SessionMap get_sessions_for_deletion(const LocalEndSessionRequest &request);
+  SessionMap get_sessions_for_deletion(const LocalEndSessionRequest& request);
 };
 
-} // namespace magma
+}  // namespace magma

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -129,6 +129,15 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   void handle_setup_callback(
       const std::uint64_t& epoch, Status status, SetupFlowsResult resp);
 
+  SessionConfig build_session_config(const LocalCreateSessionRequest& request);
+
+  void recycle_session(
+      SessionMap& session_map, const LocalCreateSessionRequest& request,
+      const std::string& imsi, const std::string& sid,
+      const std::string& core_sid, SessionConfig cfg, const bool is_wifi,
+      std::function<void(Status, LocalCreateSessionResponse)>
+          response_callback);
+
   /**
    * Get the most recently written state of sessions for Creation
    * Does not get any other sessions.


### PR DESCRIPTION
Summary: Split out functionality for recycling sessions out of CreateSession method

Differential Revision: D21096885

