### PR TITLE
[NMS] Add gateway upgrade component changes

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/components/context/GatewayTierContext.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/context/GatewayTierContext.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {gateway_id, tier, tier_id} from '@fbcnms/magma-api';
+
+import React from 'react';
+
+export type GatewayTierContextType = {
+  tiers: {[string]: tier},
+  supportedVersions: Array<string>,
+  updateTier: (key: string, val: tier) => Promise<void>,
+  removeTier: (key: string) => Promise<void>,
+  updateGatewayTier: (gatewayId: gateway_id, tierId: tier_id) => Promise<void>,
+};
+
+export default React.createContext<GatewayTierContextType>({});

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGateway.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGateway.js
@@ -19,13 +19,21 @@ import ActionTable from '../../components/ActionTable';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import EquipmentGatewayKPIs from './EquipmentGatewayKPIs';
 import GatewayCheckinChart from './GatewayCheckinChart';
+import GatewayTierContext from '../../components/context/GatewayTierContext';
 import Grid from '@material-ui/core/Grid';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
 import Paper from '@material-ui/core/Paper';
 import React, {useState} from 'react';
+import Text from '../../theme/design-system/Text';
+import TypedSelect from '@fbcnms/ui/components/TypedSelect';
 import isGatewayHealthy from '../../components/GatewayUtils';
+import {SelectEditComponent} from '../../components/ActionTable';
 
+import {CardTitleFilterRow} from '../../components/layout/CardTitleRow';
 import {colors} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
