### PR TITLE
[AGW] mobilityD: mconfig: plugin: set ip allocator type.

### DIFF
--- a/lte/cloud/go/plugin/mconfig.go
+++ b/lte/cloud/go/plugin/mconfig.go
@@ -111,8 +111,9 @@ func (s *LteMconfigBuilderServicer) Build(
 			EnbConfigsBySerial:  enbConfigsBySerial,
 		},
 		"mobilityd": &mconfig.MobilityD{
-			LogLevel: protos.LogLevel_INFO,
-			IpBlock:  gwEpc.IPBlock,
+			LogLevel:        protos.LogLevel_INFO,
+			IpBlock:         gwEpc.IPBlock,
+			IpAllocatorType: getMobilityDIPAllocator(nwEpc),
 		},
 		"mme": &mconfig.MME{
 			LogLevel:                 protos.LogLevel_INFO,
@@ -390,4 +391,15 @@ func getSubProfiles(epc *models2.NetworkEpcConfigs) map[string]*mconfig.Subscrib
 		}
 	}
 	return ret
+}
+
+func getMobilityDIPAllocator(epc *models2.NetworkEpcConfigs) mconfig.MobilityD_IpAllocatorType {
+	if epc.Mobility == nil {
+		return mconfig.MobilityD_IP_POOL
+	}
+	if epc.Mobility.IPAllocationMode == models2.DHCPBroadcastAllocationMode {
+		return mconfig.MobilityD_DHCP
+	}
+	// for other modes set IP pool allocator.
+	return mconfig.MobilityD_IP_POOL
 }


### PR DESCRIPTION
This patch maps Network Epc mobility Config to mobilityD
ip-allocation-mode mconfig.
currently ip_pool and DHCP broadcast are only configured mode
supported by AGW.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

## Summary

## Test Plan

`go test mconfig_test.go`

## Additional Information