### PR TITLE
Use public prometheus-edge-hub image for magma in helm

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -110,8 +110,8 @@ metrics:
   prometheusCache:
     create: true
     image:
-      repository: ${docker_registry}/prometheus-cache
-      tag: "${docker_tag}"
+      repository: docker.io/facebookincubator/prometheus-edge-hub
+      tag: 1.0.0
     limit: 500000
   grafana:
     create: false


### PR DESCRIPTION
Summary: The docker image is now published on dockerhub so we don't need to use the custom docker-registry.

Differential Revision: D21829685

