### PR TITLE
[SessionD] Deprecate lte specific configuration to use the new bundled fields

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -341,15 +341,18 @@ SessionTerminateRequest SessionState::make_termination_request(
   req.set_request_number(request_number_);
   req.set_ue_ipv4(config_.common_context.ue_ipv4());
   req.set_msisdn(config_.common_context.msisdn());
-  req.set_spgw_ipv4(config_.spgw_ipv4);
   req.set_apn(config_.common_context.apn());
-  req.set_imei(config_.imei);
-  req.set_plmn_id(config_.plmn_id);
-  req.set_imsi_plmn_id(config_.imsi_plmn_id);
-  req.set_user_location(config_.user_location);
   req.set_hardware_addr(config_.hardware_addr);
   req.set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req.mutable_tgpp_ctx());
+  if (config_.rat_specific_context.has_lte_context()) {
+    auto lte_context = config_.rat_specific_context.lte_context();
+    req.set_spgw_ipv4(lte_context.spgw_ipv4());
+    req.set_imei(lte_context.imei());
+    req.set_plmn_id(lte_context.plmn_id());
+    req.set_imsi_plmn_id(lte_context.imsi_plmn_id());
+    req.set_user_location(lte_context.user_location());
+  }
   // gx monitors
   for (auto& credit_pair : monitor_map_) {
     auto credit_uc = get_monitor_uc(credit_pair.first, update_criteria);
@@ -943,15 +946,18 @@ CreditUsageUpdate SessionState::make_credit_usage_update_req(
   req.set_sid(imsi_);
   req.set_msisdn(config_.common_context.msisdn());
   req.set_ue_ipv4(config_.common_context.ue_ipv4());
-  req.set_spgw_ipv4(config_.spgw_ipv4);
   req.set_apn(config_.common_context.apn());
-  req.set_imei(config_.imei);
-  req.set_plmn_id(config_.plmn_id);
-  req.set_imsi_plmn_id(config_.imsi_plmn_id);
-  req.set_user_location(config_.user_location);
   req.set_hardware_addr(config_.hardware_addr);
   req.set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req.mutable_tgpp_ctx());
+  if (config_.rat_specific_context.has_lte_context()) {
+    auto lte_context = config_.rat_specific_context.lte_context();
+    req.set_spgw_ipv4(lte_context.spgw_ipv4());
+    req.set_imei(lte_context.imei());
+    req.set_plmn_id(lte_context.plmn_id());
+    req.set_imsi_plmn_id(lte_context.imsi_plmn_id());
+    req.set_user_location(lte_context.user_location());
+  }
   req.mutable_usage()->CopyFrom(usage);
   return req;
 }

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -25,23 +25,11 @@
 #include "CreditKey.h"
 
 namespace magma {
-struct QoSInfo {
-  bool enabled;
-  uint32_t qci;
-};
-
 struct SessionConfig {
-  std::string spgw_ipv4;
-  std::string imei;
-  std::string plmn_id;
-  std::string imsi_plmn_id;
-  std::string user_location;
   std::string mac_addr;      // MAC Address for WLAN
   std::string hardware_addr; // MAC Address for WLAN (binary)
   std::string radius_session_id;
-  uint32_t bearer_id;
   // TODO The fields above will be replaced by the bundled fields below
-  QoSInfo qos_info;
   CommonSessionContext common_context;
   RatSpecificContext rat_specific_context;
 
@@ -256,10 +244,6 @@ struct SessionStateUpdateCriteria {
 };
 
 SessionStateUpdateCriteria get_default_update_criteria();
-
-std::string serialize_stored_qos_info(const QoSInfo &stored);
-
-QoSInfo deserialize_stored_qos_info(const std::string &serialized);
 
 std::string serialize_stored_session_config(const SessionConfig &stored);
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -30,11 +30,17 @@ void build_common_context(
 void build_lte_context(
     const std::string& spgw_ipv4, const std::string& imei,
     const std::string& plmn_id, const std::string& imsi_plmn_id,
-    LTESessionContext* lte_context) {
+    const std::string& user_location, uint32_t bearer_id,
+    QosInformationRequest* qos_info, LTESessionContext* lte_context) {
   lte_context->set_spgw_ipv4(spgw_ipv4);
   lte_context->set_imei(imei);
   lte_context->set_plmn_id(plmn_id);
   lte_context->set_imsi_plmn_id(imsi_plmn_id);
+  lte_context->set_user_location(user_location);
+  lte_context->set_bearer_id(bearer_id);
+  if (qos_info != nullptr) {
+    lte_context->mutable_qos_info()->CopyFrom(*qos_info);
+  }
 }
 
 void build_wlan_context(

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -27,7 +27,8 @@ void build_common_context(
 void build_lte_context(
     const std::string& spgw_ipv4, const std::string& imei,
     const std::string& plmn_id, const std::string& imsi_plmn_id,
-    LTESessionContext* lte_context);
+    const std::string& user_location, uint32_t bearer_id,
+    QosInformationRequest* qos_info, LTESessionContext* lte_context);
 
 void build_wlan_context(
     const std::string& mac_addr, const std::string& radius_session_id,

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -24,11 +24,11 @@
 using ::testing::Test;
 
 namespace magma {
-const SessionConfig test_sstate_cfg = {.spgw_ipv4 = "128.0.0.1"};
 
 class SessionStateTest : public ::testing::Test {
  protected:
   virtual void SetUp() {
+    SessionConfig test_sstate_cfg;
     auto tgpp_ctx = TgppContext();
     create_tgpp_context("gx.dest.com", "gy.dest.com", &tgpp_ctx);
     rule_store    = std::make_shared<StaticRuleStore>();

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -60,11 +60,10 @@ class LocalEnforcerTest : public ::testing::Test {
   virtual void TearDown() { folly::EventBaseManager::get()->clearEventBase(); }
 
   void initialize_lte_test_config() {
-    test_cfg_.spgw_ipv4 = "128.0.0.1";
     build_common_context(
         "", "127.0.0.1", "IMS", "", TGPP_LTE, &test_cfg_.common_context);
     build_lte_context(
-        "128.0.0.1", "", "", "",
+        "128.0.0.1", "", "", "", "", 0, nullptr,
         test_cfg_.rat_specific_context.mutable_lte_context());
   }
 
@@ -1444,15 +1443,15 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
 }
 
 TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
-  QoSInfo test_qos_info;
-  test_qos_info.enabled = true;
-  test_qos_info.qci     = 0;
+  QosInformationRequest test_qos_info;
+  test_qos_info.set_qos_class_id(0);
 
   SessionConfig test_volte_cfg;
   build_common_context(
       "", "127.0.0.1", "", "IMS", TGPP_LTE, &test_volte_cfg.common_context);
-  test_volte_cfg.bearer_id = 1;
-  test_volte_cfg.qos_info  = test_qos_info;
+  build_lte_context(
+      "", "", "", "", "", 1, &test_qos_info,
+      test_volte_cfg.rat_specific_context.mutable_lte_context());
 
   CreateSessionResponse response;
   local_enforcer->init_session_credit(

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -87,11 +87,6 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
         "0F-10-2E-12-3A-55";
     std::string core_session_id = "asdf";
     SessionConfig cfg           = {
-        .spgw_ipv4         = "",
-        .imei              = "",
-        .plmn_id           = "",
-        .imsi_plmn_id      = "",
-        .user_location     = "",
         .mac_addr          = "0f:10:2e:12:3a:55",
         .hardware_addr     = hardware_addr_bytes,
         .radius_session_id = radius_session_id};

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -121,11 +121,6 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   std::string mac_addr = "0f:10:2e:12:3a:55";
   auto sid             = id_gen_.gen_session_id(imsi);
   SessionConfig cfg    = {
-      .spgw_ipv4         = "",
-      .imei              = "",
-      .plmn_id           = "",
-      .imsi_plmn_id      = "",
-      .user_location     = "",
       .mac_addr          = mac_addr,
       .hardware_addr     = hardware_addr_bytes,
       .radius_session_id = radius_session_id};
@@ -198,14 +193,10 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   std::string imsi   = "IMSI1";
   std::string msisdn = "5100001234";
   auto sid           = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg  = {
-      .spgw_ipv4    = "spgw_ip",
-      .imei         = "imei",
-      .plmn_id      = "plmn_id",
-      .imsi_plmn_id = "imsi_plmn_id"};
+  SessionConfig cfg;
   build_common_context(imsi, "", "apn1", msisdn, TGPP_LTE, &cfg.common_context);
   build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id",
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr,
       cfg.rat_specific_context.mutable_lte_context());
 
   response.set_session_id(sid);
@@ -243,7 +234,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   build_common_context(
       imsi, "", "apn1", msisdn, TGPP_LTE, request.mutable_common_context());
   build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id",
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr,
       request.mutable_rat_specific_context()->mutable_lte_context());
 
   // Ensure session is not reported as its a duplicate
@@ -282,7 +273,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
       imsi, "", "apn1", msisdn + "magma :)", TGPP_LTE,
       request2.mutable_common_context());
   build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id",
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr,
       request2.mutable_rat_specific_context()->mutable_lte_context());
 
   // Ensure a create session for the new session is sent, the old one is
@@ -356,11 +347,6 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
       "0F-10-2E-12-3A-55";
   auto sid          = id_gen_.gen_session_id(imsi);
   SessionConfig cfg = {
-      .spgw_ipv4         = "",
-      .imei              = "",
-      .plmn_id           = "",
-      .imsi_plmn_id      = "",
-      .user_location     = "",
       .mac_addr          = "0f:10:2e:12:3a:55",
       .hardware_addr     = hardware_addr_bytes,
       .radius_session_id = radius_session_id};
@@ -414,11 +400,6 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
   std::string mac_addr = "0f:10:2e:12:3a:55";
   auto sid          = id_gen_.gen_session_id(imsi);
   SessionConfig cfg = {
-      .spgw_ipv4         = "",
-      .imei              = "",
-      .plmn_id           = "",
-      .imsi_plmn_id      = "",
-      .user_location     = "",
       .mac_addr          = mac_addr,
       .hardware_addr     = hardware_addr_bytes,
       .radius_session_id = radius_session_id};

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -66,11 +66,6 @@ class SessionStoreTest : public ::testing::Test {
         "0F-10-2E-12-3A-55";
     std::string core_session_id = "asdf";
     SessionConfig cfg           = {
-        .spgw_ipv4         = "",
-        .imei              = "",
-        .plmn_id           = "",
-        .imsi_plmn_id      = "",
-        .user_location     = "",
         .mac_addr          = "0f:10:2e:12:3a:55",
         .hardware_addr     = hardware_addr_bytes,
         .radius_session_id = radius_session_id};

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -54,11 +54,6 @@ TEST_F(StoreClientTest, test_read_and_write) {
   auto sid3                   = id_gen_.gen_session_id(imsi3);
   std::string core_session_id = "asdf";
   SessionConfig cfg           = {
-      .spgw_ipv4         = "",
-      .imei              = "",
-      .plmn_id           = "",
-      .imsi_plmn_id      = "",
-      .user_location     = "",
       .mac_addr          = "0f:10:2e:12:3a:55",
       .hardware_addr     = hardware_addr_bytes,
       .radius_session_id = radius_session_id};

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -26,27 +26,16 @@ namespace magma {
 
 class StoredStateTest : public ::testing::Test {
  protected:
-  QoSInfo get_stored_qos_info() {
-    QoSInfo stored;
-    stored.enabled = true;
-    stored.qci     = 123;
-    return stored;
-  }
-
   SessionConfig get_stored_session_config() {
     SessionConfig stored;
-    stored.spgw_ipv4         = "192.168.0.2";
-    stored.imei              = "c";
-    stored.plmn_id           = "d";
-    stored.imsi_plmn_id      = "e";
-    stored.user_location     = "f";
     stored.mac_addr          = "g";  // MAC Address for WLAN
     stored.hardware_addr     = "h";  // MAC Address for WLAN (binary)
     stored.radius_session_id = "i";
-    stored.bearer_id         = 321;
-    stored.qos_info          = get_stored_qos_info();
     build_common_context(
         "IMSI1", "ue_ipv4", "apn", "msisdn", TGPP_WLAN, &stored.common_context);
+    build_lte_context(
+        "192.168.0.2", "imei", "plmn_id", "imsi_plmn_id", "user_location", 321,
+        nullptr, stored.rat_specific_context.mutable_lte_context());
     return stored;
   }
 
@@ -158,17 +147,9 @@ TEST_F(StoredStateTest, test_stored_session_config) {
   std::string serialized     = serialize_stored_session_config(stored);
   SessionConfig deserialized = deserialize_stored_session_config(serialized);
 
-  EXPECT_EQ(deserialized.spgw_ipv4, "192.168.0.2");
-  EXPECT_EQ(deserialized.imei, "c");
-  EXPECT_EQ(deserialized.plmn_id, "d");
-  EXPECT_EQ(deserialized.imsi_plmn_id, "e");
-  EXPECT_EQ(deserialized.user_location, "f");
   EXPECT_EQ(deserialized.mac_addr, "g");
   EXPECT_EQ(deserialized.hardware_addr, "h");
   EXPECT_EQ(deserialized.radius_session_id, "i");
-  EXPECT_EQ(deserialized.bearer_id, 321);
-  EXPECT_EQ(deserialized.qos_info.enabled, true);
-  EXPECT_EQ(deserialized.qos_info.qci, 123);
 
   // compare the serialized objects
   auto original_common       = stored.common_context.SerializeAsString();
@@ -280,17 +261,9 @@ TEST_F(StoredStateTest, test_stored_session) {
   auto deserialized = deserialize_stored_session(serialized);
 
   auto config = deserialized.config;
-  EXPECT_EQ(config.spgw_ipv4, "192.168.0.2");
-  EXPECT_EQ(config.imei, "c");
-  EXPECT_EQ(config.plmn_id, "d");
-  EXPECT_EQ(config.imsi_plmn_id, "e");
-  EXPECT_EQ(config.user_location, "f");
   EXPECT_EQ(config.mac_addr, "g");
   EXPECT_EQ(config.hardware_addr, "h");
   EXPECT_EQ(config.radius_session_id, "i");
-  EXPECT_EQ(config.bearer_id, 321);
-  EXPECT_EQ(config.qos_info.enabled, true);
-  EXPECT_EQ(config.qos_info.qci, 123);
 
   auto stored_charging_credit = deserialized.credit_map[CreditKey(1, 2)];
   // test charging grant fields


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
(No longer blocked on: https://github.com/magma/magma/pull/2166, https://github.com/magma/magma/pull/2149 )
A recent change was made in https://github.com/magma/magma/pull/2063 and https://github.com/magma/magma/pull/2077 to consolidate common Non-RAT specific session context into `CommonSessionContext` and RAT specific ones into `WLANSessionContext` and `LTESessionContext`. 

This change migrates the LTE fields to read from the new `LTESessionContext`. As these fields are now deprecated, they are also removed from the `SessionConfig` structure. 

```
struct SessionConfig {
  std::string spgw_ipv4;             <- covered in RatSpecificContext
  std::string imei;                       <- covered in RatSpecificContext
  std::string plmn_id;                 <- covered in RatSpecificContext
  std::string imsi_plmn_id;        <- covered in RatSpecificContext
  std::string user_location;       <- covered in RatSpecificContext
  std::string mac_addr;      
  std::string hardware_addr; 
  std::string radius_session_id;
  uint32_t bearer_id;                 <- covered in RatSpecificContext
  CommonSessionContext common_context;
  RatSpecificContext rat_specific_context;
  bool operator== (const SessionConfig& config) const;
};
```
to 
```
struct SessionConfig {
  std::string mac_addr;          <- not yet migrated
  std::string hardware_addr;     <- not yet migrated
  std::string radius_session_id;    <- not yet migrated
  CommonSessionContext common_context;
  RatSpecificContext rat_specific_context;
  bool operator== (const SessionConfig& config) const;
};
```

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF Integ Test
S1AP Tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
