### PR TITLE
[nms][metrics] Update connected subscribers chart to use ue_registered metric

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/components/lte/LteMetrics.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/lte/LteMetrics.js
@@ -49,7 +49,7 @@ const CONFIGS: Array<MetricGraphConfig> = [
   {
     basicQueryConfigs: [
       {
-        metric: 'ue_connected',
+        metric: 'ue_registered',
         filters: [{name: 'service', value: 'mme'}],
       },
     ],


### PR DESCRIPTION
## Summary

- Updating Connected Subscribers chart on NMS metrics to use ue_registered, as this metric is more relevant to the users currently connected and attached to the gateway in oppose of ue_connected.

## Test Plan

- Spinning off local setup with AGW, Orc8r and NMS, attaching UE and ensuring ue_registered increments and its shown on metrics chart.

## Additional Information

- [ ] This change is backwards-breaking

