### PR TITLE
Fix arp table restart recovery bug

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/arp.py
+++ b/lte/gateway/python/magma/pipelined/app/arp.py
@@ -131,12 +131,12 @@ class ArpController(MagmaController):
                 self.logger.debug(
                     "%s is in directoryd, but not an active UE", rec.id)
                 continue
-            self.logger.debug("Restoring arp for IMSI %s, ip %s mac %s", rec.id,
-                              rec.fields['ipv4_addr'], rec.fields['mac_addr'])
-
-            self.add_ue_arp_flows(self._datapath,
-                                  rec.fields['ipv4_addr'],
-                                  rec.fields['mac_addr'])
+            if rec.fields['ipv4_addr'] and rec.fields['mac_addr']:
+                self.logger.debug("Restoring arp for IMSI %s, ip %s mac %s",
+                    rec.id, rec.fields['ipv4_addr'], rec.fields['mac_addr'])
+                self.add_ue_arp_flows(self._datapath,
+                                      rec.fields['ipv4_addr'],
+                                      rec.fields['mac_addr'])
 
     def add_ue_arp_flows(self, datapath, ue_ip, ue_mac):
         """

--- a/lte/gateway/python/magma/pipelined/app/li_mirror.py
+++ b/lte/gateway/python/magma/pipelined/app/li_mirror.py
@@ -100,10 +100,10 @@ class LIMirrorController(MagmaController):
                                              outbound_match, actions,
                                              priority=flows.MINIMUM_PRIORITY,
                                              resubmit_table=self.next_table)
-
-        li_match = MagmaMatch(in_port=self._li_local_port_num)
-        flows.add_output_flow(datapath, self.tbl_num, li_match, [],
-                              output_port=self._li_dst_port_num)
+        if self._li_dst_port_num:
+            li_match = MagmaMatch(in_port=self._li_local_port_num)
+            flows.add_output_flow(datapath, self.tbl_num, li_match, [],
+                                  output_port=self._li_dst_port_num)
 
     def _install_mirror_flows(self, imsis):
         parser = self._datapath.ofproto_parser


### PR DESCRIPTION
Summary: We don't always have redis infromation for subscriber IP address(when there was no dhcp handshake), so check if IP is saved before insalling rules.

Differential Revision: D21246666

