### PR TITLE
[circleci] Migrate all integration tests and publish jobs to opensource circleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,12 @@
 version: 2.1
 
-refs:
-  only_master: &only_master
-    filters:
-      branches:
-        only: master
-
 aliases:
   - &appdir
     working_directory: "nms/app"
+  - &only_master
+    filters:
+      branches:
+        only: master
 
 executors:
   node:
@@ -109,6 +107,263 @@ commands:
           paths:
             - ~/.cache/yarn
 
+  tag-push-docker:
+    description: Tag docker image and push it
+    parameters:
+      tag:
+        description: Containers to tag and push
+        type: string
+        default: ${CIRCLE_SHA1:0:8}
+      registry:
+        description: Registry to push to
+        type: string
+        default: ${DOCKER_REGISTRY}
+      username:
+        description: Username to log in as
+        type: string
+        default: ${DOCKER_USERNAME}
+      password:
+        description: Password to log in using
+        type: string
+        default: ${DOCKER_PASSWORD}
+      project:
+        description: Project images are linked to
+        type: string
+        default: ""
+      images:
+        description: Images you want to tag and push separated by |
+        type: string
+      tag-latest:
+        default: false
+        type: boolean
+    steps:
+      - run: |
+          if [ "${CIRCLE_BRANCH}" != "master" ]; then
+            echo "Push only happens for master branch"
+            exit 0
+          fi
+
+          DOCKER_REGISTRY="<< parameters.registry >>"
+          DOCKER_USERNAME="<< parameters.username >>"
+          DOCKER_PASSWORD="<< parameters.password >>"
+
+          docker login "${DOCKER_REGISTRY}" -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+
+          IMAGES="<< parameters.images >>"
+          IMAGES_ARRAY=($(echo $IMAGES | tr "|" "\n"))
+          PROJECT=<< parameters.project >>
+          TAG=<< parameters.tag >>
+          TAG_LATEST=<< parameters.tag-latest >>
+          for IMAGE in "${IMAGES_ARRAY[@]}"; do
+            IMAGE_TOSEARCH=$IMAGE
+            if [ ! -z $PROJECT ]; then
+              IMAGE_TOSEARCH="${PROJECT}_${IMAGE}"
+            fi
+            IMAGE_ID=$(docker images "$IMAGE_TOSEARCH:latest" --format "{{.ID}}")
+            docker tag "$IMAGE_ID" "${DOCKER_REGISTRY}/$IMAGE:$TAG"
+            if [ "$TAG_LATEST" = true ]; then
+              docker tag "$IMAGE_ID" "${DOCKER_REGISTRY}/$IMAGE:latest"
+            fi
+            echo "Pushing ${DOCKER_REGISTRY}/$IMAGE:$TAG"
+            docker push "${DOCKER_REGISTRY}/$IMAGE:$TAG"
+          done
+
+  magma_integ_test:
+    parameters:
+      stack:
+        description: Which stack to run integ tests for (cwf, lte)
+        type: string
+      test:
+        description: Should run tests (True, False)
+        type: string
+      build:
+        description: Should build deployment artifacts (True, False)
+        type: string
+      deploy:
+        description: Should deploy artifacts (True, False)
+        type: string
+    steps:
+      - checkout
+      - run: echo 'export MAGMA_ROOT=$(pwd)' >> $BASH_ENV
+      - run:
+          name: Install tools
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y openvpn
+      - run:
+          name: Configure and start VPN client
+          command: |
+            echo $MAGMA_OVPN_CONF | base64 -d - > ciworker.conf
+            sudo mv ciworker.conf /etc/openvpn/client.conf
+            sudo service openvpn@client restart
+      - run:
+          name: Decode and set secrets
+          command: |
+            cd ${MAGMA_ROOT}/circleci
+            echo $MAGMA_NODE_PKEY | base64 -d - > ci_node.pem
+            chmod 0400 ci_node.pem
+            echo $MAGMA_API_CERT | base64 -d - > ci_operator.pfx
+            openssl pkcs12 -in ci_operator.pfx -nocerts -out ci_operator.key.pem -nodes -passin pass:
+            openssl pkcs12 -in ci_operator.pfx -nokeys -out ci_operator.pem -passin pass:
+
+            echo $MAGMA_ROOTCA | base64 -d - > rootCA.pem
+            echo $MAGMA_CONTROL_PROXY | base64 -d - > control_proxy.yml
+
+            echo export AWS_DEFAULT_REGION="us-east-1" >> $BASH_ENV
+            echo export AWS_ACCESS_KEY_ID="$(printenv MAGMA_DEPLOY_AWS_ACCESS_KEY_ID)" >> $BASH_ENV
+            echo export AWS_SECRET_ACCESS_KEY="$(printenv MAGMA_DEPLOY_AWS_SECRET_ACCESS_KEY)" >> $BASH_ENV
+      - run:
+          name: Select python 3.7.0
+          command: pyenv global 3.7.0
+      - run:
+          name: Install python prerequisites
+          command: pip3 install fabric3 jsonpickle requests PyYAML awscli
+      # sleep 10 just in case the vpn client takes time to spin up
+      - run:
+          name: Run remote integ test
+          command: |
+            sleep 10
+            cd ${MAGMA_ROOT}/circleci
+            fab <<parameters.stack>> integ_test:repo=${CIRCLE_REPOSITORY_URL},branch=${CIRCLE_BRANCH},sha1=${CIRCLE_SHA1},run_integ_test=<<parameters.test>>,build_package=<<parameters.build>>,deploy_artifacts=<<parameters.deploy>>
+
+            mkdir -p versions
+            cp *_version versions || true
+      - store_artifacts:
+          path: /tmp/logs
+      - run:
+          name: Double-check that the node is freed
+          command: |
+            cd ${MAGMA_ROOT}/circleci
+            lease_id=$(cat lease_id.out)
+            lease_node=$(cat lease_node.out)
+            curl -X POST "https://api-staging.magma.etagecom.io/magma/v1/ci/nodes/${lease_node}/release/${lease_id}" -k --key ci_operator.key.pem --cert ci_operator.pem || true
+          when: always
+      - magma_slack_notify
+
+  magma_slack_notify:
+    description: Notify Slack on magma job failure
+    steps:
+      - run:
+          command: |
+            echo 'export SLACK_BUILD_STATUS="fail"' >> $BASH_ENV
+          name: Slack - Setting Failure Condition
+          when: on_fail
+      - run:
+          command: |
+            echo 'export SLACK_BUILD_STATUS="success"' >> $BASH_ENV
+          name: Slack - Setting Success Condition
+          when: on_success
+      - run:
+          name: Send message to Slack
+          command: |
+            author=$(git show -s --format='%an')
+            email=$(git show -s --format='%ae')
+            rel_time=$(git show -s --format='%cr')
+            abs_time=$(git show -s --format='%cd')
+            gh_text="<https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}|${CIRCLE_SHA1:0:8}> by ${author} <${email}> ${rel_time} (${abs_time})"
+
+            pretext="Job \`${CIRCLE_JOB}\` #${CIRCLE_BUILD_NUM} on branch \`${CIRCLE_BRANCH}\` of ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} failed. Check the <${CIRCLE_BUILD_URL}|build logs> for details."
+            color="#8b0902"
+
+            slack_data=$(cat \<<EOF
+            {
+              "text": "*CircleCI Job Failure*",
+              "attachments": [
+                {
+                  "color": "${color}",
+                  "pretext": "${pretext}",
+                  "fallback": "CircleCI job failure notification",
+                  "fields": [
+                    {
+                      "title": "Revision",
+                      "value": "${gh_text}",
+                      "short": false
+                    }
+                  ]
+                }
+              ]
+            }
+            EOF
+            )
+            echo $slack_data
+
+            if [ "$SLACK_BUILD_STATUS" = "fail" ] && [ "$CIRCLE_BRANCH" = "master" ]; then
+              curl -X POST -H 'Content-type: application/json' --data "${slack_data}" "${SLACK_WEBHOOK}"
+            else
+              echo "This command will only execute on failure on master."
+            fi
+          when: always
+
+  persist-githash-version:
+    parameters:
+      file_prefix:
+        type: string
+    steps:
+      - run:
+          name: Create version file
+          command: |
+            cd ${MAGMA_ROOT}/circleci
+            mkdir -p versions
+            echo "${CIRCLE_SHA1:0:8}" > versions/<< parameters.file_prefix >>_version
+
+  notify-magma:
+    description: Notify Slack when an artifact is published
+    parameters:
+      artifact_name:
+        description: Name of the artifact to include in the message
+        type: string
+      version_path:
+        description: Path to file that will contain the artifact version
+        type: string
+    steps:
+      - run:
+          name: Send slack message
+          command: |
+            if [ "${CIRCLE_BRANCH}" != "master" ]; then
+              exit 0
+            fi
+
+            author=$(git show -s --format='%an')
+            email=$(git show -s --format='%ae')
+            rel_time=$(git show -s --format='%cr')
+            abs_time=$(git show -s --format='%cd')
+            gh_text="<https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}|${CIRCLE_SHA1:0:8}> by ${author} <${email}> ${rel_time} (${abs_time})"
+
+            if [ -f ${MAGMA_ROOT}/circleci/<< parameters.version_path >> ]; then
+              ver=$(cat ${MAGMA_ROOT}/circleci/<< parameters.version_path >>)
+            else
+              ver="Unknown artifact version (this should never happen!)"
+            fi
+
+            pretext="Production artifact has been published. Promote or deploy it by following the appropriate oncall procedures."
+
+            slack_data=$(cat \<<EOF
+            {
+              "text": "*<< parameters.artifact_name >> Artifact Has Been Published*",
+              "attachments": [
+                {
+                  "color": "#36a64f",
+                  "pretext": "${pretext}",
+                  "fallback": "CircleCI workflow success notification",
+                  "fields": [
+                    {
+                      "title": "Artifact Version",
+                      "value": "\`${ver}\`",
+                      "short": false
+                    },
+                    {
+                      "title": "Revision",
+                      "value": "${gh_text}",
+                      "short": false
+                    }
+                  ]
+                }
+              ]
+            }
+            EOF
+            )
+            curl -X POST -H 'Content-type: application/json' --data "${slack_data}" "${SLACK_WEBHOOK}"
+
 jobs:
   ### CLOUD
 
