### PR TITLE
Adding event logging support to MME

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -102,6 +102,7 @@ find_library(ASYNC_GRPC ASYNC_GRPC ${MAGMA_LIB_DIR}/async_grpc)
 find_library(SERVICE303_LIB SERVICE303_LIB ${MAGMA_LIB_DIR}/service303)
 find_library(CONFIG CONFIG ${MAGMA_LIB_DIR}/config)
 find_library(SERVICE_REGISTRY SERVICE_REGISTRY ${MAGMA_LIB_DIR}/service_registry)
+find_library(EVENTD EVENTD ${MAGMA_LIB_DIR}/eventd)
 
 ################################################################
 # Add sub modules

--- a/lte/gateway/c/oai/include/mme_events.h
+++ b/lte/gateway/c/oai/include/mme_events.h
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+#pragma once
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "common_types.h"
+
+/**
+ * Helper function to initiate AsyncEventdClient in its own thread
+ */
+int event_client_init(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/lte/gateway/c/oai/lib/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(mobility_client) # LIB_MOBILITY_CLIENT
 add_subdirectory(s6a_proxy) # LIB_S6A_PROXY
 add_subdirectory(secu) # LIB_SECU
 add_subdirectory(sgs_client) # LIB_SGS_CLIENT
+add_subdirectory(event_client) # LIB_EVENT_CLIENT
 
 if (NOT EMBEDDED_SGW)
   add_subdirectory(gtpv2-c) # LIB_GTPV2C

--- a/lte/gateway/c/oai/lib/event_client/CMakeLists.txt
+++ b/lte/gateway/c/oai/lib/event_client/CMakeLists.txt
@@ -1,0 +1,32 @@
+add_compile_options(-std=c++14)
+
+include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
+
+set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
+
+set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)
+include_directories("${OUTPUT_DIR}")
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${MAGMA_LIB_DIR}/async_grpc)
+include_directories(${MAGMA_LIB_DIR}/eventd)
+
+link_directories(
+        ${MAGMA_LIB_DIR}/async_grpc
+        ${MAGMA_LIB_DIR}/eventd
+)
+
+add_library(LIB_EVENT_CLIENT
+        EventClientAPI.cpp
+        )
+
+target_link_libraries(LIB_EVENT_CLIENT
+        COMMON
+        LIB_BSTR ${EVENTD}
+        ${ASYNC_GRPC}
+        )
+
+target_include_directories(LIB_EVENT_CLIENT PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ASYNC_GRPC COMMON SERVICE_REGISTRY EVENTD
+        )

