### PR TITLE
remove seq reset for multi APs IT

### DIFF
--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -179,7 +179,7 @@ func TestAuthenticateUplinkTraffic(t *testing.T) {
 //   respond with a rule install for a pass-all dynamic rule and 250KB of quota.
 // - Trigger UE authentications through AP1 and generate traffic to  put it
 //   through the newly installed rule.
-// - Reset Ue Seqence and trigger UE authentications through AP2 and assert that
+// - Trigger UE authentications through AP2 and assert that
 //   only one CCR-I is received. Sessiond must re-use the same session
 //   during the handover.
 // - Generate traffic to put traffic through the newly installed rule.
@@ -212,9 +212,6 @@ func TestAuthenticateMultipleAPsUplinkTraffic(t *testing.T) {
 
 	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "100K"}}
 	_, err = tr.GenULTraffic(req)
-	assert.NoError(t, err)
-
-	err = tr.ResetUESeq(ues[0])
 	assert.NoError(t, err)
 
 	tr.AuthenticateWithCalledIDAndAssertSuccess(imsi, CalledStationIDs[1])

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -204,7 +204,7 @@ func (tr *TestRunner) Authenticate(imsi, calledStationID string) (*radius.Packet
 		fmt.Println(err)
 		return &radius.Packet{}, err
 	}
-	tr.t.Log("Finished Authenticating UE" )
+	tr.t.Log("Finished Authenticating UE")
 	return radiusP, nil
 }
 
@@ -225,14 +225,6 @@ func (tr *TestRunner) Disconnect(imsi, calledStationID string) (*radius.Packet, 
 	}
 	tr.t.Log("Finished Discconnecting UE")
 	return radiusP, nil
-}
-
-// ResetUESeq reset sequence for a UE allowing multiple authentication.
-//
-func (tr *TestRunner) ResetUESeq(ue *cwfprotos.UEConfig) error {
-	fmt.Printf("************************* Reset Ue Sequence for IMSI: %v\n", ue.Imsi)
-	ue.Seq--
-	return uesim.AddUE(ue)
 }
 
 // GenULTraffic simulates the UE sending traffic through the CWAG to the Internet


### PR DESCRIPTION
Summary: Removing the sequence reset as It is not needed anymore.

Reviewed By: themarwhal

Differential Revision: D22039948

