### PR TITLE
Add transformers to conductor tenant proxy

### DIFF
--- a/symphony/app/fbcnms-projects/workflows/.editorconfig
+++ b/symphony/app/fbcnms-projects/workflows/.editorconfig
@@ -1,0 +1,8 @@
+[*.js]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 80

--- a/symphony/app/fbcnms-projects/workflows/src/HttpServerSide.js
+++ b/symphony/app/fbcnms-projects/workflows/src/HttpServerSide.js
@@ -11,12 +11,11 @@
 import request from 'superagent';
 
 const HttpClient = {
-  get: (path, token) =>
+  get: (path, parentRequest) =>
     new Promise((resolve, reject) => {
       const req = request.get(path).accept('application/json');
-      if (token) {
-        req.set('Authorization', token);
-      }
+      req.header['x-auth-organization'] =
+        parentRequest.headers['x-auth-organization'];
       req.end((err, res) => {
         if (err) {
           if (res && res.error) {
@@ -31,15 +30,14 @@ const HttpClient = {
       });
     }),
 
-  delete: (path, data, token) =>
+  delete: (path, data, parentRequest) =>
     new Promise((resolve, reject) => {
       const req = request
         .delete(path, data)
         .accept('application/json')
         .query('archiveWorkflow=false');
-      if (token) {
-        req.set('Authorization', token);
-      }
+      req.header['x-auth-organization'] =
+        parentRequest.headers['x-auth-organization'];
       req.end((err, res) => {
         if (err) {
           resolve(err);
@@ -52,14 +50,13 @@ const HttpClient = {
       });
     }),
 
-  post: (path, data, token) =>
+  post: (path, data, parentRequest) =>
     new Promise((resolve, reject) => {
       const req = request
         .post(path, data)
         .set('Content-Type', 'application/json');
-      if (token) {
-        req.set('Authorization', token);
-      }
+      req.header['x-auth-organization'] =
+        parentRequest.headers['x-auth-organization'];
       req.end((err, res) => {
         if (err || !res.ok) {
           console.error('Error on post! ' + res);
@@ -72,14 +69,11 @@ const HttpClient = {
       });
     }),
 
-  put: (path, data, token) =>
+  put: (path, data, parentRequest) =>
     new Promise((resolve, reject) => {
       const req = request.put(path, data).set('Accept', 'application/json');
-
-      if (token) {
-        req.set('Authorization', token);
-      }
-
+      req.header['x-auth-organization'] =
+        parentRequest.headers['x-auth-organization'];
       req
         .then(res => {
           resolve(res);

--- a/symphony/app/fbcnms-projects/workflows/src/index.js
+++ b/symphony/app/fbcnms-projects/workflows/src/index.js
@@ -10,10 +10,19 @@
 'use strict';
 
 import ExpressApplication from 'express';
+import proxy from './proxy/proxy';
 import workflowRouter from './routes';
 
 const app = ExpressApplication();
 
-app.use('/', workflowRouter);
+async function init() {
+  const proxyTarget =
+    process.env.PROXY_TARGET || 'http://conductor-server:8080';
+  const proxyRouter = await proxy(proxyTarget);
 
-app.listen(80);
+  app.use('/', workflowRouter);
+  app.use('/proxy', proxyRouter);
+  app.listen(80);
+}
+
+init();

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/proxy.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/proxy.js
@@ -9,12 +9,15 @@
  */
 
 import Router from 'express';
+import bodyParser from 'body-parser';
 import httpProxy from 'http-proxy';
 import logging from '@fbcnms/logging';
 import {getTenantId} from './utils.js';
 
 const logger = logging.getLogger(module);
 const router = Router();
+router.use(bodyParser.urlencoded({extended: false}));
+router.use('/', bodyParser.json());
 
 export function configure(transformers, proxyTarget) {
   // Configure http-proxy

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/proxy.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/proxy.js
@@ -7,11 +7,11 @@
  * @flow
  * @format
  */
-
 import Router from 'express';
 import bodyParser from 'body-parser';
 import httpProxy from 'http-proxy';
 import logging from '@fbcnms/logging';
+import transformerRegistry from './transformer-registry';
 import {getTenantId} from './utils.js';
 
 const logger = logging.getLogger(module);
@@ -19,16 +19,17 @@ const router = Router();
 router.use(bodyParser.urlencoded({extended: false}));
 router.use('/', bodyParser.json());
 
-export function configure(transformers, proxyTarget) {
+export default async function(proxyTarget) {
+  const transformers = await transformerRegistry({proxyTarget});
+
   // Configure http-proxy
   const proxy = httpProxy.createProxyServer({
     target: proxyTarget,
   });
 
-  for (const idx in transformers) {
-    const entry = transformers[idx];
-    logger.debug(`Routing '${entry.urlPath}', ${entry.method}`);
-    router[entry.method](entry.urlPath, async (req, res) => {
+  for (const entry of transformers) {
+    logger.info(`Routing url:${entry.url}, method:${entry.method}`);
+    router[entry.method](entry.url, async (req, res) => {
       let tenantId;
       try {
         tenantId = getTenantId(req);
@@ -41,10 +42,10 @@ export function configure(transformers, proxyTarget) {
       const _write = res.write; // backup real write method
       // create wrapper that allows transforming output from target
       res.write = function(data) {
-        if (entry.afterFun) {
+        if (entry.after) {
           // TODO: parse only if data is json
           const respObj = JSON.parse(data);
-          entry.afterFun(tenantId, req, respObj, res);
+          entry.after(tenantId, req, respObj, res);
           data = JSON.stringify(respObj);
         }
         _write.call(res, data);
@@ -55,9 +56,9 @@ export function configure(transformers, proxyTarget) {
       const proxyCallback = function(proxyOptions) {
         proxy.web(req, res, proxyOptions);
       };
-      if (entry.beforeFun) {
+      if (entry.before) {
         try {
-          entry.beforeFun(tenantId, req, res, proxyCallback);
+          entry.before(tenantId, req, res, proxyCallback);
         } catch (err) {
           console.error('Got error in beforeFun', err);
           res.status(500);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
@@ -13,7 +13,12 @@ const logger = logging.getLogger(module);
 
 export default async function(registrationCtx) {
   // TODO populate from fs
-  const transformerModules = ['./transformers/metadata-taskdef'];
+  const transformerModules = [
+    './transformers/bulk',
+    './transformers/metadata-taskdef',
+    './transformers/metadata-workflowdef',
+    './transformers/workflow',
+  ];
   logger.debug(
     `Registering transformer modules: [${transformerModules}] using context ${JSON.stringify(
       registrationCtx,

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+import logging from '@fbcnms/logging';
+
+const logger = logging.getLogger(module);
+
+export default async function(registrationCtx) {
+  // TODO populate from fs
+  const transformerModules = ['./transformers/metadata-taskdef'];
+  logger.debug(
+    `Registering transformer modules: [${transformerModules}] using context ${JSON.stringify(
+      registrationCtx,
+    )}`,
+  );
+
+  const transformers = [];
+  for (const file of transformerModules) {
+    const transformerModule = await import(file);
+    const registrationFun = transformerModule.default;
+    const items = registrationFun(registrationCtx);
+    logger.debug(`Registering ${file} with ${items.length} items`);
+    transformers.push(...items);
+  }
+  logger.debug(`Returning ${JSON.stringify(transformers)}`);
+  return transformers;
+}

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/bulk.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/bulk.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import logging from '@fbcnms/logging';
+import request from 'request';
+import {
+  createProxyOptionsBuffer,
+  findValuesByJsonPath,
+  removeTenantPrefix,
+} from '../utils.js';
+
+const logger = logging.getLogger(module);
+
+// All bulk operations expect json array of workflow Ids in request.
+// Each workflow Id must belong to current tenant. Search api is
+// used to get all metadata in a single request. If there are no
+// validation issues, request is passed to the proxy target.
+/*
+curl  -H "x-auth-organization: fb-test" \
+    "localhost/proxy/api/workflow/bulk/restart" -v -X POST \
+    -H "Content-Type: application/json" \
+    -d '["381f879d-3225-4605-b1c4-91e1c00f8ab9"]'
+
+curl  -H "x-auth-organization: fb-test" \
+    "localhost/proxy/api/workflow/bulk/terminate" -v -X DELETE \
+    -H "Content-Type: application/json" \
+    -d '["7d40eb5f-6a0d-438d-a35c-3b2111e2744b"]'
+
+*/
+function bulkOperationBefore(tenantId, req, res, proxyCallback) {
+  const requestWorkflowIds = req.body; // expect JS array
+  if (!Array.isArray(requestWorkflowIds) || requestWorkflowIds.length == 0) {
+    logger.error(`Expected non empty array, got ${requestWorkflowIds}`);
+    res.status(400);
+    res.send('Expected array of workflows');
+    return;
+  }
+  // use search api to obtain workflow names
+  // Manually encode quotes due to
+  // https://github.com/request/request/issues/3181
+
+  // FIXME: query with AND does not limit result as expected
+  //const limitToTenant =
+  // `workflowType STARTS_WITH &quot;${tenantId}_&quot; AND `;
+
+  let query = 'workflowId+IN+(';
+
+  for (const workflowId of requestWorkflowIds) {
+    // TODO: sanitize using regex
+    if (/^[a-z0-9\-]+$/i.test(workflowId)) {
+      query += workflowId + ',';
+    }
+  }
+  query += ')';
+  const queryUrl = proxyTarget + '/api/workflow/search?query=' + query;
+  // first make a HTTP request to validate that all workflows belong to tenant
+  const requestOptions = {
+    url: queryUrl,
+    method: 'GET',
+  };
+  logger.debug(`Requesting ${JSON.stringify(requestOptions)}`);
+  request(requestOptions, function(error, response, body) {
+    logger.debug(`Got status code: ${response.statusCode}, body: ${body}`);
+    const searchResult = JSON.parse(body);
+    // only keep found workflows
+    // security - check WorkflowType prefix
+    removeTenantPrefix(
+      tenantId,
+      searchResult,
+      'results[*].workflowType',
+      false,
+    );
+    const foundWorkflowIds = findValuesByJsonPath(
+      searchResult,
+      'results[*].workflowId',
+      'value',
+    );
+
+    // for security reasons, make intersection between workflows and
+    // validWorkflowIds
+    for (let idx = foundWorkflowIds.length - 1; idx >= 0; idx--) {
+      const foundWorkflowId = foundWorkflowIds[idx];
+      if (requestWorkflowIds.includes(foundWorkflowId) === false) {
+        logger.warn(
+          `ElasticSearch returned workflow that was not requested:` +
+            ` ${foundWorkflowId.workflowId} in ${requestWorkflowIds}`,
+        );
+        foundWorkflowIds.splice(idx, 1);
+      }
+    }
+    logger.debug(`Sending bulk operation: ${foundWorkflowIds}`);
+    proxyCallback({buffer: createProxyOptionsBuffer(foundWorkflowIds, req)});
+  });
+}
+
+let proxyTarget;
+
+export default function(ctx) {
+  proxyTarget = ctx.proxyTarget;
+  return [
+    {
+      method: 'delete',
+      url: '/api/workflow/bulk/terminate',
+      before: bulkOperationBefore,
+    },
+    {
+      method: 'put',
+      url: '/api/workflow/bulk/pause',
+      before: bulkOperationBefore,
+    },
+    {
+      method: 'put',
+      url: '/api/workflow/bulk/resume',
+      before: bulkOperationBefore,
+    },
+    {
+      method: 'post',
+      url: '/api/workflow/bulk/retry',
+      before: bulkOperationBefore,
+    },
+    {
+      method: 'post',
+      url: '/api/workflow/bulk/restart',
+      before: bulkOperationBefore,
+    },
+  ];
+}

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
@@ -1,0 +1,178 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import logging from '@fbcnms/logging';
+
+// Currently just filters result without passing prefix to conductor.
+// TODO: implement querying by prefix in conductor
+import {
+  GLOBAL_PREFIX,
+  createProxyOptionsBuffer,
+  withUnderscore,
+} from '../utils.js';
+
+const logger = logging.getLogger(module);
+
+// Gets all task definition
+/*
+curl  -H "x-auth-organization: fb-test" "localhost/proxy/api/metadata/taskdefs"
+*/
+function getAllTaskdefsAfter(tenantId, req, respObj) {
+  // iterate over taskdefs, keep only those belonging to tenantId or global
+  // remove tenantId prefix, keep GLOBAL_
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  const globalWithUnderscore = withUnderscore(GLOBAL_PREFIX);
+  for (let idx = respObj.length - 1; idx >= 0; idx--) {
+    const taskdef = respObj[idx];
+    if (taskdef.name.indexOf(tenantWithUnderscore) == 0) {
+      taskdef.name = taskdef.name.substr(tenantWithUnderscore.length);
+    } else if (taskdef.name.indexOf(globalWithUnderscore) == 0) {
+      // noop
+    } else {
+      // remove element
+      respObj.splice(idx, 1);
+    }
+  }
+}
+function sanitizeTaskdefBefore(tenantId, taskdef) {
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  if (taskdef.name.indexOf('_') > -1) {
+    logger.error(
+      `Name of taskdef must not contain underscore: '${taskdef.name}'`,
+    );
+    throw 'Name must not contain underscore'; // TODO create Exception class
+  }
+  // prepend tenantId
+  taskdef.name = tenantWithUnderscore + taskdef.name;
+}
+// Create new task definition(s)
+// Underscore in name is not allowed.
+/*
+curl -X POST -H "x-auth-organization: fb-test"  \
+ "localhost/proxy/api/metadata/taskdefs" \
+ -H 'Content-Type: application/json' -d '
+[
+    {
+      "name": "bar",
+      "retryCount": 3,
+      "retryLogic": "FIXED",
+      "retryDelaySeconds": 10,
+      "timeoutSeconds": 300,
+      "timeoutPolicy": "TIME_OUT_WF",
+      "responseTimeoutSeconds": 180,
+      "ownerEmail": "foo@bar.baz"
+    }
+]
+'
+*/
+// TODO: should this be disabled?
+function postTaskdefsBefore(tenantId, req, res, proxyCallback) {
+  // iterate over taskdefs, prefix with tenantId
+  const reqObj = req.body;
+  for (let idx = 0; idx < reqObj.length; idx++) {
+    const taskdef = reqObj[idx];
+    sanitizeTaskdefBefore(tenantId, taskdef);
+  }
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+// Update an existing task
+// Underscore in name is not allowed.
+/*
+curl -X PUT -H "x-auth-organization: fb-test" \
+ "localhost/proxy/api/metadata/taskdefs" \
+ -H 'Content-Type: application/json' -d '
+    {
+      "name": "frinx",
+      "retryCount": 3,
+      "retryLogic": "FIXED",
+      "retryDelaySeconds": 10,
+      "timeoutSeconds": 400,
+      "timeoutPolicy": "TIME_OUT_WF",
+      "responseTimeoutSeconds": 180,
+      "ownerEmail": "foo@bar.baz"
+    }
+'
+*/
+// TODO: should this be disabled?
+function putTaskdefBefore(tenantId, req, res, proxyCallback) {
+  const reqObj = req.body;
+  const taskdef = reqObj;
+  sanitizeTaskdefBefore(tenantId, taskdef);
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+/*
+curl  -H "x-auth-organization: fb-test" \
+ "localhost/proxy/api/metadata/taskdefs/frinx"
+*/
+// Gets the task definition
+function getTaskdefByNameBefore(tenantId, req, res, proxyCallback) {
+  req.params.name = withUnderscore(tenantId) + req.params.name;
+  // modify url
+  req.url = '/api/metadata/taskdefs/' + req.params.name;
+  proxyCallback();
+}
+
+function getTaskdefByNameAfter(tenantId, req, respObj, res) {
+  if (res.status == 200) {
+    const tenantWithUnderscore = withUnderscore(tenantId);
+    // remove prefix
+    if (respObj.name && respObj.name.indexOf(tenantWithUnderscore) == 0) {
+      respObj.name = respObj.name.substr(tenantWithUnderscore.length);
+    } else {
+      logger.error(
+        `Tenant Id prefix '${tenantId}' not found, taskdef name: '${respObj.name}'`,
+      );
+      res.status(400);
+      res.send('Prefix not found'); // TODO: this exits the process
+    }
+  }
+}
+
+// TODO: can this be disabled?
+// Remove a task definition
+function deleteTaskdefByNameBefore(tenantId, req, res, proxyCallback) {
+  req.params.name = withUnderscore(tenantId) + req.params.name;
+  // modify url
+  req.url = '/api/metadata/taskdefs/' + req.params.name;
+  proxyCallback();
+}
+
+export default function() {
+  return [
+    {
+      method: 'get',
+      url: '/api/metadata/taskdefs',
+      after: getAllTaskdefsAfter,
+    },
+    {
+      method: 'post',
+      url: '/api/metadata/taskdefs',
+      before: postTaskdefsBefore,
+    },
+    {
+      method: 'put',
+      url: '/api/metadata/taskdefs',
+      before: putTaskdefBefore,
+    },
+    {
+      method: 'get',
+      url: '/api/metadata/taskdefs/:name',
+      before: getTaskdefByNameBefore,
+      after: getTaskdefByNameAfter,
+    },
+    {
+      method: 'delete',
+      url: '/api/metadata/taskdefs/:name',
+      before: deleteTaskdefByNameBefore,
+    },
+  ];
+}

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
@@ -1,0 +1,290 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import logging from '@fbcnms/logging';
+// Currently just filters result without passing prefix to conductor.
+// TODO: implement querying by prefix in conductor
+
+import qs from 'qs';
+import {
+  GLOBAL_PREFIX,
+  createProxyOptionsBuffer,
+  withUnderscore,
+} from '../utils.js';
+
+const logger = logging.getLogger(module);
+
+// Utility used in PUT, POST before methods to check that submitted workflow
+// and its tasks
+// do not contain any prefix. Prefix is added to workflowdef if input is valid.
+function sanitizeWorkflowdefBefore(tenantId, workflowdef) {
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  if (workflowdef.name.indexOf('_') == -1) {
+    // validate tasks
+    for (const task of workflowdef.tasks) {
+      if (task.name.indexOf(withUnderscore(GLOBAL_PREFIX)) == 0) {
+        // noop on GLOBAL_ tasks
+      } else if (task.name.indexOf('_') == -1) {
+        // noop on unprefixed tasks
+      } else {
+        logger.error(
+          `Task name must not contain underscore: '${tenantId}'` +
+            ` in ${JSON.stringify(task)}`,
+        );
+        // TODO create Exception class
+        throw 'Task name must not contain underscore';
+      }
+    }
+    // add prefix to tasks
+    for (const task of workflowdef.tasks) {
+      // if task does not start with GLOBAL_ prefix...
+      if (task.name.indexOf(withUnderscore(GLOBAL_PREFIX)) != 0) {
+        // add tenantId prefix
+        task.name = tenantWithUnderscore + task.name;
+      }
+    }
+    // add prefix to workflow
+    workflowdef.name = tenantWithUnderscore + workflowdef.name;
+  } else {
+    logger.error(
+      `Workflow name must not contain underscore: '${tenantId}'` +
+        ` in ${JSON.stringify(workflowdef)}`,
+    );
+    // TODO create Exception class
+    throw 'Workflow name must not contain underscore';
+  }
+}
+
+// Utility used after getting single or all workflowdefs to remove prefix from
+// workflowdef names, taskdef names.
+// Return true iif sanitization succeeded, false iif this
+// workflowdef is invalid
+function sanitizeWorkflowdefAfter(tenantId, workflowdef) {
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  if (workflowdef.name.indexOf(tenantWithUnderscore) == 0) {
+    // keep only workflows with correct taskdefs,
+    // allowed are GLOBAL and those with tenantId prefix which will be removed
+    for (const task of workflowdef.tasks) {
+      if (task.name.indexOf(withUnderscore(GLOBAL_PREFIX)) == 0) {
+        // noop
+      } else if (task.name.indexOf(tenantWithUnderscore) == 0) {
+        // remove prefix
+        task.name = task.name.substr(tenantWithUnderscore.length);
+      } else {
+        return false;
+      }
+    }
+    // remove prefix
+    workflowdef.name = workflowdef.name.substr(tenantWithUnderscore.length);
+    return true;
+  } else {
+    return false;
+  }
+}
+
+// Retrieves all workflow definition along with blueprint
+/*
+curl -H "x-auth-organization: fb-test" "localhost/proxy/api/metadata/workflow"
+*/
+function getAllWorkflowsAfter(tenantId, req, respObj) {
+  // iterate over workflows, keep only those belonging to tenantId
+  for (let workflowIdx = respObj.length - 1; workflowIdx >= 0; workflowIdx--) {
+    const workflowdef = respObj[workflowIdx];
+    const ok = sanitizeWorkflowdefAfter(tenantId, workflowdef, respObj);
+    if (!ok) {
+      logger.warn(
+        `Removing workflow with invalid task or name: ${JSON.stringify(
+          workflowdef,
+        )}`,
+      );
+      // remove element
+      respObj.splice(workflowIdx, 1);
+    }
+  }
+}
+
+// Removes workflow definition. It does not remove workflows associated
+// with the definition.
+// Version is passed as url parameter.
+/*
+curl -H "x-auth-organization: fb-test" \
+  "localhost/proxy/api/metadata/workflow/2/2" -X DELETE
+*/
+function deleteWorkflowBefore(tenantId, req, res, proxyCallback) {
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  // change URL: add prefix to name
+  const name = tenantWithUnderscore + req.params.name;
+  const newUrl = `/api/metadata/workflow/${name}/${req.params.version}`;
+  logger.debug(`Transformed url from '${req.url}' to '${newUrl}'`);
+  req.url = newUrl;
+  proxyCallback();
+}
+
+// Retrieves workflow definition along with blueprint
+// Version is passed as query parameter.
+/*
+curl -H "x-auth-organization: fb-test" \
+  "localhost/proxy/api/metadata/workflow/fx3?version=1"
+*/
+function getWorkflowBefore(tenantId, req, res, proxyCallback) {
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  const name = tenantWithUnderscore + req.params.name;
+  let newUrl = `/api/metadata/workflow/${name}`;
+  const originalQueryString = req._parsedUrl.query;
+  const parsedQuery = qs.parse(originalQueryString);
+  const version = parsedQuery['version'];
+  if (version) {
+    newUrl += '?version=' + version;
+  }
+  logger.debug(`Transformed url from '${req.url}' to '${newUrl}'`);
+  req.url = newUrl;
+  proxyCallback();
+}
+
+function getWorkflowAfter(tenantId, req, respObj) {
+  const ok = sanitizeWorkflowdefAfter(tenantId, respObj);
+  if (!ok) {
+    logger.error(
+      `Possible error in code: response contains invalid task or` +
+        `workflowdef name, tenant Id: ${tenantId}`,
+    );
+    throw 'Possible error in code: response contains' +
+      ' invalid task or workflowdef name'; // TODO create Exception class
+  }
+}
+
+// Create or update workflow definition
+// Underscore in name is not allowed.
+/*
+curl -X PUT -H "x-auth-organization: fb-test" \
+  "localhost/proxy/api/metadata/workflow" \
+  -H 'Content-Type: application/json' -d '
+[
+    {
+    "name": "fx3",
+    "description": "foo1",
+    "ownerEmail": "foo@bar.baz",
+    "version": 1,
+    "schemaVersion": 2,
+    "tasks": [
+        {
+        "name": "bar",
+        "taskReferenceName": "barref",
+        "type": "SIMPLE",
+        "inputParameters": {}
+        }
+    ]
+    }
+]'
+
+
+curl -X PUT -H "x-auth-organization: fb-test" \
+  "localhost/proxy/api/metadata/workflow" \
+  -H 'Content-Type: application/json' -d '
+[
+    {
+    "name": "fx3",
+    "description": "foo1",
+    "ownerEmail": "foo@bar.baz",
+    "version": 1,
+    "schemaVersion": 2,
+    "tasks": [
+        {
+        "name": "bar",
+        "taskReferenceName": "barref",
+        "type": "SIMPLE",
+        "inputParameters": {}
+        },
+        {
+        "name": "GLOBAL_GLOBAL1",
+        "taskReferenceName": "globref",
+        "type": "SIMPLE",
+        "inputParameters": {}
+        }
+    ]
+    }
+]'
+*/
+function putWorkflowBefore(tenantId, req, res, proxyCallback) {
+  const reqObj = req.body;
+  for (const workflowdef of reqObj) {
+    sanitizeWorkflowdefBefore(tenantId, workflowdef);
+  }
+  logger.debug(`Transformed request to ${JSON.stringify(reqObj)}`);
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+// Create a new workflow definition
+// Underscore in name is not allowed.
+/*
+curl -X POST -H "x-auth-organization: fb-test" \
+  "localhost/proxy/api/metadata/workflow" \
+  -H 'Content-Type: application/json' -d '
+
+    {
+    "name": "fx3",
+    "description": "foo1",
+    "ownerEmail": "foo@bar.baz",
+    "version": 1,
+    "schemaVersion": 2,
+    "tasks": [
+        {
+        "name": "bar",
+        "taskReferenceName": "barref",
+        "type": "SIMPLE",
+        "inputParameters": {}
+        },
+        {
+        "name": "GLOBAL_GLOBAL1",
+        "taskReferenceName": "globref",
+        "type": "SIMPLE",
+        "inputParameters": {}
+        }
+    ]
+    }
+'
+*/
+function postWorkflowBefore(tenantId, req, res, proxyCallback) {
+  const reqObj = req.body;
+  sanitizeWorkflowdefBefore(tenantId, reqObj);
+  logger.debug(`Transformed request to ${JSON.stringify(reqObj)}`);
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+export default function() {
+  return [
+    {
+      method: 'get',
+      url: '/api/metadata/workflow',
+      after: getAllWorkflowsAfter,
+    },
+    {
+      method: 'delete',
+      url: '/api/metadata/workflow/:name/:version',
+      before: deleteWorkflowBefore,
+    },
+    {
+      method: 'get',
+      url: '/api/metadata/workflow/:name',
+      before: getWorkflowBefore,
+      after: getWorkflowAfter,
+    },
+    {
+      method: 'put',
+      url: '/api/metadata/workflow',
+      before: putWorkflowBefore,
+    },
+    {
+      method: 'post',
+      url: '/api/metadata/workflow',
+      before: postWorkflowBefore,
+    },
+  ];
+}

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
@@ -1,0 +1,186 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import logging from '@fbcnms/logging';
+
+import qs from 'qs';
+import request from 'request';
+import {
+  createProxyOptionsBuffer,
+  removeTenantPrefix,
+  removeTenantPrefixes,
+  withUnderscore,
+} from '../utils.js';
+
+const logger = logging.getLogger(module);
+// Search for workflows based on payload and other parameters
+/*
+ curl -H "x-auth-organization: fb-test" \
+  "localhost/proxy/api/workflow/search?query=status+IN+(FAILED)"
+*/
+function getSearchBefore(tenantId, req, res, proxyCallback) {
+  // prefix query with workflowType STARTS_WITH tenantId_
+  const originalQueryString = req._parsedUrl.query;
+  const parsedQuery = qs.parse(originalQueryString);
+  const limitToTenant = `workflowType STARTS_WITH \'${tenantId}_'`;
+  let q = parsedQuery['query'];
+  if (q) {
+    // TODO: validate conductor query to prevent security issues
+    q = limitToTenant + ' AND (' + q + ')';
+  } else {
+    q = limitToTenant;
+  }
+  parsedQuery['query'] = q;
+  const newQueryString = qs.stringify(parsedQuery);
+  logger.debug(
+    `Transformed query string from ` +
+      `'${originalQueryString}' to '${newQueryString}`,
+  );
+  req.url = req._parsedUrl.pathname + '?' + newQueryString;
+  proxyCallback();
+}
+
+function getSearchAfter(tenantId, req, respObj) {
+  removeTenantPrefix(tenantId, respObj, 'results[*].workflowType', false);
+}
+
+// Start a new workflow with StartWorkflowRequest, which allows task to be
+// executed in a domain
+/*
+curl -X POST -H "x-auth-organization: fb-test" -H \
+"Content-Type: application/json" "localhost/proxy/api/workflow" -d '
+{
+  "name": "fx3",
+  "version": 1,
+  "correlatonId": "corr1",
+  "ownerApp": "my_owner_app",
+  "input": {
+  }
+}
+'
+*/
+function postWorkflowBefore(tenantId, req, res, proxyCallback) {
+  // name must start with prefix
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  const reqObj = req.body;
+
+  // workflowDef section is not allowed (no dynamic workflows)
+  if (reqObj.workflowDef) {
+    logger.error(
+      `Section workflowDef is not allowed ${JSON.stringify(reqObj)}`,
+    );
+    throw 'Section workflowDef is not allowed';
+  }
+  // taskToDomain section is not allowed
+  if (reqObj.taskToDomain) {
+    logger.error(
+      `Section taskToDomain is not allowed ${JSON.stringify(reqObj)}`,
+    );
+    throw 'Section taskToDomain is not allowed';
+  }
+
+  // name should not contain _
+  if (reqObj.name.indexOf('_') > -1) {
+    logger.error(`Name must not contain underscore ${JSON.stringify(reqObj)}`);
+    throw 'Name must not contain underscore'; // TODO create Exception class
+  }
+  // add prefix
+  reqObj.name = tenantWithUnderscore + reqObj.name;
+  // add taskToDomain
+  reqObj.taskToDomain = {};
+  //TODO: is this OK?
+  reqObj.taskToDomain[tenantWithUnderscore + '*'] = tenantId;
+  logger.debug(`Transformed request to ${JSON.stringify(reqObj)}`);
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+// Gets the workflow by workflow id
+/*
+curl  -H "x-auth-organization: fb-test" \
+    "localhost/proxy/api/workflow/c0a438d4-25b7-4c12-8a29-3473d98b1ad7"
+*/
+function getExecutionStatusAfter(tenantId, req, respObj) {
+  const jsonPathToAllowGlobal = {
+    workflowName: false,
+    workflowType: false,
+    'tasks[*].taskDefName': true,
+    'tasks[*].taskType': true,
+    'tasks[*].workflowTask.name': true,
+    'tasks[*].workflowTask.taskDefinition.name': true,
+    'tasks[*].workflowType': false,
+    'workflowDefinition.name': false,
+    'workflowDefinition.tasks[*].name': true,
+    'workflowDefinition.tasks[*].taskDefinition.name': true,
+  };
+  removeTenantPrefixes(tenantId, respObj, jsonPathToAllowGlobal);
+}
+
+// Removes the workflow from the system
+/*
+curl  -H "x-auth-organization: fb-test" \
+    "localhost/proxy/api/workflow/2dbb6e3e-c45d-464b-a9c9-2bbb16b7ca71/remove" \
+    -X DELETE
+*/
+function removeWorkflowBefore(tenantId, req, res, proxyCallback) {
+  const url = proxyTarget + '/api/workflow/' + req.params.workflowId;
+  // first make a HTTP request to validate that this workflow belongs to tenant
+  const requestOptions = {
+    url,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/javascript',
+    },
+  };
+  logger.debug(`Requesting ${JSON.stringify(requestOptions)}`);
+  request(requestOptions, function(error, response, body) {
+    logger.debug(`Got status code: ${response.statusCode}, body: '${body}'`);
+    const workflow = JSON.parse(body);
+    // make sure name starts with prefix
+    const tenantWithUnderscore = withUnderscore(tenantId);
+    if (workflow.workflowName.indexOf(tenantWithUnderscore) == 0) {
+      proxyCallback();
+    } else {
+      logger.error(
+        `Error trying to delete workflow of different tenant: ${tenantId},` +
+          ` workflow: ${JSON.stringify(workflow)}`,
+      );
+      res.status(401);
+      res.send('Unauthorized');
+    }
+  });
+}
+let proxyTarget;
+
+export default function(ctx) {
+  proxyTarget = ctx.proxyTarget;
+  return [
+    {
+      method: 'get',
+      url: '/api/workflow/search',
+      before: getSearchBefore,
+      after: getSearchAfter,
+    },
+    {
+      method: 'post',
+      url: '/api/workflow',
+      before: postWorkflowBefore,
+    },
+    {
+      method: 'get',
+      url: '/api/workflow/:workflowId',
+      after: getExecutionStatusAfter,
+    },
+    {
+      method: 'delete',
+      url: '/api/workflow/:workflowId/remove',
+      before: removeWorkflowBefore,
+    },
+  ];
+}

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -8,8 +8,8 @@
  * @format
  */
 
-import * as streamify from 'stream-array';
 import logging from '@fbcnms/logging';
+import streamify from 'stream-array';
 import {JSONPath} from 'jsonpath-plus';
 
 const logger = logging.getLogger(module);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -13,7 +13,10 @@ import streamify from 'stream-array';
 import {JSONPath} from 'jsonpath-plus';
 
 const logger = logging.getLogger(module);
-const GLOBAL_PREFIX = 'GLOBAL';
+
+// Global prefix for taskdefs which can be used by all tenants.
+// TODO: can we come up with an invalid tenant name?
+export const GLOBAL_PREFIX = 'GLOBAL';
 
 export function withUnderscore(s) {
   return s + '_';
@@ -22,11 +25,8 @@ export function withUnderscore(s) {
 export function getTenantId(req) {
   const tenantId = req.headers['x-auth-organization'];
   if (tenantId == null) {
+    logger.error('x-auth-organization header not found');
     throw 'x-auth-organization header not found';
-  }
-  if (/^[a-z0-9]+$/i.test(tenantId) == false) {
-    logger.error(`TenantId must be alphanumeric: '${tenantId}'`);
-    throw 'TenantId must be alphanumeric';
   }
   if (tenantId == GLOBAL_PREFIX) {
     logger.error(`Illegal name for TenantId: '${tenantId}'`);

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -20,15 +20,15 @@ import transform from 'lodash/fp/transform';
 const http = HttpClient;
 
 const router = Router();
-//TODO make configurable
-const baseURL = 'conductor-server:8080/api/';
+//TODO merge with proxy
+const baseURL = 'localhost/proxy/api/';
 const baseURLWorkflow = baseURL + 'workflow/';
 const baseURLMeta = baseURL + 'metadata/';
 const baseURLTask = baseURL + 'tasks/';
 
 router.get('/metadata/taskdefs', async (req, res, next) => {
   try {
-    const result = await http.get(baseURLMeta + 'taskdefs', req.token);
+    const result = await http.get(baseURLMeta + 'taskdefs', req);
     res.status(200).send({result});
   } catch (err) {
     next(err);
@@ -37,7 +37,7 @@ router.get('/metadata/taskdefs', async (req, res, next) => {
 
 router.get('/metadata/taskdefs', async (req, res, next) => {
   try {
-    const result = await http.get(baseURLMeta + 'taskdefs', req.token);
+    const result = await http.get(baseURLMeta + 'taskdefs', req);
     res.status(200).send({result});
   } catch (err) {
     next(err);
@@ -46,7 +46,7 @@ router.get('/metadata/taskdefs', async (req, res, next) => {
 
 router.post('/metadata/taskdef', async (req, res, next) => {
   try {
-    const result = await http.post(baseURLMeta + 'taskdefs', req.body);
+    const result = await http.post(baseURLMeta + 'taskdefs', req.body, req);
     res.status(200).send(result);
   } catch (err) {
     res.status(400).send(err.response.body);
@@ -58,7 +58,7 @@ router.get('/metadata/taskdef/:name', async (req, res, next) => {
   try {
     const result = await http.get(
       baseURLMeta + 'taskdefs/' + req.params.name,
-      req.token,
+      req,
     );
     res.status(200).send({result});
   } catch (err) {
@@ -70,7 +70,7 @@ router.delete('/metadata/taskdef/:name', async (req, res, next) => {
   try {
     const result = await http.delete(
       baseURLMeta + 'taskdefs/' + req.params.name,
-      req.token,
+      req,
     );
     res.status(200).send({result});
   } catch (err) {
@@ -80,7 +80,7 @@ router.delete('/metadata/taskdef/:name', async (req, res, next) => {
 
 router.get('/metadata/workflow', async (req, res, next) => {
   try {
-    const result = await http.get(baseURLMeta + 'workflow', req.token);
+    const result = await http.get(baseURLMeta + 'workflow', req);
     res.status(200).send({result});
   } catch (err) {
     next(err);
@@ -91,7 +91,7 @@ router.delete('/metadata/workflow/:name/:version', async (req, res, next) => {
   try {
     const result = await http.delete(
       baseURLMeta + 'workflow/' + req.params.name + '/' + req.params.version,
-      req.token,
+      req,
     );
     res.status(200).send({result});
   } catch (err) {
@@ -107,7 +107,7 @@ router.get('/metadata/workflow/:name/:version', async (req, res, next) => {
         req.params.name +
         '?version=' +
         req.params.version,
-      req.token,
+      req,
     );
     res.status(200).send({result});
   } catch (err) {
@@ -117,7 +117,7 @@ router.get('/metadata/workflow/:name/:version', async (req, res, next) => {
 
 router.put('/metadata', async (req, res, next) => {
   try {
-    const result = await http.put(baseURLMeta + 'workflow/', req.body);
+    const result = await http.put(baseURLMeta + 'workflow/', req.body, req);
     res.status(200).send(result);
   } catch (err) {
     res.status(400).send(err.response.body);
@@ -127,7 +127,7 @@ router.put('/metadata', async (req, res, next) => {
 
 router.post('/workflow', async (req, res, next) => {
   try {
-    const result = await http.post(baseURLWorkflow, req.body);
+    const result = await http.post(baseURLWorkflow, req.body, req);
     res.status(200).send(result);
   } catch (err) {
     next(err);
@@ -171,7 +171,7 @@ router.get('/executions', async (req, res, next) => {
       start +
       '&query=' +
       encodeURIComponent(query);
-    const result = await http.get(url, req.token);
+    const result = await http.get(url, req);
     const hits = result.results;
     res.status(200).send({result: {hits: hits, totalHits: result.totalHits}});
   } catch (err) {
@@ -184,7 +184,7 @@ router.delete('/bulk/terminate', async (req, res, next) => {
     const result = await http.delete(
       baseURLWorkflow + 'bulk/terminate',
       req.body,
-      req.token,
+      req,
     );
     res.status(200).send(result);
   } catch (err) {
@@ -197,7 +197,7 @@ router.put('/bulk/pause', async (req, res, next) => {
     const result = await http.put(
       baseURLWorkflow + 'bulk/pause',
       req.body,
-      req.token,
+      req,
     );
     res.status(200).send(result);
   } catch (err) {
@@ -210,7 +210,7 @@ router.put('/bulk/resume', async (req, res, next) => {
     const result = await http.put(
       baseURLWorkflow + 'bulk/resume',
       req.body,
-      req.token,
+      req,
     );
     res.status(200).send(result);
   } catch (err) {
@@ -223,7 +223,7 @@ router.post('/bulk/retry', async (req, res, next) => {
     const result = await http.post(
       baseURLWorkflow + 'bulk/retry',
       req.body,
-      req.token,
+      req,
     );
     res.status(200).send(result);
   } catch (err) {
@@ -236,7 +236,7 @@ router.post('/bulk/restart', async (req, res, next) => {
     const result = await http.post(
       baseURLWorkflow + 'bulk/restart',
       req.body,
-      req.token,
+      req,
     );
     res.status(200).send(result);
   } catch (err) {
@@ -249,7 +249,7 @@ router.delete('/workflow/:workflowId', async (req, res, next) => {
     const result = await http.delete(
       baseURLWorkflow + req.params.workflowId + '/remove',
       req.body,
-      req.token,
+      req,
     );
     res.status(200).send(result);
   } catch (err) {
@@ -261,7 +261,7 @@ router.get('/id/:workflowId', async (req, res, next) => {
   try {
     const result = await http.get(
       baseURLWorkflow + req.params.workflowId + '?includeTasks=true',
-      req.token,
+      req,
     );
     let meta = result.workflowDefinition;
     if (!meta) {
@@ -271,7 +271,7 @@ router.get('/id/:workflowId', async (req, res, next) => {
           result.workflowType +
           '?version=' +
           result.version,
-        req.token,
+        req,
       );
     }
 
@@ -308,7 +308,7 @@ router.get('/id/:workflowId', async (req, res, next) => {
     });
 
     const logs = map(task =>
-      Promise.all([task, http.get(baseURLTask + task.taskId + '/log')]),
+      Promise.all([task, http.get(baseURLTask + task.taskId + '/log', req)]),
     )(result.tasks);
     const LOG_DATE_FORMAT = 'MM/DD/YY, HH:mm:ss:SSS';
 
@@ -326,8 +326,8 @@ router.get('/id/:workflowId', async (req, res, next) => {
     const promises = map(({name, version, subWorkflowId, referenceTaskName}) =>
       Promise.all([
         referenceTaskName,
-        http.get(baseURLMeta + 'workflow/' + name + '?version=' + version),
-        http.get(baseURLWorkflow + subWorkflowId + '?includeTasks=true'),
+        http.get(baseURLMeta + 'workflow/' + name + '?version=' + version, req),
+        http.get(baseURLWorkflow + subWorkflowId + '?includeTasks=true', req),
       ]),
     )(subs);
 
@@ -382,7 +382,7 @@ router.get('/hierarchical', async (req, res, next) => {
         '&start=' +
         start +
         '&query=';
-      const result = await http.get(url, req.token);
+      const result = await http.get(url, req);
       const allData = result.results ? result.results : [];
       hits = result.totalHits ? result.totalHits : 0;
 
@@ -399,7 +399,7 @@ router.get('/hierarchical', async (req, res, next) => {
             sepWfs.map(wf =>
               http.get(
                 baseURLWorkflow + wf.workflowId + '?includeTasks=false',
-                req.token,
+                req,
               ),
             ),
           );
@@ -429,7 +429,7 @@ router.get('/hierarchical', async (req, res, next) => {
             baseURLWorkflow +
               children[i].parentWorkflowId +
               '?includeTasks=false',
-            req.token,
+            req,
           );
           parent.startTime = new Date(parent.startTime);
           parent.endTime = new Date(parent.endTime);
@@ -456,11 +456,8 @@ router.get('/hierarchical', async (req, res, next) => {
 
 router.get('/queue/data', async (req, res, next) => {
   try {
-    const sizes = await http.get(baseURLTask + 'queue/all', req.token);
-    const polldata = await http.get(
-      baseURLTask + 'queue/polldata/all',
-      req.token,
-    );
+    const sizes = await http.get(baseURLTask + 'queue/all', req);
+    const polldata = await http.get(baseURLTask + 'queue/polldata/all', req);
     polldata.forEach(pd => {
       let qname = pd.queueName;
 


### PR DESCRIPTION
Summary:
* Add metadata/taskdefs transformer
* Add metadata/workflow, workflow, workflow/bulk transformers

Test plan:
Start docker compose in symphony/integration folder with following yaml files:
* docker-compose.yaml
* docker-compose.conductor.frinx.yaml
* docker-compose.workflows.yaml

Login to fb-test.localhost, obtain connect.sid cookie and call:
```
curl --cookie "connect.sid=<value here>" http://fb-test.localhost/workflows/metadata/taskdefs
```
This should return empty array `[]` and status code 200. Note that fb-test.localhost must be resolved to localhost.