### PR TITLE
[SessionD] Deprecate core session id from SessionState

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -922,8 +922,7 @@ bool LocalEnforcer::init_session_credit(
     const std::string& session_id, const SessionConfig& cfg,
     const CreateSessionResponse& response) {
   auto session_state = std::make_unique<SessionState>(
-      imsi, session_id, response.session_id(), cfg, *rule_store_,
-      response.tgpp_ctx());
+      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx());
 
   std::unordered_set<uint32_t> charging_credits_received;
   for (const auto& credit : response.credits()) {

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -40,7 +40,6 @@ StoredSessionState SessionState::marshal() {
   marshaled.config                 = config_;
   marshaled.imsi                   = imsi_;
   marshaled.session_id             = session_id_;
-  marshaled.core_session_id        = core_session_id_;
   marshaled.subscriber_quota_state = subscriber_quota_state_;
   marshaled.tgpp_context           = tgpp_context_;
   marshaled.request_number         = request_number_;
@@ -92,7 +91,6 @@ SessionState::SessionState(
     const StoredSessionState& marshaled, StaticRuleStore& rule_store)
     : imsi_(marshaled.imsi),
       session_id_(marshaled.session_id),
-      core_session_id_(marshaled.core_session_id),
       request_number_(marshaled.request_number),
       curr_state_(marshaled.fsm_state),
       config_(marshaled.config),
@@ -139,11 +137,10 @@ SessionState::SessionState(
 
 SessionState::SessionState(
     const std::string& imsi, const std::string& session_id,
-    const std::string& core_session_id, const SessionConfig& cfg,
-    StaticRuleStore& rule_store, const magma::lte::TgppContext& tgpp_context)
+    const SessionConfig& cfg, StaticRuleStore& rule_store,
+    const magma::lte::TgppContext& tgpp_context)
     : imsi_(imsi),
       session_id_(session_id),
-      core_session_id_(core_session_id),
       // Request number set to 1, because request 0 is INIT call
       request_number_(1),
       curr_state_(SESSION_ACTIVE),

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -53,8 +53,8 @@ class SessionState {
  public:
   SessionState(
       const std::string& imsi, const std::string& session_id,
-      const std::string& core_session_id, const SessionConfig& cfg,
-      StaticRuleStore& rule_store, const magma::lte::TgppContext& tgpp_context);
+      const SessionConfig& cfg, StaticRuleStore& rule_store,
+      const magma::lte::TgppContext& tgpp_context);
 
   SessionState(
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
@@ -382,7 +382,6 @@ class SessionState {
  private:
   std::string imsi_;
   std::string session_id_;
-  std::string core_session_id_;
   uint32_t request_number_;
   SessionFsmState curr_state_;
   SessionConfig config_;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -325,7 +325,6 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   marshaled["session_level_key"] = stored.session_level_key;
   marshaled["imsi"]              = stored.imsi;
   marshaled["session_id"]        = stored.session_id;
-  marshaled["core_session_id"]   = stored.core_session_id;
   marshaled["subscriber_quota_state"] =
       static_cast<int>(stored.subscriber_quota_state);
 
@@ -382,7 +381,6 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
   stored.session_level_key = marshaled["session_level_key"].getString();
   stored.imsi              = marshaled["imsi"].getString();
   stored.session_id        = marshaled["session_id"].getString();
-  stored.core_session_id   = marshaled["core_session_id"].getString();
   stored.subscriber_quota_state =
       static_cast<magma::lte::SubscriberQuotaUpdate_Type>(
           marshaled["subscriber_quota_state"].getInt());

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -175,7 +175,6 @@ struct StoredSessionState {
   std::string session_level_key; // "" maps to nullptr
   std::string imsi;
   std::string session_id;
-  std::string core_session_id;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
   magma::lte::TgppContext tgpp_context;
   std::vector<std::string> static_rule_ids;

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -33,7 +33,7 @@ class SessionStateTest : public ::testing::Test {
     create_tgpp_context("gx.dest.com", "gy.dest.com", &tgpp_ctx);
     rule_store    = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
-        "imsi", "session", "", test_sstate_cfg, *rule_store, tgpp_ctx);
+        "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx);
     update_criteria = get_default_update_criteria();
   }
   enum RuleType {

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -714,8 +714,8 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   CreateSessionResponse response;
   create_credit_update_response(
       imsi, 1, 1024, true, response.mutable_credits()->Add());
-  auto session_state = new SessionState(
-      imsi, session_id, session_id, test_cfg_, *rule_store, tgpp_ctx);
+  auto session_state =
+      new SessionState(imsi, session_id, test_cfg_, *rule_store, tgpp_ctx);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -92,7 +92,7 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
         .radius_session_id = radius_session_id};
     auto tgpp_context           = TgppContext{};
     auto session                = std::make_unique<SessionState>(
-        imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);
+        imsi, session_id, cfg, *rule_store, tgpp_context);
     return std::move(session);
   }
 

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -71,7 +71,7 @@ class SessionStoreTest : public ::testing::Test {
         .radius_session_id = radius_session_id};
     auto tgpp_context           = TgppContext{};
     auto session                = std::make_unique<SessionState>(
-        imsi, session_id, core_session_id, cfg, *rule_store, tgpp_context);
+        imsi, session_id, cfg, *rule_store, tgpp_context);
     return std::move(session);
   }
 

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -52,13 +52,12 @@ TEST_F(StoreClientTest, test_read_and_write) {
   auto sid                    = id_gen_.gen_session_id(imsi);
   auto sid2                   = id_gen_.gen_session_id(imsi2);
   auto sid3                   = id_gen_.gen_session_id(imsi3);
-  std::string core_session_id = "asdf";
   SessionConfig cfg           = {
       .mac_addr          = "0f:10:2e:12:3a:55",
       .hardware_addr     = hardware_addr_bytes,
       .radius_session_id = radius_session_id};
-  auto rule_store             = std::make_shared<StaticRuleStore>();
-  auto tgpp_context           = TgppContext{};
+  auto rule_store   = std::make_shared<StaticRuleStore>();
+  auto tgpp_context = TgppContext{};
 
   auto store_client = new MemoryStoreClient(rule_store);
 
@@ -66,13 +65,13 @@ TEST_F(StoreClientTest, test_read_and_write) {
   std::set<std::string> requested_ids{imsi, imsi2};
   auto session_map = store_client->read_sessions(requested_ids);
 
-  auto uc      = get_default_update_criteria();
-  auto session = std::make_unique<SessionState>(
-      imsi, sid, core_session_id, cfg, *rule_store, tgpp_context);
+  auto uc = get_default_update_criteria();
+  auto session =
+      std::make_unique<SessionState>(imsi, sid, cfg, *rule_store, tgpp_context);
   auto session2 = std::make_unique<SessionState>(
-      imsi2, sid2, core_session_id, cfg, *rule_store, tgpp_context);
+      imsi2, sid2, cfg, *rule_store, tgpp_context);
   auto session3 = std::make_unique<SessionState>(
-      imsi3, sid3, core_session_id, cfg, *rule_store, tgpp_context);
+      imsi3, sid3, cfg, *rule_store, tgpp_context);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -113,7 +113,6 @@ class StoredStateTest : public ::testing::Test {
     stored.session_level_key      = "session_level_key";
     stored.imsi                   = "IMSI1";
     stored.session_id             = "session_id";
-    stored.core_session_id        = "core_session_id";
     stored.subscriber_quota_state = SubscriberQuotaUpdate_Type_VALID_QUOTA;
     stored.fsm_state              = SESSION_TERMINATING_FLOW_DELETED;
 
@@ -292,7 +291,6 @@ TEST_F(StoredStateTest, test_stored_session) {
 
   EXPECT_EQ(stored.imsi, "IMSI1");
   EXPECT_EQ(stored.session_id, "session_id");
-  EXPECT_EQ(stored.core_session_id, "core_session_id");
   EXPECT_EQ(
       stored.subscriber_quota_state, SubscriberQuotaUpdate_Type_VALID_QUOTA);
   EXPECT_EQ(stored.fsm_state, SESSION_TERMINATING_FLOW_DELETED);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This field is currently unused as it holds the same value as session_id. We assign this value by taking the returned `session_id` field from the CreateSessionResponse into PolicyDB/FeG, but in reality PolicyDB/FeG just returns the original session_id sent.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit test
CWF IntegTest
S1AP test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
