### PR TITLE
Remove SGW S1u IP address from local state

### DIFF
--- a/lte/gateway/c/oai/protos/spgw_state.proto
+++ b/lte/gateway/c/oai/protos/spgw_state.proto
@@ -217,7 +217,6 @@ message SpgwState {
     map<uint32, PccRule> predefined_pcc_rules = 4;
     repeated uint64 ipv4_list_free = 5;
     repeated uint64 ipv4_list_allocated = 6;
-    uint64 sgw_ip_address_s1u_s12_s4_up = 7;
-    GTPV1uData gtpv1u_data = 8;
+    GTPV1uData gtpv1u_data = 7;
 }
 

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -50,9 +50,6 @@ void SpgwStateConverter::state_to_proto(
 {
   proto->Clear();
 
-  proto->set_sgw_ip_address_s1u_s12_s4_up(
-    spgw_state->sgw_ip_address_S1u_S12_S4_up.s_addr);
-
   gtpv1u_data_to_proto(&spgw_state->gtpv1u_data, proto->mutable_gtpv1u_data());
 
   proto->set_last_tunnel_id(spgw_state->tunnel_id);
@@ -73,9 +70,6 @@ void SpgwStateConverter::proto_to_state(
   const SpgwState& proto,
   spgw_state_t* spgw_state)
 {
-  spgw_state->sgw_ip_address_S1u_S12_S4_up.s_addr =
-    proto.sgw_ip_address_s1u_s12_s4_up();
-
   proto_to_gtpv1u_data(proto.gtpv1u_data(), &spgw_state->gtpv1u_data);
   spgw_state->tunnel_id = proto.last_tunnel_id();
   spgw_state->gtpv1u_teid = proto.gtpv1u_teid();


### PR DESCRIPTION
Summary:
The SGW S1u IP address is always read by the SPGW task from the local config, so
this should not be persisted to data store. Traffic tests were failing before
this change as the SPGW task was trying to read the value from data store at
init and overwriting the value from config with 0.0.0.0.

Differential Revision: D21797051

