### PR TITLE
Fix global task handling in workflow proxy

### DIFF
--- a/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
+++ b/symphony/app/fbcnms-projects/workflows/src/proxy/utils.js
@@ -48,6 +48,8 @@ const SYSTEM_TASK_TYPES: Array<string> = [
   'DO_WHILE',
 ];
 
+const WHITELISTED_SIMPLE_TASKS = ['GLOBAL___js', 'GLOBAL___py'];
+
 export function isLabeledWithGroup(
   workflowdef: Workflow,
   groups: string[],
@@ -86,8 +88,13 @@ export function isForkTask(task: Task): boolean {
   return FORK === task.type;
 }
 
+function isWhitelistedSimpleTask(task: Task): boolean {
+  return task.type == 'SIMPLE' && WHITELISTED_SIMPLE_TASKS.includes(task.name);
+}
+
+// TODO: remove 'System' from name
 export function assertAllowedSystemTask(task: Task): void {
-  if (!isAllowedSystemTask(task)) {
+  if (!isAllowedSystemTask(task) && !isWhitelistedSimpleTask(task)) {
     logger.error(
       `Task type is not allowed: ` + ` in '${JSON.stringify(task)}'`,
     );
@@ -127,7 +134,14 @@ export function withInfixSeparator(s: string): string {
 export function addTenantIdPrefix(
   tenantId: string,
   objectWithName: {name: string},
+  allowGlobal: boolean = false,
 ): void {
+  if (
+    allowGlobal &&
+    objectWithName.name.indexOf(withInfixSeparator(GLOBAL_PREFIX)) == 0
+  ) {
+    return;
+  }
   assertNameIsWithoutInfixSeparator(objectWithName);
   objectWithName.name = withInfixSeparator(tenantId) + objectWithName.name;
 }

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -19,7 +19,6 @@ import logging from '@fbcnms/logging';
 import map from 'lodash/fp/map';
 import moment from 'moment';
 import transform from 'lodash/fp/transform';
-import {anythingTo} from './proxy/utils';
 
 import type {$Application, ExpressRequest, ExpressResponse} from 'express';
 import type {TaskType} from './types';
@@ -41,7 +40,7 @@ export default async function(
   baseURL: string,
   addScheduleMetadata: boolean,
 ): Promise<$Application<ExpressRequest, ExpressResponse>> {
-  const router = Router<ExpressRequest, ExpressResponse>();
+  const router = Router();
   const baseApiURL = baseURL + 'api/';
   const baseURLWorkflow = baseApiURL + 'workflow/';
   const baseURLMeta = baseApiURL + 'metadata/';
@@ -358,24 +357,21 @@ export default async function(
         );
       }
 
-      //  // required because of https://github.com/facebook/flow/issues/1414
-      const subs: Array<TaskType> = anythingTo<Array<TaskType>>(
-        filter(identity)(
-          map((task: TaskType): ?TaskType => {
-            if (task.taskType === 'SUB_WORKFLOW' && task.inputData) {
-              const subWorkflowId = task.inputData.subWorkflowId;
+      const subs = filter(identity)(
+        map((task: TaskType): ?TaskType => {
+          if (task.taskType === 'SUB_WORKFLOW' && task.inputData) {
+            const subWorkflowId = task.inputData.subWorkflowId;
 
-              if (subWorkflowId != null) {
-                return {
-                  name: task.inputData?.subWorkflowName,
-                  version: task.inputData?.subWorkflowVersion,
-                  referenceTaskName: task.referenceTaskName,
-                  subWorkflowId: subWorkflowId,
-                };
-              }
+            if (subWorkflowId != null) {
+              return {
+                name: task.inputData?.subWorkflowName,
+                version: task.inputData?.subWorkflowVersion,
+                referenceTaskName: task.referenceTaskName,
+                subWorkflowId: subWorkflowId,
+              };
             }
-          })(result.tasks || []),
-        ),
+          }
+        })(result.tasks || []),
       );
 
       const logs = map(task =>

--- a/symphony/app/fbcnms-projects/workflows/src/routes.js
+++ b/symphony/app/fbcnms-projects/workflows/src/routes.js
@@ -169,7 +169,7 @@ export default async function(
       const result = await http.put(baseURLMeta + 'workflow/', req.body, req);
       res.status(200).send(result);
     } catch (err) {
-      res.status(400).send(err.response.body);
+      res.status(400).send(err?.response?.body);
       next(err);
     }
   });

--- a/symphony/integration/docker-compose.workflows.override.yaml
+++ b/symphony/integration/docker-compose.workflows.override.yaml
@@ -8,3 +8,8 @@ services:
     command: yarn run start:dev
     volumes:
       - ${XPLAT_FBC_DIR}/fbcnms-projects/workflows/src:/app/fbcnms-projects/workflows/src
+    networks:
+      - private
+      - public
+    ports:
+      - 8088:80


### PR DESCRIPTION
Summary:
Fix bugs preventing creation of workflow with global tasks (prefixed with `GLOBAL___`).
Also fix babel compilation issues on master.

Test plan:
In order to test global tasks, POST directly to conductor bypassing the proxy:
```
curl -v \
 -H 'Content-Type: application/json' \
 ${CONDUCTOR_API}/metadata/taskdefs -X POST -d '
[
    {
      "name": "GLOBAL___js",
      "type": "SIMPLE",
      "retryCount": 3,
      "retryLogic": "FIXED",
      "retryDelaySeconds": 10,
      "timeoutSeconds": 300,
      "timeoutPolicy": "TIME_OUT_WF",
      "responseTimeoutSeconds": 180,
      "ownerEmail": "foo@bar.baz"
    }
]
'
```
Create new workflow in the UI. Click `Tasks` in the left panel. `GLOBAL___js` should appear to all tenants.

![Screenshot at 2020-06-05 22-06-04](https://user-images.githubusercontent.com/492226/83918349-d6ce9b80-a778-11ea-9a1e-2948b94742c8.png)

Create a workflow with this task. Saving it should work.