### PR TITLE
PipelineD: Add egress flow for NonNAT

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -6,10 +6,23 @@ This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
+import threading
+
 from collections import namedtuple
+
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
+from threading import Thread
+
+from scapy.arch import get_if_hwaddr
+from scapy.data import ETHER_BROADCAST, ETH_P_ARP
+from scapy.error import Scapy_Exception
+from scapy.layers.l2 import ARP, Ether
+from scapy.sendrecv import srp1
 
 from .base import MagmaController
+from magma.mobilityd import mobility_store as store
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+
 from magma.pipelined.app.li_mirror import LIMirrorController
 from magma.pipelined.openflow import flows
 from magma.pipelined.bridge_util import BridgeTools
@@ -39,21 +52,25 @@ class InOutController(MagmaController):
 
     InOutConfig = namedtuple(
         'InOutConfig',
-        ['gtp_port', 'uplink_port_name', 'mtr_ip', 'mtr_port', 'li_port_name'],
+        ['gtp_port', 'uplink_port_name', 'mtr_ip', 'mtr_port', 'li_port_name',
+         'non_nat', 'non_mat_gw_probe_frequency', 'non_nat_arp_egress_port'],
     )
+    ARP_PROBE_FREQUENCY = 300
+    UPLINK_DPCP_PORT_NAME = 'dhcp0'
 
     def __init__(self, *args, **kwargs):
         super(InOutController, self).__init__(*args, **kwargs)
         self.config = self._get_config(kwargs['config'])
         self._uplink_port = OFPP_LOCAL
         self._li_port = None
-        #TODO Alex do we want this to be cofigurable from swagger?
+        # TODO Alex do we want this to be cofigurable from swagger?
         if self.config.mtr_ip:
             self._mtr_service_enabled = True
         else:
             self._mtr_service_enabled = False
-        if (self.config.uplink_port_name):
+        if self.config.uplink_port_name:
             self._uplink_port = BridgeTools.get_ofport(self.config.uplink_port_name)
+
         if (self._service_manager.is_app_enabled(LIMirrorController.APP_NAME)
                 and self.config.li_port_name):
             self._li_port = BridgeTools.get_ofport(self.config.li_port_name)
@@ -63,6 +80,9 @@ class InOutController(MagmaController):
         self._midle_tbl_num = \
             self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL)
         self._egress_tbl_num = self._service_manager.get_table_num(EGRESS)
+        # following fields are only used in Non Nat config
+        self._dhcp_gw_info = None
+        self._gw_mac_monitor = None
 
     def _get_config(self, config_dict):
         port_name = None
@@ -79,12 +99,21 @@ class InOutController(MagmaController):
         if 'li_local_iface' in config_dict:
             li_port_name = config_dict['li_local_iface']
 
+        non_nat = config_dict.get('non_nat', False)
+        non_mat_gw_probe_freq = config_dict.get('non_mat_gw_probe_frequency',
+                                                self.ARP_PROBE_FREQUENCY)
+        non_nat_arp_egress_port = config_dict.get('non_nat_arp_egress_port',
+                                                  self.UPLINK_DPCP_PORT_NAME)
+
         return self.InOutConfig(
             gtp_port=config_dict['ovs_gtp_port_number'],
             uplink_port_name=port_name,
             mtr_ip=mtr_ip,
             mtr_port=mtr_port,
-            li_port_name=li_port_name
+            li_port_name=li_port_name,
+            non_nat=non_nat,
+            non_mat_gw_probe_frequency=non_mat_gw_probe_freq,
+            non_nat_arp_egress_port=non_nat_arp_egress_port,
         )
 
     def initialize_on_connect(self, datapath):
@@ -92,6 +121,7 @@ class InOutController(MagmaController):
         self._install_default_egress_flows(datapath)
         self._install_default_ingress_flows(datapath)
         self._install_default_middle_flows(datapath)
+        self._set_non_nat(datapath)
 
     def cleanup_on_disconnect(self, datapath):
         self.delete_all_flows(datapath)
@@ -114,24 +144,24 @@ class InOutController(MagmaController):
         # Allow passthrough pkts(skip enforcement and send to egress table)
         ps_match = MagmaMatch(passthrough=PASSTHROUGH_REG_VAL)
         flows.add_resubmit_next_service_flow(dp, self._midle_tbl_num, ps_match,
-            actions=[], priority=flows.PASSTHROUGH_PRIORITY,
-            resubmit_table=self._egress_tbl_num)
+                                             actions=[], priority=flows.PASSTHROUGH_PRIORITY,
+                                             resubmit_table=self._egress_tbl_num)
 
         match = MagmaMatch()
         flows.add_resubmit_next_service_flow(dp,
-            self._midle_tbl_num, match,
-            actions=[], priority=flows.DEFAULT_PRIORITY,
-            resubmit_table=next_tbl)
+                                             self._midle_tbl_num, match,
+                                             actions=[], priority=flows.DEFAULT_PRIORITY,
+                                             resubmit_table=next_tbl)
 
         if self._mtr_service_enabled:
             match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
                                ipv4_dst=self.config.mtr_ip)
             flows.add_output_flow(dp,
-                self._midle_tbl_num, match,
-                [], priority=flows.UE_FLOW_PRIORITY,
-                output_port=self.config.mtr_port)
+                                  self._midle_tbl_num, match,
+                                  [], priority=flows.UE_FLOW_PRIORITY,
+                                  output_port=self.config.mtr_port)
 
