### PR TITLE
Gx/Gy client fixed to use lastAVPmessage from PCRF/OCS

### DIFF
--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -58,12 +58,12 @@ type OCSConfig struct {
 
 // OCSDiamServer wraps an OCS storing subscriber accounts and their credit
 type OCSDiamServer struct {
-	diameterSettings    *diameter.DiameterClientConfig
-	ocsConfig           *OCSConfig
-	accounts            map[string]*SubscriberAccount // map of IMSI to subscriber account
-	mux                 *sm.StateMachine
-	LastMessageReceived *ccrMessage
-	mockDriver          *mock_driver.MockDriver
+	diameterSettings *diameter.DiameterClientConfig
+	ocsConfig        *OCSConfig
+	accounts         map[string]*SubscriberAccount // map of IMSI to subscriber account
+	mux              *sm.StateMachine
+	lastAVPReceived  *diam.Message
+	mockDriver       *mock_driver.MockDriver
 }
 
 // NewOCSDiamServer initializes an OCS with an empty account map
@@ -277,6 +277,15 @@ func (srv *OCSDiamServer) ReAuth(
 	case <-time.After(10 * time.Second):
 		return nil, fmt.Errorf("No RAA received")
 	}
+}
+
+// GetLastAVPreceived gets the last message in diam format received
+// Message gets overwriten every time a new CCR is sent
+func (srv *OCSDiamServer) GetLastAVPreceived() (*diam.Message, error) {
+	if srv.lastAVPReceived == nil {
+		return nil, fmt.Errorf("No AVP message received")
+	}
+	return srv.lastAVPReceived, nil
 }
 
 func sendRAR(state *SubscriberSessionState, ratingGroup *uint32, cfg *sm.Settings) error {

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/ccr_handler.go
@@ -58,12 +58,13 @@ type usedServiceUnitAVP struct {
 func getCCRHandler(srv *PCRFDiamServer) diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {
 		glog.V(2).Infof("Received CCR from %s\n", c.RemoteAddr())
+		srv.lastAVPReceived = m
 		var ccr ccrMessage
 		if err := m.Unmarshal(&ccr); err != nil {
 			glog.Errorf("Failed to unmarshal CCR %s", err)
 			return
 		}
-		srv.LastMessageReceived = &ccr
+
 		imsi, err := ccr.GetIMSI()
 		if err != nil {
 			glog.Errorf("Could not parse CCR: %s", err.Error())
@@ -157,16 +158,17 @@ func (m *ccrMessage) GetIMSI() (string, error) {
 	return "", errors.New("Could not obtain IMSI from CCR message")
 }
 
+// TODO: Remove this when not needed anymore (use findAVP from diam library)
 // Searches on ccr message for an specific AVP message based on the avp tag on ccr type (ie "Session-Id")
 // It returns on the first match it finds.
 func GetAVP(message *ccrMessage, AVPToFind string) (interface{}, error) {
 	elem := reflect.ValueOf(message)
-	calledStationID, err := findAVP(elem, "avp", AVPToFind)
+	avpFound, err := findAVP(elem, "avp", AVPToFind)
 	if err != nil {
 		glog.Errorf("Failed to find %s: %s\n", AVPToFind, err)
 		return "", err
 	}
-	return calledStationID, nil
+	return avpFound, nil
 }
 
 // Depth Search First of a specific tag:value on a element (accepts structs, pointers, slices)

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -59,13 +59,13 @@ type subscriberAccount struct {
 
 // PCRFDiamServer wraps an PCRF storing subscribers and their rules
 type PCRFDiamServer struct {
-	diameterSettings    *diameter.DiameterClientConfig
-	pcrfConfig          *PCRFConfig
-	serviceConfig       *protos.PCRFConfigs
-	subscribers         map[string]*subscriberAccount // map of imsi to to rules
-	mux                 *sm.StateMachine
-	LastMessageReceived *ccrMessage
-	mockDriver          *mock_driver.MockDriver
+	diameterSettings *diameter.DiameterClientConfig
+	pcrfConfig       *PCRFConfig
+	serviceConfig    *protos.PCRFConfigs
+	subscribers      map[string]*subscriberAccount // map of imsi to to rules
+	mux              *sm.StateMachine
+	lastAVPReceived  *diam.Message
+	mockDriver       *mock_driver.MockDriver
 }
 
 // NewPCRFDiamServer initializes an PCRF with an empty rule map
@@ -301,6 +301,15 @@ func (srv *PCRFDiamServer) AbortSession(
 	case <-time.After(10 * time.Second):
 		return nil, fmt.Errorf("No ASA received")
 	}
+}
+
+// GetLastAVPreceived gets the last message in diam format received
+// Message gets overwriten every time a new CCR is sent
+func (srv *PCRFDiamServer) GetLastAVPreceived() (*diam.Message, error) {
+	if srv.lastAVPReceived == nil {
+		return nil, fmt.Errorf("No AVP message received")
+	}
+	return srv.lastAVPReceived, nil
 }
 
 func sendASR(state *SubscriberSessionState, cfg *sm.Settings) error {


### PR DESCRIPTION
Summary:
This diff exposes the last message received on PCRF and OCS. This way we can see the
message we sent without the need to make the Gx/Gy methods publics just for test purposes

Differential Revision: D21312513

