### PR TITLE
Only schedule a termination callback if the session was previously active

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -256,6 +256,10 @@ void LocalEnforcer::terminate_service(
   for (const auto &session : it->second) {
     auto update_criteria = session_update[imsi][session->get_session_id()];
 
+    if (!session->is_active()) {
+      // If the session is terminating already, do nothing.
+      continue;
+    }
     session->start_termination(update_criteria);
 
     // tell AAA service to terminate radius session if necessary

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -233,6 +233,7 @@ class SessionState {
   DynamicRuleStore& get_dynamic_rules();
 
   uint32_t total_monitored_rules_count();
+
   bool is_active();
 
   uint32_t get_credit_key_count();
@@ -289,6 +290,9 @@ class SessionState {
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& update_criteria,
       const bool force_update = false);
+
+  SessionTerminateRequest make_termination_request(
+    SessionStateUpdateCriteria& update_criteria);
 };
 
 }  // namespace magma


### PR DESCRIPTION
Summary:
## Background on session states
Sessiond has multiple terminating states.
The reason for this being that before we can send a CCR-T to PCRF/OCS, we need to collect ALL data usage reports relating to this session from pipelined.

```  SESSION_ACTIVE                        = 0,
  SESSION_TERMINATING_FLOW_ACTIVE       = 1,
  SESSION_TERMINATING_AGGREGATING_STATS = 2,
  SESSION_TERMINATING_FLOW_DELETED      = 3,
  SESSION_TERMINATED                    = 4,
```
* When a session termination is started, sessiond will remove policy flows in pipelined. (TERMINATING_FLOW_ACTIVE). (AAA or MME is also notified at this point to kick off the user.)
* In order for the termination to complete, sessiond has to wait for pipelined to finish reporting usage for the session.
* Every time pipelined reports usage for the session, the state goes into `TERMINATING_AGGREGATING_STATS`.
* Once the report for the session is done being processed, it goes back to `TERMINATING_FLOW_ACTIVE`.
* NOTE  that If a report is received and there's no entry for the terminating session, the state transitions to  `TERMINATING_FLOW_DELETED` and the termination completes. This means that pipelined has cleaned up all flows relating to that session.

* When the termination is started, sessiond will also schedule a callback function to force a termination in case pipelined does not finish reporting usage in time.

* When either the callback is triggered or pipelined has cleaned all flows, sessiond will finally send a CCR-T to PCRF/OCS and complete the termination.

## What this diff fixes
Before this change, we could have multiple termination callbacks scheduled. Since session credit has no visibility into what the Session wide FSM state is, so it could trigger multiple calls to `terminate_service`.

The multiple callbacks do not cause any issues in connectivity etc, but it makes the log messy.
This diff ensures that we only schedule one call back per termination.

Reviewed By: karthiksubraveti

Differential Revision: D21348645

