### PR TITLE
When updates to sessions are written to SessionStore, metering usage is reported to orc8r

### DIFF
--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -15,6 +15,7 @@
 
 #include "SessionState.h"
 #include "MemoryStoreClient.h"
+#include "MeteringReporter.h"
 #include "StoredState.h"
 #include "RedisStoreClient.h"
 #include "RuleStore.h"
@@ -127,6 +128,7 @@ class SessionStore {
  private:
   std::shared_ptr<StoreClient> store_client_;
   std::shared_ptr<StaticRuleStore> rule_store_;
+  std::shared_ptr<MeteringReporter> metering_reporter_;
 };
 
 }  // namespace lte


### PR DESCRIPTION
Summary:
## Changes
- SessionStore reports session data usage to orc8r
- Added test case to test_session_store to check that metering usage is reported to orc8r

Differential Revision: D21442051

