### PR TITLE
Fixing override config check on service_configs

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -102,6 +102,7 @@ find_library(ASYNC_GRPC ASYNC_GRPC ${MAGMA_LIB_DIR}/async_grpc)
 find_library(SERVICE303_LIB SERVICE303_LIB ${MAGMA_LIB_DIR}/service303)
 find_library(CONFIG CONFIG ${MAGMA_LIB_DIR}/config)
 find_library(SERVICE_REGISTRY SERVICE_REGISTRY ${MAGMA_LIB_DIR}/service_registry)
+find_library(EVENTD EVENTD ${MAGMA_LIB_DIR}/eventd)
 
 ################################################################
 # Add sub modules

--- a/lte/gateway/c/oai/include/mme_events.h
+++ b/lte/gateway/c/oai/include/mme_events.h
@@ -33,6 +33,22 @@ extern "C" {
  */
 int event_client_init(void);
 
+/**
+ * Logs Attach successful event
+ * @param imsi
+ * @return response code
+ */
+int attach_successful(imsi64_t imsi64);
+
+/**
+ * Logs Detach successful event
+ * @param imsi
+ * @param action
+ * @return response code
+ */
+int detach_successful(imsi64_t imsi64, const char* action);
+
 #ifdef __cplusplus
 }
 #endif
+

--- a/lte/gateway/c/oai/include/mme_events.h
+++ b/lte/gateway/c/oai/include/mme_events.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+#pragma once
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "common_types.h"
+
+/**
+ * Helper function to initiate AsyncEventdClient in its own thread
+ */
+int event_client_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lte/gateway/c/oai/lib/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(mobility_client) # LIB_MOBILITY_CLIENT
 add_subdirectory(s6a_proxy) # LIB_S6A_PROXY
 add_subdirectory(secu) # LIB_SECU
 add_subdirectory(sgs_client) # LIB_SGS_CLIENT
+add_subdirectory(event_client) # LIB_EVENT_CLIENT
 
 if (NOT EMBEDDED_SGW)
   add_subdirectory(gtpv2-c) # LIB_GTPV2C

--- a/lte/gateway/c/oai/lib/event_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/event_client/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_compile_options(-std=c++14)
+
+include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
+
+set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)
+include_directories("${OUTPUT_DIR}")
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${MAGMA_LIB_DIR}/async_grpc)
+include_directories(${MAGMA_LIB_DIR}/eventd)
+
+link_directories(
+        ${MAGMA_LIB_DIR}/async_grpc
+        ${MAGMA_LIB_DIR}/eventd
+)
+
+add_library(LIB_EVENT_CLIENT
+        EventClientAPI.cpp
+        )
+
+target_link_libraries(LIB_EVENT_CLIENT
+        COMMON
+        LIB_BSTR ${EVENTD}
+        ${ASYNC_GRPC}
+        )
+
+target_include_directories(LIB_EVENT_CLIENT PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ASYNC_GRPC COMMON SERVICE_REGISTRY EVENTD
+        )

