### PR TITLE
Refactor gateway secrets subchart

### DIFF
--- a/cwf/gateway/helm/cwf/charts/secrets/Chart.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create magma cwf gateway secrets
 name: secrets
-version: 0.1.1
+version: 0.1.2
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/cwf/gateway/helm/cwf/charts/secrets/README.md
+++ b/cwf/gateway/helm/cwf/charts/secrets/README.md
@@ -7,28 +7,27 @@ with the same hwid and challenge key.
 ## TL;DR;
 
 ```bash
-# Copy secrets into subchart root
-$ mkdir charts/secrets/.secrets/gwinfo && \
-    cp -r <secrets>/* charts/secrets/.secrets/gwinfo/
-$ ls charts/secrets/.secrets/gwinfo/
+# Copy gw_challenge and snowflake into temp dir
+    cp -r <secrets>/* ../temp/
+$ ls ../temp/
 snowflake gw_challenge.key
 
 # Apply secrets
 helm template charts/secrets \
     --name <cwf release name> \
+    --set-file secrets.gwinfo.gw_challenge.key=../temp/gw_challenge.key \
+    --set-file secrets.gwinfo.gw_challenge.key=../temp/gw_challenge.key \
+    --set-file secrets.dpi_license.license_file.cwf01.bin=../temp/dpi_cwftest.bin \
     --namespace magma | kubectl -n magma apply -f -
 ```
 
 ## Overview
 
 This chart installs a secret that serves as identifiers for the gateway. 
-The secrets are expected to be provided as files and placed under
-secrets subchart root.
+The secrets are expected to be provided as files and placed in temp dir.
 ```bash
-$ ls charts/secrets/.secrets/gwinfo/
+$ ls temp/
 snowflake  gw_challenge.key
-$ pwd
-magma/cwf/gateway/helm/cwf
 ```
 
 ## Creating Gateway Info
@@ -61,3 +60,7 @@ docker credentials and their default values.
 | ---              | ---             | ---       |
 | `create` | Set to ``true`` to create cwf secrets. | `false` |
 | `secret.gwinfo` | Root relative secrets directory. | `.secrets` |
+| `secret.enabled` | Enable gwinfo secrets. | `false` |
+| `secret.gwinfo.gw_challenge.key` | gw_challenge.key file | `""` |
+| `secret.gwinfo.snowflake` | snowflake file. | `""` |
+| `secret.dpi_license.license_file.cwf01_test.bin` | dpi license file for cwf01. | `""` |

--- a/cwf/gateway/helm/cwf/charts/secrets/templates/dpi_license.secret.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/templates/dpi_license.secret.yaml
@@ -14,5 +14,9 @@ metadata:
   labels:
 {{ tuple . "cwf" "gateway" | include "labels" | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.dpi_license "/*")).AsSecrets | nindent 2 }}
+{{- if .Values.secret.dpi_license }}
+{{- range $key, $value := .Values.secret.dpi_license.license_file }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/cwf/gateway/helm/cwf/charts/secrets/templates/gwinfo.secret.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/templates/gwinfo.secret.yaml
@@ -14,5 +14,9 @@ metadata:
   labels:
 {{ tuple . "cwf" "gateway" | include "labels" | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.gwinfo "/*")).AsSecrets | nindent 2 }}
