### PR TITLE
Add event logging services to FeG

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,7 @@
 !lte/gateway/Makefile
 !lte/gateway/c
 !lte/protos/
+!lte/swagger/
 !lte/gateway/deploy
 !lte/gateway/docker/deploy
 
@@ -38,9 +39,11 @@
 !orc8r/cloud/Makefile
 !orc8r/gateway/
 !orc8r/protos/
+!orc8r/swagger/
 !orc8r/tools/ansible/roles/gateway_services/files
 !orc8r/tools/ansible/roles/pkgrepo/files
 !orc8r/tools/ansible/roles/pkgrepo/tasks
+!orc8r/tools/ansible/roles/fluent_bit/files
 !orc8r/tools/docker/
 
 !protos/

--- a/cwf/gateway/configs/control_proxy.yml
+++ b/cwf/gateway/configs/control_proxy.yml
@@ -26,6 +26,9 @@ cloud_port: 9443
 bootstrap_address: bootstrapper-controller.magma.test
 bootstrap_port: 9444
 
+fluentd_address: fluentd.magma.test
+fluentd_port: 24224
+
 # Option to use nghttpx for proxying. If disabled, the individual
 # services would establish the TLS connections themselves.
 proxy_cloud_connections: True

--- a/cwf/gateway/configs/eventd.yml
+++ b/cwf/gateway/configs/eventd.yml
@@ -1,0 +1,16 @@
+---
+#
+## Copyright (c) 2016-present, Facebook, Inc.
+## All rights reserved.
+##
+## This source code is licensed under the BSD-style license found in the
+## LICENSE file in the root directory of this source tree. An additional grant
+## of patent rights can be found in the PATENTS file in the same directory.
+
+log_level: INFO
+fluent_bit_port: 5170
+tcp_timeout: 5
+event_registry:
+  mock_subscriber_event:
+    module: orc8r
+    filename: mock_event_definitions.v1.yml

--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -26,10 +26,12 @@ non_service303_services:
   - control_proxy
   - redis
   - radius
+  - td-agent-bit
 
 # List of all possible dynamic services (enabled from gateway.mconfig)
 registered_dynamic_services:
   - redirectd
+  - td-agent-bit
 
 # list of services that are required to have meta before checking in
 # (meta = data gathered via MagmaService.register_get_status_callback())

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -83,6 +83,11 @@ services:
       retries: 3
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
 
+  eventd:
+    <<: *pyservice
+    container_name: eventd
+    command: python3.5 -m magma.eventd.main
+
   health:
     <<: *feggoservice
     image: ${DOCKER_REGISTRY}cwag_go:${IMAGE_VERSION}
@@ -214,3 +219,12 @@ services:
     depends_on:
       - redis
     command: python3.5 -m magma.state.main
+
+  td-agent-bit:
+    <<: *pyservice
+    container_name: td-agent-bit
+    command: >
+        /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py &&
+        /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"
+
+

--- a/feg/gateway/configs/control_proxy.yml
+++ b/feg/gateway/configs/control_proxy.yml
@@ -26,6 +26,9 @@ cloud_port: 9443
 bootstrap_address: bootstrapper-controller.magma.test
 bootstrap_port: 9444
 
+fluentd_address: fluentd.magma.test
+fluentd_port: 24224
+
 # Option to use nghttpx for proxying. If disabled, the individual
 # services would establish the TLS connections themselves.
 proxy_cloud_connections: True

--- a/feg/gateway/configs/eventd.yml
+++ b/feg/gateway/configs/eventd.yml
@@ -1,0 +1,16 @@
+---
+#
+## Copyright (c) 2016-present, Facebook, Inc.
+## All rights reserved.
+##
+## This source code is licensed under the BSD-style license found in the
+## LICENSE file in the root directory of this source tree. An additional grant
+## of patent rights can be found in the PATENTS file in the same directory.
+
+log_level: INFO
+fluent_bit_port: 5170
+tcp_timeout: 5
+event_registry:
+  mock_subscriber_event:
+    module: orc8r
+    filename: mock_event_definitions.v1.yml

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -24,6 +24,11 @@ magma_services:
 non_service303_services:
   - control_proxy
   - redis
+  - td-agent-bit
+
+# List of all possible dynamic services (enabled from gateway.mconfig)
+registered_dynamic_services:
+  - td-agent-bit
 
 # Init system to use to control services
 # Supported systems include: [systemd, runit, docker]

--- a/feg/gateway/configs/service_registry.yml
+++ b/feg/gateway/configs/service_registry.yml
@@ -45,6 +45,9 @@ services:
   radiusd:
     ip_address: 127.0.0.1
     port: 9115
+  eventd:
+    ip_address: 127.0.0.1
+    port: 50075
 
   # Development/Test Services
   mock_ocs:

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -52,6 +52,11 @@ services:
       USE_REMOTE_SWX_PROXY: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/eap_aka -logtostderr=true -v=0
 
+  eventd:
+    <<: *pyservice
+    container_name: eventd
+    command: python3.5 -m magma.eventd.main
+
   aaa_server:
     <<: *goservice
     container_name: aaa_server
@@ -125,3 +130,10 @@ services:
       /bin/bash -c "/usr/local/bin/generate_service_config.py --service=redis --template=redis &&
              /usr/bin/redis-server /var/opt/magma/tmp/redis.conf --daemonize no &&
              /usr/bin/redis-cli shutdown"
