### PR TITLE
Return error when failing to send ASR and add sleep to

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -424,6 +424,8 @@ func TestGxAbortSessionRequest(t *testing.T) {
 	assert.Contains(t, asa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
 
+	// Give some time for the Session Termination to process
+	tr.WaitForEnforcementStatsToSync()
 	// check if all rules have been cleaned up
 	record := recordsBySubID["IMSI"+imsi][ruleKey]
 	assert.Nil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was not removed", imsi))

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -27,7 +27,7 @@ terminate_service_when_quota_exhausted: true
 # Maximum time to wait for the flow to be deleted by pipelined before forcefully
 # terminating the session. This should be at least twice the poll interval of
 # pipelined
-session_force_termination_timeout_ms: 5000
+session_force_termination_timeout_ms: 3000
 
 # Set to true to enable sessiond support of carrier wifi
 support_carrier_wifi: true

--- a/feg/gateway/go.mod
+++ b/feg/gateway/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.3.3
 	github.com/ishidawataru/sctp v0.0.0-20190922091402-408ec287e38c
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/pcrf.go
@@ -10,7 +10,6 @@ package mock_pcrf
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net"
 	"time"
@@ -28,6 +27,7 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/sm"
 	"github.com/fiorix/go-diameter/v4/diam/sm/smpeer"
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 )
 
 // PCRFConfig defines the configuration for a PCRF server, which for now is just
@@ -294,7 +294,10 @@ func (srv *PCRFDiamServer) AbortSession(
 		resp <- &gx.PolicyAbortSessionResponse{SessionID: asa.SessionID, ResultCode: asa.ResultCode}
 	}
 	srv.mux.Handle(diam.ASA, asaHandler)
-	sendASR(account.CurrentState, srv.mux.Settings())
+	err := sendASR(account.CurrentState, srv.mux.Settings())
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to send Gx ASR")
+	}
 	select {
 	case asa := <-resp:
 		return &protos.PolicyAbortSessionResponse{SessionId: diameter.DecodeSessionID(asa.SessionID), ResultCode: asa.ResultCode}, nil


### PR DESCRIPTION
Summary:
- We should be returning error when we fail to send an ASR.
- Wait for enforcement stats to sync before checking pipelined stats in `TestGxAbortSessionRequest`
- Reducing the force termination timeout to 3sec for the tests.

Reviewed By: karthiksubraveti

Differential Revision: D21378914

