### PR TITLE
[nms] Add SAML auth strategy to nms

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/login.js
+++ b/nms/app/fbcnms-projects/magmalte/app/login.js
@@ -32,6 +32,10 @@ function LoginWrapper() {
       // $FlowFixMe - createHref exists
       action={history.createHref({pathname: '/user/login'})}
       title="Magma"
+      // eslint-disable-next-line no-warning-comments
+      // $FlowFixMe - createHref exists
+      ssoAction={history.createHref({pathname: '/user/login/saml'})}
+      ssoEnabled={window.CONFIG.appData.ssoEnabled}
       csrfToken={window.CONFIG.appData.csrfToken}
     />
   );

--- a/nms/app/fbcnms-projects/magmalte/server/app.js
+++ b/nms/app/fbcnms-projects/magmalte/server/app.js
@@ -45,6 +45,8 @@ const session = require('express-session');
 const {sequelize} = require('@fbcnms/sequelize-models');
 const OrganizationLocalStrategy = require('@fbcnms/auth/strategies/OrganizationLocalStrategy')
   .default;
+const OrganizationSamlStrategy = require('@fbcnms/auth/strategies/OrganizationSamlStrategy')
+  .default;
 
 const {access, configureAccess} = require('@fbcnms/auth/access');
 const {
@@ -78,6 +80,12 @@ app.use(passport.session()); // must be after sessionMiddleware
 
 fbcPassport.use();
 passport.use('local', OrganizationLocalStrategy());
+passport.use(
+  'saml',
+  OrganizationSamlStrategy({
+    urlPrefix: '/user',
+  }),
+);
 
 // Views
 app.set('views', path.join(__dirname, '..', 'views'));

--- a/nms/app/fbcnms-projects/magmalte/server/main/routes.js
+++ b/nms/app/fbcnms-projects/magmalte/server/main/routes.js
@@ -55,7 +55,7 @@ const handleReact = tab =>
           }
         : {tenant: '', email: '', isSuperUser: false, isReadOnlyUser: false},
       enabledFeatures: await getEnabledFeatures(req, organization?.name),
-      ssoEnabled: false,
+      ssoEnabled: !!organization?.ssoEntrypoint,
       ssoSelectedType: 'none',
       csvCharset: null,
     };


### PR DESCRIPTION
## Summary

SAML was already implemented but wasn't enabled on standalone.  This
commit enables it.

## Test Plan

* Go to https://master.localhost and edit an organization to enable SSO
* In another tab, open https://fb-test.localhost and verify "Sign In"
  button is enabled, and clicking it redirects you to the SSO IdP