### PR TITLE
Add exception handling to the State service for unavailable redis server

### DIFF
--- a/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
+++ b/orc8r/gateway/python/magma/common/redis/mocks/mock_redis.py
@@ -7,6 +7,7 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 import re
+from redis.exceptions import RedisError
 
 
 class MockRedis(object):
@@ -122,6 +123,75 @@ class MockRedis(object):
         pipe.execute()
         return func_value
 
+class MockUnavailableRedis(object):
+    """
+    MockUnavailableRedis implements a mock Redis Server that always raises
+    a connection exception
+    """
+
+    def __init__(self, host, port):
+        self.host = host
+        self.port = port
+
+    def serialize_key(self, key):
+        """ Serialize key to plaintext encoded as UTF-8 bytes. """
+        raise RedisError("mock redis error")
+
+    def deserialize_key(self, serialized):
+        """ Deserialize key from plaintext encoded as UTF-8 bytes. """
+        raise RedisError("mock redis error")
+
+    def lock(self, key):
+        raise RedisError("mock redis error")
+
+    def delete(self, key):
+        """Mock delete."""
+        raise RedisError("mock redis error")
+
+    def exists(self, key):
+        """Mock exists."""
+        raise RedisError("mock redis error")
+
+    def get(self, key):
+        """Mock get."""
+        raise RedisError("mock redis error")
+
+    def set(self, key, value):
+        """Mock set."""
+        raise RedisError("mock redis error")
+
+    def keys(self, pattern=".*"):
+        """ Mock keys with regex pattern matching."""
+        raise RedisError("mock redis error")
+
+    def hget(self, hashkey, key):
+        """Mock hget."""
+        raise RedisError("mock redis error")
+
+    def hgetall(self, hashkey):
+        """Mock hgetall."""
+        raise RedisError("mock redis error")
+
+    def hlen(self, hashkey):
+        """Mock hlen."""
+        raise RedisError("mock redis error")
+
+    def hset(self, hashkey, key, value):
+        """Mock hset."""
+        raise RedisError("mock redis error")
+
+    def hdel(self, hashkey, key):
+        """ Mock hdel"""
+        raise RedisError("mock redis error")
+
+    def pipeline(self):
+        """ Mock pipline"""
+        raise RedisError("mock redis error")
+
+    # pylint: disable=unused-argument
+    def transaction(self, func, *args, **kwargs):
+        """ Mock transaction."""
+        raise RedisError("mock redis error")
 
 class MockRedisPipeline(object):
     """Mock redis-python pipeline object. """

--- a/orc8r/gateway/python/magma/magmad/metrics.py
+++ b/orc8r/gateway/python/magma/magmad/metrics.py
@@ -5,6 +5,7 @@ All rights reserved.
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
+# pylint: disable=broad-except
 import os
 import asyncio
 from collections import OrderedDict
@@ -78,6 +79,7 @@ def metrics_collection_loop(service_config, loop=None):
     ping_params = _get_ping_params(config)
 
     while True:
+        logging.debug("Running metrics collections loop")
         if len(ping_params):
             yield from _collect_ping_metrics(ping_params, loop=loop)
         yield from _collect_load_metrics()
@@ -90,7 +92,11 @@ def _collect_service_restart_stats():
     """
     Collect the success and failure restarts for services
     """
-    service_dict = ServiceStateWrapper().get_all_services_status()
+    try:
+        service_dict = ServiceStateWrapper().get_all_services_status()
+    except Exception as e:
+        logging.error("Could not fetch service status: %s", e)
+        return
     for service_name, status in service_dict.items():
         SERVICE_RESTART_STATUS.labels(service_name=service_name,
                                       status="Failure").set(

--- a/orc8r/gateway/python/magma/state/garbage_collector.py
+++ b/orc8r/gateway/python/magma/state/garbage_collector.py
@@ -8,6 +8,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 import grpc
 import logging
+from redis.exceptions import RedisError
 
 from magma.common.grpc_client_manager import GRPCClientManager
 from magma.common.rpc_utils import grpc_async_wrapper
@@ -40,7 +41,11 @@ class GarbageCollector:
         self._grpc_client_manager = grpc_client_manager
 
     async def run_garbage_collection(self):
-        request = await self._collect_states_to_delete()
+        try:
+            request = await self._collect_states_to_delete()
+        except RedisError as e:
+            logging.error("Connecting to redis failed: %s", e)
+            return
         if request is not None:
             await self._send_to_state_service(request)
 


### PR DESCRIPTION
Summary:
This diff implements exception handling for the gateway state service. If
redis ever becomes unavailable, the service does not handle the exception gracefully.

Differential Revision: D21100446

