### PR TITLE
Fix ephemeral final action unit and info

### DIFF
--- a/cwf/gateway/Vagrantfile
+++ b/cwf/gateway/Vagrantfile
@@ -54,6 +54,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     cwag_test.vm.hostname = "cwag-test"
     cwag_test.vm.network "private_network", ip: "192.168.70.102", nic_type: "82540EM"
     cwag_test.vm.network "private_network", ip: "192.168.40.12", nic_type: "82540EM"
+    cwag_test.vm.network "forwarded_port", guest: 40000, host: 40000
     cwag_test.ssh.password = "vagrant"
     cwag_test.ssh.insert_key = true
 

--- a/cwf/gateway/configs/sessiond.yml
+++ b/cwf/gateway/configs/sessiond.yml
@@ -16,9 +16,6 @@ rule_update_inteval_sec: 1
 # completely uses up the quota. 
 usage_reporting_threshold: 0.8
 
-# Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 1024
-
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.
 # Set to false to allow users to use without any constraint.

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -42,7 +42,8 @@ class SubTests(Enum):
 
 def integ_test(gateway_host=None, test_host=None, trf_host=None,
                transfer_images=False, destroy_vm=False, no_build=False,
-               tests_to_run="all", skip_unit_tests=False, test_re=None):
+               tests_to_run="all", skip_unit_tests=False, test_re=None,
+               run_tests=True):
     """
     Run the integration tests. This defaults to running on local vagrant
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
@@ -120,6 +121,11 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
     _switch_to_vm_no_destroy(gateway_host, "cwag_test", "cwag_test.yml")
     execute(_start_ue_simulator)
     execute(_set_cwag_test_networking, cwag_br_mac)
+
+    if run_tests == "False":
+        print("run_test was set to false. Test will not be run\n"
+              "You can now run the tests manually from cwag_test")
+        sys.exit(0)
 
     if tests_to_run.value not in SubTests.MULTISESSIONPROXY.value:
         execute(_run_integ_tests, test_host, trf_host, tests_to_run, test_re)

--- a/cwf/gateway/integ_tests/sessiond.yml
+++ b/cwf/gateway/integ_tests/sessiond.yml
@@ -16,9 +16,6 @@ rule_update_inteval_sec: 1
 # completely uses up the quota. 
 usage_reporting_threshold: 0.8
 
-# Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 1024
-
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.
 # Set to false to allow users to use without any constraint.

--- a/lte/gateway/c/session_manager/CreditPool.cpp
+++ b/lte/gateway/c/session_manager/CreditPool.cpp
@@ -294,7 +294,8 @@ void ChargingCreditPool::merge_credit_update(
   if (it == credit_map_.end()) {
     return;
   }
-  it->second->set_is_final_grant(credit_update.is_final, credit_update);
+  it->second->set_is_final_grant_and_final_action(
+        credit_update.is_final, credit_update.final_action_info, credit_update);
   it->second->set_reauth(credit_update.reauth_state, credit_update);
   it->second->set_service_state(credit_update.service_state, credit_update);
   it->second->set_expiry_time(credit_update.expiry_time, credit_update);
@@ -604,7 +605,9 @@ void UsageMonitoringCreditPool::merge_credit_update(
   if (it == monitor_map_.end()) {
     return;
   }
-  it->second->credit.set_is_final_grant(credit_update.is_final, credit_update);
+
+  it->second->credit.set_is_final_grant_and_final_action(
+        credit_update.is_final, credit_update.final_action_info, credit_update);
   it->second->credit.set_reauth(credit_update.reauth_state, credit_update);
   it->second->credit.set_service_state(credit_update.service_state,
                                        credit_update);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1048,7 +1048,6 @@ void LocalEnforcer::update_charging_credits(
       session->get_charging_pool().receive_credit(
           credit_update_resp, update_criteria);
       session->set_tgpp_context(credit_update_resp.tgpp_ctx(), update_criteria);
-
       SessionState::SessionInfo info;
       std::vector<PolicyRule> gy_rules_to_deactivate;
       session->get_session_info(info);

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -80,6 +80,7 @@ StoredSessionCredit SessionCredit::marshal() {
 SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
   SessionCreditUpdateCriteria uc{};
   uc.is_final = is_final_grant_;
+  uc.final_action_info = final_action_info_;
   uc.reauth_state = reauth_state_;
   uc.service_state = service_state_;
   uc.expiry_time = expiry_time_;
@@ -93,13 +94,14 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
 SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state)
     : credit_type_(credit_type), reporting_(false),
       reauth_state_(REAUTH_NOT_NEEDED), service_state_(start_state),
-      unlimited_quota_(false), buckets_{} {}
+      unlimited_quota_(false), buckets_{}, is_final_grant_(false){}
 
 SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state,
                              bool unlimited_quota)
     : credit_type_(credit_type), reporting_(false),
       reauth_state_(REAUTH_NOT_NEEDED), service_state_(start_state),
-      unlimited_quota_(unlimited_quota), buckets_{} {}
+      unlimited_quota_(unlimited_quota), buckets_{}, is_final_grant_(false) {}
+
 
 // by default, enable service
 SessionCredit::SessionCredit(CreditType credit_type)
@@ -196,8 +198,8 @@ void SessionCredit::receive_credit(
   set_expiry_time(validity_time, update_criteria);
   reset_reporting_credit(update_criteria);
 
-  is_final_grant_ = is_final_grant;
-  final_action_info_ = final_action_info;
+  set_is_final_grant_and_final_action(
+      is_final_grant, final_action_info, update_criteria);
 
   if (reauth_state_ == REAUTH_PROCESSING) {
     set_reauth(REAUTH_NOT_NEEDED, update_criteria);
@@ -222,6 +224,19 @@ void SessionCredit::log_quota_and_usage() const {
   MLOG(MDEBUG) << "===> Reported Tx: " << buckets_[REPORTED_TX]
                << " Rx: " << buckets_[REPORTED_RX]
                << " Total: " << buckets_[REPORTED_RX] + buckets_[REPORTED_TX];
+
+  std::string final_action = "";
+  if (is_final_grant_ ) {
+    final_action += ", with final action: ";
+    final_action +=  final_action_info_.final_action;
+    if (final_action_info_.final_action ==
+        ChargingCredit_FinalAction_REDIRECT) {
+      final_action += ", redirect_server: ";
+      final_action += final_action_info_.redirect_server.redirect_server_address();
+    }
+  }
+  MLOG(MDEBUG) << "===> Is final grant: " << is_final_grant_
+               << final_action;
 }
 
 bool SessionCredit::is_quota_exhausted(float usage_reporting_threshold) const {
@@ -238,7 +253,7 @@ bool SessionCredit::is_quota_exhausted(float usage_reporting_threshold) const {
   // available quota since last report
   auto total_usage_reporting_threshold =
       std::max(0.0f, (buckets_[ALLOWED_TOTAL] - total_reported_usage) *
-                         usage_reporting_threshold);
+                usage_reporting_threshold);
 
   // reported tx/rx could be greater than allowed tx/rx
   // because some OCS/PCRF might not track tx/rx,
@@ -250,7 +265,6 @@ bool SessionCredit::is_quota_exhausted(float usage_reporting_threshold) const {
       std::max(0.0f, (buckets_[ALLOWED_RX] - buckets_[REPORTED_RX]) *
                          usage_reporting_threshold);
 
-  bool is_exhausted = false;
   if (total_usage_since_report >= total_usage_reporting_threshold) {
     MLOG(MDEBUG) << "Total Quota exhausted";
     return true;
@@ -338,9 +352,9 @@ SessionCredit::Usage SessionCredit::get_usage_for_reporting(
   usage.bytes_tx = std::min(usage.bytes_tx, usage_reporting_limit_);
   usage.bytes_rx =
       std::min(usage.bytes_rx, usage_reporting_limit_ - usage.bytes_tx);
-  MLOG(MDEBUG) << "Since this is not the last report, we will only report "
-               << "min(usage, usage_reporting_limit=" << usage_reporting_limit_
-               << ")";
+  MLOG(MDEBUG) << "Since this is not the last report (final grant), we will "
+               << "only report min(usage, usage_reporting_limit="
+               << usage_reporting_limit_ << ")";
 
   buckets_[REPORTING_TX] += usage.bytes_tx;
   buckets_[REPORTING_RX] += usage.bytes_rx;
@@ -409,10 +423,13 @@ RedirectServer SessionCredit::get_redirect_server() const {
   return final_action_info_.redirect_server;
 }
 
-void SessionCredit::set_is_final_grant(
-    bool is_final_grant, SessionCreditUpdateCriteria &update_criteria) {
-  is_final_grant_ = is_final_grant;
+void SessionCredit::set_is_final_grant_and_final_action(
+    bool is_final_grant, FinalActionInfo final_action_info,
+    SessionCreditUpdateCriteria& update_criteria) {
+  is_final_grant_          = is_final_grant;
   update_criteria.is_final = is_final_grant;
+  final_action_info_                = final_action_info;
+  update_criteria.final_action_info = final_action_info;
 }
 
 void SessionCredit::set_reauth(ReAuthState new_reauth_state,

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -137,8 +137,9 @@ public:
    * NOTE: Use only for merging updates into SessionStore
    * @param is_final_grant
    */
-  void set_is_final_grant(bool is_final_grant,
-                          SessionCreditUpdateCriteria &update_criteria);
+  void set_is_final_grant_and_final_action(
+      bool is_final_grant, FinalActionInfo final_action_info,
+      SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Set ReAuthState.

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -184,13 +184,6 @@ public:
   static float USAGE_REPORTING_THRESHOLD;
 
   /**
-   * Extra number of bytes an user could use after the quota is exhausted.
-   * Session manager will deactivate the service when
-   * used quota >= (granted quota + EXTRA_QUOTA_MARGIN)
-   */
-  static uint64_t EXTRA_QUOTA_MARGIN;
-
-  /**
    * Set to true to terminate service when the quota of a session is exhausted.
    * An user can still use up to the extra margin.
    * Set to false to allow users to use without any constraint.
@@ -224,17 +217,12 @@ private:
    * SessionUpdate.
    * We mark quota as exhausted if usage_reporting_threshold * available quota
    * is reached. (so the default is 100% of quota)
-   * We will also add a extra_quota_margin on to the available quota if it is
-   * specified.
    * Check if the session has exhausted its quota granted since the last report.
    *
    * @param usage_reporting_threshold
-   * @param extra_quota_margin Extra bytes of usage allowable before quota
-   *        is exhausted.
    * @return true if quota is exhausted for the session
    */
-  bool is_quota_exhausted(float usage_reporting_threshold = 1,
-                          uint64_t extra_quota_margin = 0) const;
+  bool is_quota_exhausted(float usage_reporting_threshold = 1) const;
 
   void log_quota_and_usage() const;
 

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -179,6 +179,7 @@ struct StoredSessionState {
 
 struct SessionCreditUpdateCriteria {
   bool is_final;
+  FinalActionInfo final_action_info;
   bool reporting;
   ReAuthState reauth_state;
   ServiceState service_state;

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -32,7 +32,6 @@
 #define MAX_USAGE_REPORTING_THRESHOLD 1.1
 #define DEFAULT_USAGE_REPORTING_THRESHOLD 0.8
 #define DEFAULT_QUOTA_EXHAUSTION_TERMINATION_MS 30000 // 30sec
-#define DEFAULT_EXTRA_QUOTA_MARGIN 1024
 
 #ifdef DEBUG
 extern "C" void __gcov_flush(void);
@@ -173,24 +172,6 @@ int main(int argc, char *argv[])
   }
   magma::SessionCredit::USAGE_REPORTING_THRESHOLD = reporting_threshold;
 
-  uint64_t margin = DEFAULT_EXTRA_QUOTA_MARGIN;
-  if (config["extra_quota_margin"].IsDefined()) {
-    auto margin_from_config = config["extra_quota_margin"].as<uint64_t>();
-    // This value specifies the amount the usage can exceed the quota before
-    // terminating the session entirely. This is for the case where pipelined
-    // reports usage faster than sessiond can report it. This value should be
-    // reasonably big, as the usage will be eventually reported properly.
-    // So use the default value if it seems small.
-    if (margin_from_config >= DEFAULT_EXTRA_QUOTA_MARGIN) {
-      margin = margin_from_config;
-    } else {
-      MLOG(MWARNING) << "The extra_quota_margin from the config "
-                     << margin_from_config << " is smaller than the default "
-                     << DEFAULT_EXTRA_QUOTA_MARGIN
-                     << ", using the default value instead.";
-    }
-  }
-  magma::SessionCredit::EXTRA_QUOTA_MARGIN = margin;
   magma::SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED =
    config["terminate_service_when_quota_exhausted"].as<bool>();
 

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -211,6 +211,7 @@ int main(int argc, char *argv[])
     session_store = new magma::SessionStore(rule_store, store_client);
     MLOG(MINFO) << "Successfully connected to Redis";
   } else {
+    MLOG(MINFO) << "Session store in memory";
     session_store = new magma::SessionStore(rule_store);
   }
   auto monitor = std::make_shared<magma::LocalEnforcer>(

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -16,9 +16,6 @@ rule_update_inteval_sec: 1
 # completely uses up the quota.
 usage_reporting_threshold: 0.8
 
-# Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 1024
-
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.
 # Set to false to allow users to use without any constraint.

--- a/lte/gateway/configs/sessiond.yml_prod
+++ b/lte/gateway/configs/sessiond.yml_prod
@@ -16,9 +16,6 @@ rule_update_inteval_sec: 15
 # completely uses up the quota. 
 usage_reporting_threshold: 0.8
 
-# Extra number of bytes an user could use after the quota is exhausted
-extra_quota_margin: 1024
-
 # Set to true to terminate service when the quota of a session is exhausted.
 # An user can still use up to the extra margin.
 # Set to false to allow users to use without any constraint.


### PR DESCRIPTION
Summary:
```is_final_grant``` was not being updated on ```update_criteria``` object when received from ```UpdateRequest```.

```final_action_info``` did not exists on ```SessionCreditUpdateCriteria``` struct, so it was never recorded

Both issues caused that after final grant was received, those attributes were not saved on the object. So next time the session was used, those settings were back to their default value. Session was never terminated by final action unit, but for quota exhaustion. When ```EXTRA_QUOTA_MARGIN``` was removed, this issue was uncovered.

This diff adds also a log line that can be use in the future to see the value of the final unit and the value of redirect server

This diff also includes a small change to help to configure cwag integ_test properly to run integ test manually from ```cwag_test```.

Differential Revision: D21822262

