### PR TITLE
Support Directoryd client needed for redirection integ TC

### DIFF
--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -144,6 +144,7 @@ services:
       - session-proxy.magma.test:127.0.0.1
       - sessiond.magma.test:127.0.0.1
       - aaa-server.magma.test:127.0.0.1
+      - directoryd.magma.test:127.0.0.1
     volumes:
       - ../integ_tests/nginx.conf:/etc/nginx/nginx.conf:ro
     command: /usr/sbin/nginx -g "daemon off;"

--- a/cwf/gateway/integ_tests/nginx.conf
+++ b/cwf/gateway/integ_tests/nginx.conf
@@ -36,6 +36,11 @@ http {
       http2_push_preload on;
     }    
 
+    location /magma.orc8r.GatewayDirectoryService/ {
+      grpc_pass grpc://directoryd.magma.test:50067;
+      http2_push_preload on;
+    }
+
     location /magma.orc8r.Streamer/ {
       grpc_set_header Content-Type "application/gprc";
       http2_push_preload on;

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -27,23 +27,26 @@ import (
 
 // todo make Op configurable, or export it in the UESimServer.
 const (
-	Op              = "\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"
-	Secret          = "123456"
-	MockHSSRemote   = "HSS_REMOTE"
-	MockPCRFRemote  = "PCRF_REMOTE"
-	MockOCSRemote   = "OCS_REMOTE"
-	MockPCRFRemote2 = "PCRF_REMOTE2"
-	MockOCSRemote2  = "OCS_REMOTE2"
-	PipelinedRemote = "pipelined.local"
-	RedisRemote     = "REDIS"
-	CwagIP          = "192.168.70.101"
-	OCSPort         = 9201
-	PCRFPort        = 9202
-	OCSPort2        = 9205
-	PCRFPort2       = 9206
-	HSSPort         = 9204
-	PipelinedPort   = 8443
-	RedisPort       = 6380
+	Op               = "\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"
+	Secret           = "123456"
+	MockHSSRemote    = "HSS_REMOTE"
+	MockPCRFRemote   = "PCRF_REMOTE"
+	MockOCSRemote    = "OCS_REMOTE"
+	MockPCRFRemote2  = "PCRF_REMOTE2"
+	MockOCSRemote2   = "OCS_REMOTE2"
+	PipelinedRemote  = "pipelined.local"
+	DirectorydRemote = "DIRECTORYD"
+	RedisRemote      = "REDIS"
+	CwagIP           = "192.168.70.101"
+	TrafficCltIP     = "192.168.128.2"
+	OCSPort          = 9201
+	PCRFPort         = 9202
+	OCSPort2         = 9205
+	PCRFPort2        = 9206
+	HSSPort          = 9204
+	PipelinedPort    = 8443
+	RedisPort        = 6380
+	DirectorydPort   = 8443
 
 	defaultMSISDN          = "5100001234"
 	defaultCalledStationID = "98-DE-D0-84-B5-47:CWF-TP-LINK_B547_5G"
@@ -84,6 +87,8 @@ func NewTestRunner(t *testing.T) *TestRunner {
 	registry.AddService(PipelinedRemote, CwagIP, PipelinedPort)
 	fmt.Printf("Adding Redis service at %s:%d\n", CwagIP, RedisPort)
 	registry.AddService(RedisRemote, CwagIP, RedisPort)
+	fmt.Printf("Adding Directoryd service at %s:%d\n", CwagIP, DirectorydPort)
+	registry.AddService(DirectorydRemote, CwagIP, DirectorydPort)
 
 	testRunner := &TestRunner{t: t,
 		activePCRFs: []string{MockPCRFRemote},


### PR DESCRIPTION
Summary:
Normally, Pipelined populate Directoryd IMSI record with ipv4_addr after seeing DHCP ACK.
For integ_test, we will need to update the record directly

Reviewed By: themarwhal

Differential Revision: D21543191

