### PR TITLE
[AGW] mobilityd: dhcp_client: implement dhcp lease

### DIFF
--- a/lte/gateway/python/defs.mk
+++ b/lte/gateway/python/defs.mk
@@ -20,4 +20,5 @@ TESTS=magma/tests \
       magma/monitord/tests
 
 SUDO_TESTS= magma/mobilityd/tests/ip_alloc_dhcp_test.py \
+	    magma/mobilityd/tests/test_dhcp_client.py \
 	    magma/pipelined/tests \

--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -9,7 +9,7 @@ of patent rights can be found in the PATENTS file in the same directory.
 Allocates IP address as per DHCP server in the uplink network.
 
 """
-
+import datetime
 import logging
 import threading
 import time
@@ -38,7 +38,8 @@ class DHCPClient:
                  dhcp_store: MutableMapping[str, DHCPDescriptor],
                  gw_info: UplinkGatewayInfo,
                  dhcp_wait: Condition,
-                 iface: str = "dhcp0"):
+                 iface: str = "dhcp0",
+                 lease_renew_wait_min: int = 30):
         """
         Implement DHCP client to allocate IP for given Mac address.
         DHCP client state is maintained in user provided hash table.
@@ -57,6 +58,10 @@ class DHCPClient:
         self._dhcp_notify = dhcp_wait
         self._dhcp_interface = iface
         self._msg_xid = 0
+        self._lease_renew_wait_min = lease_renew_wait_min
+        self._monitor_thread = threading.Thread(target=self._monitor_dhcp_state)
+        self._monitor_thread.daemon = True
+        self._monitor_thread_event = threading.Event()
 
     def run(self):
         """
@@ -68,9 +73,11 @@ class DHCPClient:
         LOG.info("DHCP sniffer started")
         # give it time to schedule the thread and start sniffing.
         time.sleep(self.THREAD_YIELD_TIME)
+        self._monitor_thread.start()
 
     def stop(self):
         self._sniffer.stop()
+        self._monitor_thread_event.set()
 
     def send_dhcp_packet(self, mac: MacAddress, state: DHCPState,
                          dhcp_desc: DHCPDescriptor = None):
@@ -83,7 +90,7 @@ class DHCPClient:
             dhcp_desc: DHCP protocol state.
         Returns:
         """
-        rel_ciaddr = None
+        ciaddr = None
 
         # generate DHCP request packet
         if state == DHCPState.DISCOVER:
@@ -98,13 +105,14 @@ class DHCPClient:
                          ("server_id", dhcp_desc.server_ip)]
             dhcp_desc.state_requested = DHCPState.REQUEST
             pkt_xid = dhcp_desc.xid
+            ciaddr = dhcp_desc.ip
         elif state == DHCPState.RELEASE:
             dhcp_opts = [("message-type", "release"),
                          ("server_id", dhcp_desc.server_ip)]
             dhcp_desc.state_requested = DHCPState.RELEASE
             self._msg_xid = self._msg_xid + 1
             pkt_xid = self._msg_xid
-            rel_ciaddr = dhcp_desc.ip
+            ciaddr = dhcp_desc.ip
         else:
             LOG.warning("Unknown egress request mac %s state %s", str(mac), state)
             return
@@ -114,16 +122,12 @@ class DHCPClient:
         with self._dhcp_notify:
             self.dhcp_client_state[mac.as_redis_key()] = dhcp_desc
 
-        LOG.debug("SEND %s mac %s hex %s xid %s", state.name,
-                  str(mac),
-                  mac,
-                  self._msg_xid)
         pkt = Ether(src=str(mac), dst="ff:ff:ff:ff:ff:ff")
         pkt /= IP(src="0.0.0.0", dst="255.255.255.255")
         pkt /= UDP(sport=68, dport=67)
-        pkt /= BOOTP(op=1, chaddr=mac.as_hex(), xid=pkt_xid, ciaddr=rel_ciaddr)
+        pkt /= BOOTP(op=1, chaddr=mac.as_hex(), xid=pkt_xid, ciaddr=ciaddr)
         pkt /= DHCP(options=dhcp_opts)
-        LOG.debug("DHCP pkt %s", pkt.summary())
+        LOG.debug("DHCP pkt %s", pkt.show(dump=True))
 
         sendp(pkt, iface=self._dhcp_interface, verbose=0)
 
@@ -159,13 +163,40 @@ class DHCPClient:
         dhcp_desc = self.dhcp_client_state[mac.as_redis_key()]
         self.send_dhcp_packet(mac, DHCPState.RELEASE, dhcp_desc)
 
-    def manage_dhcp_state(self):
+    def _monitor_dhcp_state(self):
         """
         monitor DHCP client state.
-        TODO:
-        Handle IP address lease revoke.
-
         """
