### PR TITLE
Fix qos state upon restart

### DIFF
--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -52,6 +52,8 @@ func verifyEgressRate(t *testing.T, tr *TestRunner, req *cwfprotos.GenTrafficReq
 		fmt.Printf("bit rate observed at server %.0fbps, err rate %.2f%%\n", b, errRate)
 		if (b > expRate) && (errRate > ErrMargin) {
 			fmt.Printf("recd bps %f exp bps %f\n", b, expRate)
+			// dump pipelined service state
+			dumpPipelinedState(tr)
 			assert.Fail(t, "error greater than acceptable margin")
 		}
 	}

--- a/cwf/gateway/integ_tests/service_state_dumper.go
+++ b/cwf/gateway/integ_tests/service_state_dumper.go
@@ -1,0 +1,33 @@
+// +build all qos
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package integration
+
+import "fmt"
+
+func dumpPipelinedState(tr *TestRunner) {
+	fmt.Println("******************* Dumping Pipelined State *******************")
+	cmdList := [][]string{
+		{"ovs-vsctl", "show"},
+		{"ovs-ofctl", "-O", "OpenFlow15", "meter-stats", "cwag_br0"},
+		{"ovs-ofctl", "-O", "OpenFlow15", "dump-meters", "cwag_br0"},
+		{"pipelined_cli.py", "debug", "display_flows"},
+	}
+	cmdOutputList, err := tr.RunCommandInContainer("pipelined", cmdList)
+	if err != nil {
+		fmt.Printf("error dumping pipelined state %v", err)
+		return
+	}
+	for _, cmdOutput := range cmdOutputList {
+		fmt.Printf("command : \n%v\n", cmdOutput.cmd)
+		fmt.Printf("output : \n%v\n", cmdOutput.output)
+		fmt.Printf("error : \n%v\n", cmdOutput.err)
+		fmt.Printf("\n\n")
+	}
+}

--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -109,7 +109,9 @@ class QosManager(object):
                             continue
                         in_store_qid.add(v)
                         _, imsi, rule_num, d = get_key(k)
-                        self._subscriber_map[imsi][rule_num] = (v, d)
+                        if rule_num not in self._subscriber_map[imsi]:
+                            self._subscriber_map[imsi][rule_num] = []
+                        self._subscriber_map[imsi][rule_num].append((v, d))
 
                     # purge entries from qos_store
                     for k in purge_store_set:

--- a/lte/gateway/python/magma/pipelined/tests/test_qos.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_qos.py
@@ -466,6 +466,19 @@ get_action_instruction"
         self.assertTrue(qos_mgr._qos_store[k] == exp_id)
         self.assertTrue(qos_mgr._subscriber_map[imsi][rule_num][0] == (exp_id, d))
 
+        # delete the restored rule - ensure that it gets cleaned properly
+        purge_imsi = "1"
+        purge_rule_num = 0
+        purge_qos_handle = 2
+        qos_mgr.remove_subscriber_qos(purge_imsi, purge_rule_num)
+        self.assertTrue(purge_rule_num not in qos_mgr._subscriber_map[purge_imsi])
+        if self.config["qos"]["impl"] == QosImplType.OVS_METER:
+            mock_meter_cls.del_meter.assert_called_with(MagicMock, purge_qos_handle)
+        else:
+            mock_traffic_cls.delete_class.assert_called_with(
+                self.ul_intf, purge_qos_handle
+            )
+
         # case 2 - check with empty qos configs, qos_map gets purged
         mock_meter_cls.reset_mock()
         mock_traffic_cls.reset_mock()


### PR DESCRIPTION
Summary:
Fix a bug in non clean restart logic.
Recently(D21975684) subscriber_map[imsi][rule_num] was changed to store list of tuples rather than tuple. This wasn't reflected in the restart logic. This causes exception in pipelined upon restart. This fix addresses this issue. Enhanced the unit test to also verify this case.
Additionally added a pipelined dumper function and enhanced existing container utilities to run arbitrary set of commands and get outputs. Currently i'm using this for dumping pipelined state.We could use it in additional test verification as well.

Differential Revision: D22014708

