### PR TITLE
Add basic UI for scheduling workflows

### DIFF
--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/Scheduling.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/Scheduling.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Accordion,
   Button,
@@ -14,99 +14,69 @@ import "react-bootstrap-typeahead/css/Typeahead.css";
 import { withRouter } from "react-router-dom";
 import PageCount from "../../../common/PageCount";
 import PageSelect from "../../../common/PageSelect";
-import WfLabels from "../../../common/WfLabels";
 import { HttpClient as http } from "../../../common/HttpClient";
 import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../../constants";
 import SchedulingModal from "./SchedulingModal/SchedulingModal";
 import DiagramModal from "../WorkflowDefs/DiagramModal/DiagramModal";
 
-class Scheduling extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      keywords: "",
-      labels: [],
-      data: [],
-      table: [],
-      activeRow: null,
-      activeScheduleName: null,
-      defaultPages: 20,
-      pagesCount: 1,
-      viewedPage: 1,
-      allLabels: [],
-      schedulingModal: false,
-    };
-    this.table = React.createRef();
-  }
+const Scheduling = props => {
+  const [showSchedulingModal, setShowSchedulingModal] = useState(false);
+  const [activeScheduleName, setActiveScheduleName] = useState();
+  const [activeRow, setActiveRow] = useState();
 
-  unselectActiveRow() {
-    let table = this.state.table;
-    this.setState({
-      activeRow: null,
-      table: table
-    });
-  }
-
-  componentDidMount() {
-    this.unselectActiveRow();
+  const refresh = () => {
     http.get(conductorApiUrlPrefix + "/schedule").then(res => {
-      if (res) {
-        let size = ~~(res.length / this.state.defaultPages);
-        let dataset =
-          res.sort((a, b) =>
-            a.name > b.name ? 1 : b.name > a.name ? -1 : 0
-          ) || [];
-        this.setState({
-          data: dataset,
-          pagesCount:
-            res.length % this.state.defaultPages ? ++size : size
-        });
-      }
+      let size = Math.floor(res.length / defaultPages);
+      let dataset = res.sort((a, b) =>
+          a.name > b.name ? 1 : b.name > a.name ? -1 : 0
+        ) || [];
+      setData(dataset);
+      setPagesCount(res.length % defaultPages ? ++size : size);
+      deselectActiveRow();
+      return dataset;
     });
+    return [];
+  };
+
+  const [data, setData] = useState(refresh);
+  const [pagesCount, setPagesCount] = useState(1);
+  const [defaultPages, setDefaultPages] = useState(20);
+  const [viewedPage, setViewedPage] = useState(1);
+
+
+  const deselectActiveRow = () => {
+    setActiveRow(null);
+    setActiveScheduleName(null);
   }
 
-  changeActiveRow(i) {
-    let dataset = this.state.data;
-    const deselectingCurrentRow = this.state.activeRow === i;
-    const newState = {
-      activeRow: deselectingCurrentRow ? null : i,
-      activeScheduleName: deselectingCurrentRow ? null : dataset[i]["name"]
-    };
-    this.setState(newState);
-  }
+  const changeActiveRow = (i) => {
+    const deselectingCurrentRow = activeRow === i;
+    if (deselectingCurrentRow) {
+      deselectActiveRow();
+    } else {
+      setActiveRow(i);
+      setActiveScheduleName(data[i]["name"]);
+    }
+  };
 
-  setCountPages(defaultPages, pagesCount) {
-    this.setState({
-      defaultPages: defaultPages,
-      pagesCount: pagesCount,
-      viewedPage: 1
-    });
-  }
+  const setCountPages = (defaultPages, pagesCount) => {
+    setDefaultPages(defaultPages);
+    setPagesCount(pagesCount);
+    setViewedPage(1);
+  };
 
-  setViewPage(page) {
-    this.setState({
-      viewedPage: page
-    });
-  }
-
-
-
-  delete(schedulingEntry) {
+  const deleteEntry = (schedulingEntry) => {
     console.log("Deleting", schedulingEntry.name);
     http
       .delete(conductorApiUrlPrefix + "/schedule/" + schedulingEntry.name)
       .then(() => {
-        this.componentDidMount();
-        this.unselectActiveRow();
+        deselectActiveRow();
       });
-  }
+  };
 
-  repeat() {
+  const repeat = () => {
     let output = [];
-    let defaultPages = this.state.defaultPages;
-    let viewedPage = this.state.viewedPage;
-    let dataset = this.state.data;
-    for (let i = 0; i < dataset.length; i++) {
+    for (let i = 0; i < data.length; i++) {
       if (
         i >= (viewedPage - 1) * defaultPages &&
         i < viewedPage * defaultPages
@@ -115,16 +85,16 @@ class Scheduling extends Component {
           <div className="wfRow" key={i}>
             <Accordion.Toggle
               id={`wf${i}`}
-              onClick={this.changeActiveRow.bind(this, i)}
+              onClick={changeActiveRow.bind(this, i)}
               className="clickable wfDef"
               as={Card.Header}
               variant="link"
               eventKey={i}
             >
-              <b>{dataset[i]["workflowName"]}</b> v.{dataset[i]["workflowVersion"]}
+              <b>{data[i]["workflowName"]}</b> v.{data[i]["workflowVersion"]}
               <br />
               <div className="description">
-                { dataset[i]["cronString"] }
+                { data[i]["cronString"] }
               </div>
             </Accordion.Toggle>
             <Accordion.Collapse eventKey={i}>
@@ -139,7 +109,7 @@ class Scheduling extends Component {
                 >
                   <Button
                     variant="outline-light noshadow"
-                    onClick={this.showSchedulingModal.bind(this)}
+                    onClick={flipShowSchedulingModal}
                   >
                     Edit
                   </Button>
@@ -147,7 +117,7 @@ class Scheduling extends Component {
                   <Button
                     variant="outline-danger noshadow"
                     style={{ float: "right" }}
-                    onClick={this.delete.bind(this, dataset[i])}
+                    onClick={deleteEntry.bind(this, data[i])}
                   >
                     <i className="fas fa-trash-alt" />
                   </Button>
@@ -159,70 +129,68 @@ class Scheduling extends Component {
       }
     }
     return output;
+  };
+
+  const flipShowSchedulingModal = () => {
+    setShowSchedulingModal(!showSchedulingModal);
+  };
+
+  const onModalClose = () => {
+    flipShowSchedulingModal();
+    refresh();
   }
 
-  showSchedulingModal() {
-    this.setState({
-      schedulingModal: !this.state.schedulingModal
-    });
-  }
-
-  render() {
-    let schedulingModal = this.state.schedulingModal ? (
+  return (
+    <div>
+      {showSchedulingModal ? (
       <SchedulingModal
-        name={this.state.activeScheduleName}
-        modalHandler={this.showSchedulingModal.bind(this)}
-        show={this.state.schedulingModal}
+        name={activeScheduleName}
+        onClose={onModalClose}
       />
-    ) : null;
+      ) : null}
 
-    return (
-      <div>
-        {schedulingModal}
+      <Button variant="outline-primary" style={{ marginLeft: "30px" }}
+      onClick={() => refresh()}>
+        <i className="fas fa-sync" />&nbsp;&nbsp;Refresh
+      </Button>
 
-        <Button variant="outline-primary" style={{ marginLeft: "30px" }}
-        onClick={() => this.componentDidMount()}>
-          <i className="fas fa-sync" />&nbsp;&nbsp;Refresh
-        </Button>
-
-        <div className="scrollWrapper" style={{ maxHeight: "650px" }}>
-          <Table ref={this.table}>
-            <thead>
-              <tr>
-                <th>Name/Cron</th>
-              </tr>
-            </thead>
-            <tbody>
-              <Accordion activeKey={this.state.activeRow}>
-                {this.repeat()}
-              </Accordion>
-            </tbody>
-          </Table>
-        </div>
-        <Container style={{ marginTop: "5px" }}>
-          <Row>
-            <Col sm={2}>
-              <PageCount
-                dataSize={
-                  this.state.data.length
-                }
-                defaultPages={this.state.defaultPages}
-                handler={this.setCountPages.bind(this)}
-              />
-            </Col>
-            <Col sm={8} />
-            <Col sm={2}>
-              <PageSelect
-                viewedPage={this.state.viewedPage}
-                count={this.state.pagesCount}
-                handler={this.setViewPage.bind(this)}
-              />
-            </Col>
-          </Row>
-        </Container>
+      <div className="scrollWrapper" style={{ maxHeight: "650px" }}>
+        <Table>
+          <thead>
+            <tr>
+              <th>Name/Cron</th>
+            </tr>
+          </thead>
+          <tbody>
+            <Accordion activeKey={activeRow}>
+              {repeat()}
+            </Accordion>
+          </tbody>
+        </Table>
       </div>
-    );
-  }
+      <Container style={{ marginTop: "5px" }}>
+        <Row>
+          <Col sm={2}>
+            <PageCount
+              dataSize={
+                data.length
+              }
+              defaultPages={defaultPages}
+              handler={setCountPages.bind(this)}
+            />
+          </Col>
+          <Col sm={8} />
+          <Col sm={2}>
+            <PageSelect
+              viewedPage={viewedPage}
+              count={pagesCount}
+              handler={setViewedPage}
+            />
+          </Col>
+        </Row>
+      </Container>
+    </div>
+  );
 }
 
 export default withRouter(Scheduling);

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/Scheduling.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/Scheduling.js
@@ -1,0 +1,204 @@
+import React, { Component } from "react";
+import {
+  Accordion,
+  Button,
+  Card,
+  Col,
+  Container,
+  Form,
+  Row,
+  Table
+} from "react-bootstrap";
+import { Typeahead } from "react-bootstrap-typeahead";
+import "react-bootstrap-typeahead/css/Typeahead.css";
+import { withRouter } from "react-router-dom";
+import PageCount from "../../../common/PageCount";
+import PageSelect from "../../../common/PageSelect";
+import WfLabels from "../../../common/WfLabels";
+import { HttpClient as http } from "../../../common/HttpClient";
+import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../../constants";
+
+class Scheduling extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      keywords: "",
+      labels: [],
+      data: [],
+      table: [],
+      activeRow: null,
+      activeWf: null,
+      defaultPages: 20,
+      pagesCount: 1,
+      viewedPage: 1,
+      allLabels: []
+    };
+    this.table = React.createRef();
+  }
+
+  componentWillMount() {
+
+  }
+
+  componentDidMount() {
+    http.get(conductorApiUrlPrefix + "/schedule").then(res => {
+      if (res) {
+        let size = ~~(res.length / this.state.defaultPages);
+        let dataset =
+          res.sort((a, b) =>
+            a.name > b.name ? 1 : b.name > a.name ? -1 : 0
+          ) || [];
+        this.setState({
+          data: dataset,
+          pagesCount:
+            res.length % this.state.defaultPages ? ++size : size
+        });
+      }
+    });
+  }
+
+  changeActiveRow(i) {
+    let dataset = this.state.data;
+    this.setState({
+      activeRow: this.state.activeRow === i ? null : i,
+      activeWf: dataset[i]["name"] + " / " + dataset[i]["cronString"]
+    });
+  }
+
+
+  setCountPages(defaultPages, pagesCount) {
+    this.setState({
+      defaultPages: defaultPages,
+      pagesCount: pagesCount,
+      viewedPage: 1
+    });
+  }
+
+  setViewPage(page) {
+    this.setState({
+      viewedPage: page
+    });
+  }
+
+  delete(schedulingEntry) {
+    console.log("Deleting", schedulingEntry.name);
+    http
+      .delete(conductorApiUrlPrefix + "/schedule/" + schedulingEntry.name)
+      .then(() => {
+        this.componentDidMount();
+        let table = this.state.table;
+        // if (table.length) {
+        //   table.splice(table.findIndex(wf => wf.name === name), 1);
+        // }
+        this.setState({
+          activeRow: null,
+          table: table
+        });
+      });
+  }
+
+  repeat() {
+    let output = [];
+    let defaultPages = this.state.defaultPages;
+    let viewedPage = this.state.viewedPage;
+    let dataset = this.state.data;
+    for (let i = 0; i < dataset.length; i++) {
+      if (
+        i >= (viewedPage - 1) * defaultPages &&
+        i < viewedPage * defaultPages
+      ) {
+        output.push(
+          <div className="wfRow" key={i}>
+            <Accordion.Toggle
+              id={`wf${i}`}
+              onClick={this.changeActiveRow.bind(this, i)}
+              className="clickable wfDef"
+              as={Card.Header}
+              variant="link"
+              eventKey={i}
+            >
+              <b>{dataset[i]["name"]}</b>
+              <br />
+              <div className="description">
+                { dataset[i]["cronString"] }
+              </div>
+            </Accordion.Toggle>
+            <Accordion.Collapse eventKey={i}>
+              <Card.Body style={{ padding: "0px" }}>
+                <div
+                  style={{
+                    background:
+                      "linear-gradient(-120deg, rgb(0, 147, 255) 0%, rgb(0, 118, 203) 100%)",
+                    padding: "15px",
+                    marginBottom: "10px"
+                  }}
+                >
+                  <Button
+                    variant="outline-light noshadow"
+                    onClick={() => alert('Not implemented')}
+                  >
+                    Edit
+                  </Button>
+
+                  <Button
+                    variant="outline-danger noshadow"
+                    style={{ float: "right" }}
+                    onClick={this.delete.bind(this, dataset[i])}
+                  >
+                    <i className="fas fa-trash-alt" />
+                  </Button>
+                </div>
+              </Card.Body>
+            </Accordion.Collapse>
+          </div>
+        );
+      }
+    }
+    return output;
+  }
+
+
+  render() {
+    return (
+      <div>
+        <div className="scrollWrapper" style={{ maxHeight: "650px" }}>
+          <Table ref={this.table}>
+            <thead>
+              <tr>
+                <th>Name/Cron</th>
+              </tr>
+            </thead>
+            <tbody>
+              <Accordion activeKey={this.state.activeRow}>
+                {this.repeat()}
+              </Accordion>
+            </tbody>
+          </Table>
+        </div>
+        <Container style={{ marginTop: "5px" }}>
+          <Row>
+            <Col sm={2}>
+              <PageCount
+                dataSize={
+                  this.state.data.length
+                }
+                defaultPages={this.state.defaultPages}
+                handler={this.setCountPages.bind(this)}
+              />
+            </Col>
+            <Col sm={8} />
+            <Col sm={2}>
+              <PageSelect
+                viewedPage={this.state.viewedPage}
+                count={this.state.pagesCount}
+                handler={this.setViewPage.bind(this)}
+              />
+            </Col>
+          </Row>
+        </Container>
+      </div>
+    );
+  }
+}
+
+export default withRouter(Scheduling);

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
@@ -4,42 +4,29 @@ import WorkflowDia from "../../WorkflowExec/DetailsModal/WorkflowDia/WorkflowDia
 import { HttpClient as http } from "../../../../common/HttpClient";
 import { conductorApiUrlPrefix } from "../../../../constants";
 
+const stateSubmit = "Submit";
+const stateSubmitting = "Submitting..."
+
 const SchedulingModal = props => {
-  const [schedule, setSchedule] = useState();
-  const [fromDate, setFromDate] = useState();
-  const [toDate, setToDate] = useState();
-  const [enabled, setEnabled] = useState();
-  const [cronString, setCronString] = useState();
-  const stateSubmit = "Submit";
-  const stateSubmitting = "Submitting..."
-  const [status, setStatus] = useState(stateSubmit);
-  const [error, setError] = useState();
-
-
-  useEffect(() => {
+  const [schedule, setSchedule] = useState(()=>{
     http
       .get(conductorApiUrlPrefix + "/schedule/" + props.name)
       .then(res => {
         setSchedule(res);
-        setFromDate(res.fromDate);
-        setToDate(res.toDate);
-        setEnabled(res.enabled);
-        setCronString(res.cronString);
       });
-  }, []);
+    return null;
+  });
+  const [status, setStatus] = useState(stateSubmit);
+  const [error, setError] = useState();
 
   const handleClose = () => {
-    props.modalHandler();
+    props.onClose();
   };
-
 
   const submitForm = () => {
     setError(null);
-    // update schedule object
-    schedule.enabled = enabled;
-    schedule.cronString = cronString;
     setStatus(stateSubmitting);
-    http.put(conductorApiUrlPrefix + "/schedule/" + props.name, schedule).then(res => {
+    http.put(conductorApiUrlPrefix + "/schedule/" + schedule.name, schedule).then(res => {
       handleClose();
     }).catch(error => {
       setStatus(stateSubmit);
@@ -47,11 +34,27 @@ const SchedulingModal = props => {
     });
   }
 
+  const setCronString = (str) => {
+    let mySchedule = {
+      ...schedule,
+      cronString: str
+    };
+    setSchedule(mySchedule);
+  }
+
+  const setEnabled = (enabled) => {
+    let mySchedule = {
+      ...schedule,
+      enabled: enabled
+    };
+    setSchedule(mySchedule);
+  }
+
   return (
     <Modal
       size="lg"
       dialogClassName="modal-70w"
-      show={props.show}
+      show="true"
       onHide={handleClose}
     >
       <Modal.Header>
@@ -65,7 +68,7 @@ const SchedulingModal = props => {
               type="input"
               onChange={e => setCronString(e.target.value)}
               placeholder="Enter cron pattern"
-              value={cronString}
+              value={schedule?.cronString}
             />
           </Form.Group>
           <Form.Group>
@@ -73,7 +76,7 @@ const SchedulingModal = props => {
             <Form.Control
               type="checkbox"
               onChange={e => setEnabled(e.target.checked)}
-              checked={enabled}
+              checked={schedule?.enabled}
             />
           </Form.Group>
         </Form>

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
@@ -23,12 +23,19 @@ const SchedulingModal = props => {
     const req = superagent.get(path).accept("application/json");
     req.end((err, res) => {
       if (res && res.ok) {
+        // found in db
         setSchedule(res.body);
       } else {
+        // not found, prepare new object to be created
         setSchedule({
           name: props.name,
           workflowName: props.workflowName,
-          workflowVersion: props.workflowVersion + '' // must be string
+          // workflowVersion must be string
+          workflowVersion: props.workflowVersion + '',
+          // new schedule is created with enabled: true due to
+          // https://github.com/flaviostutz/schellar/issues/5
+          enabled: true,
+          cronString: '0 * * ? * *'
         })
       }
     });

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
@@ -1,0 +1,105 @@
+import React, { useEffect, useState } from "react";
+import { Button, Modal, Form } from "react-bootstrap";
+import WorkflowDia from "../../WorkflowExec/DetailsModal/WorkflowDia/WorkflowDia";
+import { HttpClient as http } from "../../../../common/HttpClient";
+import { conductorApiUrlPrefix } from "../../../../constants";
+
+const SchedulingModal = props => {
+  const [schedule, setSchedule] = useState();
+  const [fromDate, setFromDate] = useState();
+  const [toDate, setToDate] = useState();
+  const [enabled, setEnabled] = useState();
+  const [cronString, setCronString] = useState();
+  const stateSubmit = "Submit";
+  const stateSubmitting = "Submitting..."
+  const [status, setStatus] = useState(stateSubmit);
+  const [error, setError] = useState();
+
+
+  useEffect(() => {
+    http
+      .get(conductorApiUrlPrefix + "/schedule/" + props.name)
+      .then(res => {
+        setSchedule(res);
+        setFromDate(res.fromDate);
+        setToDate(res.toDate);
+        setEnabled(res.enabled);
+        setCronString(res.cronString);
+      });
+  }, []);
+
+  const handleClose = () => {
+    props.modalHandler();
+  };
+
+
+  const submitForm = () => {
+    setError(null);
+    // update schedule object
+    schedule.enabled = enabled;
+    schedule.cronString = cronString;
+    setStatus(stateSubmitting);
+    http.put(conductorApiUrlPrefix + "/schedule/" + props.name, schedule).then(res => {
+      handleClose();
+    }).catch(error => {
+      setStatus(stateSubmit);
+      setError("Request failed:" + error);
+    });
+  }
+
+  return (
+    <Modal
+      size="lg"
+      dialogClassName="modal-70w"
+      show={props.show}
+      onHide={handleClose}
+    >
+      <Modal.Header>
+        <Modal.Title>Schedule Details</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form onSubmit={submitForm}>
+          <Form.Group>
+            <Form.Label>Cron</Form.Label>
+            <Form.Control
+              type="input"
+              onChange={e => setCronString(e.target.value)}
+              placeholder="Enter cron pattern"
+              value={cronString}
+            />
+          </Form.Group>
+          <Form.Group>
+            <Form.Label>Enabled</Form.Label>
+            <Form.Control
+              type="checkbox"
+              onChange={e => setEnabled(e.target.checked)}
+              checked={enabled}
+            />
+          </Form.Group>
+        </Form>
+      </Modal.Body>
+      <Modal.Footer>
+        <pre>
+        {error}
+        </pre>
+
+        <Button
+          variant={status === stateSubmit ? "primary" : "info" }
+          onClick={submitForm}
+          disabled={status === stateSubmitting}
+        >
+          {status === stateSubmit ? <i className="fas fa-play" /> : null}
+          {status === stateSubmitting ?
+          (<i className="fas fa-spinner fa-spin" />) : null}
+          &nbsp;&nbsp;{status}
+        </Button>
+        <Button variant="secondary" onClick={handleClose}>
+          Close
+        </Button>
+
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default SchedulingModal;

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/SchedulingModal/SchedulingModal.js
@@ -50,6 +50,24 @@ const SchedulingModal = props => {
     setSchedule(mySchedule);
   }
 
+  const getCronString = () => {
+    if (schedule != null) {
+      if (schedule.cronString != null) {
+        return schedule.cronString;
+      }
+    }
+    return "";
+  }
+
+  const getEnabled = () => {
+    if (schedule != null) {
+      if (typeof schedule.enabled === "boolean") {
+        return schedule.enabled;
+      } // backend does not send this property when disabled
+    }
+    return false;
+  }
+
   return (
     <Modal
       size="lg"
@@ -68,7 +86,7 @@ const SchedulingModal = props => {
               type="input"
               onChange={e => setCronString(e.target.value)}
               placeholder="Enter cron pattern"
-              value={schedule?.cronString}
+              value={getCronString()}
             />
           </Form.Group>
           <Form.Group>
@@ -76,7 +94,7 @@ const SchedulingModal = props => {
             <Form.Control
               type="checkbox"
               onChange={e => setEnabled(e.target.checked)}
-              checked={schedule?.enabled}
+              checked={getEnabled()}
             />
           </Form.Group>
         </Form>

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefs.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefs.js
@@ -224,6 +224,7 @@ class WorkflowDefs extends Component {
       data.description = "- FAVOURITE";
     }
     http.put(conductorApiUrlPrefix + "/metadata/", [data]).then(() => {
+      // TODO: merge with componentDidMount
       http.get(conductorApiUrlPrefix + "/metadata/workflow").then(res => {
         let dataset =
           res.result.sort((a, b) =>
@@ -459,7 +460,8 @@ class WorkflowDefs extends Component {
   onSchedulingModalClose() {
     this.setState({
       schedulingModal: false
-    })
+    });
+    this.componentDidMount();
   }
 
   getActiveRowScheduleName() {

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefs.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefs.js
@@ -17,6 +17,7 @@ import PageSelect from "../../../common/PageSelect";
 import WfLabels from "../../../common/WfLabels";
 import DefinitionModal from "./DefinitonModal/DefinitionModal";
 import DiagramModal from "./DiagramModal/DiagramModal";
+import SchedulingModal from "../Scheduling/SchedulingModal/SchedulingModal";
 import InputModal from "./InputModal/InputModal";
 import { HttpClient as http } from "../../../common/HttpClient";
 import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../../constants";
@@ -33,6 +34,7 @@ class WorkflowDefs extends Component {
       activeWf: null,
       defModal: false,
       diagramModal: false,
+      schedulingModal: false,
       defaultPages: 20,
       pagesCount: 1,
       viewedPage: 1,
@@ -277,15 +279,29 @@ class WorkflowDefs extends Component {
     return labels;
   };
 
+  getActiveWorkflowName() {
+    if (this.state.activeRow != null && this.state.data[this.state.activeRow] != null) {
+      return this.state.data[this.state.activeRow].name;
+    }
+    return null;
+  }
+
+  getActiveWorkflowVersion() {
+    if (this.state.activeRow != null && this.state.data[this.state.activeRow] != null) {
+      return this.state.data[this.state.activeRow].version;
+    }
+    return null;
+  }
+
   editWorkflow() {
-    const name = this.state.activeWf.split(" / ")[0];
-    const version = this.state.activeWf.split(" / ")[1];
+    const name = this.getActiveWorkflowName();
+    const version = this.getActiveWorkflowVersion();
     this.props.history.push(`${frontendUrlPrefix}/builder/${name}/${version}`);
   }
 
   deleteWorkflow() {
-    const name = this.state.activeWf.split(" / ")[0];
-    const version = this.state.activeWf.split(" / ")[1];
+    const name = this.getActiveWorkflowName();
+    const version = this.getActiveWorkflowVersion();
     http
       .delete(conductorApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
       .then(() => {
@@ -383,6 +399,12 @@ class WorkflowDefs extends Component {
                     />
                   </Button>
                   <Button
+                    variant="outline-light noshadow"
+                    onClick={this.showSchedulingModal.bind(this)}
+                  >
+                    {dataset[i].hasSchedule ? 'Edit schedule' : 'Create schedule'}
+                  </Button>
+                  <Button
                     variant="outline-danger noshadow"
                     style={{ float: "right" }}
                     onClick={this.deleteWorkflow.bind(this)}
@@ -422,10 +444,29 @@ class WorkflowDefs extends Component {
     });
   }
 
+  showSchedulingModal() {
+    this.setState({
+      schedulingModal: true
+    });
+  }
+
   showDiagramModal() {
     this.setState({
       diagramModal: !this.state.diagramModal
     });
+  }
+
+  onSchedulingModalClose() {
+    this.setState({
+      schedulingModal: false
+    })
+  }
+
+  getActiveRowScheduleName() {
+    if (this.state.activeRow != null && this.state.data[this.state.activeRow] != null) {
+      return this.state.data[this.state.activeRow].expectedScheduleName;
+    }
+    return null;
   }
 
   render() {
@@ -453,11 +494,19 @@ class WorkflowDefs extends Component {
       />
     ) : null;
 
+
     return (
       <div>
         {definitionModal}
         {inputModal}
         {diagramModal}
+        <SchedulingModal
+          name={this.getActiveRowScheduleName()}
+          workflowName={this.getActiveWorkflowName()}
+          workflowVersion={this.getActiveWorkflowVersion()}
+          onClose={this.onSchedulingModalClose.bind(this)}
+          show={this.state.schedulingModal}
+        />
         <Row>
           <Button
             style={{ marginBottom: "15px", marginLeft: "15px" }}

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowList.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowList.js
@@ -85,13 +85,13 @@ const WorkflowList = (props) => {
         defaultActiveKey={props.match.params.type || "defs"}
         style={{ marginBottom: "20px" }}
       >
-        <Tab eventKey="defs" title="Definitions">
+        <Tab mountOnEnter unmountOnExit eventKey="defs" title="Definitions">
           <WorkflowDefs />
         </Tab>
         <Tab mountOnEnter unmountOnExit eventKey="exec" title="Executed">
           <WorkflowExec query={query} />
         </Tab>
-        <Tab eventKey="scheduled" title="Scheduled">
+        <Tab mountOnEnter unmountOnExit eventKey="scheduled" title="Scheduled">
           <Scheduling />
         </Tab>
       </Tabs>

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowList.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowList.js
@@ -4,6 +4,7 @@ import { withRouter } from "react-router-dom";
 import { HttpClient as http } from "../../common/HttpClient";
 import WorkflowDefs from "./WorkflowDefs/WorkflowDefs";
 import WorkflowExec from "./WorkflowExec/WorkflowExec";
+import Scheduling from "./Scheduling/Scheduling";
 import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../constants";
 import {changeUrl, exportButton} from './workflowUtils'
 
@@ -90,7 +91,9 @@ const WorkflowList = (props) => {
         <Tab mountOnEnter unmountOnExit eventKey="exec" title="Executed">
           <WorkflowExec query={query} />
         </Tab>
-        <Tab eventKey="scheduled" title="Scheduled" disabled></Tab>
+        <Tab eventKey="scheduled" title="Scheduled">
+          <Scheduling />
+        </Tab>
       </Tabs>
     </Container>
   );

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/schellar.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/schellar.js
@@ -39,6 +39,11 @@ function sanitizeScheduleBefore(
     logger.error('Unexpected schedule name', {schedule, expectedName});
     throw 'Unexpected schedule name';
   }
+  if (expectedName.indexOf('/') > -1) {
+    // guard against https://github.com/flaviostutz/schellar/issues/4
+    logger.error('Cannot create schedule with name containing "/" character');
+    throw 'Cannot create schedule with name containing "/" character';
+  }
 
   // add tenantId to name
   addTenantIdPrefix(tenantId, schedule);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -111,7 +111,6 @@ export function assertNameIsWithoutInfixSeparator(objectWithName: {
   assertValueIsWithoutInfixSeparator(objectWithName.name);
 }
 
-// TODO: disallow ':'
 export function assertValueIsWithoutInfixSeparator(value: string): void {
   if (value.indexOf(INFIX_SEPARATOR) > -1) {
     logger.error(`Value must not contain '${INFIX_SEPARATOR}' in '${value}'`);

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -324,7 +324,6 @@ router.get('/id/:workflowId', async (req, res, next) => {
       ),
     );
 
-    // TODO not implemented on proxy
     const logs = map(task =>
       Promise.all([task, http.get(baseURLTask + task.taskId + '/log', req)]),
     )(result.tasks);
@@ -477,28 +476,18 @@ router.get('/hierarchical', async (req, res, next) => {
   }
 });
 
-// TODO not implemented on proxy
-router.get('/queue/data', async (req, res, next) => {
+router.get('/schedule/?', async (req, res, next) => {
   try {
-    const sizes = await http.get(baseURLTask + 'queue/all', req);
-    const polldata = await http.get(baseURLTask + 'queue/polldata/all', req);
-    polldata.forEach(pd => {
-      let qname = pd.queueName;
-
-      if (pd.domain != null) {
-        qname = pd.domain + ':' + qname;
-      }
-      pd.qsize = sizes[qname];
-    });
-    res.status(200).send({polldata});
+    const result = await http.get(baseURLSchedule, req);
+    res.status(200).send(result);
   } catch (err) {
     next(err);
   }
 });
 
-router.get('/schedule', async (req, res, next) => {
+router.get('/schedule/:name', async (req, res, next) => {
   try {
-    const result = await http.get(baseURLSchedule, req);
+    const result = await http.get(baseURLSchedule + req.params.name, req);
     res.status(200).send(result);
   } catch (err) {
     next(err);

--- a/symphony/app/fbcnms-projects/workflows/src/types.js
+++ b/symphony/app/fbcnms-projects/workflows/src/types.js
@@ -89,6 +89,7 @@ export type StartWorkflowRequest = {
 export type ScheduleRequest = {
   name: string,
   workflowName: string,
+  workflowVersion: string,
 };
 
 export type FrontendResponse = {

--- a/symphony/integration/docker-compose.conductor.frinx.yaml
+++ b/symphony/integration/docker-compose.conductor.frinx.yaml
@@ -17,6 +17,7 @@ services:
 #      - redis_data:/var/lib/redis
     networks:
       - private
+    restart: on-failure
 
   elasticsearch:
     image: frinx/fm-elasticsearch:latest
@@ -36,6 +37,7 @@ services:
 #      - elastic_data:/usr/share/elasticsearch/data
     networks:
       - private
+    restart: on-failure
     healthcheck:
       test: ["CMD", "curl", "-IGET", "http://localhost:9200"]
       interval: 2s
@@ -66,6 +68,7 @@ services:
       - public
       - private
     command: ["/app/wait_for.sh", "-t", "120",  "elasticsearch:9300", "--", "/app/startup.sh"]
+    restart: on-failure
 
   schellar:
     image: flaviostutz/schellar
@@ -85,6 +88,7 @@ services:
     networks:
       - private
       - public
+    restart: on-failure
 
   mongo:
     image: mongo:4.1.10
@@ -95,6 +99,7 @@ services:
       - 27017-27019:27017-27019
     networks:
       - private
+    restart: on-failure
 
   mongo-express:
     image: mongo-express:0.49.0
@@ -106,6 +111,7 @@ services:
     networks:
       - private
       - public
+    restart: on-failure
 
 networks:
   public:


### PR DESCRIPTION
Summary:
Add 'Scheduled' tab to workflow UI

New schedules are created in workflow definition tab. Once created, they can be updated or deleted in 'Scheduled' tab. Currently only enabled/disabled and cron string can be edited.

Test plan:
setup:
Start symphony, conductor.frinx, workflows containers.
Create new workflow named `workflow1` e.g. using the builder.
test:
Open workflow definition, expand `workflow1`. Last button in the bar should be `Create schedule` :
![1](https://user-images.githubusercontent.com/492226/82323528-78fc2e80-99d8-11ea-8084-0ffb5a01ed66.png)
Click the button, new modal window should appear:
![2](https://user-images.githubusercontent.com/492226/82323567-89aca480-99d8-11ea-90eb-742b6b35b9fc.png)
Click `Submit`. Expanding the `workflow1`, last button should be `Edit schedule`.
Click `Scheduled` tab, all schedules should appear:
![3](https://user-images.githubusercontent.com/492226/82323786-d7c1a800-99d8-11ea-89c1-4dbbe96d41ae.png)
Highlight newly created schedule, updating and deleting should work as expected.
If you set the cron expression to `0 * * ? * *`, new execution should appear every minute. Cron expressions are evaluated using [go cron library](https://github.com/robfig/cron) which in turn uses [Quartz expressions](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/tutorial-lesson-06.html)