+        while True:
+            wait_time = self._lease_renew_wait_min
+            with self._dhcp_notify:
+                for dhcp_record in self.dhcp_client_state.values():
+                    # Only process active records.
+                    if dhcp_record.state != DHCPState.ACK and \
+                       dhcp_record.state != DHCPState.REQUEST:
+                        continue
+                    # ignore already released IPs.
+                    if dhcp_record.state == DHCPState.RELEASE:
+                        continue
+                    now = datetime.datetime.now()
+                    request_state = DHCPState.REQUEST
+                    # in case of lost DHCP lease rediscover it.
+                    if now >= dhcp_record.lease_expiration_time:
+                        request_state = DHCPState.DISCOVER
+
+                    if now >= dhcp_record.lease_renew_deadline:
+                        logging.debug("sending lease renewal")
+                        self.send_dhcp_packet(dhcp_record.mac, request_state, dhcp_record)
+                    else:
+                        time_to_renew = dhcp_record.lease_renew_deadline - now
+                        wait_time = min(wait_time, time_to_renew.total_seconds())
+
+            # default in wait is 30 sec
+            wait_time = max(wait_time, self._lease_renew_wait_min)
+            logging.debug("lease renewal check after: %s sec" % wait_time)
+            self._monitor_thread_event.wait(wait_time)
+            if self._monitor_thread_event.is_set():
+                break
 
     @staticmethod
     def _get_option(packet, name):
@@ -194,7 +225,7 @@ class DHCPClient:
                 else:
                     router_ip_addr = None
 
-                lease_time = self._get_option(packet, "lease_time")
+                lease_expiration_time = self._get_option(packet, "lease_time")
                 dhcp_state = DHCPDescriptor(mac=mac_addr,
                                              ip=ip_offered,
                                              state=state,
@@ -202,7 +233,7 @@ class DHCPClient:
                                              subnet=str(ip_subnet),
                                              server_ip=packet[IP].src,
                                              router_ip=router_ip_addr,
-                                             lease_time=lease_time,
+                                             lease_expiration_time=lease_expiration_time,
                                              xid=packet[BOOTP].xid)
                 LOG.info("Record mac %s IP %s", mac_addr_key, dhcp_state)
 

--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -34,8 +34,9 @@ class DHCPDescriptor:
     def __init__(self, mac: MacAddress, ip: str,
                  state_requested: DHCPState,
                  state: DHCPState = DHCPState.UNKNOWN,
-                 subnet: str = None, server_ip=None, router_ip=None,
-                 lease_time=None, xid=None):
+                 subnet: str = None, server_ip: str = None,
+                 router_ip: str = None, lease_expiration_time: int = 0,
+                 xid: str = None):
         """
         DHCP descriptor. This object maintains all information for
         given DHCP protocol transactions.
@@ -48,7 +49,7 @@ class DHCPDescriptor:
             subnet: subnet of IP from DHCP offer or ACK
             server_ip: DHCP server IP address
             router_ip: GW IP address
-            lease_time: DHCP lease time.
+            lease_expiration_time: DHCP lease time.
             xid: XID used in DHCP protocol.
         """
         self.mac = mac
@@ -58,10 +59,10 @@ class DHCPDescriptor:
         self.state_requested = state_requested
         self.server_ip = server_ip
         self.xid = xid
-        self.lease_time = lease_time
+        self.lease_expiration_time = datetime.now() + timedelta(seconds=lease_expiration_time)
         self.router_ip = router_ip
         if self.state == DHCPState.ACK:
-            new_deadline = datetime.now() + timedelta(seconds=(lease_time / 2))
+            new_deadline = datetime.now() + timedelta(seconds=(lease_expiration_time / 2))
             self.lease_renew_deadline = new_deadline
         else:
             self.lease_renew_deadline = datetime.now()
