### PR TITLE
[policydb] Add rating_group stream name to lte cloud service_registry

### DIFF
--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -20,7 +20,7 @@ services:
       orc8r.io/obsidian_handlers: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte,/magma/v1/lte/:network_id"
-      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,rule_mappings,subscriberdb"
+      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,rule_mappings,subscriberdb,rating_groups"
 
   subscriberdb:
     host: "localhost"


### PR DESCRIPTION

## Summary

Added rating_group stream name to lte cloud's service_registry.yml.
Without this, rating groups will not be streamed to the access gateway.

## Test Plan

Verified manually by running an orc8r + AGW setup before and after the change in question.