### PR TITLE
Add echo port config to service location

### DIFF
--- a/orc8r/lib/go/registry/global_registry.go
+++ b/orc8r/lib/go/registry/global_registry.go
@@ -65,6 +65,12 @@ func GetServicePort(service string) (int, error) {
 	return globalRegistry.GetServicePort(service)
 }
 
+// GetEchoServerPort returns the listening port for the service's echo server.
+// The echo_port field needs to be added to the registry before this.
+func GetEchoServerPort(service string) (int, error) {
+	return globalRegistry.GetEchoServerPort(service)
+}
+
 // GetConnection provides a gRPC connection to a service in the registry.
 func GetConnection(service string) (*grpc.ClientConn, error) {
 	return globalRegistry.GetConnection(service)

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -25,6 +25,7 @@ type ServiceLocation struct {
 	Name         string
 	Host         string
 	Port         int
+	EchoPort     int
 	ProxyAliases map[string]int
 }
 
@@ -148,6 +149,22 @@ func (registry *ServiceRegistry) GetServicePort(service string) (int, error) {
 		return 0, fmt.Errorf("Service %s is not available", service)
 	}
 	return location.Port, nil
+}
+
+// GetEchoServerPort returns the listening port for the service's echo server.
+// The echo_port field needs to be added to the registry before this.
+func (registry *ServiceRegistry) GetEchoServerPort(service string) (int, error) {
+	registry.RLock()
+	defer registry.RUnlock()
+	location, ok := registry.ServiceLocations[strings.ToUpper(string(service))]
+	if !ok {
+		return 0, fmt.Errorf("failed to get echo server port: Service '%s' not registered", service)
+	}
+
+	if location.EchoPort == 0 {
+		return 0, fmt.Errorf("Echo server port for service %s is not available", service)
+	}
+	return location.EchoPort, nil
 }
 
 func (registry *ServiceRegistry) addUnsafe(location ServiceLocation) {

--- a/orc8r/lib/go/service/serviceregistry/service_registry.go
+++ b/orc8r/lib/go/service/serviceregistry/service_registry.go
@@ -93,8 +93,14 @@ func convertToServiceLocations(rawMap rawMapType) ([]registry.ServiceLocation, e
 		if err != nil {
 			return nil, err
 		}
+		// echoPort is an optional field used for services which run an echo
+		// server
+		echoPort, err := configMap.GetInt("echo_port")
+		if err != nil {
+			echoPort = 0
+		}
 		proxyAliases := getProxyAliases(rawMap)
-		serviceLocations = append(serviceLocations, registry.ServiceLocation{Name: strings.ToUpper(name), Host: host, Port: port, ProxyAliases: proxyAliases})
+		serviceLocations = append(serviceLocations, registry.ServiceLocation{Name: strings.ToUpper(name), Host: host, Port: port, EchoPort: echoPort, ProxyAliases: proxyAliases})
 	}
 	return serviceLocations, nil
 }


### PR DESCRIPTION
Summary:
This diff adds an echo_port configuration to the
service_registry.yml file. This will be used by any
service that has obisidian handlers.

Reviewed By: xjtian

Differential Revision: D22194463

