### PR TITLE
[nghttpx] Bring back nghttpx Dockerfile for now

### DIFF
--- a/orc8r/cloud/docker/proxy/0001-Fix-get_x509_serial-for-long-serial-numbers.patch
+++ b/orc8r/cloud/docker/proxy/0001-Fix-get_x509_serial-for-long-serial-numbers.patch
@@ -1,0 +1,44 @@
+From aad8697575d90b1763c31ad06986be0550917aac Mon Sep 17 00:00:00 2001
+From: Jacky Tian <xjtian@fb.com>
+Date: Mon, 30 Mar 2020 22:28:45 -0700
+Subject: [PATCH] Fix get_x509_serial for long serial numbers
+
+---
+ src/shrpx_tls.cc | 14 +-------------
+ 1 file changed, 1 insertion(+), 13 deletions(-)
+
+diff --git a/src/shrpx_tls.cc b/src/shrpx_tls.cc
+index 746311f0..83b148a6 100644
+--- a/src/shrpx_tls.cc
++++ b/src/shrpx_tls.cc
+@@ -2030,17 +2030,6 @@ StringRef get_x509_issuer_name(BlockAllocator &balloc, X509 *x) {
+ #endif /* !WORDS_BIGENDIAN */
+ 
+ StringRef get_x509_serial(BlockAllocator &balloc, X509 *x) {
+-#if OPENSSL_1_1_API && !defined(OPENSSL_IS_BORINGSSL)
+-  auto sn = X509_get0_serialNumber(x);
+-  uint64_t r;
+-  if (ASN1_INTEGER_get_uint64(&r, sn) != 1) {
+-    return StringRef{};
+-  }
+-
+-  r = bswap64(r);
+-  return util::format_hex(
+-      balloc, StringRef{reinterpret_cast<uint8_t *>(&r), sizeof(r)});
+-#else  // !OPENSSL_1_1_API || OPENSSL_IS_BORINGSSL
+   auto sn = X509_get_serialNumber(x);
+   auto bn = BN_new();
+   auto bn_d = defer(BN_free, bn);
+@@ -2052,8 +2041,7 @@ StringRef get_x509_serial(BlockAllocator &balloc, X509 *x) {
+   auto n = BN_bn2bin(bn, b.data());
+   assert(n <= 20);
+ 
+-  return util::format_hex(balloc, StringRef{std::begin(b), std::end(b)});
+-#endif // !OPENSSL_1_1_API
++  return util::format_hex(balloc, StringRef{b.data(), static_cast<size_t>(n)});
+ }
+ 
+ namespace {
+-- 
+2.21.0
+

--- a/orc8r/cloud/docker/proxy/Dockerfile
+++ b/orc8r/cloud/docker/proxy/Dockerfile
@@ -1,0 +1,66 @@
+ARG NGHTTP_VERSION=1.40.0
+
+FROM ubuntu:bionic as builder
+
+# From nghttp2 readme, minus libsystemd-dev
+RUN apt-get update && \
+    apt-get install -y git curl g++ make binutils autoconf automake autotools-dev libtool pkg-config \
+      zlib1g-dev libcunit1-dev openssl libssl-dev libxml2-dev libev-dev libevent-dev libjansson-dev \
+      libc-ares-dev libjemalloc-dev ruby bison \
+      cython python3-dev python-setuptools
+
+# Compile nghttp2 with serial number patch
+ARG NGHTTP_VERSION
+WORKDIR /tmp
+RUN git clone https://github.com/nghttp2/nghttp2.git
+WORKDIR /tmp/nghttp2
+RUN git checkout v${NGHTTP_VERSION}
+
+RUN git submodule update --init
+COPY /src/magma/orc8r/cloud/docker/proxy/0001-Fix-get_x509_serial-for-long-serial-numbers.patch /tmp
+RUN git apply /tmp/0001-Fix-get_x509_serial-for-long-serial-numbers.patch
+RUN autoreconf -i
+RUN automake
+RUN autoconf
+RUN ./configure --with-mruby --enable-app --disable-examples --disable-python-bindings
+RUN make
+RUN make install DESTDIR=/tmp/nghttp2/install
+
+FROM ubuntu:bionic
+
+ARG CNTLR_FILES=src/magma/orc8r/cloud/docker/controller
+ARG PROXY_FILES=src/magma/orc8r/cloud/docker/proxy
+ARG NGHTTP_VERSION
+
+# Runtime dependencies for nghttpx, supervisord, etc
+RUN apt-get update && \
+    apt-get install -y \
+        daemontools netcat openssl supervisor wget unzip \
+        libssl-dev libev-dev libevent-dev libjansson-dev libjemalloc-dev libc-ares-dev \
+        python3-pip \
+        squid
+
+# Install nghttpx
+COPY --from=builder /tmp/nghttp2/install/usr /usr
+RUN ldconfig
+
+# Install python3 deps from pip
+RUN pip3 install PyYAML jinja2
+
+# Create an empty envdir for overriding in production
+RUN mkdir -p /var/opt/magma/envdir
+
+# Copy the configs
+COPY configs /etc/magma/configs
+
+# Copy proxy scripts and configs from the context
+COPY ${PROXY_FILES}/templates /etc/magma/templates
+COPY ${PROXY_FILES}/magma_headers.rb /etc/nghttpx/magma_headers.rb
+COPY ${PROXY_FILES}/run_nghttpx.py /usr/local/bin/run_nghttpx.py
+COPY ${PROXY_FILES}/squid.conf /etc/squid/squid.conf
+COPY ${PROXY_FILES}/create_test_proxy_certs /usr/local/bin/create_test_proxy_certs
+
+# Copy the supervisor configs
+COPY ${PROXY_FILES}/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY ${CNTLR_FILES}/supervisor_logger.py /usr/local/lib/python2.7/dist-packages/supervisor_logger.py
+CMD ["/usr/bin/supervisord"]

--- a/orc8r/cloud/docker/proxy/create_test_proxy_certs
+++ b/orc8r/cloud/docker/proxy/create_test_proxy_certs
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# This script generates certs for the proxy tier for dev and testing
+set -e
+
+if [ "$TEST_MODE" != "1" ]; then
+  echo "Not running in test mode!"
+  exit 0
+fi
+
+DIR='/var/opt/magma/certs'
+mkdir -p ${DIR}
+cd ${DIR}
+
+if [ ! -f rootCA.pem ]; then
+  echo "##################"
+  echo "Creating root CA.."
+  echo "##################"
+  openssl genrsa -out rootCA.key 2048
+  openssl req -x509 -new -nodes -key rootCA.key -sha256 -days 365000 \
+        -out rootCA.pem -subj "/C=US/CN=rootca.magma.test"
+fi
+
+if [ ! -f controller.crt ]; then
+  echo "##########################"
+  echo "Creating controller cert.."
+  echo "##########################"
+  openssl genrsa -out controller.key 2048
+  openssl req -new -key controller.key -out controller.csr \
+        -subj "/C=US/CN=*.magma.test"
+  openssl x509 -req -in controller.csr -CA rootCA.pem -CAkey rootCA.key \
+        -CAcreateserial -out controller.crt -days 36400 -sha256
+fi
+
+if [ ! -f certifier.key ]; then
+  echo "#######################"
+  echo "Creating certifier CA.."
+  echo "#######################"
+  openssl genrsa -out certifier.key 2048
+  openssl req -x509 -new -nodes -key certifier.key -sha256 -days 365000 \
+        -out certifier.pem -subj "/C=US/CN=certifier.magma.test"
+fi

--- a/orc8r/cloud/docker/proxy/magma_headers.rb
+++ b/orc8r/cloud/docker/proxy/magma_headers.rb
@@ -1,0 +1,21 @@
+# Copyright (c) 2018-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+# Nghttpx can run mcruby scripts as part of each request handling:
+# See: https://nghttp2.org/documentation/nghttpx.1.html?highlight=mruby-file#mruby-scripting
+
+class App
+  def on_req(env)
+    # Inject Magma headers to inform the backend services about the client cert.
+    # The headers would be present for all requests, and a empty string as
+    # value indicate invalid cert.
+    env.req.set_header("x-magma-client-cert-cn", env.tls_client_subject_name)
+    env.req.set_header("x-magma-client-cert-serial", env.tls_client_serial.upcase)
+  end
+end
+
+App.new

--- a/orc8r/cloud/docker/proxy/run_nghttpx.py
+++ b/orc8r/cloud/docker/proxy/run_nghttpx.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+import argparse
+import logging
+
+import jinja2
+import os
+import subprocess
+import yaml
+from typing import Any, Dict
+
+CONFIGS_DIR = "/etc/magma/configs"
+TEMPLATES_DIR = "/etc/magma/templates"
+OUTPUT_DIR = "/etc/nghttpx"
+OBSIDIAN_PORT = 9081
+
+
+def _load_services() -> Dict[Any, Any]:
+    """ Return the services from the registry configs of all modules """
+    services = {}  # type: Dict[Any, Any]
+    modules = os.listdir(CONFIGS_DIR)
+    for module in modules:
+        print("Loading registry for module: %s..." % module)
+        filename = os.path.join(CONFIGS_DIR, module, "service_registry.yml")
+        with open(filename) as file:
+            registry = yaml.safe_load(file)
+            if registry and "services" in registry:
+                services.update(registry["services"])
+    return services
+
+
+def _generate_config(proxy_type: str, context: Dict[str, Any]) -> str:
+    """ Generate the nghttpx config from the template """
+    loader = jinja2.FileSystemLoader(TEMPLATES_DIR)
+    env = jinja2.Environment(loader=loader)
+    template = env.get_template("nghttpx_%s.conf.j2" % proxy_type)
+    output = template.render(context)
+    outfile = os.path.join(OUTPUT_DIR, "nghttpx_%s.conf" % proxy_type)
+    with open(outfile, "w") as file:
+        file.write(output)
+    return outfile
+
+
+def _run_nghttpx(conf: str) -> None:
+    """ Runs the nghttpx process given the config file """
+    try:
+        subprocess.run([
+            "/usr/local/bin/nghttpx",
+            "--conf=%s" % conf,
+            "/var/opt/magma/certs/controller.key",
+            "/var/opt/magma/certs/controller.crt",
+        ], check=True)
+    except subprocess.CalledProcessError as err:
+        exit(err.returncode)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Nghttpx runner")
+    parser.add_argument("proxy_type", choices=["open", "clientcert"])
+    args = parser.parse_args()
+
+    # Create the jinja context
+    context = {}  # type: Dict[str, Any]
+    context["service_registry"] = _load_services()
+    context["controller_hostname"] = os.environ["CONTROLLER_HOSTNAME"]
+    context["proxy_backends"] = os.environ["PROXY_BACKENDS"]
+    context["obsidian_port"] = OBSIDIAN_PORT
+    context["env"] = os.environ
+
+    # Generate the nghttpx config
+    conf = _generate_config(args.proxy_type, context)
+
+    # Run the nghttpx process
+    _run_nghttpx(conf)
+    logging.error("nghttpx restarting")
+
+
+if __name__ == '__main__':
+    main()

--- a/orc8r/cloud/docker/proxy/squid.conf
+++ b/orc8r/cloud/docker/proxy/squid.conf
@@ -1,0 +1,55 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+# All rights reserved.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Default Squid Configuration File
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+#
+# Recommended minimum Access Permission configuration:
+#
+# Deny requests to certain unsafe ports
+http_access deny !Safe_ports
+
+# Deny CONNECT to other than secure SSL ports
+http_access deny CONNECT !SSL_ports
+
+# Only allow cachemgr access from localhost
+http_access allow localhost manager
+http_access deny manager
+
+# http_access allow localhost
+http_access allow localhost
+
+# And finally deny all other access to this proxy
+http_access deny all
+
+# Squid normally listens to port 3128
+http_port 3128
+
+# Log to standard location
+access_log /var/log/squid/access.log
+
+# Leave coredumps in the first cache dir
+coredump_dir /var/spool/squid
+
+# Default refresh patterns
+refresh_pattern ^ftp:		1440	20%	10080
+refresh_pattern ^gopher:	1440	0%	1440
+refresh_pattern -i (/cgi-bin/|\?) 0	0%	0
+refresh_pattern (Release|Packages(.gz)*)$      0       20%     2880
+refresh_pattern .		0	20%	4320

--- a/orc8r/cloud/docker/proxy/supervisord.conf
+++ b/orc8r/cloud/docker/proxy/supervisord.conf
@@ -1,0 +1,43 @@
+[supervisord]
+nodaemon=true
+
+[program:open]
+command=/usr/bin/envdir /var/opt/magma/envdir /usr/local/bin/run_nghttpx.py open
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+autorestart=true
+
+[program:clientcert]
+command=/usr/bin/envdir /var/opt/magma/envdir /usr/local/bin/run_nghttpx.py clientcert
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+autorestart=true
+
+[program:forward_proxy]
+command=/usr/bin/envdir /var/opt/magma/envdir /usr/sbin/squid -f /etc/squid/squid.conf -N
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+autorestart=true
+
+[program:dev_setup]
+command=/usr/local/bin/create_test_proxy_certs
+stdout_logfile=/dev/fd/1
+stderr_logfile=/dev/fd/2
+stdout_logfile_maxbytes=0
+stderr_logfile_maxbytes=0
+startsecs=0
+autorestart=false
+
+[eventlistener:stdout]
+command = python -m supervisor_logger
+buffer_size = 100
+events = PROCESS_LOG
+result_handler = supervisor_logger:result_handler
+stdout_logfile=NONE
+stderr_logfile=NONE

--- a/orc8r/cloud/docker/proxy/templates/nghttpx_clientcert.conf.j2
+++ b/orc8r/cloud/docker/proxy/templates/nghttpx_clientcert.conf.j2
@@ -1,0 +1,49 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+# Listening interfaces
+frontend=0.0.0.0,9443
+frontend=::,9443
+# TODO: remove 443 after migrating the existing load balancers
+frontend=0.0.0.0,443
+frontend=::,443
+
+# Disable OCSP for the controller for now
+no-ocsp=yes
+
+# Enable access gateway cert verification
+verify-client=yes
+verify-client-cacert=/var/opt/magma/certs/certifier.pem
+
+# Header injection for client certs
+mruby-file=/etc/nghttpx/magma_headers.rb
+
+# Magma services
+{% for backend in proxy_backends.split(',') -%}
+
+# Send gRPC requests to individual services
+{% for service, value in service_registry.items() -%}
+{% if value['proxy_type'] == "clientcert" -%}
+backend={{ backend }},{{ value.port }};{{ service }}.cloud;proto=h2;no-tls;dns
+backend={{ backend }},{{ value.port }};{{ service }}-{{ controller_hostname }};proto=h2;no-tls;dns
+{% endif %}
+{% if "proxy_aliases" in value -%}
+{% for alias, map in value["proxy_aliases"].items() -%}
+backend={{ backend }},{{ map.port }};{{ alias }}.cloud;proto=h2;no-tls;dns
+backend={{ backend }},{{ map.port }};{{ alias }}-{{ controller_hostname }};proto=h2;no-tls;dns
+{% endfor -%}
+{% endif -%}
+{% endfor -%}
+
+# Send API requests to obsidian. By default, any other requests would also
+# be sent to obsidian.
+backend={{ backend }},{{obsidian_port}};;no-tls;dns
+{% endfor -%}
+
+# Proxy configs
+{% include './nghttpx_common.conf.j2' %}

--- a/orc8r/cloud/docker/proxy/templates/nghttpx_common.conf.j2
+++ b/orc8r/cloud/docker/proxy/templates/nghttpx_common.conf.j2
@@ -1,0 +1,16 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+
+accesslog-file=/dev/stdout
+# !!! If change the format below, need to change nghttpx_parser.Parse() as well.
+accesslog-format=${time_iso8601}@|@${remote_addr}@|@${http_host}@|@${server_port}@|@${request}@|@${status}@|@${body_bytes_sent}@|@${request_time}@|@${alpn}@|@${tls_client_serial}@|@${tls_client_subject_name}@|@${tls_session_reused}@|@${tls_sni}@|@${tls_protocol}@|@${tls_cipher}@|@${backend_host}@|@${backend_port}
+
+# New versions of gRPC send the http2 settings ack frame in a delayed manner
+frontend-http2-settings-timeout=1000
+
+# Uncomment the following line to enable debug logging
+# log-level=INFO

--- a/orc8r/cloud/docker/proxy/templates/nghttpx_open.conf.j2
+++ b/orc8r/cloud/docker/proxy/templates/nghttpx_open.conf.j2
@@ -1,0 +1,58 @@
+# Copyright (c) 2016-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree. An additional grant
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+# Listening interfaces
+frontend=0.0.0.0,9444
+frontend=::,9444
+# TODO: remove 8443 after migrating the existing load balancers
+frontend=0.0.0.0,8443
+frontend=::,8443
+
+# Disable OCSP for the controller for now
+no-ocsp=yes
+
+# Enable access gateway cert verification
+verify-client=no
+
+{% if 'HTTP_PROXY_HOSTNAME' in env and env['HTTP_PROXY_HOSTNAME']|length > 0 -%}
+# HTTP proxy config to forward HTTP requests
+backend={{ env['HTTP_PROXY_BACKEND'] }},443;{{ env['HTTP_PROXY_HOSTNAME'] }};tls
+host-rewrite=yes
+# TODO: Look into IPv6 support in Docker-Compose and Kubernetes
+backend-address-family=IPv4
+{% endif -%}
+
+{% if 'HTTP_PROXY_DOCKER_HOSTNAME' in env and env['HTTP_PROXY_DOCKER_HOSTNAME']|length > 0 -%}
+# HTTP proxy config to forward HTTP requests for docker images
+backend=localhost,3128;{{ env['HTTP_PROXY_DOCKER_HOSTNAME'] }}
+host-rewrite=yes
+backend-address-family=IPv4
+{% endif -%}
+
+{% if 'HTTP_PROXY_GITHUB_HOSTNAME' in env and env['HTTP_PROXY_GITHUB_HOSTNAME']|length > 0 -%}
+# HTTP proxy config to forward HTTP requests for github
+backend=localhost,3128;{{ env['HTTP_PROXY_GITHUB_HOSTNAME'] }}
+host-rewrite=yes
+backend-address-family=IPv4
+{% endif -%}
+
+# Magma services
+{% for backend in proxy_backends.split(',') -%}
+{% for service, value in service_registry.items() -%}
+{% if value['proxy_type'] == "open" -%}
+backend={{ backend }},{{ value.port }};{{ service }}.cloud;proto=h2;no-tls;dns
+backend={{ backend }},{{ value.port }};{{ service }}-{{ controller_hostname }};proto=h2;no-tls;dns
+{% endif %}
+{% endfor -%}
+# Nghttp can't send a direct error for other unknown requests.
+# Blackhole all other requests to port 9070, which is not used by any service.
+backend={{ backend }},9070;;no-tls;dns
+{% endfor -%}
+
+# Proxy configs
+{% include './nghttpx_common.conf.j2' %}


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Partial revert of diff that nuked nghttpx to just bring back the Dockerfile and supporting components while we investigate nginx closing syncRPC streams.

## Test Plan

- Just copied the old directory

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
