### PR TITLE
Update td-agent-bit config template to disable tls for unbootstrapped gateway

### DIFF
--- a/cwf/gateway/configs/gateway.mconfig
+++ b/cwf/gateway/configs/gateway.mconfig
@@ -55,6 +55,13 @@
     "dpid": {
       "@type": "type.googleapis.com/magma.mconfig.DPID",
       "logLevel": "INFO"
+    },
+    "td-agent-bit": {
+      "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+      "extraTags": {},
+      "throttleRate": 1000,
+      "throttleWindow": 5,
+      "throttleInterval": "1m"
     }
   }
 }

--- a/cwf/gateway/integ_tests/gateway.mconfig
+++ b/cwf/gateway/integ_tests/gateway.mconfig
@@ -167,6 +167,13 @@
    },
    "requestFailureThreshold": 0.5,
    "minimumRequestThreshold": 1
+  },
+  "td-agent-bit": {
+   "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+   "extraTags": {},
+   "throttleRate": 1000,
+   "throttleWindow": 5,
+   "throttleInterval": "1m"
   }
  },
  "metadata": {

--- a/cwf/gateway/integ_tests/gateway.mconfig.idle_timer
+++ b/cwf/gateway/integ_tests/gateway.mconfig.idle_timer
@@ -163,6 +163,13 @@
    },
    "requestFailureThreshold": 0.5,
    "minimumRequestThreshold": 1
+  },
+  "td-agent-bit": {
+   "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+   "extraTags": {},
+   "throttleRate": 1000,
+   "throttleWindow": 5,
+   "throttleInterval": "1m"
   }
  },
  "metadata": {

--- a/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
+++ b/cwf/gateway/integ_tests/gateway.mconfig.multi_session_proxy
@@ -188,6 +188,13 @@
    },
    "requestFailureThreshold": 0.5,
    "minimumRequestThreshold": 1
+  },
+  "td-agent-bit": {
+   "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+   "extraTags": {},
+   "throttleRate": 1000,
+   "throttleWindow": 5,
+   "throttleInterval": "1m"
   }
  },
  "metadata": {

--- a/feg/gateway/configs/gateway.mconfig
+++ b/feg/gateway/configs/gateway.mconfig
@@ -20,6 +20,13 @@
       "radiusMetricsPort": 9100,
       "radiusMetricsPath": "metrics",
       "updateIntervalSecs": 60
+    },
+    "td-agent-bit": {
+      "@type": "type.googleapis.com/magma.mconfig.FluentBit",
+      "extraTags": {},
+      "throttleRate": 1000,
+      "throttleWindow": 5,
+      "throttleInterval": "1m"
     }
   }
 }

--- a/orc8r/gateway/configs/templates/td-agent-bit.conf.template
+++ b/orc8r/gateway/configs/templates/td-agent-bit.conf.template
@@ -86,7 +86,11 @@
     Host          {{ host }}
     Port          {{ port }}
 
+    {% if is_tls_enabled %}
     tls on
+    {% else %}
+    tls off
+    {% endif %}
     tls.verify off
     tls.debug 3
     tls.ca_file {{ cacert }}

--- a/orc8r/gateway/python/scripts/generate_fluent_bit_config.py
+++ b/orc8r/gateway/python/scripts/generate_fluent_bit_config.py
@@ -12,6 +12,7 @@ and the config/mconfig for the service.
 """
 
 import logging
+import os
 
 from generate_service_config import generate_template_config
 from magma.configuration import load_service_config
@@ -49,6 +50,11 @@ def main():
         'throttle_interval': mc.throttle_interval or '1m',
         'files': mc.files_by_tag.items(),
     }
+    if certfile and os.path.exists(certfile):
+        context['is_tls_enabled'] = True
+    else:
+        context['is_tls_enabled'] = False
+
     generate_template_config(
         'td-agent-bit', 'td-agent-bit', CONFIG_OVERRIDE_DIR, context.copy()
     )


### PR DESCRIPTION
Summary:
This diff turns off tls for the td-agent-bit service if gateway certs don't exist.
This ensures that the service doesn't enter a restart loop (causing integ tests to fail).
After a successful bootstrap the service is restarted and tls will be enabled.

Differential Revision: D21808250

