### PR TITLE
[ci] Re-enable docusaurus job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -755,14 +755,15 @@ jobs:
             mv docs/readmes readmes/
             rm -rf docs/
             mv readmes/ docs/
+      # Yeah I fucked up and created mamga-... instead of magma-... oops
       - run:
           name: Deploying to GitHub Pages
           command: |
-            git config --global user.email "docusaurus-bot@users.noreply.github.com"
-            git config --global user.name "docusaurus-bot"
-            echo "machine github.com login docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
+            git config --global user.email "mamga-docusaurus-bot@users.noreply.github.com"
+            git config --global user.name "mamga-docusaurus-bot"
+            echo "machine github.com login mamga-docusaurus-bot password $GITHUB_TOKEN" > ~/.netrc
             cd website && yarn install
-            CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=docusaurus-bot yarn run publish-gh-pages
+            CUSTOM_COMMIT_MESSAGE="[skip ci] Deploy website" GIT_USER=mamga-docusaurus-bot yarn run publish-gh-pages
 
 workflows:
   version: 2.1
@@ -828,10 +829,10 @@ workflows:
             - eslint
             - nms-yarn-test
 
-  # docusaurus
-  #   jobs:
-  #     - docusaurus_build_and_deploy:
-  #         <<: *only_master
+  docusaurus:
+   jobs:
+    - docusaurus_build_and_deploy:
+        <<: *only_master
 
   fossa:
     jobs:


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Re-enable docusaurus job

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

https://app.circleci.com/pipelines/github/magma/magma/17/workflows/1735d1bf-aead-4eb3-a42d-8abd09bc6ed8/jobs/206

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
