### PR TITLE
Report Session Create/Update/Terminate Events and Failures in session_manager

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -47,7 +47,7 @@ class LocalEnforcer {
       std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
       std::shared_ptr<PipelinedClient> pipelined_client,
       std::shared_ptr<AsyncDirectorydClient> directoryd_client,
-      AsyncEventdClient& eventd_client,
+      std::shared_ptr<EventsReporter> events_reporter,
       std::shared_ptr<SpgwServiceClient> spgw_client,
       std::shared_ptr<aaa::AAAClient> aaa_client,
       long session_force_termination_timeout_ms,
@@ -228,7 +228,7 @@ class LocalEnforcer {
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
-  AsyncEventdClient& eventd_client_;
+  std::shared_ptr<EventsReporter> events_reporter_;
   std::shared_ptr<SpgwServiceClient> spgw_client_;
   std::shared_ptr<aaa::AAAClient> aaa_client_;
   std::unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -64,6 +64,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   LocalSessionManagerHandlerImpl(
       std::shared_ptr<LocalEnforcer> monitor, SessionReporter* reporter,
       std::shared_ptr<AsyncDirectorydClient> directoryd_client,
+      std::shared_ptr<EventsReporter> events_reporter,
       SessionStore& session_store);
   ~LocalSessionManagerHandlerImpl() {}
   /**
@@ -94,6 +95,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   std::shared_ptr<LocalEnforcer> enforcer_;
   SessionReporter* reporter_;
   std::shared_ptr<AsyncDirectorydClient> directoryd_client_;
+  std::shared_ptr<EventsReporter> events_reporter_;
   SessionIDGenerator id_gen_;
   uint64_t current_epoch_;
   uint64_t reported_epoch_;
@@ -165,6 +167,13 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
    *       be undefined behavior.
    */
   SessionMap get_sessions_for_deletion(const LocalEndSessionRequest& request);
+
+  void report_session_update_event(
+      SessionMap& session_map, SessionUpdate& session_update);
+
+  void report_session_update_event_failure(
+      SessionMap& session_map, SessionUpdate& session_update,
+      const std::string& failure_reason);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -21,19 +21,55 @@
 #include "magma_logging.h"
 
 namespace magma {
+namespace lte {
+
+class EventsReporter {
+ public:
+  virtual void session_created(
+      const std::unique_ptr<SessionState>& session) {};
+
+  virtual void session_create_failure(
+      const std::string& imsi,
+      const std::string& apn,
+      const std::string& mac_addr,
+      const std::string& failure_reason) {};
+
+  virtual void session_updated(std::unique_ptr<SessionState>& session) {};
+
+  virtual void session_update_failure(
+      const std::string& failure_reason,
+      std::unique_ptr<SessionState>& session) {};
+
+  virtual void session_terminated(
+      const std::unique_ptr<SessionState>& session) {};
+};
+
 /**
  * Session Events are sent to the eventd service for logging.
  */
-namespace session_events {
+class EventsReporterImpl : public EventsReporter {
+ public:
+  EventsReporterImpl(AsyncEventdClient& eventd_client);
 
-void session_created(
-    AsyncEventdClient& client,
-    const std::string& imsi,
-    const std::string& session_id);
+  void session_created(const std::unique_ptr<SessionState>& session);
 
-void session_terminated(
-    AsyncEventdClient& client,
-    const std::unique_ptr<SessionState>& session);
+  void session_create_failure(
+      const std::string& imsi,
+      const std::string& apn,
+      const std::string& mac_addr,
+      const std::string& failure_reason);
 
-}  // namespace session_events
+  void session_updated(std::unique_ptr<SessionState>& session);
+
+  void session_update_failure(
+      const std::string& failure_reason,
+      std::unique_ptr<SessionState>& session);
+
+  void session_terminated(const std::unique_ptr<SessionState>& session);
+
+ private:
+  AsyncEventdClient& eventd_client_;
+};
+
+}  // namespace lte
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -252,4 +252,20 @@ public:
                     const std::vector<PolicyRule> &));
 };
 
