### PR TITLE
[lte][agw] Updating _get_enb_label_from_request to get IP from peername request

### DIFF
--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
@@ -79,7 +79,8 @@ class StateMachineManager:
         return self._ip_serial_mapping.get_ip(enb_serial)
 
     def get_serial_of_ip(self, client_ip: str) -> str:
-        return self._ip_serial_mapping.get_serial(client_ip)
+        serial = self._ip_serial_mapping.get_serial(client_ip)
+        return serial or 'default'
 
     def _get_handler(
         self,
@@ -219,8 +220,8 @@ class IpToSerialMapping:
     def get_ip(self, serial: str) -> str:
         return self.ip_by_enb_serial[serial]
 
-    def get_serial(self, ip: str) -> str:
-        return self.enb_serial_by_ip[ip]
+    def get_serial(self, ip: str) -> Optional[str]:
+        return self.enb_serial_by_ip.get(ip, None)
 
     def has_ip(self, ip: str) -> bool:
         return ip in self.enb_serial_by_ip

--- a/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
+++ b/lte/gateway/python/magma/enodebd/state_machines/enb_acs_manager.py
@@ -78,6 +78,9 @@ class StateMachineManager:
     def get_ip_of_serial(self, enb_serial: str) -> str:
         return self._ip_serial_mapping.get_ip(enb_serial)
 
+    def get_serial_of_ip(self, client_ip: str) -> str:
+        return self._ip_serial_mapping.get_serial(client_ip)
+
     def _get_handler(
         self,
         client_ip: str,

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -126,14 +126,18 @@ class StatsManager:
     def _get_enb_label_from_request(self, request) -> str:
         label = 'default'
         ip = request.headers.get('X-Forwarded-For')
+
         if ip is None:
-            ip = request.remote_addr
+            peername = request.transport.get_extra_info('peername')
+            if peername is not None:
+                ip, _ = peername
 
         if ip is None:
             return label
 
         try:
-            label = self.enb_manager.get_serial(ip)
+            label = self.enb_manager.get_serial_of_ip(ip)
+            logger.debug('Found serial %s for ip %s', label, ip)
         except KeyError:
             logger.error("Couldn't find serial for ip", ip)
         return label

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -135,10 +135,10 @@ class StatsManager:
         if ip is None:
             return label
 
-        try:
-            label = self.enb_manager.get_serial_of_ip(ip)
+        label = self.enb_manager.get_serial_of_ip(ip)
+        if label:
             logger.debug('Found serial %s for ip %s', label, ip)
-        except KeyError:
+        else:
             logger.error("Couldn't find serial for ip", ip)
         return label
 


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Added helper method `get_serial_from_ip` to enb_acs_manager
- Added option to get IP from peername param from PM counters request

## Test Plan

- make test
- make integ_test
- Ran local setup of NMS, orc8r and eNB to ensure metric is labeled correctly

## Additional Information

- [ ] This change is backwards-breaking

