### PR TITLE
Remove reference to relay enabled/disabled for mconfig generation

### DIFF
--- a/cwf/cloud/go/plugin/mconfig.go
+++ b/cwf/cloud/go/plugin/mconfig.go
@@ -162,7 +162,6 @@ func buildFromConfigs(nwConfig *models.NetworkCarrierWifiConfigs, gwConfig *mode
 		UeIpBlock:       DefaultUeIpBlock, // Unused by CWF
 		NatEnabled:      false,
 		DefaultRuleId:   swag.StringValue(nwConfig.DefaultRuleID),
-		RelayEnabled:    true,
 		Services:        pipelineDServices,
 		AllowedGrePeers: allowedGrePeers,
 		LiImsis:         gwConfig.LiImsis,


### PR DESCRIPTION
Summary: This is a modification to the mconfig generation for the `pipelined` service from CWF.

Differential Revision: D22403271

