### PR TITLE
Adds a GitHub action to check Signed-off-by

### DIFF
--- a/.github/workflows/dco-check.yml
+++ b/.github/workflows/dco-check.yml
@@ -1,0 +1,22 @@
+name: DCO check
+on: 
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+jobs:
+  dco_check_job:
+    runs-on: ubuntu-latest
+    name: DCO Check
+    steps:
+    - name: Get PR Commits
+      id: 'get-pr-commits'
+      uses: tim-actions/get-pr-commits@master
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    - name: DCO Check
+      uses: tim-actions/dco@master
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
## Summary

This includes a yaml file that calls a GitHub action each time a
PR is created or commits are updated. It pulls the commits from
the PR and ensures that each one has a Signed-off-by status.

## Test Plan

This is identical to the DCO check that is running in the magma/community repo

