### PR TITLE
Bump flow to 0.126.1

### DIFF
--- a/symphony/app/.flowconfig
+++ b/symphony/app/.flowconfig
@@ -94,4 +94,4 @@ untyped-import
 untyped-type-import
 
 [version]
-^0.125.1
+^0.126.1


### PR DESCRIPTION
Summary:
Bump flow version, fix logging package to comply.
- typed `StreamOptions` explicitly because implicit wasn't working
- added return type for `getHttpLogger` since it was missing and assumed `any`

Differential Revision: D21965860

