### PR TITLE
Add gx test for FramedIPv4AddrRequiredEnv

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client.go
@@ -14,15 +14,15 @@ import (
 	"os"
 	"time"
 
-	"github.com/fiorix/go-diameter/v4/diam"
-	"github.com/fiorix/go-diameter/v4/diam/avp"
-	"github.com/fiorix/go-diameter/v4/diam/datatype"
-	"github.com/golang/glog"
-
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/services/session_proxy/credit_control"
 	"magma/gateway/service_registry"
 	"magma/orc8r/lib/go/util"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+	"github.com/golang/glog"
 )
 
 const (


### PR DESCRIPTION
Summary:
- Adding a unit test for this feature to cross off the item from CWF test coverage
- When `FramedIPv4AddrRequiredEnv` and `DefaultFramedIPv4AddrEnv` are  set, the ip addr in the CCR should be overwritten, and no `FramedIPv6Prefix`  should be sent.

Differential Revision: D21302225

