### PR TITLE
[agw][dev] Disable dev_tools.py DNS caching

### DIFF
--- a/lte/gateway/dev_tools.py
+++ b/lte/gateway/dev_tools.py
@@ -46,7 +46,7 @@ def register_vm():
                     ),
                 ),
             ),
-            dns=types.NetworkDNSConfig(enable_caching=True, local_ttl=60),
+            dns=types.NetworkDNSConfig(enable_caching=False, local_ttl=60),
         )
         dev_utils.cloud_post('lte', network_payload)
 


### PR DESCRIPTION
## Summary

DNS caching was breaking local dev environment. This diff turns it off for future dev setups.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking