### PR TITLE
Publishing hourly images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -823,6 +823,15 @@ jobs:
           images: 'goradius'
           tag: <<parameters.tag>>
           registry: $DOCKER_MAGMA_REGISTRY
+      - run:
+          name: Build xwfm-integ-tests
+          command: |
+            cd ${MAGMA_ROOT}
+            docker build --tag xwfm-integ-tests -f xwf/gateway/integ_tests/gw/Dockerfile ./
+      - tag-push-docker:
+          images: 'xwfm-integ-tests'
+          tag: <<parameters.tag>>
+          registry: $DOCKER_MAGMA_REGISTRY
       - magma_slack_notify
 
 workflows:


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

<!--
    [xwfm] publishing hourly images for xwfm-integ-tests 
-->

## Summary

FB uses this container to run tests, but the code is part of this external repo so we will need to get pinned hourly version for it.

## Test Plan

Cannot test jobs which requirs env_vars and should be run on master by magma team.

## Additional Information

- [ ] This change is backwards-breaking
