### PR TITLE
[cwag][health] Update CWAG health service to include radius in service health when gateway is active

### DIFF
--- a/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
+++ b/cwf/gateway/services/gateway_health/health/service_health/docker_health.go
@@ -11,6 +11,7 @@ package service_health
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/docker/docker/api/types"
@@ -20,7 +21,6 @@ import (
 
 const (
 	dockerRequestTimeout = 3 * time.Second
-	radiusServiceName    = "/radius"
 )
 
 // DockerServiceHealthProvider provides service health for
@@ -58,13 +58,11 @@ func (d *DockerServiceHealthProvider) GetUnhealthyServices() ([]string, error) {
 		if len(container.Names) == 0 {
 			continue
 		}
-		// Since we purposely stop the RADIUS server on Disable
-		// don't include in the check
-		// TODO: Remove once transport failover is implemented
-		if container.Names[0] == radiusServiceName {
-			continue
+		serviceName := container.Names[0]
+		if strings.HasPrefix(serviceName, "/") {
+			serviceName = strings.ReplaceAll(serviceName, "/", "")
 		}
-		unhealthyServices = append(unhealthyServices, container.Names[0])
+		unhealthyServices = append(unhealthyServices, serviceName)
 	}
 	return unhealthyServices, nil
 }

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer.go
@@ -27,13 +27,19 @@ const (
 	sessiondServiceName = "sessiond"
 	radiusServiceName   = "radius"
 	aaaServiceName      = "aaa_server"
+
+	disabled gatewayState = "disabled"
+	enabled  gatewayState = "enabled"
 )
+
+type gatewayState string
 
 type GatewayHealthServicer struct {
 	config        *mconfig.CwfGatewayHealthConfig
 	greProbe      gre_probe.GREProbe
 	serviceHealth service_health.ServiceHealth
 	systemHealth  system_health.SystemHealth
+	currentState  gatewayState
 }
 
 // NewGatewayHealthServicer constructs a GatewayHealthServicer.
@@ -48,6 +54,7 @@ func NewGatewayHealthServicer(
 		greProbe:      greProbe,
 		systemHealth:  systemHealth,
 		serviceHealth: serviceHealth,
+		currentState:  "",
 	}
 }
 
@@ -77,6 +84,7 @@ func (s *GatewayHealthServicer) Disable(ctx context.Context, req *protos.Disable
 	}
 	s.greProbe.Stop()
 	events.LogGatewayHealthSuccessEvent(events.GatewayDemotionSucceededEvent)
+	s.currentState = disabled
 	return ret, nil
 }
 
@@ -105,6 +113,7 @@ func (s *GatewayHealthServicer) Enable(ctx context.Context, req *orcprotos.Void)
 		return ret, err
 	}
 	events.LogGatewayHealthSuccessEvent(events.GatewayPromotionSucceededEvent)
+	s.currentState = enabled
 	return ret, nil
 }
 
@@ -172,11 +181,18 @@ func (s *GatewayHealthServicer) getServiceHealth() *protos.HealthStatus {
 		}
 	}
 	glog.V(1).Infof("unhealthy services: %v", unhealthyServices)
-	if len(unhealthyServices) > 0 {
-		return &protos.HealthStatus{
-			Health:        protos.HealthStatus_UNHEALTHY,
-			HealthMessage: fmt.Sprintf("The following services were unhealthy: %v", unhealthyServices),
-		}
+
+	// TODO: Remove radius logic once transport failover is introduced
+	unhealthyStatus := &protos.HealthStatus{
+		Health:        protos.HealthStatus_UNHEALTHY,
+		HealthMessage: fmt.Sprintf("The following services were unhealthy: %v", unhealthyServices),
+	}
+	if len(unhealthyServices) > 0 && s.currentState == enabled {
+		return unhealthyStatus
+	} else if len(unhealthyServices) > 1 && s.currentState == disabled {
+		return unhealthyStatus
+	} else if len(unhealthyServices) == 1 && s.currentState == disabled && unhealthyServices[0] != radiusServiceName {
+		return unhealthyStatus
 	}
 	return &protos.HealthStatus{
 		Health:        protos.HealthStatus_HEALTHY,

--- a/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
+++ b/cwf/gateway/services/gateway_health/servicers/health_servicer_test.go
@@ -107,6 +107,17 @@ func TestGetHealthStatus(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expectedStatus, health)
 	assertMocks(t, mockGREProbe, mockSystem, mockService)
+
+	// Simulate disabled, healthy
+	mockGREProbe.On("GetStatus").Return(healthyGRE).Once()
+	mockSystem.On("GetSystemStats").Return(&system_health.SystemStats{CpuUtilPct: 0.1, MemUtilPct: 0.1}, nil).Once()
+	mockService.On("GetUnhealthyServices").Return([]string{"radius"}, nil).Once()
+	expectedStatus.Health = protos.HealthStatus_HEALTHY
+	expectedStatus.HealthMessage = "gateway status appears healthy"
+	health, err = servicer.GetHealthStatus(context.Background(), req)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedStatus, health)
+	assertMocks(t, mockGREProbe, mockSystem, mockService)
 }
 
 func assertMocks(t *testing.T, probe *mockGREProbe, systemHealth *mockSystemHealth, serviceHealth *mockServiceHealth) {


### PR DESCRIPTION
## Summary

This diff corrects the logic used by the CWAG's health service in determining unhealthy
services. When a gateway is demoted (disabled), the radius server is stopped. This is 
done to force the WLC to see the RADIUS server as down, thereby re-routing traffic to the
active.

Previously, the radius service wasn't included in the service health check, since it is always
stopped on the standby. This diff updates the logic to include the radius server when the gateway
is active, but continues to not include it when the gateway is a standby.

This logic will be removed shortly when we introduce transport failover, as we will no longer 
intentionally stop the radius server.

## Test Plan

Added unit test. 
Tested locally on CWAG to ensure that when the radius service is stopped:
-  if the gateway is disabled, it will return healthy
-  if the gateway is enabled, it will return unhealthy.
