### PR TITLE
Adding workflow endpoints for conductor events

### DIFF
--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -586,5 +586,26 @@ export default async function(
     }
   });
 
+  router.get('/event', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.get(baseApiURL + 'event/', req);
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
+  router.delete('/event/:name', async (req: ExpressRequest, res, next) => {
+    try {
+      const result = await http.delete(
+        baseApiURL + 'event/' + req.params.name,
+        req,
+      );
+      res.status(200).send(result);
+    } catch (err) {
+      next(err);
+    }
+  });
+
   return router;
 }


### PR DESCRIPTION
The workflow UI has support for working with event handlers in conductor. Workflow backend endpoints are added in order for the UI to communicate with the conductor.

A workflow which has an event handler
![wflist](https://user-images.githubusercontent.com/4011326/83274358-fccecb80-a1cd-11ea-9504-b66726a86d2d.png)
The new list of event handlers for the workflow above
![eventlist](https://user-images.githubusercontent.com/4011326/83274412-1112c880-a1ce-11ea-80dd-4877f64d4130.png)

Test plan
Manually when creating a workflow with an event handler via builder like this
![Screenshot from 2020-05-29 17-05-44](https://user-images.githubusercontent.com/4011326/83274928-bd54af00-a1ce-11ea-9647-e4c5306a3bc8.png)