@@ -72,7 +73,7 @@ class DHCPDescriptor:
                "lease time {}, renew {} xid {}" \
             .format(self.state.name, self.state_requested.name,
                     str(self.mac), self.ip, self.subnet,
-                    self.server_ip, self.router_ip, self.lease_time,
+                    self.server_ip, self.router_ip, self.lease_expiration_time,
                     self.lease_renew_deadline, self.xid)
 
     def get_ip_address(self) -> Optional[str]:

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -1,0 +1,143 @@
+"""
+Copyright (c) 2020-present, Facebook, Inc.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+import datetime
+import logging
+import os
+import subprocess
+import sys
+import threading
+import time
+import unittest
+from freezegun import freeze_time
+
+from magma.pipelined.bridge_util import BridgeTools
+
+from magma.mobilityd.dhcp_client import DHCPClient
+from magma.mobilityd.mac import MacAddress
+from magma.mobilityd.dhcp_desc import DHCPState, DHCPDescriptor
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+from scapy.layers.dhcp import DHCP
+from scapy.layers.l2 import Ether
+from scapy.sendrecv import AsyncSniffer
+
+LOG = logging.getLogger('mobilityd.dhcp.test')
+LOG.isEnabledFor(logging.DEBUG)
+
+logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
+SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
+DHCP_IFACE = "t0uplink_p0"
+PKT_CAPTURE_WAIT = 2
+
+"""
+Test dhclient class independent of IP allocator.
+"""
+
+
+class DhcpClient(unittest.TestCase):
+    def setUp(self):
+        self._br = "t_up_br0"
+        try:
+            subprocess.check_call(["pkill", "dnsmasq"])
+        except subprocess.CalledProcessError:
+            pass
+
+        setup_dhcp_server = SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
+        subprocess.check_call([setup_dhcp_server, "t0"])
+
+        setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
+                           self._br,
+                           DHCP_IFACE,
+                           "8A:00:00:00:00:01"]
+        subprocess.check_call(setup_uplink_br)
+
+        self.dhcp_wait = threading.Condition()
+        self.dhcp_store = {}
+        self.gw_info_map = {}
+        self.gw_info = UplinkGatewayInfo(self.gw_info_map)
+        self._dhcp_client = DHCPClient(dhcp_wait=self.dhcp_wait,
+                                       dhcp_store=self.dhcp_store,
+                                       gw_info=self.gw_info,
+                                       iface="t_dhcp0",
+                                       lease_renew_wait_min=1)
+        self._dhcp_client.run()
+
+    def tearDown(self):
+        self._dhcp_client.stop()
+        BridgeTools.destroy_bridge(self._br)
+
+    @unittest.skipIf(os.getuid(), reason="needs root user")
+    def test_dhcp_lease1(self):
+        self._setup_sniffer()
+        mac1 = MacAddress("11:22:33:44:55:66")
+        dhcp1 = self._alloc_ip_address_from_dhcp(mac1)
+        self.assertEqual(dhcp1.state_requested, DHCPState.REQUEST)
+        assert (dhcp1.state == DHCPState.OFFER or dhcp1.state == DHCPState.ACK)
+
+        # trigger lease reneval before deadline
+        time1 = datetime.datetime.now() + datetime.timedelta(seconds=100)
+        self._start_sniffer()
+        with freeze_time(time1):
+            time.sleep(PKT_CAPTURE_WAIT)
+            self._stop_sniffer_and_check(DHCPState.REQUEST, mac1)
+            self.assertEqual(dhcp1.state_requested, DHCPState.REQUEST)
+            assert (dhcp1.state == DHCPState.OFFER or dhcp1.state == DHCPState.ACK)
+
+            # trigger lease after deadline
+            time2 = datetime.datetime.now() + datetime.timedelta(seconds=200)
+            self._start_sniffer()
+            with freeze_time(time2):
+                time.sleep(PKT_CAPTURE_WAIT)
+                self._stop_sniffer_and_check(DHCPState.DISCOVER, mac1)
+                self.assertEqual(dhcp1.state_requested, DHCPState.REQUEST)
+                assert (dhcp1.state == DHCPState.OFFER or dhcp1.state == DHCPState.ACK)
+
+        self._dhcp_client.release_ip_address(mac1)
+
+        dhcp1 = self.dhcp_store.get(mac1.as_redis_key())
+        self.assertEqual(dhcp1.state_requested, DHCPState.RELEASE)
+
+    def _alloc_ip_address_from_dhcp(self, mac: MacAddress) -> DHCPDescriptor:
+        retry_count = 0
+        with self.dhcp_wait:
+            dhcp_desc = None
+            while (retry_count < 60 and (dhcp_desc is None or
+                                         dhcp_desc.ip_is_allocated() is not True)):
+                if retry_count % 5 == 0:
+                    self._dhcp_client.send_dhcp_packet(mac, DHCPState.DISCOVER)
+
+                self.dhcp_wait.wait(timeout=1)
+                dhcp_desc = self._dhcp_client.get_dhcp_desc(mac)
+                retry_count = retry_count + 1
+
+            return dhcp_desc
+
+    def _handle_dhcp_req_packet(self, packet):
+        if DHCP not in packet:
+            return
+        self.pkt_list.append(packet)
+
+    def _setup_sniffer(self):
+        self._sniffer = AsyncSniffer(iface=DHCP_IFACE,
+                                     filter="udp and (port 67 or 68)",
+                                     prn=self._handle_dhcp_req_packet)
+
+    def _start_sniffer(self):
+        self.pkt_list = []
+        self._sniffer.start()
+        time.sleep(.5)
+
+    def _stop_sniffer_and_check(self, state: DHCPState, mac: MacAddress):
+        self._sniffer.stop()
+        for pkt in self.pkt_list:
+            logging.debug("pkt: %s " % pkt.summary())
+            if DHCP in pkt:
+                if pkt[DHCP].options[0][1] == int(state) and \
+                        pkt[Ether].src == str(mac):
+                    return
+        assert 0

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -102,6 +102,7 @@ setup(
         'eventlet>=0.24',
         'h2>=3.2.0',
         'hpack>=3.0',
+        'freezegun>=0.3.15'
     ],
     extras_require={
         'dev': [


### PR DESCRIPTION
Following patch add support for DHCP lease to support dynamic
ip address allocation via DHCP. DHCP state monitoring is done
in separate monitoring thread in mobilityD.


## Test Plan

`make test` and `make integ_test`