### PR TITLE
AGW: cloud: plugin: set MME NAT flag when configured at orc8r

### DIFF
--- a/lte/cloud/go/plugin/mconfig.go
+++ b/lte/cloud/go/plugin/mconfig.go
@@ -131,6 +131,7 @@ func (s *LteMconfigBuilderServicer) Build(
 			AttachedEnodebTacs:       getEnodebTacs(enbConfigsBySerial),
 			DnsPrimary:               gwEpc.DNSPrimary,
 			DnsSecondary:             gwEpc.DNSSecondary,
+			NatEnabled:               swag.BoolValue(gwEpc.NatEnabled),
 		},
 		"pipelined": &mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,

--- a/lte/cloud/go/plugin/mconfig_test.go
+++ b/lte/cloud/go/plugin/mconfig_test.go
@@ -123,6 +123,7 @@ func TestBuilder_Build(t *testing.T) {
 			CloudSubscriberdbEnabled: false,
 			EnableDnsCaching:         true,
 			AttachedEnodebTacs:       []int32{15000},
+			NatEnabled:               true,
 		},
 		"pipelined": &mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -174,6 +175,104 @@ func TestBuilder_Build(t *testing.T) {
 		},
 	}
 	err = builder.Build("n1", "gw1", graph, nw, actual)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestBuilder_Build_NonNat(t *testing.T) {
+	builder := &plugin.Builder{}
+
+	// no dnsd config, no enodebs
+	nw := configurator.Network{
+		ID: "n1",
+		Configs: map[string]interface{}{
+			lte.CellularNetworkType: models2.NewDefaultTDDNetworkConfig(),
+		},
+	}
+	gw := configurator.NetworkEntity{
+		Type: orc8r.MagmadGatewayType, Key: "gw1",
+		Associations: []storage.TypeAndKey{
+			{Type: lte.CellularGatewayType, Key: "gw1"},
+		},
+	}
+	lteGW := configurator.NetworkEntity{
+		Type: lte.CellularGatewayType, Key: "gw1",
+		Config:             newGatewayConfigNonNat(),
+		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
+	}
+	graph := configurator.EntityGraph{
+		Entities: []configurator.NetworkEntity{lteGW, gw},
+		Edges: []configurator.GraphEdge{
+			{From: gw.GetTypeAndKey(), To: lteGW.GetTypeAndKey()},
+		},
+	}
+
+	actual := map[string]proto.Message{}
+	expected := map[string]proto.Message{
+		"enodebd": &mconfig.EnodebD{
+			LogLevel: protos.LogLevel_INFO,
+			Pci:      260,
+			TddConfig: &mconfig.EnodebD_TDDConfig{
+				Earfcndl:               44590,
+				SubframeAssignment:     2,
+				SpecialSubframePattern: 7,
+			},
+			BandwidthMhz:        20,
+			AllowEnodebTransmit: true,
+			Tac:                 1,
+			PlmnidList:          "00101",
+			CsfbRat:             mconfig.EnodebD_CSFBRAT_2G,
+			Arfcn_2G:            nil,
+			EnbConfigsBySerial:  nil,
+		},
+		"mobilityd": &mconfig.MobilityD{
+			LogLevel: protos.LogLevel_INFO,
+			IpBlock:  "192.168.128.0/24",
+		},
+		"mme": &mconfig.MME{
+			LogLevel:                 protos.LogLevel_INFO,
+			Mcc:                      "001",
+			Mnc:                      "01",
+			Tac:                      1,
+			MmeCode:                  1,
+			MmeGid:                   1,
+			NonEpsServiceControl:     mconfig.MME_NON_EPS_SERVICE_CONTROL_OFF,
+			CsfbMcc:                  "001",
+			CsfbMnc:                  "01",
+			Lac:                      1,
+			RelayEnabled:             false,
+			CloudSubscriberdbEnabled: false,
+			AttachedEnodebTacs:       nil,
+			NatEnabled:               false,
+		},
+		"pipelined": &mconfig.PipelineD{
+			LogLevel:      protos.LogLevel_INFO,
+			UeIpBlock:     "192.168.128.0/24",
+			NatEnabled:    false,
+			DefaultRuleId: "",
+			Services: []mconfig.PipelineD_NetworkServices{
+				mconfig.PipelineD_ENFORCEMENT,
+			},
+		},
+		"subscriberdb": &mconfig.SubscriberDB{
+			LogLevel:     protos.LogLevel_INFO,
+			LteAuthOp:    []byte("\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"),
+			LteAuthAmf:   []byte("\x80\x00"),
+			SubProfiles:  nil,
+			RelayEnabled: false,
+		},
+		"policydb": &mconfig.PolicyDB{
+			LogLevel: protos.LogLevel_INFO,
+		},
+		"sessiond": &mconfig.SessionD{
+			LogLevel:     protos.LogLevel_INFO,
+			RelayEnabled: false,
+			WalletExhaustDetection: &mconfig.WalletExhaustDetection{
+				TerminateOnExhaust: false,
+			},
+		},
+	}
+	err := builder.Build("n1", "gw1", graph, nw, actual)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -242,6 +341,7 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 			RelayEnabled:             false,
 			CloudSubscriberdbEnabled: false,
 			AttachedEnodebTacs:       nil,
+			NatEnabled:               true,
 		},
 		"pipelined": &mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -368,6 +468,7 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 			CloudSubscriberdbEnabled: false,
 			EnableDnsCaching:         true,
 			AttachedEnodebTacs:       []int32{1},
+			NatEnabled:               true,
 		},
 		"pipelined": &mconfig.PipelineD{
 			LogLevel:      protos.LogLevel_INFO,
@@ -422,6 +523,26 @@ func newDefaultGatewayConfig() *models2.GatewayCellularConfigs {
 	}
 }
 
+func newGatewayConfigNonNat() *models2.GatewayCellularConfigs {
+	return &models2.GatewayCellularConfigs{
+		Ran: &models2.GatewayRanConfigs{
+			Pci:             260,
+			TransmitEnabled: swag.Bool(true),
+		},
+		Epc: &models2.GatewayEpcConfigs{
+			NatEnabled: swag.Bool(false),
+			IPBlock:    "192.168.128.0/24",
+		},
+		NonEpsService: &models2.GatewayNonEpsConfigs{
+			CsfbMcc:              "001",
+			CsfbMnc:              "01",
+			Lac:                  swag.Uint32(1),
+			CsfbRat:              swag.Uint32(0),
+			Arfcn2g:              nil,
+			NonEpsServiceControl: swag.Uint32(0),
+		},
+	}
+}
 func newDefaultEnodebConfig() *models2.EnodebConfiguration {
 	return &models2.EnodebConfiguration{
 		Earfcndl:               39150,


### PR DESCRIPTION

## Summary

This would allow orc8r to enable or disable NAT on AGW.

## Test Plan

`go test mconfig_test.go` 

## Additional Information
