### PR TITLE
[AGW] pipelineD: add yml config for non-nat uplink port

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -143,3 +143,4 @@ non_nat_arp_egress_port: dhcp0
 ovs_uplink_port_name: patch-up
 virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
+uplink_eth_port_name: uplink_p0

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -137,3 +137,4 @@ non_nat_arp_egress_port: dhcp0
 ovs_uplink_port_name: patch-up
 virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
+uplink_eth_port_name: eth0


### PR DESCRIPTION
This configuration would be only used in Non-Modes on AGW.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>