### PR TITLE
Fix XWF pipeline config type

### DIFF
--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -20,7 +20,7 @@
 # Changes to this file has to be replicated in pipelined.yml_prod
 
 # Differentiate between the setup type(CWF or LTE)
-setup_type: CWF
+setup_type: XWF
 
 log_level: INFO
 # Enable the services in PipelineD. Tables will be assigned to the services in


### PR DESCRIPTION
Summary: config type should be XWF and not CWF, it breaks the regression right now.

Differential Revision: D21494134

