### PR TITLE
Add trailing backslash to rulesDir in configmanager helm chart

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.33
+version: 1.4.34
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.13
+version: 1.4.14
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -107,7 +107,7 @@ prometheusConfigurer:
         targetPort: 9100
 
   prometheusConfigurerPort: 9100
-  rulesDir: "/etc/configs/alert_rules"
+  rulesDir: "/etc/configs/alert_rules/"
   prometheusURL: "orc8r-prometheus:9090"
 
   image:

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.4
 - name: metrics
   repository: ""
-  version: 1.4.13
+  version: 1.4.14
 - name: nms
   repository: ""
   version: 0.1.6

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.13
+    version: 1.4.14
     repository: ""
     condition: metrics.enabled
   - name: nms


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Add a trailing '/' to the default `rulesDir` value in the prometheus-configurer helm chart to avoid bad filepaths.

## Test Plan
Tested locally. Works by default with this change, does not without.

## Additional Information
Will publish helm chart to repo once approved.
