### PR TITLE
Fix Qos integration test

### DIFF
--- a/cwf/gateway/deploy/roles/ovs/files/load_openvswitch.sh
+++ b/cwf/gateway/deploy/roles/ovs/files/load_openvswitch.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+sudo rmmod openvswitch || /bin/true
+sudo modinfo openvswitch
+sudo modprobe openvswitch

--- a/cwf/gateway/deploy/roles/ovs/tasks/main.yml
+++ b/cwf/gateway/deploy/roles/ovs/tasks/main.yml
@@ -39,6 +39,10 @@
        - python-openvswitch
        - openvswitch-datapath-dkms
 
+- name: Load the ovs kernel module
+  become: true
+  script: load_openvswitch.sh
+
 - name: Start OVS
   service:
     name: openvswitch-switch

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -105,7 +105,7 @@ internal_ip_subnet: '192.168.0.0/16'
 # QoS parameters
 qos:
  enable: true
- impl: linux_tc
+ impl: ovs_meter
  max_rate: 1000000000
  linux_tc:
   min_idx: 2


### PR DESCRIPTION
Summary: Enable ovs_meter config and ensure ovs kernel module gets loaded.

Differential Revision: D21623667

