### PR TITLE
Increment request_number in SessionStore immediately before reporting to session_proxy

### DIFF
--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -78,6 +78,10 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
               << " charging updates and " << request.usage_monitors_size()
               << " monitor updates to OCS and PCRF";
 
+  // Before reporting and returning control to the event loop, increment the
+  // request numbers stored for the sessions in SessionStore
+  session_store_.sync_request_numbers(session_update);
+
   // report to cloud
   // NOTE: It is not possible to construct a std::function from a move-only type
   //       So because of this, we can't directly move session_map into the
@@ -469,7 +473,7 @@ SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_reporting(
   for (const RuleRecord& record : records.records()) {
     req.insert(record.sid());
   }
-  return session_store_.read_sessions_for_reporting(req);
+  return session_store_.read_sessions(req);
 }
 
 SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_deletion(

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -214,6 +214,7 @@ void SessionState::get_updates_from_charging_pool(
     fill_protos_tgpp_context(new_req->mutable_tgpp_ctx());
     new_req->mutable_usage()->CopyFrom(update);
     request_number_++;
+    update_criteria.request_number_increment++;
   }
 }
 
@@ -231,6 +232,7 @@ void SessionState::get_updates_from_monitor_pool(
     new_req->mutable_update()->CopyFrom(update);
     new_req->set_event_trigger(USAGE_REPORT);
     request_number_++;
+    update_criteria.request_number_increment++;
   }
   // todo We should also handle other event triggers here too
   auto it = pending_event_triggers_.find(REVALIDATION_TIMEOUT);
@@ -239,6 +241,7 @@ void SessionState::get_updates_from_monitor_pool(
     add_common_fields_to_usage_monitor_update(new_req);
     new_req->set_event_trigger(REVALIDATION_TIMEOUT);
     request_number_++;
+    update_criteria.request_number_increment++;
     // todo we might want to make sure that the update went successfully before
     // clearing here
     remove_event_trigger(REVALIDATION_TIMEOUT, update_criteria);

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -73,17 +73,15 @@ class SessionStore {
   SessionMap read_all_sessions();
 
   /**
-   * Read the last written values for the requested sessions through the
-   * storage interface. This also modifies the request_numbers stored before
-   * returning the SessionMap to the caller.
-   * NOTE: It is assumed that the correct number of request_numbers are
-   *       reserved on each read_sessions call. If more requests are made to
-   *       the OCS/PCRF than are requested, this can cause undefined behavior.
-   * @param req
-   * @return Last written values for requested sessions. Returns an empty vector
-   *         for subscribers that do not have active sessions.
+   * Modify the SessionMap in SessionStore to match the current state in
+   * the callback.
+   * NOTE: Call this method before reporting to other services.
+   * NOTE: To avoid race conditions, call this method immediately after
+   *       incrementing request numbers and returning control back to the
+   *       event loop.
+   * @param update_criteria
    */
-  SessionMap read_sessions_for_reporting(const SessionRead& req);
+  void sync_request_numbers(const SessionUpdate& update_criteria);
 
   /**
    * Read the last written values for the requested sessions through the
@@ -115,6 +113,7 @@ class SessionStore {
    * Attempt to update sessions with update criteria. If any update to any of
    * the sessions is invalid, the whole update request is assumed to be invalid,
    * and nothing in storage will be overwritten.
+   * NOTE: Will not update request_number. Use sync_request_numbers.
    * @param update_criteria
    * @return true if successful, otherwise the update to storage is discarded.
    */

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -17,6 +17,7 @@ SessionStateUpdateCriteria get_default_update_criteria() {
   SessionStateUpdateCriteria uc{};
   uc.is_fsm_updated = false;
   uc.is_config_updated = false;
+  uc.request_number_increment = 0;
   uc.charging_credit_to_install =
       std::unordered_map<CreditKey, StoredSessionCredit, decltype(&ccHash),
                          decltype(&ccEqual)>(4, &ccHash, &ccEqual);

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -210,6 +210,7 @@ struct SessionStateUpdateCriteria {
   // this value is only valid if one of the updated event trigger is
   // revalidation time
   google::protobuf::Timestamp revalidation_time;
+  uint32_t request_number_increment;
 
   std::set<std::string> static_rules_to_install;
   std::set<std::string> static_rules_to_uninstall;


### PR DESCRIPTION
Summary:
### Changes
- `SessionStore` has a new method called `sync_request_numbers`, which is intended to be called before a caller reports usage updates.
- New unit test in `test_session_store.cpp`, `test_sync_request_numbers`
- `SessionStore` will no longer have the request_number of each session incremented during read. Instead, readers are responsible for syncing in incremented request_numbers to SessionStore before yielding control back to the event loop
- Deleted `SessionStore`'s `read_sessions_for_reporting`

Differential Revision: D21925161

