### PR TITLE
Enable -Werror for debug builds and fix the remaining warnings

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -18,6 +18,13 @@ set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)
 add_definitions(-DLOG_WITH_GLOG)
 
+message("Build type is ${CMAKE_BUILD_TYPE}")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -Wall -Werror -Wno-unused-function"
+  )
+endif ()
+
 include_directories("${OUTPUT_DIR}")
 include_directories("${MAGMA_ROOT}/orc8r/gateway/c/common/logging")
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -74,12 +74,12 @@ LocalEnforcer::LocalEnforcer(
     magma::mconfig::SessionD mconfig)
     : reporter_(reporter),
       rule_store_(rule_store),
-      session_store_(session_store),
       pipelined_client_(pipelined_client),
       directoryd_client_(directoryd_client),
       eventd_client_(eventd_client),
       spgw_client_(spgw_client),
       aaa_client_(aaa_client),
+      session_store_(session_store),
       session_force_termination_timeout_ms_(
           session_force_termination_timeout_ms),
       quota_exhaustion_termination_on_init_ms_(

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -25,8 +25,8 @@ LocalSessionManagerHandlerImpl::LocalSessionManagerHandlerImpl(
     std::shared_ptr<LocalEnforcer> enforcer, SessionReporter* reporter,
     std::shared_ptr<AsyncDirectorydClient> directoryd_client,
     SessionStore& session_store)
-    : enforcer_(enforcer),
-      session_store_(session_store),
+    : session_store_(session_store),
+      enforcer_(enforcer),
       reporter_(reporter),
       directoryd_client_(directoryd_client),
 

--- a/lte/gateway/c/session_manager/RestartHandler.h
+++ b/lte/gateway/c/session_manager/RestartHandler.h
@@ -45,11 +45,11 @@ class RestartHandler {
   bool launch_threads_to_terminate_with_retries();
 
  private:
-  SessionStore& session_store_;
-  std::shared_ptr<LocalEnforcer> enforcer_;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
   std::shared_ptr<aaa::AsyncAAAClient> aaa_client_;
+  std::shared_ptr<LocalEnforcer> enforcer_;
   SessionReporter* reporter_;
+  SessionStore& session_store_;
   std::mutex sessions_to_terminate_lock_; // mutex to guard add/remove access to sessions_to_terminate
   std::unordered_map<std::string, std::string> sessions_to_terminate_;
   static const uint max_cleanup_retries_;

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -92,16 +92,15 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
 }
 
 SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state)
-    : credit_type_(credit_type), reporting_(false),
-      reauth_state_(REAUTH_NOT_NEEDED), service_state_(start_state),
-      unlimited_quota_(false), buckets_{}, is_final_grant_(false){}
+    : credit_type_(credit_type), reauth_state_(REAUTH_NOT_NEEDED),
+      service_state_(start_state), buckets_{}, reporting_(false),
+      unlimited_quota_(false), is_final_grant_(false){}
 
 SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state,
                              bool unlimited_quota)
-    : credit_type_(credit_type), reporting_(false),
-      reauth_state_(REAUTH_NOT_NEEDED), service_state_(start_state),
-      unlimited_quota_(unlimited_quota), buckets_{}, is_final_grant_(false) {}
-
+    : credit_type_(credit_type), reauth_state_(REAUTH_NOT_NEEDED),
+      service_state_(start_state), buckets_{}, reporting_(false),
+      unlimited_quota_(unlimited_quota), is_final_grant_(false) {}
 
 // by default, enable service
 SessionCredit::SessionCredit(CreditType credit_type)

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -197,20 +197,20 @@ public:
   static bool TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED;
 
 private:
-  bool reporting_;
-  bool is_final_grant_;
-  bool unlimited_quota_;
-  FinalActionInfo final_action_info_;
+  CreditType credit_type_;
   ReAuthState reauth_state_;
   ServiceState service_state_;
-  std::time_t expiry_time_;
+  FinalActionInfo final_action_info_;
   uint64_t buckets_[MAX_VALUES];
