### PR TITLE
Fix CWAG DPI install logic in install_gateway.sh and helm chart

### DIFF
--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -20,3 +20,4 @@ CONFIGS_TEMPLATES_PATH=/etc/magma/templates
 CERTS_VOLUME=/var/opt/magma/certs
 CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
 CONFIGS_DEFAULT_VOLUME=/etc/magma
+SECRETS_VOLUME=/var/opt/magma/secrets

--- a/cwf/gateway/helm/cwf/Chart.yaml
+++ b/cwf/gateway/helm/cwf/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: "1.0"
 description: Magma Carrier Gateway
 name: cwf
-version: 0.1.6
+version: 0.1.7
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/cwf/gateway/helm/cwf/README.md
+++ b/cwf/gateway/helm/cwf/README.md
@@ -70,7 +70,7 @@ The following table list the configurable parameters of the orchestrator chart a
 | `manifests.service` | Enable cwf service. | `True` |
 | `manifests.rbac` | Enable cwf rbac. | `True` |
 | `secrets.create` | Enable cwf secret creation | `False` |
-| `secret.gwinfo`   | Secret name containing cwf gwinfo | `cwf-secrets-gwinfo`
+| `secret.gwinfo`   | Secret name containing cwf gwinfo | `cwf-secrets-gwinfo` |
 | `cwf.type` | Gateway type argument. | `cwf` |
 | `cwf.image.docker_registry` | CWF docker registry host. | `docker.io` |
 | `cwf.image.tag` | CWF docker images tag. | `latest` |
@@ -121,13 +121,13 @@ The following table list the configurable parameters of the orchestrator chart a
     f3bc383a95db16f2e448fdf67cac133a5f9019375720b59477aebc96bacd05a9
 
     Run the following, substituting your container ID:
-    $ docker cp <container ID>:/etc/snowflake charts/secrets/.secrets
-    $ docker cp <container ID>:/var/opt/magma/certs/gw_challenge.key /charts/secrets/.secrets 
+    $ docker cp <container ID>:/etc/snowflake charts/secrets/.secrets/gwinfo
+    $ docker cp <container ID>:/var/opt/magma/certs/gw_challenge.key /charts/secrets/.secrets/gwinfo
     ```
    
     If you're instead upgrading your gateway to have persistent gwinfo,
     copy the `etc/snowflake` and `/var/opt/magma/certs/gw_challenge.key` from 
-    your gateway to `charts/secrets/.secrets` of where this chart is stored.
+    your gateway to `charts/secrets/.secrets/gwinfo` of where this chart is stored.
 
     Ensure that `secrets.create` is set to true in your vals.yaml override
 
@@ -163,5 +163,4 @@ The following table list the configurable parameters of the orchestrator chart a
    ```
 
 4. Login to NMS Dahsboard and register New Gateway
-
 

--- a/cwf/gateway/helm/cwf/charts/secrets/README.md
+++ b/cwf/gateway/helm/cwf/charts/secrets/README.md
@@ -8,9 +8,9 @@ with the same hwid and challenge key.
 
 ```bash
 # Copy secrets into subchart root
-$ mkdir charts/secrets/.secrets && \
-    cp -r <secrets>/* charts/secrets/.secrets/
-$ ls charts/secrets/.secrets
+$ mkdir charts/secrets/.secrets/gwinfo && \
+    cp -r <secrets>/* charts/secrets/.secrets/gwinfo/
+$ ls charts/secrets/.secrets/gwinfo/
 snowflake gw_challenge.key
 
 # Apply secrets
@@ -25,7 +25,7 @@ This chart installs a secret that serves as identifiers for the gateway.
 The secrets are expected to be provided as files and placed under
 secrets subchart root.
 ```bash
-$ ls charts/secrets/.secrets
+$ ls charts/secrets/.secrets/gwinfo/
 snowflake  gw_challenge.key
 $ pwd
 magma/cwf/gateway/helm/cwf

--- a/cwf/gateway/helm/cwf/charts/secrets/templates/dpi_license.secret.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/templates/dpi_license.secret.yaml
@@ -5,15 +5,14 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
+{{- if .Values.create }}
 apiVersion: v1
-appVersion: "1.0"
-description: A Helm chart to create magma cwf gateway secrets
-name: secrets
-version: 0.1.1
-engine: gotpl
-sources:
-  - https://github.com/facebookincubator/magma
-keywords:
-  - magma
-  - cwf
-  - secrets
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-secrets-dpi
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ tuple . "cwf" "gateway" | include "labels" | indent 4 }}
+data:
+{{- (.Files.Glob (print .Values.secret.dpi_license "/*")).AsSecrets | nindent 2 }}
+{{- end }}

