### PR TITLE
Fix the path of test certs for api host

### DIFF
--- a/symphony/app/fbcnms-projects/magmalte/docker-compose.yml
+++ b/symphony/app/fbcnms-projects/magmalte/docker-compose.yml
@@ -63,9 +63,9 @@ services:
 
 secrets:
   api_cert:
-    file: ${API_CERT_FILENAME:-../../../.cache/test_certs/admin_operator.pem}
+    file: ${API_CERT_FILENAME:-../../../../.cache/test_certs/admin_operator.pem}
   api_key:
-    file: ${API_PRIVATE_KEY_FILENAME:-../../../.cache/test_certs/admin_operator.key.pem}
+    file: ${API_PRIVATE_KEY_FILENAME:-../../../../.cache/test_certs/admin_operator.key.pem}
 
 networks:
   orc8r_default:


### PR DESCRIPTION
Summary:
The following ERROR occurs when testing with docker-compose for symphony.

  ERROR: for magmalte Cannot create container for service magmalte: invalid mount config 
               for type "bind": bind source path does not exist: 
                 /magma/symphony/.cache/test_certs/admin_operator.pem

Therefore, I fixed the correct path to test_certs (/magma/.cache/test_certs/admin_operator.pem).