### PR TITLE
Schedule termination for sessions that are awaiting termination on restart

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -442,6 +442,8 @@ class LocalEnforcer {
   void handle_session_init_subscriber_quota_state(
       SessionMap& session_map, const std::string& imsi,
       SessionState& session_state);
+
+  void schedule_termination(std::unordered_set<std::string>& imsis);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -168,6 +168,17 @@ bool SessionState::active_monitored_rules_exist() {
   return total_monitored_rules_count() > 0;
 }
 
+SessionFsmState SessionState::get_state() {
+  return curr_state_;
+}
+
+bool SessionState::is_terminating() {
+  if (is_active() || curr_state_ == SESSION_TERMINATION_SCHEDULED) {
+    return false;
+  }
+  return true;
+}
+
 void SessionState::get_updates_from_charging_pool(
     UpdateSessionRequest& update_request_out,
     std::vector<std::unique_ptr<ServiceAction>>* actions_out,

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -121,6 +121,8 @@ class SessionState {
   void mark_as_awaiting_termination(
       SessionStateUpdateCriteria& update_criteria);
 
+  bool is_terminating();
+
   /**
    * can_complete_termination returns whether the termination for the session
    * can be completed.
@@ -314,6 +316,8 @@ class SessionState {
   StaticRuleInstall get_static_rule_install(const std::string& rule_id);
 
   DynamicRuleInstall get_dynamic_rule_install(const std::string& rule_id);
+
+  SessionFsmState get_state();
 
  private:
   std::string imsi_;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -118,7 +118,6 @@ enum SessionFsmState {
   SESSION_TERMINATING_AGGREGATING_STATS = 2,
   SESSION_TERMINATING_FLOW_DELETED      = 3,
   SESSION_TERMINATED                    = 4,
-  // TODO All sessions in this state should be terminated on sessiond restart
   SESSION_TERMINATION_SCHEDULED         = 5
 };
 


### PR DESCRIPTION
Summary:
## Background on the SESSION_TERMINATION_SCHEDULED state
This state is only used for CWF currently. A session goes into this state when a session is initialized without a valid wallet. This usually means that the PCRF will not send down PCC rules to browse internet, and there is only the Zero-Rated rule installed. (ZR rule only allows access to a data purchasing site). We do not immediately reject the session creation in this scenario, since we want to allow the user to purchase data. Instead, we will schedule a termination in a configured amount of time. (The default is 30 seconds).

## On SessionD Restart
When SessionD restarts and we re-load all sessions, we want to make sure that the user gets kicked off in some time. We can keep this logic dumb and always just use the configured kick off time. (So if a user gets scheduled to terminate at time T+30 and SessionD restarts at time T+15, the user will end up getting kicked off at time T+45. We can change this if we need to, for now this should be good enough.

## Some Bug Fix
I realized when writing the unit test for this feature that I introduced a bug a few diffs ago. In `terminate_service` we should ignore the termination only if the session is already terminating, and not "not active". This is because "not active" also includes SESSION_TERMINATION_SCHEDULED.

## Summary of Changes
- Add 'schedule_termination' to consolidate the scheduling logic
- Add 'is_terminating' and 'get_state' to SessionState
- In `sync_sessions_on_restart` schedule terminations for sessions with SESSION_TERMINATION_SCHEDULED
- Add unit test

Differential Revision: D21450420

