### PR TITLE
Populate mandatory avps for radius

### DIFF
--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -96,13 +96,16 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 	// Currently only handling authorization requests - we have roadmap tasks to support full v2 integration T64414814
 	// When we'll have v2 support we can remove the hand crafted json packet
 	jsonPacket := map[string]map[string]interface{}{
-		"NAS-IP-Address":     {"type": "string", "value": []string{rfc2865.NASIPAddress_Get(r.Packet).String()}},
 		"Called-Station-Id":  {"type": "string", "value": []string{normalize(rfc2865.CalledStationID_GetString(r.Packet))}},
 		"Calling-Station-Id": {"type": "string", "value": []string{normalize(rfc2865.CallingStationID_GetString(r.Packet))}},
 		"NAS-Identifier":     {"type": "string", "value": []string{rfc2865.NASIdentifier_GetString(r.Packet)}},
 		"XWF-C-Version":      {"type": "string", "value": []string{analyticsVersion}},
 	}
-
+	// If no nas ip address is specified then no field will be sent
+	if rfc2865.NASIPAddress_Get(r.Packet) != nil {
+		jsonPacket["NAS-IP-Address"] =
+			map[string]interface{}{"type": "string", "value": rfc2865.NASIPAddress_Get(r.Packet).String()}
+	}
 	encodedMsg, err := json.Marshal(jsonPacket)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to marshal radius packet")


### PR DESCRIPTION
Summary:
We had instances of miss behaving access points were they were not sending nas ip and nas id.
These aren't mandatory fields to us.
The only field that needs to be corrected is the nas ip, where in case it isn't sepcified we'll not send it.

Differential Revision: D22667597

