### PR TITLE
change magmad -s to create a new bootstrapper challenge key if one doesn't exist

### DIFF
--- a/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
+++ b/orc8r/gateway/go/services/bootstrapper/gateway_info/get_info.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 
 	"magma/gateway/config"
+	"magma/gateway/services/bootstrapper/service"
 	"magma/orc8r/lib/go/security/key"
 
 	"github.com/emakeev/snowflake"
@@ -19,17 +20,15 @@ func Get() (hwId string, pubKey interface{}, err error) {
 	if err != nil {
 		return
 	}
-	challengeKeyFile := config.GetMagmadConfigs().BootstrapConfig.ChallengeKey
-	ck, err := key.ReadKey(challengeKeyFile)
+	ck, err := service.GetChallengeKey()
 	if err != nil {
-		err = fmt.Errorf("Failed to load Challenge Key from %s: %v", challengeKeyFile, err)
 		return
 	}
 	pubKey = key.PublicKey(ck)
 	return
 }
 
-// GetFormatted returns formatted string with GW infornation
+// GetFormatted returns formatted string with GW information
 func GetFormatted() (string, error) {
 	hwId, pubKey, err := Get()
 	if err != nil {

--- a/orc8r/gateway/go/services/bootstrapper/service/bootstrapper.go
+++ b/orc8r/gateway/go/services/bootstrapper/service/bootstrapper.go
@@ -84,7 +84,7 @@ func (b *Bootstrapper) Initialize() error {
 
 	b.HardwareId = hwId.String()
 
-	privKey, err := b.getChallengeKey()
+	privKey, err := GetChallengeKey()
 	if err != nil {
 		return err
 	}

--- a/orc8r/gateway/go/services/bootstrapper/service/key.go
+++ b/orc8r/gateway/go/services/bootstrapper/service/key.go
@@ -20,32 +20,37 @@ import (
 	"magma/orc8r/lib/go/security/key"
 )
 
-func (b *Bootstrapper) getChallengeKey() (privKey interface{}, err error) {
+// GetChallengeKey reads and returns the bootstrapper challenge key if present
+// or creates and returns the key if the key file doesn't exist
+func GetChallengeKey() (privKey interface{}, err error) {
 	challengeKeyFile := config.GetMagmadConfigs().BootstrapConfig.ChallengeKey
 	privKey, err = key.ReadKey(challengeKeyFile)
 	if err == nil {
 		return // all good, return the key
 	}
 	log.Printf("Bootstrapper ReadKey(%s) error: %v", challengeKeyFile, err)
-	privKey, err = key.GenerateKey(PrivateKeyType, 0)
-	if err != nil {
-		err = fmt.Errorf("Bootstrapper Generate Key error: %v", err)
-		return
-	}
-	dir := filepath.Dir(challengeKeyFile)
-	if len(dir) > 3 {
-		os.MkdirAll(dir, os.ModePerm)
-	}
-	err = key.WriteKey(challengeKeyFile, privKey)
-	if err != nil {
-		err = fmt.Errorf("Bootstrapper Write Key (%s) error: %v", challengeKeyFile, err)
-		return
-	}
-	privKey, err = key.ReadKey(challengeKeyFile)
-	if err != nil {
-		err = fmt.Errorf(
-			"Bootstrapper Failed to read recently created key from (%s) error: %v", challengeKeyFile, err)
-		return
+
+	if os.IsNotExist(err) { // file doesn't exist, try to create it
+		privKey, err = key.GenerateKey(PrivateKeyType, 0)
+		if err != nil {
+			err = fmt.Errorf("Bootstrapper Generate Key error: %v", err)
+			return
+		}
+		dir := filepath.Dir(challengeKeyFile)
+		if len(dir) > 3 {
+			os.MkdirAll(dir, os.ModePerm)
+		}
+		err = key.WriteKey(challengeKeyFile, privKey)
+		if err != nil {
+			err = fmt.Errorf("Bootstrapper Write Key (%s) error: %v", challengeKeyFile, err)
+			return
+		}
+		privKey, err = key.ReadKey(challengeKeyFile)
+		if err != nil {
+			err = fmt.Errorf(
+				"Bootstrapper Failed to read recently created key from (%s) error: %v", challengeKeyFile, err)
+			return
+		}
 	}
 	return
 }

--- a/orc8r/lib/go/security/key/key.go
+++ b/orc8r/lib/go/security/key/key.go
@@ -77,9 +77,8 @@ func WriteKey(keyFile string, priv interface{}) error {
 func ReadKey(keyFile string) (priv interface{}, err error) {
 	byteKey, err := ioutil.ReadFile(keyFile)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to open %s for reading: %s", keyFile, err)
+		return nil, err
 	}
-
 	pemKey, _ := pem.Decode(byteKey)
 	if pemKey == nil {
 		return nil, fmt.Errorf("Failed to find PEM block in file %s", keyFile)


### PR DESCRIPTION
Summary:
currently magmad -s does not create a new bootsrap GW key and only displays an existing one
It's an inconvinience as on a new unprovisioned GW one would have to run 'magmad' first and then 'magmad -s' to registed the GW.
This diff fixes the issue

Differential Revision: D21421032