+
+  td-agent-bit:
+    <<: *pyservice
+    container_name: td-agent-bit
+    command: >
+        /bin/bash -c "/usr/local/bin/generate_fluent_bit_config.py &&
+        /opt/td-agent-bit/bin/td-agent-bit -c /var/opt/magma/tmp/td-agent-bit.conf"

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -5,7 +5,7 @@ FROM ubuntu:bionic AS builder
 
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install curl make virtualenv zip \
- apt-utils software-properties-common apt-transport-https
+ apt-utils software-properties-common apt-transport-https git openjdk-8-jdk ant
 
 # Install protobuf compiler.
 RUN curl -Lfs https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o protoc3.zip && \
@@ -23,16 +23,34 @@ RUN apt-get -y update && apt-get -y install python3.5
 ENV MAGMA_ROOT /magma
 ENV PYTHON_BUILD /build/python
 ENV PIP_CACHE_HOME ~/.pipcache
+ENV CODEGEN_ROOT /var/tmp/codegen
+ENV SWAGGER_CODEGEN_JAR $CODEGEN_ROOT/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar
+ENV MVN_VERSION 3.5.4
+ENV MVN_DIR /var/tmp/apache-maven-$MVN_VERSION
+ENV M2_HOME $MVN_DIR
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
+RUN printenv > /etc/environment
+
+# Install swagger codegen
+RUN git clone -b v2.2.3 'https://github.com/swagger-api/swagger-codegen' $CODEGEN_ROOT
+RUN curl -L http://mirrors.ibiblio.org/apache/maven/maven-3/$MVN_VERSION/binaries/apache-maven-$MVN_VERSION-bin.tar.gz > $MVN_DIR-bin.tar.gz
+RUN tar -xvf $MVN_DIR-bin.tar.gz -C /var/tmp
+COPY lte/gateway/deploy/roles/dev_common/files/build_swagger_codegen.sh /var/tmp/build_swagger_codegen.sh
+RUN ./var/tmp/build_swagger_codegen.sh
 
 # Generate python proto bindings.
 COPY feg/protos $MAGMA_ROOT/feg/protos
 COPY lte/gateway/python/defs.mk $MAGMA_ROOT/lte/gateway/python/defs.mk
 COPY lte/gateway/python/Makefile $MAGMA_ROOT/lte/gateway/python/Makefile
 COPY lte/protos $MAGMA_ROOT/lte/protos
+COPY lte/swagger $MAGMA_ROOT/lte/swagger
 COPY orc8r/gateway/python/python.mk $MAGMA_ROOT/orc8r/gateway/python/python.mk
 COPY orc8r/protos $MAGMA_ROOT/orc8r/protos
+COPY orc8r/swagger $MAGMA_ROOT/orc8r/swagger
+COPY orc8r/tools/ansible/roles/fluent_bit/files $MAGMA_ROOT/orc8r/tools/ansible/roles/fluent_bit/files
 COPY protos $MAGMA_ROOT/protos
 RUN make -C $MAGMA_ROOT/lte/gateway/python protos
+RUN make -C $MAGMA_ROOT/lte/gateway/python swagger
 
 # -----------------------------------------------------------------------------
 # Production image
@@ -41,10 +59,13 @@ FROM ubuntu:bionic AS gateway_python
 
 # Add the magma apt repo
 RUN apt-get update && \
-    apt-get install -y apt-utils software-properties-common apt-transport-https
+    apt-get install -y apt-utils software-properties-common apt-transport-https curl
 COPY orc8r/tools/ansible/roles/pkgrepo/files/jfrog.pub /tmp/jfrog.pub
 RUN apt-key add /tmp/jfrog.pub && \
     apt-add-repository "deb https://magma.jfrog.io/magma/list/dev/ xenial main"
+RUN curl -L http://packages.fluentbit.io/fluentbit.key > /tmp/fluentbit.key
+RUN apt-key add /tmp/fluentbit.key && \
+    apt-add-repository "deb https://packages.fluentbit.io/ubuntu/bionic bionic main"
 
 # Install python3.5 since it's not native on bionic
 RUN apt-add-repository "ppa:deadsnakes/ppa"
@@ -52,7 +73,6 @@ RUN apt-get -y update && apt-get -y install python3.5
 
 # Install the runtime deps from apt.
 RUN apt-get -y update && apt-get -y install \
-  curl \
   iproute2 \
   libc-ares2 \
   libev4 \
@@ -71,7 +91,8 @@ RUN apt-get -y update && apt-get -y install \
   python3.5-dev \
   redis-server \
   git \
-  netcat
+  netcat \
+  td-agent-bit
 
 # Install docker.
 RUN curl -sSL https://get.docker.com/ > /tmp/get_docker.sh && \
@@ -97,3 +118,4 @@ COPY orc8r/gateway/configs/templates /etc/magma/templates
 COPY orc8r/cloud/docker/proxy/magma_headers.rb /etc/nghttpx/magma_headers.rb
 
 RUN mkdir -p /var/opt/magma/configs
+RUN mkdir -p /var/opt/magma/fluent-bit


### PR DESCRIPTION
Summary:
Add events services (eventd and fluent-bit) to FeG.
This will allow future event to propagate to the Orchestrator.

Reviewed By: themarwhal

Differential Revision: D21777266

