### PR TITLE
Adding events for SyncRPC streams connection/disconnection

### DIFF
--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -32,3 +32,9 @@ event_registry:
   restarted_services:
     module: orc8r
     filename: magmad_events.v1.yml
+  established_sync_rpc_stream:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  disconnected_sync_rpc_stream:
+    module: orc8r
+    filename: magmad_events.v1.yml

--- a/orc8r/gateway/python/magma/magmad/events.py
+++ b/orc8r/gateway/python/magma/magmad/events.py
@@ -40,3 +40,25 @@ def restarted_services(services):
             value=json.dumps(RestartedServices(services=services).to_dict()),
         )
     )
+
+
+def established_sync_rpc_stream():
+    log_event(
+        Event(
+            stream_name="magmad",
+            event_type="established_sync_rpc_stream",
+            tag=snowflake.snowflake(),
+            value="{}"
+        )
+    )
+
+
+def disconnected_sync_rpc_stream():
+    log_event(
+        Event(
+            stream_name="magmad",
+            event_type="disconnected_sync_rpc_stream",
+            tag=snowflake.snowflake(),
+            value="{}"
+        )
+    )

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -21,6 +21,7 @@ from orc8r.protos.sync_rpc_service_pb2 import SyncRPCResponse, SyncRPCRequest
 from orc8r.protos.sync_rpc_service_pb2_grpc import SyncRPCServiceStub
 
 from typing import List
+import magma.magmad.events as magmad_events
 
 
 class SyncRPCClient(threading.Thread):
@@ -93,6 +94,7 @@ class SyncRPCClient(threading.Thread):
         # and returns an iterator
         sync_rpc_requests = client.EstablishSyncRPCStream(
             self.send_sync_rpc_response())
+        magmad_events.established_sync_rpc_stream()
         # forward incoming requests from cloud to control_proxy
         self.forward_requests(sync_rpc_requests)
 
@@ -180,3 +182,4 @@ class SyncRPCClient(threading.Thread):
         self._conn_closed_table.clear()
         self._proxy_client.close_all_connections()
         self._retry_connect_sleep()
+        magmad_events.disconnected_sync_rpc_stream()

--- a/orc8r/gateway/python/magma/magmad/tests/sync_rpc_client_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/sync_rpc_client_tests.py
@@ -16,6 +16,7 @@ from orc8r.protos.sync_rpc_service_pb2 import GatewayRequest, GatewayResponse, \
 
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.sync_rpc_client import SyncRPCClient
+from unittest import mock
 
 
 class SyncRPCClientTests(unittest.TestCase):
@@ -75,6 +76,13 @@ class SyncRPCClientTests(unittest.TestCase):
                                  self._sync_rpc_client._current_delay)
             else:
                 self.assertEqual(2 ** i, self._sync_rpc_client._current_delay)
+
+    def test_disconnect_sync_rpc_event(self):
+        disconnect_sync_rpc_event_mock = mock.patch(
+            'magma.magmad.events.disconnected_sync_rpc_stream')
+        with disconnect_sync_rpc_event_mock as disconnect_sync_rpc_streams:
+            self._sync_rpc_client._cleanup_and_reconnect()
+            disconnect_sync_rpc_streams.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/orc8r/swagger/magmad_events.v1.yml
+++ b/orc8r/swagger/magmad_events.v1.yml
@@ -35,3 +35,9 @@ definitions:
         type: array
         items:
           type: string
+  established_sync_rpc_stream:
+    type: object
+    description: SyncRPC connection was established
+  disconnected_sync_rpc_stream:
+    type: object
+    description: SyncRPC stream was disconnected


### PR DESCRIPTION
Summary:
- For having improved tracing of the status of the connection of SyncRPC client on gateway, this diff adds events for establishment and disconnection of the stream that magmad sets up with dispatcher service on cloud.
- Registering events on event_registry of eventd.yml
- Adding unit test on `sync_rpc_client_tests.py`

Differential Revision: D21853302

