### PR TITLE
Use redis.yml instead of mobilityd.yml to configure redis in mobilityd

### DIFF
--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -13,4 +13,3 @@
 
 # log_level is set in mconfig. it can be overridden here
 persist_to_redis: false
-redis_port: 6380

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_factory.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_factory.py
@@ -1,0 +1,75 @@
+import redis
+import logging
+from collections import defaultdict
+from typing import MutableMapping
+
+from magma.mobilityd.ip_descriptor import IPDesc
+from lte.protos.mconfig.mconfigs_pb2 import MobilityD
+
+from magma.mobilityd import mobility_store as store
+
+from .ip_allocator_dhcp import IPAllocatorDHCP
+from .ip_allocator_base import IPAllocator
+from .ip_allocator_static import IpAllocatorStatic
+from .ip_descriptor_map import IpDescriptorMap
+from .uplink_gw import UplinkGatewayInfo
+
+
+class IPAllocatorFactory:
+    def __init__(self, ip_allocator_type, mobilityd_conf, redis_config):
+        """ Creates IP allocator, states and sid maps in redis/memory flavors
+        """
+        persist_to_redis = mobilityd_conf.get('persist_to_redis', False)
+        logging.debug('Persist to Redis: %s', persist_to_redis)
+
+        if not persist_to_redis:
+            # Do not use redis backend
+            self._assigned_ip_blocks = set()  # {ip_block}
+            self._sid_ips_map = defaultdict(IPDesc)  # {SID=>IPDesc}
+            self.ip_states = defaultdict(dict)  # {state=>{ip=>ip_desc}}
+            self.dhcp_store = {}
+            self._dhcp_gw_info = UplinkGatewayInfo(defaultdict(str))
+        else:
+            # Enable redis backend
+            redis_port = redis_config.get('port', 6380)
+            redis_host = redis_config.get('bind', 'localhost')
+            client = redis.Redis(host=redis_host,
+                                 port=redis_port)
+            self._assigned_ip_blocks = store.AssignedIpBlocksSet(client)
+            self._sid_ips_map = store.IPDescDict(client)
+            self.ip_states = store.defaultdict_key(
+                lambda key: store.ip_states(client, key))
+            self.dhcp_store = store.MacToIP()  # mac => DHCP_State
+            self._dhcp_gw_info = UplinkGatewayInfo(store.GatewayInfoMap())
+
+        self._ip_state_map = IpDescriptorMap(self.ip_states)
+        self.allocator_type = ip_allocator_type
+
+        logging.info("Using allocator: %s", self.allocator_type)
+        if self.allocator_type == MobilityD.IP_POOL:
+            self._dhcp_gw_info.read_default_gw()
+            self._ip_allocator = IpAllocatorStatic(self._assigned_ip_blocks,
+                                                   self._ip_state_map,
+                                                   self._sid_ips_map)
+        elif self.allocator_type == MobilityD.DHCP:
+            iface = mobilityd_conf.get('dhcp_iface', 'dhcp0')
+            retry_limit = mobilityd_conf.get('retry_limit', 300)
+            self._ip_allocator = IPAllocatorDHCP(self._assigned_ip_blocks,
+                                                 self._ip_state_map,
+                                                 iface=iface,
+                                                 retry_limit=retry_limit,
+                                                 dhcp_store=self.dhcp_store,
+                                                 gw_info=self._dhcp_gw_info)
+
+    def get_allocator(self) -> IPAllocator:
+        return self._ip_allocator
+
+    def get_sid_ips_map(self) -> MutableMapping[str, IPDesc]:
+        return self._sid_ips_map
+
+    def get_ip_states_map(self) -> IpDescriptorMap:
+        return self._ip_state_map
+
+    def get_dhcp_gw_info(self) -> UplinkGatewayInfo:
+        return self._dhcp_gw_info
+

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -76,6 +76,8 @@ class MacToIP(RedisFlatDict):
     Used for managing DHCP state of a Mac address.
     """
     def __init__(self):
+        #TODO this should be removed in the future when all instances of
+        #this class are able to inject its own client
         client = get_default_client()
         serde = RedisSerde(MAC_TO_IP_REDIS_TYPE,
                            get_json_serializer(), get_json_deserializer())
@@ -91,6 +93,8 @@ class GatewayInfoMap(RedisFlatDict):
     Used for mainatining uplink GW info
     """
     def __init__(self):
