### PR TITLE
[AGW] pipelined: use api from mobility for default gw info

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_pipelined.service
@@ -13,6 +13,8 @@
 Description=Magma pipelined service
 PartOf=magma@mme.service
 Before=magma@mme.service
+PartOf=magma@mobilityd.service
+After=magma@mobilityd.service
 After=openvswitch-switch.service
 Wants=openvswitch-switch.service
 

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-br.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-br.sh
@@ -12,5 +12,6 @@ ovs-vsctl --may-exist add-port "$br" "$uplink"
 
 ovs-vsctl --may-exist add-port "$br" "$DHCP_PORT" -- set interface "$DHCP_PORT" type=internal
 ifconfig "$DHCP_PORT"  up
+ifconfig "$br"  up
 
 logger "uplink bridge setup done"

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -10,12 +10,13 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import ipaddress
 import threading
 
 from collections import namedtuple
+from ipaddress import IPv4Address
 
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
-from threading import Thread
 
 from scapy.arch import get_if_hwaddr
 from scapy.data import ETHER_BROADCAST, ETH_P_ARP
@@ -24,8 +25,8 @@ from scapy.layers.l2 import ARP, Ether
 from scapy.sendrecv import srp1
 
 from .base import MagmaController
-from magma.mobilityd import mobility_store as store
-from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+from magma.pipelined.mobilityd_client import get_mobilityd_gw_info, \
+    set_mobilityd_gw_info
 
 from magma.pipelined.app.li_mirror import LIMirrorController
 from magma.pipelined.openflow import flows
@@ -34,6 +35,7 @@ from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import load_direction, Direction, \
     PASSTHROUGH_REG_VAL
 
+from ryu.lib import hub
 from ryu.lib.packet import ether_types
 
 # ingress and egress service names -- used by other controllers
@@ -61,7 +63,7 @@ class InOutController(MagmaController):
          'setup_type'],
     )
     ARP_PROBE_FREQUENCY = 300
-    UPLINK_DPCP_PORT_NAME = 'dhcp0'
+    NON_NAT_ARP_EGRESS_PORT = 'uplink_br0'
 
     def __init__(self, *args, **kwargs):
         super(InOutController, self).__init__(*args, **kwargs)
@@ -88,9 +90,9 @@ class InOutController(MagmaController):
             self._service_manager.get_table_num(PHYSICAL_TO_LOGICAL)
         self._egress_tbl_num = self._service_manager.get_table_num(EGRESS)
         # following fields are only used in Non Nat config
-        self._dhcp_gw_info = None
         self._gw_mac_monitor = None
-        self._current_upstream_mac = None
+        self._current_upstream_mac = ""
+        self._datapath = None
 
     def _get_config(self, config_dict):
         mtr_ip = None
@@ -110,7 +112,7 @@ class InOutController(MagmaController):
         non_mat_gw_probe_freq = config_dict.get('non_mat_gw_probe_frequency',
                                                 self.ARP_PROBE_FREQUENCY)
         non_nat_arp_egress_port = config_dict.get('non_nat_arp_egress_port',
-                                                  self.UPLINK_DPCP_PORT_NAME)
+                                                  self.NON_NAT_ARP_EGRESS_PORT)
 
         return self.InOutConfig(
             gtp_port=config_dict['ovs_gtp_port_number'],
@@ -169,7 +171,7 @@ class InOutController(MagmaController):
                                   [], priority=flows.UE_FLOW_PRIORITY,
                                   output_port=self.config.mtr_port)
 
