### PR TITLE
[AGW] mobilityD: do not use redis if not enabled.

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -145,6 +145,7 @@ class IPAddressManager:
             self._assigned_ip_blocks = set()  # {ip_block}
             self.sid_ips_map = defaultdict(IPDesc)  # {SID=>IPDesc}
             self._dhcp_gw_info = UplinkGatewayInfo(defaultdict(str))
+            self._dhcp_store = {}  # mac => DHCP_State
         else:
             if not redis_port:
                 raise ValueError(
@@ -153,6 +154,8 @@ class IPAddressManager:
             self._assigned_ip_blocks = store.AssignedIpBlocksSet(client)
             self.sid_ips_map = store.IPDescDict(client)
             self._dhcp_gw_info = UplinkGatewayInfo(store.GatewayInfoMap())
+            self._dhcp_store = store.MacToIP()  # mac => DHCP_State
+
 
         self.ip_state_map = IpDescriptorMap(persist_to_redis, redis_port)
         logging.info("Using allocator: %s", self.allocator_type)
@@ -163,14 +166,13 @@ class IPAddressManager:
                                            self.ip_state_map,
                                            self.sid_ips_map)
         elif self.allocator_type == MobilityD.DHCP:
-            dhcp_store = store.MacToIP()  # mac => DHCP_State
             iface = config.get('dhcp_iface', 'dhcp0')
             retry_limit = config.get('retry_limit', 300)
             ip_allocator = IPAllocatorDHCP(self._assigned_ip_blocks,
                                            self.ip_state_map,
                                            iface=iface,
                                            retry_limit=retry_limit,
-                                           dhcp_store=dhcp_store,
+                                           dhcp_store=self._dhcp_store,
                                            gw_info=self._dhcp_gw_info)
 
         if self.static_ip_enabled:


### PR DESCRIPTION
## Summary

Redis was used to share DHCP state across AGW services.
That is no longer true. so we can use in memory map
incase redis is not enabled.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


<!-- Enumerate changes you made and why you made them -->

`make test`
