### PR TITLE
Multiple Diameter - Creation of Multiplex utility and refactor Session_Proxy

### DIFF
--- a/cwf/gateway/integ_tests/multi_sessioneproxy_test.go
+++ b/cwf/gateway/integ_tests/multi_sessioneproxy_test.go
@@ -18,7 +18,7 @@ import (
 
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/feg/cloud/go/protos"
-	"magma/feg/gateway/services/session_proxy/servicers"
+	"magma/feg/gateway/multiplex"
 	"magma/lte/cloud/go/plugin/models"
 
 	"github.com/go-openapi/swag"
@@ -42,15 +42,19 @@ func generateMultipleScenarioAndAddSubscribers(t *testing.T, numUEs int) (*TestR
 	// get the instance per IMSI based on the algorithm to distribuite IMSIs on FEG
 	IMSIs := generateRandomIMSIS(numUEs, nil)
 	IMSIsPerInstance := make([][]string, numInstances, numInstances)
+	// create a multiplexor with the same value as main.go on session_proxy
+	mux, err := multiplex.NewStaticMultiplexByIMSI(numInstances)
+	assert.NoError(t, err)
 	for _, imsi := range IMSIs {
-		i, err := servicers.GetControllerIndexFromImsi(imsi, numInstances)
+		ctx := multiplex.NewContext().WithIMSI(imsi)
+		i, err := mux.GetIndex(ctx)
 		assert.NoError(t, err)
 		IMSIsPerInstance[i] = append(IMSIsPerInstance[i], imsi)
 	}
 	// Add IMSIs to each instance
 	scenario := make([]*multipleScenarioElement, 0, numInstances)
 	for i, IMSIs := range IMSIsPerInstance {
-
+		// get names of the servers for this specific instance
 		pcrfName, ocsName, err := getPCRFandOCSnamePerInstance(i)
 		assert.NoError(t, err)
 
@@ -138,15 +142,15 @@ func getPCRFandOCSnamePerInstance(instanceId int) (pcrfName string, ocsName stri
 	return
 }
 
+// TODO:
+//  * Support for multiple UEs (depends on UEsim service)
+//  * Check OCS credit has been reported (right now sessiond sends CCR after accounts
+//    are deleted from OCS and PCRF)
 // TestMultiSessionProxyMonitorAndUsageReportEnforcement is an experimental
 // test to try multiple OCS and PCRF servers. Currenty it only supports 1 UE
 // - Create one UE and add monitoring key and credit
 // - Attach UE, tranfer data, detach
 // - Check that the Monitored data by the PCRF instance is good
-// TODO:
-//  * Support for multiple UEs (depends on UEsim service)
-//  * Check OCS credit has been reported (right now sessiond sends CCR after accounts
-//    are deleted from OCS and PCRF)
 func TestMultiSessionProxyMonitorAndUsageReportEnforcement(t *testing.T) {
 	fmt.Println("\nRunning TestMultiSessionProxyUsageReportEnforcement...")
 

--- a/feg/gateway/diameter/config.go
+++ b/feg/gateway/diameter/config.go
@@ -177,8 +177,13 @@ func GetValue(flagName, defaultValue string) string {
 }
 
 // GetValueOrEnv returns value of the flagValue if it exists, then the environment
-// variable if it exists, or defaultValue if not
-func GetValueOrEnv(flagName, envVariable, defaultValue string) string {
+// variable if it exists, or defaultValue if not.
+// If idx parameter is passed, then if that idx > 1 defaultValue will be returned.
+// Note in case of many idx are passed, only the first idx will be checked.
+func GetValueOrEnv(flagName, envVariable, defaultValue string, idx ...int) string {
+	if len(idx) > 0 && idx[0] > 0 {
+		return defaultValue
+	}
 	flagValue := getFlagValue(flagName)
 	if len(flagValue) != 0 {
 		return flagValue
@@ -195,8 +200,13 @@ func GetValueOrEnv(flagName, envVariable, defaultValue string) string {
 }
 
 // GetBoolValueOrEnv returns value of the flagValue if it exists, then the environment
-// variable if it exists, or defaultValue if not
-func GetBoolValueOrEnv(flagName string, envVariable string, defaultValue bool) bool {
+// variable if it exists, or defaultValue if not.
+// If idx parameter is passed, then if that idx > 1 defaultValue will be returned.
+// Note in case of many idx are passed, only the first idx will be checked.
+func GetBoolValueOrEnv(flagName string, envVariable string, defaultValue bool, idx ...int) bool {
+	if len(idx) > 0 && idx[0] > 0 {
+		return defaultValue
+	}
 	flagValue := getFlagValue(flagName)
 	flagValueBool, err := strconv.ParseBool(flagValue)
 	if len(flagValue) != 0 && err == nil {

--- a/feg/gateway/multiplex/multiplex.go
+++ b/feg/gateway/multiplex/multiplex.go
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Package multiplex allows to create different algorithms to select out of an index base on some
+// parameters. An example of a multiplexor can be seen on StaticMultiplexByIMSI type.
+// Multiplexors in this packages use Context tyoe to obtain dynamic parameters. Right now we have
+// only identified one parameter to be used by algorithms (IMSI). But in the future more parameter
+// can be added in case other algorithms uses them
+//
+// Addition of new algorithms:
+// - if you need new dynamic (per call) parameters:
+//   > Add them to Context.
+//   > Create "With..." receivers like the one below in order to chain the calls
+//     def:     func (mp *Context) WithNewParam(newParam Type) *Context{}
+//     usage:   muxCtx := NewContext.WithIMSI("1234").WithNewParam(newParam)
+//   > Modify the context calls on magma to make sure that parameter is included where you need it
+// - Implement multiplexor interface with your new algorithm. HEre you can add some static data when
+//   you create the multiplexor (an example could be a list of predefined imsis)
+
+package multiplex
+
+import (
+	"fmt"
+
+	"magma/lte/cloud/go/protos"
+)
+
+// Multiplexor interface has to be implemented by any new Multiplexor.
+// Multiplexor can be loaded with data during creation and we can pass some dynamic parameters
+// coming from each requests (using context)
+type Multiplexor interface {
+	// GetIndex return an index based on the implementation of Multiplexor
+	GetIndex(*Context) (int, error)
+}
+
+// Context is a type used as a way to pass dynamic parameters coming from specific calls during
+// execution of service (for example CreateSessionRequest)
+type Context struct {
+	imsiNumeric uint64
+	lastError   error
+}
+
+// NewContext creates a new context
+func NewContext() *Context {
+	return &Context{}
+}
+
+// GetContext returns IMSI in uint64 format
+// That IMSI can come from different sources like IMSI string or SessionId
+func (c *Context) GetIMSI() (uint64, error) {
+	if c.lastError != nil {
+		return 0, c.lastError
+	}
+	return c.imsiNumeric, nil
+}
+
+func (c *Context) GetError() error {
+	return c.lastError
+}
+
+// WithIMSI adds imsi to context from a IMSI string (from IMSI123456789012345   123456789012345)
+func (c *Context) WithIMSI(imsi string) *Context {
+	if c == nil {
+		c = &Context{}
+	}
+	if c.lastError != nil {
+		return c
+	}
+	_, imsiNumeric, err := protos.StripPrefixFromIMSIandFormat(imsi)
+	if err != nil {
+		c.lastError = err
+		return c
+	}
+	c.imsiNumeric = imsiNumeric
+	return c
+}
+
+// WithSessionId adds imsi to context from sessionId (from IMSI123456789012345-54321 to 123456789012345)
+func (c *Context) WithSessionId(sessionId string) *Context {
+	if c == nil {
+		c = &Context{}
+	}
+	if c.lastError != nil {
+		return c
+	}
+	imsiWithPrefix, err := protos.GetIMSIwithPrefixFromSessionId(sessionId)
+	if err != nil {
+		c.lastError = err
+		return c
+	}
+	return c.WithIMSI(imsiWithPrefix)
+}
+
+// StaticMultiplexByIMSI contains is a basic Multiplexor that distribuites each IMSI to a specific
+// index based on the IMSImod(numServers)
+type StaticMultiplexByIMSI struct {
+	totalServers uint64
+}
+
+// NewStaticMultiplexByIMSI creates a StaticMultiplexByIMSI with a specific number of servers
+// That number must be specified before service is started. Context must be used to pass dynamic
+// data coming during execution of service
+func NewStaticMultiplexByIMSI(numServers int) (Multiplexor, error) {
+	if numServers < 1 {
+		return nil, fmt.Errorf("MultiplexByIMSI needs to be configured with 1 or more than 1 servers (%d configured)", numServers)
+	}
+	return &StaticMultiplexByIMSI{uint64(numServers)}, nil
+}
+
+// GetIndex provides the index of the server per that IMSI
+func (m *StaticMultiplexByIMSI) GetIndex(c *Context) (int, error) {
+	if c.lastError != nil {
+		return -1, c.lastError
+	}
+	index := int(c.imsiNumeric % m.totalServers)
+	return index, nil
+}

--- a/feg/gateway/multiplex/multiplex_test.go
+++ b/feg/gateway/multiplex/multiplex_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package multiplex_test
+
+import (
+	"magma/feg/gateway/multiplex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type muxSelectorsScenario struct {
+	sessionId     string
+	imsiStr       string
+	imsiNumeric   uint64
+	conversionErr bool
+}
+
+type multiplexorScenario struct {
+	sessionId    string
+	numServers   int
+	outputServer int
+	outputErr    bool
+}
+
+var (
+	// Scenarios to test multiplex.Context IMSI parer
+	muxSelectorTestScenarios = []muxSelectorsScenario{
+		muxSelectorsScenario{"IMSI123456789012345-54321", "IMSI123456789012345", 123456789012345, false},
+		muxSelectorsScenario{"IMSI999999999999999-54321", "IMSI999999999999999", 999999999999999, false},
+		muxSelectorsScenario{"IMSI000000000000010-54321", "IMSI000000000000010", 10, false},
+		muxSelectorsScenario{"IMSI1234AAAAA012345-54321", "IMSI1234AAAAA012345", 0, true},
+	}
+	// Scenarios to test StaticMultiplexByIMSI
+	staticMultiplexByIMSIScenario = []multiplexorScenario{
+		multiplexorScenario{"IMSI123456789012345-54321", 5, 0, false},
+		multiplexorScenario{"IMSI999999999999999-54321", 7, 5, false},
+		multiplexorScenario{"IMSI000000000000010-54321", 6, 4, false},
+		multiplexorScenario{"IMSI1234AAAAA012345-54321", -1, -1, true},
+	}
+)
+
+func TestMultiplexContextSessionIdConversions(t *testing.T) {
+	for _, scenario := range muxSelectorTestScenarios {
+		assertIMSIConversion(t, multiplex.NewContext().WithSessionId(scenario.sessionId), scenario)
+	}
+}
+
+func TestMultiplexContextIMSIstrConversions(t *testing.T) {
+	for _, scenario := range muxSelectorTestScenarios {
+		assertIMSIConversion(t, multiplex.NewContext().WithIMSI(scenario.imsiStr), scenario)
+	}
+}
+
+func assertIMSIConversion(t *testing.T, muxCtx *multiplex.Context, scenario muxSelectorsScenario) {
+	if scenario.conversionErr {
+		assert.Errorf(t, muxCtx.GetError(), "Conversion should have failed on scenario: %+v", scenario)
+	} else {
+		imsi, err := muxCtx.GetIMSI()
+		assert.NoErrorf(t, err, "on scenario: %+v", scenario)
+		assert.Equalf(t, scenario.imsiNumeric, imsi, "on scenario: %+v", scenario)
+	}
+}
+
+func TestStaticMultiplexByIMSI(t *testing.T) {
+	for _, scenario := range staticMultiplexByIMSIScenario {
+		mux, err := multiplex.NewStaticMultiplexByIMSI(scenario.numServers)
+		if scenario.outputErr {
+			assert.Errorf(t, err, "StaticMultiplexByIMSI should have returned an error on scenario: %+v", scenario)
+		} else {
+			assert.NoErrorf(t, err, "on scenario: %+v", scenario)
+			server, err := mux.GetIndex(multiplex.NewContext().WithSessionId(scenario.sessionId))
+			assert.NoError(t, err)
+			assert.Equalf(t, scenario.outputServer, server, "on scenario: %+v", scenario)
+		}
+	}
+
+}

--- a/feg/gateway/services/session_proxy/credit_control/gx/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/config.go
@@ -49,6 +49,7 @@ var (
 		DisableEUIIPv6IfNoIPFlag, false, "Don't use MAC based EUI-64 IPv6 address for Gx CCR if IP is not provided")
 )
 
+// TODO: refactor those functions to make it more simple
 // GetPCRFConfiguration returns a slice containing all configuration for all known PCRF
 func GetPCRFConfiguration() []*diameter.DiameterServerConfig {
 	configsPtr := &mconfig.SessionProxyConfig{}
@@ -87,14 +88,14 @@ func GetPCRFConfiguration() []*diameter.DiameterServerConfig {
 	for i, gxCfg := range gxConfigs {
 		diamSrvCfg := &diameter.DiameterServerConfig{
 			DiameterServerConnConfig: diameter.DiameterServerConnConfig{
-				Addr:      getValueOrEnvForIndexZero(i, diameter.AddrFlag, PCRFAddrEnv, gxCfg.GetAddress()),
-				Protocol:  getValueOrEnvForIndexZero(i, diameter.NetworkFlag, GxNetworkEnv, gxCfg.GetProtocol()),
-				LocalAddr: getValueOrEnvForIndexZero(i, diameter.LocalAddrFlag, GxLocalAddr, gxCfg.GetLocalAddress()),
+				Addr:      diameter.GetValueOrEnv(diameter.AddrFlag, PCRFAddrEnv, gxCfg.GetAddress(), i),
+				Protocol:  diameter.GetValueOrEnv(diameter.NetworkFlag, GxNetworkEnv, gxCfg.GetProtocol(), i),
+				LocalAddr: diameter.GetValueOrEnv(diameter.LocalAddrFlag, GxLocalAddr, gxCfg.GetLocalAddress(), i),
 			},
-			DestHost:          getValueOrEnvForIndexZero(i, diameter.DestHostFlag, PCRFHostEnv, gxCfg.GetDestHost()),
-			DestRealm:         getValueOrEnvForIndexZero(i, diameter.DestRealmFlag, PCRFRealmEnv, gxCfg.GetDestHost()),
-			DisableDestHost:   getBoolValueOrEnvForIndexZero(i, diameter.DisableDestHostFlag, DisableDestHostEnv, gxCfg.GetDisableDestHost()),
-			OverwriteDestHost: getBoolValueOrEnvForIndexZero(i, diameter.OverwriteDestHostFlag, OverwriteDestHostEnv, gxCfg.GetOverwriteDestHost()),
+			DestHost:          diameter.GetValueOrEnv(diameter.DestHostFlag, PCRFHostEnv, gxCfg.GetDestHost(), i),
+			DestRealm:         diameter.GetValueOrEnv(diameter.DestRealmFlag, PCRFRealmEnv, gxCfg.GetDestHost(), i),
+			DisableDestHost:   diameter.GetBoolValueOrEnv(diameter.DisableDestHostFlag, DisableDestHostEnv, gxCfg.GetDisableDestHost(), i),
+			OverwriteDestHost: diameter.GetBoolValueOrEnv(diameter.OverwriteDestHostFlag, OverwriteDestHostEnv, gxCfg.GetOverwriteDestHost(), i),
 		}
 		diamServerConfigs = append(diamServerConfigs, diamSrvCfg)
 	}
@@ -143,13 +144,13 @@ func GetGxClientConfiguration() []*diameter.DiameterClientConfig {
 			retries = 1
 		}
 		diamCliCfg := &diameter.DiameterClientConfig{
-			Host:               getValueOrEnvForIndexZero(i, diameter.HostFlag, GxDiamHostEnv, gxCfg.GetHost()),
-			Realm:              getValueOrEnvForIndexZero(i, diameter.RealmFlag, GxDiamRealmEnv, gxCfg.GetRealm()),
-			ProductName:        getValueOrEnvForIndexZero(i, diameter.ProductFlag, GxDiamProductEnv, gxCfg.GetProductName()),
+			Host:               diameter.GetValueOrEnv(diameter.HostFlag, GxDiamHostEnv, gxCfg.GetHost(), i),
+			Realm:              diameter.GetValueOrEnv(diameter.RealmFlag, GxDiamRealmEnv, gxCfg.GetRealm(), i),
+			ProductName:        diameter.GetValueOrEnv(diameter.ProductFlag, GxDiamProductEnv, gxCfg.GetProductName(), i),
 			AppID:              diam.GX_CHARGING_CONTROL_APP_ID,
 			WatchdogInterval:   diameter.DefaultWatchdogIntervalSeconds,
 			RetryCount:         uint(retries),
-			SupportedVendorIDs: getValueOrEnvForIndexZero(i, "", GxSupportedVendorIDsEnv, ""),
+			SupportedVendorIDs: diameter.GetValueOrEnv("", GxSupportedVendorIDsEnv, "", i),
 		}
 		diamClientsConfigs = append(diamClientsConfigs, diamCliCfg)
 	}
@@ -183,20 +184,4 @@ func validGxConfig(config *mconfig.SessionProxyConfig) bool {
 		}
 	}
 	return true
-}
-
-// getValueOrEnvForIndexZero gets the Value or Env for the index 0, otherwise it returns Value(string)
-func getValueOrEnvForIndexZero(index int, flagName, envVariable, defaultValue string) string {
-	if index == 0 {
-		return diameter.GetValueOrEnv(flagName, envVariable, defaultValue)
-	}
-	return defaultValue
-}
-
-// getBoolValueOrEnvForIndexZero gets the Value or Env for the index 0, otherwise it returns Value(bool)
-func getBoolValueOrEnvForIndexZero(index int, flagName string, envVariable string, defaultValue bool) bool {
-	if index == 0 {
-		return diameter.GetBoolValueOrEnv(flagName, envVariable, defaultValue)
-	}
-	return defaultValue
 }

--- a/feg/gateway/services/session_proxy/credit_control/gx/handlers.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/handlers.go
@@ -58,7 +58,7 @@ type PolicyReAuthHandler func(request *PolicyReAuthRequest) *PolicyReAuthAnswer
 func GetGxReAuthHandler(cloudRegistry service_registry.GatewayRegistry, policyDBClient policydb.PolicyDBClient) PolicyReAuthHandler {
 	return func(request *PolicyReAuthRequest) *PolicyReAuthAnswer {
 		sid := diameter.DecodeSessionID(request.SessionID)
-		imsi, err := protos.ParseIMSIfromSessionIdWithPrefix(sid)
+		imsi, err := protos.GetIMSIwithPrefixFromSessionId(sid)
 		if err != nil {
 			glog.Errorf("Error retrieving IMSI from session ID %s: %s", request.SessionID, err)
 			return &PolicyReAuthAnswer{

--- a/feg/gateway/services/session_proxy/credit_control/gy/config.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/config.go
@@ -86,6 +86,7 @@ func GetInitMethod() InitMethod {
 	return initMethod
 }
 
+// TODO: refactor those functions to make it more simple
 // GetOCSConfiguration returns the server configuration for the set OCS
 func GetOCSConfiguration() []*diameter.DiameterServerConfig {
 	configsPtr := &mconfig.SessionProxyConfig{}
@@ -124,14 +125,14 @@ func GetOCSConfiguration() []*diameter.DiameterServerConfig {
 	for i, gyCfg := range gyConfigs {
 		diamSrvCfg := &diameter.DiameterServerConfig{
 			DiameterServerConnConfig: diameter.DiameterServerConnConfig{
-				Addr:      getValueOrEnvForIndexZero(i, diameter.AddrFlag, OCSAddrEnv, gyCfg.GetAddress()),
-				Protocol:  getValueOrEnvForIndexZero(i, diameter.NetworkFlag, GyNetworkEnv, gyCfg.GetProtocol()),
-				LocalAddr: getValueOrEnvForIndexZero(i, diameter.LocalAddrFlag, GyLocalAddr, gyCfg.GetLocalAddress()),
+				Addr:      diameter.GetValueOrEnv(diameter.AddrFlag, OCSAddrEnv, gyCfg.GetAddress(), i),
+				Protocol:  diameter.GetValueOrEnv(diameter.NetworkFlag, GyNetworkEnv, gyCfg.GetProtocol(), i),
+				LocalAddr: diameter.GetValueOrEnv(diameter.LocalAddrFlag, GyLocalAddr, gyCfg.GetLocalAddress(), i),
 			},
-			DestHost:          getValueOrEnvForIndexZero(i, diameter.DestHostFlag, OCSHostEnv, gyCfg.GetDestHost()),
-			DestRealm:         getValueOrEnvForIndexZero(i, diameter.DestRealmFlag, OCSRealmEnv, gyCfg.GetDestRealm()),
-			DisableDestHost:   getBoolValueOrEnvForIndexZero(i, diameter.DisableDestHostFlag, DisableDestHostEnv, gyCfg.GetDisableDestHost()),
-			OverwriteDestHost: getBoolValueOrEnvForIndexZero(i, diameter.OverwriteDestHostFlag, OverwriteDestHostEnv, gyCfg.GetOverwriteDestHost()),
+			DestHost:          diameter.GetValueOrEnv(diameter.DestHostFlag, OCSHostEnv, gyCfg.GetDestHost(), i),
+			DestRealm:         diameter.GetValueOrEnv(diameter.DestRealmFlag, OCSRealmEnv, gyCfg.GetDestRealm(), i),
+			DisableDestHost:   diameter.GetBoolValueOrEnv(diameter.DisableDestHostFlag, DisableDestHostEnv, gyCfg.GetDisableDestHost(), i),
+			OverwriteDestHost: diameter.GetBoolValueOrEnv(diameter.OverwriteDestHostFlag, OverwriteDestHostEnv, gyCfg.GetOverwriteDestHost(), i),
 		}
 		diamServerConfigs = append(diamServerConfigs, diamSrvCfg)
 	}
@@ -179,14 +180,14 @@ func GetGyClientConfiguration() []*diameter.DiameterClientConfig {
 		}
 
 		diamCliCfg := &diameter.DiameterClientConfig{
-			Host:               getValueOrEnvForIndexZero(i, diameter.HostFlag, GyDiamHostEnv, gyCfg.GetHost()),
-			Realm:              getValueOrEnvForIndexZero(i, diameter.RealmFlag, GyDiamRealmEnv, gyCfg.GetRealm()),
-			ProductName:        getValueOrEnvForIndexZero(i, diameter.ProductFlag, GyDiamProductEnv, gyCfg.GetProductName()),
+			Host:               diameter.GetValueOrEnv(diameter.HostFlag, GyDiamHostEnv, gyCfg.GetHost(), i),
+			Realm:              diameter.GetValueOrEnv(diameter.RealmFlag, GyDiamRealmEnv, gyCfg.GetRealm(), i),
+			ProductName:        diameter.GetValueOrEnv(diameter.ProductFlag, GyDiamProductEnv, gyCfg.GetProductName(), i),
 			AppID:              diam.CHARGING_CONTROL_APP_ID,
 			WatchdogInterval:   diameter.DefaultWatchdogIntervalSeconds,
 			RetryCount:         uint(retries),
-			SupportedVendorIDs: getValueOrEnvForIndexZero(i, "", GySupportedVendorIDsEnv, ""),
-			ServiceContextId:   getValueOrEnvForIndexZero(i, "", GyServiceContextIdEnv, ""),
+			SupportedVendorIDs: diameter.GetValueOrEnv("", GySupportedVendorIDsEnv, "", i),
+			ServiceContextId:   diameter.GetValueOrEnv("", GyServiceContextIdEnv, "", i),
 		}
 		diamClientsConfigs = append(diamClientsConfigs, diamCliCfg)
 	}
@@ -223,20 +224,4 @@ func validGyConfig(config *mconfig.SessionProxyConfig) bool {
 		}
 	}
 	return true
-}
-
-// getValueOrEnvForIndexZero gets the Value or Env for the index 0, otherwise it returns Value(string)
-func getValueOrEnvForIndexZero(index int, flagName, envVariable, defaultValue string) string {
-	if index == 0 {
-		return diameter.GetValueOrEnv(flagName, envVariable, defaultValue)
-	}
-	return defaultValue
-}
-
-// getBoolValueOrEnvForIndexZero gets the Value or Env for the index 0, otherwise it returns Value(bool)
-func getBoolValueOrEnvForIndexZero(index int, flagName string, envVariable string, defaultValue bool) bool {
-	if index == 0 {
-		return diameter.GetBoolValueOrEnv(flagName, envVariable, defaultValue)
-	}
-	return defaultValue
 }

--- a/feg/gateway/services/session_proxy/credit_control/gy/handlers.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/handlers.go
@@ -25,7 +25,7 @@ import (
 func GetGyReAuthHandler(cloudRegistry service_registry.GatewayRegistry) ChargingReAuthHandler {
 	return ChargingReAuthHandler(func(request *ChargingReAuthRequest) *ChargingReAuthAnswer {
 		sid := diameter.DecodeSessionID(request.SessionID)
-		imsi, err := protos.ParseIMSIfromSessionIdWithPrefix(sid)
+		imsi, err := protos.GetIMSIwithPrefixFromSessionId(sid)
 		if err != nil {
 			glog.Errorf("Error retreiving IMSI from Session ID %s: %s", request.SessionID, err)
 			return &ChargingReAuthAnswer{

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -15,6 +15,7 @@ import (
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
+	"magma/feg/gateway/multiplex"
 	"magma/feg/gateway/policydb"
 	"magma/feg/gateway/services/session_proxy/credit_control"
 	"magma/feg/gateway/services/session_proxy/credit_control/gx"
@@ -36,17 +37,21 @@ const (
 	IMSI2          = "IMSI00102"
 	IMSI1_NOPREFIX = "00101"
 	IMSI2_NOPREFIX = "00102"
-	NUMBER_SERVERS = 5
+	IMSI1_uint64   = uint64(101)
+	IMSI2_uint64   = uint64(102)
+	NUMBER_SERVERS = 5 // Must be always bigger or equal to num of imsis
 )
 
 var (
-	imsis          = []string{"IMSI00101", "IMSI00102", "IMSI00106", "IMSI00111", "IMSI00116"}
-	imsis_noprefix = []string{"00101", "00102", "00106", "00111", "00116"}
+	imsis          = []string{IMSI1, IMSI2}
+	imsis_noprefix = []string{IMSI1_NOPREFIX, IMSI2_NOPREFIX}
+	ismis_uint64   = []uint64{IMSI1_uint64, IMSI2_uint64}
 	// as many ports as servers
 	ocs_server_ports  = []string{"3869", "3870", "3871", "3872", "3873"}
 	pcrf_server_ports = []string{"3879", "3880", "3881", "3882", "3883"}
 )
 
+// ---- MockPolicyClient ----
 type MockPolicyClient struct {
 	mock.Mock
 }
@@ -74,30 +79,7 @@ func (p *MockPolicyClient) DisableConnections(period time.Duration) {
 	return
 }
 
-type MockPolicyDBClient struct {
-	mock.Mock
-}
-
-func (client *MockPolicyDBClient) GetChargingKeysForRules(ruleIDs []string, ruleDefs []*protos.PolicyRule) []policydb.ChargingKey {
-
-	args := client.Called(ruleIDs)
-	return args.Get(0).([]policydb.ChargingKey)
-}
-
-func (client *MockPolicyDBClient) GetRuleIDsForBaseNames(baseNames []string) []string {
-	args := client.Called(baseNames)
-	return args.Get(0).([]string)
-}
-
-func (client *MockPolicyDBClient) GetPolicyRuleByID(id string) (*protos.PolicyRule, error) {
-	return nil, nil
-}
-
-func (client *MockPolicyDBClient) GetOmnipresentRules() ([]string, []string) {
-	args := client.Called()
-	return args.Get(0).([]string), args.Get(1).([]string)
-}
-
+// ---- MockCreditClient ----
 type MockCreditClient struct {
 	mock.Mock
 }
@@ -125,48 +107,86 @@ func (cc *MockCreditClient) DisableConnections(period time.Duration) {
 	return
 }
 
+// ---- MockPolicyDBClient ----
+type MockPolicyDBClient struct {
+	mock.Mock
+}
+
+func (client *MockPolicyDBClient) GetChargingKeysForRules(ruleIDs []string, ruleDefs []*protos.PolicyRule) []policydb.ChargingKey {
+
+	args := client.Called(ruleIDs)
+	return args.Get(0).([]policydb.ChargingKey)
+}
+
+func (client *MockPolicyDBClient) GetRuleIDsForBaseNames(baseNames []string) []string {
+	args := client.Called(baseNames)
+	return args.Get(0).([]string)
+}
+
+func (client *MockPolicyDBClient) GetPolicyRuleByID(id string) (*protos.PolicyRule, error) {
+	return nil, nil
+}
+
+func (client *MockPolicyDBClient) GetOmnipresentRules() ([]string, []string) {
+	args := client.Called()
+	return args.Get(0).([]string), args.Get(1).([]string)
+}
+
+//  ---- MockMultiplexor ----
+type MockMultiplexor struct {
+	mock.Mock
+	imsiToIndex map[uint64]int
+}
+
+func (mp *MockMultiplexor) GetIndex(muxCtx *multiplex.Context) (int, error) {
+	imsi, err := muxCtx.GetIMSI()
+	if err != nil {
+		return -1, err
+	}
+	return mp.imsiToIndex[imsi], nil
+}
+
+// ---- TESTS ----
 func TestSessionControllerPerSessionInit_SingleServer(t *testing.T) {
 	numberServers := 1
-	mockConfig := getTestConfig(numberServers, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(numberServers, mockConfig)
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
-
-	srv := servicers.NewCentralSessionController(
-		mockControlParams[0].CreditClient,
-		mockControlParams[0].PolicyClient,
-		mockPolicyDb,
-		mockConfig[0],
-	)
-	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, gy.PerSessionInit, numberServers)
+	mockMux := getMockMultiplexor(numberServers)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
+	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, mockMux, gy.PerSessionInit)
 }
 
 func TestSessionControllerPerSessionInit(t *testing.T) {
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb)
-	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, gy.PerSessionInit, NUMBER_SERVERS)
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
+	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, mockMux, gy.PerSessionInit)
 }
 
 func TestSessionControllerPerKeyInit(t *testing.T) {
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerKeyInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
+	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb)
-	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, gy.PerKeyInit, NUMBER_SERVERS)
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
+	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, mockMux, gy.PerKeyInit)
 }
 
 func TestStartSessionGxFail(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerKeyInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
+	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
-	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 
+	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	// Send back DIAMETER_RATING_FAILED (5031) from gx
 	mocksGx.On("SendCreditControlRequest", mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 		done := args.Get(1).(chan interface{})
@@ -179,13 +199,13 @@ func TestStartSessionGxFail(t *testing.T) {
 	}).Once()
 	// If gx fails gy should not be used at all
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 	_, err = srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	assert.Error(t, err)
@@ -193,12 +213,13 @@ func TestStartSessionGxFail(t *testing.T) {
 
 func TestStartSessionGyFail(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := mockControlParams[idx].CreditClient.(*MockCreditClient)
@@ -226,11 +247,11 @@ func TestStartSessionGyFail(t *testing.T) {
 		}
 	}).Once()
 
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
 		[]policydb.ChargingKey{{RatingGroup: 1}}, nil).Once()
 	// no omnipresent rules
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
+	mockPolicyDb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
 
 	// Send back DIAMETER_RATING_FAILED (5031) from gy
 	mocksGy.On("SendCreditControlRequest", mock.Anything, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
@@ -243,13 +264,13 @@ func TestStartSessionGyFail(t *testing.T) {
 		}
 	}).Once()
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 	_, err = srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	assert.Error(t, err)
@@ -260,11 +281,11 @@ func standardUsageTest(
 	srv servicers.CentralSessionControllerServerWithHealth,
 	controllerParams []*servicers.ControllerParam,
 	policyDb policydb.PolicyDBClient,
+	mux multiplex.Multiplexor,
 	initMethod gy.InitMethod,
-	numberServers int,
 ) error {
 	ctx := context.Background()
-	mocksPolicydb := policyDb.(*MockPolicyDBClient)
+	mockPolicyDb := policyDb.(*MockPolicyDBClient)
 
 	// Create a structure to store the pointers to the type assertions. his is needed later to
 	// be used on Enable/Disable. If it were not saved here the reference of the type to be
@@ -276,7 +297,9 @@ func standardUsageTest(
 		mocksGys = append(mocksGys, cp.CreditClient.(*MockCreditClient))
 	}
 
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, numberServers)
+	// Get the controller for this imsi
+	idx, err := mux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
+
 	assert.NoError(t, err)
 
 	mocksGx := mocksGxs[idx]
@@ -344,8 +367,8 @@ func standardUsageTest(
 	}).Once()
 
 	// send rating groups back
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
 		[]policydb.ChargingKey{
 			policydb.ChargingKey{RatingGroup: 1},
 			policydb.ChargingKey{RatingGroup: 2},
@@ -355,8 +378,8 @@ func standardUsageTest(
 			policydb.ChargingKey{RatingGroup: 20, ServiceIdTracking: true, ServiceIdentifier: 201},
 			policydb.ChargingKey{RatingGroup: 21}}, nil).Once()
 	// no omnipresent rules
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
+	mockPolicyDb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
 	multiReqType := credit_control.CRTInit // type of CCR sent to get credits
 	if initMethod == gy.PerSessionInit {
 		mocksGy.On(
@@ -378,11 +401,11 @@ func standardUsageTest(
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	mocksGy.AssertExpectations(t)
-	mocksPolicydb.AssertExpectations(t)
+	mockPolicyDb.AssertExpectations(t)
 	assert.Equal(t, 6, len(createResponse.Credits)) // 2 static, 2 dynamic, 2 base
 	assert.Equal(t, 2, len(createResponse.DynamicRules))
 
@@ -436,12 +459,15 @@ func standardUsageTest(
 	mocksGy.On("SendCreditControlRequest", mock.Anything, mock.Anything,
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTUpdate)),
 	).Return(nil).Run(returnDefaultGyResponse).Times(2)
-	updateResponse, _ := srv.UpdateSession(ctx, &protos.UpdateSessionRequest{
-		Updates: []*protos.CreditUsageUpdate{
-			createUsageUpdate(IMSI1, 1, 1, protos.CreditUsage_QUOTA_EXHAUSTED),
-			createUsageUpdate(IMSI1, 2, 2, protos.CreditUsage_TERMINATED),
+
+	updateResponse, _ := srv.UpdateSession(ctx,
+		&protos.UpdateSessionRequest{
+			Updates: []*protos.CreditUsageUpdate{
+				createUsageUpdate(IMSI1, 1, 1, protos.CreditUsage_QUOTA_EXHAUSTED),
+				createUsageUpdate(IMSI1, 2, 2, protos.CreditUsage_TERMINATED),
+			},
 		},
-	})
+	)
 	mocksGy.AssertExpectations(t)
 	assert.Equal(t, 2, len(updateResponse.Responses))
 	for _, update := range updateResponse.Responses {
@@ -450,13 +476,14 @@ func standardUsageTest(
 		assert.True(t, update.ChargingKey == 1 || update.ChargingKey == 2)
 	}
 
-	// Connection Manager tests - Disable Connections
-	for i := 0; i < numberServers; i++ {
+	// Connection Manager tests - Disable Connections for all configured servers
+	confNumOfServers := len(controllerParams)
+	for i := 0; i < confNumOfServers; i++ {
 		mocksGxs[i].On("DisableConnections", mock.Anything).Return()
 		mocksGys[i].On("DisableConnections", mock.Anything).Return()
 	}
 	void, err := srv.Disable(ctx, &fegprotos.DisableMessage{DisablePeriodSecs: 10})
-	for i := 0; i < numberServers; i++ {
+	for i := 0; i < confNumOfServers; i++ {
 		mocksGxs[i].AssertExpectations(t)
 		mocksGys[i].AssertExpectations(t)
 	}
@@ -464,13 +491,13 @@ func standardUsageTest(
 	assert.Equal(t, &orcprotos.Void{}, void)
 
 	// Connection Manager tests - Enable Connections
-	for i := 0; i < numberServers; i++ {
+	for i := 0; i < confNumOfServers; i++ {
 		mocksGxs[i].On("EnableConnections").Return()
 		mocksGys[i].On("EnableConnections").Return()
 	}
 	void, err = srv.Enable(ctx, &orcprotos.Void{})
 
-	for i := 0; i < numberServers; i++ {
+	for i := 0; i < confNumOfServers; i++ {
 		mocksGxs[i].AssertExpectations(t)
 		mocksGys[i].AssertExpectations(t)
 	}
@@ -482,12 +509,13 @@ func standardUsageTest(
 
 func TestSessionCreateWithOmnipresentRules(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 
@@ -511,22 +539,22 @@ func TestSessionCreateWithOmnipresentRules(t *testing.T) {
 			RuleInstallAVP: ruleInstalls,
 		}
 	}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"omnipresent_base_1"}).Return([]string{"omnipresent_rule_2"})
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return([]policydb.ChargingKey{}, nil).Once()
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{"omnipresent_rule_1"}, []string{"omnipresent_base_1"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"omnipresent_base_1"}).Return([]string{"omnipresent_rule_2"})
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return([]policydb.ChargingKey{}, nil).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{"omnipresent_rule_1"}, []string{"omnipresent_base_1"})
 	ctx := context.Background()
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	response, err := srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	assert.NoError(t, err)
 
 	mocksGx.AssertExpectations(t)
-	mocksPolicydb.AssertExpectations(t)
+	mockPolicyDb.AssertExpectations(t)
 
 	assert.Equal(t, 6, len(response.StaticRules))
 	expectedRuleIDs := []string{"static_rule_1", "static_rule_2", "base_rule_1", "base_rule_2", "omnipresent_rule_1", "omnipresent_rule_2"}
@@ -536,18 +564,18 @@ func TestSessionCreateWithOmnipresentRules(t *testing.T) {
 
 func TestSessionControllerTimeouts(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 
-	// Get the controller for this imsi
-	idx1, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx1, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGy_1 := mockControlParams[idx1].CreditClient.(*MockCreditClient)
 
-	idx2, err := servicers.GetControllerIndexFromImsi(IMSI2, NUMBER_SERVERS)
+	idx2, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI2))
 	assert.NoError(t, err)
 	mocksGy_2 := mockControlParams[idx2].CreditClient.(*MockCreditClient)
 
@@ -620,14 +648,15 @@ func TestSessionControllerTimeouts(t *testing.T) {
 
 func TestSessionTermination(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI2, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI2))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := mockControlParams[idx].CreditClient.(*MockCreditClient)
@@ -667,7 +696,7 @@ func TestSessionTermination(t *testing.T) {
 
 	termResponse, err := srv.TerminateSession(ctx, &protos.SessionTerminateRequest{
 		Sid:       IMSI2,
-		SessionId: fmt.Sprintf("%s-1234", IMSI2),
+		SessionId: genSessionID(IMSI2),
 		CreditUsages: []*protos.CreditUsage{
 			createUsage(2, protos.CreditUsage_TERMINATED),
 			createUsage(1, protos.CreditUsage_TERMINATED),
@@ -677,25 +706,26 @@ func TestSessionTermination(t *testing.T) {
 	mocksGx.AssertExpectations(t)
 	assert.NoError(t, err)
 	assert.Equal(t, IMSI2, termResponse.Sid)
-	assert.Equal(t, fmt.Sprintf("%s-1234", IMSI2), termResponse.SessionId)
+	assert.Equal(t, genSessionID(IMSI2), termResponse.SessionId)
 }
 
 func testGxUsageMonitoring(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 
 	// Get the controller for this imsi
-	idx_1, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx_1, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx_1 := mockControlParams[idx_1].PolicyClient.(*MockPolicyClient)
 	mocksGy_1 := mockControlParams[idx_1].CreditClient.(*MockCreditClient)
 
-	idx_2, err := servicers.GetControllerIndexFromImsi(IMSI2, NUMBER_SERVERS)
+	idx_2, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI2))
 	assert.NoError(t, err)
 	mocksGx_2 := mockControlParams[idx_2].PolicyClient.(*MockPolicyClient)
 	mocksGy_2 := mockControlParams[idx_2].CreditClient.(*MockCreditClient)
@@ -834,8 +864,8 @@ func testGxUsageMonitoring(t *testing.T) {
 		mock.MatchedBy(getGxCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
 	).Return(nil).Run(getRuleInstallGxUpdateResponse([]string{}, []string{"base_30"})).Times(1)
 
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"base_30"}).Return([]string{"base_rule_2", "base_rule_3"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"base_30"}).Return([]string{"base_rule_2", "base_rule_3"})
 
 	ruleInstallUpdateResponse, _ = srv.UpdateSession(ctx, &protos.UpdateSessionRequest{
 		UsageMonitors: []*protos.UsageMonitoringUpdateRequest{
@@ -930,8 +960,8 @@ func testGxUsageMonitoring(t *testing.T) {
 		mock.MatchedBy(getGxCCRMatcher(IMSI2_NOPREFIX, credit_control.CRTUpdate)),
 	).Return(nil).Run(getRuleDisableGxUpdateResponse([]string{}, []string{"base_30"})).Times(1)
 
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"base_30"}).Return([]string{"base_rule_3", "base_rule_4"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"base_10"}).Return([]string{"base_rule_1", "base_rule_2"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"base_30"}).Return([]string{"base_rule_3", "base_rule_4"})
 
 	ruleDisableUpdateResponse, _ = srv.UpdateSession(ctx, &protos.UpdateSessionRequest{
 		UsageMonitors: []*protos.UsageMonitoringUpdateRequest{
@@ -961,20 +991,21 @@ func TestGetHealthStatus(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 
 	// Get the controller for two imsis
-	idx_1, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx_1, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx_1 := mockControlParams[idx_1].PolicyClient.(*MockPolicyClient)
 	mocksGy_1 := mockControlParams[idx_1].CreditClient.(*MockCreditClient)
 
-	idx_2, err := servicers.GetControllerIndexFromImsi(IMSI2, NUMBER_SERVERS)
+	idx_2, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI2))
 	assert.NoError(t, err)
 	mocksGx_2 := mockControlParams[idx_2].PolicyClient.(*MockPolicyClient)
 	mocksGy_2 := mockControlParams[idx_2].CreditClient.(*MockCreditClient)
@@ -1069,9 +1100,26 @@ func TestGetHealthStatus(t *testing.T) {
 	assert.Equal(t, fegprotos.HealthStatus_UNHEALTHY, status.Health)
 }
 
-func getMockControllerParams(numServers int, mockConfig []*servicers.SessionControllerConfig) []*servicers.ControllerParam {
-	controlParams := make([]*servicers.ControllerParam, 0, numServers)
-	for i := 0; i < numServers; i++ {
+func genSessionID(imsi string) string {
+	return fmt.Sprintf("%s-1234", imsi)
+}
+
+// getMockMultiplexor loads mockMux with random controlers per each imsi and Imsi without prefix and
+// session id (this way we don't need to parse IMSIs at all)
+func getMockMultiplexor(numServers int) multiplex.Multiplexor {
+	mockMux := &MockMultiplexor{
+		imsiToIndex: make(map[uint64]int),
+	}
+	for i, imsi_uint64 := range ismis_uint64 {
+		mockMux.imsiToIndex[imsi_uint64] = i % numServers
+	}
+	return mockMux
+}
+
+// getMockControllerParams generates total of NUMBER_SERVERS . Multiplexor will decide how many will be used
+func getMockControllerParams(mockConfig []*servicers.SessionControllerConfig) []*servicers.ControllerParam {
+	controlParams := make([]*servicers.ControllerParam, 0, NUMBER_SERVERS)
+	for i := 0; i < NUMBER_SERVERS; i++ {
 		cp := &servicers.ControllerParam{
 			&MockCreditClient{},
 			&MockPolicyClient{},
@@ -1082,9 +1130,9 @@ func getMockControllerParams(numServers int, mockConfig []*servicers.SessionCont
 	return controlParams
 }
 
-func getTestConfig(numberServers int, initMethod gy.InitMethod) []*servicers.SessionControllerConfig {
+func getTestConfig(initMethod gy.InitMethod) []*servicers.SessionControllerConfig {
 	serverCfg := make([]*servicers.SessionControllerConfig, len(ocs_server_ports))
-	for i := 0; i < numberServers; i++ {
+	for i := 0; i < NUMBER_SERVERS; i++ {
 		ocs_port := ocs_server_ports[i]
 		pcrf_port := pcrf_server_ports[i]
 		srv := &servicers.SessionControllerConfig{
@@ -1112,7 +1160,7 @@ func createUsageUpdate(
 ) *protos.CreditUsageUpdate {
 	return &protos.CreditUsageUpdate{
 		Usage:         createUsage(chargingKey, requestType),
-		SessionId:     fmt.Sprintf("%s-1234", sid),
+		SessionId:     genSessionID(sid),
 		RequestNumber: requestNumber,
 		Sid:           sid,
 	}
@@ -1131,7 +1179,7 @@ func createUsageMonitoringRequest(
 			MonitoringKey: []byte(monitoringKey),
 			Level:         monitoringLevel,
 		},
-		SessionId:     fmt.Sprintf("%s-1234", sid),
+		SessionId:     genSessionID(sid),
 		RequestNumber: requestNumber,
 		Sid:           sid,
 	}
@@ -1362,12 +1410,13 @@ func getGxCCRMatcher(imsi string, ccrType credit_control.CreditRequestType) inte
 /***** UseGyForAuthOnlySuccess Test Cases *****/
 func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerKeyInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := mockControlParams[idx].CreditClient.(*MockCreditClient)
@@ -1397,10 +1446,10 @@ func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 		}
 	}).Once()
 
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
 		[]policydb.ChargingKey{{RatingGroup: 3}}, nil).Once()
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{"omnipresent_1"}, []string{}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{}).Return([]string{}).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{"omnipresent_1"}, []string{}).Once()
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{}).Return([]string{}).Once()
 
 	mocksGy.On(
 		"SendCreditControlRequest",
@@ -1409,14 +1458,14 @@ func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTInit)),
 	).Return(nil).Run(returnGySuccessNoRatingGroup).Once()
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 
 	res, err := srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	assert.NoError(t, err)
@@ -1430,12 +1479,13 @@ func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 
 func TestSessionControllerUseGyForAuthOnlyNoRatingGroup(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerKeyInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := mockControlParams[idx].CreditClient.(*MockCreditClient)
@@ -1462,11 +1512,11 @@ func TestSessionControllerUseGyForAuthOnlyNoRatingGroup(t *testing.T) {
 			RuleInstallAVP: ruleInstalls,
 		}
 	}).Once()
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
 		[]policydb.ChargingKey{}, nil).Once()
 	// no omnipresent rule
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
+	mockPolicyDb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
 
 	// Even if there are no rating groups, gy CCR-I will be called.
 	mocksGy.On(
@@ -1476,13 +1526,13 @@ func TestSessionControllerUseGyForAuthOnlyNoRatingGroup(t *testing.T) {
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTInit)),
 	).Return(nil).Run(returnGySuccessNoRatingGroup).Once()
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 	_, err = srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	assert.NoError(t, err)
@@ -1502,12 +1552,13 @@ func returnGySuccessNoRatingGroup(args mock.Arguments) {
 
 func TestSessionControllerUseGyForAuthOnlyCreditLimitReached(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerKeyInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := mockControlParams[idx].CreditClient.(*MockCreditClient)
@@ -1532,11 +1583,11 @@ func TestSessionControllerUseGyForAuthOnlyCreditLimitReached(t *testing.T) {
 			RuleInstallAVP: ruleInstalls,
 		}
 	}).Once()
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
 		[]policydb.ChargingKey{}, nil).Once()
 	// no omnipresent rule
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
+	mockPolicyDb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
 
 	// Even if there are no rating groups, gy CCR-I will be called.
 	mocksGy.On(
@@ -1546,13 +1597,13 @@ func TestSessionControllerUseGyForAuthOnlyCreditLimitReached(t *testing.T) {
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTInit)),
 	).Return(nil).Run(returnGySuccessCreditLimitReached).Once()
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 	_, err = srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	assert.NoError(t, err)
@@ -1577,12 +1628,13 @@ func returnGySuccessCreditLimitReached(args mock.Arguments) {
 
 func TestSessionControllerUseGyForAuthOnlySubscriberBarred(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerKeyInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, NUMBER_SERVERS)
+	idx, err := mockMux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := mockControlParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := mockControlParams[idx].CreditClient.(*MockCreditClient)
@@ -1607,11 +1659,11 @@ func TestSessionControllerUseGyForAuthOnlySubscriberBarred(t *testing.T) {
 			RuleInstallAVP: ruleInstalls,
 		}
 	}).Once()
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return(
 		[]policydb.ChargingKey{}, nil).Once()
 	// no omnipresent rule
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
-	mocksPolicydb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{}, []string{}).Once()
+	mockPolicyDb.On("GetRuleIDsForBaseNames", mock.Anything).Return([]string{}).Once()
 
 	// Even if there are no rating groups, gy CCR-I will be called.
 	mocksGy.On(
@@ -1621,13 +1673,13 @@ func TestSessionControllerUseGyForAuthOnlySubscriberBarred(t *testing.T) {
 		mock.MatchedBy(getGyCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTInit)),
 	).Return(nil).Run(returnGySuccessSubscriberBarred).Once()
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 	ctx := context.Background()
 	_, err = srv.CreateSession(ctx, &protos.CreateSessionRequest{
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 	mocksGx.AssertExpectations(t)
 	assert.Error(t, err)
@@ -1685,14 +1737,15 @@ func revalidationTimerTest(
 	srv servicers.CentralSessionControllerServerWithHealth,
 	controllerParams []*servicers.ControllerParam,
 	policyDb policydb.PolicyDBClient,
+	mux multiplex.Multiplexor,
 	useGyForAuthOnly bool,
 	numberServers int,
 ) {
 	ctx := context.Background()
-	mocksPolicydb := policyDb.(*MockPolicyDBClient)
+	mockPolicyDb := policyDb.(*MockPolicyDBClient)
 
 	// Get the controller for this imsi
-	idx, err := servicers.GetControllerIndexFromImsi(IMSI1, numberServers)
+	idx, err := mux.GetIndex(multiplex.NewContext().WithIMSI(IMSI1))
 	assert.NoError(t, err)
 	mocksGx := controllerParams[idx].PolicyClient.(*MockPolicyClient)
 	mocksGy := controllerParams[idx].CreditClient.(*MockCreditClient)
@@ -1704,9 +1757,9 @@ func revalidationTimerTest(
 		mock.MatchedBy(getGxCCRMatcher(IMSI1_NOPREFIX, credit_control.CRTInit)),
 	).Return(nil).Run(returnGxSuccessRevalidationTimer).Once()
 
-	mocksPolicydb.On("GetOmnipresentRules").Return([]string{"omnipresent_rule_1"}, []string{"omnipresent_base_1"})
-	mocksPolicydb.On("GetRuleIDsForBaseNames", []string{"omnipresent_base_1"}).Return([]string{"omnipresent_rule_2"})
-	mocksPolicydb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return([]policydb.ChargingKey{}, nil).Once()
+	mockPolicyDb.On("GetOmnipresentRules").Return([]string{"omnipresent_rule_1"}, []string{"omnipresent_base_1"})
+	mockPolicyDb.On("GetRuleIDsForBaseNames", []string{"omnipresent_base_1"}).Return([]string{"omnipresent_rule_2"})
+	mockPolicyDb.On("GetChargingKeysForRules", mock.Anything, mock.Anything).Return([]policydb.ChargingKey{}, nil).Once()
 
 	if useGyForAuthOnly {
 		mocksGy.On(
@@ -1721,12 +1774,12 @@ func revalidationTimerTest(
 		Subscriber: &protos.SubscriberID{
 			Id: IMSI1,
 		},
-		SessionId: fmt.Sprintf("%s-1234", IMSI1),
+		SessionId: genSessionID(IMSI1),
 	})
 
 	mocksGx.AssertExpectations(t)
 	mocksGy.AssertExpectations(t)
-	mocksPolicydb.AssertExpectations(t)
+	mockPolicyDb.AssertExpectations(t)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(createResponse.UsageMonitors))
 
@@ -1738,29 +1791,25 @@ func revalidationTimerTest(
 
 func TestSessionControllerRevalidationTimerUsed(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(NUMBER_SERVERS, gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(NUMBER_SERVERS, mockConfig)
-	mocksPolicydb := &MockPolicyDBClient{}
+	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockControlParams := getMockControllerParams(mockConfig)
+	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(NUMBER_SERVERS)
 
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mocksPolicydb)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 
-	revalidationTimerTest(t, srv, mockControlParams, mocksPolicydb, false, NUMBER_SERVERS)
+	revalidationTimerTest(t, srv, mockControlParams, mockPolicyDb, mockMux, false, NUMBER_SERVERS)
 }
 
 func TestSessionControllerUseGyForAuthOnlyRevalidationTimerUsed(t *testing.T) {
 
 	numberServers := 1
-	mockConfig := getTestConfig(numberServers, gy.PerKeyInit)
+	mockConfig := getTestConfig(gy.PerKeyInit)
 	mockConfig[0].UseGyForAuthOnly = true
-	mockControlParams := getMockControllerParams(numberServers, mockConfig)
+	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
+	mockMux := getMockMultiplexor(numberServers)
+	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
 
-	srv := servicers.NewCentralSessionController(
-		mockControlParams[0].CreditClient,
-		mockControlParams[0].PolicyClient,
-		mockPolicyDb,
-		mockConfig[0],
-	)
-
-	revalidationTimerTest(t, srv, mockControlParams, mockPolicyDb, mockConfig[0].UseGyForAuthOnly, 1)
+	revalidationTimerTest(t, srv, mockControlParams, mockPolicyDb, mockMux, mockConfig[0].UseGyForAuthOnly, 1)
 }

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -13,6 +13,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -49,27 +50,56 @@ func main() {
 			"Session Proxy Base Service name: %s does not match its managed configs key: %s",
 			serviceBaseName, credit_control.SessionProxyServiceName)
 	}
+
 	// Create the service
 	srv, err := service.NewServiceWithOptions(registry.ModuleName, registry.SESSION_PROXY)
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}
 
+	// Create configs for each server and start diam connections
+	controllerParms, policyDBClient, err := generateClientsConfsAndDiameterConnection()
+	if err != nil {
+		glog.Fatal(err)
+		return
+	}
+
+	// Add servicers to the service
+	sessionManagerAndHealthServer, err := servicers.
+		NewCentralSessionControllerDefaultMultiplexWithHealth(controllerParms, policyDBClient)
+	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, sessionManagerAndHealthServer)
+	protos.RegisterServiceHealthServer(srv.GrpcServer, sessionManagerAndHealthServer)
+
+	// Run the service
+	err = srv.Run()
+	if err != nil {
+		glog.Fatalf("Error running service: %s", err)
+	}
+}
+
+// TODO: move this to servicers and add testing
+// generateClientsConfsAndDiameterConnection reads configurations for all GXs and GYs connections configured
+// at gateway.mconfig and creates a slice containing all the requiered parameters to start CentralSessionControllers
+func generateClientsConfsAndDiameterConnection() (
+	[]*servicers.ControllerParam, *policydb.RedisPolicyDBClient, error) {
+	cloudReg := registry.Get()
+	policyDBClient, err := policydb.NewRedisPolicyDBClient(cloudReg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("Error connecting to redis store: %s", err)
+	}
+
+	// ---- Read configus from gateway.mconfig  ----
 	glog.Info("------ Reading Gx and Gy configuration ------")
 	// Global config, init Method and policyDb (static routes) are shared by all the controllers
 	gyGlobalConf := gy.GetGyGlobalConfig()
 	gxGlobalConf := gx.GetGxGlobalConfig()
-	cloudReg := registry.Get()
-	policyDBClient, err := policydb.NewRedisPolicyDBClient(cloudReg)
-	if err != nil {
-		glog.Fatalf("Error connecting to redis store: %s", err)
-	}
 	initMethod := gy.GetInitMethod()
+
 	// Each controller will take one entry of PCRF, OCS, and gx/gy clients confs
-	OCSConfs := gy.GetOCSConfiguration()
-	PCRFConfs := gx.GetPCRFConfiguration()
 	gxCliConfs := gx.GetGxClientConfiguration()
 	gyCLiConfs := gy.GetGyClientConfiguration()
+	OCSConfs := gy.GetOCSConfiguration()
+	PCRFConfs := gx.GetPCRFConfiguration()
 
 	// this is a new copy needed to fill in the controllerParms
 	OCSConfsCopy := gy.GetOCSConfiguration()
@@ -77,12 +107,13 @@ func main() {
 
 	// Exit if the number of GX and GY configurations are different
 	if len(OCSConfs) != len(PCRFConfs) {
-		glog.Fatalf("Number of Gx and Gy servers configured must be equal Gx:%d Gx:%d",
+		return nil, nil, fmt.Errorf(
+			"Number of Gx and Gy servers configured must be equal Gx:%d Gx:%d",
 			len(OCSConfs), len(PCRFConfs))
-		return
 	}
 	glog.Info("------ Done reading configuration ------")
 
+	// ---- Create diammeter connections and build parameters for CentralSessionControllersn ----
 	glog.Info("------ Create diameter connexions ------")
 	totalLen := len(OCSConfs)
 	controllerParms := make([]*servicers.ControllerParam, 0, totalLen)
@@ -136,22 +167,5 @@ func main() {
 		controllerParms = append(controllerParms, controlParam)
 	}
 	glog.Infof("------ Done creating %d diameter connexions ------", totalLen)
-
-	// Add servicers to the service
-	sessionManagerAndHealthServer := servicers.NewHealthyCentralSessionController(controllerParms, policyDBClient)
-	lteprotos.RegisterCentralSessionControllerServer(srv.GrpcServer, sessionManagerAndHealthServer)
-	protos.RegisterServiceHealthServer(srv.GrpcServer, sessionManagerAndHealthServer)
-
-	// Run the service
-	err = srv.Run()
-	if err != nil {
-		glog.Fatalf("Error running service: %s", err)
-	}
-}
-
-func maxLen(a []*diameter.DiameterServerConfig, b []*diameter.DiameterServerConfig) int {
-	if len(a) > len(b) {
-		return len(a)
-	}
-	return len(b)
+	return controllerParms, policyDBClient, nil
 }

--- a/lte/cloud/go/protos/sid.go
+++ b/lte/cloud/go/protos/sid.go
@@ -11,6 +11,7 @@ package protos
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -48,22 +49,33 @@ func SidFromString(sid string) *SubscriberID {
 	return nil
 }
 
-// ParseIMSIfromSessionIdNoPrefix extracts IMSI from a sessionId and returns only the IMSI without prefix
+// GetIMSIFromSessionId extracts IMSI from a sessionId and returns only the IMSI without prefix
 // SessionId format is is considered to be IMMSIxxxxxx-1234, where xxxxx is the imsi to be extracted
 // ie:  IMSI123456789012345-54321   ->  123456789012345
-func ParseIMSIfromSessionIdNoPrefix(sessionId string) (string, error) {
+func GetIMSIFromSessionId(sessionId string) (string, error) {
 	sessionId = strings.TrimPrefix(sessionId, "IMSI")
-	return ParseIMSIfromSessionIdWithPrefix(sessionId)
+	return GetIMSIwithPrefixFromSessionId(sessionId)
 }
 
-// ParseIMSIfromSessionIdWithPrefix extracts IMSI from a sessionId and returns the IMSI with prefix
+// GetIMSIwithPrefixFromSessionId extracts IMSI from a sessionId and returns the IMSI with prefix
 // SessionId format is is considered to be IMMSIxxxxxx-1234, where xxxxx is the imsi to be extracted
 // ie:  IMSI123456789012345-54321   ->  IMSI123456789012345
-func ParseIMSIfromSessionIdWithPrefix(sessionId string) (string, error) {
+func GetIMSIwithPrefixFromSessionId(sessionId string) (string, error) {
 	data := strings.Split(sessionId, "-")
 	if len(data) != 2 {
 		return "", fmt.Errorf("Session ID %s does not match format 'IMSI-RandNum'", sessionId)
 	}
 	return data[0], nil
+}
 
+// StripPrefixFromIMSIandFormat extracts IMSI from an IMSI with prefix. It also checks that the IMSI is only numeric
+// ie:  IMSI123456789012345   ->  123456789012345
+// It returns IMSI in two formats: string and uint64
+func StripPrefixFromIMSIandFormat(imsiWithPrefix string) (string, uint64, error) {
+	imsiNoPrefix := strings.TrimPrefix(imsiWithPrefix, "IMSI")
+	imsiUint, err := strconv.ParseUint(imsiNoPrefix, 10, 64)
+	if err != nil {
+		return "", 0, fmt.Errorf("IMSI is not numeric: %s", imsiWithPrefix)
+	}
+	return imsiNoPrefix, imsiUint, nil
 }

--- a/lte/cloud/go/protos/sid_test.go
+++ b/lte/cloud/go/protos/sid_test.go
@@ -34,18 +34,26 @@ func TestSidString(t *testing.T) {
 	assert.Equal(t, out, str)
 }
 
-func TestParseImsiFromSessionId(t *testing.T) {
+func TestIMSIandSessionIdParsers(t *testing.T) {
 	randomSid := "99999"
-	IMSI := "123456789"
+	IMSI := "123456789012345"
+	IMSInumeric := uint64(123456789012345)
 	prefixedIMSI := fmt.Sprintf("IMSI%s", IMSI)
-	magmaSid := fmt.Sprintf("%s-%s", prefixedIMSI, randomSid)
+	magmaSessionId := fmt.Sprintf("%s-%s", prefixedIMSI, randomSid)
 
-	resultIMSINoprefix, err := protos.ParseIMSIfromSessionIdNoPrefix(magmaSid)
+	// test GetIMSIFromSessionId
+	resultIMSINoprefix, err := protos.GetIMSIFromSessionId(magmaSessionId)
 	assert.NoError(t, err)
 	assert.Equal(t, resultIMSINoprefix, IMSI)
 
-	resultIMSIWithprefix, err := protos.ParseIMSIfromSessionIdWithPrefix(magmaSid)
+	// test GetIMSIwithPrefixFromSessionId
+	resultIMSIWithprefix, err := protos.GetIMSIwithPrefixFromSessionId(magmaSessionId)
 	assert.NoError(t, err)
 	assert.Equal(t, resultIMSIWithprefix, prefixedIMSI)
 
+	// test StripPrefixFromIMSIandFormat
+	resultIMSIstr, resultIMSInumeric, err := protos.StripPrefixFromIMSIandFormat(prefixedIMSI)
+	assert.NoError(t, err)
+	assert.Equal(t, resultIMSIstr, IMSI)
+	assert.Equal(t, resultIMSInumeric, IMSInumeric)
 }


### PR DESCRIPTION
Summary:
In order to allow flexibility on how the subscribers are distributed across different diam connections, we add a new utility called ```Multiplexor```. This allows us to add different algorithms independently of the implementation of the Multiple service.

Currently there is only one algo defined that distributes Subscribers across different PCRFs and OCSs based on their IMSI module (```IMSI%numServers```). But in the future we could have an algorithm that has more features like checking health of a connection or having some kind of memory.

This diff also includes other refactors to improve readability on ```session_proxy```.

This is the list of changes:
- Creation of ```multiplex.go``` and ```multiplextest.go```
- Modified "multiple_Session_proxy.go" to include a ```multiplex```
- Modified  ```integ_tests/multi_sessioneproxy_test.go``` to use ```multiplex```
- Moved ```GetValueOrEnvForIndexZero``` functions to ```diameter/conf.go```
- Reorganized ```session_proxy/main.go```

Differential Revision: D21262966

