### PR TITLE
Fixed log line in radius

### DIFF
--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -128,7 +128,7 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 	}
 	defer resp.Body.Close()
 	rc.Logger.Debug("got response", zap.String("status", resp.Status),
-		zap.String("msg", string(encodedMsg)), zap.String("url", resp.Request.URL.String()),
+		zap.ByteString("full_msg", encodedMsg), zap.String("url", resp.Request.URL.String()),
 		zap.Any("request", r.Packet.Attributes))
 
 	if resp.StatusCode != http.StatusOK {


### PR DESCRIPTION
[radius][ofpanalytics] fixing json which was invalid

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This fix is making Zap logger will output valid json which we can process.

## Test Plan

cd magma/feg
docker build --tag goradius:latest -f radius/src/Dockerfile ./


On other tab simulated radius request, looked at the docker logs and made sure that the json is valid...


{"level":"debug","ts":1596370403.4734392,"caller":"ofpanalytics/ofpanalytics.go:130","msg":"got response","host":"a21f941e2ca1","partner_shortname":"ayelet_test","app_version":"1.0.0","correlation":2854263694,"status":"200 OK","full_msg":"{\"Called-Station-Id\":{\"type\":\"string\",\"value\":[\"11:11:11:11:11:12\"]},\"Calling-Station-Id\":{\"type\":\"string\",\"value\":[\"74:81:14:52:21:c1\"]},\"NAS-IP-Address\":{\"type\":\"string\",\"value\":[\"192.168.1.1\"]},\"NAS-Identifier\":{\"type\":\"string\",\"value\":[\"blabla\"]},\"XWF-C-Version\":{\"type\":\"string\",\"value\":[\"v1.1\"]}}","url":"https://graph.expresswifi.com/radius/authorization","request":{"1":["NzQ6ODE6MTQ6NTI6MjE6YzE="],"30":["MTE6MTE6MTE6MTE6MTE6MTI="],"31":["NzQ6ODE6MTQ6NTI6MjE6YzE="],"32":["YmxhYmxh"],"4":["wKgBAQ=="]}}

## Additional Information