--- a/cwf/gateway/helm/cwf/charts/secrets/values.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/values.yaml
@@ -13,5 +13,7 @@ secret:
    # directory holding orc8r cert secrets (needed to get rootCA.pem)
   certs: orc8r-secrets-certs
   # directory holding gateway's hwid (snowflake) and challenge key
-  gwinfo: .secrets
+  gwinfo: .secrets/gwinfo
+  # directory holding gateway's DPI license file
+  dpi_license: .secrets/dpi
 

--- a/cwf/gateway/helm/cwf/charts/secrets/values.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/values.yaml
@@ -10,10 +10,7 @@ create: true
 
 # Define which secrets should be mounted by pods.
 secret:
-   # directory holding orc8r cert secrets (needed to get rootCA.pem)
-  certs: orc8r-secrets-certs
   # directory holding gateway's hwid (snowflake) and challenge key
   gwinfo: .secrets/gwinfo
   # directory holding gateway's DPI license file
   dpi_license: .secrets/dpi
-

--- a/cwf/gateway/helm/cwf/requirements.yaml
+++ b/cwf/gateway/helm/cwf/requirements.yaml
@@ -7,6 +7,6 @@
 
 dependencies:
   - name: secrets
-    version: 0.1.0
+    version: 0.1.1
     repository: ""
     condition: secrets.create

--- a/cwf/gateway/helm/cwf/templates/bin/_env.tpl
+++ b/cwf/gateway/helm/cwf/templates/bin/_env.tpl
@@ -26,6 +26,11 @@ CONFIGS_TEMPLATES_PATH=/etc/magma/templates
 CERTS_VOLUME=/var/opt/magma/certs
 CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
 CONFIGS_DEFAULT_VOLUME=/etc/magma
+SECRETS_VOLUME=/var/opt/magma/secrets
+
+{{ if .Values.cwf.dpi }}
+DPI_LICENSE_NAME={{ .Values.cwf.dpi.dpi_license_name }}
+{{- end }}
 
 {{ if .Values.cwf.env }}
 {{ .Values.cwf.env }}

--- a/cwf/gateway/helm/cwf/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf/templates/bin/_install_gateway.sh.tpl
@@ -101,9 +101,6 @@ if [ "$GW_TYPE" == "$FEG" ]; then
 fi
 
 cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose.yml .
-if [ "$GW_TYPE" == "$CWAG" ]; then
-cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml .
-fi
 cp "$INSTALL_DIR"/magma/orc8r/tools/docker/recreate_services.sh .
 cp "$INSTALL_DIR"/magma/orc8r/tools/docker/recreate_services_cron .
 
@@ -162,14 +159,27 @@ cp .env /var/opt/magma/docker/
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
 
+# When DPI is enabled
+if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
+  MODULE_DIR="cwf"
+  mkdir -p /var/opt/magma/secrets
+  cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml /var/opt/magma/docker/
+  cp "$DPI_LICENSE_NAME" /var/opt/magma/secrets/
+fi
+
 cd /var/opt/magma/docker
 
-{{- if and .Values.cwf.image.username .Values.cwf.image.password }}
+if [ ! -z "$DOCKER_USERNAME" ] && [ ! -z "$DOCKER_PASSWORD" ] && [ ! -z "$DOCKER_REGISTRY" ]; then
 echo "Logging into docker registry at $DOCKER_REGISTRY"
-docker login "$DOCKER_REGISTRY" --username {{ .Values.cwf.image.username }} --password {{ .Values.cwf.image.password }}
-{{- end }}
+docker login "$DOCKER_REGISTRY" --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
+fi
 docker-compose pull
 docker-compose -f docker-compose.yml up -d
 
+# When DPI is enabled
+if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
+  docker-compose -f docker-compose-dpi.override.yml pull
+  docker-compose -f docker-compose-dpi.override.yml up -d
+fi
 
 echo "Installed successfully!!"

--- a/cwf/gateway/helm/cwf/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf/templates/bin/_install_gateway.sh.tpl
@@ -159,12 +159,12 @@ cp .env /var/opt/magma/docker/
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
 
-# When DPI is enabled
+# Copy DPI docker files
 if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
   MODULE_DIR="cwf"
-  mkdir -p /var/opt/magma/secrets
+  mkdir -p "$SECRETS_VOLUME"
   cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml /var/opt/magma/docker/
-  cp "$DPI_LICENSE_NAME" /var/opt/magma/secrets/
+  cp "$DPI_LICENSE_NAME" "$SECRETS_VOLUME"
 fi
 
 cd /var/opt/magma/docker
@@ -176,7 +176,7 @@ fi
 docker-compose pull
 docker-compose -f docker-compose.yml up -d
 
-# When DPI is enabled
+# Pull and Run DPI container
 if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
   docker-compose -f docker-compose-dpi.override.yml pull
   docker-compose -f docker-compose-dpi.override.yml up -d

