### PR TITLE
Fix bug where rules without proper credit are installed

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -465,7 +465,8 @@ void LocalEnforcer::install_redirect_flow(
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto it = session_map.find(imsi);
           if (it == session_map.end()) {
-            MLOG(MDEBUG) << "Session for IMSI " << imsi << " not found";
+            MLOG(MWARNING) << "Session for " << imsi << " not found when "
+                           << "installing redirection rule";
             return;
           }
 
@@ -1682,10 +1683,14 @@ void LocalEnforcer::check_usage_for_reporting(
     SessionMap& session_map, SessionUpdate& session_update,
     const bool force_update) {
   std::vector<std::unique_ptr<ServiceAction>> actions;
+  // todo remove these logs
+  MLOG(MINFO) << "In check_usage_for_reporting, collecting updates... force_update=" << force_update;
   auto request =
       collect_updates(session_map, actions, session_update, force_update);
+  MLOG(MINFO) << "In check_usage_for_reporting, executing actions...";
   execute_actions(session_map, actions, session_update);
   if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
+    MLOG(MINFO) << "No update found, Will not report to Core";
     return;  // nothing to report
   }
   MLOG(MINFO) << "Sending " << request.updates_size()
@@ -1709,7 +1714,7 @@ void LocalEnforcer::check_usage_for_reporting(
                            << " to OCS and PCRF failed entirely: "
                            << status.error_message();
             } else {
-              MLOG(MDEBUG) << "Received updated responses from OCS and PCRF";
+              MLOG(MINFO) << "Received updated responses from OCS and PCRF";
               update_session_credits_and_rules(
                   *session_map_ptr, response, session_update);
               session_store_.update_sessions(session_update);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -732,11 +732,11 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
 }
 
 void LocalEnforcer::filter_rule_installs(
-    std::vector<StaticRuleInstall> static_installs,
-    std::vector<DynamicRuleInstall> dynamic_installs,
+    std::vector<StaticRuleInstall>& static_installs,
+    std::vector<DynamicRuleInstall>& dynamic_installs,
     const std::unordered_set<uint32_t>& successful_credits) {
   // Filter out static rules that we will not install nor schedule
-  std::remove_if(
+  auto end_of_valid_st_rules = std::remove_if(
       static_installs.begin(), static_installs.end(),
       [&](StaticRuleInstall& rule_install) {
         auto& id = rule_install.rule_id();
@@ -748,13 +748,15 @@ void LocalEnforcer::filter_rule_installs(
         }
         return !should_activate(rule, successful_credits);
       });
+  static_installs.erase(end_of_valid_st_rules, static_installs.end());
 
   // Filter out dynamic rules that we will not install nor schedule
-  std::remove_if(
+  auto end_of_valid_dy_rules = std::remove_if(
       dynamic_installs.begin(), dynamic_installs.end(),
       [&](DynamicRuleInstall& rule_install) {
         return !should_activate(rule_install.policy_rule(), successful_credits);
       });
+  dynamic_installs.erase(end_of_valid_dy_rules, dynamic_installs.end());
 }
 
 // return true if any credit unit is valid and has non-zero volume

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -266,8 +266,8 @@ class LocalEnforcer {
       SessionMap& session_map, SessionUpdate& session_update);
 
   void filter_rule_installs(
-      std::vector<StaticRuleInstall> static_rule_installs,
-      std::vector<DynamicRuleInstall> dynamic_rule_installs,
+      std::vector<StaticRuleInstall>& static_rule_installs,
+      std::vector<DynamicRuleInstall>& dynamic_rule_installs,
       const std::unordered_set<uint32_t>& successful_credits);
 
   std::vector<StaticRuleInstall> to_vec(

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -684,7 +684,7 @@ TEST_F(LocalEnforcerTest, test_termination_scheduling_on_sync_sessions) {
   const std::string imsi = "IMSI1";
   const std::string session_id = "1234";
   rules_to_install.push_back("rule1");
-  insert_static_rule(1, "m1", "rule1");
+  insert_static_rule(0, "m1", "rule1");
 
   // Create a CreateSessionResponse with one Gx monitor:m1 and one rule:rule1
   create_session_create_response(imsi, "m1", rules_to_install, &response);


### PR DESCRIPTION
Summary:
During rule installs, we remove rules that don't have valid credit attached to it. There was a regression to this feature, from what I can see from testing.

There were two issues:
1. we have to pass a reference to the vector so that the changes are propagated
2.  std::remove_if just shuffles the elements so that elements that meet the predicate function are in the beginning of the vector. And the function returns the new end pointer.
"A call to remove is typically followed by a call to a container's erase method, which erases the unspecified values and reduces the physical size of the container to match its new logical size."
(See here for more info: https://en.cppreference.com/w/cpp/algorithm/remove)

Note: I'll also add a unit test for this specific case, but I'm deferring for now because I'm trying to figure out another breakage.

Differential Revision: D21660161

