### PR TITLE
CWF and XWF ansible use service instead of systemctl

### DIFF
--- a/cwf/gateway/deploy/roles/ovs/tasks/main.yml
+++ b/cwf/gateway/deploy/roles/ovs/tasks/main.yml
@@ -43,6 +43,7 @@
     name: openvswitch-switch
     state: started
     enabled: yes
+    use: service
   become: true
 
 - name: Ensure OVS switch will not auto-upgrade

--- a/xwf/gateway/deploy/roles/dhcpd/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/dhcpd/tasks/main.yml
@@ -33,4 +33,5 @@
     name: isc-dhcp-server
     state: started
     enabled: yes
+    use: service
   become: true


### PR DESCRIPTION
Summary: There is problem to run this ansible in machines without systemd. I hit this problem trying to run it on xwfm docker in circleci environment. In other systems where systemd is working, service is just wrapper to systemctl, so it shouldn't metter.

Differential Revision: D21210098

