### PR TITLE
[sessiond] added GRPC messages for pipelined

### DIFF
--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -11,6 +11,8 @@
 
 #include "ServiceRegistrySingleton.h"
 #include "magma_logging.h"
+#include "GrpcMagmaUtils.h"
+#include <google/protobuf/util/time_util.h>
 
 using grpc::Status;
 
@@ -274,24 +276,6 @@ bool AsyncPipelinedClient::update_subscriber_quota_state(
   return true;
 }
 
-void AsyncPipelinedClient::setup_policy_rpc(
-    const SetupPolicyRequest& request,
-    std::function<void(Status, SetupFlowsResult)> callback) {
-  auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
-      std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncSetupPolicyFlows(
-      local_resp->get_context(), request, &queue_)));
-}
-
-void AsyncPipelinedClient::setup_ue_mac_rpc(
-    const SetupUEMacRequest& request,
-    std::function<void(Status, SetupFlowsResult)> callback) {
-  auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
-      std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(stub_->AsyncSetupUEMacFlows(
-      local_resp->get_context(), request, &queue_)));
-}
-
 bool AsyncPipelinedClient::add_gy_final_action_flow(
     const std::string& imsi, const std::string& ip_addr,
     const std::vector<std::string>& static_rules,
@@ -319,11 +303,36 @@ bool AsyncPipelinedClient::add_gy_final_action_flow(
       });
   return true;
 }
+
+void AsyncPipelinedClient::setup_policy_rpc(
+    const SetupPolicyRequest& request,
+    std::function<void(Status, SetupFlowsResult)> callback) {
+  auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
+      std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
+  local_resp->set_response_reader(std::move(stub_->AsyncSetupPolicyFlows(
+      local_resp->get_context(), request, &queue_)));
+}
+
+void AsyncPipelinedClient::setup_ue_mac_rpc(
+    const SetupUEMacRequest& request,
+    std::function<void(Status, SetupFlowsResult)> callback) {
+  auto local_resp = new AsyncLocalResponse<SetupFlowsResult>(
+      std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
+  local_resp->set_response_reader(std::move(stub_->AsyncSetupUEMacFlows(
+      local_resp->get_context(), request, &queue_)));
+}
+
 void AsyncPipelinedClient::deactivate_flows_rpc(
     const DeactivateFlowsRequest& request,
     std::function<void(Status, DeactivateFlowsResult)> callback) {
   auto local_resp = new AsyncLocalResponse<DeactivateFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
   local_resp->set_response_reader(std::move(stub_->AsyncDeactivateFlows(
       local_resp->get_context(), request, &queue_)));
 }
@@ -333,6 +342,8 @@ void AsyncPipelinedClient::activate_flows_rpc(
     std::function<void(Status, ActivateFlowsResult)> callback) {
   auto local_resp = new AsyncLocalResponse<ActivateFlowsResult>(
       std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
   local_resp->set_response_reader(std::move(
       stub_->AsyncActivateFlows(local_resp->get_context(), request, &queue_)));
 }
@@ -342,6 +353,8 @@ void AsyncPipelinedClient::add_ue_mac_flow_rpc(
     std::function<void(Status, FlowResponse)> callback) {
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
   local_resp->set_response_reader(std::move(
       stub_->AsyncAddUEMacFlow(local_resp->get_context(), request, &queue_)));
 }
@@ -351,6 +364,8 @@ void AsyncPipelinedClient::update_ipfix_flow_rpc(
     std::function<void(Status, FlowResponse)> callback) {
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
   local_resp->set_response_reader(std::move(stub_->AsyncUpdateIPFIXFlow(
       local_resp->get_context(), request, &queue_)));
 }
@@ -360,6 +375,8 @@ void AsyncPipelinedClient::delete_ue_mac_flow_rpc(
     std::function<void(Status, FlowResponse)> callback) {
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
   local_resp->set_response_reader(std::move(stub_->AsyncDeleteUEMacFlow(
       local_resp->get_context(), request, &queue_)));
 }
@@ -369,6 +386,8 @@ void AsyncPipelinedClient::update_subscriber_quota_state_rpc(
     std::function<void(Status, FlowResponse)> callback) {
   auto local_resp = new AsyncLocalResponse<FlowResponse>(
       std::move(callback), RESPONSE_TIMEOUT);
+  PrintGrpcMessage(
+      static_cast<const google::protobuf::Message&>(request));
   local_resp->set_response_reader(
       std::move(stub_->AsyncUpdateSubscriberQuotaState(
           local_resp->get_context(), request, &queue_)));


### PR DESCRIPTION
## Summary
Added GRPC pirnt messages for pipelined

To enable grpc messages, use this env var on the VM you are running the process. Note if this is a docker container you ll need to add it to docker compose, otherwise you can add it to `/etc/enviroment`
```
 MAGMA_PRINT_GRPC_PAYLOAD: 1
```

## Test Plan
make and make test in awg

