### PR TITLE
[SessionD] Fix potential redirect flow install bug + light weight refactor on sessiond_main

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -213,6 +213,11 @@ class LocalEnforcer {
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
   };
+  struct RedirectInstallInfo {
+    std::string imsi;
+    std::string session_id;
+    magma::lte::RedirectServer redirect_server;
+  };
   std::shared_ptr<SessionReporter> reporter_;
   std::shared_ptr<StaticRuleStore> rule_store_;
   std::shared_ptr<PipelinedClient> pipelined_client_;
@@ -485,9 +490,15 @@ class LocalEnforcer {
   /**
    * Install flow for redirection through pipelined
    */
-  void install_redirect_flow(
-      const std::unique_ptr<ServiceAction>& action,
+  void start_redirect_flow_install(
+      SessionMap& session_map, const std::unique_ptr<ServiceAction>& action,
       SessionUpdate& session_update);
+
+  void complete_redirect_flow_install(
+      Status status, DirectoryField resp,
+      const RedirectInstallInfo redirect_info);
+
+  PolicyRule create_redirect_rule(const RedirectInstallInfo& info);
 
   bool rules_to_process_is_not_empty(const RulesToProcess& rules_to_process);
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Two separate commits are in this PR
### Redirect Flow Install
- I was noticing an occasional SessionD crash on CI when running the `TestGyCreditExhaustionRedirect`. From the coredump, it happens when parse a JSON string in RedisClient. I've added a try/catch around the offending lines and added some logs.
- Though I was not able to concretely determine why the JSON parse failed, I've noticed that this crash happens in the DirectoryD response handling thread. This brings some potential synchronization issues since all SessionStore accesses are currently handled in the main sessiond thread. (When a redirect flow is needed, we need to reach out to DirectoryD to get the subscriber's IP address. This I believe is necessary for the CWF case since the IP address is only picked up after the UE completes DHCP.) 
- So this change proposed here is to to have the DirectoryD callback function, that is called after we receive a response, push the session data manipulation onto the main event base. This will guarantee that all of the session store accesses are ordered.
### SessionD Main cleanup
- While I was debugging with GDB, I found that the main function is very long and hard to read. Additionally some of the thread names are not very descriptive. This commit only has cosmetic changes, no real logical change.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
S1AP test
CWF Integ TEst
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
