### PR TITLE
Refactor orc8r secrets subchart

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.28
+version: 1.4.29
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create magma orchestrator secrets
 name: secrets
-version: 0.1.3
+version: 0.1.4
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/secrets/README.md
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/README.md
@@ -5,14 +5,21 @@ Orchestrator Secrets is used to apply a set of secrets required by magma orchest
 ## TL;DR;
 
 ```bash
-# Copy secrets into subchart root
-$ mkdir charts/secrets/.secrets && \
-    cp -r <secrets>/* charts/secrets/.secrets/
+# Copy secrets into temp directory
+$ mkdir ../secretstemp && \
+    cp -r <secrets>/* ../secretstemp/
 
 # Apply secrets
 helm template charts/secrets \
     --name orc8r-secrets \
     --namespace magma \
+    --set-file secret.cert.files.rootCA.pem=../secretstemp/rootCA.pem \
+    --set-file secret.cert.files.controller.crt=../secretstemp/controller.crt \
+    --set-file secret.cert.files.controller.key=../secretstemp/controller.key \
+    --set-file secret.cert.files.admin_operator.pem=../secretstemp/admin_operator.pem \
+    --set-file secret.cert.files.admin_operator.key.pem=../secretstemp/admin_operator.key.pem \
+    --set-file secret.cert.files.fluentd.pem=../secretstemp/fluentd.pem \
+    --set-file secret.cert.files.fluentd.key=../secretstemp/fluentd.key \
     --set=docker.registry=docker.io \
     --set=docker.username=username \
     --set=docker.password=password |
@@ -22,13 +29,12 @@ kubectl apply -f -
 ## Overview
 
 This chart installs a set to secrets required by magma orchestrator.
-The secrets are expected to be provided as files and placed under
-secrets subchart root.
+The secrets are expected to be provided as files and placed under temp Directory
+
 ```bash
