### PR TITLE
[orc8r][sev_fix][migration_required] Add default APN configurator migration

### DIFF
--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -35,7 +35,7 @@ type Error string
 const (
 	// ErrDefault is the default error reported for reindex failure.
 	ErrDefault Error = "state reindex error"
-	// ErrReindexPerState indicates a Reindex error occured for specific keys. Not included in any job errors.
+	// ErrReindexPerState indicates a Reindex error occurred for specific keys. Not included in any job errors.
 	ErrReindexPerState Error = "reindex error: per-state errors"
 
 	// ErrPrepare is included in job error when error source is indexer PrepareReindex call.

--- a/orc8r/cloud/go/tools/migrations/datastore_to_blobstore.go
+++ b/orc8r/cloud/go/tools/migrations/datastore_to_blobstore.go
@@ -40,7 +40,7 @@ const (
 	verCol  = "version"
 )
 
-// migrateNetworkAgnosticServiceToBlobstore migrates a network-agnostic service's data
+// MigrateNetworkAgnosticServiceToBlobstore migrates a network-agnostic service's data
 // from datastore to blobstore formats.
 //
 // Schema migration:

--- a/orc8r/cloud/go/tools/migrations/m005_certifier_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m005_certifier_to_blobstore/main.go
@@ -41,7 +41,7 @@ var (
 )
 
 // main runs the certifier_to_blobstore migration.
-// Migration without SQL error will result in `SUCCESS` printed to sderr.
+// Migration without SQL error will result in `SUCCESS` printed to stderr.
 //
 // Optional `-verify` flag logs values from certifier service, post-migration,
 // allowing manual evaluation.

--- a/orc8r/cloud/go/tools/migrations/m008_accessd_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m008_accessd_to_blobstore/main.go
@@ -41,7 +41,7 @@ var (
 )
 
 // main runs the accessd_to_blobstore migration.
-// Migration without SQL error will result in `SUCCESS` printed to sderr.
+// Migration without SQL error will result in `SUCCESS` printed to stderr.
 //
 // Optional `-verify` flag logs values from accessd service, post-migration,
 // allowing manual evaluation.

--- a/orc8r/cloud/go/tools/migrations/m009_directoryd_to_blobstore/main.go
+++ b/orc8r/cloud/go/tools/migrations/m009_directoryd_to_blobstore/main.go
@@ -34,7 +34,7 @@ const (
 )
 
 // main runs the directoryd_to_blobstore migration.
-// Migration without SQL error will result in `SUCCESS` printed to sderr.
+// Migration without SQL error will result in `SUCCESS` printed to stderr.
 //
 // This migration just deletes the old hwid_to_hostname table.
 func main() {

--- a/orc8r/cloud/go/tools/migrations/m010_default_apns/main.go
+++ b/orc8r/cloud/go/tools/migrations/m010_default_apns/main.go
@@ -1,0 +1,452 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+/*
+	m010_default_apns ensures all subscribers are associated with an APN.
+
+	Creates a default APN, then, for each subscriber without an APN, associates
+	the subscriber with the default APN. Is idempotent.
+
+	This migration touches a lot of SQL objects within a serializable
+	transaction. If the migration fails due to serialization failure, consider
+	retrying.
+
+	The migration executable imports main library code in two ways
+		- sqorc	-- statement builders
+		- other	-- optional, manual verification
+	If these imports break this executable, recourse to the following
+		- sqorc	-- fix breakage, or change statement builders to manual SQL
+				   string execs
+		- other	-- fix breakage, or remove manual verification code
+
+	In a single, serializable transaction, performs roughly the following,
+	per network:
+
+	Create default APN if not exist
+		- Access point name			-- oai.ipv4
+		- AMBR downlink				-- unlimited (200000000)
+		- AMBR uplink				-- unlimited (100000000)
+		- QoS class ID				-- 9
+		- Priority level			-- 15
+		- Preemption capability		-- true
+		- Preemption vulnerability	-- false
+
+	Associate subscribers without an APN to the default APN
+		- Create subscriber->APN assoc to default APN if not exist
+		- Merge subscriber and APN graph IDs as necessary
+
+	Validate (optional)
+		- Use the -verify flag
+		- Make calls to configurator service to ensure all subscribers have
+		  an associated APN
+		- Print a subset of subscribers for manual inspection
+*/
+
+package main
+
+import (
+	"database/sql"
+	"flag"
+	"fmt"
+	"sort"
+
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/sqorc"
+	"magma/orc8r/cloud/go/storage"
+	"magma/orc8r/cloud/go/tools/migrations"
+	"magma/orc8r/cloud/go/tools/migrations/m010_default_apns/types"
+	"magma/orc8r/lib/go/registry"
+
+	"github.com/Masterminds/squirrel"
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/golang/glog"
+	"github.com/google/uuid"
+	_ "github.com/lib/pq"
+	"github.com/pkg/errors"
+	"github.com/thoas/go-funk"
+)
+
+const (
+	apnEntType        = "apn"
+	subscriberEntType = "subscriber"
+
+	numManualVerificationsToLog = 5
+)
+
+// Duplicated from configurator
+const (
+	networksTable = "cfg_networks"
+
+	entityTable      = "cfg_entities"
+	entityAssocTable = "cfg_assocs"
+
+	nwIDCol = "id"
+
+	entPkCol   = "pk"
+	entNidCol  = "network_id"
+	entTypeCol = "type"
+	entKeyCol  = "\"key\""
+	entGidCol  = "graph_id"
+	entConfCol = "config"
+
+	aFrCol = "from_pk"
+	aToCol = "to_pk"
+
+	internalNetworkID = "network_magma_internal"
+)
+
+var (
+	dryRun bool
+	verify bool
+)
+
+// ent identifies essential entity info.
+type ent struct {
+	pk      string
+	typ     string
+	graphID string
+}
+
+func init() {
+	flag.BoolVar(&dryRun, "dry", false, "don't commit changes")
+	flag.BoolVar(&verify, "verify", false, "verify successful migration")
+	flag.Parse()
+	_ = flag.Set("alsologtostderr", "true") // enable printing to console
+}
+
+// main runs the default_apns migration.
+// Migration without SQL error will result in `SUCCESS` printed to stderr.
+//
+// Optional `-verify` flag interfaces with configurator post-migration
+// to verify successful migration.
+func main() {
+	defer glog.Flush()
+
+	glog.Info("BEGIN MIGRATION")
+
+	dbDriver := migrations.GetEnvWithDefault("SQL_DRIVER", "postgres")
+	dbSource := migrations.GetEnvWithDefault("DATABASE_SOURCE", "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable")
+	db, err := sql.Open(dbDriver, dbSource)
+	if err != nil {
+		glog.Fatal(errors.Wrap(err, "could not open db connection"))
+	}
+	builder := sqorc.GetSqlBuilder()
+
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		networks, err := getNetworks(tx, builder)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, network := range networks {
+			defaultAPN, err := createDefaultAPN(tx, builder, network)
+			if err != nil {
+				return nil, err
+			}
+			err = ensureAllSubscribersHaveAPN(tx, builder, network, defaultAPN)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		if dryRun {
+			return nil, errors.New("throwing error instead of committing because -dry was specified")
+		}
+
+		return nil, nil
+	}
+	_, err = sqorc.ExecInTx(db, &sql.TxOptions{Isolation: sql.LevelSerializable}, nil, txFn)
+	if err != nil {
+		glog.Fatal(err)
+	}
+
+	if verify {
+		err := verifyMigration()
+		if err != nil {
+			glog.Fatalf("configurator verification failed: %s", err)
+		}
+	}
+
+	glog.Info("SUCCESS")
+	glog.Info("END MIGRATION")
+}
+
+func getNetworks(tx *sql.Tx, builder sqorc.StatementBuilder) ([]string, error) {
+	rows, err := builder.
+		Select(nwIDCol).From(networksTable).
+		Where(squirrel.NotEq{nwIDCol: internalNetworkID}).
+		RunWith(tx).Query()
+	if err != nil {
+		return nil, errors.Wrap(err, "getNetworks: select networks")
+	}
+
+	var networks []string
+	for rows.Next() {
+		var n string
+		err = rows.Scan(&n)
+		if err != nil {
+			return nil, errors.Wrap(err, "getNetworks: scan network ID")
+		}
+		networks = append(networks, n)
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrap(err, "getNetworks: SQL rows error")
+	}
+
+	return networks, nil
+}
+
+// createDefaultAPN ensures the default APN exists for the network, creating
+// it if necessary.
+// Returns default APN.
+// Inserted values:
+//	- pk			-- new UUID
+//	- network_id	-- passed network
+//	- type			-- "apn"
+//	- key			-- "oai.ipv4"
+//	- graph_id		-- new UUID (different from pk)
+//	- config		-- defaultAPNVal
+func createDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (ent, error) {
+	apn, err := getDefaultAPN(tx, builder, network)
+	if err != nil {
+		return ent{}, err
+	}
+	// Return early if default APN already exists
+	if apn != nil {
+		return *apn, nil
+	}
+
+	pk, gid := newUUID(), newUUID()
+	b := builder.
+		Insert(entityTable).
+		Columns(entPkCol, entNidCol, entTypeCol, entKeyCol, entGidCol, entConfCol).
+		Values(pk, network, apnEntType, types.DefaultAPNName, gid, types.DefaultAPNVal)
+	sqlStr, args, _ := b.ToSql()
+	glog.Infof("[RUN] %s %v", sqlStr, args)
+	_, err = b.RunWith(tx).Exec()
+	if err != nil {
+		return ent{}, errors.Wrap(err, "createDefaultAPNIfNotExist: insert error")
+	}
+
+	newAPN := ent{pk: pk, typ: apnEntType, graphID: gid}
+	return newAPN, nil
+}
+
+func getDefaultAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) (*ent, error) {
+	rows, err := builder.
+		Select(entPkCol, entGidCol).From(entityTable).
+		Where(
+			squirrel.And{
+				squirrel.Eq{entNidCol: network},
+				squirrel.Eq{entKeyCol: types.DefaultAPNName},
+			},
+		).
+		RunWith(tx).Query()
+	if err != nil {
+		return nil, errors.Wrap(err, "getDefaultAPN: select existing default APN")
+	}
+
+	var apns []*ent
+	for rows.Next() {
+		apn := &ent{}
+		err = rows.Scan(&apn.pk, &apn.graphID)
+		if err != nil {
+			return nil, errors.Wrap(err, "getDefaultAPN: scan APN")
+		}
+		apns = append(apns, apn)
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrap(err, "getDefaultAPN: SQL rows error")
+	}
+
+	if len(apns) > 1 {
+		return nil, fmt.Errorf("getDefaultAPN: found more than 1 default APN for network %s %v", network, apns)
+	}
+	if len(apns) == 0 {
+		return nil, nil
+	}
+
+	return apns[0], nil
+}
+
+func ensureAllSubscribersHaveAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string, apn ent) error {
+	subs, err := getSubscribersMissingAPN(tx, builder, network)
+	if err != nil {
+		return err
+	}
+	if len(subs) == 0 {
+		return nil
+	}
+
+	subPKs := funk.Map(subs, func(s ent) string { return s.pk }).([]string)
+	allGIDs := funk.Map(append(subs, apn), func(e ent) string { return e.graphID }).([]string)
+
+	err = mapSubscribersToAPN(tx, builder, apn.pk, subPKs)
+	if err != nil {
+		return err
+	}
+
+	err = mergeGraphs(tx, builder, network, allGIDs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func getSubscribersMissingAPN(tx *sql.Tx, builder sqorc.StatementBuilder, network string) ([]ent, error) {
+	// SELECT a.graph_id,a.pk, b.pk,b.type
+	// FROM cfg_entities AS a
+	// LEFT JOIN cfg_assocs ON a.pk=from_pk
+	// LEFT JOIN cfg_entities AS b ON to_pk=b.pk
+	// WHERE a.network=network AND a.type='subscriber';
+	tblA, tblB := "a", "b"
+	nidColA := makeCol(tblA, entNidCol)
+	gidColA := makeCol(tblA, entGidCol)
+	pkColA, pkColB := makeCol(tblA, entPkCol), makeCol(tblB, entPkCol)
+	typeColA, typeColB := makeCol(tblA, entTypeCol), makeCol(tblB, entTypeCol)
+
+	rows, err := builder.
+		Select(gidColA, pkColA, pkColB, typeColB).
+		From(fmt.Sprintf("%s AS %s", entityTable, tblA)).
+		LeftJoin(fmt.Sprintf("%s ON %s=%s", entityAssocTable, pkColA, aFrCol)).
+		LeftJoin(fmt.Sprintf("%s AS %s ON %s=%s", entityTable, tblB, aToCol, pkColB)).
+		Where(
+			squirrel.And{
+				squirrel.Eq{nidColA: network},
+				squirrel.Eq{typeColA: subscriberEntType},
+			},
+		).
+		RunWith(tx).Query()
+	if err != nil {
+		return nil, errors.Wrap(err, "getSubscribersMissingAPN: select subscribers")
+	}
+
+	assocs := map[ent][]ent{}
+	for rows.Next() {
+		a := ent{typ: subscriberEntType}
+		pkB, typeB := &sql.NullString{}, &sql.NullString{}
+		err = rows.Scan(&a.graphID, &a.pk, pkB, typeB)
+		if err != nil {
+			return nil, errors.Wrap(err, "getSubscribersMissingAPN: scan subscriber")
+		}
+		assocs[a] = append(assocs[a], ent{pk: pkB.String, typ: typeB.String})
+	}
+	err = rows.Err()
+	if err != nil {
+		return nil, errors.Wrap(err, "getSubscribersMissingAPN: SQL rows error")
+	}
+
+	var subsMissingAPN []ent
+	for sub, ents := range assocs {
+		hasAPN := false
+		for _, ent := range ents {
+			if ent.typ == apnEntType {
+				hasAPN = true
+			}
+		}
+		if !hasAPN {
+			subsMissingAPN = append(subsMissingAPN, sub)
+		}
+	}
+
+	return subsMissingAPN, nil
+}
+
+func mapSubscribersToAPN(tx *sql.Tx, builder sqorc.StatementBuilder, apnPK string, subscriberPKs []string) error {
+	b := builder.Insert(entityAssocTable).Columns(aFrCol, aToCol)
+	for _, subPK := range subscriberPKs {
+		b = b.Values(subPK, apnPK)
+	}
+	sqlStr, args, _ := b.ToSql()
+	glog.Infof("[RUN] %s %v", sqlStr, args)
+	_, err := b.RunWith(tx).Exec()
+	if err != nil {
+		return errors.Wrap(err, "mapSubscribersToAPN: insert error")
+	}
+
+	return nil
+}
+
+// mergeGraphs merges the graphs for all passed graph IDs.
+// Assumes gids is non-empty.
+func mergeGraphs(tx *sql.Tx, builder sqorc.StatementBuilder, network string, gids []string) error {
+	gids = funk.UniqString(gids)
+	sort.Strings(gids)
+	mergedGID, oldGIDs := gids[0], gids[1:]
+
+	isOldGID := squirrel.Or{}
+	for _, gid := range oldGIDs {
+		isOldGID = append(isOldGID, squirrel.Eq{entGidCol: gid})
+	}
+
+	b := builder.
+		Update(entityTable).
+		Set(entGidCol, mergedGID).
+		Where(
+			squirrel.And{
+				squirrel.Eq{entNidCol: network},
+				isOldGID,
+			},
+		)
+	sqlStr, args, _ := b.ToSql()
+	glog.Infof("[RUN] %s %v", sqlStr, args)
+	_, err := b.RunWith(tx).Exec()
+	if err != nil {
+		return errors.Wrap(err, "mergeGraphs: update error")
+	}
+
+	return nil
+}
+
+// verifyMigration loads all subscribers into memory, and checks that they
+// each have an APN assoc.
+func verifyMigration() error {
+	registry.MustPopulateServices()
+
+	nids, err := configurator.ListNetworkIDs()
+	if err != nil {
+		return err
+	}
+
+	for _, nid := range nids {
+		subs, err := configurator.LoadAllEntitiesInNetwork(nid, subscriberEntType, configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
+		if err != nil {
+			return err
+		}
+
+		i := 0
+		for _, sub := range subs {
+			apns := funk.Chain(sub.Associations).
+				Filter(func(tk storage.TypeAndKey) bool { return tk.Type == apnEntType }).
+				Map(func(tk storage.TypeAndKey) string { return tk.Key }).
+				Value().([]string)
+
+			if len(apns) == 0 {
+				return fmt.Errorf("subscriber %s has no APN assocs", sub.Key)
+			}
+
+			if i < numManualVerificationsToLog {
+				glog.Infof("Subscriber %v has APN assocs %v", sub, apns)
+			}
+			i += 1
+		}
+	}
+
+	return nil
+}
+
+func newUUID() string {
+	return uuid.New().String()
+}
+
+func makeCol(table, col string) string {
+	return fmt.Sprintf("%s.%s", table, col)
+}

--- a/orc8r/cloud/go/tools/migrations/m010_default_apns/types/apn.go
+++ b/orc8r/cloud/go/tools/migrations/m010_default_apns/types/apn.go
@@ -1,0 +1,113 @@
+/*
+ Copyright (c) Facebook, Inc. and its affiliates.
+ All rights reserved.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+*/
+
+// Types copied from lte/cloud/go/services/lte/obsidian/models
+
+package types
+
+import (
+	"fmt"
+
+	"github.com/go-openapi/swag"
+	"github.com/golang/glog"
+)
+
+const (
+	DefaultAPNName = "oai.ipv4"
+
+	defaultAMBRDownlink = 200000000
+	defaultAMBRUplink   = 100000000
+
+	defaultQoSClassID                 = 9
+	defaultQoSPriorityLevel           = 15
+	defaultQoSPreemptionCapability    = true
+	defaultQoSPreemptionVulnerability = false
+)
+
+var DefaultAPNVal []byte
+
+var defaultAPN = &ApnConfiguration{
+	Ambr: &AggregatedMaximumBitrate{
+		MaxBandwidthDl: swag.Uint32(defaultAMBRDownlink),
+		MaxBandwidthUl: swag.Uint32(defaultAMBRUplink),
+	},
+	QosProfile: &QosProfile{
+		ClassID:                 swag.Int32(defaultQoSClassID),
+		PreemptionCapability:    swag.Bool(defaultQoSPreemptionCapability),
+		PreemptionVulnerability: swag.Bool(defaultQoSPreemptionVulnerability),
+		PriorityLevel:           swag.Uint32(defaultQoSPriorityLevel),
+	},
+}
+
+func init() {
+	DefaultAPNVal = defaultAPN.MustMarshalBinary()
+}
+
+type ApnConfiguration struct {
+	// ambr
+	// Required: true
+	Ambr *AggregatedMaximumBitrate `json:"ambr"`
+
+	// qos profile
+	// Required: true
+	QosProfile *QosProfile `json:"qos_profile"`
+}
+
+func (m *ApnConfiguration) MustMarshalBinary() []byte {
+	if m == nil {
+		return nil
+	}
+	bytes, err := swag.WriteJSON(m)
+	if err != nil {
+		glog.Fatalf("Error marshaling APN configuration: %v", err)
+	}
+	return bytes
+}
+
+func (m *ApnConfiguration) String() string {
+	return fmt.Sprintf("{Ambr: %v, QosProfile: %v}", m.Ambr, m.QosProfile)
+}
+
+type AggregatedMaximumBitrate struct {
+	// max bandwidth dl
+	// Required: true
+	MaxBandwidthDl *uint32 `json:"max_bandwidth_dl"`
+
+	// max bandwidth ul
+	// Required: true
+	MaxBandwidthUl *uint32 `json:"max_bandwidth_ul"`
+}
+
+func (m *AggregatedMaximumBitrate) String() string {
+	return fmt.Sprintf("{MaxBandwidthDl: %v, MaxBandwidthUl: %v}", m.MaxBandwidthDl, m.MaxBandwidthUl)
+}
+
+type QosProfile struct {
+	// class id
+	// Maximum: 255
+	// Minimum: 0
+	ClassID *int32 `json:"class_id,omitempty" magma_alt_name:"QCI"`
+
+	// preemption capability
+	PreemptionCapability *bool `json:"preemption_capability,omitempty"`
+
+	// preemption vulnerability
+	PreemptionVulnerability *bool `json:"preemption_vulnerability,omitempty"`
+
+	// priority level
+	// Maximum: 15
+	// Minimum: 0
+	PriorityLevel *uint32 `json:"priority_level,omitempty"`
+}
+
+func (m *QosProfile) String() string {
+	return fmt.Sprintf(
+		"{ClassID: %v, PreemptionCapability: %v, PreemptionVulnerability: %v, PriorityLevel: %v}",
+		m.ClassID, m.PreemptionCapability, m.PreemptionVulnerability, m.PriorityLevel,
+	)
+}


### PR DESCRIPTION
## Summary

Note: this diff does not actually require a migration, but since a previous diff should have required a migration, I'll add the `[migration_required]` tag above to include this in the list of migrations required for the next release.

As part of the APN updates, every subscriber is now expected to be associated with an APN.

The required configurator migration was not performed before the relevant AGW changes were shipped, resulting in S205307. This diff provides the stable fix for the SEV.

See `m010_default_apns/main.go` for full details, but tl;dr this migration creates a default APN per network (if not exist), and associates each APN-lacking subscriber with the default APN.

This results in ~1-5 SQL calls per network, where up to 3 of them are writes. The changes are all part of a single tx, though are logically partitioned by network. This is both for tidiness (easy to make serializable by network if needed), and because a different default APN is created for each network, leading to graph mutations that are naturally partitioned into per-network operations.

## Test Plan

Ran locally with new copy of prod db. Included verification fn confirmed that each subscriber now had an associated APN, and, in the subset of cases that were logged for manual verification, that was always the default oai.ipv4 APN.

See the full output from my local run on the prod db copy at https://gist.github.com/a89dd006369b0d298a39d4be0b53f3a4. Abbreviated output below

```
root@92824458014b:/# /var/opt/magma/bin/m010_default_apns -verify 
    
I0729 04:56:41.499084     462 main.go:130] BEGIN MIGRATION
I0729 04:56:41.516114     462 main.go:231] [RUN] INSERT INTO cfg_entities (pk,network_id,type,"key",graph_id,config) VALUES ($1,$2,$3,$4,$5,$6) [92e95f8d-c3bb-4b81-9b49-a09b1cdf173a loadstone_test1 apn oai.ipv4 e612c1ae-428c-4091-abe4-6e117e1b5c49 [123 34 97 109 98 114 34 58 123 34 109 97 120 95 98 97 110 100 119 105 100 116 104 95 100 108 34 58 50 48 48 48 48 48 48 48 48 44 34 109 97 120 95 98 97 110 100 119 105 100 116 104 95 117 108 34 58 49 48 48 48 48 48 48 48 48 125 44 34 113 111 115 95 112 114 111 102 105 108 101 34 58 123 34 99 108 97 115 115 95 105 100 34 58 57 44 34 112 114 101 101 109 112 116 105 111 110 95 99 97 112 97 98 105 108 105 116 121 34 58 116 114 117 101 44 34 112 114 101 101 109 112 116 105 111 110 95 118 117 108 110 101 114 97 98 105 108 105 116 121 34 58 102 97 108 115 101 44 34 112 114 105 111 114 105 116 121 95 108 101 118 101 108 34 58 49 53 125 125]]
I0729 04:56:41.518006     462 main.go:369] [RUN] INSERT INTO cfg_assocs (from_pk,to_pk) VALUES ($1,$2),($3,$4),($5,$6),($7,$8),($9,$10),($11,$12) [e964683e-ab33-4d95-9b37-77a55a5aa05d 92e95f8d-c3bb-4b81-9b49-a09b1cdf173a 9eec6d10-8f4b-4688-838b-a567ac56c0b5 92e95f8d-c3bb-4b81-9b49-a09b1cdf173a eb521439-aeb4-4231-b383-72ae76dde545 92e95f8d-c3bb-4b81-9b49-a09b1cdf173a 53093f53-96c4-4299-9595-52a839ae33a8 92e95f8d-c3bb-4b81-9b49-a09b1cdf173a 874bd376-bc44-4d6d-8f8d-e67ceb2899ee 92e95f8d-c3bb-4b81-9b49-a09b1cdf173a 2e0779fa-171b-4c81-a806-1b1b9847f5bf 92e95f8d-c3bb-4b81-9b49-a09b1cdf173a]
I0729 04:56:41.519320     462 main.go:400] [RUN] UPDATE cfg_entities SET graph_id = $1 WHERE (network_id = $2 AND (graph_id = $3 OR graph_id = $4 OR graph_id = $5 OR graph_id = $6 OR graph_id = $7 OR graph_id = $8)) [3a483053-be64-476c-84f1-39060f6b7f1e loadstone_test1 6a70b4a7-d592-4417-8710-17e12c63d5a6 7d496c59-02a9-4da3-a166-1a97fe122826 a0fbbb74-b523-4c28-9cd8-5e46ff275edc a7ff6f70-06e2-457c-8aaf-ae5a66427949 d3999d15-5133-4034-883e-7dcb0e91df0a e612c1ae-428c-4091-abe4-6e117e1b5c49]

...


I0729 04:56:42.013099     462 main.go:437] Subscriber {us_mural_dine subscriber IMSI208950000000016    <nil> 017c96a2-e190-4c0c-bb06-1fa711802a8a [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.013170     462 main.go:437] Subscriber {us_mural_dine subscriber IMSI311980000021461    <nil> 017c96a2-e190-4c0c-bb06-1fa711802a8a [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.013228     462 main.go:437] Subscriber {us_mural_dine subscriber IMSI311980000021462    <nil> 017c96a2-e190-4c0c-bb06-1fa711802a8a [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.013258     462 main.go:437] Subscriber {us_mural_dine subscriber IMSI311980000021463    <nil> 017c96a2-e190-4c0c-bb06-1fa711802a8a [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.013283     462 main.go:437] Subscriber {us_mural_dine subscriber IMSI311980000021464    <nil> 017c96a2-e190-4c0c-bb06-1fa711802a8a [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.023983     462 main.go:437] Subscriber {us_mural_zuni subscriber IMSI311980000021461    <nil> 00665aeb-968e-4319-8dc9-260647a4105b [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.024030     462 main.go:437] Subscriber {us_mural_zuni subscriber IMSI311980000021462    <nil> 00665aeb-968e-4319-8dc9-260647a4105b [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.024053     462 main.go:437] Subscriber {us_mural_zuni subscriber IMSI311980000021463    <nil> 00665aeb-968e-4319-8dc9-260647a4105b [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.024077     462 main.go:437] Subscriber {us_mural_zuni subscriber IMSI311980000021464    <nil> 00665aeb-968e-4319-8dc9-260647a4105b [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.024110     462 main.go:437] Subscriber {us_mural_zuni subscriber IMSI311980000021465    <nil> 00665aeb-968e-4319-8dc9-260647a4105b [apn-oai.ipv4] [] 1} has APN assocs [oai.ipv4]
I0729 04:56:42.031600     462 main.go:175] SUCCESS
I0729 04:56:42.031632     462 main.go:176] END MIGRATION
```

To further verify successful migration, consider the `mpk_test` network (previously no associated APNs) and the `us_mural_zuni` network (previously had the `oai.ipv4` default APN). After the migration, we can observe they both have a well-formatted APN.

<img width="1232" alt="Screen Shot 2020-07-18 at 12 25 03 AM" src="https://user-images.githubusercontent.com/8029544/88729010-8a5c6800-d0f8-11ea-8293-17b44f5daf6f.png">
<img width="1232" alt="Screen Shot 2020-07-18 at 12 25 22 AM" src="https://user-images.githubusercontent.com/8029544/88729014-8cbec200-d0f8-11ea-93f9-13146434fda8.png">

## Additional Information

- [x] This change is backwards-breaking

This diff itself is not a backwards-breaking change, but it acts as the sentinel for the required change. To complete the required change, run the m010_default_apns data migration.