### PR TITLE
Remove flaky complete reset test case from sanity test suite

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -53,7 +53,6 @@ s1aptests/test_attach_missing_imsi.py \
 s1aptests/test_duplicate_attach.py \
 s1aptests/test_enb_partial_reset_con_dereg.py \
 s1aptests/test_enb_partial_reset.py \
-s1aptests/test_enb_complete_reset.py \
 s1aptests/test_nas_non_delivery_for_auth.py \
 s1aptests/test_outoforder_attach_complete_ICSR.py \
 s1aptests/test_s1setup_incorrect_plmn.py \
@@ -124,6 +123,7 @@ s1aptests/test_attach_detach_attach_ul_tcp_data.py
 # s1aptests/test_attach_detach_attach_dl_tcp_data.py
 
 # TODO flaky tests we should look at
+# s1aptests/test_enb_complete_reset.py \
 # s1aptests/test_attach_detach_multi_ue_looped.py \
 
 CLOUD_TESTS = cloud_tests/checkin_test.py \


### PR DESCRIPTION
The test_enb_complete_reset.py has been failing intermittently. Removing it from sanity test suite for now. Will re-add once it has been tested for stability.

## Test Plan

N/A
