### PR TITLE
Allow everyone to maintain generated code directory

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,6 +21,8 @@ lte/gateway/release @kkahrs
 lte/gateway/python/magma/pipelined @koolzz @pshelar
 lte/gateway/python/integ_tests @ssanadhya @ulaskozat
 
-nms/ @karthiksubraveti @andreilee @xjtian @Scott8440
+lte/cloud/go/protos @magma/entire-org
+
+nms/ @karthiksubraveti @andreilee @xjtian
 
 CODEOWNERS @xjtian @amarpad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,6 @@ lte/gateway/python/integ_tests @ssanadhya @ulaskozat
 **/*.pb.go @magma/entire-org
 **/*_swaggergen.go @magma/entire-org
 
-nms/ @karthiksubraveti @andreilee @xjtian
+nms/ @karthiksubraveti @andreilee @xjtian @Scott8440
 
 CODEOWNERS @xjtian @amarpad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,7 +21,8 @@ lte/gateway/release @kkahrs
 lte/gateway/python/magma/pipelined @koolzz @pshelar
 lte/gateway/python/integ_tests @ssanadhya @ulaskozat
 
-lte/cloud/go/protos @magma/entire-org
+**/*.pb.go @magma/entire-org
+**/*_swaggergen.go @magma/entire-org
 
 nms/ @karthiksubraveti @andreilee @xjtian
 


### PR DESCRIPTION
## Summary

@amarpad requested this update to CODEOWNERS to allow everyone to maintain the generated code artifacts. There is now a team named "entire-org" that contains all magma organization members (as of today). Individuals will need to be added/removed from this team over time.
