### PR TITLE
Add GC tunning & periodic memory freeing to magmad

### DIFF
--- a/orc8r/gateway/go/services/magmad/main.go
+++ b/orc8r/gateway/go/services/magmad/main.go
@@ -12,6 +12,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"runtime/debug"
 	"time"
 
 	"github.com/golang/glog"
@@ -28,6 +29,7 @@ import (
 
 const (
 	BOOTSTRAP_RESTART_INTERVAL = time.Second * 120
+	FREE_MEMORY_INTERVAL       = time.Hour * 6
 )
 
 const usageExamples string = `
@@ -50,7 +52,9 @@ Examples:
 
 `
 
-var showGwInfo = flag.Bool("show", false, "Print out gateway information needed for GW registration")
+var (
+	showGwInfo = flag.Bool("show", false, "Print out gateway information needed for GW registration")
+)
 
 func main() {
 	oldUsage := flag.Usage
@@ -72,10 +76,13 @@ func main() {
 		os.Exit(0)
 	}
 
+	if _, isset := os.LookupEnv("GOGC"); !isset {
+		debug.SetGCPercent(20)
+	}
 	eventChan := make(chan interface{}, 2)
 
 	// Start event loop in a dedicated routine
-	go mainEventLoop(eventChan)
+	go mainEventLoop(eventChan, time.Tick(FREE_MEMORY_INTERVAL))
 
 	// Create bootstrapper
 	b := bootstrapper.NewBootstrapper(eventChan)
@@ -124,44 +131,51 @@ func main() {
 	}
 }
 
-func mainEventLoop(eventChan chan interface{}) {
-	for i := range eventChan {
-		switch e := i.(type) {
-		case bootstrapper.BootstrapCompletion:
-			if e.Result != nil {
-				glog.Errorf("bootstrap failure: %v for Gateway ID: %s", e.Result, e.HardwareId)
-			} else {
-				glog.Infof("bootstrapped GW %s", e.HardwareId)
-				if config.GetControlProxyConfigs().ProxyCloudConnection {
-					// TODO: restart control proxy only
+func mainEventLoop(eventChan <-chan interface{}, freeMemChan <-chan time.Time) {
+	for {
+		select {
+		case evnt := <-eventChan:
+			switch e := evnt.(type) {
+			case bootstrapper.BootstrapCompletion:
+				if e.Result != nil {
+					glog.Errorf("bootstrap failure: %v for Gateway ID: %s", e.Result, e.HardwareId)
 				} else {
-					// Restart all magma services
-					go func() {
-						controller := service_manager.Get()
-						for _, service := range config.GetMagmadConfigs().MagmaServices {
-							controller.Restart(service)
-						}
-					}()
-				}
-			}
-		case configurator.UpdateCompletion:
-			glog.Verbose(len(e) > 0).Infof("mconfigs updated successfully for services: %v", e)
-			// Restart all services with updated configs
-			go func() {
-				magmaServiceTable := map[string]struct{}{}
-				for _, service := range config.GetMagmadConfigs().MagmaServices {
-					magmaServiceTable[service] = struct{}{}
-				}
-				controller := service_manager.Get()
-				for _, service := range e {
-					// restart only if it's this GW's service
-					if _, ok := magmaServiceTable[service]; ok {
-						controller.Restart(service)
+					glog.Infof("bootstrapped GW %s", e.HardwareId)
+					if config.GetControlProxyConfigs().ProxyCloudConnection {
+						// TODO: restart control proxy only
+					} else {
+						// Restart all magma services
+						go func() {
+							controller := service_manager.Get()
+							for _, service := range config.GetMagmadConfigs().MagmaServices {
+								controller.Restart(service)
+							}
+						}()
 					}
 				}
-			}()
-		default:
-			glog.Errorf("unknown completion type: %T", e)
-		}
+			case configurator.UpdateCompletion:
+				glog.Verbose(len(e) > 0).Infof("mconfigs updated successfully for services: %v", e)
+				// Restart all services with updated configs
+				go func() {
+					magmaServiceTable := map[string]struct{}{}
+					for _, service := range config.GetMagmadConfigs().MagmaServices {
+						magmaServiceTable[service] = struct{}{}
+					}
+					controller := service_manager.Get()
+					for _, service := range e {
+						// restart only if it's this GW's service
+						if _, ok := magmaServiceTable[service]; ok {
+							controller.Restart(service)
+						}
+					}
+				}()
+			default:
+				glog.Errorf("unknown completion type: %T", e)
+			} // switch
+		case _, ok := <-freeMemChan:
+			if ok {
+				debug.FreeOSMemory()
+			}
+		} // select
 	}
 }

--- a/orc8r/lib/go/initflag/initflag.go
+++ b/orc8r/lib/go/initflag/initflag.go
@@ -6,21 +6,36 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 */
 // package initflag initializes (parses) Go flag if needed, it allows the noise free use of golog & other packages
-// relying on flag being parsed
+// relying on flags being parsed
 package initflag
 
 import (
 	"flag"
-	"os"
 )
 
 func init() {
+	// only if not already parsed
 	if !flag.Parsed() {
-		name := ""
-		if len(os.Args) > 0 {
-			name = os.Args[0]
-		}
-		flag.CommandLine.Init(name, flag.ContinueOnError)
-		flag.CommandLine.Parse([]string{})
+		// save original settings
+		orgUsage := flag.CommandLine.Usage
+		origOut := flag.CommandLine.Output()
+		origErrorHandling := flag.CommandLine.ErrorHandling()
+
+		// set to 'silent'
+		flag.CommandLine.Init(flag.CommandLine.Name(), flag.ContinueOnError)
+		flag.CommandLine.Usage = func() {}
+		flag.CommandLine.SetOutput(devNull{})
+		flag.Parse()
+
+		// restore original settings
+		flag.CommandLine.Init(flag.CommandLine.Name(), origErrorHandling)
+		flag.CommandLine.Usage = orgUsage
+		flag.CommandLine.SetOutput(origOut)
 	}
+}
+
+type devNull struct{}
+
+func (devNull) Write(b []byte) (int, error) {
+	return len(b), nil
 }

--- a/orc8r/lib/go/service/service.go
+++ b/orc8r/lib/go/service/service.go
@@ -55,7 +55,6 @@ var defaultKeepaliveParams = keepalive.ServerParameters{
 
 func init() {
 	flag.BoolVar(&printGrpcPayload, PrintGrpcPayloadFlag, false, "Enable GRPC Payload Printout")
-	flag.Parse()
 }
 
 type Service struct {


### PR DESCRIPTION
Summary:
Add GC tunning & periodic memory freeing to magmad to avoid OOM failures on low end gateways
Go default GC settings may not agressive enough for RAM constrained gateways & we have seen out of memory restarts on
midrange openwrt systems.

Differential Revision: D21991227

