### PR TITLE
Include DNS configs on MME init logs

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_config.c
@@ -62,24 +62,23 @@
 #define SYSTEM_CMD_MAX_STR_SIZE 512
 
 //------------------------------------------------------------------------------
-void pgw_config_init(pgw_config_t *config_pP)
-{
-  memset((char *) config_pP, 0, sizeof(*config_pP));
+void pgw_config_init(pgw_config_t* config_pP) {
+  memset((char*) config_pP, 0, sizeof(*config_pP));
   pthread_rwlock_init(&config_pP->rw_lock, NULL);
 }
 
 //------------------------------------------------------------------------------
-int pgw_config_process(pgw_config_t *config_pP)
-{
+int pgw_config_process(pgw_config_t* config_pP) {
 #if (!EMBEDDED_SGW)
   async_system_command(
-    TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR, "iptables -t mangle -F OUTPUT");
+      TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR, "iptables -t mangle -F OUTPUT");
   async_system_command(
-    TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR, "iptables -t mangle -F POSTROUTING");
+      TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
+      "iptables -t mangle -F POSTROUTING");
 
   if (config_pP->masquerade_SGI) {
     async_system_command(
-      TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR, "iptables -t nat -F PREROUTING");
+        TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR, "iptables -t nat -F PREROUTING");
   }
 #endif
 
@@ -91,24 +90,21 @@ int pgw_config_process(pgw_config_t *config_pP)
   {
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    int fd                 = socket(AF_INET, SOCK_DGRAM, 0);
     ifr.ifr_addr.sa_family = AF_INET;
     strncpy(
-      ifr.ifr_name,
-      (const char *) config_pP->ipv4.if_name_SGI->data,
-      IFNAMSIZ - 1);
+        ifr.ifr_name, (const char*) config_pP->ipv4.if_name_SGI->data,
+        IFNAMSIZ - 1);
     if (ioctl(fd, SIOCGIFADDR, &ifr)) {
       OAILOG_CRITICAL(
-        LOG_SPGW_APP,
-        "Failed to read SGI ip addresses: error %s\n",
-        strerror(errno));
+          LOG_SPGW_APP, "Failed to read SGI ip addresses: error %s\n",
+          strerror(errno));
       return RETURNerror;
     }
-    struct sockaddr_in *ipaddr = (struct sockaddr_in *) &ifr.ifr_addr;
-    if (
-      inet_ntop(
-        AF_INET, (const void *) &ipaddr->sin_addr, str_sgi, INET_ADDRSTRLEN) ==
-      NULL) {
+    struct sockaddr_in* ipaddr = (struct sockaddr_in*) &ifr.ifr_addr;
+    if (inet_ntop(
+            AF_INET, (const void*) &ipaddr->sin_addr, str_sgi,
+            INET_ADDRSTRLEN) == NULL) {
       OAILOG_ERROR(LOG_SPGW_APP, "inet_ntop");
       return RETURNerror;
     }
@@ -116,35 +112,32 @@ int pgw_config_process(pgw_config_t *config_pP)
 
     ifr.ifr_addr.sa_family = AF_INET;
     strncpy(
-      ifr.ifr_name,
-      (const char *) config_pP->ipv4.if_name_SGI->data,
-      IFNAMSIZ - 1);
+        ifr.ifr_name, (const char*) config_pP->ipv4.if_name_SGI->data,
+        IFNAMSIZ - 1);
     if (ioctl(fd, SIOCGIFMTU, &ifr)) {
       OAILOG_CRITICAL(
-        LOG_SPGW_APP, "Failed to probe SGI MTU: error %s\n", strerror(errno));
+          LOG_SPGW_APP, "Failed to probe SGI MTU: error %s\n", strerror(errno));
       return RETURNerror;
     }
     config_pP->ipv4.mtu_SGI = ifr.ifr_mtu;
     OAILOG_DEBUG(
-      LOG_SPGW_APP, "Found SGI interface MTU=%d\n", config_pP->ipv4.mtu_SGI);
+        LOG_SPGW_APP, "Found SGI interface MTU=%d\n", config_pP->ipv4.mtu_SGI);
     close(fd);
   }
   // GET S5_S8 informations
   {
     struct ifreq ifr;
     memset(&ifr, 0, sizeof(ifr));
-    int fd = socket(AF_INET, SOCK_DGRAM, 0);
+    int fd                 = socket(AF_INET, SOCK_DGRAM, 0);
     ifr.ifr_addr.sa_family = AF_INET;
     strncpy(
-      ifr.ifr_name,
-      (const char *) config_pP->ipv4.if_name_S5_S8->data,
-      IFNAMSIZ - 1);
+        ifr.ifr_name, (const char*) config_pP->ipv4.if_name_S5_S8->data,
+        IFNAMSIZ - 1);
     ioctl(fd, SIOCGIFADDR, &ifr);
