### PR TITLE
Fix SWx Client connection leak

### DIFF
--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_auth_test.go
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 package main_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -73,6 +74,7 @@ func (c testEapServiceClient) HandleIdentity(in *protos.EapIdentity) (*protos.Ea
 
 // TestEapAkaConcurent tests EAP AKA Provider
 func TestEapAkaConcurent(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -154,6 +156,7 @@ func TestEAPPeerNak(t *testing.T) {
 }
 
 func TestEAPAkaWrongPlmnId(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.NoUseSwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -187,6 +190,7 @@ func TestEAPAkaWrongPlmnId(t *testing.T) {
 }
 
 func TestEAPAkaPlmnId5(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -221,6 +225,7 @@ func TestEAPAkaPlmnId5(t *testing.T) {
 }
 
 func TestEAPAkaPlmnId6(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)

--- a/feg/gateway/services/aaa/aaa_server/aaa_aka_linked_auth_test.go
+++ b/feg/gateway/services/aaa/aaa_server/aaa_aka_linked_auth_test.go
@@ -12,6 +12,7 @@
 package main_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -28,6 +29,7 @@ import (
 
 // TestEapAkaConcurent tests EAP AKA Provider
 func TestLinkedEapAkaConcurent(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)

--- a/feg/gateway/services/aaa/servicers/authenticator.go
+++ b/feg/gateway/services/aaa/servicers/authenticator.go
@@ -112,7 +112,8 @@ func (srv *eapAuth) Handle(ctx context.Context, in *protos.Eap) (*protos.Eap, er
 			Location: "hwid", // actual hwid will be filled in by directory service
 			Fields:   map[string]string{MacAddrKey: resp.Ctx.GetMacAddr()},
 		}
-		go directoryd.UpdateRecord(updateRequest) // execute in a new goroutine in case calls to directoryd take long time
+		// execute in a new goroutine in case calls to directoryd take long time
+		go directoryd.UpdateRecord(updateRequest)
 	}
 	return resp, nil
 }

--- a/feg/gateway/services/eap/client/client_api_test.go
+++ b/feg/gateway/services/eap/client/client_api_test.go
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 package client_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -55,6 +56,7 @@ func (c testEapClient) Handle(in *protos.Eap) (*protos.Eap, error) {
 }
 
 func TestEAPClientApi(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -173,6 +175,7 @@ func TestEAPClientApi(t *testing.T) {
 }
 
 func TestEAPClientApiConcurent(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)

--- a/feg/gateway/services/eap/eap_router/eap_router_test.go
+++ b/feg/gateway/services/eap/eap_router/eap_router_test.go
@@ -9,6 +9,7 @@ LICENSE file in the root directory of this source tree.
 package main_test
 
 import (
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -87,6 +88,7 @@ func newTestEapClient(t *testing.T, addr string) testEapServiceClient {
 
 // TestEapAkaConcurent tests EAP AKA Provider
 func TestEapAkaConcurent(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -169,6 +171,7 @@ func TestEAPPeerNak(t *testing.T) {
 }
 
 func TestEAPAkaWrongPlmnId(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.NoUseSwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -204,6 +207,7 @@ func TestEAPAkaWrongPlmnId(t *testing.T) {
 }
 
 func TestEAPAkaPlmnId5(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)
@@ -240,6 +244,7 @@ func TestEAPAkaPlmnId5(t *testing.T) {
 }
 
 func TestEAPAkaPlmnId6(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service eap_test.SwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)

--- a/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_challenge_test.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/handlers/aka_challenge_test.go
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 package handlers
 
 import (
+	"os"
 	"reflect"
 	"testing"
 
@@ -32,6 +33,7 @@ var (
 )
 
 func TestAkaChallengeResp(t *testing.T) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 	var service testSwxProxy
 	cp.RegisterSwxProxyServer(srv.GrpcServer, service)

--- a/feg/gateway/services/swx_proxy/client_api.go
+++ b/feg/gateway/services/swx_proxy/client_api.go
@@ -14,15 +14,15 @@ package swx_proxy
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
-
-	"magma/feg/cloud/go/protos"
-	"magma/feg/gateway/registry"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
+
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/registry"
+	"magma/orc8r/lib/go/util"
 )
 
 // Wrapper for GRPC Client
@@ -37,8 +37,8 @@ type swxProxyClient struct {
 func getSwxProxyClient() (*swxProxyClient, error) {
 	var conn *grpc.ClientConn
 	var err error
-	if os.Getenv("USE_REMOTE_SWX_PROXY") == "1" {
-		conn, err = registry.Get().GetCloudConnection(strings.ToLower(registry.SWX_PROXY))
+	if util.GetEnvBool("USE_REMOTE_SWX_PROXY", true) {
+		conn, err = registry.Get().GetSharedCloudConnection(strings.ToLower(registry.SWX_PROXY))
 	} else {
 		conn, err = registry.GetConnection(registry.SWX_PROXY)
 	}

--- a/feg/gateway/services/swx_proxy/test_init/test_service_init.go
+++ b/feg/gateway/services/swx_proxy/test_init/test_service_init.go
@@ -10,6 +10,7 @@ package test_init
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"magma/feg/cloud/go/protos"
@@ -27,6 +28,7 @@ func StartTestService(t *testing.T) (*service.Service, error) {
 }
 
 func StartTestServiceWithCache(t *testing.T, cache *cache.Impl) (*service.Service, error) {
+	os.Setenv("USE_REMOTE_SWX_PROXY", "false")
 	srv, lis := test_utils.NewTestService(t, registry.ModuleName, registry.SWX_PROXY)
 
 	config := servicers.GetSwxProxyConfig()

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,7 +15,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1

--- a/orc8r/lib/go/util/util.go
+++ b/orc8r/lib/go/util/util.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 )
 
@@ -138,4 +139,19 @@ func IsTruthyEnv(envName string) bool {
 		return false
 	}
 	return true
+}
+
+// GetEnvBool returns value of the environment
+// variable if it exists, or defaultValue if not
+func GetEnvBool(envVariable string, defaultValue ...bool) bool {
+	if len(envVariable) > 0 {
+		if envValue := os.Getenv(envVariable); len(envValue) > 0 {
+			envValueBool, _ := strconv.ParseBool(envValue)
+			return envValueBool
+		}
+	}
+	if len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	return false
 }

--- a/orc8r/lib/go/util/util_test.go
+++ b/orc8r/lib/go/util/util_test.go
@@ -1,0 +1,28 @@
+package util_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"magma/orc8r/lib/go/util"
+)
+
+func TestEnv(t *testing.T) {
+	testEnv := "This_test_env_Should_Not_be_SET"
+	os.Unsetenv(testEnv)
+
+	assert.True(t, util.GetEnvBool(testEnv, true))
+	assert.False(t, util.GetEnvBool(testEnv))
+	assert.False(t, util.GetEnvBool(testEnv, false))
+	os.Setenv(testEnv, "1")
+
+	assert.True(t, util.GetEnvBool(testEnv), "Env value: '%s'", os.Getenv(testEnv))
+	os.Setenv(testEnv, "0")
+	assert.False(t, util.GetEnvBool(testEnv))
+	os.Setenv(testEnv, "true")
+	assert.True(t, util.GetEnvBool(testEnv), "Env value: '%s'", os.Getenv(testEnv))
+	os.Setenv(testEnv, "false")
+	assert.False(t, util.GetEnvBool(testEnv))
+}


### PR DESCRIPTION
Summary: Switch SWx client to GetSharedCloudConnection() to prevent potential connections leak

Differential Revision: D21360830

