### PR TITLE
SPGW: Set IMSI reg for ARP request of UE IP

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -59,11 +59,15 @@ void GTPApplication::event_callback(
     add_uplink_tunnel_flow(add_tunnel_event, messenger);
     add_downlink_tunnel_flow(add_tunnel_event, messenger, uplink_port_num_);
     add_downlink_tunnel_flow(add_tunnel_event, messenger, mtr_port_num_);
+    add_downlink_arp_flow(add_tunnel_event, messenger, uplink_port_num_);
+    add_downlink_arp_flow(add_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DELETE_GTP_TUNNEL) {
     auto del_tunnel_event = static_cast<const DeleteGTPTunnelEvent&>(ev);
     delete_uplink_tunnel_flow(del_tunnel_event, messenger);
     delete_downlink_tunnel_flow(del_tunnel_event, messenger, uplink_port_num_);
     delete_downlink_tunnel_flow(del_tunnel_event, messenger, mtr_port_num_);
+    delete_downlink_arp_flow(del_tunnel_event, messenger, uplink_port_num_);
+    delete_downlink_arp_flow(del_tunnel_event, messenger, mtr_port_num_);
   } else if (ev.get_type() == EVENT_DISCARD_DATA_ON_GTP_TUNNEL) {
     auto discard_tunnel_flow =
       static_cast<const HandleDataOnGTPTunnelEvent&>(ev);
@@ -101,9 +105,9 @@ void add_uplink_match(
  */
 void add_imsi_metadata(
   of13::ApplyActions &apply_actions,
-  const std::string &imsi)
+  uint64_t imsi)
 {
-  auto metadata_field = new of13::Metadata(IMSIEncoder::compact_imsi(imsi));
+  auto metadata_field = new of13::Metadata(imsi);
   of13::SetFieldAction set_metadata(metadata_field);
   apply_actions.add_action(set_metadata);
 }
@@ -112,6 +116,7 @@ void GTPApplication::add_uplink_tunnel_flow(
   const AddGTPTunnelEvent &ev,
   const OpenflowMessenger &messenger)
 {
+  auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
   uint32_t flow_priority =
     convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod uplink_fm =
@@ -130,7 +135,7 @@ void GTPApplication::add_uplink_tunnel_flow(
   apply_ul_inst.add_action(set_eth_dst);
 
   // add imsi to packet metadata to pass to other tables
-  add_imsi_metadata(apply_ul_inst, ev.get_imsi());
+  add_imsi_metadata(apply_ul_inst, imsi);
 
   uplink_fm.add_instruction(apply_ul_inst);
 
@@ -140,7 +145,7 @@ void GTPApplication::add_uplink_tunnel_flow(
 
   // Finally, send flow mod
   messenger.send_of_msg(uplink_fm, ev.get_connection());
-  OAILOG_DEBUG(LOG_GTPV1U, "Uplink flow added\n");
+  OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "Uplink flow added\n");
 }
 
 void GTPApplication::delete_uplink_tunnel_flow(
@@ -161,6 +166,23 @@ void GTPApplication::delete_uplink_tunnel_flow(
 /*
  * Helper method to add matching for adding/deleting the downlink flow
  */
+static void add_downlink_arp_match(
+  of13::FlowMod& downlink_fm,
+  const struct in_addr& ue_ip,
+  uint32_t port)
+
+{
+  // Set match on uplink port and IP eth type
+  of13::InPort uplink_port_match(port);
+  downlink_fm.add_oxm_field(uplink_port_match);
+  of13::EthType ip_type(0x0806);
+  downlink_fm.add_oxm_field(ip_type);
+
+  // Match UE IP destination
+  of13::ARPTPA arptpa(ue_ip.s_addr);
+  downlink_fm.add_oxm_field(arptpa);
+}
+
 static void add_downlink_match(
   of13::FlowMod& downlink_fm,
   const struct in_addr& ue_ip,
@@ -232,6 +254,7 @@ void GTPApplication::add_downlink_tunnel_flow(
   const OpenflowMessenger &messenger,
   uint32_t port_number)
 {
+  auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
   uint32_t flow_priority =
     convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
@@ -253,7 +276,7 @@ void GTPApplication::add_downlink_tunnel_flow(
   apply_dl_inst.add_action(set_tunnel_dst);
 
   // add imsi to packet metadata to pass to other tables
-  add_imsi_metadata(apply_dl_inst, ev.get_imsi());
+  add_imsi_metadata(apply_dl_inst, imsi);
 
   // Output to inout table
   of13::GoToTable goto_inst(NEXT_TABLE);
@@ -263,7 +286,36 @@ void GTPApplication::add_downlink_tunnel_flow(
 
   // Finally, send flow mod
   messenger.send_of_msg(downlink_fm, ev.get_connection());
-  OAILOG_DEBUG(LOG_GTPV1U, "Downlink flow added\n");
+  OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "Downlink flow added\n");
+}
+
+void GTPApplication::add_downlink_arp_flow(
+  const AddGTPTunnelEvent &ev,
+  const OpenflowMessenger &messenger,
+  uint32_t port_number)
+{
+  auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
+  uint32_t flow_priority =
+    convert_precedence_to_priority(ev.get_dl_flow_precedence());
+  of13::FlowMod downlink_fm =
+    messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
+
+  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), port_number);
+
+  of13::ApplyActions apply_dl_inst;
+
+  // add imsi to packet metadata to pass to other tables
+  add_imsi_metadata(apply_dl_inst, imsi);
+
+  // Output to inout table
+  of13::GoToTable goto_inst(NEXT_TABLE);
+
+  downlink_fm.add_instruction(apply_dl_inst);
+  downlink_fm.add_instruction(goto_inst);
+
+  // Finally, send flow mod
+  messenger.send_of_msg(downlink_fm, ev.get_connection());
+  OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "ARP flow added\n");
 }
 
 void GTPApplication::delete_downlink_tunnel_flow(
@@ -282,6 +334,22 @@ void GTPApplication::delete_downlink_tunnel_flow(
   } else {
     add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
   }
+
+  messenger.send_of_msg(downlink_fm, ev.get_connection());
+}
+
+void GTPApplication::delete_downlink_arp_flow(
+  const DeleteGTPTunnelEvent &ev,
+  const OpenflowMessenger &messenger,
+  uint32_t port_number)
+{
+  of13::FlowMod downlink_fm =
+    messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
+  // match all ports and groups
+  downlink_fm.out_port(of13::OFPP_ANY);
+  downlink_fm.out_group(of13::OFPG_ANY);
+
+  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), port_number);
 
   messenger.send_of_msg(downlink_fm, ev.get_connection());
 }

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -124,6 +124,24 @@ class GTPApplication : public Application {
    */
   uint32_t convert_precedence_to_priority(const uint32_t precedence);
 
+  /**
+   * Add Arp flow for UE IP address
+   * @param ev - AddGTPTunnelEvent containing ue ip
+   */
+  void add_downlink_arp_flow(
+    const AddGTPTunnelEvent &ev,
+    const OpenflowMessenger &messenger,
+    uint32_t port_number);
+
+  /**
+   * Delete arp flow of the UE.
+   * @param ev - AddGTPTunnelEvent containing ue ip
+   */
+  void delete_downlink_arp_flow(
+    const DeleteGTPTunnelEvent &ev,
+    const OpenflowMessenger &messenger,
+    uint32_t port_number);
+
  private:
   static const uint32_t DEFAULT_PRIORITY = 10;
   static const std::string GTP_PORT_MAC;

--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -101,6 +101,14 @@ MATCHER_P(CheckIPv4Dst, ip, "")
   return ipv4_field->value().getIPv4() == ip.s_addr;
 }
 
+MATCHER_P(CheckArpTpa, ip, "")
+{
+  auto msg = static_cast<of13::FlowMod *>(&arg);
+  auto ipv4_field =
+    static_cast<of13::ARPTPA *>(msg->get_oxm_field(of13::OFPXMT_OFB_ARP_TPA));
+  return ipv4_field->value().getIPv4() == ip.s_addr;
+}
+
 MATCHER_P(CheckEthType, eth_type, "")
 {
   auto msg = static_cast<of13::FlowMod *>(&arg);
@@ -197,6 +205,29 @@ TEST_F(GTPApplicationTest, TestAddTunnel)
       _))
     .Times(1);
 
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(of13::OFPP_LOCAL),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
+        CheckCommandType(of13::OFPFC_ADD)),
+      _))
+    .Times(1);
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(TEST_MTR_PORT),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
+        CheckCommandType(of13::OFPFC_ADD)),
+      _))
+    .Times(1);
+
   controller->dispatch_event(add_tunnel);
 }
 
