### PR TITLE
Disable li controller for cwf networks

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -38,7 +38,7 @@ static_services: [
   'tunnel_learn',
   'vlan_learn',
   'ipfix',
-  'li_mirror',
+  #'li_mirror',
   'ryu_rest_service',
   'startup_flows',
 #  'packet_tracer',
@@ -105,7 +105,7 @@ ipfix:
   obs_point_id: 1
 
 # Configuration for LI mirroring
-li_local_iface: li_port
+#li_local_iface: li_port
 li_mirror_all: false
 #li_dst_iface: eth4
 


### PR DESCRIPTION
We currently don't use it and its annoying our mcp testing env

Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
