### PR TITLE
[SessionD] Migrate reads of non-RAT specific session context from CommonSessionContext

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -44,8 +44,8 @@ aaa::add_sessions_request create_add_sessions_req(
       ctx.set_session_id(config.radius_session_id);
       ctx.set_acct_session_id(session->get_session_id());
       ctx.set_mac_addr(config.mac_addr);
-      ctx.set_msisdn(config.msisdn);
-      ctx.set_apn(config.apn);
+      ctx.set_msisdn(config.common_context.msisdn());
+      ctx.set_apn(config.common_context.apn());
       auto mutable_sessions = req.mutable_sessions();
       mutable_sessions->Add()->CopyFrom(ctx);
     }

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -59,7 +59,7 @@ void EventsReporterImpl::session_created(
   event_value[IMSI] = session_info.imsi;
   event_value[SESSION_ID] = session->get_session_id();
   event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.apn;
+  event_value[APN] = session_cfg.common_context.apn();
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
@@ -118,7 +118,7 @@ void EventsReporterImpl::session_updated(std::unique_ptr<SessionState>& session)
   event_value[IMSI] = session_info.imsi;
   event_value[IP_ADDR] = session_info.ip_addr;
   event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.apn;
+  event_value[APN] = session_cfg.common_context.apn();
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
@@ -149,7 +149,7 @@ void EventsReporterImpl::session_update_failure(
   event_value[IMSI] = session_info.imsi;
   event_value[IP_ADDR] = session_info.ip_addr;
   event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.apn;
+  event_value[APN] = session_cfg.common_context.apn();
   event_value[FAILURE_REASON] = failure_reason;
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
@@ -182,7 +182,7 @@ void EventsReporterImpl::session_terminated(
   event_value[IP_ADDR] = session_info.ip_addr;
   event_value[SESSION_ID] = session->get_session_id();
   event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.apn;
+  event_value[APN] = session_cfg.common_context.apn();
   SessionState::TotalCreditUsage usage = session->get_total_credit_usage();
   event_value[CHARGING_TX]             = usage.charging_tx;
   event_value[CHARGING_RX]             = usage.charging_rx;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -275,9 +275,9 @@ void SessionState::add_common_fields_to_usage_monitor_update(
   req->set_session_id(session_id_);
   req->set_request_number(request_number_);
   req->set_sid(imsi_);
-  req->set_ue_ipv4(config_.ue_ipv4);
+  req->set_ue_ipv4(config_.common_context.ue_ipv4());
   req->set_hardware_addr(config_.hardware_addr);
-  req->set_rat_type(config_.rat_type);
+  req->set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req->mutable_tgpp_ctx());
 }
 
@@ -339,16 +339,16 @@ SessionTerminateRequest SessionState::make_termination_request(
   req.set_sid(imsi_);
   req.set_session_id(session_id_);
   req.set_request_number(request_number_);
-  req.set_ue_ipv4(config_.ue_ipv4);
-  req.set_msisdn(config_.msisdn);
+  req.set_ue_ipv4(config_.common_context.ue_ipv4());
+  req.set_msisdn(config_.common_context.msisdn());
   req.set_spgw_ipv4(config_.spgw_ipv4);
-  req.set_apn(config_.apn);
+  req.set_apn(config_.common_context.apn());
   req.set_imei(config_.imei);
   req.set_plmn_id(config_.plmn_id);
   req.set_imsi_plmn_id(config_.imsi_plmn_id);
   req.set_user_location(config_.user_location);
   req.set_hardware_addr(config_.hardware_addr);
-  req.set_rat_type(config_.rat_type);
+  req.set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req.mutable_tgpp_ctx());
   // gx monitors
   for (auto& credit_pair : monitor_map_) {
@@ -432,12 +432,12 @@ void SessionState::set_config(const SessionConfig& config) {
 }
 
 bool SessionState::is_radius_cwf_session() const {
-  return (config_.rat_type == RATType::TGPP_WLAN);
+  return (config_.common_context.rat_type() == RATType::TGPP_WLAN);
 }
 
 void SessionState::get_session_info(SessionState::SessionInfo& info) {
   info.imsi    = imsi_;
-  info.ip_addr = config_.ue_ipv4;
+  info.ip_addr = config_.common_context.ue_ipv4();
   get_dynamic_rules().get_rules(info.dynamic_rules);
   get_gy_dynamic_rules().get_rules(info.gy_dynamic_rules);
   info.static_rules = active_static_rules_;
@@ -941,16 +941,16 @@ CreditUsageUpdate SessionState::make_credit_usage_update_req(
   req.set_session_id(session_id_);
   req.set_request_number(request_number_);
   req.set_sid(imsi_);
-  req.set_msisdn(config_.msisdn);
-  req.set_ue_ipv4(config_.ue_ipv4);
+  req.set_msisdn(config_.common_context.msisdn());
+  req.set_ue_ipv4(config_.common_context.ue_ipv4());
   req.set_spgw_ipv4(config_.spgw_ipv4);
-  req.set_apn(config_.apn);
+  req.set_apn(config_.common_context.apn());
   req.set_imei(config_.imei);
   req.set_plmn_id(config_.plmn_id);
   req.set_imsi_plmn_id(config_.imsi_plmn_id);
   req.set_user_location(config_.user_location);
   req.set_hardware_addr(config_.hardware_addr);
-  req.set_rat_type(config_.rat_type);
+  req.set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req.mutable_tgpp_ctx());
   req.mutable_usage()->CopyFrom(usage);
   return req;
@@ -1003,7 +1003,7 @@ void SessionState::get_charging_updates(
                      << " action type " << action_type;
         action->set_credit_key(key);
         action->set_imsi(imsi_);
-        action->set_ip_addr(config_.ue_ipv4);
+        action->set_ip_addr(config_.common_context.ue_ipv4());
         action->set_session_id(session_id_);
         static_rules_.get_rule_ids_for_charging_key(
             key, *action->get_mutable_rule_ids());

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -18,14 +18,16 @@
 namespace magma {
 
 bool SessionConfig::operator==(const SessionConfig& config) const {
-  return ue_ipv4.compare(config.ue_ipv4) == 0 &&
-         spgw_ipv4.compare(config.spgw_ipv4) == 0 &&
-         msisdn.compare(config.msisdn) == 0 && apn.compare(config.apn) == 0 &&
+  auto common1 = common_context.SerializeAsString();
+  auto common2 = config.common_context.SerializeAsString();
+  if (common1 != common2) {
+    return false;
+  }
+  return spgw_ipv4.compare(config.spgw_ipv4) == 0 &&
          imei.compare(config.imei) == 0 &&
          plmn_id.compare(config.plmn_id) == 0 &&
          imsi_plmn_id.compare(config.imsi_plmn_id) == 0 &&
          user_location.compare(config.user_location) == 0 &&
-         rat_type == config.rat_type &&
          hardware_addr.compare(config.hardware_addr) == 0 &&
          radius_session_id.compare(config.radius_session_id) == 0 &&
          bearer_id == config.bearer_id;
@@ -66,15 +68,11 @@ QoSInfo deserialize_stored_qos_info(const std::string& serialized) {
 
 std::string serialize_stored_session_config(const SessionConfig& stored) {
   folly::dynamic marshaled       = folly::dynamic::object;
-  marshaled["ue_ipv4"]           = stored.ue_ipv4;
   marshaled["spgw_ipv4"]         = stored.spgw_ipv4;
-  marshaled["msisdn"]            = stored.msisdn;
-  marshaled["apn"]               = stored.apn;
   marshaled["imei"]              = stored.imei;
   marshaled["plmn_id"]           = stored.plmn_id;
   marshaled["imsi_plmn_id"]      = stored.imsi_plmn_id;
   marshaled["user_location"]     = stored.user_location;
-  marshaled["rat_type"]          = static_cast<int>(stored.rat_type);
   marshaled["mac_addr"]          = stored.mac_addr;
   marshaled["hardware_addr"]     = stored.hardware_addr;
   marshaled["radius_session_id"] = stored.radius_session_id;
@@ -94,15 +92,11 @@ SessionConfig deserialize_stored_session_config(const std::string& serialized) {
   folly::dynamic marshaled = folly::parseJson(folly_serialized);
 
   auto stored          = SessionConfig{};
-  stored.ue_ipv4       = marshaled["ue_ipv4"].getString();
   stored.spgw_ipv4     = marshaled["spgw_ipv4"].getString();
-  stored.msisdn        = marshaled["msisdn"].getString();
-  stored.apn           = marshaled["apn"].getString();
   stored.imei          = marshaled["imei"].getString();
   stored.plmn_id       = marshaled["plmn_id"].getString();
   stored.imsi_plmn_id  = marshaled["imsi_plmn_id"].getString();
   stored.user_location = marshaled["user_location"].getString();
-  stored.rat_type      = static_cast<RATType>(marshaled["rat_type"].getInt());
   stored.mac_addr      = marshaled["mac_addr"].getString();
   stored.hardware_addr = marshaled["hardware_addr"].getString();
   stored.radius_session_id = marshaled["radius_session_id"].getString();

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -31,15 +31,11 @@ struct QoSInfo {
 };
 
 struct SessionConfig {
-  std::string ue_ipv4;
   std::string spgw_ipv4;
-  std::string msisdn;
-  std::string apn;
   std::string imei;
   std::string plmn_id;
   std::string imsi_plmn_id;
   std::string user_location;
-  RATType rat_type;
   std::string mac_addr;      // MAC Address for WLAN
   std::string hardware_addr; // MAC Address for WLAN (binary)
   std::string radius_session_id;

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -15,6 +15,36 @@
 
 namespace magma {
 
+void build_common_context(
+    const std::string& imsi,  // assumes IMSI prefix
+    const std::string& ue_ipv4, const std::string& apn,
+    const std::string& msisdn, const RATType rat_type,
+    CommonSessionContext* common_context) {
+  common_context->mutable_sid()->set_id(imsi);
+  common_context->set_ue_ipv4(ue_ipv4);
+  common_context->set_apn(apn);
+  common_context->set_msisdn(msisdn);
+  common_context->set_rat_type(rat_type);
+}
+
+void build_lte_context(
+    const std::string& spgw_ipv4, const std::string& imei,
+    const std::string& plmn_id, const std::string& imsi_plmn_id,
+    LTESessionContext* lte_context) {
+  lte_context->set_spgw_ipv4(spgw_ipv4);
+  lte_context->set_imei(imei);
+  lte_context->set_plmn_id(plmn_id);
+  lte_context->set_imsi_plmn_id(imsi_plmn_id);
+}
+
+void build_wlan_context(
+    const std::string& mac_addr,
+    const std::string& radius_session_id,
+    WLANSessionContext* wlan_context) {
+  wlan_context->set_mac_addr(mac_addr);
+  wlan_context->set_radius_session_id(radius_session_id);
+}
+
 void create_rule_record(
     const std::string& imsi, const std::string& rule_id, uint64_t bytes_rx,
     uint64_t bytes_tx, RuleRecord* rule_record) {

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -19,119 +19,96 @@
 namespace magma {
 using namespace lte;
 
+void build_common_context(
+    const std::string& imsi, const std::string& ue_ipv4, const std::string& apn,
+    const std::string& msisdn, const RATType rat_type,
+    CommonSessionContext* common_context);
+
+void build_lte_context(
+    const std::string& spgw_ipv4, const std::string& imei,
+    const std::string& plmn_id, const std::string& imsi_plmn_id,
+    LTESessionContext* lte_context);
+
+void build_wlan_context(
+    const std::string& mac_addr, const std::string& radius_session_id,
+    WLANSessionContext* wlan_context);
+
 void create_rule_record(
-  const std::string& imsi,
-  const std::string& rule_id,
-  uint64_t bytes_rx,
-  uint64_t bytes_tx,
-  RuleRecord* rule_record);
+    const std::string& imsi, const std::string& rule_id, uint64_t bytes_rx,
+    uint64_t bytes_tx, RuleRecord* rule_record);
 
 void create_charging_credit(
-  uint64_t volume, bool is_final, ChargingCredit* credit);
+    uint64_t volume, bool is_final, ChargingCredit* credit);
 
 void create_credit_update_response(
-    const std::string& imsi,
-    uint32_t charging_key,
-    CreditLimitType limit_type,
+    const std::string& imsi, uint32_t charging_key, CreditLimitType limit_type,
     CreditUpdateResponse* response);
 
 void create_credit_update_response(
-  const std::string& imsi,
-  uint32_t charging_key,
-  uint64_t volume,
-  CreditUpdateResponse* response);
+    const std::string& imsi, uint32_t charging_key, uint64_t volume,
+    CreditUpdateResponse* response);
 
 void create_charging_credit(
-    uint64_t total_volume,
-    uint64_t tx_volume,
-    uint64_t rx_volume,
-    bool is_final,
-    ChargingCredit* credit);
+    uint64_t total_volume, uint64_t tx_volume, uint64_t rx_volume,
+    bool is_final, ChargingCredit* credit);
 
 void create_credit_update_response(
-    const std::string& imsi,
-    uint32_t charging_key,
-    uint64_t total_volume,
-    uint64_t tx_volume,
-    uint64_t rx_volume,
-    bool is_final,
+    const std::string& imsi, uint32_t charging_key, uint64_t total_volume,
+    uint64_t tx_volume, uint64_t rx_volume, bool is_final,
     CreditUpdateResponse* response);
 
 void create_credit_update_response(
-  const std::string& imsi,
-  uint32_t charging_key,
-  uint64_t volume,
-  bool is_final,
-  CreditUpdateResponse* response);
+    const std::string& imsi, uint32_t charging_key, uint64_t volume,
+    bool is_final, CreditUpdateResponse* response);
 
 void create_monitor_credit(
-  const std::string& m_key,
-  MonitoringLevel level,
-  uint64_t volume,
-  UsageMonitoringCredit* response);
+    const std::string& m_key, MonitoringLevel level, uint64_t volume,
+    UsageMonitoringCredit* response);
 
 // When volume = 0, the action for the monitoring credit will be set to DISABLE.
 // It is CONTINUE otherwise.
 void create_monitor_update_response(
-  const std::string& imsi,
-  const std::string& m_key,
-  MonitoringLevel level,
-  uint64_t volume,
-  UsageMonitoringUpdateResponse* response);
+    const std::string& imsi, const std::string& m_key, MonitoringLevel level,
+    uint64_t volume, UsageMonitoringUpdateResponse* response);
 
 void create_monitor_update_response(
-  const std::string& imsi,
-  const std::string& m_key,
-  MonitoringLevel level,
-  uint64_t volume,
-  const std::vector<EventTrigger>& event_triggers,
-  const uint64_t revalidation_time_unix_ts,
-  UsageMonitoringUpdateResponse* response);
+    const std::string& imsi, const std::string& m_key, MonitoringLevel level,
+    uint64_t volume, const std::vector<EventTrigger>& event_triggers,
+    const uint64_t revalidation_time_unix_ts,
+    UsageMonitoringUpdateResponse* response);
 
 void create_usage_update(
-  const std::string& imsi,
-  uint32_t charging_key,
-  uint64_t bytes_rx,
-  uint64_t bytes_tx,
-  CreditUsage::UpdateType type,
-  CreditUsageUpdate* update);
+    const std::string& imsi, uint32_t charging_key, uint64_t bytes_rx,
+    uint64_t bytes_tx, CreditUsage::UpdateType type, CreditUsageUpdate* update);
 
 void create_policy_reauth_request(
-  const std::string& session_id,
-  const std::string& imsi,
-  const std::vector<std::string>& rules_to_remove,
-  const std::vector<StaticRuleInstall>& rules_to_install,
-  const std::vector<DynamicRuleInstall>& dynamic_rules_to_install,
-  const std::vector<EventTrigger>& event_triggers,
-  const uint64_t revalidation_time_unix_ts,
-  const std::vector<UsageMonitoringCredit>& usage_monitoring_credits,
-  PolicyReAuthRequest* request);
+    const std::string& session_id, const std::string& imsi,
+    const std::vector<std::string>& rules_to_remove,
+    const std::vector<StaticRuleInstall>& rules_to_install,
+    const std::vector<DynamicRuleInstall>& dynamic_rules_to_install,
+    const std::vector<EventTrigger>& event_triggers,
+    const uint64_t revalidation_time_unix_ts,
+    const std::vector<UsageMonitoringCredit>& usage_monitoring_credits,
+    PolicyReAuthRequest* request);
 
 void create_tgpp_context(
-  const std::string& gx_dest_host,
-  const std::string& gy_dest_host,
-  TgppContext* context);
+    const std::string& gx_dest_host, const std::string& gy_dest_host,
+    TgppContext* context);
 
 void create_subscriber_quota_update(
-  const std::string& imsi,
-  const std::string& ue_mac_addr,
-  const SubscriberQuotaUpdate_Type state,
-  SubscriberQuotaUpdate* update);
+    const std::string& imsi, const std::string& ue_mac_addr,
+    const SubscriberQuotaUpdate_Type state, SubscriberQuotaUpdate* update);
 
 void create_session_create_response(
-  const std::string& imsi,
-  const std::string& monitoring_key,
-  std::vector<std::string>& static_rules,
-  CreateSessionResponse* response);
+    const std::string& imsi, const std::string& monitoring_key,
+    std::vector<std::string>& static_rules, CreateSessionResponse* response);
 
 void create_policy_rule(
-  const std::string &rule_id,
-  const std::string &m_key,
-  uint32_t rating_group,
-  PolicyRule* rule);
+    const std::string& rule_id, const std::string& m_key, uint32_t rating_group,
+    PolicyRule* rule);
 
 void create_granted_units(
-  uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu);
+    uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu);
 
 magma::mconfig::SessionD get_default_mconfig();
