### PR TITLE
[Jenkins] fixed removeLastUITestCases.sed file

### DIFF
--- a/ci-scripts/removeLastUlTestCases.sed
+++ b/ci-scripts/removeLastUlTestCases.sed
@@ -15,6 +15,6 @@
 # For more information about the OpenAirInterface (OAI) Software Alliance:
 #      contact@openairinterface.org
 ################################################################################
-s@s1aptests/test_attach_detach_multiple_secondary_pdn.py \\@s1aptests/test_attach_detach_multiple_secondary_pdn.py@
+s@s1aptests/test_attach_detach_multiple_secondary_pdn.py@#s1aptests/test_attach_detach_multiple_secondary_pdn.py@
 s@s1aptests/test_attach_ul_udp_data.py@#s1aptests/test_attach_ul_udp_data.py@
 s@s1aptests/test_attach_ul_tcp_data.py@#s1aptests/test_attach_ul_tcp_data.py@


### PR DESCRIPTION
Signed-off-by: Vitalii <vitalij.kostenko@gmail.com>

## Summary

For the moment when we apply  removeLastUITestCases.sed with sed to lte/gateway/python/integ_tests/defs.mk breaks syntax in the last one

## Test Plan

Run Jenkins Test