-    def _install_default_egress_flows(self, dp):
+    def _install_default_egress_flows(self, dp, mac_addr: str = None):
         """
         Egress table is the last table that a packet touches in the pipeline.
         Output downlink traffic to gtp port, uplink trafic to LOCAL
@@ -144,7 +174,13 @@ class InOutController(MagmaController):
                               output_port=self.config.gtp_port)
 
         uplink_match = MagmaMatch(direction=Direction.OUT)
-        flows.add_output_flow(dp, self._egress_tbl_num, uplink_match, [],
+        actions = []
+        if mac_addr is not None:
+            parser = dp.ofproto_parser
+            actions.append(parser.OFPActionSetField(eth_dst=mac_addr))
+            self.logger.info("Using GW: %s actions: %s", mac_addr, str(actions))
+
+        flows.add_output_flow(dp, self._egress_tbl_num, uplink_match, actions,
                               output_port=self._uplink_port)
 
     def _install_default_ingress_flows(self, dp):
@@ -198,13 +234,101 @@ class InOutController(MagmaController):
             match = MagmaMatch(in_port=self._li_port)
             actions = [load_direction(parser, Direction.IN)]
             flows.add_resubmit_next_service_flow(dp, self._ingress_tbl_num,
-                match, actions=actions, priority=flows.DEFAULT_PRIORITY,
-                resubmit_table=self._li_table)
+                                                 match, actions=actions, priority=flows.DEFAULT_PRIORITY,
+                                                 resubmit_table=self._li_table)
 
         # set a direction bit for incoming (mtr -> UE) traffic.
         if self._mtr_service_enabled:
             match = MagmaMatch(in_port=self.config.mtr_port)
             actions = [load_direction(parser, Direction.IN)]
             flows.add_resubmit_next_service_flow(dp, self._ingress_tbl_num,
-                match, actions=actions, priority=flows.DEFAULT_PRIORITY,
-                resubmit_table=next_table)
+                                                 match, actions=actions, priority=flows.DEFAULT_PRIORITY,
+                                                 resubmit_table=next_table)
+
+    def _get_gw_mac_address(self, gw_ip: str) -> str:
+        try:
+            self.logger.debug("sending arp for IP: %s ovs egress: %s",
+                              gw_ip, self.config.non_nat_arp_egress_port)
+            eth_mac_src = get_if_hwaddr(self.config.non_nat_arp_egress_port)
+
+            pkt = Ether(dst=ETHER_BROADCAST, src=eth_mac_src)
+            pkt /= ARP(op="who-has", pdst=gw_ip, hwsrc=eth_mac_src, psrc="0.0.0.0")
+            self.logger.debug("pkt: %s", pkt.summary())
+
+            res = srp1(pkt,
+                       type=ETH_P_ARP,
+                       iface=self.config.non_nat_arp_egress_port,
+                       timeout=1,
+                       verbose=0,
+                       nofilter=1,
+                       promisc=0)
+
+            if res is not None:
+                self.logger.debug("resp: %s ", res.summary())
+                mac = res[ARP].hwsrc
+                return mac
+            else:
+                self.logger.debug("Got Null response")
+
+        except Scapy_Exception as ex:
+            self.logger.warning("Error in probing Mac address: err %s", ex)
+            return None
+
+    def _monitor_and_update(self, datapath):
+        current_feq = self.config.non_mat_gw_probe_frequency
+        current_mac = None
+        if self._dhcp_gw_info.getMac() is not None:
+            current_mac = self._dhcp_gw_info.getMac()
+            self._install_default_egress_flows(datapath, current_mac)
+            flows.set_barrier(datapath)
+
+        while True:
+            ip = self._dhcp_gw_info.getIP()
+            if ip is not None:
+                self.logger.info("GW found: %s", ip)
+                latest_mac_addr = self._get_gw_mac_address(ip)
+                if latest_mac_addr is not None:
+                    # got back to configured frequency.
+                    current_feq = self.config.non_mat_gw_probe_frequency
+                    if current_mac != latest_mac_addr:
+                        self.logger.info("Current mac %s updated gw mac: %s",
+                                         current_mac, latest_mac_addr)
+                        current_mac = latest_mac_addr
+
+                        self._install_default_egress_flows(datapath, current_mac)
+                        flows.set_barrier(datapath)
+                        self._dhcp_gw_info.update_mac(current_mac)
+            else:
+                self.logger.warning("No default GW found.")
+                # increase frequency.
+                current_feq = 1
+
+            e = threading.Event()
+            self.logger.debug("non_mat_gw_probe_frequency: %s ip: %s mac: %s",
+                              current_feq,
+                              ip, current_mac)
+            e.wait(timeout=current_feq)
+
+    def _set_non_nat(self, datapath):
+        """
+        Setup egress flow to forward traffic to internet GW.
+        Start a thread to figure out MAC address of uplink NAT gw.
+
+        :param datapath: datapath to install flows.
+        :return: None
+        """
+        if self.config.non_nat is False:
+            self.logger.info("Nat is on")
+            return
+        else:
+            self.logger.info("Non nat conf: Frequency:%s, egress port: %s, uplink: %s",
+                             self.config.non_mat_gw_probe_frequency,
+                             self.config.non_nat_arp_egress_port,
+                             self._uplink_port)
+
+        self._dhcp_gw_info = UplinkGatewayInfo(store.GatewayInfoMap())
+        self._gw_mac_monitor = Thread(target=self._monitor_and_update,
+                                      args=(datapath,))
+        self._gw_mac_monitor.setDaemon(True)
+        self._gw_mac_monitor.start()
+        threading.Event().wait(1)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,7 @@
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=mod_dl_dst:b2:a0:cc:85:80:7a,output:2

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -1,0 +1,133 @@
+"""
+Copyright (c) 2019-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import logging
+import subprocess
+import threading
+import unittest
+import warnings
+from concurrent.futures import Future
+from unittest import mock
+from magma.common.redis.mocks.mock_redis import MockRedis
+
+from magma.mobilityd.uplink_gw import DHCP_Router_key, DHCP_Router_Mac_key
+from magma.mobilityd import mobility_store as store
+
+from magma.pipelined.tests.app.start_pipelined import (
+    TestSetup,
+    PipelinedController,
+)
+from magma.pipelined.bridge_util import BridgeTools
+from magma.pipelined.tests.pipelined_test_util import (
+    start_ryu_app_thread,
+    stop_ryu_app_thread,
+    create_service_manager,
+    assert_bridge_snapshot_match,
+)
+
+
+class InOutNonNatTest(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+    script_path = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
+    uplink_br = "t_up_br0"
+    setup_done = False
+
+    @classmethod
+    def setup_uplink_br(cls):
+        subprocess.check_call(["redis-cli", "flushall"])
+
+        setup_dhcp_server = cls.script_path + "scripts/setup-test-dhcp-srv.sh"
+        subprocess.check_call([setup_dhcp_server, "t1"])
+
+        BridgeTools.destroy_bridge(cls.uplink_br)
+        setup_uplink_br = [cls.script_path + "scripts/setup-uplink-br.sh",
+                           cls.uplink_br,
+                           "t1uplink_p0",
+                           "8A:00:00:00:00:01"]
+        subprocess.check_call(setup_uplink_br)
+        cls.setup_done = True
+
+    @mock.patch("redis.Redis", MockRedis)
+    def setUp(self):
+        self._dhcp_gw_info_mock = store.GatewayInfoMap()
+
+        self._dhcp_gw_info_mock[DHCP_Router_key] = '192.168.128.100'
+        logging.info("set router key [{}]".format(self._dhcp_gw_info_mock[DHCP_Router_key]))
+
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        cls = self.__class__
+        super(InOutNonNatTest, cls).setUpClass()
+        warnings.simplefilter('ignore')
+
+        cls.setup_uplink_br()
+        cls.service_manager = create_service_manager([])
+
+        inout_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.InOut,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.InOut:
+                    inout_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'non_nat': True,
+                'non_mat_gw_probe_frequency': .2,
+                'non_nat_arp_egress_port': 't_dhcp0',
+                'ovs_uplink_port_name': 'patch-up'
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
+        cls.thread = start_ryu_app_thread(test_setup)
+
+        cls.inout_controller = inout_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+
+    @mock.patch("redis.Redis", MockRedis)
+    def testFlowSnapshotMatch(self):
+        # wait for atleast one iteration of the ARP probe.
+        while DHCP_Router_Mac_key not in self._dhcp_gw_info_mock:
+            threading.Event().wait(0.01)
+
+        threading.Event().wait(0.5)
+        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
+        print("done")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Summary:
For egress flow we need to find Mac Address of upstream GW.
This patch adds ARP probing thread to inout app. It uses
result of probe to generate egress flow that sets the mac adress.

Reviewed By: koolzz

Differential Revision: D22132782

