### PR TITLE
[SessionD] Propagate session level key updates into SessionStore

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -383,7 +383,7 @@ class SessionState {
   bool reset_reporting_monitor(
     const std::string &key, SessionStateUpdateCriteria &uc);
 
-  std::unique_ptr<std::string> get_session_level_key() const;
+  void set_session_level_key(const std::string new_key);
  private:
   std::string imsi_;
   std::string session_id_;
@@ -428,7 +428,7 @@ class SessionState {
   */
   CreditMap credit_map_;
   MonitorMap monitor_map_;
-  std::unique_ptr<std::string> session_level_key_;
+  std::string session_level_key_;
 
  private:
   /**

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -282,6 +282,9 @@ bool SessionStore::merge_into_session(
   }
 
   // Monitoring credit
+  if (update_criteria.is_session_level_key_updated) {
+    session->set_session_level_key(update_criteria.updated_session_level_key);
+  }
   for (const auto& it : update_criteria.monitor_credit_map) {
     auto key           = it.first;
     auto credit_update = it.second;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -26,6 +26,7 @@ SessionStateUpdateCriteria get_default_update_criteria() {
   uc.charging_credit_map        = std::unordered_map<
       CreditKey, SessionCreditUpdateCriteria, decltype(&ccHash),
       decltype(&ccEqual)>(4, &ccHash, &ccEqual);
+  uc.is_session_level_key_updated = false;
   return uc;
 }
 

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -235,6 +235,8 @@ struct SessionStateUpdateCriteria {
   std::unordered_map<CreditKey, SessionCreditUpdateCriteria, decltype(&ccHash),
                      decltype(&ccEqual)>
       charging_credit_map;
+  bool is_session_level_key_updated;
+  std::string updated_session_level_key;
   StoredMonitorMap monitor_credit_to_install;
   std::unordered_map<std::string, SessionCreditUpdateCriteria>
       monitor_credit_map;

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -399,15 +399,14 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
 }
 
 TEST_F(SessionStateTest, test_session_level_key) {
-  EXPECT_EQ(nullptr, session_state->get_session_level_key());
-
   receive_credit_from_pcrf("m1", 8000, MonitoringLevel::SESSION_LEVEL);
-  EXPECT_EQ("m1", *session_state->get_session_level_key());
   EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 8000);
   EXPECT_EQ(
       update_criteria.monitor_credit_to_install["m1"]
           .credit.buckets[ALLOWED_TOTAL],
       8000);
+  EXPECT_TRUE(update_criteria.is_session_level_key_updated);
+  EXPECT_EQ(update_criteria.updated_session_level_key, "m1");
 
   session_state->add_rule_usage("rule1", 5000, 3000, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 5000);
@@ -427,6 +426,13 @@ TEST_F(SessionStateTest, test_session_level_key) {
   EXPECT_EQ(single_update.level(), MonitoringLevel::SESSION_LEVEL);
   EXPECT_EQ(single_update.bytes_rx(), 3000);
   EXPECT_EQ(single_update.bytes_tx(), 5000);
+
+  // Disable session level monitor with 0 grant. Monitor should get deleted and
+  // session level key updated.
+  receive_credit_from_pcrf("m1", 0, MonitoringLevel::SESSION_LEVEL);
+  EXPECT_TRUE(update_criteria.is_session_level_key_updated);
+  EXPECT_EQ(update_criteria.updated_session_level_key, "");
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].deleted);
 }
 
 TEST_F(SessionStateTest, test_reauth_key) {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Change the type of `session_level_key_` to be string instead of string pointer. Since we keep converting back and forth between "" and nullptr, it is simpler to just have it in string. The previous implementation had a bug where it was not converting "" into nullptr correctly on unmarshalling, so this diff also fixes that issue.
Propagate any changes to the session level key by adding `is_session_level_key_updated` and `updated_session_level_key` into `SessionStateUpdateCriteria`. 
Some additional changes to unit tests to reflect this change.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
