### PR TITLE
[ci[ Update CWAG circleCI workflow to run xwf-m jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -790,13 +790,27 @@ jobs:
             cd ${MAGMA_ROOT}/xwf/docker/
             docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py --type=analytic
 
+  xwfm-deploy:
+    machine:
+      image: ubuntu-1604:201903-01
+      docker_layer_caching: true
+    environment:
+      - MAGMA_ROOT=/home/circleci/project
+    steps:
+      - checkout
+      - docker/install-dc
+      - run:
+          name: Build xwf go radius
+          command: |
+            cd ${MAGMA_ROOT}/feg
+            docker build --tag goradius -f radius/src/Dockerfile ./
+      - tag-push-docker:
+          images: 'goradius'
+          registry: $DOCKER_MAGMA_REGISTRY
+      - magma_slack_notify
+
 workflows:
   version: 2.1
-
-  xwfm:
-    jobs:
-      - xwfm-test:
-          <<: *only_master
 
   cloud:
     jobs:
@@ -833,11 +847,19 @@ workflows:
       - cwag-precommit
       - cwf-integ-test:
           <<: *only_master
+      - xwfm-test:
+          <<: *only_master
       - cwag-deploy:
           <<: *only_master
           requires:
             - cwag-precommit
             - cwf-integ-test
+      - xwfm-deploy:
+          <<: *only_master
+          requires:
+            - xwfm-test
+            - cwag-deploy
+
 
   cwf_operator:
     jobs:


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR removes the independent xwfm workflow and instead updates the CWAG job to run the xwf-m tests instead.
The PR adds a new job to publish specific xwfm images. This job requires CWAG deploy and xwfm-test to have passed. This ensures that we won't publish the xwfm specific images unless all other jobs complete successfully. This gives us the benefit of ensuring that xwfm images pass all xwf-m and cwf tests while not blocking CWAG images from being published in case of xwfm test failures.

## Test Plan

Created a branch on upstream to ensure that the changes worked correctly: https://app.circleci.com/pipelines/github/magma/magma/128/workflows/2cc4ca11-1d0b-445d-8b01-ce67457d305c
`circleci config validate` checks out locally