### PR TITLE
Add qos debugs to pipelined cli

### DIFF
--- a/cwf/gateway/integ_tests/service_state_dumper.go
+++ b/cwf/gateway/integ_tests/service_state_dumper.go
@@ -14,9 +14,7 @@ import "fmt"
 func dumpPipelinedState(tr *TestRunner) {
 	fmt.Println("******************* Dumping Pipelined State *******************")
 	cmdList := [][]string{
-		{"ovs-vsctl", "show"},
-		{"ovs-ofctl", "-O", "OpenFlow15", "meter-stats", "cwag_br0"},
-		{"ovs-ofctl", "-O", "OpenFlow15", "dump-meters", "cwag_br0"},
+		{"pipelined_cli.py", "debug", "qos"},
 		{"pipelined_cli.py", "debug", "display_flows"},
 	}
 	cmdOutputList, err := tr.RunCommandInContainer("pipelined", cmdList)

--- a/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
@@ -10,6 +10,7 @@ import logging
 from magma.pipelined.openflow.meters import MeterClass
 from .utils import IdManager
 from .types import QosInfo
+import subprocess
 
 LOG = logging.getLogger('pipelined.qos.qos_meter_impl')
 BROKEN_KERN_ERROR_MSG = "kernel module has a broken meter implementation"
@@ -94,3 +95,13 @@ class MeterManager(object):
             if stat.max_meter == 0:
                 self._qos_impl_broken = True
                 LOG.error("kernel module has a broken meter implementation")
+
+    @staticmethod
+    def dump_meter_state(meter_id):
+        try:
+            output = subprocess.check_output(["ovs-ofctl", "-O", "OpenFlow15",
+                                              "meter-stats", "cwag_br0",
+                                              "meter=%s" % meter_id])
+            print(output.decode())
+        except subprocess.CalledProcessError:
+            print("Exception dumping meter state for %s", meter_id)

--- a/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_tc_impl.py
@@ -110,6 +110,18 @@ class TrafficClass:
             qid_list.append(qid)
         return qid_list
 
+    @staticmethod
+    def dump_class_state(intf: str, qid: int):
+        qid_hex = hex(qid)
+        tc_cmd = "tc -s -d class show dev {} classid 1:{}".format(intf,
+                                                                  qid_hex)
+        args = argSplit(tc_cmd)
+        try:
+            output = subprocess.check_output(args)
+            print(output.decode())
+        except subprocess.CalledProcessError:
+            print("Exception dumping Qos State for %s", intf)
+
 
 class TCManager(object):
     """

--- a/lte/gateway/python/scripts/pipelined_cli.py
+++ b/lte/gateway/python/scripts/pipelined_cli.py
@@ -26,6 +26,7 @@ from magma.subscriberdb.sid import SIDUtils
 from magma.configuration.service_configs import load_service_config
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.service_manager import Tables
+from magma.pipelined.qos.common import QosManager
 from orc8r.protos.common_pb2 import Void
 from lte.protos.pipelined_pb2 import (
     ActivateFlowsRequest,
@@ -367,6 +368,8 @@ def create_debug_parser(apps):
                              'flows. If not set, all flows will be printed.')
     subcmd.set_defaults(func=display_flows)
 
+    subcmd = subparsers.add_parser('qos', help='Debug Qos')
+    subcmd.set_defaults(func=QosManager.debug)
 
 # --------------------------
 # Pipelined base CLI


### PR DESCRIPTION
Summary: Add ability to dump linux tc or ovs meter state from pipelined cli

Reviewed By: pshelar

Differential Revision: D22055581

