### PR TITLE
[NMS] Remove axios as a package dependency from magmalte.

### DIFF
--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -28,7 +28,6 @@
     "@material-ui/icons": "^4.0.0",
     "@material-ui/pickers": "^3.2.10",
     "@material-ui/styles": "^4.0.0",
-    "axios": "^0.19.2",
     "chart.js": "^2.7.3",
     "classnames": "^2.2.5",
     "css-loader": "^1.0.1",


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>

## Summary

The x-csrf-token being set is set in the global headers of the magmalte's
axios package. Both magma-api and magmalte should share same package and set
use the global headers here.


## Test Plan
All mutating requests were failing without this fix. Now it succeeds.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