--- a/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/event_client/EventClientAPI.cpp
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+#include "EventClientAPI.h"
+
+#include <iostream>
+#include <thread>
+#include <grpcpp/support/status.h>
+#include <orc8r/protos/common.pb.h>
+
+#include "EventdClient.h"
+
+using grpc::Status;
+using grpc::StatusCode::DEADLINE_EXCEEDED;
+using grpc::StatusCode::UNAVAILABLE;
+using magma::AsyncEventdClient;
+using magma::orc8r::Event;
+using magma::orc8r::Void;
+
+namespace magma {
+namespace lte {
+
+void init_eventd_client() {
+  auto& client = AsyncEventdClient::getInstance();
+  std::thread resp_loop_thread([&]() { client.rpc_response_loop(); });
+  resp_loop_thread.detach();
+}
+
+int log_event(const Event& event) {
+  AsyncEventdClient::getInstance().log_event(event, [=](Status status, Void v) {
+    if (status.ok()) {
+      std::cout << "[DEBUG] Success logging event: " << event.event_type()
+                << std::endl;
+    } else if (
+        status.error_code() == DEADLINE_EXCEEDED ||
+        status.error_code() == UNAVAILABLE) {
+      return 0; // Suppress error logs if eventd is unavailable
+    } else {
+      std::cout << "[ERROR] Failed to log event: " << event.event_type()
+                << "; Status: " << status.error_message() << std::endl;
+    }
+  });
+  return 0;
+}
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/oai/lib/event_client/EventClientAPI.h
+++ b/lte/gateway/c/oai/lib/event_client/EventClientAPI.h
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+#pragma once
+
+#include "orc8r/protos/eventd.pb.h"
+
+namespace magma {
+namespace lte {
+
+void init_eventd_client();
+
+int log_event(const magma::orc8r::Event& event);
+
+}  // namespace lte
+}  // namespace magma

--- a/lte/gateway/c/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/oai/oai_mme/oai_mme.c
@@ -25,6 +25,8 @@
 #include <stdbool.h>
 #include <string.h>
 
+#include "mme_events.h"
+
 #if HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -97,6 +99,7 @@ int main(int argc, char *argv[])
 
   // Service started, but not healthy yet
   send_app_health_to_service303(TASK_MME_APP, false);
+  event_client_init();
 
   CHECK_INIT_RETURN(mme_app_init(&mme_config));
   CHECK_INIT_RETURN(sctp_init(&mme_config));

--- a/lte/gateway/c/oai/tasks/mme_app/CMakeLists.txt
+++ b/lte/gateway/c/oai/tasks/mme_app/CMakeLists.txt
@@ -13,6 +13,12 @@ generate_cpp_protos("${MMEAPP_STATE_CPP_PROTOS}" "${PROTO_SRCS}"
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${LTE_OUT_DIR})
 
+set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)
+link_directories(
+        ${MAGMA_LIB_DIR}/async_grpc
+        ${MAGMA_LIB_DIR}/eventd
+)
+
 add_library(TASK_MME_APP
     mme_app_capabilities.c
     mme_app_context.c
@@ -52,6 +58,7 @@ add_library(TASK_MME_APP
     mme_app_state_converter.cpp
     mme_app_state_manager.cpp
     mme_app_state.cpp
+    mme_events.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS}
     )
@@ -64,7 +71,7 @@ target_compile_definitions(TASK_MME_APP PRIVATE
 target_link_libraries(TASK_MME_APP
   ${CONFIG_LIBRARIES}
   COMMON
-  LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU
+  LIB_BSTR LIB_HASHTABLE LIB_DIRECTORYD LIB_SECU LIB_EVENT_CLIENT
   TASK_NAS TASK_S1AP TASK_SGW TASK_SERVICE303 TASK_SCTP_SERVER
   TASK_S6A TASK_SGS protobuf cpp_redis
     )

--- a/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the OpenAirInterface (OAI) Software Alliance under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The OpenAirInterface Software Alliance licenses this file to You under
+ * the Apache License, Version 2.0  (the "License"); you may not use this file
+ * except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *-------------------------------------------------------------------------------
+ * For more information about the OpenAirInterface (OAI) Software Alliance:
+ *      contact@openairinterface.org
+ */
+
+#include "mme_events.h"
+
+#include <cstdlib>
+#include <iostream>
+
+#include "orc8r/protos/common.pb.h"
+#include "orc8r/protos/eventd.pb.h"
+
+#include "EventClientAPI.h"
+
+using magma::lte::init_eventd_client;
+
+int event_client_init(void) {
+  init_eventd_client();
+}

--- a/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
+++ b/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
@@ -12,10 +12,10 @@ include_directories("${PROJECT_SOURCE_DIR}/../common/logging")
 list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
-set(ASYNC_ORC8R_CPP_PROTOS common redis)
+set(ASYNC_ORC8R_CPP_PROTOS common redis eventd)
 set(ASYNC_LTE_CPP_PROTOS session_manager policydb subscriberdb mobilityd)
 set(ASYNC_LTE_GRPC_PROTOS session_manager mobilityd)
-set(ASYNC_ORC8R_GRPC_PROTOS "")
+set(ASYNC_ORC8R_GRPC_PROTOS eventd)
 
 generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"
   "${ASYNC_LTE_GRPC_PROTOS}"

--- a/orc8r/gateway/c/common/eventd/EventdClient.cpp
+++ b/orc8r/gateway/c/common/eventd/EventdClient.cpp
@@ -6,14 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
-#include <memory>
-#include <utility>
-
-#include <orc8r/protos/eventd.pb.h>
-#include <orc8r/protos/eventd.grpc.pb.h>
-
 #include "EventdClient.h"
-#include "GRPCReceiver.h"
+
 #include "ServiceRegistrySingleton.h"
 
 using grpc::ClientContext;

--- a/orc8r/gateway/c/common/eventd/EventdClient.h
+++ b/orc8r/gateway/c/common/eventd/EventdClient.h
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  */
+#pragma once
+
 #include <memory>
 #include <utility>
 


### PR DESCRIPTION
Summary:
- This diff adds event logging support so it can be used by MME, S1AP and SPGW to send RPC calls to eventd using `AsyncEventdClient` that sessiond already uses
- Minor updates to AsyncEventdClient as it was missing #pragma directive on header file  and some duplicate includes

Differential Revision: D22064640

