### PR TITLE
Fixing enodeb status mismatch while reporting metrics

### DIFF
--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 #
-log_level: INFO
+log_level: DEBUG
 
 tr069:
   interface: eth1 # NOTE: this value must be consistent with dnsmasq.conf

--- a/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
+++ b/lte/gateway/python/magma/enodebd/data_models/transform_for_magma.py
@@ -68,7 +68,7 @@ def bandwidth(bandwidth_rbs: Union[str, int, float]) -> float:
     if bandwidth_rbs in BANDWIDTH_RBS_TO_MHZ_MAP:
         return BANDWIDTH_RBS_TO_MHZ_MAP[bandwidth_rbs]
 
-    logger.debug('Unknown bandwidth_rbs (%s)', str(bandwidth_rbs))
+    logger.warning('Unknown bandwidth_rbs (%s)', str(bandwidth_rbs))
     if bandwidth_rbs in BANDWIDTH_MHZ_LIST:
         return bandwidth_rbs
     elif isinstance(bandwidth_rbs, str):

--- a/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
+++ b/lte/gateway/python/magma/enodebd/device_config/enodeb_configuration.py
@@ -148,5 +148,5 @@ class EnodebConfiguration():
         trparam_model = self.data_model
         tr_param = trparam_model.get_parameter(param_name)
         if tr_param is None:
-            logger.error('Parameter <%s> not defined in model', param_name)
+            logger.warning('Parameter <%s> not defined in model', param_name)
             raise ConfigurationError("Parameter not defined in model.")

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -115,7 +115,7 @@ def update_status_metrics(status: EnodebStatus) -> None:
 
 # TODO: Remove after checkins support multiple eNB status
 def get_service_status_old(
-    enb_acs_manager: StateMachineManager,
+        enb_acs_manager: StateMachineManager,
 ) -> Dict[str, Any]:
     """ Get service status compatible with older controller """
     enb_status_by_serial = get_all_enb_status(enb_acs_manager)
@@ -157,7 +157,7 @@ def get_service_status(enb_acs_manager: StateMachineManager) -> Dict[str, Any]:
 
 
 def _get_enodebd_status(
-    enb_acs_manager: StateMachineManager,
+        enb_acs_manager: StateMachineManager,
 ) -> MagmaEnodebdStatus:
     enb_status_by_serial = get_all_enb_status(enb_acs_manager)
     # Start from default values for enodebd status
@@ -209,7 +209,7 @@ def _get_enodebd_status(
 
 
 def get_all_enb_status(
-    enb_acs_manager: StateMachineManager,
+        enb_acs_manager: StateMachineManager,
 ) -> Dict[str, EnodebStatus]:
     enb_status_by_serial = {}
     serial_list = enb_acs_manager.get_connected_serial_id_list()
@@ -252,8 +252,9 @@ def get_enb_status(enodeb: EnodebAcsStateMachine) -> EnodebStatus:
     enodeb_connected = enodeb.is_enodeb_connected()
     opstate_enabled = _parse_param_as_bool(enodeb, ParameterName.OP_STATE)
     rf_tx_on = _parse_param_as_bool(enodeb, ParameterName.RF_TX_STATUS)
+    rf_tx_on = rf_tx_on and enodeb_connected
     try:
-        enb_serial =\
+        enb_serial = \
             enodeb.device_cfg.get_parameter(ParameterName.SERIAL_NUMBER)
         rf_tx_desired = get_enb_rf_tx_desired(enodeb.mconfig, enb_serial)
     except (KeyError, ConfigurationError):
@@ -279,8 +280,8 @@ def get_enb_status(enodeb: EnodebAcsStateMachine) -> EnodebStatus:
 
 
 def get_single_enb_status(
-    device_serial: str,
-    state_machine_manager: StateMachineManager
+        device_serial: str,
+        state_machine_manager: StateMachineManager
 ) -> SingleEnodebStatus:
     try:
         handler = state_machine_manager.get_handler_by_serial(device_serial)
@@ -317,7 +318,7 @@ def get_single_enb_status(
 
 
 def get_operational_states(
-    enb_acs_manager: StateMachineManager,
+        enb_acs_manager: StateMachineManager,
 ) -> List[State]:
     """
     Returns: A list of State with EnodebStatus encoded as JSON
@@ -354,8 +355,8 @@ def _empty_enb_status() -> SingleEnodebStatus:
 
 
 def _parse_param_as_bool(
-    enodeb: EnodebAcsStateMachine,
-    param_name: ParameterName
+        enodeb: EnodebAcsStateMachine,
+        param_name: ParameterName
 ) -> bool:
     try:
         return _format_as_bool(enodeb.get_parameter(param_name), param_name)
@@ -364,8 +365,8 @@ def _parse_param_as_bool(
 
 
 def _format_as_bool(
-    param_value: Union[bool, str, int],
-    param_name: Optional[Union[ParameterName, str]] = None,
+        param_value: Union[bool, str, int],
+        param_name: Optional[Union[ParameterName, str]] = None,
 ) -> bool:
     """ Returns '1' for true, and '0' for false """
     stripped_value = str(param_value).lower().strip()
@@ -399,7 +400,8 @@ def _get_gps_status_as_bool(enodeb: EnodebAcsStateMachine) -> bool:
         return False
 
 
-def _get_and_cache_gps_coords(enodeb: EnodebAcsStateMachine) -> Tuple[str, str]:
+def _get_and_cache_gps_coords(enodeb: EnodebAcsStateMachine) -> Tuple[
+    str, str]:
     """
     Read the GPS coordinates of the enB from its configuration or the
     cached coordinate file if the preceding read fails. If reading from
@@ -444,8 +446,8 @@ def _read_gps_coords_from_file():
             lines = f.readlines()
             if len(lines) != 2:
                 logger.warning('Expected to find 2 lines in GPS '
-                                'coordinate file but only found %d',
-                                len(lines))
+                               'coordinate file but only found %d',
+                               len(lines))
                 return '0', '0'
             return tuple(map(lambda l: l.strip(), lines))
     except OSError:
@@ -477,6 +479,7 @@ def _write_gps_coords_to_file(gps_lat, gps_lon):
         )
     except OSError:
         pass
