### PR TITLE
Update CWF mconfig to still stream gre peers if health config isn't defined

### DIFF
--- a/cwf/cloud/go/plugin/mconfig.go
+++ b/cwf/cloud/go/plugin/mconfig.go
@@ -193,6 +193,11 @@ func buildFromConfigs(nwConfig *models.NetworkCarrierWifiConfigs, gwConfig *mode
 		protos.FillIn(healthCfg, mc)
 		mc.GrePeers = getHealthServiceGrePeers(allowedGrePeers)
 		ret["health"] = mc
+	} else {
+		mc := &cwfmconfig.CwfGatewayHealthConfig{
+			GrePeers: getHealthServiceGrePeers(allowedGrePeers),
+		}
+		ret["health"] = mc
 	}
 	return ret, err
 }

--- a/cwf/cloud/go/plugin/mconfig_test.go
+++ b/cwf/cloud/go/plugin/mconfig_test.go
@@ -119,10 +119,10 @@ func TestBuilder_Build(t *testing.T) {
 			LogLevel: protos.LogLevel_INFO,
 		},
 		"health": &cwfmconfig.CwfGatewayHealthConfig{
-			CpuUtilThresholdPct: 0.9,
-			MemUtilThresholdPct: 0.8,
-			GreProbeInterval:    5,
-			IcmpProbePktCount:   3,
+			CpuUtilThresholdPct: 0,
+			MemUtilThresholdPct: 0,
+			GreProbeInterval:    0,
+			IcmpProbePktCount:   0,
 			GrePeers: []*cwfmconfig.CwfGatewayHealthConfigGrePeer{
 				{Ip: "1.2.3.4/24"},
 				{Ip: "1.1.1.1/24"},
@@ -164,11 +164,5 @@ var defaultgwConfig = &models.GatewayCwfConfigs{
 	IPDRExportDst: &models.IPDRExportDst{
 		IP:   "192.168.128.88",
 		Port: 2040,
-	},
-	GatewayHealthConfigs: &models.GatewayHealthConfigs{
-		CPUUtilThresholdPct:  0.9,
-		MemUtilThresholdPct:  0.8,
-		GreProbeIntervalSecs: 5,
-		IcmpProbePktCount:    3,
 	},
 }


### PR DESCRIPTION
Summary:
Right now the NMS doesn't provide CWF health config. We still need the GRE peers
to be streamed regardless.

Reviewed By: themarwhal

Differential Revision: D22059483

