### PR TITLE
Add magmad events

### DIFF
--- a/cwf/gateway/configs/eventd.yml
+++ b/cwf/gateway/configs/eventd.yml
@@ -14,3 +14,15 @@ event_registry:
   mock_subscriber_event:
     module: orc8r
     filename: mock_event_definitions.v1.yml
+  deleted_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  updated_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  processed_updates:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  restarted_services:
+    module: orc8r
+    filename: magmad_events.v1.yml

--- a/feg/gateway/configs/eventd.yml
+++ b/feg/gateway/configs/eventd.yml
@@ -14,3 +14,15 @@ event_registry:
   mock_subscriber_event:
     module: orc8r
     filename: mock_event_definitions.v1.yml
+  deleted_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  updated_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  processed_updates:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  restarted_services:
+    module: orc8r
+    filename: magmad_events.v1.yml

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -20,3 +20,15 @@ event_registry:
   session_terminated:
     module: lte
     filename: session_manager_events.v1.yml
+  deleted_stored_mconfig:
+     module: orc8r
+     filename: magmad_events.v1.yml
+  updated_stored_mconfig:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  processed_updates:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  restarted_services:
+    module: orc8r
+    filename: magmad_events.v1.yml

--- a/orc8r/gateway/python/magma/configuration/events.py
+++ b/orc8r/gateway/python/magma/configuration/events.py
@@ -1,0 +1,34 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import snowflake
+from magma.eventd.eventd_client import log_event
+from orc8r.protos.eventd_pb2 import Event
+
+
+def deleted_stored_mconfig():
+    log_event(
+        Event(
+            stream_name="magmad",
+            event_type="deleted_stored_mconfig",
+            tag=snowflake.snowflake(),
+            value="{}",
+        )
+    )
+
+
+def updated_stored_mconfig():
+    log_event(
+        Event(
+            stream_name="magmad",
+            event_type="updated_stored_mconfig",
+            tag=snowflake.snowflake(),
+            value="{}",
+        )
+    )

--- a/orc8r/gateway/python/magma/configuration/mconfig_managers.py
+++ b/orc8r/gateway/python/magma/configuration/mconfig_managers.py
@@ -12,6 +12,8 @@ from typing import Any, Generic, TypeVar
 
 import abc
 import os
+
+import magma.configuration.events as magma_configuration_events
 from google.protobuf import json_format
 from magma.common import serialization_utils
 from magma.configuration.exceptions import LoadConfigError
@@ -203,11 +205,13 @@ class MconfigManagerImpl(MconfigManager[GatewayConfigs]):
     def delete_stored_mconfig(self):
         with contextlib.suppress(FileNotFoundError):
             os.remove(self.MCONFIG_PATH)
+        magma_configuration_events.deleted_stored_mconfig()
 
     def update_stored_mconfig(self, updated_value: str) -> GatewayConfigs:
         serialization_utils.write_to_file_atomically(
             self.MCONFIG_PATH, updated_value,
         )
+        magma_configuration_events.updated_stored_mconfig()
 
     def _get_mconfig_file_path(self):
         if os.path.isfile(self.MCONFIG_PATH):

