### PR TITLE
[AGW] mobilityD: Add support for static IPs

### DIFF
--- a/lte/gateway/configs/mobilityd.yml
+++ b/lte/gateway/configs/mobilityd.yml
@@ -14,3 +14,4 @@
 # log_level is set in mconfig. it can be overridden here
 persist_to_redis: false
 redis_port: 6380
+static_ip_enabled: False

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_mobilityd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_mobilityd.service
@@ -13,6 +13,8 @@
 Description=Magma mobilityd service
 PartOf=magma@mme.service
 Before=magma@mme.service
+After=magma@subscriberdb.service
+Wants=magma@subscriberdb.service
 
 [Service]
 Type=simple

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -54,7 +54,7 @@ from magma.mobilityd.metrics import (IP_ALLOCATED_TOTAL, IP_RELEASED_TOTAL)
 from magma.common.redis.client import get_default_client
 
 from .ip_allocator_dhcp import IPAllocatorDHCP
-from .ip_allocator_static import IpAllocatorStatic
+from .ip_allocator_pool import IpAllocatorPool
 from .ip_descriptor_map import IpDescriptorMap
 from .uplink_gw import UplinkGatewayInfo
 
@@ -153,9 +153,9 @@ class IPAddressManager:
 
         if self.allocator_type == MobilityD.IP_POOL:
             self._dhcp_gw_info.read_default_gw()
-            self.ip_allocator = IpAllocatorStatic(self._assigned_ip_blocks,
-                                                  self.ip_state_map,
-                                                  self.sid_ips_map)
+            self.ip_allocator = IpAllocatorPool(self._assigned_ip_blocks,
+                                                self.ip_state_map,
+                                                self.sid_ips_map)
         elif self.allocator_type == MobilityD.DHCP:
             dhcp_store = store.MacToIP()  # mac => DHCP_State
             iface = config.get('dhcp_iface', 'dhcp0')

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -21,9 +21,13 @@ old client will not be unintentionally routed to a new client until the old
 TCP connection expires.
 
 We have plug in design for IP address allocator. today we have two allocator
-1. Static allocator, which allocates IP address from block of IP address
+1. IP_POOL allocator, which allocates IP address from block of IP address
 2. DHCP IP allocator. This allocates IP address assigned by DHCP server
    in network. This is typically used in Non NAT GW environment.
+
+IP allocator supports static IP allocation for sub set of subscribers.
+When static Ip mode is enabled, mobilityD would check subscriberDB for
+assigned IP address before allocating Ip from configured allocator.
 
 To support this semantic, an IP address can have the following states
 during it's life cycle in the IP allocator:
@@ -39,8 +43,6 @@ during it's life cycle in the IP allocator:
 from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
-from argparse import ArgumentError
-
 import logging
 import threading
 from collections import defaultdict
@@ -49,12 +51,15 @@ from typing import List, Optional, Tuple
 from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 
 from magma.mobilityd import mobility_store as store
-from magma.mobilityd.ip_descriptor import IPDesc, IPState
+
+from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.metrics import (IP_ALLOCATED_TOTAL, IP_RELEASED_TOTAL)
 from magma.common.redis.client import get_default_client
 
 from .ip_allocator_dhcp import IPAllocatorDHCP
 from .ip_allocator_pool import IpAllocatorPool
+from .ip_allocator_static import IPAllocatorStaticWrapper
+
 from .ip_descriptor_map import IpDescriptorMap
 from .uplink_gw import UplinkGatewayInfo
 
@@ -113,6 +118,7 @@ class IPAddressManager:
                  *,
                  config,
                  allocator_type,
