### PR TITLE
[circle] Use different channel for artifact publish notifications

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -339,6 +339,7 @@ commands:
 
             slack_data=$(cat \<<EOF
             {
+              "channel": "#ci-publish",
               "text": "*<< parameters.artifact_name >> Artifact Has Been Published*",
               "attachments": [
                 {


### PR DESCRIPTION
## Summary 

- Avoid spamming the CI channel

## Test Plan

- Tested the payload with curl

## Additional Information

- [ ] This change is backwards-breaking