### PR TITLE
Add a null case test for sync_sessions_on_restart

### DIFF
--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -243,7 +243,6 @@ int main(int argc, char *argv[])
     aaa_client,
     config["session_force_termination_timeout_ms"].as<long>(),
     quota_exhaust_termination_on_init_ms);
-  monitor->sync_sessions_on_restart(time(NULL));
 
   magma::service303::MagmaService server(SESSIOND_SERVICE, SESSIOND_VERSION);
   auto local_handler = std::make_unique<magma::LocalSessionManagerHandlerImpl>(
@@ -283,6 +282,7 @@ int main(int argc, char *argv[])
 
   // Block on main monitor (to keep evb in this thread)
   monitor->attachEventBase(evb);
+  monitor->sync_sessions_on_restart(time(NULL));
   monitor->start();
   server.Stop();
 


### PR DESCRIPTION
Summary:
`sync_sessions_on_restart` can add events on the event loop but was called before the event loop was attached to local enforcer. This can cause a sessiond crash when things are added to the event loop before initialization.
changing that here so that it's called after the attach.

Differential Revision: D21482296

