### PR TITLE
Updating enodebd get_status # of enodeb connected output (#2342)

### DIFF
--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -7,22 +7,23 @@ LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
-from magma.enodebd.logger import EnodebdLogger as logger
-import os
+import json
 from collections import namedtuple
-from typing import Any, Dict, List, NamedTuple, Optional, Union, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+
+import os
+from lte.protos.enodebd_pb2 import SingleEnodebStatus
 from magma.common import serialization_utils
 from magma.enodebd import metrics
 from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.device_config.configuration_util import \
     get_enb_rf_tx_desired
 from magma.enodebd.exceptions import ConfigurationError
+from magma.enodebd.logger import EnodebdLogger as logger
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_manager import \
     StateMachineManager
-from lte.protos.enodebd_pb2 import SingleEnodebStatus
 from orc8r.protos.service303_pb2 import State
-import json
 
 # There are 2 levels of caching for GPS coordinates from the enodeB: module
 # variables (in-memory) and on disk. In the event the enodeB stops reporting
@@ -159,36 +160,41 @@ def _get_enodebd_status(
     enb_acs_manager: StateMachineManager,
 ) -> MagmaEnodebdStatus:
     enb_status_by_serial = get_all_enb_status(enb_acs_manager)
+    # Start from default values for enodebd status
     n_enodeb_connected = 0
-    all_enodeb_configured = True
-    all_enodeb_opstate_enabled = True
-    all_enodeb_rf_tx_configured = True
+    all_enodeb_configured = False
+    all_enodeb_opstate_enabled = False
+    all_enodeb_rf_tx_configured = False
     any_enodeb_gps_connected = False
-    all_enodeb_ptp_connected = True
-    all_enodeb_mme_connected = True
+    all_enodeb_ptp_connected = False
+    all_enodeb_mme_connected = False
     gateway_gps_longitude = '0.0'
     gateway_gps_latitude = '0.0'
 
     def _is_rf_tx_configured(enb_status: EnodebStatus) -> bool:
         return enb_status.rf_tx_on == enb_status.rf_tx_desired
 
-    for _enb_serial, enb_status in enb_status_by_serial.items():
-        n_enodeb_connected += 1
-        if enb_status.enodeb_configured == '0':
-            all_enodeb_configured = False
-        if enb_status.opstate_enabled == '0':
-            all_enodeb_opstate_enabled = False
-        if not _is_rf_tx_configured(enb_status):
-            all_enodeb_rf_tx_configured = False
-        if enb_status.ptp_connected == '0':
-            all_enodeb_ptp_connected = False
-        if enb_status.mme_connected == '0':
-            all_enodeb_mme_connected = False
-        if any_enodeb_gps_connected == '0':
-            if enb_status.gps_connected:
-                any_enodeb_gps_connected = True
-                gateway_gps_longitude = enb_status.gps_longitude
-                gateway_gps_latitude = enb_status.gps_latitude
+    if enb_status_by_serial:
+        enb_status_list = list(enb_status_by_serial.values())
+        # Aggregate all eNB status for enodebd status, repetitive but
+        # clearer for output purposes.
+        n_enodeb_connected = sum(
+            enb_status.enodeb_connected for enb_status in enb_status_list)
+        all_enodeb_configured = all(
+            enb_status.enodeb_configured for enb_status in enb_status_list)
+        all_enodeb_mme_connected = all(
+            enb_status.mme_connected for enb_status in enb_status_list)
+        all_enodeb_opstate_enabled = all(
+            enb_status.opstate_enabled for enb_status in enb_status_list)
+        all_enodeb_ptp_connected = all(
+            enb_status.ptp_connected for enb_status in enb_status_list)
+        any_enodeb_gps_connected = any(
+            enb_status.gps_connected for enb_status in enb_status_list)
+        all_enodeb_rf_tx_configured = all(
+            _is_rf_tx_configured(enb_status) for enb_status in enb_status_list)
+        if n_enodeb_connected:
+            gateway_gps_longitude = enb_status_list[0].gps_longitude
+            gateway_gps_latitude = enb_status_list[0].gps_latitude
 
     return MagmaEnodebdStatus(
         n_enodeb_connected=str(n_enodeb_connected),

--- a/lte/gateway/python/scripts/enodebd_cli.py
+++ b/lte/gateway/python/scripts/enodebd_cli.py
@@ -104,7 +104,7 @@ def get_all_status(client, args):
     def print_enb_status(enb_status):
         print('--- eNodeB Serial:', enb_status.device_serial, '---')
         _print_str_status_line('IP Address', enb_status.ip_address)
-        _print_prop_status_line('eNodeB connected', enb_status.connected)
+        _print_prop_status_line('eNodeB Connected via TR-069', enb_status.connected)
         _print_prop_status_line('eNodeB Configured', enb_status.configured)
         _print_prop_status_line('Opstate Enabled', enb_status.opstate_enabled)
         _print_prop_status_line('RF TX on', enb_status.rf_tx_on)


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2342

- For `get_status` call on enodebd service, when an enodeb is disconnected the summarized output is not updated.
- This diff updates the aggregation of all eNodeb status to handle this case correctly.
- Also the `eNodeb connected` message on `enodebd_cli` is updated to specify connection via TR069 for clarity.

Reviewed By: themarwhal

Differential Revision: D21309803