+
 
 def _bool_to_str(b: bool) -> str:
     if b is True:

--- a/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
+++ b/lte/gateway/python/magma/enodebd/enodebd_iptables_rules.py
@@ -104,7 +104,7 @@ async def run(cmd):
     await proc.communicate()
     if proc.returncode != 0:
         # This can happen because the NAT prerouting rule didn't exist
-        logger.info('Possible error running async subprocess: %s exited with '
+        logger.error('Possible error running async subprocess: %s exited with '
                      'return code [%d].', cmd, proc.returncode)
     return proc.returncode
 

--- a/lte/gateway/python/magma/enodebd/logger.py
+++ b/lte/gateway/python/magma/enodebd/logger.py
@@ -12,7 +12,6 @@ from logging.handlers import RotatingFileHandler
 
 
 LOG_FILE = 'var/log/enodebd.log'
-LOGGER_NAME = 'debug'
 MAX_BYTES = 1024 * 1024 * 10  # 10MB
 BACKUP_COUNT = 5  # 10MB, 5 files, 50MB total
 
@@ -25,7 +24,7 @@ class EnodebdLogger:
     debug level.
     """
 
-    _LOGGER = logging.getLogger(LOGGER_NAME)  # type: logging.Logger
+    _LOGGER = logging.getLogger(__name__)  # type: logging.Logger
 
     @staticmethod
     def init() -> None:

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -189,17 +189,17 @@ class StatsManager:
 
             index = name_index_map.get(counter)
             if index is None:
-                logger.info('PM counter %s not found in PmNames', counter)
+                logger.warning('PM counter %s not found in PmNames', counter)
                 continue
 
             data_el = index_data_map.get(index)
             if data_el is None:
-                logger.info('PM counter %s not found in PmData', counter)
+                logger.warning('PM counter %s not found in PmData', counter)
                 continue
 
             if data_el.tag == 'V':
                 if subcounter is not None:
-                    logger.info('No subcounter in PM counter %s', counter)
+                    logger.warning('No subcounter in PM counter %s', counter)
                     continue
 
                 # Data is singular value
@@ -207,7 +207,7 @@ class StatsManager:
                     value = int(data_el.text)
                 except ValueError:
                     logger.info('PM value (%s) of counter %s not integer',
-                                 data_el.text, counter)
+                                data_el.text, counter)
                     continue
             elif data_el.tag == 'CV':
                 # Check whether we want just one subcounter, or sum them all
@@ -220,7 +220,7 @@ class StatsManager:
                         index = index + 1
 
                 if subcounter is not None and subcounter_index is None:
-                    logger.info('PM subcounter (%s) not found', subcounter)
+                    logger.warning('PM subcounter (%s) not found', subcounter)
                     continue
 
                 # Data is multiple sub-elements. Sum them, or select the one
@@ -234,12 +234,12 @@ class StatsManager:
                             value = value + int(sub_data_el.text)
                         index = index + 1
                 except ValueError:
-                    logger.info('PM value (%s) of counter %s not integer',
+                    logger.error('PM value (%s) of counter %s not integer',
                                  sub_data_el.text, pm_name)
                     continue
             else:
-                logger.info('Unknown PM data type (%s) of counter %s',
-                             data_el.tag, pm_name)
+                logger.warning('Unknown PM data type (%s) of counter %s',
+                               data_el.tag, pm_name)
                 continue
 
             # Apply new value to metric
@@ -339,7 +339,7 @@ class StatsManager:
         """
         Clear statistics. Called when eNodeB management plane disconnects
         """
-        logger.info('Clearing statistics')
+        logger.info('Clearing performance counter statistics')
         # Set all metrics to 0 if eNodeB not connected
         for metric in self.PM_FILE_TO_METRIC_MAP.values():
             metric.set(0)

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -13,7 +13,6 @@ from xml.etree import ElementTree
 from aiohttp import web
 from magma.common.misc_utils import get_ip_from_if
 from magma.configuration.service_configs import load_service_config
-from magma.enodebd.data_models.data_model_parameters import ParameterName
 from magma.enodebd.enodeb_status import get_enb_status, \
     update_status_metrics
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
@@ -112,16 +111,12 @@ class StatsManager:
             self._check_rf_tx_for_handler(handler)
 
     def _check_rf_tx_for_handler(self, handler: EnodebAcsStateMachine) -> None:
-        if handler.device_cfg.has_parameter(ParameterName.RF_TX_STATUS):
-            rf_tx = handler \
-                .device_cfg \
-                .get_parameter(ParameterName.RF_TX_STATUS)
-            if self._prev_rf_tx is True and rf_tx is False:
-                self._clear_stats()
-            self._prev_rf_tx = rf_tx
+        status = get_enb_status(handler)
+        if not status.rf_tx_on:
+            self._clear_stats()
+        self._prev_rf_tx = status.rf_tx_on
 
         # Update status metrics
-        status = get_enb_status(handler)
         update_status_metrics(status)
 
     @asyncio.coroutine

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -37,17 +37,22 @@ class StatsManagerTest(TestCase):
 
     def test_check_rf_tx(self):
         """ Check that stats are cleared when transmit is disabled on eNB """
-        handler = EnodebAcsStateMachineBuilder\
+        handler = EnodebAcsStateMachineBuilder \
             .build_acs_state_machine(EnodebDeviceName.BAICELLS)
-        handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, True)
-        handler.device_cfg.set_parameter(ParameterName.SERIAL_NUMBER, '123454')
-        with mock.patch('magma.enodebd.stats_manager.StatsManager'
-                        '._clear_stats') as func:
-            self.mgr._check_rf_tx_for_handler(handler)
-            func.assert_not_called()
-            handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, False)
-            self.mgr._check_rf_tx_for_handler(handler)
-            func.assert_any_call()
+        with mock.patch(
+                'magma.enodebd.devices.baicells.BaicellsHandler.is_enodeb_connected',
+                return_value=True):
+            handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS, True)
+            handler.device_cfg.set_parameter(ParameterName.SERIAL_NUMBER,
+                                             '123454')
+            with mock.patch('magma.enodebd.stats_manager.StatsManager'
+                            '._clear_stats') as func:
+                self.mgr._check_rf_tx_for_handler(handler)
+                func.assert_not_called()
+                handler.device_cfg.set_parameter(ParameterName.RF_TX_STATUS,
+                                                 False)
+                self.mgr._check_rf_tx_for_handler(handler)
+                func.assert_any_call()
 
     def test_parse_stats(self):
         """ Test that example statistics from eNodeB can be parsed, and metrics

--- a/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
+++ b/orc8r/cloud/go/pluginimpl/models/swagger.v1.yml
@@ -1314,6 +1314,7 @@ definitions:
           type: string
         example:
           mme: '/var/log/mme.log'
+          enodebd: '/var/log/enodebd.log'
           otherlog: '/var/log/otherlog.log'
       throttle_rate:
         type: integer


### PR DESCRIPTION
Summary:
- When disconnecting, there's cases when the status and stats metrics aren't cleared properly due to the `rf_tx_on` setting not updated properly, which caused an issue of some enodeb reported metrics getting into  a stuck state
- This diffs add `enodeb_connected` check on enodeb status to update and clear metrics in case the enodeb is disconnected
- Updates `test_check_rf_tx` as stats will be cleared once the enodeb is disconnected and RF tx on is false.

Differential Revision: D21753465

