### PR TITLE
[SessionD] Deprecate core session id

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -834,8 +834,7 @@ bool LocalEnforcer::init_session_credit(
     const std::string& session_id, const SessionConfig& cfg,
     const CreateSessionResponse& response) {
   auto session_state = std::make_unique<SessionState>(
-      imsi, session_id, response.session_id(), cfg, *rule_store_,
-      response.tgpp_ctx());
+      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx());
 
   std::unordered_set<uint32_t> charging_credits_received;
   for (const auto& credit : response.credits()) {

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1745,14 +1745,6 @@ void LocalEnforcer::create_bearer(
   return;
 }
 
-bool LocalEnforcer::session_with_imsi_exists(
-    SessionMap& session_map, const std::string& imsi) const {
-  if (session_map.find(imsi) != session_map.end()) {
-    return session_map[imsi].size() > 0;
-  }
-  return false;
-}
-
 bool LocalEnforcer::session_with_apn_exists(
     SessionMap& session_map, const std::string& imsi,
     const std::string& apn) const {
@@ -1763,52 +1755,6 @@ bool LocalEnforcer::session_with_apn_exists(
   for (const auto& session : it->second) {
     if (session->get_config().apn == apn) {
       return true;
-    }
-  }
-  return false;
-}
-
-bool LocalEnforcer::is_session_active(
-    SessionMap& session_map, const std::string& imsi,
-    const std::string& core_session_id) const {
-  auto it = session_map.find(imsi);
-  if (it == session_map.end()) {
-    return false;
-  }
-  for (const auto& session : it->second) {
-    if (session->get_core_session_id() == core_session_id) {
-      return session->is_active();
-    }
-  }
-  return false;
-}
-
-bool LocalEnforcer::get_core_sid_of_active_session(
-    SessionMap& session_map, const std::string& imsi,
-    std::string* core_session_id) const {
-  auto it = session_map.find(imsi);
-  if (it == session_map.end()) {
-    return false;
-  }
-  for (const auto& session : it->second) {
-    if (session->is_active()) {
-      *core_session_id = session->get_core_session_id();
-      return true;
-    }
-  }
-  return false;
-}
-
-bool LocalEnforcer::get_core_sid_of_session_with_same_config(
-    SessionMap& session_map, const std::string& imsi,
-    const SessionConfig& config, std::string* core_session_id) const {
-  auto it = session_map.find(imsi);
-  if (it != session_map.end()) {
-    for (const auto& session : it->second) {
-      if (session->is_same_config(config)) {
-        *core_session_id = session->get_core_session_id();
-        return true;
-      }
     }
   }
   return false;

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -184,24 +184,9 @@ class LocalEnforcer {
       SessionMap& session_map, PolicyReAuthRequest request,
       PolicyReAuthAnswer& answer_out, SessionUpdate& session_update);
 
-  bool session_with_imsi_exists(
-      SessionMap& session_map, const std::string& imsi) const;
-
   bool session_with_apn_exists(
       SessionMap& session_map, const std::string& imsi,
       const std::string& apn) const;
-
-  bool is_session_active(
-      SessionMap& session_map, const std::string& imsi,
-      const std::string& core_session_id) const;
-
-  bool get_core_sid_of_active_session(
-      SessionMap& session_map, const std::string& imsi,
-      std::string* core_session_id) const;
-
-  bool get_core_sid_of_session_with_same_config(
-      SessionMap& session_map, const std::string& imsi,
-      const magma::SessionConfig& config, std::string* core_session_id) const;
 
   /**
    * Set session config for the IMSI.

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -122,6 +122,44 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
       const std::string& imsi, const std::string& session_id);
 
   /**
+   * handle_create_session_cwf handles a sequence of actions needed for the
+   * RATType=WLAN case. It is responsible for responding to the original
+   * LocalCreateSession request
+   * @param session_map - SessionMap that contains all sessions with IMSI
+   * @param request - the original request coming in from AAA
+   * @param sid - newly created SessionID
+   * @param cfg - newly created SessionConfig from the LocalCreateSessionRequest
+   * @param cb - callback needed to respond to the original
+   * LocalCreateSessionRequest
+   *
+   * TODO once we migrate the proto messages to Common/RatSpecific bundled
+   * fields, we should be able to simplify the parameters a bit more.
+   */
+  void handle_create_session_cwf(
+      SessionMap& session_map, const LocalCreateSessionRequest& request,
+      const std::string& sid, SessionConfig cfg,
+      std::function<void(Status, LocalCreateSessionResponse)> cb);
+
+  /**
+   * handle_create_session_lte handles a sequence of actions needed for the
+   * RATType=LTE case. It is responsible for responding to the original
+   * LocalCreateSession request
+   * @param session_map - SessionMap that contains all sessions with IMSI
+   * @param request - the original request coming in from MMS
+   * @param sid - newly created SessionID
+   * @param cfg - newly created SessionConfig from the LocalCreateSessionRequest
+   * @param cb - callback needed to respond to the original
+   * LocalCreateSessionRequest
+   *
+   * TODO once we migrate the proto messages to Common/RatSpecific bundled
+   * fields, we should be able to simplify the parameters a bit more.
+   */
+  void handle_create_session_lte(
+      SessionMap& session_map, const LocalCreateSessionRequest& request,
+      const std::string& sid, SessionConfig cfg,
+      std::function<void(Status, LocalCreateSessionResponse)> cb);
+
+  /**
    * Send session creation request to the CentralSessionController.
    * If it is successful, create a session in session_map, and respond to
    * gRPC caller.
@@ -137,13 +175,6 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
 
   SessionConfig build_session_config(const LocalCreateSessionRequest& request);
 
-  void recycle_session(
-      SessionMap& session_map, const LocalCreateSessionRequest& request,
-      const std::string& imsi, const std::string& sid,
-      const std::string& core_sid, SessionConfig cfg, const bool is_wifi,
-      std::function<void(Status, LocalCreateSessionResponse)>
-          response_callback);
-
   /**
    * Get the most recently written state of sessions for Creation
    * Does not get any other sessions.
@@ -151,8 +182,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
    * NOTE: Call only from the main EventBase thread, otherwise there will
    *       be undefined behavior.
    */
-  SessionMap get_sessions_for_creation(
-      const LocalCreateSessionRequest& request);
+  SessionMap get_sessions_for_creation(const std::string& imsi);
 
   /**
    * Get the most recently written state of sessions for reporting usage.
@@ -178,6 +208,11 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   void report_session_update_event_failure(
       SessionMap& session_map, SessionUpdate& session_update,
       const std::string& failure_reason);
+
+  void send_local_create_session_response(
+      Status status, const std::string& sid,
+      std::function<void(Status, LocalCreateSessionResponse)>
+          response_callback);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -40,7 +40,6 @@ StoredSessionState SessionState::marshal() {
   marshaled.config                 = config_;
   marshaled.imsi                   = imsi_;
   marshaled.session_id             = session_id_;
-  marshaled.core_session_id        = core_session_id_;
   marshaled.subscriber_quota_state = subscriber_quota_state_;
   marshaled.tgpp_context           = tgpp_context_;
   marshaled.request_number         = request_number_;
@@ -97,7 +96,6 @@ SessionState::SessionState(
     const StoredSessionState& marshaled, StaticRuleStore& rule_store)
     : imsi_(marshaled.imsi),
       session_id_(marshaled.session_id),
-      core_session_id_(marshaled.core_session_id),
       request_number_(marshaled.request_number),
       curr_state_(marshaled.fsm_state),
       config_(marshaled.config),
@@ -145,11 +143,10 @@ SessionState::SessionState(
 
 SessionState::SessionState(
     const std::string& imsi, const std::string& session_id,
-    const std::string& core_session_id, const SessionConfig& cfg,
-    StaticRuleStore& rule_store, const magma::lte::TgppContext& tgpp_context)
+    const SessionConfig& cfg, StaticRuleStore& rule_store,
+    const magma::lte::TgppContext& tgpp_context)
     : imsi_(imsi),
       session_id_(session_id),
-      core_session_id_(core_session_id),
       // Request number set to 1, because request 0 is INIT call
       request_number_(1),
       curr_state_(SESSION_ACTIVE),

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -427,21 +427,6 @@ SessionState::TotalCreditUsage SessionState::get_total_credit_usage() {
   return usage;
 }
 
-bool SessionState::is_same_config(const SessionConfig& new_config) const {
-  return config_.ue_ipv4.compare(new_config.ue_ipv4) == 0 &&
-         config_.spgw_ipv4.compare(new_config.spgw_ipv4) == 0 &&
-         config_.msisdn.compare(new_config.msisdn) == 0 &&
-         config_.apn.compare(new_config.apn) == 0 &&
-         config_.imei.compare(new_config.imei) == 0 &&
-         config_.plmn_id.compare(new_config.plmn_id) == 0 &&
-         config_.imsi_plmn_id.compare(new_config.imsi_plmn_id) == 0 &&
-         config_.user_location.compare(new_config.user_location) == 0 &&
-         config_.rat_type == new_config.rat_type &&
-         config_.hardware_addr.compare(new_config.hardware_addr) == 0 &&
-         config_.radius_session_id.compare(new_config.radius_session_id) == 0 &&
-         config_.bearer_id == new_config.bearer_id;
-}
-
 std::string SessionState::get_session_id() const {
   return session_id_;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -184,13 +184,9 @@ class SessionState {
 
   std::string get_session_id() const;
 
-  std::string get_core_session_id() const { return core_session_id_; };
-
   SubscriberQuotaUpdate_Type get_subscriber_quota_state() const;
 
   bool is_radius_cwf_session() const;
-
-  bool is_same_config(const SessionConfig& new_config) const;
 
   void get_session_info(SessionState::SessionInfo& info);
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -53,8 +53,8 @@ class SessionState {
  public:
   SessionState(
       const std::string& imsi, const std::string& session_id,
-      const std::string& core_session_id, const SessionConfig& cfg,
-      StaticRuleStore& rule_store, const magma::lte::TgppContext& tgpp_context);
+      const SessionConfig& cfg, StaticRuleStore& rule_store,
+      const magma::lte::TgppContext& tgpp_context);
 
   SessionState(
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
@@ -383,7 +383,6 @@ class SessionState {
  private:
   std::string imsi_;
   std::string session_id_;
-  std::string core_session_id_;
   uint32_t request_number_;
   SessionFsmState curr_state_;
   SessionConfig config_;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -17,6 +17,20 @@
 
 namespace magma {
 
+bool SessionConfig::operator==(const SessionConfig& config) const {
+  return ue_ipv4.compare(config.ue_ipv4) == 0 &&
+         spgw_ipv4.compare(config.spgw_ipv4) == 0 &&
+         msisdn.compare(config.msisdn) == 0 && apn.compare(config.apn) == 0 &&
+         imei.compare(config.imei) == 0 &&
+         plmn_id.compare(config.plmn_id) == 0 &&
+         imsi_plmn_id.compare(config.imsi_plmn_id) == 0 &&
+         user_location.compare(config.user_location) == 0 &&
+         rat_type == config.rat_type &&
+         hardware_addr.compare(config.hardware_addr) == 0 &&
+         radius_session_id.compare(config.radius_session_id) == 0 &&
+         bearer_id == config.bearer_id;
+}
+
 SessionStateUpdateCriteria get_default_update_criteria() {
   SessionStateUpdateCriteria uc{};
   uc.is_fsm_updated             = false;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -356,7 +356,6 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   marshaled["session_level_key"] = stored.session_level_key;
   marshaled["imsi"]              = stored.imsi;
   marshaled["session_id"]        = stored.session_id;
-  marshaled["core_session_id"]   = stored.core_session_id;
   marshaled["subscriber_quota_state"] =
       static_cast<int>(stored.subscriber_quota_state);
 
@@ -413,7 +412,6 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
   stored.session_level_key = marshaled["session_level_key"].getString();
   stored.imsi              = marshaled["imsi"].getString();
   stored.session_id        = marshaled["session_id"].getString();
-  stored.core_session_id   = marshaled["core_session_id"].getString();
   stored.subscriber_quota_state =
       static_cast<magma::lte::SubscriberQuotaUpdate_Type>(
           marshaled["subscriber_quota_state"].getInt());

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -45,6 +45,8 @@ struct SessionConfig {
   std::string radius_session_id;
   uint32_t bearer_id;
   QoSInfo qos_info;
+
+  bool operator== (const SessionConfig& config) const;
 };
 
 // Session Credit

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -175,7 +175,6 @@ struct StoredSessionState {
   std::string session_level_key; // "" maps to nullptr
   std::string imsi;
   std::string session_id;
-  std::string core_session_id;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
   magma::lte::TgppContext tgpp_context;
   std::vector<std::string> static_rule_ids;

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -35,7 +35,7 @@ class SessionStateTest : public ::testing::Test {
     create_tgpp_context("gx.dest.com", "gy.dest.com", &tgpp_ctx);
     rule_store    = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
-        "imsi", "session", "", test_sstate_cfg, *rule_store, tgpp_ctx);
+        "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx);
     update_criteria = get_default_update_criteria();
   }
   enum RuleType {

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -708,7 +708,7 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   create_credit_update_response(
       imsi, 1, 1024, true, response.mutable_credits()->Add());
   auto session_state = new SessionState(
-      imsi, session_id, session_id, test_cfg, *rule_store, tgpp_ctx);
+      imsi, session_id, test_cfg, *rule_store, tgpp_ctx);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -85,7 +85,6 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     std::string radius_session_id =
         "AA-AA-AA-AA-AA-AA:TESTAP__"
         "0F-10-2E-12-3A-55";
-    std::string core_session_id = "asdf";
     SessionConfig cfg           = {.ue_ipv4           = "",
                          .spgw_ipv4         = "",
                          .msisdn            = msisdn,
@@ -100,7 +99,7 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
                          .radius_session_id = radius_session_id};
     auto tgpp_context           = TgppContext{};
     auto session                = std::make_unique<SessionState>(
-        imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);
+        imsi, session_id, cfg, *rule_store, tgpp_context);
     return std::move(session);
   }
 

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -64,7 +64,6 @@ class SessionStoreTest : public ::testing::Test {
     std::string radius_session_id =
         "AA-AA-AA-AA-AA-AA:TESTAP__"
         "0F-10-2E-12-3A-55";
-    std::string core_session_id = "asdf";
     SessionConfig cfg           = {.ue_ipv4           = "",
                          .spgw_ipv4         = "",
                          .msisdn            = msisdn,
@@ -79,7 +78,7 @@ class SessionStoreTest : public ::testing::Test {
                          .radius_session_id = radius_session_id};
     auto tgpp_context           = TgppContext{};
     auto session                = std::make_unique<SessionState>(
-        imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);
+        imsi, session_id, cfg, *rule_store, tgpp_context);
     return std::move(session);
   }
 

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -52,7 +52,6 @@ TEST_F(StoreClientTest, test_read_and_write) {
   auto sid                    = id_gen_.gen_session_id(imsi);
   auto sid2                   = id_gen_.gen_session_id(imsi2);
   auto sid3                   = id_gen_.gen_session_id(imsi3);
-  std::string core_session_id = "asdf";
   SessionConfig cfg           = {.ue_ipv4           = "",
                        .spgw_ipv4         = "",
                        .msisdn            = msisdn,
@@ -76,11 +75,11 @@ TEST_F(StoreClientTest, test_read_and_write) {
 
   auto uc      = get_default_update_criteria();
   auto session = std::make_unique<SessionState>(
-      imsi, sid, core_session_id, cfg, *rule_store, tgpp_context);
+      imsi, sid, cfg, *rule_store, tgpp_context);
   auto session2 = std::make_unique<SessionState>(
-      imsi2, sid2, core_session_id, cfg, *rule_store, tgpp_context);
+      imsi2, sid2, cfg, *rule_store, tgpp_context);
   auto session3 = std::make_unique<SessionState>(
-      imsi3, sid3, core_session_id, cfg, *rule_store, tgpp_context);
+      imsi3, sid3, cfg, *rule_store, tgpp_context);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -125,7 +125,6 @@ class StoredStateTest : public ::testing::Test {
     stored.session_level_key      = "session_level_key";
     stored.imsi                   = "IMSI1";
     stored.session_id             = "session_id";
-    stored.core_session_id        = "core_session_id";
     stored.subscriber_quota_state = SubscriberQuotaUpdate_Type_VALID_QUOTA;
     stored.fsm_state              = SESSION_TERMINATING_FLOW_DELETED;
 
@@ -329,7 +328,6 @@ TEST_F(StoredStateTest, test_stored_session) {
 
   EXPECT_EQ(stored.imsi, "IMSI1");
   EXPECT_EQ(stored.session_id, "session_id");
-  EXPECT_EQ(stored.core_session_id, "core_session_id");
   EXPECT_EQ(
       stored.subscriber_quota_state, SubscriberQuotaUpdate_Type_VALID_QUOTA);
   EXPECT_EQ(stored.fsm_state, SESSION_TERMINATING_FLOW_DELETED);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
SessionD currently stores both `session_id` and `core_session_id`, but they are the same. The field is set by the `session_id` value returned from FeG, but that value is taken from `session_id`.
This diff gets rid of the core_session_id field.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
