### PR TITLE
Fix redis disconnect bug for RedisStoreClient in sessiond

### DIFF
--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -46,6 +46,13 @@ SessionMap RedisStoreClient::read_sessions(
   // call being processed at a time, and that the writes it makes are done
   // atomically. Based on that, reads can be done without using Redis
   // transactions, or EVAL.
+  if (!client_->is_connected()) {
+    auto connected = try_redis_connect();
+    if (!connected) {
+      throw RedisReadFailed();
+    }
+  }
+
   std::unordered_map<std::string, std::future<cpp_redis::reply>> futures;
   for (const std::string& key : subscriber_ids) {
     futures[key] = client_->hget(redis_table_, key);
@@ -72,6 +79,12 @@ SessionMap RedisStoreClient::read_sessions(
 }
 
 SessionMap RedisStoreClient::read_all_sessions() {
+  if (!client_->is_connected()) {
+    auto connected = try_redis_connect();
+    if (!connected) {
+      throw RedisReadFailed();
+    }
+  }
   SessionMap session_map;
   auto hgetall_future = client_->hgetall(redis_table_);
   client_->sync_commit();
@@ -108,6 +121,12 @@ bool RedisStoreClient::write_sessions(SessionMap session_map) {
 
   // First we need to watch the keys that we intend to write to.
   // If we don't, then one HSET might succeed but another will fail.
+   if (!client_->is_connected()) {
+    auto connected = try_redis_connect();
+    if (!connected) {
+      throw RedisWriteFailed();
+    }
+  }
   std::vector<std::string> keys;
   for (auto& it : session_map) {
     keys.push_back(it.first);

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -26,6 +26,11 @@ class RedisReadFailed : public std::exception {
   RedisReadFailed() = default;
 };
 
+class RedisWriteFailed : public std::exception {
+ public:
+  RedisWriteFailed() = default;
+};
+
 /**
  * Persistent StoreClient used to allow stateless session_manager to function
  */


### PR DESCRIPTION
Summary:
This diff attempts to reconnect to Redis before reading or writing
if the Redis client is unconnected. This should fix an issue where the redis
client gets disconnected but redis is still available. This was happening often,
causing sessiond do unnecessarily crash loop.

Sessiond will still crash if Redis is unavailable.

Reviewed By: andreilee

Differential Revision: D21317580

