### PR TITLE
Refactoring orc8r/common/eventd client as static reference

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -66,7 +66,7 @@ LocalEnforcer::LocalEnforcer(
     std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
-    std::shared_ptr<AsyncEventdClient> eventd_client,
+    AsyncEventdClient& eventd_client,
     std::shared_ptr<SpgwServiceClient> spgw_client,
     std::shared_ptr<aaa::AAAClient> aaa_client,
     long session_force_termination_timeout_ms,

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -47,7 +47,7 @@ class LocalEnforcer {
       std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
       std::shared_ptr<PipelinedClient> pipelined_client,
       std::shared_ptr<AsyncDirectorydClient> directoryd_client,
-      std::shared_ptr<AsyncEventdClient> eventd_client,
+      AsyncEventdClient& eventd_client,
       std::shared_ptr<SpgwServiceClient> spgw_client,
       std::shared_ptr<aaa::AAAClient> aaa_client,
       long session_force_termination_timeout_ms,
@@ -230,7 +230,7 @@ class LocalEnforcer {
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
-  std::shared_ptr<AsyncEventdClient> eventd_client_;
+  AsyncEventdClient& eventd_client_;
   std::shared_ptr<SpgwServiceClient> spgw_client_;
   std::shared_ptr<aaa::AAAClient> aaa_client_;
   std::unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -9,6 +9,9 @@
 
 #include "SessionEvents.h"
 
+using magma::orc8r::Event;
+using magma::orc8r::Void;
+
 namespace magma {
 namespace session_events {
 
@@ -30,7 +33,7 @@ namespace session_events {
 
 
 void session_created(
-    std::shared_ptr<AsyncEventdClient> client,
+    AsyncEventdClient& client,
     const std::string& imsi,
     const std::string& session_id) {
   auto event = Event();
@@ -44,7 +47,7 @@ void session_created(
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  client->log_event(
+  client.log_event(
       event, [=](Status status, Void v) {
       if (!status.ok()) {
       MLOG(MERROR)
@@ -55,7 +58,7 @@ void session_created(
 }
 
 void session_terminated(
-    std::shared_ptr<AsyncEventdClient> client,
+    AsyncEventdClient& client,
     const std::unique_ptr<SessionState>& session) {
   auto event = Event();
   SessionState::SessionInfo session_info;
@@ -77,7 +80,7 @@ void session_terminated(
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  client->log_event(
+  client.log_event(
       event, [=](Status status, Void v) {
       if (!status.ok()) {
       MLOG(MERROR)

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -27,12 +27,12 @@ namespace magma {
 namespace session_events {
 
 void session_created(
-    std::shared_ptr<AsyncEventdClient> client,
+    AsyncEventdClient& client,
     const std::string& imsi,
     const std::string& session_id);
 
 void session_terminated(
-    std::shared_ptr<AsyncEventdClient> client,
+    AsyncEventdClient& client,
     const std::unique_ptr<SessionState>& session);
 
 }  // namespace session_events

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -135,10 +135,10 @@ int main(int argc, char *argv[])
     directoryd_client->rpc_response_loop();
   });
 
-  auto eventd_client = std::make_shared<magma::AsyncEventdClient>();
+  auto& eventd_client = magma::AsyncEventdClient::getInstance();
   std::thread eventd_thread([&]() {
     MLOG(MINFO) << "Started eventd response thread";
-    eventd_client->rpc_response_loop();
+    eventd_client.rpc_response_loop();
   });
 
   std::shared_ptr<magma::AsyncSpgwServiceClient> spgw_client;

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -152,8 +152,6 @@ public:
 
 class MockEventdClient : public AsyncEventdClient {
 public:
-  MockEventdClient() {}
-
   MOCK_METHOD2(log_event,
                void(const Event &request,
                     std::function<void(Status status, Void)> callback));

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -46,13 +46,12 @@ protected:
     session_store = std::make_shared<SessionStore>(rule_store);
     pipelined_client = std::make_shared<MockPipelinedClient>();
     directoryd_client = std::make_shared<MockDirectorydClient>();
-    eventd_client = std::make_shared<MockEventdClient>();
     spgw_client = std::make_shared<MockSpgwServiceClient>();
     aaa_client = std::make_shared<MockAAAClient>();
     auto default_mconfig = get_default_mconfig();
     local_enforcer = std::make_unique<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, eventd_client, spgw_client,
+        directoryd_client, MockEventdClient::getInstance(), spgw_client,
         aaa_client, 0, 0, default_mconfig);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
@@ -100,7 +99,6 @@ protected:
   std::unique_ptr<LocalEnforcer> local_enforcer;
   std::shared_ptr<MockPipelinedClient> pipelined_client;
   std::shared_ptr<MockDirectorydClient> directoryd_client;
-  std::shared_ptr<MockEventdClient> eventd_client;
   std::shared_ptr<MockSpgwServiceClient> spgw_client;
   std::shared_ptr<MockAAAClient> aaa_client;
   SessionMap session_map;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -42,12 +42,11 @@ protected:
     session_store = std::make_shared<SessionStore>(rule_store);
     pipelined_client = std::make_shared<MockPipelinedClient>();
     directoryd_client = std::make_shared<MockDirectorydClient>();
-    eventd_client = std::make_shared<MockEventdClient>();
     spgw_client = std::make_shared<MockSpgwServiceClient>();
     aaa_client = std::make_shared<MockAAAClient>();
     local_enforcer = std::make_unique<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, eventd_client, spgw_client,
+        directoryd_client, MockEventdClient::getInstance(), spgw_client,
         aaa_client, 0, 0, mconfig);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
@@ -87,7 +86,6 @@ protected:
   std::unique_ptr<LocalEnforcer> local_enforcer;
   std::shared_ptr<MockPipelinedClient> pipelined_client;
   std::shared_ptr<MockDirectorydClient> directoryd_client;
-  std::shared_ptr<MockEventdClient> eventd_client;
   std::shared_ptr<MockSpgwServiceClient> spgw_client;
   std::shared_ptr<MockAAAClient> aaa_client;
   SessionMap session_map;

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -57,13 +57,12 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     session_store          = std::make_shared<SessionStore>(rule_store);
     pipelined_client       = std::make_shared<MockPipelinedClient>();
     auto directoryd_client = std::make_shared<MockDirectorydClient>();
-    auto eventd_client     = std::make_shared<MockEventdClient>();
     auto spgw_client       = std::make_shared<MockSpgwServiceClient>();
     auto aaa_client        = std::make_shared<MockAAAClient>();
     auto default_mconfig = get_default_mconfig();
     local_enforcer         = std::make_shared<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, eventd_client, spgw_client, aaa_client,
+        directoryd_client, MockEventdClient::getInstance(), spgw_client, aaa_client,
         0, 0, default_mconfig);
     session_map = SessionMap{};
 

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -38,13 +38,12 @@ protected:
     session_store = std::make_shared<SessionStore>(rule_store);
     pipelined_client = std::make_shared<MockPipelinedClient>();
     auto directoryd_client = std::make_shared<MockDirectorydClient>();
-    auto eventd_client = std::make_shared<MockEventdClient>();
     auto spgw_client = std::make_shared<MockSpgwServiceClient>();
     auto aaa_client = std::make_shared<MockAAAClient>();
     auto default_mconfig = get_default_mconfig();
     local_enforcer = std::make_shared<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, eventd_client, spgw_client, aaa_client, 0, 0,
+        directoryd_client, MockEventdClient::getInstance(), spgw_client, aaa_client, 0, 0,
         default_mconfig);
     evb = new folly::EventBase();
     std::thread([&]() {

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -48,7 +48,6 @@ class SessiondTest : public ::testing::Test {
 
     pipelined_client = std::make_shared<AsyncPipelinedClient>(test_channel);
     directoryd_client = std::make_shared<AsyncDirectorydClient>(test_channel);
-    eventd_client = std::make_shared<AsyncEventdClient>(test_channel);
     spgw_client = std::make_shared<AsyncSpgwServiceClient>(test_channel);
     auto rule_store = std::make_shared<StaticRuleStore>();
     session_store = std::make_shared<SessionStore>(rule_store);
@@ -64,7 +63,7 @@ class SessiondTest : public ::testing::Test {
       *session_store,
       pipelined_client,
       directoryd_client,
-      eventd_client,
+      MockEventdClient::getInstance(),
       spgw_client,
       nullptr,
       SESSION_TERMINATION_TIMEOUT_MS,
@@ -183,7 +182,6 @@ class SessiondTest : public ::testing::Test {
   std::shared_ptr<service303::MagmaService> test_service;
   std::shared_ptr<AsyncPipelinedClient> pipelined_client;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client;
-  std::shared_ptr<AsyncEventdClient> eventd_client;
   std::shared_ptr<AsyncSpgwServiceClient> spgw_client;
   std::shared_ptr<SessionStore> session_store;
   SessionMap session_map;

--- a/orc8r/gateway/c/common/eventd/EventdClient.h
+++ b/orc8r/gateway/c/common/eventd/EventdClient.h
@@ -17,7 +17,6 @@
 using grpc::Status;
 
 namespace magma {
-using namespace orc8r;
 
 /**
  * AsyncEventdClient sends asynchronous calls to eventd
@@ -25,17 +24,20 @@ using namespace orc8r;
  */
 class AsyncEventdClient : public GRPCReceiver {
  public:
-  AsyncEventdClient();
-  explicit AsyncEventdClient(std::shared_ptr<grpc::Channel> channel);
+  AsyncEventdClient(AsyncEventdClient const &) = delete;
+  void operator=(AsyncEventdClient const &) = delete;
+
+  static AsyncEventdClient &getInstance();
 
   // Logs an event
   void log_event(
-      const Event& request,
-      std::function<void(Status status, Void)> callback);
+      const orc8r::Event& request,
+      std::function<void(Status status, orc8r::Void)> callback);
 
  private:
+  AsyncEventdClient();
   static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
-  std::unique_ptr<EventService::Stub> stub_{};
+  std::unique_ptr<orc8r::EventService::Stub> stub_{};
 };
 
 }  // namespace magma


### PR DESCRIPTION
Summary:
For making eventd client usable for both session_manager and oai code, this diff updates the `AsyncEventdClient` class implementation as static reference, this due to the need to convert functions for usages on oai C code.

- Updating MockEventdClient to support updated AsyncEventdClient implementation
- Updated unit tests on session_manager to pass reference previously as shared_ptr
- Updated LocalEnforcer class to get reference on constructor

Differential Revision: D21985923