-    struct sockaddr_in *ipaddr = (struct sockaddr_in *) &ifr.ifr_addr;
-    if (
-      inet_ntop(
-        AF_INET, (const void *) &ipaddr->sin_addr, str, INET_ADDRSTRLEN) ==
-      NULL) {
+    struct sockaddr_in* ipaddr = (struct sockaddr_in*) &ifr.ifr_addr;
+    if (inet_ntop(
+            AF_INET, (const void*) &ipaddr->sin_addr, str, INET_ADDRSTRLEN) ==
+        NULL) {
       OAILOG_ERROR(LOG_SPGW_APP, "inet_ntop");
       return RETURNerror;
     }
@@ -152,15 +145,13 @@ int pgw_config_process(pgw_config_t *config_pP)
 
     ifr.ifr_addr.sa_family = AF_INET;
     strncpy(
-      ifr.ifr_name,
-      (const char *) config_pP->ipv4.if_name_S5_S8->data,
-      IFNAMSIZ - 1);
+        ifr.ifr_name, (const char*) config_pP->ipv4.if_name_S5_S8->data,
+        IFNAMSIZ - 1);
     ioctl(fd, SIOCGIFMTU, &ifr);
     config_pP->ipv4.mtu_S5_S8 = ifr.ifr_mtu;
     OAILOG_DEBUG(
-      LOG_SPGW_APP,
-      "Foung S5_S8 interface MTU=%d\n",
-      config_pP->ipv4.mtu_S5_S8);
+        LOG_SPGW_APP, "Foung S5_S8 interface MTU=%d\n",
+        config_pP->ipv4.mtu_S5_S8);
     close(fd);
   }
   // Get IP block information
@@ -174,21 +165,18 @@ int pgw_config_process(pgw_config_t *config_pP)
     rv = get_assigned_ipv4_block(0, &netaddr, &netmask);
     if (rv != 0) {
       OAILOG_CRITICAL(
-        LOG_SPGW_APP, "ERROR in getting assigned IP block from mobilityd\n");
+          LOG_SPGW_APP, "ERROR in getting assigned IP block from mobilityd\n");
       return -1;
     }
 
 #if (!EMBEDDED_SGW)
     if (config_pP->masquerade_SGI) {
       async_system_command(
-        TASK_ASYNC_SYSTEM,
-        PGW_ABORT_ON_ERROR,
-        "iptables -t nat -I POSTROUTING -s %s/%d -o %s  ! --protocol sctp -j "
-        "SNAT --to-source %s",
-        inet_ntoa(netaddr),
-        netmask,
-        bdata(config_pP->ipv4.if_name_SGI),
-        str_sgi);
+          TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
+          "iptables -t nat -I POSTROUTING -s %s/%d -o %s  ! --protocol sctp -j "
+          "SNAT --to-source %s",
+          inet_ntoa(netaddr), netmask, bdata(config_pP->ipv4.if_name_SGI),
+          str_sgi);
     }
 
     uint32_t min_mtu = config_pP->ipv4.mtu_SGI;
@@ -198,22 +186,17 @@ int pgw_config_process(pgw_config_t *config_pP)
     }
     if (config_pP->ue_tcp_mss_clamp) {
       async_system_command(
-        TASK_ASYNC_SYSTEM,
-        PGW_ABORT_ON_ERROR,
-        "iptables -t mangle -I FORWARD -s %s/%d   -p tcp --tcp-flags SYN,RST "
-        "SYN -j TCPMSS --set-mss %u",
-        inet_ntoa(netaddr),
-        netmask,
-        min_mtu - 40);
+          TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
+          "iptables -t mangle -I FORWARD -s %s/%d   -p tcp --tcp-flags SYN,RST "
+          "SYN -j TCPMSS --set-mss %u",
+          inet_ntoa(netaddr), netmask, min_mtu - 40);
 
       async_system_command(
-        TASK_ASYNC_SYSTEM,
-        PGW_ABORT_ON_ERROR,
-        "iptables -t mangle -I FORWARD -d %s/%d -p tcp --tcp-flags SYN,RST SYN "
-        "-j TCPMSS --set-mss %u",
-        inet_ntoa(netaddr),
-        netmask,
-        min_mtu - 40);
+          TASK_ASYNC_SYSTEM, PGW_ABORT_ON_ERROR,
+          "iptables -t mangle -I FORWARD -d %s/%d -p tcp --tcp-flags SYN,RST "
+          "SYN "
+          "-j TCPMSS --set-mss %u",
+          inet_ntoa(netaddr), netmask, min_mtu - 40);
     }
 #endif
   }
@@ -224,24 +207,23 @@ int pgw_config_process(pgw_config_t *config_pP)
 }
 
 //------------------------------------------------------------------------------
