### PR TITLE
[cwf][radius] Add radius configuration with disabled analytics

### DIFF
--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -187,7 +187,7 @@ services:
     network_mode: host
     restart: always
     command: >
-      /bin/bash -c "envsubst < /etc/magma/templates/radius.conf.template > /var/opt/magma/tmp/radius.config.json &&
+      /bin/bash -c "envsubst < /etc/magma/templates/radius.analytics_disabled.conf.template > /var/opt/magma/tmp/radius.config.json &&
              envdir /var/opt/magma/envdir /var/opt/magma/bin/radius -config /var/opt/magma/tmp/radius.config.json"
 
   radiusd:

--- a/feg/gateway/docker/go/Dockerfile
+++ b/feg/gateway/docker/go/Dockerfile
@@ -127,6 +127,7 @@ ENV MAGMA_ROOT /magma
 COPY --from=builder /var/opt/magma/bin /var/opt/magma/bin
 COPY --from=builder $MAGMA_ROOT/feg/radius/src/radius /var/opt/magma/bin/radius
 COPY --from=builder $MAGMA_ROOT/feg/radius/src/config/samples/radius.cwf.config.json.template /etc/magma/templates/radius.conf.template
+COPY --from=builder $MAGMA_ROOT/feg/radius/src/config/samples/radius.cwf_analytics_disabled.config.json.template /etc/magma/templates/radius.analytics_disabled.conf.template
 
 # Copy the configs.
 COPY feg/gateway/configs /etc/magma

--- a/feg/radius/src/config/samples/radius.cwf_analytics_disabled.config.json.template
+++ b/feg/radius/src/config/samples/radius.cwf_analytics_disabled.config.json.template
@@ -1,0 +1,82 @@
+{
+    "monitoring": {
+        "census": {
+            "disable_stats": false,
+            "stat_views": ["proc"]
+        }
+    },
+    "server": {
+        "secret": "$RADIUS_SECRET",
+        "dedupWindow": "500ms",
+        "sessionStorage": {
+            "storageType": "$STORAGE_TYPE",
+            "redis": {
+              "addr": "$REDIS_ADDR"
+            }
+        },
+        "listeners": [
+            {
+                "name": "auth",
+                "type": "udp",
+                "extra": {
+                    "port": $RADIUS_AUTH_PORT
+                },
+                "modules": [
+                    {
+                        "name": "eap",
+                        "config": {
+                            "methods": [
+                                {
+                                    "name": "akamagma",
+                                    "config": {
+                                        "FegEndpoint": "$AAA_ENDPOINT"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "name": "acct",
+                "type": "udp",
+                "extra": {
+                    "port": $RADIUS_ACCT_PORT
+                },
+                "modules": [
+                    {
+                        "name": "adaptruckus",
+                        "config": {}
+                    },
+                    {
+                        "name": "coadynamic",
+                        "config": {
+                            "Port": 3799
+                        }
+                    },
+                    {
+                      "name": "magmaacct",
+                      "config": {
+                        "FegEndpoint": "$AAA_ENDPOINT"
+                      }
+                    }
+                ]
+            },
+            {
+                "name": "coa_grpc",
+                "type": "grpc",
+                "extra": {
+                    "port": $RADIUS_COA_GRPC_PORT
+                },
+                "modules": [
+                    {
+                        "name": "coadynamic",
+                        "config": {
+                            "Port": 3799
+                        }
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a configuration file for the radius server that disables analytics. For CWF, analytics are not used and may be causing issues exposed during scale testing. This PR duplicates the conf template as there are other products that use it.

## Test Plan

Ran radius on CWAG with `radius.conf.template` to ensure analytics still works and with `radius.analytics_disabled.conf.template` to ensure analytics are disabled. 
