### PR TITLE
Add test for correct values of converted histograms

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/exporters/gaugeconverter.go
@@ -96,6 +96,7 @@ func histogramToGauges(family *dto.MetricFamily) []*dto.MetricFamily {
 			},
 		}
 		sumFamily.Metric = append(sumFamily.Metric, &sumMetric)
+
 		countValue := float64(*metric.Histogram.SampleCount)
 		countMetric := dto.Metric{
 			Label: metric.Label,
@@ -104,6 +105,7 @@ func histogramToGauges(family *dto.MetricFamily) []*dto.MetricFamily {
 			},
 		}
 		countFamily.Metric = append(countFamily.Metric, &countMetric)
+
 		for _, bucket := range metric.Histogram.Bucket {
 			bucketValue := float64(*bucket.CumulativeCount)
 			bucketMetric := dto.Metric{


### PR DESCRIPTION
Summary: hcgatewood was running into some issues with histograms and I wanted to make sure it wasn't a problem with the gauge conversion. We didn't have tests for the actual values of the gauges, so this test should be added anyways.

Reviewed By: hcgatewood

Differential Revision: D21527535

