### PR TITLE
[NMS] Add ability to add network from network selector

### DIFF
--- a/nms/app/fbcnms-projects/magmalte/app/views/network/NetworkEdit.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/network/NetworkEdit.js
@@ -123,7 +123,8 @@ export default function AddEditNetworkButton(props: ButtonProps) {
   );
 }
 
-function NetworkEditDialog({open, onClose, editProps}: DialogProps) {
+export function NetworkEditDialog(props: DialogProps) {
+  const {open, editProps} = props;
   const classes = useStyles();
   const [networkId, setNetworkId] = useState<network_id>(
     editProps?.networkInfo?.id || '',
@@ -134,6 +135,13 @@ function NetworkEditDialog({open, onClose, editProps}: DialogProps) {
   const [tabPos, setTabPos] = React.useState(
     editProps ? EditTableType[editProps.editTable] : 0,
   );
+
+  const onClose = () => {
+    setNetworkInfo({});
+    setEpcConfigs({});
+    setNetworkId('');
+    props.onClose();
+  };
 
   return (
     <Dialog data-testid="editDialog" open={open} fullWidth={true} maxWidth="sm">

--- a/nms/app/fbcnms-projects/magmalte/app/views/network/NetworkInfo.js
+++ b/nms/app/fbcnms-projects/magmalte/app/views/network/NetworkInfo.js
@@ -140,7 +140,7 @@ export function NetworkInfoEdit(props: EditProps) {
       try {
         const response = await axios.post('/nms/network/create', payload);
         if (response.data.success) {
-          enqueueSnackbar(`Network $networkInfo.name} successfully created`, {
+          enqueueSnackbar(`Network ${networkInfo.name} successfully created`, {
             variant: 'success',
           });
           props.onSave(networkInfo);


### PR DESCRIPTION
## Summary

Plugged in the network creation dialog from network selector.

## Test Plan
yarn test ran fine 


![network_selector](https://user-images.githubusercontent.com/8224854/89478423-cae56280-d744-11ea-9bc7-82dfd821dbdb.gif)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
