### PR TITLE
Fix redirection rule being installed every 2 seconds

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -510,12 +510,20 @@ void SessionState::insert_dynamic_rule(
 }
 
 void SessionState::insert_gy_dynamic_rule(
-    const PolicyRule& rule,  SessionStateUpdateCriteria& update_criteria) {
+    const PolicyRule& rule, RuleLifetime& lifetime,
+    SessionStateUpdateCriteria& update_criteria) {
   if (is_gy_dynamic_rule_installed(rule.id())) {
+    MLOG(MDEBUG) << "Tried to insert "<< rule.id()
+                 <<" (gy dynamic rule), but it already existed";
     return;
   }
   update_criteria.gy_dynamic_rules_to_install.push_back(rule);
+  rule_lifetimes_[rule.id()] = lifetime;
   gy_dynamic_rules_.insert_rule(rule);
+  update_criteria.dynamic_rules_to_install.push_back(rule);
+  update_criteria.new_rule_lifetimes[rule.id()] = lifetime;
+
+
 }
 
 void SessionState::activate_static_rule(

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -215,7 +215,8 @@ class SessionState {
       SessionStateUpdateCriteria& update_criteria);
 
   void insert_gy_dynamic_rule(
-      const PolicyRule& rule, SessionStateUpdateCriteria& update_criteria);
+      const PolicyRule& rule, RuleLifetime& lifetime,
+      SessionStateUpdateCriteria& update_criteria);
 
   /**
    * Remove a currently active dynamic rule to mark it as deactivated.

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -241,10 +241,18 @@ bool SessionStore::merge_into_session(
                    << std::endl;
       return false;
     }
-    session->insert_gy_dynamic_rule(rule, uc);
-    MLOG(MERROR) << "Merge: " << session->get_session_id()
-                   << " gy dynamic rule " << rule.id()
+    if (update_criteria.new_rule_lifetimes.find(rule.id()) != update_criteria.new_rule_lifetimes.end()) {
+      auto lifetime = update_criteria.new_rule_lifetimes[rule.id()];
+      session->insert_gy_dynamic_rule(rule, lifetime, uc);
+      MLOG(MERROR) << "Merge: " << session->get_session_id()
+                   << " gy dynamic rule " << rule.id() << std::endl;
+    }
+    else{
+      MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
+                   << " because gy dynamic rule lifetime is not found"
                    << std::endl;
+      return false;
+    }
   }
   for (const auto& rule_id : update_criteria.gy_dynamic_rules_to_uninstall) {
     if (session->is_gy_dynamic_rule_installed(rule_id)) {

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -115,7 +115,9 @@ protected:
         address_type_converter(redirect_server.redirect_address_type()));
     redirect_info->set_server_address(redirect_server.redirect_server_address());
 
-    session_state->insert_gy_dynamic_rule(redirect_rule, update_criteria);
+    RuleLifetime lifetime{};
+    session_state->insert_gy_dynamic_rule(
+        redirect_rule, lifetime, update_criteria);
   }
 
   void receive_credit_from_ocs(uint32_t rating_group, uint64_t volume) {


### PR DESCRIPTION
Summary:
This diff fixes 2 issues
1- Gy redirect rule not being installed because RuleLifetime is missing
2- Pipelined being called in every cylce because we are not checking if redirect rule is already present

Differential Revision: D21910647

