### PR TITLE
make gateway.mconfig location configurable & add option to periodically copy gateway.mconfig to persistent storage

### DIFF
--- a/orc8r/gateway/go/config/magmad_config.go
+++ b/orc8r/gateway/go/config/magmad_config.go
@@ -22,6 +22,8 @@ const (
 
 	// Defaults
 	DefaultChallengeKeyFile = "/var/opt/magma/certs/gw_challenge.key"
+	DefaultStaticConfigDir  = "/etc/magma"
+	DefaultDynamicConfigDir = "/var/opt/magma/configs"
 )
 
 // BootstrapConfig bootstrapper related configuration - `yaml:"bootstrap_config"`
@@ -31,26 +33,36 @@ type BootstrapConfig struct {
 
 // MagmadCfg represents magmad.yml based configuration
 type MagmadCfg struct {
-	LogLevel                         string               `yaml:"log_level"`
-	MagmaServices                    []string             `yaml:"magma_services"`
-	NonService303Services            []string             `yaml:"non_service303_services"`
-	RegisteredDynamicServices        []string             `yaml:"registered_dynamic_services"`
-	SkipCheckinIfMissingMetaServices []string             `yaml:"skip_checkin_if_missing_meta_services"`
-	InitSystem                       string               `yaml:"init_system"`
-	BootstrapConfig                  BootstrapConfig      `yaml:"bootstrap_config"`
-	EnableConfigStreamer             bool                 `yaml:"enable_config_streamer"`
-	EnableUpgradeMamager             bool                 `yaml:"enable_upgrade_manager"`
-	EnableNetworkMonitor             bool                 `yaml:"enable_network_monitor"`
-	EnableSystemdTailer              bool                 `yaml:"enable_systemd_tailer"`
-	EnableSyncRpc                    bool                 `yaml:"enable_sync_rpc"`
-	EnableKernelVersionChecking      bool                 `yaml:"enable_kernel_version_checking"`
-	SystemdTailerPollInterval        int                  `yaml:"systemd_tailer_poll_interval"`
-	NetworkMonitorConfig             NetworkMonitorConfig `yaml:"network_monitor_config"`
-	UpgraderFactory                  UpgraderFactory      `yaml:"upgrader_factory"`
-	MconfigModules                   []string             `yaml:"mconfig_modules"`
-	Metricsd                         Metricsd             `yaml:"metricsd"`
-	GenericCommandConfig             GenericCommandConfig `yaml:"generic_command_config"`
-	ConfigStreamErrorRetryInterval   int                  `yaml:"config_stream_error_retry_interval"`
+	LogLevel                         string   `yaml:"log_level"`
+	MagmaServices                    []string `yaml:"magma_services"`
+	NonService303Services            []string `yaml:"non_service303_services"`
+	RegisteredDynamicServices        []string `yaml:"registered_dynamic_services"`
+	SkipCheckinIfMissingMetaServices []string `yaml:"skip_checkin_if_missing_meta_services"`
+	InitSystem                       string   `yaml:"init_system"`
+	// When cloud managed configs (gateway.cmconfig) are loaded by a magma service, the service first tries to
+	// load them from dynamic (most recent) configs directory - DynamicMconfigDir, if unsuccessful, the service
+	// falls back to static configs directory - StaticMconfigDir; this allows services to operate
+	StaticMconfigDir  string `yaml:"static_mconfig_dir"`
+	DynamicMconfigDir string `yaml:"dynamic_mconfig_dir"`
+	// StaticMconfigUpdateIntervalMin specifies interval in minutes dynamic gateway.mconfig from DynamicMconfigDir
+	// will be synchronized with (copied to) static gateway.mconfig in StaticMconfigDir
+	// if StaticMconfigUpdateIntervalMin <= 0 (default) - static gateway.mconfig in StaticMconfigDir will never
+	// be overwritten
+	StaticMconfigUpdateIntervalMin int                  `yaml:"static_mconfig_update_interval_minutes"`
+	BootstrapConfig                BootstrapConfig      `yaml:"bootstrap_config"`
+	EnableConfigStreamer           bool                 `yaml:"enable_config_streamer"`
+	EnableUpgradeMamager           bool                 `yaml:"enable_upgrade_manager"`
+	EnableNetworkMonitor           bool                 `yaml:"enable_network_monitor"`
+	EnableSystemdTailer            bool                 `yaml:"enable_systemd_tailer"`
+	EnableSyncRpc                  bool                 `yaml:"enable_sync_rpc"`
+	EnableKernelVersionChecking    bool                 `yaml:"enable_kernel_version_checking"`
+	SystemdTailerPollInterval      int                  `yaml:"systemd_tailer_poll_interval"`
+	NetworkMonitorConfig           NetworkMonitorConfig `yaml:"network_monitor_config"`
+	UpgraderFactory                UpgraderFactory      `yaml:"upgrader_factory"`
+	MconfigModules                 []string             `yaml:"mconfig_modules"`
+	Metricsd                       Metricsd             `yaml:"metricsd"`
+	GenericCommandConfig           GenericCommandConfig `yaml:"generic_command_config"`
+	ConfigStreamErrorRetryInterval int                  `yaml:"config_stream_error_retry_interval"`
 }
 
 // NetworkMonitorConfig is network_monitor_config configuration block from magmad.yml
@@ -116,6 +128,8 @@ func NewDefaultMgmadCfg() *MagmadCfg {
 		RegisteredDynamicServices:        []string{},
 		SkipCheckinIfMissingMetaServices: []string{},
 		InitSystem:                       "",
+		StaticMconfigDir:                 DefaultStaticConfigDir,
+		DynamicMconfigDir:                DefaultDynamicConfigDir,
 		BootstrapConfig:                  BootstrapConfig{ChallengeKey: DefaultChallengeKeyFile},
 		EnableConfigStreamer:             true,
 		EnableUpgradeMamager:             false,

--- a/orc8r/gateway/go/mconfig/impl.go
+++ b/orc8r/gateway/go/mconfig/impl.go
@@ -20,6 +20,7 @@ import (
 	"time"
 	"unsafe"
 
+	"magma/gateway/config"
 	"magma/orc8r/lib/go/protos"
 )
 
@@ -71,7 +72,7 @@ func ConfigFilePath() string {
 
 // DefaultConfigFilePath returns default GW mconfig file path
 func DefaultConfigFilePath() string {
-	return filepath.Join(DefaultConfigFileDir, MconfigFileName)
+	return filepath.Join(staticConfigFileDir(), MconfigFileName)
 }
 
 // RefreshConfigsFrom checks if Managed Config File mcpath has changed
@@ -108,7 +109,18 @@ func sameFile(oldInfo, newInfo os.FileInfo) bool {
 func configFileDir() string {
 	mcdir := os.Getenv(ConfigFileDirEnv)
 	if len(mcdir) == 0 {
-		mcdir = DefaultDynamicConfigFileDir
+		mcdir = config.GetMagmadConfigs().DynamicMconfigDir
+		if len(mcdir) == 0 {
+			mcdir = DefaultDynamicConfigFileDir
+		}
+	}
+	return mcdir
+}
+
+func staticConfigFileDir() string {
+	mcdir := config.GetMagmadConfigs().StaticMconfigDir
+	if len(mcdir) == 0 {
+		mcdir = DefaultConfigFileDir
 	}
 	return mcdir
 }

--- a/orc8r/gateway/go/services/configurator/service/configurator.go
+++ b/orc8r/gateway/go/services/configurator/service/configurator.go
@@ -97,7 +97,7 @@ func (c *Configurator) Update(ub *protos.DataUpdateBatch) bool {
 	c.Lock()
 	updateChan := c.updateChan
 	oldCfgJson, err := SaveConfigs(u.GetValue(), updateChan != nil)
-	if err != err {
+	if err != nil {
 		log.Printf("error saving new gateway mconfig: %v", err)
 		c.Unlock()
 		return false
@@ -114,6 +114,9 @@ func (c *Configurator) Update(ub *protos.DataUpdateBatch) bool {
 			log.Printf("error encoding mconfig digest: %v", err)
 		}
 	}
+	// check if we need to update static copy of configs & update them
+	updateStaticConfigs(u.GetValue())
+
 	c.Unlock()
 
 	// Prepare a list of service names with changed mconfigs and

--- a/orc8r/gateway/go/services/configurator/service/io.go
+++ b/orc8r/gateway/go/services/configurator/service/io.go
@@ -14,36 +14,60 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"time"
 
+	"magma/gateway/config"
 	"magma/gateway/mconfig"
 )
 
-// SaveConfigFile saves new gateway.configs and returns old configuration if any
+// SaveConfig saves new gateway.configs and returns old configuration if any
 func SaveConfigs(cfgJson []byte, readOldCfg bool) (oldCfgJson []byte, err error) {
 	if len(cfgJson) == 0 {
 		return oldCfgJson, fmt.Errorf("empty gateway mconfigs")
 	}
 	mconfigPath := mconfig.ConfigFilePath()
+	if readOldCfg {
+		var oerr error
+		if oldCfgJson, oerr = ioutil.ReadFile(mconfigPath); oerr != nil {
+			oldCfgJson = nil
+		}
+	}
+	err = safeSwap(mconfig.ConfigFilePath(), cfgJson)
+	if err == nil {
+		log.Printf("successfully updated mconfig in %s", mconfigPath)
+	}
+	return oldCfgJson, err
+}
+
+// updateStaticConfigs saves new gateway.configs into static mconfig location
+func updateStaticConfigs(cfgJson []byte) error {
+	intervalMin := config.GetMagmadConfigs().StaticMconfigUpdateIntervalMin
+	if intervalMin <= 0 {
+		return nil
+	}
+	intervalDuration := time.Duration(intervalMin) * time.Minute
+	mconfigPath := mconfig.DefaultConfigFilePath()
+	fi, err := os.Stat(mconfigPath)
+	if (err == nil && fi.ModTime().Add(intervalDuration).Before(time.Now())) || os.IsNotExist(err) {
+		return safeSwap(mconfigPath, cfgJson)
+	}
+	return nil
+}
+
+func safeSwap(mconfigPath string, cfgJson []byte) error {
 	newMconfigPath := mconfigPath + ".new"
 	oldMconfigPath := mconfigPath + ".old"
-	err = ioutil.WriteFile(newMconfigPath, cfgJson, 0644)
+	err := ioutil.WriteFile(newMconfigPath, cfgJson, 0644)
 	if err != nil {
-		return nil, fmt.Errorf("failed to save mconfigs into %s: %v", newMconfigPath, err)
+		return fmt.Errorf("failed to save mconfigs into %s: %v", newMconfigPath, err)
 	}
-	oerr := os.Rename(mconfigPath, oldMconfigPath)
+	oerr := os.Rename(mconfigPath, oldMconfigPath) // best effort, needed just for rollback on error
 	err = os.Rename(newMconfigPath, mconfigPath)
 	if err != nil {
 		err = fmt.Errorf("failed to move mconfigs from %s to %s: %v", newMconfigPath, mconfigPath, err)
 		if oerr == nil { // roll back if previous rename succeeded
 			os.Rename(oldMconfigPath, mconfigPath)
 		}
-	} else {
-		log.Printf("successfully updated mconfig in %s", mconfigPath)
-		if readOldCfg && oerr == nil {
-			if oldCfgJson, oerr = ioutil.ReadFile(oldMconfigPath); oerr != nil {
-				oldCfgJson = nil
-			}
-		}
 	}
-	return oldCfgJson, err
+	return err
 }


### PR DESCRIPTION
Summary:
On some systems /var/opt/magma is the location of cloud based config, but it's mounted on tmp.
This diff
1) adds an option to make gateway.mconfig location configurable and
2) adds option to periodically copy gateway.mconfig to persistent storage (/etc/magms/...

Differential Revision: D21487914