-} // namespace magma
+}  // namespace magma

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -24,9 +24,7 @@
 using ::testing::Test;
 
 namespace magma {
-const SessionConfig test_sstate_cfg = {
-    .ue_ipv4   = "127.0.0.1",
-    .spgw_ipv4 = "128.0.0.1"};
+const SessionConfig test_sstate_cfg = {.spgw_ipv4 = "128.0.0.1"};
 
 class SessionStateTest : public ::testing::Test {
  protected:

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -35,12 +35,6 @@ using grpc::Status;
 using ::testing::Test;
 
 namespace magma {
-
-const SessionConfig test_cfg = {.ue_ipv4   = "127.0.0.1",
-                                .spgw_ipv4 = "128.0.0.1",
-                                .msisdn    = "",
-                                .apn       = "IMS"};
-
 class LocalEnforcerTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
@@ -55,14 +49,24 @@ class LocalEnforcerTest : public ::testing::Test {
     auto default_mconfig = get_default_mconfig();
     local_enforcer       = std::make_unique<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
-        directoryd_client, events_reporter, spgw_client,
-        aaa_client, 0, 0, default_mconfig);
+        directoryd_client, events_reporter, spgw_client, aaa_client, 0, 0,
+        default_mconfig);
     evb = folly::EventBaseManager::get()->getEventBase();
     local_enforcer->attachEventBase(evb);
     session_map = SessionMap{};
+    initialize_lte_test_config();
   }
 
   virtual void TearDown() { folly::EventBaseManager::get()->clearEventBase(); }
+
+  void initialize_lte_test_config() {
+    test_cfg_.spgw_ipv4 = "128.0.0.1";
+    build_common_context(
+        "", "127.0.0.1", "IMS", "", TGPP_LTE, &test_cfg_.common_context);
+    build_lte_context(
+        "128.0.0.1", "", "", "",
+        test_cfg_.rat_specific_context.mutable_lte_context());
+  }
 
   void run_evb() {
     evb->runAfterDelay([this]() { local_enforcer->stop(); }, 100);
@@ -108,6 +112,7 @@ class LocalEnforcerTest : public ::testing::Test {
   std::shared_ptr<MockAAAClient> aaa_client;
   std::shared_ptr<MockEventsReporter> events_reporter;
   SessionMap session_map;
+  SessionConfig test_cfg_;
   folly::EventBase* evb;
 };
 
@@ -179,7 +184,6 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
       .WillOnce(testing::Return(true));
 
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type          = RATType::TGPP_WLAN;
   test_cwf_cfg.mac_addr          = "00:00:00:00:00:00";
   test_cwf_cfg.radius_session_id = "1234567";
 
@@ -205,16 +209,18 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
   rules_to_install->Add()->CopyFrom(rule1);
 
   // Expect rule1 to be activated
-  EXPECT_CALL(*pipelined_client,
-              activate_flows_for_rules(testing::_, testing::_, CheckCount(1),
-                                       CheckCount(0), testing::_))
-  .Times(1)
-  .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg,
-                                      response);
-  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1,
-                                                ALLOWED_TOTAL),
-            0);
+  EXPECT_CALL(
+      *pipelined_client,
+      activate_flows_for_rules(
+          testing::_, testing::_, CheckCount(1), CheckCount(0), testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_enforcer->init_session_credit(
+      session_map, "IMSI1", "1234", test_cfg_, response);
+  EXPECT_EQ(
+      local_enforcer->get_charging_credit(
+          session_map, "IMSI1", 1, ALLOWED_TOTAL),
+      0);
 }
 
 TEST_F(LocalEnforcerTest, test_init_no_credit) {
@@ -230,16 +236,18 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
   rules_to_install->Add()->CopyFrom(rule1);
 
   // Expect rule1 to not be activated
-  EXPECT_CALL(*pipelined_client,
-              activate_flows_for_rules(testing::_, testing::_, CheckCount(0),
-                                       CheckCount(0), testing::_))
-  .Times(1)
-  .WillOnce(testing::Return(true));
-  local_enforcer->init_session_credit(session_map, "IMSI1", "1234", test_cfg,
-                                      response);
-  EXPECT_EQ(local_enforcer->get_charging_credit(session_map, "IMSI1", 1,
-                                                ALLOWED_TOTAL),
-            0);
+  EXPECT_CALL(
+      *pipelined_client,
+      activate_flows_for_rules(
+          testing::_, testing::_, CheckCount(0), CheckCount(0), testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_enforcer->init_session_credit(
+      session_map, "IMSI1", "1234", test_cfg_, response);
+  EXPECT_EQ(
+      local_enforcer->get_charging_credit(
+          session_map, "IMSI1", 1, ALLOWED_TOTAL),
+      0);
 }
 
 TEST_F(LocalEnforcerTest, test_init_session_credit) {
@@ -256,7 +264,7 @@ TEST_F(LocalEnforcerTest, test_init_session_credit) {
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   EXPECT_EQ(
       local_enforcer->get_charging_credit(
@@ -270,7 +278,7 @@ TEST_F(LocalEnforcerTest, test_single_record) {
   create_credit_update_response(
       "IMSI1", 1, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   RuleRecordTable table;
@@ -308,7 +316,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records) {
   create_credit_update_response(
       "IMSI1", 2, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
@@ -357,7 +365,7 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
   create_credit_update_response(
       "IMSI1", 2, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
@@ -387,7 +395,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
   create_credit_update_response(
       "IMSI1", 1, 3072, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   insert_static_rule(1, "", "rule1");
 
   std::vector<std::unique_ptr<ServiceAction>> actions;
@@ -436,7 +444,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules) {
   auto credits = response.mutable_credits();
   create_credit_update_response("IMSI1", 1, 2048, credits->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   EXPECT_EQ(
       local_enforcer->get_charging_credit(
@@ -485,7 +493,7 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
       "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       monitor_updates->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1", test_cfg, response);
+      session_map, "IMSI1", "1", test_cfg_, response);
   assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
   assert_charging_credit("IMSI1", ALLOWED_TOTAL, {});
 
@@ -534,11 +542,11 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
 
   session_map = session_store->read_sessions(SessionRead{"IMSI1"});
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
   session_map = session_store->read_sessions(SessionRead{"IMSI2"});
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "4321", test_cfg, response2);
+      session_map, "IMSI2", "4321", test_cfg_, response2);
   session_store->create_sessions("IMSI2", std::move(session_map["IMSI2"]));
 
   session_map = session_store->read_sessions(SessionRead{"IMSI1"});
@@ -549,7 +557,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
       report_terminate_session(CheckTerminateRequestCount("IMSI1", 0, 2), _))
       .Times(1);
   local_enforcer->terminate_session(
-      session_map, "IMSI1", test_cfg.apn, update);
+      session_map, "IMSI1", test_cfg_.common_context.apn(), update);
 
   RuleRecordTable empty_table;
   local_enforcer->aggregate_records(session_map, empty_table, update);
@@ -578,7 +586,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
       "IMSI1", "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(2, "", "rule2");
 
@@ -622,7 +630,7 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
   create_credit_update_response(
       imsi, 1, 1024, true, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg, response);
+      session_map, imsi, session_id, test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
@@ -708,7 +716,7 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   create_credit_update_response(
       imsi, 1, 1024, true, response.mutable_credits()->Add());
   auto session_state = new SessionState(
-      imsi, session_id, session_id, test_cfg, *rule_store, tgpp_ctx);
+      imsi, session_id, session_id, test_cfg_, *rule_store, tgpp_ctx);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;
@@ -756,7 +764,7 @@ TEST_F(LocalEnforcerTest, test_termination_scheduling_on_sync_sessions) {
   create_session_create_response(imsi, "m1", rules_to_install, &response);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg, response);
+      session_map, imsi, session_id, test_cfg_, response);
 
   EXPECT_EQ(session_map[imsi].size(), 1);
   bool success =
@@ -800,7 +808,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   create_credit_update_response(
       "IMSI1", 1, 1024, true, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
 
@@ -844,9 +852,12 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   insert_static_rule(0, "m1", "rule3");
 
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type          = RATType::TGPP_WLAN;
-  test_cwf_cfg.mac_addr          = "00:00:00:00:00:00";
-  test_cwf_cfg.radius_session_id = "1234567";
+  auto mac_addr          = "00:00:00:00:00:00";
+  auto radius_session_id = "1234567";
+  test_cwf_cfg.mac_addr = mac_addr;
+  test_cwf_cfg.radius_session_id = radius_session_id;
+build_common_context(
+"IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
 
   local_enforcer->init_session_credit(
       session_map, "IMSI1", "1234", test_cwf_cfg, response);
@@ -888,12 +899,12 @@ TEST_F(LocalEnforcerTest, test_all) {
   create_credit_update_response(
       "IMSI1", 1, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   CreateSessionResponse response2;
   create_credit_update_response(
       "IMSI2", 2, 2048, response2.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "4321", test_cfg, response2);
+      session_map, "IMSI2", "4321", test_cfg_, response2);
 
   EXPECT_EQ(
       local_enforcer->get_charging_credit(
@@ -1018,7 +1029,7 @@ TEST_F(LocalEnforcerTest, test_re_auth) {
   insert_static_rule(1, "", "rule1");
   CreateSessionResponse response;
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   ChargingReAuthRequest reauth;
   reauth.set_sid("IMSI1");
@@ -1068,7 +1079,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules) {
   policy_rule->set_rating_group(1);
   policy_rule->set_tracking_type(PolicyRule::ONLY_OCS);
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   insert_static_rule(1, "", "rule2");
   RuleRecordTable table;
@@ -1124,7 +1135,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
       .WillOnce(testing::Return(true));
 
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
@@ -1220,7 +1231,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 }
 
 TEST_F(LocalEnforcerTest, test_usage_monitors) {
@@ -1247,7 +1258,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
       "IMSI1", "4", MonitoringLevel::SESSION_LEVEL, 2128,
       response.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   assert_charging_credit("IMSI1", ALLOWED_TOTAL, {{1, 1024}, {2, 1024}});
   assert_monitor_credit(
       "IMSI1", ALLOWED_TOTAL, {{"1", 1024}, {"3", 2048}, {"4", 2128}});
@@ -1377,7 +1388,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
       "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 2048,
       response.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
   assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}, {"3", 2048}});
 
   // IMPORTANT: save the updates into store and reload
@@ -1385,8 +1396,6 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
       session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
   EXPECT_TRUE(success);
   session_map = session_store->read_sessions(SessionRead{"IMSI1"});
-
-
 
   // Receive an update with DISABLE for mkey=3 & mkey=2, CONTINUE for mkey=1
   UpdateSessionResponse update_response;
@@ -1440,7 +1449,8 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
   test_qos_info.qci     = 0;
 
   SessionConfig test_volte_cfg;
-  test_volte_cfg.ue_ipv4   = "127.0.0.1";
+  build_common_context(
+      "", "127.0.0.1", "", "IMS", TGPP_LTE, &test_volte_cfg.common_context);
   test_volte_cfg.bearer_id = 1;
   test_volte_cfg.qos_info  = test_qos_info;
 
@@ -1494,7 +1504,7 @@ TEST_F(LocalEnforcerTest, test_rar_session_not_found) {
   // and an invalid session-id (session1)
   CreateSessionResponse response;
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "session0", test_cfg, response);
+      session_map, "IMSI1", "session0", test_cfg_, response);
   local_enforcer->init_policy_reauth(session_map, rar, raa, update);
   EXPECT_EQ(raa.result(), ReAuthResult::SESSION_NOT_FOUND);
 }
@@ -1521,7 +1531,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_init) {
   response.mutable_static_rules()->Add()->CopyFrom(static_rule_install);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg, response);
+      session_map, imsi, session_id, test_cfg_, response);
   bool success =
       session_store->create_sessions(imsi, std::move(session_map[imsi]));
   EXPECT_TRUE(success);
@@ -1553,7 +1563,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_rar) {
   create_session_create_response(imsi, mkey, rules_to_install, &response);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg, response);
+      session_map, imsi, session_id, test_cfg_, response);
   EXPECT_EQ(session_map[imsi].size(), 1);
 
   // Write and read into session store, assert success
@@ -1604,13 +1614,13 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   create_session_create_response(
       imsi1, mkey1, rules_to_install, &create_response);
   local_enforcer->init_session_credit(
-      session_map, imsi1, session_id1, test_cfg, create_response);
+      session_map, imsi1, session_id1, test_cfg_, create_response);
 
   create_response.Clear();
   create_session_create_response(
       imsi2, mkey1, rules_to_install, &create_response);
   local_enforcer->init_session_credit(
-      session_map, imsi2, session_id2, test_cfg, create_response);
+      session_map, imsi2, session_id2, test_cfg_, create_response);
 
   // Write and read into session store, assert success
   bool success =
@@ -1674,7 +1684,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update_no_monitor) {
   res->set_sid(imsi1);
   create_response.mutable_static_rules()->Add()->CopyFrom(rule_install);
   local_enforcer->init_session_credit(
-      session_map, imsi1, session_id1, test_cfg, create_response);
+      session_map, imsi1, session_id1, test_cfg_, create_response);
 
   // Write and read into session store, assert success
   bool success =
@@ -1725,12 +1735,14 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
   auto static_rule = response.mutable_static_rules()->Add();
   static_rule->set_rule_id("rule2");
   SessionConfig test_cwf_cfg1;
-  test_cwf_cfg1.rat_type          = RATType::TGPP_WLAN;
-  test_cwf_cfg1.ue_ipv4           = "127.0.0.1";
+  build_common_context(
+      "IMSI1", "127.0.0.1", "01-a1-20-c2-0f-bb:CWC_OFFLOAD", "msisdn1",
+      TGPP_WLAN, &test_cwf_cfg1.common_context);
+  build_wlan_context(
+      "11:22:00:00:22:11", "5555",
+      test_cwf_cfg1.rat_specific_context.mutable_wlan_context());
   test_cwf_cfg1.mac_addr          = "11:22:00:00:22:11";
   test_cwf_cfg1.radius_session_id = "5555";
-  test_cwf_cfg1.apn               = "01-a1-20-c2-0f-bb:CWC_OFFLOAD";
-  test_cwf_cfg1.msisdn            = "msisdn1";
   local_enforcer->init_session_credit(
       session_map, "IMSI1", "1234", test_cwf_cfg1, response);
 
@@ -1743,27 +1755,29 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
   policy_rule2->set_rating_group(1);
   policy_rule2->set_tracking_type(PolicyRule::ONLY_OCS);
   SessionConfig test_cwf_cfg2;
-  test_cwf_cfg2.rat_type          = RATType::TGPP_WLAN;
-  test_cwf_cfg2.ue_ipv4           = "127.0.0.1";
   test_cwf_cfg2.mac_addr          = "00:00:00:00:00:02";
   test_cwf_cfg2.radius_session_id = "5555";
-  test_cwf_cfg2.apn               = "03-21-00-02-00-20:Magma";
-  test_cwf_cfg2.msisdn            = "msisdn2";
+  build_common_context(
+      "IMSI2", "127.0.0.1", "03-21-00-02-00-20:Magma", "msisdn2", TGPP_WLAN,
+      &test_cwf_cfg2.common_context);
+  build_wlan_context(
+      "00:00:00:00:00:02", "5555",
+      test_cwf_cfg2.rat_specific_context.mutable_wlan_context());
   local_enforcer->init_session_credit(
       session_map, "IMSI2", "12345", test_cwf_cfg2, response2);
 
   std::vector<std::string> imsi_list       = {"IMSI2", "IMSI1"};
   std::vector<std::string> ip_address_list = {"127.0.0.1", "127.0.0.1"};
   std::vector<std::vector<std::string>> static_rule_list  = {{}, {"rule2"}};
-  std::vector<std::vector<std::string>> dynamic_rule_list = {{"rule22"},
-                                                             {"rule1"}};
+  std::vector<std::vector<std::string>> dynamic_rule_list = {
+      {"rule22"}, {"rule1"}};
 
-  std::vector<std::string> ue_mac_addrs  = {"00:00:00:00:00:02",
-                                           "11:22:00:00:22:11"};
+  std::vector<std::string> ue_mac_addrs = {
+      "00:00:00:00:00:02", "11:22:00:00:22:11"};
   std::vector<std::string> msisdns       = {"msisdn2", "msisdn1"};
-  std::vector<std::string> apn_mac_addrs = {"03-21-00-02-00-20",
-                                            "01-a1-20-c2-0f-bb"};
-  std::vector<std::string> apn_names     = {"Magma", "CWC_OFFLOAD"};
+  std::vector<std::string> apn_mac_addrs = {
+      "03-21-00-02-00-20", "01-a1-20-c2-0f-bb"};
+  std::vector<std::string> apn_names = {"Magma", "CWC_OFFLOAD"};
   EXPECT_CALL(
       *pipelined_client,
       setup_cwf(
@@ -1794,7 +1808,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
   auto static_rule = response.mutable_static_rules()->Add();
   static_rule->set_rule_id("rule2");
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg, response);
+      session_map, "IMSI1", "1234", test_cfg_, response);
 
   CreateSessionResponse response2;
   create_credit_update_response(
@@ -1805,20 +1819,20 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
   policy_rule2->set_rating_group(1);
   policy_rule2->set_tracking_type(PolicyRule::ONLY_OCS);
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "12345", test_cfg, response2);
+      session_map, "IMSI2", "12345", test_cfg_, response2);
 
   std::vector<std::string> imsi_list       = {"IMSI2", "IMSI1"};
   std::vector<std::string> ip_address_list = {"127.0.0.1", "127.0.0.1"};
   std::vector<std::vector<std::string>> static_rule_list  = {{}, {"rule2"}};
