### PR TITLE
[NMS] Plug EventTable into top level components

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/components/DashboardKPIs.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/DashboardKPIs.js
@@ -8,32 +8,19 @@
  * @format
  */
 
-import Card from '@material-ui/core/Card';
 import EnodebKPIs from './EnodebKPIs';
 import GatewayKPIs from './GatewayKPIs';
 import Grid from '@material-ui/core/Grid';
 import Paper from '@material-ui/core/Paper';
 import React from 'react';
-import Text from '../theme/design-system/Text';
 
 import {CardTitleRow} from './layout/CardTitleRow';
 import {GpsFixed} from '@material-ui/icons';
-import {makeStyles} from '@material-ui/styles';
-
-const useStyles = makeStyles(theme => ({
-  eventsTable: {
-    marginTop: theme.spacing(4),
-    textAlign: 'center',
-    padding: theme.spacing(10),
-  },
-}));
 
 export default function () {
-  const classes = useStyles();
-
   return (
     <>
-      <CardTitleRow icon={GpsFixed} label="Events (388)" />
+      <CardTitleRow icon={GpsFixed} label="Events" />
       <Grid container item zeroMinWidth alignItems="center" spacing={4}>
         <Grid item xs={12} md={6}>
           <Paper elevation={0}>
@@ -46,9 +33,6 @@ export default function () {
           </Paper>
         </Grid>
       </Grid>
-      <Card elevation={0} className={classes.eventsTable}>
-        <Text variant="body2">Events Table Goes Here</Text>
-      </Card>
     </>
   );
 }

--- a/nms/app/fbcnms-projects/magmalte/app/components/lte/LteDashboard.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/lte/LteDashboard.js
@@ -13,6 +13,7 @@ import AppBar from '@material-ui/core/AppBar';
 import DashboardAlertTable from '../DashboardAlertTable';
 import DashboardKPIs from '../DashboardKPIs';
 import EventAlertChart from '../EventAlertChart';
+import EventsTable from '../../views/events/EventsTable';
 import Grid from '@material-ui/core/Grid';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import React, {useState} from 'react';
@@ -25,6 +26,7 @@ import {DateTimePicker} from '@material-ui/pickers';
 import {NetworkCheck, People} from '@material-ui/icons';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors} from '../../theme/default';
