### PR TITLE
[ci][xwfm-deploy] Fix failing xwf-m by add openvswitch modprobe command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -824,6 +824,9 @@ jobs:
           tag: <<parameters.tag>>
           registry: $DOCKER_MAGMA_REGISTRY
       - run:
+          name: Load openvswitch kernel module for xwf integ test
+          command: sudo modprobe openvswitch
+      - run:
           name: Build xwfm-integ-tests
           command: |
             cd ${MAGMA_ROOT}


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

The xwf-m deploy job was recently modified to build and deploy the xwfm integration
test docker container. This requires openvswitch kernel module to be loaded in order
to work properly.

## Test Plan

Updated to run as a branch on upstream: https://app.circleci.com/pipelines/github/magma/magma/651/workflows/445172a9-527f-4e5a-980d-78d73f3ab67a/jobs/7321