### PR TITLE
Properly update reauth state machine

### DIFF
--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -337,12 +337,12 @@ SessionCredit::Usage SessionCredit::get_all_unreported_usage_for_reporting(
 
 SessionCredit::Usage SessionCredit::get_usage_for_reporting(
     SessionCreditUpdateCriteria &update_criteria) {
-  if (is_final_grant_) {
-    return get_all_unreported_usage_for_reporting(update_criteria);
-  }
-
   if (reauth_state_ == REAUTH_REQUIRED) {
     set_reauth(REAUTH_PROCESSING, update_criteria);
+  }
+
+  if (is_final_grant_) {
+    return get_all_unreported_usage_for_reporting(update_criteria);
   }
 
   auto usage = get_unreported_usage();


### PR DESCRIPTION
Summary:
Reauth state should be updated in any case to REAUTH_PROCESSING.
In the case of final action set to terminate, the problem is hidden as the session is deleted.
But in the case of redirection or service restriction, this is problematic and will trigger multipe CCR-U.

Reviewed By: themarwhal

Differential Revision: D21950638

