### PR TITLE
Do not save cloud managed configs if they did not change

### DIFF
--- a/orc8r/gateway/go/mconfig/impl.go
+++ b/orc8r/gateway/go/mconfig/impl.go
@@ -90,6 +90,7 @@ func RefreshConfigsFrom(mcpath string) error {
 		return fmt.Errorf("Managed Config File '%s' stat error: %v", mcpath, err)
 	}
 	if sameFile(lastFileInfo, fi) {
+		glog.V(1).Infof("mconfig '%s' is unchanged from %s", mcpath, lastFileInfo.ModTime().Format(time.RFC822))
 		return nil
 	}
 	err = loadFromFile(mcpath)

--- a/orc8r/gateway/go/services/configurator/service/io.go
+++ b/orc8r/gateway/go/services/configurator/service/io.go
@@ -23,22 +23,15 @@ import (
 )
 
 // SaveConfig saves new gateway.configs and returns old configuration if any
-func SaveConfigs(cfgJson []byte, readOldCfg bool) (oldCfgJson []byte, err error) {
+func SaveConfigs(cfgJson []byte) error {
 	if len(cfgJson) == 0 {
-		return oldCfgJson, fmt.Errorf("empty gateway mconfigs")
+		return fmt.Errorf("empty gateway mconfigs")
 	}
-	mconfigPath := mconfig.ConfigFilePath()
-	if readOldCfg {
-		var oerr error
-		if oldCfgJson, oerr = ioutil.ReadFile(mconfigPath); oerr != nil {
-			oldCfgJson = nil
-		}
-	}
-	err = safeSwap(mconfig.ConfigFilePath(), cfgJson)
+	err := safeSwap(mconfig.ConfigFilePath(), cfgJson)
 	if err == nil {
-		glog.V(1).Infof("successfully updated mconfig in %s", mconfigPath)
+		glog.V(1).Infof("successfully updated mconfig in %s", mconfig.ConfigFilePath())
 	}
-	return oldCfgJson, err
+	return err
 }
 
 // updateStaticConfigs saves new gateway.configs into static mconfig location
@@ -57,7 +50,6 @@ func updateStaticConfigs(cfgJson []byte) error {
 }
 
 func safeSwap(mconfigPath string, cfgJson []byte) error {
-	os.MkdirAll(filepath.Dir(mconfigPath), 0755)
 	newMconfigPath := mconfigPath + ".new"
 	oldMconfigPath := mconfigPath + ".old"
 	err := ioutil.WriteFile(newMconfigPath, cfgJson, 0644)
@@ -80,4 +72,8 @@ func safeSwap(mconfigPath string, cfgJson []byte) error {
 		}
 	}
 	return err
+}
+
+func readCfg() ([]byte, error) {
+	return ioutil.ReadFile(mconfig.ConfigFilePath())
 }

--- a/orc8r/gateway/go/services/magmad/main.go
+++ b/orc8r/gateway/go/services/magmad/main.go
@@ -178,6 +178,9 @@ func mainEventLoop(eventChan <-chan interface{}, freeMemChan <-chan time.Time) {
 			if ok {
 				glog.Info("purging unused memory")
 				debug.FreeOSMemory()
+				if glog.V(2) {
+					profile.LogMemStats()
+				}
 				// write out heap profile if built with -tags with_profiler, noop otherwise
 				// to use:
 				//    go tool pprof -http=127.0.0.1:9999 <path/to/magmad> <profiles_dir/memory_MMDD_HH.mm.SS.pprof>

--- a/orc8r/gateway/go/services/magmad/service/magmad.go
+++ b/orc8r/gateway/go/services/magmad/service/magmad.go
@@ -82,7 +82,7 @@ func (m *magmadService) SetConfigs(_ context.Context, cfg *protos.GatewayConfigs
 		var marshaled []byte
 		marshaled, err = protos.MarshalMconfig(cfg)
 		if err == nil {
-			_, err = config_service.SaveConfigs(marshaled, false)
+			err = config_service.SaveConfigs(marshaled)
 		}
 	}
 	return &protos.Void{}, err


### PR DESCRIPTION
Summary:
Due to inconsistent cloud config digest, orcestrator often sends configs with no changes to gateways.
Add extra verification and avoid saving unchanged configs to local storage to conserve resources & low grade flash
on low end gateways.

Differential Revision: D22134945

