### PR TITLE
[Bug_Fix] [MME_app] [Mobile_Reachability_Timer] Fixed MME crash due to Mobile Reachability Timer expiry during sanity

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -1427,7 +1427,7 @@ void mme_ue_context_update_ue_sig_connection_state(
     OAILOG_ERROR(LOG_MME_APP, "Invalid UE context received\n");
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
-  if (new_ecm_state == ECM_IDLE) {
+  if (ue_context_p->ecm_state == ECM_CONNECTED && new_ecm_state == ECM_IDLE) {
     hash_rc = hashtable_uint64_ts_remove(
         mme_ue_context_p->enb_ue_s1ap_id_ue_context_htbl,
         (const hash_key_t) ue_context_p->enb_s1ap_id_key);
@@ -1450,38 +1450,47 @@ void mme_ue_context_update_ue_sig_connection_state(
     if (mme_config.nas_config.t3412_min > 0) {
       // Start Mobile reachability timer only if peroidic TAU timer is not
       // disabled
-      nas_itti_timer_arg_t timer_callback_arg = {0};
-      timer_callback_arg.nas_timer_callback =
-          mme_app_handle_mobile_reachability_timer_expiry;
-      timer_callback_arg.nas_timer_callback_arg =
-          (void*) &(ue_context_p->mme_ue_s1ap_id);
-      if (timer_setup(
-              ue_context_p->mobile_reachability_timer.sec, 0, TASK_MME_APP,
-              INSTANCE_DEFAULT, TIMER_ONE_SHOT, &timer_callback_arg,
-              sizeof(timer_callback_arg),
-              &(ue_context_p->mobile_reachability_timer.id)) < 0) {
-        OAILOG_ERROR_UE(
-            LOG_MME_APP, ue_context_p->emm_context._imsi64,
-            "Failed to start Mobile Reachability timer for UE id "
-            " " MME_UE_S1AP_ID_FMT "\n",
-            ue_context_p->mme_ue_s1ap_id);
-        ue_context_p->mobile_reachability_timer.id = MME_APP_TIMER_INACTIVE_ID;
+      if (ue_context_p->mobile_reachability_timer.id ==
+          MME_APP_TIMER_INACTIVE_ID) {
+        // Start Mobile Reachability timer only if it is not running
+        nas_itti_timer_arg_t timer_callback_arg = {0};
+        timer_callback_arg.nas_timer_callback =
+            mme_app_handle_mobile_reachability_timer_expiry;
+        timer_callback_arg.nas_timer_callback_arg =
+            (void*) &(ue_context_p->mme_ue_s1ap_id);
+        if (timer_setup(
+                ue_context_p->mobile_reachability_timer.sec, 0, TASK_MME_APP,
+                INSTANCE_DEFAULT, TIMER_ONE_SHOT, &timer_callback_arg,
+                sizeof(timer_callback_arg),
+                &(ue_context_p->mobile_reachability_timer.id)) < 0) {
+          OAILOG_ERROR_UE(
+              LOG_MME_APP, ue_context_p->emm_context._imsi64,
+              "Failed to start Mobile Reachability timer for UE id "
+              " " MME_UE_S1AP_ID_FMT "\n",
+              ue_context_p->mme_ue_s1ap_id);
+          ue_context_p->mobile_reachability_timer.id =
+              MME_APP_TIMER_INACTIVE_ID;
+        } else {
+          ue_context_p->time_mobile_reachability_timer_started = time(NULL);
+          OAILOG_DEBUG_UE(
+              LOG_MME_APP, ue_context_p->emm_context._imsi64,
+              "Started Mobile Reachability timer for UE id " MME_UE_S1AP_ID_FMT
+              "\n",
+              ue_context_p->mme_ue_s1ap_id);
+        }
       } else {
-        ue_context_p->time_mobile_reachability_timer_started = time(NULL);
         OAILOG_DEBUG_UE(
             LOG_MME_APP, ue_context_p->emm_context._imsi64,
-            "Started Mobile Reachability timer for UE id  " MME_UE_S1AP_ID_FMT
-            "\n",
+            "Mobile Reachability timer is already started for UE id:"
+            " " MME_UE_S1AP_ID_FMT "\n",
             ue_context_p->mme_ue_s1ap_id);
       }
     }
-    if (ue_context_p->ecm_state == ECM_CONNECTED) {
-      ue_context_p->ecm_state = ECM_IDLE;
-      // Update Stats
-      update_mme_app_stats_connected_ue_sub();
-      OAILOG_INFO_UE(
-          LOG_MME_APP, ue_context_p->emm_context._imsi64, "UE STATE - IDLE.\n");
-    }
+    ue_context_p->ecm_state = ECM_IDLE;
+    // Update Stats
+    update_mme_app_stats_connected_ue_sub();
+    OAILOG_INFO_UE(
+        LOG_MME_APP, ue_context_p->emm_context._imsi64, "UE STATE - IDLE.\n");
 
   } else if (
       (ue_context_p->ecm_state == ECM_IDLE) &&
@@ -1535,6 +1544,12 @@ void mme_ue_context_update_ue_sig_connection_state(
     OAILOG_INFO_UE(
         LOG_MME_APP, ue_context_p->emm_context._imsi64,
         "UE STATE - CONNECTED.\n");
+  } else {
+    OAILOG_INFO_UE(
+        LOG_MME_APP, ue_context_p->emm_context._imsi64,
+        "Old UE ECM State (%s) is same as the new UE ECM state (%s)\n",
+        (ue_context_p->ecm_state == ECM_CONNECTED ? "CONNECTED" : "IDLE"),
+        (new_ecm_state == ECM_CONNECTED ? "CONNECTED" : "IDLE"));
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }


### PR DESCRIPTION
### Title

[Bug_Fix] [MME_app] [Mobile_Reachability_Timer] Fixed MME crash due to Mobile Reachability Timer expiry during sanity

### Summary

The MME crash was observed while handling the expiry of mobile reachability timer as part of Sanity testing. The reason for the crash is observed as one of the dangling Mobile Reachability timer which is created but without stopping it, the timer id is overwritten with new timer. So, by the time this dangling timer is expired, the UE context was already cleared and MME crashes while accessing it. This PR fixes the issue.

From the list of test cases in Sanity suite, a set of following 7 test cases were found causing creation of this unnecessary timer:
s1aptests/test_enb_partial_reset.py
s1aptests/test_enb_complete_reset.py
s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py
s1aptests/test_outoforder_attach_complete_ICSR.py
s1aptests/test_sctp_shutdown_after_multi_ue_attach.py
s1aptests/test_multi_enb_partial_reset.py
s1aptests/test_multi_enb_complete_reset.py

Note: This PR is the signed-off version of PR #2018 and hence after pulling this PR changes, PR #2018 can be closed. The new PR is raised because we were facing issue in signing off previous PR.

### Test Plan

Verified with Sanity testing

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>