-    def _install_default_egress_flows(self, dp, mac_addr: str = None):
+    def _install_default_egress_flows(self, dp, mac_addr: str = ""):
         """
         Egress table is the last table that a packet touches in the pipeline.
         Output downlink traffic to gtp port, uplink trafic to LOCAL
@@ -184,15 +186,18 @@ class InOutController(MagmaController):
         uplink_match = MagmaMatch(direction=Direction.OUT)
         actions = []
         # avoid resetting mac address on switch connect event.
-        if mac_addr is None:
+        if mac_addr == "":
             mac_addr = self._current_upstream_mac
 
-        if mac_addr is not None:
+        if mac_addr != "":
             parser = dp.ofproto_parser
-            actions.append(parser.OFPActionSetField(eth_dst=mac_addr))
+            actions.append(parser.NXActionRegLoad2(dst='eth_dst', value=mac_addr))
+
             self.logger.info("Using GW: %s actions: %s", mac_addr, str(actions))
-        self._current_upstream_mac = mac_addr
-        flows.add_output_flow(dp, self._egress_tbl_num, uplink_match, actions,
+            self._current_upstream_mac = mac_addr
+
+        flows.add_output_flow(dp, self._egress_tbl_num, uplink_match,
+                              actions=actions,
                               output_port=self._uplink_port)
 
     def _install_default_ingress_flows(self, dp):
@@ -257,15 +262,16 @@ class InOutController(MagmaController):
                                                  match, actions=actions, priority=flows.DEFAULT_PRIORITY,
                                                  resubmit_table=next_table)
 
-    def _get_gw_mac_address(self, gw_ip: str) -> str:
+    def _get_gw_mac_address(self, ip: IPv4Address) -> str:
         try:
-            self.logger.debug("sending arp for IP: %s ovs egress: %s",
-                              gw_ip, self.config.non_nat_arp_egress_port)
+            gw_ip = ipaddress.ip_address(ip.address)
+            self.logger.debug("sending arp via egress: %s",
+                              self.config.non_nat_arp_egress_port)
             eth_mac_src = get_if_hwaddr(self.config.non_nat_arp_egress_port)
 
             pkt = Ether(dst=ETHER_BROADCAST, src=eth_mac_src)
             pkt /= ARP(op="who-has", pdst=gw_ip, hwsrc=eth_mac_src, psrc="0.0.0.0")
-            self.logger.debug("pkt: %s", pkt.summary())
+            self.logger.debug("ARP Req pkt %s", pkt.show(dump=True))
 
             res = srp1(pkt,
                        type=ETH_P_ARP,
@@ -276,45 +282,42 @@ class InOutController(MagmaController):
                        promisc=0)
 
             if res is not None:
-                self.logger.debug("resp: %s ", res.summary())
+                self.logger.debug("ARP Res pkt %s", res.show(dump=True))
                 mac = res[ARP].hwsrc
                 return mac
             else:
                 self.logger.debug("Got Null response")
+                return ""
 
         except Scapy_Exception as ex:
             self.logger.warning("Error in probing Mac address: err %s", ex)
-            return None
+            return ""
+        except ValueError:
+            self.logger.warning("Invalid GW Ip address: [%s]", ip)
+            return ""
 
-    def _monitor_and_update(self, datapath):
-        current_feq = self.config.non_mat_gw_probe_frequency
-        if self._dhcp_gw_info.getMac() is not None:
-            latest_mac_addr = self._dhcp_gw_info.getMac()
-            self._install_default_egress_flows(datapath, latest_mac_addr)
-            flows.set_barrier(datapath)
-
+    def _monitor_and_update(self):
         while True:
-            ip = self._dhcp_gw_info.getIP()
-            if ip is not None:
-                self.logger.info("GW found: %s", ip)
-                latest_mac_addr = self._get_gw_mac_address(ip)
-                if latest_mac_addr is not None:
-                    # go back to configured frequency.
-                    current_feq = self.config.non_mat_gw_probe_frequency
-                    if self._current_upstream_mac != latest_mac_addr:
-                        self._install_default_egress_flows(datapath, latest_mac_addr)
-                        flows.set_barrier(datapath)
-                        self._dhcp_gw_info.update_mac(latest_mac_addr)
+            updated_info = get_mobilityd_gw_info()
+            if updated_info:
+                cached_gw_info = updated_info
+            if cached_gw_info and cached_gw_info.ip:
+                latest_mac_addr = self._get_gw_mac_address(cached_gw_info.ip)
+                if len(latest_mac_addr) == 17 and \
+                        self._current_upstream_mac != latest_mac_addr:
+                    self._install_default_egress_flows(self._datapath, latest_mac_addr)
+                    cached_gw_info.mac = latest_mac_addr
+                    set_gw_info = cached_gw_info
+                    set_mobilityd_gw_info(set_gw_info)
+                elif latest_mac_addr != "":
+                    self.logger.warning("invalid mac: %s", latest_mac_addr)
             else:
                 self.logger.warning("No default GW found.")
-                # increase frequency to reduce init latency.
-                current_feq = 1
 
-            e = threading.Event()
-            self.logger.debug("non_mat_gw_probe_frequency: %s ip: %s mac: %s",
-                              current_feq,
-                              ip, self._current_upstream_mac)
-            e.wait(timeout=current_feq)
+            self.logger.info("non_mat_gw_probe_frequency: %s mac: [%s]",
+                             self.config.non_mat_gw_probe_frequency,
+                             self._current_upstream_mac)
+            hub.sleep(self.config.non_mat_gw_probe_frequency)
 
     def _setup_non_nat_monitoring(self, datapath):
         """
