### PR TITLE
Fix small bug in Update revalidation timer

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1088,6 +1088,12 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
     SessionMap& session_map, const UpdateSessionResponse& response,
     std::unordered_set<std::string>& subscribers_to_terminate,
     SessionUpdate& session_update) {
+  // Since revalidation timer is session wide, we will only schedule one for
+  // the entire session. The expectation is that if event triggers should be
+  // included in all monitors or none.
+  // To keep track of which timer is already tracked, we will have a set of
+  // IMSIs that have pending re-validations
+  std::unordered_set<std::string> imsis_with_revalidation;
   for (const auto& usage_monitor_resp : response.usage_monitor_responses()) {
     const std::string& imsi = usage_monitor_resp.sid();
 
@@ -1103,15 +1109,6 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
                    << " during update";
       continue;
     }
-
-    // Since revalidation timer is session wide, we will only schedule one for
-    // the entire session
-
-    // TODO [REMOVE] We will log error in case we get an unexpected input here
-    // The expectation is that if event triggers should be included in all
-    // monitors or none
-    bool revalidation_scheduled = false;
-    google::protobuf::Timestamp revalidation_time;
 
     for (const auto& session : it->second) {
       auto& update_criteria = session_update[imsi][session->get_session_id()];
@@ -1168,19 +1165,18 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
         subscribers_to_terminate.insert(imsi);
       }
 
-      if (!revalidation_scheduled &&
-          revalidation_required(usage_monitor_resp.event_triggers())) {
-        schedule_revalidation(imsi, usage_monitor_resp.revalidation_time());
-        revalidation_scheduled = true;
-        // TODO remove after confirming this isn't causing issues
-        revalidation_time = usage_monitor_resp.revalidation_time();
-      } else if (revalidation_scheduled &&
-          !revalidation_required(usage_monitor_resp.event_triggers())) {
-        // TODO [Remove This Clause]
-        auto time_from_now_ms = time_difference_from_now(revalidation_time);
-        MLOG(MWARNING) << imsi << " received some usage monitors with a "
-                       << "revalidation timer in " << time_from_now_ms.count()
-                       << " and some without";
+      if (revalidation_required(usage_monitor_resp.event_triggers()) &&
+            imsis_with_revalidation.count(imsi) == 0) {
+        // All usage monitors under the same session will have the same event
+        // trigger. See proto message / FeG for why. We will modify this input
+        // logic later (Move event trigger out of UsageMonitorResponse), but
+        // here we use a set to indicate whether a timer is already accounted
+        // for.
+        // Only schedule if no other revalidation timer was scheduled for
+        // this IMSI
+        auto revalidation_time = usage_monitor_resp.revalidation_time();
+        imsis_with_revalidation.insert(imsi);
+        schedule_revalidation(imsi, revalidation_time);
       }
     }
   }
@@ -1616,6 +1612,7 @@ bool LocalEnforcer::revalidation_required(
   return it != event_triggers.end();
 }
 
+// Todo support scheduling revalidation for different sessions for a IMSI
 void LocalEnforcer::schedule_revalidation(
     const std::string& imsi,
     const google::protobuf::Timestamp& revalidation_time) {

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1407,9 +1407,10 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   UpdateSessionResponse update_response;
   std::vector<std::string> rules_to_install;
   std::vector<EventTrigger> event_triggers{EventTrigger::REVALIDATION_TIMEOUT};
-  const std::string mkey = "m1";
+  const std::string mkey1 = "m1";
+  const std::string mkey2 = "m2";
   rules_to_install.push_back("rule1");
-  insert_static_rule(1, mkey, "rule1");
+  insert_static_rule(1, mkey1, "rule1");
 
   // create two sessions
   const std::string imsi1 = "IMSI1";
@@ -1417,18 +1418,15 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   const std::string imsi2 = "IMSI2";
   const std::string session_id2 = "5678";
 
-
   // Create a CreateSessionResponse with one Gx monitor, PCC rule
-  create_session_create_response(imsi1, mkey, rules_to_install, &create_response);
+  create_session_create_response(imsi1, mkey1, rules_to_install, &create_response);
   local_enforcer->init_session_credit(session_map, imsi1, session_id1, test_cfg,
                                       create_response);
 
   create_response.Clear();
-  create_session_create_response(imsi2, mkey, rules_to_install, &create_response);
+  create_session_create_response(imsi2, mkey1, rules_to_install, &create_response);
   local_enforcer->init_session_credit(session_map, imsi2, session_id2, test_cfg,
                                       create_response);
-  EXPECT_EQ(session_map[imsi1].size(), 1);
-  EXPECT_EQ(session_map[imsi2].size(), 1);
 
   // Write and read into session store, assert success
   bool success = session_store->create_sessions(imsi1, std::move(session_map[imsi1]));
@@ -1439,12 +1437,17 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   EXPECT_EQ(session_map[imsi1].size(), 1);
   EXPECT_EQ(session_map[imsi2].size(), 1);
 
-  // Create a UpdateSessionResponse with a REVALIDATION event trigger
+  auto revalidation_timer = time(NULL);
+  // IMSI1 has two separate monitors with the same revalidation timer
+  // IMSI2 does not have a revalidation timer
   auto monitor = update_response.mutable_usage_monitor_responses()->Add();
-  create_monitor_update_response(imsi1, mkey, MonitoringLevel::PCC_RULE_LEVEL,
-                                 1024, event_triggers, time(NULL), monitor);
+  create_monitor_update_response(imsi1, mkey1, MonitoringLevel::PCC_RULE_LEVEL,
+                                 1024, event_triggers, revalidation_timer, monitor);
   monitor = update_response.mutable_usage_monitor_responses()->Add();
-  create_monitor_update_response(imsi2, mkey, MonitoringLevel::PCC_RULE_LEVEL,
+  create_monitor_update_response(imsi1, mkey2, MonitoringLevel::PCC_RULE_LEVEL,
+                                 1024, event_triggers, revalidation_timer, monitor);
+  monitor = update_response.mutable_usage_monitor_responses()->Add();
+  create_monitor_update_response(imsi1, mkey1, MonitoringLevel::PCC_RULE_LEVEL,
                                  1024, monitor);
   auto update = SessionStore::get_default_session_update(session_map);
   // This should trigger a revalidation to be scheduled
@@ -1455,8 +1458,9 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   success = session_store->update_sessions(update);
   EXPECT_TRUE(success);
 
-  EXPECT_CALL(*reporter, report_updates(CheckUpdateRequestCount(1, 0), _)).Times(1);
-  // schedule_revalidation puts two things on the event loop
+  // Report 2 monitors for IMSI1
+  EXPECT_CALL(*reporter, report_updates(CheckUpdateRequestCount(2, 0), _)).Times(1);
+  // a single schedule_revalidation puts two things on the event loop
   evb->loopOnce();
   evb->loopOnce();
 }


### PR DESCRIPTION
Summary:
## Previous Behavior
- UpdateSessionResponse can return `UsageMonitorResponse` for each (session, mkey). Since revalidation timers are session wide, we need only schedule a revalidation per session.
- Previously before this fix, a revalidation timer for each monitor was being scheduled

## New behavior
- Keep track of imsis that already have a revalidation timer scheduled, and only schedule a new revalidation timer if that IMSI is not already tracked

## Next Steps
- I have to modify the revalidation timer call flow to take in both IMSI & SessionID since there can be multiple sessions per IMSI.

Reviewed By: ulaskozat

Differential Revision: D21686162