@@ -130,6 +385,7 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/orc8r/cloud/docker
             python3 build.py -t
+      - magma_slack_notify
 
   insync-checkin:
     machine:
@@ -154,6 +410,7 @@ jobs:
       - run: git add .
       - run: git status
       - run: git diff-index --quiet HEAD
+      - magma_slack_notify
 
   orc8r-build:
     machine:
@@ -175,7 +432,15 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/orc8r/cloud/docker
             python3 build.py -a --nocache --parallel
-      # TODO: docker login and push here
+      - tag-push-docker:
+          project: orc8r
+          images: "nginx|controller"
+      - persist-githash-version:
+          file_prefix: orc8r
+      - notify-magma:
+          artifact_name: Orchestrator Images
+          version_path: versions/orc8r_version
+      - magma_slack_notify
 
   ### GATEWAY
 
@@ -196,6 +461,7 @@ jobs:
             cd ${MAGMA_ROOT}/orc8r/gateway/go
             go test ./...
             go vet ./...
+      - magma_slack_notify
 
   feg-precommit:
     docker:
@@ -214,6 +480,7 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/feg/gateway
             make -C ${MAGMA_ROOT}/feg/gateway precommit
+      - magma_slack_notify
 
   feg-build:
     machine:
@@ -227,7 +494,16 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/feg/gateway/docker
             DOCKER_REGISTRY=feg_ docker-compose build --parallel
