### PR TITLE
Add CWF IPFIX Integ Test

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -110,6 +110,7 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
     host = env.hosts[0]
     cwag_test_br_mac = cwag_test_host_to_mac[host]
     execute(_set_cwag_test_configs)
+    execute(_start_ipfix_controller)
 
     # Get back to the gateway vm to setup static arp
     _switch_to_vm_no_destroy(gateway_host, "cwag", "cwag_dev.yml")
@@ -204,6 +205,17 @@ def _set_cwag_test_configs():
     sudo('mkdir -p /etc/magma')
     # Create empty uesim config
     sudo('touch /etc/magma/uesim.yml')
+
+
+def _start_ipfix_controller():
+    """ Install and start the ipfix collector"""
+    with cd("$MAGMA_ROOT"):
+        sudo('curl -L https://sourceforge.net/projects/libipfix/files/RELEASES/libipfix-dev_0.8.1-1ubuntu1_amd64.deb/download?use_mirror=autoselect --output  libipfix-dev_0.8.1-1ubuntu1_amd64.deb')
+        sudo('apt install ./libipfix-dev_0.8.1-1ubuntu1_amd64.deb')
+        sudo('mkdir -p records')
+        sudo('rm -rf records/*')
+        sudo('pkill ipfix_collector > /dev/null &', pty=False, warn_only=True)
+        sudo('tmux new -d \'/usr/bin/ipfix_collector -4tu -p 4740 -o /home/vagrant/magma/records\'')
 
 
 def _set_cwag_test_networking(mac):
