### PR TITLE
[SessionD] Fix terminate handling logic to be per-session not IMSI

### DIFF
--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -134,4 +134,17 @@ std::string raa_result_to_str(ReAuthResult res) {
       return "UNKNOWN_RESULT";
   }
 }
+
+std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state) {
+  switch (state) {
+    case SubscriberQuotaUpdate_Type_VALID_QUOTA:
+      return "VALID_QUOTA";
+    case SubscriberQuotaUpdate_Type_NO_QUOTA:
+      return "NO_QUOTA";
+    case SubscriberQuotaUpdate_Type_TERMINATE:
+      return "TERMINATE";
+    default:
+      return "INVALID";
+  }
+}
 }  // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -28,4 +28,6 @@ std::string session_fsm_state_to_str(SessionFsmState state);
 std::string credit_update_type_to_str(CreditUsage::UpdateType update);
 
 std::string raa_result_to_str(ReAuthResult res);
+
+std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -145,11 +145,15 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   /**
-   * Starts the termination process for the session. When termination completes,
-   * the call back function is executed.
-   * @param imsi - imsi of the subscirber
+   * terminate_session handles externally triggered session termination.
+   * This assumes that the termination is coming from the access component, so
+   * it does not notify the termination back to the access component.
+   * @param session_map
+   * @param imsi
+   * @param apn
+   * @param session_update
    */
