### PR TITLE
Serialize/deserialize session fsm state

### DIFF
--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -319,7 +319,7 @@ deserialize_stored_usage_monitoring_pool(std::string &serialized) {
 
 std::string serialize_stored_session(StoredSessionState &stored) {
   folly::dynamic marshaled = folly::dynamic::object;
-
+  marshaled["fsm_state"] = static_cast<int>(stored.fsm_state);
   marshaled["config"] = serialize_stored_session_config(stored.config);
   marshaled["charging_pool"] =
       serialize_stored_charging_credit_pool(stored.charging_pool);
@@ -360,7 +360,7 @@ StoredSessionState deserialize_stored_session(std::string &serialized) {
   folly::dynamic marshaled = folly::parseJson(folly_serialized);
 
   auto stored = StoredSessionState{};
-
+  stored.fsm_state = SessionFsmState(marshaled["fsm_state"].getInt());
   stored.config =
       deserialize_stored_session_config(marshaled["config"].getString());
   stored.charging_pool = deserialize_stored_charging_credit_pool(

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -130,6 +130,7 @@ protected:
     stored.session_id = "session_id";
     stored.core_session_id = "core_session_id";
     stored.subscriber_quota_state = SubscriberQuotaUpdate_Type_VALID_QUOTA;
+    stored.fsm_state = SESSION_TERMINATING_FLOW_DELETED;
 
     magma::lte::TgppContext tgpp_context;
     tgpp_context.set_gx_dest_host("gx");
@@ -390,6 +391,8 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(stored.core_session_id, "core_session_id");
   EXPECT_EQ(stored.subscriber_quota_state,
             SubscriberQuotaUpdate_Type_VALID_QUOTA);
+  EXPECT_EQ(stored.fsm_state,
+            SESSION_TERMINATING_FLOW_DELETED);
 
   EXPECT_EQ(stored.tgpp_context.gx_dest_host(), "gx");
   EXPECT_EQ(stored.tgpp_context.gy_dest_host(), "gy");


### PR DESCRIPTION
Summary:
The state was not being properly stored on stateless mode.
`TestGxUsageReportEnforcement` was not passing on stateless since the termination request was not being properly sent

modified unit test to assert serialization/deserialization happens for fsm_state

Differential Revision: D21858853

