### PR TITLE
[lte][agw][mobilityd] Forcefully update the ipblock from config.

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -112,7 +112,6 @@ s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
-s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -64,6 +64,10 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         ip_block = _get_ip_block(mconfig.ip_block)
         if ip_block is not None:
             try:
+                #forcefully remove the existing ip blocks
+                self._ipv4_allocator.remove_ip_blocks(
+                    *self._ipv4_allocator.list_added_ip_blocks(),
+                    force=True)
                 self.add_ip_block(ip_block)
             except OverlappedIPBlocksError:
                 logging.error("Overlapped IP block: %s", ip_block)


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

- When IP block was set for the AGW via orchestrator, it was not treated as authoritative state when state was persisted to Redis; rather it was added as a new IP block.
- Removed a stateless test case from sanity as the test case ignores that subnet allocation is a config state.

## Test Plan

make integ_test.

Use swagger api in orc8r to set ip block.