--- a/orc8r/gateway/python/magma/eventd/eventd_client.py
+++ b/orc8r/gateway/python/magma/eventd/eventd_client.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+import logging
+
+import grpc
+from google.protobuf.json_format import MessageToDict
+from magma.common.service_registry import ServiceRegistry
+from orc8r.protos.eventd_pb2 import Event
+from orc8r.protos.eventd_pb2_grpc import EventServiceStub
+
+
+EVENTD_SERVICE_NAME = "eventd"
+DEFAULT_GRPC_TIMEOUT = 10
+IPV4_ADDR_KEY = "ipv4_addr"
+
+
+def log_event(event: Event) -> None:
+    """
+    Make RPC call to 'LogEvent' method of local eventD service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(
+            EVENTD_SERVICE_NAME, ServiceRegistry.LOCAL
+        )
+    except ValueError:
+        logging.error("Cant get RPC channel to %s", EVENTD_SERVICE_NAME)
+        return
+    client = EventServiceStub(chan)
+    try:
+        # Location will be filled in by directory service
+        client.LogEvent(event, DEFAULT_GRPC_TIMEOUT)
+    except grpc.RpcError as err:
+        logging.error(
+            "LogEvent error for event: %s, [%s] %s",
+            MessageToDict(event),
+            err.code(),
+            err.details(),
+        )

--- a/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
+++ b/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
@@ -12,7 +12,7 @@ from unittest import TestCase
 
 from jsonschema import ValidationError
 
-from ..rpc_servicer import EventDRpcServicer
+from magma.eventd.rpc_servicer import EventDRpcServicer
 from magma.common.service import MagmaService
 
 
@@ -29,7 +29,8 @@ class EventValidationTests(TestCase):
             'tcp_timeout': '',
             'event_registry': {
                 'simple_event': test_events_location,
-                'array_and_object_event': test_events_location
+                'array_and_object_event': test_events_location,
+                'null_event': test_events_location,
             },
         }
         servicer = EventDRpcServicer(config)
@@ -67,6 +68,9 @@ class EventValidationTests(TestCase):
         # Does not error when the fields are equivalent
         self.validate_event(json.dumps({'foo': 'asdf', 'bar': 123}),
                             'simple_event')
+
+        # Does not error when event has no fields
+        self.validate_event(json.dumps({}), 'null_event')
 
     def test_type_checking(self):
         # Does not error when the types match

--- a/orc8r/gateway/python/magma/magmad/config_manager.py
+++ b/orc8r/gateway/python/magma/magmad/config_manager.py
@@ -11,6 +11,7 @@ import asyncio
 import logging
 from typing import Any, List
 
+import magma.magmad.events as magmad_events
 from magma.common.service import MagmaService
 from magma.common.streamer import StreamerClient
 from magma.configuration.mconfig_managers import MconfigManager, \
@@ -117,3 +118,5 @@ class ConfigManager(StreamerClient.Callback):
             )
 
         self._mconfig = mconfig
+
+        magmad_events.processed_updates(updates)

--- a/orc8r/gateway/python/magma/magmad/events.py
+++ b/orc8r/gateway/python/magma/magmad/events.py
@@ -1,0 +1,42 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+import json
+import snowflake
+
+from google.protobuf.json_format import MessageToDict
+from magma.eventd.eventd_client import log_event
+from orc8r.protos.eventd_pb2 import Event
+from orc8r.swagger.models.processed_updates import ProcessedUpdates
+from orc8r.swagger.models.restarted_services import RestartedServices
+
+
+def processed_updates(updates):
+    # Convert updates to dicts for JSON serializability
+    dict_updates = [MessageToDict(u) for u in updates]
+    log_event(
+        Event(
+            stream_name="magmad",
+            event_type="processed_updates",
+            tag=snowflake.snowflake(),
+            value=json.dumps(ProcessedUpdates(updates=dict_updates).to_dict()),
+        )
+    )
+
+
+def restarted_services(services):
+    # Convert to a list for JSON serializability
+    services = list(services)
+    log_event(
+        Event(
+            stream_name="magmad",
+            event_type="restarted_services",
+            tag=snowflake.snowflake(),
+            value=json.dumps(RestartedServices(services=services).to_dict()),
+        )
+    )

--- a/orc8r/gateway/python/magma/magmad/service_manager.py
+++ b/orc8r/gateway/python/magma/magmad/service_manager.py
@@ -15,6 +15,7 @@ from enum import Enum
 from typing import List, Tuple
 
 from magma.magmad.service_poller import ServicePoller
+import magma.magmad.events as magmad_events
 
 
 class ServiceState(Enum):
@@ -105,6 +106,7 @@ class ServiceManager(object):
         await asyncio.gather(
             *[self._service_control[s].restart_process() for s in services]
         )
+        magmad_events.restarted_services(services)
 
     async def update_dynamic_services(self, dynamic_services: List[str]):
         """

--- a/orc8r/swagger/magmad_events.v1.yml
+++ b/orc8r/swagger/magmad_events.v1.yml
@@ -1,0 +1,37 @@
+---
+swagger: '2.0'
+
+info:
+  title: Magmad events
+  description: These denote events that happen within Magmad on the AGW
+  version: 1.0.0
+
+definitions:
+  deleted_stored_mconfig:
+    type: object
+    description: The stored mconfig was deleted
+  updated_stored_mconfig:
+    type: object
+    description: The stored mconfig was updated
+  processed_updates:
+    type: object
+    description: Stream updates were successfully processed
+    properties:
+      updates:
+        type: array
+        items:
+          type: object
+          properties:
+            key:
+              type: string
+            value:
+              type: string
+              format: byte
+  restarted_services:
+    type: object
+    description: Services were restarted
+    properties:
+      services:
+        type: array
+        items:
+          type: string

--- a/orc8r/swagger/test_event_definitions.yml
+++ b/orc8r/swagger/test_event_definitions.yml
@@ -30,3 +30,6 @@ definitions:
         type: object
         additionalProperties:
           type: integer
+  null_event:
+    type: object
+    description: An event with no properties


### PR DESCRIPTION
Summary:
## Changes
- Add several `magmad` events, regarding updates to the gateway's mconfig, and service restarts
- `magmad` adds utility functions to talk to `eventd`
- new event types are specified in swagger files

Reviewed By: mpgermano

Differential Revision: D21700415

