### PR TITLE
Updating use_stateless check usages

### DIFF
--- a/lte/gateway/c/oai/include/state_manager.h
+++ b/lte/gateway/c/oai/include/state_manager.h
@@ -159,20 +159,17 @@ class StateManager {
       is_initialized,
       "StateManager init() function should be called to initialize state");
 
-    if(persist_state_enabled) {
-      ProtoUe ue_proto = ProtoUe();
-      StateConverter::ue_to_proto(ue_context, &ue_proto);
-      std::string key = IMSI_PREFIX + imsi_str + ":" + task_name;
-      if (redis_client->write_proto(key, ue_proto) != RETURNok) {
-        OAILOG_ERROR(
-          log_task,
-          "Failed to write UE state to db for IMSI %s",
+    ProtoUe ue_proto = ProtoUe();
+    StateConverter::ue_to_proto(ue_context, &ue_proto);
+    std::string key = IMSI_PREFIX + imsi_str + ":" + task_name;
+    if (redis_client->write_proto(key, ue_proto) != RETURNok) {
+      OAILOG_ERROR(
+          log_task, "Failed to write UE state to db for IMSI %s",
           imsi_str.c_str());
-        return;
-      }
-      OAILOG_DEBUG(
-        log_task, "Finished writing UE state for IMSI %s", imsi_str.c_str());
+      return;
     }
+    OAILOG_DEBUG(
+        log_task, "Finished writing UE state for IMSI %s", imsi_str.c_str());
   }
 
   std::string get_imsi_str(imsi64_t imsi64)
@@ -207,6 +204,11 @@ class StateManager {
    * Virtual function for freeing state_cache_p
    */
   virtual void free_state() = 0;
+
+  bool is_persist_state_enabled() const
+  {
+    return persist_state_enabled;
+  }
 
  protected:
   StateManager():
@@ -247,6 +249,8 @@ class StateManager {
   bool state_dirty;
   // Flag for enabling writing and reading to db.
   bool persist_state_enabled;
+
+ protected:
   std::string table_key;
   std::string task_name;
   log_proto_t log_task;

--- a/lte/gateway/c/oai/include/state_manager.h
+++ b/lte/gateway/c/oai/include/state_manager.h
@@ -83,7 +83,7 @@ class StateManager {
       is_initialized,
       "StateManager init() function should be called to initialize state");
 
-    return state_imsi_ht;
+    return state_ue_ht;
   }
 
   /**
@@ -117,7 +117,7 @@ class StateManager {
       StateConverter::proto_to_ue(ue_proto, ue_context);
 
       hashtable_ts_insert(
-        state_imsi_ht, get_imsi_from_key(key), (void*) ue_context);
+        state_ue_ht, get_imsi_from_key(key), (void*) ue_context);
       OAILOG_DEBUG(log_task, "Reading UE state from db for %s", key.c_str());
     }
     return RETURNok;
@@ -214,7 +214,7 @@ class StateManager {
     state_dirty(false),
     persist_state_enabled(false),
     state_cache_p(nullptr),
-    state_imsi_ht(nullptr),
+    state_ue_ht(nullptr),
     log_task(LOG_UTIL),
     redis_client(std::make_unique<RedisClient>())
   {
@@ -237,7 +237,7 @@ class StateManager {
 
   // TODO: Make this a unique_ptr
   StateType* state_cache_p;
-  hash_table_ts_t* state_imsi_ht;
+  hash_table_ts_t* state_ue_ht;
   // TODO: Revisit one shared connection for all types of state
   std::unique_ptr<RedisClient> redis_client;
   // Flag for check asserting if the state has been initialized.

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state.cpp
@@ -71,14 +71,16 @@ hash_table_ts_t* get_mme_ue_state()
 
 void put_mme_ue_state(mme_app_desc_t* mme_app_desc_p, imsi64_t imsi64)
 {
-  if (imsi64 != INVALID_IMSI64) {
-    ue_mm_context_t* ue_context = NULL;
-    ue_context =
-      mme_ue_context_exists_imsi(&mme_app_desc_p->mme_ue_contexts, imsi64);
-    if(ue_context) {
-      auto imsi_str = MmeNasStateManager::getInstance().get_imsi_str(imsi64);
-      MmeNasStateManager::getInstance().write_ue_state_to_db(
-        ue_context, imsi_str);
+  if(MmeNasStateManager::getInstance().is_persist_state_enabled()) {
+    if (imsi64 != INVALID_IMSI64) {
+      ue_mm_context_t* ue_context = NULL;
+      ue_context =
+          mme_ue_context_exists_imsi(&mme_app_desc_p->mme_ue_contexts, imsi64);
+      if (ue_context) {
+        auto imsi_str = MmeNasStateManager::getInstance().get_imsi_str(imsi64);
+        MmeNasStateManager::getInstance().write_ue_state_to_db(
+            ue_context, imsi_str);
+      }
     }
   }
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_manager.cpp
@@ -156,7 +156,7 @@ void MmeNasStateManager::create_hashtables() {
       "Problem with mme_ue_s1ap_id_ue_context_htbl in MME_APP");
   btrunc(b, 0);
   bassigncstr(b, UE_ID_UE_CTXT_TABLE_NAME);
-  state_imsi_ht = hashtable_ts_create(
+  state_ue_ht = hashtable_ts_create(
       max_ue_htbl_lists_, nullptr, mme_app_state_free_ue_context, b);
   btrunc(b, 0);
   bassigncstr(b, ENB_UE_ID_MME_UE_ID_TABLE_NAME);
@@ -188,7 +188,7 @@ void MmeNasStateManager::clear_mme_nas_hashtables() {
     return;
   }
 
-  hashtable_ts_destroy(state_imsi_ht);
+  hashtable_ts_destroy(state_ue_ht);
   hashtable_uint64_ts_destroy(
       state_cache_p->mme_ue_contexts.imsi_mme_ue_id_htbl);
   hashtable_uint64_ts_destroy(
@@ -224,7 +224,7 @@ int MmeNasStateManager::read_ue_state_from_db() {
       MmeNasStateConverter::proto_to_ue(ue_proto, ue_context);
 
       hashtable_ts_insert(
-          state_imsi_ht, ue_context->mme_ue_s1ap_id, (void*) ue_context);
+          state_ue_ht, ue_context->mme_ue_s1ap_id, (void*) ue_context);
       OAILOG_DEBUG(
           log_task,
           "Inserted UE state with key mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT,

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -67,13 +67,15 @@ void put_spgw_state()
 
 void put_spgw_ue_state(spgw_state_t* spgw_state, imsi64_t imsi64)
 {
-  uint64_t teid;
-  hashtable_uint64_ts_get(
-    spgw_state->imsi_teid_htbl, (const hash_key_t) imsi64, &teid);
-  auto spgw_ctxt = sgw_cm_get_spgw_context(teid);
-  if(spgw_ctxt) {
-    auto imsi_str = SpgwStateManager::getInstance().get_imsi_str(imsi64);
-    SpgwStateManager::getInstance().write_ue_state_to_db(spgw_ctxt, imsi_str);
+  if(SpgwStateManager::getInstance().is_persist_state_enabled()) {
+    uint64_t teid;
+    hashtable_uint64_ts_get(
+        spgw_state->imsi_teid_htbl, (const hash_key_t) imsi64, &teid);
+    auto spgw_ctxt = sgw_cm_get_spgw_context(teid);
+    if (spgw_ctxt) {
+      auto imsi_str = SpgwStateManager::getInstance().get_imsi_str(imsi64);
+      SpgwStateManager::getInstance().write_ue_state_to_db(spgw_ctxt, imsi_str);
+    }
   }
 }
 

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_manager.cpp
@@ -61,7 +61,7 @@ void SpgwStateManager::create_state()
   state_cache_p = (spgw_state_t*) calloc(1, sizeof(spgw_state_t));
 
   bstring b = bfromcstr(S11_BEARER_CONTEXT_INFO_HT_NAME);
-  state_imsi_ht = hashtable_ts_create(
+  state_ue_ht = hashtable_ts_create(
     SGW_STATE_CONTEXT_HT_MAX_SIZE,
     nullptr,
     (void (*)(void**)) sgw_free_s11_bearer_context_information,
@@ -103,7 +103,7 @@ void SpgwStateManager::free_state()
   }
 
   if (
-    hashtable_ts_destroy(state_imsi_ht) !=
+    hashtable_ts_destroy(state_ue_ht) !=
     HASH_TABLE_OK) {
     OAI_FPRINTF_ERR(
       "An error occurred while destroying SGW s11_bearer_context_information "
@@ -141,7 +141,7 @@ int SpgwStateManager::read_ue_state_from_db()
     SpgwStateConverter::proto_to_ue(ue_proto, ue_context);
 
     hashtable_ts_insert(
-      state_imsi_ht,
+      state_ue_ht,
       ue_context->sgw_eps_bearer_context_information.s_gw_teid_S11_S4,
       (void*) ue_context);
     OAILOG_DEBUG(log_task, "Reading UE state from db for %s", key.c_str());


### PR DESCRIPTION
Summary: - When writing UE context on MME tasks, we can save a function call to pull up the state pointer by preemptively using `persist_state_enabled` flag on SPGW and MME state managers.

Differential Revision: D21191885

