### PR TITLE
Export additional metrics from conductor

### DIFF
--- a/symphony/integration/fluentd/Dockerfile
+++ b/symphony/integration/fluentd/Dockerfile
@@ -9,3 +9,4 @@ USER root
 
 # Install prometheus plugin
 RUN fluent-gem install fluent-plugin-prometheus
+RUN fluent-gem install fluent-plugin-rewrite-tag-filter

--- a/symphony/integration/fluentd/fluent_conductor.conf
+++ b/symphony/integration/fluentd/fluent_conductor.conf
@@ -1,50 +1,133 @@
-; syslog is used for conductor metrics streaming
+# syslog is used for conductor metrics streaming
 <source>
-  @type syslog
-  port 5170
-  bind 0.0.0.0
-  tag conductor
-    <parse>
-     ; only allow TIMER metrics of workflow execution and extract tenant ID
-      @type regexp
-      expression /^.*type=TIMER, name=workflow_execution.class-WorkflowMonitor.+workflowName-(?<tenant>.*)_(?<workflow>.+), count=(?<count>\d+), min=(?<min>[\d.]+), max=(?<max>[\d.]+), mean=(?<mean>[\d.]+).*$/
-      types count:integer,min:float,max:float,mean:float
-    </parse>
+	@type syslog
+	port 5170
+	bind 0.0.0.0
+	tag conductor
+	<parse>
+		@type none
+	</parse>
 </source>
 
-<filter conductor.local1.info>
-    @type prometheus
-    <metric>
-      name conductor_workflow_count
-      type gauge
-      desc The total number of executed workflows
-      key count
-      <labels>
-        workflow ${workflow}
-        tenant ${tenant}
-        user ${email}
-      </labels>
-    </metric>
-    <metric>
-      name conductor_workflow_max_duration
-      type gauge
-      desc Max duration in millis for a workflow
-      key max
-      <labels>
-        workflow ${workflow}
-        tenant ${tenant}
-        user ${email}
-      </labels>
-    </metric>
-    <metric>
-      name conductor_workflow_mean_duration
-      type gauge
-      desc Mean duration in millis for a workflow
-      key mean
-      <labels>
-        workflow ${workflow}
-        tenant ${tenant}
-        user ${email}
-      </labels>
-    </metric>
+# routing: match and stream metrics into different pipelines (add tag prefix)
+<match conductor.local1.info>
+	@type rewrite_tag_filter
+	<rule>
+		# workflow execution timer per tenant
+		key message
+		pattern /^.*type=TIMER, name=workflow_execution.class-WorkflowMonitor.*$/
+		tag workflow_success_timer
+	</rule>
+	<rule>
+		# workflow failure counter per tenant
+		key message
+		pattern /^.*type=METER, name=workflow_failure.class-WorkflowMonitor.+status-FAILED.*$/
+		tag workflow_failure_meter
+	</rule>
+	<rule>
+		# worker polling per task type (no tenancy info)
+		key message
+		pattern /^.*type=METER, name=task_poll.class-WorkflowMonitor.*$/
+		tag taskType_poll_meter
+	</rule>
+</match>
+
+<filter workflow_success_timer>
+	@type parser
+	key_name message
+	<parse>
+		@type regexp
+		expression /^.*workflowName-(?<tenant>.*)___(?<workflow>.+), count=(?<count>\d+), min=(?<min>[\d.]+), max=(?<max>[\d.]+), mean=(?<mean>[\d.]+).*$/
+		types count:integer,min:float,max:float,mean:float
+	</parse>
+</filter>
+
+<filter workflow_success_timer>
+	@type prometheus
+	<metric>
+		name conductor_workflow_count
+		type gauge
+		desc The total number of executed workflows
+		key count
+		<labels>
+			workflow ${workflow}
+			tenant ${tenant}
+		</labels>
+	</metric>
+	<metric>
+		name conductor_workflow_max_duration
+		type gauge
+		desc Max duration in millis for a workflow
+		key max
+		<labels>
+			workflow ${workflow}
+			tenant ${tenant}
+		</labels>
+	</metric>
+	<metric>
+		name conductor_workflow_mean_duration
+		type gauge
+		desc Mean duration in millis for a workflow
+		key mean
+		<labels>
+			workflow ${workflow}
+			tenant ${tenant}
+		</labels>
+	</metric>
+</filter>
+
+<filter workflow_failure_meter>
+	@type parser
+	key_name message
+	<parse>
+		@type regexp
+		expression /^.*workflowName-(?<tenant>.*)___(?<workflow>.+), count=(?<count>\d+).*$/
+		types count:integer
+	</parse>
+</filter>
+
+<filter workflow_failure_meter>
+	@type prometheus
+	<metric>
+		name conductor_workflow_failure_count
+		type gauge
+		desc The total number of failed workflows
+		key count
+		<labels>
+			workflow ${workflow}
+			tenant ${tenant}
+		</labels>
+	</metric>
+</filter>
+
+<filter taskType_poll_meter>
+	@type parser
+	key_name message
+	<parse>
+		@type regexp
+		expression /^.*taskType-(?<taskType>.*), count=(?<count>\d+), mean_rate=(?<mean>[\d.]+).*$/
+		types count:integer,mean:float
+	</parse>
+</filter>
+
+<filter taskType_poll_meter>
+	@type prometheus
+	<metric>
+		name conductor_taskType_poll_count
+		type gauge
+		desc The total number of poll requests by workers
+		key count
+		<labels>
+			taskType ${taskType}
+		</labels>
+	</metric>
+	<metric>
+		name conductor_taskType_mean_poll_frequency
+		type gauge
+		desc Mean worker polling frequency in polls/second
+		key mean
+		<labels>
+			taskType ${taskType}
+		</labels>
+	</metric>
 </filter>


### PR DESCRIPTION
+ workflow failures
+ worker poll stats

refactor conductor fluentd.conf to start using tag rewrite for better
metrics "routing"

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>