### PR TITLE
Updated magma services to use log-level defined in mconfig

### DIFF
--- a/lte/gateway/configs/directoryd.yml
+++ b/lte/gateway/configs/directoryd.yml
@@ -7,4 +7,4 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. It can be overridden here

--- a/lte/gateway/configs/enodebd.yml
+++ b/lte/gateway/configs/enodebd.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 #
-log_level: INFO
+# log_level is set in mconfig. It can be overridden here
 
 tr069:
   interface: eth1 # NOTE: this value must be consistent with dnsmasq.conf

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -7,7 +7,7 @@
 ## LICENSE file in the root directory of this source tree. An additional grant
 ## of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 fluent_bit_port: 5170
 tcp_timeout: 5
 event_registry:

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree.
 ################################################################################
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 
 # List of services for magmad to control
 magma_services:

--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 persist_to_redis: false
 redis_port: 6380
 allocator_type: ip_pool

--- a/lte/gateway/configs/monitord.yml
+++ b/lte/gateway/configs/monitord.yml
@@ -7,5 +7,5 @@
 ## LICENSE file in the root directory of this source tree. An additional grant
 ## of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 mtr_interface: mtr0

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -22,7 +22,8 @@
 # Differentiate between the setup type(CWF or LTE)
 setup_type: LTE
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
+
 # Enable the services in PipelineD. Tables will be assigned to the services in
 # the same order as the list. Cloud managed services will be initialized
 # after these static services.

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -22,7 +22,8 @@
 # Differentiate between the setup type(CWF or LTE)
 setup_type: LTE
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
+
 # Enable the services in PipelineD. Tables will be assigned to the services in
 # the same order as the list. Cloud managed services will be initialized
 # after these static services.

--- a/lte/gateway/configs/policydb.yml
+++ b/lte/gateway/configs/policydb.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 
 # Enable streaming from the cloud for policy updates
 enable_streaming: True

--- a/lte/gateway/configs/redirectd.yml
+++ b/lte/gateway/configs/redirectd.yml
@@ -7,6 +7,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 
 http_port: 8080

--- a/lte/gateway/configs/state.yml
+++ b/lte/gateway/configs/state.yml
@@ -7,7 +7,7 @@
 ## LICENSE file in the root directory of this source tree. An additional grant
 ## of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 
 #state_protos:
 #  - proto_file:  - file to load proto from

--- a/lte/gateway/configs/subscriberdb.yml
+++ b/lte/gateway/configs/subscriberdb.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+# log_level is set in mconfig. it can be overridden here
 
 # Host address of the Diameter/S6A MME server
 host_address: 0.0.0.0 # Bind to all interfaces

--- a/lte/gateway/configs/tarazedd.yml
+++ b/lte/gateway/configs/tarazedd.yml
@@ -7,8 +7,6 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
-
 # The PDU credentials for PDU configuration
 pdu_username: admin
 pdu_password: facebook

--- a/orc8r/gateway/python/magma/common/service.py
+++ b/orc8r/gateway/python/magma/common/service.py
@@ -277,7 +277,8 @@ class MagmaService(Service303Servicer):
             config_level = None
         else:
             config_level = self._config.get('log_level', None)
-
+            if config_level is None and self._mconfig is not None:
+                config_level = LogLevel.Name(self._mconfig.log_level)
         try:
             proto_level = LogLevel.Value(config_level)
         except ValueError:


### PR DESCRIPTION
Summary: Previously, magma services would only read log level defined in their respective yml file inside `/lte/gateway/configs`. Now if that log level happens to be missing/undefined, the service will look at its mconfig and use the log level defined there.

Differential Revision: D21937200

