### PR TITLE
Deserialization of stored charging credit pool is faulty

### DIFF
--- a/lte/gateway/c/session_manager/CreditKey.h
+++ b/lte/gateway/c/session_manager/CreditKey.h
@@ -20,10 +20,9 @@ using namespace lte;
 struct CreditKey {
   uint32_t rating_group;
   uint32_t service_identifier;
-  bool use_sid;
-  CreditKey() : rating_group(0), service_identifier(0), use_sid(false) {}
-  CreditKey(uint32_t rg) : rating_group(rg), service_identifier(0), use_sid(false) {}
-  CreditKey(uint32_t rg, uint32_t si) : rating_group(rg), service_identifier(si), use_sid(true) {}
+  CreditKey() : rating_group(0), service_identifier(0) {}
+  CreditKey(uint32_t rg) : rating_group(rg), service_identifier(0) {}
+  CreditKey(uint32_t rg, uint32_t si) : rating_group(rg), service_identifier(si) {}
   CreditKey(const PolicyRule *rule)   { set(rule); }
   CreditKey(const PolicyRule &rule)   { set(&rule); }
   CreditKey(const CreditUsage *usage) { set(usage); }
@@ -36,15 +35,15 @@ struct CreditKey {
   CreditKey *set(const PolicyRule *rule) {
     if (rule != nullptr) {
       rating_group = rule->rating_group();
-      use_sid = rule->has_service_identifier();
-      service_identifier = use_sid ? rule->service_identifier().value() : 0;
+      service_identifier = rule->has_service_identifier() ?
+          rule->service_identifier().value() : 0;
     }
     return this;
   }
   void set_rule(PolicyRule *rule) const {
     if (rule != nullptr) {
       rule->set_rating_group(rating_group);
-      if (use_sid) {
+      if (service_identifier) {
         rule->mutable_service_identifier()->set_value(service_identifier);
       } else {
         rule->release_service_identifier();
@@ -54,15 +53,15 @@ struct CreditKey {
   CreditKey *set(const CreditUsage *usage) {
     if (usage != nullptr) {
       rating_group = usage->charging_key();
-      use_sid = usage->has_service_identifier();
-      service_identifier = use_sid ? usage->service_identifier().value() : 0;
+      service_identifier = usage->has_service_identifier() ?
+        usage->service_identifier().value() : 0;
     }
     return this;
   }
   void set_credit_usage(CreditUsage *usage) const {
     if (usage != nullptr) {
       usage->set_charging_key(rating_group);
-      if (use_sid) {
+      if (service_identifier) {
         usage->mutable_service_identifier()->set_value(service_identifier);
       } else {
         usage->release_service_identifier();
@@ -72,16 +71,16 @@ struct CreditKey {
   CreditKey *set(const CreditUpdateResponse *update) {
     if (update != nullptr) {
       rating_group = update->charging_key();
-      use_sid = update->has_service_identifier();
-      service_identifier = use_sid ? update->service_identifier().value() : 0;
+      service_identifier = update->has_service_identifier() ?
+        update->service_identifier().value() : 0;
     }
     return this;
   }
   CreditKey *set(const ChargingReAuthRequest *reath) {
     if (reath != nullptr) {
       rating_group = reath->charging_key();
-      use_sid = reath->has_service_identifier();
-      service_identifier = use_sid ? reath->service_identifier().value() : 0;
+      service_identifier = reath->has_service_identifier() ?
+        reath->service_identifier().value() : 0;
     }
     return this;
   }
@@ -89,7 +88,7 @@ struct CreditKey {
 
 inline std::ostream &operator<<(std::ostream &s, const CreditKey &k) {
   s << "RG: " << k.rating_group;
-  if (k.use_sid) {
+  if (k.service_identifier) {
     s << ", SI: " << k.service_identifier;
   }
   return s;
@@ -98,7 +97,7 @@ inline std::ostream &operator<<(std::ostream &s, const CreditKey &k) {
 inline size_t ccHash(const CreditKey& k) {
   static const int ccHashShift = sizeof(size_t) > sizeof(uint32_t) ? 32 : 1;
   size_t res = std::hash<uint32_t>()(k.rating_group) << ccHashShift;
-  if (k.use_sid) {
+  if (k.service_identifier) {
     res += std::hash<uint32_t>()(k.service_identifier);
   }
   return res;
@@ -106,8 +105,8 @@ inline size_t ccHash(const CreditKey& k) {
 
 inline bool ccEqual(const CreditKey& l, const CreditKey& r){
   return (l.rating_group == r.rating_group) &&
-         (l.use_sid == r.use_sid) &&
-         ((!l.use_sid) || (l.service_identifier == r.service_identifier));
+         ((!l.service_identifier) ||
+          (l.service_identifier == r.service_identifier));
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/CreditPool.cpp
+++ b/lte/gateway/c/session_manager/CreditPool.cpp
@@ -33,7 +33,6 @@ StoredChargingCreditPool ChargingCreditPool::marshal() {
     auto key = CreditKey();
     key.rating_group = credit_pair.first.rating_group;
     key.service_identifier = credit_pair.first.service_identifier;
-    key.use_sid = credit_pair.first.use_sid;
     credit_map[key] = credit_pair.second->marshal();
   }
   marshaled.credit_map = credit_map;


### PR DESCRIPTION
Summary:
In stateless mode, we don't serialize all the fields of CreditKey (rating group, service identifier but not use_sid).
During deserialization, we reconstruct the key using the constructor CreditKey(uint32_t rg, uint32_t si) which set use_sid to true in all the cases.
Except that service identifier is very often set to 0 => use_sid should be False.
Lookup in credit_map is then failing.

Reviewed By: themarwhal

Differential Revision: D21857619

