### PR TITLE
Fix tab positions when accessing through URL

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/components/TabUtils.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/TabUtils.js
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+import {findIndex} from 'lodash';
+
+// Get current tab position within tabList from url specified
+export function GetCurrentTabPos(url: string, tabItems: Array<string>): number {
+  const tabPos = findIndex(tabItems, route =>
+    location.pathname.startsWith(url + '/' + route),
+  );
+  return tabPos != -1 ? tabPos : 0;
+}
+
+export const DetailTabItems = ['overview', 'event', 'config'];

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -31,6 +31,7 @@ import Text from '../../theme/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 
 import {CardTitleRow} from '../../components/layout/CardTitleRow';
+import {DetailTabItems, GetCurrentTabPos} from '../../components/TabUtils.js';
 import {EnodebJsonConfig} from './EnodebDetailConfig';
 import {EnodebStatus, EnodebSummary} from './EnodebDetailSummaryStatus';
 import {Redirect, Route, Switch} from 'react-router-dom';
@@ -95,10 +96,10 @@ type Props = {
 };
 export function EnodebDetail(props: Props) {
   const classes = useStyles();
-  const [tabPos, setTabPos] = useState(0);
   const {relativePath, relativeUrl, match} = useRouter();
   const enodebSerial: string = nullthrows(match.params.enodebSerial);
   const [enbInfo, setEnbInfo] = useState(props.enbInfo[enodebSerial]);
+
   return (
     <>
       <div className={classes.topBar}>
@@ -109,8 +110,7 @@ export function EnodebDetail(props: Props) {
         <Grid container direction="row" justify="flex-end" alignItems="center">
           <Grid item xs={6}>
             <Tabs
-              value={tabPos}
-              onChange={(event, v) => setTabPos(v)}
+              value={GetCurrentTabPos(match.url, DetailTabItems)}
               indicatorColor="primary"
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentDashboard.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentDashboard.js
@@ -31,6 +31,7 @@ import Text from '../../theme/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
 
+import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -191,8 +192,9 @@ function EquipmentDashboardInternal({
   enbInfo: {[string]: EnodebInfo},
 }) {
   const classes = useStyles();
-  const {relativePath, relativeUrl} = useRouter();
-  const [tabPos, setTabPos] = React.useState(0);
+  const {relativePath, relativeUrl, match} = useRouter();
+  const tabPos = GetCurrentTabPos(match.url, ['gateway', 'enodeb']);
+
   return (
     <>
       <div className={classes.topBar}>
@@ -204,7 +206,6 @@ function EquipmentDashboardInternal({
           <Grid item xs={6}>
             <Tabs
               value={tabPos}
-              onChange={(_, v) => setTabPos(v)}
               indicatorColor="primary"
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailMain.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailMain.js
@@ -36,6 +36,7 @@ import Text from '../../theme/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 
 import {CardTitleRow} from '../../components/layout/CardTitleRow';
+import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -99,7 +100,6 @@ export function GatewayDetail({
   enbInfo: {[string]: EnodebInfo},
 }) {
   const classes = useStyles();
-  const [tabPos, setTabPos] = React.useState(0);
   const {relativePath, relativeUrl, match} = useRouter();
   const gatewayId: string = nullthrows(match.params.gatewayId);
   const gwInfo = lteGateways[gatewayId];
@@ -124,8 +124,13 @@ export function GatewayDetail({
         <Grid container direction="row" justify="flex-end" alignItems="center">
           <Grid item xs={8}>
             <Tabs
-              value={tabPos}
-              onChange={(_, v) => setTabPos(v)}
+              value={GetCurrentTabPos(match.url, [
+                'overview',
+                'event',
+                'log',
+                'alert',
+                'config',
+              ])}
               indicatorColor="primary"
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"

--- a/nms/app/fbcnms-projects/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -31,6 +31,7 @@ import Text from '../../theme/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 
 import {CardTitleRow} from '../../components/layout/CardTitleRow';
+import {DetailTabItems, GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -94,7 +95,6 @@ export default function SubscriberDetail(props: {
   subscriberMap: ?{[string]: subscriber},
 }) {
   const classes = useStyles();
-  const [tabPos, setTabPos] = React.useState(0);
   const {relativePath, relativeUrl, match} = useRouter();
   const subscriberId: string = nullthrows(match.params.subscriberId);
   const subscriberInfo = props.subscriberMap?.[subscriberId];
@@ -112,8 +112,7 @@ export default function SubscriberDetail(props: {
         <Grid container direction="row" justify="flex-end" alignItems="center">
           <Grid item xs={12}>
             <Tabs
-              value={tabPos}
-              onChange={(event, v) => setTabPos(v)}
+              value={GetCurrentTabPos(match.url, DetailTabItems)}
               indicatorColor="primary"
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"

--- a/nms/app/fbcnms-projects/magmalte/app/views/traffic/TrafficOverview.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/traffic/TrafficOverview.js
@@ -20,6 +20,7 @@ import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Text from '@fbcnms/ui/components/design-system/Text';
 
+import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -89,8 +90,7 @@ const useStyles = makeStyles(theme => ({
 
 export default function TrafficDashboard() {
   const classes = useStyles();
-  const {relativePath, relativeUrl} = useRouter();
-  const [tabPos, setTabPos] = React.useState(0);
+  const {relativePath, relativeUrl, match} = useRouter();
 
   return (
     <>
@@ -104,8 +104,7 @@ export default function TrafficDashboard() {
         <Grid container>
           <Grid item xs={6}>
             <Tabs
-              value={tabPos}
-              onChange={(_, v) => setTabPos(v)}
+              value={GetCurrentTabPos(match.url, ['policy', 'apn'])}
               indicatorColor="primary"
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"


### PR DESCRIPTION
## Summary

Whenever we directly use URLs to access the pages, the pages always showed the default tab despite the url containing some other match.  This fix addresses this issue.

## Test Plan
yarn tests passed fine

Before
![Screen Shot 2020-07-21 at 10 38 22 AM](https://user-images.githubusercontent.com/8224854/88096439-8013fa00-cb4b-11ea-901c-3117efec7dbc.png)

After
<img width="1680" alt="Screen Shot 2020-07-21 at 12 09 44 PM" src="https://user-images.githubusercontent.com/8224854/88096368-607cd180-cb4b-11ea-85dc-2515ef123a93.png">


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