--- a/cwf/gateway/helm/cwf/templates/deployment.yaml
+++ b/cwf/gateway/helm/cwf/templates/deployment.yaml
@@ -187,6 +187,11 @@ spec:
             - name: {{ $envAll.Values.secret.configs.cwf }}
               mountPath: /var/opt/magma/configs
             {{- end }}
+            {{- if .Values.secret.dpi_license }}
+            - name: cwf-dpi-license
+              mountPath: /opt/magma/{{ $envAll.Values.cwf.dpi.dpi_license_name }}
+              subPath: {{ $envAll.Values.cwf.dpi.dpi_license_name }}
+            {{- end }}
       volumes:
         {{- if .Values.secret.gwinfo }}
         - name: hwid
@@ -212,5 +217,10 @@ spec:
         - name: {{ $envAll.Values.secret.configs.cwf }}
           secret:
             secretName: {{ $envAll.Values.secret.configs.cwf }}
+        {{- end }}
+        {{- if .Values.secret.dpi_license }}
+        - name: cwf-dpi-license
+          secret:
+            secretName: {{ required "secret.dpi_license must be provided" .Values.secret.dpi_license }}
         {{- end }}
 {{- end }}

--- a/cwf/gateway/helm/cwf/values.yaml
+++ b/cwf/gateway/helm/cwf/values.yaml
@@ -25,6 +25,7 @@ secrets:
 secret:
   certs: orc8r-secrets-certs
   gwinfo: cwf-secrets-gwinfo
+#  dpi_licence: cwf-secrets-dpi
 
 ## Key Values for docker inside VM
 cwf:
@@ -43,8 +44,10 @@ cwf:
   repo:
     url: https://github.com/facebookincubator/magma.git
     branch: master
-#  env: |
-#    DPI_LICENSE_NAME=123
+#  dpi:
+#    dpi_license_name: cwf01.bin
+#  env:
+#    key=value
 
 ## Key Values for VM running using virtlet runtime
 image:

--- a/cwf/gateway/helm/cwf/values.yaml
+++ b/cwf/gateway/helm/cwf/values.yaml
@@ -24,7 +24,7 @@ secrets:
 # Define which secrets should be mounted by pods.
 secret:
   certs: orc8r-secrets-certs
-  gwinfo: cwf-secrets-gwinfo
+#  gwinfo: cwf-secrets-gwinfo
 #  dpi_licence: cwf-secrets-dpi
 
 ## Key Values for docker inside VM
@@ -45,8 +45,8 @@ cwf:
     url: https://github.com/facebookincubator/magma.git
     branch: master
 #  dpi:
-#    dpi_license_name: cwf01.bin
-#  env:
+#    dpi_license_name: cwftest.bin
+#  env: |
 #    key=value
 
 ## Key Values for VM running using virtlet runtime

--- a/feg/gateway/helm/feg/Chart.yaml
+++ b/feg/gateway/helm/feg/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: "1.0"
 description: Magma Federated Gateway
 name: feg
-version: 0.1.5
+version: 0.1.6
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/feg/gateway/helm/feg/templates/bin/_install_gateway.sh.tpl
+++ b/feg/gateway/helm/feg/templates/bin/_install_gateway.sh.tpl
@@ -101,9 +101,6 @@ if [ "$GW_TYPE" == "$FEG" ]; then
 fi
 
 cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose.yml .
-if [ "$GW_TYPE" == "$CWAG" ]; then
-cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml .
-fi
 cp "$INSTALL_DIR"/magma/orc8r/tools/docker/recreate_services.sh .
 cp "$INSTALL_DIR"/magma/orc8r/tools/docker/recreate_services_cron .
 
@@ -162,13 +159,27 @@ cp .env /var/opt/magma/docker/
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
 
+# When DPI is enabled
+if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
+  MODULE_DIR="cwf"
+  mkdir -p /var/opt/magma/secrets
+  cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml /var/opt/magma/docker/
+  cp "$DPI_LICENSE_NAME" /var/opt/magma/secrets/
+fi
+
 cd /var/opt/magma/docker
 
-{{- if and .Values.feg.image.username .Values.feg.image.password }}
+if [ ! -z "$DOCKER_USERNAME" ] && [ ! -z "$DOCKER_PASSWORD" ] && [ ! -z "$DOCKER_REGISTRY" ]; then
 echo "Logging into docker registry at $DOCKER_REGISTRY"
-docker login "$DOCKER_REGISTRY" --username {{ .Values.feg.image.username }} --password {{ .Values.feg.image.password }}
-{{- end }}
+docker login "$DOCKER_REGISTRY" --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
+fi
 docker-compose pull
 docker-compose -f docker-compose.yml up -d