-      # TODO: docker login and push here
+      - tag-push-docker:
+          project: feg
+          images: "gateway_go|gateway_python"
+          registry: $DOCKER_FEG_REGISTRY
+      - persist-githash-version:
+          file_prefix: feg
+      - notify-magma:
+          artifact_name: FeG
+          version_path: versions/feg_version
+      - magma_slack_notify
 
   cwag-precommit:
     docker:
@@ -246,6 +522,17 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/cwf/gateway
             make -C ${MAGMA_ROOT}/cwf/gateway precommit
+      - magma_slack_notify
+
+  cwf-integ-test:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - magma_integ_test:
+          stack: cwf
+          test: 'True'
+          build: 'False'
+          deploy: 'False'
 
   cwag-deploy:
     machine:
@@ -258,27 +545,20 @@ jobs:
       - checkout
       - docker/install-dc
       - run:
-          name: Create appropriate build tag for upgrades
-          command: |
-            set +o pipefail
-
-            cd ${MAGMA_ROOT}/circleci
-            mkdir -p versions
-
-            hash=$(git rev-parse HEAD)
-            container_version=${hash:0:8}
-            echo ${container_version} > versions/cwag_version
-      - run:
           name: Build CWAG containers
           command: |
             cd ${MAGMA_ROOT}/cwf/gateway/docker
             docker-compose -f docker-compose.yml -f docker-compose.override.yml build --parallel
