### PR TITLE
Add MeteringReporter for reporting session traffic usage to orc8r from gateway

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -121,6 +121,8 @@ add_library(SESSION_MANAGER
     RedisStoreClient.cpp
     RedisStoreClient.h
     StoreClient.h
+    MeteringReporter.cpp
+    MeteringReporter.h
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )

--- a/lte/gateway/c/session_manager/MeteringReporter.cpp
+++ b/lte/gateway/c/session_manager/MeteringReporter.cpp
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "MagmaService.h"
+#include "MeteringReporter.h"
+
+namespace magma {
+namespace lte {
+
+const char* COUNTER_NAME       = "ue_traffic";
+const char* LABEL_IMSI         = "IMSI";
+const char* LABEL_SESSION_ID   = "session_id";
+const char* LABEL_DIRECTION    = "direction";
+const char* DIRECTION_UP       = "up";
+const char* DIRECTION_DOWN     = "down";
+
+MeteringReporter::MeteringReporter() {}
+
+bool MeteringReporter::report_usage(
+    const std::string& imsi, const std::string& session_id,
+    SessionStateUpdateCriteria& update_criteria) {
+  double total_tx = 0;
+  double total_rx = 0;
+
+  // Charging credit
+  for (const auto& it : update_criteria.charging_credit_map) {
+    auto credit_update = it.second;
+    total_tx += (double) credit_update.bucket_deltas[USED_TX];
+    total_rx += (double) credit_update.bucket_deltas[USED_RX];
+  }
+
+  // Monitoring credit
+  for (const auto& it : update_criteria.monitor_credit_map) {
+    auto credit_update  = it.second;
+    total_tx += (double) credit_update.bucket_deltas[USED_TX];
+    total_rx += (double) credit_update.bucket_deltas[USED_RX];
+  }
+
+  report_upload(imsi, session_id, total_tx);
+  report_download(imsi, session_id, total_rx);
+}
+
+void MeteringReporter::report_upload(
+    const std::string& imsi, const std::string& session_id,
+    double unreported_usage_bytes) {
+  report_traffic(
+      imsi, session_id, DIRECTION_UP, unreported_usage_bytes);
+}
+
+void MeteringReporter::report_download(
+    const std::string& imsi, const std::string& session_id,
+    double unreported_usage_bytes) {
+  report_traffic(
+      imsi, session_id, DIRECTION_DOWN, unreported_usage_bytes);
+}
+
+void MeteringReporter::report_traffic(
+    const std::string& imsi, const std::string& session_id,
+    const std::string& traffic_direction, double unreported_usage_bytes) {
+  increment_counter(
+      COUNTER_NAME, unreported_usage_bytes, size_t(3), LABEL_IMSI, imsi.c_str(),
+      LABEL_SESSION_ID, session_id.c_str(),
+      LABEL_DIRECTION, traffic_direction.c_str());
+}
+
+void MeteringReporter::increment_counter(
+    const char* name, double increment, size_t n_labels, ...) {
+  va_list ap;
+  va_start(ap, n_labels);
+  MetricsSingleton::Instance().IncrementCounter(name, increment, n_labels, ap);
+  va_end(ap);
+}
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/MeteringReporter.h
+++ b/lte/gateway/c/session_manager/MeteringReporter.h
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "StoredState.h"
+
+namespace magma {
+namespace lte {
+
+class MeteringReporter {
+ public:
+  MeteringReporter();
+
+  /**
+   * Report all unreported traffic usage for a session.
+   * All charging and monitoring keys are aggregated.
+   */
+  bool report_usage(
+      const std::string& imsi, const std::string& session_id,
+      SessionStateUpdateCriteria& update_criteria);
+
+ private:
+  /**
+   * Report upload traffic usage for a session
+   */
+  void report_upload(
+      const std::string& imsi, const std::string& session_id,
+      double unreported_usage_bytes);
+
+  /**
+   * Report download traffic usage for a session
+   */
+  void report_download(
+      const std::string& imsi, const std::string& session_id,
+      double unreported_usage_bytes);
+
+  /**
+   * Report traffic usage for a session
+   */
+  void report_traffic(
+      const std::string& imsi, const std::string& session_id,
+      const std::string& traffic_direction, double unreported_usage_bytes);
+
+  void increment_counter(
+      const char* name, double increment, size_t n_labels, ...);
+};
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -14,7 +14,8 @@ target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
 foreach(session_test session_credit local_enforcer cloud_reporter
         session_manager_handler sessiond_integ session_state credit_pool
-        session_store store_client stored_state proxy_responder_handler)
+        session_store store_client stored_state proxy_responder_handler
+        metering_reporter)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/test_metering_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_metering_reporter.cpp
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+
+#include "MeteringReporter.h"
+#include "MetricsSingleton.h"
+#include "MagmaService.h"
+
+using magma::orc8r::MetricsContainer;
+using ::testing::Test;
+
+namespace magma {
+
+class MeteringReporterTest : public ::testing::Test {
+ protected:
+  bool is_equal(
+      io::prometheus::client::LabelPair label_pair, const char*& name,
+      const char*& value) {
+    return label_pair.name().compare(name) == 0 &&
+           label_pair.value().compare(value) == 0;
+  }
+};
+
+TEST_F(MeteringReporterTest, test_reporting) {
+  auto IMSI_LABEL        = "IMSI";
+  auto SESSION_ID_LABEL  = "session_id";
+  auto DIRECTION_LABEL   = "direction";
+
+  auto IMSI           = "imsi";
+  auto SESSION_ID     = "session_1";
+  auto MONITORING_KEY = "mk1";
+  auto DIRECTION_UP   = "up";
+  auto DIRECTION_DOWN = "down";
+
+  auto UPLOADED_BYTES   = 5;
+  auto DOWNLOADED_BYTES = 7;
+
+  auto uc = get_default_update_criteria();
+  SessionCreditUpdateCriteria credit_uc{};
+  credit_uc.bucket_deltas[USED_TX]      = UPLOADED_BYTES;
+  credit_uc.bucket_deltas[USED_RX]      = DOWNLOADED_BYTES;
+  uc.monitor_credit_map[MONITORING_KEY] = credit_uc;
+
+  auto reporter = new MeteringReporter();
+  reporter->report_usage(IMSI, SESSION_ID, uc);
+
+  // verify if UE traffic metrics are recorded properly
+  auto resp = new MetricsContainer();
+  auto magma_service =
+      std::make_shared<service303::MagmaService>("test_service", "1.0");
+  magma_service->GetMetrics(nullptr, nullptr, resp);
+  for (auto const& fam : resp->family()) {
+    if (fam.name().compare("ue_traffic") == 0) {
+      for (auto const& m : fam.metric()) {
+        for (auto const& l : m.label()) {
+          EXPECT_TRUE(
+              is_equal(l, IMSI_LABEL, IMSI) ||
+              is_equal(l, SESSION_ID_LABEL, SESSION_ID) ||
+              l.name().compare(DIRECTION_LABEL) == 0);
+
+          if (is_equal(l, DIRECTION_LABEL, DIRECTION_UP)) {
+            EXPECT_EQ(m.counter().value(), UPLOADED_BYTES);
+          } else if (is_equal(l, DIRECTION_LABEL, DIRECTION_DOWN)) {
+            EXPECT_EQ(m.counter().value(), DOWNLOADED_BYTES);
+          }
+        }
+      }
+      break;
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace magma


### PR DESCRIPTION
Summary: Added a `MeteringReporter` class for reporting upload and download usage of each session to the orc8r. This object operates on the `SessionStateUpdateCriteria` struct, as this makes it convenient to report session traffic usage right before session updates are written back into persistent storage with `SessionStore`.

Reviewed By: xjtian

Differential Revision: D21270984

