### PR TITLE
[AGW] non-nat: tests: keep separate bridges for UT

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -174,6 +174,7 @@ class DHCPClient:
             wait_time = self._lease_renew_wait_min
             with self._dhcp_notify:
                 for dhcp_record in self.dhcp_client_state.values():
+                    logging.debug("monitor state: %s", dhcp_record)
                     # Only process active records.
                     if dhcp_record.state != DHCPState.ACK and \
                        dhcp_record.state != DHCPState.REQUEST:
@@ -182,6 +183,7 @@ class DHCPClient:
                     if dhcp_record.state == DHCPState.RELEASE:
                         continue
                     now = datetime.datetime.now()
+                    logging.debug("monitor time: %s", now)
                     request_state = DHCPState.REQUEST
                     # in case of lost DHCP lease rediscover it.
                     if now >= dhcp_record.lease_expiration_time:

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-br.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-br.sh
@@ -2,7 +2,7 @@
 
 br=$1
 uplink=$2
-DHCP_PORT="t_dhcp0"
+DHCP_PORT=$3
 
 # setup bridge
 ovs-vsctl --may-exist add-br "$br"

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -57,11 +57,11 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
                            self._br,
                            "t0uplink_p0",
-                           "8A:00:00:00:00:01"]
+                           "t0_dhcp1"]
         subprocess.check_call(setup_uplink_br)
 
         config = {
-            'dhcp_iface': 't_dhcp0',
+            'dhcp_iface': 't0uplink_p0',
             'retry_limit': 50,
             'allocator_type': 'dhcp',
             'persist_to_redis': False,

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -35,7 +35,7 @@ LOG.isEnabledFor(logging.DEBUG)
 
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
-DHCP_IFACE = "t0uplink_p0"
+DHCP_IFACE = "cl1_dhcp0"
 PKT_CAPTURE_WAIT = 2
 
 """
@@ -45,19 +45,19 @@ Test dhclient class independent of IP allocator.
 
 class DhcpClient(unittest.TestCase):
     def setUp(self):
-        self._br = "t_up_br0"
+        self._br = "dh_br0"
         try:
             subprocess.check_call(["pkill", "dnsmasq"])
         except subprocess.CalledProcessError:
             pass
 
         setup_dhcp_server = SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
-        subprocess.check_call([setup_dhcp_server, "t0"])
+        subprocess.check_call([setup_dhcp_server, "cl1"])
 
         setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
                            self._br,
-                           DHCP_IFACE,
-                           "8A:00:00:00:00:01"]
+                           "cl1uplink_p0",
+                           DHCP_IFACE]
         subprocess.check_call(setup_uplink_br)
 
         self.dhcp_wait = threading.Condition()
@@ -67,7 +67,7 @@ class DhcpClient(unittest.TestCase):
         self._dhcp_client = DHCPClient(dhcp_wait=self.dhcp_wait,
                                        dhcp_store=self.dhcp_store,
                                        gw_info=self.gw_info,
-                                       iface="t_dhcp0",
+                                       iface=DHCP_IFACE,
                                        lease_renew_wait_min=1)
         self._dhcp_client.run()
 

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -52,18 +52,20 @@ class InOutNonNatTest(unittest.TestCase):
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
     SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
-    UPLINK_BR = "t_up_br0"
-    NON_NAT_ARP_EGRESS_PORT = "t1uplink_p0"
+    UPLINK_BR = "up_inout_br0"
+    NON_NAT_ARP_EGRESS_PORT = "tinouplink_p0"
+    DHCP_PORT = "tino_dhcp"
 
     @classmethod
     def setup_uplink_br(cls):
         setup_dhcp_server = cls.SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
-        subprocess.check_call([setup_dhcp_server, "t1"])
+        subprocess.check_call([setup_dhcp_server, "tino"])
 
         BridgeTools.destroy_bridge(cls.UPLINK_BR)
         setup_uplink_br = [cls.SCRIPT_PATH + "scripts/setup-uplink-br.sh",
                            cls.UPLINK_BR,
-                           cls.NON_NAT_ARP_EGRESS_PORT]
+                           cls.NON_NAT_ARP_EGRESS_PORT,
+                           cls.DHCP_PORT]
         subprocess.check_call(setup_uplink_br)
         inout.get_mobilityd_gw_info = mocked_get_mobilityd_gw_info
         inout.set_mobilityd_gw_info = mocked_set_mobilityd_gw_info


### PR DESCRIPTION
## Summary

Non-NAT related tests involves creating test bridges.
This patch create separate bridge for each test to
avoids any interference from other test.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!-- Enumerate changes you made and why you made them -->

## Test Plan

`make test_python`

