### PR TITLE
Use NULL to indicate output rule param is not needed

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -720,11 +720,10 @@ void LocalEnforcer::schedule_dynamic_rule_deactivation(
                            << "during removal of dynamic rule "
                            << dynamic_rule.policy_rule().id();
           } else {
-            PolicyRule rule_dont_care;
             for (const auto& session : it->second) {
               auto& uc = session_update[imsi][session->get_session_id()];
               session->remove_dynamic_rule(
-                  dynamic_rule.policy_rule().id(), &rule_dont_care, uc);
+                  dynamic_rule.policy_rule().id(), NULL, uc);
             }
             session_store_.update_sessions(session_update);
           }
@@ -1600,9 +1599,8 @@ void LocalEnforcer::process_rules_to_install(
     if (deactivation_time > current_time) {
       schedule_dynamic_rule_deactivation(imsi, rule_install);
     } else if (deactivation_time > 0) {
-      PolicyRule rule_dont_care;
       session.remove_dynamic_rule(
-          rule_install.policy_rule().id(), &rule_dont_care, update_criteria);
+          rule_install.policy_rule().id(), NULL, update_criteria);
       rules_to_deactivate.dynamic_rules.push_back(rule_install.policy_rule());
     }
   }

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -134,23 +134,21 @@ void PolicyRuleBiMap::insert_rule(const PolicyRule& rule)
   }
 }
 
-bool PolicyRuleBiMap::get_rule(const std::string& rule_id, PolicyRule* rule)
-{
+bool PolicyRuleBiMap::get_rule(
+  const std::string& rule_id, PolicyRule* rule_out) {
   std::lock_guard<std::mutex> lock(map_mutex_);
   auto it = rules_by_rule_id_.find(rule_id);
   if (it == rules_by_rule_id_.end()) {
     return false;
   }
-  if (rule != NULL) {
-    rule->CopyFrom(*it->second);
+  if (rule_out != NULL) {
+    rule_out->CopyFrom(*it->second);
   }
   return true;
 }
 
 bool PolicyRuleBiMap::remove_rule(
-  const std::string& rule_id,
-  PolicyRule* rule_out)
-{
+  const std::string& rule_id, PolicyRule* rule_out) {
   std::lock_guard<std::mutex> lock(map_mutex_);
   auto it = rules_by_rule_id_.find(rule_id);
   if (it == rules_by_rule_id_.end()) {
@@ -158,7 +156,7 @@ bool PolicyRuleBiMap::remove_rule(
   }
 
   auto rule_ptr = it->second;
-  if (rule_out) {
+  if (rule_out != NULL) {
     rule_out->CopyFrom(*rule_ptr);
   }
 

--- a/lte/gateway/c/session_manager/RuleStore.h
+++ b/lte/gateway/c/session_manager/RuleStore.h
@@ -69,10 +69,11 @@ class PolicyRuleBiMap {
   // If the rule is found, copy the rule into the output parameter and return
   // true. Otherwise, return false.
   // If the output rule param is NULL, the rule object is not copied.
-  virtual bool get_rule(const std::string& rule_id, PolicyRule* rule);
+  virtual bool get_rule(const std::string& rule_id, PolicyRule* rule_out);
 
   // Remove a rule from the store by ID. Returns true if the rule ID was found.
-  // The removed rule will be copied into rule_out
+  // The removed rule will be copied into rule_out.
+  // If the output rule param is NULL, the rule object is not copied.
   virtual bool remove_rule(const std::string& rule_id, PolicyRule* rule_out);
 
   /**

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -642,7 +642,6 @@ bool SessionState::deactivate_scheduled_static_rule(
 
 void SessionState::sync_rules_to_time(
     std::time_t current_time, SessionStateUpdateCriteria& update_criteria) {
-  PolicyRule _rule_unused;
   // Update active static rules
   for (const std::string& rule_id : active_static_rules_) {
     if (should_rule_be_deactivated(rule_id, current_time)) {
@@ -664,7 +663,7 @@ void SessionState::sync_rules_to_time(
   dynamic_rules_.get_rule_ids(dynamic_rule_ids);
   for (const std::string& rule_id : dynamic_rule_ids) {
     if (should_rule_be_deactivated(rule_id, current_time)) {
-      remove_dynamic_rule(rule_id, &_rule_unused, update_criteria);
+      remove_dynamic_rule(rule_id, NULL, update_criteria);
     }
   }
   // Update scheduled dynamic rules
@@ -673,7 +672,7 @@ void SessionState::sync_rules_to_time(
     if (should_rule_be_active(rule_id, current_time)) {
       install_scheduled_dynamic_rule(rule_id, update_criteria);
     } else if (should_rule_be_deactivated(rule_id, current_time)) {
-      remove_scheduled_dynamic_rule(rule_id, &_rule_unused, update_criteria);
+      remove_scheduled_dynamic_rule(rule_id, NULL, update_criteria);
     }
   }
 }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -208,13 +208,12 @@ bool SessionStore::merge_into_session(
 
     }
   }
-  PolicyRule* _ = {};
   for (const auto& rule_id : update_criteria.dynamic_rules_to_uninstall) {
     if (session->is_dynamic_rule_installed(rule_id)) {
-      session->remove_dynamic_rule(rule_id, _, uc);
+      session->remove_dynamic_rule(rule_id, NULL, uc);
     } else if (session->is_dynamic_rule_scheduled(rule_id)) {
       session->install_scheduled_static_rule(rule_id, uc);
-      session->remove_dynamic_rule(rule_id, _, uc);
+      session->remove_dynamic_rule(rule_id, NULL, uc);
     } else {
       MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
                 << " because dynamic rule already uninstalled: " << rule_id
@@ -256,7 +255,7 @@ bool SessionStore::merge_into_session(
   }
   for (const auto& rule_id : update_criteria.gy_dynamic_rules_to_uninstall) {
     if (session->is_gy_dynamic_rule_installed(rule_id)) {
-      session->remove_gy_dynamic_rule(rule_id, _, uc);
+      session->remove_gy_dynamic_rule(rule_id, NULL, uc);
     } else {
       MLOG(MERROR) << "Failed to merge: " << session->get_session_id()
                 << " because gy dynamic rule already uninstalled: " << rule_id


### PR DESCRIPTION
Summary:
- In `PolicyRuleBiMap`, `get_rule` and `remove_rule` has an optional rule_out parameter to copy the rule into the variable.
- We have several instances where we pass a throwaway variable when we don't need the rule definition. This can be confusing when reading the code, so this diff replaces all of those to NULL.

Differential Revision: D22233191

