### PR TITLE
[NMS] Simplify state management in equipment components

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/components/ActionTable.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/ActionTable.js
@@ -193,6 +193,7 @@ export default function ActionTable<T>(props: ActionTableProps<T>) {
               if (item.handleFunc) {
                 item.handleFunc();
               }
+              handleClose();
             }}>
             {item.name}
           </MenuItem>

--- a/nms/app/fbcnms-projects/magmalte/app/components/context/EnodebContext.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/context/EnodebContext.js
@@ -13,18 +13,19 @@
  * @flow strict-local
  * @format
  */
-import type {tier, tier_id} from '@fbcnms/magma-api';
+import type {EnodebInfo} from '../lte/EnodebUtils';
+import type {network_ran_configs} from '@fbcnms/magma-api';
 
 import React from 'react';
 
-type GatewayTierState = {
-  tiers: {[string]: tier},
-  supportedVersions: Array<string>,
+type EnodebState = {
+  enbInfo: {[string]: EnodebInfo},
+  lteRanConfigs?: network_ran_configs,
 };
 
-export type GatewayTierContextType = {
-  state: GatewayTierState,
-  setState: (key: tier_id, val?: tier) => Promise<void>,
+export type EnodebContextType = {
+  state: EnodebState,
+  setState: (key: string, val?: EnodebInfo) => Promise<void>,
 };
 
-export default React.createContext<GatewayTierContextType>({});
+export default React.createContext<EnodebContextType>({});

--- a/nms/app/fbcnms-projects/magmalte/app/components/context/GatewayContext.js
+++ b/nms/app/fbcnms-projects/magmalte/app/components/context/GatewayContext.js
@@ -13,18 +13,15 @@
  * @flow strict-local
  * @format
  */
-import type {tier, tier_id} from '@fbcnms/magma-api';
+import type {UpdateGatewayProps} from '../../state/EquipmentState';
+import type {gateway_id, lte_gateway} from '@fbcnms/magma-api';
 
 import React from 'react';
 
-type GatewayTierState = {
-  tiers: {[string]: tier},
-  supportedVersions: Array<string>,
+export type GatewayContextType = {
+  state: {[string]: lte_gateway},
+  setState: (key: gateway_id, val?: lte_gateway) => Promise<void>,
+  updateGateway: (props: $Shape<UpdateGatewayProps>) => Promise<void>,
 };
 
-export type GatewayTierContextType = {
-  state: GatewayTierState,
-  setState: (key: tier_id, val?: tier) => Promise<void>,
-};
-
-export default React.createContext<GatewayTierContextType>({});
+export default React.createContext<GatewayContextType>({});

--- a/nms/app/fbcnms-projects/magmalte/app/state/EquipmentState.js
+++ b/nms/app/fbcnms-projects/magmalte/app/state/EquipmentState.js
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {EnodebInfo} from '../components/lte/EnodebUtils';
+import type {
+  enodeb_serials,
+  gateway_epc_configs,
+  gateway_id,
+  gateway_ran_configs,
+  generic_command_params,
+  lte_gateway,
+  magmad_gateway_configs,
+  network_id,
+  ping_request,
+  tier,
+  tier_id,
+} from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+/************************** Gateway Tier State *******************************/
+type InitTierStateProps = {
+  networkId: network_id,
+  setTiers: ({[string]: tier}) => void,
+  enqueueSnackbar: (msg: string, cfg: {}) => ?(string | number),
+};
+
+export async function InitTierState(props: InitTierStateProps) {
+  const {networkId, setTiers, enqueueSnackbar} = props;
+  let tierIdList = [];
+  try {
+    tierIdList = await MagmaV1API.getNetworksByNetworkIdTiers({networkId});
+  } catch (e) {
+    enqueueSnackbar('failed fetching tier information', {variant: 'error'});
+  }
+
+  const requests = tierIdList.map(tierId => {
+    try {
+      return MagmaV1API.getNetworksByNetworkIdTiersByTierId({
+        networkId,
+        tierId,
+      });
+    } catch (e) {
+      enqueueSnackbar('failed fetching tier information for ' + tierId, {
+        variant: 'error',
+      });
+      return;
+    }
+  });
+
+  const tierResponse = await Promise.all(requests);
+  const tiers = {};
+  // reduce function gives a flow lint, hence using forEach instead
+  tierResponse.filter(Boolean).forEach(item => {
+    tiers[item.id] = item;
+  });
+  setTiers(tiers);
+}
+
+type TierStateProps = {
+  networkId: network_id,
+  tiers: {[string]: tier},
+  setTiers: ({[string]: tier}) => void,
+  key: tier_id,
+  value?: tier,
+};
+
+export async function SetTierState(props: TierStateProps) {
+  const {networkId, tiers, setTiers, key, value} = props;
+  if (value != null) {
+    if (!(key in tiers)) {
+      await MagmaV1API.postNetworksByNetworkIdTiers({
+        networkId: networkId,
+        tier: value,
+      });
+    } else {
+      await MagmaV1API.putNetworksByNetworkIdTiersByTierId({
+        networkId: networkId,
+        tierId: key,
+        tier: value,
+      });
+    }
+    setTiers({...tiers, [key]: value});
+  } else {
+    await MagmaV1API.deleteNetworksByNetworkIdTiersByTierId({
+      networkId: networkId,
+      tierId: key,
+    });
+    const newTiers = {...tiers};
+    delete newTiers[key];
+    setTiers(newTiers);
+  }
+}
+
+/**************************** Enode State ************************************/
+type InitEnodeStateProps = {
+  networkId: network_id,
+  setEnbInfo: ({[string]: EnodebInfo}) => void,
+  enqueueSnackbar: (msg: string, cfg: {}) => ?(string | number),
+};
+
+export async function InitEnodeState(props: InitEnodeStateProps) {
+  const {networkId, setEnbInfo, enqueueSnackbar} = props;
+  let enb = {};
+  try {
+    enb = await MagmaV1API.getLteByNetworkIdEnodebs({networkId});
+  } catch (e) {
+    enqueueSnackbar('failed fetching enodeb information', {
+      variant: 'error',
+    });
+    return [];
+  }
+
+  let err = false;
+  const requests = Object.keys(enb).map(async k => {
+    try {
+      const {serial} = enb[k];
+      // eslint-disable-next-line max-len
+      const enbSt = await MagmaV1API.getLteByNetworkIdEnodebsByEnodebSerialState(
+        {
+          networkId: networkId,
+          enodebSerial: serial,
+        },
+      );
+      return [enb[k], enbSt];
+    } catch (e) {
+      err = true;
+      return [enb[k], {}];
+    }
+  });
+  if (err) {
+    enqueueSnackbar('failed fetching enodeb state information', {
+      variant: 'error',
+    });
+  }
+  const enbResp = await Promise.all(requests);
+  const enbInfo = {};
+  enbResp.filter(Boolean).forEach(r => {
+    if (r.length > 0) {
+      const [enb, enbSt] = r;
+      if (enb != null && enbSt != null) {
+        enbInfo[enb.serial] = {
+          enb: enb,
+          enb_state: enbSt,
+        };
+      }
+    }
+  });
+  setEnbInfo(enbInfo);
+}
+
+type EnodebStateProps = {
+  networkId: network_id,
+  enbInfo: {[string]: EnodebInfo},
+  setEnbInfo: ({[string]: EnodebInfo}) => void,
+  key: string,
+  value?: EnodebInfo,
+};
+
+export async function SetEnodebState(props: EnodebStateProps) {
+  const {networkId, enbInfo, setEnbInfo, key, value} = props;
+  if (value != null) {
+    if (!(key in enbInfo)) {
+      await MagmaV1API.postLteByNetworkIdEnodebs({
+        networkId: networkId,
+        enodeb: value.enb,
+      });
+      setEnbInfo({...enbInfo, [key]: value});
+    } else {
+      await MagmaV1API.putLteByNetworkIdEnodebsByEnodebSerial({
+        networkId: networkId,
+        enodebSerial: key,
+        enodeb: value.enb,
+      });
+      const prevEnbSt = enbInfo[key].enb_state;
+      setEnbInfo({...enbInfo, [key]: {enb_state: prevEnbSt, enb: value.enb}});
+    }
+  } else {
+    await MagmaV1API.deleteLteByNetworkIdEnodebsByEnodebSerial({
+      networkId: networkId,
+      enodebSerial: key,
+    });
+    const newEnbInfo = {...enbInfo};
+    delete newEnbInfo[key];
+    setEnbInfo(newEnbInfo);
+  }
+}
+
+/**************************** Gateway State **********************************/
+type GatewayStateProps = {
+  networkId: network_id,
+  lteGateways: {[string]: lte_gateway},
+  setLteGateways: ({[string]: lte_gateway}) => void,
+  key: gateway_id,
+  value?: lte_gateway,
+};
+
+export async function SetGatewayState(props: GatewayStateProps) {
+  const {networkId, lteGateways, setLteGateways, key, value} = props;
+  if (value != null) {
+    if (!(key in lteGateways)) {
+      await MagmaV1API.postLteByNetworkIdGateways({
+        networkId: networkId,
+        gateway: value,
+      });
+      setLteGateways({...lteGateways, [key]: value});
+    } else {
+      await MagmaV1API.putLteByNetworkIdGatewaysByGatewayId({
+        networkId: networkId,
+        gatewayId: key,
+        gateway: value,
+      });
+      setLteGateways({...lteGateways, [key]: value});
+    }
+  } else {
+    await MagmaV1API.deleteLteByNetworkIdGatewaysByGatewayId({
+      networkId: networkId,
+      gatewayId: key,
+    });
+    const newLteGateways = {...lteGateways};
+    delete newLteGateways[key];
+    setLteGateways(newLteGateways);
+  }
+}
+
+export type UpdateGatewayProps = {
+  gatewayId: gateway_id,
+  tierId?: tier_id,
+  magmadConfigs?: magmad_gateway_configs,
+  epcConfigs?: gateway_epc_configs,
+  ranConfigs?: gateway_ran_configs,
+  enbs?: enodeb_serials,
+  networkId: network_id,
+  setLteGateways: ({[string]: lte_gateway}) => void,
+};
+
+export async function UpdateGateway(props: UpdateGatewayProps) {
+  const {networkId, gatewayId, setLteGateways} = props;
+  if (props.tierId !== undefined) {
+    await MagmaV1API.putLteByNetworkIdGatewaysByGatewayIdTier({
+      networkId,
+      gatewayId: gatewayId,
+      tierId: JSON.stringify(`"${props.tierId}"`),
+    });
+  }
+  const requests = [];
+  if (props.magmadConfigs !== undefined) {
+    requests.push(
+      MagmaV1API.putLteByNetworkIdGatewaysByGatewayIdMagmad({
+        networkId,
+        gatewayId: gatewayId,
+        magmad: props.magmadConfigs,
+      }),
+    );
+  }
+  if (props.epcConfigs !== undefined) {
+    requests.push(
+      MagmaV1API.putLteByNetworkIdGatewaysByGatewayIdCellularEpc({
+        networkId,
+        gatewayId: gatewayId,
+        config: props.epcConfigs,
+      }),
+    );
+  }
+  if (props.ranConfigs !== undefined) {
+    requests.push(
+      MagmaV1API.putLteByNetworkIdGatewaysByGatewayIdCellularRan({
+        networkId,
+        gatewayId: gatewayId,
+        config: props.ranConfigs,
+      }),
+    );
+  }
+
+  if (props.enbs !== undefined) {
+    requests.push(
+      MagmaV1API.putLteByNetworkIdGatewaysByGatewayIdConnectedEnodebSerials({
+        networkId,
+        gatewayId: gatewayId,
+        serials: props.enbs,
+      }),
+    );
+  }
+  await Promise.all(requests);
+  const gateways = await MagmaV1API.getLteByNetworkIdGateways({
+    networkId,
+  });
+  setLteGateways(gateways);
+}
+
+export type GatewayCommandProps = {
+  networkId: network_id,
+  gatewayId: gateway_id,
+  command: string,
+  pingRequest?: ping_request,
+  params?: generic_command_params,
+};
+
+export async function RunGatewayCommands(props: GatewayCommandProps) {
+  const {networkId, gatewayId} = props;
+
+  switch (props.command) {
+    case 'reboot':
+      return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandReboot(
+        {networkId, gatewayId},
+      );
+
+    case 'ping':
+      if (props.pingRequest != null) {
+        return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandPing(
+          {networkId, gatewayId, pingRequest: props.pingRequest},
+        );
+      }
+
+    default:
+      if (props.params != null) {
+        return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandReboot(
+          {networkId, gatewayId, parameters: props.params},
+        );
+      }
+  }
+}

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -13,13 +13,12 @@
  * @flow strict-local
  * @format
  */
-import type {EnodebInfo} from '../../components/lte/EnodebUtils';
-
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DateTimeMetricChart from '../../components/DateTimeMetricChart';
 import EnodebConfig from './EnodebDetailConfig';
+import EnodebContext from '../../components/context/EnodebContext';
 import GatewayLogs from './GatewayLogs';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
@@ -39,8 +38,8 @@ import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
-import {useState} from 'react';
 
 const useStyles = makeStyles(theme => ({
   dashboardRoot: {
@@ -93,14 +92,12 @@ const useStyles = makeStyles(theme => ({
 }));
 const CHART_TITLE = 'Bandwidth Usage';
 
-type Props = {
-  enbInfo: {[string]: EnodebInfo},
-};
-export function EnodebDetail(props: Props) {
+export function EnodebDetail() {
+  const ctx = useContext(EnodebContext);
   const classes = useStyles();
   const {relativePath, relativeUrl, match} = useRouter();
   const enodebSerial: string = nullthrows(match.params.enodebSerial);
-  const [enbInfo, setEnbInfo] = useState(props.enbInfo[enodebSerial]);
+  const enbInfo = ctx.state.enbInfo[enodebSerial];
 
   return (
     <>
@@ -133,12 +130,7 @@ export function EnodebDetail(props: Props) {
               />
             </Tabs>
           </Grid>
-          <Grid
-            item
-            xs={6}
-            direction="row"
-            justify="flex-end"
-            alignItems="center">
+          <Grid item xs={6}>
             <Grid container justify="flex-end" alignItems="center" spacing={2}>
               <Grid item>
                 <Button className={classes.appBarBtnSecondary}>
@@ -155,32 +147,12 @@ export function EnodebDetail(props: Props) {
         </Grid>
       </AppBar>
       <Switch>
-        <Route
-          path={relativePath('/overview')}
-          render={() => <Overview enbInfo={enbInfo} />}
-        />
+        <Route path={relativePath('/overview')} component={Overview} />
         <Route
           path={relativePath('/config/json')}
-          render={() => (
-            <EnodebJsonConfig
-              enbInfo={enbInfo}
-              onSave={enb => {
-                setEnbInfo({...enbInfo, enb: enb});
-              }}
-            />
-          )}
+          component={EnodebJsonConfig}
         />
-        <Route
-          path={relativePath('/config')}
-          render={() => (
-            <EnodebConfig
-              enbInfo={enbInfo}
-              onSave={enb => {
-                setEnbInfo({...enbInfo, enb: enb});
-              }}
-            />
-          )}
-        />
+        <Route path={relativePath('/config')} component={EnodebConfig} />
         <Route path={relativePath('/logs')} component={GatewayLogs} />
         <Redirect to={relativeUrl('/overview')} />
       </Switch>
@@ -188,10 +160,12 @@ export function EnodebDetail(props: Props) {
   );
 }
 
-function Overview({enbInfo}: {enbInfo: EnodebInfo}) {
+function Overview() {
+  const ctx = useContext(EnodebContext);
   const classes = useStyles();
   const {match} = useRouter();
   const enodebSerial: string = nullthrows(match.params.enodebSerial);
+  const enbInfo = ctx.state.enbInfo[enodebSerial];
   return (
     <div className={classes.dashboardRoot}>
       <Grid container spacing={4}>
@@ -202,12 +176,12 @@ function Overview({enbInfo}: {enbInfo: EnodebInfo}) {
                 icon={SettingsInputAntennaIcon}
                 label={enbInfo.enb.name}
               />
-              <EnodebSummary enbInfo={enbInfo} />
+              <EnodebSummary />
             </Grid>
 
             <Grid item xs={12} md={6} alignItems="center">
               <CardTitleRow icon={GraphicEqIcon} label="Status" />
-              <EnodebStatus enbInfo={enbInfo} />
+              <EnodebStatus />
             </Grid>
           </Grid>
         </Grid>

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
@@ -13,21 +13,27 @@
  * @flow strict-local
  * @format
  */
-import type {EnodebInfo} from '../../components/lte/EnodebUtils';
 import type {KPIRows} from '../../components/KPIGrid';
 
 import Card from '@material-ui/core/Card';
+import EnodebContext from '../../components/context/EnodebContext';
 import KPIGrid from '../../components/KPIGrid';
 import React from 'react';
+import nullthrows from '@fbcnms/util/nullthrows';
 
 import {isEnodebHealthy} from '../../components/lte/EnodebUtils';
+import {useContext} from 'react';
+import {useRouter} from '@fbcnms/ui/hooks';
 
-export function EnodebSummary({enbInfo}: {enbInfo: EnodebInfo}) {
+export function EnodebSummary() {
+  const {match} = useRouter();
+  const enodebSerial: string = nullthrows(match.params.enodebSerial);
+
   const kpiData: KPIRows[] = [
     [
       {
         category: 'eNodeB Serial Number',
-        value: enbInfo.enb.serial,
+        value: enodebSerial,
         statusCircle: false,
       },
     ],
@@ -39,7 +45,12 @@ export function EnodebSummary({enbInfo}: {enbInfo: EnodebInfo}) {
   );
 }
 
-export function EnodebStatus({enbInfo}: {enbInfo: EnodebInfo}) {
+export function EnodebStatus() {
+  const ctx = useContext(EnodebContext);
+  const {match} = useRouter();
+  const enodebSerial: string = nullthrows(match.params.enodebSerial);
+  const enbInfo = ctx.state.enbInfo[enodebSerial];
+
   const isEnbHealthy = isEnodebHealthy(enbInfo);
 
   const kpiData: KPIRows[] = [

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentEnodeb.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentEnodeb.js
@@ -13,19 +13,22 @@
  * @flow strict-local
  * @format
  */
-import type {EnodebInfo} from '../../components/lte/EnodebUtils';
+import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
 
 import ActionTable from '../../components/ActionTable';
 import DateTimeMetricChart from '../../components/DateTimeMetricChart';
+import EnodebContext from '../../components/context/EnodebContext';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
+import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {colors} from '../../theme/default';
 import {isEnodebHealthy} from '../../components/lte/EnodebUtils';
 import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
-import {useState} from 'react';
 
 const CHART_TITLE = 'Total Throughput';
 
@@ -71,9 +74,8 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export default function Enodeb({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {
+export default function Enodeb() {
   const classes = useStyles();
-
   return (
     <div className={classes.dashboardRoot}>
       <Grid container justify="space-between" spacing={3}>
@@ -87,7 +89,7 @@ export default function Enodeb({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {
           />
         </Grid>
         <Grid item xs={12}>
-          <EnodeTable enbInfo={enbInfo} />
+          <EnodebTable />
         </Grid>
       </Grid>
     </div>
@@ -102,16 +104,19 @@ type EnodebRowType = {
   reportedTime: Date,
 };
 
-function EnodeTable({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {
+function EnodebTableRaw(props: WithAlert) {
   const {history, relativeUrl} = useRouter();
+  const ctx = useContext(EnodebContext);
   const [currRow, setCurrRow] = useState<EnodebRowType>({});
+  const enbInfo = ctx.state.enbInfo;
+  const enqueueSnackbar = useEnqueueSnackbar();
   const enbRows: Array<EnodebRowType> = Object.keys(enbInfo).map(
     (serialNum: string) => {
       const enbInf = enbInfo[serialNum];
       return {
         name: enbInf.enb.name,
         id: serialNum,
-        sessionName: enbInf.enb_state.fsm_state,
+        sessionName: enbInf.enb_state?.fsm_state ?? 'not available',
         health: isEnodebHealthy(enbInf) ? 'Good' : 'Bad',
         reportedTime: new Date(enbInf.enb_state.time_reported ?? 0),
       };
@@ -144,7 +149,26 @@ function EnodeTable({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {
             history.push(relativeUrl('/' + currRow.id + '/config'));
           },
         },
-        {name: 'Remove'},
+        {
+          name: 'Remove',
+          handleFunc: () => {
+            props
+              .confirm(`Are you sure you want to delete ${currRow.id}?`)
+              .then(async confirmed => {
+                if (!confirmed) {
+                  return;
+                }
+
+                try {
+                  await ctx.setState(currRow.id);
+                } catch (e) {
+                  enqueueSnackbar('failed deleting enodeb ' + currRow.id, {
+                    variant: 'error',
+                  });
+                }
+              });
+          },
+        },
         {name: 'Deactivate'},
         {name: 'Reboot'},
       ]}
@@ -155,3 +179,5 @@ function EnodeTable({enbInfo}: {enbInfo: {[string]: EnodebInfo}}) {
     />
   );
 }
+
+const EnodebTable = withAlert(EnodebTableRaw);

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGateway.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGateway.js
@@ -13,12 +13,14 @@
  * @flow strict-local
  * @format
  */
+import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
 import type {gateway_id, lte_gateway} from '@fbcnms/magma-api';
 
 import ActionTable from '../../components/ActionTable';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import EquipmentGatewayKPIs from './EquipmentGatewayKPIs';
 import GatewayCheckinChart from './GatewayCheckinChart';
+import GatewayContext from '../../components/context/GatewayContext';
 import GatewayTierContext from '../../components/context/GatewayTierContext';
 import Grid from '@material-ui/core/Grid';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
@@ -27,9 +29,10 @@ import React, {useState} from 'react';
 import Text from '../../theme/design-system/Text';
 import TypedSelect from '@fbcnms/ui/components/TypedSelect';
 import isGatewayHealthy from '../../components/GatewayUtils';
-import {SelectEditComponent} from '../../components/ActionTable';
+import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {CardTitleFilterRow} from '../../components/layout/CardTitleRow';
+import {SelectEditComponent} from '../../components/ActionTable';
 import {colors} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext} from 'react';
@@ -81,11 +84,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export default function Gateway({
-  lteGateways,
-}: {
-  lteGateways: {[string]: lte_gateway},
-}) {
+export default function Gateway() {
   const classes = useStyles();
 
   return (
@@ -96,11 +95,11 @@ export default function Gateway({
         </Grid>
         <Grid item xs={12}>
           <Paper elevation={0}>
-            <EquipmentGatewayKPIs lteGateways={lteGateways} />
+            <EquipmentGatewayKPIs />
           </Paper>
         </Grid>
         <Grid item xs={12}>
-          <GatewayTable lteGateways={lteGateways} />
+          <GatewayTable />
         </Grid>
       </Grid>
     </div>
@@ -129,9 +128,11 @@ const ViewTypes = {
   UPGRADE: 'Upgrade',
 };
 
-function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
+function GatewayTableRaw(props: WithAlert) {
   const classes = useStyles();
   const ctx = useContext(GatewayTierContext);
+  const gwCtx = useContext(GatewayContext);
+  const lteGateways = gwCtx.state;
   const {history, relativeUrl} = useRouter();
   const [currRow, setCurrRow] = useState<EquipmentGatewayRowType>({});
   const [currentView, setCurrentView] = useState<$Keys<typeof ViewTypes>>(
@@ -228,7 +229,7 @@ function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
                   {...props}
                   defaultValue={props.value}
                   value={props.value}
-                  content={Object.keys(ctx.tiers)}
+                  content={Object.keys(ctx.state.tiers)}
                   onChange={value => props.onChange(value)}
                 />
               ),
@@ -239,10 +240,13 @@ function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
             pageSizeOptions: [5, 10],
           }}
           editable={{
-            onRowUpdate: (newData, oldData) =>
-              new Promise((resolve, reject) => {
+            onRowUpdate: async (newData, oldData) =>
+              new Promise(async (resolve, reject) => {
                 try {
-                  ctx.updateGatewayTier(newData.id, newData.tier);
+                  await gwCtx.updateGateway({
+                    gatewayId: newData.id,
+                    tierId: newData.tier,
+                  });
                   const dataUpdate = [...lteGatewayUpgradeRows];
                   const index = oldData.tableData.id;
                   dataUpdate[index] = newData;
@@ -282,7 +286,27 @@ function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
                 history.push(relativeUrl('/' + currRow.id + '/config'));
               },
             },
-            {name: 'Remove'},
+            {
+              name: 'Remove',
+              handleFunc: () => {
+                props
+                  .confirm(`Are you sure you want to delete ${currRow.id}?`)
+                  .then(async confirmed => {
+                    if (!confirmed) {
+                      return;
+                    }
+
+                    try {
+                      await gwCtx.setState(currRow.id);
+                    } catch (e) {
+                      enqueueSnackbar('failed deleting gateway ' + currRow.id, {
+                        variant: 'error',
+                      });
+                    }
+                  });
+              },
+            },
+
             {name: 'Deactivate'},
             {name: 'Reboot'},
           ]}
@@ -295,3 +319,5 @@ function GatewayTable({lteGateways}: {lteGateways: {[string]: lte_gateway}}) {
     </>
   );
 }
+
+const GatewayTable = withAlert(GatewayTableRaw);

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGatewayKPIs.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/EquipmentGatewayKPIs.js
@@ -16,12 +16,15 @@
 import type {KPIData} from '../../components/KPITray';
 import type {lte_gateway} from '@fbcnms/magma-api';
 
+import GatewayContext from '../../components/context/GatewayContext';
 import KPITray from '../../components/KPITray';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import React from 'react';
 import isGatewayHealthy from '../../components/GatewayUtils';
 import nullthrows from '@fbcnms/util/nullthrows';
 import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
+
+import {useContext} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const getLatency = (resp, fn) => {
@@ -33,12 +36,11 @@ const getLatency = (resp, fn) => {
   return respArr && respArr.length ? fn(...respArr).toFixed(2) : 0;
 };
 
-export default function EquipmentGatewayKPIs({
-  lteGateways,
-}: {
-  lteGateways: {[string]: lte_gateway},
-}) {
+export default function EquipmentGatewayKPIs() {
   const {match} = useRouter();
+  const ctx = useContext(GatewayContext);
+  const lteGateways = ctx.state;
+
   const networkId: string = nullthrows(match.params.networkId);
   const timeRange = '3h';
   const {response: maxResponse} = useMagmaAPI(

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailEnodebs.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailEnodebs.js
@@ -13,15 +13,16 @@
  * @flow strict-local
  * @format
  */
-import ActionTable from '../../components/ActionTable';
-import React from 'react';
-
 import type {EnodebInfo} from '../../components/lte/EnodebUtils';
 import type {lte_gateway} from '@fbcnms/magma-api';
 
+import ActionTable from '../../components/ActionTable';
+import EnodebContext from '../../components/context/EnodebContext';
+import React from 'react';
+
 import {isEnodebHealthy} from '../../components/lte/EnodebUtils';
+import {useContext, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
-import {useState} from 'react';
 
 type EnodebRowType = {
   name: string,
@@ -29,14 +30,19 @@ type EnodebRowType = {
   health: string,
 };
 
-export default function GatewayDetailEnodebs({
-  gwInfo,
-  enbInfo,
-}: {
-  gwInfo: lte_gateway,
-  enbInfo: {[string]: EnodebInfo},
-}) {
+export default function GatewayDetailEnodebs({gwInfo}: {gwInfo: lte_gateway}) {
   const {history, match} = useRouter();
+  const enbCtx = useContext(EnodebContext);
+  const enbInfo =
+    gwInfo.connected_enodeb_serials?.reduce(
+      (enbs: {[string]: EnodebInfo}, serial: string) => {
+        if (enbCtx.state.enbInfo[serial] != null) {
+          enbs[serial] = enbCtx.state.enbInfo[serial];
+        }
+        return enbs;
+      },
+      {},
+    ) || {};
   const [currRow, setCurrRow] = useState<EnodebRowType>({});
 
   const enbRows: Array<EnodebRowType> = Object.keys(enbInfo).map(

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailMain.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailMain.js
@@ -13,9 +13,6 @@
  * @flow strict-local
  * @format
  */
-import type {EnodebInfo} from '../../components/lte/EnodebUtils';
-import type {lte_gateway} from '@fbcnms/magma-api';
-
 import AccessAlarmIcon from '@material-ui/icons/AccessAlarm';
 import AppBar from '@material-ui/core/AppBar';
 import Button from '@material-ui/core/Button';
@@ -23,6 +20,8 @@ import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import EventsTable from '../../views/events/EventsTable';
 import GatewayConfig from './GatewayDetailConfig';
+import GatewayContext from '../../components/context/GatewayContext';
+import GatewayDetailEnodebs from './GatewayDetailEnodebs';
 import GatewayDetailStatus from './GatewayDetailStatus';
 import GatewayLogs from './GatewayLogs';
 import GatewaySummary from './GatewaySummary';
@@ -47,8 +46,8 @@ import {GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
-import {useState} from 'react';
 
 const useStyles = makeStyles(theme => ({
   dashboardRoot: {
@@ -100,27 +99,11 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export function GatewayDetail({
-  lteGateways,
-  enbInfo,
-}: {
-  lteGateways: {[string]: lte_gateway},
-  enbInfo: {[string]: EnodebInfo},
-}) {
+export function GatewayDetail() {
   const classes = useStyles();
   const {relativePath, relativeUrl, match} = useRouter();
   const gatewayId: string = nullthrows(match.params.gatewayId);
-  const [gwInfo, setGwInfo] = useState(lteGateways[gatewayId]);
-  const gwEnbs =
-    gwInfo.connected_enodeb_serials?.reduce(
-      (enbs: {[string]: EnodebInfo}, serial: string) => {
-        if (enbInfo[serial]) {
-          enbs[serial] = enbInfo[serial];
-        }
-        return enbs;
-      },
-      {},
-    ) || {};
+  const gwCtx = useContext(GatewayContext);
 
   return (
     <>
@@ -205,41 +188,20 @@ export function GatewayDetail({
       <Switch>
         <Route
           path={relativePath('/config/json')}
-          render={() => (
-            <GatewayJsonConfig
-              gwInfo={gwInfo}
-              onSave={gateway => {
-                setGwInfo(gateway);
-              }}
-            />
-          )}
+          component={GatewayJsonConfig}
         />
-        <Route
-          path={relativePath('/config')}
-          render={() => (
-            <GatewayConfig
-              gwInfo={gwInfo}
-              enbInfo={gwEnbs}
-              onSave={gateway => {
-                setGwInfo(gateway);
-              }}
-            />
-          )}
-        />
+        <Route path={relativePath('/config')} component={GatewayConfig} />
         <Route
           path={relativePath('/event')}
           render={() => (
             <EventsTable
               eventStream="GATEWAY"
-              tags={gwInfo.device.hardware_id}
+              tags={gwCtx.state[gatewayId].device.hardware_id}
               sz="lg"
             />
           )}
         />
-        <Route
-          path={relativePath('/overview')}
-          render={() => <GatewayOverview gwInfo={gwInfo} enbInfo={gwEnbs} />}
-        />
+        <Route path={relativePath('/overview')} component={GatewayOverview} />
         <Route path={relativePath('/logs')} component={GatewayLogs} />
         <Redirect to={relativeUrl('/overview')} />
       </Switch>
@@ -247,10 +209,12 @@ export function GatewayDetail({
   );
 }
 
-function GatewayOverview({gwInfo}: {gwInfo: lte_gateway}) {
+function GatewayOverview() {
   const classes = useStyles();
   const {match} = useRouter();
   const gatewayId: string = nullthrows(match.params.gatewayId);
+  const ctx = useContext(GatewayContext);
+  const gwInfo = ctx.state[gatewayId];
 
   return (
     <div className={classes.dashboardRoot}>
@@ -282,9 +246,7 @@ function GatewayOverview({gwInfo}: {gwInfo: lte_gateway}) {
                 icon={SettingsInputAntennaIcon}
                 label="Connected eNodeBs"
               />
-              <Paper className={classes.paper} elevation={0}>
-                <Text variant="body2">Connected eNodeB Information</Text>
-              </Paper>
+              <GatewayDetailEnodebs gwInfo={gwInfo} />
             </Grid>
             <Grid item>
               <CardTitleRow icon={PeopleIcon} label="Subscribers" />

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/GatewayDetailStatus.js
@@ -18,8 +18,8 @@ import type {lte_gateway} from '@fbcnms/magma-api';
 
 import KPIGrid from '../../components/KPIGrid';
 import React from 'react';
-
 import isGatewayHealthy from '../../components/GatewayUtils';
+
 export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
   let checkInTime = new Date(0);
   if (

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/UpgradeTiersDialog.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/UpgradeTiersDialog.js
@@ -145,10 +145,10 @@ function UpgradeDetails(props: DialogProps) {
   const [updatedTierEntries, setUpdatedTierEntries] = useState(new Set());
   const [removedTierEntries, setRemovedTierEntries] = useState(new Set());
   const [tierEntries, setTierEntries] = useState(
-    Object.keys(ctx.tiers).map(tierId => ({
+    Object.keys(ctx.state.tiers).map(tierId => ({
       id: tierId,
-      name: ctx.tiers[tierId].name,
-      version: ctx.tiers[tierId].version,
+      name: ctx.state.tiers[tierId].name,
+      version: ctx.state.tiers[tierId].version,
     })),
   );
   const saveTier = async () => {
@@ -157,8 +157,8 @@ function UpgradeDetails(props: DialogProps) {
         continue;
       }
       try {
-        await ctx.updateTier(tier.id, {
-          ...(ctx.tiers[tier.id] ?? {gateways: [], images: []}),
+        await ctx.setState(tier.id, {
+          ...(ctx.state.tiers[tier.id] ?? {gateways: [], images: []}),
           ...tier,
         });
       } catch (e) {
@@ -170,7 +170,7 @@ function UpgradeDetails(props: DialogProps) {
 
     for (const tierId of removedTierEntries) {
       try {
-        await ctx.removeTier(tierId);
+        await ctx.setState(tierId);
       } catch (e) {
         const errMsg = e.response?.data?.message ?? e.message ?? e;
         setError('error removing ' + tierId + ' : ' + errMsg);
@@ -221,7 +221,7 @@ function UpgradeDetails(props: DialogProps) {
                   {...props}
                   defaultValue={props.value}
                   value={props.value}
-                  content={ctx.supportedVersions}
+                  content={ctx.state.supportedVersions}
                   onChange={value => props.onChange(value)}
                 />
               ),
@@ -276,8 +276,8 @@ function UpgradeDetails(props: DialogProps) {
 function SupportedVersions() {
   const [open, setOpen] = useState(false);
   const ctx = useContext(GatewayTierContext);
-  const newVersions = ctx.supportedVersions.slice(0, 10);
-  const olderVersion = ctx.supportedVersions.slice(10);
+  const newVersions = ctx.state.supportedVersions.slice(0, 10);
+  const olderVersion = ctx.state.supportedVersions.slice(10);
   return newVersions.length > 0 ? (
     <DialogContent>
       <List component={Paper}>

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/__tests__/EnodebDetailMainTest.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/__tests__/EnodebDetailMainTest.js
@@ -16,6 +16,7 @@
 import type {promql_return_object} from '@fbcnms/magma-api';
 
 import 'jest-dom/extend-expect';
+import EnodebContext from '../../../components/context/EnodebContext';
 import EnodebDetail from '../EnodebDetailMain';
 import MagmaAPIBindings from '@fbcnms/magma-api';
 import MomentUtils from '@date-io/moment';
@@ -115,10 +116,16 @@ describe('<Enodeb />', () => {
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <MuiThemeProvider theme={defaultTheme}>
           <MuiStylesThemeProvider theme={defaultTheme}>
-            <Route
-              path="/nms/:networkId/enodeb/:enodebSerial/overview"
-              render={props => <EnodebDetail {...props} enbInfo={enbInfo} />}
-            />
+            <EnodebContext.Provider
+              value={{
+                state: {enbInfo: enbInfo},
+                setState: async _ => {},
+              }}>
+              <Route
+                path="/nms/:networkId/enodeb/:enodebSerial/overview"
+                render={props => <EnodebDetail {...props} enbInfo={enbInfo} />}
+              />
+            </EnodebContext.Provider>
           </MuiStylesThemeProvider>
         </MuiThemeProvider>
       </MuiPickersUtilsProvider>

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/__tests__/EquipmentEnodebTest.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/__tests__/EquipmentEnodebTest.js
@@ -17,6 +17,7 @@ import type {promql_return_object} from '@fbcnms/magma-api';
 
 import 'jest-dom/extend-expect';
 import Enodeb from '../EquipmentEnodeb';
+import EnodebContext from '../../../components/context/EnodebContext';
 import MagmaAPIBindings from '@fbcnms/magma-api';
 import MomentUtils from '@date-io/moment';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
@@ -113,10 +114,13 @@ describe('<Enodeb />', () => {
       <MuiPickersUtilsProvider utils={MomentUtils}>
         <MuiThemeProvider theme={defaultTheme}>
           <MuiStylesThemeProvider theme={defaultTheme}>
-            <Route
-              path="/nms/:networkId/enodeb/"
-              render={props => <Enodeb {...props} enbInfo={enbInfo} />}
-            />
+            <EnodebContext.Provider
+              value={{
+                state: {enbInfo: enbInfo},
+                setState: async _ => {},
+              }}>
+              <Route path="/nms/:networkId/enodeb/" render={_ => <Enodeb />} />
+            </EnodebContext.Provider>
           </MuiStylesThemeProvider>
         </MuiThemeProvider>
       </MuiPickersUtilsProvider>

--- a/nms/app/fbcnms-projects/magmalte/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -15,6 +15,7 @@
  */
 import 'jest-dom/extend-expect';
 import Gateway from '../EquipmentGateway';
+import GatewayContext from '../../../components/context/GatewayContext';
 import MagmaAPIBindings from '@fbcnms/magma-api';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
@@ -138,10 +139,17 @@ describe('<Gateway />', () => {
     <MemoryRouter initialEntries={['/nms/mynetwork/gateway']} initialIndex={0}>
       <MuiThemeProvider theme={defaultTheme}>
         <MuiStylesThemeProvider theme={defaultTheme}>
-          <Route
-            path="/nms/:networkId/gateway/"
-            render={props => <Gateway {...props} lteGateways={lteGateways} />}
-          />
+          <GatewayContext.Provider
+            value={{
+              state: lteGateways,
+              setState: async _ => {},
+              updateGateway: async _ => {},
+            }}>
+            <Route
+              path="/nms/:networkId/gateway/"
+              render={props => <Gateway {...props} lteGateways={lteGateways} />}
+            />
+          </GatewayContext.Provider>
         </MuiStylesThemeProvider>
       </MuiThemeProvider>
     </MemoryRouter>


### PR DESCRIPTION
## Summary

- Cleaned up Enodeb/Gateway state across various components. Moved it a separate top level context
- Moved all api side code/state to separate functions within EquipmentState
- Added delete handler for Enodeb and Gateway from the overview page

## Test Plan
- yarn test runs fine
- Fixed few tests in Equipment and they all pass
- Manually verified clicking on NMS, everything seems to be working fine.

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
