### PR TITLE
Add ReAuth reason to AVP

### DIFF
--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -613,3 +613,4 @@ k8s.io/client-go v8.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodB
 k8s.io/kube-openapi v0.0.0-20180629012420-d83b052f768a/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 labix.org/v2/mgo v0.0.0-20140701140051-000000000287/go.mod h1:Lg7AYkt1uXJoR9oeSZ3W/8IXLdvOfIITgZnommstyz4=
 launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
+layeh.com/radius v0.0.0-20200615152116-663b41c3bf86/go.mod h1:lGEjzZ49j7EhtyvqZboqTYD6tnw/NR0S8ix1PXHfRgE=

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/feg/cloud/go/protos"
 	fegProtos "magma/feg/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
+	"magma/feg/gateway/services/session_proxy/credit_control/gy"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 
@@ -352,10 +353,16 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 		SetQuotaGrant(quotaGrant)
 	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
 
+	expectedMSCC := &protos.MultipleServicesCreditControl{
+		RatingGroup: 1,
+		UpdateType:  int32(gy.FORCED_REAUTHORISATION),
+	}
 	// We expect an update request with some usage update after reauth
-	updateRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_UPDATE)
+	updateRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_UPDATE).
+		SetMSCC(expectedMSCC)
 	updateAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant)
-	updateExpectation := protos.NewGyCreditControlExpectation().Expect(updateRequest).Return(updateAnswer)
+	updateExpectation := protos.NewGyCreditControlExpectation().Expect(updateRequest).
+		Return(updateAnswer)
 	expectations := []*protos.GyCreditControlExpectation{initExpectation, updateExpectation}
 
 	// On unexpected requests, just return the default update answer

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -377,13 +377,15 @@ func getMSCCAVP(requestType credit_control.CreditRequestType, credits *UsedCredi
 			diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(credits.TotalOctets)),
 		}
 
+		// For documentation on where the reporting reason AVP is placed, see section 7.2.175 on
+		// https://www.etsi.org/deliver/etsi_ts/132200_132299/132299/12.06.00_60/ts_132299v120600p.pdf
 		switch credits.Type {
-		case FINAL, VALIDITY_TIMER_EXPIRED:
+		case FINAL, VALIDITY_TIMER_EXPIRED, FORCED_REAUTHORISATION, QHT, RATING_CONDITION_CHANGE:
 			avpGroup = append(
 				avpGroup,
 				diam.NewAVP(
 					avp.ReportingReason, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, datatype.Enumerated(credits.Type)))
-		case QUOTA_EXHAUSTED:
+		case QUOTA_EXHAUSTED, THRESHOLD, OTHER_QUOTA_TYPE, POOL_EXHAUSTED:
 			usuGrp = append(
 				usuGrp,
 				diam.NewAVP(

--- a/feg/gateway/services/testcore/ocs/mock_ocs/mock.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/mock.go
@@ -88,13 +88,16 @@ func compareMsccAgainstExpected(actualMscc map[uint32]ccrCredit, expectedMscc []
 		if !exists {
 			return false
 		}
-		actualTotal := actualCredit.UsedServiceUnit.TotalOctets
-		expectedTotal := expectedCredit.UsedServiceUnit.TotalOctets
-		if !mock_driver.EqualWithinDelta(actualTotal, expectedTotal, delta) {
-			return false
+		// If there is no expectation set for UsedServiceUnit, don't assert
+		if expectedCredit.UsedServiceUnit != nil {
+			actualTotal := actualCredit.UsedServiceUnit.TotalOctets
+			expectedTotal := expectedCredit.UsedServiceUnit.TotalOctets
+			if !mock_driver.EqualWithinDelta(actualTotal, expectedTotal, delta) {
+				return false
+			}
 		}
 		switch gy.UsedCreditsType(expectedCredit.UpdateType) {
-		case gy.VALIDITY_TIMER_EXPIRED, gy.FINAL:
+		case gy.VALIDITY_TIMER_EXPIRED, gy.FINAL, gy.FORCED_REAUTHORISATION:
 			return expectedCredit.UpdateType == int32(actualCredit.ReportingReason)
 		case gy.QUOTA_EXHAUSTED:
 			return expectedCredit.UpdateType == int32(actualCredit.UsedServiceUnit.ReportingReason)


### PR DESCRIPTION
Summary:
SessionProxy previously was not propagating the ReportingReason for Gy UpdateRequests properly. There are two ways the reporting reason can be relayed: in the MSCC and in the USU.  For the spec see section 7.2.175 in https://www.etsi.org/deliver/etsi_ts/132200_132299/132299/12.06.00_60/ts_132299v120600p.pdf .

Also added some reporting reason assertion in `TestGyCreditExhaustionRedirect`

Reviewed By: emakeev

Differential Revision: D22454402

