### PR TITLE
Add logging of some GRPC messages

### DIFF
--- a/cwf/gateway/docker/docker-compose.override.yml
+++ b/cwf/gateway/docker/docker-compose.override.yml
@@ -32,6 +32,8 @@ services:
       dockerfile: cwf/gateway/docker/python/Dockerfile
 
   sessiond:
+    environment:
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
     build:
       context: ${BUILD_CONTEXT}
       dockerfile: cwf/gateway/docker/c/Dockerfile

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -148,9 +148,10 @@ add_library(SESSION_MANAGER
     StoreClient.h
     MeteringReporter.cpp
     MeteringReporter.h
+    GrpcMagmaUtils.cpp
+    GrpcMagmaUtils.h
     ${PROTO_SRCS}
-    ${PROTO_HDRS}
-    )
+    ${PROTO_HDRS})
 
 target_link_libraries(SESSION_MANAGER
   SERVICE303_LIB SERVICE_REGISTRY ASYNC_GRPC CONFIG POLICYDB EVENTD

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#include <string>
+#include <google/protobuf/message.h>
+#include "magma_logging.h"
+#include "GrpcMagmaUtils.h"
+
+#define MAGMA_PRINT_GRPC_PAYLOAD "MAGMA_PRINT_GRPC_PAYLOAD"
+
+std::string grpcLoginLevel = get_env_var(MAGMA_PRINT_GRPC_PAYLOAD);
+
+std::string get_env_var(std::string const& key) {
+  MLOG(MINFO) << "Checking env var " << key;
+  char* val;
+  val = getenv(key.c_str());
+  std::string retval = "" ;
+  if (val != NULL) {
+    retval = val;
+  }
+  return std::string(retval);
+}
+
+void PrintGrpcMessage(const google::protobuf::Message& message){
+  if (grpcLoginLevel == "1") {
+      const google::protobuf::Descriptor* desc = message.GetDescriptor();
+      MLOG(MINFO) << "\n"
+                  << "  " << desc->full_name().c_str() << " {\n"
+                  << indentText(message.DebugString(), 6)
+                  << "  }";
+    }
+}
+
+std::string indentText(std::string basicString, int indent) {
+  std::stringstream iss(basicString);
+  std::string blanks(indent, ' ');
+  std::string result = "";
+  while(iss.good())
+  {
+    std::string SingleLine;
+    getline(iss,SingleLine,'\n');
+    //skip empty lines
+    if (SingleLine == ""){
+      continue;
+    }
+    result += blanks;
+    result += SingleLine;
+    // do not add \n on the last line
+    result += "\n";
+  }
+  return result;
+}

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.h
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.h
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2016-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+#pragma once
+
+#include "GRPCReceiver.h"
+
+std::string get_env_var(std::string const& key);
+
+void PrintGrpcMessage(const google::protobuf::Message& message);
+
+std::string indentText(std::string basicString, int indent);

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -13,6 +13,7 @@
 
 #include "LocalSessionManagerHandler.h"
 #include "magma_logging.h"
+#include "GrpcMagmaUtils.h"
 
 using grpc::Status;
 
@@ -94,6 +95,8 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
       [this, request, session_update,
        session_map_ptr = std::make_shared<SessionMap>(std::move(session_map))](
           Status status, UpdateSessionResponse response) mutable {
+        PrintGrpcMessage(
+            static_cast<const google::protobuf::Message&>(response));
         if (!status.ok()) {
           MLOG(MERROR) << "Update of size " << request.updates_size()
                        << " to OCS failed entirely: " << status.error_message();
@@ -264,6 +267,7 @@ void LocalSessionManagerHandlerImpl::CreateSession(
     ServerContext* context, const LocalCreateSessionRequest* request,
     std::function<void(Status, LocalCreateSessionResponse)> response_callback) {
   auto& request_cpy = *request;
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread([this, context,
                                                     response_callback,
                                                     request_cpy]() {
@@ -340,6 +344,8 @@ void LocalSessionManagerHandlerImpl::send_create_session(
       [this, imsi, sid, cfg, response_callback,
        session_map_ptr = std::make_shared<SessionMap>(std::move(session_map))](
           Status status, CreateSessionResponse response) mutable {
+        PrintGrpcMessage(
+            static_cast<const google::protobuf::Message&>(response));
         if (status.ok()) {
           bool success = enforcer_->init_session_credit(
               *session_map_ptr, imsi, sid, cfg, response);
@@ -427,6 +433,7 @@ void LocalSessionManagerHandlerImpl::EndSession(
     ServerContext* context, const LocalEndSessionRequest* request,
     std::function<void(Status, LocalEndSessionResponse)> response_callback) {
   auto& request_cpy = *request;
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread(
       [this, request_cpy = std::move(request_cpy), response_callback]() {
         auto session_map = get_sessions_for_deletion(request_cpy);

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -13,6 +13,9 @@
 #include "SessionProxyResponderHandler.h"
 #include "magma_logging.h"
 
+#include "magma_logging.h"
+#include "GrpcMagmaUtils.h"
+
 using grpc::Status;
 
 namespace magma {
@@ -24,6 +27,7 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
     ServerContext* context, const ChargingReAuthRequest* request,
     std::function<void(Status, ChargingReAuthAnswer)> response_callback) {
   auto& request_cpy = *request;
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MDEBUG) << "Received a Gy (Charging) ReAuthRequest for "
                << request->session_id() << " and charging_key "
                << request->charging_key();
@@ -43,6 +47,7 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
         if (update_success) {
           MLOG(MDEBUG) << "Sending RAA response for Gy ReAuth "
                        << request_cpy.session_id();
+          PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
           response_callback(Status::OK, ans);
         } else {
           // Todo If update fails, we should rollback changes from the request
@@ -51,6 +56,7 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
               grpc::ABORTED,
               "ChargingReAuth no longer valid due to another update that "
               "updated the session first.");
+          PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
           response_callback(status, ans);
         }
         MLOG(MDEBUG) << "Sent RAA response for Gy ReAuth "
@@ -62,6 +68,7 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
     ServerContext* context, const PolicyReAuthRequest* request,
     std::function<void(Status, PolicyReAuthAnswer)> response_callback) {
   auto& request_cpy = *request;
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   MLOG(MDEBUG) << "Received a Gx (Policy) ReAuthRequest for session_id "
                << request->session_id();
   enforcer_->get_event_base().runInEventBaseThread(
@@ -77,6 +84,7 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
         if (update_success) {
           MLOG(MDEBUG) << "Sending RAA response for Gx ReAuth "
                        << request_cpy.session_id();
+          PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
           response_callback(Status::OK, ans);
         } else {
         // Todo If update fails, we should rollback changes from the request
@@ -85,6 +93,7 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
               grpc::ABORTED,
               "PolicyReAuth no longer valid due to another update that "
               "updated the session first.");
+          PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
           response_callback(status, ans);
         }
         MLOG(MDEBUG) << "Sent RAA response for Gx ReAuth "

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -11,6 +11,7 @@
 #include "ServiceRegistrySingleton.h"
 #include "SessionReporter.h"
 #include "magma_logging.h"
+#include "GrpcMagmaUtils.h"
 
 namespace magma {
 
@@ -62,6 +63,7 @@ void SessionReporterImpl::report_updates(
   const UpdateSessionRequest& request,
   ReporterCallbackFn<UpdateSessionResponse> callback)
 {
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
   auto controller_response = new AsyncEvbResponse<UpdateSessionResponse>(
     base_, callback, RESPONSE_TIMEOUT);
   controller_response->set_response_reader(std::move(stub_->AsyncUpdateSession(
@@ -72,6 +74,7 @@ void SessionReporterImpl::report_create_session(
   const CreateSessionRequest& request,
   ReporterCallbackFn<CreateSessionResponse> callback)
 {
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
   auto controller_response = new AsyncEvbResponse<CreateSessionResponse>(
     base_, callback, RESPONSE_TIMEOUT);
   controller_response->set_response_reader(std::move(stub_->AsyncCreateSession(
@@ -82,6 +85,7 @@ void SessionReporterImpl::report_terminate_session(
   const SessionTerminateRequest& request,
   ReporterCallbackFn<SessionTerminateResponse> callback)
 {
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request));
   auto controller_response = new AsyncEvbResponse<SessionTerminateResponse>(
     base_, callback, RESPONSE_TIMEOUT);
   controller_response->set_response_reader(

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -23,6 +23,7 @@
 #include "magma_logging.h"
 #include "SessionCredit.h"
 #include "SessionStore.h"
+#include "GrpcMagmaUtils.h"
 
 #define SESSIOND_SERVICE "sessiond"
 #define SESSION_PROXY_SERVICE "session_proxy"
@@ -104,15 +105,14 @@ int main(int argc, char *argv[])
   __gcov_flush();
 #endif
 
-  MLOG(MINFO) << "Starting Session Manager";
   magma::init_logging(argv[0]);
+
   auto mconfig = load_mconfig();
   auto config =
     magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, mconfig));
-
+  MLOG(MINFO) << "Starting Session Manager";
   folly::EventBase *evb = folly::EventBaseManager::get()->getEventBase();
-
 
   // prep rule manager and rule update loop
   auto rule_store = std::make_shared<magma::StaticRuleStore>();


### PR DESCRIPTION
Summary:
This diff adds the capability to show some GRPC messages through the log.
To enable this we just need to set the following var env `MAGMA_PRINT_GRPC_PAYLOAD = 1`

The messages that will be displayed are limited to reduce the verbosity. Pipelined messages, SPGW, AAA_server are not displayed, but they can be easilty added in case they were necessary

Note we have left out `update request` comming from pipeliend since this is too verbose and only includes information that can be seen through other logs.

This is an example of update request and its response
```
essiond         | I0709 02:14:12.114149     8 SessionStore.cpp:61] sync_request_numbers: Writing into session store
sessiond         | I0709 02:14:12.115883     8 GrpcMagmaUtils.cpp:33] --- GRPC message ---
sessiond         |   magma.lte.UpdateSessionRequest {
sessiond         |       updates {
sessiond         |         usage {
sessiond         |           charging_key: 1
sessiond         |           type: REAUTH_REQUIRED
sessiond         |         }
sessiond         |         session_id: "IMSI941716891309035-183657"
sessiond         |         request_number: 2
sessiond         |         sid: "IMSI941716891309035"
sessiond         |         msisdn: "5100001234"
sessiond         |         apn: "98-DE-D0-84-B5-47:CWF-TP-LINK_B547_5G"
sessiond         |         rat_type: TGPP_WLAN
sessiond         |         hardware_addr: "\312\247\217\020\200B"
sessiond         |         tgpp_ctx {
sessiond         |           gx_dest_host: "pcrf.epc.mnc001.mcc001.3gppnetwork.org"
sessiond         |           gy_dest_host: "sdp1c.epc.mnc001.mcc001.3gppnetwork.org"
sessiond         |         }
sessiond         |       }
sessiond         |   }
sessiond         | I0709 02:14:12.122038     8 GrpcMagmaUtils.cpp:33] --- GRPC message ---
sessiond         |   magma.lte.UpdateSessionResponse {
sessiond         |       responses {
sessiond         |         success: true
sessiond         |         sid: "IMSI941716891309035"
sessiond         |         charging_key: 1
sessiond         |         credit {
sessiond         |           validity_time: 60
sessiond         |           is_final: true
sessiond         |           granted_units {
sessiond         |             total {
sessiond         |               is_valid: true
sessiond         |               volume: 3145728
sessiond         |             }
sessiond         |             tx {
sessiond         |               is_valid: true
sessiond         |             }
sessiond         |             rx {
sessiond         |               is_valid: true
sessiond         |             }
sessiond         |           }
sessiond         |           redirect_server {
sessiond         |           }
sessiond         |         }
sessiond         |         result_code: 2001
sessiond         |         tgpp_ctx {
sessiond         |           gx_dest_host: "pcrf.epc.mnc001.mcc001.3gppnetwork.org"
sessiond         |           gy_dest_host: "sdp1c.epc.mnc001.mcc001.3gppnetwork.org"
sessiond         |         }
sessiond         |       }
sessiond         |   }
sessiond         | I0709 02:14:12.122133     8 SessionState.cpp:816] IMSI941716891309035-183657 Received a charging credit for RG: 1
sessiond         | I0709 02:14:12.122139     8 SessionCredit.cpp:118] Received the following credit total_volume=3145728 tx_volume=0 rx_volume=0 grant_tracking_type=TOTAL_ONLY
sessiond         | I0709 02:14:12.122143     8 SessionCredit.cpp:324] ===> Used     Tx: 4452951 Rx: 5541 Total: 4458492
```

Differential Revision: D22450189

