### PR TITLE
Restart ingress service from inside the test

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -34,7 +34,6 @@ class SubTests(Enum):
     GY = "gy"
     QOS = "qos"
     MULTISESSIONPROXY = "multi_session_proxy"
-    FEGFAILURE = "feg_failure"
 
     @staticmethod
     def list():
@@ -137,30 +136,8 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
     execute(_start_ue_simulator)
     execute(_set_cwag_test_networking, cwag_br_mac)
 
-    if tests_to_run.value not in (SubTests.MULTISESSIONPROXY.value,
-                                    SubTests.FEGFAILURE.value):
+    if tests_to_run.value not in SubTests.MULTISESSIONPROXY.value:
         execute(_run_integ_tests, test_host, trf_host, tests_to_run, test_re)
-
-    # Setup environment for cwag_feg_link_down if required
-    if tests_to_run.value in (SubTests.ALL.value,
-                              SubTests.FEGFAILURE.value):
-        # CWAG VM
-        if not gateway_host:
-            vagrant_setup("cwag", False)
-        else:
-            ansible_setup(gateway_host, "cwag", "cwag_dev.yml")
-
-        # Stop not necessary services for this test case
-        execute(_stop_docker_services, ["ingress"])
-        execute(_check_docker_services)
-
-        # CWAG_TEST VM
-        if not test_host:
-            vagrant_setup("cwag_test", False)
-        else:
-            ansible_setup(test_host, "cwag_test", "cwag_test.yml")
-        execute(_run_integ_tests, test_host, trf_host,
-                SubTests.FEGFAILURE, test_re)
 
     # Setup environment for multi service proxy if required
     if tests_to_run.value in (SubTests.ALL.value,

--- a/cwf/gateway/integ_tests/feg_failure_test.go
+++ b/cwf/gateway/integ_tests/feg_failure_test.go
@@ -1,4 +1,4 @@
-// +build feg_failure
+// +build all
 
 /*
  * Copyright (c) Facebook, Inc. and its affiliates.
@@ -27,12 +27,14 @@ func TestLinkFailureCWAGtoFEG(t *testing.T) {
 	tr := NewTestRunner(t)
 	ruleManager, err := NewRuleManager()
 	assert.NoError(t, err)
+	assert.NoError(t, tr.PauseService("ingress"))
 
 	defer func() {
 		// Clear hss, ocs, and pcrf
 		assert.NoError(t, clearOCSMockDriver())
 		assert.NoError(t, ruleManager.RemoveInstalledRules())
 		assert.NoError(t, tr.CleanUp())
+		assert.NoError(t, tr.RestartService("ingress"))
 	}()
 
 	ues, err := tr.ConfigUEs(1)

--- a/cwf/gateway/integ_tests/gx_qos_restart_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_restart_test.go
@@ -67,9 +67,7 @@ const (
 func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg string) {
 	tr := NewTestRunner(t)
 
-	err := tr.RestartService("pipelined", true)
-	fmt.Println("Restarting service")
-
+	err := tr.RestartService("pipelined")
 	if err != nil {
 		fmt.Printf("error restarting pipelined %v", err)
 		assert.Fail(t, "failed restarting pipelined")
@@ -130,7 +128,7 @@ func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg strin
 
 	// modify pipelined yml to set clean_restart
 	cfgCh <- restartCfg
-	err = tr.RestartService("pipelined", true)
+	err = tr.RestartService("pipelined")
 	if err != nil {
 		fmt.Printf("error restarting pipelined %v", err)
 		assert.Fail(t, "failed restarting pipelined")


### PR DESCRIPTION
Summary:
- Previously, to test FeG <-> SessionD link failure, we were stopping the ingress container in the fabfile, and running the test
- Now that we have the ability to talk to docker conatiners from the tests, we can make the fabfile simpler by just pausing & restarting ingress from inside thet test

Reviewed By: ymasmoudi

Differential Revision: D21721744

