### PR TITLE
[AGW]: uplink_br0: configure using DHCP

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -33,7 +33,7 @@ iface patch-up inet manual
     ovs_extra set interface ${IFACE} ofport_request=2
 
 allow-ovs uplink_br0
-iface uplink_br0 inet manual
+iface uplink_br0 inet dhcp
     ovs_type OVSBridge
     ovs_ports dhcp0 patch-agw
 

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -418,7 +418,7 @@ class ServiceManager:
         static_services = self._magma_service.config['static_services']
         nat_enabled = self._magma_service.config.get('nat_enabled', False)
         setup_type = self._magma_service.config.get('setup_type', None)
-        if nat_enabled is False and setup_type == 'LTE':
+        if setup_type == 'LTE':
             static_services.append(self.__class__.UPLINK_BRIDGE_NAME)
             logging.info("added uplink bridge controller")
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -1,4 +1,4 @@
- priority=2000,udp,in_port=3,tp_dst=68 actions=output:1,output:2
+ priority=2000,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=1000,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=1000,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100 actions=NORMAL


### PR DESCRIPTION
## Summary

Use DHCP to setup uplink_br0. This would allow AGW deployment
where SGi interface is also used for management access.
This patch also add cleanup functionality for changing Non-NAT mode
to NATed mode by removing physical interface from uplink_br0.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Test Plan
make test
make integ_test