### PR TITLE
[SessionD] Migrate the unmarshal functionality to the constructor

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -19,6 +19,19 @@
 #include "magma_logging.h"
 
 namespace magma {
+ChargingGrant::ChargingGrant(const StoredChargingGrant& marshaled) {
+  credit = SessionCredit(marshaled.credit);
+
+  final_action_info.final_action = marshaled.final_action_info.final_action;
+  final_action_info.redirect_server =
+      marshaled.final_action_info.redirect_server;
+
+  reauth_state   = marshaled.reauth_state;
+  service_state  = marshaled.service_state;
+  expiry_time    = marshaled.expiry_time;
+  is_final_grant = marshaled.is_final;
+}
+
 StoredChargingGrant ChargingGrant::marshal() {
   StoredChargingGrant marshaled{};
   marshaled.is_final                       = is_final_grant;
@@ -30,24 +43,6 @@ StoredChargingGrant ChargingGrant::marshal() {
   marshaled.expiry_time   = expiry_time;
   marshaled.credit        = credit.marshal();
   return marshaled;
-}
-
-ChargingGrant ChargingGrant::unmarshal(const StoredChargingGrant& marshaled) {
-  ChargingGrant charging;
-  charging.credit = SessionCredit::unmarshal(marshaled.credit);
-
-  FinalActionInfo final_action_info;
-  final_action_info.final_action = marshaled.final_action_info.final_action;
-  final_action_info.redirect_server =
-      marshaled.final_action_info.redirect_server;
-  charging.final_action_info = final_action_info;
-
-  charging.reauth_state   = marshaled.reauth_state;
-  charging.service_state  = marshaled.service_state;
-  charging.expiry_time    = marshaled.expiry_time;
-  charging.is_final_grant = marshaled.is_final;
-
-  return charging;
 }
 
 void ChargingGrant::receive_charging_grant(

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -43,11 +43,10 @@ struct ChargingGrant {
   ChargingGrant() : credit(), is_final_grant(false),
     service_state(SERVICE_ENABLED), reauth_state(REAUTH_NOT_NEEDED) {}
 
+  ChargingGrant(const StoredChargingGrant &marshaled);
+
   // ChargingGrant -> StoredChargingGrant
   StoredChargingGrant marshal();
-
-  // StoredChargingGrant -> ChargingGrant
-  static ChargingGrant unmarshal(const StoredChargingGrant &marshaled);
 
   void receive_charging_grant(const magma::lte::ChargingCredit& credit,
                               SessionCreditUpdateCriteria* uc=NULL);

--- a/lte/gateway/c/session_manager/Monitor.h
+++ b/lte/gateway/c/session_manager/Monitor.h
@@ -29,20 +29,19 @@ struct Monitor {
   // monitoring key
   MonitoringLevel level;
 
+  Monitor() {}
+
+  Monitor(const StoredMonitor &marshaled) {
+    credit = SessionCredit(marshaled.credit);
+    level = marshaled.level;
+  }
+
   // Marshal into StoredMonitor structure used in SessionStore
   StoredMonitor marshal() {
     StoredMonitor marshaled{};
     marshaled.credit = credit.marshal();
     marshaled.level = level;
     return marshaled;
-  }
-
-  // Unmarshal from StoredMonitor structure used in SessionStore
-  static std::unique_ptr<Monitor> unmarshal(const StoredMonitor &marshaled) {
-    Monitor monitor;
-    monitor.credit = SessionCredit::unmarshal(marshaled.credit);
-    monitor.level = marshaled.level;
-    return std::make_unique<Monitor>(monitor);
   }
 };
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -35,7 +35,7 @@ class SessionCredit {
 
   SessionCredit(ServiceState start_state, CreditLimitType limit_type);
 
-  static SessionCredit unmarshal(const StoredSessionCredit& marshaled);
+  SessionCredit(const StoredSessionCredit &marshaled);
 
   StoredSessionCredit marshal();
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -105,7 +105,7 @@ SessionState::SessionState(
   session_level_key_ = marshaled.session_level_key;
   for (auto it : marshaled.monitor_map) {
     Monitor monitor;
-    monitor.credit = SessionCredit::unmarshal(it.second.credit);
+    monitor.credit = SessionCredit(it.second.credit);
     monitor.level  = it.second.level;
 
     monitor_map_[it.first] = std::make_unique<Monitor>(monitor);
@@ -113,7 +113,7 @@ SessionState::SessionState(
 
   for (const auto& it : marshaled.credit_map) {
     credit_map_[it.first] =
-        std::make_unique<ChargingGrant>(ChargingGrant::unmarshal(it.second));
+        std::make_unique<ChargingGrant>(ChargingGrant(it.second));
   }
 
   for (const std::string& rule_id : marshaled.static_rule_ids) {
@@ -1110,10 +1110,10 @@ bool SessionState::add_to_monitor(
 }
 
 void SessionState::set_monitor(
-    const std::string& key, std::unique_ptr<Monitor> monitor,
+    const std::string& key, Monitor monitor,
     SessionStateUpdateCriteria& update_criteria) {
-  update_criteria.monitor_credit_to_install[key] = monitor->marshal();
-  monitor_map_[key]                              = std::move(monitor);
+  update_criteria.monitor_credit_to_install[key] = monitor.marshal();
+  monitor_map_[key] = std::make_unique<Monitor>(monitor);
 }
 
 bool SessionState::reset_reporting_monitor(

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -377,8 +377,7 @@ class SessionState {
                       uint64_t used_rx, SessionStateUpdateCriteria &uc);
 
   void set_monitor(
-    const std::string &key, std::unique_ptr<Monitor> monitor,
-    SessionStateUpdateCriteria &uc);
+      const std::string& key, Monitor monitor, SessionStateUpdateCriteria& uc);
 
   bool reset_reporting_monitor(
     const std::string &key, SessionStateUpdateCriteria &uc);

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -277,8 +277,7 @@ bool SessionStore::merge_into_session(
   for (const auto& it : update_criteria.charging_credit_to_install) {
     auto key           = it.first;
     auto stored_credit = it.second;
-    session->set_charging_credit(
-        key, ChargingGrant::unmarshal(stored_credit), _);
+    session->set_charging_credit(key, ChargingGrant(stored_credit), _);
   }
 
   // Monitoring credit
@@ -293,7 +292,7 @@ bool SessionStore::merge_into_session(
   for (const auto& it : update_criteria.monitor_credit_to_install) {
     auto key            = it.first;
     auto stored_monitor = it.second;
-    session->set_monitor(key, Monitor::unmarshal(stored_monitor), _);
+    session->set_monitor(key, Monitor(stored_monitor), _);
   }
   return true;
 }

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -42,7 +42,7 @@ TEST(test_marshal_unmarshal, test_session_credit) {
   // Check that after marshaling/unmarshaling that the fields are still the
   // same.
   auto marshaled = credit.marshal();
-  auto credit_2  = SessionCredit::unmarshal(marshaled);
+  SessionCredit credit_2(marshaled);
 
   EXPECT_EQ(credit_2.get_credit(USED_TX), (uint64_t) 39u);
   EXPECT_EQ(credit_2.get_credit(USED_RX), (uint64_t) 40u);

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -204,7 +204,7 @@ TEST_F(SessionStateTest, test_marshal_unmarshal) {
   EXPECT_EQ(unmarshaled->get_charging_credit(1, ALLOWED_TOTAL), 1024);
   EXPECT_EQ(unmarshaled->get_monitor("m1", ALLOWED_TOTAL), 1024);
   EXPECT_EQ(unmarshaled->is_static_rule_installed("rule1"), true);
-  EXPECT_EQ(session_state->is_dynamic_rule_installed("rule2"), false);
+  EXPECT_EQ(unmarshaled->is_dynamic_rule_installed("rule2"), false);
 }
 
 TEST_F(SessionStateTest, test_insert_credit) {

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -357,8 +357,7 @@ TEST_F(SessionStoreTest, test_read_and_write) {
   // Check for installation of new monitoring credit
   session_map[imsi].front()->set_monitor(
       monitoring_key2,
-      Monitor::unmarshal(
-          update_criteria.monitor_credit_to_install[monitoring_key2]),
+      Monitor(update_criteria.monitor_credit_to_install[monitoring_key2]),
       uc);
   EXPECT_EQ(
       session_map[imsi].front()->get_monitor(monitoring_key2, USED_TX), 100);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
For `SessionCredit`, `ChargingGrant`, and `Monitor`, we don't really need a separate `unmarshal` function to construct the object from a stored struct. Move this logic into the constructors so that the use is clear.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
