### PR TITLE
[DOC]Remove all refs to facebookincubator.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Magma has three major components:
 ![Magma architecture diagram](docs/readmes/assets/magma_overview.png?raw=true "Magma Architecture")
 
 ## Usage Docs
-The documentation for developing and using Magma is available at: [https://facebookincubator.github.io/magma](https://facebookincubator.github.io/magma)
+The documentation for developing and using Magma is available at: [https://magma.github.io/magma](https://magma.github.io/magma)
 
 ## Join the Magma Community
 

--- a/cwf/gateway/integ_tests/README.md
+++ b/cwf/gateway/integ_tests/README.md
@@ -1,22 +1,22 @@
 ---
 id: readme_cwag_integ_test
-title: CWAG Integration Test 
+title: CWAG Integration Test
 hide_title: true
 ---
-## Integration Test Setup 
-This integration currently uses 3 separate VMs to run the tests: `cwag-test` 
+## Integration Test Setup
+This integration currently uses 3 separate VMs to run the tests: `cwag-test`
 and `cwag-dev` in `magma/cwf/gateway`, and `magma-trfserver` in `magma/lte/gateway`.
 The fabfile in this directory can be used to automate the setup needed to run
 the test.
 
-###  `cwag-dev` 
-This VM will build and run all cwag services and mock core services needed to 
-run the test. See the various `docker-compose` files in `cwf/gateway/docker` 
-to see the complete list of services. 
+###  `cwag-dev`
+This VM will build and run all cwag services and mock core services needed to
+run the test. See the various `docker-compose` files in `cwf/gateway/docker`
+to see the complete list of services.
 
 ### `cwag-test`
-This VM will be used to run the tests. We will also run a UE simulator service 
-to simulate a UE device in the test. 
+This VM will be used to run the tests. We will also run a UE simulator service
+to simulate a UE device in the test.
 
 ### `magma-trfserver`
 This VM runs an iperf3 server.
@@ -40,10 +40,10 @@ This VM runs an iperf3 server.
 * Gy ReAuth Request/Answer flow
 * Gy Final-Unit-Action-Terminate enforcement
 
-## Running the test 
+## Running the test
 #### Requirements
-* fabric3 
-* see https://facebookincubator.github.io/magma/docs/basics/prerequisites for 
+* fabric3
+* see https://magma.github.io/magma/docs/basics/prerequisites for
 our prerequisites on running our VMs.
 
 To the run the test, run `fab integ_test` from `magma/cwf/gateway`.
@@ -56,55 +56,55 @@ This fabfile will
 * Clean up (Kill the UE sim on `cwag-test` and stop the iperf3 server on `magma-trfserver`)
 
 #### Fab script parameters
-* `no_build`: The fabfile by default stops, rebuilds, and starts all containers. If you 
-only want to restart the containers, and not rebuild everything, run 
-`fab integ_test:no_build=True`. 
-* `tests_to_run`: By default, the fab script will run all existing tests. You can 
-specify a subset of them with this flag. For example, run `fab integ_test:tests_to_run=gx`, 
+* `no_build`: The fabfile by default stops, rebuilds, and starts all containers. If you
+only want to restart the containers, and not rebuild everything, run
+`fab integ_test:no_build=True`.
+* `tests_to_run`: By default, the fab script will run all existing tests. You can
+specify a subset of them with this flag. For example, run `fab integ_test:tests_to_run=gx`,
 to only run Gx tests. See the fabfile for more options.
 
 ## Debugging on `cwag-dev` VM
 * To see the list of running services, run `docker ps` in the `cwag-dev` VM.
 * To see per-service logs, run `docker-compose logs <container_name>`
 * To go into a running container, run `docker-compose exec <container_name> bash`
-* `/usr/local/bin/pipelined_cli.py` in pipelined service maybe useful for 
+* `/usr/local/bin/pipelined_cli.py` in pipelined service maybe useful for
 viewing installed flows for debugging.
 
 ## Before you commit any code...
 Before committing, please make sure you run the commands below to test and format.
-  * If you touch anything in `magma/cwf/gateway`, run `make precommit` on the 
+  * If you touch anything in `magma/cwf/gateway`, run `make precommit` on the
   `cwag-dev` VM, under `magma/cwf/gateway`.
-  * If you touch anything in `magma/feg/gateway`, run `make precommit` inside 
+  * If you touch anything in `magma/feg/gateway`, run `make precommit` inside
   the FeG test container.
     * `cd magma/feg/gateway/docker`
     * `docker-compose up -d test`
     * `docker-compose exec test /bin/bash`
     * `make precommit`
-  * If you touch anything in `magma/.../cloud/go`, please run the 
+  * If you touch anything in `magma/.../cloud/go`, please run the
   orc8r precommit.
     * `cd magma/orc8r/cloud/go/docker`
     * `./build.py -m`
     * `make precommit`
 
-Additionally, if you write any new tests, please summarize what the test does 
-in a comment above the test. See existing tests for example.  
+Additionally, if you write any new tests, please summarize what the test does
+in a comment above the test. See existing tests for example.
 
 ## FAQ
 
 #### Unit tests are not able to run: `/cwf/gateway: No such file or directory`
 
-&rightarrow; The cwag-dev VM probably did not provision properly. Run 
-`vagrant provision cwag` in `magma/cwf/gateway` to provision the VM again 
-to see specific errors. 
+&rightarrow; The cwag-dev VM probably did not provision properly. Run
+`vagrant provision cwag` in `magma/cwf/gateway` to provision the VM again
+to see specific errors.
 
 #### Docker is failing to build due to lack of space
 
-&rightarrow; Since docker does not garbage collect previously built images, we 
-will have to manually prune them. Run `docker system df` to see memory usage 
-and what can be deleted. To remove these images, run 
+&rightarrow; Since docker does not garbage collect previously built images, we
+will have to manually prune them. Run `docker system df` to see memory usage
+and what can be deleted. To remove these images, run
 `docker image prune --filter until=12h`.
 
 #### All traffic hang and then fail
-&rightarrow; This is an issue we've observed occasionally. We have not found 
-the root cause yet. Assuming the issue is not with the CWAG services, one 
-remedy you can try is to destroy all VMs and start them again. 
+&rightarrow; This is an issue we've observed occasionally. We have not found
+the root cause yet. Assuming the issue is not with the CWAG services, one
+remedy you can try is to destroy all VMs and start them again.

--- a/docs/docusaurus/siteConfig.js
+++ b/docs/docusaurus/siteConfig.js
@@ -29,7 +29,7 @@ const users = [
 const siteConfig = {
   title: 'Magma', // Title for your website.
   tagline: 'Bring more people online by enabling operators with open, flexible, and extensible network solutions',
-  url: 'https://facebookincubator.github.io', // Your website URL
+  url: 'https://magma.github.io', // Your website URL
   baseUrl: '/magma/', // Base URL for your project */
   // For github.io type URLs, you would set the url and baseUrl like:
   //   url: 'https://facebook.github.io',
@@ -37,7 +37,7 @@ const siteConfig = {
 
   // Used for publishing and more
   projectName: 'magma',
-  organizationName: 'facebookincubator',
+  organizationName: 'magma',
   // For top-level user or org sites, the organization is still the same.
   // e.g., for the https://JoelMarcey.github.io site, it would be set like...
   //   organizationName: 'Facebook'
@@ -48,7 +48,7 @@ const siteConfig = {
   headerLinks: [
     {doc: 'basics/introduction', label: 'Docs'},
     {page: 'help', label: 'Help'},
-    {href: 'https://github.com/facebookincubator/magma', label: 'Github'},
+    {href: 'https://github.com/magma/magma', label: 'Github'},
   ],
 
   // If you have users set above, you add it here:

--- a/docs/docusaurus/versioned_docs/version-1.0.0/lte/config_agw.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/lte/config_agw.md
@@ -12,10 +12,10 @@ Before beginning to configure your Magma Access Gateway, you will need to make
 sure that it is running all services without crashing. You will also need a
 working Orchestrator setup. Please follow the instructions in
 "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for a
+https://magma.github.io/magma/docs/orc8r/deploying)" for a
 successful Orchestrator installation.
 
-You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://facebookincubator.github.io/magma/docs/lte/setup_deb)".
+You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://magma.github.io/magma/docs/lte/setup_deb)".
 For this part, we strongly recommend that you SSH into the AGW box from a host
 machine instead of using the AGW directly.
 

--- a/docs/docusaurus/versioned_docs/version-1.0.0/lte/enodebd.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/lte/enodebd.md
@@ -8,9 +8,9 @@ original_id: enodebd
 ## Prerequisites
 
 Make sure you follow the instructions in "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for successful
+https://magma.github.io/magma/docs/orc8r/deploying)" for successful
 installation of Orchestrator and the instructions in "[AGW Configuration](
-https://facebookincubator.github.io/magma/docs/lte/config_agw)" to provision and
+https://magma.github.io/magma/docs/lte/config_agw)" to provision and
 configure your Access Gateway (AGW).
 
 ## S1 interface

--- a/docs/docusaurus/versioned_docs/version-1.0.1/lte/config_agw.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.1/lte/config_agw.md
@@ -12,10 +12,10 @@ Before beginning to configure your Magma Access Gateway, you will need to make
 sure that it is running all services without crashing. You will also need a
 working Orchestrator setup. Please follow the instructions in
 "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for a
+https://magma.github.io/magma/docs/orc8r/deploying)" for a
 successful Orchestrator installation.
 
-You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://facebookincubator.github.io/magma/docs/lte/setup_deb)".
+You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://magma.github.io/magma/docs/lte/setup_deb)".
 For this part, we strongly recommend that you SSH into the AGW box from a host
 machine instead of using the AGW directly.
 

--- a/docs/docusaurus/versioned_docs/version-1.0.1/lte/enodebd.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.1/lte/enodebd.md
@@ -8,9 +8,9 @@ original_id: enodebd
 ## Prerequisites
 
 Make sure you follow the instructions in "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for successful
+https://magma.github.io/magma/docs/orc8r/deploying)" for successful
 installation of Orchestrator and the instructions in "[AGW Configuration](
-https://facebookincubator.github.io/magma/docs/lte/config_agw)" to provision and
+https://magma.github.io/magma/docs/lte/config_agw)" to provision and
 configure your Access Gateway (AGW).
 
 ## S1 interface

--- a/docs/docusaurus/versioned_docs/version-1.1.0/faq/magma_faq.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/faq/magma_faq.md
@@ -76,7 +76,7 @@ This section lists some of the commonly asked questions related to Magma operati
   - Login to Gateway, then run `sudo checkin_cli.py`.
 
 ### Where can I find API endpoint?
-  - If you have followed the [install guide](https://facebookincubator.github.io/magma/docs/orc8r/deploy_install), it'll be at `https://api.youdomain.com/apidocs/v1/` (the trailing slash is important).
+  - If you have followed the [install guide](https://magma.github.io/magma/docs/orc8r/deploy_install), it'll be at `https://api.youdomain.com/apidocs/v1/` (the trailing slash is important).
   - You will need to load the `admin_operator.pfx` certificate into your keychain/browser, otherwise, API access will be blocked.
 
 ### How can I use Swagger UI to trigger API request?

--- a/docs/docusaurus/versioned_docs/version-1.1.0/lte/config_agw.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/lte/config_agw.md
@@ -12,10 +12,10 @@ Before beginning to configure your Magma Access Gateway, you will need to make
 sure that it is running all services without crashing. You will also need a
 working Orchestrator setup. Please follow the instructions in
 "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for a
+https://magma.github.io/magma/docs/orc8r/deploying)" for a
 successful Orchestrator installation.
 
-You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://facebookincubator.github.io/magma/docs/lte/setup_deb)".
+You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://magma.github.io/magma/docs/lte/setup_deb)".
 For this part, we strongly recommend that you SSH into the AGW box from a host
 machine instead of using the AGW directly.
 

--- a/docs/docusaurus/versioned_docs/version-1.1.0/lte/enodebd.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/lte/enodebd.md
@@ -8,9 +8,9 @@ original_id: enodebd
 ## Prerequisites
 
 Make sure you follow the instructions in "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for successful
+https://magma.github.io/magma/docs/orc8r/deploying)" for successful
 installation of Orchestrator and the instructions in "[AGW Configuration](
-https://facebookincubator.github.io/magma/docs/lte/config_agw)" to provision and
+https://magma.github.io/magma/docs/lte/config_agw)" to provision and
 configure your Access Gateway (AGW).
 
 ## S1 interface

--- a/docs/readmes/faq/magma_faq.md
+++ b/docs/readmes/faq/magma_faq.md
@@ -75,7 +75,7 @@ This section lists some of the commonly asked questions related to Magma operati
   - Login to Gateway, then run `sudo checkin_cli.py`.
 
 ### Where can I find API endpoint?
-  - If you have followed the [install guide](https://facebookincubator.github.io/magma/docs/orc8r/deploy_install), it'll be at `https://api.youdomain.com/apidocs/v1/` (the trailing slash is important).
+  - If you have followed the [install guide](https://magma.github.io/magma/docs/orc8r/deploy_install), it'll be at `https://api.youdomain.com/apidocs/v1/` (the trailing slash is important).
   - You will need to load the `admin_operator.pfx` certificate into your keychain/browser, otherwise, API access will be blocked.
 
 ### How can I use Swagger UI to trigger API request?

--- a/docs/readmes/lte/config_agw.md
+++ b/docs/readmes/lte/config_agw.md
@@ -11,10 +11,10 @@ Before beginning to configure your Magma Access Gateway, you will need to make
 sure that it is running all services without crashing. You will also need a
 working Orchestrator setup. Please follow the instructions in
 "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for a
+https://magma.github.io/magma/docs/orc8r/deploying)" for a
 successful Orchestrator installation.
 
-You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://facebookincubator.github.io/magma/docs/lte/setup_deb)".
+You also should have completed all the steps in "[Access Gateway Setup (On Bare Metal)](https://magma.github.io/magma/docs/lte/setup_deb)".
 For this part, we strongly recommend that you SSH into the AGW box from a host
 machine instead of using the AGW directly.
 

--- a/docs/readmes/lte/enodebd.md
+++ b/docs/readmes/lte/enodebd.md
@@ -7,9 +7,9 @@ hide_title: true
 ## Prerequisites
 
 Make sure you follow the instructions in "[Deploying Orchestrator](
-https://facebookincubator.github.io/magma/docs/orc8r/deploying)" for successful
+https://magma.github.io/magma/docs/orc8r/deploying)" for successful
 installation of Orchestrator and the instructions in "[AGW Configuration](
-https://facebookincubator.github.io/magma/docs/lte/config_agw)" to provision and
+https://magma.github.io/magma/docs/lte/config_agw)" to provision and
 configure your Access Gateway (AGW).
 
 ## S1 interface

--- a/orc8r/cloud/deploy/terraform/README.md
+++ b/orc8r/cloud/deploy/terraform/README.md
@@ -1,7 +1,7 @@
 # Orchestrator Terraform
 
 Content has been moved to
-https://facebookincubator.github.io/magma/docs/next/orc8r/deploy_install.
+https://magma.github.io/magma/docs/next/orc8r/deploy_install.
 
 The old root module which used to be in this directory has been deprecated.
 Check the upgrade steps in the link above to upgrade to the new deployment

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/README.md
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade/README.md
@@ -19,7 +19,7 @@ unexpected planned step in the output of `terraform apply` before it asks
 for confirmation.
 
 Detailed upgrade steps can be found in the Orchestrator documentation at
-https://facebookincubator.github.io/magma.
+https://magma.github.io/magma.
 
 ## Providers
 

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -1,7 +1,7 @@
 # Orchestrator Helm Deployment
 
 The contents of this README have been moved to the "Deploying Orchestrator"
-section of the docs: https://facebookincubator.github.io/magma.
+section of the docs: https://magma.github.io/magma.
 
 If you're running locally in Minikube, see the section below.
 
@@ -99,7 +99,7 @@ mkdir -p charts/secrets/.secrets/certs
 # You need to add the following files to the certs directory:
 #   bootstrapper.key certifier.key certifier.pem vpn_ca.crt vpn_ca.key
 #   admin_operator.pem admin_operator.key.pem nms_nginx.pem nms_nginx.key.pem
-#   controller.crt controller.key rootCA.pem 
+#   controller.crt controller.key rootCA.pem
 # The controller.crt, controller.key and rootCA.pem are the certificate info
 # for your public domain name.
 # For local testing, you can do the following after running Orc8r using docker:

--- a/orc8r/gateway/go/services/magmad/README.md
+++ b/orc8r/gateway/go/services/magmad/README.md
@@ -2,7 +2,7 @@
 
 [![facebookincubator](https://circleci.com/gh/facebookincubator/magma.svg?style=shield)](https://circleci.com/gh/facebookincubator/magma)
 
-**magmad** service is a core part of [magma](https://facebookincubator.github.io/magma) gateway platform, it is required on every gateway and facilitates the following gateway functionality:
+**magmad** service is a core part of [magma](https://magma.github.io/magma) gateway platform, it is required on every gateway and facilitates the following gateway functionality:
 
 * Maintaining and displaying unique gateway identity information necessary for the gateway register on and join a network
 * Bootstraping gateway on the network and maintaining gateway's client certificates
@@ -21,8 +21,8 @@
 ## Implementation
 
 This is Go native implementation of magmad service, it is intended as a 'drop in' replacement of python based magmad service
-on systems with limited resources or lack of full python support. 
-It'll work with all existing *magmad.yml*, *service_registry.yml* and *control_proxy.yml* configurations located in 
+on systems with limited resources or lack of full python support.
+It'll work with all existing *magmad.yml*, *service_registry.yml* and *control_proxy.yml* configurations located in
 */etc/magma/configs* or legacy */etc/magma* directories.
 
 Current implementation requires at least 15MB of RAM and 3MB of storage (compressed) on most supported systems/architectures.
@@ -41,7 +41,7 @@ To build:
 * To reduce magmad binary size, you may use the following options:
   * *GOOS=linux GOARCH=arm go build -o ~/bin/arm/magmad.prod -ldflags="-s -w" magma/gateway/services/magmad*
   * You can also use [upx](https://upx.github.io/) to compress the binary:
-    * *upx --brute -o ~/bin/arm/magmad ~/bin/arm/magmad.prod* 
+    * *upx --brute -o ~/bin/arm/magmad ~/bin/arm/magmad.prod*
 
 ## Supported Architectures & Systems
 


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com

## Summary

Remove all refs to facebookincubator.github.io (old doc)
New docusaurus config (has been erased due to the import)

## Test Plan

grep -r "facebookincubator.github.io" ~/magma

## Additional Information

- [ ] This change is backwards-breaking
