### PR TITLE
Format label values properly

### DIFF
--- a/cwf/cloud/go/services/analytics/analytics/main.go
+++ b/cwf/cloud/go/services/analytics/analytics/main.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"strconv"
 	"time"
 
 	"magma/cwf/cloud/go/cwf"
@@ -22,7 +23,7 @@ import (
 
 	"github.com/golang/glog"
 	promAPI "github.com/prometheus/client_golang/api"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -118,7 +119,7 @@ func getXAPCalculations(daysList []int, gauge *prometheus.GaugeVec, metricName s
 			CalculationParams: analytics.CalculationParams{
 				Days:            dayParam,
 				RegisteredGauge: gauge,
-				Labels:          prometheus.Labels{analytics.DaysLabel: string(dayParam)},
+				Labels:          prometheus.Labels{analytics.DaysLabel: strconv.Itoa(dayParam)},
 				Name:            metricName,
 			},
 		})
@@ -134,7 +135,7 @@ func getUserThroughputCalculations(daysList []int, gauge *prometheus.GaugeVec, m
 				CalculationParams: analytics.CalculationParams{
 					Days:            dayParam,
 					RegisteredGauge: gauge,
-					Labels:          prometheus.Labels{analytics.DaysLabel: string(dayParam)},
+					Labels:          prometheus.Labels{analytics.DaysLabel: strconv.Itoa(dayParam)},
 					Name:            metricName,
 				},
 				Direction:     dir,
@@ -153,7 +154,7 @@ func getAPThroughputCalculations(daysList []int, gauge *prometheus.GaugeVec, met
 				CalculationParams: analytics.CalculationParams{
 					Days:            dayParam,
 					RegisteredGauge: gauge,
-					Labels:          prometheus.Labels{analytics.DaysLabel: string(dayParam)},
+					Labels:          prometheus.Labels{analytics.DaysLabel: strconv.Itoa(dayParam)},
 					Name:            metricName,
 				},
 				Direction:     dir,
@@ -172,7 +173,7 @@ func getUserConsumptionCalculations(daysList []int, gauge *prometheus.GaugeVec, 
 				CalculationParams: analytics.CalculationParams{
 					Days:            dayParam,
 					RegisteredGauge: gauge,
-					Labels:          prometheus.Labels{analytics.DaysLabel: string(dayParam)},
+					Labels:          prometheus.Labels{analytics.DaysLabel: strconv.Itoa(dayParam)},
 					Name:            metricName,
 				},
 				Direction: dir,

--- a/cwf/cloud/go/services/analytics/analytics/main_test.go
+++ b/cwf/cloud/go/services/analytics/analytics/main_test.go
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package main
+
+import (
+	"strconv"
+	"testing"
+
+	"magma/cwf/cloud/go/services/analytics"
+	"magma/orc8r/lib/go/metrics"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetXAPCalculations(t *testing.T) {
+	xapGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: activeUsersMetricName}, []string{analytics.DaysLabel, metrics.NetworkLabelName})
+	calcs := getXAPCalculations([]int{1, 7, 30}, xapGauge, "metricName")
+	for _, calc := range calcs {
+		xapCalc := calc.(*analytics.XAPCalculation)
+		assert.Equal(t, strconv.Itoa(xapCalc.Days), xapCalc.Labels[analytics.DaysLabel])
+	}
+}
+
+func TestGetUserThroughputCalculations(t *testing.T) {
+	userThroughputGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: userThroughputMetricName}, []string{analytics.DaysLabel, metrics.NetworkLabelName, analytics.DirectionLabel})
+	calcs := getUserThroughputCalculations([]int{1, 7, 30}, userThroughputGauge, "metricName")
+	for _, calc := range calcs {
+		c := calc.(*analytics.UserThroughputCalculation)
+		assert.Equal(t, strconv.Itoa(c.Days), c.Labels[analytics.DaysLabel])
+	}
+}
+
+func TestGetUserConsumptionCalculations(t *testing.T) {
+	userConsumptionGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: userConsumptionMetricName}, []string{analytics.DaysLabel, metrics.NetworkLabelName, analytics.DirectionLabel})
+	calcs := getUserConsumptionCalculations([]int{1, 7, 30}, userConsumptionGauge, "metricName")
+	for _, calc := range calcs {
+		c := calc.(*analytics.UserConsumptionCalculation)
+		assert.Equal(t, strconv.Itoa(c.Days), c.Labels[analytics.DaysLabel])
+	}
+}
+
+func TestGetAPThroughputCalculations(t *testing.T) {
+	apThroughputGauge := prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: apThroughputMetricName}, []string{analytics.DaysLabel, metrics.NetworkLabelName, analytics.DirectionLabel, analytics.APNLabel})
+	calcs := getAPThroughputCalculations([]int{1, 7, 30}, apThroughputGauge, "metricName")
+	for _, calc := range calcs {
+		c := calc.(*analytics.APThroughputCalculation)
+		assert.Equal(t, strconv.Itoa(c.Days), c.Labels[analytics.DaysLabel])
+	}
+}


### PR DESCRIPTION
Summary: The label for "days" (e.g. 7 days indicating this data covers a week: https://pxl.cl/15FP0), was actually being formatted as `\u0007`. Convert the int to a string properly to fix this.

Differential Revision: D21232466

