### PR TITLE
Attach devmand obsidian handlers to devmand service

### DIFF
--- a/cwf/cloud/configs/service_registry.yml
+++ b/cwf/cloud/configs/service_registry.yml
@@ -17,3 +17,7 @@ services:
     port: 9115
     echo_port: 10115
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/cwf"

--- a/cwf/cloud/go/plugin/plugin.go
+++ b/cwf/cloud/go/plugin/plugin.go
@@ -10,10 +10,8 @@ package plugin
 
 import (
 	"magma/cwf/cloud/go/cwf"
-	"magma/cwf/cloud/go/services/cwf/obsidian/handlers"
 	"magma/cwf/cloud/go/services/cwf/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/metricsd"
@@ -58,9 +56,7 @@ func (*CwfOrchestratorPlugin) GetMetricsProfiles(metricsConfig *config.ConfigMap
 }
 
 func (*CwfOrchestratorPlugin) GetObsidianHandlers(metricsConfig *config.ConfigMap) []obsidian.Handler {
-	return plugin.FlattenHandlerLists(
-		handlers.GetHandlers(),
-	)
+	return []obsidian.Handler{}
 }
 
 func (*CwfOrchestratorPlugin) GetStreamerProviders() []providers.StreamProvider {

--- a/cwf/cloud/go/services/cwf/cwf/main.go
+++ b/cwf/cloud/go/services/cwf/cwf/main.go
@@ -11,6 +11,8 @@ package main
 import (
 	"magma/cwf/cloud/go/cwf"
 	cwf_service "magma/cwf/cloud/go/services/cwf"
+	"magma/cwf/cloud/go/services/cwf/obsidian/handlers"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/service"
 
 	"github.com/golang/glog"
@@ -21,6 +23,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating cwf service %s", err)
 	}
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running service and echo server: %s", err)

--- a/devmand/cloud/configs/service_registry.yml
+++ b/devmand/cloud/configs/service_registry.yml
@@ -12,3 +12,7 @@ services:
     port: 9116
     echo_port: 10116
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/symphony"

--- a/devmand/cloud/go/plugin/plugin.go
+++ b/devmand/cloud/go/plugin/plugin.go
@@ -11,7 +11,6 @@ package plugin
 
 import (
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/metricsd"
@@ -21,7 +20,6 @@ import (
 	"magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/config"
 	"orc8r/devmand/cloud/go/devmand"
-	"orc8r/devmand/cloud/go/services/devmand/obsidian/handlers"
 	"orc8r/devmand/cloud/go/services/devmand/obsidian/models"
 )
 
@@ -63,9 +61,7 @@ func (*DevmandOrchestratorPlugin) GetMetricsProfiles(metricsConfig *config.Confi
 
 // GetObsidianHandlers gets the devmand obsidian handlers
 func (*DevmandOrchestratorPlugin) GetObsidianHandlers(metricsConfig *config.ConfigMap) []obsidian.Handler {
-	return plugin.FlattenHandlerLists(
-		handlers.GetHandlers(),
-	)
+	return []obsidian.Handler{}
 }
 
 // GetStreamerProviders gets the stream providers

--- a/devmand/cloud/go/services/devmand/devmand/main.go
+++ b/devmand/cloud/go/services/devmand/devmand/main.go
@@ -9,9 +9,11 @@
 package main
 
 import (
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/service"
 	"orc8r/devmand/cloud/go/devmand"
 	devmand_service "orc8r/devmand/cloud/go/services/devmand"
+	"orc8r/devmand/cloud/go/services/devmand/obsidian/handlers"
 
 	"github.com/golang/glog"
 )
@@ -21,6 +23,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating devmand service %s", err)
 	}
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running service and echo server: %s", err)

--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -12,6 +12,10 @@ services:
     port: 9114
     echo_port: 10114
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/feg,/magma/v1/feg_lte"
 
   feg_relay:
     host: "localhost"

--- a/feg/cloud/go/plugin/plugin.go
+++ b/feg/cloud/go/plugin/plugin.go
@@ -13,10 +13,8 @@ package plugin
 
 import (
 	"magma/feg/cloud/go/feg"
-	"magma/feg/cloud/go/services/feg/obsidian/handlers"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/metricsd"
@@ -62,9 +60,7 @@ func (*FegOrchestratorPlugin) GetMetricsProfiles(metricsConfig *config.ConfigMap
 }
 
 func (*FegOrchestratorPlugin) GetObsidianHandlers(metricsConfig *config.ConfigMap) []obsidian.Handler {
-	return plugin.FlattenHandlerLists(
-		handlers.GetHandlers(),
-	)
+	return []obsidian.Handler{}
 }
 
 func (*FegOrchestratorPlugin) GetStreamerProviders() []providers.StreamProvider {

--- a/feg/cloud/go/services/feg/feg/main.go
+++ b/feg/cloud/go/services/feg/feg/main.go
@@ -11,6 +11,8 @@ package main
 import (
 	"magma/feg/cloud/go/feg"
 	feg_service "magma/feg/cloud/go/services/feg"
+	"magma/feg/cloud/go/services/feg/obsidian/handlers"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/service"
 
 	"github.com/golang/glog"
@@ -21,6 +23,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating feg service %s", err)
 	}
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running service and echo server: %s", err)

--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -13,7 +13,9 @@ services:
     proxy_type: "clientcert"
     labels:
       orc8r.io/stream_provider: "true"
+      orc8r.io/obsidian_handlers: "true"
     annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte,/magma/v1/lte/:network_id"
       orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,rule_mappings,subscriberdb"
 
   subscriberdb:
@@ -21,9 +23,19 @@ services:
     port: 9083
     echo_port: 10083
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte/:network_id/subscribers"
 
   policydb:
     host: "localhost"
     port: 9085
     echo_port: 10085
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/networks/:network_id/policies,
+        /magma/v1/networks/:network_id/rating_groups

--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -11,15 +11,11 @@ package plugin
 import (
 	"magma/lte/cloud/go/lte"
 	lte_service "magma/lte/cloud/go/services/lte"
-	lte_handlers "magma/lte/cloud/go/services/lte/obsidian/handlers"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
-	policydb_handlers "magma/lte/cloud/go/services/policydb/obsidian/handlers"
 	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/lte/cloud/go/services/subscriberdb"
-	subscriberdb_handlers "magma/lte/cloud/go/services/subscriberdb/obsidian/handlers"
 	subscriberdb_models "magma/lte/cloud/go/services/subscriberdb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
-	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/metricsd"
@@ -84,11 +80,7 @@ func (*LteOrchestratorPlugin) GetMetricsProfiles(metricsConfig *config.ConfigMap
 }
 
 func (*LteOrchestratorPlugin) GetObsidianHandlers(metricsConfig *config.ConfigMap) []obsidian.Handler {
-	return plugin.FlattenHandlerLists(
-		lte_handlers.GetHandlers(),
-		policydb_handlers.GetHandlers(),
-		subscriberdb_handlers.GetHandlers(),
-	)
+	return []obsidian.Handler{}
 }
 
 func (*LteOrchestratorPlugin) GetStreamerProviders() []providers.StreamProvider {

--- a/lte/cloud/go/services/lte/lte/main.go
+++ b/lte/cloud/go/services/lte/lte/main.go
@@ -11,7 +11,9 @@ package main
 import (
 	"magma/lte/cloud/go/lte"
 	lte_service "magma/lte/cloud/go/services/lte"
+	"magma/lte/cloud/go/services/lte/obsidian/handlers"
 	"magma/lte/cloud/go/services/lte/servicers"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/streamer/protos"
 
@@ -25,7 +27,7 @@ func main() {
 	}
 
 	protos.RegisterStreamProviderServer(srv.GrpcServer, servicers.NewLTEStreamProviderServicer())
-
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running LTE service and echo server: %s", err)

--- a/lte/cloud/go/services/policydb/policydb/main.go
+++ b/lte/cloud/go/services/policydb/policydb/main.go
@@ -12,7 +12,9 @@ import (
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/policydb"
+	"magma/lte/cloud/go/services/policydb/obsidian/handlers"
 	"magma/lte/cloud/go/services/policydb/servicers"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/service"
 
 	"github.com/golang/glog"
@@ -26,7 +28,7 @@ func main() {
 	}
 	assignmentServicer := servicers.NewPolicyAssignmentServer()
 	protos.RegisterPolicyAssignmentControllerServer(srv.GrpcServer, assignmentServicer)
-
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running service and echo server: %s", err)

--- a/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
+++ b/lte/cloud/go/services/subscriberdb/subscriberdb/main.go
@@ -11,6 +11,8 @@ package main
 import (
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/services/subscriberdb"
+	"magma/lte/cloud/go/services/subscriberdb/obsidian/handlers"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/service"
 
 	"github.com/golang/glog"
@@ -24,6 +26,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating service: %s", err)
 	}
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetHandlers())
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running service and echo server: %s", err)

--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -29,6 +29,14 @@ services:
     proxy_type: "clientcert"
     labels:
       orc8r.io/metrics_exporter: "true"
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/networks/:network_id/alerts,
+        /magma/v1/networks/:network_id/metrics,
+        /magma/v1/networks/:network_id/prometheus,
+        /magma/v1/tenants/:tenant_id/metrics,
+        /magma/v1/tenants/targets_metadata
 
   certifier:
     host: "localhost"
@@ -85,9 +93,22 @@ services:
     port: 9112
     echo_port: 10112
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /,
+        /magma/v1/networks,
+        /magma/v1/networks/:network_id,
+        /magma/v1/channels,
+        /magma/v1/events
 
   tenants:
     host: "localhost"
     port: 9110
     echo_port: 10110
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/tenants,/magma/v1/tenants/:tenants_id"

--- a/orc8r/cloud/docker/controller/supervisord.conf
+++ b/orc8r/cloud/docker/controller/supervisord.conf
@@ -159,7 +159,7 @@ stderr_events_enabled=true
 # LTE services
 
 [program:lte]
-command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/lte -logtostderr=true -v=0
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/lte -run_echo_server=true -logtostderr=true -v=0
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
@@ -167,7 +167,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:policydb]
-command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/policydb -logtostderr=true -v=0
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/policydb -run_echo_server=true -logtostderr=true -v=0
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE
@@ -175,7 +175,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:subscriberdb]
-command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/subscriberdb -logtostderr=true -v=0
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/subscriberdb -run_echo_server=true -logtostderr=true -v=0
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE

--- a/orc8r/cloud/go/obsidian/handler.go
+++ b/orc8r/cloud/go/obsidian/handler.go
@@ -156,6 +156,16 @@ func AttachAll(e *echo.Echo, m ...echo.MiddlewareFunc) {
 	}
 }
 
+// AttachHandlers attaches the provided obsidian handlers to the echo server
+func AttachHandlers(e *echo.Echo, handlers []Handler, m ...echo.MiddlewareFunc) {
+	for _, handler := range handlers {
+		ei := echoHandlerInitializers[handler.Methods]
+		if ei != nil {
+			ei(e, handler.Path, handler.HandlerFunc, m...)
+		}
+	}
+}
+
 func HttpError(err error, code ...int) *echo.HTTPError {
 	var status = http.StatusInternalServerError
 	if len(code) > 0 && code[0] >= http.StatusContinue &&

--- a/orc8r/cloud/go/obsidian/reverse_proxy/reverse_proxy.go
+++ b/orc8r/cloud/go/obsidian/reverse_proxy/reverse_proxy.go
@@ -10,52 +10,78 @@ package reverse_proxy
 
 import (
 	"fmt"
-	"net"
 	"net/url"
+	"strings"
 
-	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/lib/go/registry"
 
 	"github.com/golang/glog"
 	"github.com/labstack/echo"
 	"github.com/labstack/echo/middleware"
 )
 
-// ReverseProxy is a middleware function to properly route requests based off
-// of the request's remote address
-func ReverseProxy(next echo.HandlerFunc) echo.HandlerFunc {
-	urlString := fmt.Sprintf("http://localhost:%d", obsidian.Port)
-	localObsidianURL, err := url.Parse(urlString)
+// AddReverseProxyPaths adds reverse proxying from the echo server to every
+// service that has registered obsidian handlers. The proxying is based off of
+// the path prefixes that have been registered in the services' annotations.
+func AddReverseProxyPaths(server *echo.Echo) (*echo.Echo, error) {
+	pathPrefixesByAddr, err := getEchoServerAddressToPathPrefixes()
 	if err != nil {
-		glog.Error(err)
+		return nil, err
 	}
-	targets := []*middleware.ProxyTarget{
-		{
-			URL: localObsidianURL,
-		},
+	// Echo does not enforce a one to one mapping of path to group.
+	// To ensure that every group registers a unique path, track the
+	// paths that have been registered.
+	registeredPaths := map[string]string{}
+	for addr, prefixes := range pathPrefixesByAddr {
+		for _, prefix := range prefixes {
+			if registeredAddr, exists := registeredPaths[prefix]; exists {
+				glog.Errorf("path prefix '%s' was added to multiple addresses: %s, %s", prefix, registeredAddr, addr.String())
+				continue
+			}
+			target := []*middleware.ProxyTarget{
+				{
+					URL: addr,
+				},
+			}
+			g := server.Group(prefix)
+			g.Use(middleware.Proxy(middleware.NewRoundRobinBalancer(target)))
+			registeredPaths[prefix] = addr.String()
+		}
 	}
-	reverseProxyMiddleware := middleware.Proxy(middleware.NewRoundRobinBalancer(targets))
-	return func(c echo.Context) error {
-		glog.V(1).Infof("Received request in the reverse proxy middleware with remote addr: %s", c.RealIP())
+	return server, nil
+}
+
+func getEchoServerAddressToPathPrefixes() (map[*url.URL][]string, error) {
+	pathPrefixesByAddr := map[*url.URL][]string{}
+	services := registry.FindServices(orc8r.ObsidianHandlersLabel)
+	for _, srv := range services {
+		prefixAnnotation, err := registry.GetAnnotation(srv, orc8r.ObsidianHandlersPathPrefixesAnnotation)
 		if err != nil {
-			return err
+			return map[*url.URL][]string{}, err
 		}
-		remoteIP, _, _ := net.SplitHostPort(c.Request().RemoteAddr)
-		if c.RealIP() == "127.0.0.1" || remoteIP == "127.0.0.1" {
-			glog.V(1).Infof("Request IP addr is localhost. Sending to next middleware.")
-			return next(c)
-		}
-		// Re-route non-localhost requests to localhost:<obsidian_port>
-		// This is an intermediate implementation state needed to de-compose
-		// the Orchestrator plugin
-		remoteAddr := c.Request().RemoteAddr
-		_, p, err := net.SplitHostPort(remoteAddr)
+		trimmedPrefixAnnotation := strings.Trim(prefixAnnotation, "\n")
+		strippedPrefixAnnotation := strings.ReplaceAll(trimmedPrefixAnnotation, " ", "")
+		pathPrefixes := strings.Split(strippedPrefixAnnotation, orc8r.AnnotationListSeparator)
+		echoServerAddress, err := getEchoServerAddressForService(srv)
 		if err != nil {
-			return err
+			return map[*url.URL][]string{}, err
 		}
-		updatedRemoteAddr := fmt.Sprintf("127.0.0.1:%s", p)
-		c.Request().RemoteAddr = updatedRemoteAddr
-		reverseProxyHandler := reverseProxyMiddleware(next)
-		glog.V(1).Infof("Request IP addr is NOT localhost. Reverse proxying to %s", urlString)
-		return reverseProxyHandler(c)
+		pathPrefixesByAddr[echoServerAddress] = pathPrefixes
 	}
+	return pathPrefixesByAddr, nil
+}
+
+func getEchoServerAddressForService(service string) (*url.URL, error) {
+	echoPort, err := registry.GetEchoServerPort(service)
+	if err != nil {
+		return nil, err
+	}
+	serviceAddr, err := registry.GetServiceAddress(service)
+	if err != nil || len(serviceAddr) == 0 {
+		return nil, err
+	}
+	splitServiceAddr := strings.Split(serviceAddr, ":")
+	rawUrl := fmt.Sprintf("http://%s:%d", splitServiceAddr[0], echoPort)
+	return url.Parse(rawUrl)
 }

--- a/orc8r/cloud/go/obsidian/server/server.go
+++ b/orc8r/cloud/go/obsidian/server/server.go
@@ -101,7 +101,11 @@ func Start() {
 		e.Use(access.Middleware)
 	}
 
-	e.Use(reverse_proxy.ReverseProxy)
+	e, err = reverse_proxy.AddReverseProxyPaths(e)
+	if err != nil {
+		log.Fatalf("Error adding reverse proxy paths: %s", err)
+	}
+
 	if obsidian.TLS {
 		err = e.StartServer(e.TLSServer)
 	} else {

--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -22,13 +22,15 @@ const (
 
 	DnsdNetworkType = "dnsd_network"
 
-	MetricsExporterLabel = "orc8r.io/metrics_exporter"
-	StateIndexerLabel    = "orc8r.io/state_indexer"
-	StreamProviderLabel  = "orc8r.io/stream_provider"
+	MetricsExporterLabel  = "orc8r.io/metrics_exporter"
+	ObsidianHandlersLabel = "orc8r.io/obsidian_handlers"
+	StateIndexerLabel     = "orc8r.io/state_indexer"
+	StreamProviderLabel   = "orc8r.io/stream_provider"
 
-	StateIndexerVersionAnnotation   = "orc8r.io/state_indexer_version"
-	StateIndexerTypesAnnotation     = "orc8r.io/state_indexer_types"
-	StreamProviderStreamsAnnotation = "orc8r.io/stream_provider_streams"
+	ObsidianHandlersPathPrefixesAnnotation = "orc8r.io/obsidian_handlers_path_prefixes"
+	StateIndexerVersionAnnotation          = "orc8r.io/state_indexer_version"
+	StateIndexerTypesAnnotation            = "orc8r.io/state_indexer_types"
+	StreamProviderStreamsAnnotation        = "orc8r.io/stream_provider_streams"
 
 	AnnotationListSeparator = ","
 )

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -9,11 +9,8 @@ LICENSE file in the root directory of this source tree.
 package pluginimpl
 
 import (
-	"net/http"
-
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
-	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
@@ -21,18 +18,13 @@ import (
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/metricsd/collection"
 	"magma/orc8r/cloud/go/services/metricsd/exporters"
-	metricsdh "magma/orc8r/cloud/go/services/metricsd/obsidian/handlers"
-	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
 	"magma/orc8r/cloud/go/services/state/indexer"
 	"magma/orc8r/cloud/go/services/streamer/providers"
-	tenantsh "magma/orc8r/cloud/go/services/tenants/obsidian/handlers"
 	"magma/orc8r/lib/go/definitions"
 	"magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/config"
-
-	"github.com/labstack/echo"
 )
 
 // BaseOrchestratorPlugin is the OrchestratorPlugin for the orc8r module
@@ -84,22 +76,7 @@ func (*BaseOrchestratorPlugin) GetMetricsProfiles(metricsConfig *config.ConfigMa
 }
 
 func (*BaseOrchestratorPlugin) GetObsidianHandlers(metricsConfig *config.ConfigMap) []obsidian.Handler {
-	return plugin.FlattenHandlerLists(
-		// v1 handlers
-		metricsdh.GetObsidianHandlers(metricsConfig),
-		handlers.GetObsidianHandlers(),
-		tenantsh.GetObsidianHandlers(),
-		[]obsidian.Handler{{
-			Path:    "/",
-			Methods: obsidian.GET,
-			HandlerFunc: func(c echo.Context) error {
-				return c.JSON(
-					http.StatusOK,
-					"hello",
-				)
-			},
-		}},
-	)
+	return []obsidian.Handler{}
 }
 
 func (*BaseOrchestratorPlugin) GetStreamerProviders() []providers.StreamProvider {

--- a/orc8r/cloud/go/service/service.go
+++ b/orc8r/cloud/go/service/service.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	runEchoServerFlag = "run_echo_server"
+	RunEchoServerFlag = "run_echo_server"
 )
 
 var (
@@ -37,7 +37,7 @@ var (
 )
 
 func init() {
-	flag.BoolVar(&runEchoServer, runEchoServerFlag, false, "Run echo HTTP server with service")
+	flag.BoolVar(&runEchoServer, RunEchoServerFlag, false, "Run echo HTTP server with service")
 }
 
 // OrchestratorService defines a service which extends the generic platform

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -12,10 +12,12 @@ import (
 	"os"
 	"time"
 
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/metricsd/collection"
+	"magma/orc8r/cloud/go/services/metricsd/obsidian/handlers"
 	exporter_protos "magma/orc8r/cloud/go/services/metricsd/protos"
 	"magma/orc8r/cloud/go/services/metricsd/servicers"
 	"magma/orc8r/lib/go/protos"
@@ -50,6 +52,7 @@ func main() {
 	go controllerServicer.ConsumeCloudMetrics(metricsCh, os.Getenv("HOST_NAME"))
 	gatherer.Run()
 
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers(srv.Config))
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error running metricsd service: %s", err)

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/handlers.go
@@ -10,6 +10,7 @@ package handlers
 
 import (
 	"fmt"
+	"net/http"
 
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/obsidian"
@@ -152,6 +153,16 @@ func GetObsidianHandlers() []obsidian.Handler {
 		}
 	}
 
+	ret = append(ret, obsidian.Handler{
+		Path:    "/",
+		Methods: obsidian.GET,
+		HandlerFunc: func(c echo.Context) error {
+			return c.JSON(
+				http.StatusOK,
+				"hello",
+			)
+		},
+	})
 	return ret
 }
 

--- a/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
+++ b/orc8r/cloud/go/services/orchestrator/orchestrator/main.go
@@ -9,9 +9,11 @@
 package main
 
 import (
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/orchestrator"
+	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
 
 	"github.com/golang/glog"
 )
@@ -21,6 +23,8 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating orchestrator service %s", err)
 	}
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
+
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running service and echo server: %s", err)

--- a/orc8r/cloud/go/services/tenants/tenants/main.go
+++ b/orc8r/cloud/go/services/tenants/tenants/main.go
@@ -10,9 +10,11 @@ package main
 
 import (
 	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/tenants"
+	"magma/orc8r/cloud/go/services/tenants/obsidian/handlers"
 	"magma/orc8r/cloud/go/services/tenants/servicers"
 	"magma/orc8r/cloud/go/services/tenants/servicers/storage"
 	"magma/orc8r/cloud/go/sqorc"
@@ -43,6 +45,7 @@ func main() {
 		glog.Fatalf("Error creating tenants server: %s", err)
 	}
 	protos.RegisterTenantsServiceServer(srv.GrpcServer, server)
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 
 	err = srv.Run()
 	if err != nil {


### PR DESCRIPTION
Summary:
This diff removes the obsidian handlers from the devmand plugin
and attaches them to the echo server running in the devmand service.
We also add the proper label /magma/v1/symphony to the service registry
to ensure that obsidian will reverse proxy correctly.

Reviewed By: xjtian

Differential Revision: D22544903