@@ -334,14 +337,11 @@ class InOutController(MagmaController):
             self.logger.info("No GW MAC probe for %s", self.config.setup_type)
             return
         else:
-            self.logger.info("Non nat conf: Frequency:%s, egress port: %s, uplink: %s",
-                             self.config.non_mat_gw_probe_frequency,
+            self.logger.info("Non nat conf: egress port: %s, uplink: %s",
                              self.config.non_nat_arp_egress_port,
                              self._uplink_port)
 
-        self._dhcp_gw_info = UplinkGatewayInfo(store.GatewayInfoMap())
-        self._gw_mac_monitor = Thread(target=self._monitor_and_update,
-                                      args=(datapath,))
-        self._gw_mac_monitor.setDaemon(True)
-        self._gw_mac_monitor.start()
+        self._datapath = datapath
+        self._gw_mac_monitor = hub.spawn(self._monitor_and_update)
+
         threading.Event().wait(1)

--- a/lte/gateway/python/magma/pipelined/mobilityd_client.py
+++ b/lte/gateway/python/magma/pipelined/mobilityd_client.py
@@ -1,0 +1,60 @@
+"""
+Copyright (c) Facebook, Inc. and its affiliates.
+All rights reserved.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+"""
+
+import grpc
+import logging
+
+from magma.common.service_registry import ServiceRegistry
+from orc8r.protos.common_pb2 import Void
+from lte.protos.mobilityd_pb2 import GWInfo
+from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
+
+SERVICE_NAME = "mobilityd"
+IPV4_ADDR_KEY = "ipv4_addr"
+
+
+def get_mobilityd_gw_info() -> GWInfo:
+    """
+    Make RPC call to 'GetGatewayInfo' method of local mobilityD service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(SERVICE_NAME,
+                                               ServiceRegistry.LOCAL)
+    except ValueError:
+        logging.error('Cant get RPC channel to %s', SERVICE_NAME)
+        return GWInfo()
+
+    client = MobilityServiceStub(chan)
+    try:
+        return client.GetGatewayInfo(Void())
+    except grpc.RpcError as err:
+        logging.error(
+            "GetGatewayInfoRequest error[%s] %s",
+            err.code(),
+            err.details())
+
+
+def set_mobilityd_gw_info(gwinfo: GWInfo):
+    """
+    Make RPC call to 'SetGatewayInfo' method of local mobilityD service
+    """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(SERVICE_NAME,
+                                               ServiceRegistry.LOCAL)
+    except ValueError:
+        logging.error('Cant get RPC channel to %s', SERVICE_NAME)
+        return
+
+    client = MobilityServiceStub(chan)
+    try:
+        client.SetGatewayInfo(gwinfo)
+    except grpc.RpcError as err:
+        logging.error(
+            "GetGatewayInfoRequest error[%s] %s",
+            err.code(),
+            err.details())

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
@@ -4,4 +4,4 @@
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=mod_dl_dst:b2:a0:cc:85:80:7a,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2


### PR DESCRIPTION
This patch would use monilityD APIs rather than accessing redis
directly from pipelineD for retrieving GW info
This has following related changes:
1. Add mobilityD service dependency for pipelineD
2. change ARP egress dev to uplink_br0
3. add mobilityd_client
4. mock mobilityd api in in-out unit test

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
## Test Plan

`make test_python`
`make integ_test`