### PR TITLE
Magma: mobilityD: Fix dhcp ip release

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -140,7 +140,7 @@ class IPAllocatorDHCP(IPAllocator):
 
         Returns: None
         """
-        self._dhcp_client.release_ip_address(MacAddress(sid))
+        self._dhcp_client.release_ip_address(create_mac_from_sid(sid))
         # Remove the IP from free IP list, since DHCP is the
         # owner of this IP
         self._ip_state_map.remove_ip_from_state(deleted_ip, IPState.FREE)

--- a/lte/gateway/python/magma/mobilityd/scripts/dnsd.conf
+++ b/lte/gateway/python/magma/mobilityd/scripts/dnsd.conf
@@ -10,6 +10,7 @@ domain=ue_dns
 no-resolv
 bogus-priv
 
+dhcp-option=3,192.168.128.211
 # interface=uplink_p1
 dhcp-range=192.168.128.100,192.168.128.210,2m
 local-ttl=0

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-test-dhcp-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-test-dhcp-srv.sh
@@ -13,6 +13,7 @@ ip link set dev  "$prefix"uplink_p1 netns "$prefix"dhcp_srv
 ip netns exec    "$prefix"dhcp_srv   ifconfig  "$prefix"uplink_p1 192.168.128.100/24
 ip netns exec    "$prefix"dhcp_srv   ifconfig  "$prefix"uplink_p1 hw ether b2:a0:cc:85:80:7a
 ip netns exec    "$prefix"dhcp_srv   ifconfig  "$prefix"uplink_p1 up
+ip netns exec    "$prefix"dhcp_srv   ip addr add 192.168.128.211  dev "$prefix"uplink_p1
 PID=$(pgrep -f "dnsmasq.*mobilityd.*$prefix")
 if [[ -n "$PID" ]]
 then

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -20,6 +20,12 @@ from magma.mobilityd.ip_address_man import IPAddressManager, MappingNotFoundErro
 from unittest import mock
 from magma.common.redis.mocks.mock_redis import MockRedis
 from magma.pipelined.bridge_util import BridgeTools
+from magma.mobilityd import mobility_store as store
+
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+
+from magma.mobilityd.mac import create_mac_from_sid, MacAddress
+from magma.mobilityd.dhcp_desc import DHCPState
 
 LOG = logging.getLogger('mobilityd.dhcp.test')
 LOG.isEnabledFor(logging.DEBUG)
@@ -44,8 +50,6 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
     def setUp(self):
         self._br = "t_up_br0"
 
-        subprocess.check_call(["redis-cli", "flushall"])
-
         setup_dhcp_server = SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
         subprocess.check_call([setup_dhcp_server, "t0"])
 
@@ -69,14 +73,26 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         self._dhcp_allocator.ip_allocator.stop_dhcp_sniffer()
         BridgeTools.destroy_bridge(self._br)
 
+    @mock.patch("redis.Redis", MockRedis)
     @unittest.skipIf(os.getuid(), reason="needs root user")
     def test_ip_alloc(self):
         sid1 = "IMSI02917"
         ip1 = self._dhcp_allocator.alloc_ip_address(sid1)
+        threading.Event().wait(2)
+        gw_map = store.GatewayInfoMap()
+        dhcp_gw_info = UplinkGatewayInfo(gw_map)
+        dhcp_store = store.MacToIP()  # mac => DHCP_State
 
-        threading.Event().wait(2)
+        self.assertEqual(str(dhcp_gw_info.getIP()), "192.168.128.211")
         self._dhcp_allocator.release_ip_address(sid1, ip1)
-        threading.Event().wait(2)
+
+        # wait for DHCP release
+        threading.Event().wait(7)
+        mac1 = create_mac_from_sid(sid1)
+        dhcp_state1 = dhcp_store.get(mac1.as_redis_key())
+
+        self.assertEqual(dhcp_state1.state, DHCPState.RELEASE)
+
         ip1_1 = self._dhcp_allocator.alloc_ip_address(sid1)
         threading.Event().wait(2)
         self.assertEqual(str(ip1), str(ip1_1))
@@ -111,7 +127,11 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
                          [ip_network('192.168.128.0/24')])
 
         # wait for DHCP release
-        threading.Event().wait(20)
+        threading.Event().wait(7)
+        mac4 = create_mac_from_sid(sid4)
+        dhcp_state = dhcp_store.get(mac4.as_redis_key())
+
+        self.assertEqual(dhcp_state.state, DHCPState.RELEASE)
         ip4_2 = self._dhcp_allocator.alloc_ip_address(sid4)
         self.assertEqual(ip4, ip4_2)
 

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -60,7 +60,7 @@ class InOutNonNatTest(unittest.TestCase):
     def setUp(self):
         self._dhcp_gw_info_mock = store.GatewayInfoMap()
 
-        self._dhcp_gw_info_mock[DHCP_Router_key] = '192.168.128.100'
+        self._dhcp_gw_info_mock[DHCP_Router_key] = '192.168.128.211'
         logging.info("set router key [{}]".format(self._dhcp_gw_info_mock[DHCP_Router_key]))
 
         """


### PR DESCRIPTION
Summary: Following patch fixes DHCP ip release.

Differential Revision: D22407425

