### PR TITLE
Fetch orc8r state from NMS and update Gateway KPI tray

### DIFF
--- a/symphony/app/fbcnms-projects/magmalte/app/components/GatewayKPIs.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/components/GatewayKPIs.js
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardHeader from '@material-ui/core/CardHeader';
+import CellWifiIcon from '@material-ui/icons/CellWifi';
+import Grid from '@material-ui/core/Grid';
+import React from 'react';
+import Text from '@fbcnms/ui/components/design-system/Text';
+
+function fetchGatewayKPIs() {
+  const mockKPIs = [
+    {category: 'Severe Events', value: 10},
+    {category: 'Connected', value: 20},
+    {category: 'Disconnected', value: 30},
+  ];
+  return mockKPIs;
+}
+
+export default function GatewayKPIs() {
+  const mockKPIs = fetchGatewayKPIs();
+  return (
+    <Grid container alignItems="center">
+      <Grid item>
+        <Card elevation={0}>
+          <CardHeader title="Gateways" />
+          <CardContent>
+            <CellWifiIcon fontSize="large" />
+          </CardContent>
+        </Card>
+      </Grid>
+      {mockKPIs.map((kpi, i) => (
+        <Grid item key={i}>
+          <Card variant="outlined">
+            <CardHeader title={kpi.category} />
+            <CardContent>
+              <Text variant="h6">{kpi.value}</Text>
+            </CardContent>
+          </Card>
+        </Grid>
+      ))}
+    </Grid>
+  );
+}

--- a/symphony/app/fbcnms-projects/magmalte/app/components/GatewayKPIs.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/components/GatewayKPIs.js
@@ -13,20 +13,39 @@ import CardContent from '@material-ui/core/CardContent';
 import CardHeader from '@material-ui/core/CardHeader';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import Grid from '@material-ui/core/Grid';
-import React from 'react';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import React, {useEffect, useState} from 'react';
 import Text from '@fbcnms/ui/components/design-system/Text';
+import nullthrows from '@fbcnms/util/nullthrows';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
+import type {lte_gateway} from '@fbcnms/magma-api';
 
-function fetchGatewayKPIs() {
-  const mockKPIs = [
-    {category: 'Severe Events', value: 10},
-    {category: 'Connected', value: 20},
-    {category: 'Disconnected', value: 30},
-  ];
-  return mockKPIs;
-}
+const GATEWAY_KEEPALIVE_TIMEOUT_MS = 1000 * 5 * 60;
 
 export default function GatewayKPIs() {
-  const mockKPIs = fetchGatewayKPIs();
+  const [gatewaySt, setGatewaySt] = useState({});
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchSt = async () => {
+      try {
+        const resp = await MagmaV1API.getLteByNetworkIdGateways({
+          networkId: networkId,
+        });
+        setGatewaySt(resp);
+      } catch (error) {
+        enqueueSnackbar('Error getting gateway information', {
+          variant: 'error',
+        });
+      }
+    };
+    fetchSt();
+  }, [networkId, enqueueSnackbar]);
+
+  const [upCount, downCount] = gatewayStatus(gatewaySt);
   return (
     <Grid container alignItems="center">
       <Grid item>
@@ -37,16 +56,57 @@ export default function GatewayKPIs() {
           </CardContent>
         </Card>
       </Grid>
-      {mockKPIs.map((kpi, i) => (
-        <Grid item key={i}>
-          <Card variant="outlined">
-            <CardHeader title={kpi.category} />
-            <CardContent>
-              <Text variant="h6">{kpi.value}</Text>
-            </CardContent>
-          </Card>
-        </Grid>
-      ))}
+      <Grid item>
+        <Card variant="outlined">
+          <CardHeader title="Severe Events" />
+          <CardContent>
+            <Text variant="h6" data-testid="Severe Events">
+              0
+            </Text>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item>
+        <Card variant="outlined">
+          <CardHeader title="Connected" />
+          <CardContent>
+            <Text variant="h6" data-testid="Connected">
+              {upCount ?? 0}
+            </Text>
+          </CardContent>
+        </Card>
+      </Grid>
+      <Grid item>
+        <Card variant="outlined">
+          <CardHeader title="Disconnected" />
+          <CardContent>
+            <Text variant="h6" data-testid="Disconnected">
+              {downCount ?? 0}
+            </Text>
+          </CardContent>
+        </Card>
+      </Grid>
     </Grid>
   );
+}
+
+function gatewayStatus(gatewaySt: {[string]: lte_gateway}): [number, number] {
+  let upCount = 0;
+  let downCount = 0;
+  Object.keys(gatewaySt)
+    .map((k: string) => gatewaySt[k])
+    .filter((g: lte_gateway) => g.cellular && g.id)
+    .map(function(gateway: lte_gateway) {
+      const {status} = gateway;
+      let isBackhaulDown = true;
+      if (status != null) {
+        const checkin = status.checkin_time;
+        if (checkin != null) {
+          const duration = Date.now() - checkin;
+          isBackhaulDown = duration > GATEWAY_KEEPALIVE_TIMEOUT_MS;
+        }
+      }
+      isBackhaulDown ? downCount++ : upCount++;
+    });
+  return [upCount, downCount];
 }

