### PR TITLE
Insert redirection rules to gy_dynamic_rules_to_install list only

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -585,13 +585,10 @@ void SessionState::insert_gy_dynamic_rule(
                  <<" (gy dynamic rule), but it already existed";
     return;
   }
-  update_criteria.gy_dynamic_rules_to_install.push_back(rule);
   rule_lifetimes_[rule.id()] = lifetime;
   gy_dynamic_rules_.insert_rule(rule);
-  update_criteria.dynamic_rules_to_install.push_back(rule);
+  update_criteria.gy_dynamic_rules_to_install.push_back(rule);
   update_criteria.new_rule_lifetimes[rule.id()] = lifetime;
-
-
 }
 
 void SessionState::activate_static_rule(


### PR DESCRIPTION
Summary:
Currently, the redirect rule is inserted both lists : gy_dynamic_rules_to_install and dynamic_rules_to_install.

After rule deactivation, only gy_dynamic_rule is updated and thus redirect rule in dynamic_rule will trigger new
requests to pipelined to activate it again.

```
ERROR:GYController:Activating redirection imsi IMSI189917347186615, rule.id - redirect : 192.168.128.2
INFO:GYController:Saved redirect rule for 192.168.0.2 in Redis
ERROR:EnforcementController:Redirect Exception for imsi IMSI189917347186615, rule.id - redirect : '' does not appear to be an IPv4 or IPv6 address
```

Reviewed By: themarwhal

Differential Revision: D22112356