-      # TODO: login and push
-      - persist_to_workspace:
-          # can't reference env vars in the yaml so we'll repeat the path
-          root: ~/project/circleci
-          paths:
-            - versions/cwag_version
+      - tag-push-docker:
+          project: cwf
+          images: 'cwag_go|gateway_go|gateway_python|gateway_sessiond|gateway_pipelined'
+          registry: $DOCKER_MAGMA_REGISTRY
+      - persist-githash-version:
+          file_prefix: cwag
+      - notify-magma:
+          artifact_name: CWAG
+          version_path: versions/cwag_version
+      - magma_slack_notify
 
   lte-test:
     machine:
@@ -308,6 +588,30 @@ jobs:
             mkdir ${CODEGEN_ROOT}
             wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.2.3/swagger-codegen-cli-2.2.3.jar -O $SWAGGER_CODEGEN_JAR
             make -C $MAGMA_ROOT/lte/gateway/python test_all
+      - magma_slack_notify
+
+  lte-integ-test:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - magma_integ_test:
+          stack: lte
+          test: 'True'
+          build: 'False'
+          deploy: 'False'
+
+  lte-agw-deploy:
+    machine:
+      image: ubuntu-1604:201903-01
+    steps:
+      - magma_integ_test:
+          stack: lte
+          test: 'False'
+          build: 'True'
+          deploy: 'True'
+      - notify-magma:
+          artifact_name: LTE AGW
+          version_path: versions/magma_version
 
   ## CWF OPERATOR
 
@@ -328,13 +632,13 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator
             make -C ${MAGMA_ROOT}/cwf/k8s/cwf_operator precommit
+      - magma_slack_notify
 
   cwf-operator-build:
     machine:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
     environment:
-      - NMS_ROOT=/home/circleci/project/fbcode/magma/magma/symphony/app/fbcnms-projects/magmalte
       - MAGMA_MODULES_FILE=/home/circleci/project/circleci/modules.yml
       - MAGMA_ROOT=/home/circleci/project
     steps:
@@ -344,7 +648,16 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/cwf/k8s/cwf_operator/docker
             DOCKER_REGISTRY=cwf_ docker-compose build --parallel
