### PR TITLE
Change mysql dialect to mariadb in orc8r helm chart

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -9,7 +9,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.31
+version: 1.4.32
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -8,7 +8,7 @@
 apiVersion: v1
 description: Magma NMS
 name: nms
-version: 0.1.7
+version: 0.1.8
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
@@ -29,7 +29,7 @@ magmalte:
     mysql_db: magma
     mysql_user: magma
     mysql_pass: password
-    mysql_dialect: mysql
+    mysql_dialect: mariadb
     grafana_address: orc8r-user-grafana:3000
 
   labels: {}

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: ""
     condition: metrics.enabled
   - name: nms
-    version: 0.1.7
+    version: 0.1.8
     repository: ""
     condition: nms.enabled
   - name: logging


### PR DESCRIPTION
Summary: Or8cr uses a maria db, but the dialect env var is set as mysql. This can lead to redirect loops when trying to view the NMS.

Differential Revision: D22014664

