### PR TITLE
Add events to FeG health service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@
 !cwf/cloud/
 !cwf/gateway/
 !cwf/k8s
+!cwf/swagger/
 
 !feg/cloud/
 !feg/gateway/

--- a/cwf/gateway/configs/eventd.yml
+++ b/cwf/gateway/configs/eventd.yml
@@ -44,3 +44,16 @@ event_registry:
   session_termination_failed:
     module: feg
     filename: aaa_server_events.v1.yml
+  gateway_promotion_succeeded:
+    module: cwf
+    filename: health_events.v1.yml
+  gateway_promotion_failed:
+    module: cwf
+    filename: health_events.v1.yml
+  gateway_demotion_succeded:
+    module: cwf
+    filename: health_events.v1.yml
+  gateway_demotion_failed:
+    module: cwf
+    filename: health_events.v1.yml
+

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -101,6 +101,7 @@ services:
       - ${CONFIGS_DEFAULT_VOLUME}:/etc/magma
       - ${CONFIGS_TEMPLATES_PATH}:/etc/magma/templates
       - ${CONTROL_PROXY_PATH}:/etc/magma/control_proxy.yml
+      - /etc/snowflake:/etc/snowflake
       - /var/run/docker.sock:/var/run/docker.sock
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
 

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -94,6 +94,7 @@ github.com/elastic/gosigar v0.9.0/go.mod h1:cdorVVzy1fhmEqmtgqkoE3bYtCfSCkVyjTyC
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/emakeev/go-diameter/v4 v4.0.6 h1:C0ns4G2CHqYn4XrcVwqBWI8l7LcxwtP2N6Us7yoW3E4=
 github.com/emakeev/go-diameter/v4 v4.0.6/go.mod h1:Qx/+pf+c9sBUHWq1d7EH3bkdwN8U0mUpdy9BieDw6UQ=
+github.com/emakeev/snowflake v0.0.0-20200206205012-767080b052fe h1:AtQCu1EME1N7Gwb4BNcpeKNxPmMK6G2QCeN+rVJO1EM=
 github.com/emakeev/snowflake v0.0.0-20200206205012-767080b052fe/go.mod h1:kEQPRPTu2Cm00AIGJ0SWq8pOfa9kPZozrZ5/2XN2PB4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
@@ -311,6 +312,7 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/montanaflynn/stats v0.0.0-20180911141734-db72e6cae808/go.mod h1:wL8QJuTMNUDYhXwkmfOly8iTdp5TEcJFWZD2D7SIkUc=
+github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39 h1:diqTAr+wSpYUQHsyj80KOYO+TUf9RqjnKsARAsDDxaE=
 github.com/moriyoshi/routewrapper v0.0.0-20180228100351-e52d8d14cf39/go.mod h1:58NWw+g5pMuFB1BxO0ZVEQRDC09iqiiI5JHBGtl5Jyk=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=