+                 subscriberdb_rpc_stub=None,
                  recycling_interval: int = DEFAULT_IP_RECYCLE_INTERVAL):
         """ Initializes a new IP allocator
 
@@ -133,12 +139,12 @@ class IPAddressManager:
 
         self._recycle_timer = None  # reference to recycle timer
         self._recycling_interval_seconds = recycling_interval
+        self.static_ip_enabled = config.get('static_ip_enabled', False)
 
         if not persist_to_redis:
             self._assigned_ip_blocks = set()  # {ip_block}
             self.sid_ips_map = defaultdict(IPDesc)  # {SID=>IPDesc}
             self._dhcp_gw_info = UplinkGatewayInfo(defaultdict(str))
-
         else:
             if not redis_port:
                 raise ValueError(
@@ -153,19 +159,25 @@ class IPAddressManager:
 
         if self.allocator_type == MobilityD.IP_POOL:
             self._dhcp_gw_info.read_default_gw()
-            self.ip_allocator = IpAllocatorPool(self._assigned_ip_blocks,
-                                                self.ip_state_map,
-                                                self.sid_ips_map)
+            ip_allocator = IpAllocatorPool(self._assigned_ip_blocks,
+                                           self.ip_state_map,
+                                           self.sid_ips_map)
         elif self.allocator_type == MobilityD.DHCP:
             dhcp_store = store.MacToIP()  # mac => DHCP_State
             iface = config.get('dhcp_iface', 'dhcp0')
             retry_limit = config.get('retry_limit', 300)
-            self.ip_allocator = IPAllocatorDHCP(self._assigned_ip_blocks,
-                                                self.ip_state_map,
-                                                iface=iface,
-                                                retry_limit=retry_limit,
-                                                dhcp_store=dhcp_store,
-                                                gw_info=self._dhcp_gw_info)
+            ip_allocator = IPAllocatorDHCP(self._assigned_ip_blocks,
+                                           self.ip_state_map,
+                                           iface=iface,
+                                           retry_limit=retry_limit,
+                                           dhcp_store=dhcp_store,
+                                           gw_info=self._dhcp_gw_info)
+
+        if self.static_ip_enabled:
+            self.ip_allocator = IPAllocatorStaticWrapper(subscriberdb_rpc_stub=subscriberdb_rpc_stub,
+                                                         ip_allocator=ip_allocator)
+        else:
+            self.ip_allocator = ip_allocator
 
     def add_ip_block(self, ipblock: ip_network):
         """ Add a block of IP addresses to the free IP list
@@ -301,8 +313,6 @@ class IPAddressManager:
 
             # Now try to allocate it from underlying allocator.
             ip_desc = self.ip_allocator.alloc_ip_address(sid)
-            ip_desc.sid = sid
-            ip_desc.state = IPState.ALLOCATED
             self.ip_state_map.add_ip_to_state(ip_desc.ip, ip_desc, IPState.ALLOCATED)
             self.sid_ips_map[sid] = ip_desc
 
@@ -393,13 +403,9 @@ class IPAddressManager:
         with self._lock:
             for ip in self.ip_state_map.list_ips(IPState.REAPED):
                 ip_desc = self.ip_state_map.mark_ip_state(ip, IPState.FREE)
-                sid = ip_desc.sid
-                ip_block = ip_desc.ip_block
-                ip_desc.sid = None
-
+                self.ip_allocator.release_ip(ip_desc)
                 # update SID-IP map
-                del self.sid_ips_map[sid]
-                self.ip_allocator.release_ip(sid, ip, ip_block)
+                del self.sid_ips_map[ip_desc.sid]
 
             # Set timer for the next round of recycling
             self._recycle_timer = None

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -48,7 +48,7 @@ class IPAllocator(ABC):
         ...
 
     @abstractmethod
-    def release_ip(self, sid: str, ip: ip_address, ip_block: ip_network):
+    def release_ip(self, ip_desc: IPDesc):
         ...
 
 

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -33,7 +33,7 @@ from .ip_allocator_base import IPAllocator, NoAvailableIPError, \
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
 