+
+# When DPI is enabled
+if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
+  docker-compose -f docker-compose-dpi.override.yml pull
+  docker-compose -f docker-compose-dpi.override.yml up -d
+fi
 
 echo "Installed successfully!!"

--- a/feg/gateway/helm/feg/templates/bin/_install_gateway.sh.tpl
+++ b/feg/gateway/helm/feg/templates/bin/_install_gateway.sh.tpl
@@ -159,12 +159,12 @@ cp .env /var/opt/magma/docker/
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
 
-# When DPI is enabled
+# Copy DPI docker files
 if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
   MODULE_DIR="cwf"
-  mkdir -p /var/opt/magma/secrets
+  mkdir -p "$SECRETS_VOLUME"
   cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml /var/opt/magma/docker/
-  cp "$DPI_LICENSE_NAME" /var/opt/magma/secrets/
+  cp "$DPI_LICENSE_NAME" "$SECRETS_VOLUME"
 fi
 
 cd /var/opt/magma/docker
@@ -176,7 +176,7 @@ fi
 docker-compose pull
 docker-compose -f docker-compose.yml up -d
 
-# When DPI is enabled
+# Pull and Run DPI container
 if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
   docker-compose -f docker-compose-dpi.override.yml pull
   docker-compose -f docker-compose-dpi.override.yml up -d

--- a/feg/gateway/helm/feg/values.yaml
+++ b/feg/gateway/helm/feg/values.yaml
@@ -24,7 +24,7 @@ secrets:
 # Define which secrets should be mounted by pods.
 secret:
   certs: orc8r-secrets-certs
-  gwinfo: feg-secrets-gwinfo
+#  gwinfo: feg-secrets-gwinfo
 
 ## Key Values for docker inside VM
 feg:

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -107,10 +107,6 @@ if [ "$GW_TYPE" == "$FEG" ]; then
 fi
 
 cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose.yml .
-if [ "$GW_TYPE" == "$CWAG" ]; then
-  cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml .
-fi
-
 cp "$INSTALL_DIR"/magma/orc8r/tools/docker/recreate_services.sh .
 cp "$INSTALL_DIR"/magma/orc8r/tools/docker/recreate_services_cron .
 
@@ -169,11 +165,27 @@ cp .env /var/opt/magma/docker/
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
 
+# When DPI is enabled
+if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
+  MODULE_DIR="cwf"
+  mkdir -p /var/opt/magma/secrets
+  cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml /var/opt/magma/docker/
+  cp "$DPI_LICENSE_NAME" /var/opt/magma/secrets/
+fi
+
 cd /var/opt/magma/docker
 
-echo "Logging into docker registry at $DOCKER_REGISTRY"
-docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REGISTRY"
+if [ ! -z "$DOCKER_USERNAME" ] && [ ! -z "$DOCKER_PASSWORD" ] && [ ! -z "$DOCKER_REGISTRY" ]; then
+ echo "Logging into docker registry at $DOCKER_REGISTRY"
+ docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD" "$DOCKER_REGISTRY"
+fi
 docker-compose pull
 docker-compose -f docker-compose.yml up -d
+
+# When DPI is enabled
+if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
+  docker-compose -f docker-compose-dpi.override.yml pull
+  docker-compose -f docker-compose-dpi.override.yml up -d
+fi
 
 echo "Installed successfully!!"

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -165,12 +165,12 @@ cp .env /var/opt/magma/docker/
 cp recreate_services.sh /var/opt/magma/docker/
 cp recreate_services_cron /etc/cron.d/
 
-# When DPI is enabled
+# Copy DPI docker files
 if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
   MODULE_DIR="cwf"
-  mkdir -p /var/opt/magma/secrets
+  mkdir -p "$SECRETS_VOLUME"
   cp "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/docker/docker-compose-dpi.override.yml /var/opt/magma/docker/
-  cp "$DPI_LICENSE_NAME" /var/opt/magma/secrets/
+  cp "$DPI_LICENSE_NAME" "$SECRETS_VOLUME"
 fi
 
 cd /var/opt/magma/docker
@@ -182,7 +182,7 @@ fi
 docker-compose pull
 docker-compose -f docker-compose.yml up -d
 
-# When DPI is enabled
+# Pull and Run DPI container
 if [ "$GW_TYPE" == "$CWAG" ] && [ -f "$DPI_LICENSE_NAME" ]; then
   docker-compose -f docker-compose-dpi.override.yml pull
   docker-compose -f docker-compose-dpi.override.yml up -d


### PR DESCRIPTION
  This PR Summary:

        Fix CWAG DPI install logic.
        Fix Docker login condition when enabled.
        Update cwf secrets subchart to have DPI license file
        Bump helm chart version to 1.0.7