### PR TITLE
[DOC]Redirect to magma.github.io

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,22 +1,5 @@
-<!--
-Copyright (c) Facebook, Inc. and its affiliates.
-All rights reserved.
-
-This source code is licensed under the BSD-style license found in the
-LICENSE file in the root directory of this source tree.
--->
-
-<!DOCTYPE HTML>
-<html lang="en-US">
-  <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=docs/basics/introduction.html">
-    <script type="text/javascript">
-      window.location.href = 'docs/basics/introduction.html';
-    </script>
-    <title>Magma</title>
-  </head>
-  <body>
-    If you are not redirected automatically, follow this <a href="docs/basics/introduction.html">link</a>.
-  </body>
-</html>
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to https://magma.github.io/magma/docs/basics/introduction.html</title>
+<meta http-equiv="refresh" content="0; URL=https://magma.github.io/magma/docs/basics/introduction.html">
+<link rel="canonical" href="https://magma.github.io/magma/docs/basics/introduction.html">


### PR DESCRIPTION
## Summary

Redirect documentation to the new github pages

## Test Plan

Go to https://facebookincubator.github.io/magma/docs/lte/setup_deb and make sure it redirects you to https://magma.github.io/magma/docs/basics/introduction.html

# Additional Information

Need to disable the docusaurus job on facebookincubator

