### PR TITLE
Adding ability to choose template for radius docker

### DIFF
--- a/feg/radius/src/Dockerfile
+++ b/feg/radius/src/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as builder
 RUN apk add git gcc musl-dev bash protobuf
 COPY radius/src /src/radius
-COPY radius/src/config/samples/radius.cwf.config.json.template /src/radius/radius.config.json.template
+COPY radius/src/config/samples/*template /src/radius/config/
 COPY radius/lib/go/ /src/lib/go
 WORKDIR /src/radius
 ENV GOPROXY https://proxy.golang.org
@@ -11,7 +11,7 @@ RUN ./run.sh build
 FROM alpine
 RUN apk add gettext musl
 COPY --from=builder /src/radius/radius /app/
-COPY --from=builder /src/radius/radius.config.json.template /app/
+COPY --from=builder /src/radius/config/ /app/
 COPY radius/src/docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod 0755 /app/docker-entrypoint.sh
 WORKDIR /app

--- a/feg/radius/src/docker-entrypoint.sh
+++ b/feg/radius/src/docker-entrypoint.sh
@@ -7,5 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 ################################################################################
 
-/usr/bin/envsubst < ./radius.config.json.template > ./radius.config.json
+TEMPLATE="${TEMPLATE_ENV:-radius.cwf.config.json.template}"
+
+/usr/bin/envsubst < "${TEMPLATE}" > ./radius.config.json
 ./radius


### PR DESCRIPTION
Summary:
In order to support goradius for xwf-m added the ability to chose a template of running with an env variable.

Defaults to the default config if none passed

Differential Revision: D21524340

