### PR TITLE
[lte] [agw] Remove extra comment in lte traffic server

### DIFF
--- a/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
+++ b/lte/gateway/deploy/roles/trfserver/files/traffic_server.py
@@ -12,7 +12,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-"""
 
 # Standard Python and PyPi modules
 import argparse


### PR DESCRIPTION
## Summary

An extra triple quote was added in traffic_server.py while updating the copyright header. The server was failing to start due to this. This change removes the extra triple quote.

## Test Plan

Destroy all dev VMs and run `fab integ_test` in lte/gateway

