### PR TITLE
Create a ChargingGrant struct to keep track of Gy grant specific information

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -13,6 +13,11 @@ add_compile_options(-std=c++14)
 
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
+if (NOT BUILD_TESTS)
+  set (CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+  set (CMAKE_LINKER_FLAGS_DEBUG "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
+endif ()
+
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 
 set(MAGMA_LIB_DIR $ENV{C_BUILD}/magma_common)

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -90,6 +90,8 @@ link_directories(
 add_library(SESSION_MANAGER
     AAAClient.cpp
     AAAClient.h
+    ChargingGrant.cpp
+    ChargingGrant.h
     EnumToString.cpp
     EnumToString.h
     SessionManagerServer.cpp

--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <limits>
+
+#include "ChargingGrant.h"
+#include "magma_logging.h"
+
+namespace magma {
+  StoredChargingGrant ChargingGrant::marshal() {
+    StoredChargingGrant marshaled{};
+    marshaled.is_final = is_final_grant;
+    marshaled.final_action_info.final_action =
+      final_action_info.final_action;
+    marshaled.final_action_info.redirect_server =
+      final_action_info.redirect_server;
+    marshaled.reauth_state = reauth_state;
+    marshaled.service_state = service_state;
+    marshaled.expiry_time = expiry_time;
+    marshaled.credit = credit.marshal();
+    return marshaled;
+  }
+
+  ChargingGrant ChargingGrant::unmarshal(const StoredChargingGrant &marshaled) {
+    ChargingGrant charging;
+    charging.credit =
+      SessionCredit::unmarshal(marshaled.credit, CreditType::CHARGING);
+
+    FinalActionInfo final_action_info;
+    final_action_info.final_action = marshaled.final_action_info.final_action;
+    final_action_info.redirect_server =
+        marshaled.final_action_info.redirect_server;
+    charging.final_action_info = final_action_info;
+
+    charging.reauth_state = marshaled.reauth_state;
+    charging.service_state = marshaled.service_state;
+    charging.expiry_time = marshaled.expiry_time;
+    charging.is_final_grant = marshaled.is_final;
+
+    return charging;
+  }
+
+  void ChargingGrant::set_final_action_info(const magma::lte::ChargingCredit &credit) {
+    if (credit.is_final()) {
+      final_action_info.final_action = credit.final_action();
+      if (credit.final_action() == ChargingCredit_FinalAction_REDIRECT) {
+        final_action_info.redirect_server = credit.redirect_server();
+      }
+    }
+  }
+} // namespace magma

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "StoredState.h"
+#include "SessionCredit.h"
+
+namespace magma {
+
+// ChargingGrant is a struct because all fields are public
+struct ChargingGrant {
+  // Keep track of used/reported/allowed bytes
+  SessionCredit credit;
+  // When this is true, final_action should be acted on upon credit exhaust
+  bool is_final_grant;
+  // Only valid if is_final_grant is true
+  FinalActionInfo final_action_info;
+  // The number of seconds for which the credit is valid
+  std::time_t expiry_time;
+  ServiceState service_state;
+  ReAuthState reauth_state;
+
+  ChargingGrant() : credit(CreditType::CHARGING) {}
+
+  StoredChargingGrant marshal();
+
+  static ChargingGrant unmarshal(const StoredChargingGrant &marshaled);
+
+  void set_final_action_info(const magma::lte::ChargingCredit &credit);
+};
+
+}  // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -86,16 +86,16 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
 }
 
 SessionCredit::SessionCredit(CreditType credit_type, ServiceState start_state)
-    : credit_type_(credit_type), reauth_state_(REAUTH_NOT_NEEDED),
-      service_state_(start_state), buckets_{}, reporting_(false),
-      credit_limit_type_(FINITE), is_final_grant_(false) {}
+    : buckets_{}, reporting_(false), credit_limit_type_(FINITE),
+      credit_type_(credit_type), reauth_state_(REAUTH_NOT_NEEDED),
+      service_state_(start_state), is_final_grant_(false) {}
 
 SessionCredit::SessionCredit(
   CreditType credit_type, ServiceState start_state,
   CreditLimitType credit_limit_type)
-    : credit_type_(credit_type), reauth_state_(REAUTH_NOT_NEEDED),
-      service_state_(start_state), buckets_{}, reporting_(false),
-      credit_limit_type_(credit_limit_type), is_final_grant_(false) {}
+    : buckets_{}, reporting_(false), credit_limit_type_(credit_limit_type),
+      credit_type_(credit_type), reauth_state_(REAUTH_NOT_NEEDED),
+      service_state_(start_state), is_final_grant_(false) {}
 
 // by default, enable service & finite credit
 SessionCredit::SessionCredit(CreditType credit_type)
@@ -308,7 +308,6 @@ SessionCredit::Usage SessionCredit::get_all_unreported_usage_for_reporting(
   return usage;
 }
 
-// Todo Return Proto CreditUsage
 SessionCredit::Usage SessionCredit::get_usage_for_reporting(
     SessionCreditUpdateCriteria &update_criteria) {
   if (reauth_state_ == REAUTH_REQUIRED) {
@@ -525,6 +524,8 @@ GrantTrackingType SessionCredit::determine_grant_tracking_type(
 }
 
 void SessionCredit::log_quota_and_usage() const {
+  MLOG(MDEBUG) << "===> Grant tracking type "
+               << grant_type_to_str(grant_tracking_type_);
   MLOG(MDEBUG) << "===> Used     Tx: " << buckets_[USED_TX]
                << " Rx: " << buckets_[USED_RX]
                << " Total: " << buckets_[USED_TX] + buckets_[USED_RX];
@@ -534,8 +535,6 @@ void SessionCredit::log_quota_and_usage() const {
   MLOG(MDEBUG) << "===> Reported Tx: " << buckets_[REPORTED_TX]
                << " Rx: " << buckets_[REPORTED_RX]
                << " Total: " << buckets_[REPORTED_RX] + buckets_[REPORTED_TX];
-  MLOG(MDEBUG) << "===> Grant tracking type "
-               << grant_type_to_str(grant_tracking_type_);
 
   std::string final_action = "";
   if (is_final_grant_ ) {

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -215,16 +215,18 @@ public:
   static bool TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED;
 
 private:
-  CreditType credit_type_;
-  ReAuthState reauth_state_;
-  ServiceState service_state_;
   uint64_t buckets_[MAX_VALUES];
   bool reporting_;
   CreditLimitType credit_limit_type_;
-  bool is_final_grant_;
   GrantTrackingType grant_tracking_type_;
-  FinalActionInfo final_action_info_;
-  std::time_t expiry_time_;
+
+  CreditType credit_type_; // TODO remove
+
+  ReAuthState reauth_state_; // TODO move to ChargingGrant
+  ServiceState service_state_; // TODO move to ChargingGrant
+  bool is_final_grant_; // TODO move to ChargingGrant
+  FinalActionInfo final_action_info_; // TODO move to ChargingGrant
+  std::time_t expiry_time_; // TODO move to ChargingGrant
 
 private:
   void log_quota_and_usage() const;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -19,10 +19,12 @@
 #include "CreditKey.h"
 #include "SessionCredit.h"
 #include "Monitor.h"
+#include "ChargingGrant.h"
 
 namespace magma {
 typedef std::unordered_map<CreditKey, std::unique_ptr<SessionCredit>,
                  decltype(&ccHash), decltype(&ccEqual)> CreditMap;
+typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
 static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 /**
  * SessionState keeps track of a current UE session in the PCEF, recording
@@ -409,8 +411,7 @@ class SessionState {
   * credit
   */
   CreditMap credit_map_;
-
-  std::unordered_map<std::string, std::unique_ptr<Monitor>> monitor_map_;
+  MonitorMap monitor_map_;
   std::unique_ptr<std::string> session_level_key_;
 
  private:

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -149,6 +149,15 @@ struct StoredMonitor {
   MonitoringLevel level;
 };
 
+struct StoredChargingGrant {
+  StoredSessionCredit credit;
+  bool is_final;
+  FinalActionInfo final_action_info;
+  ReAuthState reauth_state;
+  ServiceState service_state;
+  std::time_t expiry_time;
+};
+
 struct RuleLifetime {
   std::time_t activation_time; // Unix timestamp
   std::time_t deactivation_time; // Unix timestamp


### PR DESCRIPTION
Summary:
## Migrate Gy Specific logic out of SessionCredit into ChargingGrant
- `SessionCredit` currently have quite a bit of Gy specific logic. Since the class is used to track usage/quota for both Gx and Gy credits, it would simplify things to have two separate structures `Monitor` and `ChargingGrant` that use `SessionCredit` for only credit accounting.
- `ChargingGrant` will hold final unit action info, expiry time, reauth state, and service state. These fields will be moved out of `SessionCredit` after the migration is complete.
- It will be serialized to `StoredChargingGrant` for serialization

## What this diff chnages
- Define the `ChargingGrant` structure
- Define the `StoredChargingGrant` structure
- Define the marshal/unmarshal functions between the two structures
- Small amount of random refactor.
  - Move `get_final_action_info` into the Charging section of SessionState

Differential Revision: D22098794

