### PR TITLE
[orc8r][agw] SyncRPC client close_connections fix, improvements to forward_request

### DIFF
--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -95,11 +95,12 @@ class ControlProxyHttpClient(object):
                 SyncRPCResponse(heartBeat=False, reqId=req_id,
                                 respBody=GatewayResponse(err=str(e))))
         finally:
-            del self._connection_table[req_id]
             client.close_connection()
+            del self._connection_table[req_id]
 
     def close_all_connections(self):
-        for _, client in self._connection_table.items():
+        connections = list(self._connection_table.values())
+        for client in connections:
             client.close_connection()
         self._connection_table.clear()
 

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -136,8 +136,7 @@ class SyncRPCClient(threading.Thread):
                 self.forward_request(req)
             except grpc.RpcError as err:
                 logging.error(
-                    "[SyncRPC] Failing to forward request, err: %s"
-                    % err.details())
+                    "[SyncRPC] Failing to forward request, err: %s" % err.details())
                 raise err
 
     def forward_request(self, request: SyncRPCRequest) -> None:

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -136,8 +136,8 @@ class SyncRPCClient(threading.Thread):
                 self.forward_request(req)
             except grpc.RpcError as err:
                 logging.error(
-                    "[SyncRPC] Failing to forward request, err: {}".format(
-                        err.details()))
+                    "[SyncRPC] Failing to forward request, err: %s"
+                    % err.details())
                 raise err
 
     def forward_request(self, request: SyncRPCRequest) -> None:

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -129,13 +129,16 @@ class SyncRPCClient(threading.Thread):
         end of the iterator sync_rpc_requests, or encounters an error)
 
         """
-        try:
-            while True:
-                logging.debug("[SyncRPC] Waiting for requests")
+        logging.info("[SyncRPC] Waiting for requests")
+        while True:
+            try:
                 req = next(sync_rpc_requests)
                 self.forward_request(req)
-        except grpc.RpcError as err:
-            raise err
+            except grpc.RpcError as err:
+                logging.error(
+                    "[SyncRPC] Failing to forward request, err: {}".format(
+                        err.details()))
+                raise err
 
     def forward_request(self, request: SyncRPCRequest) -> None:
         if request.heartBeat:
@@ -143,6 +146,7 @@ class SyncRPCClient(threading.Thread):
             return
 
         if request.connClosed:
+            logging.debug("[SyncRPC] Got connClosed from cloud")
             self._conn_closed_table[request.reqId] = True
             return
 

--- a/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
+++ b/orc8r/gateway/python/magma/magmad/sync_rpc_client.py
@@ -136,7 +136,8 @@ class SyncRPCClient(threading.Thread):
                 self.forward_request(req)
             except grpc.RpcError as err:
                 logging.error(
-                    "[SyncRPC] Failing to forward request, err: %s" % err.details())
+                    "[SyncRPC] Failing to forward request, err: %s",
+                    err.details())
                 raise err
 
     def forward_request(self, request: SyncRPCRequest) -> None:


### PR DESCRIPTION
## Summary

- Increasing some logging verbosity on sync_rpc_client
- Fixing loop for forward_request func on sync_rpc_client to exit in case of failure
- Updating close_connections on proxy_client implementation to not iterate over dict (causing RuntimeError: dictionary size changed over iteration in case a connection was deleted)

## Test Plan

- tested on mcp02 with ixia testing
- tested locally with local orc8r and agw 

## Additional Information

- [ ] This change is backwards-breaking