--- a/symphony/app/fbcnms-projects/magmalte/app/components/__tests__/GatewayKPI-test.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/components/__tests__/GatewayKPI-test.js
@@ -1,0 +1,101 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+import 'jest-dom/extend-expect';
+import GatewayKPIs from '../GatewayKPIs';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import React from 'react';
+import axiosMock from 'axios';
+import {MemoryRouter, Route} from 'react-router-dom';
+import {cleanup, render, wait} from '@testing-library/react';
+import type {lte_gateway} from '@fbcnms/magma-api';
+
+afterEach(cleanup);
+
+const mockSt: lte_gateway = {
+  id: 'test_gw1',
+  name: 'test_gateway',
+  description: 'hello I am a gateway',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: '',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  connected_enodeb_serials: [],
+  cellular: {
+    epc: {
+      ip_block: '192.168.0.1/24',
+      nat_enabled: true,
+    },
+    ran: {
+      pci: 620,
+      transmit_enabled: true,
+    },
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+
+describe('<GatewaysKPIs />', () => {
+  beforeEach(() => {
+    const mockUpSt = Object.assign({}, mockSt);
+    mockUpSt['status'] = {
+      checkin_time: Date.now(),
+      meta: {
+        gps_latitude: '0',
+        gps_longitude: '0',
+        gps_connected: '0',
+        enodeb_connected: '0',
+        mme_connected: '0',
+      },
+    };
+    MagmaAPIBindings.getLteByNetworkIdGateways.mockResolvedValue({
+      test1: mockSt,
+      test2: mockSt,
+      test3: mockUpSt,
+    });
+  });
+
+  afterEach(() => {
+    axiosMock.get.mockClear();
+  });
+
+  const Wrapper = () => (
+    <MemoryRouter initialEntries={['/nms/mynetwork']} initialIndex={0}>
+      <Route path="/nms/:networkId" component={GatewayKPIs} />
+    </MemoryRouter>
+  );
+  it('renders', async () => {
+    const {getByTestId} = render(<Wrapper />);
+    await wait();
+
+    expect(MagmaAPIBindings.getLteByNetworkIdGateways).toHaveBeenCalledTimes(1);
+    expect(getByTestId('Connected')).toHaveTextContent('1');
+    expect(getByTestId('Disconnected')).toHaveTextContent('2');
+  });
+});

--- a/symphony/app/fbcnms-projects/magmalte/app/components/lte/LteDashboard.js
+++ b/symphony/app/fbcnms-projects/magmalte/app/components/lte/LteDashboard.js
@@ -10,6 +10,7 @@
  */
 
 import AppBar from '@material-ui/core/AppBar';
+import GatewayKPIs from '../GatewayKPIs';
 import Grid from '@material-ui/core/Grid';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import Paper from '@material-ui/core/Paper';
@@ -120,9 +121,7 @@ function LteNetworkDashboard() {
 
         <Grid item xs={6}>
           <Paper elevation={2}>
-            <div className={classes.contentPlaceholder}>
-              Gateway KPIs Go Here
-            </div>
+            <GatewayKPIs />
           </Paper>
         </Grid>
 


### PR DESCRIPTION
Summary: Add handlers to pull data from orc8r and display connected and disconnected gateways. Still figuring out how to pull severe event related info.

Reviewed By: Scott8440

Differential Revision: D21371145

