### PR TITLE
Add Pushover Unit Tests and Duration Fields to AlertManager

### DIFF
--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
@@ -87,6 +87,11 @@ func TestClient_CreateReceiver(t *testing.T) {
 	assert.NoError(t, err)
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 
+	// Create Pushover Receiver
+	err = client.CreateReceiver(testNID, tc.SamplePushoverReceiver)
+	assert.NoError(t, err)
+	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
+
 	// Create Email receiver
 	err = client.CreateReceiver(testNID, tc.SampleEmailReceiver)
 	assert.NoError(t, err)
@@ -100,6 +105,7 @@ func TestClient_CreateReceiver(t *testing.T) {
 func TestClient_GetReceivers(t *testing.T) {
 	client, _ := newTestClient()
 	recs, err := client.GetReceivers(testNID)
+
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(recs))
 	assert.Equal(t, "receiver", recs[0].Name)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config/receiver.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/config/receiver.go
@@ -20,9 +20,10 @@ import (
 type Receiver struct {
 	Name string `yaml:"name" json:"name"`
 
-	SlackConfigs   []*SlackConfig   `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
-	WebhookConfigs []*WebhookConfig `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
-	EmailConfigs   []*EmailConfig   `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	SlackConfigs    []*SlackConfig    `yaml:"slack_configs,omitempty" json:"slack_configs,omitempty"`
+	WebhookConfigs  []*WebhookConfig  `yaml:"webhook_configs,omitempty" json:"webhook_configs,omitempty"`
+	EmailConfigs    []*EmailConfig    `yaml:"email_configs,omitempty" json:"email_configs,omitempty"`
+	PushoverConfigs []*PushoverConfig `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 }
 
 // Secure replaces the receiver's name with a tenantID prefix
@@ -92,6 +93,23 @@ type EmailConfig struct {
 	HTML         string            `yaml:"html,omitempty" json:"html,omitempty"`
 	Text         string            `yaml:"text,omitempty" json:"text,omitempty"`
 	RequireTLS   *bool             `yaml:"require_tls,omitempty" json:"require_tls,omitempty"`
+}
+
+// PushoverConfig uses string instead of Secret for the UserKey and Token
+// field so that it is mashaled as is instead of being obscured which is how
+// alertmanager handles secrets. Otherwise the secrets would be obscured on
+// write to the yml file, making it unusable.
+type PushoverConfig struct {
+	HTTPConfig *common.HTTPConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	UserKey  string `yaml:"user_key" json:"user_key"`
+	Token    string `yaml:"token" json:"token"`
+	Title    string `yaml:"title,omitempty" json:"title,omitempty"`
+	Message  string `yaml:"message,omitempty" json:"message,omitempty"`
+	URL      string `yaml:"url,omitempty" json:"url,omitempty"`
+	Priority string `yaml:"priority,omitempty" json:"priority,omitempty"`
+	Retry    string `yaml:"retry,omitempty" json:"retry,omitempty"`
+	Expire   string `yaml:"expire,omitempty" json:"expire,omitempty"`
 }
 
 // MarshalYAML implements the yaml.Marshaler interface for EmailConfig and

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/handlers/handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/handlers/handlers.go
@@ -277,10 +277,18 @@ func decodeReceiverPostRequest(c echo.Context) (config.Receiver, error) {
 	}
 	receiver := config.Receiver{}
 	err = json.Unmarshal(body, &receiver)
-	if err != nil {
-		return config.Receiver{}, fmt.Errorf("error unmarshalling payload: %v", err)
+	if err == nil {
+		return receiver, nil
 	}
-	return receiver, nil
+
+	// Try to unmarshal into the ReceiverJSONWrapper struct if prometheus struct doesn't work
+	jsonPayload := config.ReceiverJSONWrapper{}
+	err = json.Unmarshal(body, &jsonPayload)
+	if err != nil {
+		return receiver, fmt.Errorf("error unmarshalling payload: %v", err)
+	}
+
+	return jsonPayload.ToReceiverFmt()
 }
 
 func decodeRoutePostRequest(c echo.Context) (config.Route, error) {

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/handlers/handlers_test.go
@@ -366,7 +366,7 @@ func TestDecodeReceiverPostRequest(t *testing.T) {
 		Name bool `json:"name"`
 	}{false}, http.MethodPost, "/", v1receiverPath, testNID)
 	conf, err = decodeReceiverPostRequest(c)
-	assert.EqualError(t, err, `error unmarshalling payload: json: cannot unmarshal bool into Go struct field Receiver.name of type string`)
+	assert.EqualError(t, err, `error unmarshalling payload: json: cannot unmarshal bool into Go struct field ReceiverJSONWrapper.name of type string`)
 }
 
 func TestDecodeRoutePostRequest(t *testing.T) {

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
@@ -62,7 +62,7 @@ var (
 	SampleConfig = config.Config{
 		Route: &SampleRoute,
 		Receivers: []*config.Receiver{
-			&SampleSlackReceiver, &SampleReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
+			&SampleSlackReceiver, &SampleReceiver, &SamplePushoverReceiver, &SampleWebhookReceiver, &SampleEmailReceiver,
 		},
 	}
 )

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/test_common/configs.go
@@ -32,6 +32,13 @@ var (
 			Channel:  "slack_alert_channel",
 		}},
 	}
+	SamplePushoverReceiver = config.Receiver{
+		Name: "pushover_receiver",
+		PushoverConfigs: []*config.PushoverConfig{{
+			UserKey: "101",
+			Token:   "1",
+		}},
+	}
 	SampleWebhookReceiver = config.Receiver{
 		Name: "webhook_receiver",
 		WebhookConfigs: []*config.WebhookConfig{{


### PR DESCRIPTION
Summary:
This diff adds unit test support for pushover on AlertManager.

Also adds duration fields for the Expire and Retry fields of the pushover.

Documentation updates will be the last in this chain of commits.

Reviewed By: Scott8440

Differential Revision: D21844124

