### PR TITLE
Add AAA session store method to retreive session CTX by IMSI "attomically"

### DIFF
--- a/feg/gateway/services/aaa/session.go
+++ b/feg/gateway/services/aaa/session.go
@@ -59,6 +59,8 @@ type SessionTable interface {
 	GetSession(sid string) (session Session)
 	// FindSession returns session ID corresponding to the given IMSI (empty string if not found)
 	FindSession(imsi string) (sessionId string)
+	// GetSessionByImsi returns session corresponding to the given IMSI or nil if not found
+	GetSessionByImsi(imsi string) (session Session)
 	// RemoveSession - removes the session with the given SID and returns it, returns nil if not found
 	RemoveSession(sid string) Session
 	// SetTimeout - [Re]sets the session's cleanup timeout to fire after tout duration

--- a/feg/gateway/services/aaa/store/in_memory.go
+++ b/feg/gateway/services/aaa/store/in_memory.go
@@ -173,6 +173,19 @@ func (st *memSessionTable) FindSession(imsi string) (sid string) {
 	return sid
 }
 
+// GetSessionByImsi returns session corresponding to the given IMSI or nil if not found
+func (st *memSessionTable) GetSessionByImsi(imsi string) aaa.Session {
+	var s *memSession
+	if st != nil {
+		st.rwl.RLock()
+		if sid, ok := st.sids[imsi]; ok {
+			s, _ = st.sm[sid]
+		}
+		st.rwl.RUnlock()
+	}
+	return s
+}
+
 // RemoveSession - removes the session with the given SID and returns it
 func (st *memSessionTable) RemoveSession(sid string) aaa.Session {
 	if st != nil {

--- a/orc8r/gateway/go/mconfig/test_utils.go
+++ b/orc8r/gateway/go/mconfig/test_utils.go
@@ -11,9 +11,12 @@ package mconfig
 import (
 	"io/ioutil"
 	"os"
+	"time"
 )
 
 func CreateLoadTempConfig(configJSON string) error {
+	StopRefreshTicker()
+
 	tmpfile, err := ioutil.TempFile("", "mconfig_test")
 	if err != nil {
 		return err
@@ -26,7 +29,7 @@ func CreateLoadTempConfig(configJSON string) error {
 	tmpfile.Close()
 	defer os.Remove(mcpath)
 
-	StopRefreshTicker()
+	time.Sleep(time.Second) // give extra time for in-flight RefreshTicker to complete
 
 	return RefreshConfigsFrom(mcpath)
 }


### PR DESCRIPTION
Summary: Add AAA session store method to retreive session CTX by IMSI "attomically" to avoid inconsistencies between FindSession() and GetSession() calls & optimize locking.

Differential Revision: D21966286

