### PR TITLE
Fix Revalidation Timer SessionD Crash

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -384,7 +384,7 @@ func TestGxAbortSessionRequest(t *testing.T) {
 // - Check policy usage and assert revalidation-time-static-pass-all is installed and
 //   no traffic passed
 // Note: things might get weird if there are clock skews
-func testGxRevalidationTime(t *testing.T) {
+func TestGxRevalidationTime(t *testing.T) {
 	fmt.Println("\nRunning TestGxRevalidationTime...")
 
 	tr := NewTestRunner(t)
@@ -459,6 +459,8 @@ func testGxRevalidationTime(t *testing.T) {
 	assert.NoError(t, setPCRFExpectations(expectations, nil))
 
 	tr.DisconnectAndAssertSuccess(imsi)
+	// Wait for termination to go through
+	time.Sleep(3 * time.Second)
 	tr.WaitForEnforcementStatsToSync()
 
 	// Assert that we saw a Terminate request

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -177,7 +177,7 @@ void create_subscriber_quota_update(
   update->set_update_type(state);
 }
 
-void create_cwf_session_create_response(
+void create_session_create_response(
   const std::string& imsi,
   const std::string& monitoring_key,
   std::vector<std::string>& static_rules,

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -88,7 +88,7 @@ void create_subscriber_quota_update(
   const SubscriberQuotaUpdate_Type state,
   SubscriberQuotaUpdate* update);
 
-void create_cwf_session_create_response(
+void create_session_create_response(
   const std::string& imsi,
   const std::string& monitoring_key,
   std::vector<std::string>& static_rules,

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -117,7 +117,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   // Only the active sessions are not recycled, to ensure that
   // this session is not automatically scheduled for termination
   // when RAT Type is WLAN, it needs monitoring keys...
-  create_cwf_session_create_response(imsi, monitoring_key, static_rules,
+  create_session_create_response(imsi, monitoring_key, static_rules,
                                      &response);
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(imsi, 1, 1536,


### PR DESCRIPTION
Summary:
## Issue
- When a revalidation timer was triggered sessiond would crash.
- More Details here T58172385
## What was wrong
- In `check_usage_for_reporting`, a callback function for usage reporting is defined. The problem was that the session_update variable was passed by reference not value. This meant that when the variable was cleared from the stack, the callback no longer held the correct values.

## Fix
- Pass 'session_update' by make a shared_pointer out of a copied value.

## Note
- When I was adding unit tests, I discovered that revalidation timers triggered by a CCA-Init is still broken. This is because when the revalidation is scheduled, the session information is not properly stored in session map/store yet. This I will fix in another diff because: 1. This needs a slightly bigger fix 2. This behavior doesn't happen very often.
- When the feature is fixed, I'll enable the unit test for that case.

Differential Revision: D21474391