--- a/cwf/gateway/registry/local_registry.go
+++ b/cwf/gateway/registry/local_registry.go
@@ -17,6 +17,7 @@ import (
 const (
 	ModuleName = "cwf"
 
+	Eventd        = "EVENTD"
 	GatewayHealth = "HEALTH"
 	UeSim         = "UESIM"
 	Radiusd       = "RADIUSD"
@@ -44,6 +45,7 @@ func addLocalService(serviceType string, port int) {
 }
 
 func init() {
+	addLocalService(Eventd, 50075)
 	addLocalService(UeSim, 10101)
 	addLocalService(GatewayHealth, 9107)
 	addLocalService(Radiusd, 10102)

--- a/cwf/gateway/services/gateway_health/events/events.go
+++ b/cwf/gateway/services/gateway_health/events/events.go
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"magma/gateway/eventd"
+	"magma/gateway/status"
+	orcprotos "magma/orc8r/lib/go/protos"
+
+	"github.com/golang/glog"
+)
+
+const (
+	healthStreamName               = "health"
+	GatewayPromotionSucceededEvent = "gateway_promotion_succeeded"
+	GatewayPromotionFailedEvent    = "gateway_promotion_failed"
+	GatewayDemotionSucceededEvent  = "gateway_demotion_succeeded"
+	GatewayDemotionFailedEvent     = "gateway_demotion_failed"
+)
+
+// GatewayHealthFailed event
+type GatewayHealthFailed struct {
+	FailureReason string `json:"failure_reason"`
+}
+
+// LogGatewayHealthSuccessEvent logs a successful promotion/demotion event.
+func LogGatewayHealthSuccessEvent(eventType string) {
+	go logEvent(eventType, "{}")
+}
+
+// LogGatewayHealthFailedEvent logs a failed promotion/demotion event with its
+// associated error.
+func LogGatewayHealthFailedEvent(eventType string, failureReason string) {
+	failedEvent := GatewayHealthFailed{
+		FailureReason: failureReason,
+	}
+	serializedHealthEvent, err := json.Marshal(failedEvent)
+	if err != nil {
+		glog.Errorf("Could not serialize %s event: %s", eventType, err)
+		return
+	}
+	go logEvent(eventType, fmt.Sprintf("%s", serializedHealthEvent))
+}
+
+func logEvent(eventType string, eventValue string) {
+	hwid := status.GetHwId()
+	event := &orcprotos.Event{
+		StreamName: healthStreamName,
+		EventType:  eventType,
+		Tag:        hwid,
+		Value:      eventValue,
+	}
+	err := eventd.V(eventd.DefaultVerbosity).Log(event)
+	if err != nil {
+		glog.Errorf("Sending %s event failed: %s", eventType, err)
+	}
+}

--- a/cwf/swagger/health_events.v1.yml
+++ b/cwf/swagger/health_events.v1.yml
@@ -1,0 +1,27 @@
+---
+swagger: '2.0'
+
+info:
+  title: CWAG Health Event definitions
+  description: These events occur in the health service
+  version: 1.0.0
+
+definitions:
+  gateway_promotion_succeeded:
+    type: object
+    description: Gateway successfully promoted to active
+  gateway_promotion_failed:
+    type: object
+    description: Gateway promotion to active failed
+    properties:
+      failure_reason:
+        type: string
+  gateway_demotion_succeded:
+    type: object
+    description: Gateway successfully demoted to standby
+  gateway_demotion_failed:
+    type: object
+    description: Gateway demotion to standby failed
+    properties:
+      failure_reason:
+        type: string

--- a/feg/gateway/configs/eventd.yml
+++ b/feg/gateway/configs/eventd.yml
@@ -26,3 +26,21 @@ event_registry:
   restarted_services:
     module: orc8r
     filename: magmad_events.v1.yml
+  disconnected_sync_rpc_stream:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  established_sync_rpc_stream:
+    module: orc8r
+    filename: magmad_events.v1.yml
+  gateway_promotion_succeeded:
+    module: feg
+    filename: health_events.v1.yml
+  gateway_promotion_failed:
+    module: feg
+    filename: health_events.v1.yml
+  gateway_demotion_succeded:
+    module: feg
+    filename: health_events.v1.yml
+  gateway_demotion_failed:
+    module: feg
+    filename: health_events.v1.yml

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -71,6 +71,7 @@ services:
 
   health:
     <<: *goservice
+    volumes: *snowflake_volumes
     container_name: health
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/gateway_health -logtostderr=true -v=0
 

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -39,6 +39,7 @@ COPY lte/gateway/deploy/roles/dev_common/files/build_swagger_codegen.sh /var/tmp
 RUN ./var/tmp/build_swagger_codegen.sh
 
 # Generate python proto bindings.
+COPY cwf/swagger $MAGMA_ROOT/cwf/swagger
 COPY feg/protos $MAGMA_ROOT/feg/protos
 COPY feg/swagger $MAGMA_ROOT/feg/swagger
 COPY lte/gateway/python/defs.mk $MAGMA_ROOT/lte/gateway/python/defs.mk
@@ -51,7 +52,7 @@ COPY orc8r/swagger $MAGMA_ROOT/orc8r/swagger
 COPY orc8r/tools/ansible/roles/fluent_bit/files $MAGMA_ROOT/orc8r/tools/ansible/roles/fluent_bit/files
 COPY protos $MAGMA_ROOT/protos
 RUN make -C $MAGMA_ROOT/lte/gateway/python protos
-ENV SWAGGER_LIST lte_swagger_specs feg_swagger_specs orc8r_swagger_specs
+ENV SWAGGER_LIST lte_swagger_specs feg_swagger_specs cwf_swagger_specs orc8r_swagger_specs
 RUN make -C $MAGMA_ROOT/orc8r/gateway/python swagger
 
 # -----------------------------------------------------------------------------

--- a/feg/gateway/services/gateway_health/events/events.go
+++ b/feg/gateway/services/gateway_health/events/events.go
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"magma/feg/cloud/go/protos"
+	"magma/gateway/eventd"
+	"magma/gateway/status"
+	orcprotos "magma/orc8r/lib/go/protos"
+
+	"github.com/golang/glog"
+)
+
+const (
+	healthStreamName               = "health"
+	GatewayPromotionSucceededEvent = "gateway_promotion_succeeded"
+	GatewayPromotionFailedEvent    = "gateway_promotion_failed"
+	GatewayDemotionSucceededEvent  = "gateway_demotion_succeeded"
+	GatewayDemotionFailedEvent     = "gateway_demotion_failed"
+)
+
+// GatewayHealthFailed event
+type GatewayHealthFailed struct {
+	FailureReason string `json:"failure_reason"`
+}
+
+// LogGatewayHealthSuccessEvent logs a successful promotion/demotion event.
+func LogGatewayHealthSuccessEvent(eventType string, prevAction protos.HealthResponse_RequestedAction) {
+	if !shouldLogEvent(eventType, prevAction) {
+		return
+	}
+	go logEvent(eventType, "{}")
+}
+
+// LogGatewayHealthFailedEvent logs a failed promotion/demotion event with its
+// associated error.
+func LogGatewayHealthFailedEvent(eventType string, failureReason string, prevAction protos.HealthResponse_RequestedAction) {
+	if !shouldLogEvent(eventType, prevAction) {
+		return
+	}
+	failedEvent := GatewayHealthFailed{
+		FailureReason: failureReason,
+	}
+	serializedHealthEvent, err := json.Marshal(failedEvent)
+	if err != nil {
+		glog.Errorf("Could not serialize %s event: %s", eventType, err)
+		return
+	}
+	go logEvent(eventType, fmt.Sprintf("%s", serializedHealthEvent))
+}
+
+func logEvent(eventType string, eventValue string) {
+	hwid := status.GetHwId()
+	event := &orcprotos.Event{
+		StreamName: healthStreamName,
+		EventType:  eventType,
+		Tag:        hwid,
+		Value:      eventValue,
+	}
+	err := eventd.V(eventd.DefaultVerbosity).Log(event)
+	if err != nil {
+		glog.Errorf("Sending %s event failed: %s", eventType, err)
+	}
+}
+
+func shouldLogEvent(eventType string, prevAction protos.HealthResponse_RequestedAction) bool {
+	// Avoid polluting event logs by only logging new gateway actions
+	// (or repeated failures)
+	switch prevAction {
+	case protos.HealthResponse_SYSTEM_UP:
+		if eventType == GatewayPromotionSucceededEvent {
+			return false
+		}
+		return true
+	case protos.HealthResponse_SYSTEM_DOWN:
+		if eventType == GatewayDemotionSucceededEvent {
+			return false
+		}
+		return true
+	case protos.HealthResponse_NONE:
+		return true
+	default:
+		return true
+	}
+}

--- a/feg/swagger/health_events.v1.yml
+++ b/feg/swagger/health_events.v1.yml
@@ -1,0 +1,27 @@
+---
+swagger: '2.0'
+
+info:
+  title: FeG Health Event definitions
+  description: These events occur in the health service
+  version: 1.0.0
+
+definitions:
+  gateway_promotion_succeeded:
+    type: object
+    description: Gateway successfully promoted to active
+  gateway_promotion_failed:
+    type: object
+    description: Gateway promotion to active failed
+    properties:
+      failure_reason:
+        type: string
+  gateway_demotion_succeded:
+    type: object
+    description: Gateway successfully demoted to standby
+  gateway_demotion_failed:
+    type: object
+    description: Gateway demotion to standby failed
+    properties:
+      failure_reason:
+        type: string


### PR DESCRIPTION
Summary:
This diffs add promotion/demotion events to the
Feg's health service. Since the FeG health service receives
repeated calls to either promote/demote, we only send an
event for the first one of these successful events to avoid
log pollution.

Reviewed By: xjtian

Differential Revision: D22354313