@@ -68,6 +76,9 @@ const useStyles = makeStyles(theme => ({
     margin: theme.spacing(1),
     minWidth: 120,
   },
+  viewLabelText: {
+    color: colors.primary.comet,
+  },
 }));
 
 export default function Gateway({
@@ -105,12 +116,32 @@ type EquipmentGatewayRowType = {
   checkInTime: Date,
 };
 
+type EquipmentGatewayUpgradeType = {
+  name: string,
+  id: gateway_id,
+  hardwareId: string,
+  tier: string,
+  currentVersion: string,
+};
+
+const ViewTypes = {
+  STATUS: 'Status',
+  UPGRADE: 'Upgrade',
+};
+
 function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
+  const classes = useStyles();
+  const ctx = useContext(GatewayTierContext);
   const {history, relativeUrl} = useRouter();
   const [currRow, setCurrRow] = useState<EquipmentGatewayRowType>({});
-  const lteGatewayRows: Array<EquipmentGatewayRowType> = Object.keys(
-    lteGateways,
-  )
+  const [currentView, setCurrentView] = useState<$Keys<typeof ViewTypes>>(
+    'STATUS',
+  );
+  const lteGatewayRows: Array<EquipmentGatewayRowType> = [];
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  const lteGatewayRowSt: Array<EquipmentGatewayUpgradeType> = [];
+  Object.keys(lteGateways)
     .map((gwId: string) => lteGateways[gwId])
     .filter((g: lte_gateway) => g.cellular && g.id)
     .map((gateway: lte_gateway) => {
@@ -127,52 +158,140 @@ function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
       ) {
         checkInTime = new Date(gateway.status.checkin_time);
       }
-
-      return {
+      const packages = gateway.status?.platform_info?.packages || [];
+      lteGatewayRows.push({
         name: gateway.name,
         id: gateway.id,
         num_enodeb: numEnodeBs,
         num_subscribers: 0,
         health: isGatewayHealthy(gateway) ? 'Good' : 'Bad',
         checkInTime: checkInTime,
-      };
+      });
+
+      lteGatewayRowSt.push({
+        name: gateway.name,
+        id: gateway.id,
+        hardwareId: gateway.device.hardware_id,
+        tier: gateway.tier,
+        currentVersion:
+          packages.find(p => p.name === 'magma')?.version || 'Not Reported',
+      });
     });
+  const [lteGatewayUpgradeRows, setLteGatewayUpgradeRows] = useState(
+    lteGatewayRowSt,
+  );
 
   return (
-    <ActionTable
-      titleIcon={CellWifiIcon}
-      title={'Gateways'}
-      data={lteGatewayRows}
-      columns={[
-        {title: 'Name', field: 'name'},
-        {title: 'ID', field: 'id'},
-        {title: 'enodeBs', field: 'num_enodeb', type: 'numeric'},
-        {title: 'Subscribers', field: 'num_subscribers', type: 'numeric'},
-        {title: 'Health', field: 'health'},
-        {title: 'Check In Time', field: 'checkInTime', type: 'datetime'},
-      ]}
-      handleCurrRow={(row: EquipmentGatewayRowType) => setCurrRow(row)}
-      menuItems={[
-        {
-          name: 'View',
-          handleFunc: () => {
-            history.push(relativeUrl('/' + currRow.id));
-          },
-        },
-        {
-          name: 'Edit',
-          handleFunc: () => {
-            history.push(relativeUrl('/' + currRow.id + '/config'));
-          },
-        },
-        {name: 'Remove'},
-        {name: 'Deactivate'},
-        {name: 'Reboot'},
-      ]}
-      options={{
-        actionsColumnIndex: -1,
-        pageSizeOptions: [5, 10],
-      }}
-    />
+    <>
+      <CardTitleFilterRow
+        key="title"
+        icon={CellWifiIcon}
+        label={'Gateways(' + lteGatewayRows.length + ')'}
+        filter={() => (
+          <Grid container justify="flex-end" alignItems="center" spacing={1}>
+            <Grid item>
+              <Text variant="body3" className={classes.viewLabelText}>
+                View
+              </Text>
+            </Grid>
+            <Grid item>
+              <TypedSelect
+                input={<OutlinedInput />}
+                value={currentView}
+                items={{
+                  STATUS: 'Status',
+                  UPGRADE: 'Upgrade',
+                }}
+                onChange={setCurrentView}
+              />
+            </Grid>
+          </Grid>
+        )}
+      />
+      {currentView === 'UPGRADE' ? (
+        <ActionTable
+          data={lteGatewayUpgradeRows}
+          columns={[
+            {title: 'Name', field: 'name', editable: 'never'},
+            {title: 'ID', field: 'id', editable: 'never'},
+            {title: 'Hardware ID', field: 'hardwareId', editable: 'never'},
+            {
+              title: 'Current Version',
+              field: 'currentVersion',
+              editable: 'never',
+            },
+            {
+              title: 'Tier',
+              field: 'tier',
+              editComponent: props => (
+                <SelectEditComponent
+                  {...props}
+                  defaultValue={props.value}
+                  value={props.value}
+                  content={Object.keys(ctx.tiers)}
+                  onChange={value => props.onChange(value)}
+                />
+              ),
+            },
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [5, 10],
+          }}
+          editable={{
+            onRowUpdate: (newData, oldData) =>
+              new Promise((resolve, reject) => {
+                try {
+                  ctx.updateGatewayTier(newData.id, newData.tier);
+                  const dataUpdate = [...lteGatewayUpgradeRows];
+                  const index = oldData.tableData.id;
+                  dataUpdate[index] = newData;
+                  setLteGatewayUpgradeRows([...dataUpdate]);
+                  resolve();
+                } catch (e) {
+                  enqueueSnackbar('failed saving gateway tier information', {
+                    variant: 'error',
+                  });
+                  reject();
+                }
+              }),
+          }}
+        />
+      ) : (
+        <ActionTable
+          data={lteGatewayRows}
+          columns={[
+            {title: 'Name', field: 'name'},
+            {title: 'ID', field: 'id'},
+            {title: 'enodeBs', field: 'num_enodeb', type: 'numeric'},
+            {title: 'Subscribers', field: 'num_subscribers', type: 'numeric'},
+            {title: 'Health', field: 'health'},
+            {title: 'Check In Time', field: 'checkInTime', type: 'datetime'},
+          ]}
+          handleCurrRow={(row: EquipmentGatewayRowType) => setCurrRow(row)}
+          menuItems={[
+            {
+              name: 'View',
+              handleFunc: () => {
+                history.push(relativeUrl('/' + currRow.id));
+              },
+            },
+            {
+              name: 'Edit',
+              handleFunc: () => {
+                history.push(relativeUrl('/' + currRow.id + '/config'));
+              },
+            },
+            {name: 'Remove'},
+            {name: 'Deactivate'},
+            {name: 'Reboot'},
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [5, 10],
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/UpgradeTiersDialog.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/UpgradeTiersDialog.js
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import ActionTable from '../../components/ActionTable';
+import Button from '@material-ui/core/Button';
+import Collapse from '@material-ui/core/Collapse';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '../../theme/design-system/DialogTitle';
+import Divider from '@material-ui/core/Divider';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import FormLabel from '@material-ui/core/FormLabel';
+import GatewayTierContext from '../../components/context/GatewayTierContext';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import Paper from '@material-ui/core/Paper';
+import React from 'react';
+import Tab from '@material-ui/core/Tab';
+import Tabs from '@material-ui/core/Tabs';
+import Text from '@fbcnms/ui/components/design-system/Text';
+
+import {SelectEditComponent} from '../../components/ActionTable';
+import {colors, typography} from '../../theme/default';
+import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(3),
+    flexGrow: 1,
+  },
+  topBar: {
+    backgroundColor: colors.primary.mirage,
+    padding: '20px 40px 20px 40px',
+    color: colors.primary.white,
+  },
+  tabBar: {
+    backgroundColor: colors.primary.brightGray,
+    color: colors.primary.white,
+  },
+  tabs: {
+    color: colors.primary.white,
+  },
+  tab: {
+    fontSize: '18px',
+    textTransform: 'none',
+  },
+  tabLabel: {
+    padding: '16px 0 16px 0',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  tabIconLabel: {
+    marginRight: '8px',
+  },
+  appBarBtn: {
+    color: colors.primary.white,
+    background: colors.primary.comet,
+    fontFamily: typography.button.fontFamily,
+    fontWeight: typography.button.fontWeight,
+    fontSize: typography.button.fontSize,
+    lineHeight: typography.button.lineHeight,
+    letterSpacing: typography.button.letterSpacing,
+
+    '&:hover': {
+      background: colors.primary.mirage,
+    },
+  },
+  appBarBtnSecondary: {
+    color: colors.primary.white,
+  },
+  input: {
+    display: 'inline-flex',
+    margin: '5px 0',
+    width: '50%',
+    fullWidth: true,
+  },
+}));
+
+export default function UpgradeButton() {
+  const classes = useStyles();
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <UpgradeDialog open={open} onClose={() => setOpen(false)} />
+      <Button
+        variant="text"
+        onClick={() => setOpen(true)}
+        className={classes.appBarBtnSecondary}>
+        {'Upgrade'}
+      </Button>
+    </>
+  );
+}
+
+type DialogProps = {
+  open: boolean,
+  onClose: () => void,
+};
+
+function UpgradeDialog(props: DialogProps) {
+  const classes = useStyles();
+  const [tabPos, setTabPos] = useState(0);
+
+  return (
+    <Dialog
+      data-testid="editDialog"
+      open={props.open}
+      fullWidth={true}
+      maxWidth="lg">
+      <DialogTitle label={'Upgrade Tiers'} onClose={props.onClose} />
+      <Tabs
+        value={tabPos}
+        onChange={(_, v) => setTabPos(v)}
+        indicatorColor="primary"
+        className={classes.tabBar}>
+        <Tab key="upgradeTiers" label={'Tiers'} />; ;
+        <Tab key="supportedVersions" label={'Supported Versions'} />
+      </Tabs>
+      {tabPos === 0 && <UpgradeDetails {...props} />}
+      {tabPos === 1 && <SupportedVersions {...props} />}
+    </Dialog>
+  );
+}
+
+function UpgradeDetails(props: DialogProps) {
+  const ctx = useContext(GatewayTierContext);
+  const [error, setError] = useState('');
+  const [updatedTierEntries, setUpdatedTierEntries] = useState(new Set());
+  const [removedTierEntries, setRemovedTierEntries] = useState(new Set());
+  const [tierEntries, setTierEntries] = useState(
+    Object.keys(ctx.tiers).map(tierId => ({
+      id: tierId,
+      name: ctx.tiers[tierId].name,
+      version: ctx.tiers[tierId].version,
+    })),
+  );
+  const saveTier = async () => {
+    for (const tier of tierEntries) {
+      if (!updatedTierEntries.has(tier.id)) {
+        continue;
+      }
+      try {
+        await ctx.updateTier(tier.id, {
+          ...(ctx.tiers[tier.id] ?? {gateways: [], images: []}),
+          ...tier,
+        });
+      } catch (e) {
+        const errMsg = e.response?.data?.message ?? e.message ?? e;
+        setError('error saving ' + tier.id + ' : ' + errMsg);
+        return;
+      }
+    }
+
+    for (const tierId of removedTierEntries) {
+      try {
+        await ctx.removeTier(tierId);
+      } catch (e) {
+        const errMsg = e.response?.data?.message ?? e.message ?? e;
+        setError('error removing ' + tierId + ' : ' + errMsg);
+        return;
+      }
+    }
+    props.onClose();
+  };
+
+  return (
+    <>
+      <DialogContent>
+        {error !== '' && <FormLabel error>{error}</FormLabel>}
+
+        <ActionTable
+          data={tierEntries}
+          columns={[
+            {
+              title: 'Tier ID',
+              field: 'id',
+              editable: 'onAdd',
+              editComponent: props => (
+                <OutlinedInput
+                  variant="outlined"
+                  type="text"
+                  value={props.value}
+                  onChange={e => props.onChange(e.target.value)}
+                />
+              ),
+            },
+            {
+              title: 'Tier Name',
+              field: 'name',
+              editComponent: props => (
+                <OutlinedInput
+                  variant="outlined"
+                  type="text"
+                  value={props.value}
+                  onChange={e => props.onChange(e.target.value)}
+                />
+              ),
+            },
+            {
+              title: 'Software Version',
+              field: 'version',
+              editComponent: props => (
+                <SelectEditComponent
+                  {...props}
+                  defaultValue={props.value}
+                  value={props.value}
+                  content={ctx.supportedVersions}
+                  onChange={value => props.onChange(value)}
+                />
+              ),
+            },
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [10, 15],
+          }}
+          editable={{
+            onRowAdd: newData =>
+              new Promise((resolve, _) => {
+                setTierEntries([...tierEntries, newData]);
+                setUpdatedTierEntries(
+                  new Set([...updatedTierEntries, newData.id]),
+                );
+                resolve();
+              }),
+            onRowUpdate: (newData, oldData) =>
+              new Promise((resolve, _) => {
+                const dataUpdate = [...tierEntries];
+                const index = oldData.tableData.id;
+                dataUpdate[index] = newData;
+                setTierEntries([...dataUpdate]);
+                setUpdatedTierEntries(
+                  new Set([...updatedTierEntries, newData.id]),
+                );
+                resolve();
+              }),
+            onRowDelete: oldData =>
+              new Promise(resolve => {
+                const dataDelete = [...tierEntries];
+                const index = oldData.tableData.id;
+                dataDelete.splice(index, 1);
+                setTierEntries([...dataDelete]);
+                setRemovedTierEntries(
+                  new Set([...removedTierEntries, oldData.id]),
+                );
+                resolve();
+              }),
+          }}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose}> Cancel </Button>
+        <Button onClick={saveTier}> Save </Button>
+      </DialogActions>
+    </>
+  );
+}
+
+function SupportedVersions() {
+  const [open, setOpen] = useState(false);
+  const ctx = useContext(GatewayTierContext);
+  const newVersions = ctx.supportedVersions.slice(0, 10);
+  const olderVersion = ctx.supportedVersions.slice(10);
+  return newVersions.length > 0 ? (
+    <DialogContent>
+      <List component={Paper}>
+        {newVersions.map((version, i) => (
+          <>
+            <ListItem key={version}>
+              {version}
+              {i === 0 && <b> (Newest Version)</b>}
+            </ListItem>
+            {i < newVersions.length - 1 && <Divider />}
+          </>
+        ))}
+      </List>
+      {olderVersion.length > 0 && (
+        <List component={Paper}>
+          <ListItem button onClick={() => setOpen(!open)}>
+            {open ? <ExpandLess /> : <ExpandMore />}
+            Older Versions
+          </ListItem>
+          <Collapse key="olderVersions" in={open} timeout="auto" unmountOnExit>
+            {olderVersion.map((version, i) => (
+              <>
+                <ListItem key={version}>{version}</ListItem>
+                {i < olderVersion.length - 1 && <Divider />}
+              </>
+            ))}
+          </Collapse>
+        </List>
+      )}
+    </DialogContent>
+  ) : (
+    <Text>no supported versions found</Text>
+  );
+}


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>

## Summary

Updated views to include gateway upgrade component. This PR contains following changes
- Added a switch view to display gateway upgrade status
- Added a editable upgrade tier table
- Added a supported versions list

## Test Plan
yarn test all succeeds
https://www.dropbox.com/s/h96ib9ep5hqtzit/upgrade_video.mov?dl=0

new -> 
![upgrade_change](https://user-images.githubusercontent.com/8224854/88962918-facfca00-d25b-11ea-83bd-ca4f330112f5.gif)
uutvriglbvihlhcr
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
