### PR TITLE
Adding read-only version of workflow ui 

### DIFF
--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/App.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/App.js
@@ -29,7 +29,7 @@ const store = createStore(
   composeEnhancers(applyMiddleware(thunk))
 );
 
-function App(props) {
+function App(props : { setBuilderActive?: (param: boolean) => void }) {
   const hideHeader = () => {
     return props?.setBuilderActive ? props.setBuilderActive(true) : null;
   };

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/Grapher.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/Grapher.js
@@ -4,11 +4,46 @@ import { select } from "d3-selection";
 import { Row, Col } from "react-bootstrap";
 import Clipboard from "clipboard";
 import TaskModal from "./TaskModal";
+import type {Task} from "./flowtypes";
 
 new Clipboard(".btn");
 
-class Grapher extends Component {
-  constructor(props) {
+type SubGraph = {
+  n: [],
+  vx: {},
+  layout: {}
+};
+
+type Props = {
+  innerGraph?:?[],
+  layout: {},
+  edges: [],
+  vertices: {},
+  defs?: {},
+  def?: {}
+};
+
+type StateType = {
+  innerGraph:?[],
+  subGraph: ?SubGraph,
+  showSideBar: boolean,
+  selectedTask: Task,
+  showSubGraph: boolean,
+  subGraphId: string
+};
+
+type Parent = {
+  insert: (shape: string, st: string) => {
+    attr: (t: string, sp: string) => {}
+  }
+};
+
+class Grapher extends Component<Props, StateType> {
+  grapher: any;
+  setSvgRef: (param: {} | null) => {} | null;
+  svgElem: {} | null;
+
+  constructor(props : Props) {
     super(props);
 
     this.state = {};
@@ -89,7 +124,7 @@ class Grapher extends Component {
     this.forceUpdate();
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentWillReceiveProps(nextProps: Props) {
     this.setState({
       innerGraph: nextProps.innerGraph
     });

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/HttpClient.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/HttpClient.js
@@ -1,7 +1,7 @@
 const request = require("superagent");
 
 const HttpClient = {
-  get: (path, token) =>
+  get: (path: string, token: string) =>
     new Promise((resolve, reject) => {
       const req = request.get(path).accept("application/json");
       if (token) {
@@ -21,7 +21,7 @@ const HttpClient = {
       });
     }),
 
-  delete: (path, data, token) =>
+  delete: (path: string, data: [{}], token: string) =>
     new Promise((resolve, reject) => {
       const req = request
         .delete(path, data)
@@ -42,7 +42,7 @@ const HttpClient = {
       });
     }),
 
-  post: (path, data, token) =>
+  post: (path: string, data: [{}], token: string) =>
     new Promise((resolve, reject) => {
       const req = request
         .post(path, data)
@@ -62,7 +62,7 @@ const HttpClient = {
       });
     }),
 
-  put: (path, data, token) =>
+  put: (path: string, data: [{}], token: string) =>
     new Promise((resolve, reject) => {
       const req = request.put(path, data).set("Accept", "application/json");
 

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/PageCount.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/PageCount.js
@@ -1,8 +1,16 @@
 import React, { Component } from "react";
 import Pagination from "react-bootstrap/Pagination";
 
-class PageCount extends Component {
-  constructor(props) {
+type Props = {
+  defaultPages: number,
+  handler: (defaultPageCount: number, pageCount: number) => void,
+  dataSize: number
+};
+
+type StateType = {};
+
+class PageCount extends Component<Props, StateType> {
+  constructor(props: Props) {
     super(props);
     this.state = {};
   }

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/PageSelect.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/PageSelect.js
@@ -1,8 +1,19 @@
 import React, { Component } from "react";
 import Pagination from "react-bootstrap/Pagination";
 
-class PageSelect extends Component {
-  constructor(props) {
+type Props = {
+  viewedPage: number,
+  defaultPages: number,
+  count: number,
+  indent: number,
+  handler: (defaultPageCount: number, pageCount?: number) => void,
+  dataSize: number
+};
+
+type StateType = {};
+
+class PageSelect extends Component<Props, StateType> {
+  constructor(props: Props) {
     super(props);
     this.state = {};
   }

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/TaskModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/TaskModal.js
@@ -1,7 +1,15 @@
 import React from "react";
 import { Col, Container, Modal, Row, Tab, Tabs } from "react-bootstrap";
 import Highlight from "react-highlight.js";
-const TaskModal = props => {
+import type {Task} from "./flowtypes";
+
+type Props = {
+  task: Task,
+  show: boolean,
+  handle: () => void
+};
+
+const TaskModal = (props:Props) => {
   let task = props.task;
   let show = props.show;
   return (

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/WfLabels.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/WfLabels.js
@@ -2,7 +2,13 @@ import React from "react";
 import { Label } from "semantic-ui-react";
 import { wfLabelsColor } from "../constants";
 
-const WfLabels = props => {
+type Props = {
+  index: number,
+  search: () => void,
+  label: string
+};
+
+const WfLabels = (props: Props) => {
   let color =
     props.index >= wfLabelsColor.length
       ? wfLabelsColor[0]
@@ -16,7 +22,7 @@ const WfLabels = props => {
       circular
       size="tiny"
       style={{ backgroundColor: color, color: "white" }}
-      {...props}
+      {...(props: any)}
     >
       <p>{props.label}</p>
     </Label>

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/common/flowtypes.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/common/flowtypes.js
@@ -1,0 +1,11 @@
+export type Task = {
+  taskType: string,
+  status: string,
+  reasonForIncompletion: string,
+  referenceTaskName: string,
+  callbackAfterSeconds: number,
+  pollCount: number,
+  logs: {},
+  inputData: {},
+  outputData: {}
+};

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowList.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowList.js
@@ -1,4 +1,3 @@
-import { saveAs } from "file-saver";
 import React from "react";
 import { Button, Container, Tab, Tabs } from "react-bootstrap";
 import { withRouter } from "react-router-dom";
@@ -6,13 +5,42 @@ import { HttpClient as http } from "../../common/HttpClient";
 import WorkflowDefs from "./WorkflowDefs/WorkflowDefs";
 import WorkflowExec from "./WorkflowExec/WorkflowExec";
 import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../constants";
+import {changeUrl, exportButton} from './workflowUtils'
 
-const JSZip = require("jszip");
+const workflowModifyButtons = (openFileUpload, history) => {
+  return [
+      <Button
+          variant="outline-primary"
+          style={{ marginLeft: "30px" }}
+          onClick={() => history.push(frontendUrlPrefix + "/builder")}
+      >
+        <i className="fas fa-plus" />
+        &nbsp;&nbsp;New
+      </Button>,
+      <Button
+      variant="outline-primary"
+      style={{ marginLeft: "5px" }}
+      onClick={openFileUpload}
+  >
+    <i className="fas fa-file-import" />
+    &nbsp;&nbsp;Import
+  </Button>
+  ];
+}
+
+const upperMenu = (history, openFileUpload) => {
+  return(
+    <h1 style={{ marginBottom: "20px" }}>
+    <i style={{ color: "grey" }} className="fas fa-cogs" />
+    &nbsp;&nbsp;Workflows
+    { workflowModifyButtons(openFileUpload, history) }
+    { exportButton() }
+  </h1>);
+}
 
 const WorkflowList = (props) => {
-  const changeUrl = (e) => {
-    props.history.push(frontendUrlPrefix + "/" + e);
-  };
+  let urlUpdater = changeUrl(props.history);
+  let query = props.match.params.wfid ? props.match.params.wfid : null;
 
   const importFiles = (e) => {
     const files = e.currentTarget.files;
@@ -29,7 +57,7 @@ const WorkflowList = (props) => {
         let definition = JSON.parse(e.target.result);
         fileList.push(definition);
         if (!--count) {
-          http.put(conductorApiUrlPrefix + "/metadata", fileList).then(() => {
+          http.put(conductorApiUrlPrefix + '/metadata', fileList).then(() => {
             window.location.reload();
           });
         }
@@ -38,23 +66,6 @@ const WorkflowList = (props) => {
     }
   };
 
-  const exportFile = () => {
-    http.get(conductorApiUrlPrefix + "/metadata/workflow").then((res) => {
-      const zip = new JSZip();
-      let workflows = res.result || [];
-
-      workflows.forEach((wf) => {
-        zip.file(wf.name + ".json", JSON.stringify(wf, null, 2));
-      });
-
-      zip.generateAsync({ type: "blob" }).then(function(content) {
-        saveAs(content, "workflows.zip");
-      });
-    });
-  };
-
-  let query = props.match.params.wfid ? props.match.params.wfid : null;
-
   const openFileUpload = () => {
     document.getElementById("upload-files").click();
     document
@@ -62,39 +73,14 @@ const WorkflowList = (props) => {
       .addEventListener("change", importFiles);
   };
 
+  let menu = upperMenu(props.history, openFileUpload);
+
   return (
     <Container style={{ textAlign: "left", marginTop: "20px" }}>
-      <h1 style={{ marginBottom: "20px" }}>
-        <i style={{ color: "grey" }} className="fas fa-cogs" />
-        &nbsp;&nbsp;Workflows
-        <Button
-          variant="outline-primary"
-          style={{ marginLeft: "30px" }}
-          onClick={() => props.history.push(frontendUrlPrefix + "/builder")}
-        >
-          <i className="fas fa-plus" />
-          &nbsp;&nbsp;New
-        </Button>
-        <Button
-          variant="outline-primary"
-          style={{ marginLeft: "5px" }}
-          onClick={openFileUpload}
-        >
-          <i className="fas fa-file-import" />
-          &nbsp;&nbsp;Import
-        </Button>
-        <Button
-          variant="outline-primary"
-          style={{ marginLeft: "5px" }}
-          onClick={exportFile}
-        >
-          <i className="fas fa-file-export" />
-          &nbsp;&nbsp;Export
-        </Button>
-      </h1>
+      {menu}
       <input id="upload-files" multiple type="file" hidden />
       <Tabs
-        onSelect={(e) => changeUrl(e)}
+        onSelect={(e) => urlUpdater(e)}
         defaultActiveKey={props.match.params.type || "defs"}
         style={{ marginBottom: "20px" }}
       >

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowListReadOnly.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowListReadOnly.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Container, Tab, Tabs } from "react-bootstrap";
+import { withRouter } from "react-router-dom";
+import WorkflowDefs from "./WorkflowDefs/WorkflowDefs";
+import WorkflowExec from "./WorkflowExec/WorkflowExec";
+import {changeUrl, exportButton} from './workflowUtils'
+
+const WorkflowListReadOnly = (props) => {
+  let urlUpdater = changeUrl(props.history);
+  let query = props.match.params.wfid ? props.match.params.wfid : null;
+
+  return (
+      <Container style={{ textAlign: "left", marginTop: "20px" }}>
+        <h1 style={{ marginBottom: "20px" }}>
+          <i style={{ color: "grey" }} className="fas fa-cogs" />
+          &nbsp;&nbsp;Workflows
+          {exportButton()}
+        </h1>
+        <input id="upload-files" multiple type="file" hidden />
+        <Tabs
+            onSelect={(e) => urlUpdater(e)}
+            defaultActiveKey={props.match.params.type || "defs"}
+            style={{ marginBottom: "20px" }}
+        >
+          <Tab eventKey="defs" title="Definitions">
+            <WorkflowDefs />
+          </Tab>
+          <Tab mountOnEnter unmountOnExit eventKey="exec" title="Executed">
+            <WorkflowExec query={query} />
+          </Tab>
+          <Tab eventKey="scheduled" title="Scheduled" disabled></Tab>
+        </Tabs>
+      </Container>
+  );
+};
+
+export default withRouter(WorkflowListReadOnly);

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/workflowUtils.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/workflowUtils.js
@@ -1,0 +1,40 @@
+import { saveAs } from "file-saver";
+import {conductorApiUrlPrefix, frontendUrlPrefix} from "../../constants";
+import {HttpClient as http} from "../../common/HttpClient";
+import { Button } from "react-bootstrap";
+import React from "react";
+
+const JSZip = require("jszip");
+
+export const changeUrl = (history) => {
+ return function(e) {
+    history.push(frontendUrlPrefix + "/" + e);
+  };
+};
+
+const exportFile = () => {
+  http.get(conductorApiUrlPrefix + '/metadata/workflow').then((res) => {
+    const zip = new JSZip();
+    let workflows = res.result || [];
+
+    workflows.forEach((wf) => {
+      zip.file(wf.name + ".json", JSON.stringify(wf, null, 2));
+    });
+
+    zip.generateAsync({ type: "blob" }).then(function(content) {
+      saveAs(content, "workflows.zip");
+    });
+  });
+};
+
+export const exportButton = () => {
+  return (
+      <Button
+          variant="outline-primary"
+          style={{ marginLeft: "5px" }}
+          onClick={exportFile}>
+        <i className="fas fa-file-export" />
+        &nbsp;&nbsp;Export
+      </Button>
+  );
+}


### PR DESCRIPTION
Based on new role-based access requirements it will be neccesary to have 2 versions of the UI - read-only and full functionality

The new read-only (i.e. cannot change or creare new workflows) workflow ui looks like this:

![readonlyworkflow](https://user-images.githubusercontent.com/4011326/81798454-5a95bf00-9510-11ea-9e5c-468d16b5e191.png)