### PR TITLE
Add pipelined ue_mac retry callback

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -245,6 +245,7 @@ class LocalEnforcer {
   // [CWF-ONLY] This configures how long we should wait before terminating a
   // session after it is created without any monitoring quota
   long quota_exhaustion_termination_on_init_ms_;
+  std::chrono::seconds retry_timeout_;
 
  private:
   /**
@@ -398,6 +399,14 @@ class LocalEnforcer {
   void schedule_revalidation(
       SessionMap& session_map,
       const google::protobuf::Timestamp& revalidation_time);
+
+  void handle_add_ue_mac_flow_callback(
+    const SubscriberID& sid,
+    const std::string& ue_mac_addr,
+    const std::string& msisdn,
+    const std::string& ap_mac_addr,
+    const std::string& ap_name,
+    Status status, FlowResponse resp);
 
   void check_usage_for_reporting(
       SessionMap& session_map, SessionUpdate& session_update,

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -270,16 +270,12 @@ bool AsyncPipelinedClient::add_ue_mac_flow(
     const std::string& ue_mac_addr,
     const std::string& msisdn,
     const std::string& ap_mac_addr,
-    const std::string& ap_name)
+    const std::string& ap_name,
+    std::function<void(Status status, FlowResponse)> callback)
 {
   auto req = create_add_ue_mac_flow_req(sid, ue_mac_addr, msisdn, ap_mac_addr,
     ap_name);
-  add_ue_mac_flow_rpc(req, [ue_mac_addr](Status status, FlowResponse resp) {
-    if (!status.ok()) {
-      MLOG(MERROR) << "Could not add flow for subscriber with UE MAC"
-                   << ue_mac_addr << ": " << status.error_message();
-    }
-  });
+  add_ue_mac_flow_rpc(req, callback);
   return true;
 }
 

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -92,7 +92,8 @@ class PipelinedClient {
     const std::string &ue_mac_addr,
     const std::string &msisdn,
     const std::string &ap_mac_addr,
-    const std::string &ap_name) = 0;
+    const std::string &ap_name,
+    std::function<void(Status status, FlowResponse)> callback) = 0;
 
   /**
    * Update the IPFIX export rule in pipeliend
@@ -200,7 +201,8 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
     const std::string& ue_mac_addr,
     const std::string& msisdn,
     const std::string& ap_mac_addr,
-    const std::string& ap_name);
+    const std::string& ap_name,
+    std::function<void(Status status, FlowResponse)> callback);
 
   /**
    * Update the IPFIX export rule in pipeliend
@@ -227,6 +229,12 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
     const std::string &ip_addr,
     const std::vector<std::string> &static_rules,
     const std::vector<PolicyRule> &dynamic_rules);
+
+  void handle_add_ue_mac_callback(
+      const magma::UEMacFlowRequest req,
+      const int retries,
+      Status status,
+      FlowResponse resp);
 
  private:
   static const uint32_t RESPONSE_TIMEOUT = 6; // seconds

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -64,7 +64,7 @@ public:
       .WillByDefault(Return(true));
     ON_CALL(*this, activate_flows_for_rules(_, _, _, _))
         .WillByDefault(Return(true));
-    ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _)).WillByDefault(Return(true));
+    ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _, _)).WillByDefault(Return(true));
     ON_CALL(*this, delete_ue_mac_flow(_, _)).WillByDefault(Return(true));
     ON_CALL(*this, update_ipfix_flow(_, _, _, _, _))
         .WillByDefault(Return(true));
@@ -104,14 +104,15 @@ public:
       const std::string& ip_addr,
       const std::vector<std::string>& static_rules,
       const std::vector<PolicyRule>& dynamic_rules));
-  MOCK_METHOD5(
+  MOCK_METHOD6(
     add_ue_mac_flow,
     bool(
       const SubscriberID &sid,
       const std::string &ue_mac_addr,
       const std::string &msisdn,
       const std::string &ap_mac_addr,
-      const std::string &ap_name));
+      const std::string &ap_name,
+      std::function<void(Status status, FlowResponse)> callback));
   MOCK_METHOD2(
     delete_ue_mac_flow,
     bool(

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -178,7 +178,7 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
 
   EXPECT_CALL(*pipelined_client,
               add_ue_mac_flow(testing::_, testing::_, testing::_, testing::_,
-                              testing::_))
+                              testing::_, testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 
@@ -1592,7 +1592,7 @@ TEST_F(LocalEnforcerTest, test_valid_apn_parsing) {
 
   EXPECT_CALL(*pipelined_client,
               add_ue_mac_flow(testing::_, testing::_, "msisdn",
-                              "03-21-00-02-00-20", "Magma"))
+                              "03-21-00-02-00-20", "Magma", testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 
@@ -1616,7 +1616,8 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
 
   EXPECT_CALL(*pipelined_client,
               add_ue_mac_flow(testing::_, testing::_, "msisdn_test", "",
-                              "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay"))
+                              "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay",
+                              testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 


### PR DESCRIPTION
Summary: First point of multiple sessiond retries for installing pipelined rules

Reviewed By: themarwhal

Differential Revision: D21025991

