### PR TITLE
Fix small bug that leads to incorrect session store update

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -493,7 +493,7 @@ UpdateSessionRequest LocalEnforcer::collect_updates(
     for (const auto& session : session_pair.second) {
       std::string imsi     = session_pair.first;
       std::string sid      = session->get_session_id();
-      auto update_criteria = session_update[imsi][sid];
+      auto& update_criteria = session_update[imsi][sid];
       session->get_updates(request, &actions, update_criteria, force_update);
     }
   }


### PR DESCRIPTION
Summary:
it's always important to pass things by reference if they need to be updated

the update criteria variable is passed to session->get_updates to be modified. It is then used in the caller of this func.

Differential Revision: D21789760

