### PR TITLE
memory & CPU profiling for magma go services (#2630)

### DIFF
--- a/orc8r/gateway/go/services/magmad/status/metrics.go
+++ b/orc8r/gateway/go/services/magmad/status/metrics.go
@@ -49,9 +49,9 @@ func reportMetrics(maxQueueLen int) error {
 	return err
 }
 
-func enqueueMetrics(service string, serviceMetrics *protos.MetricsContainer) {
+func enqueueMetrics(service string, serviceMetrics *protos.MetricsContainer) int {
 	if len(serviceMetrics.GetFamily()) == 0 {
-		return
+		return 0
 	}
 	for _, f := range serviceMetrics.Family {
 		if f != nil {
@@ -63,7 +63,7 @@ func enqueueMetrics(service string, serviceMetrics *protos.MetricsContainer) {
 			}
 		}
 	}
-	metricsQueue.Append(serviceMetrics.Family...)
+	return metricsQueue.Append(serviceMetrics.Family...)
 }
 
 func collectMetrics() (result []*prometheus.MetricFamily) {

--- a/orc8r/lib/go/profile/memstats.go
+++ b/orc8r/lib/go/profile/memstats.go
@@ -1,0 +1,39 @@
+//
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// Package profile provides CPU & memory profiling helper functions
+package profile
+
+import (
+	"bytes"
+	"fmt"
+	"runtime"
+
+	"github.com/golang/glog"
+)
+
+// LogMemStats collects the process memory stats and logs them out @ INFO level
+func LogMemStats() {
+	memStats := &runtime.MemStats{}
+	runtime.ReadMemStats(memStats)
+	glog.Info(MemStatsToString(memStats))
+}
+
+// MemStatsToString returns a string with formatted runtime.MemStats
+func MemStatsToString(s *runtime.MemStats) string {
+	if s == nil {
+		return ""
+	}
+	var b = new(bytes.Buffer)
+	fmt.Fprintf(b, "Allocated:%9d; Objects#:%6d; Stack:%7d; VM:%9d\nBySize:",
+		s.Alloc, s.HeapObjects, s.StackSys, s.Sys)
+	for i := len(s.BySize) - 1; i > 0; i-- {
+		fmt.Fprintf(b, " %d*%d;", s.BySize[i].Size, s.BySize[i].Mallocs-s.BySize[i].Frees)
+	}
+	return b.String()
+}

--- a/orc8r/lib/go/profile/profiler_disabled.go
+++ b/orc8r/lib/go/profile/profiler_disabled.go
@@ -1,0 +1,32 @@
+//
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// +build !with_profiler
+
+// Package profile provides CPU & memory profiling helper functions
+// profiling is enabled by with_profiler build tag
+package profile
+
+import "os"
+
+// empty stubs for disabled profiler builds
+
+// MemWrite stub
+func MemWrite() error {
+	return nil
+}
+
+// CpuStart stub
+func CpuStart() (*os.File, error) {
+	return nil, nil
+}
+
+// CpuStop stub
+func CpuStop(f *os.File) error {
+	return nil
+}

--- a/orc8r/lib/go/profile/profiler_enabled.go
+++ b/orc8r/lib/go/profile/profiler_enabled.go
@@ -1,0 +1,75 @@
+//
+// Copyright (c) Facebook, Inc. and its affiliates.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree.
+//
+
+// +build with_profiler
+
+// Package profile provides CPU & memory profiling helper functions
+// profiling is enabled by with_profiler build tag
+package profile
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"runtime"
+	"runtime/pprof"
+	"time"
+)
+
+const (
+	memoryProfFileFmt = "%s/memory_%s.pprof"
+	cpuProfFileFmt    = "%s/cpu_%s.pprof"
+	timeFmt           = "0102_15.04.05"
+)
+
+var profileDir = flag.String("profiles_dir", os.TempDir(), "Destination directory for profiler files")
+
+// MemWrite creates memory profile file, invokes GC and collects & writes memory profile
+func MemWrite() error {
+	os.MkdirAll(*profileDir, os.ModeDir)
+	fname := fmt.Sprintf(memoryProfFileFmt, *profileDir, time.Now().Format(timeFmt))
+	f, err := os.Create(fname)
+	if err != nil {
+		return fmt.Errorf("could not create memory profile in '%s': %v", fname, err)
+	}
+	defer f.Close()
+	runtime.GC() // get up-to-date statistics
+	if err := pprof.Lookup("heap").WriteTo(f, 1); err != nil {
+		return fmt.Errorf("could not write memory profile in '%s': %v", fname, err)
+	}
+	return nil
+}
+
+// CpuStart creates a new CPU profile file and starts CPU profiling
+// CpuStart will only return a non-nil file pointer on success, so
+// it should be safe to do:
+//     f, _ := profile.CpuStart()
+//     ... // run profiled logic
+//     profile.CpuStop(f)
+func CpuStart() (*os.File, error) {
+	os.MkdirAll(*profileDir, os.ModeDir)
+	fname := fmt.Sprintf(cpuProfFileFmt, *profileDir, time.Now().Format(timeFmt))
+	f, err := os.Create(fname)
+	if err != nil {
+		return nil, fmt.Errorf("could not create CPU profile in '%s': %v", fname, err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		f.Close()
+		return nil, fmt.Errorf("could not start CPU profile: ", err)
+	}
+	return f, nil
+}
+
+// CpuStop collects and writes started CPU profile and closes the profile file
+func CpuStop(f *os.File) error {
+	pprof.StopCPUProfile()
+	if f != nil {
+		return f.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookexternal/fbc/pull/2630

API for memory & CPU profiling on magma go services,
+ an example of heap profile usage on magmad

Differential Revision: D22031680

