### PR TITLE
[cwag_integ_test] Remove APV with 0 octets from Granted Units on Mock PCRF and Mock OCS

### DIFF
--- a/cwf/gateway/docker/docker-compose.integ-test.yml
+++ b/cwf/gateway/docker/docker-compose.integ-test.yml
@@ -99,13 +99,17 @@ services:
   pcrf:
     <<: *feggoservice
     container_name: pcrf
+    environment:
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/pcrf -logtostderr=true -v=2
 
   ocs:
     <<: *feggoservice
     container_name: ocs
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/ocs -logtostderr=true -v=2
-
+    environment:
+      MAGMA_PRINT_GRPC_PAYLOAD: 0
+   
   pcrf2:
     <<: *feggoservice
     container_name: pcrf2

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -97,7 +97,7 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 	assert.NotNil(t, record,
 		fmt.Sprintf("Policy usage record for imsi: %v rule: 'static-pass-all-raa1' does not exist", imsi))
 	assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
-	if (record.BytesTx == uint64(0) && record.BytesRx == uint64(0)) {
+	if record.BytesTx == uint64(0) && record.BytesRx == uint64(0) {
 		dumpPipelinedState(tr)
 	}
 	// Send ReAuth Request to update quota

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -83,7 +83,7 @@ func TestGyReAuth(t *testing.T) {
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: "4.5M"}}
+		Volume: &wrappers.StringValue{Value: "4.0M"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
@@ -117,7 +117,7 @@ func TestGyReAuth(t *testing.T) {
 	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
 	// Generate over 7M of data to check that initial quota was updated
-	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "5M"}}
+	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "6M"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ccr_handler.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ccr_handler.go
@@ -305,11 +305,7 @@ func toGrantedUnitsAVP(resultCode uint32, validityTime uint32, quotaGrant *proto
 	creditGroup := &diam.GroupedAVP{
 		AVP: []*diam.AVP{
 			diam.NewAVP(avp.GrantedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{
-				AVP: []*diam.AVP{
-					diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetTotalOctets())),
-					diam.NewAVP(avp.CCInputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetInputOctets())),
-					diam.NewAVP(avp.CCOutputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetOutputOctets())),
-				},
+				AVP: toGrantedServiceUnitAVP(quotaGrant),
 			}),
 			diam.NewAVP(avp.ValidityTime, avp.Mbit, 0, datatype.Unsigned32(validityTime)),
 			diam.NewAVP(avp.RatingGroup, avp.Mbit, 0, datatype.Unsigned32(ratingGroup)),
@@ -322,4 +318,18 @@ func toGrantedUnitsAVP(resultCode uint32, validityTime uint32, quotaGrant *proto
 		)
 	}
 	return diam.NewAVP(avp.MultipleServicesCreditControl, avp.Mbit, 0, creditGroup)
+}
+
+func toGrantedServiceUnitAVP(quotaGrant *protos.Octets) []*diam.AVP {
+	res := []*diam.AVP{}
+	if quotaGrant.GetTotalOctets() != 0 {
+		res = append(res, diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetTotalOctets())))
+	}
+	if quotaGrant.GetInputOctets() != 0 {
+		res = append(res, diam.NewAVP(avp.CCInputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetInputOctets())))
+	}
+	if quotaGrant.GetOutputOctets() != 0 {
+		res = append(res, diam.NewAVP(avp.CCOutputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetOutputOctets())))
+	}
+	return res
 }

--- a/feg/gateway/services/testcore/pcrf/mock_pcrf/conversions.go
+++ b/feg/gateway/services/testcore/pcrf/mock_pcrf/conversions.go
@@ -145,15 +145,25 @@ func toUsageMonitoringInfoAVP(monitoringKey string, quotaGrant *protos.Octets, l
 		AVP: []*diam.AVP{
 			diam.NewAVP(avp.MonitoringKey, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(monitoringKey)),
 			diam.NewAVP(avp.GrantedServiceUnit, avp.Mbit, 0, &diam.GroupedAVP{
-				AVP: []*diam.AVP{
-					diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetTotalOctets())),
-					diam.NewAVP(avp.CCInputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetInputOctets())),
-					diam.NewAVP(avp.CCOutputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetOutputOctets())),
-				},
+				AVP: toGrantedServiceUnitAVP(quotaGrant),
 			}),
 			diam.NewAVP(avp.UsageMonitoringLevel, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Enumerated(level)),
 		},
 	})
+}
+
+func toGrantedServiceUnitAVP(quotaGrant *protos.Octets) []*diam.AVP {
+	res := []*diam.AVP{}
+	if quotaGrant.GetTotalOctets() != 0 {
+		res = append(res, diam.NewAVP(avp.CCTotalOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetTotalOctets())))
+	}
+	if quotaGrant.GetInputOctets() != 0 {
+		res = append(res, diam.NewAVP(avp.CCInputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetInputOctets())))
+	}
+	if quotaGrant.GetOutputOctets() != 0 {
+		res = append(res, diam.NewAVP(avp.CCOutputOctets, avp.Mbit, 0, datatype.Unsigned64(quotaGrant.GetOutputOctets())))
+	}
+	return res
 }
 
 func toRuleInstallAVPs(ruleNames, ruleBaseNames []string, ruleDefs []*protos.RuleDefinition, activationTime, deactivationTime *timestamp.Timestamp) []*diam.AVP {

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -399,9 +399,9 @@ void SessionCredit::log_quota_and_usage() const {
                << ",  Reporting: " << reporting_;
   // TODO: delete once we tested it works for both credit and monitors
   MLOG(MDEBUG) << "===> Current Granted Units (tx/rx/total) "
-               << buckets_[ALLOWED_TOTAL] - buckets_[ALLOWED_FLOOR_TOTAL] << "/"
                << buckets_[ALLOWED_TX] - buckets_[ALLOWED_FLOOR_TX] << "/"
-               << buckets_[ALLOWED_RX] - buckets_[ALLOWED_FLOOR_RX];
+               << buckets_[ALLOWED_RX] - buckets_[ALLOWED_FLOOR_RX] << "/"
+               << buckets_[ALLOWED_TOTAL] - buckets_[ALLOWED_FLOOR_TOTAL];
 }
 
 void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {


### PR DESCRIPTION
[cwag_integ_test] Remove APV with 0 octets from Granted Units on Mock PCRF and Mock OCS

Signed-off-by: Oriol Batalla <obatalla@fb.com>

## Summary

In order to support testing tracking type `ALL` (tx, rx and total) that was introduced on [PR2140](https://github.com/magma/magma/pull/2140), we need to remove AVPs that contains value = 0 from Mock OCS and Mock PCRF so we can test the result deterministically. If those avps are not removed we will always have `All` with credit equal to 0 and we will be exhausted of credit all the time.

So with this PR, every time Mock OCS or Mock PCRF sends Granted Units, it will send only those values that are different to 0. Otherwise it will not send that specific AVP

This PR also includes some changes on cwag integ test to adapt the grant values to the new algorithm on [PR2140](https://github.com/magma/magma/pull/2140)


**Note** cwag_integ_test is working in local, but slower VMs may affect to traffic calculations we just modified. We may need more fine tunning once it is run on CI with slower VMs

**Note** in future PRs we need to change how we determine the type of a grant in sessiond. Right now this is decided per grant basis. We will need to determine it only at the first grant received, and mantained the same until the monitor is exhausted



## Test Plan

AGW
make test 

Feg
make precommit

Orcr8r
./build -g
make precommit

cwag_integ_test
fab integ_test

## Additional Information

- [ ] This change is backwards-breaking

