### PR TITLE
Session Manager will install policies without credit grant if charging key is infinite-credit

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -778,13 +778,6 @@ void LocalEnforcer::filter_rule_installs(
   dynamic_installs.erase(end_of_valid_dy_rules, dynamic_installs.end());
 }
 
-// return true if any credit unit is valid and has non-zero volume
-static bool contains_credit(const GrantedUnits& gsu) {
-  return (gsu.total().is_valid() && gsu.total().volume() > 0) ||
-         (gsu.tx().is_valid() && gsu.tx().volume() > 0) ||
-         (gsu.rx().is_valid() && gsu.rx().volume() > 0);
-}
-
 bool LocalEnforcer::handle_session_init_rule_updates(
     SessionMap& session_map, const std::string& imsi,
     SessionState& session_state, const CreateSessionResponse& response,
@@ -843,8 +836,7 @@ bool LocalEnforcer::init_session_credit(
   std::unordered_set<uint32_t> charging_credits_received;
   for (const auto& credit : response.credits()) {
     auto uc = get_default_update_criteria();
-    session_state->receive_charging_credit(credit, uc);
-    if (credit.success() && contains_credit(credit.credit().granted_units())) {
+    if (session_state->receive_charging_credit(credit, uc)) {
       charging_credits_received.insert(credit.charging_key());
     }
   }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -144,6 +144,16 @@ class SessionState {
   bool reset_reporting_charging_credit(const CreditKey &key,
                               SessionStateUpdateCriteria &update_criteria);
 
+  /**
+   * Receive the credit grant if the credit update was successful
+   *
+   * @param update
+   * @param uc
+   * @return True if usage for the charging key is allowed after receiving
+   *         the credit response. This requires that the credit update was
+   *         a success. Also it must either be an infinite credit rating group,
+   *         or have associated credit grant.
+   */
   bool receive_charging_credit(const CreditUpdateResponse &update,
                                SessionStateUpdateCriteria &update_criteria);
 
@@ -423,8 +433,25 @@ class SessionState {
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& uc);
 
+  /**
+   * Receive the credit grant if the credit update was successful
+   *
+   * @param update
+   * @param uc
+   * @return True if usage for the charging key is allowed after receiving
+   *         the credit response. This requires that the credit update was
+   *         a success. Also it must either be an infinite credit rating group,
+   *         or have associated credit grant.
+   */
   bool init_charging_credit(
     const CreditUpdateResponse &update, SessionStateUpdateCriteria &uc);
+
+  /**
+   * Return true if any credit unit is valid and has non-zero volume
+   */
+  bool contains_credit(const GrantedUnits& gsu);
+
+  bool is_infinite_credit(const CreditUpdateResponse& response);
 
   /**
    * For this session, add the UsageMonitoringUpdateRequest to the

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -27,6 +27,18 @@ void create_charging_credit(
   credit->set_is_final(is_final);
 }
 
+void create_credit_update_response(
+  const std::string& imsi,
+  uint32_t charging_key,
+  CreditLimitType limit_type,
+  CreditUpdateResponse* response)
+{
+  response->set_success(true);
+  response->set_sid(imsi);
+  response->set_charging_key(charging_key);
+  response->set_limit_type(limit_type);
+}
+
 // defaults to not final credit
 void create_credit_update_response(
     const std::string& imsi, uint32_t charging_key, uint64_t volume,

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -26,6 +26,12 @@ void create_charging_credit(
   uint64_t volume, bool is_final, ChargingCredit* credit);
 
 void create_credit_update_response(
+    const std::string& imsi,
+    uint32_t charging_key,
+    CreditLimitType limit_type,
+    CreditUpdateResponse* response);
+
+void create_credit_update_response(
   const std::string& imsi,
   uint32_t charging_key,
   uint64_t volume,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -187,6 +187,56 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
       1024);
 }
 
+TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
+  insert_static_rule(1, "", "rule1");
+
+  CreateSessionResponse response;
+  auto credits = response.mutable_credits();
+  create_credit_update_response("IMSI1", 1, INFINITE_METERED, credits->Add());
+
+  StaticRuleInstall rule1;
+  rule1.set_rule_id("rule1");
+  auto rules_to_install = response.mutable_static_rules();
+  rules_to_install->Add()->CopyFrom(rule1);
+
+  // Expect rule1 to be activated
+  EXPECT_CALL(*pipelined_client,
+              activate_flows_for_rules(testing::_, testing::_, CheckCount(1),
+                                       CheckCount(0), testing::_))
+  .Times(1)
+  .WillOnce(testing::Return(true));
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg,
+                                      response);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1,
+                                                ALLOWED_TOTAL),
+            0);
+}
+
+TEST_F(LocalEnforcerTest, test_init_no_credit) {
+  insert_static_rule(1, "", "rule1");
+
+  CreateSessionResponse response;
+  auto credits = response.mutable_credits();
+  create_credit_update_response("IMSI1", 1, FINITE, credits->Add());
+
+  StaticRuleInstall rule1;
+  rule1.set_rule_id("rule1");
+  auto rules_to_install = response.mutable_static_rules();
+  rules_to_install->Add()->CopyFrom(rule1);
+
+  // Expect rule1 to not be activated
+  EXPECT_CALL(*pipelined_client,
+              activate_flows_for_rules(testing::_, testing::_, CheckCount(0),
+                                       CheckCount(0), testing::_))
+  .Times(1)
+  .WillOnce(testing::Return(true));
+  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg,
+                                      response);
+  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1,
+                                                ALLOWED_TOTAL),
+            0);
+}
+
 TEST_F(LocalEnforcerTest, test_init_session_credit) {
   insert_static_rule(1, "", "rule1");
 

--- a/lte/gateway/python/magma/policydb/main.py
+++ b/lte/gateway/python/magma/policydb/main.py
@@ -41,7 +41,9 @@ def main():
     chan = ServiceRegistry.get_rpc_channel('subscriberdb',
                                            ServiceRegistry.LOCAL)
     subscriberdb_stub = SubscriberDBStub(chan)
-    session_servicer = SessionRpcServicer(service.mconfig, subscriberdb_stub)
+    session_servicer = SessionRpcServicer(service.mconfig,
+                                          rating_groups_dict,
+                                          subscriberdb_stub)
     session_servicer.add_to_server(service.rpc_server)
 
     orc8r_chan = ServiceRegistry.get_rpc_channel('policydb',

--- a/lte/gateway/python/magma/policydb/servicers/session_servicer.py
+++ b/lte/gateway/python/magma/policydb/servicers/session_servicer.py
@@ -12,7 +12,7 @@ import logging
 from typing import List
 from lte.protos.mconfig import mconfigs_pb2
 from lte.protos.policydb_pb2 import PolicyRule, FlowDescription, \
-    FlowMatch
+    FlowMatch, RatingGroup
 from lte.protos.session_manager_pb2 import CreateSessionRequest, \
     CreateSessionResponse, UpdateSessionRequest, SessionTerminateResponse, \
     UpdateSessionResponse, StaticRuleInstall, DynamicRuleInstall,\
@@ -21,6 +21,7 @@ from lte.protos.session_manager_pb2_grpc import \
     CentralSessionControllerServicer, \
     add_CentralSessionControllerServicer_to_server
 from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
+from magma.policydb.rating_group_store import RatingGroupsDict
 from orc8r.protos.common_pb2 import NetworkID
 
 
@@ -36,19 +37,27 @@ class SessionRpcServicer(CentralSessionControllerServicer):
     def __init__(
         self,
         mconfig: mconfigs_pb2.PolicyDB,
+        rating_groups_by_id: RatingGroupsDict,
         subscriberdb_stub: SubscriberDBStub,
     ):
         self._mconfig = mconfig
         self._network_id = NetworkID(id="_")
+        self._rating_groups_by_id = rating_groups_by_id
         self._subscriberdb_stub = subscriberdb_stub
 
-    @property
-    def infinite_credit_charging_keys(self) -> List[int]:
-        return self._mconfig.infinite_unmetered_charging_keys
+    def get_infinite_credit_charging_keys(self) -> List[int]:
+        keys = []
+        for rating_group in self._rating_groups_by_id.values():
+            if rating_group.limit_type == RatingGroup.INFINITE_UNMETERED:
+                keys.append(rating_group.id)
+        return keys
 
-    @property
-    def postpay_charging_keys(self) -> List[int]:
-        return self._mconfig.infinite_metered_charging_keys
+    def _get_postpay_charging_keys(self) -> List[int]:
+        keys = []
+        for rating_group in self._rating_groups_by_id.values():
+            if rating_group.limit_type == RatingGroup.INFINITE_METERED:
+                keys.append(rating_group.id)
+        return keys
 
     def add_to_server(self, server):
         """ Add the servicer to a gRPC server """
@@ -64,13 +73,16 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         """
         Handles create session request from MME by installing the necessary
         flows in pipelined's enforcement app.
+
+        NOTE: truncate the 'IMSI' prefix
         """
         imsi = request.subscriber.id
+        imsi_number = imsi[4:]
         logging.info('Creating a session for subscriber ID: %s', imsi)
         return CreateSessionResponse(
             credits=self._get_credits(imsi),
-            static_rules=self._get_rules_for_imsi(imsi),
-            dynamic_rules=self._get_default_dynamic_rules(imsi),
+            static_rules=self._get_rules_for_imsi(imsi_number),
+            dynamic_rules=self._get_default_dynamic_rules(imsi_number),
             session_id=request.session_id,
         )
 
@@ -112,7 +124,6 @@ class SessionRpcServicer(CentralSessionControllerServicer):
     ) -> List[DynamicRuleInstall]:
         """
         Get a list of dynamic rules to install for whitelisting.
-        These rules will whitelist traffic to/from the captive portal server.
         """
         dynamic_rules = []
         # Build the rule id to be globally unique
@@ -165,6 +176,10 @@ class SessionRpcServicer(CentralSessionControllerServicer):
         ]
 
     def _get_rules_for_imsi(self, imsi: str) -> List[StaticRuleInstall]:
+        """
+        Get the list of static rules to be installed for a subscriber
+        NOTE: Remove "IMSI" prefix from imsi argument.
+        """
         try:
             info = self._subscriberdb_stub.GetSubscriberData(NetworkID(id=imsi))
             return [StaticRuleInstall(rule_id=rule_id)
@@ -174,21 +189,21 @@ class SessionRpcServicer(CentralSessionControllerServicer):
             return []
 
     def _get_credits(self, sid: str) -> List[CreditUpdateResponse]:
-        if len(self.infinite_credit_charging_keys) != 0:
-            return [CreditUpdateResponse(
+        infinite_credit_keys = self.get_infinite_credit_charging_keys()
+        postpay_keys = self._get_postpay_charging_keys()
+        credit_updates = []
+        for charging_key in infinite_credit_keys:
+            credit_updates.append(CreditUpdateResponse(
                 success=True,
                 sid=sid,
-                charging_key=self.infinite_credit_charging_keys[0],
-                result_code=1,
+                charging_key=charging_key,
                 limit_type=CreditLimitType.Value("INFINITE_UNMETERED")
-            )]
-        return []
-
-    def _get_rules_for_imsi(self, imsi: str) -> List[StaticRuleInstall]:
-        try:
-            info = self._subscriberdb_stub.GetSubscriberData(NetworkID(id=imsi))
-            return [StaticRuleInstall(rule_id=rule_id)
-                    for rule_id in info.lte.assigned_policies]
-        except grpc.RpcError:
-            logging.error('Unable to find data for subscriber %s', imsi)
-            return []
+            ))
+        for charging_key in postpay_keys:
+            credit_updates.append(CreditUpdateResponse(
+                success=True,
+                sid=sid,
+                charging_key=charging_key,
+                limit_type=CreditLimitType.Value("INFINITE_METERED")
+            ))
+        return credit_updates

--- a/lte/gateway/python/magma/policydb/tests/test_session_servicer.py
+++ b/lte/gateway/python/magma/policydb/tests/test_session_servicer.py
@@ -10,6 +10,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 import unittest
 from typing import List
 from lte.protos.mconfig import mconfigs_pb2
+from lte.protos.policydb_pb2 import RatingGroup
 from lte.protos.session_manager_pb2 import CreateSessionRequest, \
     UpdateSessionRequest, CreditUsageUpdate, SessionTerminateRequest, \
     CreditUpdateResponse, CreditLimitType
@@ -26,8 +27,13 @@ USR = '''
     success: true
     sid: "abc"
     charging_key: 1
-    result_code: 1
     limit_type: INFINITE_UNMETERED
+  }
+  responses {
+    success: true
+    sid: "abc"
+    charging_key: 2
+    limit_type: INFINITE_METERED
   }'''
 
 
@@ -48,14 +54,23 @@ class MockSubscriberDBStub:
 
 class SessionRpcServicerTest(unittest.TestCase):
     def setUp(self):
+        rating_groups_by_id= {
+            1: RatingGroup(
+                id=1,
+                limit_type=RatingGroup.INFINITE_UNMETERED,
+            ),
+            2: RatingGroup(
+                id=2,
+                limit_type=RatingGroup.INFINITE_METERED,
+            ),
+        }
         self.servicer = SessionRpcServicer(self._get_mconfig(),
+                                           rating_groups_by_id,
                                            MockSubscriberDBStub())
 
     def _get_mconfig(self) -> mconfigs_pb2.PolicyDB:
         return mconfigs_pb2.PolicyDB(
             log_level=1,
-            infinite_unmetered_charging_keys=[1],
-            infinite_metered_charging_keys=[2],
         )
 
     def tearDown(self):
@@ -105,7 +120,8 @@ class SessionRpcServicerTest(unittest.TestCase):
         session_response = self._rm_whitespace(str(resp))
         expected = self._rm_whitespace(USR)
         self.assertEqual(session_response, expected, 'There should be an '
-                         'infinite, unmetered credit grant')
+                         'infinite, unmetered credit grant and an infinite, '
+                         'metered credit grant')
 
     def test_TerminateSession(self):
         """


### PR DESCRIPTION
Summary:
## Changes
- `session_manager` will now install policies without a credit grant as long as the associated charging key is marked as having infinite credit

Differential Revision: D22405354

