### PR TITLE
SPGW: GTP-APP: Use configured uplink port num

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -38,10 +38,19 @@ int start_of_controller(bool persist_state)
 {
   static openflow::PagingApplication paging_app;
   static openflow::BaseApplication base_app(persist_state);
+  int uplink_port_num_;
+
+  if (spgw_config.sgw_config.ovs_config.uplink_port_num == 65534) {      // convert it to OF 1.3 LOCAL port no.
+    uplink_port_num_ = 0xfffffffe;
+  } else {
+    uplink_port_num_ = spgw_config.sgw_config.ovs_config.uplink_port_num;
+  }
+
   static openflow::GTPApplication gtp_app(
     std::string(bdata(spgw_config.sgw_config.ovs_config.uplink_mac)),
     spgw_config.sgw_config.ovs_config.gtp_port_num,
-    spgw_config.sgw_config.ovs_config.mtr_port_num);
+    spgw_config.sgw_config.ovs_config.mtr_port_num,
+    uplink_port_num_);
   // Base app registers first, because it deletes/creates default flow
   ctrl.register_for_event(&base_app, openflow::EVENT_SWITCH_UP);
   ctrl.register_for_event(&base_app, openflow::EVENT_ERROR);

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -41,10 +41,12 @@ const std::string GTPApplication::GTP_PORT_MAC = "02:00:00:00:00:01";
 GTPApplication::GTPApplication(
   const std::string &uplink_mac,
   uint32_t gtp_port_num,
-  uint32_t mtr_port_num):
+  uint32_t mtr_port_num,
+  uint32_t uplink_port_num):
   uplink_mac_(uplink_mac),
   gtp_port_num_(gtp_port_num),
-  mtr_port_num_(mtr_port_num)
+  mtr_port_num_(mtr_port_num),
+  uplink_port_num_(uplink_port_num)
 {
 }
 
@@ -55,26 +57,26 @@ void GTPApplication::event_callback(
   if (ev.get_type() == EVENT_ADD_GTP_TUNNEL) {
     auto add_tunnel_event = static_cast<const AddGTPTunnelEvent&>(ev);
     add_uplink_tunnel_flow(add_tunnel_event, messenger);
-    add_downlink_tunnel_flow(add_tunnel_event, messenger, of13::OFPP_LOCAL);
+    add_downlink_tunnel_flow(add_tunnel_event, messenger, uplink_port_num_);
     add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DELETE_GTP_TUNNEL) {
     auto del_tunnel_event = static_cast<const DeleteGTPTunnelEvent&>(ev);
     delete_uplink_tunnel_flow(del_tunnel_event, messenger);
-    delete_downlink_tunnel_flow(del_tunnel_event, messenger, of13::OFPP_LOCAL);
+    delete_downlink_tunnel_flow(del_tunnel_event, messenger, uplink_port_num_);
     delete_downlink_tunnel_flow(del_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DISCARD_DATA_ON_GTP_TUNNEL) {
     auto discard_tunnel_flow =
       static_cast<const HandleDataOnGTPTunnelEvent&>(ev);
     discard_uplink_tunnel_flow(discard_tunnel_flow, messenger);
     discard_downlink_tunnel_flow(
-      discard_tunnel_flow, messenger, of13::OFPP_LOCAL);
+      discard_tunnel_flow, messenger, uplink_port_num_);
     discard_downlink_tunnel_flow(discard_tunnel_flow, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_FORWARD_DATA_ON_GTP_TUNNEL) {
     auto forward_tunnel_flow =
       static_cast<const HandleDataOnGTPTunnelEvent&>(ev);
     forward_uplink_tunnel_flow(forward_tunnel_flow, messenger);
     forward_downlink_tunnel_flow(
-      forward_tunnel_flow, messenger, of13::OFPP_LOCAL);
+      forward_tunnel_flow, messenger, uplink_port_num_);
     forward_downlink_tunnel_flow(forward_tunnel_flow, messenger, mtr_port_num_);
   }
 }

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -36,7 +36,8 @@ class GTPApplication : public Application {
   GTPApplication(
     const std::string& uplink_mac,
     uint32_t gtp_port_num,
-    uint32_t mtr_port_num);
+    uint32_t mtr_port_num,
+    uint32_t uplink_port_num);
 
  private:
   /**
@@ -136,6 +137,8 @@ class GTPApplication : public Application {
    * Initialising with 1
    */
   const uint64_t cookie = 1;
+
+  const uint32_t uplink_port_num_;
 };
 
 } // namespace openflow

--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -41,11 +41,13 @@ class GTPApplicationTest : public ::testing::Test {
   static constexpr const char *TEST_GTP_MAC = "1.2.3.4.5.6";
   static const uint32_t TEST_GTP_PORT = 123;
   static const uint32_t TEST_MTR_PORT = 1155;
+  static const uint32_t TEST_UPLINK_PORT = of13::OFPP_LOCAL;
 
  protected:
   virtual void SetUp()
   {
-    gtp_app = new GTPApplication(TEST_GTP_MAC, TEST_GTP_PORT, TEST_MTR_PORT);
+    gtp_app = new GTPApplication(TEST_GTP_MAC, TEST_GTP_PORT, TEST_MTR_PORT,
+		                             TEST_UPLINK_PORT);
     messenger = std::shared_ptr<MockMessenger>(new MockMessenger());
 
     controller = std::unique_ptr<OpenflowController>(


### PR DESCRIPTION
Summary:
SPGW support configuring port number, but alwys uses LOCAL port as uplink
port. Following patch fixes it.
This would be useful for Non-nat config.

Reviewed By: ardzoht

Differential Revision: D22062878

