### PR TITLE
Add clang-format hook for sessiond_manager

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -11,6 +11,9 @@ PROJECT(SessionManager)
 
 add_compile_options(-std=c++14)
 
+set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/modules")
+include(FindClangFormat)
+
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 
 if (NOT BUILD_TESTS)
@@ -156,6 +159,15 @@ target_link_libraries(SESSION_MANAGER
   prometheus-cpp tacopie
   )
 
+if (CLANG_FORMAT)
+  add_custom_target(
+          clang-format
+          COMMAND ${CLANG_FORMAT}
+          -style=file
+          -i
+          ${ALL_CXX_SOURCE_FILES}
+  )
+endif ()
 
 add_executable(sessiond ${PROJECT_SOURCE_DIR}/sessiond_main.cpp)
 

--- a/lte/gateway/c/session_manager/modules/FindClangFormat.cmake
+++ b/lte/gateway/c/session_manager/modules/FindClangFormat.cmake
@@ -1,0 +1,14 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+file(GLOB_RECURSE
+        ALL_CXX_SOURCE_FILES
+        *.[chi]pp *.[chi]xx *.cc *.hh *.ii *.[CHI]
+        )
+
+find_program(CLANG_FORMAT "clang-format")
+message("Found CLANG_FORMAT: ${CLANG_FORMAT}")


### PR DESCRIPTION
Summary: Add a cmake hook for clang format to make it consistent with MME code

Reviewed By: themarwhal

Differential Revision: D22428352

