### PR TITLE
Updated traffic script to scan for wifi

### DIFF
--- a/orc8r/gateway/python/scripts/traffic.py
+++ b/orc8r/gateway/python/scripts/traffic.py
@@ -7,20 +7,26 @@ All rights reserved.
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
+import os
+import sys
 
 
-def scan_wifi():
-    pass
-
+def scan_wifi(interface):
+    out = os.system('nmcli device wifi list | grep {}'.format(interface))
+    if out != 0:
+        raise Exception()
 
 def send_traffic():
     pass
 
 
-def main():
-    scan_wifi()
+def main(argv):
+    try:
+        scan_wifi(argv[1])
+    except Exception:
+        print('Error interface {} not found'.format(argv[1]))
     send_traffic()
 
 
 if __name__ == '__main__':
-    main()
+    main(sys.argv)


### PR DESCRIPTION
Summary:
The traffic script will take in a target wifi interface as its command line argument. It will scan wifi networks to see if the targeted interface exists.

It should be noted that I researched different python library solutions for wifi scanning and connectivity (scapy, wifi, python-wifi) these libraries were either outdated (written in python2) and no longer supported or gave me weird errors where the fix would've been extremely hacky. I decided to proceed with os calls to progress through this task.

Differential Revision: D22286624

