### PR TITLE
Fix policydb for local pcrf

### DIFF
--- a/lte/cloud/go/plugin/mconfig.go
+++ b/lte/cloud/go/plugin/mconfig.go
@@ -407,7 +407,7 @@ func getPolicydbMconfig(networkID string) *mconfig.PolicyDB {
 	}
 }
 
-func getRatingGroups(networkID string) map[uint32]*models2.RatingGroup {
+func getRatingGroups(networkID string) map[uint32]*policyModels.RatingGroup {
 	ratingGroupEnts, err := configurator.LoadAllEntitiesInNetwork(
 		networkID, lte.RatingGroupEntityType,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
@@ -415,7 +415,7 @@ func getRatingGroups(networkID string) map[uint32]*models2.RatingGroup {
 	if err != nil {
 		glog.Errorf("Could not get rating groups of network")
 	}
-	ratingGroups := map[uint32]*models2.RatingGroup{}
+	ratingGroups := map[uint32]*policyModels.RatingGroup{}
 	for _, ent := range ratingGroupEnts {
 		ratingGroup := (ent.Config).(*policyModels.RatingGroup)
 		id := uint32(ratingGroup.ID)

--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -87,6 +87,8 @@
     },
     "policydb": {
       "@type": "type.googleapis.com/magma.mconfig.PolicyDB",
+      "infiniteUnmeteredChargingKeys": [],
+      "infiniteMeteredChargingKeys": [],
       "logLevel": "INFO"
     },
     "redirectd": {


### PR DESCRIPTION
Summary:
## Changes
- Remove IMSI prefix, allowing assigned policy rules to be retrieved correctly for a subscriber from subscriberdb
- Infinite credit grants provided for both metered and unmetered charging keys

Reviewed By: themarwhal

Differential Revision: D22362818