-int pgw_config_parse_file(pgw_config_t *config_pP)
-{
-  config_t cfg = {0};
-  config_setting_t *setting_pgw = NULL;
-  config_setting_t *subsetting = NULL;
-  config_setting_t *sub2setting = NULL;
-  char *if_S5_S8 = NULL;
-  char *if_SGI = NULL;
-  char *masquerade_SGI = NULL;
-  char *ue_tcp_mss_clamping = NULL;
-  char *default_dns = NULL;
-  char *default_dns_sec = NULL;
-  const char *astring = NULL;
-  bstring address = NULL;
-  bstring cidr = NULL;
-  bstring mask = NULL;
-  int num = 0;
-  int i = 0;
+int pgw_config_parse_file(pgw_config_t* config_pP) {
+  config_t cfg                  = {0};
+  config_setting_t* setting_pgw = NULL;
+  config_setting_t* subsetting  = NULL;
+  config_setting_t* sub2setting = NULL;
+  char* if_S5_S8                = NULL;
+  char* if_SGI                  = NULL;
+  char* masquerade_SGI          = NULL;
+  char* ue_tcp_mss_clamping     = NULL;
+  char* default_dns             = NULL;
+  char* default_dns_sec         = NULL;
+  const char* astring           = NULL;
+  bstring address               = NULL;
+  bstring cidr                  = NULL;
+  bstring mask                  = NULL;
+  int num                       = 0;
+  int i                         = 0;
   unsigned char buf_in_addr[sizeof(struct in_addr)];
   struct in_addr addr_start;
   bstring system_cmd = NULL;
@@ -258,16 +240,12 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
      */
     if (!config_read_file(&cfg, bdata(config_pP->config_file))) {
       OAILOG_ERROR(
-        LOG_SPGW_APP,
-        "%s:%d - %s\n",
-        bdata(config_pP->config_file),
-        config_error_line(&cfg),
-        config_error_text(&cfg));
+          LOG_SPGW_APP, "%s:%d - %s\n", bdata(config_pP->config_file),
+          config_error_line(&cfg), config_error_text(&cfg));
       config_destroy(&cfg);
       AssertFatal(
-        1 == 0,
-        "Failed to parse SP-GW configuration file %s!\n",
-        bdata(config_pP->config_file));
+          1 == 0, "Failed to parse SP-GW configuration file %s!\n",
+          bdata(config_pP->config_file));
     }
   } else {
     OAILOG_ERROR(LOG_SPGW_APP, "No SP-GW configuration file provided!\n");
@@ -276,9 +254,8 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
   }
 
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "Parsing configuration file provided %s\n",
-    bdata(config_pP->config_file));
+      LOG_SPGW_APP, "Parsing configuration file provided %s\n",
+      bdata(config_pP->config_file));
 
   system_cmd = bfromcstr("");
 
@@ -286,31 +263,26 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
 
   if (setting_pgw) {
     subsetting = config_setting_get_member(
-      setting_pgw, PGW_CONFIG_STRING_NETWORK_INTERFACES_CONFIG);
+        setting_pgw, PGW_CONFIG_STRING_NETWORK_INTERFACES_CONFIG);
 
     if (subsetting) {
       if ((config_setting_lookup_string(
-             subsetting,
-             PGW_CONFIG_STRING_PGW_INTERFACE_NAME_FOR_S5_S8,
-             (const char **) &if_S5_S8) &&
+               subsetting, PGW_CONFIG_STRING_PGW_INTERFACE_NAME_FOR_S5_S8,
+               (const char**) &if_S5_S8) &&
            config_setting_lookup_string(
-             subsetting,
-             PGW_CONFIG_STRING_PGW_INTERFACE_NAME_FOR_SGI,
-             (const char **) &if_SGI) &&
+               subsetting, PGW_CONFIG_STRING_PGW_INTERFACE_NAME_FOR_SGI,
+               (const char**) &if_SGI) &&
            config_setting_lookup_string(
-             subsetting,
-             PGW_CONFIG_STRING_PGW_MASQUERADE_SGI,
-             (const char **) &masquerade_SGI) &&
+               subsetting, PGW_CONFIG_STRING_PGW_MASQUERADE_SGI,
+               (const char**) &masquerade_SGI) &&
            config_setting_lookup_string(
-             subsetting,
-             PGW_CONFIG_STRING_UE_TCP_MSS_CLAMPING,
-             (const char **) &ue_tcp_mss_clamping))) {
+               subsetting, PGW_CONFIG_STRING_UE_TCP_MSS_CLAMPING,
+               (const char**) &ue_tcp_mss_clamping))) {
         config_pP->ipv4.if_name_S5_S8 = bfromcstr(if_S5_S8);
-        config_pP->ipv4.if_name_SGI = bfromcstr(if_SGI);
+        config_pP->ipv4.if_name_SGI   = bfromcstr(if_SGI);
         OAILOG_DEBUG(
-          LOG_SPGW_APP,
-          "Parsing configuration file found SGI: on %s\n",
-          bdata(config_pP->ipv4.if_name_SGI));
+            LOG_SPGW_APP, "Parsing configuration file found SGI: on %s\n",
+            bdata(config_pP->ipv4.if_name_SGI));
 
         if (strcasecmp(masquerade_SGI, "yes") == 0) {
           config_pP->masquerade_SGI = true;
@@ -328,20 +300,20 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
         }
       } else {
         OAILOG_WARNING(
-          LOG_SPGW_APP, "CONFIG P-GW / NETWORK INTERFACES parsing failed\n");
+            LOG_SPGW_APP, "CONFIG P-GW / NETWORK INTERFACES parsing failed\n");
       }
     } else {
       OAILOG_WARNING(
-        LOG_SPGW_APP, "CONFIG P-GW / NETWORK INTERFACES not found\n");
+          LOG_SPGW_APP, "CONFIG P-GW / NETWORK INTERFACES not found\n");
     }
 
     //!!!------------------------------------!!!
