### PR TITLE
Adding owners for Jenkins CI and AGW integ tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,8 @@
 .circleci/ @xjtian @tmdzk
 circleci/ @xjtian @tmdzk
 
+ci-scripts/ @rdefosse @tmdzk
+
 */cloud/ @xjtian @mpgermano @hcgatewood
 
 orc8r/ @xjtian @mpgermano @hcgatewood @emakeev
@@ -14,8 +16,10 @@ lte/gateway @xjtian @ardzoht
 lte/gateway/c/session_manager @themarwhal @uri200
 lte/gateway/c/oai @ssanadhya @ulaskozat @lionelgo
 lte/gateway/c/sctpd @ssanadhya @ulaskozat
+lte/gateway/docker @rdefosse @tmdzk
 lte/gateway/release @kkahrs
 lte/gateway/python/magma/pipelined @koolzz @pshelar
+lte/gateway/python/integ_tests @ssanadhya @ulaskozat
 
 nms/ @karthiksubraveti @andreilee @xjtian
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Adding owners for:
- ci-scripts: Jenkins CI which tests MME against OAI HSS and OAI CUPS SPGW, in addition to subscriberdb and embedded SPGW. 
- lte/gateway/docker: docker files for containerized MME
- lte/gateway/integ_tests: S1AP integration tests

## Test Plan

N/A