+import {magmaEventTypes} from '../../views/events/EventsTable';
 import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -169,14 +171,10 @@ function LteNetworkDashboard({startEnd}: {startEnd: [moment, moment]}) {
         </Grid>
 
         <Grid item xs={12}>
-          {/* <Text>
-            <GpsFixed /> Events
-          </Text>
-          <EventsTable
-            eventTypes={magmaEventTypes.NETWORK}
-            gatewayHardwareId={'f9a9fc7c-7977-474d-9617-8a309479f2bb'}
-          /> */}
           <DashboardKPIs />
+        </Grid>
+        <Grid item xs={12}>
+          <EventsTable eventTypes={magmaEventTypes.NETWORK} sz="md" />
         </Grid>
       </Grid>
     </div>

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -18,7 +18,6 @@ import EnodebConfig from './EnodebDetailConfig';
 import GatewayLogs from './GatewayLogs';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
-import MyLocationIcon from '@material-ui/icons/MyLocation';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import Paper from '@material-ui/core/Paper';
 import PeopleIcon from '@material-ui/icons/People';
@@ -31,9 +30,9 @@ import Text from '../../theme/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
 
 import {CardTitleRow} from '../../components/layout/CardTitleRow';
-import {DetailTabItems, GetCurrentTabPos} from '../../components/TabUtils.js';
 import {EnodebJsonConfig} from './EnodebDetailConfig';
 import {EnodebStatus, EnodebSummary} from './EnodebDetailSummaryStatus';
+import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -110,7 +109,7 @@ export function EnodebDetail(props: Props) {
         <Grid container direction="row" justify="flex-end" alignItems="center">
           <Grid item xs={6}>
             <Tabs
-              value={GetCurrentTabPos(match.url, DetailTabItems)}
+              value={GetCurrentTabPos(match.url, ['overview', 'config'])}
               indicatorColor="primary"
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"
@@ -120,13 +119,6 @@ export function EnodebDetail(props: Props) {
                 component={NestedRouteLink}
                 label={<OverviewTabLabel />}
                 to="/overview"
-                className={classes.tab}
-              />
-              <Tab
-                key="Event"
-                component={NestedRouteLink}
-                label={<EventTabLabel />}
-                to="/event"
                 className={classes.tab}
               />
               <Tab
@@ -237,14 +229,7 @@ function Overview({enbInfo}: {enbInfo: EnodebInfo}) {
         </Grid>
         <Grid item xs={12}>
           <Grid container spacing={4}>
-            <Grid item xs={6}>
-              <CardTitleRow icon={MyLocationIcon} label="Events" />
-              <Paper className={classes.paper} elevation={0}>
-                <Text variant="body2">Event Information</Text>
-              </Paper>
-            </Grid>
-
-            <Grid item xs={6}>
+            <Grid item xs={12}>
               <CardTitleRow icon={PeopleIcon} label="Subscribers" />
               <Paper className={classes.paper} elevation={0}>
                 <Text variant="body2">Subscribers data</Text>
@@ -272,16 +257,6 @@ function ConfigTabLabel() {
   return (
     <div className={classes.tabLabel}>
       <SettingsIcon className={classes.tabIconLabel} /> Config
-    </div>
-  );
-}
-
-function EventTabLabel() {
-  const classes = useStyles();
-
-  return (
-    <div className={classes.tabLabel}>
-      <MyLocationIcon className={classes.tabIconLabel} /> Event
     </div>
   );
 }

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailMain.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailMain.js
@@ -16,6 +16,7 @@ import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
+import EventsTable from '../../views/events/EventsTable';
 import GatewayConfig from './GatewayDetailConfig';
 import GatewayDetailStatus from './GatewayDetailStatus';
 import GatewayLogs from './GatewayLogs';
@@ -39,6 +40,7 @@ import {CardTitleRow} from '../../components/layout/CardTitleRow';
 import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
+import {magmaEventTypes} from '../../views/events/EventsTable';
 import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -200,6 +202,16 @@ export function GatewayDetail({
           render={() => <GatewayConfig gwInfo={gwInfo} enbInfo={gwEnbs} />}
         />
         <Route
+          path={relativePath('/event')}
+          render={() => (
+            <EventsTable
+              eventTypes={magmaEventTypes.GATEWAY}
+              eventKey={gwInfo.device.hardware_id}
+              sz="lg"
+            />
+          )}
+        />
+        <Route
           path={relativePath('/overview')}
           render={() => <GatewayOverview gwInfo={gwInfo} enbInfo={gwEnbs} />}
         />
@@ -226,9 +238,11 @@ function GatewayOverview({gwInfo}: {gwInfo: lte_gateway}) {
             </Grid>
             <Grid item xs={12} alignItems="center">
               <CardTitleRow icon={MyLocationIcon} label="Events" />
-              <Paper className={classes.paper} elevation={0}>
-                <Text variant="body2">Event Information</Text>
-              </Paper>
+              <EventsTable
+                eventTypes={magmaEventTypes.GATEWAY}
+                eventKey={gwInfo.device.hardware_id}
+                sz="sm"
+              />
             </Grid>
           </Grid>
         </Grid>

--- a/nms/app/fbcnms-projects/magmalte/app/views/events/EventsTable.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/events/EventsTable.js
@@ -10,28 +10,23 @@
 
 import type {event as MagmaEvent} from '@fbcnms/magma-api';
 
+import ActionTable from '../../components/ActionTable';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import ExpansionPanel from '@material-ui/core/ExpansionPanel';
 import ExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails';
 import ExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
-import Paper from '@material-ui/core/Paper';
-import React, {useState} from 'react';
-import Table from '@material-ui/core/Table';
-import TableBody from '@material-ui/core/TableBody';
-import TableCell from '@material-ui/core/TableCell';
-import TableFooter from '@material-ui/core/TableFooter';
-import TableHead from '@material-ui/core/TableHead';
-import TablePagination from '@material-ui/core/TablePagination';
-import TableRow from '@material-ui/core/TableRow';
-
+import MyLocationIcon from '@material-ui/icons/MyLocation';
+import React from 'react';
 import nullthrows from '@fbcnms/util/nullthrows';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
-import {filter, flatMap, map, slice, some} from 'lodash';
+
+import {filter, flatMap, map, some} from 'lodash';
 import {makeStyles} from '@material-ui/styles';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
+import {useState} from 'react';
 
 const useStyles = makeStyles(theme => ({
   header: {
@@ -53,6 +48,9 @@ const useStyles = makeStyles(theme => ({
   eventDetailValue: {
     'max-width': '500px',
     overflow: 'scroll',
+  },
+  dashboardRoot: {
+    margin: theme.spacing(5),
   },
 }));
 
@@ -80,17 +78,71 @@ export const magmaEventTypes = Object.freeze({
   SUBSCRIBER: 3,
 });
 
+type EventRowType = {
+  ts: string,
+  eventType: string,
+  eventDescription: string,
+  value: {},
+  hardwareID: string,
+  tag: string,
+};
+
+type EventDescriptionProps = {
+  rowData: EventRowType,
+};
+
+function ExpandEvent(props: EventDescriptionProps) {
+  const classes = useStyles();
+  const eventDetails = {
+    hardware_id: props.rowData.hardwareID,
+    tag: props.rowData.tag,
+  };
+  const [expanded, setExpanded] = useState(false);
+  if (props.rowData.value) {
+    for (const [key, value] of Object.entries(props.rowData.value)) {
+      eventDetails[key] = value;
+    }
+  }
+  return (
+    <ExpansionPanel
+      elevation={0}
+      expanded={expanded}
+      onChange={() => setExpanded(!expanded)}>
+      <ExpansionPanelSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls="panel1bh-content">
+        {Object.keys(eventDetails).join(', ')}
+      </ExpansionPanelSummary>
+      <ExpansionPanelDetails>
+        <table>
+          <tbody>
+            {Object.entries(eventDetails).map((entry, i) => (
+              <tr key={i}>
+                <td>{entry[0]}: </td>
+                <td className={classes.eventDetailValue}>
+                  {JSON.stringify(entry[1])}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </ExpansionPanelDetails>
+    </ExpansionPanel>
+  );
+}
+
 export default function EventsTable({
   eventTypes,
-  gatewayHardwareId,
+  eventKey,
+  sz,
 }: {
   eventTypes: number,
-  gatewayHardwareId: string,
+  eventKey?: string,
+  sz: 'sm' | 'md' | 'lg',
 }) {
+  const classes = useStyles();
   const {match} = useRouter();
   const enqueueSnackbar = useEnqueueSnackbar();
-  const [rowsPerPage, setRowsPerPage] = useState(10);
-  const [page, setPage] = useState(0);
   const magmadEvents = useMagmaAPI(
     MagmaV1API.getEventsByNetworkIdByStreamName,
     {
@@ -126,6 +178,10 @@ export default function EventsTable({
     return <LoadingFiller />;
   }
 
+  if (some(renderedEvents, s => s.isLoading)) {
+    return <LoadingFiller />;
+  }
+
   const errored = filter(renderedEvents, s => s.error);
   const errors = map(errored, e => e.error.message);
   errors.forEach(err => enqueueSnackbar(err, {variant: 'error'}));
@@ -134,101 +190,81 @@ export default function EventsTable({
   const unfiltered: Array<MagmaEvent> = flatMap(loaded, s => s.response);
   let events = unfiltered;
   if (eventTypes === magmaEventTypes.GATEWAY) {
-    events = filter(unfiltered, s => s.hardware_id === gatewayHardwareId);
+    events = filter(unfiltered, s => s.hardware_id === eventKey);
   }
 
-  const eventsStartIndex = page * rowsPerPage;
-  const eventsEndIndex = eventsStartIndex + rowsPerPage;
-  const rows = map(
-    slice(events, eventsStartIndex, eventsEndIndex),
-    (event, index: number) => <EventTableRow key={index} event={event} />,
-  );
+  const eventRows: Array<EventRowType> = events.map(event => {
+    return {
+      ts: event.timestamp,
+      eventType: event.event_type,
+      eventDescription: getEventDescription(event),
+      value: event.value,
+      hardwareID: event.hardware_id,
+      tag: event.tag,
+    };
+  });
 
   return (
-    <Paper elevation={2}>
-      <Table>
-        <TableHead>
-          <TableRow>
-            <TableCell>Timestamp</TableCell>
-            <TableCell>Event Type</TableCell>
-            <TableCell>Description</TableCell>
-            <TableCell>More details</TableCell>
-            <TableCell />
-          </TableRow>
-        </TableHead>
-        <TableBody>{rows}</TableBody>
-        {events.length === 0 && (
-          <TableFooter>
-            <TableRow>
-              <TableCell colSpan="3">No events found</TableCell>
-            </TableRow>
-          </TableFooter>
-        )}
-      </Table>
-      <TablePagination
-        rowsPerPageOptions={[10, 50, 100]}
-        component="div"
-        count={events.length}
-        rowsPerPage={rowsPerPage}
-        page={page}
-        onChangePage={(_, newPage) => setPage(newPage)}
-        onChangeRowsPerPage={e => {
-          setRowsPerPage(parseInt(e.target.value, 10));
-          setPage(0);
-        }}
-      />
-    </Paper>
-  );
-}
-
-type Props = {
-  event: MagmaEvent,
-};
-
-function EventTableRow(props: Props) {
-  const classes = useStyles();
-  const {event} = props;
-  const [expanded, setExpanded] = useState(false);
-
-  const eventDetails = {
-    hardware_id: event.hardware_id,
-    tag: event.tag,
-  };
-  for (const [key, value] of Object.entries(event.value)) {
-    eventDetails[key] = value;
-  }
-
-  return (
-    <TableRow>
-      <TableCell>{new Date(event.timestamp).toString()}</TableCell>
-      <TableCell>{event.event_type}</TableCell>
-      <TableCell>{getEventDescription(event)}</TableCell>
-      <TableCell>
-        <ExpansionPanel
-          elevation={0}
-          expanded={expanded}
-          onChange={() => setExpanded(!expanded)}>
-          <ExpansionPanelSummary
-            expandIcon={<ExpandMoreIcon />}
-            aria-controls="panel1bh-content">
-            {Object.keys(eventDetails).join(', ')}
-          </ExpansionPanelSummary>
-          <ExpansionPanelDetails>
-            <table>
-              <tbody>
-                {Object.entries(eventDetails).map((entry, i) => (
-                  <tr key={i}>
-                    <td>{entry[0]}: </td>
-                    <td className={classes.eventDetailValue}>
-                      {JSON.stringify(entry[1])}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </ExpansionPanelDetails>
-        </ExpansionPanel>
-      </TableCell>
-    </TableRow>
+    <>
+      {sz === 'sm' && (
+        <ActionTable
+          title=""
+          data={eventRows}
+          columns={[
+            {title: 'Timestamp', field: 'ts', type: 'datetime'},
+            {title: 'EventType', field: 'eventType'},
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [5],
+            toolbar: false,
+          }}
+        />
+      )}
+      {sz === 'md' && (
+        <ActionTable
+          title="Events"
+          titleIcon={MyLocationIcon}
+          data={eventRows}
+          columns={[
+            {title: 'Timestamp', field: 'ts', type: 'datetime'},
+            {title: 'Event Type', field: 'eventType'},
+            {title: 'Event Description', field: 'eventDescription'},
+            {
+              title: 'More Details',
+              field: 'eventDescription',
+              render: rowData => <ExpandEvent rowData={rowData} />,
+            },
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [10, 20],
+          }}
+        />
+      )}
+      {sz === 'lg' && (
+        <div className={classes.dashboardRoot}>
+          <ActionTable
+            title="Events"
+            titleIcon={MyLocationIcon}
+            data={eventRows}
+            columns={[
+              {title: 'Timestamp', field: 'ts', type: 'datetime'},
+              {title: 'Event Type', field: 'eventType'},
+              {title: 'Event Description', field: 'eventDescription'},
+              {
+                title: 'More Details',
+                field: 'eventDescription',
+                render: rowData => <ExpandEvent rowData={rowData} />,
+              },
+            ]}
+            options={{
+              actionsColumnIndex: -1,
+              pageSizeOptions: [10, 20],
+            }}
+          />
+        </div>
+      )}
+    </>
   );
 }

--- a/nms/app/fbcnms-projects/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -14,13 +14,12 @@ import type {subscriber} from '../../../../../fbcnms-packages/fbcnms-magma-api';
 import AppBar from '@material-ui/core/AppBar';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DateTimeMetricChart from '../../components/DateTimeMetricChart';
-import GpsFixed from '@material-ui/icons/GpsFixed';
+import EventsTable from '../../views/events/EventsTable';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
 import KPIGrid from '../../components/KPIGrid';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
-import Paper from '@material-ui/core/Paper';
 import PersonIcon from '@material-ui/icons/Person';
 import React from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
@@ -34,6 +33,7 @@ import {CardTitleRow} from '../../components/layout/CardTitleRow';
 import {DetailTabItems, GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
+import {magmaEventTypes} from '../../views/events/EventsTable';
 import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -153,6 +153,12 @@ export default function SubscriberDetail(props: {
           path={relativePath('/overview')}
           render={() => <Overview subscriberInfo={subscriberInfo} />}
         />
+        <Route
+          path={relativePath('/event')}
+          render={() => (
+            <EventsTable sz="lg" eventTypes={magmaEventTypes.SUBSCRIBER} />
+          )}
+        />
         <Redirect to={relativeUrl('/overview')} />
       </Switch>
     </>
@@ -188,12 +194,11 @@ function Overview(props: {subscriberInfo: subscriber}) {
           />
         </Grid>
         <Grid item xs={12}>
-          <Grid item xs={12}>
-            <CardTitleRow icon={GpsFixed} label="Events" />
-            <Paper className={classes.paper} elevation={0}>
-              <Text variant="body2">Event Table Goes Here</Text>
-            </Paper>
-          </Grid>
+          <EventsTable
+            eventTypes={magmaEventTypes.SUBSCRIBER}
+            eventKey={props.subscriberInfo.id}
+            sz="md"
+          />
         </Grid>
       </Grid>
     </div>


### PR DESCRIPTION
## Summary

- EventTable was removed for some reason from LTE dashboard. Added that back. 
- Plugged in the event table with gateway and subscriber detail pane. 
- Remove event table information from eNodeB. 
- Added material table support for event table and created three different size variations to be used as a card, page and a wider component. 

## Test Plan
![eventTable](https://user-images.githubusercontent.com/8224854/88295007-b8354d00-ccb1-11ea-9562-dc386c2e2269.gif)

