### PR TITLE
Use protobuf serialization/deserialization functions for RedirectServer struct

### DIFF
--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -44,12 +44,6 @@ struct SessionConfig {
 };
 
 // Session Credit
-
-struct StoredRedirectServer {
-  RedirectServer_RedirectAddressType redirect_address_type;
-  std::string redirect_server_address;
-};
-
 struct FinalActionInfo {
   ChargingCredit_FinalAction final_action;
   RedirectServer redirect_server;
@@ -235,12 +229,6 @@ QoSInfo deserialize_stored_qos_info(const std::string &serialized);
 std::string serialize_stored_session_config(const SessionConfig &stored);
 
 SessionConfig deserialize_stored_session_config(const std::string &serialized);
-
-std::string
-serialize_stored_redirect_server(const StoredRedirectServer &stored);
-
-StoredRedirectServer
-deserialize_stored_redirect_server(const std::string &serialized);
 
 std::string serialize_stored_final_action_info(const FinalActionInfo &stored);
 

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -47,14 +47,6 @@ protected:
     return stored;
   }
 
-  StoredRedirectServer get_stored_redirect_server() {
-    StoredRedirectServer stored;
-    stored.redirect_address_type = RedirectServer_RedirectAddressType::
-        RedirectServer_RedirectAddressType_IPV6;
-    stored.redirect_server_address = "redirect_server_address";
-    return stored;
-  }
-
   FinalActionInfo get_stored_final_action_info() {
     FinalActionInfo stored;
     stored.final_action =
@@ -171,18 +163,6 @@ TEST_F(StoredStateTest, test_stored_session_config) {
   EXPECT_EQ(deserialized.bearer_id, 321);
   EXPECT_EQ(deserialized.qos_info.enabled, true);
   EXPECT_EQ(deserialized.qos_info.qci, 123);
-}
-
-TEST_F(StoredStateTest, test_stored_redirect_server) {
-  auto stored = get_stored_redirect_server();
-
-  auto serialized = serialize_stored_redirect_server(stored);
-  auto deserialized = deserialize_stored_redirect_server(serialized);
-
-  EXPECT_EQ(deserialized.redirect_address_type,
-            RedirectServer_RedirectAddressType::
-                RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(deserialized.redirect_server_address, "redirect_server_address");
 }
 
 TEST_F(StoredStateTest, test_stored_final_action_info) {


### PR DESCRIPTION
Summary:
- `StoredRedirectServer` is only used for serialization/deserialization purposes.
- Since `RedirectServer` is a protobuf struct, we can simply use the protobuf serialization/deserialization methods to simplify things a bit

Differential Revision: D22185508

