### PR TITLE
Make OmniRuleTest less flaky

### DIFF
--- a/cwf/gateway/integ_tests/container_utils.go
+++ b/cwf/gateway/integ_tests/container_utils.go
@@ -28,6 +28,7 @@ func (tr *TestRunner) findContainer(cli *dockerClient.Client, serviceName string
 
 //RestartService adds ability to restart a particular service managed by docker
 func (tr *TestRunner) RestartService(serviceName string, cleanRestart bool) error {
+	fmt.Printf("Restarting %v, with clean restart=%v", serviceName, cleanRestart)
 	ctx := context.Background()
 	cli, err := dockerClient.NewEnvClient()
 	if err != nil {
@@ -39,7 +40,7 @@ func (tr *TestRunner) RestartService(serviceName string, cleanRestart bool) erro
 		fmt.Printf("error %v getting container id \n", err)
 		return err
 	}
-	timeout := time.Duration(30 * time.Second)
+	timeout := 30 * time.Second
 	err = cli.ContainerRestart(ctx, containerID, &timeout)
 	return err
 }

--- a/cwf/gateway/integ_tests/gx_qos_restart_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_restart_test.go
@@ -68,7 +68,6 @@ func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg strin
 	tr := NewTestRunner(t)
 
 	err := tr.RestartService("pipelined", true)
-	fmt.Println("Restarting service")
 
 	if err != nil {
 		fmt.Printf("error restarting pipelined %v", err)

--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -111,7 +111,7 @@ func TestOmnipresentRules(t *testing.T) {
 	// With all monitored rules gone, the session should terminate
 	recordsBySubID, err = tr.GetPolicyUsage()
 	assert.NoError(t, err)
-	assert.Empty(t, recordsBySubID)
+	assert.Empty(t, recordsBySubID[prependIMSIPrefix(imsi)])
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)


### PR DESCRIPTION
Summary:
On CI, one of the failures we were seeing was:
```] out: wait for flows to get deactivated
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out: ************************* Removing a network wide rule
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out: --- FAIL: TestOmnipresentRules (13.54s)
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out:     test_runner.go:196: Finished Authenticating UE. Resulting RADIUS Packet: &{2 2 [71 22 172 69 255 238 132 91 253 7 185 216 109 92 54 34] [49 50 51 52 53 54] map[1:[[48 50 53 50 55 50 57 51 53 54 52 52 52 52 57 53 64 119 108 97 110 46 109 110 99 48 48 49 46 109 99 99 48 48 49 46 51 103 112 112 110 101 116 119 111 114 107 46 111 114 103]] 26:[[0 0 1 55 17 52 234 221 117 21 29 110 136 156 236 236 133 150 109 101 188 96 208 50 215 22 183 95 25 21 195 249 192 16 135 71 92 56 112 53 131 116 82 109 70 18 158 129 230 20 48 128 93 192 34 142] [0 0 1 55 16 52 165 81 14 107 114 237 63 158 36 207 32 68 252 251 121 19 80 30 9 103 249 207 29 3 147 139 173 19 38 18 52 202 138 37 203 215 107 7 113 155 221 144 18 244 103 22 78 126 34 113]] 79:[[3 2 0 4]] 80:[[255 236 113 244 253 251 88 66 146 184 246 27 145 255 152 20]]]}
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out:     omni_rules_test.go:114:
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out:         	Error Trace:	omni_rules_test.go:114
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out:         	Error:      	Should be empty, but was map[IMSI966708043855403:map[static-ULQos-246404:sid:"IMSI966708043855403" rule_id:"static-ULQos-246404" ]]
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out:         	Test:       	TestOmnipresentRules
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out:     test_runner.go:215: Finished Discconnecting UE. Resulting RADIUS Packet: &{5 114 [238 92 238 253 88 155 141 172 247 188 83 48 242 51 245 139] [49 50 51 52 53 54] map[44:[[57 56 45 68 69 45 68 48 45 56 52 45 66 53 45 52 55 58 67 87 70 45 84 80 45 76 73 78 75 95 66 53 52 55 95 53 71 95 95 54 101 58 98 49 58 97 55 58 52 50 58 52 51 58 52 53]]]}
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out: FAIL
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out: exit status 1
[magma@10.240.0.13] out: [vagrant@127.0.0.1:2201] out: FAIL	magma/cwf/gateway/integ_tests	908.451s
```
This is due to some other test failing and not cleaning up properly.
So instead of asserting that all records are empty, just assert that all records for that IMSI are impty.

Also move the "restart service" log to inside the RestartService function so we can log what service we're restarting

Reviewed By: ymasmoudi

Differential Revision: D21617460

