### PR TITLE
Update PcoProtocolOrContainerId contents on NAS state proto

### DIFF
--- a/lte/protos/oai/nas_state.proto
+++ b/lte/protos/oai/nas_state.proto
@@ -326,7 +326,7 @@ message BearerQos {
 message PcoProtocolOrContainerId {
   uint32 id = 1;
   uint32 length = 2;
-  string contents = 3;
+  bytes contents = 3;
 }
 
 // protocol_configuration_options_t


### PR DESCRIPTION
Summary:
- `PcoProtocolOrContainerId` message part of the NAS state proto contains a value `contents` which is filled by MME, this value contains bytes value which at parsing can throw error due to invalid UTF-8 byte sequence.
- This diff updates `contents` variable to be of `bytes` type

Differential Revision: D22281336

