### PR TITLE
[CI]Disable docusaurus bot in order to setup redirect to new doc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -633,10 +633,10 @@ workflows:
               - cloud-test
               - orc8r-gateway-test
 
-  docusaurus_build_and_deploy:
-    jobs:
-      - docusaurus_build_and_deploy:
-          <<: *only_master
+  # docusaurus_build_and_deploy:
+  #   jobs:
+  #     - docusaurus_build_and_deploy:
+  #         <<: *only_master
 
   southpoll_test_and_publish:
     jobs:


### PR DESCRIPTION
[CI]Disable docusaurus bot in order to setup redirect to new doc

## Summary

In order to redirect facebookincubator.github.io ->. magma.github.io we need to disable the autodeploy of the doc

## Test Plan

Let CI run 

## Additional Information
None