### PR TITLE
.github: add dependabot integration for Go and JS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: nms/app
+  schedule:
+    interval: daily
+- package-ecosystem: gomod
+  directory: orc8r/cloud/go
+  schedule:
+    interval: daily


### PR DESCRIPTION
## Summary
GitHub dependabot will auto-create a PR when a new package is released to NPM.
Added Go integration as well.

## Test Plan

Works great for Symphony. 
![image](https://user-images.githubusercontent.com/7413593/89192750-a6a34d80-d5ad-11ea-972d-afbe820fa6db.png)
