### PR TITLE
Add event handler API to conductor proxy

### DIFF
--- a/symphony/app/fbcnms-projects/workflows/src/proxy/proxy.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/proxy.js
@@ -52,7 +52,11 @@ export default async function(proxyTarget) {
       };
 
       // start with 'before'
-      logger.debug(`REQ ${req.method} ${req.url} tenantId ${tenantId}`);
+      logger.info(
+        `REQ ${req.method} ${
+          req.url
+        } tenantId ${tenantId} body ${JSON.stringify(req.body)}`,
+      );
       const proxyCallback = function(proxyOptions) {
         proxy.web(req, res, proxyOptions);
       };

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
@@ -18,6 +18,7 @@ export default async function(registrationCtx) {
     './transformers/metadata-taskdef',
     './transformers/metadata-workflowdef',
     './transformers/workflow',
+    './transformers/event',
   ];
   logger.debug(
     `Registering transformer modules: [${transformerModules}] using context ${JSON.stringify(

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/event.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/event.js
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import logging from '@fbcnms/logging';
+import {createProxyOptionsBuffer} from '../utils.js';
+
+const logger = logging.getLogger(module);
+
+/*
+curl -H "x-auth-organization: fb-test" \
+ "localhost/proxy/api/event" -X PUT -H 'Content-Type: application/json' -d '
+{
+    "actions": [
+        {
+            "action": "complete_task",
+            "complete_task": {
+                "output": {},
+                "taskRefName": "${targetTaskRefName}",
+                "workflowId": "${targetWorkflowId}"
+            }
+        }
+    ],
+    "active": true,
+    "event": "conductor:event:eventTaskRefZUEX",
+    "name": "event_eventTaskRefZUEX"
+}
+' -v
+*/
+function postEventBefore(tenantId, req, res, proxyCallback) {
+  const reqObj = req.body;
+  logger.debug(`Transforming '${JSON.stringify(reqObj)}'`);
+  // TODO: prefix name
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+function putEventBefore(tenantId, req, res, proxyCallback) {
+  const reqObj = req.body;
+  logger.debug(`Transforming '${JSON.stringify(reqObj)}'`);
+  // TODO: prefix name
+  proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
+}
+
+export default function() {
+  return [
+    {
+      method: 'post',
+      url: '/api/event',
+      before: postEventBefore,
+    },
+    {
+      method: 'put',
+      url: '/api/event',
+      before: putEventBefore,
+    },
+  ];
+}

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
@@ -14,9 +14,9 @@ import logging from '@fbcnms/logging';
 // TODO: implement querying by prefix in conductor
 import {
   GLOBAL_PREFIX,
-  INFIX_SEPARATOR,
+  addTenantIdPrefix,
+  assertAllowedSystemTask,
   createProxyOptionsBuffer,
-  isAllowedSystemTask,
   withUnderscore,
 } from '../utils.js';
 
@@ -46,24 +46,10 @@ function getAllTaskdefsAfter(tenantId, req, respObj) {
 
 // Used in POST and PUT
 function sanitizeTaskdefBefore(tenantId, taskdef) {
-  const tenantWithUnderscore = withUnderscore(tenantId);
-  if (taskdef.name.indexOf(INFIX_SEPARATOR) > -1) {
-    logger.error(
-      `Name of taskdef must not contain '${INFIX_SEPARATOR}': '${taskdef.name}'`,
-    );
-    throw 'Name must not contain underscore'; // TODO create Exception class
-  }
   // only whitelisted system tasks are allowed
-  if (!isAllowedSystemTask(taskdef)) {
-    logger.error(
-      `Task type is not allowed: '${tenantId}'` +
-        ` in '${JSON.stringify(taskdef)}'`,
-    );
-    // TODO create Exception class
-    throw 'Task type is not allowed';
-  }
+  assertAllowedSystemTask(taskdef);
   // prepend tenantId
-  taskdef.name = tenantWithUnderscore + taskdef.name;
+  addTenantIdPrefix(tenantId, taskdef);
 }
 // Create new task definition(s)
 // Underscore in name is not allowed.

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
@@ -16,7 +16,7 @@ import {
   addTenantIdPrefix,
   assertAllowedSystemTask,
   createProxyOptionsBuffer,
-  withUnderscore,
+  withInfixSeparator,
 } from '../utils.js';
 
 const logger = logging.getLogger(module);
@@ -28,11 +28,11 @@ curl  -H "x-auth-organization: fb-test" "localhost/proxy/api/metadata/taskdefs"
 function getAllTaskdefsAfter(tenantId, req, respObj) {
   // iterate over taskdefs, keep only those belonging to tenantId or global
   // remove tenantId prefix, keep GLOBAL_
-  const tenantWithUnderscore = withUnderscore(tenantId);
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   for (let idx = respObj.length - 1; idx >= 0; idx--) {
     const taskdef = respObj[idx];
-    if (taskdef.name.indexOf(tenantWithUnderscore) == 0) {
-      taskdef.name = taskdef.name.substr(tenantWithUnderscore.length);
+    if (taskdef.name.indexOf(tenantWithInfixSeparator) == 0) {
+      taskdef.name = taskdef.name.substr(tenantWithInfixSeparator.length);
     } else {
       // remove element
       respObj.splice(idx, 1);
@@ -110,7 +110,7 @@ curl -H "x-auth-organization: fb-test" \
 */
 // Gets the task definition
 function getTaskdefByNameBefore(tenantId, req, res, proxyCallback) {
-  req.params.name = withUnderscore(tenantId) + req.params.name;
+  req.params.name = withInfixSeparator(tenantId) + req.params.name;
   // modify url
   req.url = '/api/metadata/taskdefs/' + req.params.name;
   proxyCallback();
@@ -118,10 +118,10 @@ function getTaskdefByNameBefore(tenantId, req, res, proxyCallback) {
 
 function getTaskdefByNameAfter(tenantId, req, respObj, res) {
   if (res.status == 200) {
-    const tenantWithUnderscore = withUnderscore(tenantId);
+    const tenantWithInfixSeparator = withInfixSeparator(tenantId);
     // remove prefix
-    if (respObj.name && respObj.name.indexOf(tenantWithUnderscore) == 0) {
-      respObj.name = respObj.name.substr(tenantWithUnderscore.length);
+    if (respObj.name && respObj.name.indexOf(tenantWithInfixSeparator) == 0) {
+      respObj.name = respObj.name.substr(tenantWithInfixSeparator.length);
     } else {
       logger.error(
         `Tenant Id prefix '${tenantId}' not found, taskdef name: '${respObj.name}'`,
@@ -139,7 +139,7 @@ curl -H "x-auth-organization: fb-test" \
  "localhost/api/metadata/taskdefs/bar" -X DELETE -v
 */
 function deleteTaskdefByNameBefore(tenantId, req, res, proxyCallback) {
-  req.params.name = withUnderscore(tenantId) + req.params.name;
+  req.params.name = withInfixSeparator(tenantId) + req.params.name;
   // modify url
   req.url = '/api/metadata/taskdefs/' + req.params.name;
   proxyCallback();

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
@@ -13,7 +13,6 @@ import logging from '@fbcnms/logging';
 // Currently just filters result without passing prefix to conductor.
 // TODO: implement querying by prefix in conductor
 import {
-  GLOBAL_PREFIX,
   addTenantIdPrefix,
   assertAllowedSystemTask,
   createProxyOptionsBuffer,
@@ -30,13 +29,10 @@ function getAllTaskdefsAfter(tenantId, req, respObj) {
   // iterate over taskdefs, keep only those belonging to tenantId or global
   // remove tenantId prefix, keep GLOBAL_
   const tenantWithUnderscore = withUnderscore(tenantId);
-  const globalWithUnderscore = withUnderscore(GLOBAL_PREFIX);
   for (let idx = respObj.length - 1; idx >= 0; idx--) {
     const taskdef = respObj[idx];
     if (taskdef.name.indexOf(tenantWithUnderscore) == 0) {
       taskdef.name = taskdef.name.substr(tenantWithUnderscore.length);
-    } else if (taskdef.name.indexOf(globalWithUnderscore) == 0) {
-      // noop
     } else {
       // remove element
       respObj.splice(idx, 1);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
@@ -14,7 +14,6 @@ import logging from '@fbcnms/logging';
 
 import qs from 'qs';
 import {
-  GLOBAL_PREFIX,
   addTenantIdPrefix,
   assertAllowedSystemTask,
   createProxyOptionsBuffer,
@@ -49,9 +48,7 @@ function sanitizeWorkflowdefAfter(tenantId, workflowdef) {
     // keep only workflows with correct taskdefs,
     // allowed are GLOBAL and those with tenantId prefix which will be removed
     for (const task of workflowdef.tasks) {
-      if (task.name.indexOf(withUnderscore(GLOBAL_PREFIX)) == 0) {
-        // noop
-      } else if (task.name.indexOf(tenantWithUnderscore) == 0) {
+      if (task.name.indexOf(tenantWithUnderscore) == 0) {
         // remove prefix
         task.name = task.name.substr(tenantWithUnderscore.length);
       } else {

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
@@ -18,7 +18,7 @@ import {
   assertAllowedSystemTask,
   createProxyOptionsBuffer,
   isSubworkflowTask,
-  withUnderscore,
+  withInfixSeparator,
 } from '../utils.js';
 
 const logger = logging.getLogger(module);
@@ -49,8 +49,8 @@ function sanitizeWorkflowdefBefore(tenantId, workflowdef) {
 // Return true iif sanitization succeeded, false iif this
 // workflowdef is invalid
 function sanitizeWorkflowdefAfter(tenantId, workflowdef) {
-  const tenantWithUnderscore = withUnderscore(tenantId);
-  if (workflowdef.name.indexOf(tenantWithUnderscore) == 0) {
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
+  if (workflowdef.name.indexOf(tenantWithInfixSeparator) == 0) {
     // keep only workflows with correct taskdefs,
     // allowed are GLOBAL and those with tenantId prefix which will be removed
 
@@ -59,20 +59,20 @@ function sanitizeWorkflowdefAfter(tenantId, workflowdef) {
       if (isSubworkflowTask(task)) {
         if (task.subWorkflowParam?.name) {
           task.subWorkflowParam.name = task.subWorkflowParam.name.substr(
-            tenantWithUnderscore.length,
+            tenantWithInfixSeparator.length,
           );
         }
       }
 
-      if (task.name.indexOf(tenantWithUnderscore) == 0) {
+      if (task.name.indexOf(tenantWithInfixSeparator) == 0) {
         // remove prefix
-        task.name = task.name.substr(tenantWithUnderscore.length);
+        task.name = task.name.substr(tenantWithInfixSeparator.length);
       } else {
         return false;
       }
     }
     // remove prefix
-    workflowdef.name = workflowdef.name.substr(tenantWithUnderscore.length);
+    workflowdef.name = workflowdef.name.substr(tenantWithInfixSeparator.length);
     return true;
   } else {
     return false;
@@ -108,9 +108,9 @@ curl -H "x-auth-organization: fb-test" \
   "localhost/proxy/api/metadata/workflow/2/2" -X DELETE
 */
 function deleteWorkflowBefore(tenantId, req, res, proxyCallback) {
-  const tenantWithUnderscore = withUnderscore(tenantId);
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   // change URL: add prefix to name
-  const name = tenantWithUnderscore + req.params.name;
+  const name = tenantWithInfixSeparator + req.params.name;
   const newUrl = `/api/metadata/workflow/${name}/${req.params.version}`;
   logger.debug(`Transformed url from '${req.url}' to '${newUrl}'`);
   req.url = newUrl;
@@ -124,8 +124,8 @@ curl -H "x-auth-organization: fb-test" \
   "localhost/proxy/api/metadata/workflow/fx3?version=1"
 */
 function getWorkflowBefore(tenantId, req, res, proxyCallback) {
-  const tenantWithUnderscore = withUnderscore(tenantId);
-  const name = tenantWithUnderscore + req.params.name;
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
+  const name = tenantWithInfixSeparator + req.params.name;
   let newUrl = `/api/metadata/workflow/${name}`;
   const originalQueryString = req._parsedUrl.query;
   const parsedQuery = qs.parse(originalQueryString);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
@@ -17,7 +17,7 @@ import {
   createProxyOptionsBuffer,
   removeTenantPrefix,
   removeTenantPrefixes,
-  withUnderscore,
+  withInfixSeparator,
 } from '../utils.js';
 
 const logger = logging.getLogger(module);
@@ -69,7 +69,7 @@ curl -X POST -H "x-auth-organization: fb-test" -H \
 */
 function postWorkflowBefore(tenantId, req, res, proxyCallback) {
   // name must start with prefix
-  const tenantWithUnderscore = withUnderscore(tenantId);
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   const reqObj = req.body;
 
   // workflowDef section is not allowed (no dynamic workflows)
@@ -92,7 +92,7 @@ function postWorkflowBefore(tenantId, req, res, proxyCallback) {
   // add taskToDomain
   reqObj.taskToDomain = {};
   //TODO: is this OK?
-  reqObj.taskToDomain[tenantWithUnderscore + '*'] = tenantId;
+  reqObj.taskToDomain[tenantWithInfixSeparator + '*'] = tenantId;
   logger.debug(`Transformed request to ${JSON.stringify(reqObj)}`);
   proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
 }
@@ -138,8 +138,8 @@ function removeWorkflowBefore(tenantId, req, res, proxyCallback) {
     logger.debug(`Got status code: ${response.statusCode}, body: '${body}'`);
     const workflow = JSON.parse(body);
     // make sure name starts with prefix
-    const tenantWithUnderscore = withUnderscore(tenantId);
-    if (workflow.workflowName.indexOf(tenantWithUnderscore) == 0) {
+    const tenantWithInfixSeparator = withInfixSeparator(tenantId);
+    if (workflow.workflowName.indexOf(tenantWithInfixSeparator) == 0) {
       proxyCallback();
     } else {
       logger.error(

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
@@ -13,7 +13,7 @@ import logging from '@fbcnms/logging';
 import qs from 'qs';
 import request from 'request';
 import {
-  INFIX_SEPARATOR,
+  addTenantIdPrefix,
   createProxyOptionsBuffer,
   removeTenantPrefix,
   removeTenantPrefixes,
@@ -87,15 +87,8 @@ function postWorkflowBefore(tenantId, req, res, proxyCallback) {
     throw 'Section taskToDomain is not allowed';
   }
 
-  // name should not contain _
-  if (reqObj.name.indexOf(INFIX_SEPARATOR) > -1) {
-    logger.error(
-      `Name must not contain '${INFIX_SEPARATOR}': '${JSON.stringify(reqObj)}'`,
-    );
-    throw 'Name must not contain INFIX_SEPARATOR'; // TODO create Exception class
-  }
   // add prefix
-  reqObj.name = tenantWithUnderscore + reqObj.name;
+  addTenantIdPrefix(tenantId, reqObj);
   // add taskToDomain
   reqObj.taskToDomain = {};
   //TODO: is this OK?

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow.js
@@ -13,6 +13,7 @@ import logging from '@fbcnms/logging';
 import qs from 'qs';
 import request from 'request';
 import {
+  INFIX_SEPARATOR,
   createProxyOptionsBuffer,
   removeTenantPrefix,
   removeTenantPrefixes,
@@ -87,9 +88,11 @@ function postWorkflowBefore(tenantId, req, res, proxyCallback) {
   }
 
   // name should not contain _
-  if (reqObj.name.indexOf('_') > -1) {
-    logger.error(`Name must not contain underscore ${JSON.stringify(reqObj)}`);
-    throw 'Name must not contain underscore'; // TODO create Exception class
+  if (reqObj.name.indexOf(INFIX_SEPARATOR) > -1) {
+    logger.error(
+      `Name must not contain '${INFIX_SEPARATOR}': '${JSON.stringify(reqObj)}'`,
+    );
+    throw 'Name must not contain INFIX_SEPARATOR'; // TODO create Exception class
   }
   // add prefix
   reqObj.name = tenantWithUnderscore + reqObj.name;
@@ -111,7 +114,6 @@ function getExecutionStatusAfter(tenantId, req, respObj) {
     workflowName: false,
     workflowType: false,
     'tasks[*].taskDefName': true,
-    'tasks[*].taskType': true,
     'tasks[*].workflowTask.name': true,
     'tasks[*].workflowTask.taskDefinition.name': true,
     'tasks[*].workflowType': false,

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -38,12 +38,40 @@ const SYSTEM_TASK_TYPES = [
   'DO_WHILE',
 ];
 
-export function isAllowedSystemTask(task) {
+function isAllowedSystemTask(task) {
   return SYSTEM_TASK_TYPES.includes(task.type);
+}
+
+export function assertAllowedSystemTask(task) {
+  if (!isAllowedSystemTask(task)) {
+    logger.error(
+      `Task type is not allowed: ` + ` in '${JSON.stringify(task)}'`,
+    );
+    // TODO create Exception class
+    throw 'Task type is not allowed';
+  }
 }
 
 export function withUnderscore(s) {
   return s + INFIX_SEPARATOR;
+}
+
+export function addTenantIdPrefix(tenantId, objectWithName) {
+  const tenantWithUnderscore = withUnderscore(tenantId);
+  objectWithName.name =
+    tenantWithUnderscore +
+    assertNameIsWithoutInfixSeparator(objectWithName).name;
+}
+
+export function assertNameIsWithoutInfixSeparator(objectWithName) {
+  if (objectWithName.name.indexOf(INFIX_SEPARATOR) > -1) {
+    logger.error(
+      `Name must not contain '${INFIX_SEPARATOR}'` +
+        ` in '${JSON.stringify(objectWithName)}'`,
+    );
+    // TODO create Exception class
+    throw 'Name must not contain underscore';
+  }
 }
 
 export function getTenantId(req) {

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -56,14 +56,14 @@ export function assertAllowedSystemTask(task) {
   }
 }
 
-export function withUnderscore(s) {
+export function withInfixSeparator(s) {
   return s + INFIX_SEPARATOR;
 }
 
 export function addTenantIdPrefix(tenantId, objectWithName) {
-  const tenantWithUnderscore = withUnderscore(tenantId);
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   objectWithName.name =
-    tenantWithUnderscore +
+    tenantWithInfixSeparator +
     assertNameIsWithoutInfixSeparator(objectWithName).name;
 }
 
@@ -114,8 +114,8 @@ export function createProxyOptionsBuffer(modifiedBody, req) {
 // Setting allowGlobal to true implies that tasks are being processed,
 // those starting with global prefix will not be touched.
 export function removeTenantPrefix(tenantId, json, jsonPath, allowGlobal) {
-  const tenantWithUnderscore = withUnderscore(tenantId);
-  const globalPrefix = withUnderscore(GLOBAL_PREFIX);
+  const tenantWithInfixSeparator = withInfixSeparator(tenantId);
+  const globalPrefix = withInfixSeparator(GLOBAL_PREFIX);
   const result = findValuesByJsonPath(json, jsonPath);
   for (const idx in result) {
     const item = result[idx];
@@ -124,7 +124,7 @@ export function removeTenantPrefix(tenantId, json, jsonPath, allowGlobal) {
       continue;
     }
     // expect tenantId prefix
-    if (prop.indexOf(tenantWithUnderscore) != 0) {
+    if (prop.indexOf(tenantWithInfixSeparator) != 0) {
       logger.error(
         `Name must start with tenantId prefix` +
           `tenantId:'${tenantId}',json:'${json}',jsonPath:'${jsonPath}'` +
@@ -133,7 +133,9 @@ export function removeTenantPrefix(tenantId, json, jsonPath, allowGlobal) {
       throw 'Name must start with tenantId prefix'; // TODO create Exception class
     }
     // remove prefix
-    item.parent[item.parentProperty] = prop.substr(tenantWithUnderscore.length);
+    item.parent[item.parentProperty] = prop.substr(
+      tenantWithInfixSeparator.length,
+    );
   }
 }
 

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -15,7 +15,6 @@ import {JSONPath} from 'jsonpath-plus';
 const logger = logging.getLogger(module);
 
 // Global prefix for taskdefs which can be used by all tenants.
-// TODO: can we come up with an invalid tenant name?
 export const GLOBAL_PREFIX = 'GLOBAL';
 
 // This is used to separate tenant id from name in workflowdefs and taskdefs
@@ -87,11 +86,6 @@ export function getTenantId(req) {
   return tenantId;
 }
 
-// TODO: deprecated, use removeTenantPrefix
-export function removeTenantId(json, attr, tenantId) {
-  removeTenantPrefix(tenantId, json, attr, false);
-}
-
 export function createProxyOptionsBuffer(modifiedBody, req) {
   // if request transformer returned modified body,
   // serialize it to new request stream. Original
@@ -111,6 +105,9 @@ export function createProxyOptionsBuffer(modifiedBody, req) {
   return streamify(modifiedBody);
 }
 
+// Mass remove tenant prefix from json object.
+// Setting allowGlobal to true implies that tasks are being processed,
+// those starting with global prefix will not be touched.
 export function removeTenantPrefix(tenantId, json, jsonPath, allowGlobal) {
   const tenantWithUnderscore = withUnderscore(tenantId);
   const globalPrefix = withUnderscore(GLOBAL_PREFIX);
@@ -135,6 +132,7 @@ export function removeTenantPrefix(tenantId, json, jsonPath, allowGlobal) {
   }
 }
 
+// See removeTenantPrefix
 export function removeTenantPrefixes(tenantId, json, jsonPathToAllowGlobal) {
   for (const key in jsonPathToAllowGlobal) {
     removeTenantPrefix(tenantId, json, key, jsonPathToAllowGlobal[key]);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -20,11 +20,12 @@ export const GLOBAL_PREFIX = 'GLOBAL';
 // This is used to separate tenant id from name in workflowdefs and taskdefs
 export const INFIX_SEPARATOR = '___';
 
+const SUB_WORKFLOW = 'SUB_WORKFLOW';
 const SYSTEM_TASK_TYPES = [
+  SUB_WORKFLOW,
   'DECISION',
   'EVENT',
   'HTTP',
-  'SUB_WORKFLOW',
   'FORK',
   'FORK_JOIN_DYNAMIC',
   'JOIN',
@@ -39,6 +40,10 @@ const SYSTEM_TASK_TYPES = [
 
 function isAllowedSystemTask(task) {
   return SYSTEM_TASK_TYPES.includes(task.type);
+}
+
+export function isSubworkflowTask(task) {
+  return SUB_WORKFLOW === task.type;
 }
 
 export function assertAllowedSystemTask(task) {

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -62,9 +62,8 @@ export function withInfixSeparator(s) {
 
 export function addTenantIdPrefix(tenantId, objectWithName) {
   const tenantWithInfixSeparator = withInfixSeparator(tenantId);
-  objectWithName.name =
-    tenantWithInfixSeparator +
-    assertNameIsWithoutInfixSeparator(objectWithName).name;
+  assertNameIsWithoutInfixSeparator(objectWithName);
+  objectWithName.name = tenantWithInfixSeparator + objectWithName.name;
 }
 
 export function assertNameIsWithoutInfixSeparator(objectWithName) {

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -18,8 +18,32 @@ const logger = logging.getLogger(module);
 // TODO: can we come up with an invalid tenant name?
 export const GLOBAL_PREFIX = 'GLOBAL';
 
+// This is used to separate tenant id from name in workflowdefs and taskdefs
+export const INFIX_SEPARATOR = '___';
+
+const SYSTEM_TASK_TYPES = [
+  'DECISION',
+  'EVENT',
+  'HTTP',
+  'SUB_WORKFLOW',
+  'FORK',
+  'FORK_JOIN_DYNAMIC',
+  'JOIN',
+  'EXCLUSIVE_JOIN',
+  'WAIT',
+  'DYNAMIC',
+  'LAMBDA',
+  'TERMINATE',
+  'KAFKA_PUBLISH',
+  'DO_WHILE',
+];
+
+export function isAllowedSystemTask(task) {
+  return SYSTEM_TASK_TYPES.includes(task.type);
+}
+
 export function withUnderscore(s) {
-  return s + '_';
+  return s + INFIX_SEPARATOR;
 }
 
 export function getTenantId(req) {

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -14,10 +14,12 @@ import bodyParser from 'body-parser';
 import filter from 'lodash/fp/filter';
 import forEach from 'lodash/fp/forEach';
 import identity from 'lodash/fp/identity';
+import logging from '@fbcnms/logging';
 import map from 'lodash/fp/map';
 import moment from 'moment';
 import transform from 'lodash/fp/transform';
 
+const logger = logging.getLogger(module);
 const http = HttpClient;
 
 //TODO merge with proxy
@@ -29,15 +31,6 @@ const baseURLTask = baseURL + 'tasks/';
 
 router.use(bodyParser.urlencoded({extended: false}));
 router.use('/', bodyParser.json());
-
-router.get('/metadata/taskdefs', async (req, res, next) => {
-  try {
-    const result = await http.get(baseURLMeta + 'taskdefs', req);
-    res.status(200).send({result});
-  } catch (err) {
-    next(err);
-  }
-});
 
 router.get('/metadata/taskdefs', async (req, res, next) => {
   try {
@@ -126,6 +119,26 @@ router.put('/metadata', async (req, res, next) => {
   } catch (err) {
     res.status(400).send(err.response.body);
     next(err);
+  }
+});
+
+// Conductor only allows POST for event handler creation
+// and PUT for updating. This code works around the issue by
+// trying PUT if POST fails.
+router.post('/event', async (req, res, next) => {
+  try {
+    const result = await http.post(baseURL + 'event', req.body, req);
+    res.status(200).send(result);
+  } catch (err) {
+    logger.info(`Got exception ${JSON.stringify(err)} while POSTing event`);
+    try {
+      const result = await http.put(baseURL + 'event', req.body, req);
+      res.status(200).send(result);
+    } catch (e) {
+      logger.info(`Got exception ${JSON.stringify(e)} while PUTting event`);
+      res.status(400).send('Post and Put failed');
+      next(e);
+    }
   }
 });
 
@@ -458,6 +471,7 @@ router.get('/hierarchical', async (req, res, next) => {
   }
 });
 
+// TODO not implemented on proxy
 router.get('/queue/data', async (req, res, next) => {
   try {
     const sizes = await http.get(baseURLTask + 'queue/all', req);

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -10,6 +10,7 @@
 
 import HttpClient from './HttpServerSide';
 import Router from 'express';
+import bodyParser from 'body-parser';
 import filter from 'lodash/fp/filter';
 import forEach from 'lodash/fp/forEach';
 import identity from 'lodash/fp/identity';
@@ -19,12 +20,15 @@ import transform from 'lodash/fp/transform';
 
 const http = HttpClient;
 
-const router = Router();
 //TODO merge with proxy
+const router = Router();
 const baseURL = 'localhost/proxy/api/';
 const baseURLWorkflow = baseURL + 'workflow/';
 const baseURLMeta = baseURL + 'metadata/';
 const baseURLTask = baseURL + 'tasks/';
+
+router.use(bodyParser.urlencoded({extended: false}));
+router.use('/', bodyParser.json());
 
 router.get('/metadata/taskdefs', async (req, res, next) => {
   try {


### PR DESCRIPTION
Summary:
* Add /event API endpoint
* Add explicit list of allowed system task types.
* Change infix separator from '_' to '___'

Event handler proxy is currently not prefixing event names. This will be fixed later.
