### PR TITLE
Adding const to format string for OAI logging (#2297)

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -1541,7 +1541,7 @@ void log_message_prefix_id(
   const char* const source_fileP,
   const unsigned int line_numP,
   uint64_t prefix_id,
-  char* format, ...) {
+  const char* format, ...) {
   va_list args;
   void* new_item_p                                 = NULL;
   log_queue_item_t* new_item_p_sync                = NULL;

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -342,7 +342,7 @@ void log_message_prefix_id(
     const char* source_fileP,
     unsigned int line_numP,
     uint64_t prefix_id,
-    char* format, ...)
+    const char* format, ...)
     __attribute__((format(printf, 6, 7)));
 
 void log_message_int(


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2297

- Using `OAILOG_<LEVEL>_UE` macros on C++ throws a warning and stops compilation for `make build_oai`:
```
Warning: ISO C++11 does not allow conversion from string literal to 'char *'
```

- Adding `const` to format parameter fixes this

Reviewed By: uri200

Differential Revision: D21182393

