### PR TITLE
Restructuring S1AP task to save state indexed by UE

### DIFF
--- a/lte/gateway/c/oai/protos/s1ap_state.proto
+++ b/lte/gateway/c/oai/protos/s1ap_state.proto
@@ -22,7 +22,7 @@ message EnbDescription {
   uint32 instreams = 9;        // sctp_stream_id_t
   uint32 outstreams = 10;      // sctp_stream_id_t
 
-  map<uint32, UeDescription> ues = 11; // enbueid -> UeDescription
+  map<uint64, uint64> ue_ids = 11; // enb_ue_s1ap_id -> comp_s1ap_id
 }
 
 message UeDescription {
@@ -34,6 +34,8 @@ message UeDescription {
   uint32 sctp_stream_send = 6; // sctp_stream_id_t
 
   S1apTimer s1ap_ue_context_rel_timer = 7; // struct s1ap_timer_t
+
+  uint32 sctp_assoc_id = 8; // sctp_assoc_id_t
 }
 
 message S1apState {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -112,7 +112,7 @@ int s1ap_mme_handle_initial_ue_message(
     "New Initial UE message received with eNB UE S1AP ID: " ENB_UE_S1AP_ID_FMT
     "\n",
     enb_ue_s1ap_id);
-  ue_ref = s1ap_state_get_ue_enbid(eNB_ref, enb_ue_s1ap_id);
+  ue_ref = s1ap_state_get_ue_enbid(eNB_ref->sctp_assoc_id, enb_ue_s1ap_id);
 
   if (ue_ref == NULL) {
     tai_t tai = {0};
@@ -149,7 +149,7 @@ int s1ap_mme_handle_initial_ue_message(
 
     // On which stream we received the message
     ue_ref->sctp_stream_recv = stream;
-    ue_ref->sctp_stream_send = ue_ref->enb->next_sctp_stream;
+    ue_ref->sctp_stream_send = eNB_ref->next_sctp_stream;
 
     /*
      * Increment the sctp stream for the eNB association.
@@ -161,11 +161,11 @@ int s1ap_mme_handle_initial_ue_message(
      * TODO task#15456359.
      * Below logic seems to be incorrect , revisit it.
      */
-    ue_ref->enb->next_sctp_stream += 1;
-    if (ue_ref->enb->next_sctp_stream >= ue_ref->enb->instreams) {
-      ue_ref->enb->next_sctp_stream = 1;
+    eNB_ref->next_sctp_stream += 1;
+    if (eNB_ref->next_sctp_stream >= eNB_ref->instreams) {
+      eNB_ref->next_sctp_stream = 1;
     }
-    s1ap_dump_enb(ue_ref->enb);
+    s1ap_dump_enb(eNB_ref);
     // TAI mandatory IE
     OCTET_STRING_TO_TAC(&initialUEMessage_p->tai.tAC, tai.tac);
     DevAssert(initialUEMessage_p->tai.pLMNidentity.size == 3);
@@ -216,7 +216,7 @@ int s1ap_mme_handle_initial_ue_message(
 #else
     s1ap_mme_itti_s1ap_initial_ue_message(
       assoc_id,
-      ue_ref->enb->enb_id,
+      eNB_ref->enb_id,
       ue_ref->enb_ue_s1ap_id,
       initialUEMessage_p->nas_pdu.buf,
       initialUEMessage_p->nas_pdu.size,
@@ -275,7 +275,7 @@ int s1ap_mme_handle_uplink_nas_transport(
     enb_ref = s1ap_state_get_enb(state, assoc_id);
 
     if (!(ue_ref = s1ap_state_get_ue_enbid(
-            enb_ref,
+            enb_ref->sctp_assoc_id,
             (enb_ue_s1ap_id_t) uplinkNASTransport_p->eNB_UE_S1AP_ID))) {
       OAILOG_WARNING(
         LOG_S1AP,
@@ -292,7 +292,7 @@ int s1ap_mme_handle_uplink_nas_transport(
       (mme_ue_s1ap_id_t) uplinkNASTransport_p->mme_ue_s1ap_id);
 
     if (!(ue_ref = s1ap_state_get_ue_mmeid(
-            state, uplinkNASTransport_p->mme_ue_s1ap_id))) {
+        uplinkNASTransport_p->mme_ue_s1ap_id))) {
       OAILOG_WARNING(
         LOG_S1AP,
         "Received S1AP UPLINK_NAS_TRANSPORT No UE is attached to this "
@@ -367,7 +367,7 @@ int s1ap_mme_handle_nas_non_delivery(
 
   if (
     (ue_ref = s1ap_state_get_ue_mmeid(
-       state, nasNonDeliveryIndication_p->mme_ue_s1ap_id)) == NULL) {
+       nasNonDeliveryIndication_p->mme_ue_s1ap_id)) == NULL) {
     OAILOG_DEBUG(
       LOG_S1AP,
       "No UE is attached to this mme UE s1ap id: " MME_UE_S1AP_ID_FMT "\n",
@@ -423,7 +423,7 @@ int s1ap_generate_downlink_nas_transport(
     sctp_assoc_id_t sctp_assoc_id = (sctp_assoc_id_t)(uintptr_t) id;
     enb_description_t *enb_ref = s1ap_state_get_enb(state, sctp_assoc_id);
     if (enb_ref) {
-      ue_ref = s1ap_state_get_ue_enbid(enb_ref, enb_ue_s1ap_id);
+      ue_ref = s1ap_state_get_ue_enbid(enb_ref->sctp_assoc_id, enb_ue_s1ap_id);
     } else {
       OAILOG_ERROR(
         LOG_S1AP, "No eNB for SCTP association id %d \n", sctp_assoc_id);
@@ -432,7 +432,7 @@ int s1ap_generate_downlink_nas_transport(
   }
   // TODO remove soon:
   if (!ue_ref) {
-    ue_ref = s1ap_state_get_ue_mmeid(state, ue_id);
+    ue_ref = s1ap_state_get_ue_mmeid(ue_id);
   }
   // finally!
   if (!ue_ref) {
@@ -504,7 +504,7 @@ int s1ap_generate_downlink_nas_transport(
     free(buffer_p);
     s1ap_mme_itti_send_sctp_request(
       &b,
-      ue_ref->enb->sctp_assoc_id,
+      ue_ref->sctp_assoc_id,
       ue_ref->sctp_stream_send,
       ue_ref->mme_ue_s1ap_id);
     free_s1ap_downlinknastransport(downlinkNasTransport);
@@ -532,12 +532,12 @@ int s1ap_generate_s1ap_e_rab_setup_req(
     sctp_assoc_id_t sctp_assoc_id = (sctp_assoc_id_t)(uintptr_t) id;
     enb_description_t *enb_ref = s1ap_state_get_enb(state, sctp_assoc_id);
     if (enb_ref) {
-      ue_ref = s1ap_state_get_ue_enbid(enb_ref, enb_ue_s1ap_id);
+      ue_ref = s1ap_state_get_ue_enbid(enb_ref->sctp_assoc_id, enb_ue_s1ap_id);
     }
   }
   // TODO remove soon:
   if (!ue_ref) {
-    ue_ref = s1ap_state_get_ue_mmeid(state, ue_id);
+    ue_ref = s1ap_state_get_ue_mmeid(ue_id);
   }
   // finally!
   if (!ue_ref) {
@@ -708,7 +708,7 @@ int s1ap_generate_s1ap_e_rab_setup_req(
     bstring b = blk2bstr(buffer_p, length);
     s1ap_mme_itti_send_sctp_request(
       &b,
-      ue_ref->enb->sctp_assoc_id,
+      ue_ref->sctp_assoc_id,
       ue_ref->sctp_stream_send,
       ue_ref->mme_ue_s1ap_id);
   }
@@ -742,7 +742,7 @@ void s1ap_handle_conn_est_cnf(
     LOG_S1AP,
     "Received Connection Establishment Confirm from MME_APP for ue_id = %u\n",
     conn_est_cnf_pP->ue_id);
-  ue_ref = s1ap_state_get_ue_mmeid(state, conn_est_cnf_pP->ue_id);
+  ue_ref = s1ap_state_get_ue_mmeid(conn_est_cnf_pP->ue_id);
   if (!ue_ref) {
     OAILOG_ERROR(
       LOG_S1AP,
@@ -755,7 +755,9 @@ void s1ap_handle_conn_est_cnf(
 
   imsi64_t imsi64;
   s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
-  hashtable_uint64_ts_get(imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) conn_est_cnf_pP->ue_id, &imsi64);
+  hashtable_uint64_ts_get(
+      imsi_map->mme_ue_id_imsi_htbl, (const hash_key_t) conn_est_cnf_pP->ue_id,
+      &imsi64);
 
   /*
    * Start the outcome response timer.
@@ -936,7 +938,7 @@ void s1ap_handle_conn_est_cnf(
   free_s1ap_initialcontextsetuprequest(initialContextSetupRequest_p);
   s1ap_mme_itti_send_sctp_request(
     &b,
-    ue_ref->enb->sctp_assoc_id,
+    ue_ref->sctp_assoc_id,
     ue_ref->sctp_stream_send,
     ue_ref->mme_ue_s1ap_id);
   OAILOG_FUNC_OUT(LOG_S1AP);
@@ -956,17 +958,22 @@ void s1ap_handle_mme_ue_id_notification(
   enb_description_t *enb_ref = s1ap_state_get_enb(state, sctp_assoc_id);
   if (enb_ref) {
     ue_description_t *ue_ref =
-      s1ap_state_get_ue_enbid(enb_ref, enb_ue_s1ap_id);
+      s1ap_state_get_ue_enbid(enb_ref->sctp_assoc_id, enb_ue_s1ap_id);
     if (ue_ref) {
       ue_ref->mme_ue_s1ap_id = mme_ue_s1ap_id;
       hashtable_rc_t h_rc = hashtable_ts_insert(
-        &state->mmeid2associd,
-        (const hash_key_t) mme_ue_s1ap_id,
-        (void *) (uintptr_t) sctp_assoc_id);
+          &state->mmeid2associd,
+          (const hash_key_t) mme_ue_s1ap_id,
+          (void *) (uintptr_t) sctp_assoc_id);
+
+      hashtable_uint64_ts_insert(
+          &enb_ref->ue_id_coll,
+          (const hash_key_t) mme_ue_s1ap_id,
+          ue_ref->comp_s1ap_id);
 
       OAILOG_DEBUG(
         LOG_S1AP,
-        "Associated  sctp_assoc_id %d, enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT
+        "Associated sctp_assoc_id %d, enb_ue_s1ap_id " ENB_UE_S1AP_ID_FMT
         ", mme_ue_s1ap_id " MME_UE_S1AP_ID_FMT ":%s \n",
         sctp_assoc_id,
         enb_ue_s1ap_id,
@@ -1005,11 +1012,11 @@ int s1ap_generate_s1ap_e_rab_rel_cmd(
     sctp_assoc_id_t sctp_assoc_id = (sctp_assoc_id_t)(uintptr_t) id;
     enb_description_t *enb_ref = s1ap_state_get_enb(state, sctp_assoc_id);
     if (enb_ref) {
-      ue_ref = s1ap_state_get_ue_enbid(enb_ref, enb_ue_s1ap_id);
+      ue_ref = s1ap_state_get_ue_enbid(enb_ref->sctp_assoc_id, enb_ue_s1ap_id);
     }
   }
   if (!ue_ref) {
-    ue_ref = s1ap_state_get_ue_mmeid(state, ue_id);
+    ue_ref = s1ap_state_get_ue_mmeid(ue_id);
   }
   if (!ue_ref) {
     /*
@@ -1088,7 +1095,7 @@ int s1ap_generate_s1ap_e_rab_rel_cmd(
     bstring b = blk2bstr(buffer_p, length);
     s1ap_mme_itti_send_sctp_request(
       &b,
-      ue_ref->enb->sctp_assoc_id,
+      ue_ref->sctp_assoc_id,
       ue_ref->sctp_stream_send,
       ue_ref->mme_ue_s1ap_id);
   }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.h
@@ -42,12 +42,23 @@ enb_description_t* s1ap_state_get_enb(
   sctp_assoc_id_t assoc_id);
 
 ue_description_t* s1ap_state_get_ue_enbid(
-  enb_description_t* enb,
+  sctp_assoc_id_t sctp_assoc_id,
   enb_ue_s1ap_id_t enb_ue_s1ap_id);
 
 ue_description_t* s1ap_state_get_ue_mmeid(
-  s1ap_state_t* state,
   mme_ue_s1ap_id_t mme_ue_s1ap_id);
+
+ue_description_t* s1ap_state_get_ue_imsi(imsi64_t imsi64);
+
+/**
+ * Return unique composite id for S1AP UE context
+ * @param sctp_assoc_id unique SCTP assoc id
+ * @param enb_ue_s1ap_id unique UE s1ap ID on eNB
+ * @return uint64_t of composite id
+ */
+uint64_t s1ap_get_comp_s1ap_id(
+    sctp_assoc_id_t sctp_assoc_id,
+    enb_ue_s1ap_id_t enb_ue_s1ap_id);
 
 /**
  * Converts s1ap_imsi_map to protobuf and saves it into data store
@@ -59,17 +70,25 @@ void put_s1ap_imsi_map(void);
  */
 s1ap_imsi_map_t * get_s1ap_imsi_map(void);
 
-bool s1ap_enb_find_ue_by_mme_ue_id_cb(
-  __attribute__((unused)) hash_key_t keyP,
-  void* elementP,
-  void* parameterP,
-  void** resultP);
+hash_table_ts_t* get_s1ap_ue_state(void);
+
+int read_s1ap_ue_state_db(void);
+
+void put_s1ap_ue_state(imsi64_t imsi64);
+
+void delete_s1ap_ue_state(imsi64_t imsi64);
 
 bool s1ap_ue_compare_by_mme_ue_id_cb(
   __attribute__((unused)) hash_key_t keyP,
   void* elementP,
   void* parameterP,
   void** resultP);
+
+bool s1ap_ue_compare_by_imsi(
+    __attribute__((unused)) hash_key_t keyP,
+    void* elementP,
+    void* parameterP,
+    void** resultP);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
@@ -38,6 +38,7 @@ extern "C" {
 
 namespace {
 constexpr char S1AP_STATE_TABLE[] = "s1ap_state";
+constexpr char S1AP_TASK_NAME[] = "S1AP";
 }
 
 namespace magma {
@@ -76,6 +77,12 @@ class S1apStateManager :
    * Frees all memory allocated on s1ap_state cache struct
    */
   void free_state() override;
+
+  /**
+   * Reads S1AP context state for all UEs in db
+   * @return operation response code
+   */
+  int read_ue_state_from_db() override;
 
   /**
    * Serializes s1ap_imsi_map to proto and saves it into data store

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_types.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_types.h
@@ -84,13 +84,13 @@ enum s1_ue_state_s {
  *  Generated every time a new InitialUEMessage is received
  **/
 typedef struct ue_description_s {
-  struct enb_description_s *enb; ///< Which eNB this UE is attached to
-
   enum s1_ue_state_s s1_ue_state; ///< S1AP UE state
 
   enb_ue_s1ap_id_t
     enb_ue_s1ap_id : 24;           ///< Unique UE id over eNB (24 bits wide)
   mme_ue_s1ap_id_t mme_ue_s1ap_id; ///< Unique UE id over MME (32 bits wide)
+  sctp_assoc_id_t sctp_assoc_id; ///< Assoc id of eNB which this UE is attached
+  uint64_t comp_s1ap_id; ///< Unique composite UE id (sctp_assoc_id & enb_ue_s1ap_id)
 
   /** SCTP stream on which S1 message will be sent/received.
    *  During an UE S1 connection, a pair of streams is
@@ -146,8 +146,8 @@ typedef struct enb_description_s {
   /** UE list for this eNB **/
   /*@{*/
   uint32_t nb_ue_associated; ///< Number of NAS associated UE on this eNB
-  hash_table_ts_t
-    ue_coll; // contains ue_description_s, key is ue_description_s.?;
+  hash_table_uint64_ts_t ue_id_coll; ///< Contains comp_s1ap_id assoc to
+                                     ///< enodeb, key is mme_ue_s1ap_id;
   /*@}*/
   // Wait for associated UE clean-up timer during sctp shutdown
   struct s1ap_timer_t s1ap_enb_assoc_clean_up_timer;


### PR DESCRIPTION
Summary:
- For restructuring MME tasks state to be per UE and be saved into redis to support state replication, this completes UE context restructure on S1AP task.
- Adding `comp_s1ap_id` to s1ap ue context, which is a unique composite id between `sctp_assoc_id` and `enb_ue_s1ap_id` to identify an UE in S1AP context.
- Adding write_to and read_from UE state functions to save UE context to redis

Differential Revision: D21191550

