### PR TITLE
Add new test cases to sanity suite

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -28,6 +28,7 @@ s1aptests/test_attach_service_ue_radio_capability.py \
 s1aptests/test_attach_service_multi_ue.py \
 s1aptests/test_attach_ipv4v6_pdn_type.py \
 s1aptests/test_service_info.py \
+s1aptests/test_attach_detach_with_ovs.py \
 s1aptests/test_resync.py \
 s1aptests/test_standalone_pdn_conn_req.py \
 s1aptests/test_attach_act_dflt_ber_ctxt_rej.py \
@@ -82,7 +83,8 @@ s1aptests/test_attach_detach_multiple_secondary_pdn.py \
 s1aptests/test_attach_detach_nw_triggered_delete_secondary_pdn.py \
 s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py \
 s1aptests/test_attach_ul_udp_data.py \
-s1aptests/test_attach_ul_tcp_data.py
+s1aptests/test_attach_ul_tcp_data.py \
+s1aptests/test_attach_detach_rar_tcp_data.py
 #s1aptests/test_attach_ue_ctxt_release_cmp_delay.py \
 #s1aptests/test_attach_dl_udp_data.py \
 #s1aptests/test_attach_dl_tcp_data.py

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -28,7 +28,6 @@ s1aptests/test_attach_service_ue_radio_capability.py \
 s1aptests/test_attach_service_multi_ue.py \
 s1aptests/test_attach_ipv4v6_pdn_type.py \
 s1aptests/test_service_info.py \
-s1aptests/test_attach_detach_with_ovs.py \
 s1aptests/test_resync.py \
 s1aptests/test_standalone_pdn_conn_req.py \
 s1aptests/test_attach_act_dflt_ber_ctxt_rej.py \
@@ -80,6 +79,8 @@ s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py \
 s1aptests/test_attach_detach_disconnect_default_pdn.py \
 s1aptests/test_attach_detach_maxbearers_twopdns.py \
 s1aptests/test_attach_detach_multiple_secondary_pdn.py \
+s1aptests/test_attach_detach_nw_triggered_delete_secondary_pdn.py \
+s1aptests/test_attach_detach_nw_triggered_delete_last_pdn.py \
 s1aptests/test_attach_ul_udp_data.py \
 s1aptests/test_attach_ul_tcp_data.py
 #s1aptests/test_attach_ue_ctxt_release_cmp_delay.py \


### PR DESCRIPTION
Summary:
Added test_attach_detach_nw_triggered_delete_secondary_pdn.py, test_attach_detach_nw_triggered_delete_last_pdn.py and test_attach_detach_rar_tcp_data.py test cases to sanity suite

Test Plan:
Executed S1 SIM sanity suite