### PR TITLE
Fix sessiond segfault due to DynamicRuleInstall not having a valid policy_rule

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -692,9 +692,10 @@ void LocalEnforcer::schedule_static_rule_deactivation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_deactivation(
-    const std::string& imsi, const DynamicRuleInstall& dynamic_rule) {
+    const std::string& imsi, DynamicRuleInstall& dynamic_rule) {
   std::vector<std::string> static_rules;
-  std::vector<PolicyRule> dynamic_rules{dynamic_rule.policy_rule()};
+  PolicyRule* policy = dynamic_rule.release_policy_rule();
+  std::vector<PolicyRule> dynamic_rules{*policy};
 
   auto delta = time_difference_from_now(dynamic_rule.deactivation_time());
   MLOG(MDEBUG) << "Scheduling subscriber " << imsi << " dynamic rule "
@@ -1532,7 +1533,7 @@ void LocalEnforcer::process_rules_to_install(
     }
   }
 
-  for (const auto& rule_install : dynamic_rule_installs) {
+  for (auto& rule_install : dynamic_rule_installs) {
     auto activation_time =
         TimeUtil::TimestampToSeconds(rule_install.activation_time());
     auto deactivation_time =

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -369,7 +369,7 @@ class LocalEnforcer {
       const std::string& imsi, const StaticRuleInstall& static_rule);
 
   void schedule_dynamic_rule_deactivation(
-      const std::string& imsi, const DynamicRuleInstall& dynamic_rule);
+      const std::string& imsi, DynamicRuleInstall& dynamic_rule);
 
   /**
    * Get the monitoring credits from PolicyReAuthRequest (RAR) message

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -789,11 +789,10 @@ StaticRuleInstall SessionState::get_static_rule_install(const std::string& rule_
 DynamicRuleInstall SessionState::get_dynamic_rule_install(const std::string& rule_id) {
   DynamicRuleInstall rule_install{};
   auto lifetime = get_rule_lifetime(rule_id);
-  PolicyRule policy_rule;
-  if (!dynamic_rules_.get_rule(rule_id, &policy_rule)) {
-    scheduled_dynamic_rules_.get_rule(rule_id, &policy_rule);
+  PolicyRule* policy_rule = rule_install.mutable_policy_rule();
+  if (!dynamic_rules_.get_rule(rule_id, policy_rule)) {
+    scheduled_dynamic_rules_.get_rule(rule_id, policy_rule);
   }
-  rule_install.set_allocated_policy_rule(&policy_rule);
   rule_install.mutable_activation_time()->set_seconds(lifetime.activation_time);
   rule_install.mutable_deactivation_time()->set_seconds(lifetime.deactivation_time);
   return rule_install;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -631,6 +631,20 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   session_map_2[imsi].front()->schedule_static_rule("rule3", lifetime3, uc);
   session_map_2[imsi].front()->schedule_static_rule("rule4", lifetime4, uc);
 
+  PolicyRule d1;
+  d1.set_id("dynamic_rule1");
+  PolicyRule d2;
+  d2.set_id("dynamic_rule2");
+  PolicyRule d3;
+  d3.set_id("dynamic_rule3");
+  PolicyRule d4;
+  d4.set_id("dynamic_rule4");
+
+  session_map_2[imsi].front()->insert_dynamic_rule(d1, lifetime1, uc);
+  session_map_2[imsi].front()->schedule_dynamic_rule(d2, lifetime2, uc);
+  session_map_2[imsi].front()->schedule_dynamic_rule(d3, lifetime3, uc);
+  session_map_2[imsi].front()->schedule_dynamic_rule(d4, lifetime4, uc);
+
   EXPECT_EQ(uc.new_scheduled_static_rules.count("rule2"), 1);
   EXPECT_EQ(uc.new_scheduled_static_rules.count("rule3"), 1);
   EXPECT_EQ(uc.new_scheduled_static_rules.count("rule4"), 1);
@@ -649,6 +663,11 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   EXPECT_FALSE(session->is_static_rule_installed("rule2"));
   EXPECT_TRUE(session->is_static_rule_installed("rule3"));
   EXPECT_FALSE(session->is_static_rule_installed("rule4"));
+
+  EXPECT_FALSE(session->is_dynamic_rule_installed("dynamic_rule1"));
+  EXPECT_FALSE(session->is_dynamic_rule_installed("dynamic_rule2"));
+  EXPECT_TRUE(session->is_dynamic_rule_installed("dynamic_rule3"));
+  EXPECT_FALSE(session->is_dynamic_rule_installed("dynamic_rule4"));
 }
 
 // Make sure sessions that are scheduled to be terminated before sync are


### PR DESCRIPTION
Summary: A misuse of protobuf led to copies of `DynamicRuleInstall` getting created that were not valid, because of the missing `policy_rule` field. This would cause SEGFAULT whenever `install_scheduled_dynamic_rule` was called.

Differential Revision: D21632821

