### PR TITLE
Updated FEG Vagrant VM to run with dockerized FEG

### DIFF
--- a/feg/gateway/Vagrantfile
+++ b/feg/gateway/Vagrantfile
@@ -11,42 +11,75 @@
 VAGRANTFILE_API_VERSION = "2"
 Vagrant.require_version ">=1.9.1"
 
+
+# Docker version: this will run a VM with docker installed so you can build the containers
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # Mount magma directory
+  config.vm.synced_folder "../..", "/home/vagrant/magma"
+
+  config.vm.define :feg, primary: true do |feg|
+    feg.vm.box = "generic/ubuntu1804"
+    feg.vm.box_version = "1.9.12"
+    feg.vbguest.auto_update = false
+    feg.vm.hostname = "magma-feg-dev"
+    feg.vm.network "private_network", ip:  "192.168.110.10", nic_type: "82540EM"
+    feg.vm.network "private_network", ip:  "192.168.120.10", nic_type: "82540EM"
+    feg.ssh.password = "vagrant"
+    feg.ssh.insert_key = true
+
+    feg.vm.provider "virtualbox" do |vb|
+      vb.name = "feg-dev"
+      vb.linked_clone = true
+      vb.customize ["modifyvm", :id, "--memory", "4096"]
+      vb.customize ["modifyvm", :id, "--cpus", "2"]
+      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
+    end
+    feg.vm.provision "ansible" do |ansible|
+      ansible.host_key_checking = false
+      ansible.playbook = "deploy/feg.dev.docker.yml"
+      ansible.inventory_path = "deploy/hosts"
+      ansible.verbose = 'v'
+    end
+  end
+end
+
+# Baremetal Version: this will install feg into services (no docker). This is lightweight version
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.synced_folder "../..", "/home/vagrant/magma"
 
-  config.vm.define :feg, primary: true do |feg|
-    feg.vm.box = "fbcmagma/magma_feg"
-    feg.vm.box_version = "1.0.1551298575"
-    feg.vm.hostname = "magma-feg-dev"
-    feg.vbguest.auto_update = false
-    feg.vm.network "private_network", ip: "192.168.90.101"
-    feg.vm.network "private_network", ip: "192.168.80.101"
-    feg.vm.network "forwarded_port", guest: 9109, host: 9109
-    feg.vm.network "forwarded_port", guest: 1812, host: 1812, protocol: "udp"
+  config.vm.define :feg_bare, primary: true do |feg_bare|
+    feg_bare.vm.box = "fbcmagma/magma_feg"
+    feg_bare.vm.box_version = "1.0.1551298575"
+    feg_bare.vm.hostname = "magma-feg-dev-bare"
+    feg_bare.vbguest.auto_update = false
+    feg_bare.vm.network "private_network", ip: "192.168.90.101"
+    feg_bare.vm.network "private_network", ip: "192.168.80.101"
+    feg_bare.vm.network "forwarded_port", guest: 9109, host: 9109
+    feg_bare.vm.network "forwarded_port", guest: 1812, host: 1812, protocol: "udp"
 
-    feg.ssh.password = "vagrant"
-    feg.ssh.insert_key = true
+    feg_bare.ssh.password = "vagrant"
+    feg_bare.ssh.insert_key = true
 
     config.vm.provider "virtualbox" do |v|
       v.linked_clone = true
       v.memory = 1536
       v.cpus = 2
     end
-    feg.vm.provision "ansible" do |ansible|
+    feg_bare.vm.provision "ansible" do |ansible|
       ansible.host_key_checking = false
-      ansible.playbook = "deploy/feg.dev.yml"
+      ansible.playbook = "deploy/feg.dev.bare.yml"
       ansible.limit = "all"
       ansible.verbose = true
     end
   end
 
-  config.vm.define :feg_prod, autostart: false do |feg_prod|
-    feg_prod.vm.box = "bento/ubuntu-16.04"
-    feg_prod.vm.hostname = "magma-feg-prod"
-    feg_prod.vbguest.auto_update = false
-    feg_prod.vm.network "private_network", ip: "192.168.91.10"
-    feg_prod.vm.network "private_network", ip: "192.168.81.100"
+  config.vm.define :feg_prod_bare, autostart: false do |feg_prod_bare|
+    feg_prod_bare.vm.box = "bento/ubuntu-16.04"
+    feg_prod_bare.vm.hostname = "magma-feg-prod"
+    feg_prod_bare.vbguest.auto_update = false
+    feg_prod_bare.vm.network "private_network", ip: "192.168.91.10"
+    feg_prod_bare.vm.network "private_network", ip: "192.168.81.100"
     config.vm.provider "virtualbox" do |v|
       v.customize ['modifyvm', :id, '--natnet1', '10.0.3.0/24']
       v.linked_clone = true
