### PR TITLE
Clean up memory leak from SessionState

### DIFF
--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -141,7 +141,9 @@ bool PolicyRuleBiMap::get_rule(const std::string& rule_id, PolicyRule* rule)
   if (it == rules_by_rule_id_.end()) {
     return false;
   }
-  rule->CopyFrom(*it->second);
+  if (rule != NULL) {
+    rule->CopyFrom(*it->second);
+  }
   return true;
 }
 

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -65,6 +65,10 @@ class PolicyRuleBiMap {
 
   virtual void insert_rule(const PolicyRule& rule);
 
+  // Get the rule definition associated with the given rule_id
+  // If the rule is found, copy the rule into the output parameter and return
+  // true. Otherwise, return false.
+  // If the output rule param is NULL, the rule object is not copied.
   virtual bool get_rule(const std::string& rule_id, PolicyRule* rule);
 
   // Remove a rule from the store by ID. Returns true if the rule ID was found.

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -473,8 +473,7 @@ bool SessionState::get_monitoring_key_for_rule_id(
 }
 
 bool SessionState::is_dynamic_rule_scheduled(const std::string& rule_id) {
-  auto _ = new PolicyRule();
-  return scheduled_dynamic_rules_.get_rule(rule_id, _);
+  return scheduled_dynamic_rules_.get_rule(rule_id, NULL);
 }
 
 bool SessionState::is_static_rule_scheduled(const std::string& rule_id) {
@@ -482,13 +481,11 @@ bool SessionState::is_static_rule_scheduled(const std::string& rule_id) {
 }
 
 bool SessionState::is_dynamic_rule_installed(const std::string& rule_id) {
-  auto _ = new PolicyRule();
-  return dynamic_rules_.get_rule(rule_id, _);
+  return dynamic_rules_.get_rule(rule_id, NULL);
 }
 
 bool SessionState::is_gy_dynamic_rule_installed(const std::string& rule_id) {
-  auto _ = new PolicyRule();
-  return gy_dynamic_rules_.get_rule(rule_id, _);
+  return gy_dynamic_rules_.get_rule(rule_id, NULL);
 }
 
 bool SessionState::is_static_rule_installed(const std::string& rule_id) {


### PR DESCRIPTION
Summary:
Running valgrind on sessiond and running `make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py`
(Also the memory leak observed was scaling with the number of UEs so it was definitely an actual issue)

Before the change
```==5861==
==5861== 14,912 (3,840 direct, 11,072 indirect) bytes in 32 blocks are definitely lost in loss record 1,727 of 1,729
==5861==    at 0x4C2C21F: operator new(unsigned long) (vg_replace_malloc.c:334)
==5861==    by 0x6E6342: magma::SessionState::is_dynamic_rule_installed(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) (SessionState.cpp:486)
==5861==    by 0x745780: magma::lte::SessionStore::merge_into_session(std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> >&, magma::SessionStateUpdateCriteria&) (SessionStore.cpp:213)
==5861==    by 0x744201: magma::lte::SessionStore::update_sessions(std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, magma::SessionStateUpdateCriteria, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, magma::SessionStateUpdateCriteria> > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, magma::SessionStateUpdateCriteria, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, magma::SessionStateUpdateCriteria> > > > > > const&) (SessionStore.cpp:104)
==5861==    by 0x693858: magma::LocalSessionManagerHandlerImpl::end_session(std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::vector<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> >, std::allocator<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> > > >, std::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, std::vector<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> >, std::allocator<std::unique_ptr<magma::SessionState, std::default_delete<magma::SessionState> > > > > > >&, magma::lte::LocalEndSessionRequest const&, std::function<void (grpc::Status, magma::lte::LocalEndSessionResponse)>) (LocalSessionManagerHandler.cpp:445)
==5861==    by 0x6935AA: magma::LocalSessionManagerHandlerImpl::EndSession(grpc::ServerContext*, magma::lte::LocalEndSessionRequest const*, std::function<void (grpc::Status, magma::lte::LocalEndSessionResponse)>)::{lambda()#1}::operator()() const (LocalSessionManagerHandler.cpp:433)
==5861==    by 0x695BD1: void folly::detail::function::FunctionTraits<void ()>::callBig<magma::LocalSessionManagerHandlerImpl::EndSession(grpc::ServerContext*, magma::lte::LocalEndSessionRequest const*, std::function<void (grpc::Status, magma::lte::LocalEndSessionResponse)>)::{lambda()#1}>(folly::detail::function::Data&) (Function.h:321)
==5861==    by 0x54BDF8D: folly::NotificationQueue<folly::Function<void ()> >::Consumer::consumeMessages(bool, unsigned long*) (in /usr/local/lib/libfolly.so.57.0.0)
==5861==    by 0x97AD59F: event_base_loop (in /usr/lib/x86_64-linux-gnu/libevent-2.0.so.5.1.9)
==5861==    by 0x54B8D2F: folly::EventBase::loopBody(int) (in /usr/local/lib/libfolly.so.57.0.0)
==5861==    by 0x54BA375: folly::EventBase::loopForever() (in /usr/local/lib/libfolly.so.57.0.0)
==5861==    by 0x6AC968: magma::LocalEnforcer::start() (LocalEnforcer.cpp:125)
==5861==
==5861== LEAK SUMMARY:
==5861==    definitely lost: 7,680 bytes in 64 blocks
==5861==    indirectly lost: 11,072 bytes in 224 blocks
==5861==      possibly lost: 43,919 bytes in 100 blocks
==5861==    still reachable: 528,915 bytes in 7,075 blocks
==5861==                       of which reachable via heuristic:
==5861==                         stdstring          : 181 bytes in 2 blocks
==5861==                         multipleinheritance: 3,090 bytes in 10 blocks
==5861==         suppressed: 0 bytes in 0 blocks
==5861== Reachable blocks (those to which a pointer was found) are not shown.
==5861== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==5861==
==5861== For counts of detected and suppressed errors, rerun with: -v
==5861== ERROR SUMMARY: 71 errors from 71 contexts (suppressed: 0 from 0)
vagrant@magma-dev:~/magma/lte/gateway$
```

After the change
```==10143==
==10143== LEAK SUMMARY:
==10143==    definitely lost: 0 bytes in 0 blocks
==10143==    indirectly lost: 0 bytes in 0 blocks
==10143==      possibly lost: 39,878 bytes in 97 blocks
==10143==    still reachable: 529,283 bytes in 7,078 blocks
==10143==                       of which reachable via heuristic:
==10143==                         stdstring          : 181 bytes in 2 blocks
==10143==                         multipleinheritance: 3,090 bytes in 10 blocks
==10143==         suppressed: 0 bytes in 0 blocks
==10143== Reachable blocks (those to which a pointer was found) are not shown.
==10143== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==10143==
==10143== For counts of detected and suppressed errors, rerun with: -v
==10143== ERROR SUMMARY: 67 errors from 67 contexts (suppressed: 0 from 0)
```

Reviewed By: karthiksubraveti

Differential Revision: D22042230

