### PR TITLE
Add Pushover Support to AlertManager

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
@@ -87,6 +87,11 @@ func TestClient_CreateReceiver(t *testing.T) {
 	assert.NoError(t, err)
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 
+	// Create Pushover Receiver
+	err = client.CreateReceiver(testNID, tc.SamplePushoverReceiver)
+	assert.NoError(t, err)
+	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
+
 	// Create Email receiver
 	err = client.CreateReceiver(testNID, tc.SampleEmailReceiver)
 	assert.NoError(t, err)
@@ -100,6 +105,7 @@ func TestClient_CreateReceiver(t *testing.T) {
 func TestClient_GetReceivers(t *testing.T) {
 	client, _ := newTestClient()
 	recs, err := client.GetReceivers(testNID)
+
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(recs))
 	assert.Equal(t, "receiver", recs[0].Name)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config/receiver.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config/receiver.go
@@ -20,9 +20,10 @@ import (
 type Receiver struct {
 	Name string `yaml:"name" json:"name"`
 
-	SlackConfigs   []*SlackConfig   `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs []*WebhookConfig `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	EmailConfigs   []*EmailConfig   `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	SlackConfigs    []*SlackConfig    `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs  []*WebhookConfig  `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EmailConfigs    []*EmailConfig    `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PushoverConfigs []*PushoverConfig `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 }
 
 // Secure replaces the receiver's name with a tenantID prefix
@@ -92,6 +93,23 @@ type EmailConfig struct {
 	HTML         string            `yaml:"html,omitempty" json:"html,omitempty"`
 	Text         string            `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS   *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+}
+
+// PushoverConfig uses string instead of Secret for the UserKey and Token
+// field so that it is mashaled as is instead of being obscured which is how
+// alertmanager handles secrets. Otherwise the secrets would be obscured on
+// write to the yml file, making it unusable.
+type PushoverConfig struct {
+	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	UserKey  string `yaml:"user_key" json:"user_key"`
+	Token    string `yaml:"token" json:"token"`
+	Title    string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message  string `yaml:"message,omitempty" json:"message,omitempty"`
+	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
+	Priority string `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Retry    string `yaml:"retry,omitempty" json:"retry,omitempty"`
+	Expire   string `yaml:"expire,omitempty" json:"expire,omitempty"`
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for EmailConfig and

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
@@ -32,6 +32,13 @@ var (
 			Channel:  "slack_alert_channel",
 		}},
 	}
+	SamplePushoverReceiver = config.Receiver{
+		Name: "pushover_receiver",
+		PushoverConfigs: []*config.PushoverConfig{{
+			UserKey: "101",
+			Token:   "1",
+		}},
+	}
 	SampleWebhookReceiver = config.Receiver{
 		Name: "webhook_receiver",
 		WebhookConfigs: []*config.WebhookConfig{{


### PR DESCRIPTION
Summary: This diff adds pushover support to the alertmanager. Documentation and unit tests will be added in smaller diffs in the stack.

Reviewed By: Scott8440

Differential Revision: D21831322