@@ -56,3 +89,5 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
 end
+
+

--- a/feg/gateway/deploy/feg.dev.bare.yml
+++ b/feg/gateway/deploy/feg.dev.bare.yml
@@ -7,8 +7,9 @@
 # LICENSE file in the root directory of this source tree.
 ################################################################################
 
+# FEG baremetal config
 - name: Set up Magma Federated Gateway build environment on a local machine
-  hosts: feg
+  hosts: feg_bare
   become: yes
   vars:
     magma_root: /home/{{ ansible_user }}/magma

--- a/feg/gateway/deploy/feg.dev.docker.yml
+++ b/feg/gateway/deploy/feg.dev.docker.yml
@@ -1,0 +1,33 @@
+---
+################################################################################
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+################################################################################
+
+- name: Set up Magma Federated Gateway build environment on a local machine
+  hosts: feg
+  become: yes
+  vars:
+    - magma_root: /home/{{ ansible_user }}/magma
+    - user: "{{ ansible_user }}"
+    - preburn: false
+    - full_provision: true
+
+  roles:
+    - role: gomod_cache
+    - role: distro_snapshot
+      vars:
+        distro: bionic
+        distro_root: "{{ lookup('env', 'FEG_DISTRO_ARCHIVE') | regex_replace('(^.*/+|)([^/]+)\\.tar\\.gz$', '\\2') }}"
+        distro_archive: "{{ lookup('env', 'FEG_DISTRO_ARCHIVE') }}"
+        distro_sha256: "{{ lookup('env', 'FEG_DISTRO_SHA256') }}"
+    - role: test_certs
+    - role: golang
+
+  tasks:
+    - include_role:
+        name: docker
+        tasks_from: install

--- a/feg/gateway/deploy/hosts
+++ b/feg/gateway/deploy/hosts
@@ -1,2 +1,5 @@
 [feg]
-magma ansible_ssh_host=192.168.90.10 ansible_ssh_port=22 ansible_user=vagrant
+magma-feg-dev  ansible_ssh_host=192.168.110.10 ansible_ssh_port=22 ansible_user=vagrant
+
+[feg_bare]
+magma-feg-dev-bare ansible_ssh_host=192.168.90.10 ansible_ssh_port=22 ansible_user=vagrant

--- a/magma/feg/gateway/deploy/roles/feg_services/files/magma_control_proxy.service
+++ b/magma/feg/gateway/deploy/roles/feg_services/files/magma_control_proxy.service
@@ -1,0 +1,25 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+[Unit]
+Description=Magma %i service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStartPre=/usr/bin/env python3 /usr/local/bin/generate_nghttpx_config.py
+ExecStart=/bin/bash -c "PATH=$PATH:/usr/sbin:/usr/local/bin /usr/bin/env nghttpx --conf /var/opt/magma/tmp/nghttpx.conf"
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=%i
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target

--- a/magma/feg/gateway/deploy/roles/feg_services/files/magma_magmad.service
+++ b/magma/feg/gateway/deploy/roles/feg_services/files/magma_magmad.service
@@ -1,0 +1,26 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+#
+[Unit]
+Description=Magma %i service
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/environment
+ExecStart=/usr/bin/env python3 -m magma.%i.main
+ExecStopPost=/usr/bin/env python3 /usr/local/bin/service_util.py %i
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=%i
+User=root
+Restart=always
+RestartSec=5s
+StartLimitInterval=0
+KillMode=process
+MemoryLimit=300M
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Summary:
This diff updates the FEG VM, which was still using not dockerized version of FEG.

Note that we do not need this VM for development or prod. But some external contributors are not able to run FEG easily on baremetal due to missing libraries to install docker or other issues with APT.

Also, note that same behaviour may be achieved with ```install_gateway.sh```. But that script may require ubuntu 18.04. So this VM allows easy deployment of FEG

Reviewed By: emakeev

Differential Revision: D21671539

