### PR TITLE
UeSim : Updating the config base map when only the override yml file is specified.

### DIFF
--- a/cwf/gateway/tools/uesim_cli/main.go
+++ b/cwf/gateway/tools/uesim_cli/main.go
@@ -93,6 +93,7 @@ func handleAuthCmd(cmd *commands.Command, args []string) int {
 	imsi := strings.TrimSpace(f.Arg(0))
 	req := &protos.AuthenticateRequest{
 		Imsi: imsi,
+		CalledStationID: "76-02-DE-AD-BE-FF",
 	}
 	res, err := uesim.Authenticate(req)
 	if err != nil || res == nil {

--- a/orc8r/lib/go/service/config/service_config.go
+++ b/orc8r/lib/go/service/config/service_config.go
@@ -175,9 +175,7 @@ func getServiceConfigFilePath(moduleName, serviceName, configDir, oldConfigDir s
 
 func updateMap(baseMap, overrides *ConfigMap) *ConfigMap {
 	for k, v := range overrides.RawMap {
-		if _, ok := baseMap.RawMap[k]; ok {
-			baseMap.RawMap[k] = v
-		}
+		baseMap.RawMap[k] = v
 	}
 	return baseMap
 }


### PR DESCRIPTION
Summary: In case where the base config yaml is missing and just the override config yaml is specified, uesim is not able to pick up the values inside the override file.

Reviewed By: themarwhal

Differential Revision: D21969772

