### PR TITLE
[NMS] set API_HOST env var in NMS docker-compose file

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/docker-compose.yml
+++ b/nms/app/fbcnms-projects/magmalte/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       API_CERT_FILENAME: /run/secrets/api_cert
       API_PRIVATE_KEY_FILENAME: /run/secrets/api_key
-      API_HOST: ${API_HOST:-proxy:9443}
+      API_HOST: host.docker.internal:9443
       PORT: 8081
       HOST: 0.0.0.0
       MYSQL_HOST: mariadb

--- a/nms/app/fbcnms-projects/magmalte/docker-compose.yml
+++ b/nms/app/fbcnms-projects/magmalte/docker-compose.yml
@@ -45,7 +45,7 @@ services:
     environment:
       API_CERT_FILENAME: /run/secrets/api_cert
       API_PRIVATE_KEY_FILENAME: /run/secrets/api_key
-      API_HOST: host.docker.internal:9443
+      API_HOST: ${API_HOST:-nginx:9443}
       PORT: 8081
       HOST: 0.0.0.0
       MYSQL_HOST: mariadb


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

* Set the API_HOST to `host.docker.internal:9443` explicitly, since otherwise it would require a .env file to be generated. This allows the NMS to work locally without any manual setup.

## Test Plan
NMS loads after building container and logging in:
![image](https://user-images.githubusercontent.com/13274915/88216591-26c2ce00-cc12-11ea-8628-565f2da511d0.png)
