### PR TITLE
Fix CI failures

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -43,11 +43,7 @@ class QosManager(object):
         try:
             qos_impl_type = QosImplType(config["qos"]["impl"])
         except ValueError:
-            LOG.error(
-                "{} is not a valid qos implementation type({})".format(
-                    qos_impl_type, QosImplType.list()
-                )
-            )
+            LOG.error("%s is not a valid qos impl type", qos_impl_type)
             raise
 
         if qos_impl_type == QosImplType.OVS_METER:


### PR DESCRIPTION
Summary:
Fix CI failures caused due to
- pylint error
- qos test failure caused by normalizing IMSI change

Differential Revision: D21983472