+{{- if .Values.secret.enabled }}
+{{- range $key, $value := .Values.secret.gwinfo }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/cwf/gateway/helm/cwf/charts/secrets/values.yaml
+++ b/cwf/gateway/helm/cwf/charts/secrets/values.yaml
@@ -10,7 +10,19 @@ create: true
 
 # Define which secrets should be mounted by pods.
 secret:
-  # directory holding gateway's hwid (snowflake) and challenge key
-  gwinfo: .secrets/gwinfo
-  # directory holding gateway's DPI license file
-  dpi_license: .secrets/dpi
+  enabled: true
+  # Variable holding gateway's hwid (snowflake) and challenge key
+  gwinfo:
+  # gw_challenge.key: |-
+  #     ....
+  #     ....
+  # snowflake: |-
+  #     ....
+  #     ....
+
+  # Variable holding gateway's DPI license file
+  #dpi_license:
+  #  license_file:
+  #    key: |-
+  #      ....
+  #      ....

--- a/cwf/gateway/helm/cwf/requirements.yaml
+++ b/cwf/gateway/helm/cwf/requirements.yaml
@@ -7,6 +7,6 @@
 
 dependencies:
   - name: secrets
-    version: 0.1.1
+    version: 0.1.2
     repository: ""
     condition: secrets.create

--- a/feg/gateway/helm/feg/charts/secrets/Chart.yaml
+++ b/feg/gateway/helm/feg/charts/secrets/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create magma feg gateway secrets
 name: secrets
-version: 0.1.0
+version: 0.1.1
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/feg/gateway/helm/feg/charts/secrets/README.md
+++ b/feg/gateway/helm/feg/charts/secrets/README.md
@@ -7,28 +7,26 @@ recreated with the same hwid and challenge key.
 ## TL;DR;
 
 ```bash
-# Copy secrets into subchart root
-$ mkdir charts/secrets/.secrets && \
-    cp -r <secrets>/* charts/secrets/.secrets/
-$ ls charts/secrets/.secrets
+# Copy gw_challenge and snowflake into temp dir
+    cp -r <secrets>/* ../temp/
+$ ls temp/
 snowflake gw_challenge.key
 
 # Apply secrets
 helm template charts/secrets \
     --name <feg release name> \
+    --set-file secrets.gwinfo.gw_challenge.key=../temp/gw_challenge.key \
+    --set-file secrets.gwinfo.snowflake=../temp/snowflake \
     --namespace magma | kubectl -n magma apply -f -
 ```
 
 ## Overview
 
 This chart installs a secret that serves as identifiers for the gateway. 
-The secrets are expected to be provided as files and placed under
-secrets subchart root.
+The secrets are expected to be provided as files and placed in temp dir.
 ```bash
-$ ls charts/secrets/.secrets
+$ ls temp/
 snowflake  gw_challenge.key
-$ pwd
-magma/feg/gateway/helm/feg
 ```
 
 ## Creating Gateway Info
@@ -60,4 +58,6 @@ their default values.
 | Parameter        | Description     | Default   |
 | ---              | ---             | ---       |
 | `create` | Set to ``true`` to create feg secrets. | `false` |
-| `secret.gwinfo` | Root relative secrets directory. | `.secrets` |
+| `secret.enabled` | Enable gwinfo secrets. | `false` |
+| `secret.gwinfo.gw_challenge.key` | gw_challenge.key file | `""` |
+| `secret.gwinfo.snowflake` | snowflake file. | `""` |

--- a/feg/gateway/helm/feg/charts/secrets/templates/gwinfo.secret.yaml
+++ b/feg/gateway/helm/feg/charts/secrets/templates/gwinfo.secret.yaml
@@ -14,5 +14,9 @@ metadata:
   labels:
 {{ tuple . "feg" "gateway" | include "labels" | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.gwinfo "/*")).AsSecrets | nindent 2 }}
+{{- if .Values.secret.enabled }}
+{{- range $key, $value := .Values.secret.gwinfo }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/feg/gateway/helm/feg/charts/secrets/values.yaml
+++ b/feg/gateway/helm/feg/charts/secrets/values.yaml
@@ -10,8 +10,12 @@ create: true
 
 # Define which secrets should be mounted by pods.
 secret:
-   # directory holding orc8r cert secrets (needed to get rootCA.pem)
-  certs: orc8r-secrets-certs
-  # directory holding gateway's hwid (snowflake) and challenge key
-  gwinfo: .secrets
-
+  enabled: false
+  # variable holding gateway's hwid (snowflake) and challenge key
+  gwinfo:
+  # gw_challenge.key: |-
+  #     ....
+  #     ....
+  # snowflake: |-
+  #     ....
+  #     ....

--- a/feg/gateway/helm/feg/requirements.yaml
+++ b/feg/gateway/helm/feg/requirements.yaml
@@ -7,6 +7,6 @@
 
 dependencies:
   - name: secrets
-    version: 0.1.0
+    version: 0.1.1
     repository: ""
     condition: secrets.create


### PR DESCRIPTION
In this Diff we refactor the secret subchart to follow best practice like

1. load certs from ourside helm chart directory

   ```bash
	example: helm install --name cwf01 --namespace magma -f global-vals.yaml \
                 --set-file secrets.gwinfo.snowflake=/path/to/file/snowflake

   ```

2. having option to load secrets or files from override values.

   ```bash
	secret:
          enabled: false
            # variable holding gateway's hwid (snowflake) and challenge key
          gwinfo:
            snowflake: |-
              f3bc383a95db16f2e448fdf67cac133a5f9019375720b59477
   ```
3. encrypting vals file with secrets if needed.

Signed-off-by: reddydodda <reddydodda@gmail.com>