-class IpAllocatorStatic(IPAllocator):
+class IpAllocatorPool(IPAllocator):
 
     def __init__(self,
                  assigned_ip_blocks: Set[ip_network],

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -198,10 +198,13 @@ class IpAllocatorPool(IPAllocator):
         """
         # if an IP is not yet allocated for the UE, allocate a new IP
         if self._ip_state_map.get_ip_count(IPState.FREE):
-            return self._ip_state_map.pop_ip_from_state(IPState.FREE)
+            ip_desc = self._ip_state_map.pop_ip_from_state(IPState.FREE)
+            ip_desc.sid = sid
+            ip_desc.state = IPState.ALLOCATED
+            return ip_desc
         else:
             logging.error("Run out of available IP addresses")
             raise NoAvailableIPError("No available IP addresses")
 
-    def release_ip(self, sid, ip, ip_block):
+    def release_ip(self, ip_desc: IPDesc):
         pass

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -1,0 +1,92 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+This is one of ip allocator for ip address manager.
+The IP allocator accepts IP blocks (range of IP addresses), and supports
+allocating and releasing IP addresses from the assigned IP blocks.
+"""
+
+from __future__ import absolute_import, division, print_function, \
+    unicode_literals
+
+from ipaddress import ip_address, ip_network
+from typing import List
+
+from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
+from magma.mobilityd.ip_allocator_base import IPAllocator
+from magma.mobilityd.subscriberdb_client import SubscriberDbClient
+
+DEFAULT_IP_RECYCLE_INTERVAL = 15
+
+
+class IPAllocatorStaticWrapper(IPAllocator):
+
+    def __init__(self, subscriberdb_rpc_stub, ip_allocator: IPAllocator):
+        """ Initializes a static IP allocator
+            This is wrapper around other configured Ip allocator. If subscriber
+            does have static IP, it uses underlying IP allocator to allocate IP
+            for the subscriber.
+        """
+        self._subscriber_client = SubscriberDbClient(subscriberdb_rpc_stub)
+        self._ip_allocator = ip_allocator
+
+    def add_ip_block(self, ipblock: ip_network):
+        """ Add a block of IP addresses to the free IP list
+        """
+        self._ip_allocator.add_ip_block(ipblock)
+
+    def remove_ip_blocks(self, ipblocks: List[ip_network],
+                         _force: bool = False) -> List[ip_network]:
+        """ Remove allocated IP blocks.
+        """
+        return self._ip_allocator.remove_ip_blocks(ipblocks, _force)
+
+    def list_added_ip_blocks(self) -> List[ip_network]:
+        """ List IP blocks added to the IP allocator
+        Return:
+             copy of the list of assigned IP blocks
+        """
+        return self._ip_allocator.list_added_ip_blocks()
+
+    def list_allocated_ips(self, ipblock: ip_network) -> List[ip_address]:
+        """ List IP addresses allocated from a given IP block
+        """
+        return self._ip_allocator.list_allocated_ips(ipblock)
+
+    def alloc_ip_address(self, sid: str) -> IPDesc:
+        """ Check if subscriber has static IP assigned.
+        If it is not allocated use IP allocator to assign an IP.
+        """
+        ip_desc = self._allocate_static_ip(sid)
+        if ip_desc is None:
+            ip_desc = self._ip_allocator.alloc_ip_address(sid)
+        return ip_desc
+
+    def release_ip(self, ip_desc: IPDesc):
+        """
+        Statically allocated IPs do not need to do any update on
+        ip release
+        """
+        if ip_desc.type != IPType.STATIC:
+            self._ip_allocator.release_ip(ip_desc)
+
+    def _allocate_static_ip(self, sid: str) -> IPDesc:
+        """
+        Check if static IP allocation is enabled and then check
+        subscriber DB for assigned static IP for the SID
+        """
+        ip_addr = self._subscriber_client.get_subscriber_ip(sid)
+        if ip_addr is None:
+            return None
+        return IPDesc(ip=ip_addr, state=IPState.ALLOCATED,
+                      sid=sid, ip_block=ip_addr, ip_type=IPType.STATIC)
+

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -14,15 +14,19 @@ limitations under the License.
 from magma.common.service import MagmaService
 from magma.mobilityd.rpc_servicer import MobilityServiceRpcServicer
 from lte.protos.mconfig import mconfigs_pb2
+from magma.common.service_registry import ServiceRegistry
+from lte.protos.subscriberdb_pb2_grpc import SubscriberDBStub
 
 
 def main():
     """ main() for MobilityD """
     service = MagmaService('mobilityd', mconfigs_pb2.MobilityD())
 
+    chan = ServiceRegistry.get_rpc_channel('subscriberdb', ServiceRegistry.LOCAL)
+
     # Add all servicers to the server
     mobility_service_servicer = MobilityServiceRpcServicer(
-        service.mconfig, service.config)
+        service.mconfig, service.config, SubscriberDBStub(chan))
     mobility_service_servicer.add_to_server(service.rpc_server)
 
     # Run the service loop

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -26,7 +26,7 @@ from magma.subscriberdb.sid import SIDUtils
 
 from .ip_address_man import IPAddressManager, IPNotInUseError, MappingNotFoundError
 
