### PR TITLE
Track policy rule lifetimes for subscribers

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -24,16 +24,16 @@
 
 namespace {
 
-std::chrono::milliseconds
-time_difference_from_now(const google::protobuf::Timestamp &timestamp) {
+std::chrono::milliseconds time_difference_from_now(
+    const google::protobuf::Timestamp& timestamp) {
   auto rule_time_sec =
       google::protobuf::util::TimeUtil::TimestampToSeconds(timestamp);
-  auto now = time(NULL);
+  auto now   = time(NULL);
   auto delta = std::max(rule_time_sec - now, 0L);
   std::chrono::seconds sec(delta);
   return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
 }
-} // namespace
+}  // namespace
 
 namespace magma {
 
@@ -45,28 +45,26 @@ using google::protobuf::util::TimeUtil;
 // We will treat rule install/uninstall failures as all-or-nothing - that is,
 // if we get a bad response from the pipelined client, we'll mark all the rules
 // as failed in the response
-static void mark_rule_failures(const bool activate_success,
-                               const bool deactivate_success,
-                               const PolicyReAuthRequest &request,
-                               PolicyReAuthAnswer &answer_out);
+static void mark_rule_failures(
+    const bool activate_success, const bool deactivate_success,
+    const PolicyReAuthRequest& request, PolicyReAuthAnswer& answer_out);
 // For command level result codes, we will mark the subscriber to be terminated
 // if the result code indicates a permanent failure.
 static void handle_command_level_result_code(
-    const std::string &imsi, const uint32_t result_code,
-    std::unordered_set<std::string> &subscribers_to_terminate);
-static bool is_valid_mac_address(const char *mac);
-static int get_apn_split_locaion(const std::string &apn);
-static bool parse_apn(const std::string &apn, std::string &mac_addr,
-                      std::string &name);
+    const std::string& imsi, const uint32_t result_code,
+    std::unordered_set<std::string>& subscribers_to_terminate);
+static bool is_valid_mac_address(const char* mac);
+static int get_apn_split_locaion(const std::string& apn);
+static bool parse_apn(
+    const std::string& apn, std::string& mac_addr, std::string& name);
 
