### PR TITLE
Code cleanup : remove unused args, return-type mismatch, sign compare

### DIFF
--- a/lte/gateway/c/session_manager/DirectorydClient.cpp
+++ b/lte/gateway/c/session_manager/DirectorydClient.cpp
@@ -85,7 +85,7 @@ bool AsyncDirectorydClient::delete_directoryd_record(
 }
 
 
-bool AsyncDirectorydClient::get_all_directoryd_records(
+void AsyncDirectorydClient::get_all_directoryd_records(
   std::function<void(Status status, AllDirectoryRecords)> callback)
 {
   magma::Void request;

--- a/lte/gateway/c/session_manager/DirectorydClient.h
+++ b/lte/gateway/c/session_manager/DirectorydClient.h
@@ -60,7 +60,7 @@ class AsyncDirectorydClient : public GRPCReceiver {
    * Get all directory records
    * @return true if the operation was successful
    */
-  bool get_all_directoryd_records(
+  void get_all_directoryd_records(
     std::function<void(Status status, AllDirectoryRecords)> callback);
 
  private:

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -422,6 +422,9 @@ static RedirectInformation_AddressType address_type_converter(
       return RedirectInformation_AddressType_URL;
     case RedirectServer_RedirectAddressType_SIP_URI:
       return RedirectInformation_AddressType_SIP_URI;
+    default:
+      MLOG(MERROR) << "Unknown redirect address type!";
+      return RedirectInformation_AddressType_IPv4;
   }
 }
 
@@ -573,6 +576,9 @@ static bool should_activate(
     case PolicyRule::NO_TRACKING:
       MLOG(MINFO) << "Activating untracked rule " << rule.id();
       break;
+    default:
+      MLOG(MINFO) << "Invalid rule tracking type " << rule.id();
+      return false;
   }
   return true;
 }

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -401,7 +401,7 @@ std::string LocalSessionManagerHandlerImpl::convert_mac_addr_to_str(
     return res;
   }
   res.reserve(l * 3 - 1);
-  for (int i = 0; i < l; i++) {
+  for (size_t i = 0; i < l; i++) {
     if (i > 0) {
       res.push_back(':');
     }

--- a/lte/gateway/c/session_manager/MeteringReporter.cpp
+++ b/lte/gateway/c/session_manager/MeteringReporter.cpp
@@ -22,7 +22,7 @@ const char* DIRECTION_DOWN     = "down";
 
 MeteringReporter::MeteringReporter() {}
 
-bool MeteringReporter::report_usage(
+void MeteringReporter::report_usage(
     const std::string& imsi, const std::string& session_id,
     SessionStateUpdateCriteria& update_criteria) {
   double total_tx = 0;

--- a/lte/gateway/c/session_manager/MeteringReporter.h
+++ b/lte/gateway/c/session_manager/MeteringReporter.h
@@ -21,7 +21,7 @@ class MeteringReporter {
    * Report all unreported traffic usage for a session.
    * All charging and monitoring keys are aggregated.
    */
-  bool report_usage(
+  void report_usage(
       const std::string& imsi, const std::string& session_id,
       SessionStateUpdateCriteria& update_criteria);
 

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -95,7 +95,7 @@ SessionMap RedisStoreClient::read_all_sessions() {
     return session_map;
   }
   auto array = reply.as_array();
-  for (int i = 0; i < array.size(); i += 2) {
+  for (size_t i = 0; i < array.size(); i += 2) {
     auto key_reply = array[i];
     if (!key_reply.is_string()) {
       MLOG(MERROR) << "Non string key found in sessions from redis";

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -184,9 +184,10 @@ convert_update_type_to_proto(CreditUpdateType update_type) {
       return CreditUsage::REAUTH_REQUIRED;
     case CREDIT_VALIDITY_TIMER_EXPIRED:
       return CreditUsage::VALIDITY_TIMER_EXPIRED;
+    default:
+      MLOG(MERROR) << "Converting invalid update type " << update_type;
+      return CreditUsage::QUOTA_EXHAUSTED;
   }
-  MLOG(MERROR) << "Converting invalid update type " << update_type;
-  return CreditUsage::QUOTA_EXHAUSTED;
 }
 
 static uint64_t get_granted_units(const CreditUnit &unit,
@@ -312,8 +313,8 @@ void SessionState::get_monitor_updates(
     auto usage = credit.get_usage_for_reporting(*credit_uc);
     auto update = make_usage_monitor_update(
         usage, mkey, monitor_pair.second->level);
-
     auto new_req = update_request_out.mutable_usage_monitors()->Add();
+
     add_common_fields_to_usage_monitor_update(new_req);
     new_req->mutable_update()->CopyFrom(update);
     new_req->set_event_trigger(USAGE_REPORT);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -105,7 +105,10 @@ protected:
   folly::EventBase *evb;
 };
 
-MATCHER_P(CheckCount, count, "") { return arg.size() == count; }
+MATCHER_P(CheckCount, count, "") {
+  int arg_count = arg.size();
+  return arg_count == count;
+}
 
 MATCHER_P2(CheckUpdateRequestCount, monitorCount, chargingCount, "") {
   auto req = static_cast<const UpdateSessionRequest>(arg);
@@ -132,7 +135,7 @@ MATCHER_P4(CheckSessionInfos, imsi_list, ip_address_list, static_rule_lists,
   if (infos.size() != imsi_list.size())
     return false;
 
-  for (int i = 0; i < infos.size(); i++) {
+  for (size_t i = 0; i < infos.size(); i++) {
     if (infos[i].imsi != imsi_list[i])
       return false;
     if (infos[i].ip_addr != ip_address_list[i])
@@ -141,11 +144,11 @@ MATCHER_P4(CheckSessionInfos, imsi_list, ip_address_list, static_rule_lists,
       return false;
     if (infos[i].dynamic_rules.size() != dynamic_rule_ids_lists[i].size())
       return false;
-    for (int r_index = 0; i < infos[i].static_rules.size(); i++) {
+    for (size_t r_index = 0; i < infos[i].static_rules.size(); i++) {
       if (infos[i].static_rules[r_index] != static_rule_lists[i][r_index])
         return false;
     }
-    for (int r_index = 0; i < infos[i].dynamic_rules.size(); i++) {
+    for (size_t r_index = 0; i < infos[i].dynamic_rules.size(); i++) {
       if (infos[i].dynamic_rules[r_index].id() !=
           dynamic_rule_ids_lists[i][r_index])
         return false;

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -94,10 +94,11 @@ protected:
 
 MATCHER_P2(CheckQuotaUpdateState, size, expected_states, "") {
   auto updates = static_cast<const std::vector<SubscriberQuotaUpdate>>(arg);
-  if (updates.size() != size) {
+  int updates_size = updates.size();
+  if (updates_size != size) {
     return false;
   }
-  for (int i = 0; i < updates.size(); i++) {
+  for (int i = 0; i < updates_size; i++) {
     if (updates[i].update_type() != expected_states[i]) {
       return false;
     }

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -92,7 +92,8 @@ MATCHER_P(CheckUpdateSessionRequest, request_number, "")
 {
   auto request = static_cast<const UpdateSessionRequest&>(arg);
   for (const auto& credit_usage_update : request.updates()) {
-    return credit_usage_update.request_number() == request_number;
+    int req_number = credit_usage_update.request_number();
+    return req_number == request_number;
   }
   return false;
 }

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -96,7 +96,10 @@ protected:
       return RedirectInformation_AddressType_URL;
     case RedirectServer_RedirectAddressType_SIP_URI:
       return RedirectInformation_AddressType_SIP_URI;
+    default:
+      return RedirectInformation_AddressType_IPv4;
     }
+
   }
 
   void insert_gy_redirection_rule(const std::string &rule_id){


### PR DESCRIPTION
Summary: Code cleanup : remove unused args, return-type mismatch, sign compare

Reviewed By: themarwhal

Differential Revision: D22014811

