### PR TITLE
Updating test for IP recycling on ip_allocator

### DIFF
--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -190,7 +190,7 @@ class IPAllocatorTests(unittest.TestCase):
         self._allocator.release_ip_address('SID0', ip0)
 
         # Wait for auto-recycler to kick in
-        time.sleep(1.2 * self.RECYCLING_INTERVAL_SECONDS)
+        time.sleep(2 * self.RECYCLING_INTERVAL_SECONDS)
 
         ip3 = self._allocator.alloc_ip_address('SID3')
         self.assertEqual(ip0, ip3)
@@ -198,7 +198,7 @@ class IPAllocatorTests(unittest.TestCase):
         self._allocator.release_ip_address('SID1', ip1)
 
         # Wait for auto-recycler to kick in
-        time.sleep(1.2 * self.RECYCLING_INTERVAL_SECONDS)
+        time.sleep(2 * self.RECYCLING_INTERVAL_SECONDS)
 
         ip4 = self._allocator.alloc_ip_address('SID4')
         self.assertEqual(ip1, ip4)
@@ -206,7 +206,7 @@ class IPAllocatorTests(unittest.TestCase):
         self._allocator.release_ip_address('SID2', ip2)
 
         # Wait for auto-recycler to kick in
-        time.sleep(1.2 * self.RECYCLING_INTERVAL_SECONDS)
+        time.sleep(2 * self.RECYCLING_INTERVAL_SECONDS)
 
         ip5 = self._allocator.alloc_ip_address('SID5')
         self.assertEqual(ip2, ip5)


### PR DESCRIPTION
Summary:
- IP allocator tests are failing with flakiness due to the recycler on ip_allocator not getting triggered, this causes a unit test to fail because IP's are still being treated as allocated waiting the next recycling cycle to be executed.

- This diff increments the waiting time to allow the recycler to be triggered.

Differential Revision: D21412175