+        #TODO this should be removed in the future when all instances of
+        #this class are able to inject its own client
         client = get_default_client()
         serde = RedisSerde(DHCP_GW_INFO_REDIS_TYPE,
                            get_json_serializer(), get_json_deserializer())

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -52,12 +52,12 @@ def _get_ip_block(ip_block_str):
 class MobilityServiceRpcServicer(MobilityServiceServicer):
     """ gRPC based server for the IPAllocator. """
 
-    def __init__(self, mconfig, config):
+    def __init__(self, mconfig, config, ip_allocator_factory):
         # TODO: consider adding gateway mconfig to decide whether to
         # persist to Redis
 
         self._ipv4_allocator = IPAddressManager(config=config,
-                                                allocator_type=mconfig.ip_allocator_type)
+                                                ip_allocator_factory=ip_allocator_factory)
 
         # Load IP block from the configurable mconfig file
         # No dynamic reloading support for now, assume restart after updates

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -24,6 +24,7 @@ from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 
 from magma.mobilityd.ip_address_man import IPAddressManager, \
     IPNotInUseError, MappingNotFoundError
+from magma.mobilityd.ip_allocator_factory import IPAllocatorFactory
 from magma.mobilityd.ip_allocator_static import IPBlockNotFoundError, \
     NoAvailableIPError
 
@@ -46,12 +47,15 @@ class IPAllocatorTests(unittest.TestCase):
         config = {
             'recycling_interval': recycling_interval,
             'persist_to_redis': False,
-            'redis_port': 6379,
         }
+        redis_config = {'port': 6380,
+                        'bind': 'localhost'}
+        ip_allocator_factory = IPAllocatorFactory(
+            MobilityD.IP_POOL, config, redis_config)
         self._allocator = IPAddressManager(
             recycling_interval=recycling_interval,
-            allocator_type=MobilityD.IP_POOL,
-            config=config)
+            config=config,
+            ip_allocator_factory=ip_allocator_factory)
         self._allocator.add_ip_block(self._block)
 
     def setUp(self):

--- a/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/rpc_servicer_tests.py
@@ -27,6 +27,7 @@ from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
 from magma.mobilityd.rpc_servicer import IPVersionNotSupportedError, \
     MobilityServiceRpcServicer
+from magma.mobilityd.ip_allocator_factory import IPAllocatorFactory
 from magma.subscriberdb.sid import SIDUtils
 from orc8r.protos.common_pb2 import Void
 
@@ -51,7 +52,12 @@ class RpcTests(unittest.TestCase):
         config = {'persist_to_redis': False,
                   'redis_port': None,
                   'allocator_type': "ip_pool"}
-        self._servicer = MobilityServiceRpcServicer(mconfig, config)
+        redis_config = {'port': 6380,
+                        'bind': 'localhost'}
+        ip_allocator_factory = IPAllocatorFactory(
+            MobilityD.IP_POOL, config, redis_config)
+        self._servicer = MobilityServiceRpcServicer(
+            mconfig, config, ip_allocator_factory)
         self._servicer.add_to_server(self._rpc_server)
         self._rpc_server.start()
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

1. Enable `IpDescriptorMap` to receive redis host and port (not only port)
2. Get redis configuration from redis.yml with `get_service_config_value()`
3. Configure `IpDescriptorMap` with these values
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Assure `lte/gateway/configs/mobilityd.yml` is configured with `persist_to_redis: true`

In MAGMA_VM: `cd /home/vagrant/magma/lte/gateway && make test`
In MAGMA_TEST: `cd /home/vagrant/magma/lte/gateway/python/integ_tests && make integ_test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

# Additional Information

[ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
