### PR TITLE
Add handler to get tenant names from alertmanager-configurer

### DIFF
--- a/devmand/cloud/go/go.sum
+++ b/devmand/cloud/go/go.sum
@@ -369,6 +369,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.3.1/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.2.0 h1:Hbg2NidpLE8veEBkEZTL3CvlkUIVzuU9jDplZO54c48=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/client_test.go
@@ -50,6 +50,7 @@ receivers:
 - name: test_receiver
 - name: receiver
 - name: other_tenant_base_route
+- name: sample_tenant_base_route
 - name: test_slack
   slack_configs:
   - api_url: http://slack.com/12345
@@ -87,11 +88,6 @@ func TestClient_CreateReceiver(t *testing.T) {
 	assert.NoError(t, err)
 	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
 
-	// Create Pushover Receiver
-	err = client.CreateReceiver(testNID, tc.SamplePushoverReceiver)
-	assert.NoError(t, err)
-	fsClient.AssertCalled(t, "WriteFile", "test/alertmanager.yml", mock.Anything, mock.Anything)
-
 	// Create Email receiver
 	err = client.CreateReceiver(testNID, tc.SampleEmailReceiver)
 	assert.NoError(t, err)
@@ -105,7 +101,6 @@ func TestClient_CreateReceiver(t *testing.T) {
 func TestClient_GetReceivers(t *testing.T) {
 	client, _ := newTestClient()
 	recs, err := client.GetReceivers(testNID)
-
 	assert.NoError(t, err)
 	assert.Equal(t, 4, len(recs))
 	assert.Equal(t, "receiver", recs[0].Name)
@@ -180,8 +175,16 @@ func TestClient_GetRoute(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, config.Route{Receiver: "other_tenant_base_route", Match: map[string]string{"tenantID": "other"}}, *route)
 
-	route, err = client.GetRoute("no-network")
+	_, err = client.GetRoute("no-network")
 	assert.Error(t, err)
+}
+
+func TestClient_GetTenants(t *testing.T) {
+	client, _ := newTestClient()
+
+	tenants, err := client.GetTenants()
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"other", "sample"}, tenants)
 }
 
 func newTestClient() (AlertmanagerClient, *mocks.FSClient) {

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/mocks/AlertmanagerClient.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/client/mocks/AlertmanagerClient.go
@@ -112,6 +112,29 @@ func (_m *AlertmanagerClient) GetRoute(tenantID string) (*config.Route, error) {
 	return r0, r1
 }
 
+// GetTenants provides a mock function with given fields:
+func (_m *AlertmanagerClient) GetTenants() ([]string, error) {
+	ret := _m.Called()
+
+	var r0 []string
+	if rf, ok := ret.Get(0).(func() []string); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // ModifyTenantRoute provides a mock function with given fields: tenantID, route
 func (_m *AlertmanagerClient) ModifyTenantRoute(tenantID string, route *config.Route) error {
 	ret := _m.Called(tenantID, route)

--- a/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/docs/swagger-v1.yml
+++ b/orc8r/cloud/go/services/metricsd/prometheus/configmanager/alertmanager/docs/swagger-v1.yml
@@ -3,7 +3,7 @@ swagger: '2.0'
 info:
   title: Alertmanager Configurer Model Definitions and Paths
   description: Alertmanager Configurer REST APIs
-  version: 1.0.1
+  version: 1.0.2
 basePath: /v1
 paths:
   /{tenant_id}/receiver:
@@ -125,6 +125,17 @@ paths:
       responses:
         '200':
           description: OK
+        default:
+          $ref: '#/responses/UnexpectedError'
+
+  /tenants:
+    get:
+      summary: List configured tenants
+      tags:
+        - Tenants
+      responses:
+        '200':
+          description: List of configured tenants
         default:
           $ref: '#/responses/UnexpectedError'
 
@@ -292,31 +303,6 @@ definitions:
       dismiss_text:
         type: string
 
-  pushover_receiver:
-    type: object
-    required:
-      - user_key
-      - token
-    properties:
-      http_config:
-        $ref: '#/definitions/http_config'
-      user_key:
-        type: string
-      token:
-        type: string
-      title:
-        type: string
-      message:
-        type: string
-      url:
-        type: string
-      priority:
-        type: string
-      retry:
-        type: string
-      expire:
-        type: string
-
   pagerduty_receiver:
     type: object
     required:
@@ -416,6 +402,31 @@ definitions:
       url:
         type: string
         format: uri
+
+  pushover_receiver:
+    type: object
+    required:
+      - user_key
+      - token
+    properties:
+      http_config:
+        $ref: '#/definitions/http_config'
+      user_key:
+        type: string
+      token:
+        type: string
+      title:
+        type: string
+      message:
+        type: string
+      url:
+        type: string
+      priority:
+        type: string
+      retry:
+        type: string
+      expire:
+        type: string
 
   routing_tree:
     type: object


### PR DESCRIPTION
Summary:
For the standalone UI we need a way to know what tenants exist in the system. In the NMS, this source of truth exists outside of configmanager. However when it's run as a standalone system, the only source for this information is the alertmanager configurer itself.

Adding this allows the UI to be populated with a list of tenants to select from

Differential Revision: D21892027