-      # TODO: docker login and push here
+      - tag-push-docker:
+          project: cwf
+          images: "operator"
+          registry: $DOCKER_MAGMA_REGISTRY
+      - persist-githash-version:
+          file_prefix: cwf_operator
+      - notify-magma:
+          artifact_name: CWF Operator
+          version_path: versions/cwf_operator_version
+      - magma_slack_notify
 
   ### NMS
 
@@ -362,6 +675,7 @@ jobs:
           name: flow typecheck
           <<: *appdir
           command: yarn run flow
+      - magma_slack_notify
 
   eslint:
     executor: node
@@ -372,6 +686,7 @@ jobs:
           name: eslint
           <<: *appdir
           command: yarn run eslint ./
+      - magma_slack_notify
 
   nms-yarn-test:
     executor: node
@@ -382,6 +697,7 @@ jobs:
           name: yarn test
           <<: *appdir
           command: yarn test:ci
+      - magma_slack_notify
 
   nms-build:
     machine:
@@ -396,6 +712,15 @@ jobs:
           command: |
             cd ${MAGMA_ROOT}/nms/app/fbcnms-projects/magmalte
             docker-compose build magmalte
+      - tag-push-docker:
+          project: magmalte
+          images: "magmalte"
+      - persist-githash-version:
+          file_prefix: nms
+      - notify-magma:
+          artifact_name: NMS
+          version_path: versions/nms_version
+      - magma_slack_notify
 
   ### FOSSA
 
@@ -415,6 +740,7 @@ jobs:
       - run: tar xzf fossa-cli_1.0.11_linux_amd64.tar.gz
       - run: cp /tmp/magma/fossa /usr/local/bin/
       - run: ${MAGMA_ROOT}/circleci/fossa-analyze-go.sh
+      - magma_slack_notify
 
   ### DOCUSAURUS
 
@@ -458,7 +784,12 @@ workflows:
   agw:
     jobs:
       - lte-test
-    # TODO: migrate LTE integ test and build here. We can get rid of lte-test after that
+      - lte-integ-test:
+          <<: *only_master
+      - lte-agw-deploy:
+          <<: *only_master
+          requires:
+            - lte-integ-test
 
   feg:
     jobs:
@@ -470,15 +801,20 @@ workflows:
   cwag:
     jobs:
       - cwag-precommit
+      - cwf-integ-test:
+          <<: *only_master
       - cwag-deploy:
+          <<: *only_master
           requires:
             - cwag-precommit
-      # TODO: migrate CWF integ test here
+            - cwf-integ-test
 
   cwf_operator:
     jobs:
       - cwf-operator-precommit
-      - cwf-operator-build
+      - cwf-operator-build:
+          requires:
+            - cwf-operator-precommit
 
   nms:
     jobs:

--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -64,24 +64,14 @@ def integ_test(repo: str = 'git@github.com:facebookincubator/magma.git',
                build_package: str = 'False',
                deploy_artifacts: str = 'False',
                package_cert: str = 'rootCA.pem',
-               package_control_proxy: str = 'control_proxy.yml',
-               docker_registry: str = DEFAULT_DOCKER_REG,
-               docker_user: str = 'magmaci-bot',
-               jfrog_key: str = 'jfrog_key',
-               build_number: str = '0',
-               workflow_names: str = 'lte-integ-test;cwf-integ-test',
-               circle_key: str = 'circleci_key'):
+               package_control_proxy: str = 'control_proxy.yml'):
     if env.stack not in STACKS:
         raise ValueError(f'Stack {env.stack} is not a valid stack.')
     should_test = run_integ_test == 'True'
     should_build = build_package == 'True'
     should_deploy = deploy_artifacts == 'True'
 
