### PR TITLE
[SessionD] Remove deprecated unit test for recently removed QoSInfo struct

### DIFF
--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -131,16 +131,6 @@ class StoredStateTest : public ::testing::Test {
   }
 };
 
-TEST_F(StoredStateTest, test_stored_qos_info) {
-  auto stored = get_stored_qos_info();
-
-  auto serialized   = serialize_stored_qos_info(stored);
-  auto deserialized = deserialize_stored_qos_info(serialized);
-
-  EXPECT_EQ(deserialized.enabled, true);
-  EXPECT_EQ(deserialized.qci, 123);
-}
-
 TEST_F(StoredStateTest, test_stored_session_config) {
   auto stored = get_stored_session_config();
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I removed the QosInfo struct as it is no longer used in https://github.com/magma/magma/pull/2238/files, but I forgot to commit the unit test change :/ 
(Need to start running SessionD unit tests in CircleCI precommit)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
