### PR TITLE
mobility: set default GW for ip pool allocator type

### DIFF
--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -82,8 +82,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         sid1 = "IMSI02917"
         ip1 = self._dhcp_allocator.alloc_ip_address(sid1)
         threading.Event().wait(2)
-        gw_map = store.GatewayInfoMap()
-        dhcp_gw_info = UplinkGatewayInfo(gw_map)
+        dhcp_gw_info = self._dhcp_allocator._dhcp_gw_info
         dhcp_store = store.MacToIP()  # mac => DHCP_State
 
         self.assertEqual(str(dhcp_gw_info.getIP()), "192.168.128.211")

--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -23,21 +23,20 @@ class DefGwTest(unittest.TestCase):
     """
     Validate default router setting.
     """
+    def setUp(self):
+        self.gw_store = defaultdict(str)
+        self.dhcp_gw_info = UplinkGatewayInfo(self.gw_store)
 
     def test_gw_ip_for_DHCP(self):
-        gw_store = defaultdict(str)
-        dhcp_gw_info = UplinkGatewayInfo(gw_store)
-        self.assertEqual(dhcp_gw_info.getIP(), None)
-        self.assertEqual(dhcp_gw_info.getMac(), None)
+        self.assertEqual(self.dhcp_gw_info.getIP(), None)
+        self.assertEqual(self.dhcp_gw_info.getMac(), None)
 
     def test_gw_ip_for_Ip_pool(self):
-        gw_store = defaultdict(str)
-        dhcp_gw_info = UplinkGatewayInfo(gw_store)
-        dhcp_gw_info.read_default_gw()
+        self.dhcp_gw_info.read_default_gw()
 
         def_gw_cmd = "ip route show |grep default| awk '{print $3}'"
         p = subprocess.Popen([def_gw_cmd], stdout=subprocess.PIPE, shell=True)
         def_ip = p.stdout.read().decode("utf-8").strip()
-        self.assertEqual(dhcp_gw_info.getIP(), str(def_ip))
-        self.assertEqual(dhcp_gw_info.getMac(), None)
+        self.assertEqual(self.dhcp_gw_info.getIP(), str(def_ip))
+        self.assertEqual(self.dhcp_gw_info.getMac(), None)
 

--- a/lte/gateway/python/magma/mobilityd/tests/uplink_gw_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/uplink_gw_tests.py
@@ -1,0 +1,43 @@
+"""
+Copyright (c) 2020-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+
+import logging
+import unittest
+from collections import defaultdict
+import subprocess
+
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+
+LOG = logging.getLogger('mobilityd.def_gw.test')
+LOG.isEnabledFor(logging.DEBUG)
+
+
+class DefGwTest(unittest.TestCase):
+    """
+    Validate default router setting.
+    """
+
+    def test_gw_ip_for_DHCP(self):
+        gw_store = defaultdict(str)
+        dhcp_gw_info = UplinkGatewayInfo(gw_store)
+        self.assertEqual(dhcp_gw_info.getIP(), None)
+        self.assertEqual(dhcp_gw_info.getMac(), None)
+
+    def test_gw_ip_for_Ip_pool(self):
+        gw_store = defaultdict(str)
+        dhcp_gw_info = UplinkGatewayInfo(gw_store)
+        dhcp_gw_info.read_default_gw()
+
+        def_gw_cmd = "ip route show |grep default| awk '{print $3}'"
+        p = subprocess.Popen([def_gw_cmd], stdout=subprocess.PIPE, shell=True)
+        def_ip = p.stdout.read().decode("utf-8").strip()
+        self.assertEqual(dhcp_gw_info.getIP(), str(def_ip))
+        self.assertEqual(dhcp_gw_info.getMac(), None)
+

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -15,7 +15,7 @@ from typing import MutableMapping, Optional
 DHCP_Router_key = "DHCPRouterKey"
 DHCP_Router_Mac_key = "DHCPRouterMacKey"
 
-
+# TODO: move helper class to separate directory.
 class UplinkGatewayInfo:
     def __init__(self, gw_info_map: MutableMapping[str, str]):
         """

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -8,6 +8,8 @@ of patent rights can be found in the PATENTS file in the same directory.
 
 """
 import logging
+import netifaces
+
 from typing import MutableMapping, Optional
 
 DHCP_Router_key = "DHCPRouterKey"
@@ -30,6 +32,15 @@ class UplinkGatewayInfo:
         if DHCP_Router_key in self._backing_map:
             self._current_ip = self._backing_map.get(DHCP_Router_key)
             return self._current_ip
+
+    def read_default_gw(self):
+        gws = netifaces.gateways()
+        logging.info("Using GW info: %s", gws)
+        if gws is not None:
+            default_gw = gws['default']
+            if default_gw is not None and \
+                    default_gw[netifaces.AF_INET] is not None:
+                self.update_ip(default_gw[netifaces.AF_INET][0])
 
     def ip_exists(self) -> bool:
         return DHCP_Router_key in self._backing_map


### PR DESCRIPTION
mobility: set default GW for ip pool allocator type

## Summary

This gw ip would be used in bridged mode.

## Test Plan

Ran `make test_python` test locally.
Ran ` make integ_test` locally.
# Additional Information

