### PR TITLE
Gy CCR-I is expected with CCR-number AVP = 0

### DIFF
--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -88,7 +88,6 @@ func getCCRInitialCreditRequest(
 	imsi string,
 	pReq *protos.CreateSessionRequest,
 	keys []policydb.ChargingKey,
-	initMethod gy.InitMethod,
 ) *gy.CreditControlRequest {
 	var msgType credit_control.CreditRequestType
 	var qos *gy.QosRequestInfo
@@ -100,11 +99,7 @@ func getCCRInitialCreditRequest(
 		}
 	}
 
-	if initMethod == gy.PerKeyInit {
-		msgType = credit_control.CRTInit
-	} else {
-		msgType = credit_control.CRTUpdate
-	}
+	msgType = credit_control.CRTInit
 	usedCredits := make([]*gy.UsedCredits, 0, len(keys))
 	for _, key := range keys {
 		uc := &gy.UsedCredits{RatingGroup: key.RatingGroup}
@@ -116,7 +111,7 @@ func getCCRInitialCreditRequest(
 	}
 	return &gy.CreditControlRequest{
 		SessionID:     pReq.SessionId,
-		RequestNumber: 1,
+		RequestNumber: 0,
 		IMSI:          imsi,
 		UeIPV4:        pReq.UeIpv4,
 		SpgwIPV4:      pReq.SpgwIpv4,

--- a/feg/gateway/services/session_proxy/servicers/policy.go
+++ b/feg/gateway/services/session_proxy/servicers/policy.go
@@ -32,7 +32,7 @@ func (srv *CentralSessionController) sendInitialGxRequest(imsi string, pReq *pro
 		SessionID:     pReq.SessionId,
 		Type:          credit_control.CRTInit,
 		IMSI:          imsi,
-		RequestNumber: 1,
+		RequestNumber: 0,
 		IPAddr:        pReq.UeIpv4,
 		SpgwIPV4:      pReq.SpgwIpv4,
 		Apn:           pReq.Apn,

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -103,23 +103,12 @@ func (srv *CentralSessionController) CreateSession(
 	credits := []*protos.CreditUpdateResponse{}
 
 	if len(chargingKeys) > 0 {
-		if srv.cfg.InitMethod == gy.PerSessionInit {
-			_, err = srv.sendSingleCreditRequest(getCCRInitRequest(imsi, request))
-			metrics.UpdateGyRecentRequestMetrics(err)
-			if err != nil {
-				metrics.OcsCcrInitSendFailures.Inc()
-				glog.Errorf("Failed to send first single credit request: %s", err)
-				return nil, err
-			}
-			metrics.OcsCcrInitRequests.Inc()
-		}
-
-		gyCCRInit := getCCRInitialCreditRequest(imsi, request, chargingKeys, srv.cfg.InitMethod)
+		gyCCRInit := getCCRInitialCreditRequest(imsi, request, chargingKeys)
 		gyCCAInit, err := srv.sendSingleCreditRequest(gyCCRInit)
 		metrics.UpdateGyRecentRequestMetrics(err)
 		if err != nil {
 			metrics.OcsCcrInitSendFailures.Inc()
-			glog.Errorf("Failed to send second single credit request: %s", err)
+			glog.Errorf("Failed to send initial credit request: %s", err)
 			return nil, err
 		}
 		gyOriginHost = gyCCAInit.OriginHost

--- a/feg/gateway/services/session_proxy/servicers/session_controller_test.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller_test.go
@@ -147,27 +147,9 @@ func (mp *MockMultiplexor) GetIndex(muxCtx *multiplex.Context) (int, error) {
 }
 
 // ---- TESTS ----
-func TestSessionControllerPerSessionInit_SingleServer(t *testing.T) {
-	numberServers := 1
-	mockConfig := getTestConfig(gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(mockConfig)
-	mockPolicyDb := &MockPolicyDBClient{}
-	mockMux := getMockMultiplexor(numberServers)
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
-	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, mockMux, gy.PerSessionInit)
-}
 
-func TestSessionControllerPerSessionInit(t *testing.T) {
-	mockConfig := getTestConfig(gy.PerSessionInit)
-	mockControlParams := getMockControllerParams(mockConfig)
-	mockPolicyDb := &MockPolicyDBClient{}
-	mockMux := getMockMultiplexor(NUMBER_SERVERS)
-	srv := servicers.NewCentralSessionControllers(mockControlParams, mockPolicyDb, mockMux)
-	standardUsageTest(t, srv, mockControlParams, mockPolicyDb, mockMux, gy.PerSessionInit)
-}
-
-func TestSessionControllerPerKeyInit(t *testing.T) {
-	mockConfig := getTestConfig(gy.PerKeyInit)
+func TestSessionControllerInit(t *testing.T) {
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -177,7 +159,7 @@ func TestSessionControllerPerKeyInit(t *testing.T) {
 
 func TestStartSessionGxFail(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -213,7 +195,7 @@ func TestStartSessionGxFail(t *testing.T) {
 
 func TestStartSessionGyFail(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -509,7 +491,7 @@ func standardUsageTest(
 
 func TestSessionCreateWithOmnipresentRules(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -564,7 +546,7 @@ func TestSessionCreateWithOmnipresentRules(t *testing.T) {
 
 func TestSessionControllerTimeouts(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -648,7 +630,7 @@ func TestSessionControllerTimeouts(t *testing.T) {
 
 func TestSessionTermination(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -711,7 +693,7 @@ func TestSessionTermination(t *testing.T) {
 
 func testGxUsageMonitoring(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -991,7 +973,7 @@ func TestGetHealthStatus(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -1130,7 +1112,7 @@ func getMockControllerParams(mockConfig []*servicers.SessionControllerConfig) []
 	return controlParams
 }
 
-func getTestConfig(initMethod gy.InitMethod) []*servicers.SessionControllerConfig {
+func getTestConfig() []*servicers.SessionControllerConfig {
 	serverCfg := make([]*servicers.SessionControllerConfig, len(ocs_server_ports))
 	for i := 0; i < NUMBER_SERVERS; i++ {
 		ocs_port := ocs_server_ports[i]
@@ -1145,7 +1127,6 @@ func getTestConfig(initMethod gy.InitMethod) []*servicers.SessionControllerConfi
 				Protocol: "tcp"},
 			},
 			RequestTimeout: time.Millisecond,
-			InitMethod:     initMethod,
 		}
 		serverCfg[i] = srv
 	}
@@ -1410,7 +1391,7 @@ func getGxCCRMatcher(imsi string, ccrType credit_control.CreditRequestType) inte
 /***** UseGyForAuthOnlySuccess Test Cases *****/
 func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -1479,7 +1460,7 @@ func TestSessionControllerUseGyForAuthOnlySuccess(t *testing.T) {
 
 func TestSessionControllerUseGyForAuthOnlyNoRatingGroup(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -1552,7 +1533,7 @@ func returnGySuccessNoRatingGroup(args mock.Arguments) {
 
 func TestSessionControllerUseGyForAuthOnlyCreditLimitReached(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -1628,7 +1609,7 @@ func returnGySuccessCreditLimitReached(args mock.Arguments) {
 
 func TestSessionControllerUseGyForAuthOnlySubscriberBarred(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -1791,7 +1772,7 @@ func revalidationTimerTest(
 
 func TestSessionControllerRevalidationTimerUsed(t *testing.T) {
 	// Set up mocks
-	mockConfig := getTestConfig(gy.PerSessionInit)
+	mockConfig := getTestConfig()
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}
 	mockMux := getMockMultiplexor(NUMBER_SERVERS)
@@ -1804,7 +1785,7 @@ func TestSessionControllerRevalidationTimerUsed(t *testing.T) {
 func TestSessionControllerUseGyForAuthOnlyRevalidationTimerUsed(t *testing.T) {
 
 	numberServers := 1
-	mockConfig := getTestConfig(gy.PerKeyInit)
+	mockConfig := getTestConfig()
 	mockConfig[0].UseGyForAuthOnly = true
 	mockControlParams := getMockControllerParams(mockConfig)
 	mockPolicyDb := &MockPolicyDBClient{}

--- a/feg/gateway/services/session_proxy/session_proxy/main.go
+++ b/feg/gateway/services/session_proxy/session_proxy/main.go
@@ -89,7 +89,6 @@ func generateClientsConfsAndDiameterConnection() (
 	// Global config, init Method and policyDb (static routes) are shared by all the controllers
 	gyGlobalConf := gy.GetGyGlobalConfig()
 	gxGlobalConf := gx.GetGxGlobalConfig()
-	initMethod := gy.GetInitMethod()
 
 	// Each controller will take one entry of PCRF, OCS, and gx/gy clients confs
 	gxCliConfs := gx.GetGxClientConfiguration()
@@ -120,7 +119,6 @@ func generateClientsConfsAndDiameterConnection() (
 			OCSConfig:        OCSConfs[i],
 			PCRFConfig:       PCRFConfs[i],
 			RequestTimeout:   3 * time.Second,
-			InitMethod:       initMethod,
 			UseGyForAuthOnly: util.IsTruthyEnv(gy.UseGyForAuthOnlyEnv),
 		}
 		// Fill in gx and gy config for controller i

--- a/feg/gateway/services/testcore/ocs/mock_ocs/mock_driven_ocs_test.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/mock_driven_ocs_test.go
@@ -48,9 +48,10 @@ func TestOCSExpectations(t *testing.T) {
 	initExpectation := fegprotos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
 
 	updateReq := fegprotos.NewGyCCRequest(test.IMSI1, fegprotos.CCRequestType_UPDATE).
-		SetRequestNumber(2).
+		SetRequestNumber(1).
 		SetMSCC(&fegprotos.MultipleServicesCreditControl{RatingGroup: 1, UsedServiceUnit: &fegprotos.Octets{TotalOctets: 100}})
 	updateAnswer := fegprotos.NewGyCCAnswer(diam.Success)
+	updateAnswer.RequestNumber = 1
 	updateExpectation := fegprotos.NewGyCreditControlExpectation().Expect(updateReq).Return(updateAnswer)
 
 	terminateReq := fegprotos.NewGyCCRequest(test.IMSI1, fegprotos.CCRequestType_TERMINATION)
@@ -77,7 +78,7 @@ func TestOCSExpectations(t *testing.T) {
 		SessionID:     "1",
 		Type:          credit_control.CRTInit,
 		IMSI:          test.IMSI1,
-		RequestNumber: 1,
+		RequestNumber: 0,
 	}
 	done := make(chan interface{}, 1000)
 	assert.NoError(t, gyClient.SendCreditControlRequest(&serverConfig, done, ccrInit))
@@ -88,7 +89,7 @@ func TestOCSExpectations(t *testing.T) {
 		SessionID:     "1",
 		Type:          credit_control.CRTUpdate,
 		IMSI:          test.IMSI1,
-		RequestNumber: 2,
+		RequestNumber: 1,
 		Credits:       []*gy.UsedCredits{{TotalOctets: 100, RatingGroup: 1}},
 	}
 	done = make(chan interface{}, 1000)
@@ -108,6 +109,7 @@ func TestOCSExpectations(t *testing.T) {
 
 func assertCCAIsEqualToExpectedAnswer(t *testing.T, actual *gy.CreditControlAnswer, expectation *fegprotos.GyCreditControlAnswer) {
 	assert.Equal(t, actual.ResultCode, expectation.ResultCode)
+	assert.Equal(t, actual.RequestNumber, expectation.RequestNumber)
 	actualCreditsByKey := getCreditByKey(actual.Credits)
 	expectedCreditsByKey := getExpectedCreditByKey(expectation.QuotaGrants)
 	for rg, credit := range expectedCreditsByKey {

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -108,8 +108,8 @@ SessionState::SessionState(
       session_id_(session_id),
       core_session_id_(core_session_id),
       config_(cfg),
-      // Request number set to 2, because request 1 is INIT call
-      request_number_(2),
+      // Request number set to 1, because request 0 is INIT call
+      request_number_(1),
       curr_state_(SESSION_ACTIVE),
       charging_pool_(imsi),
       monitor_pool_(imsi),


### PR DESCRIPTION
Summary:
Gy CCR-I is expected with CCR-number AVP = 0, but under some conditions, we'll start it from 1.
this diff fixes the issue. It also fixes the start # for Gx

Differential Revision: D21596631

