### PR TITLE
[lte] Remove unused magma_oai vm

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -116,39 +116,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     end
   end
 
-  config.vm.define :magma_oai, autostart: false do |magma_oai|
-    # Get our prepackaged box from the atlas cloud, based on
-    # - ubuntu/xenial64
-    # - linux kernel from debian jessie backports
-    # - updated vbguest-tool
-    magma_oai.vm.box = "fbcmagma/ubuntu"
-    magma_oai.vm.box_version = "1.3"
-    magma_oai.vm.hostname = "magma-oai"
-    magma_oai.vbguest.auto_update = false
-
-    # Create a private network, which allows host-only access to the machine
-    # using a specific IP.
-    magma_oai.vm.network "private_network", ip: "192.168.60.145", nic_type: "82540EM"
-
-    magma_oai.vm.provider "virtualbox" do |vb|
-      vb.name = "magma-oai"
-      vb.linked_clone = true
-      vb.customize ["modifyvm", :id, "--memory", "4096"]
-      vb.customize ["modifyvm", :id, "--cpus", "4"]
-      vb.customize ["modifyvm", :id, "--nicpromisc2", "allow-all"]
-      vb.customize ["modifyvm", :id, "--uartmode1", "disconnected"]
-    end
-
-    magma_oai.vm.provision "ansible" do |ansible|
-      ansible.host_key_checking = false
-      ansible.playbook = "deploy/magma_oai.yml"
-      ansible.inventory_path = "deploy/hosts"
-      ansible.raw_arguments = ENV.fetch("ANSIBLE_ARGS", "").split(";") +
-                              ["--timeout=30"]
-      ansible.verbose = 'v'
-    end
-  end
-
   config.vm.define :magma_prod, autostart: false do |magma_prod|
     magma_prod.vm.synced_folder ".", "/vagrant", disabled: true
     magma_prod.vm.synced_folder "../..", "/home/vagrant/magma", disabled: true


### PR DESCRIPTION
## Summary

`magma_oai` VM is no longer used and the box it references doesn't exist, so removing it.

## Test Plan

`vagrant status` still works