### PR TITLE
Fix standby session timeout bug for CWAG HA

### DIFF
--- a/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
@@ -61,8 +61,8 @@ func (d *DockerServiceHealthProvider) GetUnhealthyServices() ([]string, error) {
 	return unhealthyServices, nil
 }
 
-// Enable restarts the service provided
-func (d *DockerServiceHealthProvider) Enable(service string) error {
+// Restart restarts the service provided
+func (d *DockerServiceHealthProvider) Restart(service string) error {
 	sessiondID, err := d.getContainerID(service)
 	if err != nil {
 		return err
@@ -71,14 +71,14 @@ func (d *DockerServiceHealthProvider) Enable(service string) error {
 	return d.dockerClient.ContainerRestart(context.Background(), sessiondID, &timeout)
 }
 
-// Disable stops the service provided
-func (d *DockerServiceHealthProvider) Disable(service string) error {
-	sessiondID, err := d.getContainerID(service)
+// Stop stops the service provided
+func (d *DockerServiceHealthProvider) Stop(service string) error {
+	serviceID, err := d.getContainerID(service)
 	if err != nil {
 		return err
 	}
 	timeout := dockerRequestTimeout
-	return d.dockerClient.ContainerStop(context.Background(), sessiondID, &timeout)
+	return d.dockerClient.ContainerStop(context.Background(), serviceID, &timeout)
 }
 
 func (d *DockerServiceHealthProvider) getContainerID(serviceName string) (string, error) {

--- a/cwf/gateway/services/gateway_health/health/service_health/service_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/service_health.go
@@ -15,13 +15,9 @@ type ServiceHealth interface {
 	// unhealthy state.
 	GetUnhealthyServices() ([]string, error)
 
-	// Enable allows the enabling of service level functionality for the
-	// provided service. It is up to implementors to determine
-	// the specific functionality.
-	Enable(service string) error
+	// Restart restarts the provided service.
+	Restart(service string) error
 
-	// Disable allows the disabling of service level functionality for the
-	// provided service. It is up to implementors to determine
-	// the specific functionality.
-	Disable(service string) error
+	// Stop stops the provided service.
+	Stop(service string) error
 }

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer.go
@@ -25,6 +25,7 @@ import (
 const (
 	sessiondServiceName = "sessiond"
 	radiusServiceName   = "radius"
+	aaaServiceName      = "aaa_server"
 )
 
 type GatewayHealthServicer struct {
@@ -61,7 +62,12 @@ func (s *GatewayHealthServicer) Disable(ctx context.Context, req *protos.Disable
 		return ret, err
 	}
 	// Stop the RADIUS server so that the WLC perceives it as down.
-	err = s.serviceHealth.Disable(radiusServiceName)
+	err = s.serviceHealth.Stop(radiusServiceName)
+	if err != nil {
+		return ret, err
+	}
+	// Restart the AAA server to clear in-memory sessions
+	err = s.serviceHealth.Restart(aaaServiceName)
 	if err != nil {
 		return ret, err
 	}
@@ -77,11 +83,11 @@ func (s *GatewayHealthServicer) Enable(ctx context.Context, req *orcprotos.Void)
 	if err != nil {
 		return ret, err
 	}
-	err = s.serviceHealth.Enable(sessiondServiceName)
+	err = s.serviceHealth.Restart(sessiondServiceName)
 	if err != nil {
 		return ret, err
 	}
-	err = s.serviceHealth.Enable(radiusServiceName)
+	err = s.serviceHealth.Restart(radiusServiceName)
 	if err != nil {
 		return ret, err
 	}

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
@@ -58,8 +58,8 @@ func TestGetHealthStatus(t *testing.T) {
 
 	// Simulate successful enable
 	mockSystem.On("Enable").Return(nil)
-	mockService.On("Enable", "radius").Return(nil)
-	mockService.On("Enable", "sessiond").Return(nil)
+	mockService.On("Restart", "radius").Return(nil)
+	mockService.On("Restart", "sessiond").Return(nil)
 	mockGREProbe.On("Start").Return(nil)
 	_, err = servicer.Enable(context.Background(), req)
 	assert.NoError(t, err)
@@ -79,7 +79,8 @@ func TestGetHealthStatus(t *testing.T) {
 	// Simulate successful disable
 	disableReq := &protos.DisableMessage{}
 	mockSystem.On("Disable").Return(nil)
-	mockService.On("Disable", "radius").Return(nil)
+	mockService.On("Stop", "radius").Return(nil)
+	mockService.On("Restart", "aaa_server").Return(nil)
 	mockGREProbe.On("Stop").Return()
 	_, err = servicer.Disable(context.Background(), disableReq)
 	assert.NoError(t, err)
@@ -123,12 +124,12 @@ func (m *mockServiceHealth) GetUnhealthyServices() ([]string, error) {
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *mockServiceHealth) Enable(service string) error {
+func (m *mockServiceHealth) Restart(service string) error {
 	args := m.Called(service)
 	return args.Error(0)
 }
 
-func (m *mockServiceHealth) Disable(service string) error {
+func (m *mockServiceHealth) Stop(service string) error {
 	args := m.Called(service)
 	return args.Error(0)
 }


### PR DESCRIPTION
Summary:
When we failover gateways, the existing sessions
should be transferred to the new active. Since the AAA server
sessions on the standby aren't clear, eventually these sessions
timeout and terminate the sessiond session. Since sessiond sessions
are shared via Redis, this ultimately causes a termination of an
active session on the active gateway.

This diff fixes this behavior by restarting the AAA server on the Disable
RPC call. Restarting the AAA server will clear standby sessions will ensuring
the service is still in an idle state.

Reviewed By: koolzz

Differential Revision: D21783169

