### PR TITLE
Add EnumToString h/cpp so that we consolidate print utility functions

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -85,6 +85,8 @@ link_directories(
 add_library(SESSION_MANAGER
     AAAClient.cpp
     AAAClient.h
+    EnumToString.cpp
+    EnumToString.h
     SessionManagerServer.cpp
     SessionManagerServer.h
     LocalSessionManagerHandler.cpp

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include "EnumToString.h"
+
+namespace magma {
+  std::string reauth_state_to_str(ReAuthState state) {
+    switch (state) {
+    case REAUTH_NOT_NEEDED:
+      return "REAUTH_NOT_NEEDED";
+    case REAUTH_REQUIRED:
+      return "REAUTH_REQUIRED";
+    case REAUTH_PROCESSING:
+      return "REAUTH_PROCESSING";
+    default:
+      return "INVALID REAUTH STATE";
+    }
+  }
+
+  std::string service_state_to_str(ServiceState state) {
+    switch (state) {
+    case SERVICE_ENABLED:
+      return "SERVICE_ENABLED";
+    case SERVICE_NEEDS_DEACTIVATION:
+      return "SERVICE_NEEDS_DEACTIVATION";
+    case SERVICE_DISABLED:
+      return "SERVICE_DISABLED";
+    case SERVICE_NEEDS_ACTIVATION:
+      return "SERVICE_NEEDS_ACTIVATION";
+    case SERVICE_REDIRECTED:
+      return "SERVICE_REDIRECTED";
+    case SERVICE_RESTRICTED:
+      return "SERVICE_RESTRICTED";
+    default:
+      return "INVALID SERVICE STATE";
+    }
+  }
+
+  std::string final_action_to_str(ChargingCredit_FinalAction final_action) {
+    switch (final_action) {
+    case ChargingCredit_FinalAction_TERMINATE:
+      return "TERMINATE";
+    case ChargingCredit_FinalAction_REDIRECT:
+      return "REDIRECT";
+    case ChargingCredit_FinalAction_RESTRICT_ACCESS:
+      return "RESTRICT_ACCESS";
+    default:
+      return "INVALID FINAL ACTION";
+    }
+  }
+
+  std::string session_fsm_state_to_str(SessionFsmState state) {
+    switch (state) {
+    case SESSION_ACTIVE:
+      return "SESSION_ACTIVE";
+    case SESSION_TERMINATING_FLOW_ACTIVE:
+      return "SESSION_TERMINATING_FLOW_ACTIVE";
+    case SESSION_TERMINATING_AGGREGATING_STATS:
+      return "SESSION_TERMINATING_AGGREGATING_STATS";
+    case SESSION_TERMINATING_FLOW_DELETED:
+      return "SESSION_TERMINATING_FLOW_DELETED";
+    case SESSION_TERMINATED:
+      return "SESSION_TERMINATED";
+    case SESSION_TERMINATION_SCHEDULED:
+      return "SESSION_TERMINATION_SCHEDULED";
+    default:
+      return "INVALID SESSION FSM STATE";
+    }
+  }
+} // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "StoredState.h"
+
+namespace magma {
+std::string reauth_state_to_str(ReAuthState state);
+
+std::string service_state_to_str(ServiceState state);
+
+std::string final_action_to_str(ChargingCredit_FinalAction final_action);
+
+std::string session_fsm_state_to_str(SessionFsmState state);
+}  // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 
 #include "DiameterCodes.h"
+#include "EnumToString.h"
 #include "SessionCredit.h"
 #include "magma_logging.h"
 
@@ -17,9 +18,6 @@ namespace magma {
 
 float SessionCredit::USAGE_REPORTING_THRESHOLD = 0.8;
 bool SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
-std::string final_action_to_str(ChargingCredit_FinalAction final_action);
-std::string service_state_to_str(ServiceState state);
-std::string reauth_state_to_str(ReAuthState state);
 
 std::unique_ptr<SessionCredit>
 SessionCredit::unmarshal(const StoredSessionCredit &marshaled,
@@ -485,49 +483,5 @@ void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {
                << " tx=" << buckets_[REPORTING_TX]
                << " rx=" << buckets_[REPORTING_RX];
 }
-
-std::string final_action_to_str(ChargingCredit_FinalAction final_action) {
-  switch (final_action) {
-  case ChargingCredit_FinalAction_TERMINATE:
-    return "TERMINATE";
-  case ChargingCredit_FinalAction_REDIRECT:
-    return "REDIRECT";
-  case ChargingCredit_FinalAction_RESTRICT_ACCESS:
-    return "RESTRICT_ACCESS";
-  default:
-    return "";
-  }
+// magma namespace
 }
-
-std::string service_state_to_str(ServiceState state) {
-  switch (state) {
-  case SERVICE_ENABLED:
-    return "SERVICE_ENABLED";
-  case SERVICE_NEEDS_DEACTIVATION:
-    return "SERVICE_NEEDS_DEACTIVATION";
-  case SERVICE_DISABLED:
-    return "SERVICE_DISABLED";
-  case SERVICE_NEEDS_ACTIVATION:
-    return "SERVICE_NEEDS_ACTIVATION";
-  case SERVICE_REDIRECTED:
-    return "SERVICE_REDIRECTED";
-  case SERVICE_RESTRICTED:
-    return "SERVICE_RESTRICTED";
-  default:
-    return "INVALID SERVICE STATE";
-  }
-}
-
-std::string reauth_state_to_str(ReAuthState state) {
-  switch (state) {
-  case REAUTH_NOT_NEEDED:
-    return "REAUTH_NOT_NEEDED";
-  case REAUTH_REQUIRED:
-    return "REAUTH_REQUIRED";
-  case REAUTH_PROCESSING:
-    return "REAUTH_PROCESSING";
-  default:
-    return "INVALID REAUTH STATE";
-  }
-}
-} // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -16,14 +16,13 @@
 #include <google/protobuf/util/time_util.h>
 
 #include "CreditKey.h"
+#include "EnumToString.h"
 #include "RuleStore.h"
 #include "SessionState.h"
 #include "StoredState.h"
 #include "magma_logging.h"
 
 namespace magma {
-
-std::string session_fsm_state_to_str(SessionFsmState state);
 
 std::unique_ptr<SessionState> SessionState::unmarshal(
     const StoredSessionState& marshaled, StaticRuleStore& rule_store) {
@@ -792,25 +791,6 @@ void SessionState::set_fsm_state(SessionFsmState new_state,
     curr_state_ = new_state;
     uc.is_fsm_updated = true;
     uc.updated_fsm_state = new_state;
-  }
-}
-
-std::string session_fsm_state_to_str(SessionFsmState state) {
-  switch (state) {
-  case SESSION_ACTIVE:
-    return "SESSION_ACTIVE";
-  case SESSION_TERMINATING_FLOW_ACTIVE:
-    return "SESSION_TERMINATING_FLOW_ACTIVE";
-  case SESSION_TERMINATING_AGGREGATING_STATS:
-    return "SESSION_TERMINATING_AGGREGATING_STATS";
-  case SESSION_TERMINATING_FLOW_DELETED:
-    return "SESSION_TERMINATING_FLOW_DELETED";
-  case SESSION_TERMINATED:
-    return "SESSION_TERMINATED";
-  case SESSION_TERMINATION_SCHEDULED:
-    return "SESSION_TERMINATION_SCHEDULED";
-  default:
-    return "INVALID SESSION FSM STATE";
   }
 }
 


### PR DESCRIPTION
Summary: Moving these static enum to string functions into a separate file so that they can be used by multiple files

Reviewed By: andreilee

Differential Revision: D22163464

