### PR TITLE
[orc8r][docs] Document the api.* endpoint in orc8r deploy doc

### DIFF
--- a/docs/readmes/orc8r/deploy_install.md
+++ b/docs/readmes/orc8r/deploy_install.md
@@ -309,14 +309,17 @@ deployment by visiting the master NMS organization at e.g.
 `https://master.nms.yoursubdomain.yourdomain.com` and logging in with the
 `ADMIN_USER_EMAIL` and `ADMIN_USER_PASSWORD` provided above.
 
-NOTE: the `https://` is required. If you self-signed certs above, the browser will
-rightfully complain. Either ignore the browser warnings at your own risk (some
-versions of Chrome won't allow this at all), or e.g.
+NOTE: the `https://` is required. If you self-signed certs above, the browser
+will rightfully complain. Either ignore the browser warnings at your own risk
+(some versions of Chrome won't allow this at all), or e.g.
 [import the root CA from above on a per-browser basis
 ](https://stackoverflow.com/questions/7580508/getting-chrome-to-accept-self-signed-localhost-certificate)
 
-You can also visit the AWS endpoints directly. The relevant services are
-`nginx-proxy` for NMS and `orc8r-proxy` for Orchestrator API.
+For interacting with the Orchestrator REST API, a good starting point is the
+Swagger UI available at `https://api.yoursubdomain.yourdomain.com/apidocs/v1/`.
+
+If desired, you can also visit the AWS endpoints directly. The relevant
+services are `nginx-proxy` for NMS and `orc8r-proxy` for Orchestrator API.
 Remember to include `https://`, as well as the port number for non-standard
 TLS ports.
 


### PR DESCRIPTION
## Summary

XWF fresh deployment was unclear on the REST API endpoint. This change makes it clear directly in the install guide.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking