### PR TITLE
[AGW] Add enodeb labels to uplink and downlink data(new version)

### DIFF
--- a/lte/gateway/python/magma/enodebd/metrics.py
+++ b/lte/gateway/python/magma/enodebd/metrics.py
@@ -82,6 +82,6 @@ STAT_ERAB_REL_REQ_OAM_INTV = Gauge(
     'erab_release_requests_oam_intervention',
     'ERAB release requests due to OAM intervention')
 STAT_PDCP_USER_PLANE_BYTES_UL = Gauge(
-    'pdcp_user_plane_bytes_ul', 'User plane uplink bytes at PDCP')
+    'pdcp_user_plane_bytes_ul', 'User plane uplink bytes at PDCP', ['enodeb'])
 STAT_PDCP_USER_PLANE_BYTES_DL = Gauge(
-    'pdcp_user_plane_bytes_dl', 'User plane downlink bytes at PDCP')
+    'pdcp_user_plane_bytes_dl', 'User plane downlink bytes at PDCP', ['enodeb'])

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -119,6 +119,21 @@ class StatsManager:
         # Update status metrics
         update_status_metrics(status)
 
+    def _get_enb_label_from_request(self, request) -> str:
+        label = 'default'
+        ip = request.headers.get('X-Forwarded-For')
+        if ip is None:
+            ip = request.remote_addr
+
+        if ip is None:
+            return label
+
+        try:
+            label = self.enb_manager.get_serial(ip)
+        except KeyError:
+            logger.error("Couldn't find serial for ip", ip)
+        return label
+
     @asyncio.coroutine
     def _post_handler(self, request) -> web.Response:
         """ HTTP POST handler """
@@ -126,12 +141,12 @@ class StatsManager:
         body = yield from request.read()
 
         root = ElementTree.fromstring(body)
-        self._parse_pm_xml(root)
+        self._parse_pm_xml(self._get_enb_label_from_request(request), root)
 
         # Return success response
         return web.Response()
 
-    def _parse_pm_xml(self, xml_root) -> None:
+    def _parse_pm_xml(self, enb_label, xml_root) -> None:
         """
         Parse performance management XML from eNodeB and populate metrics.
         The schema for this XML document, along with an example, is shown in
@@ -142,7 +157,7 @@ class StatsManager:
             names = measurement.find('PmName')
             data = measurement.find('PmData')
             if object_type == 'EutranCellTdd':
-                self._parse_tdd_counters(names, data)
+                self._parse_tdd_counters(enb_label, names, data)
             elif object_type == 'ManagedElement':
                 # Currently no counters to parse
                 pass
@@ -150,7 +165,7 @@ class StatsManager:
                 # Currently no counters to parse
                 pass
 
-    def _parse_tdd_counters(self, names, data):
+    def _parse_tdd_counters(self, enb_label, names, data):
         """
         Parse eNodeB performance management counters from TDD structure.
         Most of the logic is just to extract the correct counter based on the
@@ -238,7 +253,10 @@ class StatsManager:
                 continue
 
             # Apply new value to metric
-            metric.set(value)
+            if pm_name == 'PDCP.UpOctUl' or pm_name == 'PDCP.UpOctDl':
+                metric.labels(enb_label).set(value)
+            else:
+                metric.set(value)
 
     def _build_index_to_data_map(self, data_etree):
         """

--- a/lte/gateway/python/magma/enodebd/tests/pm_file_example.xml
+++ b/lte/gateway/python/magma/enodebd/tests/pm_file_example.xml
@@ -538,7 +538,7 @@
     <V i="91">0</V>
     <V i="92">0</V>
     <V i="93">0</V>
-    <V i="94">0</V>
+    <V i="94">1000</V>
     <CV i="95">
       <SN>PDCP.UpOctUl.1</SN>
       <SV>0</SV>
@@ -559,7 +559,7 @@
       <SN>PDCP.UpOctUl.9</SN>
       <SV>0</SV>
     </CV>
-    <V i="96">0</V>
+    <V i="96">500</V>
     <CV i="97">
       <SN>PDCP.UpOctDl.1</SN>
       <SV>0</SV>

--- a/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
+++ b/lte/gateway/python/magma/enodebd/tests/stats_manager_tests.py
@@ -62,7 +62,7 @@ class StatsManagerTest(TestCase):
                                                         'pm_file_example.xml')
 
         root = ElementTree.fromstring(pm_file_example)
-        self.mgr._parse_pm_xml(root)
+        self.mgr._parse_pm_xml('1234', root)
 
         # Check that metrics were correctly populated
         # See '<V i="5">123</V>' in pm_file_example
@@ -79,3 +79,12 @@ class StatsManagerTest(TestCase):
         erab_rel_req_radio_conn_lost = \
             metrics.STAT_ERAB_REL_REQ_RADIO_CONN_LOST.collect()
         self.assertEqual(erab_rel_req_radio_conn_lost[0].samples[0][2], 65537)
+
+        pdcp_user_plane_bytes_ul = \
+            metrics.STAT_PDCP_USER_PLANE_BYTES_UL.collect()
+        pdcp_user_plane_bytes_dl = \
+            metrics.STAT_PDCP_USER_PLANE_BYTES_DL.collect()
+        self.assertEqual(pdcp_user_plane_bytes_ul[0].samples[0][1], {'enodeb': '1234'})
+        self.assertEqual(pdcp_user_plane_bytes_dl[0].samples[0][1], {'enodeb': '1234'})
+        self.assertEqual(pdcp_user_plane_bytes_ul[0].samples[0][2], 1000)
+        self.assertEqual(pdcp_user_plane_bytes_dl[0].samples[0][2], 500)


### PR DESCRIPTION
## Summary
We need uplink and downlink data to be labelled with eNodeB labels. 

## Test Plan
Updated the existing test to verify the new changes
