### PR TITLE
Add version support and logging

### DIFF
--- a/feg/radius/src/Dockerfile
+++ b/feg/radius/src/Dockerfile
@@ -6,7 +6,7 @@ COPY radius/lib/go/ /src/lib/go
 WORKDIR /src/radius
 ENV GOPROXY https://proxy.golang.org
 RUN go mod download
-RUN ./run.sh build 
+RUN ./run.sh build
 
 FROM alpine
 RUN apk add gettext musl
@@ -15,4 +15,7 @@ COPY --from=builder /src/radius/config/ /app/
 COPY radius/src/docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod 0755 /app/docker-entrypoint.sh
 WORKDIR /app
+# Add version file with default BUILD_NUM unless set otherwise in build command
+ARG BUILD_NUM=1.0.0
+RUN echo "${BUILD_NUM}" > /app/VERSION
 # ENTRYPOINT [ "./docker-entrypoint.sh" ]

--- a/feg/radius/src/main.go
+++ b/feg/radius/src/main.go
@@ -11,6 +11,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
@@ -18,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"sort"
+	"strings"
 	"syscall"
 
 	"fbc/cwf/radius/config"
@@ -29,6 +31,8 @@ import (
 
 	"go.uber.org/zap"
 )
+
+const versionFile = "/app/VERSION"
 
 func createLogger(encoding string) (*zap.Logger, error) {
 	if encoding == "json" {
@@ -90,6 +94,7 @@ func main() {
 	if config.Monitoring.Scuba != nil {
 		logger = logger.With(zap.String("partner_shortname", config.Monitoring.Scuba.PartnerShortName))
 	}
+	logger = logger.With(zap.String("app_version", GetVersion()))
 	loader := loader.NewStaticLoader(logger)
 
 	// Create server
@@ -136,4 +141,13 @@ func getHostIdentifier() string {
 
 	// Just a random, unstable identifer
 	return fmt.Sprintf("random:%d", rand.Intn(9999999))
+}
+
+// GetVersion returns version of the app
+func GetVersion() string {
+	data, err := ioutil.ReadFile(versionFile)
+	if err != nil {
+		return "NA"
+	}
+	return strings.TrimSuffix(string(data), "\n")
 }


### PR DESCRIPTION
Summary: After Adding CI to build, test and push latest go_radius located at magma repo, its time we will know  which version is running on our prod hosts using new column called "app_version"

Differential Revision: D22432581

