### PR TITLE
Fix facebookexternal magma flow (#2482)

### DIFF
--- a/symphony/.circleci/config.yml
+++ b/symphony/.circleci/config.yml
@@ -495,6 +495,19 @@ jobs:
           name: install flow
           <<: *appdir
           command: yarn add --dev -W flow-bin@0.120
+      - restore_cache:
+          name: Restore Yarn Package Cache
+          keys:
+            - yarn-packages-{{ checksum "app/yarn.lock" }}
+      - run:
+          name: Install Dependencies
+          <<: *appdir
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          name: Save Yarn Package Cache
+          key: yarn-packages-{{ checksum "app/yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
       - run:
           name: flow typecheck
           <<: *appdir

--- a/symphony/app/.flowconfig
+++ b/symphony/app/.flowconfig
@@ -66,6 +66,7 @@ node_modules/mapbox-gl/dist/mapbox-gl.js.flow
 [declarations]
 <PROJECT_ROOT>/fbcnms-projects/inventory/node_modules/relay-runtime/.*
 <PROJECT_ROOT>/fbcnms-packages/fbcnms-ui/node_modules/relay-runtime/.*
+<PROJECT_ROOT>/node_modules/relay-runtime/.*
 
 [lints]
 all=warn

--- a/symphony/app/fbcnms-packages/fbcnms-relay/package.json
+++ b/symphony/app/fbcnms-packages/fbcnms-relay/package.json
@@ -9,6 +9,7 @@
         "@fbcnms/babel-register": "^0.1.0",
         "core-js": "^2.6.9",
         "graphql": "^14.5.8",
+        "prepend-file": "^1.3.1",
         "relay-compiler": "^8.0.0",
         "yargs": "^13.3.0"
     }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2482

The installed dependencies in external all live in the root directory. We need to add relay as a "declaration" - i.e. use the flow types, but don't check that they compile.

Also add `prepend-file` to the relay compiler because it's used and needed but not listed, resulting in build errors. (It was probably fine in our directory since it's a dependency of another package).

Reviewed By: rckclmbr

Differential Revision: D21670505

