### PR TITLE
[agw] [mme] Make GCC diagnostic macros clang compliant

### DIFF
--- a/lte/gateway/c/oai/common/gcc_diag.h
+++ b/lte/gateway/c/oai/common/gcc_diag.h
@@ -32,20 +32,18 @@
 #define FILE_GCC_DIAG_SEEN
 
 #if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 402
-#define OAI_GCC_DIAG_STR(s) #s
-#define OAI_GCC_DIAG_JOINSTR(x, y) OAI_GCC_DIAG_STR(x##y)
 #define OAI_GCC_DIAG_DO_PRAGMA(x) _Pragma(#x)
 #define OAI_GCC_DIAG_PRAGMA(x) OAI_GCC_DIAG_DO_PRAGMA(GCC diagnostic x)
 #if ((__GNUC__ * 100) + __GNUC_MINOR__) >= 406
 #define OAI_GCC_DIAG_OFF(x)                                                    \
   OAI_GCC_DIAG_PRAGMA(push)                                                    \
-  OAI_GCC_DIAG_PRAGMA(ignored OAI_GCC_DIAG_JOINSTR(-W, x))
+  OAI_GCC_DIAG_PRAGMA(ignored x)
 #define OAI_GCC_DIAG_ON(x) OAI_GCC_DIAG_PRAGMA(pop)
 #else
 #define OAI_GCC_DIAG_OFF(x)                                                    \
-  OAI_GCC_DIAG_PRAGMA(ignored OAI_GCC_DIAG_JOINSTR(-W, x))
+  OAI_GCC_DIAG_PRAGMA(ignored x)
 #define OAI_GCC_DIAG_ON(x)                                                     \
-  OAI_GCC_DIAG_PRAGMA(warning OAI_GCC_DIAG_JOINSTR(-W, x))
+  OAI_GCC_DIAG_PRAGMA(warning x)
 #endif
 #else
 #define OAI_GCC_DIAG_OFF(x)

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -439,12 +439,10 @@ const char* const get_short_file_name(const char* const source_file_nameP);
                  n*LOG_MESSAGE_ADD() (n=0..N) */
 #define OAILOG_STREAM_HEX(lOgLeVeL, pRoTo, mEsSaGe, sTrEaM, sIzE)              \
   do {                                                                         \
-    /* clang-format off */ \
-                                                                   OAI_GCC_DIAG_OFF(pointer-sign);                                                   \
-    /* clang-format on */                                                      \
+    OAI_GCC_DIAG_OFF("-Wpointer-sign");                                        \
     log_stream_hex(                                                            \
         lOgLeVeL, pRoTo, __FILE__, __LINE__, mEsSaGe, sTrEaM, sIzE);           \
-    OAI_GCC_DIAG_ON(pointer - sign);                                           \
+    OAI_GCC_DIAG_ON("-Wpointer-sign");                                         \
   } while (0); /*!< \brief trace buffer content */
 #if DEBUG_IS_ON
 #define OAILOG_DEBUG(pRoTo, ...)                                               \

