### PR TITLE
[AGW] deployment: setup gtp-br0 with IP address

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -1,6 +1,8 @@
 # Add L3 OVS switch gtp_br0 with gtp0, veth0_ovs, and int_nat_peer
 allow-ovs gtp_br0
-iface gtp_br0 inet manual
+iface gtp_br0 inet static
+    address 192.168.128.1
+    netmask 255.255.255.0
     up sysctl net.ipv4.ip_forward=1
     up iptables -t mangle -A FORWARD -i gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400
     up iptables -t mangle -A FORWARD -o gtp_br0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss 1400


### PR DESCRIPTION
There are couple of services on AGW that depends on gtp_br0 ip address
Following patch restores statically configured IP address (192.168.128.1)
on the interface.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Summary

## Test Plan

`vagrant destroy magma` and `vagrant up magma`, gtp_br0 has IP address.