### PR TITLE
initd based service manager

### DIFF
--- a/orc8r/gateway/go/services/magmad/service_manager/initd_controller.go
+++ b/orc8r/gateway/go/services/magmad/service_manager/initd_controller.go
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+// package service_manager defines and implements API for service management
+package service_manager
+
+import (
+	"os"
+	"os/exec"
+)
+
+// InitdController - initd based controller implementation
+type InitdController struct {
+	TailLogsCmd string
+}
+
+// DefaultInitdLogTailCmd logs tail command if none is specified
+const DefaultInitdLogTailCmd = "tail -f /var/log/syslog"
+
+// Name returns runit controller type name
+func (InitdController) Name() string {
+	return "initd"
+}
+
+// CmdName returns the base name of the start/stop/status command
+func (InitdController) CmdName(service string) string {
+	return "/etc/init.d/" + service
+}
+
+// Start starts service and returns error if unsuccessful
+func (c InitdController) Start(service string) error {
+	return exec.Command(c.CmdName(service), "start").Run()
+}
+
+// Stop stops service and returns error if unsuccessful
+func (c InitdController) Stop(service string) error {
+	return exec.Command(c.CmdName(service), "stop").Run()
+}
+
+// Restart restarts service and returns error if unsuccessful
+func (c InitdController) Restart(service string) error {
+	return exec.Command(c.CmdName(service), "restart").Run()
+}
+
+// GetState returns the given service state or error if unsuccessful
+func (c InitdController) GetState(service string) (ServiceState, error) {
+	err := exec.Command(c.CmdName(service), "status").Run()
+	if err != nil {
+		exitErr, ok := err.(*exec.ExitError)
+		if ok && exitErr != nil && exitErr.ExitCode() != 0 {
+			return Inactive, nil
+		}
+		return Error, err
+	}
+	return Active, nil
+}
+
+// TailLogs executes command to start tailing service logs and returns string chan to receive log strings
+// closing the chan will terminate tailing
+func (c InitdController) TailLogs(service string) (chan string, *os.Process, error) {
+	var cmd *exec.Cmd
+	tailCmd := c.TailLogsCmd
+	if len(tailCmd) == 0 {
+		tailCmd = DefaultInitdLogTailCmd
+	}
+	if len(service) == 0 {
+		cmd = exec.Command("sh", "-c", tailCmd)
+	} else {
+		cmd = exec.Command("sh", "-c", tailCmd+" | grep \" "+service+"\"")
+	}
+	return StartCmdWithStderrStdoutTailer(cmd)
+}

--- a/orc8r/gateway/go/services/magmad/service_manager/runit_controller.go
+++ b/orc8r/gateway/go/services/magmad/service_manager/runit_controller.go
@@ -66,7 +66,7 @@ func (c RunitController) TailLogs(service string) (chan string, *os.Process, err
 	if len(service) == 0 {
 		cmd = exec.Command("logread", "-f")
 	} else {
-		cmd = exec.Command("sh", "-c", "logread | grep "+service)
+		cmd = exec.Command("sh", "-c", "logread -f | grep "+service)
 	}
 	return StartCmdWithStderrStdoutTailer(cmd)
 }

--- a/orc8r/gateway/go/services/magmad/service_manager/service_manager.go
+++ b/orc8r/gateway/go/services/magmad/service_manager/service_manager.go
@@ -27,6 +27,8 @@ var (
 		strings.ToLower(DockerController{}.Name()):  DockerController{},
 		strings.ToLower(SystemdController{}.Name()): SystemdController{},
 		strings.ToLower(RunitController{}.Name()):   RunitController{},
+		"initd": InitdController{TailLogsCmd: DefaultInitdLogTailCmd},
+		"procd": InitdController{TailLogsCmd: "logread -f"},
 	}
 	defaultController = DockerController{}
 )


### PR DESCRIPTION
Summary:
initd based service manager
also can be used on procd based systems (OpenWRT)

Reviewed By: sfaludi

Differential Revision: D22263600