-from .ip_allocator_static import IPBlockNotFoundError, NoAvailableIPError, \
+from .ip_allocator_pool import IPBlockNotFoundError, NoAvailableIPError, \
     OverlappedIPBlocksError
 
 from .ip_allocator_base import DuplicatedIPAllocationError

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -23,13 +23,13 @@ from lte.protos.mobilityd_pb2_grpc import MobilityServiceServicer, \
 from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import return_void
 from magma.subscriberdb.sid import SIDUtils
-
 from .ip_address_man import IPAddressManager, IPNotInUseError, MappingNotFoundError
 
 from .ip_allocator_pool import IPBlockNotFoundError, NoAvailableIPError, \
     OverlappedIPBlocksError
 
 from .ip_allocator_base import DuplicatedIPAllocationError
+
 
 def _get_ip_block(ip_block_str):
     """ Convert string into ipaddress.ip_network. Support both IPv4 or IPv6
@@ -52,11 +52,12 @@ def _get_ip_block(ip_block_str):
 class MobilityServiceRpcServicer(MobilityServiceServicer):
     """ gRPC based server for the IPAllocator. """
 
-    def __init__(self, mconfig, config):
+    def __init__(self, mconfig, config, subscriberdb_rpc_stub=None):
         # TODO: consider adding gateway mconfig to decide whether to
         # persist to Redis
 
         self._ipv4_allocator = IPAddressManager(config=config,
+                                                subscriberdb_rpc_stub=subscriberdb_rpc_stub,
                                                 allocator_type=mconfig.ip_allocator_type)
 
         # Load IP block from the configurable mconfig file

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -1,0 +1,62 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ipaddress
+import grpc
+import logging
+
+from magma.subscriberdb.sid import SIDUtils
+
+
+class SubscriberDbClient:
+    def __init__(self, subscriberdb_rpc_stub):
+        self.subscriber_client = subscriberdb_rpc_stub
+
+    def get_subscriber_ip(self, sid: str) -> ipaddress.ip_address:
+        """
+        Make RPC call to 'GetSubscriberData' method of local SubscriberDB
+        service to get assigned IP address if any.
+        """
+        if self.subscriber_client is None:
+            return None
+
+        ip_addr = None
+        try:
+            if '.' in sid:
+                imsi, apn_name = sid.split('.')
+            else:
+                imsi, apn_name = sid, ''
+
+            data = self.subscriber_client.GetSubscriberData(SIDUtils.to_pb(imsi))
+            if data and data.non_3gpp and data.non_3gpp.apn_config:
+                for apn_config in data.non_3gpp.apn_config:
+                    if apn_config.service_selection == '*':
+                        ip_addr = apn_config.assigned_static_ip
+                    if apn_config.service_selection == apn_name:
+                        ip_addr = apn_config.assigned_static_ip
+                        break
+
+                if ip_addr is not None:
+                    return ipaddress.ip_address(ip_addr)
+            return None
+
+        except ValueError:
+            logging.warning("Invalid sid or ip %s: [%s]", sid, ip_addr)
+            return None
+
+        except grpc.RpcError as err:
+            logging.error(
+                "GetSubscriberData error[%s] %s",
+                err.code(),
+                err.details())
+            return None

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -27,8 +27,7 @@ from unittest import mock
 from magma.common.redis.mocks.mock_redis import MockRedis
 from magma.pipelined.bridge_util import BridgeTools
 from magma.mobilityd import mobility_store as store
-
-from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+from magma.mobilityd.ip_descriptor import IPDesc, IPType, IPState
 
 from magma.mobilityd.mac import create_mac_from_sid
 from magma.mobilityd.dhcp_desc import DHCPState
@@ -119,9 +118,10 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         self.assertNotEqual(ip1, ip3)
         self.assertNotEqual(ip2, ip3)
         # release unallocated IP of SID
-        self._dhcp_allocator.ip_allocator.release_ip("IMSI033",
-                                                     ip3,
-                                                     ip_network("1.1.1.0/24"))
+        ip_unallocated = IPDesc(ip=ip3, state=IPState.ALLOCATED,
+               sid="IMSI033", ip_block=ip_network("1.1.1.0/24"),
+               ip_type=IPType.DHCP)
+        self._dhcp_allocator.ip_allocator.release_ip(ip_unallocated)
         self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(),
                          [ip_network('192.168.128.0/24')])
 

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -24,7 +24,7 @@ from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 
 from magma.mobilityd.ip_address_man import IPAddressManager, \
     IPNotInUseError, MappingNotFoundError
-from magma.mobilityd.ip_allocator_static import IPBlockNotFoundError, \
+from magma.mobilityd.ip_allocator_pool import IPBlockNotFoundError, \
     NoAvailableIPError
 
 # If the preallocated IP addresses in ip_address_man.py code

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -1,0 +1,258 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import ipaddress
+import unittest
+
+from magma.mobilityd import subscriberdb_client
+
+from lte.protos.subscriberdb_pb2 import (
+    LTESubscription,
+    SubscriberData,
+    SubscriberState,
+    SubscriberID,
+    SubscriberUpdate,
+    Non3GPPUserProfile,
+    APNConfiguration,
+)
+
+from lte.protos.mconfig.mconfigs_pb2 import MobilityD
+from magma.mobilityd.ip_descriptor import IPDesc, IPType
+from magma.mobilityd.ip_address_man import IPAddressManager, \
+    IPNotInUseError, MappingNotFoundError
+from magma.subscriberdb.sid import SIDUtils
+
+
+class MockedSubscriberDBStub:
+    # subscriber map
+    subs = {}
+
+    def __init__(self):
+        pass
+
+    def GetSubscriberData(self, sid):
+        cls = self.__class__
+        return cls.subs.get(str(sid), None)
+
+    @classmethod
+    def add_sub(cls, sid: str, apn: str, ip: str):
+        sub_db_sid = SIDUtils.to_pb(sid)
+        lte = LTESubscription()
+        lte.state = LTESubscription.ACTIVE
+        state = SubscriberState()
+        state.lte_auth_next_seq = 1
+        non_3gpp = Non3GPPUserProfile()
+        subs_data = SubscriberData(sid=sub_db_sid, lte=lte, state=state, non_3gpp=non_3gpp)
+
+        cls.subs[str(sub_db_sid)] = subs_data
+        cls.add_sub_ip(sid, apn, ip)
+
+    @classmethod
+    def add_incomplete_sub(cls, sid: str):
+        sub_db_sid = SIDUtils.to_pb(sid)
+        lte = LTESubscription()
+        lte.state = LTESubscription.ACTIVE
+        state = SubscriberState()
+        state.lte_auth_next_seq = 1
+        subs_data = SubscriberData(sid=sub_db_sid, lte=lte, state=state)
+        cls.subs[str(sub_db_sid)] = subs_data
+
+    @classmethod
+    def add_sub_ip(cls, sid: str, apn: str, ip: str):
+        sub_db_sid = SIDUtils.to_pb(sid)
+        apn_config = APNConfiguration()
+        apn_config.context_id = 1
+        apn_config.service_selection = apn
+        apn_config.assigned_static_ip = ip
+
+        subs_data = cls.subs[str(sub_db_sid)]
+        subs_data.non_3gpp.apn_config.extend([apn_config])
+
+    @classmethod
+    def clear_subs(cls):
+        cls.subs = {}
+
+
+class StaticIPAllocationTests(unittest.TestCase):
+    """
+    Test class for the Mobilityd Static IP Allocator
+    """
+    RECYCLING_INTERVAL_SECONDS = 1
+
+    def _new_ip_allocator(self, recycling_interval):
+        """
+        Creates and sets up an IPAllocator with the given recycling interval.
+        """
+        config = {
+            'recycling_interval': recycling_interval,
+            'persist_to_redis': False,
+            'redis_port': 6379,
+            'static_ip_enabled': True,
+        }
+        self._allocator = IPAddressManager(
+            recycling_interval=recycling_interval,
+            allocator_type=MobilityD.IP_POOL,
+            subscriberdb_rpc_stub=MockedSubscriberDBStub(),
+            config=config)
+        self._allocator.add_ip_block(self._block)
+
+    def setUp(self):
+        self._block = ipaddress.ip_network('192.168.0.0/28')
+        self._new_ip_allocator(self.RECYCLING_INTERVAL_SECONDS)
+
+    def tearDown(self):
+        MockedSubscriberDBStub.clear_subs()
+
+    def check_type(self, sid: str, type: IPType):
+        ip_desc = self._allocator.sid_ips_map[sid]
+        self.assertEqual(ip_desc.type, type)
+
+    def test_get_ip_for_subscriber(self):
+        """ test get_ip_for_sid without any assignment """
+        sid = 'IMSI11'
+        ip0 = self._allocator.alloc_ip_address(sid)
+
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ip_for_subscriber_with_apn(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_different_apn(self):
+        """ test get_ip_for_sid with different APN assigned ip"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="xyz", ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ip_for_subscriber_with_wildcard_apn(self):
+        """ test wildcard apn"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_wildcard_and_exact_apn(self):
+        """ test IP assignement from multiple  APNs"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        assigned_ip_wild = '22.22.22.22'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_invalid_ip(self):
+        """ test invalid data from DB """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.hh'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(str(ip0), assigned_ip)
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ip_for_subscriber_with_multi_apn_but_no_match(self):
+        """ test IP assignment from multiple  APNs"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        assigned_ip_wild = '22.22.22.22'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="abc", ip=assigned_ip_wild)
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ip_for_subscriber_with_incomplete_sub(self):
+        """ test IP assignment from subscriber without non_3gpp config"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        MockedSubscriberDBStub.add_incomplete_sub(sid=imsi)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.check_type(sid, IPType.IP_POOL)
+
+    def test_get_ip_for_subscriber_with_wildcard_no_apn(self):
+        """ test wildcard apn"""
+        imsi = 'IMSI110'
+        sid = imsi
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)


### PR DESCRIPTION
## Summary

    This patch check subscriberDB for statically assigned
    IP address for given subscriber before allocating IP
    address. It uses GRPC channel to communicate to local
    SubscriberDB service.

## Test Plan

`make test`
`make integ_test`
