### PR TITLE
Make result of alert route GET postable

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client.go
@@ -305,7 +305,9 @@ func secureRoute(tenantID string, route *config.Route) {
 // unsecureRoute traverses a routing tree and reverts receiver
 // names to their non-prefixed original names
 func unsecureRoute(tenantID string, route *config.Route) {
-	route.Receiver = config.UnsecureReceiverName(route.Receiver, tenantID)
+	if !strings.HasSuffix(route.Receiver, config.TenantBaseRoutePostfix) {
+		route.Receiver = config.UnsecureReceiverName(route.Receiver, tenantID)
+	}
 	for _, childRoute := range route.Routes {
 		unsecureRoute(tenantID, childRoute)
 	}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
@@ -172,7 +172,7 @@ func TestClient_GetRoute(t *testing.T) {
 
 	route, err := client.GetRoute(otherNID)
 	assert.NoError(t, err)
-	assert.Equal(t, config.Route{Receiver: "tenant_base_route", Match: map[string]string{"tenantID": "other"}}, *route)
+	assert.Equal(t, config.Route{Receiver: "other_tenant_base_route", Match: map[string]string{"tenantID": "other"}}, *route)
 
 	route, err = client.GetRoute("no-network")
 	assert.Error(t, err)


### PR DESCRIPTION
Summary: We remove the prefixes from receiver names in routes on GETs in order to decrease confusion, but since the base route is special and not created by the user anyways, it doesn't need to be unsecured. This makes the GET/change/POST flow easier since you can POST exactly what you just received from the GET

Reviewed By: rckclmbr

Differential Revision: D21429043

