### PR TITLE
Use useEffect instead of manual detection when initializing Scheduling

### DIFF
--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/Scheduling.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/Scheduling/Scheduling.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import {
   Accordion,
   Button,
@@ -47,8 +47,11 @@ const Scheduling = props => {
     });
   }
 
-  // if no network request was executed yet...
-  !(data || error) && refresh();
+  useEffect(() => {
+    // do network request just once
+    refresh();
+  }, []);
+
 
   const deselectActiveRow = () => {
     setActiveRow(null);


### PR DESCRIPTION
Use `useEffect` to load list of schedules from the server once the component is ready. Use `[]` to disable doing network request for each render. Remove code that manually detected and fired component initialization.