### PR TITLE
[AGW] mobilityD: Fix typo in IPDesc() parameter name

### DIFF
--- a/lte/gateway/python/magma/mobilityd/serialize_utils.py
+++ b/lte/gateway/python/magma/mobilityd/serialize_utils.py
@@ -115,7 +115,7 @@ def _ip_desc_from_proto(proto):
     sid = proto.sid.id
     ip_type = _desc_type_proto_to_str(proto.type)
     return ip_descriptor.IPDesc(ip=ip, ip_block=ip_block, state=state,
-                                sid=sid, type=ip_type)
+                                sid=sid, ip_type=ip_type)
 
 
 def serialize_ip_block(block):


### PR DESCRIPTION
Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Summary


## Test Plan
Following test was failing without this patch, now it works.

make integ_test TESTS=s1aptests/test_attach_detach_with_mme_restart.py

## Additional Information