### PR TITLE
[cwag_integ_test] fix TestGyReAuth

### DIFF
--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -17,9 +17,9 @@ package integration
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
-	"math"
 
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
@@ -83,8 +83,8 @@ func TestGyReAuth(t *testing.T) {
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: "400K"},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "400K"},
 		Bitrate: &wrappers.StringValue{Value: "1M"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -121,6 +121,7 @@ func TestGyReAuth(t *testing.T) {
 	// Generate over 1M of data to check that initial quota was updated
 	req = &cwfprotos.GenTrafficRequest{Imsi: imsi,
 		Volume: &wrappers.StringValue{Value: "1M"},
+	}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 	"time"
+	"math"
 
 	cwfprotos "magma/cwf/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
@@ -58,7 +59,7 @@ func TestGyReAuth(t *testing.T) {
 		&fegprotos.CreditInfo{
 			Imsi:        imsi,
 			ChargingKey: 1,
-			Volume:      &fegprotos.Octets{TotalOctets: 7 * MegaBytes},
+			Volume:      &fegprotos.Octets{TotalOctets: 500 * KiloBytes},
 			UnitType:    fegprotos.CreditInfo_Bytes,
 		},
 	)
@@ -83,7 +84,8 @@ func TestGyReAuth(t *testing.T) {
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: "4.0M"}}
+		Volume: &wrappers.StringValue{Value: "400K"},
+		Bitrate: &wrappers.StringValue{Value: "1M"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
@@ -96,12 +98,12 @@ func TestGyReAuth(t *testing.T) {
 	assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
 	assert.True(t, record.BytesTx <= uint64(5*MegaBytes+Buffer), fmt.Sprintf("policy usage: %v", record))
 
-	// Top UP extra credits (10M total)
+	// Top UP extra credits (2.5M total)
 	err = setCreditOnOCS(
 		&fegprotos.CreditInfo{
 			Imsi:        imsi,
 			ChargingKey: ratingGroup,
-			Volume:      &fegprotos.Octets{TotalOctets: 3 * MegaBytes},
+			Volume:      &fegprotos.Octets{TotalOctets: 2 * MegaBytes},
 			UnitType:    fegprotos.CreditInfo_Bytes,
 		},
 	)
@@ -116,8 +118,9 @@ func TestGyReAuth(t *testing.T) {
 	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
-	// Generate over 7M of data to check that initial quota was updated
-	req = &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "6M"}}
+	// Generate over 1M of data to check that initial quota was updated
+	req = &cwfprotos.GenTrafficRequest{Imsi: imsi,
+		Volume: &wrappers.StringValue{Value: "1M"},
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
@@ -127,8 +130,8 @@ func TestGyReAuth(t *testing.T) {
 	assert.NoError(t, err)
 	record = recordsBySubID["IMSI"+imsi]["static-pass-all-ocs2"]
 	assert.NotNil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was removed", imsi))
-	assert.True(t, record.BytesTx > uint64(8*MegaBytes+Buffer), fmt.Sprintf("did not pass data over initial quota %v", record))
-	assert.True(t, record.BytesTx <= uint64(10*MegaBytes+Buffer), fmt.Sprintf("policy usage: %v", record))
+	assert.True(t, record.BytesTx > uint64(400*KiloBytes+Buffer), fmt.Sprintf("did not pass data over initial quota %v", record))
+	assert.True(t, record.BytesTx <= uint64(math.Round(2.4*MegaBytes+Buffer)), fmt.Sprintf("policy usage: %v", record))
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This fix tries to reduce the amount of traffic transferred, but at the same time imposes a bitrate to make sure
the generation of traffic takes at least 5 seconds (so pipelined si able to report traffic and sessiond is able to act accordingly with updates)

## Test Plan

integ test 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