-    subsetting =
-      config_setting_get_member(setting_pgw, PGW_CONFIG_STRING_IP_ADDRESS_POOL);
+    subsetting = config_setting_get_member(
+        setting_pgw, PGW_CONFIG_STRING_IP_ADDRESS_POOL);
 
     if (subsetting) {
       sub2setting = config_setting_get_member(
-        subsetting, PGW_CONFIG_STRING_IPV4_ADDRESS_LIST);
+          subsetting, PGW_CONFIG_STRING_IPV4_ADDRESS_LIST);
 
       if (sub2setting) {
         num = config_setting_length(sub2setting);
@@ -352,35 +324,31 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
           if (astring) {
             cidr = bfromcstr(astring);
             AssertFatal(
-              BSTR_OK == btrimws(cidr),
-              "Error in PGW_CONFIG_STRING_IPV4_ADDRESS_LIST %s",
-              astring);
-            struct bstrList *list =
-              bsplit(cidr, PGW_CONFIG_STRING_IPV4_PREFIX_DELIMITER);
+                BSTR_OK == btrimws(cidr),
+                "Error in PGW_CONFIG_STRING_IPV4_ADDRESS_LIST %s", astring);
+            struct bstrList* list =
+                bsplit(cidr, PGW_CONFIG_STRING_IPV4_PREFIX_DELIMITER);
             AssertFatal(2 == list->qty, "Bad CIDR address %s", bdata(cidr));
 
             address = list->entry[0];
-            mask = list->entry[1];
+            mask    = list->entry[1];
 
             if (inet_pton(AF_INET, bdata(address), buf_in_addr) == 1) {
               memcpy(&addr_start, buf_in_addr, sizeof(struct in_addr));
               // valid address
-              prefix_mask = atoi((const char *) mask->data);
+              prefix_mask = atoi((const char*) mask->data);
 
-              if (
-                (prefix_mask >= 2) && (prefix_mask < 32) &&
-                (config_pP->num_ue_pool < PGW_NUM_UE_POOL_MAX)) {
+              if ((prefix_mask >= 2) && (prefix_mask < 32) &&
+                  (config_pP->num_ue_pool < PGW_NUM_UE_POOL_MAX)) {
                 memcpy(
-                  &config_pP->ue_pool_addr[config_pP->num_ue_pool],
-                  buf_in_addr,
-                  sizeof(struct in_addr));
+                    &config_pP->ue_pool_addr[config_pP->num_ue_pool],
+                    buf_in_addr, sizeof(struct in_addr));
                 config_pP->ue_pool_mask[config_pP->num_ue_pool] = prefix_mask;
                 config_pP->num_ue_pool += 1;
               } else {
                 OAILOG_ERROR(
-                  LOG_SPGW_APP,
-                  "CONFIG POOL ADDR IPV4: BAD MASQ: %d\n",
-                  prefix_mask);
+                    LOG_SPGW_APP, "CONFIG POOL ADDR IPV4: BAD MASQ: %d\n",
+                    prefix_mask);
               }
             }
             bstrListDestroy(list);
@@ -389,36 +357,32 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
         }
       } else {
         OAILOG_WARNING(
-          LOG_SPGW_APP, "CONFIG POOL ADDR IPV4: NO IPV4 ADDRESS FOUND\n");
+            LOG_SPGW_APP, "CONFIG POOL ADDR IPV4: NO IPV4 ADDRESS FOUND\n");
       }
 
