### PR TITLE
Pass mysql_dialect option in nms helm chart

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.15
+version: 1.4.16
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 description: Magma NMS
 name: nms
-version: 0.1.3
+version: 0.1.4
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
@@ -71,6 +71,8 @@ spec:
               value: {{ .Values.magmalte.env.mysql_db | quote }}
             - name: MYSQL_HOST
               value: {{ .Values.magmalte.env.mysql_host | quote }}
+            - name: MYSQL_DIALECT
+              value: {{ .Values.magmalte.env.mysql_dialect | quote }}
             - name: MYSQL_PASS
               valueFrom:
                 secretKeyRef:

--- a/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
@@ -32,6 +32,7 @@ magmalte:
     mysql_db: magma
     mysql_user: magma
     mysql_pass: password
+    mysql_dialect: mysql
 
   labels: {}
 

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 1.4.12
 - name: nms
   repository: ""
-  version: 0.1.3
+  version: 0.1.4
 - name: logging
   repository: ""
   version: 0.1.9

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: ""
     condition: metrics.enabled
   - name: nms
-    version: 0.1.3
+    version: 0.1.4
     repository: ""
     condition: nms.enabled
   - name: logging


### PR DESCRIPTION
Summary: mysql_dialect was added to the docker-compose, but not the helm chart. This allows use of the nms with mariadb.

Differential Revision: D21140730