-  std::vector<std::vector<std::string>> dynamic_rule_list = {{"rule22"},
-                                                             {"rule1"}};
+  std::vector<std::vector<std::string>> dynamic_rule_list = {
+      {"rule22"}, {"rule1"}};
 
-  std::vector<std::string> ue_mac_addrs  = {"00:00:00:00:00:02",
-                                           "11:22:00:00:22:11"};
+  std::vector<std::string> ue_mac_addrs = {
+      "00:00:00:00:00:02", "11:22:00:00:22:11"};
   std::vector<std::string> msisdns       = {"msisdn2", "msisdn1"};
-  std::vector<std::string> apn_mac_addrs = {"03-21-00-02-00-20",
-                                            "01-a1-20-c2-0f-bb"};
-  std::vector<std::string> apn_names     = {"Magma", "CWC_OFFLOAD"};
+  std::vector<std::string> apn_mac_addrs = {
+      "03-21-00-02-00-20", "01-a1-20-c2-0f-bb"};
+  std::vector<std::string> apn_names = {"Magma", "CWC_OFFLOAD"};
   EXPECT_CALL(
       *pipelined_client,
       setup_lte(
@@ -1842,12 +1856,17 @@ TEST_F(LocalEnforcerTest, test_valid_apn_parsing) {
   auto credits = response.mutable_credits();
   create_credit_update_response("IMSI1", 1, 1024, credits->Add());
 
+  auto apn               = "03-21-00-02-00-20:Magma";
+  auto mac_addr          = "00:00:00:00:00:02";
+  auto radius_session_id = "5555";
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type          = RATType::TGPP_WLAN;
-  test_cwf_cfg.mac_addr          = "00:00:00:00:00:02";
-  test_cwf_cfg.radius_session_id = "5555";
-  test_cwf_cfg.apn               = "03-21-00-02-00-20:Magma";
-  test_cwf_cfg.msisdn            = "msisdn";
+  test_cwf_cfg.mac_addr          = mac_addr;
+  test_cwf_cfg.radius_session_id = radius_session_id;
+  build_common_context(
+      "IMSI1", "", apn, "msisdn", TGPP_WLAN, &test_cwf_cfg.common_context);
+  build_wlan_context(
+      mac_addr, radius_session_id,
+      test_cwf_cfg.rat_specific_context.mutable_wlan_context());
 
   local_enforcer->init_session_credit(
       session_map, "IMSI1", "1234", test_cwf_cfg, response);
@@ -1878,12 +1897,18 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
   auto credits = response.mutable_credits();
   create_credit_update_response("IMSI1", 1, 1024, credits->Add());
 
+  auto apn               = "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay";
+  auto mac_addr          = "00:00:00:00:00:02";
+  auto radius_session_id = "5555";
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type          = RATType::TGPP_WLAN;
-  test_cwf_cfg.mac_addr          = "00:00:00:00:00:02";
-  test_cwf_cfg.radius_session_id = "5555";
-  test_cwf_cfg.apn               = "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay";
-  test_cwf_cfg.msisdn            = "msisdn";
+  test_cwf_cfg.mac_addr          = mac_addr;
+  test_cwf_cfg.radius_session_id = radius_session_id;
+  build_common_context(
+      "IMSI1", "127.0.0.1", apn, "msisdn", TGPP_WLAN,
+      &test_cwf_cfg.common_context);
+  build_wlan_context(
+      mac_addr, radius_session_id,
+      test_cwf_cfg.rat_specific_context.mutable_wlan_context());
 
   local_enforcer->init_session_credit(
       session_map, "IMSI1", "1234", test_cwf_cfg, response);

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -118,7 +118,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota) {
 
   std::vector<std::string> static_rules{"static_1"};
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+  build_common_context(
+      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
 
@@ -144,7 +145,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota) {
 
   std::vector<std::string> static_rules{};  // no rule installs
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+  build_common_context(
+      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
 
@@ -166,7 +168,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar) {
 
   std::vector<std::string> static_rules{"static_1"};
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+  build_common_context(
+      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
   local_enforcer->init_session_credit(
@@ -200,7 +203,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update) {
 
   std::vector<std::string> static_rules{"static_1", "static_2"};
   SessionConfig test_cwf_cfg;
-  test_cwf_cfg.rat_type = RATType::TGPP_WLAN;
+  build_common_context(
+      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
   local_enforcer->init_session_credit(

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -86,18 +86,15 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
         "AA-AA-AA-AA-AA-AA:TESTAP__"
         "0F-10-2E-12-3A-55";
     std::string core_session_id = "asdf";
-    SessionConfig cfg           = {.ue_ipv4           = "",
-                         .spgw_ipv4         = "",
-                         .msisdn            = msisdn,
-                         .apn               = "",
-                         .imei              = "",
-                         .plmn_id           = "",
-                         .imsi_plmn_id      = "",
-                         .user_location     = "",
-                         .rat_type          = RATType::TGPP_WLAN,
-                         .mac_addr          = "0f:10:2e:12:3a:55",
-                         .hardware_addr     = hardware_addr_bytes,
-                         .radius_session_id = radius_session_id};
+    SessionConfig cfg           = {
+        .spgw_ipv4         = "",
+        .imei              = "",
+        .plmn_id           = "",
+        .imsi_plmn_id      = "",
+        .user_location     = "",
+        .mac_addr          = "0f:10:2e:12:3a:55",
+        .hardware_addr     = hardware_addr_bytes,
+        .radius_session_id = radius_session_id};
     auto tgpp_context           = TgppContext{};
     auto session                = std::make_unique<SessionState>(
         imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -118,19 +118,22 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   std::string radius_session_id =
       "AA-AA-AA-AA-AA-AA:TESTAP__"
       "0F-10-2E-12-3A-55";
-  auto sid          = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg = {.ue_ipv4           = "",
-                       .spgw_ipv4         = "",
-                       .msisdn            = msisdn,
-                       .apn               = "apn1",
-                       .imei              = "",
-                       .plmn_id           = "",
-                       .imsi_plmn_id      = "",
-                       .user_location     = "",
-                       .rat_type          = RATType::TGPP_WLAN,
-                       .mac_addr          = "0f:10:2e:12:3a:55",
-                       .hardware_addr     = hardware_addr_bytes,
-                       .radius_session_id = radius_session_id};
+  std::string mac_addr = "0f:10:2e:12:3a:55";
+  auto sid             = id_gen_.gen_session_id(imsi);
+  SessionConfig cfg    = {
+      .spgw_ipv4         = "",
+      .imei              = "",
+      .plmn_id           = "",
+      .imsi_plmn_id      = "",
+      .user_location     = "",
+      .mac_addr          = mac_addr,
+      .hardware_addr     = hardware_addr_bytes,
+      .radius_session_id = radius_session_id};
+  build_common_context(
+      imsi, "", "apn1", msisdn, TGPP_WLAN, &cfg.common_context);
+  build_wlan_context(
+      mac_addr, radius_session_id,
+      cfg.rat_specific_context.mutable_wlan_context());
 
   response.set_session_id(sid);
   // Only the active sessions are not recycled, to ensure that
@@ -152,7 +155,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   EXPECT_FALSE(it == session_map.end());
   EXPECT_EQ(session_map["IMSI1"].size(), 1);
   auto& session = session_map["IMSI1"][0];
-  EXPECT_EQ(session->get_config().apn, "apn1");
+  EXPECT_EQ(session->get_config().common_context.apn(), "apn1");
 
   grpc::ServerContext create_context;
   request.mutable_sid()->set_id("IMSI1");
@@ -161,6 +164,11 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   request.set_msisdn(msisdn);
   request.set_radius_session_id(radius_session_id);
   request.set_apn("apn2");  // Update APN
+  build_common_context(
+      imsi, "", "apn2", msisdn, TGPP_WLAN, request.mutable_common_context());
+  build_wlan_context(
+      mac_addr, radius_session_id,
+      request.mutable_rat_specific_context()->mutable_wlan_context());
 
   // Ensure session is not reported as its a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
@@ -178,7 +186,7 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   EXPECT_FALSE(it == session_map.end());
   EXPECT_EQ(session_map["IMSI1"].size(), 1);
   auto& session_apn2 = session_map["IMSI1"][0];
-  EXPECT_EQ(session_apn2->get_config().apn, "apn2");
+  EXPECT_EQ(session_apn2->get_config().common_context.apn(), "apn2");
 }
 
 TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
@@ -191,15 +199,14 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   std::string msisdn = "5100001234";
   auto sid           = id_gen_.gen_session_id(imsi);
   SessionConfig cfg  = {
-      .ue_ipv4       = "",
-      .spgw_ipv4     = "",
-      .msisdn        = msisdn,
-      .apn           = "apn1",
-      .imei          = "",
-      .plmn_id       = "",
-      .imsi_plmn_id  = "",
-      .user_location = "",
-      .rat_type      = RATType::TGPP_LTE};
+      .spgw_ipv4    = "spgw_ip",
+      .imei         = "imei",
+      .plmn_id      = "plmn_id",
+      .imsi_plmn_id = "imsi_plmn_id"};
+  build_common_context(imsi, "", "apn1", msisdn, TGPP_LTE, &cfg.common_context);
+  build_lte_context(
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id",
+      cfg.rat_specific_context.mutable_lte_context());
 
   response.set_session_id(sid);
   create_session_create_response(imsi, monitoring_key, static_rules, &response);
@@ -218,7 +225,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   EXPECT_FALSE(it == session_map.end());
   EXPECT_EQ(session_map["IMSI1"].size(), 1);
   auto& session = session_map["IMSI1"][0];
-  EXPECT_EQ(session->get_config().apn, "apn1");
+  EXPECT_EQ(session->get_config().common_context.apn(), "apn1");
 
   // Only active, identical sessions can be recycled for LTE
   // The previously created session is active and this request has the same
@@ -229,6 +236,15 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   request.set_rat_type(RATType::TGPP_LTE);
   request.set_msisdn(msisdn);
   request.set_apn("apn1");
+  request.set_spgw_ipv4("spgw_ip");
+  request.set_imei("imei");
+  request.set_plmn_id("plmn_id");
+  request.set_imsi_plmn_id("imsi_plmn_id");
+  build_common_context(
+      imsi, "", "apn1", msisdn, TGPP_LTE, request.mutable_common_context());
+  build_lte_context(
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id",
+      request.mutable_rat_specific_context()->mutable_lte_context());
 
   // Ensure session is not reported as its a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
@@ -252,7 +268,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   EXPECT_FALSE(it == session_map.end());
   EXPECT_EQ(session_map["IMSI1"].size(), 1);
   auto& session_apn2 = session_map["IMSI1"][0];
-  EXPECT_EQ(session_apn2->get_config().apn, "apn1");
+  EXPECT_EQ(session_apn2->get_config().common_context.apn(), "apn1");
 
   // Now make the config not identical but with the same APN=apn1, this should
   // trigger a terminate for the existing and a creation for the new session
@@ -262,6 +278,12 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   request2.set_rat_type(RATType::TGPP_LTE);
   request2.set_msisdn(msisdn + "magma :)");  // different msisdn
   request2.set_apn("apn1");
+  build_common_context(
+      imsi, "", "apn1", msisdn + "magma :)", TGPP_LTE,
+      request2.mutable_common_context());
+  build_lte_context(
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id",
+      request2.mutable_rat_specific_context()->mutable_lte_context());
 
   // Ensure a create session for the new session is sent, the old one is
   // terminated
@@ -333,18 +355,15 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
       "AA-AA-AA-AA-AA-AA:TESTAP__"
       "0F-10-2E-12-3A-55";
   auto sid          = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg = {.ue_ipv4           = "",
-                       .spgw_ipv4         = "",
-                       .msisdn            = msisdn,
-                       .apn               = "apn1",
-                       .imei              = "",
-                       .plmn_id           = "",
-                       .imsi_plmn_id      = "",
-                       .user_location     = "",
-                       .rat_type          = RATType::TGPP_LTE,
-                       .mac_addr          = "0f:10:2e:12:3a:55",
-                       .hardware_addr     = hardware_addr_bytes,
-                       .radius_session_id = radius_session_id};
+  SessionConfig cfg = {
+      .spgw_ipv4         = "",
+      .imei              = "",
+      .plmn_id           = "",
+      .imsi_plmn_id      = "",
+      .user_location     = "",
+      .mac_addr          = "0f:10:2e:12:3a:55",
+      .hardware_addr     = hardware_addr_bytes,
+      .radius_session_id = radius_session_id};
 
   SessionRead req  = {"IMSI1"};
   auto session_map = session_store->read_sessions(req);
@@ -391,19 +410,23 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
   std::string radius_session_id =
       "AA-AA-AA-AA-AA-AA:TESTAP__"
       "0F-10-2E-12-3A-55";
+  std::string apn   = "apn1";
+  std::string mac_addr = "0f:10:2e:12:3a:55";
   auto sid          = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg = {.ue_ipv4           = "",
-                       .spgw_ipv4         = "",
-                       .msisdn            = msisdn,
-                       .apn               = "apn1",
-                       .imei              = "",
-                       .plmn_id           = "",
-                       .imsi_plmn_id      = "",
-                       .user_location     = "",
-                       .rat_type          = RATType::TGPP_LTE,
-                       .mac_addr          = "0f:10:2e:12:3a:55",
-                       .hardware_addr     = hardware_addr_bytes,
-                       .radius_session_id = radius_session_id};
+  SessionConfig cfg = {
+      .spgw_ipv4         = "",
+      .imei              = "",
+      .plmn_id           = "",
+      .imsi_plmn_id      = "",
+      .user_location     = "",
+      .mac_addr          = mac_addr,
+      .hardware_addr     = hardware_addr_bytes,
+      .radius_session_id = radius_session_id};
+
+  build_common_context(imsi, "", apn, msisdn, TGPP_WLAN, &cfg.common_context);
+  build_wlan_context(
+      mac_addr, radius_session_id,
+      cfg.rat_specific_context.mutable_wlan_context());
 
   SessionRead req  = {"IMSI1"};
   auto session_map = session_store->read_sessions(req);

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -65,18 +65,15 @@ class SessionStoreTest : public ::testing::Test {
         "AA-AA-AA-AA-AA-AA:TESTAP__"
         "0F-10-2E-12-3A-55";
     std::string core_session_id = "asdf";
-    SessionConfig cfg           = {.ue_ipv4           = "",
-                         .spgw_ipv4         = "",
-                         .msisdn            = msisdn,
-                         .apn               = "",
-                         .imei              = "",
-                         .plmn_id           = "",
-                         .imsi_plmn_id      = "",
-                         .user_location     = "",
-                         .rat_type          = RATType::TGPP_WLAN,
-                         .mac_addr          = "0f:10:2e:12:3a:55",
-                         .hardware_addr     = hardware_addr_bytes,
-                         .radius_session_id = radius_session_id};
+    SessionConfig cfg           = {
+        .spgw_ipv4         = "",
+        .imei              = "",
+        .plmn_id           = "",
+        .imsi_plmn_id      = "",
+        .user_location     = "",
+        .mac_addr          = "0f:10:2e:12:3a:55",
+        .hardware_addr     = hardware_addr_bytes,
+        .radius_session_id = radius_session_id};
     auto tgpp_context           = TgppContext{};
     auto session                = std::make_unique<SessionState>(
         imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -53,18 +53,15 @@ TEST_F(StoreClientTest, test_read_and_write) {
   auto sid2                   = id_gen_.gen_session_id(imsi2);
   auto sid3                   = id_gen_.gen_session_id(imsi3);
   std::string core_session_id = "asdf";
-  SessionConfig cfg           = {.ue_ipv4           = "",
-                       .spgw_ipv4         = "",
-                       .msisdn            = msisdn,
-                       .apn               = "",
-                       .imei              = "",
-                       .plmn_id           = "",
-                       .imsi_plmn_id      = "",
-                       .user_location     = "",
-                       .rat_type          = RATType::TGPP_WLAN,
-                       .mac_addr          = "0f:10:2e:12:3a:55",
-                       .hardware_addr     = hardware_addr_bytes,
-                       .radius_session_id = radius_session_id};
+  SessionConfig cfg           = {
+      .spgw_ipv4         = "",
+      .imei              = "",
+      .plmn_id           = "",
+      .imsi_plmn_id      = "",
+      .user_location     = "",
+      .mac_addr          = "0f:10:2e:12:3a:55",
+      .hardware_addr     = hardware_addr_bytes,
+      .radius_session_id = radius_session_id};
   auto rule_store             = std::make_shared<StaticRuleStore>();
   auto tgpp_context           = TgppContext{};
 

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -16,6 +16,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include "ProtobufCreators.h"
 #include "StoredState.h"
 #include "magma_logging.h"
 
@@ -34,20 +35,18 @@ class StoredStateTest : public ::testing::Test {
 
   SessionConfig get_stored_session_config() {
     SessionConfig stored;
-    stored.ue_ipv4           = "192.168.0.1";
     stored.spgw_ipv4         = "192.168.0.2";
-    stored.msisdn            = "a";
-    stored.apn               = "b";
     stored.imei              = "c";
     stored.plmn_id           = "d";
     stored.imsi_plmn_id      = "e";
     stored.user_location     = "f";
-    stored.rat_type          = RATType::TGPP_WLAN;
     stored.mac_addr          = "g";  // MAC Address for WLAN
     stored.hardware_addr     = "h";  // MAC Address for WLAN (binary)
     stored.radius_session_id = "i";
     stored.bearer_id         = 321;
     stored.qos_info          = get_stored_qos_info();
+    build_common_context(
+        "IMSI1", "ue_ipv4", "apn", "msisdn", TGPP_WLAN, &stored.common_context);
     return stored;
   }
 
@@ -159,21 +158,26 @@ TEST_F(StoredStateTest, test_stored_session_config) {
   std::string serialized     = serialize_stored_session_config(stored);
   SessionConfig deserialized = deserialize_stored_session_config(serialized);
 
-  EXPECT_EQ(deserialized.ue_ipv4, "192.168.0.1");
   EXPECT_EQ(deserialized.spgw_ipv4, "192.168.0.2");
-  EXPECT_EQ(deserialized.msisdn, "a");
-  EXPECT_EQ(deserialized.apn, "b");
   EXPECT_EQ(deserialized.imei, "c");
   EXPECT_EQ(deserialized.plmn_id, "d");
   EXPECT_EQ(deserialized.imsi_plmn_id, "e");
   EXPECT_EQ(deserialized.user_location, "f");
-  EXPECT_EQ(deserialized.rat_type, RATType::TGPP_WLAN);
   EXPECT_EQ(deserialized.mac_addr, "g");
   EXPECT_EQ(deserialized.hardware_addr, "h");
   EXPECT_EQ(deserialized.radius_session_id, "i");
   EXPECT_EQ(deserialized.bearer_id, 321);
   EXPECT_EQ(deserialized.qos_info.enabled, true);
   EXPECT_EQ(deserialized.qos_info.qci, 123);
+
+  // compare the serialized objects
+  auto original_common       = stored.common_context.SerializeAsString();
+  auto original_rat_specific = stored.rat_specific_context.SerializeAsString();
+  auto recovered_common      = deserialized.common_context.SerializeAsString();
+  auto recovered_rat_specific =
+      deserialized.rat_specific_context.SerializeAsString();
+  EXPECT_EQ(original_common, recovered_common);
+  EXPECT_EQ(original_rat_specific, recovered_rat_specific);
 }
 
 TEST_F(StoredStateTest, test_stored_final_action_info) {
@@ -276,15 +280,11 @@ TEST_F(StoredStateTest, test_stored_session) {
   auto deserialized = deserialize_stored_session(serialized);
 
   auto config = deserialized.config;
-  EXPECT_EQ(config.ue_ipv4, "192.168.0.1");
   EXPECT_EQ(config.spgw_ipv4, "192.168.0.2");
-  EXPECT_EQ(config.msisdn, "a");
-  EXPECT_EQ(config.apn, "b");
   EXPECT_EQ(config.imei, "c");
   EXPECT_EQ(config.plmn_id, "d");
   EXPECT_EQ(config.imsi_plmn_id, "e");
   EXPECT_EQ(config.user_location, "f");
-  EXPECT_EQ(config.rat_type, RATType::TGPP_WLAN);
   EXPECT_EQ(config.mac_addr, "g");
   EXPECT_EQ(config.hardware_addr, "h");
   EXPECT_EQ(config.radius_session_id, "i");


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
(No longer blocked on: https://github.com/magma/magma/pull/2166, https://github.com/magma/magma/pull/2149 )
A recent change was made in https://github.com/magma/magma/pull/2063 and https://github.com/magma/magma/pull/2077 to consolidate common Non-RAT specific session context into `CommonSessionContext` and RAT specific ones into `WLANSessionContext` and `LTESessionContext`. 

This change migrates the reads of these fields to read from the new `CommonSessionContext`. As these fields are now deprecated, they are also removed from the `SessionConfig` structure. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF Integ Test
S1AP Tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
