### PR TITLE
Cleaning debug logging on enodebd

### DIFF
--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 #
-log_level: INFO
+log_level: DEBUG
 
 tr069:
   interface: eth1 # NOTE: this value must be consistent with dnsmasq.conf

--- a/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
+++ b/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
@@ -68,7 +68,7 @@ def bandwidth(bandwidth_rbs: Union[str, int, float]) -> float:
     if bandwidth_rbs in BANDWIDTH_RBS_TO_MHZ_MAP:
         return BANDWIDTH_RBS_TO_MHZ_MAP[bandwidth_rbs]
 
-    logger.debug('Unknown bandwidth_rbs (%s)', str(bandwidth_rbs))
+    logger.warning('Unknown bandwidth_rbs (%s)', str(bandwidth_rbs))
     if bandwidth_rbs in BANDWIDTH_MHZ_LIST:
         return bandwidth_rbs
     elif isinstance(bandwidth_rbs, str):

--- a/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
+++ b/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
@@ -148,5 +148,5 @@ class EnodebConfiguration():
         trparam_model = self.data_model
         tr_param = trparam_model.get_parameter(param_name)
         if tr_param is None:
-            logger.error('Parameter <%s> not defined in model', param_name)
+            logger.warning('Parameter <%s> not defined in model', param_name)
             raise ConfigurationError("Parameter not defined in model.")

--- a/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
+++ b/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
@@ -104,7 +104,7 @@ async def run(cmd):
     await proc.communicate()
     if proc.returncode != 0:
         # This can happen because the NAT prerouting rule didn't exist
-        logger.info('Possible error running async subprocess: %s exited with '
+        logger.error('Possible error running async subprocess: %s exited with '
                      'return code [%d].', cmd, proc.returncode)
     return proc.returncode
 

--- a/lte/gateway/python/magma/enodebd/logger.py
+++ b/lte/gateway/python/magma/enodebd/logger.py
@@ -12,7 +12,6 @@ from logging.handlers import RotatingFileHandler
 
 
 LOG_FILE = 'var/log/enodebd.log'
-LOGGER_NAME = 'debug'
 MAX_BYTES = 1024 * 1024 * 10  # 10MB
 BACKUP_COUNT = 5  # 10MB, 5 files, 50MB total
 
@@ -25,7 +24,7 @@ class EnodebdLogger:
     debug level.
     """
 
-    _LOGGER = logging.getLogger(LOGGER_NAME)  # type: logging.Logger
+    _LOGGER = logging.getLogger(__name__)  # type: logging.Logger
 
     @staticmethod
     def init() -> None:

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -189,17 +189,17 @@ class StatsManager:
 
             index = name_index_map.get(counter)
             if index is None:
-                logger.info('PM counter %s not found in PmNames', counter)
+                logger.warning('PM counter %s not found in PmNames', counter)
                 continue
 
             data_el = index_data_map.get(index)
             if data_el is None:
-                logger.info('PM counter %s not found in PmData', counter)
+                logger.warning('PM counter %s not found in PmData', counter)
                 continue
 
             if data_el.tag == 'V':
                 if subcounter is not None:
-                    logger.info('No subcounter in PM counter %s', counter)
+                    logger.warning('No subcounter in PM counter %s', counter)
                     continue
 
                 # Data is singular value
@@ -207,7 +207,7 @@ class StatsManager:
                     value = int(data_el.text)
                 except ValueError:
                     logger.info('PM value (%s) of counter %s not integer',
-                                 data_el.text, counter)
+                                data_el.text, counter)
                     continue
             elif data_el.tag == 'CV':
                 # Check whether we want just one subcounter, or sum them all
@@ -220,7 +220,7 @@ class StatsManager:
                         index = index + 1
 
                 if subcounter is not None and subcounter_index is None:
-                    logger.info('PM subcounter (%s) not found', subcounter)
+                    logger.warning('PM subcounter (%s) not found', subcounter)
                     continue
 
                 # Data is multiple sub-elements. Sum them, or select the one
@@ -234,12 +234,12 @@ class StatsManager:
                             value = value + int(sub_data_el.text)
                         index = index + 1
                 except ValueError:
-                    logger.info('PM value (%s) of counter %s not integer',
+                    logger.error('PM value (%s) of counter %s not integer',
                                  sub_data_el.text, pm_name)
                     continue
             else:
-                logger.info('Unknown PM data type (%s) of counter %s',
-                             data_el.tag, pm_name)
+                logger.warning('Unknown PM data type (%s) of counter %s',
+                               data_el.tag, pm_name)
                 continue
 
             # Apply new value to metric
@@ -339,7 +339,7 @@ class StatsManager:
         """
         Clear statistics. Called when eNodeB management plane disconnects
         """
-        logger.info('Clearing statistics')
+        logger.info('Clearing performance counter statistics')
         # Set all metrics to 0 if eNodeB not connected
         for metric in self.PM_FILE_TO_METRIC_MAP.values():
             metric.set(0)


### PR DESCRIPTION
Summary:
- Currently, there are many logging on enodebd that are misleading or should be on lower/higher verbosity level
- This diff updates some of logging usages to make enodebd logger more relevant

Differential Revision: D21753464

