### PR TITLE
Rbac workflows proxy

### DIFF
--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/constants.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/constants.js
@@ -61,4 +61,5 @@ export const taskDescriptions = {
 };
 
 export const conductorApiUrlPrefix = "/workflows";
+export const conductorRbacApiUrlPrefix = conductorApiUrlPrefix + "/rbac";
 export const frontendUrlPrefix = "/hub/workflows";

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/DefinitonModal/DefinitionModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/DefinitonModal/DefinitionModal.js
@@ -6,12 +6,13 @@ import { conductorApiUrlPrefix } from "../../../../constants";
 
 const DefinitionModal = (props) => {
   const [definition, setDefinition] = useState("");
+  const backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
 
   useEffect(() => {
     const name = props.wf.split(" / ")[0];
     const version = props.wf.split(" / ")[1];
     http
-      .get(conductorApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
+      .get(backendApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
       .then((res) => {
         setDefinition(JSON.stringify(res.result, null, 2));
       });

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/DiagramModal/DiagramModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/DiagramModal/DiagramModal.js
@@ -6,12 +6,13 @@ import { conductorApiUrlPrefix } from "../../../../constants";
 
 const DiagramModal = props => {
   const [meta, setMeta] = useState([]);
+  const backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
 
   useEffect(() => {
     const name = props.wf.split(" / ")[0];
     const version = props.wf.split(" / ")[1];
     http
-      .get(conductorApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
+      .get(backendApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
       .then(res => {
         setMeta(res.result);
       });

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/InputModal/InputModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/InputModal/InputModal.js
@@ -67,6 +67,7 @@ function InputModal(props) {
     values: []
   });
   const [waitingWfs, setWaitingWfs] = useState([]);
+  const backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
 
   useEffect(() => {
     let name = props.wf.split(" / ")[0];
@@ -75,7 +76,7 @@ function InputModal(props) {
     setVersion(Number(props.wf.split(" / ")[1]));
 
     http
-      .get(conductorApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
+      .get(backendApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
       .then(res => {
         let definition = JSON.stringify(res.result, null, 2);
         let description = res.result?.description?.split("-")[0] || "";
@@ -107,7 +108,7 @@ function InputModal(props) {
       let q = 'status:"RUNNING"';
       http
         .get(
-          conductorApiUrlPrefix + "/executions/?q=&h=&freeText=" +
+          backendApiUrlPrefix + "/executions/?q=&h=&freeText=" +
             q +
             "&start=" +
             0 +
@@ -116,7 +117,7 @@ function InputModal(props) {
         .then(res => {
           let runningWfs = res.result?.hits || [];
           let promises = runningWfs.map(wf => {
-            return http.get(conductorApiUrlPrefix + "/id/" + wf.workflowId);
+            return http.get(backendApiUrlPrefix + "/id/" + wf.workflowId);
           });
 
           Promise.all(promises).then(results => {
@@ -187,7 +188,7 @@ function InputModal(props) {
       }
     }
     setStatus("Executing...");
-    http.post(conductorApiUrlPrefix + "/workflow", JSON.stringify(payload)).then(res => {
+    http.post(backendApiUrlPrefix + "/workflow", JSON.stringify(payload)).then(res => {
       setStatus(res.statusText);
       setWfId(res.body.text);
 

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefs.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefs.js
@@ -22,7 +22,7 @@ import InputModal from "./InputModal/InputModal";
 import { HttpClient as http } from "../../../common/HttpClient";
 import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../../constants";
 
-class WorkflowDefs extends Component {
+export class WorkflowDefs extends Component {
   constructor(props) {
     super(props);
     this.state = {
@@ -42,6 +42,7 @@ class WorkflowDefs extends Component {
     };
     this.table = React.createRef();
     this.onEditSearch = this.onEditSearch.bind(this);
+    this.backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
   }
 
   componentWillMount() {
@@ -49,7 +50,7 @@ class WorkflowDefs extends Component {
   }
 
   componentDidMount() {
-    http.get(conductorApiUrlPrefix + "/metadata/workflow").then(res => {
+    http.get(this.backendApiUrlPrefix + "/metadata/workflow").then(res => {
       if (res.result) {
         let size = ~~(res.result.length / this.state.defaultPages);
         let dataset =
@@ -223,9 +224,9 @@ class WorkflowDefs extends Component {
     } else {
       data.description = "- FAVOURITE";
     }
-    http.put(conductorApiUrlPrefix + "/metadata/", [data]).then(() => {
+    http.put(this.backendApiUrlPrefix + "/metadata/", [data]).then(() => {
       // TODO: merge with componentDidMount
-      http.get(conductorApiUrlPrefix + "/metadata/workflow").then(res => {
+      http.get(this.backendApiUrlPrefix + "/metadata/workflow").then(res => {
         let dataset =
           res.result.sort((a, b) =>
             a.name > b.name ? 1 : b.name > a.name ? -1 : 0
@@ -304,7 +305,7 @@ class WorkflowDefs extends Component {
     const name = this.getActiveWorkflowName();
     const version = this.getActiveWorkflowVersion();
     http
-      .delete(conductorApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
+      .delete(this.backendApiUrlPrefix + "/metadata/workflow/" + name + "/" + version)
       .then(() => {
         this.componentDidMount();
         let table = this.state.table;
@@ -316,6 +317,95 @@ class WorkflowDefs extends Component {
           table: table
         });
       });
+  }
+
+  repeatDeleteButton() {
+    return (
+      <Button
+      variant="outline-danger noshadow"
+      style={{ float: "right" }}
+      onClick={this.deleteWorkflow.bind(this)}
+    >
+      <i className="fas fa-trash-alt" />
+    </Button>
+    );
+  }
+
+  repeatFavouriteButton(dataset) {
+    return (
+      <Button
+        variant="outline-light noshadow"
+        onClick={this.updateFavourite.bind(this, dataset)}
+      >
+        <i
+          className={
+            dataset["description"] &&
+            dataset["description"].includes("FAVOURITE")
+              ? "fa fa-star"
+              : "far fa-star"
+          }
+          style={{ cursor: "pointer" }}
+        />
+      </Button>
+    );
+  }
+
+  repeatEditButton() {
+    return (
+      <Button
+        variant="outline-light noshadow"
+        onClick={this.editWorkflow.bind(this)}
+      >
+        Edit
+      </Button>
+    );
+  }
+
+  repeatScheduleButton(dataset) {
+    return (
+      <Button
+      variant="outline-light noshadow"
+      onClick={this.showSchedulingModal.bind(this)}
+      >
+        {dataset.hasSchedule ? 'Edit schedule' : 'Create schedule'}
+      </Button>
+    );
+  }
+
+  repeatButtons(dataset) {
+    return (
+      <div
+      style={{
+        background:
+          "linear-gradient(-120deg, rgb(0, 147, 255) 0%, rgb(0, 118, 203) 100%)",
+        padding: "15px",
+        marginBottom: "10px"
+      }}
+    >
+      <Button
+        variant="outline-light noshadow"
+        onClick={this.showInputModal.bind(this)}
+      >
+        Execute
+      </Button>
+      <Button
+        variant="outline-light noshadow"
+        onClick={this.showDefinitionModal.bind(this)}
+      >
+        Definition
+      </Button>
+      {this.repeatEditButton()}
+      <Button
+        variant="outline-light noshadow"
+        onClick={this.showDiagramModal.bind(this)}
+      >
+        Diagram
+      </Button>
+      {this.repeatScheduleButton(dataset)}
+      {this.repeatFavouriteButton(dataset)}
+      {this.repeatDeleteButton()}
+    </div>
+    );
   }
 
   repeat() {
@@ -353,66 +443,7 @@ class WorkflowDefs extends Component {
             </Accordion.Toggle>
             <Accordion.Collapse eventKey={i}>
               <Card.Body style={{ padding: "0px" }}>
-                <div
-                  style={{
-                    background:
-                      "linear-gradient(-120deg, rgb(0, 147, 255) 0%, rgb(0, 118, 203) 100%)",
-                    padding: "15px",
-                    marginBottom: "10px"
-                  }}
-                >
-                  <Button
-                    variant="outline-light noshadow"
-                    onClick={this.showInputModal.bind(this)}
-                  >
-                    Execute
-                  </Button>
-                  <Button
-                    variant="outline-light noshadow"
-                    onClick={this.showDefinitionModal.bind(this)}
-                  >
-                    Definition
-                  </Button>
-                  <Button
-                    variant="outline-light noshadow"
-                    onClick={this.editWorkflow.bind(this)}
-                  >
-                    Edit
-                  </Button>
-                  <Button
-                    variant="outline-light noshadow"
-                    onClick={this.showDiagramModal.bind(this)}
-                  >
-                    Diagram
-                  </Button>
-                  <Button
-                    variant="outline-light noshadow"
-                    onClick={this.updateFavourite.bind(this, dataset[i])}
-                  >
-                    <i
-                      className={
-                        dataset[i]["description"] &&
-                        dataset[i]["description"].includes("FAVOURITE")
-                          ? "fa fa-star"
-                          : "far fa-star"
-                      }
-                      style={{ cursor: "pointer" }}
-                    />
-                  </Button>
-                  <Button
-                    variant="outline-light noshadow"
-                    onClick={this.showSchedulingModal.bind(this)}
-                  >
-                    {dataset[i].hasSchedule ? 'Edit schedule' : 'Create schedule'}
-                  </Button>
-                  <Button
-                    variant="outline-danger noshadow"
-                    style={{ float: "right" }}
-                    onClick={this.deleteWorkflow.bind(this)}
-                  >
-                    <i className="fas fa-trash-alt" />
-                  </Button>
-                </div>
+                {this.repeatButtons(dataset)}
                 <div className="accordBody">
                   <b>Tasks</b>
                   <br />
@@ -470,121 +501,160 @@ class WorkflowDefs extends Component {
     }
     return null;
   }
-
-  render() {
-    let definitionModal = this.state.defModal ? (
+  renderDefinitionModal() {
+    return this.state.defModal ? (
       <DefinitionModal
         wf={this.state.activeWf}
         modalHandler={this.showDefinitionModal.bind(this)}
         show={this.state.defModal}
+        backendApiUrlPrefix={this.backendApiUrlPrefix}
       />
     ) : null;
+  }
 
-    let inputModal = this.state.inputModal ? (
+  renderInputModal() {
+    return this.state.inputModal ? (
       <InputModal
         wf={this.state.activeWf}
         modalHandler={this.showInputModal.bind(this)}
         show={this.state.inputModal}
+        backendApiUrlPrefix={this.backendApiUrlPrefix}
       />
     ) : null;
+  }
 
-    let diagramModal = this.state.diagramModal ? (
+  renderDiagramModal() {
+    return this.state.diagramModal ? (
       <DiagramModal
         wf={this.state.activeWf}
         modalHandler={this.showDiagramModal.bind(this)}
         show={this.state.diagramModal}
+        backendApiUrlPrefix={this.backendApiUrlPrefix}
       />
     ) : null;
+  }
 
-
-    return (
-      <div>
-        {definitionModal}
-        {inputModal}
-        {diagramModal}
-        <SchedulingModal
+  renderSchedulingModal() {
+    return (<SchedulingModal
           name={this.getActiveRowScheduleName()}
           workflowName={this.getActiveWorkflowName()}
           workflowVersion={this.getActiveWorkflowVersion()}
           onClose={this.onSchedulingModalClose.bind(this)}
           show={this.state.schedulingModal}
+        />);
+  }
+
+  renderFavouritesHeader() {
+    return (<Button
+      style={{ marginBottom: "15px", marginLeft: "15px" }}
+      onClick={this.searchFavourites.bind(this)}
+      title="Favourites"
+    >
+      <i
+        className={
+          this.state.labels.length
+            ? this.state.labels.includes("FAVOURITE")
+              ? "fa fa-star"
+              : "far fa-star"
+            : "far fa-star"
+        }
+        style={{ cursor: "pointer" }}
+      />
+    </Button>);
+  }
+
+  renderSearchByLabel() {
+    return (
+      <Col>
+      <Typeahead
+        id="typeaheadDefs"
+        selected={this.state.labels}
+        onChange={this.onLabelSearch.bind(this)}
+        clearButton
+        labelKey="name"
+        multiple
+        options={this.state.allLabels}
+        placeholder="Search by label."
+      />
+    </Col>
+    );
+  }
+
+  renderSearchByKeyword() {
+    return (
+      <Col>
+      <Form.Group>
+        <Form.Control
+          value={this.state.keywords}
+          onChange={this.onEditSearch}
+          placeholder="Search by keyword."
         />
+      </Form.Group>
+    </Col>
+    );
+  }
+
+  renderWorkflowTable() {
+    return (
+      <div className="scrollWrapper" style={{ maxHeight: "650px" }}>
+      <Table ref={this.table}>
+        <thead>
+          <tr>
+            <th>Name/Version</th>
+          </tr>
+        </thead>
+        <tbody>
+          <Accordion activeKey={this.state.activeRow}>
+            {this.repeat()}
+          </Accordion>
+        </tbody>
+      </Table>
+    </div>
+    );
+  }
+
+  renderWorkflowTableFooter() {
+    return (
+      <Container style={{ marginTop: "5px" }}>
+      <Row>
+        <Col sm={2}>
+          <PageCount
+            dataSize={
+              this.state.keywords === "" || this.state.table.length > 0
+                ? this.state.table.length
+                : this.state.data.length
+            }
+            defaultPages={this.state.defaultPages}
+            handler={this.setCountPages.bind(this)}
+          />
+        </Col>
+        <Col sm={8} />
+        <Col sm={2}>
+          <PageSelect
+            viewedPage={this.state.viewedPage}
+            count={this.state.pagesCount}
+            handler={this.setViewPage.bind(this)}
+          />
+        </Col>
+      </Row>
+    </Container>
+    );
+  }
+
+  render() {
+    return (
+      <div>
+        {this.renderDefinitionModal()}
+        {this.renderInputModal()}
+        {this.renderDiagramModal()}
+        {this.renderSchedulingModal()}
         <Row>
-          <Button
-            style={{ marginBottom: "15px", marginLeft: "15px" }}
-            onClick={this.searchFavourites.bind(this)}
-            title="Favourites"
-          >
-            <i
-              className={
-                this.state.labels.length
-                  ? this.state.labels.includes("FAVOURITE")
-                    ? "fa fa-star"
-                    : "far fa-star"
-                  : "far fa-star"
-              }
-              style={{ cursor: "pointer" }}
-            />
-          </Button>
-          <Col>
-            <Typeahead
-              id="typeaheadDefs"
-              selected={this.state.labels}
-              onChange={this.onLabelSearch.bind(this)}
-              clearButton
-              labelKey="name"
-              multiple
-              options={this.state.allLabels}
-              placeholder="Search by label."
-            />
-          </Col>
-          <Col>
-            <Form.Group>
-              <Form.Control
-                value={this.state.keywords}
-                onChange={this.onEditSearch}
-                placeholder="Search by keyword."
-              />
-            </Form.Group>
-          </Col>
+          {this.renderFavouritesHeader()}
+          {this.renderSearchByLabel()}
+          {this.renderSearchByKeyword()}
         </Row>
-        <div className="scrollWrapper" style={{ maxHeight: "650px" }}>
-          <Table ref={this.table}>
-            <thead>
-              <tr>
-                <th>Name/Version</th>
-              </tr>
-            </thead>
-            <tbody>
-              <Accordion activeKey={this.state.activeRow}>
-                {this.repeat()}
-              </Accordion>
-            </tbody>
-          </Table>
-        </div>
-        <Container style={{ marginTop: "5px" }}>
-          <Row>
-            <Col sm={2}>
-              <PageCount
-                dataSize={
-                  this.state.keywords === "" || this.state.table.length > 0
-                    ? this.state.table.length
-                    : this.state.data.length
-                }
-                defaultPages={this.state.defaultPages}
-                handler={this.setCountPages.bind(this)}
-              />
-            </Col>
-            <Col sm={8} />
-            <Col sm={2}>
-              <PageSelect
-                viewedPage={this.state.viewedPage}
-                count={this.state.pagesCount}
-                handler={this.setViewPage.bind(this)}
-              />
-            </Col>
-          </Row>
-        </Container>
+        {this.renderWorkflowTable()}
+        {this.renderWorkflowTableFooter()}
       </div>
     );
   }

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefsReadOnly.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowDefs/WorkflowDefsReadOnly.js
@@ -1,0 +1,63 @@
+import React, { Component } from "react";
+import {
+  Accordion,
+  Button,
+  Card,
+  Col,
+  Container,
+  Form,
+  Row,
+  Table,
+} from "react-bootstrap";
+import { WorkflowDefs } from "./WorkflowDefs";
+import { Typeahead } from "react-bootstrap-typeahead";
+import "react-bootstrap-typeahead/css/Typeahead.css";
+import { withRouter } from "react-router-dom";
+import PageCount from "../../../common/PageCount";
+import PageSelect from "../../../common/PageSelect";
+import WfLabels from "../../../common/WfLabels";
+import DefinitionModal from "./DefinitonModal/DefinitionModal";
+import DiagramModal from "./DiagramModal/DiagramModal";
+import InputModal from "./InputModal/InputModal";
+import { HttpClient as http } from "../../../common/HttpClient";
+import { conductorApiUrlPrefix, frontendUrlPrefix } from "../../../constants";
+
+class WorkflowDefsReadOnly extends WorkflowDefs {
+  constructor(props) {
+    super(props);
+  }
+
+  repeatDeleteButton() {
+    return (null);
+  }
+
+  repeatFavouriteButton(dataset) {
+    return (null);
+  }
+  
+  repeatScheduleButton(dataset) {
+    return (null);
+  }
+
+  repeatEditButton() {
+    return (null);
+  }
+
+  render() {
+    return (
+      <div>
+        {this.renderDefinitionModal()}
+        {this.renderInputModal()}
+        {this.renderDiagramModal()}
+        <Row>
+          {this.renderSearchByLabel()}
+          {this.renderSearchByKeyword()}
+        </Row>
+        {this.renderWorkflowTable()}
+        {this.renderWorkflowTableFooter()}
+      </div>
+    );
+  }
+}
+
+export default withRouter(WorkflowDefsReadOnly);

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowExec/DetailsModal/DetailsModal.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowExec/DetailsModal/DetailsModal.js
@@ -44,6 +44,8 @@ class DetailsModal extends Component {
       taskDetail: {},
       taskModal: false
     };
+
+    this.backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
   }
 
   componentDidMount() {
@@ -55,7 +57,7 @@ class DetailsModal extends Component {
   }
 
   getData() {
-    http.get(conductorApiUrlPrefix + "/id/" + this.props.wfId).then(res => {
+    http.get(this.backendApiUrlPrefix + "/id/" + this.props.wfId).then(res => {
       let inputsArray = [
         ...new Set(
           JSON.stringify(res.meta, null, 2).match(
@@ -95,7 +97,7 @@ class DetailsModal extends Component {
   executeWorkflow() {
     this.setState({ status: "Executing..." });
     http
-      .post(conductorApiUrlPrefix + "/workflow", JSON.stringify(this.state.input))
+      .post(this.backendApiUrlPrefix + "/workflow", JSON.stringify(this.state.input))
       .then(res => {
         this.setState({
           status: res.statusText
@@ -185,31 +187,31 @@ class DetailsModal extends Component {
   }
 
   terminateWfs() {
-    http.delete(conductorApiUrlPrefix + "/bulk/terminate", [this.state.wfId]).then(() => {
+    http.delete(this.backendApiUrlPrefix + "/bulk/terminate", [this.state.wfId]).then(() => {
       this.getData();
     });
   }
 
   pauseWfs() {
-    http.put(conductorApiUrlPrefix + "/bulk/pause", [this.state.wfId]).then(() => {
+    http.put(this.backendApiUrlPrefix + "/bulk/pause", [this.state.wfId]).then(() => {
       this.getData();
     });
   }
 
   resumeWfs() {
-    http.put(conductorApiUrlPrefix + "/bulk/resume", [this.state.wfId]).then(() => {
+    http.put(this.backendApiUrlPrefix + "/bulk/resume", [this.state.wfId]).then(() => {
       this.getData();
     });
   }
 
   retryWfs() {
-    http.post(conductorApiUrlPrefix + "/bulk/retry", [this.state.wfId]).then(() => {
+    http.post(this.backendApiUrlPrefix + "/bulk/retry", [this.state.wfId]).then(() => {
       this.getData();
     });
   }
 
   restartWfs() {
-    http.post(conductorApiUrlPrefix + "/bulk/restart", [this.state.wfId]).then(() => {
+    http.post(this.backendApiUrlPrefix + "/bulk/restart", [this.state.wfId]).then(() => {
       this.getData();
     });
   }

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowExec/WorkflowBulk/WorkflowBulk.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowExec/WorkflowBulk/WorkflowBulk.js
@@ -11,6 +11,7 @@ import {
 } from "react-bootstrap";
 import { connect } from "react-redux";
 import * as bulkActions from "../../../../store/actions/bulk";
+import { conductorApiUrlPrefix } from "../../../../constants";
 
 class WorkflowBulk extends Component {
   constructor(props) {
@@ -18,6 +19,7 @@ class WorkflowBulk extends Component {
     this.state = {
       showBulk: null
     };
+    this.backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
   }
 
   performOperation(e) {
@@ -28,7 +30,7 @@ class WorkflowBulk extends Component {
     }
 
     let operation = e.target.value;
-    performBulkOperation(operation, selectedWfs, this.props.pageCount);
+    performBulkOperation(operation, selectedWfs, this.props.pageCount, this.backendApiUrlPrefix);
     this.props.bulkOperation();
     this.props.selectAllWfs();
   }
@@ -188,8 +190,8 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = dispatch => {
   return {
-    performBulkOperation: (operation, wfs, defaultPages) =>
-      dispatch(bulkActions.performBulkOperation(operation, wfs, defaultPages)),
+    performBulkOperation: (operation, wfs, defaultPages, backendApiUrlPrefix) =>
+      dispatch(bulkActions.performBulkOperation(operation, wfs, defaultPages, backendApiUrlPrefix)),
     setView: value => dispatch(bulkActions.setView(value))
   };
 };

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowExec/WorkflowExec.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowExec/WorkflowExec.js
@@ -22,6 +22,7 @@ import DetailsModal from "./DetailsModal/DetailsModal";
 import WorkflowBulk from "./WorkflowBulk/WorkflowBulk";
 import "./WorkflowExec.css";
 import { HttpClient as http } from "../../../common/HttpClient";
+import { conductorApiUrlPrefix } from "../../../constants";
 
 class WorkflowExec extends Component {
   constructor(props) {
@@ -42,15 +43,17 @@ class WorkflowExec extends Component {
       sort: [2, 2, 2]
     };
     this.table = React.createRef();
+    this.backendApiUrlPrefix = props.backendApiUrlPrefix ?? conductorApiUrlPrefix;
   }
 
   componentWillMount() {
     if (this.props.query) this.props.updateByQuery(this.props.query);
     this.state.allData
-      ? this.props.fetchNewData(this.state.viewedPage, this.state.defaultPages)
+      ? this.props.fetchNewData(this.state.viewedPage, this.state.defaultPages, this.backendApiUrlPrefix)
       : this.props.fetchParentWorkflows(
           this.state.viewedPage,
-          this.state.defaultPages
+          this.state.defaultPages,
+          this.backendApiUrlPrefix
         );
   }
 
@@ -93,12 +96,13 @@ class WorkflowExec extends Component {
       this.props.query !== prevProps.query
     ) {
       if (this.state.allData) {
-        this.props.fetchNewData(this.state.viewedPage, this.state.defaultPages);
+        this.props.fetchNewData(this.state.viewedPage, this.state.defaultPages, this.backendApiUrlPrefix);
       } else {
         this.props.checkedWorkflows([0]);
         this.props.fetchParentWorkflows(
           this.state.viewedPage,
-          this.state.defaultPages
+          this.state.defaultPages,
+          this.backendApiUrlPrefix
         );
         this.update([], []);
       }
@@ -196,11 +200,11 @@ class WorkflowExec extends Component {
 
   setCountPages(defaultPages, pagesCount) {
     if (this.state.allData) {
-      this.props.fetchNewData(1, defaultPages);
+      this.props.fetchNewData(1, defaultPages, this.backendApiUrlPrefix);
     } else {
       this.props.updateSize(1);
       this.props.checkedWorkflows([0]);
-      this.props.fetchParentWorkflows(1, defaultPages);
+      this.props.fetchParentWorkflows(1, defaultPages, this.backendApiUrlPrefix);
       this.state.openParentWfs.forEach(parent =>
         this.showChildrenWorkflows(parent, null, null)
       );
@@ -215,9 +219,9 @@ class WorkflowExec extends Component {
 
   setViewPage(page) {
     if (this.state.allData) {
-      this.props.fetchNewData(page, this.state.defaultPages);
+      this.props.fetchNewData(page, this.state.defaultPages, this.backendApiUrlPrefix);
     } else {
-      this.props.fetchParentWorkflows(page, this.state.defaultPages);
+      this.props.fetchParentWorkflows(page, this.state.defaultPages, this.backendApiUrlPrefix);
       this.state.openParentWfs.forEach(parent =>
         this.showChildrenWorkflows(parent, null, null)
       );
@@ -420,8 +424,8 @@ class WorkflowExec extends Component {
     if (this.timeout) clearTimeout(this.timeout);
     this.timeout = setTimeout(() => {
       this.state.allData
-        ? this.props.fetchNewData(1, this.state.defaultPages)
-        : this.props.fetchParentWorkflows(1, this.state.defaultPages);
+        ? this.props.fetchNewData(1, this.state.defaultPages, this.backendApiUrlPrefix)
+        : this.props.fetchParentWorkflows(1, this.state.defaultPages, this.backendApiUrlPrefix);
     }, 300);
 
     this.setState({
@@ -433,7 +437,7 @@ class WorkflowExec extends Component {
   changeLabels(e) {
     this.props.updateByLabel(e[0]);
     if (this.state.allData) {
-      this.props.fetchNewData(1, this.state.defaultPages);
+      this.props.fetchNewData(1, this.state.defaultPages, this.backendApiUrlPrefix);
     } else {
       this.state.openParentWfs.forEach(parent =>
         this.showChildrenWorkflows(parent, null, null)
@@ -441,7 +445,7 @@ class WorkflowExec extends Component {
       this.update([], []);
       this.props.updateSize(1);
       this.props.checkedWorkflows([0]);
-      this.props.fetchParentWorkflows(1, this.state.defaultPages);
+      this.props.fetchParentWorkflows(1, this.state.defaultPages, this.backendApiUrlPrefix);
     }
     this.setState({
       viewedPage: 1,
@@ -479,14 +483,16 @@ class WorkflowExec extends Component {
         modalHandler={this.showDetailsModal.bind(this)}
         refreshTable={
           this.state.allData
-            ? this.props.fetchNewData.bind(this, 1, this.state.defaultPages)
+            ? this.props.fetchNewData.bind(this, 1, this.state.defaultPages, this.backendApiUrlPrefix)
             : this.props.fetchParentWorkflows.bind(
                 this,
                 1,
-                this.state.defaultPages
+                this.state.defaultPages,
+                this.backendApiUrlPrefix,
               )
         }
         show={this.state.detailsModal}
+        backendApiUrlPrefix={this.backendApiUrlPrefix}
       />
     ) : null;
 
@@ -499,6 +505,7 @@ class WorkflowExec extends Component {
           pageCount={this.state.defaultPages}
           selectAllWfs={this.selectAllWfs.bind(this)}
           bulkOperation={this.clearView.bind(this)}
+          backendApiUrlPrefix={this.backendApiUrlPrefix}
         />
 
         <hr style={{ marginTop: "-20px" }} />
@@ -642,10 +649,10 @@ const mapDispatchToProps = dispatch => {
   return {
     updateByQuery: query => dispatch(searchActions.updateQuery(query)),
     updateByLabel: label => dispatch(searchActions.updateLabel(label)),
-    fetchNewData: (viewedPage, defaultPages) =>
-      dispatch(searchActions.fetchNewData(viewedPage, defaultPages)),
-    fetchParentWorkflows: (viewedPage, defaultPages) =>
-      dispatch(searchActions.fetchParentWorkflows(viewedPage, defaultPages)),
+    fetchNewData: (viewedPage, defaultPages, backendApiUrlPrefix) =>
+      dispatch(searchActions.fetchNewData(viewedPage, defaultPages, backendApiUrlPrefix)),
+    fetchParentWorkflows: (viewedPage, defaultPages, backendApiUrlPrefix) =>
+      dispatch(searchActions.fetchParentWorkflows(viewedPage, defaultPages, backendApiUrlPrefix)),
     updateParents: children => dispatch(searchActions.updateParents(children)),
     deleteParents: children => dispatch(searchActions.deleteParents(children)),
     updateSize: size => dispatch(searchActions.updateSize(size)),

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowListReadOnly.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/pages/workflowList/WorkflowListReadOnly.js
@@ -1,9 +1,10 @@
 import React from "react";
 import { Container, Tab, Tabs } from "react-bootstrap";
 import { withRouter } from "react-router-dom";
-import WorkflowDefs from "./WorkflowDefs/WorkflowDefs";
+import WorkflowDefsReadOnly from "./WorkflowDefs/WorkflowDefsReadOnly";
 import WorkflowExec from "./WorkflowExec/WorkflowExec";
 import {changeUrl, exportButton} from './workflowUtils'
+import { conductorRbacApiUrlPrefix } from "../../constants";
 
 const WorkflowListReadOnly = (props) => {
   let urlUpdater = changeUrl(props.history);
@@ -13,8 +14,7 @@ const WorkflowListReadOnly = (props) => {
       <Container style={{ textAlign: "left", marginTop: "20px" }}>
         <h1 style={{ marginBottom: "20px" }}>
           <i style={{ color: "grey" }} className="fas fa-cogs" />
-          &nbsp;&nbsp;Workflows
-          {exportButton()}
+          &nbsp;&nbsp;Service Portal
         </h1>
         <input id="upload-files" multiple type="file" hidden />
         <Tabs
@@ -22,13 +22,12 @@ const WorkflowListReadOnly = (props) => {
             defaultActiveKey={props.match.params.type || "defs"}
             style={{ marginBottom: "20px" }}
         >
-          <Tab eventKey="defs" title="Definitions">
-            <WorkflowDefs />
+          <Tab mountOnEnter unmountOnExit eventKey="defs" title="Definitions">
+            <WorkflowDefsReadOnly backendApiUrlPrefix={conductorRbacApiUrlPrefix}/>
           </Tab>
           <Tab mountOnEnter unmountOnExit eventKey="exec" title="Executed">
-            <WorkflowExec query={query} />
+            <WorkflowExec query={query} backendApiUrlPrefix={conductorRbacApiUrlPrefix}/>
           </Tab>
-          <Tab eventKey="scheduled" title="Scheduled" disabled></Tab>
         </Tabs>
       </Container>
   );

--- a/symphony/app/fbcnms-projects/hub/app/components/workflow/store/actions/searchExecs.js
+++ b/symphony/app/fbcnms-projects/hub/app/components/workflow/store/actions/searchExecs.js
@@ -37,13 +37,13 @@ const createQuery = ({ query, label }) => {
   return q;
 };
 
-export const fetchNewData = (viewedPage, defaultPages) => {
+export const fetchNewData = (viewedPage, defaultPages, backendApiUrlPrefix) => {
   return (dispatch, getState) => {
     let q = createQuery(getState().searchReducer);
     let page = (viewedPage - 1) * defaultPages;
     http
       .get(
-        conductorApiUrlPrefix + "/executions/?q=&h=&freeText=" +
+        backendApiUrlPrefix + "/executions/?q=&h=&freeText=" +
           q +
           "&start=" +
           page +
@@ -68,7 +68,7 @@ export const receiveNewData = data => {
   return { type: RECEIVE_NEW_DATA, data };
 };
 
-export const fetchParentWorkflows = (viewedPage, defaultPages) => {
+export const fetchParentWorkflows = (viewedPage, defaultPages, backendApiUrlPrefix) => {
   return (dispatch, getState) => {
     let page = viewedPage - 1;
 
@@ -76,7 +76,7 @@ export const fetchParentWorkflows = (viewedPage, defaultPages) => {
     let q = createQuery(getState().searchReducer);
     http
       .get(
-        conductorApiUrlPrefix + "/hierarchical/?freeText=" +
+        backendApiUrlPrefix + "/hierarchical/?freeText=" +
           q +
           "&start=" +
           checkedWfs[page] +

--- a/symphony/app/fbcnms-projects/workflows/src/index.js
+++ b/symphony/app/fbcnms-projects/workflows/src/index.js
@@ -11,9 +11,22 @@
 
 import ExpressApplication from 'express';
 import proxy from './proxy/proxy';
-import rbacProxy from './proxy/rbacProxy';
 import workflowRouter from './routes';
+import {getUserGroups, getUserRole} from './proxy/utils.js';
 import {groupsForUser} from './proxy/graphqlGroups';
+
+import bulk from './proxy/transformers/bulk';
+import event from './proxy/transformers/event';
+import metadataTaskdef from './proxy/transformers/metadata-taskdef';
+import metadataWorkflowdef from './proxy/transformers/metadata-workflowdef';
+import schellar from './proxy/transformers/schellar';
+import task from './proxy/transformers/task';
+import workflow from './proxy/transformers/workflow';
+
+import metadataWorkflowdefRbac from './proxy/transformers/metadata-workflowdef-rbac';
+import workflowRbac from './proxy/transformers/workflow-rbac';
+
+import type {$Application, ExpressRequest, ExpressResponse} from 'express';
 
 const app = ExpressApplication();
 
@@ -23,9 +36,10 @@ const adminAccess = (role, groups) => {
   return role === OWNER_ROLE || groups.includes(NETWORK_ADMIN_GROUP);
 };
 
-// const generalAccess = (role, groups) => {
-//   return true;
-// };
+const generalAccess = (_role, _groups) => {
+  return true;
+};
+
 async function init() {
   const proxyTarget =
     process.env.PROXY_TARGET || 'http://conductor-server:8080';
@@ -34,14 +48,58 @@ async function init() {
   const proxyRouter = await proxy(
     proxyTarget,
     schellarTarget,
+    // TODO populate from fs
+    [
+      bulk,
+      event,
+      metadataTaskdef,
+      metadataWorkflowdef,
+      workflow,
+      task,
+      schellar,
+    ],
     adminAccess,
     groupsForUser,
   );
-  const rbacRouter = await rbacProxy(adminAccess, groupsForUser);
 
-  app.use('/', workflowRouter);
+  app.use('/', await workflowRouter('http://localhost/proxy/', true));
   app.use('/proxy', proxyRouter);
-  app.use('/rbac', rbacRouter);
+
+  const rbacConductorRouter: $Application<
+    ExpressRequest,
+    ExpressResponse,
+  > = await workflowRouter('http://localhost/rbac_proxy/', false);
+  // Expose a simple boolean endpoint to check if current user is privileged
+  rbacConductorRouter.get(
+    '/editableworkflows',
+    async (req: ExpressRequest, res, _) => {
+      res
+        .status(200)
+        .send(
+          adminAccess(
+            getUserRole(req),
+            await getUserGroups(req, groupsForUser),
+          ),
+        );
+    },
+  );
+
+  const rbacRouter = await proxy(
+    proxyTarget,
+    'UNSUPPORTED', // Scheduling not allowed
+    [
+      metadataWorkflowdefRbac,
+      workflowRbac,
+      // FIXME override task and bulk and implement user group checks
+      task,
+      bulk,
+    ],
+    generalAccess,
+    groupsForUser,
+  );
+
+  app.use('/rbac', rbacConductorRouter);
+  app.use('/rbac_proxy', rbacRouter);
   app.listen(80);
 }
 

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformer-registry.js
@@ -9,14 +9,6 @@
  */
 import logging from '@fbcnms/logging';
 
-import bulk from './transformers/bulk';
-import event from './transformers/event';
-import metadataTaskdef from './transformers/metadata-taskdef';
-import metadataWorkflowdef from './transformers/metadata-workflowdef';
-import schellar from './transformers/schellar';
-import task from './transformers/task';
-import workflow from './transformers/workflow';
-
 import type {
   TransformerCtx,
   TransformerEntry,
@@ -27,25 +19,16 @@ const logger = logging.getLogger(module);
 
 export default async function(
   registrationCtx: TransformerCtx,
+  transformFx: Array<TransformerRegistrationFun>,
 ): Promise<Array<TransformerEntry>> {
-  // TODO populate from fs
-  const transformerModules: Array<TransformerRegistrationFun> = [
-    bulk,
-    event,
-    metadataTaskdef,
-    metadataWorkflowdef,
-    workflow,
-    task,
-    schellar,
-  ];
   logger.debug(
     `Registering transformer modules: [${JSON.stringify(
-      transformerModules,
+      transformFx,
     )}] using context ${JSON.stringify(registrationCtx)}`,
   );
 
   const transformers: Array<TransformerEntry> = [];
-  for (const registrationFun of transformerModules) {
+  for (const registrationFun of transformFx) {
     const items: Array<TransformerEntry> = registrationFun(registrationCtx);
     transformers.push(...items);
   }

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/bulk.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/bulk.js
@@ -36,7 +36,13 @@ curl  -H "x-auth-organization: fb-test" \
     -d '["7d40eb5f-6a0d-438d-a35c-3b2111e2744b"]'
 
 */
-const bulkOperationBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const bulkOperationBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const requestWorkflowIds = req.body; // expect JS array
   if (!Array.isArray(requestWorkflowIds) || requestWorkflowIds.length == 0) {
     logger.error('Expected non empty array', {requestWorkflowIds});

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/event.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/event.js
@@ -61,14 +61,26 @@ function sanitizeEvent(tenantId: string, event: Event) {
   }
 }
 
-const postEventBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const postEventBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const reqObj = req.body;
   logger.debug('Transforming', {reqObj});
   sanitizeEvent(tenantId, anythingTo<Event>(reqObj));
   proxyCallback({buffer: createProxyOptionsBuffer(reqObj, req)});
 };
 
-const putEventBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const putEventBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const reqObj = req.body;
   logger.debug('Transforming', {reqObj});
   sanitizeEvent(tenantId, anythingTo<Event>(reqObj));

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-taskdef.js
@@ -33,7 +33,7 @@ const logger = logging.getLogger(module);
 /*
 curl  -H "x-auth-organization: fb-test" "localhost/proxy/api/metadata/taskdefs"
 */
-const getAllTaskdefsAfter: AfterFun = (tenantId, req, respObj) => {
+const getAllTaskdefsAfter: AfterFun = (tenantId, groups, req, respObj) => {
   const tasks = anythingTo<Array<Task>>(respObj);
   // iterate over taskdefs, keep only those belonging to tenantId or global
   // remove tenantId prefix, keep GLOBAL_
@@ -77,7 +77,13 @@ curl -X POST -H "x-auth-organization: fb-test"  \
 '
 */
 // TODO: should this be disabled?
-const postTaskdefsBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const postTaskdefsBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   // iterate over taskdefs, prefix with tenantId
   const reqObj = req.body;
   if (reqObj != null && Array.isArray(reqObj)) {
@@ -111,7 +117,13 @@ curl -X PUT -H "x-auth-organization: fb-test" \
 '
 */
 // TODO: should this be disabled?
-const putTaskdefBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const putTaskdefBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const reqObj = req.body;
   if (reqObj != null && typeof reqObj === 'object') {
     const taskdef = anythingTo<Task>(reqObj);
@@ -130,6 +142,7 @@ curl -H "x-auth-organization: fb-test" \
 // Gets the task definition
 const getTaskdefByNameBefore: BeforeFun = (
   tenantId,
+  groups,
   req,
   res,
   proxyCallback,
@@ -140,7 +153,13 @@ const getTaskdefByNameBefore: BeforeFun = (
   proxyCallback();
 };
 
-const getTaskdefByNameAfter: AfterFun = (tenantId, req, respObj, res) => {
+const getTaskdefByNameAfter: AfterFun = (
+  tenantId,
+  groups,
+  req,
+  respObj,
+  res,
+) => {
   const task = anythingTo<Task>(respObj);
   const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   // remove prefix
@@ -163,6 +182,7 @@ curl -H "x-auth-organization: fb-test" \
 */
 const deleteTaskdefByNameBefore: BeforeFun = (
   tenantId,
+  groups,
   req,
   res,
   proxyCallback,

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef-rbac.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef-rbac.js
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import logging from '@fbcnms/logging';
+
+import {anythingTo, isLabeledWithGroup} from '../utils.js';
+import {
+  getAllWorkflowsAfter as getAllWorkflowsAfterDelegate,
+  getWorkflowAfter as getWorkflowAfterDelegate,
+  getWorkflowBefore as getWorkflowBeforeDelegate,
+} from './metadata-workflowdef.js';
+import type {AfterFun, TransformerRegistrationFun, Workflow} from '../../types';
+
+const logger = logging.getLogger(module);
+
+const getAllWorkflowsAfter: AfterFun = (
+  tenantId,
+  groups,
+  req,
+  respObj,
+  res,
+) => {
+  const workflows: Array<Workflow> = anythingTo<Array<Workflow>>(respObj);
+  for (
+    let workflowIdx = workflows.length - 1;
+    workflowIdx >= 0;
+    workflowIdx--
+  ) {
+    const workflowdef = workflows[workflowIdx];
+    if (!isLabeledWithGroup(workflowdef, groups)) {
+      workflows.splice(workflowIdx, 1);
+    }
+  }
+  getAllWorkflowsAfterDelegate(tenantId, groups, req, respObj, res);
+};
+
+export const getWorkflowAfter: AfterFun = (
+  tenantId,
+  groups,
+  req,
+  respObj,
+  res,
+) => {
+  const workflowdef: Workflow = anythingTo<Workflow>(respObj);
+  if (!isLabeledWithGroup(workflowdef, groups)) {
+    // fail if workflow is outside of user's groups
+    logger.error(
+      `User accessing unauthorized workflow: ${workflowdef.name} for tenant: ${tenantId}`,
+    );
+    res.status(401).send('User unauthorized to access this endpoint');
+  }
+
+  getWorkflowAfterDelegate(tenantId, groups, req, respObj, res);
+};
+
+const registration: TransformerRegistrationFun = () => [
+  {
+    method: 'get',
+    url: '/api/metadata/workflow',
+    after: getAllWorkflowsAfter,
+  },
+  {
+    method: 'get',
+    url: '/api/metadata/workflow/:name',
+    before: getWorkflowBeforeDelegate,
+    after: getWorkflowAfter,
+  },
+];
+
+export default registration;

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/metadata-workflowdef.js
@@ -200,7 +200,12 @@ function sanitizeWorkflowTaskdefAfter(
 /*
 curl -H "x-auth-organization: fb-test" "localhost/proxy/api/metadata/workflow"
 */
-const getAllWorkflowsAfter: AfterFun = (tenantId, req, respObj) => {
+export const getAllWorkflowsAfter: AfterFun = (
+  tenantId,
+  groups,
+  req,
+  respObj,
+) => {
   const workflows: Array<Workflow> = anythingTo<Array<Workflow>>(respObj);
   // iterate over workflows, keep only those belonging to tenantId
   for (
@@ -229,7 +234,13 @@ const getAllWorkflowsAfter: AfterFun = (tenantId, req, respObj) => {
 curl -H "x-auth-organization: fb-test" \
   "localhost/proxy/api/metadata/workflow/2/2" -X DELETE
 */
-const deleteWorkflowBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const deleteWorkflowBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   // change URL: add prefix to name
   const name = tenantWithInfixSeparator + req.params.name;
@@ -245,7 +256,13 @@ const deleteWorkflowBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
 curl -H "x-auth-organization: fb-test" \
   "localhost/proxy/api/metadata/workflow/fx3?version=1"
 */
-const getWorkflowBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+export const getWorkflowBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const tenantWithInfixSeparator = withInfixSeparator(tenantId);
   const name = tenantWithInfixSeparator + req.params.name;
   let newUrl = `/api/metadata/workflow/${name}`;
@@ -260,7 +277,7 @@ const getWorkflowBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
   proxyCallback();
 };
 
-const getWorkflowAfter: AfterFun = (tenantId, req, respObj) => {
+export const getWorkflowAfter: AfterFun = (tenantId, groups, req, respObj) => {
   const workflow = anythingTo<Workflow>(respObj);
   const ok = sanitizeWorkflowdefAfter(tenantId, workflow);
   if (!ok) {
@@ -325,7 +342,13 @@ curl -X PUT -H "x-auth-organization: fb-test" \
     }
 ]'
 */
-const putWorkflowBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const putWorkflowBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const workflows: Array<Workflow> = anythingTo<Array<Workflow>>(req.body);
   for (const workflowdef of workflows) {
     sanitizeWorkflowdefBefore(tenantId, workflowdef);
@@ -364,7 +387,13 @@ curl -X POST -H "x-auth-organization: fb-test" \
     }
 '
 */
-const postWorkflowBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const postWorkflowBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const workflow: Workflow = anythingTo<Workflow>(req.body);
   sanitizeWorkflowdefBefore(tenantId, workflow);
   logger.debug(`Transformed request to ${JSON.stringify(workflow)}`);

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/schellar.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/schellar.js
@@ -56,7 +56,7 @@ curl http://localhost/proxy/schedule \
   -H "X-Auth-Organization: fb-test" \
   -H 'Content-Type: application/json'
 */
-const getAllBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const getAllBefore: BeforeFun = (tenantId, groups, req, res, proxyCallback) => {
   req.url = '/schedule';
   proxyCallback({target: schellarTarget});
 };
@@ -84,7 +84,7 @@ function removeWrongPrefixesFromArray(
   }
 }
 
-const getAllAfter: AfterFun = (tenantId, req, respObj) => {
+const getAllAfter: AfterFun = (tenantId, groups, req, respObj) => {
   if (respObj != null && Array.isArray(respObj)) {
     removeWrongPrefixesFromArray(tenantId, anythingTo(respObj), '$.name');
     removeTenantPrefix(tenantId, respObj, '$[*].workflowName', false);
@@ -100,7 +100,7 @@ curl http://localhost/proxy/schedule/workflow1 \
   -H "X-Auth-Organization: fb-test" \
   -H 'Content-Type: application/json'
 */
-const getBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const getBefore: BeforeFun = (tenantId, groups, req, res, proxyCallback) => {
   const reqName = req.params.name;
   req.url = '/schedule/' + withInfixSeparator(tenantId) + reqName;
   proxyCallback({target: schellarTarget});
@@ -131,7 +131,7 @@ curl -X POST http://localhost/proxy/schedule \
   }
 '
 */
-const postBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const postBefore: BeforeFun = (tenantId, groups, req, res, proxyCallback) => {
   req.url = '/schedule';
   const schedule = anythingTo<ScheduleRequest>(req.body);
   sanitizeScheduleBefore(tenantId, schedule);
@@ -161,7 +161,7 @@ curl -X PUT http://localhost/proxy/schedule/workflow1 \
 '
 */
 // Renaming is not supported by proxy - url name must be equal to workflowName
-const putBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const putBefore: BeforeFun = (tenantId, groups, req, res, proxyCallback) => {
   const schedule = anythingTo<ScheduleRequest>(req.body);
   let reqName = req.params.name;
   if (reqName !== schedule.name) {
@@ -185,7 +185,7 @@ curl -X DELETE \
   -H 'Content-Type: application/json' \
   http://localhost/proxy/schedule/workflow1
 */
-const deleteBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+const deleteBefore: BeforeFun = (tenantId, groups, req, res, proxyCallback) => {
   const reqName = req.params.name;
   req.url = '/schedule/' + withInfixSeparator(tenantId) + reqName;
   proxyCallback({target: schellarTarget});

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/task.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/task.js
@@ -16,7 +16,13 @@ import type {BeforeFun, TransformerRegistrationFun} from '../../types';
 const logger = logging.getLogger(module);
 let proxyTarget;
 
-const getLogBefore: BeforeFun = (tenantId, req, res, proxyCallback) => {
+export const getLogBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
   const url = proxyTarget + '/api/tasks/' + req.params.taskId;
   // first make a HTTP request to validate that this workflow belongs to tenant
   const requestOptions = {

--- a/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow-rbac.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/transformers/workflow-rbac.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright 2004-present Facebook. All Rights Reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+import {anythingTo, getUserEmail} from '../utils.js';
+import {
+  getExecutionStatusAfter as getExecutionStatusAfterDelegate,
+  getSearchAfter as getSearchAfterDelegate,
+  getSearchBefore as getSearchBeforeDelegate,
+  postWorkflowBefore as postWorkflowBeforeDelegate,
+  removeWorkflowBefore as removeWorkflowBeforeDelegate,
+  updateQuery,
+} from './workflow.js';
+import type {
+  AfterFun,
+  BeforeFun,
+  StartWorkflowRequest,
+  TransformerRegistrationFun,
+} from '../../types';
+
+const postWorkflowBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
+  // FIXME verify workflow def has proper groups attached to it
+  const reqObj = anythingTo<StartWorkflowRequest>(req.body);
+  // Put userEmail into correlationId
+  reqObj.correlationId = getUserEmail(req);
+  postWorkflowBeforeDelegate(tenantId, groups, req, res, proxyCallback);
+};
+
+const getExecutionStatusAfter: AfterFun = (
+  tenantId,
+  groups,
+  req,
+  respObj,
+  res,
+) => {
+  // FIXME verify workflow def has proper groups attached to it
+  getExecutionStatusAfterDelegate(tenantId, groups, req, respObj, res);
+};
+
+export const removeWorkflowBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
+  // FIXME verify workflow def has proper groups attached to it
+  removeWorkflowBeforeDelegate(tenantId, groups, req, res, proxyCallback);
+};
+
+export const getSearchBefore: BeforeFun = (
+  tenantId,
+  groups,
+  req,
+  res,
+  proxyCallback,
+) => {
+  // Prefix query with correlationId == userEmail
+  // This limits the search to workflows started by current user
+  const userEmail = getUserEmail(req);
+  const originalQueryString = req._parsedUrl.query;
+  const limitToTenant = `correlationId = \'${userEmail}\'`;
+  const newQueryString = updateQuery(originalQueryString, limitToTenant);
+  req._parsedUrl.query = newQueryString;
+  getSearchBeforeDelegate(tenantId, groups, req, res, proxyCallback);
+};
+
+const registration: TransformerRegistrationFun = function() {
+  return [
+    {
+      method: 'get',
+      url: '/api/workflow/search',
+      before: getSearchBefore,
+      after: getSearchAfterDelegate,
+    },
+    {
+      method: 'post',
+      url: '/api/workflow',
+      before: postWorkflowBefore,
+    },
+    {
+      method: 'get',
+      url: '/api/workflow/:workflowId',
+      after: getExecutionStatusAfter,
+    },
+    {
+      method: 'delete',
+      url: '/api/workflow/:workflowId/remove',
+      before: removeWorkflowBefore,
+    },
+  ];
+};
+
+export default registration;

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -1,10 +1,11 @@
+/* eslint-disable flowtype/require-valid-file-annotation */
+/* Disabled flow and also disabled eslint flow annotation check TODO */
 /**
  * Copyright 2004-present Facebook. All Rights Reserved.
  *
  * This source code is licensed under the BSD-style license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @flow
  * @format
  */
 
@@ -20,74 +21,11 @@ import moment from 'moment';
 import transform from 'lodash/fp/transform';
 import {anythingTo} from './proxy/utils';
 
-import type {ExpressRequest, ExpressResponse} from 'express';
+import type {$Application, ExpressRequest, ExpressResponse} from 'express';
 import type {TaskType} from './types';
 
 const logger = logging.getLogger(module);
 const http = HttpClient;
-
-//TODO merge with proxy
-const router = Router<ExpressRequest, ExpressResponse>();
-const baseURL = 'http://localhost/proxy/';
-const baseApiURL = baseURL + 'api/';
-const baseURLWorkflow = baseApiURL + 'workflow/';
-const baseURLMeta = baseApiURL + 'metadata/';
-const baseURLTask = baseApiURL + 'tasks/';
-const eventURL = baseApiURL + 'event';
-const baseURLSchedule = baseURL + 'schedule/';
-
-router.use(bodyParser.urlencoded({extended: false}));
-router.use('/', bodyParser.json());
-
-router.get('/metadata/taskdefs', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.get(baseURLMeta + 'taskdefs', req);
-    res.status(200).send({result});
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/metadata/taskdef', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.post(baseURLMeta + 'taskdefs', req.body, req);
-    res.status(200).send(result);
-  } catch (err) {
-    res.status(400).send(err.response.body);
-    next(err);
-  }
-});
-
-router.get(
-  '/metadata/taskdef/:name',
-  async (req: ExpressRequest, res, next) => {
-    try {
-      const result = await http.get(
-        baseURLMeta + 'taskdefs/' + req.params.name,
-        req,
-      );
-      res.status(200).send({result});
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-router.delete(
-  '/metadata/taskdef/:name',
-  async (req: ExpressRequest, res, next) => {
-    try {
-      const result = await http.delete(
-        baseURLMeta + 'taskdefs/' + req.params.name,
-        null,
-        req,
-      );
-      res.status(200).send({result});
-    } catch (err) {
-      next(err);
-    }
-  },
-);
 
 const findSchedule = (schedules, name) => {
   for (const schedule of schedules) {
@@ -98,225 +36,229 @@ const findSchedule = (schedules, name) => {
   return null;
 };
 
-router.get('/metadata/workflow', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.get(baseURLMeta + 'workflow', req);
-    // combine with schedules
-    const schedules = await http.get(baseURLSchedule, req);
-    for (const workflowDef of result) {
-      const expectedScheduleName = workflowDef.name + ':' + workflowDef.version;
-      const found = findSchedule(schedules, expectedScheduleName);
-      workflowDef.hasSchedule = found != null;
-      workflowDef.expectedScheduleName = expectedScheduleName;
-    }
+//TODO merge with proxy
+export default async function(
+  baseURL: string,
+  addScheduleMetadata: boolean,
+): Promise<$Application<ExpressRequest, ExpressResponse>> {
+  const router = Router<ExpressRequest, ExpressResponse>();
+  const baseApiURL = baseURL + 'api/';
+  const baseURLWorkflow = baseApiURL + 'workflow/';
+  const baseURLMeta = baseApiURL + 'metadata/';
+  const baseURLTask = baseApiURL + 'tasks/';
+  const eventURL = baseApiURL + 'event';
+  const baseURLSchedule = baseURL + 'schedule/';
 
-    res.status(200).send({result});
-  } catch (err) {
-    next(err);
-  }
-});
+  router.use(bodyParser.urlencoded({extended: false}));
+  router.use('/', bodyParser.json());
 
-router.delete(
-  '/metadata/workflow/:name/:version',
-  async (req: ExpressRequest, res, next) => {
+  router.get('/metadata/taskdefs', async (req: ExpressRequest, res, next) => {
     try {
-      const result = await http.delete(
-        baseURLMeta + 'workflow/' + req.params.name + '/' + req.params.version,
-        null,
-        req,
-      );
+      const result = await http.get(baseURLMeta + 'taskdefs', req);
       res.status(200).send({result});
     } catch (err) {
       next(err);
     }
-  },
-);
+  });
 
-router.get(
-  '/metadata/workflow/:name/:version',
-  async (req: ExpressRequest, res, next) => {
+  router.post('/metadata/taskdef', async (req: ExpressRequest, res, next) => {
     try {
-      const result = await http.get(
-        baseURLMeta +
-          'workflow/' +
-          req.params.name +
-          '?version=' +
-          req.params.version,
-        req,
-      );
-      res.status(200).send({result});
-    } catch (err) {
-      next(err);
-    }
-  },
-);
-
-router.put('/metadata', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.put(baseURLMeta + 'workflow/', req.body, req);
-    res.status(200).send(result);
-  } catch (err) {
-    res.status(400).send(err.response.body);
-    next(err);
-  }
-});
-
-// Conductor only allows POST for event handler creation
-// and PUT for updating. This code works around the issue by
-// trying PUT if POST fails.
-router.post('/event', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.post(eventURL, req.body, req);
-    res.status(200).send(result);
-  } catch (err) {
-    logger.info(`Got exception ${JSON.stringify(err)} while POSTing event`);
-    try {
-      const result = await http.put(eventURL, req.body, req);
+      const result = await http.post(baseURLMeta + 'taskdefs', req.body, req);
       res.status(200).send(result);
-    } catch (e) {
-      logger.info(`Got exception ${JSON.stringify(e)} while PUTting event`);
-      res.status(400).send('Post and Put failed');
-      next(e);
+    } catch (err) {
+      res.status(400).send(err.response.body);
+      next(err);
     }
-  }
-});
+  });
 
-router.post('/workflow', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.post(baseURLWorkflow, req.body, req);
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
+  router.get(
+    '/metadata/taskdef/:name',
+    async (req: ExpressRequest, res, next) => {
+      try {
+        const result = await http.get(
+          baseURLMeta + 'taskdefs/' + req.params.name,
+          req,
+        );
+        res.status(200).send({result});
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
 
-router.get('/executions', async (req: ExpressRequest, res, next) => {
-  try {
-    const freeText = [];
-    if (req.query.freeText !== '') {
-      freeText.push(req.query.freeText);
-    } else {
-      freeText.push('*');
+  router.delete(
+    '/metadata/taskdef/:name',
+    async (req: ExpressRequest, res, next) => {
+      try {
+        const result = await http.delete(
+          baseURLMeta + 'taskdefs/' + req.params.name,
+          null,
+          req,
+        );
+        res.status(200).send({result});
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  router.get('/metadata/workflow', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.get(baseURLMeta + 'workflow', req);
+      // combine with schedules
+      // FIXME this should not be here, schedules must be isolated from
+      // the rest of workflow API !
+      if (addScheduleMetadata) {
+        const schedules = await http.get(baseURLSchedule, req);
+        for (const workflowDef of result) {
+          const expectedScheduleName =
+            workflowDef.name + ':' + workflowDef.version;
+          const found = findSchedule(schedules, expectedScheduleName);
+          workflowDef.hasSchedule = found != null;
+          workflowDef.expectedScheduleName = expectedScheduleName;
+        }
+      }
+
+      res.status(200).send({result});
+    } catch (err) {
+      next(err);
     }
+  });
 
-    let h: string = '-1';
-    if (req.query.h !== 'undefined' && req.query.h !== '') {
-      /* $FlowFixMe req.query is user-controlled input, properties and values
-       in this object are untrusted and should be validated before trusting */
-      h = req.query.h;
+  router.delete(
+    '/metadata/workflow/:name/:version',
+    async (req: ExpressRequest, res, next) => {
+      try {
+        const result = await http.delete(
+          baseURLMeta +
+            'workflow/' +
+            req.params.name +
+            '/' +
+            req.params.version,
+          null,
+          req,
+        );
+        res.status(200).send({result});
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  router.get(
+    '/metadata/workflow/:name/:version',
+    async (req: ExpressRequest, res, next) => {
+      try {
+        const result = await http.get(
+          baseURLMeta +
+            'workflow/' +
+            req.params.name +
+            '?version=' +
+            req.params.version,
+          req,
+        );
+        res.status(200).send({result});
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  router.put('/metadata', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.put(baseURLMeta + 'workflow/', req.body, req);
+      res.status(200).send(result);
+    } catch (err) {
+      res.status(400).send(err.response.body);
+      next(err);
     }
-    if (h !== '-1') {
-      freeText.push('startTime:[now-' + h + 'h TO now]');
+  });
+
+  // Conductor only allows POST for event handler creation
+  // and PUT for updating. This code works around the issue by
+  // trying PUT if POST fails.
+  router.post('/event', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.post(eventURL, req.body, req);
+      res.status(200).send(result);
+    } catch (err) {
+      logger.info(`Got exception ${JSON.stringify(err)} while POSTing event`);
+      try {
+        const result = await http.put(eventURL, req.body, req);
+        res.status(200).send(result);
+      } catch (e) {
+        logger.info(`Got exception ${JSON.stringify(e)} while PUTting event`);
+        res.status(400).send('Post and Put failed');
+        next(e);
+      }
     }
-    let start: number = 0;
-    if (!isNaN(req.query.start)) {
-      // $FlowFixMe: isNaN is sketchy and accepts arrays
-      start = req.query.start;
+  });
+
+  router.post('/workflow', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.post(baseURLWorkflow, req.body, req);
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
     }
-    let size: number = 1000;
-    if (req.query.size !== 'undefined' && req.query.size !== '') {
-      /* $FlowFixMe req.query is user-controlled input, properties and values
-       in this object are untrusted and should be validated before trusting */
-      size = req.query.size;
+  });
+
+  router.get('/executions', async (req: ExpressRequest, res, next) => {
+    try {
+      const freeText = [];
+      if (req.query.freeText !== '') {
+        freeText.push(req.query.freeText);
+      } else {
+        freeText.push('*');
+      }
+
+      let h: string = '-1';
+      if (req.query.h !== 'undefined' && req.query.h !== '') {
+        /* FIXME req.query is user-controlled input, properties and values
+         in this object are untrusted and should be validated before trusting */
+        h = req.query.h;
+      }
+      if (h !== '-1') {
+        freeText.push('startTime:[now-' + h + 'h TO now]');
+      }
+      let start: number = 0;
+      if (!isNaN(req.query.start)) {
+        // FIXME: isNaN is sketchy and accepts arrays
+        start = req.query.start;
+      }
+      let size: number = 1000;
+      if (req.query.size !== 'undefined' && req.query.size !== '') {
+        /* FIXME req.query is user-controlled input, properties and values
+         in this object are untrusted and should be validated before trusting */
+        size = req.query.size;
+      }
+
+      const query = req.query.q;
+
+      const url =
+        baseURLWorkflow +
+        'search?size=' +
+        size +
+        '&sort=startTime:DESC&freeText=' +
+        encodeURIComponent(freeText.join(' AND ')) +
+        '&start=' +
+        start +
+        '&query=' +
+        /* FIXME: req.query is user-controlled input and could
+         be an array. Needs to be checked */
+        encodeURIComponent(query);
+      const result = await http.get(url, req);
+      const hits = result.results;
+      res.status(200).send({result: {hits: hits, totalHits: result.totalHits}});
+    } catch (err) {
+      next(err);
     }
+  });
 
-    const query = req.query.q;
-
-    const url =
-      baseURLWorkflow +
-      'search?size=' +
-      size +
-      '&sort=startTime:DESC&freeText=' +
-      encodeURIComponent(freeText.join(' AND ')) +
-      '&start=' +
-      start +
-      '&query=' +
-      /* $FlowFixMe: req.query is user-controlled input and could
-        be an array. Needs to be checked */
-      encodeURIComponent(query);
-    const result = await http.get(url, req);
-    const hits = result.results;
-    res.status(200).send({result: {hits: hits, totalHits: result.totalHits}});
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.delete('/bulk/terminate', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.delete(
-      baseURLWorkflow + 'bulk/terminate',
-      req.body,
-      req,
-    );
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/bulk/pause', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.put(
-      baseURLWorkflow + 'bulk/pause',
-      req.body,
-      req,
-    );
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/bulk/resume', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.put(
-      baseURLWorkflow + 'bulk/resume',
-      req.body,
-      req,
-    );
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/bulk/retry', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.post(
-      baseURLWorkflow + 'bulk/retry',
-      req.body,
-      req,
-    );
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.post('/bulk/restart', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.post(
-      baseURLWorkflow + 'bulk/restart',
-      req.body,
-      req,
-    );
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.delete(
-  '/workflow/:workflowId',
-  async (req: ExpressRequest, res, next) => {
-    const archiveWorkflow = req.query.archiveWorkflow === 'true';
+  router.delete('/bulk/terminate', async (req: ExpressRequest, res, next) => {
     try {
       const result = await http.delete(
-        baseURLWorkflow +
-          req.params.workflowId +
-          '/remove?archiveWorkflow=' +
-          archiveWorkflow.toString(),
+        baseURLWorkflow + 'bulk/terminate',
         req.body,
         req,
       );
@@ -324,249 +266,325 @@ router.delete(
     } catch (err) {
       next(err);
     }
-  },
-);
+  });
 
-router.get('/id/:workflowId', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.get(
-      baseURLWorkflow + req.params.workflowId + '?includeTasks=true',
-      req,
-    );
-    let meta = result.workflowDefinition;
-    if (!meta) {
-      meta = await http.get(
-        baseURLMeta +
-          'workflow/' +
-          result.workflowType +
-          '?version=' +
-          result.version,
+  router.put('/bulk/pause', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.put(
+        baseURLWorkflow + 'bulk/pause',
+        req.body,
         req,
       );
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
     }
+  });
 
-    //  // required because of https://github.com/facebook/flow/issues/1414
-    const subs: Array<TaskType> = anythingTo<Array<TaskType>>(
-      filter(identity)(
-        map((task: TaskType): ?TaskType => {
-          if (task.taskType === 'SUB_WORKFLOW' && task.inputData) {
-            const subWorkflowId = task.inputData.subWorkflowId;
-
-            if (subWorkflowId != null) {
-              return {
-                name: task.inputData?.subWorkflowName,
-                version: task.inputData?.subWorkflowVersion,
-                referenceTaskName: task.referenceTaskName,
-                subWorkflowId: subWorkflowId,
-              };
-            }
-          }
-        })(result.tasks || []),
-      ),
-    );
-
-    const logs = map(task =>
-      Promise.all([task, http.get(baseURLTask + task.taskId + '/log', req)]),
-    )(result.tasks);
-    const LOG_DATE_FORMAT = 'MM/DD/YY, HH:mm:ss:SSS';
-
-    await Promise.all(logs).then(result => {
-      forEach(([task, logs]) => {
-        if (logs) {
-          task.logs = map(
-            ({createdTime, log}) =>
-              `${moment(createdTime).format(LOG_DATE_FORMAT)} : ${log}`,
-          )(logs);
-        }
-      })(result);
-    });
-
-    const fun: (
-      Array<TaskType>,
-    ) => Array<
-      Promise<mixed>,
-    > = map(({name, version, subWorkflowId, referenceTaskName}) =>
-      Promise.all([
-        referenceTaskName,
-        http.get(baseURLMeta + 'workflow/' + name + '?version=' + version, req),
-        http.get(baseURLWorkflow + subWorkflowId + '?includeTasks=true', req),
-      ]),
-    );
-    const promises = fun(subs);
-
-    const subworkflows = await Promise.all(promises).then(result => {
-      return transform(
-        result,
-        (result, [key, meta, wfe]) => {
-          result[key] = {meta, wfe};
-        },
-        {},
-      );
-    });
-
-    res.status(200).send({result, meta, subworkflows: subworkflows});
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.get('/hierarchical', async (req: ExpressRequest, res, next) => {
-  try {
-    let size: number = 1000;
-    if (req.query.size !== 'undefined' && req.query.size !== '') {
-      /* $FlowFixMe req.query is user-controlled input, properties and values
-       in this object are untrusted and should be validated before trusting */
-      size = req.query.size;
-    }
-
-    let count = 0;
-    let start: number = 0;
-    if (!isNaN(req.query.start)) {
-      // $FlowFixMe: isNaN is sketchy and accepts arrays
-      start = req.query.start;
-      count = Number(start);
-    }
-
-    const freeText = [];
-    if (req.query.freeText !== '') {
-      freeText.push(req.query.freeText);
-    } else {
-      freeText.push('*');
-    }
-
-    const parents = [];
-    const children = [];
-
-    let hits = 0;
-    while (parents.length < size) {
-      const url =
-        baseURLWorkflow +
-        'search?size=' +
-        size * 10 +
-        '&sort=startTime:DESC&freeText=' +
-        encodeURIComponent(freeText.join(' AND ')) +
-        '&start=' +
-        start +
-        '&query=';
-      const result = await http.get(url, req);
-      const allData = result.results ? result.results : [];
-      hits = result.totalHits ? result.totalHits : 0;
-
-      const separatedWfs = [];
-      const chunk = 5;
-
-      for (let i = 0, j = allData.length; i < j; i += chunk) {
-        separatedWfs.push(allData.slice(i, i + chunk));
-      }
-
-      for (let i = 0; i < separatedWfs.length; i++) {
-        const wfs = async function(sepWfs) {
-          return await Promise.all(
-            sepWfs.map(wf =>
-              http.get(
-                baseURLWorkflow + wf.workflowId + '?includeTasks=false',
-                req,
-              ),
-            ),
-          );
-        };
-        let checked = 0;
-        const responses = await wfs(separatedWfs[i]);
-        for (let j = 0; j < responses.length; j++) {
-          if (responses[j].parentWorkflowId) {
-            separatedWfs[i][j]['parentWorkflowId'] =
-              responses[j].parentWorkflowId;
-            children.push(separatedWfs[i][j]);
-          } else {
-            parents.push(separatedWfs[i][j]);
-            if (parents.length === size) {
-              checked = j + 1;
-              break;
-            }
-          }
-          checked = j + 1;
-        }
-        count += checked;
-        if (parents.length >= size) break;
-      }
-      if (req.query.freeText !== '') {
-        for (let i = 0; i < children.length; i++) {
-          const parent = await http.get(
-            baseURLWorkflow +
-              children[i].parentWorkflowId +
-              '?includeTasks=false',
-            req,
-          );
-          parent.startTime = new Date(parent.startTime);
-          parent.endTime = new Date(parent.endTime);
-          if (
-            parent.parentWorkflowId &&
-            !children.find(wf => wf.workflowId === parent.workflowId)
-          )
-            children.push(parent);
-          if (
-            !parent.parentWorkflowId &&
-            !parents.find(wf => wf.workflowId === parent.workflowId)
-          )
-            parents.push(parent);
-        }
-      }
-      start = Number(start) + size * 10;
-      if (Number(start) >= hits) break;
-    }
-    res.status(200).send({parents, children, count, hits});
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.get('/schedule/?', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.get(baseURLSchedule, req);
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.get('/schedule/:name', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.get(baseURLSchedule + req.params.name, req);
-    res.status(200).send(result);
-  } catch (err) {
-    next(err);
-  }
-});
-
-router.put('/schedule/:name', async (req: ExpressRequest, res, next) => {
-  const urlWithName = baseURLSchedule + req.params.name;
-  try {
-    // create using POST
-    const result = await http.post(baseURLSchedule, req.body, req);
-    res.status(result.statusCode).send(result.text);
-  } catch (e) {
+  router.put('/bulk/resume', async (req: ExpressRequest, res, next) => {
     try {
-      // update using PUT
-      const result = await http.put(urlWithName, req.body, req);
-      res.status(result.statusCode).send(result.text);
+      const result = await http.put(
+        baseURLWorkflow + 'bulk/resume',
+        req.body,
+        req,
+      );
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/bulk/retry', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.post(
+        baseURLWorkflow + 'bulk/retry',
+        req.body,
+        req,
+      );
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.post('/bulk/restart', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.post(
+        baseURLWorkflow + 'bulk/restart',
+        req.body,
+        req,
+      );
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete(
+    '/workflow/:workflowId',
+    async (req: ExpressRequest, res, next) => {
+      const archiveWorkflow = req.query.archiveWorkflow === 'true';
+      try {
+        const result = await http.delete(
+          baseURLWorkflow +
+            req.params.workflowId +
+            '/remove?archiveWorkflow=' +
+            archiveWorkflow.toString(),
+          req.body,
+          req,
+        );
+        res.status(200).send(result);
+      } catch (err) {
+        next(err);
+      }
+    },
+  );
+
+  router.get('/id/:workflowId', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.get(
+        baseURLWorkflow + req.params.workflowId + '?includeTasks=true',
+        req,
+      );
+      let meta = result.workflowDefinition;
+      if (!meta) {
+        meta = await http.get(
+          baseURLMeta +
+            'workflow/' +
+            result.workflowType +
+            '?version=' +
+            result.version,
+          req,
+        );
+      }
+
+      //  // required because of https://github.com/facebook/flow/issues/1414
+      const subs: Array<TaskType> = anythingTo<Array<TaskType>>(
+        filter(identity)(
+          map((task: TaskType): ?TaskType => {
+            if (task.taskType === 'SUB_WORKFLOW' && task.inputData) {
+              const subWorkflowId = task.inputData.subWorkflowId;
+
+              if (subWorkflowId != null) {
+                return {
+                  name: task.inputData?.subWorkflowName,
+                  version: task.inputData?.subWorkflowVersion,
+                  referenceTaskName: task.referenceTaskName,
+                  subWorkflowId: subWorkflowId,
+                };
+              }
+            }
+          })(result.tasks || []),
+        ),
+      );
+
+      const logs = map(task =>
+        Promise.all([task, http.get(baseURLTask + task.taskId + '/log', req)]),
+      )(result.tasks);
+      const LOG_DATE_FORMAT = 'MM/DD/YY, HH:mm:ss:SSS';
+
+      await Promise.all(logs).then(result => {
+        forEach(([task, logs]) => {
+          if (logs) {
+            task.logs = map(
+              ({createdTime, log}) =>
+                `${moment(createdTime).format(LOG_DATE_FORMAT)} : ${log}`,
+            )(logs);
+          }
+        })(result);
+      });
+
+      const fun: (
+        Array<TaskType>,
+      ) => Array<
+        Promise<mixed>,
+      > = map(({name, version, subWorkflowId, referenceTaskName}) =>
+        Promise.all([
+          referenceTaskName,
+          http.get(
+            baseURLMeta + 'workflow/' + name + '?version=' + version,
+            req,
+          ),
+          http.get(baseURLWorkflow + subWorkflowId + '?includeTasks=true', req),
+        ]),
+      );
+      const promises = fun(subs);
+
+      const subworkflows = await Promise.all(promises).then(result => {
+        return transform(
+          result,
+          (result, [key, meta, wfe]) => {
+            result[key] = {meta, wfe};
+          },
+          {},
+        );
+      });
+
+      res.status(200).send({result, meta, subworkflows: subworkflows});
+    } catch (err) {
+      console.log(err);
+      next(err);
+    }
+  });
+
+  router.get('/hierarchical', async (req: ExpressRequest, res, next) => {
+    try {
+      let size: number = 1000;
+      if (req.query.size !== 'undefined' && req.query.size !== '') {
+        /* FIXME req.query is user-controlled input, properties and values
+         in this object are untrusted and should be validated before trusting */
+        size = req.query.size;
+      }
+
+      let count = 0;
+      let start: number = 0;
+      if (!isNaN(req.query.start)) {
+        // FIXME: isNaN is sketchy and accepts arrays
+        start = req.query.start;
+        count = Number(start);
+      }
+
+      const freeText = [];
+      if (req.query.freeText !== '') {
+        freeText.push(req.query.freeText);
+      } else {
+        freeText.push('*');
+      }
+
+      const parents = [];
+      const children = [];
+
+      let hits = 0;
+      while (parents.length < size) {
+        const url =
+          baseURLWorkflow +
+          'search?size=' +
+          size * 10 +
+          '&sort=startTime:DESC&freeText=' +
+          encodeURIComponent(freeText.join(' AND ')) +
+          '&start=' +
+          start +
+          '&query=';
+        const result = await http.get(url, req);
+        const allData = result.results ? result.results : [];
+        hits = result.totalHits ? result.totalHits : 0;
+
+        const separatedWfs = [];
+        const chunk = 5;
+
+        for (let i = 0, j = allData.length; i < j; i += chunk) {
+          separatedWfs.push(allData.slice(i, i + chunk));
+        }
+
+        for (let i = 0; i < separatedWfs.length; i++) {
+          const wfs = async function(sepWfs) {
+            return await Promise.all(
+              sepWfs.map(wf =>
+                http.get(
+                  baseURLWorkflow + wf.workflowId + '?includeTasks=false',
+                  req,
+                ),
+              ),
+            );
+          };
+          let checked = 0;
+          const responses = await wfs(separatedWfs[i]);
+          for (let j = 0; j < responses.length; j++) {
+            if (responses[j].parentWorkflowId) {
+              separatedWfs[i][j]['parentWorkflowId'] =
+                responses[j].parentWorkflowId;
+              children.push(separatedWfs[i][j]);
+            } else {
+              parents.push(separatedWfs[i][j]);
+              if (parents.length === size) {
+                checked = j + 1;
+                break;
+              }
+            }
+            checked = j + 1;
+          }
+          count += checked;
+          if (parents.length >= size) break;
+        }
+        if (req.query.freeText !== '') {
+          for (let i = 0; i < children.length; i++) {
+            const parent = await http.get(
+              baseURLWorkflow +
+                children[i].parentWorkflowId +
+                '?includeTasks=false',
+              req,
+            );
+            parent.startTime = new Date(parent.startTime);
+            parent.endTime = new Date(parent.endTime);
+            if (
+              parent.parentWorkflowId &&
+              !children.find(wf => wf.workflowId === parent.workflowId)
+            )
+              children.push(parent);
+            if (
+              !parent.parentWorkflowId &&
+              !parents.find(wf => wf.workflowId === parent.workflowId)
+            )
+              parents.push(parent);
+          }
+        }
+        start = Number(start) + size * 10;
+        if (Number(start) >= hits) break;
+      }
+      res.status(200).send({parents, children, count, hits});
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/schedule/?', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.get(baseURLSchedule, req);
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.get('/schedule/:name', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.get(baseURLSchedule + req.params.name, req);
+      res.status(200).send(result);
     } catch (err) {
       logger.warn('Failed to POST and PUT', {error: err});
       next(err);
     }
-  }
-});
+  });
 
-router.delete('/schedule/:name', async (req: ExpressRequest, res, next) => {
-  try {
-    const result = await http.delete(
-      baseURLSchedule + req.params.name,
-      null,
-      req,
-    );
-    res.status(result.statusCode).send(result.text);
-  } catch (err) {
-    next(err);
-  }
-});
+  router.put('/schedule/:name', async (req: ExpressRequest, res, next) => {
+    const urlWithName = baseURLSchedule + req.params.name;
+    try {
+      // create using POST
+      const result = await http.post(baseURLSchedule, req.body, req);
+      res.status(result.statusCode).send(result.text);
+    } catch (e) {
+      try {
+        // update using PUT
+        const result = await http.put(urlWithName, req.body, req);
+        res.status(result.statusCode).send(result.text);
+      } catch (err) {
+        next(err);
+      }
+    }
+  });
 
-export default router;
+  router.delete('/schedule/:name', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.delete(
+        baseURLSchedule + req.params.name,
+        null,
+        req,
+      );
+      res.status(result.statusCode).send(result.text);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  return router;
+}

--- a/symphony/app/fbcnms-projects/workflows/src/types.js
+++ b/symphony/app/fbcnms-projects/workflows/src/types.js
@@ -32,6 +32,7 @@ export type ProxyCallback = (proxyOptions?: mixed) => void;
 
 export type BeforeFun = (
   tenantId: string,
+  groups: string[],
   req: ProxyRequest,
   res: ProxyResponse,
   proxyCallback: ProxyCallback,
@@ -39,6 +40,7 @@ export type BeforeFun = (
 
 export type AfterFun = (
   tenantId: string,
+  groups: string[],
   req: ProxyRequest,
   respObj: ?mixed,
   res: ProxyResponse,
@@ -77,6 +79,7 @@ export type Event = {
 
 export type Workflow = {
   name: string,
+  description: string,
   tasks: Array<Task>,
 };
 
@@ -84,6 +87,7 @@ export type StartWorkflowRequest = {
   name: string,
   workflowDef?: mixed,
   taskToDomain?: mixed,
+  correlationId?: string,
 };
 
 export type ScheduleRequest = {


### PR DESCRIPTION
**Summary:**

Create a second level proxy in workflows/ which performs additional filtering based on User's groups.
In general it only shows workflow definitions which belong to user's groups and only shows executions which were triggered by current user.

UI that talks to this proxy is called Service porta and is constructed from the same set of components that build workflow UI (but they are further limited).

**TODOs**
- In the workflows/rbac proxy, additional checks need to be introduced in order to prevent users accessing workflow resources from outside their groups
- routes.js should not mix scheduling with the core workflow REST API, refactor the /metadata/workflow endpoint
- Add user group caching (per session) so that groups do not have to be looked up for every single request

**Notes**
- The commit is bigger since there was some refactoring required e.g. routes.js -> move all the code into a function for re-usability or WorkflowDefs -> refactor render into smaller components for re-usability
- User group management does not have a UI and graphQL needs to be used directly

**Test plan**
- As fbuser@fb.com create 2 arbitrary workflows. Mark one of them with "OPERATOR" label.
![image](https://user-images.githubusercontent.com/3070975/82577606-84438b80-9b8b-11ea-8594-e0e70d1fae0b.png)
- You should see following workflow definitions
![image](https://user-images.githubusercontent.com/3070975/82577729-ad641c00-9b8b-11ea-9a51-f381db513bdb.png)
- Go into master UI and add second user (fbuser2@fb.com) to fb-test organization
- Via graphQL, create group "operator" and assign user fbuser2@fb.com to it
![image](https://user-images.githubusercontent.com/3070975/82577891-ec926d00-9b8b-11ea-81b1-685378f6e1a4.png)
`mutation addUserGroupOperator {
  addUsersGroup(input: { name: "operator" }) {
    id
    name
    status
    members {
      authID
    }
  }
}
mutation editUsersGroupAddUser2ToOpers {
  editUsersGroup(
    input: { id: 171798691841, description: "test", members: [167503724545] }
  ) {
    id
    members {
      id
      email
    }
  }
}`
- Now logout as fbuser@fb.com and login as fbuser2@fb.com and in the workflow view you should see limited UI (service portal) with only 1 of the workflows accessible
![image](https://user-images.githubusercontent.com/3070975/82578004-1a77b180-9b8c-11ea-89b0-0cfa08aaf4d9.png)


Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>