### PR TITLE
[NMS][minor] Fix metric label used for querying subscriber usage

### DIFF
--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -195,8 +195,8 @@ function Overview(props: {subscriberInfo: subscriber}) {
           <DateTimeMetricChart
             title={CHART_TITLE}
             queries={[
-              `ue_traffic{imsi="${props.subscriberInfo.id}",direction="down"}`,
-              `ue_traffic{imsi="${props.subscriberInfo.id}",direction="up"}`,
+              `ue_traffic{IMSI="${props.subscriberInfo.id}",direction="down"}`,
+              `ue_traffic{IMSI="${props.subscriberInfo.id}",direction="up"}`,
             ]}
             legendLabels={['Download', 'Upload']}
           />


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>
# Summary
- Fixed metric label

## Test Plan
<img width="1680" alt="Screen Shot 2020-08-07 at 12 04 55 PM" src="https://user-images.githubusercontent.com/8224854/89679571-3d218880-d8a6-11ea-9d7d-ef1615ef839e.png">


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