-    workflow_list = list(filter(lambda x: x, workflow_names.split(';')))
-    circle_key_val = local(f'cat {circle_key}', capture=True)
-    lease = _acquire_lease_with_retry(repo, int(build_number), workflow_list,
-                                      circle_key_val,
-                                      api_url, cert_file, cert_key_file)
+    lease = _acquire_lease_with_retry(api_url, cert_file, cert_key_file)
     if lease is None:
         print('Did not acquire a node lease in a reasonable time frame.')
         with open(f'{env.stack}_test_status', 'w+') as f:
@@ -118,13 +108,7 @@ def integ_test(repo: str = 'git@github.com:facebookincubator/magma.git',
             if env.stack == LTE_STACK:
                 _deploy_lte_packages(repo, magma_root)
             elif env.stack == CWF_STACK:
-                append_oss_hash = 'facebookincubator/magma' not in repo
-                # Rebuild the containers if we didn't run the integ tests in
-                # this same job
-                should_rebuild = not should_test
-                _deploy_cwf_images(repo, magma_root,
-                                   docker_registry, docker_user, jfrog_key,
-                                   append_oss_hash, should_rebuild)
+                raise Exception('CWAG artifacts should be built on Circle')
     except CommandTimeout as e:
         print('Remote run timed out, this probably indicates a problem '
               'with the job')
@@ -154,11 +138,7 @@ def _set_host_for_lease(lease: NodeLease, node_ssh_key: str):
     env.disable_known_hosts = True
 
 
-def _acquire_lease_with_retry(repo: str,
-                              build_number: int,
-                              workflow_names: List[str],
-                              circle_key: str,
-                              api_url: str,
+def _acquire_lease_with_retry(api_url: str,
                               cert_file: str,
                               cert_key_file: str) -> Optional[NodeLease]:
     lease_retries = 0
@@ -170,16 +150,6 @@ def _acquire_lease_with_retry(repo: str,
             return lease
         lease_retries += 1
         print('No nodes found, trying again after 5 minutes...')
-        should_cancel = _do_newer_running_workflows_exist(
-            repo,
-            build_number, workflow_names, circle_key,
-        )
-        if should_cancel:
-            # TODO: If we `circleci step halt` an integ test job here, how
-            #  do we also skip the build/deploy job later in the workflow?
-            print('Newer running workflows exist in the queue, I should '
-                  'cancel myself when my developer implements this '
-                  'functionality')
         sleep(300)
     return None
 
@@ -278,6 +248,7 @@ def _run_remote_cwf_integ_test(repo: str, magma_root: str):
             local('sudo mv cwf-artifacts/* /tmp/logs/')
         sys.exit(result.return_code)
 
+
 def _run_remote_lte_package(repo: str, magma_root: str,
                             package_cert: str, package_control_proxy: str,
                             destroy_vm: bool):
@@ -326,91 +297,6 @@ def _deploy_lte_packages(repo: str, magma_root: str):
           f'--acl bucket-owner-full-control')
     local(f'aws s3 cp packages.tar.gz {s3_path}.deps.tar.gz '
           f'--acl bucket-owner-full-control')
-
-
-def _deploy_cwf_images(repo: str, magma_root: str,
-                       docker_registry: str, user: str, jfrog_key: str,
-                       append_oss_hash: bool, rebuild: bool):
-    repo_name = _get_repo_name(repo)
-
-    if rebuild:
-        with cd(f'{repo_name}/{magma_root}/cwf/gateway/docker'):
-            # Note: it seems like the --parallel flag makes the fabric output
-            # unreadable, with all build outputs interleaved
-            run('docker-compose '
-                '-f docker-compose.yml '
-                '-f docker-compose.override.yml '
-                'build --parallel')
-
-    local_hash = local('git rev-parse HEAD', capture=True)
-    container_version = local_hash[:8]
-
-    put(jfrog_key, '/tmp/jfrog_key')
-    with cd(f'{repo_name}/{magma_root}/cwf/gateway/docker'):
-        for img in CWF_IMAGES:
-            run(f'../../../orc8r/tools/docker/publish.sh '
-                f'-r {docker_registry} -i {img} '
-                f'-u {user} -p /tmp/jfrog_key -v {container_version}')
-
-    if append_oss_hash:
-        oss_hash = _find_matching_opensource_commit(magma_root)
-        container_version = f'{container_version}|{oss_hash}'
-    local(f'echo "{container_version}" > cwag_version')
-
-
-def _find_matching_opensource_commit(
-        magma_root: str,
-        oss_repo: str = 'https://github.com/facebookincubator/magma.git ',
-) -> str:
-    # Find corresponding hash in opensource repo by grabbing the message of the
-    # latest commit to the magma root directory of the current repository then
-    # searching for it in the open source repo
-    commit_subj = local(f'git --no-pager log --oneline --pretty=format:"%s" '
-                        f'-- {magma_root} | head -n 1', capture=True)
-    local('rm -rf /tmp/ossmagma')
-    local('mkdir -p /tmp/ossmagma')
-    local(f'git clone {oss_repo} /tmp/ossmagma/magma')
-    with lcd('/tmp/ossmagma/magma'):
-        oss_hash = local(f'git --no-pager log --oneline --pretty=format:"%h" '
-                         f'--grep=\'{commit_subj}\' | head -n 1', capture=True)
-        return oss_hash
-
-
-def _do_newer_running_workflows_exist(repo: str,
-                                      build_number: int,
-                                      workflow_names: List[str],
-                                      circle_key: str) -> bool:
-    repo_org, repo_name = _get_repo_org(repo), _get_repo_name(repo)
-    circle_url = 'https://circleci.com/api/v1.1/project/gh'
-    resp = requests.get(f'{circle_url}/{repo_org}/{repo_name}?'
-                        f'circle-token={circle_key}&'
-                        f'filter=running')
-    if resp.status_code != 200:
-        print(f'Got status code {resp.status_code} from CircleCI API, will '
-              f'not perform auto-cancellation for this job.')
-        return False
-    builds = resp.json()
-    match = list(filter(lambda b: b['build_num'] == build_number, builds))
-    if not match:
-        print('Did not find the current build in the list of recent builds, '
-              'assuming that this is super out of date. Will report that '
-              'this build should be canceled.')
-        return True
-    this_build = match[0]
-    this_build_start = dateutil.parser.isoparse(this_build['start_time'])
-    for b in builds:
-        # Ignore ourselves
-        if b['build_num'] == build_number:
-            continue
-        if b['workflows']['workflow_name'] not in workflow_names:
-            continue
-
-        other_start = dateutil.parser.isoparse(b['start_time'])
-        if other_start > this_build_start:
-            print(f'Found build f{b["build_num"]} with start time after the '
-                  f'current build, will stop this run now.')
-            return True
-    return False
 
 
 def _destroy_vms(repo: str, magma_root: str,

--- a/cwf/k8s/cwf_operator/docker/Dockerfile
+++ b/cwf/k8s/cwf_operator/docker/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y bzr curl daemontools gcc
 
 # Install Golang 1.13.
 WORKDIR /usr/local
-RUN curl https://dl.google.com/go/go1.13.4.linux-amd64.tar.gz -O && \
+RUN curl https://facebookconnectivity.jfrog.io/artifactory/generic/go1.13.4.linux-amd64.tar.gz -O && \
     tar xf go1.13.4.linux-amd64.tar.gz && \
     cp -r go/bin/* /usr/local/bin/
 


### PR DESCRIPTION
## Summary 

- Move integ tests and docker publish steps into this repo
- Some differences from the old internal jobs because we're using a couple different workflows in this config instead of a megaworkflow.

## Test Plan

- https://app.circleci.com/pipelines/github/facebookincubator/magma?branch=fullcircle
- There are a few legit failing tests (nms) and cwag integ might flake, but we already got some publish notifications on slack.

## Additional Information

- [ ] This change is backwards-breaking