-  void terminate_subscriber(
+  void terminate_session(
       SessionMap& session_map, const std::string& imsi, const std::string& apn,
       SessionUpdate& session_update);
 
@@ -234,7 +238,7 @@ class LocalEnforcer {
    * aggregated.
    */
   void notify_new_report_for_sessions(
-      SessionMap& session_map, SessionUpdate &session_update);
+      SessionMap& session_map, SessionUpdate& session_update);
 
   /**
    * notify_finish_report_for_sessions notifies all sessions that the
@@ -324,8 +328,8 @@ class LocalEnforcer {
 
   /**
    * Completes the session termination and executes the callback function
-   * registered in terminate_subscriber.
-   * complete_termination is called some time after terminate_subscriber
+   * registered in terminate_session.
+   * complete_termination is called some time after terminate_session
    * when the flows no longer appear in the usage report, meaning that they have
    * been deleted.
    * It is also called after a timeout to perform forced termination.
@@ -377,35 +381,98 @@ class LocalEnforcer {
       const google::protobuf::RepeatedField<int>& event_triggers);
 
   void schedule_revalidation(
-      const std::string& imsi,
-      SessionState& session,
+      const std::string& imsi, SessionState& session,
       const google::protobuf::Timestamp& revalidation_time,
       SessionStateUpdateCriteria& update_criteria);
 
   void handle_add_ue_mac_flow_callback(
-    const SubscriberID& sid,
-    const std::string& ue_mac_addr,
-    const std::string& msisdn,
-    const std::string& ap_mac_addr,
-    const std::string& ap_name,
-    Status status, FlowResponse resp);
+      const SubscriberID& sid, const std::string& ue_mac_addr,
+      const std::string& msisdn, const std::string& ap_mac_addr,
+      const std::string& ap_name, Status status, FlowResponse resp);
 
   void handle_activate_ue_flows_callback(
-    const std::string& imsi,
-    const std::string& ip_addr,
-    const std::vector<std::string>& static_rules,
-    const std::vector<PolicyRule>& dynamic_rules,
-    Status status, ActivateFlowsResult resp);
+      const std::string& imsi, const std::string& ip_addr,
+      const std::vector<std::string>& static_rules,
+      const std::vector<PolicyRule>& dynamic_rules, Status status,
+      ActivateFlowsResult resp);
 
   /**
-   * Deactivate rules for certain IMSI.
-   * Notify AAA service if the session is a CWF session.
+   * find_and_terminate_session call start_session_termination on a session with
+   * IMSI + session id.
+   * @return true if start_session_termination was called, false if session was
+   * not found
    */
-  void terminate_service(
+  bool find_and_terminate_session(
       SessionMap& session_map, const std::string& imsi,
-      const std::vector<std::string>& rule_ids,
-      const std::vector<PolicyRule>& dynamic_rules,
-      SessionUpdate& session_update);
+      const std::string& session_id, SessionUpdate& session_update);
+
+  /**
+   * start_session_termination starts the termination process. This includes:
+   * 1. Update the Session FSM State to Terminating
+   * 2. Remove all policies attached to the session
+   * 3. If notify_access param is set, communicate to the access component
+   * 4. Propagate subscriber wallet status
+   * 5. Schedule a callback to force termination if termination is not completed
+   *    in a set amount of time
+   * @param imsi
+   * @param session
+   * @param notify_access: bool to determine whether the access component needs
+   * notification
+   * @param update_criteria
+   */
+  void start_session_termination(
+      const std::string& imsi, const std::unique_ptr<SessionState>& session,
+      bool notify_access, SessionStateUpdateCriteria& update_criteria);
+
+  /**
+   * handle_force_termination_timeout is scheduled to run when a termination
+   * process starts. If the session did not terminate itself properly within the
+   * timeout, this function will force the termination to complete.
+   * @param imsi
+   * @param session_id
+   */
+  void handle_force_termination_timeout(
+      const std::string& imsi, const std::string& session_id);
+
+  /**
+   * remove_all_rules_for_termination talks to PipelineD and removes all rules
+   * attached to the session
+   * @param imsi
+   * @param session
+   * @param update_criteria
+   */
+  void remove_all_rules_for_termination(
+      const std::string& imsi, const std::unique_ptr<SessionState>& session,
+      SessionStateUpdateCriteria& update_criteria);
+
+  /**
+   * notify_termination_to_access_service cases on the session's rat type and
+   * communicates to the appropriate access client to notify the session's
+   * termination.
+   * LTE -> MME, WLAN -> AAA
+   * @param imsi
+   * @param session_id
+   * @param config
+   */
+  void notify_termination_to_access_service(
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& config);
+  /**
+   * handle_subscriber_quota_state_change will update the session's wallet state
+   * to the desired new_state and propagate that state PipelineD.
+   * @param imsi
+   * @param session
+   * @param new_state
+   * @param update_criteria
+   */
+  void handle_subscriber_quota_state_change(
+      const std::string& imsi, SessionState& session,
+      SubscriberQuotaUpdate_Type new_state,
+      SessionStateUpdateCriteria& update_criteria);
+
+  void handle_subscriber_quota_state_change(
+      const std::string& imsi, SessionState& session,
+      SubscriberQuotaUpdate_Type new_state);
 
   /**
    * Deactivate rules for multiple IMSIs.
@@ -420,7 +487,7 @@ class LocalEnforcer {
    */
   void install_redirect_flow(
       const std::unique_ptr<ServiceAction>& action,
-      SessionUpdate &session_update);
+      SessionUpdate& session_update);
 
   bool rules_to_process_is_not_empty(const RulesToProcess& rules_to_process);
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -483,7 +483,7 @@ void LocalSessionManagerHandlerImpl::end_session(
     std::function<void(Status, LocalEndSessionResponse)> response_callback) {
   try {
     auto update = SessionStore::get_default_session_update(session_map);
-    enforcer_->terminate_subscriber(session_map, sid.id(), apn, update);
+    enforcer_->terminate_session(session_map, sid.id(), apn, update);
 
     bool update_success = session_store_.update_sessions(update);
     if (update_success) {

--- a/lte/gateway/c/session_manager/ServiceAction.h
+++ b/lte/gateway/c/session_manager/ServiceAction.h
@@ -46,6 +46,12 @@ class ServiceAction {
     return *this;
   }
 
+  ServiceAction &set_session_id(const std::string &session_id)
+  {
+    session_id_ = std::make_unique<std::string>(session_id);
+    return *this;
+  }
+
   ServiceAction &set_ip_addr(const std::string &ip_addr)
   {
     ip_addr_ = std::make_unique<std::string>(ip_addr);
@@ -69,6 +75,12 @@ class ServiceAction {
    * exception if there is none stored
    */
   const std::string &get_imsi() const { return *imsi_; }
+
+  /**
+   * get_imsi returns the associated IMSI for the action, or throws a nullptr
+   * exception if there is none stored
+   */
+  const std::string &get_session_id() const { return *session_id_; }
 
   /**
    * get_ip_addr returns the associated subscriber's ip_addr for the action,
@@ -100,6 +112,7 @@ class ServiceAction {
  private:
   ServiceActionType action_type_;
   std::unique_ptr<std::string> imsi_;
+  std::unique_ptr<std::string> session_id_;
   std::unique_ptr<std::string> ip_addr_;
   CreditKey credit_key_;
   std::vector<std::string> rule_ids_;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1004,6 +1004,7 @@ void SessionState::get_charging_updates(
         action->set_credit_key(key);
         action->set_imsi(imsi_);
         action->set_ip_addr(config_.ue_ipv4);
+        action->set_session_id(session_id_);
         static_rules_.get_rule_ids_for_charging_key(
             key, *action->get_mutable_rule_ids());
         dynamic_rules_.get_rule_definitions_for_charging_key(


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I think we had some logical issues in out terminate logic in the current implementation of SessionD.
A change was introduced  awhile back so that a subscriber can have multiple sessions, meaning that one IMSI can point to multiple sessions. However, we did all termination logic based on IMSI only. This meant that we could be terminating unrelated sessions. (Say IMSI1 has SessionA and SessionB. If SessionB was to be terminated due to some reason, we would terminate both SessionA and SessionB. I do not think this is expected.)

This change makes the change to handle all termination logic by IMSI+SessionID. 

I've also refactored a bit of the termination logic.

Some background is that we handle network triggered session termination and externally triggered termination a little differently. For network triggered termination, often due to quota exhaustion or some error with the network, will require SessionD to reach out to the access component (MME/AAA) to detach the user. On the other hand, we do not need to do this for termination triggered by MME/AAA.

`terminate_subscriber` -> `terminate_session`: this function is used for externally triggered session termination. (So detach/ASR, etc.)
`terminate_service` -> `start_session_termination`: `terminate_service` was used for internally triggered session termination, only. But I've refactored a bit so that we use this function for both internal/externally triggered termination.


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
