### PR TITLE
[cwag_integ_test] fix TestGxUsageReportEnforcement

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -91,7 +91,7 @@ func TestGxUsageReportEnforcement(t *testing.T) {
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
-	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("300K")}}
+	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: *swag.String("200K")}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>


## Summary

Change value to make sure second update is not triggered

## Test Plan

cwag integ test

## Additional Information

- [ ] This change is backwards-breaking


