### PR TITLE
Add grpc connection reuse to CWF operator

### DIFF
--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -41,7 +41,7 @@ RUN go mod download; exit 0
 # Copy and build the go code.
 COPY feg/cloud/go/protos $MAGMA_ROOT/feg/cloud/go/protos
 COPY lte/cloud/go/protos $MAGMA_ROOT/lte/cloud/go/protos
-COPY orc8r/lib/go/protos $MAGMA_ROOT/orc8r/lib/go/protos
+COPY orc8r/lib/go $MAGMA_ROOT/orc8r/lib/go
 COPY cwf/k8s/cwf_operator/cmd $MAGMA_ROOT/cwf/k8s/cwf_operator/cmd
 COPY cwf/k8s/cwf_operator/pkg $MAGMA_ROOT/cwf/k8s/cwf_operator/pkg
 COPY cwf/k8s/cwf_operator/version $MAGMA_ROOT/cwf/k8s/cwf_operator/version

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -38,6 +38,7 @@ require (
 
 	magma/feg/cloud/go/protos v0.0.0
 	magma/lte/cloud/go v0.0.0 // indirect
+	magma/orc8r/lib/go v0.0.0
 	magma/orc8r/lib/go/protos v0.0.0
 	sigs.k8s.io/controller-runtime v0.5.1
 )

--- a/cwf/k8s/cwf_operator/go.sum
+++ b/cwf/k8s/cwf_operator/go.sum
@@ -1104,6 +1104,7 @@ golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e h1:3G+cUijn7XD+S4eJFddp53Pv7+slrESplyjG25HgL+k=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20160608215109-65a8d08c6292/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1156,6 +1157,7 @@ golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934 h1:u/E0NqCIWRDAo9WCFo6Ko49njPFDLSd3z+X1HgWDMpE=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170810154203-b19bf474d317/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/cwf/k8s/cwf_operator/pkg/health_client/health_client.go
+++ b/cwf/k8s/cwf_operator/pkg/health_client/health_client.go
@@ -10,24 +10,29 @@ package health_client
 
 import (
 	"context"
-	"fmt"
-	"time"
 
+	"magma/cwf/k8s/cwf_operator/pkg/registry"
 	"magma/feg/cloud/go/protos"
 	orc8rprotos "magma/orc8r/lib/go/protos"
-
-	"google.golang.org/grpc"
 )
 
-const (
-	GrpcMaxDelaySec   = 10
-	GrpcMaxTimeoutSec = 10
-)
+type HealthClient struct {
+	registry.ConnectionRegistry
+}
 
