### PR TITLE
Speed up prometheus label values endpoint on default

### DIFF
--- a/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
@@ -651,6 +651,16 @@ paths:
           type: string
           description: Label name to get values of
           required: true
+        - in: query
+          name: start
+          type: string
+          description: start time of the requested range (UnixTime or RFC3339)
+          required: true
+        - in: query
+          name: end
+          type: string
+          description: end time of the requested range (UnixTime or RFC3339)
+          required: false
       responses:
         '200':
           description: List of label values


### PR DESCRIPTION
Summary:
After grafana was pushed to prod, we saw that the dashboards were not loading. This is because the dasbhoards make a request to the "label values" endpoint to get the list of available networkIDs, gatewayIDs, and maybe some others.

In general this endpoint is pretty quick, however we had to reroute it in the API to enable multitenancy. This uses the "series" endpoint which is in general much slower.

By default this queries from the beginning of time to the end, however since most metric series' existences don't change very often, it should be completely valid to restrict that search to a much smaller time span. In some experiments on prod with curl I saw massive speed improvements by just restricting the time (see test plan).

Allowing start/end parameters keeps the flexibility for some edge cases where one might really need to query a longer time span.

Differential Revision: D21411967