@@ -347,7 +359,6 @@ def _run_integ_tests(test_host, trf_host, tests_to_run: SubTests,
                 execute(_clean_up)
             print("Integration Test returned ", result.return_code)
             sys.exit(result.return_code)
-
 
 
 def _clean_up():

--- a/cwf/gateway/integ_tests/gateway.mconfig
+++ b/cwf/gateway/integ_tests/gateway.mconfig
@@ -113,6 +113,10 @@
    "services": [
       "ENFORCEMENT"
    ],
+   "ipdrExportDst": {
+     "ip": "192.168.40.12",
+     "port": 4740
+   },
    "allowedGrePeers": [
     {"ip": "192.168.70.102"}
    ]

--- a/cwf/gateway/integ_tests/ipfix_test.go
+++ b/cwf/gateway/integ_tests/ipfix_test.go
@@ -1,0 +1,160 @@
+// +build all
+
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package integration
+
+import (
+	"fmt"
+	cwfprotos "magma/cwf/cloud/go/protos"
+	"magma/feg/cloud/go/protos"
+	"magma/lte/cloud/go/plugin/models"
+	"testing"
+	"time"
+    "io/ioutil"
+	"strings"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/go-openapi/swag"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/stretchr/testify/assert"
+)
+
+// - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
+//   respond with a rule install (usage-enforcement-static-pass-all), 250KB of
+//   quota.
+//   Generate traffic and assert the CCR-I is received.
+// - Set an expectation for a CCR-U with >80% of data usage to be sent up to
+// 	 PCRF, to which it will response with more quota.
+//   Generate traffic and assert the CCR-U is received.
+// - Generate traffic to put traffic through the newly installed rule.
+//   Assert that there's > 0 data usage in the rule.
+// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+// - Assert that IPDR records were properly exported
+func TestIpfixEnforcement(t *testing.T) {
+	fmt.Println("\nRunning IPFIX TEST...")
+	tr := NewTestRunner(t)
+
+	// Enable IPFIX exporting
+	enableIpfixExport()
+	err := tr.RestartService("pipelined")
+	if err != nil {
+		fmt.Printf("error restarting pipelined %v", err)
+		assert.Fail(t, "failed restarting pipelined")
+	}
+
+	ruleManager, err := NewRuleManager()
+	assert.NoError(t, err)
+	assert.NoError(t, usePCRFMockDriver())
+	defer func() {
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearPCRFMockDriver())
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
+	ues, err := tr.ConfigUEs(1)
+	assert.NoError(t, err)
+	imsi := ues[0].GetImsi()
+
+	err = ruleManager.AddStaticPassAllToDB("usage-enforcement-static-pass-all", "mkey1", 0, models.PolicyRuleTrackingTypeONLYPCRF, 3)
+	assert.NoError(t, err)
+	tr.WaitForPoliciesToSync()
+
+	usageMonitorInfo := getUsageInformation("mkey1", 250*KiloBytes)
+
+	initRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_INITIAL)
+	initAnswer := protos.NewGxCCAnswer(diam.Success).
+		SetStaticRuleInstalls([]string{"usage-enforcement-static-pass-all"}, []string{}).
+		SetUsageMonitorInfo(usageMonitorInfo)
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	// We expect an update request with some usage update (probably around 80-100% of the given quota)
+	updateRequest1 := protos.NewGxCCRequest(imsi, protos.CCRequestType_UPDATE).
+		SetUsageMonitorReport(usageMonitorInfo).
+		SetUsageReportDelta(250 * KiloBytes * 0.2)
+	updateAnswer1 := protos.NewGxCCAnswer(diam.Success).SetUsageMonitorInfo(usageMonitorInfo)
+	updateExpectation1 := protos.NewGxCreditControlExpectation().Expect(updateRequest1).Return(updateAnswer1)
+	expectations := []*protos.GxCreditControlExpectation{initExpectation, updateExpectation1}
+	// On unexpected requests, just return the default update answer
+	assert.NoError(t, setPCRFExpectations(expectations, updateAnswer1))
+
+	tr.AuthenticateAndAssertSuccess(imsi)
+
+	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("500K")}}
+	_, err = tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	tr.WaitForEnforcementStatsToSync()
+
+	// When we initiate a UE disconnect, we expect a terminate request to go up
+	terminateRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_TERMINATION)
+	terminateAnswer := protos.NewGxCCAnswer(diam.Success)
+	terminateExpectation := protos.NewGxCreditControlExpectation().Expect(terminateRequest).Return(terminateAnswer)
+	expectations = []*protos.GxCreditControlExpectation{terminateExpectation}
+	assert.NoError(t, setPCRFExpectations(expectations, nil))
+
+	tr.DisconnectAndAssertSuccess(imsi)
+	tr.WaitForEnforcementStatsToSync()
+
+	// Wait for CCR-T to propagate up
+	time.Sleep(3 * time.Second)
+
+	// Collector saves files in 'YearMonthDate' format
+	//year, month, day := time.Now().Date()
+	ipfixDir := fmt.Sprintf("/home/vagrant/magma/records/%s/1/", IPDRControllerIP)
+
+	// Check if ipdr export file was created
+	files, err := ioutil.ReadDir(ipfixDir)
+	assert.NoError(t, err)
+	assert.NotEqual(t, len(files), 0)
+
+	ipfixFileDir := fmt.Sprintf("%s/%s", ipfixDir, files[len(files)-1].Name())
+	file, err := ioutil.ReadFile(ipfixFileDir)
+	assert.NoError(t, err)
+
+	ipdrExport := string(file)
+	imsiStr, err := getEncodedIMSI(imsi)
+	assert.NoError(t, err)
+
+	imsiIPFIXRecord := fmt.Sprintf("%s, %s, %s, %s", imsiStr, ipfixMSISDN,
+		ipfixApnMacAddress, ipfixApnName)
+
+	// Check if export contains the data from this test
+	assert.True(t, strings.Contains(ipdrExport, imsiIPFIXRecord))
+
+	// Disable IPFIX exporting
+	disableIpfixExport()
+	err = tr.RestartService("pipelined")
+	if err != nil {
+		fmt.Printf("error restarting pipelined %v", err)
+		assert.Fail(t, "failed restarting pipelined")
+	}
+}
+
+func enableIpfixExport() {
+	replacePipelinedConfigValue("#'ipfix'", "'ipfix'")
+}
+
+func disableIpfixExport() {
+	replacePipelinedConfigValue("'ipfix'", "#'ipfix'")
+}
+
+func replacePipelinedConfigValue(old string, new string) {
+	path := "/home/vagrant/magma/cwf/gateway/integ_tests/pipelined.yml"
+	read, err := ioutil.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+
+	newContents := strings.Replace(string(read), old, new, -1)
+	err = ioutil.WriteFile(path, []byte(newContents), 0)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -34,6 +34,7 @@ static_services: [
   'tunnel_learn',
   'vlan_learn',
   'li_mirror',
+  #'ipfix',
   'startup_flows',
   'ryu_rest_service',
 ]
@@ -134,8 +135,8 @@ li_mirror_all: false
 
 # Configuration for IPFIX sampling
 ipfix:
-  enabled: false
-  probability: 65
+  enabled: true
+  probability: 65535
   collector_set_id: 1
   cache_timeout: 60
   obs_domain_id: 1


### PR DESCRIPTION
Summary:
Unfortunately can't include DPI here fo now because its a pain(DPI can't be hosted).
Integ test runs traffic with IPDR exporting enabled in OVS and checks that the record files were generated. For now just verfifies imsi, msisdn, apn name and apn mac.

Reviewed By: karthiksubraveti

Differential Revision: D21656397