--- a/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+#include "EventClientAPI.h"
+
+#include <iostream>
+#include <thread>
+#include <grpcpp/support/status.h>
+#include <orc8r/protos/common.pb.h>
+
+#include "EventdClient.h"
+
+using grpc::Status;
+using magma::AsyncEventdClient;
+using magma::orc8r::Event;
+using magma::orc8r::Void;
+
+namespace magma {
+namespace lte {
+
+void init_eventd_client() {
+  auto& client = AsyncEventdClient::getInstance();
+  std::thread resp_loop_thread([&]() { client.rpc_response_loop(); });
+  resp_loop_thread.detach();
+}
+
+int log_event(const Event& event) {
+  AsyncEventdClient::getInstance().log_event(event, [=](Status status, Void v) {
+    if (status.ok()) {
+      std::cout << "[DEBUG] Success logging event: " << event.event_type()
+                << std::endl;
+    } else {
+      std::cout << "[ERROR] Failed to log event: " << event.event_type()
+                << "; Status: " << status.error_message() << std::endl;
+    }
+  });
+  return 0;
+}
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/oai/lib/event_client/EventClientAPI.h
+++ b/lte/gateway/c/oai/lib/event_client/EventClientAPI.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+#pragma once
+
+#include "orc8r/protos/eventd.pb.h"
+
+namespace magma {
+namespace lte {
+
+void init_eventd_client();
+
+int log_event(const magma::orc8r::Event& event);
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/oai/lib/mobility_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/mobility_client/CMakeLists.txt
@@ -48,9 +48,10 @@ target_link_libraries(LIB_MOBILITY_CLIENT
         COMMON
         LIB_BSTR
         LIB_PCEF
+        ${ASYNC_GRPC} ${SERVICE_REGISTRY}
 )
 
 target_include_directories(LIB_MOBILITY_CLIENT PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ASYNC_GRPC COMMON
+    ASYNC_GRPC COMMON SERVICE_REGISTRY
 )

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -36,11 +36,6 @@
 
 using grpc::Channel;
 using grpc::Status;
-
-// TODO: MobilityService IP:port config (t14002037)
-#define MOBILITYD_ENDPOINT "localhost:60051"
-
-using grpc::Channel;
 using grpc::ChannelCredentials;
 using grpc::CreateChannel;
 using grpc::InsecureChannelCredentials;

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.cpp
@@ -22,7 +22,6 @@
 #include "MobilityServiceClient.h"
 
 #include <cassert>
-#include <grpcpp/channel.h>
 #include <grpcpp/impl/codegen/client_context.h>
 #include <grpcpp/impl/codegen/status.h>
 #include <netinet/in.h>
@@ -30,7 +29,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <log.h>
 #include <thread>
 
 #include "lte/protos/mobilityd.grpc.pb.h"
@@ -38,15 +36,14 @@
 #include "orc8r/protos/common.pb.h"
 #include "lte/protos/subscriberdb.pb.h"
 
+#include "ServiceRegistrySingleton.h"
+
 using grpc::Channel;
 using grpc::ClientContext;
 using grpc::Status;
 using grpc::ChannelCredentials;
 using grpc::InsecureChannelCredentials;
 using magma::orc8r::Void;
-
-// TODO: MobilityService IP:port config (t14002037)
-#define MOBILITYD_ENDPOINT "localhost:60051"
 
 namespace magma {
 namespace lte {
@@ -197,9 +194,8 @@ void MobilityServiceClient::ReleaseIPv4AddressRPC(
 
 MobilityServiceClient::MobilityServiceClient()
 {
-  const std::shared_ptr<ChannelCredentials> cred = InsecureChannelCredentials();
-  const std::shared_ptr<Channel> channel =
-    CreateChannel(MOBILITYD_ENDPOINT, cred);
+  auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+      "mobilityd", ServiceRegistrySingleton::LOCAL);
   stub_ = MobilityService::NewStub(channel);
   std::thread resp_loop_thread([&]() { rpc_response_loop(); });
   resp_loop_thread.detach();

--- a/lte/gateway/c/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/oai/oai_mme/oai_mme.c
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "mme_events.h"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -97,6 +99,7 @@ int main(int argc, char *argv[])
 
   // Service started, but not healthy yet
   send_app_health_to_service303(TASK_MME_APP, false);
+  event_client_init();
 
   CHECK_INIT_RETURN(mme_app_init(&mme_config));
   CHECK_INIT_RETURN(sctp_init(&mme_config));

--- a/lte/gateway/c/oai/tasks/mme_app/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/mme_app/CMakeLists.txt
@@ -13,6 +13,12 @@ generate_cpp_protos("${MMEAPP_STATE_CPP_PROTOS}" "${PROTO_SRCS}"
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${LTE_OUT_DIR})
 
+set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)
+link_directories(
+        ${MAGMA_LIB_DIR}/async_grpc
+        ${MAGMA_LIB_DIR}/eventd
+)
+
 add_library(TASK_MME_APP
     mme_app_capabilities.c
     mme_app_context.c
@@ -52,6 +58,7 @@ add_library(TASK_MME_APP
     mme_app_state_converter.cpp
     mme_app_state_manager.cpp
     mme_app_state.cpp
+    mme_events.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )
@@ -64,7 +71,7 @@ target_compile_definitions(TASK_MME_APP PRIVATE
 target_link_libraries(TASK_MME_APP
   ${CONFIG_LIBRARIES}
   COMMON
-  LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU
+  LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU LIB_EVENT_CLIENT
   TASK_NAS TASK_S1AP TASK_SGW TASK_SERVICE303 TASK_SCTP_SERVER
   TASK_S6A TASK_SGS protobuf cpp_redis
     )

--- a/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+#include "mme_events.h"
+
+#include <cstdlib>
+#include <iostream>
+
+#include "orc8r/protos/common.pb.h"
+#include "orc8r/protos/eventd.pb.h"
+
+#include "EventClientAPI.h"
+
+using magma::lte::init_eventd_client;
+
+int event_client_init(void) {
+  init_eventd_client();
+}

--- a/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
@@ -23,14 +23,70 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <folly/Format.h>
+#include <folly/json.h>
+#include <folly/dynamic.h>
+#include <grpcpp/support/status.h>
 
+#include "conversions.h"
+#include "common_types.h"
 #include "orc8r/protos/common.pb.h"
 #include "orc8r/protos/eventd.pb.h"
 
 #include "EventClientAPI.h"
 
+using grpc::Status;
+using magma::orc8r::Event;
+using magma::orc8r::Void;
+using magma::lte::log_event;
 using magma::lte::init_eventd_client;
+using magma::orc8r::Void;
+
+namespace {
+constexpr char MME_STREAM_NAME[]   = "mme";
+constexpr char ATTACH_SUCCESSFUL[] = "attach_successful";
+constexpr char DETACH_SUCCESSFUL[] = "detach_successful";
+}  // namespace
 
 int event_client_init(void) {
   init_eventd_client();
+}
+
+int attach_successful(imsi64_t imsi64) {
+  Event eventRequest = Event();
+  eventRequest.set_event_type(ATTACH_SUCCESSFUL);
+  eventRequest.set_stream_name(MME_STREAM_NAME);
+
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+
+  std::string event_value_string = folly::toJson(event_value);
+  eventRequest.set_value(event_value_string);
+  eventRequest.set_tag(imsi_str);
+
+  int rc = log_event(eventRequest);
+  return rc;
+}
+
+int detach_successful(imsi64_t imsi64, const char* action) {
+  Event eventRequest = Event();
+  eventRequest.set_event_type(DETACH_SUCCESSFUL);
+  eventRequest.set_stream_name(MME_STREAM_NAME);
+
+  char imsi_str[IMSI_BCD_DIGITS_MAX + 1];
+  IMSI64_TO_STRING(imsi64, (char*) imsi_str, IMSI_BCD_DIGITS_MAX);
+
+  folly::dynamic event_value = folly::dynamic::object;
+  event_value["imsi"]        = imsi_str;
+  event_value["action"]      = action;
+
+  std::string event_value_string = folly::toJson(event_value);
+  eventRequest.set_value(event_value_string);
+  eventRequest.set_tag(imsi_str);
+
+  int rc = log_event(eventRequest);
+  return rc;
 }

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -58,16 +58,26 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "mme_events.h"
 #include "bstrlib.h"
 #include "dynamic_memory_check.h"
 #include "assertions.h"
 #include "log.h"
 #include "nas_timer.h"
 #include "common_types.h"
+#include "conversions.h"
+#include "service303.h"
+#include "common_defs.h"
+#include "mme_app_state.h"
+#include "mme_app_defs.h"
+#include "nas_procedures.h"
+
 #include "3gpp_24.008.h"
 #include "3gpp_36.401.h"
-#include "conversions.h"
+#include "3gpp_23.003.h"
+#include "3gpp_24.301.h"
 #include "3gpp_requirements_24.301.h"
+
 #include "nas_message.h"
 #include "mme_app_ue_context.h"
 #include "emm_proc.h"
@@ -77,27 +87,21 @@
 #include "esm_sapDef.h"
 #include "esm_sap.h"
 #include "emm_cause.h"
-#include "mme_config.h"
-#include "mme_app_itti_messaging.h"
-#include "service303.h"
-#include "common_ies.h"
-#include "3gpp_23.003.h"
-#include "3gpp_24.301.h"
-#include "AdditionalUpdateType.h"
-#include "EmmCause.h"
-#include "EpsNetworkFeatureSupport.h"
-#include "TrackingAreaIdentity.h"
-#include "TrackingAreaIdentityList.h"
-#include "common_defs.h"
 #include "emm_asDef.h"
 #include "emm_cnDef.h"
 #include "emm_fsm.h"
 #include "emm_regDef.h"
 #include "esm_data.h"
-#include "mme_app_state.h"
-#include "nas_procedures.h"
-#include "dynamic_memory_check.h"
-#include "mme_app_defs.h"
+#include "mme_config.h"
+#include "mme_app_itti_messaging.h"
+#include "common_ies.h"
+
+#include "AdditionalUpdateType.h"
+#include "EmmCause.h"
+#include "EpsNetworkFeatureSupport.h"
+#include "TrackingAreaIdentity.h"
+#include "TrackingAreaIdentityList.h"
+
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -795,6 +799,7 @@ int emm_proc_attach_complete(
         ue_id);
       emm_proc_emm_informtion(ue_mm_context);
       increment_counter("ue_attach", 1, 1, "result", "attach_proc_successful");
+      attach_successful(ue_mm_context->emm_context._imsi64);
     }
   } else if (esm_sap.err != ESM_SAP_DISCARDED) {
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/Detach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Detach.c
@@ -45,6 +45,7 @@
 #include "esm_data.h"
 #include "esm_sapDef.h"
 #include "mme_api.h"
+#include "mme_events.h"
 #include "nas_procedures.h"
 
 /****************************************************************************/
@@ -374,6 +375,7 @@ int emm_proc_detach_request(
   if (params->switch_off) {
     increment_counter("ue_detach", 1, 1, "result", "success");
     increment_counter("ue_detach", 1, 1, "action", "detach_accept_not_sent");
+    detach_successful(emm_ctx->_imsi64, "detach_accept_not_sent");
     rc = RETURNok;
   } else {
     /*
@@ -403,6 +405,7 @@ int emm_proc_detach_request(
     rc = emm_sap_send(&emm_sap);
     increment_counter("ue_detach", 1, 1, "result", "success");
     increment_counter("ue_detach", 1, 1, "action", "detach_accept_sent");
+    detach_successful(emm_ctx->_imsi64, "detach_accept_sent");
     /*
     * If Detach request is recieved for IMSI only then don't trigger session release and
     * don't clear emm context return from here

--- a/lte/gateway/configs/eventd.yml
+++ b/lte/gateway/configs/eventd.yml
@@ -38,3 +38,9 @@ event_registry:
   disconnected_sync_rpc_stream:
     module: orc8r
     filename: magmad_events.v1.yml
+  attach_successful:
+    module: lte
+    filename: mme_events.v1.yml
+  detach_successful:
+    module: lte
+    filename: mme_events.v1.yml

--- a/lte/swagger/mme_events.v1.yml
+++ b/lte/swagger/mme_events.v1.yml
@@ -1,0 +1,24 @@
+
+---
+swagger: '2.0'
+
+info:
+  title: MME event definitions
+  description: These events occur in MME task
+  version: 1.0.0
+
+definitions:
+  attach_successful:
+    type: object
+    description: Used to track when UE attaches successfully
+    properties:
+      imsi:
+        type: string
+  detach_successful:
+    type: object
+    description: Used to track when UE detaches successfully
+    properties:
+      imsi:
+        type: string
+      action:
+        type: string

--- a/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
+++ b/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
@@ -12,10 +12,10 @@ include_directories("${PROJECT_SOURCE_DIR}/../common/logging")
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
-set(ASYNC_ORC8R_CPP_PROTOS common)
+set(ASYNC_ORC8R_CPP_PROTOS common eventd)
 set(ASYNC_LTE_CPP_PROTOS session_manager policydb subscriberdb mobilityd)
 set(ASYNC_LTE_GRPC_PROTOS session_manager mobilityd)
-set(ASYNC_ORC8R_GRPC_PROTOS "")
+set(ASYNC_ORC8R_GRPC_PROTOS eventd)
 
 generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
   "${ASYNC_LTE_GRPC_PROTOS}"

--- a/orc8r/gateway/c/common/eventd/EventdClient.cpp
+++ b/orc8r/gateway/c/common/eventd/EventdClient.cpp
@@ -6,14 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-#include <memory>
-#include <utility>
-
-#include <orc8r/protos/eventd.pb.h>
-#include <orc8r/protos/eventd.grpc.pb.h>
-
 #include "EventdClient.h"
-#include "GRPCReceiver.h"
+
 #include "ServiceRegistrySingleton.h"
 
 using grpc::ClientContext;

--- a/orc8r/gateway/c/common/eventd/EventdClient.h
+++ b/orc8r/gateway/c/common/eventd/EventdClient.h
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+#pragma once
+
 #include <memory>
 #include <utility>
 

--- a/orc8r/gateway/python/magma/configuration/service_configs.py
+++ b/orc8r/gateway/python/magma/configuration/service_configs.py
@@ -37,7 +37,7 @@ def load_override_config(service_name: str) -> Any:
     override_file_name = _override_file_name(service_name)
     if os.path.isfile(override_file_name):
         return _load_yaml_file(override_file_name)
-    return {}
+    return None
 
 
 def save_override_config(service_name: str, cfg: Any):


### PR DESCRIPTION
Summary:
- directoryd was failing to start as no yml file now has no content to load (log_level was moved to mconfig), and with the override config check getting triggered due to `load_override_config` returning empty directory, it throws:

```
Jun 17 07:38:43 magma-dev directoryd[5597]: Traceback (most recent call last):
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
Jun 17 07:38:43 magma-dev directoryd[5597]:     "__main__", mod_spec)
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
Jun 17 07:38:43 magma-dev directoryd[5597]:     exec(code, run_globals)
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/directoryd/main.py", line 31, in <module>
Jun 17 07:38:43 magma-dev directoryd[5597]:     main()
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/directoryd/main.py", line 17, in main
Jun 17 07:38:43 magma-dev directoryd[5597]:     service = MagmaService('directoryd', mconfigs_pb2.DirectoryD())
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/service.py", line 91, in __init__
Jun 17 07:38:43 magma-dev directoryd[5597]:     self.reload_config()
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/service.py", line 192, in reload_config
Jun 17 07:38:43 magma-dev directoryd[5597]:     self._config = load_service_config(self._name)
Jun 17 07:38:43 magma-dev directoryd[5597]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/configuration/service_configs.py", line 78, in load_se
Jun 17 07:38:43 magma-dev directoryd[5597]:     cfg.update(overrides)
```

Differential Revision: D22087431

