### PR TITLE
Add stop functionality to GRE probe for CWAG health service

### DIFF
--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -401,6 +401,7 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
+github.com/shirou/gopsutil v2.20.3+incompatible h1:0JVooMPsT7A7HqEYdydp/OfjSOYSjhXV7w1hkKj/NPQ=
 github.com/shirou/gopsutil v2.20.3+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=

--- a/cwf/gateway/services/gateway_health/health/gre_probe/gre_probe.go
+++ b/cwf/gateway/services/gateway_health/health/gre_probe/gre_probe.go
@@ -14,6 +14,9 @@ type GREProbe interface {
 	// Start begins the probe of the GRE endpoint(s).
 	Start() error
 
+	// Stop stops the probe of the GRE endpoint(s).
+	Stop()
+
 	// GetStatus fetches the status of the GRE probe. The GREProbeStatus
 	// returned contains slices of reachable and unreachable endpoint IPs.
 	GetStatus() *GREProbeStatus

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer.go
@@ -61,7 +61,12 @@ func (s *GatewayHealthServicer) Disable(ctx context.Context, req *protos.Disable
 		return ret, err
 	}
 	// Stop the RADIUS server so that the WLC perceives it as down.
-	return ret, s.serviceHealth.Disable(radiusServiceName)
+	err = s.serviceHealth.Disable(radiusServiceName)
+	if err != nil {
+		return ret, err
+	}
+	s.greProbe.Stop()
+	return ret, nil
 }
 
 // Enable ensures ICMP is enabled on eth1, then restarts radius and sessiond
@@ -80,7 +85,7 @@ func (s *GatewayHealthServicer) Enable(ctx context.Context, req *orcprotos.Void)
 	if err != nil {
 		return ret, err
 	}
-	return ret, nil
+	return ret, s.greProbe.Start()
 }
 
 // GetHealthStatus retrieves a health status object which contains the current

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
@@ -60,6 +60,7 @@ func TestGetHealthStatus(t *testing.T) {
 	mockSystem.On("Enable").Return(nil)
 	mockService.On("Enable", "radius").Return(nil)
 	mockService.On("Enable", "sessiond").Return(nil)
+	mockGREProbe.On("Start").Return(nil)
 	_, err = servicer.Enable(context.Background(), req)
 	assert.NoError(t, err)
 	assertMocks(t, mockGREProbe, mockSystem, mockService)
@@ -79,6 +80,7 @@ func TestGetHealthStatus(t *testing.T) {
 	disableReq := &protos.DisableMessage{}
 	mockSystem.On("Disable").Return(nil)
 	mockService.On("Disable", "radius").Return(nil)
+	mockGREProbe.On("Stop").Return()
 	_, err = servicer.Disable(context.Background(), disableReq)
 	assert.NoError(t, err)
 	assertMocks(t, mockGREProbe, mockSystem, mockService)
@@ -157,6 +159,10 @@ type mockGREProbe struct {
 func (m *mockGREProbe) Start() error {
 	args := m.Called()
 	return args.Error(0)
+}
+
+func (m *mockGREProbe) Stop() {
+	_ = m.Called()
 }
 
 func (m *mockGREProbe) GetStatus() *gre_probe.GREProbeStatus {


### PR DESCRIPTION
Summary:
When a CWAG is demoted, we block ICMP on the eth1
interface to ensure that traffic will properly be re-routed.
Due to this, the ICMP GRE probe will always fail when a gateway
is in standby. This causes the gateway to appear unhealthy.
To avoid this, we stop the probe on gateway demotion and start
the probe on gateway promotion.

Reviewed By: xjtian

Differential Revision: D21219399

