### PR TITLE
[NMS] Small refactor in lte dashboard

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/components/DashboardAlertTable.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/DashboardAlertTable.js
@@ -55,11 +55,7 @@ export default function () {
   }
 
   const data: AlertTable = {Critical: [], Major: [], Minor: [], Other: []};
-  if (!response) {
-    return null;
-  }
-
-  const alerts: Array<prom_firing_alert> = response;
+  const alerts: Array<prom_firing_alert> = response ?? [];
   alerts.forEach(alert => {
     const labelInfo = {
       job: alert.labels['job'] || '',

--- a/nms/app/fbcnms-projects/magmalte/app/components/lte/LteDashboard.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/lte/LteDashboard.js
@@ -103,13 +103,6 @@ function LteDashboard() {
                 to="/network"
                 className={classes.tab}
               />
-              <Tab
-                key="Subscribers"
-                component={NestedRouteLink}
-                label={<DashboardTabLabel label="Subscribers" />}
-                to="#"
-                className={classes.tab}
-              />
             </Tabs>
           </Grid>
           <Grid item xs={6}>

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentEnodeb.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentEnodeb.js
@@ -138,7 +138,12 @@ function EnodeTable({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {
             history.push(relativeUrl('/' + currRow.id));
           },
         },
-        {name: 'Edit'},
+        {
+          name: 'Edit',
+          handleFunc: () => {
+            history.push(relativeUrl('/' + currRow.id + '/config'));
+          },
+        },
         {name: 'Remove'},
         {name: 'Deactivate'},
         {name: 'Reboot'},

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGateway.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGateway.js
@@ -159,7 +159,12 @@ function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
             history.push(relativeUrl('/' + currRow.id));
           },
         },
-        {name: 'Edit'},
+        {
+          name: 'Edit',
+          handleFunc: () => {
+            history.push(relativeUrl('/' + currRow.id + '/config'));
+          },
+        },
         {name: 'Remove'},
         {name: 'Deactivate'},
         {name: 'Reboot'},

--- a/nms/app/fbcnms-projects/magmalte/app/views/subscriber/SubscriberOverview.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/subscriber/SubscriberOverview.js
@@ -270,7 +270,12 @@ function SubscriberDashboardInternal({
                       history.push(relativeUrl('/' + currRow.imsi));
                     },
                   },
-                  {name: 'Edit'},
+                  {
+                    name: 'Edit',
+                    handleFunc: () => {
+                      history.push(relativeUrl('/' + currRow.imsi + '/config'));
+                    },
+                  },
                   {name: 'Remove'},
                 ]}
                 options={{


### PR DESCRIPTION
## Summary
- removed subscriber tab
- unconditionally display alert table. earlier we would not display alert table if there were no alerts
- Added links from edit select to config components in gateway, enodeb and subscriber

## Test Plan

yarn test passes
old

<img width="1680" alt="Screen Shot 2020-07-30 at 2 09 39 PM" src="https://user-images.githubusercontent.com/8224854/88977881-7ab55e80-d273-11ea-954b-4c229cc606da.png">

new
<img width="1676" alt="Screen Shot 2020-07-30 at 2 46 25 PM" src="https://user-images.githubusercontent.com/8224854/88977895-830d9980-d273-11ea-8b2b-cba8ea83da49.png">

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
