### PR TITLE
Switching AAA server logs to glog

### DIFF
--- a/feg/gateway/services/aaa/servicers/accounting.go
+++ b/feg/gateway/services/aaa/servicers/accounting.go
@@ -11,13 +11,11 @@ package servicers
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"strings"
 	"time"
 
-	"magma/gateway/directoryd"
-
+	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -28,6 +26,7 @@ import (
 	"magma/feg/gateway/services/aaa/metrics"
 	"magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/aaa/session_manager"
+	"magma/gateway/directoryd"
 	lte_protos "magma/lte/cloud/go/protos"
 	orcprotos "magma/orc8r/lib/go/protos"
 )
@@ -108,7 +107,7 @@ func (srv *accountingService) Stop(_ context.Context, req *protos.StopRequest) (
 	s := srv.sessions.RemoveSession(sid)
 	if s == nil {
 		// Log error and return OK, no need to stop accounting for already removed session
-		log.Printf("Accounting Stop: Session %s is not found", sid)
+		glog.Warningf("Accounting Stop: Session %s is not found", sid)
 		return &protos.AcctResp{}, nil
 	}
 

--- a/feg/gateway/services/aaa/servicers/common.go
+++ b/feg/gateway/services/aaa/servicers/common.go
@@ -11,14 +11,14 @@ package servicers
 
 import (
 	"fmt"
-	"log"
 	"time"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"magma/feg/cloud/go/protos/mconfig"
 	"magma/feg/gateway/services/aaa"
-
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 // GetIdleSessionTimeout returns Idle Session Timeout Duration if set in mconfigs or DefaultSessionTimeout otherwise
@@ -33,7 +33,7 @@ func GetIdleSessionTimeout(cfg *mconfig.AAAConfig) time.Duration {
 
 func Errorf(code codes.Code, format string, a ...interface{}) error {
 	msg := fmt.Sprintf(format, a...)
-	log.Printf("%s; [RPC: %s]", msg, code.String())
+	glog.Errorf("%s; [RPC: %s]", msg, code.String())
 	return status.Errorf(code, msg)
 }
 
@@ -42,7 +42,7 @@ func Error(code codes.Code, err error) error {
 		if se, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
 			code = se.GRPCStatus().Code()
 		}
-		log.Printf("%v; [RPC: %s]", err, code.String())
+		glog.Errorf("%v; [RPC: %s]", err, code.String())
 		return status.Error(code, err.Error())
 	}
 	return nil

--- a/feg/gateway/services/aaa/servicers/responders.go
+++ b/feg/gateway/services/aaa/servicers/responders.go
@@ -11,19 +11,18 @@ package servicers
 
 import (
 	"fmt"
-	"log"
 
-	"magma/feg/gateway/services/aaa/metrics"
-	"magma/gateway/directoryd"
-
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/proto"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
+	"magma/feg/gateway/services/aaa/metrics"
 	"magma/feg/gateway/services/aaa/protos"
 	"magma/feg/gateway/services/aaa/session_manager"
+	"magma/gateway/directoryd"
 	lteprotos "magma/lte/cloud/go/protos"
 	orcprotos "magma/orc8r/lib/go/protos"
 )
@@ -49,14 +48,14 @@ func (srv *accountingService) AbortSession(
 	if len(sid) == 0 {
 		res.Code = lteprotos.AbortSessionResult_USER_NOT_FOUND
 		res.ErrorMessage = fmt.Sprintf("Session for IMSI: %s is not found", imsi)
-		log.Print(res.ErrorMessage)
+		glog.Error(res.ErrorMessage)
 		return res, nil
 	}
 	s := srv.sessions.GetSession(sid)
 	if s == nil {
 		res.Code = lteprotos.AbortSessionResult_SESSION_NOT_FOUND
 		res.ErrorMessage = fmt.Sprintf("Session for Radius Session ID: %s and IMSI: %s is not found", sid, imsi)
-		log.Print(res.ErrorMessage)
+		glog.Error(res.ErrorMessage)
 		return res, nil
 	}
 	s.Lock()
@@ -71,7 +70,7 @@ func (srv *accountingService) AbortSession(
 		res.ErrorMessage = fmt.Sprintf(
 			"Accounting Session ID Mismatch for RadSID %s and IMSI: %s. Requested: %s, recorded: %s",
 			sid, imsi, req.GetSessionId(), asid)
-		log.Print(res.ErrorMessage)
+		glog.Error(res.ErrorMessage)
 		return res, nil
 	}
 	if srv.config.GetAccountingEnabled() {
@@ -99,7 +98,7 @@ func (srv *accountingService) AbortSession(
 		res.Code = lteprotos.AbortSessionResult_RADIUS_SERVER_ERROR
 		res.ErrorMessage = fmt.Sprintf(
 			"Radius Disconnect Error: %v for IMSI: %s, Acct SID: %s, Radius SID: %s", err, imsi, asid, sid)
-		log.Print(res.ErrorMessage)
+		glog.Error(res.ErrorMessage)
 		return res, nil
 	}
 	return res, err

--- a/feg/gateway/services/aaa/session_manager/client_api.go
+++ b/feg/gateway/services/aaa/session_manager/client_api.go
@@ -12,8 +12,8 @@ package session_manager
 import (
 	"errors"
 	"fmt"
-	"log"
 
+	"github.com/golang/glog"
 	"golang.org/x/net/context"
 
 	"magma/feg/gateway/registry"
@@ -30,7 +30,7 @@ func getSessionManagerClient() (*sessionManagerClient, error) {
 	conn, err := registry.GetConnection(registry.SESSION_MANAGER)
 	if err != nil {
 		errMsg := fmt.Sprintf("Local SessionManager client initialization error: %s", err)
-		log.Printf(errMsg)
+		glog.Error(errMsg)
 		return nil, errors.New(errMsg)
 	}
 	return &sessionManagerClient{protos.NewLocalSessionManagerClient(conn)}, err

--- a/feg/gateway/services/aaa/store/in_memory.go
+++ b/feg/gateway/services/aaa/store/in_memory.go
@@ -11,12 +11,13 @@ package store
 
 import (
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 	"unsafe"
+
+	"github.com/golang/glog"
 
 	"magma/feg/gateway/services/aaa"
 	"magma/feg/gateway/services/aaa/metrics"
@@ -112,7 +113,7 @@ func (st *memSessionTable) AddSession(
 		if len(overwrite) > 0 && overwrite[0] {
 			if oldSession != nil {
 				oldImsi := oldSession.imsi
-				log.Printf("Session with SID: %s already exist, will overwrite. Old IMSI: %s, New IMSI: %s",
+				glog.Warningf("Session with SID: %s already exist, will overwrite. Old IMSI: %s, New IMSI: %s",
 					sid, oldImsi, imsi)
 
 				oldSession.StopTimeout()
@@ -135,7 +136,7 @@ func (st *memSessionTable) AddSession(
 				oldImsiSession.StopTimeout()
 			}
 			delete(st.sids, oldSessionId)
-			log.Printf("old session with SID: %s found for IMSI: %s, will remove", oldSessionId, imsi)
+			glog.Infof("old session with SID: %s found for IMSI: %s, will remove", oldSessionId, imsi)
 		}
 	}
 	st.sm[sid] = s
@@ -253,7 +254,7 @@ func cleanupTimer(ctx *cleanupTimerCtx) {
 			if ctx.notifyRoutine != nil {
 				notifyResult = ctx.notifyRoutine(s)
 			}
-			log.Printf(
+			glog.Infof(
 				"Timed out session '%s' for SessionId: %s; IMSI: %s; Identity: %s; MAC: %s; IP: %s; notify result: %v",
 				ctx.sidKey, s.GetSessionId(), s.GetImsi(), s.GetIdentity(), s.GetMacAddr(), s.GetIpAddr(), notifyResult)
 


### PR DESCRIPTION
Summary: due to popular demand, moving aaa server logs to glog format

Reviewed By: uri200

Differential Revision: D21941778

