### PR TITLE
Add SessionState's FSM state to SessionStateUpdateCriteria

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -245,7 +245,8 @@ class LocalEnforcer {
    * report is going to be
    * aggregated.
    */
-  void notify_new_report_for_sessions(SessionMap& session_map);
+  void notify_new_report_for_sessions(
+      SessionMap& session_map, SessionUpdate &session_update);
 
   /**
    * notify_finish_report_for_sessions notifies all sessions that the

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -102,6 +102,11 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
 bool SessionStore::merge_into_session(
     std::unique_ptr<SessionState>& session,
     const SessionStateUpdateCriteria& update_criteria) {
+  // FSM State
+  if (update_criteria.is_fsm_updated) {
+    session->set_fsm_state(update_criteria.updated_fsm_state);
+  }
+
   // Config
   if (update_criteria.is_config_updated) {
     session->unmarshal_config(update_criteria.updated_config);

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -14,6 +14,7 @@ namespace magma {
 
 SessionStateUpdateCriteria get_default_update_criteria() {
   SessionStateUpdateCriteria uc{};
+  uc.is_fsm_updated = false;
   uc.is_config_updated = false;
   uc.charging_credit_to_install =
       std::unordered_map<CreditKey, StoredSessionCredit, decltype(&ccHash),

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -64,7 +64,7 @@ protected:
     rule.set_id(rule_id);
     rule.set_rating_group(charging_key);
     rule.set_monitoring_key(m_key);
-    rule.set_tracking_type(PolicyRule::ONLY_OCS);
+    rule.set_tracking_type(PolicyRule::OCS_AND_PCRF);
     rule_store->insert_rule(rule);
   }
 
@@ -119,6 +119,9 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   // when RAT Type is WLAN, it needs monitoring keys...
   create_cwf_session_create_response(imsi, monitoring_key, static_rules,
                                      &response);
+  response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  create_credit_update_response(imsi, 1, 1536,
+                                response.mutable_credits()->Add());
 
   SessionRead req = {"IMSI1"};
   auto session_map = session_store->read_sessions(req);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -248,18 +248,19 @@ TEST_F(SessionStateTest, test_can_complete_termination) {
   EXPECT_EQ(session_state->can_complete_termination(), false);
 
   // If the rule is still being reported, termination should not be completed.
-  session_state->new_report();
+  auto _uc = get_default_update_criteria();
+  session_state->new_report(_uc);
   EXPECT_EQ(session_state->can_complete_termination(), false);
   session_state->add_used_credit("rule1", 100, 100, update_criteria);
   EXPECT_EQ(session_state->can_complete_termination(), false);
   EXPECT_EQ(update_criteria.monitor_credit_map.size(), 0);
-  session_state->finish_report();
+  session_state->finish_report(_uc);
   EXPECT_EQ(session_state->can_complete_termination(), false);
 
   // The rule is not reported, termination can be completed.
-  session_state->new_report();
+  session_state->new_report(_uc);
   EXPECT_EQ(session_state->can_complete_termination(), false);
-  session_state->finish_report();
+  session_state->finish_report(_uc);
   EXPECT_EQ(session_state->can_complete_termination(), true);
 
   // Termination should only be completed once.


### PR DESCRIPTION
Summary:
## Changes
- Added `fsm_state` to StoredSessionState
- SessionStore will now keep track of updates to SessionState's `fsm_state`

```
make integ_test TESTS=s1aptests/test_attach_detach_looped.py
```

```
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.038194 16781 LocalSessionManagerHandler.cpp:305] Found session with the same IMSI IMSI001010000000001 but different APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.040478 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.040678 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-157852 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.208640 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.211057 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.211316 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-235083 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.250090 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.252710 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.252970 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-591976 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.402112 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.404748 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.405030 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-538780 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.443574 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.446584 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.446925 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-248140 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.602809 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.605024 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.605358 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-365914 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.643714 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.646360 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.647104 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-199569 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.805003 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.807922 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.808287 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-112633 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.850075 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.853425 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:19 magma-dev sessiond[16781]: I0501 00:50:19.853889 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-579278 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
May 01 00:50:20 magma-dev sessiond[16781]: I0501 00:50:20.003687 16781 LocalSessionManagerHandler.cpp:321] Found a session in termination with the same IMSI IMSI001010000000001 and same APN oai.ipv4, will request a new session from PCRF/PCF
May 01 00:50:20 magma-dev sessiond[16781]: I0501 00:50:20.005874 16781 LocalEnforcer.cpp:465] Activating untracked rule whitelist_sid-IMSI001010000000001
May 01 00:50:20 magma-dev sessiond[16781]: I0501 00:50:20.006275 16781 LocalSessionManagerHandler.cpp:353] Successfully initialized new session IMSI001010000000001-278204 in sessiond for subscriber IMSI001010000000001 with default bearer id 5
```

Differential Revision: D21341630

