### PR TITLE
Cleanup ipfix internal pkt sampling flows properly

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -94,7 +94,7 @@ allow_unknown_arps: False
 # Configuration for IPFIX sampling
 ipfix:
   enabled: true
-  probability: 650
+  probability: 65
   collector_set_id: 1
   cache_timeout: 60
   obs_domain_id: 1

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -124,7 +124,7 @@ li_mirror_all: false
 # Configuration for IPFIX sampling
 ipfix:
   enabled: false
-  probability: 650
+  probability: 65
   collector_set_id: 1
   cache_timeout: 60
   obs_domain_id: 1

--- a/lte/gateway/python/magma/pipelined/app/dpi.py
+++ b/lte/gateway/python/magma/pipelined/app/dpi.py
@@ -38,6 +38,7 @@ APP_PROTOS = {"facebook_messenger": 1, "instagram": 2, "youtube": 3,
 SERVICE_IDS = {"other": 0, "chat": 1, "audio": 2, "video": 3}
 DEFAULT_DPI_ID = 0
 
+
 class DPIController(MagmaController):
     """
     DPI controller.

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -48,8 +48,14 @@ class IPFIXController(MagmaController):
         self.ipfix_config = self._get_ipfix_config(kwargs['config'],
                                                    kwargs['mconfig'])
         self._bridge_name = kwargs['config']['bridge_name']
-        self._ipfix_sample_tbl_num = \
-            self._service_manager.INTERNAL_IPFIX_SAMPLE_TABLE_NUM
+        self._dpi_enabled = kwargs['config']['dpi']['enabled']
+        # If DPI enabled don't sample normal traffic, sample only internal pkts
+        if self._dpi_enabled:
+            self._ipfix_sample_tbl_num = \
+                self._service_manager.INTERNAL_IPFIX_SAMPLE_TABLE_NUM
+            self.ipfix_config.probability = 65535
+        else:
+            self._ipfix_sample_tbl_num = self.tbl_num
         self._datapath = None
 
     def _get_ipfix_config(self, config_dict: Dict,
@@ -176,19 +182,36 @@ class IPFIXController(MagmaController):
 
         imsi_hex = hex(encode_imsi(imsi))
         pdp_start_epoch = int(time.time())
-        max_probability = 65535
-        action_str = (
-            'ovs-ofctl add-flow {} "table={},priority={},metadata={},'
-            'actions=sample(probability={},collector_set_id={},'
-            'obs_domain_id={},obs_point_id={},apn_mac_addr={},msisdn={},'
-            'apn_name=\\\"{}\\\",pdp_start_epoch={}, ingress)"'
-        ).format(
-            self._bridge_name, self._ipfix_sample_tbl_num,
-            flows.UE_FLOW_PRIORITY, imsi_hex, max_probability,
-            self.ipfix_config.collector_set_id, self.ipfix_config.obs_domain_id,
-            self.ipfix_config.obs_point_id, apn_mac_addr.replace("-", ":"),
-            msisdn, apn_name, pdp_start_epoch
-        )
+        if self._dpi_enabled:
+            action_str = (
+                'ovs-ofctl add-flow {} "table={},priority={},metadata={},'
+                'actions=sample(probability={},collector_set_id={},'
+                'obs_domain_id={},obs_point_id={},apn_mac_addr={},msisdn={},'
+                'apn_name=\\\"{}\\\",pdp_start_epoch={}, ingress)"'
+            ).format(
+                self._bridge_name, self._ipfix_sample_tbl_num,
+                flows.UE_FLOW_PRIORITY, imsi_hex, self.ipfix_config.probability,
+                self.ipfix_config.collector_set_id,
+                self.ipfix_config.obs_domain_id, self.ipfix_config.obs_point_id,
+                apn_mac_addr.replace("-", ":"), msisdn, apn_name,
+                pdp_start_epoch
+            )
+        else:
+            action_str = (
+                'ovs-ofctl add-flow {} "table={},priority={},metadata={},'
+                'actions=sample(probability={},collector_set_id={},'
+                'obs_domain_id={},obs_point_id={},apn_mac_addr={},msisdn={},'
+                'apn_name=\\\"{}\\\",pdp_start_epoch={},sampling_port={}),'
+                'resubmit(,{})"'
+            ).format(
+                self._bridge_name, self._ipfix_sample_tbl_num,
+                flows.UE_FLOW_PRIORITY, imsi_hex, self.ipfix_config.probability,
+                self.ipfix_config.collector_set_id,
+                self.ipfix_config.obs_domain_id, self.ipfix_config.obs_point_id,
+                apn_mac_addr.replace("-", ":"), msisdn, apn_name,
+                pdp_start_epoch, self.ipfix_config.sampling_port,
+                self.next_main_table
+            )
         try:
             subprocess.Popen(action_str, shell=True).wait()
         except subprocess.CalledProcessError as e:
@@ -210,22 +233,4 @@ class IPFIXController(MagmaController):
             return
 
         match = MagmaMatch(imsi=encode_imsi(imsi))
-        flows.delete_flow(self._datapath, self.tbl_num, match)
-
-    def deactivate_rules(self, imsi: str) -> None:
-        """
-        Deactivate flows for a subscriber.
-
-        Args:
-            imsi (string): subscriber id
-        """
-        if self._datapath is None:
-            self.logger.error('Datapath not initialized')
-            return
-
-        if not imsi:
-            self.logger.error('No subscriber specified')
-            return
-
-        match = MagmaMatch(imsi=encode_imsi(imsi))
-        flows.delete_flow(self._datapath, self.tbl_num, match)
+        flows.delete_flow(self._datapath, self._ipfix_sample_tbl_num, match)


### PR DESCRIPTION
Summary: Removes flows when needed, also adds a fallback on when DPI isn't enabled to sample all user traffic

Reviewed By: uri200

Differential Revision: D21366800