--- a/lte/gateway/c/oai/lib/gtpv2-c/nwgtpv2c-0.11/src/NwGtpv2c.c
+++ b/lte/gateway/c/oai/lib/gtpv2-c/nwgtpv2c-0.11/src/NwGtpv2c.c
@@ -1610,17 +1610,17 @@ nw_rc_t nwGtpv2cInitialize(
   memset(thiz, 0, sizeof(nw_gtpv2c_stack_t));
 
   if (thiz) {
-    OAI_GCC_DIAG_OFF(pointer - to - int - cast);
+    OAI_GCC_DIAG_OFF("-Wpointer-to-int-cast");
     thiz->id     = (uint32_t) thiz;
     thiz->seqNum = ((uint32_t) thiz) & 0x0000FFFF;
-    OAI_GCC_DIAG_ON(pointer - to - int - cast);
+    OAI_GCC_DIAG_ON("-Wpointer-to-int-cast");
     RB_INIT(&(thiz->tunnelMap));
     RB_INIT(&(thiz->outstandingTxSeqNumMap));
     RB_INIT(&(thiz->outstandingRxSeqNumMap));
     RB_INIT(&(thiz->activeTimerList));
-    OAI_GCC_DIAG_OFF(pointer - to - int - cast);
+    OAI_GCC_DIAG_OFF("-Wpointer-to-int-cast");
     thiz->hTmrMinHeap = (NwPtrT) nwGtpv2cTmrMinHeapNew(10000);
-    OAI_GCC_DIAG_ON(pointer - to - int - cast);
+    OAI_GCC_DIAG_ON("-Wpointer-to-int-cast");
     NW_GTPV2C_INIT_MSG_IE_PARSE_INFO(thiz, NW_GTP_ECHO_RSP);
 
     // For S11 interface
@@ -1793,11 +1793,11 @@ nw_rc_t nwGtpv2cFinalize(NW_IN nw_gtpv2c_stack_handle_t hGtpcStackHandle) {
       ((nw_gtpv2c_stack_t*) hGtpcStackHandle)
           ->pGtpv2cMsgIeParseInfo[NW_GTP_IDENTIFICATION_RSP]);
 
-  OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+  OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
   nwGtpv2cTmrMinHeapDelete(
       (NwGtpv2cTmrMinHeapT*) ((nw_gtpv2c_stack_t*) hGtpcStackHandle)
           ->hTmrMinHeap);
-  OAI_GCC_DIAG_ON(int - to - pointer - cast);
+  OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
   free_wrapper((void**) &hGtpcStackHandle);
   return NW_OK;
 }
@@ -2180,11 +2180,11 @@ nw_rc_t nwGtpv2cProcessTimeout(void* arg) {
 
   if (thiz->activeTimerInfo == timeoutInfo) {
     thiz->activeTimerInfo = NULL;
-    OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+    OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
     rc = nwGtpv2cTmrMinHeapRemove(
         (NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap,
         timeoutInfo->timerMinHeapIndex);
-    OAI_GCC_DIAG_ON(int - to - pointer - cast);
+    OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
     timeoutInfo->next       = gpGtpv2cTimeoutInfoPool;
     gpGtpv2cTimeoutInfoPool = timeoutInfo;
     rc = ((timeoutInfo)->timeoutCallbackFunc)(timeoutInfo->timeoutArg);
@@ -2198,34 +2198,34 @@ nw_rc_t nwGtpv2cProcessTimeout(void* arg) {
   }
 
   NW_ASSERT(gettimeofday(&tv, NULL) == 0);
-  OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+  OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
   timeoutInfo =
       nwGtpv2cTmrMinHeapPeek((NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap);
-  OAI_GCC_DIAG_ON(int - to - pointer - cast);
+  OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
 
   while ((timeoutInfo) != NULL) {
     if (NW_GTPV2C_TIMER_CMP_P(&timeoutInfo->tvTimeout, &tv, >)) break;
 
-    OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+    OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
     rc = nwGtpv2cTmrMinHeapRemove(
         (NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap,
         timeoutInfo->timerMinHeapIndex);
-    OAI_GCC_DIAG_ON(int - to - pointer - cast);
+    OAI_GCC_DIAG_ON(int-to-pointer-cast);
     timeoutInfo->next       = gpGtpv2cTimeoutInfoPool;
     gpGtpv2cTimeoutInfoPool = timeoutInfo;
     rc = ((timeoutInfo)->timeoutCallbackFunc)(timeoutInfo->timeoutArg);
-    OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+    OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
     timeoutInfo =
         nwGtpv2cTmrMinHeapPeek((NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap);
-    OAI_GCC_DIAG_ON(int - to - pointer - cast);
+    OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
   }
 
   // activeTimerInfo may be reset by the timeoutCallbackFunc call above
   if (thiz->activeTimerInfo == NULL) {
-    OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+    OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
     timeoutInfo =
         nwGtpv2cTmrMinHeapPeek((NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap);
-    OAI_GCC_DIAG_ON(int - to - pointer - cast);
+    OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
 
     if (timeoutInfo) {
       NW_GTPV2C_TIMER_SUB(&timeoutInfo->tvTimeout, &tv, &tv);
@@ -2273,10 +2273,10 @@ nw_rc_t nwGtpv2cStartTimer(
     timeoutInfo->tvTimeout.tv_sec  = timeoutSec;
     timeoutInfo->tvTimeout.tv_usec = timeoutUsec;
     NW_GTPV2C_TIMER_ADD(&tv, &timeoutInfo->tvTimeout, &timeoutInfo->tvTimeout);
-    OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+    OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
     rc = nwGtpv2cTmrMinHeapInsert(
         (NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap, timeoutInfo);
-    OAI_GCC_DIAG_ON(int - to - pointer - cast);
+    OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
 #if 0
 
       do {
@@ -2422,10 +2422,10 @@ nw_rc_t nwGtpv2cStopTimer(
   NW_ASSERT(thiz != NULL);
   OAILOG_FUNC_IN(LOG_GTPV2C);
   timeoutInfo = (nw_gtpv2c_timeout_info_t*) hTimer;
-  OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+  OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
   rc = nwGtpv2cTmrMinHeapRemove(
       (NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap, timeoutInfo->timerMinHeapIndex);
-  OAI_GCC_DIAG_ON(int - to - pointer - cast);
+  OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
   timeoutInfo->next       = gpGtpv2cTimeoutInfoPool;
   gpGtpv2cTimeoutInfoPool = timeoutInfo;
   //    OAILOG_DEBUG (LOG_GTPV2C, "Stopping active timer 0x%" PRIxPTR " for info
@@ -2447,10 +2447,10 @@ nw_rc_t nwGtpv2cStopTimer(
       OAILOG_INFO(
           LOG_GTPV2C, "Stopped active timer 0x%" PRIxPTR " for info 0x%p!\n",
           timeoutInfo->hTimer, timeoutInfo);
-    OAI_GCC_DIAG_OFF(int - to - pointer - cast);
+    OAI_GCC_DIAG_OFF("-Wint-to-pointer-cast");
     timeoutInfo =
         nwGtpv2cTmrMinHeapPeek((NwGtpv2cTmrMinHeapT*) thiz->hTmrMinHeap);
-    OAI_GCC_DIAG_ON(int - to - pointer - cast);
+    OAI_GCC_DIAG_ON("-Wint-to-pointer-cast");
 
     if (timeoutInfo) {
       NW_ASSERT(gettimeofday(&tv, NULL) == 0);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_detach.c
@@ -84,12 +84,10 @@ void mme_app_send_delete_session_request(
       ue_context_p->pdn_contexts[cid]->s_gw_address_s11_s4.address.ipv4_address;
   S11_DELETE_SESSION_REQUEST(message_p).edns_peer_ip.addr_v4.sin_family =
       AF_INET;
-  /* clang-format off */
-  OAI_GCC_DIAG_OFF(pointer-to-int-cast);
-  /* clang-format on */
+  OAI_GCC_DIAG_OFF("-Wpointer-to-int-cast");
   S11_DELETE_SESSION_REQUEST(message_p).sender_fteid_for_cp.teid =
       (teid_t) ue_context_p;
-  OAI_GCC_DIAG_ON(pointer - to - int - cast);
+  OAI_GCC_DIAG_ON("-Wpointer-to-int-cast");
   S11_DELETE_SESSION_REQUEST(message_p).sender_fteid_for_cp.interface_type =
       S11_MME_GTP_C;
   mme_config_read_lock(&mme_config);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -272,11 +272,9 @@ int mme_app_send_s11_create_session_req(
    * Use the address of ue_context as unique TEID: Need to find better here
    * and will generate unique id only for 32 bits platforms.
    */
-  /* clang-format off */
-  OAI_GCC_DIAG_OFF(pointer-to-int-cast);
-  /* clang-format on */
+  OAI_GCC_DIAG_OFF("-Wpointer-to-int-cast");
   session_request_p->sender_fteid_for_cp.teid = (teid_t) ue_mm_context;
-  OAI_GCC_DIAG_ON(pointer - to - int - cast);
+  OAI_GCC_DIAG_ON("-Wpointer-to-int-cast");
   session_request_p->sender_fteid_for_cp.interface_type = S11_MME_GTP_C;
   mme_config_read_lock(&mme_config);
   session_request_p->sender_fteid_for_cp.ipv4_address.s_addr =


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

This change modifies the OAI_GCC_DIAG_OFF and OAI_GCC_DIAG_ON macros to accept string argument and makes it clang friendly. 

## Test Plan

For agw_of: S1AP integration tests
For mme: In dev VM, `make FEATURES=mme run` succeeds, integration testing will be done in CI

