### PR TITLE
[orc8r][agw] SyncRPC adding close_connection check

### DIFF
--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -11,7 +11,6 @@ import logging
 
 import aioh2
 import h2.events
-from h2.exceptions import ProtocolError
 
 from orc8r.protos.sync_rpc_service_pb2 import GatewayResponse, SyncRPCResponse
 

--- a/orc8r/gateway/python/magma/magmad/proxy_client.py
+++ b/orc8r/gateway/python/magma/magmad/proxy_client.py
@@ -96,15 +96,19 @@ class ControlProxyHttpClient(object):
                 SyncRPCResponse(heartBeat=False, reqId=req_id,
                                 respBody=GatewayResponse(err=str(e))))
         finally:
-            client.close_connection()
             del self._connection_table[req_id]
+            try:
+                client.close_connection()
+            except AttributeError as e:
+                logging.error('[SyncRPC] Error while trying to close conn: %s',
+                              str(e))
 
     def close_all_connections(self):
         connections = list(self._connection_table.values())
         for client in connections:
             try:
                 client.close_connection()
-            except (ConnectionAbortedError, ProtocolError) as e:
+            except (ConnectionAbortedError, AttributeError) as e:
                 logging.error('[SyncRPC] Error while trying to close conn: %s',
                               str(e))
         self._connection_table.clear()


### PR DESCRIPTION
## Summary

- Adding try/except check for close_connection as SyncRPC complains when connection is already closed

## Test Plan

- tested on feg02 on mcp2 setup
- running make test

## Additional Information

- [ ] This change is backwards-breaking