-static SubscriberQuotaUpdate
-make_subscriber_quota_update(const std::string &imsi,
-                             const std::string &ue_mac_addr,
-                             const SubscriberQuotaUpdate_Type state);
+static SubscriberQuotaUpdate make_subscriber_quota_update(
+    const std::string& imsi, const std::string& ue_mac_addr,
+    const SubscriberQuotaUpdate_Type state);
 
 LocalEnforcer::LocalEnforcer(
     std::shared_ptr<SessionReporter> reporter,
-    std::shared_ptr<StaticRuleStore> rule_store, SessionStore &session_store,
+    std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
     std::shared_ptr<AsyncEventdClient> eventd_client,
@@ -74,30 +72,34 @@ LocalEnforcer::LocalEnforcer(
     std::shared_ptr<aaa::AAAClient> aaa_client,
     long session_force_termination_timeout_ms,
     long quota_exhaustion_termination_on_init_ms)
-    : reporter_(reporter), rule_store_(rule_store),
-      session_store_(session_store), pipelined_client_(pipelined_client),
-      directoryd_client_(directoryd_client), eventd_client_(eventd_client),
-      spgw_client_(spgw_client), aaa_client_(aaa_client),
+    : reporter_(reporter),
+      rule_store_(rule_store),
+      session_store_(session_store),
+      pipelined_client_(pipelined_client),
+      directoryd_client_(directoryd_client),
+      eventd_client_(eventd_client),
+      spgw_client_(spgw_client),
+      aaa_client_(aaa_client),
       session_force_termination_timeout_ms_(
           session_force_termination_timeout_ms),
       quota_exhaustion_termination_on_init_ms_(
           quota_exhaustion_termination_on_init_ms) {}
 
-void LocalEnforcer::notify_new_report_for_sessions(SessionMap &session_map) {
-  for (const auto &session_pair : session_map) {
-    for (const auto &session : session_pair.second) {
+void LocalEnforcer::notify_new_report_for_sessions(SessionMap& session_map) {
+  for (const auto& session_pair : session_map) {
+    for (const auto& session : session_pair.second) {
       session->new_report();
     }
   }
 }
 
 void LocalEnforcer::notify_finish_report_for_sessions(
-    SessionMap &session_map, SessionUpdate &session_update) {
+    SessionMap& session_map, SessionUpdate& session_update) {
   // Iterate through sessions and notify that report has finished. Terminate any
   // sessions that can be terminated.
   std::vector<std::pair<std::string, std::string>> imsi_to_terminate;
-  for (const auto &session_pair : session_map) {
-    for (const auto &session : session_pair.second) {
+  for (const auto& session_pair : session_map) {
+    for (const auto& session : session_pair.second) {
       session->finish_report();
       if (session->can_complete_termination()) {
         imsi_to_terminate.push_back(
@@ -105,24 +107,33 @@ void LocalEnforcer::notify_finish_report_for_sessions(
       }
     }
   }
-  for (const auto &imsi_sid_pair : imsi_to_terminate) {
-    SessionStateUpdateCriteria &update_criteria =
+  for (const auto& imsi_sid_pair : imsi_to_terminate) {
+    SessionStateUpdateCriteria& update_criteria =
         session_update[imsi_sid_pair.first][imsi_sid_pair.second];
-    complete_termination(session_map, imsi_sid_pair.first, imsi_sid_pair.second,
-                         update_criteria);
+    complete_termination(
+        session_map, imsi_sid_pair.first, imsi_sid_pair.second,
+        update_criteria);
   }
 }
 
-void LocalEnforcer::start() { evb_->loopForever(); }
+void LocalEnforcer::start() {
+  evb_->loopForever();
+}
 
-void LocalEnforcer::attachEventBase(folly::EventBase *evb) { evb_ = evb; }
+void LocalEnforcer::attachEventBase(folly::EventBase* evb) {
+  evb_ = evb;
+}
 
-void LocalEnforcer::stop() { evb_->terminateLoopSoon(); }
+void LocalEnforcer::stop() {
+  evb_->terminateLoopSoon();
+}
 
-folly::EventBase &LocalEnforcer::get_event_base() { return *evb_; }
+folly::EventBase& LocalEnforcer::get_event_base() {
+  return *evb_;
+}
 
 bool LocalEnforcer::setup(
-    SessionMap &session_map, const std::uint64_t &epoch,
+    SessionMap& session_map, const std::uint64_t& epoch,
     std::function<void(Status status, SetupFlowsResult)> callback) {
   std::vector<SessionState::SessionInfo> session_infos;
   std::vector<SubscriberQuotaUpdate> quota_updates;
@@ -132,7 +143,7 @@ bool LocalEnforcer::setup(
   std::vector<std::string> apn_names;
   auto cwf = false;
   for (auto it = session_map.begin(); it != session_map.end(); it++) {
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       SessionState::SessionInfo session_info;
       session->get_session_info(session_info);
       session_infos.push_back(session_info);
@@ -146,33 +157,33 @@ bool LocalEnforcer::setup(
       if (!parse_apn(apn, apn_mac_addr, apn_name)) {
         MLOG(MWARNING) << "Failed mac/name parsiong for apn " << apn;
         apn_mac_addr = "";
-        apn_name = apn;
+        apn_name     = apn;
       }
       apn_mac_addrs.push_back(apn_mac_addr);
       apn_names.push_back(apn_name);
       if (session->is_radius_cwf_session()) {
-        cwf = true;
-        SubscriberQuotaUpdate update =
-            make_subscriber_quota_update(session_info.imsi, ue_mac_addr,
-                                         session->get_subscriber_quota_state());
+        cwf                          = true;
+        SubscriberQuotaUpdate update = make_subscriber_quota_update(
+            session_info.imsi, ue_mac_addr,
+            session->get_subscriber_quota_state());
         quota_updates.push_back(update);
       }
     }
   }
   if (cwf) {
-    return pipelined_client_->setup_cwf(session_infos, quota_updates,
-                                        ue_mac_addrs, msisdns, apn_mac_addrs,
-                                        apn_names, epoch, callback);
+    return pipelined_client_->setup_cwf(
+        session_infos, quota_updates, ue_mac_addrs, msisdns, apn_mac_addrs,
+        apn_names, epoch, callback);
   } else {
     return pipelined_client_->setup_lte(session_infos, epoch, callback);
   }
 }
 
-void LocalEnforcer::aggregate_records(SessionMap &session_map,
-                                      const RuleRecordTable &records,
-                                      SessionUpdate &session_update) {
-  notify_new_report_for_sessions(session_map); // unmark all credits
-  for (const RuleRecord &record : records.records()) {
+void LocalEnforcer::aggregate_records(
+    SessionMap& session_map, const RuleRecordTable& records,
+    SessionUpdate& session_update) {
+  notify_new_report_for_sessions(session_map);  // unmark all credits
+  for (const RuleRecord& record : records.records()) {
     auto it = session_map.find(record.sid());
     if (it == session_map.end()) {
       MLOG(MERROR) << "Could not find session for IMSI " << record.sid()
@@ -186,25 +197,25 @@ void LocalEnforcer::aggregate_records(SessionMap &session_map,
                   << " rx bytes for rule " << record.rule_id();
     }
     // Update sessions
-    for (const auto &session : it->second) {
-      SessionStateUpdateCriteria &uc =
+    for (const auto& session : it->second) {
+      SessionStateUpdateCriteria& uc =
           session_update[record.sid()][session->get_session_id()];
-      session->add_used_credit(record.rule_id(), record.bytes_tx(),
-                               record.bytes_rx(), uc);
+      session->add_used_credit(
+          record.rule_id(), record.bytes_tx(), record.bytes_rx(), uc);
     }
   }
   notify_finish_report_for_sessions(session_map, session_update);
 }
 
 void LocalEnforcer::execute_actions(
-    SessionMap &session_map,
-    const std::vector<std::unique_ptr<ServiceAction>> &actions,
-    SessionUpdate &session_update) {
-  for (const auto &action_p : actions) {
+    SessionMap& session_map,
+    const std::vector<std::unique_ptr<ServiceAction>>& actions,
+    SessionUpdate& session_update) {
+  for (const auto& action_p : actions) {
     if (action_p->get_type() == TERMINATE_SERVICE) {
-      terminate_service(session_map, action_p->get_imsi(),
-                        action_p->get_rule_ids(),
-                        action_p->get_rule_definitions(), session_update);
+      terminate_service(
+          session_map, action_p->get_imsi(), action_p->get_rule_ids(),
+          action_p->get_rule_definitions(), session_update);
     } else if (action_p->get_type() == ACTIVATE_SERVICE) {
       pipelined_client_->activate_flows_for_rules(
           action_p->get_imsi(), action_p->get_ip_addr(),
@@ -214,15 +225,15 @@ void LocalEnforcer::execute_actions(
     } else if (action_p->get_type() == RESTRICT_ACCESS) {
       MLOG(MWARNING) << "RESTRICT_ACCESS mode is unsupported"
                      << ", will just terminate the service.";
-      terminate_service(session_map, action_p->get_imsi(),
-                        action_p->get_rule_ids(),
-                        action_p->get_rule_definitions(), session_update);
+      terminate_service(
+          session_map, action_p->get_imsi(), action_p->get_rule_ids(),
+          action_p->get_rule_definitions(), session_update);
     }
   }
 }
 
 void LocalEnforcer::set_termination_callback(
-    SessionMap &session_map, const std::string &imsi, const std::string &apn,
+    SessionMap& session_map, const std::string& imsi, const std::string& apn,
     std::function<void(SessionTerminateRequest)> on_termination_callback) {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
@@ -230,7 +241,7 @@ void LocalEnforcer::set_termination_callback(
                  << " during termination";
     throw SessionNotFound();
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     session->set_termination_callback(on_termination_callback);
   }
 }
@@ -238,10 +249,10 @@ void LocalEnforcer::set_termination_callback(
 // Terminates sessions that correspond to the given IMSI.
 // (For session termination triggered by sessiond)
 void LocalEnforcer::terminate_service(
-    SessionMap &session_map, const std::string &imsi,
-    const std::vector<std::string> &rule_ids,
-    const std::vector<PolicyRule> &dynamic_rules,
-    SessionUpdate &session_update) {
+    SessionMap& session_map, const std::string& imsi,
+    const std::vector<std::string>& rule_ids,
+    const std::vector<PolicyRule>& dynamic_rules,
+    SessionUpdate& session_update) {
   pipelined_client_->deactivate_flows_for_rules(imsi, rule_ids, dynamic_rules);
 
   auto it = session_map.find(imsi);
@@ -251,7 +262,7 @@ void LocalEnforcer::terminate_service(
     return;
   }
 
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     auto update_criteria = session_update[imsi][session->get_session_id()];
 
     session->start_termination(update_criteria);
@@ -274,8 +285,8 @@ void LocalEnforcer::terminate_service(
       }
       MLOG(MDEBUG) << "Setting subscriber quota state as TERMINATE "
                    << "for subscriber " << imsi;
-      session->set_subscriber_quota_state(SubscriberQuotaUpdate_Type_TERMINATE,
-                                          update_criteria);
+      session->set_subscriber_quota_state(
+          SubscriberQuotaUpdate_Type_TERMINATE, update_criteria);
       report_subscriber_state_to_pipelined(
           imsi, mac_addr, SubscriberQuotaUpdate_Type_TERMINATE);
     } else {
@@ -293,15 +304,15 @@ void LocalEnforcer::terminate_service(
     evb_->runAfterDelay(
         [this, imsi, session_id] {
           MLOG(MDEBUG) << "Forced service termination for IMSI " << imsi;
-          SessionRead req = {imsi};
+          SessionRead req  = {imsi};
           auto session_map = session_store_.read_sessions_for_deletion(req);
           auto session_update =
               SessionStore::get_default_session_update(session_map);
           if (session_update[imsi].find(session_id) !=
               session_update[imsi].end()) {
-            auto &update_criteria = session_update[imsi][session_id];
-            complete_termination(session_map, imsi, session_id,
-                                 update_criteria);
+            auto& update_criteria = session_update[imsi][session_id];
+            complete_termination(
+                session_map, imsi, session_id, update_criteria);
             bool end_success = session_store_.update_sessions(session_update);
             if (end_success) {
               MLOG(MDEBUG) << "Ended session " << imsi
@@ -322,28 +333,28 @@ void LocalEnforcer::terminate_service(
 }
 
 // TODO: make session_manager.proto and policydb.proto to use common field
-static RedirectInformation_AddressType
-address_type_converter(RedirectServer_RedirectAddressType address_type) {
+static RedirectInformation_AddressType address_type_converter(
+    RedirectServer_RedirectAddressType address_type) {
   switch (address_type) {
-  case RedirectServer_RedirectAddressType_IPV4:
-    return RedirectInformation_AddressType_IPv4;
-  case RedirectServer_RedirectAddressType_IPV6:
-    return RedirectInformation_AddressType_IPv6;
-  case RedirectServer_RedirectAddressType_URL:
-    return RedirectInformation_AddressType_URL;
-  case RedirectServer_RedirectAddressType_SIP_URI:
-    return RedirectInformation_AddressType_SIP_URI;
+    case RedirectServer_RedirectAddressType_IPV4:
+      return RedirectInformation_AddressType_IPv4;
+    case RedirectServer_RedirectAddressType_IPV6:
+      return RedirectInformation_AddressType_IPv6;
+    case RedirectServer_RedirectAddressType_URL:
+      return RedirectInformation_AddressType_URL;
+    case RedirectServer_RedirectAddressType_SIP_URI:
+      return RedirectInformation_AddressType_SIP_URI;
   }
 }
 
-static PolicyRule
-create_redirect_rule(const std::unique_ptr<ServiceAction> &action) {
+static PolicyRule create_redirect_rule(
+    const std::unique_ptr<ServiceAction>& action) {
   PolicyRule redirect_rule;
   redirect_rule.set_id("redirect");
   redirect_rule.set_priority(LocalEnforcer::REDIRECT_FLOW_PRIORITY);
   action->get_credit_key().set_rule(&redirect_rule);
 
-  RedirectInformation *redirect_info = redirect_rule.mutable_redirect();
+  RedirectInformation* redirect_info = redirect_rule.mutable_redirect();
   redirect_info->set_support(RedirectInformation_Support_ENABLED);
 
   auto redirect_server = action->get_redirect_server();
@@ -355,14 +366,14 @@ create_redirect_rule(const std::unique_ptr<ServiceAction> &action) {
 }
 
 void LocalEnforcer::install_redirect_flow(
-    const std::unique_ptr<ServiceAction> &action) {
+    const std::unique_ptr<ServiceAction>& action) {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules{create_redirect_rule(action)};
-  const std::string &imsi = action->get_imsi();
+  const std::string& imsi = action->get_imsi();
 
   auto request = directoryd_client_->get_directoryd_ip_field(
-      imsi, [this, imsi, static_rules, dynamic_rules](Status status,
-                                                      DirectoryField resp) {
+      imsi, [this, imsi, static_rules, dynamic_rules](
+                Status status, DirectoryField resp) {
         if (!status.ok()) {
           MLOG(MERROR) << "Could not fetch subscriber " << imsi << "ip, "
                        << "redirection fails, error: "
@@ -375,14 +386,14 @@ void LocalEnforcer::install_redirect_flow(
 }
 
 UpdateSessionRequest LocalEnforcer::collect_updates(
-    SessionMap &session_map,
-    std::vector<std::unique_ptr<ServiceAction>> &actions,
-    SessionUpdate &session_update, const bool force_update) const {
+    SessionMap& session_map,
+    std::vector<std::unique_ptr<ServiceAction>>& actions,
+    SessionUpdate& session_update, const bool force_update) const {
   UpdateSessionRequest request;
-  for (const auto &session_pair : session_map) {
-    for (const auto &session : session_pair.second) {
-      std::string imsi = session_pair.first;
-      std::string sid = session->get_session_id();
+  for (const auto& session_pair : session_map) {
+    for (const auto& session : session_pair.second) {
+      std::string imsi     = session_pair.first;
+      std::string sid      = session->get_session_id();
       auto update_criteria = session_update[imsi][sid];
       session->get_updates(request, &actions, update_criteria, force_update);
     }
@@ -390,9 +401,9 @@ UpdateSessionRequest LocalEnforcer::collect_updates(
   return request;
 }
 
-void LocalEnforcer::reset_updates(SessionMap &session_map,
-                                  const UpdateSessionRequest &failed_request) {
-  for (const auto &update : failed_request.updates()) {
+void LocalEnforcer::reset_updates(
+    SessionMap& session_map, const UpdateSessionRequest& failed_request) {
+  for (const auto& update : failed_request.updates()) {
     auto it = session_map.find(update.sid());
     if (it == session_map.end()) {
       MLOG(MERROR) << "Could not reset credit for IMSI " << update.sid()
@@ -400,7 +411,7 @@ void LocalEnforcer::reset_updates(SessionMap &session_map,
       return;
     }
 
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       // When updates are reset, they aren't written back into SessionStore,
       // so we can just put in a default UpdateCriteria
       auto uc = get_default_update_criteria();
@@ -408,7 +419,7 @@ void LocalEnforcer::reset_updates(SessionMap &session_map,
           CreditKey(update.usage()), uc);
     }
   }
-  for (const auto &update : failed_request.usage_monitors()) {
+  for (const auto& update : failed_request.usage_monitors()) {
     auto it = session_map.find(update.sid());
     if (it == session_map.end()) {
       MLOG(MERROR) << "Could not reset credit for IMSI " << update.sid()
@@ -416,7 +427,7 @@ void LocalEnforcer::reset_updates(SessionMap &session_map,
       return;
     }
 
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       // When updates are reset, they aren't written back into SessionStore,
       // so we can just put in a default UpdateCriteria
       auto uc = get_default_update_criteria();
@@ -432,9 +443,9 @@ void LocalEnforcer::reset_updates(SessionMap &session_map,
  * If a rule has a monitoring key, it is not required that a usage monitor is
  * installed with quota
  */
-static bool
-should_activate(const PolicyRule &rule,
-                const std::unordered_set<uint32_t> &successful_credits) {
+static bool should_activate(
+    const PolicyRule& rule,
+    const std::unordered_set<uint32_t>& successful_credits) {
   if (rule.tracking_type() == PolicyRule::ONLY_OCS ||
       rule.tracking_type() == PolicyRule::OCS_AND_PCRF) {
     const bool exists = successful_credits.count(rule.rating_group()) > 0;
@@ -446,29 +457,29 @@ should_activate(const PolicyRule &rule,
     }
   }
   switch (rule.tracking_type()) {
-  case PolicyRule::ONLY_PCRF:
-    MLOG(MINFO) << "Activating Gx tracked rule " << rule.id()
-                << " with monitoring key " << rule.monitoring_key();
-    break;
-  case PolicyRule::ONLY_OCS:
-    MLOG(MINFO) << "Activating Gy tracked rule " << rule.id()
-                << " with rating group " << rule.rating_group();
-    break;
-  case PolicyRule::OCS_AND_PCRF:
-    MLOG(MINFO) << "Activating Gx+Gy tracked rule " << rule.id()
-                << " with monitoring key " << rule.monitoring_key()
-                << " with rating group " << rule.rating_group();
-    break;
-  case PolicyRule::NO_TRACKING:
-    MLOG(MINFO) << "Activating untracked rule " << rule.id();
-    break;
+    case PolicyRule::ONLY_PCRF:
+      MLOG(MINFO) << "Activating Gx tracked rule " << rule.id()
+                  << " with monitoring key " << rule.monitoring_key();
+      break;
+    case PolicyRule::ONLY_OCS:
+      MLOG(MINFO) << "Activating Gy tracked rule " << rule.id()
+                  << " with rating group " << rule.rating_group();
+      break;
+    case PolicyRule::OCS_AND_PCRF:
+      MLOG(MINFO) << "Activating Gx+Gy tracked rule " << rule.id()
+                  << " with monitoring key " << rule.monitoring_key()
+                  << " with rating group " << rule.rating_group();
+      break;
+    case PolicyRule::NO_TRACKING:
+      MLOG(MINFO) << "Activating untracked rule " << rule.id();
+      break;
   }
   return true;
 }
 
 void LocalEnforcer::schedule_static_rule_activation(
-    const std::string &imsi, const std::string &ip_addr,
-    const StaticRuleInstall &static_rule) {
+    const std::string& imsi, const std::string& ip_addr,
+    const StaticRuleInstall& static_rule) {
   std::vector<std::string> static_rules{static_rule.rule_id()};
   std::vector<PolicyRule> dynamic_rules;
 
@@ -490,10 +501,11 @@ void LocalEnforcer::schedule_static_rule_activation(
                            << "during installation of static rule "
                            << static_rule.rule_id();
           } else {
-            for (const auto &session : it->second) {
+            for (const auto& session : it->second) {
               if (session->get_subscriber_ip_addr() == ip_addr) {
-                auto &uc = session_update[imsi][session->get_session_id()];
-                session->activate_static_rule(static_rule.rule_id(), uc);
+                auto& uc = session_update[imsi][session->get_session_id()];
+                session->install_scheduled_static_rule(
+                    static_rule.rule_id(), uc);
               }
             }
             auto update_success =
@@ -505,8 +517,8 @@ void LocalEnforcer::schedule_static_rule_activation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_activation(
-    const std::string &imsi, const std::string &ip_addr,
-    const DynamicRuleInstall &dynamic_rule) {
+    const std::string& imsi, const std::string& ip_addr,
+    const DynamicRuleInstall& dynamic_rule) {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules{dynamic_rule.policy_rule()};
 
@@ -528,10 +540,11 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
                            << "during installation of dynamic rule "
                            << dynamic_rule.policy_rule().id();
           } else {
-            for (const auto &session : it->second) {
+            for (const auto& session : it->second) {
               if (session->get_subscriber_ip_addr() == ip_addr) {
-                auto &uc = session_update[imsi][session->get_session_id()];
-                session->insert_dynamic_rule(dynamic_rule.policy_rule(), uc);
+                auto& uc = session_update[imsi][session->get_session_id()];
+                session->install_scheduled_dynamic_rule(
+                    dynamic_rule.policy_rule().id(), uc);
               }
             }
             auto update_success =
@@ -543,7 +556,7 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
 }
 
 void LocalEnforcer::schedule_static_rule_deactivation(
-    const std::string &imsi, const StaticRuleInstall &static_rule) {
+    const std::string& imsi, const StaticRuleInstall& static_rule) {
   std::vector<std::string> static_rules{static_rule.rule_id()};
   std::vector<PolicyRule> dynamic_rules;
 
@@ -557,20 +570,20 @@ void LocalEnforcer::schedule_static_rule_deactivation(
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto session_update =
               session_store_.get_default_session_update(session_map);
-          pipelined_client_->deactivate_flows_for_rules(imsi, static_rules,
-                                                        dynamic_rules);
+          pipelined_client_->deactivate_flows_for_rules(
+              imsi, static_rules, dynamic_rules);
           auto it = session_map.find(imsi);
           if (it == session_map.end()) {
             MLOG(MWARNING) << "Could not find session for IMSI " << imsi
                            << "during removal of static rule "
                            << static_rule.rule_id();
           } else {
-            for (const auto &session : it->second) {
-              auto &uc = session_update[imsi][session->get_session_id()];
+            for (const auto& session : it->second) {
+              auto& uc = session_update[imsi][session->get_session_id()];
               if (!session->deactivate_static_rule(static_rule.rule_id(), uc))
-                MLOG(MWARNING) << "Could not find rule "
-                               << static_rule.rule_id() << "for IMSI " << imsi
-                               << " during static rule removal";
+                MLOG(MWARNING)
+                    << "Could not find rule " << static_rule.rule_id()
+                    << "for IMSI " << imsi << " during static rule removal";
             }
             auto update_success =
                 session_store_.update_sessions(session_update);
@@ -581,7 +594,7 @@ void LocalEnforcer::schedule_static_rule_deactivation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_deactivation(
-    const std::string &imsi, const DynamicRuleInstall &dynamic_rule) {
+    const std::string& imsi, const DynamicRuleInstall& dynamic_rule) {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules{dynamic_rule.policy_rule()};
 
@@ -595,8 +608,8 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto session_update =
               session_store_.get_default_session_update(session_map);
-          pipelined_client_->deactivate_flows_for_rules(imsi, static_rules,
-                                                        dynamic_rules);
+          pipelined_client_->deactivate_flows_for_rules(
+              imsi, static_rules, dynamic_rules);
           auto it = session_map.find(imsi);
           if (it == session_map.end()) {
             MLOG(MWARNING) << "Could not find session for IMSI " << imsi
@@ -604,10 +617,10 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
                            << dynamic_rule.policy_rule().id();
           } else {
             PolicyRule rule_dont_care;
-            for (const auto &session : it->second) {
-              auto &uc = session_update[imsi][session->get_session_id()];
-              session->remove_dynamic_rule(dynamic_rule.policy_rule().id(),
-                                           &rule_dont_care, uc);
+            for (const auto& session : it->second) {
+              auto& uc = session_update[imsi][session->get_session_id()];
+              session->remove_dynamic_rule(
+                  dynamic_rule.policy_rule().id(), &rule_dont_care, uc);
             }
             auto update_success =
                 session_store_.update_sessions(session_update);
@@ -617,97 +630,65 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
   });
 }
 
-void LocalEnforcer::process_create_session_response(
-    SessionMap &session_map, const CreateSessionResponse &response,
-    const std::unordered_set<uint32_t> &successful_credits,
-    const std::string &imsi, const std::string &ip_addr,
-    RulesToProcess &rules_to_activate, RulesToProcess &rules_to_deactivate) {
-  std::time_t current_time = time(NULL);
-  for (const auto &static_rule : response.static_rules()) {
-    auto id = static_rule.rule_id();
-    PolicyRule rule;
-    if (!rule_store_->get_rule(id, &rule)) {
-      LOG(ERROR) << "Not activating rule " << id
-                 << " because it could not be found";
-      continue;
-    }
-    if (should_activate(rule, successful_credits)) {
-      auto activation_time =
-          TimeUtil::TimestampToSeconds(static_rule.activation_time());
-      if (activation_time > current_time) {
-        schedule_static_rule_activation(imsi, ip_addr, static_rule);
-      } else {
-        // activation time is an optional field in the proto message
-        // it will be set as 0 by default
-        // when it is 0 or some past time, the rule should be activated instanly
-        rules_to_activate.static_rules.push_back(id);
-      }
+void LocalEnforcer::filter_rule_installs(
+    std::vector<StaticRuleInstall> static_installs,
+    std::vector<DynamicRuleInstall> dynamic_installs,
+    const std::unordered_set<uint32_t>& successful_credits) {
+  // Filter out static rules that we will not install nor schedule
+  std::remove_if(
+      static_installs.begin(), static_installs.end(),
+      [&](StaticRuleInstall& rule_install) {
+        auto& id = rule_install.rule_id();
+        PolicyRule rule;
+        if (!rule_store_->get_rule(id, &rule)) {
+          LOG(ERROR) << "Not activating rule " << id
+                     << " because it could not be found";
+          return true;
+        }
+        return !should_activate(rule, successful_credits);
+      });
 
-      auto deactivation_time =
-          TimeUtil::TimestampToSeconds(static_rule.deactivation_time());
-      if (deactivation_time > current_time) {
-        schedule_static_rule_deactivation(imsi, static_rule);
-      } else if (deactivation_time > 0) {
-        // deactivation time is an optional field in the proto message
-        // it will be set as 0 by default
-        // when it is some past time, the rule should be deactivated instantly
-        rules_to_deactivate.static_rules.push_back(id);
-      }
-    }
-  }
-
-  for (const auto &dynamic_rule : response.dynamic_rules()) {
-    if (should_activate(dynamic_rule.policy_rule(), successful_credits)) {
-      auto activation_time =
-          TimeUtil::TimestampToSeconds(dynamic_rule.activation_time());
-      if (activation_time > current_time) {
-        schedule_dynamic_rule_activation(imsi, ip_addr, dynamic_rule);
-      } else {
-        rules_to_activate.dynamic_rules.push_back(dynamic_rule.policy_rule());
-      }
-      auto deactivation_time =
-          TimeUtil::TimestampToSeconds(dynamic_rule.deactivation_time());
-      if (deactivation_time > current_time) {
-        schedule_dynamic_rule_deactivation(imsi, dynamic_rule);
-      } else if (deactivation_time > 0) {
-        rules_to_deactivate.dynamic_rules.push_back(dynamic_rule.policy_rule());
-      }
-    }
-  }
+  // Filter out dynamic rules that we will not install nor schedule
+  std::remove_if(
+      dynamic_installs.begin(), dynamic_installs.end(),
+      [&](DynamicRuleInstall& rule_install) {
+        return !should_activate(rule_install.policy_rule(), successful_credits);
+      });
 }
 
 // return true if any credit unit is valid and has non-zero volume
-static bool contains_credit(const GrantedUnits &gsu) {
+static bool contains_credit(const GrantedUnits& gsu) {
   return (gsu.total().is_valid() && gsu.total().volume() > 0) ||
          (gsu.tx().is_valid() && gsu.tx().volume() > 0) ||
          (gsu.rx().is_valid() && gsu.rx().volume() > 0);
 }
 
 bool LocalEnforcer::handle_session_init_rule_updates(
-    SessionMap &session_map, const std::string &imsi,
-    SessionState &session_state, const CreateSessionResponse &response,
-    std::unordered_set<uint32_t> &charging_credits_received) {
+    SessionMap& session_map, const std::string& imsi,
+    SessionState& session_state, const CreateSessionResponse& response,
+    std::unordered_set<uint32_t>& charging_credits_received) {
   auto ip_addr = session_state.get_subscriber_ip_addr();
 
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
 
-  process_create_session_response(session_map, response,
-                                  charging_credits_received, imsi, ip_addr,
-                                  rules_to_activate, rules_to_deactivate);
+  // Can use a default UpdateCriteria since SessionStore's create and update
+  // methods are separate.
+  std::vector<StaticRuleInstall> static_rule_installs =
+      to_vec(response.static_rules());
+  std::vector<DynamicRuleInstall> dynamic_rule_installs =
+      to_vec(response.dynamic_rules());
+  filter_rule_installs(
+      static_rule_installs, dynamic_rule_installs, charging_credits_received);
+
+  auto uc = get_default_update_criteria();
+  process_rules_to_install(
+      session_state, imsi, static_rule_installs, dynamic_rule_installs,
+      rules_to_activate, rules_to_deactivate, uc);
 
   // activate_flows_for_rules() should be called even if there is no rule to
   // activate, because pipelined activates a "drop all packet" rule
   // when no rule is provided as the parameter.
-  // Can use a default UpdateCriteria since SessionStore's create and update
-  // methods are separate.
-  auto uc = get_default_update_criteria();
-  for (const auto &static_rule : rules_to_activate.static_rules) {
-    session_state.activate_static_rule(static_rule, uc);
-  }
-  for (const auto &policy_rule : rules_to_activate.dynamic_rules) {
-    session_state.insert_dynamic_rule(policy_rule, uc);
-  }
   bool activate_success = pipelined_client_->activate_flows_for_rules(
       imsi, ip_addr, rules_to_activate.static_rules,
       rules_to_activate.dynamic_rules);
@@ -717,15 +698,6 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   // when no rule is provided as the parameter
   bool deactivate_success = true;
   if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    for (const auto &static_rule : rules_to_deactivate.static_rules) {
-      if (!session_state.deactivate_static_rule(static_rule, uc))
-        MLOG(MWARNING) << "Could not find rule " << static_rule << "for IMSI "
-                       << imsi << " during static rule removal";
-    }
-    for (const auto &policy_rule : rules_to_deactivate.dynamic_rules) {
-      PolicyRule rule_dont_care;
-      session_state.remove_dynamic_rule(policy_rule.id(), &rule_dont_care, uc);
-    }
     deactivate_success = pipelined_client_->deactivate_flows_for_rules(
         imsi, rules_to_deactivate.static_rules,
         rules_to_deactivate.dynamic_rules);
@@ -734,16 +706,16 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   return activate_success && deactivate_success;
 }
 
-bool LocalEnforcer::init_session_credit(SessionMap &session_map,
-                                        const std::string &imsi,
-                                        const std::string &session_id,
-                                        const SessionConfig &cfg,
-                                        const CreateSessionResponse &response) {
-  auto session_state = new SessionState(imsi, session_id, response.session_id(),
-                                        cfg, *rule_store_, response.tgpp_ctx());
+bool LocalEnforcer::init_session_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, const SessionConfig& cfg,
+    const CreateSessionResponse& response) {
+  auto session_state = new SessionState(
+      imsi, session_id, response.session_id(), cfg, *rule_store_,
+      response.tgpp_ctx());
 
   std::unordered_set<uint32_t> charging_credits_received;
-  for (const auto &credit : response.credits()) {
+  for (const auto& credit : response.credits()) {
     auto uc = get_default_update_criteria();
     session_state->get_charging_pool().receive_credit(credit, uc);
     if (credit.success() && contains_credit(credit.credit().granted_units())) {
@@ -752,7 +724,7 @@ bool LocalEnforcer::init_session_credit(SessionMap &session_map,
   }
   // We don't have to check 'success' field for monitors because command level
   // errors are handled in session proxy
-  for (const auto &monitor : response.usage_monitors()) {
+  for (const auto& monitor : response.usage_monitors()) {
     if (revalidation_required(monitor.event_triggers())) {
       schedule_revalidation(session_map, monitor.revalidation_time());
     }
@@ -772,17 +744,17 @@ bool LocalEnforcer::init_session_credit(SessionMap &session_map,
     if (!parse_apn(cfg.apn, apn_mac_addr, apn_name)) {
       MLOG(MWARNING) << "Failed mac/name parsing for apn " << cfg.apn;
       apn_mac_addr = "";
-      apn_name = cfg.apn;
+      apn_name     = cfg.apn;
     }
-    auto ue_mac_addr = session_state->get_mac_addr();
+    auto ue_mac_addr             = session_state->get_mac_addr();
     bool add_ue_mac_flow_success = pipelined_client_->add_ue_mac_flow(
         sid, ue_mac_addr, cfg.msisdn, apn_mac_addr, apn_name);
     if (!add_ue_mac_flow_success) {
       MLOG(MERROR) << "Failed to add UE MAC flow for subscriber " << imsi;
     }
 
-    handle_session_init_subscriber_quota_state(session_map, imsi,
-                                               *session_state);
+    handle_session_init_subscriber_quota_state(
+        session_map, imsi, *session_state);
   }
 
   auto it = session_map.find(imsi);
@@ -803,8 +775,8 @@ bool LocalEnforcer::init_session_credit(SessionMap &session_map,
 }
 
 void LocalEnforcer::handle_session_init_subscriber_quota_state(
-    SessionMap &session_map, const std::string &imsi,
-    SessionState &session_state) {
+    SessionMap& session_map, const std::string& imsi,
+    SessionState& session_state) {
   auto ue_mac_addr = session_state.get_mac_addr();
   // This method only used for session creation and not updates, so
   // UpdateCriteria is unused.
@@ -820,10 +792,10 @@ void LocalEnforcer::handle_session_init_subscriber_quota_state(
   }
   MLOG(MDEBUG) << "No monitoring rules are installed, setting subscriber "
                << "quota state as NO_QUOTA for subscriber " << imsi;
-  session_state.set_subscriber_quota_state(SubscriberQuotaUpdate_Type_NO_QUOTA,
-                                           uc);
-  report_subscriber_state_to_pipelined(imsi, ue_mac_addr,
-                                       SubscriberQuotaUpdate_Type_NO_QUOTA);
+  session_state.set_subscriber_quota_state(
+      SubscriberQuotaUpdate_Type_NO_QUOTA, uc);
+  report_subscriber_state_to_pipelined(
+      imsi, ue_mac_addr, SubscriberQuotaUpdate_Type_NO_QUOTA);
 
   // Schedule a session termination for a configured number of seconds after
   // session create
@@ -835,22 +807,23 @@ void LocalEnforcer::handle_session_init_subscriber_quota_state(
       [this, imsi] {
         MLOG(MDEBUG) << "Starting termination due to quota exhaustion for"
                      << " IMSI " << imsi;
-        SessionRead req = {imsi};
+        SessionRead req  = {imsi};
         auto session_map = session_store_.read_sessions_for_deletion(req);
-        auto it = session_map.find(imsi);
+        auto it          = session_map.find(imsi);
         if (it == session_map.end()) {
           MLOG(MDEBUG) << "Session for IMSI " << imsi << " not found";
           return;
         }
         SessionUpdate session_update =
             SessionStore::get_default_session_update(session_map);
-        for (const auto &session : it->second) {
+        for (const auto& session : it->second) {
           RulesToProcess rules;
           populate_rules_from_session_to_remove(imsi, session, rules);
           // terminate_service will properly propagate subscriber quota state
           // as terminated
-          terminate_service(session_map, imsi, rules.static_rules,
-                            rules.dynamic_rules, session_update);
+          terminate_service(
+              session_map, imsi, rules.static_rules, rules.dynamic_rules,
+              session_update);
         }
         bool end_success = session_store_.update_sessions(session_update);
         if (end_success) {
@@ -864,7 +837,7 @@ void LocalEnforcer::handle_session_init_subscriber_quota_state(
 }
 
 void LocalEnforcer::report_subscriber_state_to_pipelined(
-    const std::string &imsi, const std::string &ue_mac_addr,
+    const std::string& imsi, const std::string& ue_mac_addr,
     const SubscriberQuotaUpdate_Type state) {
   auto update = make_subscriber_quota_update(imsi, ue_mac_addr, state);
   bool add_subscriber_quota_state_success =
@@ -877,9 +850,9 @@ void LocalEnforcer::report_subscriber_state_to_pipelined(
 }
 
 void LocalEnforcer::complete_termination(
-    SessionMap &session_map, const std::string &imsi,
-    const std::string &session_id,
-    SessionStateUpdateCriteria &update_criteria) {
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id,
+    SessionStateUpdateCriteria& update_criteria) {
   // If the session cannot be found in session_map, or a new session has
   // already begun, do nothing.
   auto it = session_map.find(imsi);
@@ -918,38 +891,39 @@ void LocalEnforcer::complete_termination(
 }
 
 bool LocalEnforcer::rules_to_process_is_not_empty(
-    const RulesToProcess &rules_to_process) {
+    const RulesToProcess& rules_to_process) {
   return rules_to_process.static_rules.size() > 0 ||
          rules_to_process.dynamic_rules.size() > 0;
 }
 
 void LocalEnforcer::terminate_multiple_services(
-    SessionMap &session_map, const std::unordered_set<std::string> &imsis,
-    SessionUpdate &session_update) {
-  for (const auto &imsi : imsis) {
+    SessionMap& session_map, const std::unordered_set<std::string>& imsis,
+    SessionUpdate& session_update) {
+  for (const auto& imsi : imsis) {
     auto it = session_map.find(imsi);
     if (it == session_map.end()) {
       continue;
     }
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       RulesToProcess rules;
       populate_rules_from_session_to_remove(imsi, session, rules);
-      terminate_service(session_map, imsi, rules.static_rules,
-                        rules.dynamic_rules, session_update);
+      terminate_service(
+          session_map, imsi, rules.static_rules, rules.dynamic_rules,
+          session_update);
     }
   }
 }
 
 void LocalEnforcer::update_charging_credits(
-    SessionMap &session_map, const UpdateSessionResponse &response,
-    std::unordered_set<std::string> &subscribers_to_terminate,
-    SessionUpdate &session_update) {
-  for (const auto &credit_update_resp : response.responses()) {
-    const std::string &imsi = credit_update_resp.sid();
+    SessionMap& session_map, const UpdateSessionResponse& response,
+    std::unordered_set<std::string>& subscribers_to_terminate,
+    SessionUpdate& session_update) {
+  for (const auto& credit_update_resp : response.responses()) {
+    const std::string& imsi = credit_update_resp.sid();
 
     if (!credit_update_resp.success()) {
-      handle_command_level_result_code(imsi, credit_update_resp.result_code(),
-                                       subscribers_to_terminate);
+      handle_command_level_result_code(
+          imsi, credit_update_resp.result_code(), subscribers_to_terminate);
       continue;
     }
 
@@ -959,26 +933,26 @@ void LocalEnforcer::update_charging_credits(
                    << credit_update_resp.sid() << " during update";
       continue;
     }
-    for (const auto &session : it->second) {
-      std::string sid = session->get_session_id();
-      SessionStateUpdateCriteria &update_criteria = session_update[imsi][sid];
-      session->get_charging_pool().receive_credit(credit_update_resp,
-                                                  update_criteria);
+    for (const auto& session : it->second) {
+      std::string sid                             = session->get_session_id();
+      SessionStateUpdateCriteria& update_criteria = session_update[imsi][sid];
+      session->get_charging_pool().receive_credit(
+          credit_update_resp, update_criteria);
       session->set_tgpp_context(credit_update_resp.tgpp_ctx(), update_criteria);
     }
   }
 }
 
 void LocalEnforcer::update_monitoring_credits_and_rules(
-    SessionMap &session_map, const UpdateSessionResponse &response,
-    std::unordered_set<std::string> &subscribers_to_terminate,
-    SessionUpdate &session_update) {
-  for (const auto &usage_monitor_resp : response.usage_monitor_responses()) {
-    const std::string &imsi = usage_monitor_resp.sid();
+    SessionMap& session_map, const UpdateSessionResponse& response,
+    std::unordered_set<std::string>& subscribers_to_terminate,
+    SessionUpdate& session_update) {
+  for (const auto& usage_monitor_resp : response.usage_monitor_responses()) {
+    const std::string& imsi = usage_monitor_resp.sid();
 
     if (!usage_monitor_resp.success()) {
-      handle_command_level_result_code(imsi, usage_monitor_resp.result_code(),
-                                       subscribers_to_terminate);
+      handle_command_level_result_code(
+          imsi, usage_monitor_resp.result_code(), subscribers_to_terminate);
       continue;
     }
 
@@ -990,32 +964,31 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
     }
 
     if (revalidation_required(usage_monitor_resp.event_triggers())) {
-      schedule_revalidation(session_map,
-                            usage_monitor_resp.revalidation_time());
+      schedule_revalidation(
+          session_map, usage_monitor_resp.revalidation_time());
     }
 
-    for (const auto &session : it->second) {
-      auto &update_criteria = session_update[imsi][session->get_session_id()];
-      session->get_monitor_pool().receive_credit(usage_monitor_resp,
-                                                 update_criteria);
+    for (const auto& session : it->second) {
+      auto& update_criteria = session_update[imsi][session->get_session_id()];
+      session->get_monitor_pool().receive_credit(
+          usage_monitor_resp, update_criteria);
       session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), update_criteria);
 
       RulesToProcess rules_to_activate;
       RulesToProcess rules_to_deactivate;
 
-      process_rules_to_remove(imsi, session,
-                              usage_monitor_resp.rules_to_remove(),
-                              rules_to_deactivate, update_criteria);
+      process_rules_to_remove(
+          imsi, session, usage_monitor_resp.rules_to_remove(),
+          rules_to_deactivate, update_criteria);
 
-      process_rules_to_install(session_map, imsi, session,
-                               usage_monitor_resp.static_rules_to_install(),
-                               usage_monitor_resp.dynamic_rules_to_install(),
-                               rules_to_activate, rules_to_deactivate,
-                               update_criteria);
+      process_rules_to_install(
+          *session, imsi, to_vec(usage_monitor_resp.static_rules_to_install()),
+          to_vec(usage_monitor_resp.dynamic_rules_to_install()),
+          rules_to_activate, rules_to_deactivate, update_criteria);
 
-      auto ip_addr = session->get_subscriber_ip_addr();
+      auto ip_addr            = session->get_subscriber_ip_addr();
       bool deactivate_success = true;
-      bool activate_success = true;
+      bool activate_success   = true;
 
       if (rules_to_process_is_not_empty(rules_to_deactivate)) {
         // TODO: modify the SessionUpdate
@@ -1054,28 +1027,27 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
 }
 
 void LocalEnforcer::update_session_credits_and_rules(
-    SessionMap &session_map, const UpdateSessionResponse &response,
-    SessionUpdate &session_update) {
+    SessionMap& session_map, const UpdateSessionResponse& response,
+    SessionUpdate& session_update) {
   // These subscribers will include any subscriber that received a permanent
   // diameter error code. Additionally, it will also include CWF sessions that
   // have run out of monitoring quota.
   std::unordered_set<std::string> subscribers_to_terminate;
 
-  update_charging_credits(session_map, response, subscribers_to_terminate,
-                          session_update);
-  update_monitoring_credits_and_rules(session_map, response,
-                                      subscribers_to_terminate, session_update);
+  update_charging_credits(
+      session_map, response, subscribers_to_terminate, session_update);
+  update_monitoring_credits_and_rules(
+      session_map, response, subscribers_to_terminate, session_update);
 
-  terminate_multiple_services(session_map, subscribers_to_terminate,
-                              session_update);
+  terminate_multiple_services(
+      session_map, subscribers_to_terminate, session_update);
 }
 
 // terminate_subscriber (for externally triggered EndSession)
 // terminates the session that is associated with the given imsi and apn
-void LocalEnforcer::terminate_subscriber(SessionMap &session_map,
-                                         const std::string &imsi,
-                                         const std::string &apn,
-                                         SessionUpdate &session_update) {
+void LocalEnforcer::terminate_subscriber(
+    SessionMap& session_map, const std::string& imsi, const std::string& apn,
+    SessionUpdate& session_update) {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     MLOG(MERROR) << "Could not find session for IMSI " << imsi
@@ -1083,19 +1055,19 @@ void LocalEnforcer::terminate_subscriber(SessionMap &session_map,
     throw SessionNotFound();
   }
 
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     if (session->get_apn() == apn) {
-      SessionStateUpdateCriteria &update_criteria =
+      SessionStateUpdateCriteria& update_criteria =
           session_update[imsi][session->get_session_id()];
       RulesToProcess rules_to_deactivate;
       // The assumption here is that
       // mutually exclusive rule names are used for different apns
       populate_rules_from_session_to_remove(imsi, session, rules_to_deactivate);
       bool deactivate_success = true;
-      for (const std::string &static_rule : rules_to_deactivate.static_rules) {
+      for (const std::string& static_rule : rules_to_deactivate.static_rules) {
         update_criteria.static_rules_to_uninstall.insert(static_rule);
       }
-      for (const PolicyRule &dynamic_rule : rules_to_deactivate.dynamic_rules) {
+      for (const PolicyRule& dynamic_rule : rules_to_deactivate.dynamic_rules) {
         update_criteria.dynamic_rules_to_uninstall.insert(dynamic_rule.id());
       }
       deactivate_success = pipelined_client_->deactivate_flows_for_rules(
@@ -1131,15 +1103,15 @@ void LocalEnforcer::terminate_subscriber(SessionMap &session_map,
       // force terminate the session.
       evb_->runAfterDelay(
           [this, imsi, session_id] {
-            SessionRead req = {imsi};
+            SessionRead req  = {imsi};
             auto session_map = session_store_.read_sessions_for_deletion(req);
             auto session_update =
                 SessionStore::get_default_session_update(session_map);
-            SessionStateUpdateCriteria &update_criteria =
+            SessionStateUpdateCriteria& update_criteria =
                 session_update[imsi][session_id];
             MLOG(MDEBUG) << "Completing forced termination for IMSI " << imsi;
-            complete_termination(session_map, imsi, session_id,
-                                 update_criteria);
+            complete_termination(
+                session_map, imsi, session_id, update_criteria);
 
             bool end_success = session_store_.update_sessions(session_update);
             if (end_success) {
@@ -1156,15 +1128,14 @@ void LocalEnforcer::terminate_subscriber(SessionMap &session_map,
   }
 }
 
-uint64_t LocalEnforcer::get_charging_credit(SessionMap &session_map,
-                                            const std::string &imsi,
-                                            const CreditKey &charging_key,
-                                            Bucket bucket) const {
+uint64_t LocalEnforcer::get_charging_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const CreditKey& charging_key, Bucket bucket) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return 0;
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     uint64_t credit =
         session->get_charging_pool().get_credit(charging_key, bucket);
     if (credit > 0) {
@@ -1174,15 +1145,14 @@ uint64_t LocalEnforcer::get_charging_credit(SessionMap &session_map,
   return 0;
 }
 
-uint64_t LocalEnforcer::get_monitor_credit(SessionMap &session_map,
-                                           const std::string &imsi,
-                                           const std::string &mkey,
-                                           Bucket bucket) const {
+uint64_t LocalEnforcer::get_monitor_credit(
+    SessionMap& session_map, const std::string& imsi, const std::string& mkey,
+    Bucket bucket) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return 0;
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     uint64_t credit = session->get_monitor_pool().get_credit(mkey, bucket);
     if (credit > 0) {
       return credit;
@@ -1191,26 +1161,25 @@ uint64_t LocalEnforcer::get_monitor_credit(SessionMap &session_map,
   return 0;
 }
 
-ChargingReAuthAnswer::Result
-LocalEnforcer::init_charging_reauth(SessionMap &session_map,
-                                    ChargingReAuthRequest request,
-                                    SessionUpdate &session_update) {
+ChargingReAuthAnswer::Result LocalEnforcer::init_charging_reauth(
+    SessionMap& session_map, ChargingReAuthRequest request,
+    SessionUpdate& session_update) {
   auto it = session_map.find(request.sid());
   if (it == session_map.end()) {
     MLOG(MERROR) << "Could not find session for subscriber " << request.sid()
                  << " during reauth";
     return ChargingReAuthAnswer::SESSION_NOT_FOUND;
   }
-  SessionStateUpdateCriteria &update_criteria =
+  SessionStateUpdateCriteria& update_criteria =
       session_update[request.sid()][request.session_id()];
   if (request.type() == ChargingReAuthRequest::SINGLE_SERVICE) {
     MLOG(MDEBUG) << "Initiating reauth of key " << request.charging_key()
                  << " for subscriber " << request.sid() << " for session "
                  << request.session_id();
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       if (session->get_session_id() == request.session_id()) {
-        return session->get_charging_pool().reauth_key(CreditKey(request),
-                                                       update_criteria);
+        return session->get_charging_pool().reauth_key(
+            CreditKey(request), update_criteria);
       }
     }
     MLOG(MERROR) << "Could not find session for subscriber " << request.sid()
@@ -1219,7 +1188,7 @@ LocalEnforcer::init_charging_reauth(SessionMap &session_map,
   }
   MLOG(MDEBUG) << "Initiating reauth of all keys for subscriber "
                << request.sid() << " for session" << request.session_id();
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     if (session->get_session_id() == request.session_id()) {
       return session->get_charging_pool().reauth_all(update_criteria);
     }
@@ -1230,10 +1199,9 @@ LocalEnforcer::init_charging_reauth(SessionMap &session_map,
   return ChargingReAuthAnswer::SESSION_NOT_FOUND;
 }
 
-void LocalEnforcer::init_policy_reauth(SessionMap &session_map,
-                                       PolicyReAuthRequest request,
-                                       PolicyReAuthAnswer &answer_out,
-                                       SessionUpdate &session_update) {
+void LocalEnforcer::init_policy_reauth(
+    SessionMap& session_map, PolicyReAuthRequest request,
+    PolicyReAuthAnswer& answer_out, SessionUpdate& session_update) {
   auto it = session_map.find(request.imsi());
   if (it == session_map.end()) {
     MLOG(MERROR) << "Could not find session for subscriber " << request.imsi()
@@ -1243,17 +1211,17 @@ void LocalEnforcer::init_policy_reauth(SessionMap &session_map,
   }
 
   bool deactivate_success = true;
-  bool activate_success = true;
+  bool activate_success   = true;
   // For empty session_id, apply changes to all sessions of subscriber
   // Changes are applied on a best-effort basis, so failures for one session
   // won't stop changes from being applied for subsequent sessions.
   if (request.session_id() == "") {
-    bool all_activated = true;
+    bool all_activated   = true;
     bool all_deactivated = true;
-    for (const auto &session : it->second) {
-      init_policy_reauth_for_session(session_map, request, session,
-                                     activate_success, deactivate_success,
-                                     session_update);
+    for (const auto& session : it->second) {
+      init_policy_reauth_for_session(
+          session_map, request, session, activate_success, deactivate_success,
+          session_update);
       all_activated &= activate_success;
       all_deactivated &= deactivate_success;
     }
@@ -1261,12 +1229,12 @@ void LocalEnforcer::init_policy_reauth(SessionMap &session_map,
     mark_rule_failures(all_activated, all_deactivated, request, answer_out);
   } else {
     bool session_id_valid = false;
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       if (session->get_session_id() == request.session_id()) {
         session_id_valid = true;
-        init_policy_reauth_for_session(session_map, request, session,
-                                       activate_success, deactivate_success,
-                                       session_update);
+        init_policy_reauth_for_session(
+            session_map, request, session, activate_success, deactivate_success,
+            session_update);
       }
     }
     if (!session_id_valid) {
@@ -1276,21 +1244,21 @@ void LocalEnforcer::init_policy_reauth(SessionMap &session_map,
       answer_out.set_result(ReAuthResult::SESSION_NOT_FOUND);
       return;
     }
-    mark_rule_failures(activate_success, deactivate_success, request,
-                       answer_out);
+    mark_rule_failures(
+        activate_success, deactivate_success, request, answer_out);
   }
   answer_out.set_result(ReAuthResult::UPDATE_INITIATED);
 }
 
 void LocalEnforcer::init_policy_reauth_for_session(
-    SessionMap &session_map, const PolicyReAuthRequest &request,
-    const std::unique_ptr<SessionState> &session, bool &activate_success,
-    bool &deactivate_success, SessionUpdate &session_update) {
+    SessionMap& session_map, const PolicyReAuthRequest& request,
+    const std::unique_ptr<SessionState>& session, bool& activate_success,
+    bool& deactivate_success, SessionUpdate& session_update) {
   std::string imsi = request.imsi();
-  SessionStateUpdateCriteria &update_criteria =
+  SessionStateUpdateCriteria& update_criteria =
       session_update[imsi][session->get_session_id()];
 
-  activate_success = true;
+  activate_success   = true;
   deactivate_success = true;
   receive_monitoring_credit_from_rar(request, session, update_criteria);
 
@@ -1302,35 +1270,22 @@ void LocalEnforcer::init_policy_reauth_for_session(
     schedule_revalidation(session_map, request.revalidation_time());
   }
 
-  process_rules_to_remove(imsi, session, request.rules_to_remove(),
-                          rules_to_deactivate, update_criteria);
+  process_rules_to_remove(
+      imsi, session, request.rules_to_remove(), rules_to_deactivate,
+      update_criteria);
 
   process_rules_to_install(
-      session_map, imsi, session, request.rules_to_install(),
-      request.dynamic_rules_to_install(), rules_to_activate,
+      *session, imsi, to_vec(request.rules_to_install()),
+      to_vec(request.dynamic_rules_to_install()), rules_to_activate,
       rules_to_deactivate, update_criteria);
 
   auto ip_addr = session->get_subscriber_ip_addr();
   if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    for (const std::string &static_rule : rules_to_deactivate.static_rules) {
-      update_criteria.static_rules_to_uninstall.insert(static_rule);
-    }
-    for (const PolicyRule &dynamic_rule : rules_to_deactivate.dynamic_rules) {
-      update_criteria.dynamic_rules_to_uninstall.insert(dynamic_rule.id());
-    }
     deactivate_success = pipelined_client_->deactivate_flows_for_rules(
         request.imsi(), rules_to_deactivate.static_rules,
         rules_to_deactivate.dynamic_rules);
   }
   if (rules_to_process_is_not_empty(rules_to_activate)) {
-    for (const std::string &static_rule : rules_to_activate.static_rules) {
-      update_criteria.static_rules_to_install.insert(static_rule);
-    }
-    for (const PolicyRule &dynamic_rule : rules_to_activate.dynamic_rules) {
-      if (!session->is_dynamic_rule_installed(dynamic_rule.id())) {
-        update_criteria.dynamic_rules_to_install.push_back(dynamic_rule);
-      }
-    }
     activate_success = pipelined_client_->activate_flows_for_rules(
         request.imsi(), ip_addr, rules_to_activate.static_rules,
         rules_to_activate.dynamic_rules);
@@ -1341,41 +1296,42 @@ void LocalEnforcer::init_policy_reauth_for_session(
       !session->active_monitored_rules_exist()) {
     RulesToProcess rules;
     populate_rules_from_session_to_remove(imsi, session, rules);
-    terminate_service(session_map, imsi, rules.static_rules,
-                      rules.dynamic_rules, session_update);
+    terminate_service(
+        session_map, imsi, rules.static_rules, rules.dynamic_rules,
+        session_update);
     return;
   }
   if (!session->is_radius_cwf_session()) {
-    create_bearer(activate_success, session, request,
-                  rules_to_activate.dynamic_rules);
+    create_bearer(
+        activate_success, session, request, rules_to_activate.dynamic_rules);
   }
 }
 
 void LocalEnforcer::receive_monitoring_credit_from_rar(
-    const PolicyReAuthRequest &request,
-    const std::unique_ptr<SessionState> &session,
-    SessionStateUpdateCriteria &update_criteria) {
+    const PolicyReAuthRequest& request,
+    const std::unique_ptr<SessionState>& session,
+    SessionStateUpdateCriteria& update_criteria) {
   UsageMonitoringUpdateResponse monitoring_credit;
   monitoring_credit.set_session_id(request.session_id());
   monitoring_credit.set_sid("IMSI" + request.session_id());
   monitoring_credit.set_success(true);
-  UsageMonitoringCredit *credit = monitoring_credit.mutable_credit();
+  UsageMonitoringCredit* credit = monitoring_credit.mutable_credit();
 
-  for (const auto &usage_monitoring_credit :
+  for (const auto& usage_monitoring_credit :
        request.usage_monitoring_credits()) {
     credit->CopyFrom(usage_monitoring_credit);
-    session->get_monitor_pool().receive_credit(monitoring_credit,
-                                               update_criteria);
+    session->get_monitor_pool().receive_credit(
+        monitoring_credit, update_criteria);
   }
 }
 
 void LocalEnforcer::process_rules_to_remove(
-    const std::string &imsi, const std::unique_ptr<SessionState> &session,
+    const std::string& imsi, const std::unique_ptr<SessionState>& session,
     const google::protobuf::RepeatedPtrField<std::basic_string<char>>
         rules_to_remove,
-    RulesToProcess &rules_to_deactivate,
-    SessionStateUpdateCriteria &update_criteria) {
-  for (const auto &rule_id : rules_to_remove) {
+    RulesToProcess& rules_to_deactivate,
+    SessionStateUpdateCriteria& update_criteria) {
+  for (const auto& rule_id : rules_to_remove) {
     // Try to remove as dynamic rule first
     PolicyRule dy_rule;
     bool is_dynamic =
@@ -1392,87 +1348,118 @@ void LocalEnforcer::process_rules_to_remove(
 }
 
 void LocalEnforcer::populate_rules_from_session_to_remove(
-    const std::string &imsi, const std::unique_ptr<SessionState> &session,
-    RulesToProcess &rules_to_deactivate) {
+    const std::string& imsi, const std::unique_ptr<SessionState>& session,
+    RulesToProcess& rules_to_deactivate) {
   SessionState::SessionInfo info;
   session->get_session_info(info);
-  for (const auto &policyrule : info.dynamic_rules) {
+  for (const auto& policyrule : info.dynamic_rules) {
     rules_to_deactivate.dynamic_rules.push_back(policyrule);
   }
-  for (const auto &staticrule : info.static_rules) {
+  for (const auto& staticrule : info.static_rules) {
     rules_to_deactivate.static_rules.push_back(staticrule);
   }
 }
 
-void LocalEnforcer::process_rules_to_install(
-    SessionMap &session_map, const std::string &imsi,
-    const std::unique_ptr<SessionState> &session,
+std::vector<StaticRuleInstall> LocalEnforcer::to_vec(
     const google::protobuf::RepeatedPtrField<magma::lte::StaticRuleInstall>
-        static_rules_to_install,
+        static_rule_installs) {
+  std::vector<StaticRuleInstall> out;
+  for (const auto& install : static_rule_installs) {
+    out.push_back(install);
+  }
+  return out;
+}
+
+std::vector<DynamicRuleInstall> LocalEnforcer::to_vec(
     const google::protobuf::RepeatedPtrField<magma::lte::DynamicRuleInstall>
-        dynamic_rules_to_install,
-    RulesToProcess &rules_to_activate, RulesToProcess &rules_to_deactivate,
-    SessionStateUpdateCriteria &update_criteria) {
+        dynamic_rule_installs) {
+  std::vector<DynamicRuleInstall> out;
+  for (const auto& install : dynamic_rule_installs) {
+    out.push_back(install);
+  }
+  return out;
+}
+
+void LocalEnforcer::process_rules_to_install(
+    SessionState& session, const std::string& imsi,
+    std::vector<StaticRuleInstall> static_rule_installs,
+    std::vector<DynamicRuleInstall> dynamic_rule_installs,
+    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+    SessionStateUpdateCriteria& update_criteria) {
   std::time_t current_time = time(NULL);
-  auto ip_addr = session->get_subscriber_ip_addr();
-  for (const auto &static_rule : static_rules_to_install) {
+  std::string ip_addr      = session.get_subscriber_ip_addr();
+  for (const auto& rule_install : static_rule_installs) {
+    const auto& id = rule_install.rule_id();
     auto activation_time =
-        TimeUtil::TimestampToSeconds(static_rule.activation_time());
+        TimeUtil::TimestampToSeconds(rule_install.activation_time());
+    auto deactivation_time =
+        TimeUtil::TimestampToSeconds(rule_install.deactivation_time());
+    RuleLifetime lifetime{
+        // TODO: check if we're building the time correctly
+        .activation_time   = std::time_t(activation_time),
+        .deactivation_time = std::time_t(deactivation_time),
+    };
     if (activation_time > current_time) {
-      schedule_static_rule_activation(imsi, ip_addr, static_rule);
+      session.schedule_static_rule(id, lifetime, update_criteria);
+      schedule_static_rule_activation(imsi, ip_addr, rule_install);
     } else {
-      session->activate_static_rule(static_rule.rule_id(), update_criteria);
-      rules_to_activate.static_rules.push_back(static_rule.rule_id());
+      session.activate_static_rule(id, lifetime, update_criteria);
+      rules_to_activate.static_rules.push_back(id);
     }
 
-    auto deactivation_time =
-        TimeUtil::TimestampToSeconds(static_rule.deactivation_time());
     if (deactivation_time > current_time) {
-      schedule_static_rule_deactivation(imsi, static_rule);
-    } else if (deactivation_time > 0) {
-      if (!session->deactivate_static_rule(static_rule.rule_id(),
-                                           update_criteria))
-        MLOG(MWARNING) << "Could not find rule " << static_rule.rule_id()
-                       << "for IMSI " << imsi << " during static rule removal";
-      rules_to_deactivate.static_rules.push_back(static_rule.rule_id());
+      schedule_static_rule_deactivation(imsi, rule_install);
+    } else if (deactivation_time > 0) {  // 0: never scheduled to deactivate
+      if (!session.deactivate_static_rule(id, update_criteria)) {
+        MLOG(MWARNING) << "Could not find rule " << id << "for IMSI " << imsi
+                       << " during static rule removal";
+      }
+      rules_to_deactivate.static_rules.push_back(id);
     }
   }
 
-  for (const auto &dynamic_rule : dynamic_rules_to_install) {
+  for (const auto& rule_install : dynamic_rule_installs) {
     auto activation_time =
-        TimeUtil::TimestampToSeconds(dynamic_rule.activation_time());
-    if (activation_time > current_time) {
-      schedule_dynamic_rule_activation(imsi, ip_addr, dynamic_rule);
-    } else {
-      session->insert_dynamic_rule(dynamic_rule.policy_rule(), update_criteria);
-      rules_to_activate.dynamic_rules.push_back(dynamic_rule.policy_rule());
-    }
-
+        TimeUtil::TimestampToSeconds(rule_install.activation_time());
     auto deactivation_time =
-        TimeUtil::TimestampToSeconds(dynamic_rule.deactivation_time());
+        TimeUtil::TimestampToSeconds(rule_install.deactivation_time());
+    RuleLifetime lifetime{
+        // TODO: check if we're building the time correctly
+        .activation_time   = std::time_t(activation_time),
+        .deactivation_time = std::time_t(deactivation_time),
+    };
+    if (activation_time > current_time) {
+      session.schedule_dynamic_rule(
+          rule_install.policy_rule(), lifetime, update_criteria);
+      schedule_dynamic_rule_activation(imsi, ip_addr, rule_install);
+    } else {
+      session.insert_dynamic_rule(
+          rule_install.policy_rule(), lifetime, update_criteria);
+      rules_to_activate.dynamic_rules.push_back(rule_install.policy_rule());
+    }
     if (deactivation_time > current_time) {
-      schedule_dynamic_rule_deactivation(imsi, dynamic_rule);
+      schedule_dynamic_rule_deactivation(imsi, rule_install);
     } else if (deactivation_time > 0) {
       PolicyRule rule_dont_care;
-      session->remove_dynamic_rule(dynamic_rule.policy_rule().id(),
-                                   &rule_dont_care, update_criteria);
-      rules_to_deactivate.dynamic_rules.push_back(dynamic_rule.policy_rule());
+      session.remove_dynamic_rule(
+          rule_install.policy_rule().id(), &rule_dont_care, update_criteria);
+      rules_to_deactivate.dynamic_rules.push_back(rule_install.policy_rule());
     }
   }
 }
 
 bool LocalEnforcer::revalidation_required(
-    const google::protobuf::RepeatedField<int> &event_triggers) {
-  auto it = std::find(event_triggers.begin(), event_triggers.end(),
-                      REVALIDATION_TIMEOUT);
+    const google::protobuf::RepeatedField<int>& event_triggers) {
+  auto it = std::find(
+      event_triggers.begin(), event_triggers.end(), REVALIDATION_TIMEOUT);
   return it != event_triggers.end();
 }
 
 void LocalEnforcer::schedule_revalidation(
-    SessionMap &session_map,
-    const google::protobuf::Timestamp &revalidation_time) {
+    SessionMap& session_map,
+    const google::protobuf::Timestamp& revalidation_time) {
   SessionRead req;
-  for (const auto &it : session_map) {
+  for (const auto& it : session_map) {
     req.insert(it.first);
   }
   auto delta = time_difference_from_now(revalidation_time);
@@ -1490,9 +1477,9 @@ void LocalEnforcer::schedule_revalidation(
 }
 
 void LocalEnforcer::create_bearer(
-    const bool activate_success, const std::unique_ptr<SessionState> &session,
-    const PolicyReAuthRequest &request,
-    const std::vector<PolicyRule> &dynamic_rules) {
+    const bool activate_success, const std::unique_ptr<SessionState>& session,
+    const PolicyReAuthRequest& request,
+    const std::vector<PolicyRule>& dynamic_rules) {
   if (!activate_success || !session->qos_enabled() || !request.has_qos_info()) {
     MLOG(MDEBUG) << "Not creating bearer";
     return;
@@ -1508,55 +1495,57 @@ void LocalEnforcer::create_bearer(
   return;
 }
 
-void LocalEnforcer::check_usage_for_reporting(SessionMap &session_map,
-                                              SessionUpdate &session_update,
-                                              const bool force_update) {
+void LocalEnforcer::check_usage_for_reporting(
+    SessionMap& session_map, SessionUpdate& session_update,
+    const bool force_update) {
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto request =
       collect_updates(session_map, actions, session_update, force_update);
   execute_actions(session_map, actions, session_update);
   if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
-    return; // nothing to report
+    return;  // nothing to report
   }
   MLOG(MDEBUG) << "Sending " << request.updates_size()
                << " charging updates and " << request.usage_monitors_size()
                << " monitor updates to OCS and PCRF";
 
   // report to cloud
-  (*reporter_).report_updates(request, [
-    this, request,
-    session_map_ptr = std::make_shared<SessionMap>(std::move(session_map)),
-    &session_update
-  ](Status status, UpdateSessionResponse response) {
-    if (!status.ok()) {
-      MLOG(MERROR) << "Update of size " << request.updates_size()
-                   << " to OCS and PCRF failed entirely: "
-                   << status.error_message();
-    } else {
-      MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
-      update_session_credits_and_rules(*session_map_ptr, response,
-                                       session_update);
-      session_store_.update_sessions(session_update);
-    }
-  });
+  (*reporter_)
+      .report_updates(
+          request,
+          [this, request,
+           session_map_ptr =
+               std::make_shared<SessionMap>(std::move(session_map)),
+           &session_update](Status status, UpdateSessionResponse response) {
+            if (!status.ok()) {
+              MLOG(MERROR) << "Update of size " << request.updates_size()
+                           << " to OCS and PCRF failed entirely: "
+                           << status.error_message();
+            } else {
+              MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
+              update_session_credits_and_rules(
+                  *session_map_ptr, response, session_update);
+              session_store_.update_sessions(session_update);
+            }
+          });
 }
 
-bool LocalEnforcer::session_with_imsi_exists(SessionMap &session_map,
-                                             const std::string &imsi) const {
+bool LocalEnforcer::session_with_imsi_exists(
+    SessionMap& session_map, const std::string& imsi) const {
   if (session_map.find(imsi) != session_map.end()) {
     return session_map[imsi].size() > 0;
   }
   return false;
 }
 
-bool LocalEnforcer::session_with_apn_exists(SessionMap &session_map,
-                                            const std::string &imsi,
-                                            const std::string &apn) const {
+bool LocalEnforcer::session_with_apn_exists(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& apn) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     if (session->get_apn() == apn) {
       return true;
     }
@@ -1565,13 +1554,13 @@ bool LocalEnforcer::session_with_apn_exists(SessionMap &session_map,
 }
 
 bool LocalEnforcer::is_session_active(
-    SessionMap &session_map, const std::string &imsi,
-    const std::string &core_session_id) const {
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& core_session_id) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     if (session->get_core_session_id() == core_session_id) {
       return session->is_active();
     }
@@ -1579,14 +1568,14 @@ bool LocalEnforcer::is_session_active(
   return false;
 }
 
-bool LocalEnforcer::has_active_session(SessionMap &session_map,
-                                       const std::string &imsi,
-                                       std::string *core_session_id) const {
+bool LocalEnforcer::has_active_session(
+    SessionMap& session_map, const std::string& imsi,
+    std::string* core_session_id) const {
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
     return false;
   }
-  for (const auto &session : it->second) {
+  for (const auto& session : it->second) {
     if (session->is_active()) {
       *core_session_id = session->get_core_session_id();
       return true;
@@ -1596,11 +1585,11 @@ bool LocalEnforcer::has_active_session(SessionMap &session_map,
 }
 
 bool LocalEnforcer::session_with_same_config_exists(
-    SessionMap &session_map, const std::string &imsi,
-    const SessionConfig &config, std::string *core_session_id) const {
+    SessionMap& session_map, const std::string& imsi,
+    const SessionConfig& config, std::string* core_session_id) const {
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
-    for (const auto &session : it->second) {
+    for (const auto& session : it->second) {
       if (session->is_same_config(config)) {
         *core_session_id = session->get_core_session_id();
         return true;
@@ -1610,17 +1599,16 @@ bool LocalEnforcer::session_with_same_config_exists(
   return false;
 }
 
-void LocalEnforcer::handle_cwf_roaming(SessionMap &session_map,
-                                       const std::string &imsi,
-                                       const SessionConfig &config,
-                                       SessionUpdate &session_update) {
+void LocalEnforcer::handle_cwf_roaming(
+    SessionMap& session_map, const std::string& imsi,
+    const SessionConfig& config, SessionUpdate& session_update) {
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
-    for (const auto &session : it->second) {
-      auto &update_criteria = session_update[imsi][session->get_session_id()];
+    for (const auto& session : it->second) {
+      auto& update_criteria = session_update[imsi][session->get_session_id()];
       session->set_config(config);
       update_criteria.is_config_updated = true;
-      update_criteria.updated_config = session->marshal_config();
+      update_criteria.updated_config    = session->marshal_config();
       // TODO Check for event triggers and send updates to the core if needed
       MLOG(MDEBUG) << "Updating IPFIX flow for subscriber " << imsi;
       SubscriberID sid;
@@ -1630,9 +1618,9 @@ void LocalEnforcer::handle_cwf_roaming(SessionMap &session_map,
       if (!parse_apn(config.apn, apn_mac_addr, apn_name)) {
         MLOG(MWARNING) << "Failed mac/name parsiong for apn " << config.apn;
         apn_mac_addr = "";
-        apn_name = config.apn;
+        apn_name     = config.apn;
       }
-      auto ue_mac_addr = session->get_mac_addr();
+      auto ue_mac_addr             = session->get_mac_addr();
       bool add_ue_mac_flow_success = pipelined_client_->update_ipfix_flow(
           sid, ue_mac_addr, config.msisdn, apn_mac_addr, apn_name);
       if (!add_ue_mac_flow_success) {
@@ -1643,8 +1631,8 @@ void LocalEnforcer::handle_cwf_roaming(SessionMap &session_map,
 }
 
 static void handle_command_level_result_code(
-    const std::string &imsi, const uint32_t result_code,
-    std::unordered_set<std::string> &subscribers_to_terminate) {
+    const std::string& imsi, const uint32_t result_code,
+    std::unordered_set<std::string>& subscribers_to_terminate) {
   const bool is_permanent_failure =
       DiameterCodeHandler::is_permanent_failure(result_code);
   if (is_permanent_failure) {
@@ -1659,13 +1647,12 @@ static void handle_command_level_result_code(
   }
 }
 
-static void mark_rule_failures(const bool activate_success,
-                               const bool deactivate_success,
-                               const PolicyReAuthRequest &request,
-                               PolicyReAuthAnswer &answer_out) {
+static void mark_rule_failures(
+    const bool activate_success, const bool deactivate_success,
+    const PolicyReAuthRequest& request, PolicyReAuthAnswer& answer_out) {
   auto failed_rules = *answer_out.mutable_failed_rules();
   if (!deactivate_success) {
-    for (const std::string &rule_id : request.rules_to_remove()) {
+    for (const std::string& rule_id : request.rules_to_remove()) {
       failed_rules[rule_id] = PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
     }
   }
@@ -1673,7 +1660,7 @@ static void mark_rule_failures(const bool activate_success,
     for (const StaticRuleInstall rule : request.rules_to_install()) {
       failed_rules[rule.rule_id()] = PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
     }
-    for (const DynamicRuleInstall &d_rule :
+    for (const DynamicRuleInstall& d_rule :
          request.dynamic_rules_to_install()) {
       failed_rules[d_rule.policy_rule().id()] =
           PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
@@ -1681,7 +1668,7 @@ static void mark_rule_failures(const bool activate_success,
   }
 }
 
-static bool is_valid_mac_address(const char *mac) {
+static bool is_valid_mac_address(const char* mac) {
   int i = 0;
   int s = 0;
 
@@ -1701,8 +1688,8 @@ static bool is_valid_mac_address(const char *mac) {
   return (i == 12 && s == 5);
 }
 
-static bool parse_apn(const std::string &apn, std::string &mac_addr,
-                      std::string &name) {
+static bool parse_apn(
+    const std::string& apn, std::string& mac_addr, std::string& name) {
   // Format is mac:name, if format check fails return failure
   // Format example - 1C-B9-C4-36-04-F0:Wifi-Offload-hotspot20
   if (apn.empty()) {
@@ -1722,10 +1709,9 @@ static bool parse_apn(const std::string &apn, std::string &mac_addr,
   return true;
 }
 
-static SubscriberQuotaUpdate
-make_subscriber_quota_update(const std::string &imsi,
-                             const std::string &ue_mac_addr,
-                             const SubscriberQuotaUpdate_Type state) {
+static SubscriberQuotaUpdate make_subscriber_quota_update(
+    const std::string& imsi, const std::string& ue_mac_addr,
+    const SubscriberQuotaUpdate_Type state) {
   SubscriberQuotaUpdate update;
   auto sid = update.mutable_sid();
   sid->set_id(imsi);
@@ -1733,4 +1719,4 @@ make_subscriber_quota_update(const std::string &imsi,
   update.set_update_type(state);
   return update;
 }
-} // namespace magma
+}  // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -256,16 +256,17 @@ class LocalEnforcer {
   void notify_finish_report_for_sessions(
       SessionMap& session_map, SessionUpdate& session_update);
 
-  /**
-   * Process the create session response to get rules to activate/deactivate
-   * instantly and schedule rules with activation/deactivation time info
-   * to activate/deactivate later. No state change is made.
-   */
-  void process_create_session_response(
-      SessionMap& session_map, const CreateSessionResponse& response,
-      const std::unordered_set<uint32_t>& successful_credits,
-      const std::string& imsi, const std::string& ip_addr,
-      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate);
+  void filter_rule_installs(
+      std::vector<StaticRuleInstall> static_rule_installs,
+      std::vector<DynamicRuleInstall> dynamic_rule_installs,
+      const std::unordered_set<uint32_t>& successful_credits);
+
+  std::vector<StaticRuleInstall> to_vec(
+      const google::protobuf::RepeatedPtrField<magma::lte::StaticRuleInstall>
+          static_rule_installs);
+  std::vector<DynamicRuleInstall> to_vec(
+      const google::protobuf::RepeatedPtrField<magma::lte::DynamicRuleInstall>
+          dynamic_rule_installs);
 
   /**
    * Processes the charging component of UpdateSessionResponse.
@@ -316,12 +317,9 @@ class LocalEnforcer {
    * TODO separate out logic that modifies state vs logic that does not.
    */
   void process_rules_to_install(
-      SessionMap& session_map, const std::string& imsi,
-      const std::unique_ptr<SessionState>& session,
-      const google::protobuf::RepeatedPtrField<magma::lte::StaticRuleInstall>
-          static_rules_to_install,
-      const google::protobuf::RepeatedPtrField<magma::lte::DynamicRuleInstall>
-          dynamic_rules_to_install,
+      SessionState& session, const std::string& imsi,
+      std::vector<StaticRuleInstall> static_rule_installs,
+      std::vector<DynamicRuleInstall> dynamic_rule_installs,
       RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
       SessionStateUpdateCriteria& update_criteria);
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -217,20 +217,73 @@ class SessionState {
 
   bool is_static_rule_installed(const std::string& rule_id);
 
-  void insert_dynamic_rule(
-      const PolicyRule& rule, SessionStateUpdateCriteria& update_criteria);
+  /**
+   * Add a dynamic rule to the session which is currently active.
+   */
+  void insert_dynamic_rule(const PolicyRule &rule,
+                           RuleLifetime &lifetime,
+                           SessionStateUpdateCriteria &update_criteria);
 
-  void activate_static_rule(
-      const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
+  /**
+   * Add a static rule to the session which is currently active.
+   */
+  void activate_static_rule(const std::string &rule_id,
+                            RuleLifetime &lifetime,
+                            SessionStateUpdateCriteria &update_criteria);
 
+  /**
+   * Remove a currently active dynamic rule to mark it as deactivated.
+   *
+   * @param rule_id ID of the rule to be removed.
+   * @param rule_out Will point to the removed rule.
+   * @param update_criteria Tracks updates to the session. To be passed back to
+   *                        the SessionStore to resolve issues of concurrent
+   *                        updates to a session.
+   * @return True if successfully removed.
+   */
   bool remove_dynamic_rule(
       const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& update_criteria);
 
+  /**
+   * Remove a currently active static rule to mark it as deactivated.
+   *
+   * @param rule_id ID of the rule to be removed.
+   * @param update_criteria Tracks updates to the session. To be passed back to
+   *                        the SessionStore to resolve issues of concurrent
+   *                        updates to a session.
+   * @return True if successfully removed.
+   */
   bool deactivate_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
 
   DynamicRuleStore& get_dynamic_rules();
+
+  /**
+   * Schedule a dynamic rule for activation in the future.
+   */
+  void schedule_dynamic_rule(const PolicyRule &rule,
+                             RuleLifetime &lifetime,
+                           SessionStateUpdateCriteria &update_criteria);
+
+  /**
+   * Schedule a static rule for activation in the future.
+   */
+  void schedule_static_rule(const std::string &rule_id,
+                            RuleLifetime &lifetime,
+                            SessionStateUpdateCriteria &update_criteria);
+
+  /**
+   * Mark a scheduled dynamic rule as activated.
+   */
+  void install_scheduled_dynamic_rule(const std::string &rule_id,
+                                     SessionStateUpdateCriteria &update_criteria);
+
+  /**
+   * Mark a scheduled static rule as activated.
+   */
+  void install_scheduled_static_rule(const std::string &rule_id,
+                                      SessionStateUpdateCriteria &update_criteria);
 
   uint32_t total_monitored_rules_count();
   bool is_active();
@@ -295,7 +348,15 @@ class SessionState {
   // Dynamic rules that are currently installed for the session
   DynamicRuleStore dynamic_rules_;
 
- private:
+  // Static rules that are scheduled for installation for the session
+  std::set<std::string> scheduled_static_rules_;
+  // Dynamic rules that are scheduled for installation for the session
+  DynamicRuleStore scheduled_dynamic_rules_;
+  // Activation & deactivation times for each rule that is either currently
+  // installed, or scheduled for installation for this session
+  std::unordered_map<std::string, RuleLifetime> rule_lifetimes_;
+
+private:
   /**
    * For this session, add the CreditUsageUpdate to the UpdateSessionRequest.
    * Also

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -122,7 +122,7 @@ class SessionStore {
  private:
   static bool merge_into_session(
       std::unique_ptr<SessionState>& session,
-      const SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& update_criteria);
 
  private:
   std::shared_ptr<StoreClient> store_client_;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -116,6 +116,11 @@ struct StoredUsageMonitoringCreditPool {
   std::unordered_map<std::string, StoredMonitor> monitor_map;
 };
 
+struct RuleLifetime {
+  std::time_t activation_time; // Unix timestamp
+  std::time_t deactivation_time; // Unix timestamp
+};
+
 struct StoredSessionState {
   SessionConfig config;
   StoredChargingCreditPool charging_pool;
@@ -127,6 +132,9 @@ struct StoredSessionState {
   magma::lte::TgppContext tgpp_context;
   std::vector<std::string> static_rule_ids;
   std::vector<PolicyRule> dynamic_rules;
+  std::set<std::string> scheduled_static_rules;
+  std::vector<PolicyRule> scheduled_dynamic_rules;
+  std::unordered_map<std::string, RuleLifetime> rule_lifetimes;
   uint32_t request_number;
 };
 
@@ -149,8 +157,11 @@ struct SessionStateUpdateCriteria {
   SessionConfig updated_config;
   std::set<std::string> static_rules_to_install;
   std::set<std::string> static_rules_to_uninstall;
+  std::set<std::string> new_scheduled_static_rules;
   std::vector<PolicyRule> dynamic_rules_to_install;
   std::set<std::string> dynamic_rules_to_uninstall;
+  std::vector<PolicyRule> new_scheduled_dynamic_rules;
+  std::unordered_map<std::string, RuleLifetime> new_rule_lifetimes;
   std::unordered_map<CreditKey, StoredSessionCredit, decltype(&ccHash),
                      decltype(&ccEqual)>
       charging_credit_to_install;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -446,7 +446,11 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
   insert_static_rule(0, "1", "rule1");
 
   CreateSessionResponse response;
-  response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  auto rules = response.mutable_static_rules()->Add();
+  rules->mutable_rule_id()->assign("rule1");
+  rules->mutable_activation_time()->set_seconds(0);
+  rules->mutable_deactivation_time()->set_seconds(0);
+
   auto monitor_updates = response.mutable_usage_monitors();
   create_monitor_update_response("IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL,
                                  1024, monitor_updates->Add());

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -172,7 +172,11 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   // 2) Create bare-bones session for IMSI1
   auto uc      = get_default_update_criteria();
   auto session = get_session(sid, rule_store);
-  session->activate_static_rule(rule_id_3, uc);
+  RuleLifetime lifetime{
+    .activation_time = std::time_t(0),
+    .deactivation_time = std::time_t(0),
+  };
+  session->activate_static_rule(rule_id_3, lifetime, uc);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session->get_request_number(), 2);
   EXPECT_EQ(session->is_static_rule_installed(rule_id_3), true);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -39,8 +39,8 @@ protected:
     DYNAMIC = 1,
   };
 
-  void insert_rule(uint32_t rating_group, const std::string &m_key,
-                   const std::string &rule_id, RuleType rule_type) {
+  PolicyRule build_rule(uint32_t rating_group, const std::string &m_key,
+                   const std::string &rule_id) {
     PolicyRule rule;
     rule.set_id(rule_id);
     rule.set_rating_group(rating_group);
@@ -54,16 +54,48 @@ protected:
     } else {
       rule.set_tracking_type(PolicyRule::NO_TRACKING);
     }
+    return rule;
+  }
+
+  void insert_rule(uint32_t rating_group, const std::string &m_key,
+                   const std::string &rule_id, RuleType rule_type,
+                   std::time_t activation_time, std::time_t deactivation_time) {
+    PolicyRule rule = build_rule(rating_group, m_key, rule_id);
+    RuleLifetime lifetime{
+        .activation_time = activation_time,
+        .deactivation_time = deactivation_time,
+    };
     switch (rule_type) {
     case STATIC:
       // insert into list of existing rules
       rule_store->insert_rule(rule);
       // mark the rule as active in session
-      session_state->activate_static_rule(rule_id, update_criteria);
+      session_state->activate_static_rule(rule_id, lifetime, update_criteria);
       break;
     case DYNAMIC:
-      session_state->insert_dynamic_rule(rule, update_criteria);
+      session_state->insert_dynamic_rule(rule, lifetime, update_criteria);
       break;
+    }
+  }
+
+  void schedule_rule(uint32_t rating_group, const std::string &m_key,
+                   const std::string &rule_id, RuleType rule_type,
+                   std::time_t activation_time, std::time_t deactivation_time) {
+    PolicyRule rule = build_rule(rating_group, m_key, rule_id);
+    RuleLifetime lifetime{
+      .activation_time = activation_time,
+      .deactivation_time = deactivation_time,
+    };
+    switch (rule_type) {
+      case STATIC:
+        // insert into list of existing rules
+        rule_store->insert_rule(rule);
+        // mark the rule as scheduled in the session
+        session_state->schedule_static_rule(rule_id, lifetime, update_criteria);
+        break;
+      case DYNAMIC:
+        session_state->schedule_dynamic_rule(rule, lifetime, update_criteria);
+        break;
     }
   }
 
@@ -101,15 +133,20 @@ protected:
   }
 
   void activate_rule(uint32_t rating_group, const std::string &m_key,
-                     const std::string &rule_id, RuleType rule_type) {
-    PolicyRule rule = get_rule(rating_group, m_key, rule_id);
+                     const std::string &rule_id, RuleType rule_type,
+                     std::time_t activation_time, std::time_t deactivation_time) {
+      PolicyRule rule = get_rule(rating_group, m_key, rule_id);
+    RuleLifetime lifetime{
+        .activation_time = activation_time,
+        .deactivation_time = deactivation_time,
+    };
     switch (rule_type) {
     case STATIC:
       rule_store->insert_rule(rule);
-      session_state->activate_static_rule(rule_id, update_criteria);
+      session_state->activate_static_rule(rule_id, lifetime, update_criteria);
       break;
     case DYNAMIC:
-      session_state->insert_dynamic_rule(rule, update_criteria);
+      session_state->insert_dynamic_rule(rule, lifetime, update_criteria);
       break;
     }
   }
@@ -121,12 +158,12 @@ protected:
 };
 
 TEST_F(SessionStateTest, test_session_rules) {
-  activate_rule(1, "m1", "rule1", DYNAMIC);
+  activate_rule(1, "m1", "rule1", DYNAMIC, 0, 0);
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
-  activate_rule(2, "m2", "rule2", STATIC);
+  activate_rule(2, "m2", "rule2", STATIC, 0, 0);
   EXPECT_EQ(2, session_state->total_monitored_rules_count());
   // add a OCS-ONLY static rule
-  activate_rule(3, "", "rule3", STATIC);
+  activate_rule(3, "", "rule3", STATIC, 0, 0);
   EXPECT_EQ(2, session_state->total_monitored_rules_count());
 
   std::vector<std::string> rules_out{};
@@ -169,11 +206,47 @@ TEST_F(SessionStateTest, test_session_rules) {
             session_state->get_dynamic_rules().remove_rule("rule1", &rule_out));
 }
 
+/**
+ * Check that rule scheduling and installation works from the perspective of
+ * tracking in SessionState
+ */
+TEST_F(SessionStateTest, test_rule_scheduling) {
+  auto _uc = get_default_update_criteria(); // unused
+
+  // First schedule a dynamic and static rule. They are treated as inactive.
+  schedule_rule(1, "m1", "rule1", DYNAMIC, 0, 0);
+  EXPECT_EQ(0, session_state->total_monitored_rules_count());
+  EXPECT_FALSE(session_state->is_dynamic_rule_installed("rule1"));
+
+  schedule_rule(2, "m2", "rule2", STATIC, 0, 0);
+  EXPECT_EQ(0, session_state->total_monitored_rules_count());
+  EXPECT_FALSE(session_state->is_static_rule_installed("rule2"));
+
+  // Now suppose some time has passed, and it's time to mark scheduled rules
+  // as active. The responsibility is given to the session owner to make
+  // these calls
+  session_state->install_scheduled_dynamic_rule("rule1", _uc);
+  EXPECT_EQ(1, session_state->total_monitored_rules_count());
+  EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule1"));
+
+  session_state->install_scheduled_static_rule("rule2", _uc);
+  EXPECT_EQ(2, session_state->total_monitored_rules_count());
+  EXPECT_TRUE(session_state->is_static_rule_installed("rule2"));
+}
+
 TEST_F(SessionStateTest, test_marshal_unmarshal) {
   EXPECT_EQ(update_criteria.static_rules_to_install.size(), 0);
-  insert_rule(1, "m1", "rule1", STATIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   EXPECT_EQ(session_state->is_static_rule_installed("rule1"), true);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
+  EXPECT_EQ(update_criteria.static_rules_to_install.size(), 1);
+
+  std::time_t activation_time = static_cast<std::time_t>(std::stoul("2020:04:15 09:10:11"));
+  std::time_t deactivation_time = static_cast<std::time_t>(std::stoul("2020:04:15 09:10:12"));
+
+  EXPECT_EQ(update_criteria.new_rule_lifetimes.size(), 1);
+  schedule_rule(1, "m1", "rule2", DYNAMIC, activation_time, deactivation_time);
+  EXPECT_EQ(session_state->is_dynamic_rule_installed("rule2"), false);
   EXPECT_EQ(update_criteria.static_rules_to_install.size(), 1);
 
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 0);
@@ -195,11 +268,12 @@ TEST_F(SessionStateTest, test_marshal_unmarshal) {
   EXPECT_EQ(unmarshaled->get_monitor_pool().get_credit("m1", ALLOWED_TOTAL),
             1024);
   EXPECT_EQ(unmarshaled->is_static_rule_installed("rule1"), true);
+  EXPECT_EQ(session_state->is_dynamic_rule_installed("rule2"), false);
 }
 
 TEST_F(SessionStateTest, test_insert_credit) {
   EXPECT_EQ(update_criteria.static_rules_to_install.size(), 0);
-  insert_rule(1, "m1", "rule1", STATIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
   EXPECT_TRUE(std::find(update_criteria.static_rules_to_install.begin(),
                         update_criteria.static_rules_to_install.end(),
@@ -233,7 +307,7 @@ TEST_F(SessionStateTest, test_termination) {
 }
 
 TEST_F(SessionStateTest, test_can_complete_termination) {
-  insert_rule(1, "m1", "rule1", STATIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
   EXPECT_TRUE(std::find(update_criteria.static_rules_to_install.begin(),
                         update_criteria.static_rules_to_install.end(),
@@ -268,8 +342,8 @@ TEST_F(SessionStateTest, test_can_complete_termination) {
 }
 
 TEST_F(SessionStateTest, test_add_used_credit) {
-  insert_rule(1, "m1", "rule1", STATIC);
-  insert_rule(2, "m2", "dyn_rule1", DYNAMIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
+  insert_rule(2, "m2", "dyn_rule1", DYNAMIC, 0, 0);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
   EXPECT_TRUE(std::find(update_criteria.static_rules_to_install.begin(),
                         update_criteria.static_rules_to_install.end(),
@@ -333,9 +407,9 @@ TEST_F(SessionStateTest, test_add_used_credit) {
 }
 
 TEST_F(SessionStateTest, test_mixed_tracking_rules) {
-  insert_rule(0, "m1", "dyn_rule1", DYNAMIC);
-  insert_rule(2, "", "dyn_rule2", DYNAMIC);
-  insert_rule(3, "m3", "dyn_rule3", DYNAMIC);
+  insert_rule(0, "m1", "dyn_rule1", DYNAMIC, 0, 0);
+  insert_rule(2, "", "dyn_rule2", DYNAMIC, 0, 0);
+  insert_rule(3, "m3", "dyn_rule3", DYNAMIC, 0, 0);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
   // Installing a rule doesn't install credit
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 0);
@@ -418,7 +492,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
 }
 
 TEST_F(SessionStateTest, test_reauth_key) {
-  insert_rule(1, "", "rule1", STATIC);
+  insert_rule(1, "", "rule1", STATIC, 0, 0);
 
   receive_credit_from_ocs(1, 1500);
 
@@ -482,8 +556,8 @@ TEST_F(SessionStateTest, test_reauth_new_key) {
 }
 
 TEST_F(SessionStateTest, test_reauth_all) {
-  insert_rule(1, "", "rule1", STATIC);
-  insert_rule(2, "", "dyn_rule1", DYNAMIC);
+  insert_rule(1, "", "rule1", STATIC, 0, 0);
+  insert_rule(2, "", "dyn_rule1", DYNAMIC, 0, 0);
   EXPECT_EQ(false, session_state->active_monitored_rules_exist());
   EXPECT_TRUE(std::find(update_criteria.static_rules_to_install.begin(),
                         update_criteria.static_rules_to_install.end(),
@@ -514,7 +588,7 @@ TEST_F(SessionStateTest, test_reauth_all) {
 TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
   receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
   receive_credit_from_ocs(1, 1024);
-  insert_rule(1, "m1", "rule1", STATIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   session_state->add_used_credit("rule1", 1024, 0, update_criteria);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
 
@@ -544,7 +618,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
 }
 
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
-  insert_rule(0, "", "rule1", STATIC);
+  insert_rule(0, "", "rule1", STATIC, 0, 0);
   session_state->add_used_credit("rule1", 2000, 1000, update_criteria);
   SessionState::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
@@ -555,7 +629,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
 }
 
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_single_key) {
-  insert_rule(1, "", "rule1", STATIC);
+  insert_rule(1, "", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   session_state->add_used_credit("rule1", 2000, 1000, update_criteria);
   SessionState::TotalCreditUsage actual =
@@ -567,7 +641,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_single_key) {
 }
 
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_multiple_key) {
-  insert_rule(1, "m1", "rule1", STATIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   session_state->add_used_credit("rule1", 2000, 1000, update_criteria);
@@ -582,8 +656,8 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_multiple_key) {
 TEST_F(SessionStateTest, test_get_total_credit_usage_multiple_rule_shared_key) {
   // Shared monitoring key
   // One rule is dynamic
-  insert_rule(1, "m1", "rule1", STATIC);
-  insert_rule(0, "m1", "rule2", DYNAMIC);
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
+  insert_rule(0, "m1", "rule2", DYNAMIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   session_state->add_used_credit("rule1", 1000, 10, update_criteria);

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -79,7 +79,8 @@ TEST_F(StoreClientTest, test_read_and_write) {
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 
-  session->activate_static_rule("rule1", uc);
+  RuleLifetime lifetime{};
+  session->activate_static_rule("rule1", lifetime, uc);
   EXPECT_EQ(session->is_static_rule_installed("rule1"), true);
 
   EXPECT_EQ(session_map.size(), 2);

--- a/lte/protos/session_manager.proto
+++ b/lte/protos/session_manager.proto
@@ -442,12 +442,14 @@ message CreateSessionResponse {
 message StaticRuleInstall {
   string rule_id = 1;
   google.protobuf.Timestamp activation_time = 2;
+  // Optional field. Set as 0 to mark as unused
   google.protobuf.Timestamp deactivation_time = 3;
 }
 
 message DynamicRuleInstall {
   PolicyRule policy_rule = 1;
   google.protobuf.Timestamp activation_time = 2;
+  // Optional field. Set as 0 to mark as unused
   google.protobuf.Timestamp deactivation_time = 3;
 }
 


### PR DESCRIPTION
Summary:
Policy rule lifetimes need to be tracked by `session_manager` so that on restart of the service, rules can be correctly installed and uninstalled in the future if they were scheduled to do so.

This revision does not include the rescheduling of rule activation/deactivation upon service restart. That will come in a separate revision

## Changes
- Add a `RuleLifetime` struct to more easily track policy rule lifetimes
- `SessionState` tracks policy rule lifetimes, both for rules already installed, and those scheduled to be installed
- `SessionState` methods modified so that any rule activations and tracking require also specifying the lifetime of the policy rule
- Refactored `LocalEnforcer` to remove `process_create_session_response`, decomposing its functionality into a new method, `filter_rule_installs` and an existing method, `process_rule_installs`

Differential Revision: D21055817