-      if (
-        config_setting_lookup_string(
-          setting_pgw,
-          PGW_CONFIG_STRING_DEFAULT_DNS_IPV4_ADDRESS,
-          (const char **) &default_dns) &&
-        config_setting_lookup_string(
-          setting_pgw,
-          PGW_CONFIG_STRING_DEFAULT_DNS_SEC_IPV4_ADDRESS,
-          (const char **) &default_dns_sec)) {
+      if (config_setting_lookup_string(
+              setting_pgw, PGW_CONFIG_STRING_DEFAULT_DNS_IPV4_ADDRESS,
+              (const char**) &default_dns) &&
+          config_setting_lookup_string(
+              setting_pgw, PGW_CONFIG_STRING_DEFAULT_DNS_SEC_IPV4_ADDRESS,
+              (const char**) &default_dns_sec)) {
         bdestroy_wrapper(&config_pP->ipv4.if_name_S5_S8);
         config_pP->ipv4.if_name_S5_S8 = bfromcstr(if_S5_S8);
         IPV4_STR_ADDR_TO_INADDR(
-          default_dns,
-          config_pP->ipv4.default_dns,
-          "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS !\n");
+            default_dns, config_pP->ipv4.default_dns,
+            "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS !\n");
         IPV4_STR_ADDR_TO_INADDR(
-          default_dns_sec,
-          config_pP->ipv4.default_dns_sec,
-          "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS SEC!\n");
+            default_dns_sec, config_pP->ipv4.default_dns_sec,
+            "BAD IPv4 ADDRESS FORMAT FOR DEFAULT DNS SEC!\n");
         OAILOG_DEBUG(
-          LOG_SPGW_APP,
-          "Parsing configuration file default primary DNS IPv4 address: %s\n",
-          default_dns);
+            LOG_SPGW_APP,
+            "Parsing configuration file default primary DNS IPv4 address: %s\n",
+            default_dns);
         OAILOG_DEBUG(
-          LOG_SPGW_APP,
-          "Parsing configuration file default secondary DNS IPv4 address: %s\n",
-          default_dns_sec);
+            LOG_SPGW_APP,
+            "Parsing configuration file default secondary DNS IPv4 address: "
+            "%s\n",
+            default_dns_sec);
       } else {
         OAILOG_WARNING(LOG_SPGW_APP, "NO DNS CONFIGURATION FOUND\n");
       }
