### PR TITLE
Add cwf-operator jobs to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,6 +176,24 @@ jobs:
             cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway precommit
 
+  cwf-operator-precommit:
+    docker:
+      - image: circleci/golang:1.13-buster-node-browsers-legacy
+    environment:
+      - GO111MODULE=on
+      - GOPROXY=https://proxy.golang.org
+    steps:
+      - checkout
+      - run: echo 'export MAGMA_ROOT=$(pwd)' >> $BASH_ENV
+      - run: ./circleci/golang_before_install.sh
+      - run-with-retry:
+          command: go mod download
+          workdir: ${MAGMA_ROOT}/cwf/k8s/cwf_operator
+      - run:
+          command: |
+            cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator
+            make -C ${MAGMA_ROOT}/cwf/k8s/cwf_operator precommit
+
   cloud-test:
     machine:
       image: ubuntu-1604:201903-01
@@ -589,6 +607,7 @@ workflows:
     jobs:
       - feg-precommit
       - cwag-precommit
+      - cwf-operator-precommit
       - cloud-test
       - orc8r-gateway-test
       - lte-test

--- a/cwf/k8s/cwf_operator/Makefile
+++ b/cwf/k8s/cwf_operator/Makefile
@@ -29,3 +29,4 @@ vet::
 build::
 	go install ./...
 
+precommit: fmt test vet

--- a/cwf/k8s/cwf_operator/docker/.env
+++ b/cwf/k8s/cwf_operator/docker/.env
@@ -1,0 +1,8 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+COMPOSE_PROJECT_NAME=cwf

--- a/cwf/k8s/cwf_operator/docker/docker-compose.yml
+++ b/cwf/k8s/cwf_operator/docker/docker-compose.yml
@@ -6,7 +6,7 @@
 version: "3.7"
 
 services:
-  cwf_operator:
+  operator:
     build:
       context: ../../../../
       dockerfile: cwf/k8s/cwf_operator/docker/Dockerfile


### PR DESCRIPTION
Summary:
This diff adds a precommit and build job
to circleCI for the cwf_operator. The operator is
a new magma component that is needed for CWAG HA deployment.

Reviewed By: xjtian

Differential Revision: D22454008

