### PR TITLE
[magma][testcontroller] Updated testcontroller to enable dynamic start states

### DIFF
--- a/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/handlers/testcontroller_handlers_test.go
@@ -346,6 +346,7 @@ func defaultEnodebdTestConfig() *models.EnodebdTestConfig {
 			TransmitEnabled:        swag.Bool(true),
 		},
 		SubscriberID: swag.String("IMSI1234567890"),
+		StartState: "check_for_upgrade",
 	}
 }
 
@@ -374,6 +375,7 @@ func enodebdNoTrafficTestConfig() *models.EnodebdTestConfig {
 			TransmitEnabled:        swag.Bool(true),
 		},
 		SubscriberID: swag.String("IMSI1234567890"),
+		StartState: "check_for_upgrade",
 	}
 }
 

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/models/enodebd_test_config_swaggergen.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/models/enodebd_test_config_swaggergen.go
@@ -48,6 +48,10 @@ type EnodebdTestConfig struct {
 	// Min Length: 1
 	SsidPw string `json:"ssid_pw,omitempty"`
 
+	// Specify which testcontroller state to begin on
+	// Min Length: 1
+	StartState string `json:"start_state,omitempty"`
+
 	// SubscriberID that will be used to fetch subscriber state
 	// Required: true
 	// Min Length: 1
@@ -88,6 +92,10 @@ func (m *EnodebdTestConfig) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateSsidPw(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStartState(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -196,6 +204,19 @@ func (m *EnodebdTestConfig) validateSsidPw(formats strfmt.Registry) error {
 	}
 
 	if err := validate.MinLength("ssid_pw", "body", string(m.SsidPw), 1); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *EnodebdTestConfig) validateStartState(formats strfmt.Registry) error {
+
+	if swag.IsZero(m.StartState) { // not required
+		return nil
+	}
+
+	if err := validate.MinLength("start_state", "body", string(m.StartState), 1); err != nil {
 		return err
 	}
 

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/models/swagger.v1.yml
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/models/swagger.v1.yml
@@ -415,6 +415,11 @@ definitions:
         description: SubscriberID that will be used to fetch subscriber state
         type: string
         minLength: 1
+      start_state:
+        description: Specify which testcontroller state to begin on
+        type: string
+        minLength: 1
+        example: "check_for_upgrade"
       # TODO: more params (params to flip between)
 
   agw_test_config:

--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd.go
@@ -339,8 +339,24 @@ States with traffic tests enabled:
 		> "Check for upgrade" pings slack, 1 minute
 */
 
-func startNewTest(*enodebdE2ETestStateMachine, *models.EnodebdTestConfig) (string, time.Duration, error) {
-	return checkForUpgradeState, time.Minute, nil
+func startNewTest(machine *enodebdE2ETestStateMachine, config *models.EnodebdTestConfig) (string, time.Duration, error) {
+	states := []string{
+		checkForUpgradeState,
+		rebootEnodeb1State,
+		reconfigEnodebState1,
+		restoreEnodebConfigState1,
+		subscriberInactiveState,
+		subscriberActiveState,
+	}
+	if config.StartState != "" {
+		if !find(states, config.StartState) {
+			// Invalid state, default to check_for_upgrade
+			return checkForUpgradeState, time.Minute, errors.Errorf("Invalid starting state. Defaulting to check_for_upgrade")
+		}
+	} else {
+		return checkForUpgradeState, time.Minute, nil
+	}
+	return config.StartState, time.Minute, nil
 }
 
 func makeSubscriberStateHandler(desiredState string, successState string) handlerFunc {
@@ -611,6 +627,14 @@ func verifyUpgrade(stateNumber int, successState string, machine *enodebdE2ETest
 }
 
 // State handler helpers
+func find(slice []string, val string) bool {
+    for _, item := range slice {
+        if item == val {
+            return true
+        }
+    }
+    return false
+}
 
 func getLatestRepoMagmaVersion(client HttpClient, url string, releaseChannel string) (string, error) {
 	url = fmt.Sprintf("%s/dists/%s/main/binary-amd64/Packages", url, releaseChannel)


### PR DESCRIPTION
Signed-off-by: Joey Jiemjitpolchai <joeyjiem@fb.com>

## Summary
Updated testcontroller to take in a start state. Makes troubleshooting a failed state easier since we can now just jump to that failing state.

## Test Plan
All unit tests successfully run and pass