### PR TITLE
magma: SPGW: dynamically add route on UE attach

### DIFF
--- a/lte/gateway/c/oai/include/pgw_config.h
+++ b/lte/gateway/c/oai/include/pgw_config.h
@@ -102,7 +102,6 @@ typedef struct pgw_config_s {
     uint8_t mask_S5_S8;        // read from system
 
     bstring if_name_SGI;
-    struct in_addr SGI;
     uint32_t mtu_SGI;        // read from system
     struct in_addr addr_sgi; // read from system
     uint8_t mask_sgi;        // read from system

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
@@ -231,6 +231,11 @@ int libgtpnl_send_end_marker(struct in_addr enb, uint32_t tei)
   return -EOPNOTSUPP;
 }
 
+const char *libgtpnl_get_dev_name()
+{
+  return GTP_DEVNAME;
+}
+
 static const struct gtp_tunnel_ops libgtpnl_ops = {
   .init = libgtpnl_init,
   .uninit = libgtpnl_uninit,
@@ -238,6 +243,7 @@ static const struct gtp_tunnel_ops libgtpnl_ops = {
   .add_tunnel = libgtpnl_add_tunnel,
   .del_tunnel = libgtpnl_del_tunnel,
   .send_end_marker = libgtpnl_send_end_marker,
+  .get_dev_name = libgtpnl_get_dev_name,
 };
 
 const struct gtp_tunnel_ops *gtp_tunnel_ops_init_libgtpnl(void)

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -25,10 +25,13 @@
 #include <stdlib.h>
 
 #include "assertions.h"
+#include "bstrlib.h"
 #include "log.h"
 #include "gtpv1u.h"
 #include "ControllerMain.h"
 #include "3gpp_23.003.h"
+#include "spgw_config.h"
+
 
 extern struct gtp_tunnel_ops gtp_tunnel_ops;
 
@@ -152,6 +155,11 @@ int openflow_send_end_marker(struct in_addr enb, uint32_t tei)
   return rc;
 }
 
+const char *openflow_get_dev_name(void)
+{
+  return bdata(spgw_config.sgw_config.ovs_config.bridge_name);
+}
+
 static const struct gtp_tunnel_ops openflow_ops = {
   .init = openflow_init,
   .uninit = openflow_uninit,
@@ -163,6 +171,7 @@ static const struct gtp_tunnel_ops openflow_ops = {
   .add_paging_rule = openflow_add_paging_rule,
   .delete_paging_rule = openflow_delete_paging_rule,
   .send_end_marker = openflow_send_end_marker,
+  .get_dev_name = openflow_get_dev_name,
 };
 
 const struct gtp_tunnel_ops *gtp_tunnel_ops_init_openflow(void)

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -153,6 +153,7 @@ struct gtp_tunnel_ops {
   int (*add_paging_rule)(struct in_addr ue);
   int (*delete_paging_rule)(struct in_addr ue);
   int (*send_end_marker) (struct in_addr enbode, uint32_t i_tei);
+  const char *(*get_dev_name)(void);
 };
 
 #if ENABLE_OPENFLOW
@@ -161,4 +162,7 @@ const struct gtp_tunnel_ops *gtp_tunnel_ops_init_openflow(void);
 const struct gtp_tunnel_ops *gtp_tunnel_ops_init_libgtpnl(void);
 #endif
 
+int gtpv1u_add_tunnel(
+    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
 #endif /* FILE_GTPV1_U_SEEN */

--- a/lte/gateway/c/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_config.c
@@ -84,7 +84,6 @@ int pgw_config_process(pgw_config_t* config_pP) {
 
   // Get ipv4 address
   char str[INET_ADDRSTRLEN];
-  char str_sgi[INET_ADDRSTRLEN];
 
   // GET SGi informations
   {
@@ -92,25 +91,7 @@ int pgw_config_process(pgw_config_t* config_pP) {
     memset(&ifr, 0, sizeof(ifr));
     int fd                 = socket(AF_INET, SOCK_DGRAM, 0);
     ifr.ifr_addr.sa_family = AF_INET;
-    strncpy(
-        ifr.ifr_name, (const char*) config_pP->ipv4.if_name_SGI->data,
-        IFNAMSIZ - 1);
-    if (ioctl(fd, SIOCGIFADDR, &ifr)) {
-      OAILOG_CRITICAL(
-          LOG_SPGW_APP, "Failed to read SGI ip addresses: error %s\n",
-          strerror(errno));
-      return RETURNerror;
-    }
-    struct sockaddr_in* ipaddr = (struct sockaddr_in*) &ifr.ifr_addr;
-    if (inet_ntop(
-            AF_INET, (const void*) &ipaddr->sin_addr, str_sgi,
-            INET_ADDRSTRLEN) == NULL) {
-      OAILOG_ERROR(LOG_SPGW_APP, "inet_ntop");
-      return RETURNerror;
-    }
-    config_pP->ipv4.SGI.s_addr = ipaddr->sin_addr.s_addr;
 
-    ifr.ifr_addr.sa_family = AF_INET;
     strncpy(
         ifr.ifr_name, (const char*) config_pP->ipv4.if_name_SGI->data,
         IFNAMSIZ - 1);
@@ -587,9 +568,6 @@ void pgw_config_display(pgw_config_t* config_p) {
   OAILOG_INFO(
       LOG_SPGW_APP, "    SGi iface ............: %s\n",
       bdata(config_p->ipv4.if_name_SGI));
-  OAILOG_INFO(
-      LOG_SPGW_APP, "    SGi ip  (read)........: %s\n",
-      inet_ntoa(*((struct in_addr*) &config_p->ipv4.SGI)));
   OAILOG_INFO(
       LOG_SPGW_APP, "    SGi MTU (read)........: %u\n", config_p->ipv4.mtu_SGI);
   OAILOG_INFO(

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -547,7 +547,7 @@ int sgw_handle_sgi_endpoint_updated(
             "ERROR in forwarding data on TUNNEL err=%d\n", rv);
         }
       } else {
-        rv = gtp_tunnel_ops->add_tunnel(
+        rv = gtpv1u_add_tunnel(
           ue,
           enb,
           eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
@@ -1619,7 +1619,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
                 dlflow.udp_dst_port = packet_filter.singleremoteport;
               }
             }
-            rc = gtp_tunnel_ops->add_tunnel(
+            rc = gtpv1u_add_tunnel(
               ue,
               enb,
               eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,

--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -1,8 +1,6 @@
 # Add L3 OVS switch gtp_br0 with gtp0, veth0_ovs, and int_nat_peer
 allow-ovs gtp_br0
-iface gtp_br0 inet static
-    address 192.168.128.1
-    netmask 255.255.255.0
+iface gtp_br0 inet manual
     up sysctl net.ipv4.ip_forward=1
     up iptables -t mangle -A FORWARD -i gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
     up iptables -t mangle -A FORWARD -o gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400


### PR DESCRIPTION
Summary:
Today AGW adds static route on startup. That makes it hard to change it
according to mobility ipblock assignment. This patch fixes it, by configuring
route according to mobilityD configuration.
This patch also removes IP address from gtp_br0 which is not used.

Differential Revision: D22418055