@@ -451,28 +415,27 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
     }
 
     if (config_setting_lookup_string(
-          setting_pgw,
-          PGW_CONFIG_STRING_NAS_FORCE_PUSH_PCO,
-          (const char **) &astring)) {
+            setting_pgw, PGW_CONFIG_STRING_NAS_FORCE_PUSH_PCO,
+            (const char**) &astring)) {
       if (strcasecmp(astring, "yes") == 0) {
         config_pP->force_push_pco = true;
         OAILOG_DEBUG(
-          LOG_SPGW_APP,
-          "Protocol configuration options: push MTU, push DNS, IP address "
-          "allocation via NAS signalling\n");
+            LOG_SPGW_APP,
+            "Protocol configuration options: push MTU, push DNS, IP address "
+            "allocation via NAS signalling\n");
       } else {
         config_pP->force_push_pco = false;
       }
     }
     if (config_setting_lookup_int(
-          setting_pgw, PGW_CONFIG_STRING_UE_MTU, &mtu)) {
+            setting_pgw, PGW_CONFIG_STRING_UE_MTU, &mtu)) {
       config_pP->ue_mtu = mtu;
     } else {
       config_pP->ue_mtu = 1463;
     }
     OAILOG_DEBUG(LOG_SPGW_APP, "UE MTU : %u\n", config_pP->ue_mtu);
     if (config_setting_lookup_string(
-          setting_pgw, PGW_RELAY_ENABLED, (const char **) &astring)) {
+            setting_pgw, PGW_RELAY_ENABLED, (const char**) &astring)) {
       if (strcasecmp(astring, "yes") == 0) {
         config_pP->relay_enabled = true;
         OAILOG_DEBUG(LOG_SPGW_APP, "Enabling relay through PCEF\n");
@@ -484,16 +447,14 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
     subsetting = config_setting_get_member(setting_pgw, PGW_CONFIG_STRING_PCEF);
     if (subsetting) {
       if ((config_setting_lookup_string(
-            subsetting,
-            PGW_CONFIG_STRING_PCEF_ENABLED,
-            (const char **) &astring))) {
+              subsetting, PGW_CONFIG_STRING_PCEF_ENABLED,
+              (const char**) &astring))) {
         if (strcasecmp(astring, "yes") == 0) {
           config_pP->pcef.enabled = true;
 
           if (config_setting_lookup_string(
-                subsetting,
-                PGW_CONFIG_STRING_TRAFFIC_SHAPPING_ENABLED,
-                (const char **) &astring)) {
+                  subsetting, PGW_CONFIG_STRING_TRAFFIC_SHAPPING_ENABLED,
+                  (const char**) &astring)) {
             if (strcasecmp(astring, "yes") == 0) {
               config_pP->pcef.traffic_shaping_enabled = true;
               OAILOG_DEBUG(LOG_SPGW_APP, "Traffic shapping enabled\n");
@@ -503,9 +464,8 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
           }
 
           if (config_setting_lookup_string(
-                subsetting,
-                PGW_CONFIG_STRING_TCP_ECN_ENABLED,
-                (const char **) &astring)) {
+                  subsetting, PGW_CONFIG_STRING_TCP_ECN_ENABLED,
+                  (const char**) &astring)) {
             if (strcasecmp(astring, "yes") == 0) {
               config_pP->pcef.tcp_ecn_enabled = true;
               OAILOG_DEBUG(LOG_SPGW_APP, "TCP ECN enabled\n");
@@ -516,59 +476,54 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
 
           libconfig_int sdf_id = 0;
           if (config_setting_lookup_int(
-                subsetting,
-                PGW_CONFIG_STRING_AUTOMATIC_PUSH_DEDICATED_BEARER_PCC_RULE,
-                &sdf_id)) {
+                  subsetting,
+                  PGW_CONFIG_STRING_AUTOMATIC_PUSH_DEDICATED_BEARER_PCC_RULE,
+                  &sdf_id)) {
             AssertFatal(
-              (sdf_id < SDF_ID_MAX) && (sdf_id >= 0),
-              "Bad SDF identifier value %d for dedicated bearer",
-              sdf_id);
+                (sdf_id < SDF_ID_MAX) && (sdf_id >= 0),
+                "Bad SDF identifier value %d for dedicated bearer", sdf_id);
             config_pP->pcef.automatic_push_dedicated_bearer_sdf_identifier =
-              sdf_id;
+                sdf_id;
           }
 
           if (config_setting_lookup_int(
-                subsetting,
-                PGW_CONFIG_STRING_DEFAULT_BEARER_STATIC_PCC_RULE,
-                &sdf_id)) {
+                  subsetting, PGW_CONFIG_STRING_DEFAULT_BEARER_STATIC_PCC_RULE,
+                  &sdf_id)) {
             AssertFatal(
-              (sdf_id < SDF_ID_MAX) && (sdf_id >= 0),
-              "Bad SDF identifier value %d for default bearer",
-              sdf_id);
+                (sdf_id < SDF_ID_MAX) && (sdf_id >= 0),
+                "Bad SDF identifier value %d for default bearer", sdf_id);
             config_pP->pcef.default_bearer_sdf_identifier = sdf_id;
           }
 
           sub2setting = config_setting_get_member(
-            subsetting, PGW_CONFIG_STRING_PUSH_STATIC_PCC_RULES);
+              subsetting, PGW_CONFIG_STRING_PUSH_STATIC_PCC_RULES);
           if (sub2setting != NULL) {
             num = config_setting_length(sub2setting);
 
             AssertFatal(
-              num <= (SDF_ID_MAX - 1),
-              "Too many PCC rules defined (%d>%d)",
-              num,
-              SDF_ID_MAX);
+                num <= (SDF_ID_MAX - 1), "Too many PCC rules defined (%d>%d)",
+                num, SDF_ID_MAX);
 
             for (i = 0; i < num; i++) {
               config_pP->pcef.preload_static_sdf_identifiers[i] =
-                config_setting_get_int_elem(sub2setting, i);
+                  config_setting_get_int_elem(sub2setting, i);
             }
           }
 
           libconfig_int apn_ambr_ul = 0;
           if (config_setting_lookup_int(
-                subsetting, PGW_CONFIG_STRING_APN_AMBR_UL, &apn_ambr_ul)) {
+                  subsetting, PGW_CONFIG_STRING_APN_AMBR_UL, &apn_ambr_ul)) {
             AssertFatal(
-              (0 < apn_ambr_ul), "Bad APN AMBR UL value %d", apn_ambr_ul);
+                (0 < apn_ambr_ul), "Bad APN AMBR UL value %d", apn_ambr_ul);
             config_pP->pcef.apn_ambr_ul = apn_ambr_ul;
           } else {
             config_pP->pcef.apn_ambr_ul = 50000;
           }
           libconfig_int apn_ambr_dl = 0;
           if (config_setting_lookup_int(
-                subsetting, PGW_CONFIG_STRING_APN_AMBR_DL, &apn_ambr_dl)) {
+                  subsetting, PGW_CONFIG_STRING_APN_AMBR_DL, &apn_ambr_dl)) {
             AssertFatal(
-              (0 < apn_ambr_dl), "Bad APN AMBR DL value %d", apn_ambr_dl);
+                (0 < apn_ambr_dl), "Bad APN AMBR DL value %d", apn_ambr_dl);
             config_pP->pcef.apn_ambr_dl = apn_ambr_dl;
           } else {
             config_pP->pcef.apn_ambr_dl = 50000;
@@ -578,13 +533,12 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
         }
       } else {
         OAILOG_WARNING(
-          LOG_SPGW_APP,
-          "CONFIG P-GW / %s parsing failed\n",
-          PGW_CONFIG_STRING_PCEF);
+            LOG_SPGW_APP, "CONFIG P-GW / %s parsing failed\n",
+            PGW_CONFIG_STRING_PCEF);
       }
     } else {
       OAILOG_WARNING(
-        LOG_SPGW_APP, "CONFIG P-GW / %s not found\n", PGW_CONFIG_STRING_PCEF);
+          LOG_SPGW_APP, "CONFIG P-GW / %s not found\n", PGW_CONFIG_STRING_PCEF);
     }
   } else {
     OAILOG_WARNING(LOG_SPGW_APP, "CONFIG P-GW not found\n");
@@ -595,109 +549,103 @@ int pgw_config_parse_file(pgw_config_t *config_pP)
 }
 
 //------------------------------------------------------------------------------
