### PR TITLE
Get rid of `set_termination_callback` since it's only used in tests

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -306,20 +306,6 @@ void LocalEnforcer::execute_actions(
   }
 }
 
-void LocalEnforcer::set_termination_callback(
-    SessionMap& session_map, const std::string& imsi, const std::string& apn,
-    std::function<void(SessionTerminateRequest)> on_termination_callback) {
-  auto it = session_map.find(imsi);
-  if (it == session_map.end()) {
-    MLOG(MERROR) << "Could not find session for IMSI " << imsi
-                 << " during termination";
-    throw SessionNotFound();
-  }
-  for (const auto& session : it->second) {
-    session->set_termination_callback(on_termination_callback);
-  }
-}
-
 // Terminates sessions that correspond to the given IMSI.
 // (For session termination triggered by sessiond)
 void LocalEnforcer::terminate_service(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -219,10 +219,6 @@ class LocalEnforcer {
       const std::vector<std::unique_ptr<ServiceAction>>& actions,
       SessionUpdate& session_update);
 
-  void set_termination_callback(
-      SessionMap& session_map, const std::string& imsi, const std::string& apn,
-      std::function<void(SessionTerminateRequest)> on_termination_callback);
-
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
  private:

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -112,9 +112,6 @@ class SessionState {
    */
   void start_termination(SessionStateUpdateCriteria& update_criteria);
 
-  void set_termination_callback(
-      std::function<void(SessionTerminateRequest)> on_termination_callback);
-
   /**
    * mark_as_awaiting_termination transitions the session state from
    * SESSION_ACTIVE to SESSION_TERMINATION_SCHEDULED

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -396,19 +396,6 @@ TEST_F(SessionStateTest, test_insert_credit) {
             1024);
 }
 
-TEST_F(SessionStateTest, test_termination) {
-  std::promise<void> termination_promise;
-  MockSessionReporter reporter;
-
-  session_state->start_termination(update_criteria);
-  session_state->set_termination_callback([&termination_promise](
-      SessionTerminateRequest term_req) { termination_promise.set_value(); });
-  session_state->complete_termination(reporter, update_criteria);
-  auto status =
-      termination_promise.get_future().wait_for(std::chrono::seconds(0));
-  EXPECT_EQ(status, std::future_status::ready);
-}
-
 TEST_F(SessionStateTest, test_can_complete_termination) {
   MockSessionReporter reporter;
 


### PR DESCRIPTION
Summary: Both LocalEnforcer and SessionState had functions that's only used in testing : `set_termination_callback`. So getting rid of them and asserting on the termination request by using the mock reporter

Reviewed By: andreilee

Differential Revision: D21762849

