### PR TITLE
[BugFix] [s1ap] [sctp_shutdown] Fixed MME crash during UE context cleanup in S1ap Enb deregister indication for large number of UEs

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_handlers.c
@@ -1825,19 +1825,16 @@ int s1ap_mme_handle_path_switch_request(
 typedef struct arg_s1ap_send_enb_dereg_ind_s {
   uint8_t current_ue_index;
   uint handled_ues;
-  MessageDef *message_p;
+  MessageDef* message_p;
 } arg_s1ap_send_enb_dereg_ind_t;
 
 //------------------------------------------------------------------------------
 static bool s1ap_send_enb_deregistered_ind(
-  __attribute__((unused)) const hash_key_t keyP,
-  uint64_t const dataP,
-  void *argP,
-  void **resultP)
-{
-  arg_s1ap_send_enb_dereg_ind_t *arg = (arg_s1ap_send_enb_dereg_ind_t *) argP;
-  ue_description_t *ue_ref_p = NULL;
-  imsi64_t imsi64 = INVALID_IMSI64;
+    __attribute__((unused)) const hash_key_t keyP, uint64_t const dataP,
+    void* argP, void** resultP) {
+  arg_s1ap_send_enb_dereg_ind_t* arg = (arg_s1ap_send_enb_dereg_ind_t*) argP;
+  ue_description_t* ue_ref_p         = NULL;
+  imsi64_t imsi64                    = INVALID_IMSI64;
   /*
    * Ask for a release of each UE context associated to the eNB
    */
@@ -1847,41 +1844,42 @@ static bool s1ap_send_enb_deregistered_ind(
   if (ue_ref_p) {
     if (arg->current_ue_index == 0) {
       arg->message_p =
-        itti_alloc_new_message(TASK_S1AP, S1AP_ENB_DEREGISTERED_IND);
+          itti_alloc_new_message(TASK_S1AP, S1AP_ENB_DEREGISTERED_IND);
     }
     if (ue_ref_p->mme_ue_s1ap_id == INVALID_MME_UE_S1AP_ID) {
-      // Send deregistered ind for this also and let MMEAPP find the context using enb_ue_s1ap_id_key
+      // Send deregistered ind for this also and let MMEAPP find the context
+      // using enb_ue_s1ap_id_key
       OAILOG_WARNING(LOG_S1AP, "UE with invalid MME s1ap id found");
     }
 
     s1ap_imsi_map_t* imsi_map = get_s1ap_imsi_map();
     hashtable_uint64_ts_get(
-      imsi_map->mme_ue_id_imsi_htbl,
-      (const hash_key_t) ue_ref_p->mme_ue_s1ap_id,
-      &imsi64);
+        imsi_map->mme_ue_id_imsi_htbl,
+        (const hash_key_t) ue_ref_p->mme_ue_s1ap_id, &imsi64);
 
     AssertFatal(
-      arg->current_ue_index < S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE,
-      "Too many deregistered UEs reported in S1AP_ENB_DEREGISTERED_IND "
-      "message ");
+        arg->current_ue_index < S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE,
+        "Too many deregistered UEs reported in S1AP_ENB_DEREGISTERED_IND "
+        "message ");
     S1AP_ENB_DEREGISTERED_IND(arg->message_p)
-      .mme_ue_s1ap_id[arg->current_ue_index] = ue_ref_p->mme_ue_s1ap_id;
+        .mme_ue_s1ap_id[arg->current_ue_index] = ue_ref_p->mme_ue_s1ap_id;
     S1AP_ENB_DEREGISTERED_IND(arg->message_p)
-      .enb_ue_s1ap_id[arg->current_ue_index] = ue_ref_p->enb_ue_s1ap_id;
+        .enb_ue_s1ap_id[arg->current_ue_index] = ue_ref_p->enb_ue_s1ap_id;
+
+    arg->handled_ues++;
+    arg->current_ue_index =
+        (uint8_t)(arg->handled_ues % S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE);
 
     // max ues reached
     if (arg->current_ue_index == 0 && arg->handled_ues > 0) {
       S1AP_ENB_DEREGISTERED_IND(arg->message_p).nb_ue_to_deregister =
-        S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE;
+          S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE;
 
       arg->message_p->ittiMsgHeader.imsi = imsi64;
       itti_send_msg_to_task(TASK_MME_APP, INSTANCE_DEFAULT, arg->message_p);
       arg->message_p = NULL;
     }
 
-    arg->handled_ues++;
-    arg->current_ue_index =
-      (uint8_t)(arg->handled_ues % S1AP_ITTI_UE_PER_DEREGISTER_MESSAGE);
     *resultP = arg->message_p;
   } else {
     OAILOG_TRACE(LOG_S1AP, "No valid UE provided in callback: %p\n", ue_ref_p);


### PR DESCRIPTION
## Summary:
If some test case fails because of some unexpected message when large number of UEs (issue found with at least 512 UEs) are attached with Magma MME, SCTP shutdown was triggered and MME was getting crashed when sending Enb deregister indication from S1ap to MME App. The reason for the crash was that the ITTI message was sent between the S1ap and MME app for this cleanup in chunk of 128 UEs, where the next chunk was created but a reference to old pointer was sent. This PR fixes the issue.

## Test Plan:
Sanity with S1APTester is verified.