-void pgw_config_display(pgw_config_t *config_p)
-{
+void pgw_config_display(pgw_config_t* config_p) {
   OAILOG_INFO(
-    LOG_SPGW_APP, "==== EURECOM %s v%s ====\n", PACKAGE_NAME, PACKAGE_VERSION);
+      LOG_SPGW_APP, "==== EURECOM %s v%s ====\n", PACKAGE_NAME,
+      PACKAGE_VERSION);
   OAILOG_INFO(LOG_SPGW_APP, "Configuration:\n");
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "- File .................................: %s\n",
-    bdata(config_p->config_file));
+      LOG_SPGW_APP, "- File .................................: %s\n",
+      bdata(config_p->config_file));
 
   OAILOG_INFO(LOG_SPGW_APP, "- S5-S8:\n");
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "    S5_S8 iface ..........: %s\n",
-    bdata(config_p->ipv4.if_name_S5_S8));
+      LOG_SPGW_APP, "    S5_S8 iface ..........: %s\n",
+      bdata(config_p->ipv4.if_name_S5_S8));
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "    S5_S8 ip  (read)......: %s\n",
-    inet_ntoa(*((struct in_addr *) &config_p->ipv4.S5_S8)));
+      LOG_SPGW_APP, "    S5_S8 ip  (read)......: %s\n",
+      inet_ntoa(*((struct in_addr*) &config_p->ipv4.S5_S8)));
   OAILOG_INFO(
-    LOG_SPGW_APP, "    S5_S8 MTU (read)......: %u\n", config_p->ipv4.mtu_S5_S8);
+      LOG_SPGW_APP, "    S5_S8 MTU (read)......: %u\n",
+      config_p->ipv4.mtu_S5_S8);
   OAILOG_INFO(LOG_SPGW_APP, "- SGi:\n");
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "    SGi iface ............: %s\n",
-    bdata(config_p->ipv4.if_name_SGI));
+      LOG_SPGW_APP, "    SGi iface ............: %s\n",
+      bdata(config_p->ipv4.if_name_SGI));
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "    SGi ip  (read)........: %s\n",
-    inet_ntoa(*((struct in_addr *) &config_p->ipv4.SGI)));
+      LOG_SPGW_APP, "    SGi ip  (read)........: %s\n",
+      inet_ntoa(*((struct in_addr*) &config_p->ipv4.SGI)));
   OAILOG_INFO(
-    LOG_SPGW_APP, "    SGi MTU (read)........: %u\n", config_p->ipv4.mtu_SGI);
+      LOG_SPGW_APP, "    SGi MTU (read)........: %u\n", config_p->ipv4.mtu_SGI);
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "    User TCP MSS clamping : %s\n",
-    config_p->ue_tcp_mss_clamp == 0 ? "false" : "true");
+      LOG_SPGW_APP, "    User TCP MSS clamping : %s\n",
+      config_p->ue_tcp_mss_clamp == 0 ? "false" : "true");
   OAILOG_INFO(
     LOG_SPGW_APP,
     "    User IP masquerading  : %s\n",
     config_p->masquerade_SGI == 0 ? "false" : "true");
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "- PCEF support ...........: %s (in development)\n",
-    config_p->pcef.enabled == 0 ? "false" : "true");
+      LOG_SPGW_APP, "- PCEF support ...........: %s (in development)\n",
+      config_p->pcef.enabled == 0 ? "false" : "true");
   if (config_p->pcef.enabled) {
     OAILOG_INFO(
-      LOG_SPGW_APP,
-      "    Traffic shaping ......: %s (TODO it soon)\n",
-      config_p->pcef.traffic_shaping_enabled == 0 ? "false" : "true");
+        LOG_SPGW_APP, "    Traffic shaping ......: %s (TODO it soon)\n",
+        config_p->pcef.traffic_shaping_enabled == 0 ? "false" : "true");
     OAILOG_INFO(
-      LOG_SPGW_APP,
-      "    TCP ECN  .............: %s\n",
-      config_p->pcef.tcp_ecn_enabled == 0 ? "false" : "true");
+        LOG_SPGW_APP, "    TCP ECN  .............: %s\n",
+        config_p->pcef.tcp_ecn_enabled == 0 ? "false" : "true");
     OAILOG_INFO(
-      LOG_SPGW_APP,
-      "    Push dedicated bearer SDF ID: %d (testing dedicated bearer "
-      "functionality down to OAI UE/COSTS UE)\n",
-      config_p->pcef.automatic_push_dedicated_bearer_sdf_identifier);
+        LOG_SPGW_APP,
+        "    Push dedicated bearer SDF ID: %d (testing dedicated bearer "
+        "functionality down to OAI UE/COSTS UE)\n",
+        config_p->pcef.automatic_push_dedicated_bearer_sdf_identifier);
     OAILOG_INFO(
-      LOG_SPGW_APP,
-      "    Default bearer SDF ID.: %d\n",
-      config_p->pcef.default_bearer_sdf_identifier);
+        LOG_SPGW_APP, "    Default bearer SDF ID.: %d\n",
+        config_p->pcef.default_bearer_sdf_identifier);
     bstring pcc_rules = bfromcstralloc(64, "(");
     for (int i = 0; i < (SDF_ID_MAX - 1); i++) {
       if (i == 0) {
         bformata(
-          pcc_rules, " %u", config_p->pcef.preload_static_sdf_identifiers[i]);
+            pcc_rules, " %u", config_p->pcef.preload_static_sdf_identifiers[i]);
         if (!config_p->pcef.preload_static_sdf_identifiers[i]) {
           break;
         }
       } else {
         if (config_p->pcef.preload_static_sdf_identifiers[i]) {
           bformata(
-            pcc_rules,
-            ", %u",
-            config_p->pcef.preload_static_sdf_identifiers[i]);
+              pcc_rules, ", %u",
+              config_p->pcef.preload_static_sdf_identifiers[i]);
         } else
           break;
       }
     }
     bcatcstr(pcc_rules, " )");
     OAILOG_INFO(
-      LOG_SPGW_APP, "    Preloaded static PCC Rules.: %s\n", bdata(pcc_rules));
+        LOG_SPGW_APP, "    Preloaded static PCC Rules.: %s\n",
+        bdata(pcc_rules));
     bdestroy_wrapper(&pcc_rules);
 
     OAILOG_INFO(
-      LOG_SPGW_APP,
-      "    APN AMBR UL ..........: %" PRIu64 " (Kilo bits/s)\n",
-      config_p->pcef.apn_ambr_ul);
+        LOG_SPGW_APP, "    APN AMBR UL ..........: %" PRIu64 " (Kilo bits/s)\n",
+        config_p->pcef.apn_ambr_ul);
     OAILOG_INFO(
-      LOG_SPGW_APP,
-      "    APN AMBR DL ..........: %" PRIu64 " (Kilo bits/s)\n",
-      config_p->pcef.apn_ambr_dl);
+        LOG_SPGW_APP, "    APN AMBR DL ..........: %" PRIu64 " (Kilo bits/s)\n",
+        config_p->pcef.apn_ambr_dl);
   }
