### PR TITLE
Remove function that's only used for testing from SessionState and modify complete_termination log

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -128,17 +128,6 @@ class SessionState {
    * termination, this function should only be called when
    * can_complete_termination returns true.
    */
-  void complete_termination(SessionStateUpdateCriteria& update_criteria);
-
-  /**
-   * complete_termination collects final usages for all credits into a
-   * SessionTerminateRequest and calls the on termination callback with the
-   * request.
-   * Note that complete_termination will forcefully complete the termination
-   * no matter the current state of the session. To properly complete the
-   * termination, this function should only be called when
-   * can_complete_termination returns true.
-   */
   void complete_termination(
       SessionReporter& reporter, SessionStateUpdateCriteria& update_criteria);
 


### PR DESCRIPTION
Summary:
- It seems like `complete_termination` with no reporter parameter was only used for testing, so removing that function and using a mock reporter in the test
- We were seeing "Encountered unexpected state ..." log on error level, when it's not really an error. Only log as an error when the state is ACTIVE, because that is an unexpected state. Log on INFO level for states `SESSION_TERMINATING_FLOW_ACTIVE` and `SESSION_TERMINATING_FLOW_ACTIVE`, so that it's clear the function is triggered by the scheduled callback.

Differential Revision: D21378825

