### PR TITLE
fix vet warning in lib/go

### DIFF
--- a/orc8r/lib/go/initflag/initflag.go
+++ b/orc8r/lib/go/initflag/initflag.go
@@ -51,7 +51,7 @@ func init() {
 	}
 	// Check if the process needs to redirect stdout to stderr
 	if *stdoutToStderr {
-		stdout, os.Stdout = os.Stderr, os.Stdout
+		stdout, os.Stdout = os.Stdout, os.Stderr
 	}
 }
 

--- a/orc8r/lib/go/initflag/syslog.go
+++ b/orc8r/lib/go/initflag/syslog.go
@@ -107,8 +107,8 @@ func redirectToSyslog() error {
 		syslogWriter.Emerg(msg)
 		os.Stderr = stderr
 		log.SetOutput(stderr)
-		if *stdoutToStderr {
-			os.Stdout = stderr
+		if *stdoutToStderr && stdout != nil {
+			os.Stdout = stdout
 		}
 		log.Print(msg) // also log into stderr
 		writer.Close()


### PR DESCRIPTION
Summary: fix vet warning in lib/go due to redundant stdout assignment

Reviewed By: uri200

Differential Revision: D22304466

