### PR TITLE
Properly stall Gy Redirection Flows in Session Store

### DIFF
--- a/lte/gateway/c/session_manager/CreditPool.cpp
+++ b/lte/gateway/c/session_manager/CreditPool.cpp
@@ -123,7 +123,8 @@ void UsageMonitoringCreditPool::populate_output_actions(
 
 void ChargingCreditPool::get_updates(
     std::string imsi, std::string ip_addr, StaticRuleStore &static_rules,
-    DynamicRuleStore *dynamic_rules, std::vector<CreditUsage> *updates_out,
+    DynamicRuleStore *dynamic_rules, DynamicRuleStore *gy_dynamic_rules,
+    std::vector<CreditUsage> *updates_out,
     std::vector<std::unique_ptr<ServiceAction>> *actions_out,
     SessionStateUpdateCriteria &update_criteria) {
   for (auto &credit_pair : credit_map_) {
@@ -451,7 +452,7 @@ get_monitor_update_from_struct(const SessionCredit::Usage &usage_in,
 
 void UsageMonitoringCreditPool::get_updates(
     std::string imsi, std::string ip_addr, StaticRuleStore &static_rules,
-    DynamicRuleStore *dynamic_rules,
+    DynamicRuleStore *dynamic_rules, DynamicRuleStore *gy_dynamic_rules,
     std::vector<UsageMonitorUpdate> *updates_out,
     std::vector<std::unique_ptr<ServiceAction>> *actions_out,
     SessionStateUpdateCriteria &update_criteria) {

--- a/lte/gateway/c/session_manager/CreditPool.h
+++ b/lte/gateway/c/session_manager/CreditPool.h
@@ -46,6 +46,7 @@ public:
   virtual void
   get_updates(std::string imsi, std::string ip_addr,
               StaticRuleStore &static_rules, DynamicRuleStore *dynamic_rules,
+              DynamicRuleStore *gy_dynamic_rules,
               std::vector<UpdateRequestType> *updates_out,
               std::vector<std::unique_ptr<ServiceAction>> *actions_out,
               SessionStateUpdateCriteria &update_criteria) = 0;
@@ -109,6 +110,7 @@ public:
   void get_updates(std::string imsi, std::string ip_addr,
                    StaticRuleStore &static_rules,
                    DynamicRuleStore *dynamic_rules,
+                   DynamicRuleStore *gy_dynamic_rules,
                    std::vector<CreditUsage> *updates_out,
                    std::vector<std::unique_ptr<ServiceAction>> *actions_out,
                    SessionStateUpdateCriteria &update_criteria) override;
@@ -196,6 +198,7 @@ public:
   void get_updates(std::string imsi, std::string ip_addr,
                    StaticRuleStore &static_rules,
                    DynamicRuleStore *dynamic_rules,
+                   DynamicRuleStore *gy_dynamic_rules,
                    std::vector<UsageMonitorUpdate> *updates_out,
                    std::vector<std::unique_ptr<ServiceAction>> *actions_out,
                    SessionStateUpdateCriteria &update_criteria) override;

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -447,11 +447,11 @@ void LocalEnforcer::install_redirect_flow(
     const std::unique_ptr<ServiceAction>& action,
     SessionUpdate &session_update) {
   std::vector<std::string> static_rules;
-  std::vector<PolicyRule> dynamic_rules{create_redirect_rule(action)};
+  std::vector<PolicyRule> gy_dynamic_rules{create_redirect_rule(action)};
   const std::string &imsi = action->get_imsi();
 
   directoryd_client_->get_directoryd_ip_field(
-      imsi, [this, imsi, static_rules, dynamic_rules]
+      imsi, [this, imsi, static_rules, gy_dynamic_rules]
         (Status status, DirectoryField resp) {
 
         if (!status.ok()) {
@@ -469,11 +469,11 @@ void LocalEnforcer::install_redirect_flow(
           auto session_update =
             session_store_.get_default_session_update(session_map);
           pipelined_client_->add_gy_final_action_flow(
-            imsi, resp.value(), static_rules, dynamic_rules);
+            imsi, resp.value(), static_rules, gy_dynamic_rules);
 
           for (const auto &session : it->second) {
             auto &uc = session_update[imsi][session->get_session_id()];
-            session->insert_gy_dynamic_rule(dynamic_rules.front(), uc);
+            session->insert_gy_dynamic_rule(gy_dynamic_rules.front(), uc);
           }
           session_store_.update_sessions(session_update);
         }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -233,6 +233,30 @@ bool SessionStore::merge_into_session(
     session->schedule_dynamic_rule(rule, lifetime, uc);
   }
 
+  // Gy Dynamic rules
+  for (const auto& rule : update_criteria.gy_dynamic_rules_to_install) {
+    if (session->is_gy_dynamic_rule_installed(rule.id())) {
+      MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
+                   << " because gy dynamic rule already installed: " << rule.id()
+                   << std::endl;
+      return false;
+    }
+    session->insert_gy_dynamic_rule(rule, uc);
+    MLOG(MERROR) << "Merge: " << session->get_session_id()
+                   << " gy dynamic rule " << rule.id()
+                   << std::endl;
+  }
+  for (const auto& rule_id : update_criteria.gy_dynamic_rules_to_uninstall) {
+    if (session->is_gy_dynamic_rule_installed(rule_id)) {
+      session->remove_gy_dynamic_rule(rule_id, _, uc);
+    } else {
+      MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
+                << " because gy dynamic rule already uninstalled: " << rule_id
+                << std::endl;
+      return false;
+    }
+  }
+
   // Charging credit
   for (const auto& it : update_criteria.charging_credit_map) {
     auto key           = it.first;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -395,6 +395,14 @@ std::string serialize_stored_session(StoredSessionState &stored) {
   }
   marshaled["dynamic_rules"] = dynamic_rules;
 
+  folly::dynamic gy_dynamic_rules = folly::dynamic::array;
+  for (const auto &rule : stored.gy_dynamic_rules) {
+    std::string gy_dynamic_rule;
+    rule.SerializeToString(&gy_dynamic_rule);
+    gy_dynamic_rules.push_back(gy_dynamic_rule);
+  }
+  marshaled["gy_dynamic_rules"] = gy_dynamic_rules;
+
   marshaled["request_number"] = std::to_string(stored.request_number);
 
   std::string serialized = folly::toJson(marshaled);
@@ -438,6 +446,12 @@ StoredSessionState deserialize_stored_session(std::string &serialized) {
     PolicyRule policy_rule;
     policy_rule.ParseFromString(policy.getString());
     stored.dynamic_rules.push_back(policy_rule);
+  }
+
+  for (auto &policy : marshaled["gy_dynamic_rules"]) {
+    PolicyRule policy_rule;
+    policy_rule.ParseFromString(policy.getString());
+    stored.gy_dynamic_rules.push_back(policy_rule);
   }
 
   stored.request_number = static_cast<uint32_t>(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -175,10 +175,10 @@ struct StoredSessionState {
   magma::lte::TgppContext tgpp_context;
   std::vector<std::string> static_rule_ids;
   std::vector<PolicyRule> dynamic_rules;
+  std::vector<PolicyRule> gy_dynamic_rules;
   std::set<std::string> scheduled_static_rules;
   std::vector<PolicyRule> scheduled_dynamic_rules;
   std::unordered_map<std::string, RuleLifetime> rule_lifetimes;
-  std::vector<PolicyRule> gy_dynamic_rules;
   uint32_t request_number;
   EventTriggerStatus pending_event_triggers;
   google::protobuf::Timestamp revalidation_time;
@@ -216,7 +216,9 @@ struct SessionStateUpdateCriteria {
   std::set<std::string> static_rules_to_uninstall;
   std::set<std::string> new_scheduled_static_rules;
   std::vector<PolicyRule> dynamic_rules_to_install;
+  std::vector<PolicyRule> gy_dynamic_rules_to_install;
   std::set<std::string> dynamic_rules_to_uninstall;
+  std::set<std::string> gy_dynamic_rules_to_uninstall;
   std::vector<PolicyRule> new_scheduled_dynamic_rules;
   std::unordered_map<std::string, RuleLifetime> new_rule_lifetimes;
   std::unordered_map<CreditKey, StoredSessionCredit, decltype(&ccHash),

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -740,6 +740,9 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   EXPECT_EQ(rules_out_ptr.size(), 1);
   EXPECT_EQ(rules_out_ptr[0], "redirect");
 
+  EXPECT_EQ(session_state->is_gy_dynamic_rule_installed("redirect"), true);
+  EXPECT_EQ(update_criteria.gy_dynamic_rules_to_install.size(), 1);
+
   PolicyRule rule_out;
   EXPECT_EQ(true, session_state->remove_gy_dynamic_rule("redirect", &rule_out,
                                                         update_criteria));
@@ -747,6 +750,9 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   rules_out = {};
   session_state->get_gy_dynamic_rules().get_rule_ids(rules_out_ptr);
   EXPECT_EQ(rules_out_ptr.size(), 0);
+
+  EXPECT_EQ(session_state->is_gy_dynamic_rule_installed("redirect"), false);
+  EXPECT_EQ(update_criteria.gy_dynamic_rules_to_uninstall.size(), 1);
 
   rules_out = {};
   session_state->get_gy_dynamic_rules().get_rule_ids_for_monitoring_key("m1",


### PR DESCRIPTION
Summary:
SessionState differentiates between Gx and Gy dynamic rules, SessionStore/SessionUpdateCriteria do not.
This means that SessionState is not restored properly when its read from SessionStore.

Reviewed By: themarwhal

Differential Revision: D21879394

