### PR TITLE
Adding scripts to configure stateless mode

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+SRC_DIR=$MAGMA_ROOT/lte/gateway/deploy/roles/magma/files
+SERVICE_LIST=("mme" "mobilityd" "pipelined" "sessiond")
+RETURN_STATELESS=0
+RETURN_STATEFUL=1
+RETURN_CORRUPT=2
+RETURN_INVALID=3
+
+function check_stateless_agw {
+  echo "Checking stateless AGW config"
+  num_stateful=0
+  for service_name in "${SERVICE_LIST[@]}"
+  do
+    if ! "$SRC_DIR/config_stateless_$service_name.sh" check; then
+      num_stateful=$((num_stateful + 1))
+    fi
+  done
+  if [[ $num_stateful -eq 0 ]]; then
+    return $RETURN_STATELESS
+  elif [[ $num_stateful -eq ${#SERVICE_LIST[@]} ]]; then
+    return $RETURN_STATEFUL
+  fi
+  return $RETURN_CORRUPT
+}
+
+if [[ $1 == "check" ]]; then
+  check_stateless_agw; ret_check=$?
+  if [[ $ret_check -eq 1 ]]; then
+    echo "AGW is stateful."
+    exit $RETURN_STATEFUL
+  elif [[ $ret_check -eq 2 ]]; then
+    echo "Some AGW services are stateless, while others are not."
+    echo "Please run with enable/disable command to fix it."
+    exit $RETURN_CORRUPT
+  fi
+
+  echo "AGW is stateless."
+  exit $RETURN_STATELESS
+elif [[ $1 == "disable" ]]; then
+  check_stateless_agw; ret_check=$?
+  if [[ $ret_check -eq 1 ]]; then
+    echo "Nothing to disable, AGW is stateful"
+  exit $RETURN_STATEFUL
+  fi
+
+  echo "Disabling stateless AGW config"
+  for service_name in "${SERVICE_LIST[@]}"
+  do
+    sudo "$SRC_DIR/config_stateless_$service_name.sh" disable
+  done
+elif [[ $1 == "enable" ]]; then
+  if check_stateless_agw; then      # Checks whether return was success, i.e. 0
+    echo "Nothing to enable, AGW is stateless"
+    exit $RETURN_STATELESS
+  fi
+  echo "Enabling stateless AGW config"
+  for service_name in "${SERVICE_LIST[@]}"
+  do
+    sudo "$SRC_DIR/config_stateless_$service_name.sh" enable
+  done
+else
+  echo "Invalid argument. Use one of the following"
+  echo "check: Run a check whether AGW is stateless or not"
+  echo "enable: Enable stateless mode, do nothing if already stateless"
+  echo "disable: Disable stateless mode, do nothing if already stateful"
+  exit $RETURN_INVALID
+fi
+
+sudo service magma@* stop
+
+# Remove all stored state from redis
+sudo service magma@redis start
+redis-cli -p 6380 FLUSHALL
+sudo service magma@redis stop
+
+sudo service magma@magmad start
+# Sleep for a bit so OVS and Magma services come up before proceeding
+sleep 15
+echo "Config complete"
+
+check_stateless_agw; ret_check=$?
+exit $ret_check

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_mme.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_mme.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+MME_DEPS=("magma@mobilityd" "magma@pipelined" "magma@sessiond" "sctpd")
+
+function check_systemd_file {
+  service_name=$1
+  if grep -q "^#PartOf=magma@mme" /etc/systemd/system/"$service_name".service
+  then
+    return 0
+  fi
+  echo "The $service_name service will restart with MME, i.e. stateful."
+  exit 1
+}
+
+if [[ $1 == "check" ]]; then
+  # check dependency in systemd files of other services
+  for service_name in "${MME_DEPS[@]}"
+  do
+    check_systemd_file "$service_name"
+  done
+
+  #check service config
+  if ! grep -q "use_stateless.*true" /etc/magma/mme.yml; then
+    echo "MME config file is stateful."
+    exit 1
+  fi
+
+  echo "MME service is stateless."
+  exit 0
+elif [[ $1 == "disable" ]]; then
+  echo "Disabling stateless MME config"
+  # force other services to restart when MME restarts
+  for service_name in "${MME_DEPS[@]}"
+  do
+    sudo sed -e '/PartOf=magma@mme/ s/^#*//' -i \
+      /etc/systemd/system/"$service_name".service
+  done
+
+  # change use_stateless setting in mme.yml
+  sed -e '/use_stateless/ s/true/false/' -i /etc/magma/mme.yml
+elif [[ $1 == "enable" ]]; then
+  echo "Enabling stateless MME config"
+  # stop other services from restarting when MME restarts
+  for service_name in "${MME_DEPS[@]}"
+  do
+    sudo sed -e '/PartOf=magma@mme/ s/^#*/#/' -i \
+      /etc/systemd/system/"$service_name".service
+  done
+
+  # change use_stateless setting in mme.yml
+  sed -e '/use_stateless/ s/false/true/' -i /etc/magma/mme.yml
+else
+  echo "Invalid argument. Use one of the following"
+  echo "check: Run a check whether MME is stateless or not"
+  echo "enable: Enable stateless mode, do nothing if already stateless"
+  echo "disable: Disable stateless mode, do nothing if already stateful"
+  exit 0
+fi
+
+# reload systemd config
+sudo systemctl daemon-reload

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_mobilityd.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_mobilityd.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [[ $1 == "check" ]]; then
+  # check dependency in systemd files of other services
+  if ! grep -q "^#PartOf=magma@mobilityd" /etc/systemd/system/magma@mme.service
+  then
+    echo "MME will restart with mobilityd, i.e. stateful."
+    exit 1
+  fi
+
+  #check service config
+  if ! grep -q "persist_to_redis.*true" /etc/magma/mobilityd.yml; then
+    echo "Mobilityd config file is stateful."
+    exit 1
+  fi
+
+  echo "Mobilityd service is stateless."
+  exit 0
+elif [[ $1 == "disable" ]]; then
+  echo "Disabling stateless mobilityd config"
+  # restore restart dependencies between mobilityd and other services
+  sudo sed -e '/PartOf=magma@mobilityd/ s/^#*//' -i \
+    /etc/systemd/system/magma@mme.service
+
+  # change persist_to_redis setting in mobilityd.yml
+  sed -e '/persist_to_redis/ s/true/false/' -i /etc/magma/mobilityd.yml
+elif [[ $1 == "enable" ]]; then
+  echo "Enabling stateless mobilityd config"
+  # remove restart dependencies between mobilityd and other services
+  sudo sed -e '/PartOf=magma@mobilityd/ s/^#*/#/' -i \
+    /etc/systemd/system/magma@mme.service
+
+  # change persist_to_redis setting in mobilityd.yml
+  sed -e '/persist_to_redis/ s/false/true/' -i /etc/magma/mobilityd.yml
+else
+  echo "Invalid argument. Use one of the following"
+  echo "check: Run a check whether Mobilityd is stateless or not"
+  echo "enable: Enable stateless mode, do nothing if already stateless"
+  echo "disable: Disable stateless mode, do nothing if already stateful"
+  exit 0
+fi
+
+# reload systemd config
+sudo systemctl daemon-reload

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_pipelined.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_pipelined.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [[ $1 == "check" ]]; then
+  # check dependency in systemd files of other services
+  if ! grep -q "^#PartOf=magma@pipelined" /etc/systemd/system/magma@mme.service
+  then
+    echo "MME will restart with pipelined, i.e. stateful."
+    exit 1
+  fi
+
+  #check service config
+  if ! grep -q "clean_restart.*false" /etc/magma/pipelined.yml; then
+    echo "Pipelined config file is stateful."
+    exit 1
+  fi
+
+  echo "Pipelined service is stateless."
+  exit 0
+elif [[ $1 == "disable" ]]; then
+  echo "Disabling stateless pipelined config"
+  # restore restart dependencies between pipelined and other services
+  sudo sed -e '/PartOf=magma@pipelined/ s/^#*//' -i \
+    /etc/systemd/system/magma@mme.service
+
+  # change clean_restart setting in pipelined.yml
+  sed -e '/clean_restart/ s/false/true/' -i /etc/magma/pipelined.yml
+elif [[ $1 == "enable" ]]; then
+  echo "Enabling stateless pipelined config"
+  # remove restart dependencies between pipelined and other services
+  sudo sed -e '/PartOf=magma@pipelined/ s/^#*/#/' -i \
+    /etc/systemd/system/magma@mme.service
+
+  # change clean_restart setting in pipelined.yml
+  sed -e '/clean_restart/ s/true/false/' -i /etc/magma/pipelined.yml
+else
+  echo "Invalid argument. Use one of the following"
+  echo "check: Run a check whether Pipelined is stateless or not"
+  echo "enable: Enable stateless mode, do nothing if already stateless"
+  echo "disable: Disable stateless mode, do nothing if already stateful"
+  exit 0
+fi
+
+# reload systemd config
+sudo systemctl daemon-reload

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_sessiond.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_sessiond.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+if [[ $1 == "check" ]]; then
+  # check dependency in systemd files of other services
+  if ! grep -q "^#PartOf=magma@sessiond" /etc/systemd/system/magma@mme.service
+  then
+    echo "MME will restart with sessiond, i.e. stateful."
+    exit 1
+  fi
+
+  #check service config
+  if ! grep -q "support_stateless.*true" /etc/magma/sessiond.yml; then
+    echo "Sessiond config file is stateful."
+    exit 1
+  fi
+
+  echo "Sessiond service is stateless."
+  exit 0
+elif [[ $1 == "disable" ]]; then
+  echo "Disabling stateless sessiond config"
+  # restore restart dependencies between sessiond and other services
+  sudo sed -e '/PartOf=magma@sessiond/ s/^#*//' -i \
+    /etc/systemd/system/magma@mme.service
+
+  # change support_stateless setting in sessiond.yml
+  sed -e '/support_stateless/ s/true/false/' -i /etc/magma/sessiond.yml
+elif [[ $1 == "enable" ]]; then
+  echo "Enabling stateless sessiond config"
+  # remove restart dependencies between sessiond and other services
+  sudo sed -e '/PartOf=magma@sessiond/ s/^#*/#/' -i \
+    /etc/systemd/system/magma@mme.service
+
+  # change support_stateless setting in sessiond.yml
+  sed -e '/support_stateless/ s/false/true/' -i /etc/magma/sessiond.yml
+else
+  echo "Invalid argument. Use one of the following"
+  echo "check: Run a check whether Sessiond is stateless or not"
+  echo "enable: Enable stateless mode, do nothing if already stateless"
+  echo "disable: Disable stateless mode, do nothing if already stateful"
+  exit 0
+fi
+
+# reload systemd config
+sudo systemctl daemon-reload


### PR DESCRIPTION
Summary:
This change adds scripts to enable, disable and check stateless mode for each
AGW service. The primary use of these services is for manual testing/debugging
and to use for integration testing.

In future, the config for all services will be controlled by a single flag in
magmad config.

Differential Revision: D21924443

