### PR TITLE
Fix the issue of "key is not found" in get_service_config_value

### DIFF
--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -145,7 +145,8 @@ def _get_context():
     context["csfb_mcc"] = _get_csfb_mcc()
     context["csfb_mnc"] = _get_csfb_mnc()
     context["lac"] = _get_lac()
-    context["use_stateless"] = get_service_config_value("mme", "use_stateless", "")
+    use_stateless = get_service_config_value("mme", "use_stateless", False)
+    context["use_stateless"] = "" if use_stateless == False else use_stateless    
     context["attached_enodeb_tacs"] = _get_attached_enodeb_tacs()
     # set ovs params
     for key in (

--- a/lte/gateway/python/scripts/generate_oai_config.py
+++ b/lte/gateway/python/scripts/generate_oai_config.py
@@ -145,8 +145,7 @@ def _get_context():
     context["csfb_mcc"] = _get_csfb_mcc()
     context["csfb_mnc"] = _get_csfb_mnc()
     context["lac"] = _get_lac()
-    use_stateless = get_service_config_value("mme", "use_stateless", False)
-    context["use_stateless"] = "" if use_stateless == False else use_stateless    
+    context["use_stateless"] = get_service_config_value("mme", "use_stateless", "") or ""
     context["attached_enodeb_tacs"] = _get_attached_enodeb_tacs()
     # set ovs params
     for key in (

--- a/orc8r/gateway/python/magma/configuration/service_configs.py
+++ b/orc8r/gateway/python/magma/configuration/service_configs.py
@@ -111,7 +111,7 @@ def get_service_config_value(service: str, param: str, default: Any) -> Any:
     cached_service_configs[service] = service_configs
 
     config_value = service_configs.get(param)
-    if config_value:
+    if config_value is not None:
         return config_value
     else:
         logging.error(


### PR DESCRIPTION
Summary:
The following ERROR occurs when loading yml configs under the folder magma/lte/gateway/configs, 

  ERROR:root:Error retrieving config for mme, key not found: use_stateless
  ERROR:root:Error retrieving config for control_proxy, key not found: allow_http_proxy

Because the value of boolean false is interpreted as nonexistent key, 
I fixed the function of get_service_config_value,
and this fix supresses the above ERROR messages by generate_oai_config.py and generate_nghttpx_config.py.