### PR TITLE
Updating mobilityd IP desc store per subscriber

### DIFF
--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -8,36 +8,40 @@ of patent rights can be found in the PATENTS file in the same directory.
 """
 from collections import defaultdict
 
-from magma.common.redis.containers import RedisHashDict, RedisSet
+from magma.common.redis.containers import RedisFlatDict, RedisHashDict, \
+    RedisSet
+from magma.common.redis.serializers import RedisSerde
 from magma.mobilityd import serialize_utils
+
+IPDESC_REDIS_TYPE = "mobilityd_ipdesc_record"
+IPSTATES_REDIS_TYPE = "mobilityd:ip_states:{}"
+IPBLOCKS_REDIS_TYPE = "mobilityd:assigned_ip_blocks"
 
 
 class AssignedIpBlocksSet(RedisSet):
     def __init__(self, client):
         super().__init__(
             client,
-            "mobilityd:assigned_ip_blocks",
+            IPBLOCKS_REDIS_TYPE,
             serialize_utils.serialize_ip_block,
             serialize_utils.deserialize_ip_block,
         )
 
 
-class SIDIPsDict(RedisHashDict):
+class IPDescDict(RedisFlatDict):
     def __init__(self, client):
-        super().__init__(
-            client,
-            "mobilityd:sid_to_descriptors",
-            serialize_utils.serialize_ip_descs,
-            serialize_utils.deserialize_ip_descs,
-            default_factory=list,
-        )
+        serde = RedisSerde(IPDESC_REDIS_TYPE,
+                           serialize_utils.serialize_ip_desc,
+                           serialize_utils.deserialize_ip_desc,
+                           )
+        super().__init__(client, serde)
 
 
 def ip_states(client, key):
     """ Get Redis view of IP states. """
     redis_dict = RedisHashDict(
         client,
-        "mobilityd:ip_to_descriptor:{}".format(key),
+        IPSTATES_REDIS_TYPE.format(key),
         serialize_utils.serialize_ip_desc,
         serialize_utils.deserialize_ip_desc,
     )


### PR DESCRIPTION
Summary:
This diff:

- Updates SID => IPs map to SID => IPDesc instead of SID => [IPDesc] as each <Subscriber,APN> composite key should allow only one IP allocated.
- Updates IP desc store persistance in redis as `IMSIxxx.<apn_name>:mobilityd_ip_desc_record` for stateless mobilityd and state replication support.
- Updates composite key for subscriber to `IMSIXXXX.<apn_name>` on ip_allocator

Differential Revision: D21262424

