### PR TITLE
Use Redis to save pipelined enforcement state

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
+++ b/lte/gateway/python/magma/pipelined/tests/app/start_pipelined.py
@@ -178,7 +178,8 @@ class StartThread(object):
         manager.load_apps(app_lists)
         contexts = manager.create_contexts()
         contexts['sids_by_ip'] = {}     # shared by both metering apps
-        contexts['rule_id_mapper'] = RuleIDToNumMapper()
+        contexts['rule_id_mapper'] = \
+            self._test_setup.service_manager.rule_id_mapper
         contexts['internal_ip_allocator'] = \
             InternalIPAllocator(self._test_setup.config)
         contexts['session_rule_version_mapper'] = \

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -348,7 +348,14 @@ def create_service_manager(services: List[int],
     magma_service.config = {
         'static_services': static_services
     }
-    return ServiceManager(magma_service)
+    service_manager = ServiceManager(magma_service)
+
+    # Workaround as we don't use redis in unit tests
+    service_manager.rule_id_mapper._rule_nums_by_rule = {}
+    service_manager.rule_id_mapper._rules_by_rule_num = {}
+    service_manager.session_rule_version_mapper._version_by_imsi_and_rule = {}
+
+    return service_manager
 
 
 def _parse_flow(flow):


### PR DESCRIPTION
Summary:
Currently we're losing a bit of stats on restart recovery as we lost the policy rule id/versio mappings on pipelined restarts. By using redis we can preserve them and recover the enforcement/enf_stats table gracefully.

For unit tests stick with regular python dicts.

Reviewed By: karthiksubraveti

Differential Revision: D21852940

