### PR TITLE
Refactor SessionCredit to handle empty GSU case properly

### DIFF
--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -65,8 +65,6 @@ namespace magma {
       return "RX_ONLY";
     case TX_AND_RX:
       return "TX_AND_RX";
-    case NO_TRACKING:
-      return "NO_TRACKING";
     default:
       return "INVALID GRANT TRACKING TYPE";
     }

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1118,8 +1118,7 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
 
     for (const auto& session : it->second) {
       auto& update_criteria = session_update[imsi][session->get_session_id()];
-      session->receive_monitor(
-          usage_monitor_resp, update_criteria);
+      session->receive_monitor(usage_monitor_resp, update_criteria);
       session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), update_criteria);
 
       RulesToProcess rules_to_activate;

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -58,12 +58,13 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
   return uc;
 }
 
-SessionCredit::SessionCredit(ServiceState start_state)
-    : buckets_{}, reporting_(false), credit_limit_type_(FINITE) {}
+SessionCredit::SessionCredit(ServiceState start_state):
+  SessionCredit(start_state, FINITE) {}
 
 SessionCredit::SessionCredit(
   ServiceState start_state, CreditLimitType credit_limit_type)
-    : buckets_{}, reporting_(false), credit_limit_type_(credit_limit_type) {}
+    : buckets_{}, reporting_(false), credit_limit_type_(credit_limit_type),
+      grant_tracking_type_(TOTAL_ONLY) {}
 
 // by default, enable service & finite credit
 SessionCredit::SessionCredit(): SessionCredit(SERVICE_ENABLED, FINITE) {}
