### PR TITLE
Omni rules to ocs

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -38,6 +38,7 @@ class SubTests(Enum):
     GX = "gx"
     GY = "gy"
     QOS = "qos"
+    OMNI = "omnipresent"
     MULTISESSIONPROXY = "multi_session_proxy"
 
     @staticmethod
@@ -47,8 +48,8 @@ class SubTests(Enum):
 
 def integ_test(gateway_host=None, test_host=None, trf_host=None,
                gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml",
-               transfer_images=False, destroy_vm=False, no_build=False,
-               tests_to_run="all", skip_unit_tests=False, test_re=None,
+               transfer_images=False, destroy_vm=False, no_build=True,
+               tests_to_run="omnipresent", skip_unit_tests=False, test_re=None,
                run_tests=True):
     """
     Run the integration tests. This defaults to running on local vagrant

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -48,8 +48,8 @@ class SubTests(Enum):
 
 def integ_test(gateway_host=None, test_host=None, trf_host=None,
                gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml",
-               transfer_images=False, destroy_vm=False, no_build=True,
-               tests_to_run="omnipresent", skip_unit_tests=False, test_re=None,
+               transfer_images=False, destroy_vm=False, no_build=False,
+               tests_to_run="all", skip_unit_tests=False, test_re=None,
                run_tests=True):
     """
     Run the integration tests. This defaults to running on local vagrant

--- a/cwf/gateway/integ_tests/Makefile
+++ b/cwf/gateway/integ_tests/Makefile
@@ -12,6 +12,7 @@ AUTH=Authenticate
 GX=Gx
 GY=Gy
 MULTISP=MultiSessionProxy
+OMNI=Omnipresent
 
 define execute_test
  	echo "Running test: $(1)"
@@ -42,6 +43,10 @@ gy:
 multi_session_proxy:
 	echo "Running Multi Session Proxy Tests..."
 	go test -run $(MULTISP)
+
+omnipresent:
+	echo "Running Omni Tests..."
+	$(foreach test,$(OMNI),$(call execute_test,$(test));)
 
 restart:
 	echo "Running restart tests..."

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -96,13 +96,14 @@ func (srv *CentralSessionController) CreateSession(
 	metrics.PcrfCcrInitRequests.Inc()
 
 	staticRuleInstalls, dynamicRuleInstalls := gx.ParseRuleInstallAVPs(srv.dbClient, gxCCAInit.RuleInstallAVP)
-	chargingKeys := srv.getChargingKeysFromRuleInstalls(staticRuleInstalls, dynamicRuleInstalls)
 	eventTriggers, revalidationTime := gx.GetEventTriggersRelatedInfo(gxCCAInit.EventTriggers, gxCCAInit.RevalidationTime)
 
 	// These rules should not be tracked by OCS or PCRF, they come directly from the orc8r
 	omnipresentRuleIDs, omnipresentBaseNames := srv.dbClient.GetOmnipresentRules()
 	omnipresentRuleIDs = append(omnipresentRuleIDs, srv.dbClient.GetRuleIDsForBaseNames(omnipresentBaseNames)...)
 	staticRuleInstalls = append(staticRuleInstalls, gx.RuleIDsToProtosRuleInstalls(omnipresentRuleIDs)...)
+
+	chargingKeys := srv.getChargingKeysFromRuleInstalls(staticRuleInstalls, dynamicRuleInstalls)
 
 	var gxOriginHost, gyOriginHost string = gxCCAInit.OriginHost, ""
 	if srv.cfg.UseGyForAuthOnly {


### PR DESCRIPTION
<!--
    #2104 :  Gy should be triggered for Omnipresent rules when they are configured with Rating group
-->

## Summary

1. The changes now include the rating groups configured for omnipresent rules  

## Test Plan

Integ_test for testing the change is added in the changes. 

## Additional Information

- [ ] This change is backwards-breaking -- NO

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
