### PR TITLE
Add option to disable http_proxy for docker upgrader in magmad

### DIFF
--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -56,6 +56,7 @@ upgrader_factory:
   module: magma.magmad.upgrade.docker_upgrader
   class: DockerUpgraderFactory
   gateway_module: cwf
+  use_proxy: True
 
 mconfig_modules:
   - orc8r.protos.mconfig.mconfigs_pb2

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -44,6 +44,7 @@ upgrader_factory:
   module: magma.magmad.upgrade.docker_upgrader
   class: DockerUpgraderFactory
   gateway_module: feg
+  use_proxy: True
 
 mconfig_modules:
   - orc8r.protos.mconfig.mconfigs_pb2

--- a/openwrt/gateway/configs/etc/magma/configs/magmad.yml
+++ b/openwrt/gateway/configs/etc/magma/configs/magmad.yml
@@ -37,6 +37,7 @@ enable_sync_rpc: True
 
 upgrader_factory:
   gateway_module: openwrt
+  use_proxy: True
 
 mconfig_modules:
 

--- a/xwf/gateway/configs/magmad.yml
+++ b/xwf/gateway/configs/magmad.yml
@@ -40,6 +40,7 @@ upgrader_factory:
   module: magma.magmad.upgrade.docker_upgrader
   class: DockerUpgraderFactory
   gateway_module: xwf
+  use_proxy: False
 
 mconfig_modules:
   - orc8r.protos.mconfig.mconfigs_pb2


### PR DESCRIPTION
Summary:
xwf-m gateways will have internet access and are remotely managed by an orc8r in aws.
We don't neet to go through the proxy to clone magma repo.

Reviewed By: mpgermano

Differential Revision: D21718332

