### PR TITLE
Make RestartHandler more thread-safe

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -13,6 +13,11 @@ add_compile_options(-std=c++14)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
+if (NOT BUILD_TESTS)
+  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+endif ()
+
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)

--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -41,6 +41,8 @@ class RestartHandler {
  private:
   void terminate_previous_session(
       const std::string& sid, const std::string& session_id);
+  bool populate_sessions_to_terminate_with_retries();
+  bool launch_threads_to_terminate_with_retries();
 
  private:
   SessionStore& session_store_;
@@ -48,6 +50,7 @@ class RestartHandler {
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
   std::shared_ptr<aaa::AsyncAAAClient> aaa_client_;
   SessionReporter* reporter_;
+  std::mutex sessions_to_terminate_lock_; // mutex to guard add/remove access to sessions_to_terminate
   std::unordered_map<std::string, std::string> sessions_to_terminate_;
   static const uint max_cleanup_retries_;
   static const uint rpc_retry_interval_s_;

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -62,7 +62,7 @@ meter:
   idle_timeout: 0
 
 enforcement:
-  poll_interval: 2
+  poll_interval: 200
 
 # Enable polling mobilityd to identify which subscriber sessions need to be
 # terminated. If disabling this, make sure to set a valid idle_timeout for

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -7,7 +7,7 @@
 # LICENSE file in the root directory of this source tree. An additional grant
 # of patent rights can be found in the PATENTS file in the same directory.
 
-log_level: INFO
+log_level: DEBUG 
 rule_update_inteval_sec: 1
 
 # Session manager will report the usage when the usage is greater than

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multi_ue.py
@@ -25,7 +25,7 @@ class TestAttachDetachMultiUe(unittest.TestCase):
     def test_attach_detach_multi_ue(self):
         """ Same as attach detach but for 32 UEs """
         ue_ids = []
-        num_ues = 32
+        num_ues = 250
         self._s1ap_wrapper.configUEDevice(num_ues)
         for _ in range(num_ues):
             req = self._s1ap_wrapper.ue_req

--- a/orc8r/gateway/c/common/async_grpc/GRPCReceiver.h
+++ b/orc8r/gateway/c/common/async_grpc/GRPCReceiver.h
@@ -67,6 +67,7 @@ public:
     context_.set_deadline(
       std::chrono::system_clock::now() + std::chrono::seconds(timeout_sec));
   }
+  virtual ~AsyncGRPCResponse() = default;
 
   virtual void handle_response() {}
 
@@ -76,8 +77,8 @@ public:
    */
   void set_response_reader(
       std::unique_ptr<grpc::ClientAsyncResponseReader<ResponseType>> reader) {
-    reader->Finish(&response_, &status_, this);
     response_reader_ = std::move(reader);
+    response_reader_->Finish(&response_, &status_, this);
   }
 
   /**


### PR DESCRIPTION
Summary:
## Issue
- See here for paste of ASAN output: P133390744
  - `for (const auto& iter : sessions_to_terminate_) {` on line 72 was accessing a freed address
  - `sessions_to_terminate_.erase(sid);` on line 133 frees the address in a created thread
- This probably happens, when one of the thread spawned reaches the second line, when the original thread is still accessing/modifying the map

## Solution
- Introduced a mutex to guard reads/writes/deletes for the sessions_to_terminate map

## Other Cosmetic Changes
- Created `populate_sessions_to_terminate_with_retries` to consolidate logic that fetches session IDs from DirectoryD
- Some comments

Differential Revision: D22067121

