### PR TITLE
Removing the hardcoded oai.ipv4

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_maxbearers_twopdns.py
@@ -72,7 +72,7 @@ class TestMaximumBearersTwoPdnsPerUe(unittest.TestCase):
 
             # Add dedicated bearer for default bearer 5
             print(
-                "********************** Adding dedicated bearer to oai.ipv4"
+                "********************** Adding dedicated bearer to magma.ipv4"
                 " PDN"
             )
             self._spgw_util.create_bearer(

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_dedicated_bearer_deactivate.py
@@ -69,7 +69,7 @@ class TestSecondaryPdnConnWithDedBearerDeactivateReq(unittest.TestCase):
 
             # Add dedicated bearer for default bearer 5
             print(
-                "********************** Adding dedicated bearer to oai.ipv4"
+                "********************** Adding dedicated bearer to magma.ipv4"
                 " PDN"
             )
             self._spgw_util.create_bearer(
@@ -157,7 +157,7 @@ class TestSecondaryPdnConnWithDedBearerDeactivateReq(unittest.TestCase):
                 deactv_bearer_req.bearerId,
             )
             time.sleep(5)
-            # Delete dedicated bearer of secondary PDN (oai.ipv4 apn)
+            # Delete dedicated bearer of default PDN (magma.ipv4 apn)
             self._spgw_util.delete_bearer(
                 "IMSI" + "".join([str(i) for i in req.imsi]),
                 5,

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_information.py
@@ -27,7 +27,7 @@ class TestEsmInformation(unittest.TestCase):
         """ Testing of sending Esm Information procedure """
         num_ues = 1
 
-        self._s1ap_wrapper.configUEDevice_ues_same_imsi(num_ues)
+        self._s1ap_wrapper.configUEDevice(num_ues)
         print("************************* sending Attach Request for ue-id : 1")
         attach_req = s1ap_types.ueAttachRequest_t()
         attach_req.ue_Id = 1
@@ -95,7 +95,7 @@ class TestEsmInformation(unittest.TestCase):
         esm_info_response.ue_Id = 1
         esm_info_response.tId = esm_info_req.tId
         esm_info_response.pdnAPN_pr.pres = 1
-        s = "oai.ipv4"
+        s = "magma.ipv4"
         esm_info_response.pdnAPN_pr.len = len(s)
         esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
             *[ctypes.c_ubyte(ord(c)) for c in s[:100]]

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_missing_imsi.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_missing_imsi.py
@@ -24,9 +24,9 @@ class TestAttachMissingImsi(unittest.TestCase):
 
     def test_attach_missing_imsi(self):
         """ Attaching with IMSI missing from subscriberd """
-        ue_id = 1
-
         self._s1ap_wrapper.configUEDevice(1)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
         print("************************* Running End to End attach for ",
               "UE id ", ue_id)
         self._s1ap_wrapper._sub_util.cleanup()
@@ -40,10 +40,11 @@ class TestAttachMissingImsi(unittest.TestCase):
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
 
+        ue_id = 2
         print("************************* Adding IMSI entry for UE id ", ue_id)
         # Adding IMSI to subscriberdb
         self._s1ap_wrapper.configUEDevice_without_checking_gw_health(1)
-        ue_id = 2
+
         time.sleep(5)
 
         print("************************* Rerunning End to End attach for ",

--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -103,24 +103,10 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
         ula.total_ambr.max_bandwidth_dl = profile.max_dl_bit_rate
         ula.all_apns_included = 0
 
-        apn = ula.apn.add()
-        apn.context_id = 0
-        apn.service_selection = "oai.ipv4"
-        apn.qos_profile.class_id = 9
-        apn.qos_profile.priority_level = 15
-        apn.qos_profile.preemption_capability = 1
-        apn.qos_profile.preemption_vulnerability = 0
-
-        apn.ambr.max_bandwidth_ul = profile.max_ul_bit_rate
-        apn.ambr.max_bandwidth_dl = profile.max_dl_bit_rate
-        apn.pdn = s6a_proxy_pb2.UpdateLocationAnswer.APNConfiguration.IPV4
-
-        # Secondary PDN
         context_id = 0
         for apn in sub_data.non_3gpp.apn_config:
             sec_apn = ula.apn.add()
-            # Context id 0 is assigned to oai.ipv4 apn. So start from 1
-            sec_apn.context_id = context_id + 1
+            sec_apn.context_id = context_id
             context_id += 1
             sec_apn.service_selection = apn.service_selection
             sec_apn.qos_profile.class_id = apn.qos_profile.class_id


### PR DESCRIPTION
Summary:
Currently hardcoded oai.ipv4 leads to confusion and misuse of APN configuration available at NMS. The change removes this hardcoded APN and makes the configuration done through NMS or swagger API as the ground truth.

Due to this change, sanity test suite had to be modified as well to remove any dependency on the hardcoded APN.

Differential Revision: D22105333

