### PR TITLE
[agw] [mme] Return from S6A ULA handler on ULA failure response

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
@@ -243,6 +243,8 @@ int mme_app_handle_s6a_update_location_ans(
             "Failed to handle Un-successful ULA message for ue_id (%u)\n",
             ue_mm_context->mme_ue_s1ap_id);
         OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
+      } else {
+        OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNok);
       }
     }
   } else {


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

In cases where Update Location Answer(ULA) reports non-success response code, the call to  mme_app_handle_s6a_update_location_ans does not return after handling the ULA failure. The log in [ula_fail_mishandling.txt](https://github.com/magma/magma/files/5023792/ula_fail_mishandling.txt) shows the ULA success procedure being called after ULA failure is reported. This leads to a segmentation fault and, in turn, service crash. This change fixes the issue.

## Test Plan

Regression testing: S1ap integration tests
Reproduced the Seg fault with the patch in [ula_failure_seg_fault.txt](https://github.com/magma/magma/files/5023785/ula_failure_seg_fault.txt). The Seg Fault does not occur after making the changes in this PR.

