### PR TITLE
[sessiond] is_quota_exhausted calculated using last grant received

### DIFF
--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -61,6 +61,8 @@ std::string final_action_to_str(ChargingCredit_FinalAction final_action) {
 
 std::string grant_type_to_str(GrantTrackingType grant_type) {
   switch (grant_type) {
+    case ALL_TOTAL_TX_RX:
+      return "ALL_TOTAL_TX_RX";
     case TOTAL_ONLY:
       return "TOTAL_ONLY";
     case TX_ONLY:

--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
@@ -12,7 +12,6 @@
  */
 
 #include <string>
-#include <google/protobuf/message.h>
 #include "magma_logging.h"
 #include "GrpcMagmaUtils.h"
 
@@ -31,12 +30,13 @@ std::string get_env_var(std::string const& key) {
   return std::string(retval);
 }
 
-void PrintGrpcMessage(const google::protobuf::Message& message) {
+void PrintGrpcMessage(const google::protobuf::Message& msg) {
   if (grpcLoginLevel == "1") {
-    const google::protobuf::Descriptor* desc = message.GetDescriptor();
+    // Lazy log strategy
+    const google::protobuf::Descriptor* desc = msg.GetDescriptor();
     MLOG(MINFO) << "\n"
                 << "  " << desc->full_name().c_str() << " {\n"
-                << indentText(message.DebugString(), 6) << "  }";
+                << indentText(msg.DebugString(), 6) << "  }";
   }
 }
 

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -68,7 +68,7 @@ SessionCredit::SessionCredit(ServiceState start_state)
 
 SessionCredit::SessionCredit(
     ServiceState start_state, CreditLimitType credit_limit_type)
-    : buckets_{},
+    : buckets_{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ,0},
       reporting_(false),
       credit_limit_type_(credit_limit_type),
       grant_tracking_type_(TOTAL_ONLY) {}
@@ -110,7 +110,17 @@ void SessionCredit::mark_failure(
 
 void SessionCredit::receive_credit(
     const GrantedUnits& gsu, SessionCreditUpdateCriteria* uc) {
+
   grant_tracking_type_ = determine_grant_tracking_type(gsu);
+
+  // Floor represent the previous value of ALLOWED counters before grant is applied
+  // They will only be updated if a valid grant is received
+  buckets_[ALLOWED_FLOOR_TOTAL] =
+      calculate_allowed_floor(gsu.total(), ALLOWED_TOTAL, ALLOWED_FLOOR_TOTAL);
+  buckets_[ALLOWED_FLOOR_TX] =
+      calculate_allowed_floor(gsu.total(), ALLOWED_TX, ALLOWED_FLOOR_TX);
+  buckets_[ALLOWED_FLOOR_RX] =
+      calculate_allowed_floor(gsu.total(), ALLOWED_RX, ALLOWED_FLOOR_RX);
 
   // Clear invalid values
   uint64_t total_volume = gsu.total().is_valid() ? gsu.total().volume() : 0;
@@ -123,8 +133,10 @@ void SessionCredit::receive_credit(
   buckets_[ALLOWED_RX] += rx_volume;
 
   MLOG(MINFO) << "Received the following credit"
-              << " total_volume=" << total_volume << " tx_volume=" << tx_volume
-              << " rx_volume=" << rx_volume << " grant_tracking_type="
+              << " total_volume=" << total_volume
+              << " tx_volume=" << tx_volume
+              << " rx_volume=" << rx_volume
+              << " grant_tracking_type="
               << grant_type_to_str(grant_tracking_type_);
 
   // Update reporting/reported bytes
@@ -140,28 +152,46 @@ void SessionCredit::receive_credit(
 
     uc->bucket_deltas[REPORTED_RX] += buckets_[REPORTING_RX];
     uc->bucket_deltas[REPORTED_TX] += buckets_[REPORTING_TX];
+
+    uc->bucket_deltas[ALLOWED_FLOOR_TOTAL] = buckets_[ALLOWED_FLOOR_TOTAL];
+    uc->bucket_deltas[ALLOWED_FLOOR_TX] = buckets_[ALLOWED_FLOOR_TX];
+    uc->bucket_deltas[ALLOWED_FLOOR_RX] = buckets_[ALLOWED_FLOOR_RX];
   }
 
   reset_reporting_credit(uc);
   log_quota_and_usage();
 }
 
+uint64_t SessionCredit::calculate_allowed_floor(CreditUnit cu, Bucket allowed, Bucket floor){
+  if (cu.is_valid() && cu.volume() !=0 ) {
+    // only advance floor when there is a new grant
+    return buckets_[allowed];
+  }
+  return buckets_[floor];
+}
+
 bool SessionCredit::is_quota_exhausted(float threshold) const {
   if (credit_limit_type_ != FINITE) {
     return false;
   }
-  uint64_t total_reported = buckets_[REPORTED_TX] + buckets_[REPORTED_RX];
-  uint64_t total_usage    = buckets_[USED_TX] + buckets_[USED_RX];
 
   bool rx_exhausted = compute_quota_exhausted(
-      buckets_[ALLOWED_RX], buckets_[REPORTED_RX], buckets_[USED_RX],
-      threshold);
+      buckets_[ALLOWED_RX],  buckets_[USED_RX],
+      threshold,
+      buckets_[ALLOWED_FLOOR_RX]);
   bool tx_exhausted = compute_quota_exhausted(
-      buckets_[ALLOWED_TX], buckets_[REPORTED_TX], buckets_[USED_TX],
-      threshold);
+      buckets_[ALLOWED_TX],  buckets_[USED_TX],
+      threshold,
+      buckets_[ALLOWED_FLOOR_TX]);
+  bool total_exhausted = compute_quota_exhausted(
+      buckets_[ALLOWED_TOTAL], buckets_[USED_TX] + buckets_[USED_RX],
+      threshold, buckets_[ALLOWED_FLOOR_TOTAL]);
 
   bool is_exhausted = false;
   switch (grant_tracking_type_) {
+    case ALL_TOTAL_TX_RX:
+      is_exhausted = rx_exhausted || tx_exhausted || total_exhausted;
+      break;
     case RX_ONLY:
       is_exhausted = rx_exhausted;
       break;
@@ -172,8 +202,7 @@ bool SessionCredit::is_quota_exhausted(float threshold) const {
       is_exhausted = rx_exhausted || tx_exhausted;
       break;
     case TOTAL_ONLY:
-      is_exhausted = compute_quota_exhausted(
-          buckets_[ALLOWED_TOTAL], total_reported, total_usage, threshold);
+      is_exhausted = total_exhausted;
       break;
     default:
       MLOG(MERROR) << "Invalid grant_tracking_type="
@@ -203,7 +232,6 @@ SessionCredit::Usage SessionCredit::get_usage_for_reporting(
   auto usage = get_unreported_usage();
   // Apply reporting limits since the user is not getting terminated.
   // We never want to report more than the amount we've received
-  apply_reporting_limits(usage);
 
   buckets_[REPORTING_TX] += usage.bytes_tx;
   buckets_[REPORTING_RX] += usage.bytes_rx;
@@ -279,15 +307,33 @@ uint64_t SessionCredit::compute_reporting_limit(
 }
 
 bool SessionCredit::compute_quota_exhausted(
-    const uint64_t allowed, const uint64_t reported, const uint64_t used,
-    float threshold_ratio) const {
-  uint64_t unreported_usage = 0;
-  if (used > reported) {
-    unreported_usage = used - reported;
+    const uint64_t allowed, const uint64_t used,
+    float threshold_ratio, const uint64_t floor) const {
+  // current_granted_units: difference between current allowed and past
+  // allowed (floor). This value is equivalent to the grant received.
+  // Credit will be considered exhausted if the remaining credit is below
+  // a percentage of the current granted units
+
+  if (floor > allowed) {
+    // This should never happen because floor should always be the previous
+    // allowed value
+    MLOG(MERROR) << "Error: Floor value is higher than allowed value "
+        << floor << ">" << allowed ;
+    return true;
   }
-  uint64_t grant_left = allowed - reported;
-  auto threshold      = std::max(0.0f, grant_left * threshold_ratio);
-  return unreported_usage >= threshold;
+
+  if (used >= allowed){
+    // if we used more that we are allowed, we are for sure out of quota
+    return true;
+  }
+
+  uint64_t remaining_credit = allowed - used;
+  uint64_t current_granted_units = allowed - floor;
+  // this step is necessary to avoid precision issues of float
+  int integer_threshold_ratio = 100 - int(threshold_ratio * 100);
+  uint64_t threshold  = (current_granted_units * integer_threshold_ratio)/100;
+
+  return  remaining_credit <= threshold;
 }
 
 bool SessionCredit::is_reporting() const {
@@ -314,11 +360,17 @@ void SessionCredit::add_credit(
 // Determine the grant's tracking type by looking at which values are valid.
 GrantTrackingType SessionCredit::determine_grant_tracking_type(
     const GrantedUnits& grant) {
-  if (grant.total().is_valid()) {
-    return TOTAL_ONLY;
-  }
+
+  bool total_valid = grant.total().is_valid();
   bool tx_valid = grant.tx().is_valid();
   bool rx_valid = grant.rx().is_valid();
+
+  if (total_valid && tx_valid && rx_valid){
+    return ALL_TOTAL_TX_RX;
+  }
+  if (total_valid) {
+    return TOTAL_ONLY;
+  }
   if (tx_valid && rx_valid) {
     return TX_AND_RX;
   } else if (tx_valid) {
@@ -345,6 +397,11 @@ void SessionCredit::log_quota_and_usage() const {
   MLOG(MDEBUG) << "===> Grant tracking type "
                << grant_type_to_str(grant_tracking_type_)
                << ",  Reporting: " << reporting_;
+  // TODO: delete once we tested it works for both credit and monitors
+  MLOG(MDEBUG) << "===> Current Granted Units (tx/rx/total) "
+               << buckets_[ALLOWED_TOTAL] - buckets_[ALLOWED_FLOOR_TOTAL] << "/"
+               << buckets_[ALLOWED_TX] - buckets_[ALLOWED_FLOOR_TX] << "/"
+               << buckets_[ALLOWED_RX] - buckets_[ALLOWED_FLOOR_RX];
 }
 
 void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -23,7 +23,7 @@ namespace magma {
  * there is an update (quota exhausted, etc)
  */
 class SessionCredit {
-public:
+ public:
   struct Usage {
     uint64_t bytes_tx;
     uint64_t bytes_rx;
@@ -35,7 +35,7 @@ public:
 
   SessionCredit(ServiceState start_state, CreditLimitType limit_type);
 
-  static SessionCredit unmarshal(const StoredSessionCredit &marshaled);
+  static SessionCredit unmarshal(const StoredSessionCredit& marshaled);
 
   StoredSessionCredit marshal();
 
@@ -49,8 +49,9 @@ public:
    * add_used_credit increments USED_TX and USED_RX
    * as being recently updated
    */
-  void add_used_credit(uint64_t used_tx, uint64_t used_rx,
-                       SessionCreditUpdateCriteria &update_criteria);
+  void add_used_credit(
+      uint64_t used_tx, uint64_t used_rx,
+      SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * reset_reporting_credit resets the REPORTING_* to 0
@@ -74,11 +75,11 @@ public:
    * one if no update exists. Check has_update before calling.
    * This method also sets the REPORTING_* credit buckets
    */
-  SessionCredit::Usage
-  get_usage_for_reporting(SessionCreditUpdateCriteria &update_criteria);
+  SessionCredit::Usage get_usage_for_reporting(
+      SessionCreditUpdateCriteria& update_criteria);
 
   SessionCredit::Usage get_all_unreported_usage_for_reporting(
-      SessionCreditUpdateCriteria &update_criteria);
+      SessionCreditUpdateCriteria& update_criteria);
 
   /**
    * Returns true if either of REPORTING_* buckets are more than 0
@@ -90,8 +91,8 @@ public:
    */
   uint64_t get_credit(Bucket bucket) const;
 
-  void set_grant_tracking_type(GrantTrackingType g_type,
-    SessionCreditUpdateCriteria& uc);
+  void set_grant_tracking_type(
+      GrantTrackingType g_type, SessionCreditUpdateCriteria& uc);
 
   /**
    * Add credit to the specified bucket. This does not necessarily correspond
@@ -100,18 +101,22 @@ public:
    * @param credit
    * @param bucket
    */
-  void add_credit(uint64_t credit, Bucket bucket,
-                  SessionCreditUpdateCriteria &update_criteria);
+  void add_credit(
+      uint64_t credit, Bucket bucket,
+      SessionCreditUpdateCriteria& update_criteria);
   /**
-   * is_quota_exhausted checks if any of the tx, rx, or combined tx+rx are
-   * exhausted. The exception to this is if ALLOWED_RX or ALLOWED_TX are 0,
-   * which occurs for an OCS/PCRF which do not individually track tx/rx. In this
-   * scenario, only the total matters.
+   * is_quota_exhausted checks if any of the remaining quota (Allowed - Used)
+   * on tx, rx, or tx+rx amounts are under a specific threshold, and depending
+   * on the grant_tracking_type_ (which selects which of those thresholds
+   * matters), it decides if quota is exhausted. The threshold which those three
+   * usages are compare against it is a percentage of the amount of last
+   * received grant. So basically the algorithm is: if quota remaining is under
+   * a percentage of the last received grant, we mark it as exhausted for that
+   * leg (rx/tx/total). If percentage is 1 (100%) then that leg will be marked
+   * as exhausted when it gets to the top of its corresponding grant.
    *
    * Quota usage is measured by reporting from pipelined since the last
    * SessionUpdate.
-   * We mark quota as exhausted if usage_reporting_threshold * available quota
-   * is reached. (so the default is 100% of quota)
    * Check if the session has exhausted its quota granted since the last report.
    *
    * @param usage_reporting_threshold
@@ -134,13 +139,14 @@ public:
    * Set to false to allow users to use without any constraint.
    */
   static bool TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED;
-private:
+
+ private:
   uint64_t buckets_[MAX_VALUES];
   bool reporting_;
   CreditLimitType credit_limit_type_;
   GrantTrackingType grant_tracking_type_;
 
-private:
+ private:
   void log_quota_and_usage() const;
 
   SessionCredit::Usage get_unreported_usage() const;
@@ -149,13 +155,16 @@ private:
 
   GrantTrackingType determine_grant_tracking_type(const GrantedUnits& grant);
 
-  bool compute_quota_exhausted(const uint64_t allowed,
-    const uint64_t reported, const uint64_t used, float threshold_ratio) const;
+  bool compute_quota_exhausted(
+      const uint64_t allowed, const uint64_t used, float threshold_ratio,
+      const uint64_t grantedUnits) const;
 
   uint64_t compute_reporting_limit(
-    const uint64_t allowed, const uint64_t reported) const;
+      const uint64_t allowed, const uint64_t reported) const;
 
   void apply_reporting_limits(SessionCredit::Usage& usage);
+
+  uint64_t calculate_allowed_floor(CreditUnit cu, Bucket allowed, Bucket floor);
 };
 
-} // namespace magma
+}  // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -66,16 +66,28 @@ typedef std::unordered_map<magma::lte::EventTrigger, EventTriggerState> EventTri
  * Each value is in terms of a volume unit - either bytes or seconds
  */
 enum Bucket {
+  // USED: the actual used quota by the UE.
+  // USED = REPORTED + REPORTING
   USED_TX = 0,
   USED_RX = 1,
+  // ALLOWED: the granted units received
   ALLOWED_TOTAL = 2,
   ALLOWED_TX = 3,
   ALLOWED_RX = 4,
+  // REPORTING: quota that is in transit to be acknowledged by OCS/PCRF
   REPORTING_TX = 5,
   REPORTING_RX = 6,
+  // REPORTED: quota that has been acknowledged by OCS/PCRF
   REPORTED_TX = 7,
   REPORTED_RX = 8,
-  MAX_VALUES = 9,
+  // ALLOWED_FLOOR: saves the previous ALLOWED value after a new grant is received
+  // last_valid_nonzero_received_grant = ALLOWED - ALLOWED_FLOOR
+  ALLOWED_FLOOR_TOTAL = 9,
+  ALLOWED_FLOOR_TX    = 10,
+  ALLOWED_FLOOR_RX    = 11,
+
+  // delimiter to iterate enum
+  MAX_VALUES = 12,
 };
 
 enum ReAuthState {
@@ -98,6 +110,7 @@ enum GrantTrackingType {
   TX_ONLY = 1,
   RX_ONLY = 2,
   TX_AND_RX = 3,
+  ALL_TOTAL_TX_RX = 4,
 };
 
 /**

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -59,6 +59,34 @@ void create_credit_update_response(
   response->set_charging_key(charging_key);
 }
 
+void create_charging_credit(
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    bool is_final,
+    ChargingCredit* credit)
+{
+  create_granted_units(&total_volume, &tx_volume, &rx_volume, credit->mutable_granted_units());
+  credit->set_type(ChargingCredit::BYTES);
+  credit->set_is_final(is_final);
+}
+
+void create_credit_update_response(
+    const std::string& imsi,
+    uint32_t charging_key,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    bool is_final,
+    CreditUpdateResponse* response)
+{
+  create_charging_credit(
+      total_volume, tx_volume, rx_volume, is_final, response->mutable_credit());
+  response->set_success(true);
+  response->set_sid(imsi);
+  response->set_charging_key(charging_key);
+}
+
 void create_usage_update(
     const std::string& imsi, uint32_t charging_key, uint64_t bytes_rx,
     uint64_t bytes_tx, CreditUsage::UpdateType type,

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -41,6 +41,22 @@ void create_credit_update_response(
   uint64_t volume,
   CreditUpdateResponse* response);
 
+void create_charging_credit(
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    bool is_final,
+    ChargingCredit* credit);
+
+void create_credit_update_response(
+    const std::string& imsi,
+    uint32_t charging_key,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    bool is_final,
+    CreditUpdateResponse* response);
+
 void create_credit_update_response(
   const std::string& imsi,
   uint32_t charging_key,

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -134,6 +134,14 @@ class SessionStateTest : public ::testing::Test {
     session_state->receive_charging_credit(charge_resp, update_criteria);
   }
 
+  void receive_credit_from_ocs(uint32_t rating_group, uint64_t total_volume,
+                               uint64_t tx_volume,uint64_t rx_volume, bool is_final) {
+    CreditUpdateResponse charge_resp;
+    create_credit_update_response("IMSI1", rating_group,total_volume, tx_volume,
+                                  rx_volume, is_final, &charge_resp);
+    session_state->receive_charging_credit(charge_resp, update_criteria);
+  }
+
   void receive_credit_from_pcrf(
       const std::string& mkey, uint64_t volume, MonitoringLevel level) {
     UsageMonitoringUpdateResponse monitor_resp;

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -52,16 +52,29 @@ TEST(test_track_credit, test_session_credit) {
   SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
-  uint64_t grant = 1024;
-  create_granted_units(&grant, NULL, NULL, &gsu);
+  uint64_t total_grant = 300;
+  uint64_t tx_grant = 100;
+  uint64_t rx_grant = 200;
+  create_granted_units(&total_grant, &tx_grant, &rx_grant, &gsu);
 
   credit.receive_credit(gsu, &uc);
 
-  EXPECT_EQ(1024, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(300, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(100, credit.get_credit(ALLOWED_TX));
+  EXPECT_EQ(200, credit.get_credit(ALLOWED_RX));
+  EXPECT_EQ(0, credit.get_credit(ALLOWED_FLOOR_TOTAL));
+  EXPECT_EQ(0, credit.get_credit(ALLOWED_FLOOR_TX));
+  EXPECT_EQ(0, credit.get_credit(ALLOWED_FLOOR_RX));
   EXPECT_EQ(0, credit.get_credit(USED_TX));
+  EXPECT_EQ(0, credit.get_credit(USED_RX));
 
   // Check that the update criteria also includes the changes
-  EXPECT_EQ(uc.bucket_deltas[ALLOWED_TOTAL], 1024);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_TOTAL], 300);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_TX], 100);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_RX], 200);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_FLOOR_TOTAL], 0);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_FLOOR_TX], 0);
+  EXPECT_EQ(uc.bucket_deltas[ALLOWED_FLOOR_RX], 0);
   EXPECT_EQ(uc.bucket_deltas[USED_TX], 0);
 }
 
@@ -147,8 +160,8 @@ TEST(test_collect_updates_none_available, test_session_credit) {
   EXPECT_FALSE(credit.is_quota_exhausted(0.8));
 }
 
-// The maximum of reported usage is capped by what is granted even when an user
-// overused.
+// The maximum of reported usage is NOT capped by what is granted even when an
+// user overused.
 TEST(test_collect_updates_when_overusing, test_session_credit) {
   SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
@@ -161,12 +174,12 @@ TEST(test_collect_updates_when_overusing, test_session_credit) {
   EXPECT_TRUE(credit.is_quota_exhausted(0.8));
   auto update = credit.get_usage_for_reporting(uc);
   EXPECT_EQ(update.bytes_tx, 510);
-  EXPECT_EQ(update.bytes_rx, 490);
+  EXPECT_EQ(update.bytes_rx, 500);
 
   EXPECT_TRUE(credit.is_reporting());
   EXPECT_TRUE(uc.reporting);
   EXPECT_EQ(credit.get_credit(REPORTING_TX), 510);
-  EXPECT_EQ(credit.get_credit(REPORTING_RX), 490);
+  EXPECT_EQ(credit.get_credit(REPORTING_RX), 500);
   // Only track how much has been reported. The currently reporting amount
   // should be held in memory only.
   EXPECT_EQ(uc.bucket_deltas[REPORTING_TX], 0);
@@ -197,13 +210,86 @@ TEST(test_add_rx_tx_credit, test_session_credit) {
   EXPECT_TRUE(credit.is_quota_exhausted(0.8));
   auto update2 = credit.get_usage_for_reporting(uc);
   EXPECT_EQ(update2.bytes_tx, 50);
-  EXPECT_EQ(update2.bytes_rx, 1000);
+  EXPECT_EQ(update2.bytes_rx, 2000);
 
   // receive rx, tx, but no usage
   gsu.Clear();
   create_granted_units(NULL, &grant, &grant, &gsu);
   credit.receive_credit(gsu, &uc);
   EXPECT_FALSE(credit.is_quota_exhausted(0.8));
+}
+
+TEST(test_counting_algorithm, test_session_credit) {
+  SessionCredit credit;
+  SessionCreditUpdateCriteria uc{};
+  GrantedUnits gsu;
+  uint64_t total_grant = 300;
+  uint64_t tx_grant    = 100;
+  uint64_t rx_grant    = 200;
+  create_granted_units(&total_grant, &tx_grant, &rx_grant, &gsu);
+
+  // receive total = 300 tx = 100, rx = 200
+  credit.receive_credit(gsu, &uc);
+  EXPECT_EQ(uc.grant_tracking_type, ALL_TOTAL_TX_RX);
+  // use tx and rx = 99 + 150 = 249
+  credit.add_used_credit(99, 150, uc);
+  EXPECT_TRUE(credit.is_quota_exhausted(0.8));
+  EXPECT_FALSE(credit.is_quota_exhausted(1));
+  auto update = credit.get_usage_for_reporting(uc);
+  EXPECT_EQ(update.bytes_tx, 99);
+  EXPECT_EQ(update.bytes_rx, 150);
+
+  // receive another total = 300 tx = 100, rx = 200,
+  // cumulative: total = 600 tx = 200, rx = 400
+  credit.receive_credit(gsu, &uc);
+  EXPECT_EQ(uc.grant_tracking_type, ALL_TOTAL_TX_RX);
+  EXPECT_EQ(600, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(200, credit.get_credit(ALLOWED_TX));
+  EXPECT_EQ(400, credit.get_credit(ALLOWED_RX));
+  EXPECT_EQ(300, credit.get_credit(ALLOWED_FLOOR_TOTAL));
+  EXPECT_EQ(100, credit.get_credit(ALLOWED_FLOOR_TX));
+  EXPECT_EQ(200, credit.get_credit(ALLOWED_FLOOR_RX));
+  EXPECT_EQ(99, credit.get_credit(USED_TX));
+  EXPECT_EQ(150, credit.get_credit(USED_RX));
+  // use tx and rx = 1 + 50
+  // cumulative = 100 + 200 = 300
+  credit.add_used_credit(1, 50, uc);
+  EXPECT_FALSE(credit.is_quota_exhausted(0.8));
+  // right before triggering the update (just under80% of the grant)
+  // use tx and rx = 79 + 100
+  // cumulative = 179 + 300 = 479
+  credit.add_used_credit(79, 100, uc);
+  EXPECT_FALSE(credit.is_quota_exhausted(0.8));
+  // right after triggering the update (just got over 80% of the grant)
+  // use tx and rx = 1 + 0
+  // cumulative = 180 + 300 = 460
+  credit.add_used_credit(1, 0, uc);
+  EXPECT_TRUE(credit.is_quota_exhausted(0.8));
+  EXPECT_FALSE(credit.is_quota_exhausted(1));
+  // exhausted by tx
+  // use tx and rx = 20 + 100
+  // cumulative = 200 + 400 = 600
+  credit.add_used_credit(20, 100, uc);
+  EXPECT_TRUE(credit.is_quota_exhausted(0.8));
+  EXPECT_TRUE(credit.is_quota_exhausted(1));
+
+  // receive one grant more with 0 granted units
+  gsu.Clear();
+  total_grant = 0;
+  tx_grant    = 0;
+  rx_grant    = 0;
+  create_granted_units(&total_grant, &tx_grant, &rx_grant, &gsu);
+  credit.receive_credit(gsu, &uc);
+  EXPECT_EQ(uc.grant_tracking_type, ALL_TOTAL_TX_RX);
+  EXPECT_EQ(600, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(200, credit.get_credit(ALLOWED_TX));
+  EXPECT_EQ(400, credit.get_credit(ALLOWED_RX));
+  EXPECT_EQ(300, credit.get_credit(ALLOWED_FLOOR_TOTAL));
+  EXPECT_EQ(100, credit.get_credit(ALLOWED_FLOOR_TX));
+  EXPECT_EQ(200, credit.get_credit(ALLOWED_FLOOR_RX));
+  EXPECT_EQ(200, credit.get_credit(USED_TX));
+  EXPECT_EQ(400, credit.get_credit(USED_RX));
+  EXPECT_TRUE(credit.is_quota_exhausted(1));
 }
 
 TEST(test_is_quota_exhausted_total_only, test_session_credit) {
@@ -263,6 +349,7 @@ TEST(test_is_quota_exhausted_tx_only, test_session_credit) {
 // Assert that receiving an invalid GSU does not change the way we track
 // credits. If we request an additional quota and receive an empty GSU, the
 // quota should still be exhausted.
+
 TEST(test_is_quota_exhausted_after_empty_grant, test_session_credit) {
   SessionCredit credit;
   SessionCreditUpdateCriteria uc{};

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -26,6 +26,7 @@
 using ::testing::Test;
 
 namespace magma {
+
 TEST_F(SessionStateTest, test_session_rules) {
   activate_rule(1, "m1", "rule1", DYNAMIC, 0, 0);
   EXPECT_EQ(1, session_state->total_monitored_rules_count());
@@ -747,6 +748,66 @@ TEST_F(SessionStateTest, test_empty_credit_grant) {
   session_state->add_rule_usage("rule1", 100, 100, update_criteria);
   auto credit_uc = update_criteria.charging_credit_map[1];
   EXPECT_EQ(credit_uc.service_state, SERVICE_NEEDS_DEACTIVATION);
+}
+
+TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
+  // add one rule with credits
+  insert_rule(1, "", "rule1", STATIC, 0, 0);
+  EXPECT_TRUE(
+      std::find(
+          update_criteria.static_rules_to_install.begin(),
+          update_criteria.static_rules_to_install.end(),
+          "rule1") != update_criteria.static_rules_to_install.end());
+
+  receive_credit_from_ocs(1, 3000, 2000, 2000, false);
+  EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
+  EXPECT_EQ(
+      update_criteria.charging_credit_to_install[CreditKey(1)]
+          .credit.buckets[ALLOWED_TOTAL],3000);
+  EXPECT_EQ(
+      update_criteria.charging_credit_to_install[CreditKey(1)]
+          .credit.buckets[ALLOWED_TX],2000);
+  EXPECT_EQ(
+      update_criteria.charging_credit_to_install[CreditKey(1)]
+          .credit.buckets[ALLOWED_RX],2000);
+
+  // add usage for 2 times to go over quota
+  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
+  EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
+
+  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
+  EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
+
+  // check if we need to report the usage
+  UpdateSessionRequest update;
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  session_state->get_updates(update, &actions, update_criteria);
+  EXPECT_EQ(actions.size(), 0);
+  EXPECT_EQ(update.updates_size(), 1);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_TX], 4000);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_RX], 2000);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].service_state, SERVICE_ENABLED);
+  EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
+  EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
+
+  // recive final unit without grant
+  receive_credit_from_ocs(1, 0, 0, 0, true);
+  EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[REPORTED_TX], 4000);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[REPORTED_RX], 2000);
+  EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].service_state, SERVICE_ENABLED);
+  EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
+
+  // force to check for the state (no traffic sent)
+  session_state->add_rule_usage("rule1", 0, 0, update_criteria);
+  EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
+  EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
+  EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].service_state, SERVICE_NEEDS_DEACTIVATION);
+  EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -146,6 +146,9 @@ class SessionStoreTest : public ::testing::Test {
     credit2.buckets[REPORTING_RX]  = 6;
     credit2.buckets[REPORTED_TX]   = 7;
     credit2.buckets[REPORTED_RX]   = 8;
+    credit2.buckets[ALLOWED_FLOOR_TOTAL] = 9;
+    credit2.buckets[ALLOWED_FLOOR_TX]    = 10;
+    credit2.buckets[ALLOWED_FLOOR_RX]    = 11;
     monitor2.level                 = SESSION_LEVEL;
     monitor2.credit                = credit2;
     update_criteria.monitor_credit_to_install[monitoring_key2] = monitor2;
@@ -164,6 +167,9 @@ class SessionStoreTest : public ::testing::Test {
     bucket_deltas[REPORTING_RX]     = 6;
     bucket_deltas[REPORTED_TX]      = 7;
     bucket_deltas[REPORTED_RX]      = 8;
+    bucket_deltas[ALLOWED_FLOOR_TOTAL] = 9;
+    bucket_deltas[ALLOWED_FLOOR_TX]    = 10;
+    bucket_deltas[ALLOWED_FLOOR_RX]    = 11;
     monitoring_update.bucket_deltas = bucket_deltas;
 
     update_criteria.monitor_credit_map =


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>


## Summary
This PR includes:

- Change of the `is_quota_exhausted` algorithm: 
In order to trigger the update before hitting the allowed credit, we were using the a percentage of the difference between `allowed` and `reported` values to trigger the update. But since reported is a growing number, the difference became smaller in each iteration, so the percentage. That problem is has no impact when values are small but when values get bigger, that cause the update threshold to be trigger too late. To avoid the dependency on a variable threshold, we will use percentage of the last grant received. To do that, we will save at `ALLOWED_TOTAL_FLOOR`, `ALLOWED_TX_FLOOR` , `ALLOWED_RX_FLOOR` the last ALLOWED limit. `So received_grant = ALLOWED_X - ALLOWED_X_FLOOR`
```
	if (Allowed - Reported) < percent*(Allowed - Allowed_floor) then quota_is_exhausted
```	
note we will not consider reporting traffic for now. But we may add it in the future if we observe it could 	be beneficial.

- Removal of capping reporting overused quota: 
The idea behind this is OCS should be aware of any over usage, sessiond should be hiding those values. OCS may be able to take measures if UE is overusing (for example give bigger grant, or reduce QOS)

- Addition of `ALL_TOTAL_TX_RX` to the grant type. This will be used for cases where we receive all, TX, RX and TOTAL grants. Note other vendors (Cisco, Nokia) just sends the TOTAL value and ignore TX and RX (see this [link](https://infocenter.nokia.com/public/7750SR160R4A/index.jsp?topic=%2Fcom.sr.Gy%2Fhtml%2F7750_sr_os_diameter_gy_interface.html) at 2.2.2.5. Diameter Gy CCA – Granted-Service-Unit grouped AVP, and also [here](https://www.juniper.net/documentation/en_US/junos/topics/topic-map/3gpp-policy-charging-control-provisioning-accounting.html#id-understanding-gy-interactions-between-the-router-and-the-ocs))


## Test Plan
make test on AGW
Test on TerraVM

## Additional Information

- [ ] This change is backwards-breaking
