### PR TITLE
Don't return base receiver in GET request

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client.go
@@ -98,6 +98,9 @@ func (c *client) GetReceivers(tenantID string) ([]config.Receiver, error) {
 	recs := make([]config.Receiver, 0)
 	for _, rec := range conf.Receivers {
 		if strings.HasPrefix(rec.Name, config.ReceiverTenantPrefix(tenantID)) {
+			if rec.Name == config.ReceiverTenantPrefix(tenantID)+config.TenantBaseRoutePostfix {
+				continue
+			}
 			rec.Unsecure(tenantID)
 			recs = append(recs, *rec)
 		}

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
@@ -109,7 +109,7 @@ func TestClient_GetReceivers(t *testing.T) {
 
 	recs, err = client.GetReceivers(otherNID)
 	assert.NoError(t, err)
-	assert.Equal(t, 2, len(recs))
+	assert.Equal(t, 1, len(recs))
 
 	recs, err = client.GetReceivers("bad_nid")
 	assert.NoError(t, err)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
 )
 
 const (
@@ -39,6 +40,7 @@ func main() {
 	}
 
 	e := echo.New()
+	e.Use(middleware.CORS())
 
 	receiverClient := client.NewClient(*alertmanagerConfPath, *alertmanagerURL, tenancy, fsclient.NewFSClient())
 

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/prometheus/server.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
+	"github.com/labstack/echo/middleware"
 )
 
 const (
@@ -57,6 +58,8 @@ func main() {
 	}
 
 	e := echo.New()
+	e.Use(middleware.CORS())
+
 	handlers.RegisterBaseHandlers(e)
 	handlers.RegisterV0Handlers(e, alertClient)
 	handlers.RegisterV1Handlers(e, alertClient)


### PR DESCRIPTION
Summary: Small cleanup for the configmanager. The <tenantID>_tenant_base_route receiver exists for technical reasons to allow independent routing across tenants. The user will never interact with this receiver directly, so it's confusing when it shows up in the UI under the list of receivers.

Reviewed By: xjtian

Differential Revision: D21824833

