### PR TITLE
Add test for Charging Update fail on the command level

### DIFF
--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -281,6 +281,7 @@ func getSingleCreditResponseFromCCA(
 		ChargingKey: receivedCredit.RatingGroup,
 		Credit:      getSingleChargingCreditFromCCA(receivedCredit),
 		TgppCtx:     tgppCtx,
+		ResultCode:  answer.ResultCode,
 	}
 
 	if receivedCredit.ServiceIdentifier != nil {

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1821,9 +1821,9 @@ static void handle_command_level_result_code(
   const bool is_permanent_failure =
       DiameterCodeHandler::is_permanent_failure(result_code);
   if (is_permanent_failure) {
-    MLOG(MERROR) << "Received permanent failure result code: " << result_code
-                 << "for IMSI " << imsi
-                 << "during update. Terminating Subscriber.";
+    MLOG(MERROR) << imsi << " Received permanent failure result code: "
+                 << result_code
+                 << " during update. Terminating Subscriber.";
     subscribers_to_terminate.insert(imsi);
   } else {
     // only log transient errors for now


### PR DESCRIPTION
Summary:
FeG change:
- In session proxy, if either the command level result code or MSCC level result code fails, we should propagate back the command level result code so we can act accordingly.

## Old Behavior
If we receive a command level failure OR MSCC level failure we ignore the message
## New Behavior
1. If we receive a command level failure AND it is 5XXX (permanent error code), we terminate the subscriber.
2. If we receive a command level failure AND it is NOT 5XXX, we ignore the message
3. If we receive a MSCC level failure, we ignore the message

I'm still figuring out what to do in the following cases
1. Command level: 2001, MSCC level 5XXX => Does this mean the subscriber should be terminated? Or do we remove the Gy Monitor relating to the message?
2. Command level: 2001, MSCC level not-5XXX => ??

This diff also includes a basic integration test to test the command level failure for Gy CCR/A-U.

Reviewed By: karthiksubraveti

Differential Revision: D21572011

