### PR TITLE
Remove CreditType from SessionCredit

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -10,6 +10,7 @@
 #include <limits>
 
 #include "ChargingGrant.h"
+#include "EnumToString.h"
 #include "magma_logging.h"
 
 namespace magma {
@@ -63,7 +64,7 @@ namespace magma {
     uc.expiry_time = expiry_time;
 
     // todo overwrite these in later diffs
-    //uc.reauth_state = reauth_state;
+    uc.reauth_state = reauth_state;
     //uc.service_state = service_state_;
     return uc;
   }
@@ -80,7 +81,7 @@ namespace magma {
     if (credit.is_reporting()) {
       return false; // No update
     }
-    if (credit.is_reauth_required()) {
+    if (reauth_state == REAUTH_REQUIRED) {
       *update_type = CreditUsage::REAUTH_REQUIRED;
       return true;
     }
@@ -97,6 +98,17 @@ namespace magma {
       return true;
     }
     return false;
-}
+  }
+
+  void ChargingGrant::set_reauth_state(
+    const ReAuthState new_state, SessionCreditUpdateCriteria& uc) {
+    if (reauth_state != new_state) {
+      MLOG(MDEBUG) << "ReAuth state change from "
+                   << reauth_state_to_str(reauth_state) << " to "
+                   << reauth_state_to_str(new_state);
+    }
+    reauth_state = new_state;
+    uc.reauth_state = new_state;
+  }
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -7,6 +7,7 @@
  * of patent rights can be found in the PATENTS file in the same directory.
  */
 
+#include <ctime>
 #include <limits>
 
 #include "ChargingGrant.h"
@@ -31,7 +32,7 @@ namespace magma {
   ChargingGrant ChargingGrant::unmarshal(const StoredChargingGrant &marshaled) {
     ChargingGrant charging;
     charging.credit =
-      SessionCredit::unmarshal(marshaled.credit, CreditType::CHARGING);
+      SessionCredit::unmarshal(marshaled.credit);
 
     FinalActionInfo final_action_info;
     final_action_info.final_action = marshaled.final_action_info.final_action;

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -44,15 +44,11 @@ struct ChargingGrant {
   // StoredChargingGrant -> ChargingGrant
   static ChargingGrant unmarshal(const StoredChargingGrant &marshaled);
 
-  // Set is_final_grant and final_action_info values
-  void set_final_action_info(const magma::lte::ChargingCredit &credit);
+  void receive_charging_grant(const magma::lte::ChargingCredit& credit,
+                              SessionCreditUpdateCriteria* uc=NULL);
 
   // Returns a SessionCreditUpdateCriteria that reflects the current state
   SessionCreditUpdateCriteria get_update_criteria();
-
-  // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
-  // and assign it to expiry_time
-  void set_expiry_time_as_timestamp(uint32_t delta_time_sec);
 
   // Determine whether the charging grant should send an update request
   // Return true if an update is required, with the update_type set to indicate

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -28,11 +28,26 @@ struct ChargingGrant {
 
   ChargingGrant() : credit(CreditType::CHARGING) {}
 
+  // ChargingGrant -> StoredChargingGrant
   StoredChargingGrant marshal();
 
+  // StoredChargingGrant -> ChargingGrant
   static ChargingGrant unmarshal(const StoredChargingGrant &marshaled);
 
+  // Set is_final_grant and final_action_info values
   void set_final_action_info(const magma::lte::ChargingCredit &credit);
+
+  SessionCreditUpdateCriteria get_update_criteria();
+
+  // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
+  // and assign it to expiry_time
+  void set_expiry_time_as_timestamp(uint32_t delta_time_sec);
+
+  // Determine whether the charging grant should send an update request
+  // Return true if an update is required, with the update_type set to indicate
+  // the reason.
+  // Return false otherwise. In this case, update_type is untouched.
+  bool get_update_type(CreditUsage::UpdateType* update_type) const;
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -48,6 +48,8 @@ struct ChargingGrant {
   // the reason.
   // Return false otherwise. In this case, update_type is untouched.
   bool get_update_type(CreditUsage::UpdateType* update_type) const;
+
+  void set_reauth_state(const ReAuthState new_state, SessionCreditUpdateCriteria &uc);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include "ServiceAction.h"
 #include "StoredState.h"
 #include "SessionCredit.h"
 
@@ -35,7 +36,7 @@ struct ChargingGrant {
   ReAuthState reauth_state;
 
   // Default states
-  ChargingGrant() : credit(CreditType::CHARGING), is_final_grant(false),
+  ChargingGrant() : credit(), is_final_grant(false),
     service_state(SERVICE_ENABLED), reauth_state(REAUTH_NOT_NEEDED) {}
 
   // ChargingGrant -> StoredChargingGrant
@@ -56,25 +57,9 @@ struct ChargingGrant {
   // Return false otherwise. In this case, update_type is untouched.
   bool get_update_type(CreditUsage::UpdateType* update_type) const;
 
-  // Return true if the service needs to be deactivated
-  bool should_deactivate_service() const;
-
   // get_action returns the action to take on the credit based on the last
   // update. If no action needs to take place, CONTINUE_SERVICE is returned.
   ServiceActionType get_action(SessionCreditUpdateCriteria &update_criteria);
-
-  // Convert FinalAction enum to ServiceActionType
-  ServiceActionType final_action_to_action(
-    const ChargingCredit_FinalAction action) const;
-
-  // Set the object and update criteria's reauth state to new_state.
-  void set_reauth_state(const ReAuthState new_state, SessionCreditUpdateCriteria &uc);
-
-  // Set the object and update criteria's service state to new_state.
-  void set_service_state(const ServiceState new_service_state, SessionCreditUpdateCriteria &uc);
-
-  // Log final action related information
-  void log_final_action_info() const;
 
   // Get unreported usage from credit and return as part of CreditUsage
   // The update_type is also included in CreditUsage
@@ -82,6 +67,30 @@ struct ChargingGrant {
   // usage, otherwise we only include unreported usage up to the allocated amount.
   CreditUsage get_credit_usage(CreditUsage::UpdateType update_type,
     SessionCreditUpdateCriteria& uc, bool is_terminate);
+
+  // Return true if the service needs to be deactivated
+  bool should_deactivate_service() const;
+
+  // Convert FinalAction enum to ServiceActionType
+  ServiceActionType final_action_to_action(
+    const ChargingCredit_FinalAction action) const;
+
+  // Set is_final_grant and final_action_info values
+  void set_final_action_info(
+    const magma::lte::ChargingCredit& credit, SessionCreditUpdateCriteria& uc);
+
+  // Set the object and update criteria's reauth state to new_state.
+  void set_reauth_state(const ReAuthState new_state, SessionCreditUpdateCriteria &uc);
+
+  // Set the object and update criteria's service state to new_state.
+  void set_service_state(const ServiceState new_service_state, SessionCreditUpdateCriteria &uc);
+
+  // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
+  // and assign it to expiry_time
+  void set_expiry_time_as_timestamp(uint32_t rel_time_sec);
+
+  // Log final action related information
+  void log_final_action_info() const;
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -90,4 +90,29 @@ namespace magma {
       return "INVALID SESSION FSM STATE";
     }
   }
+
+  std::string credit_update_type_to_str(CreditUsage::UpdateType update) {
+    switch (update) {
+      case CreditUsage::THRESHOLD:
+        return "THRESHOLD";
+      case CreditUsage::QHT:
+        return "QHT";
+      case CreditUsage::TERMINATED:
+        return "TERMINATED";
+      case CreditUsage::QUOTA_EXHAUSTED:
+        return "QUOTA_EXHAUSTED";
+      case CreditUsage::VALIDITY_TIMER_EXPIRED:
+        return "VALIDITY_TIMER_EXPIRED";
+      case CreditUsage::OTHER_QUOTA_TYPE:
+        return "OTHER_QUOTA_TYPE";
+      case CreditUsage::RATING_CONDITION_CHANGE:
+        return "RATING_CONDITION_CHANGE";
+      case CreditUsage::REAUTH_REQUIRED:
+        return "REAUTH_REQUIRED";
+      case CreditUsage::POOL_EXHAUSTED:
+        return "POOL_EXHAUSTED";
+      default:
+        return "INVALID CREDIT UPDATE TYPE";
+    }
+  }
 } // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -20,4 +20,6 @@ std::string final_action_to_str(ChargingCredit_FinalAction final_action);
 std::string grant_type_to_str(GrantTrackingType grant_type);
 
 std::string session_fsm_state_to_str(SessionFsmState state);
+
+std::string credit_update_type_to_str(CreditUsage::UpdateType update);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/Monitor.h
+++ b/lte/gateway/c/session_manager/Monitor.h
@@ -25,8 +25,6 @@ struct Monitor {
   // monitoring key
   MonitoringLevel level;
 
-  Monitor() : credit(CreditType::MONITORING) {}
-
   // Marshal into StoredMonitor structure used in SessionStore
   StoredMonitor marshal() {
     StoredMonitor marshaled{};
@@ -38,7 +36,7 @@ struct Monitor {
   // Unmarshal from StoredMonitor structure used in SessionStore
   static std::unique_ptr<Monitor> unmarshal(const StoredMonitor &marshaled) {
     Monitor monitor;
-    monitor.credit = SessionCredit::unmarshal(marshaled.credit, MONITORING);
+    monitor.credit = SessionCredit::unmarshal(marshaled.credit);
     monitor.level = marshaled.level;
     return std::make_unique<Monitor>(monitor);
   }

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -280,23 +280,6 @@ bool SessionCredit::validity_timer_expired() const {
   return time(NULL) >= expiry_time_;
 }
 
-CreditUpdateType SessionCredit::get_update_type() const {
-  if (is_reporting()) {
-    return CREDIT_NO_UPDATE;
-  } else if (is_reauth_required()) {
-    return CREDIT_REAUTH_REQUIRED;
-  } else if (is_final_grant_ && is_quota_exhausted(1)) {
-    // Don't request updates if there's no quota left
-    return CREDIT_NO_UPDATE;
-  } else if (is_quota_exhausted(SessionCredit::USAGE_REPORTING_THRESHOLD)) {
-    return CREDIT_QUOTA_EXHAUSTED;
-  } else if (validity_timer_expired()) {
-    return CREDIT_VALIDITY_TIMER_EXPIRED;
-  } else {
-    return CREDIT_NO_UPDATE;
-  }
-}
-
 SessionCredit::Usage SessionCredit::get_all_unreported_usage_for_reporting(
     SessionCreditUpdateCriteria &update_criteria) {
   auto usage = get_unreported_usage();

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -8,31 +8,11 @@
  */
 #pragma once
 
-#include <ctime>
-#include <memory>
-#include <unordered_map>
-#include <unordered_set>
-
 #include <lte/protos/session_manager.grpc.pb.h>
 
-#include "CreditKey.h"
-#include "ServiceAction.h"
 #include "StoredState.h"
 
 namespace magma {
-
-enum CreditUpdateType {
-  CREDIT_NO_UPDATE = 0,
-  CREDIT_QUOTA_EXHAUSTED = 1,
-  CREDIT_VALIDITY_TIMER_EXPIRED = 2,
-  CREDIT_REAUTH_REQUIRED = 3
-};
-
-enum CreditType {
-  MONITORING = 0,
-  CHARGING = 1,
-};
-
 /**
  * SessionCredit tracks all the credit volumes associated with a charging key
  * for a user. It can receive used credit, add allowed credit, and check if
@@ -45,18 +25,17 @@ public:
     uint64_t bytes_rx;
   };
 
-  static SessionCredit unmarshal(
-    const StoredSessionCredit &marshaled, CreditType credit_type);
+  static SessionCredit unmarshal(const StoredSessionCredit &marshaled);
 
   StoredSessionCredit marshal();
 
   SessionCreditUpdateCriteria get_update_criteria();
 
-  SessionCredit(CreditType credit_type);
+  SessionCredit();
 
-  SessionCredit(CreditType credit_type, ServiceState start_state);
+  SessionCredit(ServiceState start_state);
 
-  SessionCredit(CreditType credit_type, ServiceState start_state,
+  SessionCredit(ServiceState start_state,
                 CreditLimitType credit_limit_type);
 
   /**
@@ -153,8 +132,6 @@ private:
   bool reporting_;
   CreditLimitType credit_limit_type_;
   GrantTrackingType grant_tracking_type_;
-
-  CreditType credit_type_; // TODO remove
 
 private:
   void log_quota_and_usage() const;

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -70,20 +70,18 @@ public:
    * reset_reporting_credit resets the REPORTING_* to 0
    * Also marks the session as not in reporting.
    */
-  void reset_reporting_credit(SessionCreditUpdateCriteria &update_criteria);
+  void reset_reporting_credit(SessionCreditUpdateCriteria* uc);
 
   /**
    * Credit update has failed to the OCS, so mark this credit as failed so it
    * can be cut off accordingly
    */
-  void mark_failure(uint32_t code,
-                    SessionCreditUpdateCriteria &update_criteria);
+  void mark_failure(uint32_t code, SessionCreditUpdateCriteria* uc);
   /**
    * receive_credit increments ALLOWED* and moves the REPORTING_* credit to
    * the REPORTED_* credit
    */
-  void receive_credit(const GrantedUnits& gsu, uint32_t validity_time,
-                      SessionCreditUpdateCriteria &uc);
+  void receive_credit(const GrantedUnits& gsu, SessionCreditUpdateCriteria* uc);
 
   /**
    * get_update returns a filled-in CreditUsage if an update exists, and a blank
@@ -105,14 +103,6 @@ public:
    * Helper function to get the credit in a particular bucket
    */
   uint64_t get_credit(Bucket bucket) const;
-
-  /**
-   * Set expiry time of SessionCredit
-   * NOTE: Use only for merging updates into SessionStore
-   * @param expiry_time
-   */
-  void set_expiry_time(std::time_t expiry_time,
-                       SessionCreditUpdateCriteria &update_criteria);
 
   void set_grant_tracking_type(GrantTrackingType g_type,
     SessionCreditUpdateCriteria& uc);
@@ -158,9 +148,6 @@ public:
    * Set to false to allow users to use without any constraint.
    */
   static bool TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED;
-
-  // Make public temporarily for the migration
-  bool validity_timer_expired() const;
 private:
   uint64_t buckets_[MAX_VALUES];
   bool reporting_;
@@ -169,13 +156,8 @@ private:
 
   CreditType credit_type_; // TODO remove
 
-  std::time_t expiry_time_; // TODO move to ChargingGrant
-
 private:
   void log_quota_and_usage() const;
-
-  void set_expiry_time(uint32_t validity_time,
-                       SessionCreditUpdateCriteria &update_criteria);
 
   SessionCredit::Usage get_unreported_usage() const;
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -83,8 +83,7 @@ public:
    * the REPORTED_* credit
    */
   void receive_credit(const GrantedUnits& gsu, uint32_t validity_time,
-                      bool is_final_grant, FinalActionInfo final_action_info,
-                      SessionCreditUpdateCriteria &update_criteria);
+                      SessionCreditUpdateCriteria &uc);
 
   /**
    * get_update returns a filled-in CreditUsage if an update exists, and a blank
@@ -98,47 +97,14 @@ public:
       SessionCreditUpdateCriteria &update_criteria);
 
   /**
-   * get_action returns the action to take on the credit based on the last
-   * update. If no action needs to take place, CONTINUE_SERVICE is returned.
-   */
-  ServiceActionType get_action(SessionCreditUpdateCriteria &update_criteria);
-
-  /**
    * Returns true if either of REPORTING_* buckets are more than 0
    */
   bool is_reporting() const;
 
   /**
-   * Returns true if service is being redirected
-   */
-  bool is_service_redirected() const;
-
-  /**
    * Helper function to get the credit in a particular bucket
    */
   uint64_t get_credit(Bucket bucket) const;
-
-  /**
-   * Returns
-   */
-  RedirectServer get_redirect_server() const;
-
-  /**
-   * Mark SessionCredit as having been given the final grant.
-   * NOTE: Use only for merging updates into SessionStore
-   * @param is_final_grant
-   */
-  void set_is_final_grant_and_final_action(
-      bool is_final_grant, FinalActionInfo final_action_info,
-      SessionCreditUpdateCriteria& update_criteria);
-
-  /**
-   * Set ServiceState.
-   * NOTE: Use only for merging updates into SessionStore
-   * @param service_state
-   */
-  void set_service_state(ServiceState new_service_state,
-                         SessionCreditUpdateCriteria &update_criteria);
 
   /**
    * Set expiry time of SessionCredit
@@ -195,8 +161,6 @@ public:
 
   // Make public temporarily for the migration
   bool validity_timer_expired() const;
-
-  bool is_final_grant() const {return is_final_grant_;};
 private:
   uint64_t buckets_[MAX_VALUES];
   bool reporting_;
@@ -205,20 +169,13 @@ private:
 
   CreditType credit_type_; // TODO remove
 
-  ServiceState service_state_; // TODO move to ChargingGrant
-  bool is_final_grant_; // TODO move to ChargingGrant
-  FinalActionInfo final_action_info_; // TODO move to ChargingGrant
   std::time_t expiry_time_; // TODO move to ChargingGrant
 
 private:
   void log_quota_and_usage() const;
 
-  bool should_deactivate_service() const;
-
   void set_expiry_time(uint32_t validity_time,
                        SessionCreditUpdateCriteria &update_criteria);
-
-  ServiceActionType get_action_for_deactivating_service() const;
 
   SessionCredit::Usage get_unreported_usage() const;
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -214,6 +214,12 @@ public:
    */
   static bool TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED;
 
+  // Make public temporarily for the migration
+  bool is_reauth_required() const;
+
+  bool validity_timer_expired() const;
+
+  bool is_final_grant() const {return is_final_grant_;};
 private:
   uint64_t buckets_[MAX_VALUES];
   bool reporting_;
@@ -233,12 +239,8 @@ private:
 
   bool should_deactivate_service() const;
 
-  bool validity_timer_expired() const;
-
   void set_expiry_time(uint32_t validity_time,
                        SessionCreditUpdateCriteria &update_criteria);
-
-  bool is_reauth_required() const;
 
   ServiceActionType get_action_for_deactivating_service() const;
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -87,13 +87,6 @@ public:
                       SessionCreditUpdateCriteria &update_criteria);
 
   /**
-   * get_update_type returns the type of update required for the credit. If no
-   * update is required, it returns CREDIT_NO_UPDATE. Else, it returns an update
-   * type
-   */
-  CreditUpdateType get_update_type() const;
-
-  /**
    * get_update returns a filled-in CreditUsage if an update exists, and a blank
    * one if no update exists. Check has_update before calling.
    * This method also sets the REPORTING_* credit buckets
@@ -126,12 +119,6 @@ public:
   uint64_t get_credit(Bucket bucket) const;
 
   /**
-   * Mark the credit to be in the REAUTH_REQUIRED state. The next time
-   * get_update is called, this credit will report its usage.
-   */
-  void reauth(SessionCreditUpdateCriteria &update_criteria);
-
-  /**
    * Returns
    */
   RedirectServer get_redirect_server() const;
@@ -144,14 +131,6 @@ public:
   void set_is_final_grant_and_final_action(
       bool is_final_grant, FinalActionInfo final_action_info,
       SessionCreditUpdateCriteria& update_criteria);
-
-  /**
-   * Set ReAuthState.
-   * NOTE: Use only for merging updates into SessionStore
-   * @param reauth_state
-   */
-  void set_reauth(ReAuthState reauth_state,
-                  SessionCreditUpdateCriteria &update_criteria);
 
   /**
    * Set ServiceState.
@@ -215,8 +194,6 @@ public:
   static bool TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED;
 
   // Make public temporarily for the migration
-  bool is_reauth_required() const;
-
   bool validity_timer_expired() const;
 
   bool is_final_grant() const {return is_final_grant_;};
@@ -228,7 +205,6 @@ private:
 
   CreditType credit_type_; // TODO remove
 
-  ReAuthState reauth_state_; // TODO move to ChargingGrant
   ServiceState service_state_; // TODO move to ChargingGrant
   bool is_final_grant_; // TODO move to ChargingGrant
   FinalActionInfo final_action_info_; // TODO move to ChargingGrant

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -108,7 +108,7 @@ SessionState::SessionState(
       std::make_unique<std::string>(marshaled.session_level_key);
   for (auto it : marshaled.monitor_map) {
     Monitor monitor;
-    monitor.credit = SessionCredit::unmarshal(it.second.credit, MONITORING);
+    monitor.credit = SessionCredit::unmarshal(it.second.credit);
     monitor.level = it.second.level;
 
     monitor_map_[it.first] = std::make_unique<Monitor>(monitor);
@@ -842,8 +842,7 @@ bool SessionState::init_charging_credit(
               << update.charging_key();
 
   auto charging_grant = std::make_unique<ChargingGrant>();
-  charging_grant->credit =
-    SessionCredit(CreditType::CHARGING, SERVICE_ENABLED, update.limit_type());
+  charging_grant->credit = SessionCredit(SERVICE_ENABLED, update.limit_type());
 
   charging_grant->receive_charging_grant(update.credit());
   update_criteria.charging_credit_to_install[CreditKey(update)] =
@@ -877,7 +876,7 @@ ReAuthResult SessionState::reauth_key(const CreditKey &charging_key,
   }
   // charging_key cannot be found, initialize credit and engage reauth
   auto grant = std::make_unique<ChargingGrant>();
-  grant->credit = SessionCredit(CreditType::CHARGING, SERVICE_DISABLED);
+  grant->credit = SessionCredit(SERVICE_DISABLED);
   grant->reauth_state = REAUTH_REQUIRED;
   grant->service_state = SERVICE_DISABLED;
   update_criteria.charging_credit_to_install[charging_key] = grant->marshal();

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -157,11 +157,7 @@ deserialize_stored_charging_grant(const std::string &serialized) {
 std::string serialize_stored_session_credit(StoredSessionCredit &stored) {
   folly::dynamic marshaled = folly::dynamic::object;
   marshaled["reporting"] = stored.reporting;
-  marshaled["is_final"] = stored.is_final;
   marshaled["credit_limit_type"] = static_cast<int>(stored.credit_limit_type);
-  marshaled["final_action_info"] =
-      serialize_stored_final_action_info(stored.final_action_info);
-  marshaled["service_state"] = static_cast<int>(stored.service_state);
   marshaled["expiry_time"] = std::to_string(stored.expiry_time);
   marshaled["buckets"] = folly::dynamic::object();
   marshaled["grant_tracking_type"] =
@@ -183,13 +179,8 @@ deserialize_stored_session_credit(const std::string &serialized) {
 
   auto stored = StoredSessionCredit{};
   stored.reporting = marshaled["reporting"].getBool();
-  stored.is_final = marshaled["is_final"].getBool();
   stored.credit_limit_type =
     static_cast<CreditLimitType>(marshaled["credit_limit_type"].getInt());
-  stored.final_action_info = deserialize_stored_final_action_info(
-      marshaled["final_action_info"].getString());
-  stored.service_state =
-      static_cast<ServiceState>(marshaled["service_state"].getInt());
   stored.expiry_time = static_cast<std::time_t>(
       std::stoul(marshaled["expiry_time"].getString()));
   stored.grant_tracking_type = static_cast<GrantTrackingType>(

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -158,7 +158,6 @@ std::string serialize_stored_session_credit(StoredSessionCredit &stored) {
   folly::dynamic marshaled = folly::dynamic::object;
   marshaled["reporting"] = stored.reporting;
   marshaled["credit_limit_type"] = static_cast<int>(stored.credit_limit_type);
-  marshaled["expiry_time"] = std::to_string(stored.expiry_time);
   marshaled["buckets"] = folly::dynamic::object();
   marshaled["grant_tracking_type"] =
     static_cast<int>(stored.grant_tracking_type);
@@ -181,8 +180,6 @@ deserialize_stored_session_credit(const std::string &serialized) {
   stored.reporting = marshaled["reporting"].getBool();
   stored.credit_limit_type =
     static_cast<CreditLimitType>(marshaled["credit_limit_type"].getInt());
-  stored.expiry_time = static_cast<std::time_t>(
-      std::stoul(marshaled["expiry_time"].getString()));
   stored.grant_tracking_type = static_cast<GrantTrackingType>(
     marshaled["grant_tracking_type"].getInt());
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -161,7 +161,6 @@ std::string serialize_stored_session_credit(StoredSessionCredit &stored) {
   marshaled["credit_limit_type"] = static_cast<int>(stored.credit_limit_type);
   marshaled["final_action_info"] =
       serialize_stored_final_action_info(stored.final_action_info);
-  marshaled["reauth_state"] = static_cast<int>(stored.reauth_state);
   marshaled["service_state"] = static_cast<int>(stored.service_state);
   marshaled["expiry_time"] = std::to_string(stored.expiry_time);
   marshaled["buckets"] = folly::dynamic::object();
@@ -189,8 +188,6 @@ deserialize_stored_session_credit(const std::string &serialized) {
     static_cast<CreditLimitType>(marshaled["credit_limit_type"].getInt());
   stored.final_action_info = deserialize_stored_final_action_info(
       marshaled["final_action_info"].getString());
-  stored.reauth_state =
-      static_cast<ReAuthState>(marshaled["reauth_state"].getInt());
   stored.service_state =
       static_cast<ServiceState>(marshaled["service_state"].getInt());
   stored.expiry_time = static_cast<std::time_t>(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -137,7 +137,6 @@ struct StoredSessionCredit {
   bool is_final;
   CreditLimitType credit_limit_type;
   FinalActionInfo final_action_info;
-  ReAuthState reauth_state;
   ServiceState service_state;
   std::time_t expiry_time;
   std::unordered_map<Bucket, uint64_t> buckets;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -135,7 +135,6 @@ enum SessionFsmState {
 struct StoredSessionCredit {
   bool reporting;
   CreditLimitType credit_limit_type;
-  std::time_t expiry_time;
   std::unordered_map<Bucket, uint64_t> buckets;
   GrantTrackingType grant_tracking_type;
 };

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -134,10 +134,7 @@ enum SessionFsmState {
 
 struct StoredSessionCredit {
   bool reporting;
-  bool is_final;
   CreditLimitType credit_limit_type;
-  FinalActionInfo final_action_info;
-  ServiceState service_state;
   std::time_t expiry_time;
   std::unordered_map<Bucket, uint64_t> buckets;
   GrantTrackingType grant_tracking_type;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -186,12 +186,15 @@ struct StoredSessionState {
 
 // Update Criteria
 struct SessionCreditUpdateCriteria {
+  // Maintained by ChargingGrant
   bool is_final;
   FinalActionInfo final_action_info;
-  bool reporting;
   ReAuthState reauth_state;
   ServiceState service_state;
   std::time_t expiry_time;
+
+  // Maintained by SessionCredit
+  bool reporting;
   GrantTrackingType grant_tracking_type;
   // Do not mark REPORTING buckets, but do mark REPORTED
   std::unordered_map<Bucket, uint64_t> bucket_deltas;

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 foreach(session_test session_credit local_enforcer cloud_reporter
         session_manager_handler sessiond_integ session_state
         session_store store_client stored_state proxy_responder_handler
-        metering_reporter local_enforcer_wallet_exhaust)
+        metering_reporter local_enforcer_wallet_exhaust charging_grant)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -22,7 +22,8 @@ void create_rule_record(
   uint64_t bytes_tx,
   RuleRecord* rule_record);
 
-void create_charging_credit(uint64_t volume, ChargingCredit* credit);
+void create_charging_credit(
+  uint64_t volume, bool is_final, ChargingCredit* credit);
 
 void create_credit_update_response(
   const std::string& imsi,

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -15,32 +15,44 @@
 
 using ::testing::Test;
 
-#define HIGH_CREDIT 1000000
-
 namespace magma {
 
 class ChargingGrantTest : public ::testing::Test {
 protected:
   ChargingGrant get_default_grant() {
-    FinalActionInfo final_action = {
-    .final_action = ChargingCredit_FinalAction_TERMINATE,
-    };
-    final_action.redirect_server.set_redirect_address_type(
-      RedirectServer_RedirectAddressType::RedirectServer_RedirectAddressType_IPV6);
-    final_action.redirect_server.set_redirect_server_address("addr");
-
     ChargingGrant grant;
-    grant.is_final_grant = true;
-    grant.final_action_info = final_action;
+    grant.is_final_grant = false;
     grant.expiry_time = time(NULL);
-    grant.service_state = SERVICE_NEEDS_ACTIVATION;
-    grant.reauth_state = REAUTH_PROCESSING;
+    grant.service_state = SERVICE_ENABLED;
+    grant.reauth_state = REAUTH_NOT_NEEDED;
     return grant;
+  }
+
+  ChargingGrant get_default_grant(ChargingCredit_FinalAction action) {
+    auto grant = get_default_grant();
+    grant.is_final_grant = true;
+    grant.final_action_info = get_final_action_info(action);
+    return grant;
+  }
+
+  FinalActionInfo get_final_action_info(ChargingCredit_FinalAction action) {
+    FinalActionInfo fa;
+    fa.final_action = action;
+    if (action == ChargingCredit_FinalAction_REDIRECT) {
+      fa.redirect_server.set_redirect_address_type(
+        RedirectServer_RedirectAddressType::RedirectServer_RedirectAddressType_IPV6);
+      fa.redirect_server.set_redirect_server_address("addr");
+    }
+    return fa;
   }
 };
 
 TEST_F(ChargingGrantTest, test_marshal) {
-  ChargingGrant grant = get_default_grant();
+  // Get a grant with REDIRECT final action since that fills out all the fields
+  ChargingGrant grant = get_default_grant(ChargingCredit_FinalAction_REDIRECT);
+  // Set ReAuth state and service state to non-0 values
+  grant.service_state = SERVICE_DISABLED;
+  grant.reauth_state = REAUTH_REQUIRED;
 
   StoredChargingGrant stored = grant.marshal();
   EXPECT_EQ(grant.is_final_grant, stored.is_final);
@@ -67,7 +79,8 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
 
   auto uc = grant.get_update_criteria();
   create_granted_units(&total_grant, NULL, NULL, &gsu);
-  grant.credit.receive_credit(gsu, 0, false, final_action_info, uc);
+  grant.credit.receive_credit(gsu, 0, uc);
+  grant.is_final_grant = false;
   EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
 
   grant.credit.add_used_credit(2000, 0, uc);
@@ -87,8 +100,9 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
   EXPECT_FALSE(grant.get_update_type(&update_type));
 
   // Receive a final grant
-  grant.credit.receive_credit(gsu, 0, true, final_action_info, uc);
+  grant.credit.receive_credit(gsu, 0, uc);
   EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
+  grant.is_final_grant = true;
   grant.credit.reset_reporting_credit(uc);
 
   EXPECT_FALSE(grant.get_update_type(&update_type));
@@ -98,6 +112,185 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
   grant.reauth_state = REAUTH_REQUIRED;
   EXPECT_TRUE(grant.get_update_type(&update_type));
   EXPECT_EQ(update_type, CreditUsage::REAUTH_REQUIRED);
+}
+
+TEST_F(ChargingGrantTest, test_should_deactivate_service) {
+  // Create a grant with some quota
+  ChargingGrant grant;
+  GrantedUnits gsu;
+  uint64_t total_grant = 1000;
+  create_granted_units(&total_grant, NULL, NULL, &gsu);
+  auto uc = grant.get_update_criteria();
+  grant.credit.receive_credit(gsu, 0, uc);
+  EXPECT_FALSE(grant.credit.is_quota_exhausted(0.8));
+
+  // If quota is not exhausted, don't deactivate
+  grant.is_final_grant = true;
+  grant.final_action_info.final_action = ChargingCredit_FinalAction_TERMINATE;
+  grant.service_state = SERVICE_ENABLED;
+  EXPECT_FALSE(grant.should_deactivate_service());
+
+  // Exhaust quota
+  uc = grant.get_update_criteria();
+  grant.credit.add_used_credit(2000, 0, uc);
+  EXPECT_TRUE(grant.credit.is_quota_exhausted(0.8));
+
+  // Test TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED flag && is_final
+  SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = false;
+  grant.is_final_grant = true;
+  grant.final_action_info.final_action = ChargingCredit_FinalAction_TERMINATE;
+  grant.service_state = SERVICE_ENABLED;
+  EXPECT_FALSE(grant.should_deactivate_service());
+
+  // Test TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED is set && is_final
+  SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
+  grant.is_final_grant = true;
+  grant.final_action_info.final_action = ChargingCredit_FinalAction_TERMINATE;
+  grant.service_state = SERVICE_ENABLED;
+  EXPECT_TRUE(grant.should_deactivate_service());
+
+  // If service state is not ENABLED we should not deactivate service
+  SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED = true;
+  grant.is_final_grant = true;
+  grant.final_action_info.final_action = ChargingCredit_FinalAction_TERMINATE;
+  grant.service_state = SERVICE_DISABLED;
+  EXPECT_FALSE(grant.should_deactivate_service());
+}
+
+TEST_F(ChargingGrantTest, test_get_action) {
+  ChargingGrant grant = get_default_grant();
+  auto uc = grant.get_update_criteria();
+  GrantedUnits gsu;
+  uint64_t total_grant = 1024;
+  create_granted_units(&total_grant, NULL, NULL, &gsu);
+
+  // Not a final grant
+  grant.is_final_grant = false;
+  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.add_used_credit(1024, 0, uc);
+  auto cont_action = grant.get_action(uc);
+  EXPECT_EQ(cont_action, CONTINUE_SERVICE);
+  // Check both the grant's service_state and update criteria
+  EXPECT_EQ(grant.service_state, CONTINUE_SERVICE);
+  EXPECT_EQ(uc.service_state, CONTINUE_SERVICE);
+
+  // Final with TERMINATE final action
+  grant.is_final_grant = true;
+  grant.final_action_info =
+    get_final_action_info(ChargingCredit_FinalAction_TERMINATE);
+  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.add_used_credit(2048, 0, uc);
+  grant.credit.add_used_credit(30, 20, uc);
+  grant.service_state = SERVICE_NEEDS_DEACTIVATION;
+  auto term_action = grant.get_action(uc);
+  // Check that the update criteria also includes the changes
+  EXPECT_EQ(term_action, TERMINATE_SERVICE);
+
+  // Termination action only returned once
+  auto repeated_action = grant.get_action(uc);
+  EXPECT_EQ(repeated_action, CONTINUE_SERVICE);
+}
+
+TEST_F(ChargingGrantTest, test_get_action_redirect) {
+  ChargingGrant grant = get_default_grant();
+  auto uc = grant.get_update_criteria();
+  GrantedUnits gsu;
+  uint64_t total_grant = 1024;
+  create_granted_units(&total_grant, NULL, NULL, &gsu);
+
+  // Final with REDIRECT final action
+  grant.is_final_grant = true;
+  grant.final_action_info =
+    get_final_action_info(ChargingCredit_FinalAction_REDIRECT);
+  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.add_used_credit(2048, 0, uc);
+  grant.credit.add_used_credit(30, 20, uc);
+  grant.service_state = SERVICE_NEEDS_DEACTIVATION;
+  auto term_action = grant.get_action(uc);
+  // Check that the update criteria also includes the changes
+  EXPECT_EQ(term_action, REDIRECT);
+
+  // Termination action only returned once
+  auto repeated_action = grant.get_action(uc);
+  EXPECT_EQ(repeated_action, CONTINUE_SERVICE);
+}
+
+// test_tolerance_quota_exhausted checks that user will not be terminated if
+// quota is exhausted but not final unit indication is received.
+// That can happen if the quota reported by pipeline is too big and we go over
+// both the threshold (0.8) and the maximum allowed quota
+TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
+  auto grant = get_default_grant();
+  auto& credit = grant.credit;
+  auto uc = grant.get_update_criteria();
+  GrantedUnits gsu;
+  uint64_t total_grant = 1000;
+  create_granted_units(&total_grant, NULL, NULL, &gsu);
+  grant.credit.receive_credit(gsu, 0, uc);
+  EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
+
+  // Not a final credit
+  grant.is_final_grant = false;
+  credit.add_used_credit(2000, 0, uc);
+  EXPECT_EQ(uc.bucket_deltas[USED_TX], 2000);
+  EXPECT_TRUE(credit.is_quota_exhausted(0.8));
+  // continue the service even we are over the quota (but not final unit)
+  EXPECT_EQ(grant.get_action(uc), CONTINUE_SERVICE);
+
+  // Check how much we will report (as much as the total allowed, the rest
+  // will be left unreported and reported in future updates)
+  CreditUsage::UpdateType update_type;
+  EXPECT_TRUE(grant.get_update_type(&update_type));
+  auto c_usage = grant.get_credit_usage(update_type, uc, false);
+  EXPECT_EQ(c_usage.bytes_tx(), 1000);
+  EXPECT_EQ(c_usage.bytes_rx(), 0);
+  // we have used 2000 but we will report only what we were granted
+  EXPECT_EQ(credit.get_credit(USED_TX), 2000);
+  EXPECT_EQ(credit.get_credit(REPORTING_TX), 1000);
+
+  // Now receive new quota (not final unit)
+  uc = grant.get_update_criteria(); // reset UC
+  grant.credit.receive_credit(gsu, 0, uc);
+  EXPECT_EQ(credit.get_credit(ALLOWED_TOTAL), 2000);
+  EXPECT_EQ(credit.get_credit(REPORTED_TX), 1000);
+  EXPECT_EQ(credit.get_credit(USED_TX), 2000);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_TOTAL], 1000);
+
+  // Trigger an update again, we expect the rest to be reported
+  uc = grant.get_update_criteria(); // reset UC
+  EXPECT_TRUE(grant.get_update_type(&update_type));
+  c_usage = grant.get_credit_usage(update_type, uc, false);
+  EXPECT_EQ(c_usage.bytes_tx(), 1000);
+  EXPECT_EQ(c_usage.bytes_rx(), 0);
+  // we have used 2000 but we will report only what we were granted
+  EXPECT_EQ(credit.get_credit(USED_TX), 2000);
+  EXPECT_EQ(credit.get_credit(REPORTING_TX), 1000);
+
+  // receive some more FINAL grant that will go over part of the used and not
+  // reported credit
+  uc = grant.get_update_criteria(); // reset UC
+  grant.is_final_grant = true;
+  grant.final_action_info =
+    get_final_action_info(ChargingCredit_FinalAction_TERMINATE);
+  grant.credit.receive_credit(gsu, 0, uc);
+  EXPECT_EQ(credit.get_credit(ALLOWED_TOTAL), 3000);
+  EXPECT_EQ(credit.get_credit(REPORTED_TX), 2000);
+  EXPECT_EQ(credit.get_credit(USED_TX), 2000);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_TOTAL], 1000);
+
+  // Use enough credit to exceed the given quota
+  uc = grant.get_update_criteria(); // reset UC
+  credit.add_used_credit(1500, 0, uc);
+  EXPECT_EQ(uc.bucket_deltas[USED_TX], 1500);
+  EXPECT_EQ(credit.get_credit(ALLOWED_TOTAL), 3000);
+  EXPECT_EQ(credit.get_credit(REPORTED_TX), 2000);
+  EXPECT_EQ(credit.get_credit(USED_TX), 3500);
+  EXPECT_TRUE(credit.is_quota_exhausted(1)); // 100% exceeded
+  EXPECT_TRUE(grant.should_deactivate_service());
+  grant.set_service_state(SERVICE_NEEDS_DEACTIVATION, uc);
+
+  // Since this is the final grant, we should not report anything
+  EXPECT_FALSE(grant.get_update_type(&update_type));
 }
 
 int main(int argc, char **argv) {

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -79,7 +79,7 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
 
   auto uc = grant.get_update_criteria();
   create_granted_units(&total_grant, NULL, NULL, &gsu);
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   grant.is_final_grant = false;
   EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
 
@@ -100,10 +100,10 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
   EXPECT_FALSE(grant.get_update_type(&update_type));
 
   // Receive a final grant
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
   grant.is_final_grant = true;
-  grant.credit.reset_reporting_credit(uc);
+  grant.credit.reset_reporting_credit(&uc);
 
   EXPECT_FALSE(grant.get_update_type(&update_type));
 
@@ -121,7 +121,7 @@ TEST_F(ChargingGrantTest, test_should_deactivate_service) {
   uint64_t total_grant = 1000;
   create_granted_units(&total_grant, NULL, NULL, &gsu);
   auto uc = grant.get_update_criteria();
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   EXPECT_FALSE(grant.credit.is_quota_exhausted(0.8));
 
   // If quota is not exhausted, don't deactivate
@@ -166,7 +166,7 @@ TEST_F(ChargingGrantTest, test_get_action) {
 
   // Not a final grant
   grant.is_final_grant = false;
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   grant.credit.add_used_credit(1024, 0, uc);
   auto cont_action = grant.get_action(uc);
   EXPECT_EQ(cont_action, CONTINUE_SERVICE);
@@ -178,7 +178,7 @@ TEST_F(ChargingGrantTest, test_get_action) {
   grant.is_final_grant = true;
   grant.final_action_info =
     get_final_action_info(ChargingCredit_FinalAction_TERMINATE);
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   grant.credit.add_used_credit(2048, 0, uc);
   grant.credit.add_used_credit(30, 20, uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
@@ -202,7 +202,7 @@ TEST_F(ChargingGrantTest, test_get_action_redirect) {
   grant.is_final_grant = true;
   grant.final_action_info =
     get_final_action_info(ChargingCredit_FinalAction_REDIRECT);
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   grant.credit.add_used_credit(2048, 0, uc);
   grant.credit.add_used_credit(30, 20, uc);
   grant.service_state = SERVICE_NEEDS_DEACTIVATION;
@@ -226,7 +226,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   GrantedUnits gsu;
   uint64_t total_grant = 1000;
   create_granted_units(&total_grant, NULL, NULL, &gsu);
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
 
   // Not a final credit
@@ -250,7 +250,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
 
   // Now receive new quota (not final unit)
   uc = grant.get_update_criteria(); // reset UC
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   EXPECT_EQ(credit.get_credit(ALLOWED_TOTAL), 2000);
   EXPECT_EQ(credit.get_credit(REPORTED_TX), 1000);
   EXPECT_EQ(credit.get_credit(USED_TX), 2000);
@@ -272,7 +272,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   grant.is_final_grant = true;
   grant.final_action_info =
     get_final_action_info(ChargingCredit_FinalAction_TERMINATE);
-  grant.credit.receive_credit(gsu, 0, uc);
+  grant.credit.receive_credit(gsu, &uc);
   EXPECT_EQ(credit.get_credit(ALLOWED_TOTAL), 3000);
   EXPECT_EQ(credit.get_credit(REPORTED_TX), 2000);
   EXPECT_EQ(credit.get_credit(USED_TX), 2000);

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -92,6 +92,12 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
   grant.credit.reset_reporting_credit(uc);
 
   EXPECT_FALSE(grant.get_update_type(&update_type));
+
+  // Set reauth state to be REAUTH_REQUIRED && final_grant
+  grant.is_final_grant = true;
+  grant.reauth_state = REAUTH_REQUIRED;
+  EXPECT_TRUE(grant.get_update_type(&update_type));
+  EXPECT_EQ(update_type, CreditUsage::REAUTH_REQUIRED);
 }
 
 int main(int argc, char **argv) {

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -1,0 +1,102 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#include <chrono>
+#include <thread>
+
+#include "ChargingGrant.h"
+#include "ProtobufCreators.h"
+#include <gtest/gtest.h>
+
+using ::testing::Test;
+
+#define HIGH_CREDIT 1000000
+
+namespace magma {
+
+class ChargingGrantTest : public ::testing::Test {
+protected:
+  ChargingGrant get_default_grant() {
+    FinalActionInfo final_action = {
+    .final_action = ChargingCredit_FinalAction_TERMINATE,
+    };
+    final_action.redirect_server.set_redirect_address_type(
+      RedirectServer_RedirectAddressType::RedirectServer_RedirectAddressType_IPV6);
+    final_action.redirect_server.set_redirect_server_address("addr");
+
+    ChargingGrant grant;
+    grant.is_final_grant = true;
+    grant.final_action_info = final_action;
+    grant.expiry_time = time(NULL);
+    grant.service_state = SERVICE_NEEDS_ACTIVATION;
+    grant.reauth_state = REAUTH_PROCESSING;
+    return grant;
+  }
+};
+
+TEST_F(ChargingGrantTest, test_marshal) {
+  ChargingGrant grant = get_default_grant();
+
+  StoredChargingGrant stored = grant.marshal();
+  EXPECT_EQ(grant.is_final_grant, stored.is_final);
+  EXPECT_EQ(grant.final_action_info.final_action,
+            stored.final_action_info.final_action);
+
+  auto redirect = grant.final_action_info.redirect_server;
+  auto stored_redirect = stored.final_action_info.redirect_server;
+  EXPECT_EQ(redirect.redirect_server_address(),
+            stored_redirect.redirect_server_address());
+  EXPECT_EQ(redirect.redirect_address_type(),
+            stored_redirect.redirect_address_type());
+
+  EXPECT_EQ(grant.expiry_time, stored.expiry_time);
+  EXPECT_EQ(grant.service_state, stored.service_state);
+  EXPECT_EQ(grant.reauth_state, stored.reauth_state);
+}
+
+TEST_F(ChargingGrantTest, test_get_update_type) {
+  ChargingGrant grant = get_default_grant();
+  GrantedUnits gsu;
+  uint64_t total_grant = 1000;
+  FinalActionInfo final_action_info;
+
+  auto uc = grant.get_update_criteria();
+  create_granted_units(&total_grant, NULL, NULL, &gsu);
+  grant.credit.receive_credit(gsu, 0, false, final_action_info, uc);
+  EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
+
+  grant.credit.add_used_credit(2000, 0, uc);
+  EXPECT_TRUE(grant.credit.is_quota_exhausted(0.8));
+  // Credit is exhausted, we expect a quota exhaustion updat type
+  CreditUsage::UpdateType update_type;
+  EXPECT_TRUE(grant.get_update_type(&update_type));
+  EXPECT_EQ(update_type, CreditUsage::QUOTA_EXHAUSTED);
+
+  // Check how much we will report (as much as the total allowed, the rest
+  // will be left unreported and reported in future updates)
+  auto update = grant.credit.get_usage_for_reporting(uc);
+  EXPECT_EQ(update.bytes_tx, 1000);
+  EXPECT_TRUE(grant.credit.is_reporting());
+
+  // Credit is being reported, no update necessary
+  EXPECT_FALSE(grant.get_update_type(&update_type));
+
+  // Receive a final grant
+  grant.credit.receive_credit(gsu, 0, true, final_action_info, uc);
+  EXPECT_EQ(uc.grant_tracking_type, TOTAL_ONLY);
+  grant.credit.reset_reporting_credit(uc);
+
+  EXPECT_FALSE(grant.get_update_type(&update_type));
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+} // namespace magma

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -15,18 +15,12 @@
 
 using ::testing::Test;
 
-#define HIGH_CREDIT 1000000
-
 namespace magma {
 const FinalActionInfo default_final_action_info = {
     .final_action = ChargingCredit_FinalAction_TERMINATE};
 
-class SessionCreditParameterizedTest
-    : public ::testing::TestWithParam<CreditType> {};
-
-TEST_P(SessionCreditParameterizedTest, test_marshal_unmarshal) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_marshal_unmarshal, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
 
   // Set some fields here to non default values. Credit is used.
@@ -44,15 +38,14 @@ TEST_P(SessionCreditParameterizedTest, test_marshal_unmarshal) {
   // Check that after marshaling/unmarshaling that the fields are still the
   // same.
   auto marshaled = credit.marshal();
-  auto credit_2 = SessionCredit::unmarshal(marshaled, credit_type);
+  auto credit_2 = SessionCredit::unmarshal(marshaled);
 
   EXPECT_EQ(credit_2.get_credit(USED_TX), (uint64_t)39u);
   EXPECT_EQ(credit_2.get_credit(USED_RX), (uint64_t)40u);
 }
 
-TEST_P(SessionCreditParameterizedTest, test_track_credit) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_track_credit, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1024;
@@ -68,9 +61,8 @@ TEST_P(SessionCreditParameterizedTest, test_track_credit) {
   EXPECT_EQ(uc.bucket_deltas[USED_TX], 0);
 }
 
-TEST_P(SessionCreditParameterizedTest, test_add_received_credit) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_add_received_credit, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1024;
@@ -89,9 +81,8 @@ TEST_P(SessionCreditParameterizedTest, test_add_received_credit) {
   EXPECT_EQ(uc.bucket_deltas[USED_RX], 60);
 }
 
-TEST_P(SessionCreditParameterizedTest, test_collect_updates) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_collect_updates, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1024;
@@ -116,10 +107,8 @@ TEST_P(SessionCreditParameterizedTest, test_collect_updates) {
 
 // Default usage reporting threshold is 0.8, so session manager will report
 // when quota is not completely used up.
-TEST_P(SessionCreditParameterizedTest,
-       test_collect_updates_when_nearly_exhausted) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_collect_updates_when_nearly_exhausted, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1000;
@@ -142,9 +131,8 @@ TEST_P(SessionCreditParameterizedTest,
   EXPECT_EQ(uc.bucket_deltas[REPORTING_RX], 0);
 }
 
-TEST_P(SessionCreditParameterizedTest, test_collect_updates_none_available) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_collect_updates_none_available, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1000;
@@ -157,9 +145,8 @@ TEST_P(SessionCreditParameterizedTest, test_collect_updates_none_available) {
 
 // The maximum of reported usage is capped by what is granted even when an user
 // overused.
-TEST_P(SessionCreditParameterizedTest, test_collect_updates_when_overusing) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_collect_updates_when_overusing, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1000;
@@ -182,9 +169,8 @@ TEST_P(SessionCreditParameterizedTest, test_collect_updates_when_overusing) {
   EXPECT_EQ(uc.bucket_deltas[REPORTING_RX], 0);
 }
 
-TEST_P(SessionCreditParameterizedTest, test_add_rx_tx_credit) {
-  CreditType credit_type = GetParam();
-  SessionCredit credit(credit_type);
+TEST(test_add_rx_tx_credit, test_session_credit) {
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
   uint64_t grant = 1000;
@@ -216,11 +202,8 @@ TEST_P(SessionCreditParameterizedTest, test_add_rx_tx_credit) {
   EXPECT_FALSE(credit.is_quota_exhausted(0.8));
 }
 
-INSTANTIATE_TEST_CASE_P(SessionCreditTests, SessionCreditParameterizedTest,
-                        ::testing::Values(MONITORING, CHARGING));
-
 TEST(test_is_quota_exhausted_total_only, test_session_credit) {
-  SessionCredit credit(CreditType::CHARGING);
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
 
   GrantedUnits gsu;
@@ -238,7 +221,7 @@ TEST(test_is_quota_exhausted_total_only, test_session_credit) {
 }
 
 TEST(test_is_quota_exhausted_rx_only, test_session_credit) {
-  SessionCredit credit(CreditType::CHARGING);
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
 
   GrantedUnits gsu;
@@ -256,7 +239,7 @@ TEST(test_is_quota_exhausted_rx_only, test_session_credit) {
 }
 
 TEST(test_is_quota_exhausted_tx_only, test_session_credit) {
-  SessionCredit credit(CreditType::CHARGING);
+  SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
 
   GrantedUnits gsu;

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -353,18 +353,14 @@ TEST_F(SessionStateTest, test_insert_credit) {
               update_criteria.static_rules_to_install.end());
 
   receive_credit_from_ocs(1, 1024);
-  EXPECT_EQ(session_state->get_charging_credit(1, ALLOWED_TOTAL),
-            1024);
+  EXPECT_EQ(session_state->get_charging_credit(1, ALLOWED_TOTAL), 1024);
   EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)].
-            credit.buckets[ALLOWED_TOTAL],
-            1024);
+            credit.buckets[ALLOWED_TOTAL], 1024);
 
   receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
-  EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL),
-            1024);
+  EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1024);
   EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"].
-            credit.buckets[ALLOWED_TOTAL],
-            1024);
+            credit.buckets[ALLOWED_TOTAL], 1024);
 }
 
 TEST_F(SessionStateTest, test_can_complete_termination) {
@@ -419,15 +415,13 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
   receive_credit_from_ocs(2, 6000);
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 2);
   EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)]
-            .credit.buckets[ALLOWED_TOTAL],
-            3000);
+            .credit.buckets[ALLOWED_TOTAL], 3000);
 
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   receive_credit_from_pcrf("m2", 6000, MonitoringLevel::PCC_RULE_LEVEL);
   EXPECT_EQ(update_criteria.monitor_credit_to_install.size(), 2);
   EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"]
-            .credit.buckets[ALLOWED_TOTAL],
-            3000);
+            .credit.buckets[ALLOWED_TOTAL], 3000);
 
   session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
@@ -483,14 +477,12 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
   receive_credit_from_ocs(3, 8000);
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 2);
   EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(2)]
-            .credit.buckets[ALLOWED_TOTAL],
-            6000);
+            .credit.buckets[ALLOWED_TOTAL], 6000);
 
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
   receive_credit_from_pcrf("m3", 8000, MonitoringLevel::PCC_RULE_LEVEL);
   EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"]
-                .credit.buckets[ALLOWED_TOTAL],
-            3000);
+                .credit.buckets[ALLOWED_TOTAL], 3000);
 
   session_state->add_rule_usage("dyn_rule1", 2000, 1000, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
@@ -568,17 +560,13 @@ TEST_F(SessionStateTest, test_reauth_key) {
   std::vector<std::unique_ptr<ServiceAction>> actions;
   session_state->get_updates(update, &actions, update_criteria);
   EXPECT_EQ(update.updates_size(), 1);
-  EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_TX),
-            1000);
-  EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_RX),
-            500);
+  EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_TX), 1000);
+  EXPECT_EQ(session_state->get_charging_credit(1, REPORTING_RX), 500);
   // Reporting value is not tracked by UpdateCriteria
   EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)]
-                .bucket_deltas[REPORTING_TX],
-            0);
+                .bucket_deltas[REPORTING_TX], 0);
   EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)]
-                .bucket_deltas[REPORTING_RX],
-            0);
+                .bucket_deltas[REPORTING_RX], 0);
   // credit is already reporting, no update needed
   auto uc = get_default_update_criteria();
   auto reauth_res = session_state->reauth_key(1, uc);
@@ -614,11 +602,9 @@ TEST_F(SessionStateTest, test_reauth_new_key) {
   EXPECT_EQ(usage.bytes_rx(), 0);
 
   receive_credit_from_ocs(1, 1024);
-  EXPECT_EQ(session_state->get_charging_credit(1, ALLOWED_TOTAL),
-            1024);
+  EXPECT_EQ(session_state->get_charging_credit(1, ALLOWED_TOTAL), 1024);
   EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)]
-                .bucket_deltas[ALLOWED_TOTAL],
-            1024);
+                .bucket_deltas[ALLOWED_TOTAL], 1024);
 }
 
 TEST_F(SessionStateTest, test_reauth_all) {
@@ -658,16 +644,12 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
   session_state->add_rule_usage("rule1", 1024, 0, update_criteria);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
 
-  EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL),
-            1024);
-  EXPECT_EQ(session_state->get_charging_credit(1, ALLOWED_TOTAL),
-            1024);
+  EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1024);
+  EXPECT_EQ(session_state->get_charging_credit(1, ALLOWED_TOTAL), 1024);
   EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)]
-                .credit.buckets[ALLOWED_TOTAL],
-            1024);
+                .credit.buckets[ALLOWED_TOTAL], 1024);
   EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"]
-                .credit.buckets[ALLOWED_TOTAL],
-            1024);
+                .credit.buckets[ALLOWED_TOTAL], 1024);
 
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
@@ -774,6 +756,34 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   EXPECT_EQ(false,
             session_state->get_dynamic_rules().remove_rule("redirect",
                 &rule_out));
+}
+
+TEST_F(SessionStateTest, test_final_credit_install) {
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
+  CreditUpdateResponse charge_resp;
+  charge_resp.set_success(true);
+  charge_resp.set_sid("IMSI1");
+  charge_resp.set_charging_key(1);
+
+  bool is_final = true;
+  auto p_credit = charge_resp.mutable_credit();
+  create_charging_credit(1024, is_final, p_credit);
+  auto redirect = p_credit->mutable_redirect_server();
+  redirect->set_redirect_server_address("google.com");
+  redirect->set_redirect_address_type(RedirectServer_RedirectAddressType_URL);
+  p_credit->set_final_action(ChargingCredit_FinalAction_REDIRECT);
+
+  session_state->receive_charging_credit(charge_resp, update_criteria);
+
+  // Test that the update criteria is filled out properly
+  EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
+  auto u_credit = update_criteria.charging_credit_to_install[1];
+  EXPECT_TRUE(u_credit.is_final);
+  auto fa = u_credit.final_action_info;
+  EXPECT_EQ(fa.final_action, ChargingCredit_FinalAction_REDIRECT);
+  EXPECT_EQ(fa.redirect_server.redirect_server_address(), "google.com");
+  EXPECT_EQ(fa.redirect_server.redirect_address_type(),
+            RedirectServer_RedirectAddressType_URL);
 }
 
 int main(int argc, char **argv) {

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -761,7 +761,7 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   EXPECT_EQ(rules_out_ptr.size(), 1);
   EXPECT_EQ(rules_out_ptr[0], "redirect");
 
-  EXPECT_EQ(session_state->is_gy_dynamic_rule_installed("redirect"), true);
+  EXPECT_TRUE(session_state->is_gy_dynamic_rule_installed("redirect"));
   EXPECT_EQ(update_criteria.gy_dynamic_rules_to_install.size(), 1);
 
   PolicyRule rule_out;
@@ -772,7 +772,7 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
   session_state->get_gy_dynamic_rules().get_rule_ids(rules_out_ptr);
   EXPECT_EQ(rules_out_ptr.size(), 0);
 
-  EXPECT_EQ(session_state->is_gy_dynamic_rule_installed("redirect"), false);
+  EXPECT_FALSE(session_state->is_gy_dynamic_rule_installed("redirect"));
   EXPECT_EQ(update_criteria.gy_dynamic_rules_to_uninstall.size(), 1);
 
   rules_out = {};
@@ -782,13 +782,11 @@ TEST_F(SessionStateTest, test_install_gy_rules) {
 
   std::string mkey;
   // searching for non-existent rule should fail
-  EXPECT_EQ(false,
-            session_state->get_dynamic_rules().get_monitoring_key_for_rule_id(
-                "redirect", &mkey));
+  EXPECT_FALSE(session_state->get_dynamic_rules().
+               get_monitoring_key_for_rule_id("redirect", &mkey));
   // deleting an already deleted rule should fail
-  EXPECT_EQ(false,
-            session_state->get_dynamic_rules().remove_rule("redirect",
-                &rule_out));
+  EXPECT_FALSE(session_state->get_dynamic_rules().remove_rule("redirect",
+               &rule_out));
 }
 
 TEST_F(SessionStateTest, test_final_credit_install) {

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -137,9 +137,7 @@ class SessionStoreTest : public ::testing::Test {
     auto monitor2 = StoredMonitor{};
     auto credit2 = StoredSessionCredit{};
     credit2.reporting = false;
-    credit2.is_final = false;
     credit2.credit_limit_type = INFINITE_METERED;
-    credit2.service_state = SERVICE_ENABLED;
     credit2.expiry_time = 0;
     credit2.buckets = std::unordered_map<Bucket, uint64_t>{};
     credit2.buckets[USED_TX] = 100;
@@ -157,9 +155,7 @@ class SessionStoreTest : public ::testing::Test {
 
     // Monitoring credit updates
     SessionCreditUpdateCriteria monitoring_update{};
-    monitoring_update.is_final = false;
     monitoring_update.reauth_state = REAUTH_NOT_NEEDED;
-    monitoring_update.service_state = SERVICE_ENABLED;
     monitoring_update.expiry_time = 0;
     auto bucket_deltas = std::unordered_map<Bucket, uint64_t>{};
     bucket_deltas[USED_TX] = 111;

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -138,7 +138,6 @@ class SessionStoreTest : public ::testing::Test {
     auto credit2 = StoredSessionCredit{};
     credit2.reporting = false;
     credit2.credit_limit_type = INFINITE_METERED;
-    credit2.expiry_time = 0;
     credit2.buckets = std::unordered_map<Bucket, uint64_t>{};
     credit2.buckets[USED_TX] = 100;
     credit2.buckets[USED_RX] = 200;

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -63,19 +63,7 @@ protected:
     StoredSessionCredit stored;
 
     stored.reporting = true;
-    stored.is_final = true;
     stored.credit_limit_type = INFINITE_METERED;
-
-    stored.final_action_info.final_action =
-        ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT;
-    stored.final_action_info.redirect_server.set_redirect_address_type(
-        RedirectServer_RedirectAddressType::
-            RedirectServer_RedirectAddressType_IPV6);
-    stored.final_action_info.redirect_server.set_redirect_server_address(
-        "redirect_server_address");
-
-    stored.service_state = SERVICE_NEEDS_ACTIVATION;
-
     stored.expiry_time = 16;
 
     stored.buckets[USED_TX] = 12345;
@@ -207,20 +195,7 @@ TEST_F(StoredStateTest, test_stored_session_credit) {
   auto deserialized = deserialize_stored_session_credit(serialized);
 
   EXPECT_EQ(deserialized.reporting, true);
-  EXPECT_EQ(deserialized.is_final, true);
   EXPECT_EQ(deserialized.credit_limit_type, INFINITE_METERED);
-
-  EXPECT_EQ(deserialized.final_action_info.final_action,
-            ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT);
-  EXPECT_EQ(
-      deserialized.final_action_info.redirect_server.redirect_address_type(),
-      RedirectServer_RedirectAddressType::
-          RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(
-      deserialized.final_action_info.redirect_server.redirect_server_address(),
-      "redirect_server_address");
-
-  EXPECT_EQ(deserialized.service_state, SERVICE_NEEDS_ACTIVATION);
 
   EXPECT_EQ(deserialized.expiry_time, 16);
   EXPECT_EQ(deserialized.buckets[USED_TX], 12345);
@@ -236,18 +211,7 @@ TEST_F(StoredStateTest, test_stored_monitor) {
   auto deserialized = deserialize_stored_monitor(serialized);
 
   EXPECT_EQ(deserialized.credit.reporting, true);
-  EXPECT_EQ(deserialized.credit.is_final, true);
   EXPECT_EQ(deserialized.credit.credit_limit_type, INFINITE_METERED);
-  EXPECT_EQ(deserialized.credit.final_action_info.final_action,
-            ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT);
-  EXPECT_EQ(deserialized.credit.final_action_info.redirect_server
-                .redirect_address_type(),
-            RedirectServer_RedirectAddressType::
-                RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(deserialized.credit.final_action_info.redirect_server
-                .redirect_server_address(),
-            "redirect_server_address");
-  EXPECT_EQ(deserialized.credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(deserialized.credit.expiry_time, 16);
   EXPECT_EQ(deserialized.credit.buckets[USED_TX], 12345);
   EXPECT_EQ(deserialized.credit.buckets[ALLOWED_TOTAL], 54321);
@@ -284,17 +248,6 @@ TEST_F(StoredStateTest, test_stored_charging_credit_map) {
   EXPECT_EQ(credit.buckets[ALLOWED_TOTAL], 54321);
 
   // test session credit fields that will be deprecated
-  EXPECT_EQ(credit.is_final, true);
-  EXPECT_EQ(credit.final_action_info.final_action,
-            ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT);
-  EXPECT_EQ(
-      credit.final_action_info.redirect_server.redirect_address_type(),
-      RedirectServer_RedirectAddressType::
-          RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(
-      credit.final_action_info.redirect_server.redirect_server_address(),
-      "redirect_server_address");
-  EXPECT_EQ(credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(credit.expiry_time, 16);
 }
 
@@ -306,18 +259,7 @@ TEST_F(StoredStateTest, test_stored_monitor_map) {
 
   auto stored_monitor = deserialized["mk1"];
   EXPECT_EQ(stored_monitor.credit.reporting, true);
-  EXPECT_EQ(stored_monitor.credit.is_final, true);
   EXPECT_EQ(stored_monitor.credit.credit_limit_type, INFINITE_METERED);
-  EXPECT_EQ(stored_monitor.credit.final_action_info.final_action,
-            ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT);
-  EXPECT_EQ(stored_monitor.credit.final_action_info.redirect_server
-                .redirect_address_type(),
-            RedirectServer_RedirectAddressType::
-                RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(stored_monitor.credit.final_action_info.redirect_server
-                .redirect_server_address(),
-            "redirect_server_address");
-  EXPECT_EQ(stored_monitor.credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(stored_monitor.credit.expiry_time, 16);
   EXPECT_EQ(stored_monitor.credit.buckets[USED_TX], 12345);
   EXPECT_EQ(stored_monitor.credit.buckets[ALLOWED_TOTAL], 54321);
@@ -366,40 +308,18 @@ TEST_F(StoredStateTest, test_stored_session) {
   // test session credit fields
   auto credit = stored_charging_credit.credit;
   EXPECT_EQ(credit.reporting, true);
-  EXPECT_EQ(credit.is_final, true);
   EXPECT_EQ(credit.buckets[USED_TX], 12345);
   EXPECT_EQ(credit.buckets[ALLOWED_TOTAL], 54321);
   EXPECT_EQ(credit.credit_limit_type, INFINITE_METERED);
 
   // test session credit to be deprecated
-  EXPECT_EQ(credit.final_action_info.final_action,
-            ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT);
-  EXPECT_EQ(
-      credit.final_action_info.redirect_server.redirect_address_type(),
-      RedirectServer_RedirectAddressType::
-          RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(
-      credit.final_action_info.redirect_server.redirect_server_address(),
-      "redirect_server_address");
-  EXPECT_EQ(credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(credit.expiry_time, 16);
 
   EXPECT_EQ(deserialized.session_level_key, "session_level_key");
 
   auto stored_monitor = deserialized.monitor_map["mk1"];
   EXPECT_EQ(stored_monitor.credit.reporting, true);
-  EXPECT_EQ(stored_monitor.credit.is_final, true);
   EXPECT_EQ(stored_monitor.credit.credit_limit_type, INFINITE_METERED);
-  EXPECT_EQ(stored_monitor.credit.final_action_info.final_action,
-            ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT);
-  EXPECT_EQ(stored_monitor.credit.final_action_info.redirect_server
-                .redirect_address_type(),
-            RedirectServer_RedirectAddressType::
-                RedirectServer_RedirectAddressType_IPV6);
-  EXPECT_EQ(stored_monitor.credit.final_action_info.redirect_server
-                .redirect_server_address(),
-            "redirect_server_address");
-  EXPECT_EQ(stored_monitor.credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(stored_monitor.credit.expiry_time, 16);
   EXPECT_EQ(stored_monitor.credit.buckets[USED_TX], 12345);
   EXPECT_EQ(stored_monitor.credit.buckets[ALLOWED_TOTAL], 54321);

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -74,7 +74,6 @@ protected:
     stored.final_action_info.redirect_server.set_redirect_server_address(
         "redirect_server_address");
 
-    stored.reauth_state = REAUTH_REQUIRED;
     stored.service_state = SERVICE_NEEDS_ACTIVATION;
 
     stored.expiry_time = 16;
@@ -99,8 +98,8 @@ protected:
     stored.final_action_info.redirect_server.set_redirect_server_address(
         "redirect_server_address");
 
-    stored.reauth_state = REAUTH_REQUIRED;
     stored.service_state = SERVICE_NEEDS_ACTIVATION;
+    stored.reauth_state = REAUTH_REQUIRED;
 
     stored.expiry_time = 32;
     stored.credit = get_stored_session_credit();
@@ -221,7 +220,6 @@ TEST_F(StoredStateTest, test_stored_session_credit) {
       deserialized.final_action_info.redirect_server.redirect_server_address(),
       "redirect_server_address");
 
-  EXPECT_EQ(deserialized.reauth_state, REAUTH_REQUIRED);
   EXPECT_EQ(deserialized.service_state, SERVICE_NEEDS_ACTIVATION);
 
   EXPECT_EQ(deserialized.expiry_time, 16);
@@ -249,7 +247,6 @@ TEST_F(StoredStateTest, test_stored_monitor) {
   EXPECT_EQ(deserialized.credit.final_action_info.redirect_server
                 .redirect_server_address(),
             "redirect_server_address");
-  EXPECT_EQ(deserialized.credit.reauth_state, REAUTH_REQUIRED);
   EXPECT_EQ(deserialized.credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(deserialized.credit.expiry_time, 16);
   EXPECT_EQ(deserialized.credit.buckets[USED_TX], 12345);
@@ -297,7 +294,6 @@ TEST_F(StoredStateTest, test_stored_charging_credit_map) {
   EXPECT_EQ(
       credit.final_action_info.redirect_server.redirect_server_address(),
       "redirect_server_address");
-  EXPECT_EQ(credit.reauth_state, REAUTH_REQUIRED);
   EXPECT_EQ(credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(credit.expiry_time, 16);
 }
@@ -321,7 +317,6 @@ TEST_F(StoredStateTest, test_stored_monitor_map) {
   EXPECT_EQ(stored_monitor.credit.final_action_info.redirect_server
                 .redirect_server_address(),
             "redirect_server_address");
-  EXPECT_EQ(stored_monitor.credit.reauth_state, REAUTH_REQUIRED);
   EXPECT_EQ(stored_monitor.credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(stored_monitor.credit.expiry_time, 16);
   EXPECT_EQ(stored_monitor.credit.buckets[USED_TX], 12345);
@@ -386,7 +381,6 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(
       credit.final_action_info.redirect_server.redirect_server_address(),
       "redirect_server_address");
-  EXPECT_EQ(credit.reauth_state, REAUTH_REQUIRED);
   EXPECT_EQ(credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(credit.expiry_time, 16);
 
@@ -405,7 +399,6 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(stored_monitor.credit.final_action_info.redirect_server
                 .redirect_server_address(),
             "redirect_server_address");
-  EXPECT_EQ(stored_monitor.credit.reauth_state, REAUTH_REQUIRED);
   EXPECT_EQ(stored_monitor.credit.service_state, SERVICE_NEEDS_ACTIVATION);
   EXPECT_EQ(stored_monitor.credit.expiry_time, 16);
   EXPECT_EQ(stored_monitor.credit.buckets[USED_TX], 12345);

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -64,7 +64,6 @@ protected:
 
     stored.reporting = true;
     stored.credit_limit_type = INFINITE_METERED;
-    stored.expiry_time = 16;
 
     stored.buckets[USED_TX] = 12345;
     stored.buckets[ALLOWED_TOTAL] = 54321;
@@ -197,7 +196,6 @@ TEST_F(StoredStateTest, test_stored_session_credit) {
   EXPECT_EQ(deserialized.reporting, true);
   EXPECT_EQ(deserialized.credit_limit_type, INFINITE_METERED);
 
-  EXPECT_EQ(deserialized.expiry_time, 16);
   EXPECT_EQ(deserialized.buckets[USED_TX], 12345);
   EXPECT_EQ(deserialized.buckets[ALLOWED_TOTAL], 54321);
 
@@ -212,7 +210,6 @@ TEST_F(StoredStateTest, test_stored_monitor) {
 
   EXPECT_EQ(deserialized.credit.reporting, true);
   EXPECT_EQ(deserialized.credit.credit_limit_type, INFINITE_METERED);
-  EXPECT_EQ(deserialized.credit.expiry_time, 16);
   EXPECT_EQ(deserialized.credit.buckets[USED_TX], 12345);
   EXPECT_EQ(deserialized.credit.buckets[ALLOWED_TOTAL], 54321);
   EXPECT_EQ(deserialized.level, MonitoringLevel::PCC_RULE_LEVEL);
@@ -246,9 +243,6 @@ TEST_F(StoredStateTest, test_stored_charging_credit_map) {
   EXPECT_EQ(credit.credit_limit_type, INFINITE_METERED);
   EXPECT_EQ(credit.buckets[USED_TX], 12345);
   EXPECT_EQ(credit.buckets[ALLOWED_TOTAL], 54321);
-
-  // test session credit fields that will be deprecated
-  EXPECT_EQ(credit.expiry_time, 16);
 }
 
 TEST_F(StoredStateTest, test_stored_monitor_map) {
@@ -260,7 +254,6 @@ TEST_F(StoredStateTest, test_stored_monitor_map) {
   auto stored_monitor = deserialized["mk1"];
   EXPECT_EQ(stored_monitor.credit.reporting, true);
   EXPECT_EQ(stored_monitor.credit.credit_limit_type, INFINITE_METERED);
-  EXPECT_EQ(stored_monitor.credit.expiry_time, 16);
   EXPECT_EQ(stored_monitor.credit.buckets[USED_TX], 12345);
   EXPECT_EQ(stored_monitor.credit.buckets[ALLOWED_TOTAL], 54321);
   EXPECT_EQ(stored_monitor.level, MonitoringLevel::PCC_RULE_LEVEL);
@@ -312,15 +305,11 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(credit.buckets[ALLOWED_TOTAL], 54321);
   EXPECT_EQ(credit.credit_limit_type, INFINITE_METERED);
 
-  // test session credit to be deprecated
-  EXPECT_EQ(credit.expiry_time, 16);
-
   EXPECT_EQ(deserialized.session_level_key, "session_level_key");
 
   auto stored_monitor = deserialized.monitor_map["mk1"];
   EXPECT_EQ(stored_monitor.credit.reporting, true);
   EXPECT_EQ(stored_monitor.credit.credit_limit_type, INFINITE_METERED);
-  EXPECT_EQ(stored_monitor.credit.expiry_time, 16);
   EXPECT_EQ(stored_monitor.credit.buckets[USED_TX], 12345);
   EXPECT_EQ(stored_monitor.credit.buckets[ALLOWED_TOTAL], 54321);
   EXPECT_EQ(stored_monitor.level, MonitoringLevel::PCC_RULE_LEVEL);


### PR DESCRIPTION
Summary:
## Migrate Gy Specific logic out of SessionCredit into ChargingGrant
- `SessionCredit` currently have quite a bit of Gy specific logic. Since the class is used to track usage/quota for both Gx and Gy credits, it would simplify things to have two separate structures `Monitor` and `ChargingGrant` that use `SessionCredit` for only credit accounting.
- `ChargingGrant` will hold final unit action info, expiry time, reauth state, and service state. These fields will be moved out of `SessionCredit` after the migration is complete.
- It will be serialized to `StoredChargingGrant` for serialization

## What this diff changes
- SessionCredit no longer holds any Gx/Gy specific logic so remove the CreditType. :)
- Rearrange some function declarations in ChargingGrant.h so bunch get_* set_*, etc.

Differential Revision: D22292931