@@ -240,6 +271,30 @@ TEST_F(GTPApplicationTest, TestDeleteTunnel)
         CheckInPort(TEST_MTR_PORT),
         CheckEthType(0x0800),
         CheckIPv4Dst(ue_ip),
+        CheckCommandType(of13::OFPFC_DELETE)),
+      _))
+    .Times(1);
+
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(of13::OFPP_LOCAL),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
+        CheckCommandType(of13::OFPFC_DELETE)),
+      _))
+    .Times(1);
+
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(TEST_MTR_PORT),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
         CheckCommandType(of13::OFPFC_DELETE)),
       _))
     .Times(1);
@@ -316,6 +371,29 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlow)
       _))
     .Times(1);
 
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(of13::OFPP_LOCAL),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
+        CheckCommandType(of13::OFPFC_ADD)),
+      _))
+    .Times(1);
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(TEST_MTR_PORT),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
+        CheckCommandType(of13::OFPFC_ADD)),
+      _))
+    .Times(1);
+
   controller->dispatch_event(add_tunnel);
 }
 
@@ -378,6 +456,30 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlow)
         CheckIPv4Proto(dl_flow.ip_proto),
         CheckTcpDstPort(dl_flow.tcp_dst_port),
         CheckTcpSrcPort(dl_flow.tcp_src_port),
+        CheckCommandType(of13::OFPFC_DELETE)),
+      _))
+    .Times(1);
+
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(of13::OFPP_LOCAL),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
+        CheckCommandType(of13::OFPFC_DELETE)),
+      _))
+    .Times(1);
+
+  EXPECT_CALL(
+    *messenger,
+    send_of_msg(
+      AllOf(
+        CheckTableId(0),
+        CheckInPort(TEST_MTR_PORT),
+        CheckEthType(0x0806),
+        CheckArpTpa(ue_ip),
         CheckCommandType(of13::OFPFC_DELETE)),
       _))
     .Times(1);


### PR DESCRIPTION
Summary:
We need to distinguish between random ARPs vs
UE IP address ARPs. SPGW can set IMSI so that can
be used my pipelind ARP responder.

Reviewed By: ardzoht

Differential Revision: D22132667