+  std::time_t expiry_time_;
   /**
    * Limit for the total usage (tx + rx) in credit updates to prevent
    * session manager from reporting more usage than granted
    */
   uint64_t usage_reporting_limit_;
-  CreditType credit_type_;
+  bool reporting_;
+  bool unlimited_quota_;
+  bool is_final_grant_;
 
 private:
   /**

--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -80,9 +80,9 @@ AsyncGRPCRequest<GRPCService, RequestType, ResponseType>::AsyncGRPCRequest(
   ServerCompletionQueue *cq,
   GRPCService &service):
   cq_(cq),
-  service_(service),
   status_(PROCESS),
-  responder_(&ctx_)
+  responder_(&ctx_),
+  service_(service)
 {
 }
 

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.h
@@ -66,8 +66,8 @@ class SessionProxyResponderHandlerImpl : public SessionProxyResponderHandler {
       std::function<void(Status, PolicyReAuthAnswer)> response_callback);
 
  private:
-  SessionStore& session_store_;
   std::shared_ptr<LocalEnforcer> enforcer_;
+  SessionStore& session_store_;
 
  private:
   /**

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -19,8 +19,8 @@ AsyncEvbResponse<ResponseType>::AsyncEvbResponse(
   folly::EventBase* base,
   std::function<void(grpc::Status, ResponseType)> callback,
   uint32_t timeout_sec):
-  base_(base),
-  AsyncGRPCResponse<ResponseType>(callback, timeout_sec)
+  AsyncGRPCResponse<ResponseType>(callback, timeout_sec),
+  base_(base)
 {
 }
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -92,18 +92,18 @@ StoredSessionState SessionState::marshal() {
 
 SessionState::SessionState(
     const StoredSessionState& marshaled, StaticRuleStore& rule_store)
-    : request_number_(marshaled.request_number),
-      curr_state_(marshaled.fsm_state),
-      config_(marshaled.config),
-      imsi_(marshaled.imsi),
+    : imsi_(marshaled.imsi),
       session_id_(marshaled.session_id),
       core_session_id_(marshaled.core_session_id),
+      request_number_(marshaled.request_number),
+      curr_state_(marshaled.fsm_state),
+      config_(marshaled.config),
       subscriber_quota_state_(marshaled.subscriber_quota_state),
       tgpp_context_(marshaled.tgpp_context),
-      credit_map_(4, &ccHash, &ccEqual),
       static_rules_(rule_store),
       pending_event_triggers_(marshaled.pending_event_triggers),
-      revalidation_time_(marshaled.revalidation_time) {
+      revalidation_time_(marshaled.revalidation_time),
+      credit_map_(4, &ccHash, &ccEqual) {
 
   session_level_key_ =
       std::make_unique<std::string>(marshaled.session_level_key);
@@ -147,13 +147,13 @@ SessionState::SessionState(
     : imsi_(imsi),
       session_id_(session_id),
       core_session_id_(core_session_id),
-      config_(cfg),
       // Request number set to 1, because request 0 is INIT call
       request_number_(1),
       curr_state_(SESSION_ACTIVE),
-      credit_map_(4, &ccHash, &ccEqual),
+      config_(cfg),
       tgpp_context_(tgpp_context),
-      static_rules_(rule_store) {}
+      static_rules_(rule_store),
+      credit_map_(4, &ccHash, &ccEqual) {}
 
 std::unique_ptr<Monitor>
 SessionState::unmarshal_monitor(const StoredMonitor &marshaled) {

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -124,8 +124,8 @@ class SessionStore {
       SessionStateUpdateCriteria& update_criteria);
 
  private:
-  std::shared_ptr<StoreClient> store_client_;
   std::shared_ptr<StaticRuleStore> rule_store_;
+  std::shared_ptr<StoreClient> store_client_;
   std::shared_ptr<MeteringReporter> metering_reporter_;
 };
 


### PR DESCRIPTION
Summary:
This is the last commit to fix all the warnings (-Werror=reorder) in sessiond
and enable gcc -Werror for debug builds

Reviewed By: themarwhal

Differential Revision: D22114592

