### PR TITLE
[orc8r][service303] Fix service303 registry error

### DIFF
--- a/orc8r/cloud/go/tools/service303_cli/main.go
+++ b/orc8r/cloud/go/tools/service303_cli/main.go
@@ -43,6 +43,7 @@ var gatewayID string
 func main() {
 	flag.Parse()
 	plugin.LoadAllPluginsFatalOnError(&plugin.DefaultOrchestratorPluginLoader{})
+	registry.MustPopulateServices()
 
 	services = registry.ListAllServices()
 	gwServices = gateway_registry.ListAllGwServices()


### PR DESCRIPTION
## Summary

Ensure that the service registry is populated for the service303 CLI

## Test Plan

Ran locally.
