### PR TITLE
Switch gy integ tests to use ocs mockdriver

### DIFF
--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -95,7 +95,7 @@ func TestAuthenticateFail(t *testing.T) {
 
 	tr.AuthenticateAndAssertFail(imsiFail)
 
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{{ExpectationIndex: 0, ExpectationMet: true}}
@@ -147,7 +147,7 @@ func TestAuthenticateUplinkTraffic(t *testing.T) {
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{
@@ -214,7 +214,7 @@ func TestAuthenticateMultipleAPsUplinkTraffic(t *testing.T) {
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{

--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -107,7 +107,7 @@ func TestGxUsageReportEnforcement(t *testing.T) {
 	}
 
 	// Assert that reasonable CCR-I and at least one CCR-U were sent up to the PCRF
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{
@@ -130,7 +130,7 @@ func TestGxUsageReportEnforcement(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	// Assert that we saw a Terminate request
-	resultByIndex, errByIndex, err = getAssertExpectationsResult()
+	resultByIndex, errByIndex, err = getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult = []*protos.ExpectationResult{
@@ -214,7 +214,7 @@ func TestGxMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	assert.NotNil(t, record1, fmt.Sprintf("No policy usage record for imsi: %v rule=static-pass-all-1", imsi))
 
 	// Assert that a CCR-I was sent up to the PCRF
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{
@@ -245,7 +245,7 @@ func TestGxMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	tr.WaitForEnforcementStatsToSync()
 
 	// Assert that we sent back a CCA-Update with RuleRemovals
-	resultByIndex, errByIndex, err = getAssertExpectationsResult()
+	resultByIndex, errByIndex, err = getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult = []*protos.ExpectationResult{
@@ -359,7 +359,7 @@ func testGxRuleInstallTime(t *testing.T) {
 	assert.NotNil(t, recordsBySubID[prependIMSIPrefix(imsi)]["static-pass-all-1"])
 	assert.Nil(t, recordsBySubID[prependIMSIPrefix(imsi)]["static-pass-all-2"])
 
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{
@@ -508,7 +508,7 @@ func testGxRevalidationTime(t *testing.T) {
 	}
 
 	// Assert that reasonable CCR-I and at least one CCR-U were sent up to the PCRF
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{
@@ -528,7 +528,7 @@ func testGxRevalidationTime(t *testing.T) {
 	tr.WaitForEnforcementStatsToSync()
 
 	// Assert that we saw a Terminate request
-	resultByIndex, errByIndex, err = getAssertExpectationsResult()
+	resultByIndex, errByIndex, err = getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult = []*protos.ExpectationResult{

--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -288,7 +288,7 @@ func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
 	assert.NotNil(t, record, fmt.Sprintf("No policy usage record for imsi: %v", imsi))
 
 	// Assert that reasonable CCR-I and at least one CCR-U were sent up to the PCRF
-	resultByIndex, errByIndex, err := getAssertExpectationsResult()
+	resultByIndex, errByIndex, err := getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult := []*protos.ExpectationResult{
@@ -309,7 +309,7 @@ func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
 	time.Sleep(6 * time.Second)
 
 	// Assert that we saw a Terminate request
-	resultByIndex, errByIndex, err = getAssertExpectationsResult()
+	resultByIndex, errByIndex, err = getPCRFAssertExpectationsResult()
 	assert.NoError(t, err)
 	assert.Empty(t, errByIndex)
 	expectedResult = []*protos.ExpectationResult{

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -11,12 +11,13 @@ package integration
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	cwfprotos "magma/cwf/cloud/go/protos"
+	"magma/feg/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/lte/cloud/go/plugin/models"
 
+	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
@@ -40,19 +41,11 @@ func ocsCreditExhaustionTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwf
 			MaxUsageOctets: &fegprotos.Octets{TotalOctets: MaxUsageBytes},
 			MaxUsageTime:   MaxUsageTime,
 			ValidityTime:   ValidityTime,
+			UseMockDriver:  true,
 		},
 	)
 
 	ue := ues[0]
-	setCreditOnOCS(
-		&fegprotos.CreditInfo{
-			Imsi:        ue.Imsi,
-			ChargingKey: 1,
-			Volume:      &fegprotos.Octets{TotalOctets: 7 * 1024 * KiloBytes},
-			UnitType:    fegprotos.CreditInfo_Bytes,
-		},
-	)
-
 	// Set a pass all rule to be installed by pcrf with a monitoring key to trigger updates
 	err = ruleManager.AddUsageMonitor(ue.Imsi, "mkey-ocs", 20*KiloBytes, 10*KiloBytes)
 	assert.NoError(t, err)
@@ -71,25 +64,55 @@ func ocsCreditExhaustionTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwf
 	return tr, ruleManager, ues[0]
 }
 
+// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//   respond with a quota grant of 4M.
+//   Generate traffic and assert the CCR-I is received.
+// - Set an expectation for a CCR-U with >80% of data usage to be sent up to
+// 	 OCS, to which it will response with more quota.
+//   Generate traffic and assert the CCR-U is received with final quota grant.
+// - Generate 5M traffic to exceed 100% of the quota and trigger session termination
+// - Assert that UE flows are deleted.
+// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
 func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionWithCRRU...")
 
 	tr, ruleManager, ue := ocsCreditExhaustionTestSetup(t)
 	defer func() {
 		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearOCSMockDriver())
 		assert.NoError(t, ruleManager.RemoveInstalledRules())
 		assert.NoError(t, tr.CleanUp())
 	}()
 
-	setCreditOnOCS(
-		&fegprotos.CreditInfo{
-			Imsi:        ue.Imsi,
-			ChargingKey: 1,
-			Volume:      &fegprotos.Octets{TotalOctets: 7 * 1024 * KiloBytes},
-			UnitType:    fegprotos.CreditInfo_Bytes,
+	quotaGrant := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 5 * MegaBytes,
 		},
-	)
+		IsFinalCredit: false,
+		ResultCode:    2001,
+	}
+	initRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant)
+	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
 
+	// We expect an update request with some usage update (probably around 80-100% of the given quota)
+	finalQuotaGrant := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 2 * MegaBytes,
+		},
+		IsFinalCredit:   true,
+		FinalUnitAction: fegprotos.FinalUnitAction_Terminate,
+		ResultCode:      2001,
+	}
+	updateRequest1 := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_UPDATE, 2)
+	updateAnswer1 := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(finalQuotaGrant)
+	updateExpectation1 := protos.NewGyCreditControlExpectation().Expect(updateRequest1).Return(updateAnswer1)
+	expectations := []*protos.GyCreditControlExpectation{initExpectation, updateExpectation1}
+
+	// On unexpected requests, just return the default update answer
+	assert.NoError(t, setOCSExpectations(expectations, updateAnswer1))
 	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
 
 	// we need to generate over 80% of the quota to trigger a CCR update
@@ -98,41 +121,95 @@ func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
 
+	// Assert that enforcement_stats rules are properly installed and the right
+	// amount of data was passed through
+	recordsBySubID, err := tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	record := recordsBySubID["IMSI"+ue.GetImsi()]["static-pass-all-ocs2"]
+	assert.NotNil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was removed", ue.GetImsi()))
+	if record != nil {
+		// We should not be seeing > 1024k data here
+		assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
+		assert.True(t, record.BytesTx <= uint64(5*MegaBytes+Buffer), fmt.Sprintf("policy usage: %v", record))
+	}
+
+	// Assert that reasonable CCR-I and at least one CCR-U were sent up to the OCS
+	resultByIndex, errByIndex, err := getOCSAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult := []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+		{ExpectationIndex: 1, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+
+	// When we initiate a UE disconnect, we expect a terminate request to go up
+	terminateRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_TERMINATION, 3)
+	terminateAnswer := protos.NewGyCCAnswer(diam.Success)
+	terminateExpectation := protos.NewGyCreditControlExpectation().Expect(terminateRequest).Return(terminateAnswer)
+	expectations = []*protos.GyCreditControlExpectation{terminateExpectation}
+	assert.NoError(t, setOCSExpectations(expectations, nil))
+
 	// we need to generate over 100% of the quota to trigger a session termination
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
-	// Wait for session termination
-	time.Sleep(3 * time.Second)
 
 	// Check that UE mac flow is removed
-	recordsBySubID, err := tr.GetPolicyUsage()
+	recordsBySubID, err = tr.GetPolicyUsage()
 	assert.NoError(t, err)
-	record := recordsBySubID["IMSI"+ue.GetImsi()]["static-pass-all-ocs2"]
+	record = recordsBySubID["IMSI"+ue.GetImsi()]["static-pass-all-ocs2"]
 	assert.Nil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was not removed", ue.GetImsi()))
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(ue.GetImsi())
+	tr.WaitForEnforcementStatsToSync()
+
+	// Assert that we saw a Terminate request
+	resultByIndex, errByIndex, err = getOCSAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult = []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
 }
 
+// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//   respond with a quota grant of 4M.
+//   Generate traffic and assert the CCR-I is received.
+// - Generate 5M traffic to exceed 100% of the quota and trigger session termination
+// - Assert that UE flows are deleted.
+// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
 func TestGyCreditExhaustionWithoutCRRU(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionWithoutCRRU...")
 
 	tr, ruleManager, ue := ocsCreditExhaustionTestSetup(t)
 	defer func() {
 		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearOCSMockDriver())
 		assert.NoError(t, ruleManager.RemoveInstalledRules())
 		assert.NoError(t, tr.CleanUp())
 	}()
 
-	setCreditOnOCS(
-		&fegprotos.CreditInfo{
-			Imsi:        ue.Imsi,
-			ChargingKey: 1,
-			Volume:      &fegprotos.Octets{TotalOctets: 4 * 1024 * KiloBytes},
-			UnitType:    fegprotos.CreditInfo_Bytes,
+	quotaGrant := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 4 * MegaBytes,
 		},
-	)
+		IsFinalCredit:   true,
+		FinalUnitAction: fegprotos.FinalUnitAction_Terminate,
+		ResultCode:      2001,
+	}
+	initRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_INITIAL, 1)
+	initAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant)
+	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	defaultUpdateAnswer := protos.NewGyCCAnswer(diam.Success)
+	expectations := []*protos.GyCreditControlExpectation{initExpectation}
+
+	// On unexpected requests, just return the default update answer
+	assert.NoError(t, setOCSExpectations(expectations, defaultUpdateAnswer))
 	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
 
 	// we need to generate over 100% of the quota to trigger a session termination
@@ -141,15 +218,38 @@ func TestGyCreditExhaustionWithoutCRRU(t *testing.T) {
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
 
-	// Wait for session termination to go through
-	time.Sleep(5 * time.Second)
+	// Assert that reasonable CCR-I was sent to OCS
+	resultByIndex, errByIndex, err := getOCSAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult := []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
+
+	// When we initiate a UE disconnect, we expect a terminate request to go up
+	terminateRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_TERMINATION, 3)
+	terminateAnswer := protos.NewGyCCAnswer(diam.Success)
+	terminateExpectation := protos.NewGyCreditControlExpectation().Expect(terminateRequest).Return(terminateAnswer)
+	expectations = []*protos.GyCreditControlExpectation{terminateExpectation}
+	assert.NoError(t, setOCSExpectations(expectations, nil))
 
 	// Check that UE mac flow is removed
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
 	record := recordsBySubID["IMSI"+ue.GetImsi()]["static-pass-all-ocs2"]
-	assert.Nil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was not removed", ue.GetImsi()))
+	assert.Nil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was removed", ue.GetImsi()))
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(ue.GetImsi())
+	tr.WaitForEnforcementStatsToSync()
+
+	// Assert that we saw a Terminate request
+	resultByIndex, errByIndex, err = getOCSAssertExpectationsResult()
+	assert.NoError(t, err)
+	assert.Empty(t, errByIndex)
+	expectedResult = []*protos.ExpectationResult{
+		{ExpectationIndex: 0, ExpectationMet: true},
+	}
+	assert.ElementsMatch(t, expectedResult, resultByIndex)
 }

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -86,7 +86,7 @@ func getHSSClient() (*hssClient, error) {
 	}, err
 }
 
-// addSubscriber tries to add this subscriber to the HSS server.
+// addSubscriberToHSS tries to add this subscriber to the HSS server.
 // This function returns an AlreadyExists error if the subscriber has already
 // been added.
 // Input: The subscriber data which will be added.
@@ -104,6 +104,9 @@ func addSubscriberToHSS(sub *lteprotos.SubscriberData) error {
 	return err
 }
 
+// deleteSubscriberFromHSS tries to add delete subscriber from the HSS server.
+// If the subscriber is not found, then this call is ignored.
+// Input: The id of the subscriber to be deleted.
 func deleteSubscribersFromHSS(subscriberID string) error {
 	cli, err := getHSSClient()
 	if err != nil {
@@ -116,7 +119,6 @@ func deleteSubscribersFromHSS(subscriberID string) error {
 /**  ========== PCRF Helpers ========== **/
 // getPCRFClient is a utility function to get an RPC connection to a
 // remote PCRF service.
-
 func getPCRFClient(instanceName string) (*pcrfClient, error) {
 	var conn *grpc.ClientConn
 	var err error
@@ -136,6 +138,8 @@ func getPCRFClient(instanceName string) (*pcrfClient, error) {
 	}, err
 }
 
+// sendPolicyReAuthRequest initiates a RAR request from PCRF server to sessiond.
+// Input: Policy RAR Target
 func sendPolicyReAuthRequest(target *fegprotos.PolicyReAuthTarget) (*fegprotos.PolicyReAuthAnswer, error) {
 	return sendPolicyReAuthRequestPerInstance(MockPCRFRemote, target)
 }
@@ -149,6 +153,8 @@ func sendPolicyReAuthRequestPerInstance(instanceName string, target *fegprotos.P
 	return raa, err
 }
 
+// sendPolicyAbortSession initiates an abort request from PCRF server to sessiond.
+// Input: Policy abort session request
 func sendPolicyAbortSession(target *fegprotos.PolicyAbortSessionRequest) (*fegprotos.PolicyAbortSessionResponse, error) {
 	return sendPolicyAbortSessionPerInstance(MockPCRFRemote, target)
 }
@@ -162,7 +168,7 @@ func sendPolicyAbortSessionPerInstance(instanceName string, target *fegprotos.Po
 	return raa, err
 }
 
-// addSubscriber tries to add this subscriber to the PCRF server.
+// addSubscriberToPCRF tries to add this subscriber to the PCRF server.
 // Input: The subscriber data which will be added.
 func addSubscriberToPCRF(sub *lteprotos.SubscriberID) error {
 	return addSubscriberToPCRFPerInstance(MockPCRFRemote, sub)
@@ -177,6 +183,7 @@ func addSubscriberToPCRFPerInstance(instanceName string, sub *lteprotos.Subscrib
 	return err
 }
 
+// clearSubscriberToPCRF tries to clear all subscribers from the PCRF server.
 func clearSubscribersFromPCRF() error {
 	return clearSubscribersFromPCRFPerInstance(MockPCRFRemote)
 }
@@ -216,6 +223,7 @@ func addPCRFUsageMonitorsPerInstance(instanceName string, monitorInfo *fegprotos
 	return err
 }
 
+// usePCRFMockDriver enable MockPCRFDriver
 func usePCRFMockDriver() error {
 	return usePCRFMockDriverPerInstance(MockPCRFRemote)
 }
@@ -229,6 +237,7 @@ func usePCRFMockDriverPerInstance(instanceName string) error {
 	return err
 }
 
+// clearPCRFMockDriver disable MockPCRFDriver
 func clearPCRFMockDriver() error {
 	return clearPCRFMockDriverPerInstance(MockPCRFRemote)
 }
@@ -242,6 +251,7 @@ func clearPCRFMockDriverPerInstance(instanceName string) error {
 	return err
 }
 
+// setPCRFExpectations allows to set the expectations in PCRF
 func setPCRFExpectations(expectations []*fegprotos.GxCreditControlExpectation, defaultAnswer *fegprotos.GxCreditControlAnswer) error {
 	return setPCRFExpectationsPerInstance(MockPCRFRemote, expectations, defaultAnswer)
 }
@@ -262,11 +272,12 @@ func setPCRFExpectationsPerInstance(instanceName string, expectations []*fegprot
 	return err
 }
 
-func getAssertExpectationsResult() ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
-	return getAssertExpectationsResultPerInstance(MockPCRFRemote)
+// getPCRFAssertExpectationsResult allows to get the expectations results in PCRF
+func getPCRFAssertExpectationsResult() ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
+	return getPCRFAssertExpectationsResultPerInstance(MockPCRFRemote)
 }
 
-func getAssertExpectationsResultPerInstance(instanceName string) ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
+func getPCRFAssertExpectationsResultPerInstance(instanceName string) ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
 	cli, err := getPCRFClient(instanceName)
 	if err != nil {
 		return nil, nil, nil
@@ -372,6 +383,72 @@ func sendChargingReAuthRequestPerInstance(instanceName string, imsi string, rati
 	raa, err := cli.ReAuth(context.Background(),
 		&fegprotos.ChargingReAuthTarget{Imsi: imsi, RatingGroup: ratingGroup})
 	return raa, err
+}
+
+// useOCSMockDriver enables MockOCSDriver
+func useOCSMockDriver() error {
+	return useOCSMockDriverPerInstance(MockOCSRemote)
+}
+
+func useOCSMockDriverPerInstance(instanceName string) error {
+	cli, err := getOCSClient(instanceName)
+	if err != nil {
+		return err
+	}
+	_, err = cli.SetOCSSettings(context.Background(), &fegprotos.OCSConfig{UseMockDriver: true})
+	return err
+}
+
+// clearOCSMockDriver disable MockOCSDriver
+func clearOCSMockDriver() error {
+	return clearOCSMockDriverPerInstance(MockOCSRemote)
+}
+
+func clearOCSMockDriverPerInstance(instanceName string) error {
+	cli, err := getOCSClient(instanceName)
+	if err != nil {
+		return err
+	}
+	_, err = cli.SetOCSSettings(context.Background(), &fegprotos.OCSConfig{UseMockDriver: false})
+	return err
+}
+
+// setOCSExpectations allows to set the expectations in OCS
+func setOCSExpectations(expectations []*fegprotos.GyCreditControlExpectation, defaultAnswer *fegprotos.GyCreditControlAnswer) error {
+	return setOCSExpectationsPerInstance(MockOCSRemote, expectations, defaultAnswer)
+}
+
+func setOCSExpectationsPerInstance(instanceName string, expectations []*fegprotos.GyCreditControlExpectation, defaultAnswer *fegprotos.GyCreditControlAnswer) error {
+	cli, err := getOCSClient(instanceName)
+	if err != nil {
+		return err
+	}
+	request := &fegprotos.GyCreditControlExpectations{
+		Expectations: expectations,
+		GyDefaultCca: defaultAnswer,
+	}
+	if defaultAnswer != nil {
+		request.UnexpectedRequestBehavior = fegprotos.UnexpectedRequestBehavior_CONTINUE_WITH_DEFAULT_ANSWER
+	}
+	_, err = cli.SetExpectations(context.Background(), request)
+	return err
+}
+
+// getOCSAssertExpectationsResult allows to get the expectations results in OCS
+func getOCSAssertExpectationsResult() ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
+	return getOCSAssertExpectationsResultPerInstance(MockOCSRemote)
+}
+
+func getOCSAssertExpectationsResultPerInstance(instanceName string) ([]*fegprotos.ExpectationResult, []*fegprotos.ErrorByIndex, error) {
+	cli, err := getOCSClient(instanceName)
+	if err != nil {
+		return nil, nil, nil
+	}
+	res, err := cli.AssertExpectations(context.Background(), &protos.Void{})
+	if err != nil {
+		return nil, nil, err
+	}
+	return res.Results, res.Errors, nil
 }
 
 /**  ========== Pipelined Helpers ========== **/


### PR DESCRIPTION
Summary: Switch gy integ tests to use ocs mockdriver

Reviewed By: themarwhal

Differential Revision: D21226448