+  OAILOG_INFO(LOG_SPGW_APP, "- DNS Configuration:\n");
+  OAILOG_INFO(
+      LOG_SPGW_APP, "    IPv4 Primary Address ..........: %s\n",
+      inet_ntoa(*((struct in_addr*) &config_p->ipv4.default_dns)));
+  OAILOG_INFO(
+      LOG_SPGW_APP, "    IPv4 Secondary Address ..........: %s\n",
+      inet_ntoa(*((struct in_addr*) &config_p->ipv4.default_dns_sec)));
   OAILOG_INFO(LOG_SPGW_APP, "- Helpers:\n");
   OAILOG_INFO(
-    LOG_SPGW_APP,
-    "    Push PCO (DNS+MTU) ........: %s\n",
-    config_p->force_push_pco == 0 ? "false" : "true");
+      LOG_SPGW_APP, "    Push PCO (DNS+MTU) ........: %s\n",
+      config_p->force_push_pco == 0 ? "false" : "true");
 }
 
-void free_pgw_config(pgw_config_t* pgw_config_p)
-{
+void free_pgw_config(pgw_config_t* pgw_config_p) {
   bdestroy_wrapper(&pgw_config_p->ipv4.if_name_S5_S8);
   bdestroy_wrapper(&pgw_config_p->ipv4.if_name_SGI);
   return;


### PR DESCRIPTION
Summary:
- Adding IPv4 primary and secondary addresses on PGW config logs on MME initialization
- Reformatting code on `pgw_config`

Reviewed By: themarwhal

Differential Revision: D21507151

