### PR TITLE
[agw] [mme] Remove epoll and event data members from ITTI task

### DIFF
--- a/lte/gateway/c/oai/lib/itti/intertask_interface.h
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.h
@@ -37,7 +37,6 @@
 #ifndef INTERTASK_INTERFACE_H_
 #define INTERTASK_INTERFACE_H_
 
-#include <sys/epoll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
@@ -47,8 +46,6 @@
 #include "intertask_interface_conf.h"
 #include "intertask_interface_types.h"
 #include "itti_types.h"
-
-struct epoll_event;
 
 #define ITTI_MSG_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.messageId)
 #define ITTI_MSG_ORIGIN_ID(mSGpTR) ((mSGpTR)->ittiMsgHeader.originTaskId)


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

After the move to ZMQ based ITTI messaging, we do not need the epoll and event fds in ITTI tasks. This change cleans up these unused members. It also removes a memory leak from the calloc call in itti_init.

## Test Plan

agw_of: S1AP integration tests
mme: Code compiles with `make FEATURES=mme build_oai`, functional testing will be done in Jenkins CI