-$ ls charts/secrets/.secrets
-certs  configs envdir
-$ pwd
-magma/orc8r/cloud/helm/orc8r
+$ ls ../secretstemp
+rootCA.pem controller.crt controller.key admin_operator.pem admin_operator.key.pem fluentd.pem fluentd.key
+
 ```
 ## Image Pull Secret
 
@@ -43,9 +49,11 @@ docker credentials and their default values.
 | Parameter        | Description     | Default   |
 | ---              | ---             | ---       |
 | `create` | Set to ``true`` to create orc8r secrets. | `false` |
-| `secret.certs` | Root relative certs directory. | `.secrets/certs` |
-| `secret.configs` | Root relative configs directory. | `.secrets/configs` |
-| `secret.envdir` | Root relative envdir directory. | `.secrets/envdir` |
+| `secret.certs.enabled` | Enable certs. | `false` |
+| `secret.certs.files.controller.crt` | controller pem file. | `""` |
+| `secret.certs.files.controller.key` | controller key file. | `""` |
+| `secret.certs.files.rootCA.pem` | rootCA.pem file. | `""` |
+| `secret.configs.enabled` | Enable configs. | `false` |
 | `docker.registry` | Docker registry. | `""` |
 | `docker.username` | Docker registry username. | `""` |
 | `docker.password` | Docker registry password. | `""` |

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/certs.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/certs.secret.yaml
@@ -14,5 +14,9 @@ metadata:
   labels:
 {{ include "labels" . | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.certs "/*")).AsSecrets | nindent 2 }}
+{{- if .Values.secret.certs.enabled }}
+{{- range $key, $value := .Values.secret.certs.files }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-cwf.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-cwf.secret.yaml
@@ -16,5 +16,9 @@ metadata:
   labels:
 {{ include "labels" . | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.configs "/cwf/*.yml")).AsSecrets | nindent 2}}
+{{- if .Values.secret.configs.enabled }}
+{{- range $key, $value := .Values.secret.configs.cwf }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
@@ -16,5 +16,9 @@ metadata:
   labels:
 {{ include "labels" . | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.configs "/orc8r/*.yml")).AsSecrets | nindent 2 }}
+{{- if .Values.secret.configs.enabled }}
+{{- range $key, $value := .Values.secret.configs.orc8r }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/envdir.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/envdir.secret.yaml
@@ -14,5 +14,9 @@ metadata:
   labels:
 {{ include "labels" . | indent 4 }}
 data:
-{{- (.Files.Glob (print .Values.secret.envdir "/*")).AsSecrets | nindent 2 }}
+{{- if .Values.secret.envdir }}
+{{- range $key, $value := .Values.secret.envdir }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -46,7 +46,7 @@ secret:
   configs:
     enabled: true
     orc8r:
-      metricsd: |-
+      metricsd.yml: |-
         profile: "prometheus"
 
         prometheusQueryAddress: "http://orc8r-prometheus:9090"

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -10,12 +10,59 @@ create: true
 
 # orc8r secret configuration
 secret:
-  # base directory holding cert secrets
-  certs: .secrets/certs
+  certs:
+    enabled: false
+  # files:
+  #   #Controller Crt
+  #   controller.crt: |-
+  #     ...
+  #     ...
+  #   #Controller Key
+  #   controller.key: |-
+  #     ...
+  #     ...
+  #   #rootCA
+  #   rootca: |-
+  #     ...
+  #     ...
+  #   #NMS Operator Crt
+  #   admin_operator.pem: |-
+  #     ...
+  #     ...
+  #   #NMS Operator Key
+  #   admin_operator.key.pem: |-
+  #     ...
+  #     ...
+  #   #Fluentd Crt
+  #   fluentd.pem: |-
+  #     ...
+  #     ...
+  #   #Fluentd Key
+  #   fluentd.key: |-
+  #     ...
+  #     ...
+
   # base directory holding config secrets.
-  configs: .secrets/configs
-  # base directory holding envdir secrets.
-  envdir: .secrets/envdir
+  configs:
+    enabled: false
+  # orc8r:
+  #   metricsd: |-
+  #     profile: "prometheus"
+  #
+  #     prometheusQueryAddress: "http://orc8r-prometheus:9090"
+  #     prometheusPushAddresses:
+  #       - "http://orc8r-prometheus-cache:9091/metrics"
+  #
+  #     alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2/alerts"
+  #     prometheusConfigServiceURL: "http://orc8r-config-manager:9100"
+  #     alertmanagerConfigServiceURL: "http://orc8r-config-manager:9101"
+  #
+  # cwf:
+  #   key: value
+
+# base directory holding envdir secrets.
+# envdir:
+#   key: value
 
 # private docker registry credentials
 docker:

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -44,19 +44,19 @@ secret:
 
   # base directory holding config secrets.
   configs:
-    enabled: false
-  # orc8r:
-  #   metricsd: |-
-  #     profile: "prometheus"
-  #
-  #     prometheusQueryAddress: "http://orc8r-prometheus:9090"
-  #     prometheusPushAddresses:
-  #       - "http://orc8r-prometheus-cache:9091/metrics"
-  #
-  #     alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2/alerts"
-  #     prometheusConfigServiceURL: "http://orc8r-config-manager:9100"
-  #     alertmanagerConfigServiceURL: "http://orc8r-config-manager:9101"
-  #
+    enabled: true
+    orc8r:
+      metricsd: |-
+        profile: "prometheus"
+
+        prometheusQueryAddress: "http://orc8r-prometheus:9090"
+        prometheusPushAddresses:
+          - "http://orc8r-prometheus-cache:9091/metrics"
+
+        alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2/alerts"
+        prometheusConfigServiceURL: "http://orc8r-config-manager:9100"
+        alertmanagerConfigServiceURL: "http://orc8r-config-manager:9101"
+
   # cwf:
   #   key: value
 

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: secrets
   repository: ""
-  version: 0.1.3
+  version: 0.1.4
 - name: metrics
   repository: ""
   version: 1.4.13

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -7,7 +7,7 @@
 
 dependencies:
   - name: secrets
-    version: 0.1.3
+    version: 0.1.4
     repository: ""
     condition: secrets.create
   - name: metrics


### PR DESCRIPTION
In this Diff we refactor the secret subchart to follow best practice like

1. load certs from ourside helm chart directory

  ```
      example: helm template charts/secrets \
                --name orc8r-secrets \
                --namespace magma \
                --set-file secret.cert.files.rootCA.pem=../secretstemp/rootCA.pem \
                --set-file secret.cert.files.controller.crt=../secretstemp/controller.crt \
                --set-file secret.cert.files.controller.key=../secretstemp/controller.key \
                --set-file secret.cert.files.admin_operator.pem=../secretstemp/admin_operator.pem \
                --set-file secret.cert.files.admin_operator.key.pem=../secretstemp/admin_operator.key.pem \
                --set-file secret.cert.files.fluentd.pem=../secretstemp/fluentd.pem \
                --set-file secret.cert.files.fluentd.key=../secretstemp/fluentd.key \
                --set=docker.registry=docker.io \
                --set=docker.username=username \
                --set=docker.password=password |
                kubectl apply -f -

  ```

2. having option to load secrets or files from override values.

  ```
     secret:
       certs:
         enabled: false
         files:
         #Controller Crt
         controller.crt: |-
           ...
           ...
         #Controller Key
         controller.key: |-
           ...
           ...
         #rootCA
         rootca: |-
           ...
           ...

  ```
3. encrypting vals file if needed.