### PR TITLE
Test Session IDLE timer feature

### DIFF
--- a/cwf/gateway/integ_tests/container_utils.go
+++ b/cwf/gateway/integ_tests/container_utils.go
@@ -1,16 +1,105 @@
 package integration
 
 import (
+	"archive/tar"
+	"bufio"
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	dockerTypes "github.com/docker/docker/api/types"
 	dockerFilters "github.com/docker/docker/api/types/filters"
 	dockerClient "github.com/docker/docker/client"
+	"github.com/stretchr/testify/assert"
 )
+
+const (
+	configDir       string = "/var/opt/magma/configs/"
+	mconfigFileName string = "gateway.mconfig"
+)
+
+//RestartService adds ability to restart a particular service managed by docker
+func (tr *TestRunner) RestartService(serviceName string) error {
+	fmt.Printf("Restarting docker container: %v\n", serviceName)
+	ctx := context.Background()
+	cli, containerID, err := tr.getDockerClientAndContainerID(serviceName)
+	if err != nil {
+		return err
+	}
+	timeout := 30 * time.Second
+	err = cli.ContainerRestart(ctx, containerID, &timeout)
+	return err
+}
+
+//StopService adds ability to stop a particular service managed by docker
+func (tr *TestRunner) PauseService(serviceName string) error {
+	fmt.Printf("Pausing docker container: %v\n", serviceName)
+	ctx := context.Background()
+	cli, containerID, err := tr.getDockerClientAndContainerID(serviceName)
+	if err != nil {
+		return err
+	}
+	err = cli.ContainerPause(ctx, containerID)
+	return err
+}
+
+// OverwriteMConfig adds ability to overwrite the mconfig file with a specified
+// file
+func (tr *TestRunner) OverwriteMConfig(mconfigPath string, serviceName string) error {
+	fmt.Printf("Overwriting mconfig for %v with %v\n", serviceName, mconfigPath)
+	ctx := context.Background()
+	cli, containerID, err := tr.getDockerClientAndContainerID(serviceName)
+	if err != nil {
+		return err
+	}
+
+	archive, err := tr.tarArchiveFromPath(mconfigPath, mconfigFileName)
+	if err != nil {
+		return err
+	}
+
+	copyOptions := dockerTypes.CopyToContainerOptions{AllowOverwriteDirWithFile: true}
+	err = cli.CopyToContainer(ctx, containerID, configDir, archive, copyOptions)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+//ScanContainerLogs provides ability to scan the container logs for a string
+func (tr *TestRunner) ScanContainerLogs(serviceName string, line string) int {
+	ctx := context.Background()
+	cli, containerID, err := tr.getDockerClientAndContainerID(serviceName)
+	if err != nil {
+		return 0
+	}
+	reader, _ := cli.ContainerLogs(ctx, containerID, dockerTypes.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
+	defer reader.Close()
+
+	b, _ := ioutil.ReadAll(reader)
+	content := string(b)
+	return strings.Count(content, line)
+}
+
+func (tr *TestRunner) getDockerClientAndContainerID(serviceName string) (*dockerClient.Client, string, error) {
+	cli, err := dockerClient.NewEnvClient()
+	if err != nil {
+		fmt.Printf("error %v getting a new client \n", err)
+		return nil, "", err
+	}
+	containerID, err := tr.findContainer(cli, serviceName)
+	if err != nil {
+		fmt.Printf("error %v getting container id \n", err)
+		return nil, "", err
+	}
+	return cli, containerID, nil
+}
 
 func (tr *TestRunner) findContainer(cli *dockerClient.Client, serviceName string) (string, error) {
 	filter := dockerFilters.NewArgs()
@@ -26,60 +115,40 @@ func (tr *TestRunner) findContainer(cli *dockerClient.Client, serviceName string
 	return containers[0].ID, nil
 }
 
-//RestartService adds ability to restart a particular service managed by docker
-func (tr *TestRunner) RestartService(serviceName string) error {
-	fmt.Printf("Restarting docker container: %v\n", serviceName)
-	ctx := context.Background()
-	cli, err := dockerClient.NewEnvClient()
-	if err != nil {
-		fmt.Printf("error %v getting a new client \n", err)
-		return err
-	}
-	containerID, err := tr.findContainer(cli, serviceName)
-	if err != nil {
-		fmt.Printf("error %v getting container id \n", err)
-		return err
-	}
-	timeout := 30 * time.Second
-	err = cli.ContainerRestart(ctx, containerID, &timeout)
-	return err
-}
+// path : path to the file to tar archive
+// filename : the desired file name
+func (tr *TestRunner) tarArchiveFromPath(path string, filename string) (io.Reader, error) {
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
 
-//StopService adds ability to stop a particular service managed by docker
-func (tr *TestRunner) PauseService(serviceName string) error {
-	fmt.Printf("Pausing docker container: %v\n", serviceName)
-	ctx := context.Background()
-	cli, err := dockerClient.NewEnvClient()
-	if err != nil {
-		fmt.Printf("error %v getting a new client \n", err)
-		return err
-	}
-	containerID, err := tr.findContainer(cli, serviceName)
-	if err != nil {
-		fmt.Printf("error %v getting container id \n", err)
-		return err
-	}
-	err = cli.ContainerPause(ctx, containerID)
-	return err
-}
+	ok := filepath.Walk(path, func(file string, fi os.FileInfo, err error) error {
+		assert.NoError(tr.t, err)
 
-//ScanContainerLogs provides ability to scan the container logs for a string
-func (tr *TestRunner) ScanContainerLogs(serviceName string, line string) int {
-	ctx := context.Background()
-	cli, err := dockerClient.NewEnvClient()
-	if err != nil {
-		fmt.Printf("error %v getting a new client \n", err)
-		return 0
-	}
-	containerID, err := tr.findContainer(cli, serviceName)
-	if err != nil {
-		fmt.Printf("error %v getting container id \n", err)
-		return 0
-	}
-	reader, _ := cli.ContainerLogs(ctx, containerID, dockerTypes.ContainerLogsOptions{ShowStdout: true, ShowStderr: true})
-	defer reader.Close()
+		// Create header & overwrite the Name field with desired filename
+		header, err := tar.FileInfoHeader(fi, filename)
+		assert.NoError(tr.t, err)
+		header.Name = filename
+		err = tw.WriteHeader(header)
+		assert.NoError(tr.t, err)
 
-	b, _ := ioutil.ReadAll(reader)
-	content := string(b)
-	return strings.Count(content, line)
+		f, err := os.Open(file)
+		assert.NoError(tr.t, err)
+		if fi.IsDir() {
+			return nil
+		}
+		_, err = io.Copy(tw, f)
+		assert.NoError(tr.t, err)
+		assert.NoError(tr.t, f.Close())
+
+		return nil
+	})
+
+	if ok != nil {
+		return nil, ok
+	}
+	ok = tw.Close()
+	if ok != nil {
+		return nil, ok
+	}
+	return bufio.NewReader(&buf), nil
 }

--- a/cwf/gateway/integ_tests/gateway.mconfig.idle_timer
+++ b/cwf/gateway/integ_tests/gateway.mconfig.idle_timer
@@ -1,0 +1,171 @@
+{
+ "configsByKey": {
+  "hss": {
+   "@type": "type.googleapis.com/magma.mconfig.HSSConfig",
+   "server": {
+    "protocol": "sctp",
+    "address": "localhost:3868",
+    "localAddress": "localhost:3869",
+    "destHost": "hw-hss.epc.mnc001.mcc01.3gppnetwork.org",
+    "destRealm": "epc.mnc001.mcc01.3gppnetwork.org"
+   },
+   "lteAuthOp": "EREREREREREREREREREREQ==",
+   "lteAuthAmf": "Z0E=",
+   "subProfiles": {
+    "additionalProp1": {
+     "maxUlBitRate": "100000000",
+     "maxDlBitRate": "200000000"
+    },
+    "additionalProp2": {
+     "maxUlBitRate": "100000000",
+     "maxDlBitRate": "200000000"
+    },
+    "additionalProp3": {
+     "maxUlBitRate": "100000000",
+     "maxDlBitRate": "200000000"
+    }
+   },
+   "defaultSubProfile": {
+    "maxUlBitRate": "100000000",
+    "maxDlBitRate": "200000000"
+   }
+  },
+  "swx_proxy": {
+   "@type": "type.googleapis.com/magma.mconfig.SwxConfig",
+   "logLevel": "INFO",
+   "servers": [
+      {
+      "protocol": "sctp",
+      "address": "localhost:3868",
+      "retransmits": 0,
+      "watchdogInterval": 0,
+      "retryCount": 0,
+      "localAddress": "localhost:3869",
+      "productName": "magma",
+      "realm": "epc.mnc001.mcc01.3gppnetwork.org",
+      "host": "swx-mgm1.epc.mnc001.mcc01.3gppnetwork.org",
+      "destRealm": "epc.mnc001.mcc01.3gppnetwork.org",
+      "destHost": "hw-hss.epc.mnc001.mcc01.3gppnetwork.org"
+      }
+    ],
+
+   "verifyAuthorization": false
+  },
+  "sessiond": {
+   "@type": "type.googleapis.com/magma.mconfig.SessionD",
+   "logLevel": "INFO",
+   "relayEnabled": true
+  },
+  "aaa_server": {
+   "@type": "type.googleapis.com/magma.mconfig.AAAConfig",
+   "logLevel": "INFO",
+   "IdleSessionTimeoutMs": 3000,
+   "CreateSessionOnAuth": true,
+   "AccountingEnabled": true
+  },
+  "control_proxy": {
+   "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
+   "logLevel": "INFO"
+  },
+  "directoryd": {
+   "@type": "type.googleapis.com/magma.mconfig.DirectoryD",
+   "logLevel": "INFO"
+  },
+  "eap_aka": {
+   "@type": "type.googleapis.com/magma.mconfig.EapAkaConfig",
+   "logLevel": "INFO",
+   "timeout": {
+    "ChallengeMs": 20000,
+    "ErrorNotificationMs": 10000,
+    "SessionMs": 43200000,
+    "SessionAuthenticatedMs": 5000
+   }
+  },
+  "magmad": {
+   "@type": "type.googleapis.com/magma.mconfig.MagmaD",
+   "logLevel": "INFO",
+   "checkinInterval": 60,
+   "checkinTimeout": 10,
+   "autoupgradeEnabled": true,
+   "autoupgradePollInterval": 300,
+   "packageVersion": "0.0.0-0",
+   "images": [
+   ],
+   "tierId": "default",
+   "featureFlags": {
+    "newfeature1": true,
+    "newfeature2": false
+   },
+   "dynamicServices": [
+   ]
+  },
+  "metricsd": {
+   "@type": "type.googleapis.com/magma.mconfig.MetricsD",
+   "logLevel": "INFO"
+  },
+  "pipelined": {
+   "@type": "type.googleapis.com/magma.mconfig.PipelineD",
+   "logLevel": "INFO",
+   "ueIpBlock": "192.168.128.0/24",
+   "natEnabled": true,
+   "defaultRuleId": "default_rule_1",
+   "relayEnabled": true,
+   "services": [
+      "ENFORCEMENT"
+   ],
+   "allowedGrePeers": [
+    {"ip": "192.168.70.102"}
+   ]
+  },
+  "state": {
+   "@type": "type.googleapis.com/magma.mconfig.State",
+   "logLevel": "INFO"
+  },
+  "session_proxy": {
+   "@type": "type.googleapis.com/magma.mconfig.SessionProxyConfig",
+   "logLevel": "INFO",
+   "gx": {
+    "servers": [
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50003",
+       "retransmits": 0,
+       "watchdogInterval": 30,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50004",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "pcrf.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
+      }
+    ]
+   },
+   "gy": {
+    "servers": [
+      {
+       "protocol": "tcp",
+       "address": "127.0.0.1:50001",
+       "retransmits": 0,
+       "watchdogInterval": 30,
+       "retryCount": 0,
+       "localAddress": "127.0.0.1:50002",
+       "productName": "magma",
+       "realm": "magma.svc.cluster.local",
+       "host": "feg.magma.svc.cluster.local",
+       "destRealm": "epc.mnc001.mcc001.3gppnetwork.org",
+       "destHost": "sdp1c.epc.mnc001.mcc001.3gppnetwork.org",
+       "disableDestHost": false
+      }
+    ],
+    "initMethod": "PER_KEY"
+   },
+   "requestFailureThreshold": 0.5,
+   "minimumRequestThreshold": 1
+  }
+ },
+ "metadata": {
+  "createdAt": "1561709117"
+ }
+}

--- a/cwf/gateway/integ_tests/idle_timer_test.go
+++ b/cwf/gateway/integ_tests/idle_timer_test.go
@@ -1,0 +1,81 @@
+// +build all
+
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package integration
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"magma/feg/cloud/go/protos"
+
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/stretchr/testify/assert"
+)
+
+// - Set an expectation for a CCR-I to be sent up to PCRF, to which it will
+//   respond with a rule install for a pass-all dynamic rule and 250KB of
+//   quota.
+//   Trigger a authentication and assert the CCR-I is received.
+//   Wait for the Idle Timer to kick off and trigger a disconnect
+//   The Idle Timer length is set in AAA_service's mconfig
+func TestIdleTimer(t *testing.T) {
+	fmt.Println("\nRunning TestIdleTimer...")
+	tr := NewTestRunner(t)
+	assert.NoError(t, usePCRFMockDriver())
+	// Overwrite the mconfig to have a shorter idle timer length
+	err := tr.OverwriteMConfig("./gateway.mconfig.idle_timer", "aaa_server")
+	assert.NoError(t, err)
+	assert.NoError(t, tr.RestartService("aaa_server"))
+	// give it a second after the restart...
+	time.Sleep(1 * time.Second)
+	defer func() {
+		err = tr.OverwriteMConfig("gateway.mconfig", "aaa_server")
+		assert.NoError(t, err)
+		assert.NoError(t, tr.RestartService("aaa_server"))
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearPCRFMockDriver())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
+	ues, err := tr.ConfigUEs(1)
+	assert.NoError(t, err)
+
+	imsi := ues[0].GetImsi()
+	usageMonitorInfo := getUsageInformation("mkey1", 250*KiloBytes)
+
+	initRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_INITIAL)
+	initAnswer := protos.NewGxCCAnswer(diam.Success).
+		SetDynamicRuleInstall(getPassAllRuleDefinition("dynamic-pass-all", "mkey1", nil, 100)).
+		SetUsageMonitorInfo(usageMonitorInfo)
+	initExpectation := protos.NewGxCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+	// return success with credit on unexpected requests
+	defaultAnswer := protos.NewGxCCAnswer(2001).SetUsageMonitorInfo(usageMonitorInfo)
+	assert.NoError(t, setPCRFExpectations([]*protos.GxCreditControlExpectation{initExpectation}, defaultAnswer))
+
+	tr.AuthenticateAndAssertSuccess(imsi)
+
+	tr.AssertAllGxExpectationsMetNoError()
+
+	// If there is no activity for > Idle Timer, AAA service will send a
+	// terminate request
+	terminateRequest := protos.NewGxCCRequest(imsi, protos.CCRequestType_TERMINATION)
+	terminateAnswer := protos.NewGxCCAnswer(diam.Success)
+	terminateExpectation := protos.NewGxCreditControlExpectation().Expect(terminateRequest).Return(terminateAnswer)
+	expectations := []*protos.GxCreditControlExpectation{terminateExpectation}
+	assert.NoError(t, setPCRFExpectations(expectations, nil))
+
+	// Wait for Session Idle Timer to kick off + Wait for Termination to go through
+	// Idle Timer = 3 + Session forced termination timeout = 3 + some buffer
+	time.Sleep(8 * time.Second)
+
+	tr.AssertAllGxExpectationsMetNoError()
+}


### PR DESCRIPTION
Summary:
There's a gateway configuration for the AAA service that kicks off a session that has been idle for >configured amount of time.

Since the default value for idle timer is big, I'm swapping in a smaller value for this test by overwriting the default mconfig. (The value is big by default because we don't want this feature interfering with the other tests)

Also some light refactor to the fabfile to use helper functions `_switch_to_vm` & `_switch_to_vm_no_destroy`

Reviewed By: uri200

Differential Revision: D21557933