+class MockEventsReporter : public EventsReporter{
+ public:
+  MOCK_METHOD1(session_created,
+               void(const std::unique_ptr<SessionState> &));
+  MOCK_METHOD4(session_create_failure,
+               void(const std::string &, const std::string &,
+                   const std::string &, const std::string &));
+  MOCK_METHOD1(session_updated,
+               void(std::unique_ptr<SessionState> &));
+  MOCK_METHOD2(session_update_failure,
+               void(const std::string &,
+                   const std::unique_ptr<SessionState> &));
+  MOCK_METHOD1(session_terminated,
+               void(const std::unique_ptr<SessionState> &));
+};
+
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -48,10 +48,11 @@ class LocalEnforcerTest : public ::testing::Test {
     directoryd_client    = std::make_shared<MockDirectorydClient>();
     spgw_client          = std::make_shared<MockSpgwServiceClient>();
     aaa_client           = std::make_shared<MockAAAClient>();
+    events_reporter      = std::make_shared<MockEventsReporter>();
     auto default_mconfig = get_default_mconfig();
     local_enforcer       = std::make_unique<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, MockEventdClient::getInstance(), spgw_client,
+        directoryd_client, events_reporter, spgw_client,
         aaa_client, 0, 0, default_mconfig);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
@@ -102,6 +103,7 @@ class LocalEnforcerTest : public ::testing::Test {
   std::shared_ptr<MockDirectorydClient> directoryd_client;
   std::shared_ptr<MockSpgwServiceClient> spgw_client;
   std::shared_ptr<MockAAAClient> aaa_client;
+  std::shared_ptr<MockEventsReporter> events_reporter;
   SessionMap session_map;
   folly::EventBase* evb;
 };

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -43,9 +43,10 @@ class LocalEnforcerTest : public ::testing::Test {
     directoryd_client = std::make_shared<MockDirectorydClient>();
     spgw_client       = std::make_shared<MockSpgwServiceClient>();
     aaa_client        = std::make_shared<MockAAAClient>();
+    events_reporter   = std::make_shared<MockEventsReporter>();
     local_enforcer    = std::make_unique<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, MockEventdClient::getInstance(), spgw_client,
+        directoryd_client, events_reporter, spgw_client,
         aaa_client, 0, 0, mconfig);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
@@ -89,6 +90,7 @@ class LocalEnforcerTest : public ::testing::Test {
   std::shared_ptr<MockDirectorydClient> directoryd_client;
   std::shared_ptr<MockSpgwServiceClient> spgw_client;
   std::shared_ptr<MockAAAClient> aaa_client;
+  std::shared_ptr<MockEventsReporter> events_reporter;
   SessionMap session_map;
   folly::EventBase* evb;
 };

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -60,11 +60,12 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     auto directoryd_client = std::make_shared<MockDirectorydClient>();
     auto spgw_client       = std::make_shared<MockSpgwServiceClient>();
     auto aaa_client        = std::make_shared<MockAAAClient>();
+    auto events_reporter   = std::make_shared<MockEventsReporter>();
     auto default_mconfig   = get_default_mconfig();
     local_enforcer         = std::make_shared<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, MockEventdClient::getInstance(), spgw_client,
-        aaa_client, 0, 0, default_mconfig);
+        directoryd_client, events_reporter, spgw_client, aaa_client, 0, 0,
+        default_mconfig);
     session_map = SessionMap{};
 
     proxy_responder = std::make_shared<SessionProxyResponderHandlerImpl>(

--- a/lte/swagger/session_manager_events.v1.yml
+++ b/lte/swagger/session_manager_events.v1.yml
@@ -16,11 +16,57 @@ definitions:
         type: string
       session_id:
         type: string
+      apn:
+        type: string
+      mac_addr:
+        type: string
+  session_create_failure:
+    type: object
+    description: Used to track when a session creation failed
+    properties:
+      imsi:
+        type: string
+      apn:
+        type: string
+      mac_addr:
+        type: string
+      failure_reason:
+        type: string
+  session_updated:
+    type: object
+    description: Used to track when a session update is reported
+    properties:
+      imsi:
+        type: string
+      apn:
+        type: string
+      mac_addr:
+        type: string
+      ip_addr:
+        type: string
+  session_update_failure:
+    type: object
+    description: Used to track when a session update has failed
+    properties:
+      imsi:
+        type: string
+      apn:
+        type: string
+      mac_addr:
+        type: string
+      ip_addr:
+        type: string
+      failure_reason:
+        type: string
   session_terminated:
     type: object
     description: Used to track total session metrics
     properties:
       imsi:
+        type: string
+      apn:
+        type: string
+      mac_addr:
         type: string
       ip_addr:
         type: string


### PR DESCRIPTION
Summary:
## Changes
- Added `EventsReporter` to allow easy mocking of event reporting from `session_manager`
- Added `session_create_failure`, `session_updated`, `session_update_failure`, and `session_terminated` to event reporting
- Added new swagger types for the new event types
- Added new fields to existing `sessiond` events

Reviewed By: mpgermano

Differential Revision: D22215092

