### PR TITLE
build-magma.sh will now also generate swagger dependencies of eventd

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -231,6 +231,7 @@ ORC8R_PY_DEPS=`${RELEASE_DIR}/pydep lockfile ${RELEASE_DIR}/magma.lockfile`
 
 cd ${PY_LTE}
 make protos
+make swagger
 PKG_VERSION=${FULL_VERSION} ${PY_VERSION} setup.py install --root ${PY_TMP_BUILD} --install-layout deb \
     --no-compile --single-version-externally-managed
 ${RELEASE_DIR}/pydep finddep -l ${RELEASE_DIR}/magma.lockfile setup.py


### PR DESCRIPTION
Summary: Swagger dependencies of `eventd` service were not being generated due to a missing make step that runs during regular development, but not in `build-magma.sh`

Differential Revision: D21561534