-// getClient is a utility function to get an RPC connection to
-// the gateway's health service for the provided service address.
-func getClient(serviceAddr string) (protos.ServiceHealthClient, error) {
-	conn, err := getConnection(serviceAddr)
+// NewHealthClient creates a new health client with an embedded connection
+// registry, to allow for reuse of existing connections.
+func NewHealthClient() *HealthClient {
+	connReg := registry.NewK8sConnectionRegistry()
+	return &HealthClient{
+		ConnectionRegistry: connReg,
+	}
+}
+
+// getGatewayClient is a utility function to get an RPC connection to
+// the health service at the provided service address.
+func (h *HealthClient) getGatewayClient(addr string, port int) (protos.ServiceHealthClient, error) {
+	conn, err := h.GetConnection(addr, port)
 	if err != nil {
 		return nil, err
 	}
@@ -37,8 +42,8 @@ func getClient(serviceAddr string) (protos.ServiceHealthClient, error) {
 
 // GetHealthStatus calls the provided service address to obtain health
 // status from a gateway.
-func GetHealthStatus(address string) (*protos.HealthStatus, error) {
-	client, err := getClient(address)
+func (h *HealthClient) GetHealthStatus(address string, port int) (*protos.HealthStatus, error) {
+	client, err := h.getGatewayClient(address, port)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +52,8 @@ func GetHealthStatus(address string) (*protos.HealthStatus, error) {
 
 // Enable calls the provided service address to enable gateway functionality
 // after a standby gateway is promoted.
-func Enable(address string) error {
-	client, err := getClient(address)
+func (h *HealthClient) Enable(address string, port int) error {
+	client, err := h.getGatewayClient(address, port)
 	if err != nil {
 		return err
 	}
@@ -58,27 +63,12 @@ func Enable(address string) error {
 
 // Disable calls the provided service address to disable gateway functionality
 // after an active gateway is demoted.
-func Disable(address string) error {
+func (h *HealthClient) Disable(address string, port int) error {
 	req := &protos.DisableMessage{}
-	client, err := getClient(address)
+	client, err := h.getGatewayClient(address, port)
 	if err != nil {
 		return err
 	}
 	_, err = client.Disable(context.Background(), req)
 	return err
-}
-
-// getConnection provides a gRPC connection to a service in the registry.
-func getConnection(serviceAddr string) (*grpc.ClientConn, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), GrpcMaxTimeoutSec*time.Second)
-	defer cancel()
-	conn, err := grpc.DialContext(ctx, serviceAddr, grpc.WithBackoffMaxDelay(GrpcMaxDelaySec*time.Second),
-		grpc.WithBlock(),
-		grpc.WithInsecure())
-	if err != nil {
-		return nil, fmt.Errorf("Address: %s GRPC Dial error: %s", serviceAddr, err)
-	} else if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	return conn, nil
 }

--- a/cwf/k8s/cwf_operator/pkg/registry/registry.go
+++ b/cwf/k8s/cwf_operator/pkg/registry/registry.go
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	orc8rregistry "magma/orc8r/lib/go/registry"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	GrpcMaxDelaySec   = 10
+	GrpcMaxTimeoutSec = 10
+)
+
+// ConnectionRegistry defines an interface to get a gRPC connection to a
+// a service.
+type ConnectionRegistry interface {
+	GetConnection(addr string, port int) (*grpc.ClientConn, error)
+}
+
+type k8sConnectionRegistry struct {
+	sync.RWMutex
+	*orc8rregistry.ServiceRegistry
+}
+
+// NewK8sConnectionRegistry creates and initializes a connection registry.
+func NewK8sConnectionRegistry() *k8sConnectionRegistry {
+	return &k8sConnectionRegistry{
+		sync.RWMutex{},
+		orc8rregistry.New(),
+	}
+}
+
+// GetConnection gets a connection to a kubernetes service at service:port.
+// The connection implementation uses orc8r/lib's service registry, which will
+// reuse a gRPC connection if it already exists.
+func (r *k8sConnectionRegistry) GetConnection(service string, port int) (*grpc.ClientConn, error) {
+	serviceAddr := fmt.Sprintf("%s:%d", service, port)
+	exists := doesServiceExist(r.ListAllServices(), serviceAddr)
+	if !exists {
+		// Kubernetes services can be reached at svc:port
+		// Here we map svc:port -> addr (svc:port) in the registry to ensure
+		// that the connections will work properly even if service port changes
+		loc := orc8rregistry.ServiceLocation{Name: serviceAddr, Host: service, Port: port}
+		r.AddService(loc)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), GrpcMaxTimeoutSec*time.Second)
+	defer cancel()
+
+	return r.GetConnectionImpl(ctx, serviceAddr)
+}
+
+func doesServiceExist(serviceList []string, service string) bool {
+	for _, svc := range serviceList {
+		if svc == service {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Summary:
This diff is a result of issues seen duing CWAG HA
SIT testing. Previously, we created a new connection for
each client call to the gateway health service. This has
shown to be resource intensive which is problematic for
a variety of reasons (i.e. wasted k8s control plane time,
longer failovers, etc.)

This diff adds a service connection registry by using
the existing registry in orc8r/lib. Since k8s services
are dynamic and external, here we add services on the
fly.

We set service name to svc:port rather than just
svc as in theory a gw port could change during runtime.
This ensures that if this ever occurs, we won't use
the old connection that no longer works.

Reviewed By: xjtian

Differential Revision: D22451948

