### PR TITLE
Move lib/go module to use glog

### DIFF
--- a/orc8r/gateway/go/config/control_proxy_config.go
+++ b/orc8r/gateway/go/config/control_proxy_config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/golang/glog"
 
 	"magma/orc8r/lib/go/definitions"
+	_ "magma/orc8r/lib/go/initflag"
 	"magma/orc8r/lib/go/service/config"
 )
 

--- a/orc8r/gateway/go/mconfig/impl.go
+++ b/orc8r/gateway/go/mconfig/impl.go
@@ -22,6 +22,7 @@ import (
 	"github.com/golang/glog"
 
 	"magma/gateway/config"
+	_ "magma/orc8r/lib/go/initflag"
 	"magma/orc8r/lib/go/protos"
 )
 

--- a/orc8r/gateway/go/service_registry/shared_registry.go
+++ b/orc8r/gateway/go/service_registry/shared_registry.go
@@ -9,11 +9,11 @@ LICENSE file in the root directory of this source tree.
 package service_registry
 
 import (
-	"flag"
 	"sync/atomic"
 
 	"github.com/golang/glog"
 
+	_ "magma/orc8r/lib/go/initflag"
 	platform_registry "magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/serviceregistry"
 )
@@ -32,13 +32,7 @@ func Get() GatewayRegistry {
 		// moduleName is "" since all feg configs lie in /etc/magma without a module name
 		locations, err := serviceregistry.LoadServiceRegistryConfig("")
 		if err != nil {
-			if flag.Parsed() {
-				glog.Warningf(serviceRegLoadErrorFmt, err)
-			} else {
-				// glog prints an additional error message if logging happens before flag.Parse(), in this case -
-				// only log with higher verbosity
-				glog.V(1).Infof(serviceRegLoadErrorFmt, err)
-			}
+			glog.Warningf(serviceRegLoadErrorFmt, err)
 			// return registry, but don't store/cache it
 			return reg
 		}

--- a/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_broker_test.go
+++ b/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_broker_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"magma/orc8r/lib/go/protos"
 	"net"
 	"net/http"
 	"strconv"
@@ -30,6 +29,8 @@ import (
 	"golang.org/x/net/http2"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
+
+	"magma/orc8r/lib/go/protos"
 )
 
 func parseHeaders(hdr http.Header) map[string]string {

--- a/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_client.go
+++ b/orc8r/gateway/go/services/sync_rpc/service/sync_rpc_client.go
@@ -17,9 +17,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"magma/gateway/service_registry"
-	"magma/orc8r/lib/go/definitions"
-	"magma/orc8r/lib/go/protos"
 	"net"
 	"net/http"
 	"net/url"
@@ -30,6 +27,11 @@ import (
 
 	"github.com/golang/glog"
 	"golang.org/x/net/http2"
+
+	"magma/gateway/service_registry"
+	"magma/orc8r/lib/go/definitions"
+	_ "magma/orc8r/lib/go/initflag"
+	"magma/orc8r/lib/go/protos"
 )
 
 const (

--- a/orc8r/gateway/go/status/gateway_status.go
+++ b/orc8r/gateway/go/status/gateway_status.go
@@ -113,15 +113,15 @@ func GetNetworkInfo() *NetworkInfo {
 	for i, ni := range netInterfaces {
 		// dumb down, interface status
 		status := "UNKNOWN"
-	statCovertLoop:
+	statConvertLoop:
 		for _, f := range ni.Flags {
 			switch strings.ToLower(f) {
 			case "up":
 				status = "UP"
-				break statCovertLoop
+				break statConvertLoop
 			case "down", "disabled":
 				status = "DOWN"
-				break statCovertLoop
+				break statConvertLoop
 			}
 		}
 		netIface := &NetworkInterface{

--- a/orc8r/lib/go/initflag/initflag.go
+++ b/orc8r/lib/go/initflag/initflag.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// package initflag initializes (parses) Go flag if needed, it allows the noise free use of golog & other packages
+// relying on flag being parsed
+package initflag
+
+import (
+	"flag"
+	"os"
+)
+
+func init() {
+	if !flag.Parsed() {
+		name := ""
+		if len(os.Args) > 0 {
+			name = os.Args[0]
+		}
+		flag.CommandLine.Init(name, flag.ContinueOnError)
+		flag.CommandLine.Parse([]string{})
+	}
+}

--- a/orc8r/lib/go/protos/identity_helper.go
+++ b/orc8r/lib/go/protos/identity_helper.go
@@ -12,12 +12,12 @@ package protos
 
 import (
 	"fmt"
-	"log"
 	"reflect"
 
 	"golang.org/x/net/context"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"github.com/golang/glog"
 )
 
 // Identity type names table. Every Identity type should add a unique type name
@@ -125,7 +125,7 @@ func (id *Identity) HashString() string {
 			if typ.Kind() == reflect.Ptr {
 				typ = typ.Elem() // dereference if ptr
 			}
-			log.Printf(
+			glog.Errorf(
 				"Magma Identity ERROR: type '%s' is missing Hashable Type Name",
 				typ.Name())
 		}

--- a/orc8r/lib/go/service/config/config_map.go
+++ b/orc8r/lib/go/service/config/config_map.go
@@ -11,8 +11,9 @@ package config
 import (
 	"errors"
 	"fmt"
-	"log"
 	"reflect"
+
+	"github.com/golang/glog"
 )
 
 // ConfigMap represents a map generated from a service YML file.
@@ -114,7 +115,7 @@ func (c *ConfigMap) GetMap(key string) (map[interface{}]interface{}, error) {
 func (c *ConfigMap) MustGetInt(key string) int {
 	param, err := c.GetInt(key)
 	if err != nil {
-		log.Fatalf("Error retrieving %s: %v\n", key, err)
+		glog.Fatalf("Error retrieving %s: %v\n", key, err)
 	}
 	return param
 }
@@ -123,7 +124,7 @@ func (c *ConfigMap) MustGetInt(key string) int {
 func (c *ConfigMap) MustGetBool(key string) bool {
 	param, err := c.GetBool(key)
 	if err != nil {
-		log.Fatalf("Error retrieving %s: %v\n", key, err)
+		glog.Fatalf("Error retrieving %s: %v\n", key, err)
 	}
 	return param
 }
@@ -132,7 +133,7 @@ func (c *ConfigMap) MustGetBool(key string) bool {
 func (c *ConfigMap) MustGetString(key string) string {
 	str, err := c.GetString(key)
 	if err != nil {
-		log.Fatalf("Error retrieving %s: %v\n", key, err)
+		glog.Fatalf("Error retrieving %s: %v\n", key, err)
 	}
 	return str
 }
@@ -141,7 +142,7 @@ func (c *ConfigMap) MustGetString(key string) string {
 func (c *ConfigMap) MustGetStrings(key string) []string {
 	param, err := c.GetStrings(key)
 	if err != nil {
-		log.Fatalf("Error retrieving %s: %v\n", key, err)
+		glog.Fatalf("Error retrieving %s: %v\n", key, err)
 	}
 	return param
 }
@@ -150,7 +151,7 @@ func (c *ConfigMap) MustGetStrings(key string) []string {
 func (c *ConfigMap) MustGetMap(key string) map[interface{}]interface{} {
 	param, err := c.GetMap(key)
 	if err != nil {
-		log.Fatalf("Error retrieving %s: %v\n", key, err)
+		glog.Fatalf("Error retrieving %s: %v\n", key, err)
 	}
 	return param
 }

--- a/orc8r/lib/go/service/config/service_config.go
+++ b/orc8r/lib/go/service/config/service_config.go
@@ -11,13 +11,15 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
 
+	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
+
+	_ "magma/orc8r/lib/go/initflag"
 )
 
 var (
@@ -42,7 +44,7 @@ func GetServiceConfig(moduleName string, serviceName string) (*ConfigMap, error)
 func MustGetServiceConfig(moduleName string, serviceName string) *ConfigMap {
 	cfg, err := GetServiceConfig(moduleName, serviceName)
 	if err != nil {
-		log.Fatal(err)
+		glog.Fatal(err)
 	}
 	return cfg
 }
@@ -76,13 +78,13 @@ func GetStructuredServiceConfigExt(
 	if err == nil {
 		err = yaml.Unmarshal(yamlFileData, out)
 		if err != nil {
-			log.Printf("Structured CFG: Error Unmarshaling '%s' into type %T: %v", ymlFilePath, out, err)
+			glog.Errorf("Structured CFG: Error Unmarshaling '%s' into type %T: %v", ymlFilePath, out, err)
 		} else {
-			log.Printf("Successfully loaded structured '%s::%s' service configs from '%s'",
+			glog.Infof("Successfully loaded structured '%s::%s' service configs from '%s'",
 				moduleName, serviceName, ymlFilePath)
 		}
 	} else {
-		log.Printf("Structured CFG: Error Reading '%s': %v", ymlFilePath, err)
+		glog.Errorf("Structured CFG: Error Reading '%s': %v", ymlFilePath, err)
 	}
 	// Overwrite params from override configs
 	var oerr error
@@ -92,14 +94,14 @@ func GetStructuredServiceConfigExt(
 		if oerr == nil {
 			oerr = yaml.Unmarshal(yamlFileData, out)
 			if oerr != nil {
-				log.Printf("Structured CFG: Error Unmarshaling Override file '%s' into type %T: %v",
+				glog.Errorf("Structured CFG: Error Unmarshaling Override file '%s' into type %T: %v",
 					ymlQWFilePath, out, err)
 			} else {
-				log.Printf("Successfully loaded Override configs for service %s:%s from '%s'",
+				glog.Infof("Successfully loaded Override configs for service %s:%s from '%s'",
 					moduleName, serviceName, ymlQWFilePath)
 			}
 		} else {
-			log.Printf("Structured CFG:Error Loading Override configs from '%s': %v", ymlQWFilePath, err)
+			glog.Errorf("Structured CFG:Error Loading Override configs from '%s': %v", ymlQWFilePath, err)
 		}
 	} else {
 		ymlQWFilePath = ""
@@ -134,20 +136,20 @@ func getServiceConfigImpl(moduleName, serviceName, configDir, oldConfigDir, conf
 	if err != nil {
 		// If error - try Override cfg
 		config = &ConfigMap{RawMap: map[interface{}]interface{}{}}
-		log.Printf("Error Loading %s::%s configs from '%s': %v", moduleName, serviceName, configFileName, err)
+		glog.Errorf("Error Loading %s::%s configs from '%s': %v", moduleName, serviceName, configFileName, err)
 	} else {
-		log.Printf("Successfully loaded '%s::%s' service configs from '%s'", moduleName, serviceName, configFileName)
+		glog.Infof("Successfully loaded '%s::%s' service configs from '%s'", moduleName, serviceName, configFileName)
 	}
 
 	overrideFileName := filepath.Join(configOverrideDir, moduleName, fmt.Sprintf("%s.yml", serviceName))
 	if fi, serr := os.Stat(overrideFileName); serr == nil && !fi.IsDir() {
 		overrides, oerr := loadYamlFile(overrideFileName)
 		if oerr != nil {
-			log.Printf("Error Loading %s Override configs from '%s': %v", serviceName, overrideFileName, oerr)
+			glog.Errorf("Error Loading %s Override configs from '%s': %v", serviceName, overrideFileName, oerr)
 			return config, err
 		}
 		config = updateMap(config, overrides)
-		log.Printf("Successfully loaded Override configs for service %s:%s from '%s'",
+		glog.Infof("Successfully loaded Override configs for service %s:%s from '%s'",
 			moduleName, serviceName, overrideFileName)
 		err = nil
 	}
@@ -164,7 +166,7 @@ func getServiceConfigFilePath(moduleName, serviceName, configDir, oldConfigDir s
 		old := configFileName
 		configFileName = filepath.Join(oldConfigDir, moduleName, fmt.Sprintf("%s.yml", serviceName))
 		if fi, err := os.Stat(configFileName); err != nil || fi.IsDir() {
-			log.Printf("Cannot find '%s': %v, or Legacy Service Registry Configuration: '%s': %v",
+			glog.Warningf("Cannot find '%s': %v, or Legacy Service Registry Configuration: '%s': %v",
 				old, nerr, configFileName, err)
 		}
 	}

--- a/orc8r/lib/go/service/logcodec.go
+++ b/orc8r/lib/go/service/logcodec.go
@@ -11,8 +11,8 @@ package service
 import (
 	"bytes"
 	"fmt"
-	"log"
 
+	"github.com/golang/glog"
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/grpc/encoding"
@@ -38,7 +38,7 @@ func printMessage(prefix string, v interface{}) {
 	} else {
 		payload = fmt.Sprintf("\n\t %T is not proto.Message; %+v", v, v)
 	}
-	log.Printf("%s%T: %s", prefix, v, payload)
+	glog.Infof("%s%T: %s", prefix, v, payload)
 }
 
 // Marshal of GRPC Codec interface

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -55,6 +55,7 @@ var defaultKeepaliveParams = keepalive.ServerParameters{
 
 func init() {
 	flag.BoolVar(&printGrpcPayload, PrintGrpcPayloadFlag, false, "Enable GRPC Payload Printout")
+	flag.Parse()
 }
 
 type Service struct {
@@ -83,10 +84,8 @@ type Service struct {
 
 // NewServiceWithOptions returns a new GRPC orchestrator service implementing
 // service303 with the specified grpc server options.
-// NewServiceWithOptions will also call flag.Parse() prior to cerating the service.
 // It will not instantiate the service with the identity checking middleware.
 func NewServiceWithOptions(moduleName string, serviceName string, serverOptions ...grpc.ServerOption) (*Service, error) {
-	flag.Parse()
 	return NewServiceWithOptionsImpl(moduleName, serviceName, serverOptions...)
 }
 

--- a/orc8r/lib/go/service/service303.go
+++ b/orc8r/lib/go/service/service303.go
@@ -13,10 +13,10 @@ import (
 	"fmt"
 	"strconv"
 
+	"golang.org/x/net/context"
+
 	"magma/orc8r/lib/go/metrics"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // GetServiceInfo returns service-level info (name, version, status, etc...)

--- a/orc8r/lib/go/service/serviceregistry/service_registry.go
+++ b/orc8r/lib/go/service/serviceregistry/service_registry.go
@@ -10,8 +10,9 @@ package serviceregistry
 
 import (
 	"fmt"
-	"log"
 	"strings"
+
+	"github.com/golang/glog"
 
 	"magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/config"
@@ -37,7 +38,7 @@ func LoadServiceRegistryConfig(moduleName string) ([]registry.ServiceLocation, e
 	}
 	locations, err := convertToServiceLocations(rawMap)
 	if err != nil {
-		log.Printf("Failed to load in service registry for %s:%s.yml: %v", moduleName, serviceRegistryFilename, err)
+		glog.Errorf("Failed to load in service registry for %s:%s.yml: %v", moduleName, serviceRegistryFilename, err)
 	}
 	return locations, err
 }


### PR DESCRIPTION
Summary: lib/go uses log & glog logging facilities, switch all logging to golog

Reviewed By: uri200

Differential Revision: D21962085

