### PR TITLE
Some log adjustments

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -292,7 +292,7 @@ void LocalEnforcer::terminate_service(
     // terminate the session.
     evb_->runAfterDelay(
         [this, imsi, session_id] {
-          MLOG(MDEBUG) << "Forced service termination for IMSI " << imsi;
+          MLOG(MDEBUG) << "Forced service termination for " << imsi;
           SessionRead req = {imsi};
           auto session_map = session_store_.read_sessions_for_deletion(req);
           auto session_update =
@@ -308,8 +308,8 @@ void LocalEnforcer::terminate_service(
                            << " with session_id: " << session_id;
             } else {
               MLOG(MERROR)
-                  << "Failed to update SessionStore with ended session " << imsi
-                  << " and session_id: " << session_id;
+                  << "Failed to update SessionStore with ended session "
+                  << imsi << " and session_id: " << session_id;
             }
           } else {
             MLOG(MDEBUG) << "Not forcing termination for session " << imsi
@@ -905,12 +905,12 @@ void LocalEnforcer::complete_termination(
       // after erasing the element
       update_criteria.is_session_ended = true;
       it->second.erase(session_it--);
-      MLOG(MDEBUG) << "Successfully terminated session for IMSI " << imsi
+      MLOG(MDEBUG) << "Successfully terminated session for " << imsi
                    << "session ID " << session_id;
       // No session left for this IMSI
       if (it->second.size() == 0) {
         session_map.erase(imsi);
-        MLOG(MDEBUG) << "All sessions terminated for IMSI " << imsi;
+        MLOG(MDEBUG) << "All sessions terminated for " << imsi;
       }
       break;
     }

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -376,7 +376,7 @@ SessionCredit::Usage SessionCredit::get_unreported_usage() const {
   if (buckets_[USED_RX] > report) {
     usage.bytes_rx = buckets_[USED_RX] - report;
   }
-  MLOG(MDEBUG) << "Data usage since last report is tx=" << usage.bytes_tx
+  MLOG(MDEBUG) << "===> Data usage since last report is tx=" << usage.bytes_tx
                << " rx=" << usage.bytes_rx;
   return usage;
 }
@@ -466,9 +466,9 @@ void SessionCredit::add_credit(uint64_t credit, Bucket bucket,
 }
 
 void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {
-  MLOG(MDEBUG) << "Amount reporting for this report:"
+  MLOG(MDEBUG) << "===> Amount reporting for this report:"
                << " tx=" << usage.bytes_tx << " rx=" << usage.bytes_rx;
-  MLOG(MDEBUG) << "The total amount currently being reported:"
+  MLOG(MDEBUG) << "===> The total amount currently being reported:"
                << " tx=" << buckets_[REPORTING_TX]
                << " rx=" << buckets_[REPORTING_RX];
 }

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -15,6 +15,7 @@
 using grpc::Status;
 
 namespace magma {
+std::string charging_raa_result_to_str(ChargingReAuthAnswer::Result res);
 
 SessionProxyResponderHandlerImpl::SessionProxyResponderHandlerImpl(
     std::shared_ptr<LocalEnforcer> enforcer, SessionStore& session_store)
@@ -34,7 +35,8 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
             SessionStore::get_default_session_update(session_map);
         auto result =
             enforcer_->init_charging_reauth(session_map, request_cpy, update);
-        MLOG(MDEBUG) << "Result of Gy (Charging) ReAuthRequest " << result;
+        MLOG(MDEBUG) << "Result of Gy (Charging) ReAuthRequest "
+                     << charging_raa_result_to_str(result);
         ChargingReAuthAnswer ans;
         ans.set_result(result);
 
@@ -92,5 +94,20 @@ SessionMap SessionProxyResponderHandlerImpl::get_sessions_for_policy(
     const PolicyReAuthRequest& request) {
   SessionRead req = {request.imsi()};
   return session_store_.read_sessions(req);
+}
+
+std::string charging_raa_result_to_str(ChargingReAuthAnswer::Result res) {
+  switch (res) {
+    case UPDATE_INITIATED:
+      return "UPDATE_INITIATED";
+    case UPDATE_NOT_NEEDED:
+      return "UPDATE_NOT_NEEDED";
+    case SESSION_NOT_FOUND:
+      return "SESSION_NOT_FOUND";
+    case OTHER_FAILURE:
+      return "OTHER_FAILURE";
+    default:
+      return "UNKNOWN_RESULT";
+  }
 }
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -68,7 +68,7 @@ bool SessionStore::create_sessions(
 }
 
 bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
-  MLOG(MDEBUG) << "Running update_sessions";
+  MLOG(MDEBUG) << "Updating session changes in SessionStore (update_sessions)";
   // Read the current state
   auto subscriber_ids = std::set<std::string>{};
   for (const auto& it : update_criteria) {

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -181,7 +181,7 @@ int main(int argc, char *argv[])
     // reports usage faster than sessiond can report it. This value should be
     // reasonably big, as the usage will be eventually reported properly.
     // So use the default value if it seems small.
-    if (margin_from_config > DEFAULT_EXTRA_QUOTA_MARGIN) {
+    if (margin_from_config >= DEFAULT_EXTRA_QUOTA_MARGIN) {
       margin = margin_from_config;
     } else {
       MLOG(MWARNING) << "The extra_quota_margin from the config "


### PR DESCRIPTION
Summary:
- remove "IMSI" from some logs because the imsi variable already contains the prefix
- The log `MLOG(MDEBUG) << "Running update_sessions";` is slightly confusing because it sounds like it's talking about cloud updates when it is about session store
- Some ReAuthAnswer result conversion so that it's easier to understand

Reviewed By: andreilee

Differential Revision: D21301475

