### PR TITLE
Small refactor remove functions of little value

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -36,14 +36,15 @@ aaa::add_sessions_request create_add_sessions_req(
       if (!session->is_radius_cwf_session()) {
         continue;
       }
+      auto config = session->get_config();
       magma::SessionState::SessionInfo session_info;
       session->get_session_info(session_info);
       ctx.set_imsi(session_info.imsi);
-      ctx.set_session_id(session->get_radius_session_id());
+      ctx.set_session_id(config.radius_session_id);
       ctx.set_acct_session_id(session->get_session_id());
-      ctx.set_mac_addr(session->get_mac_addr());
-      ctx.set_msisdn(session->get_msisdn());
-      ctx.set_apn(session->get_apn());
+      ctx.set_mac_addr(config.mac_addr);
+      ctx.set_msisdn(config.msisdn);
+      ctx.set_apn(config.apn);
       auto mutable_sessions = req.mutable_sessions();
       mutable_sessions->Add()->CopyFrom(ctx);
     }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -158,23 +158,7 @@ class SessionState {
 
   std::string get_session_id() const;
 
-  std::string get_subscriber_ip_addr() const;
-
-  std::string get_mac_addr() const;
-
-  std::string get_msisdn() const;
-
-  std::string get_hardware_addr() const { return config_.hardware_addr; }
-
-  std::string get_radius_session_id() const;
-
-  std::string get_apn() const;
-
   std::string get_core_session_id() const { return core_session_id_; };
-
-  uint32_t get_bearer_id() const;
-
-  uint32_t get_qci() const;
 
   SubscriberQuotaUpdate_Type get_subscriber_quota_state() const;
 
@@ -183,8 +167,6 @@ class SessionState {
   bool is_same_config(const SessionConfig& new_config) const;
 
   void get_session_info(SessionState::SessionInfo& info);
-
-  bool qos_enabled() const;
 
   void set_tgpp_context(
       const magma::lte::TgppContext& tgpp_context,
@@ -325,9 +307,11 @@ class SessionState {
     SessionFsmState new_state,
     SessionStateUpdateCriteria& uc = UNUSED_UPDATE_CRITERIA);
 
-  StaticRuleInstall get_static_rule_install(const std::string& rule_id);
+  StaticRuleInstall get_static_rule_install(
+    const std::string& rule_id, const RuleLifetime& lifetime);
 
-  DynamicRuleInstall get_dynamic_rule_install(const std::string& rule_id);
+  DynamicRuleInstall get_dynamic_rule_install(
+    const std::string& rule_id, const RuleLifetime& lifetime);
 
   SessionFsmState get_state();
 


### PR DESCRIPTION
Summary:
Remove these functions that just grab things from the config. They're often only used once or twice, and it's the same as just getting the fields from session->get_config();
```  std::string get_subscriber_ip_addr() const;

  std::string get_mac_addr() const;

  std::string get_msisdn() const;

  std::string get_hardware_addr() const { return config_.hardware_addr; }

  std::string get_radius_session_id() const;

  std::string get_apn() const;
```

Add RuleLifeTime as param to `get_static_rule_install`, and `get_dynamic_rule_install` to remove redundant calls to get_rule_lifetime

Reviewed By: uri200

Differential Revision: D21761970