@@ -314,8 +315,8 @@ GrantTrackingType SessionCredit::determine_grant_tracking_type(
   } else if (rx_valid) {
     return RX_ONLY;
   } else {
-    MLOG(MWARNING) << "Received a GSU with no valid grants";
-    return NO_TRACKING;
+    MLOG(MWARNING) << "Received a GSU with no valid grants, keeping the same type";
+    return grant_tracking_type_;
   }
 }
 

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -94,7 +94,6 @@ enum GrantTrackingType {
   TX_ONLY = 1,
   RX_ONLY = 2,
   TX_AND_RX = 3,
-  NO_TRACKING = 4,
 };
 
 /**

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -817,6 +817,43 @@ TEST_F(SessionStateTest, test_final_credit_install) {
             RedirectServer_RedirectAddressType_URL);
 }
 
+// We want to test a case where we do not receive a GSU, but we receive a
+// final_action on credit exhaust.
+TEST_F(SessionStateTest, test_empty_credit_grant) {
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
+  CreditUpdateResponse charge_resp;
+  charge_resp.set_success(true);
+  charge_resp.set_sid("IMSI1");
+  charge_resp.set_charging_key(1);
+
+  // A ChargingCredit with no GSU but FinalAction
+  auto p_credit = charge_resp.mutable_credit();
+  p_credit->set_type(ChargingCredit::BYTES);
+  p_credit->set_is_final(true);
+  p_credit->set_final_action(ChargingCredit_FinalAction_TERMINATE);
+
+  session_state->receive_charging_credit(charge_resp, update_criteria);
+
+  // Test that the update criteria is filled out properly
+  EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
+  auto u_credit = update_criteria.charging_credit_to_install[1];
+  EXPECT_TRUE(u_credit.is_final);
+  EXPECT_EQ(u_credit.final_action_info.final_action,
+            ChargingCredit_FinalAction_TERMINATE);
+
+  // At this point, the charging credit for RG=1 should have no available quota
+  // and the tracking should be the default, TOTAL_ONLY
+  EXPECT_EQ(u_credit.credit.grant_tracking_type, TOTAL_ONLY);
+  EXPECT_EQ(u_credit.credit.buckets[ALLOWED_TOTAL], 0);
+  EXPECT_EQ(u_credit.credit.buckets[ALLOWED_TX], 0);
+  EXPECT_EQ(u_credit.credit.buckets[ALLOWED_RX], 0);
+
+  // Report some rule usage, and ensure the final action gets triggered
+  session_state->add_rule_usage("rule1", 100, 100, update_criteria);
+  auto credit_uc = update_criteria.charging_credit_map[1];
+  EXPECT_EQ(credit_uc.service_state, SERVICE_NEEDS_DEACTIVATION);
+}
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
   FLAGS_logtostderr = 1;


### PR DESCRIPTION
Summary:
# A Very Long Background {emoji:1f605}
This diff tackles the specific case where we receive a GSU with all three fields, (total, rx, tx), are marked as invalid. For more context, when SessionProxy deals with the `GrantedServiceUnit` AVP, it translates the information into this protobug message.
```message CreditUnit {
  bool is_valid = 1;
  uint64 volume = 2;
}

message GrantedUnits {
  CreditUnit total = 1;
  CreditUnit tx = 2;
  CreditUnit rx = 3;
}
```
For each credit type, if an AVP is specified `is_valid` is set to `true` and the `volume` is filled in. Otherwise, `is_valid` is false and `volume` is set to 0.
The GX spec specifies in the doc below that there that there are 4 valid combinations of these grant types. (total only, rx only, tx only, and rx and tx).
(https://www.etsi.org/deliver/etsi_ts/129200_129299/129212/09.03.00_60/ts_129212v090300p.pdf) PG 29

The question here is what the intended behavior is for Gy. For example, if both total and rx are specified, do we just trigger on whichever threshold is met?
My assumption in the previous refactor was that since Gx and Gy both use the same AVP for GSU, the behavior is the same. But this could be a wrong assumption, so we can fix that if it is wrong.

I previously refactored `SessionCredit` to look at the GSU proto message, and infer how we should decide when the credit has exhausted its quota. D22115988 (https://github.com/facebookincubator/magma/commit/76017999a1ee6b45e86015856690310b801e3943). Here's some background into why I made that change.
 ---
## A bit about the implementation details pre-refactor
Before this change, when we received a volume with `is_valid=false`, we would set the volume to 0 for the following cases:

- Receiving existing / Initializing Gy ChargingCredits
- Receiving existing Gx UsageMonitors

We would set the volume to max int for
- Initializing a Gx UsageMonitor

I think the original intention here was that for Gy charging grants, treat invalid GSU as just receiving 0 credit. This way, even after receiving an invalid credit, we correctly calculate its quota status as "exhausted".
For Gx, I'm honestly not sure as to why we treat initializing and updating an existing monitor differently. One thing worth noting is that `SessionProxy` will disable any monitors with 0 GSU. So this might not matter either way. (SP code: https://www.internalfb.com/intern/diffusion/FBS/browsefile/master/fbcode/magma/feg/gateway/services/session_proxy/credit_control/gx/model_conversion.go?lines=300)

But since we don't persist which values are valid or not, this poses an issue. For example, take a case where we receive Tx=400 and Rx=500 values but an invalid Total value. (And that this credit is from Gy.) With the previous implementation, we would receive the following: (total=0, tx=400, rx=500). The following is a snippet of how we calculate whether the quota has been exhausted:
```bool SessionCredit::is_quota_exhausted(float usage_reporting_threshold) const {
  // used quota since last report
  uint64_t total_reported_usage = buckets_[REPORTED_TX] + buckets_[REPORTED_RX];
  uint64_t total_usage_since_report = std::max(uint64_t(0), buckets_[USED_TX] + buckets_[USED_RX] - total_reported_usage);
  uint64_t tx_usage_since_report = std::max(uint64_t(0), buckets_[USED_TX] - buckets_[REPORTED_TX]);
  uint64_t rx_usage_since_report = std::max(uint64_t(0), buckets_[USED_RX] - buckets_[REPORTED_RX]);

  // available quota since last report
  auto total_usage_reporting_threshold = std::max(0.0f, (buckets_[ALLOWED_TOTAL] - total_reported_usage) * usage_reporting_threshold);

  // reported tx/rx could be greater than allowed tx/rx
  // because some OCS/PCRF might not track tx/rx,
  // and 0 is added to the allowed credit when an credit update is received
  auto tx_usage_reporting_threshold = std::max(0.0f, (buckets_[ALLOWED_TX] - buckets_[REPORTED_TX]) *  usage_reporting_threshold);
  auto rx_usage_reporting_threshold = std::max(0.0f, (buckets_[ALLOWED_RX] - buckets_[REPORTED_RX]) * usage_reporting_threshold);

  if (total_usage_since_report >= total_usage_reporting_threshold) {
    return true;
  } else if ((buckets_[ALLOWED_TX] > 0) && (tx_usage_since_report >= tx_usage_reporting_threshold)) {
    return true;
  } else if ((buckets_[ALLOWED_RX] > 0) && (rx_usage_since_report >= rx_usage_reporting_threshold)) {
    return true;
  }
  return false;
}
```
When we check `total_usage_since_report >= total_usage_reporting_threshold`, we incorrectly infer that quota has been exhausted here.

 ---
# What this diff changes
The refactor linked above had a bug where on receiving invalid GSUs the grant_tracking_type was set to `NO_TRACKING`. This was actually wrong because, we could have a case where we don't receive a valid GSU but receive a valid FinalAction. So to fix this, on receiving an invalid GSU, we should just leave the TrackingType as it is. This way, even after receiving an invalid GSU, if the quota was exhausted before, it will continue to be exhausted.
This change means that the type `NO_TRACKING` is no longer needed, so we'll just get rid of it here.
Additionally, now that we have a functionality to persist grant tracking type and not calculate it everytime  we receive a credit, we will initialize the tracking type to `TOTAL_ONLY` on `SessionCredit` creation.

I've added unit tests on the credit level and session state level to cover these cases.

Reviewed By: uri200

Differential Revision: D22389654

