### PR TITLE
Updated Session Manager to use log level defined in mconfig

### DIFF
--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -72,10 +72,13 @@ static const std::shared_ptr<grpc::Channel> get_controller_channel(
   }
 }
 
-static uint32_t get_log_verbosity(const YAML::Node &config)
+static uint32_t get_log_verbosity(const YAML::Node &config, magma::mconfig::SessionD mconfig)
 {
   if (!config["log_level"].IsDefined()) {
-    return MINFO;
+    if(mconfig.log_level() < 0 || mconfig.log_level() > 4){
+      return MINFO;
+    }
+    return mconfig.log_level();
   }
   std::string log_level = config["log_level"].as<std::string>();
   if (log_level == "DEBUG") {
@@ -106,7 +109,7 @@ int main(int argc, char *argv[])
   auto mconfig = load_mconfig();
   auto config =
     magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
-  magma::set_verbosity(get_log_verbosity(config));
+  magma::set_verbosity(get_log_verbosity(config, mconfig));
 
   folly::EventBase *evb = folly::EventBaseManager::get()->getEventBase();
 


### PR DESCRIPTION
Summary: Previously, Session Manager would only read log level defined in `/lte/gateway/configs/sessiond.yml`. If that log level happens to be missing/undefined, the service will look at its mconfig and use the log level defined there.

Differential Revision: D22146789

