### PR TITLE
[SessionD] Deprecate WLAN specific SessionConfig fields and migrate to using the RatSpecific bundled fields

### DIFF
--- a/lte/gateway/c/session_manager/AAAClient.cpp
+++ b/lte/gateway/c/session_manager/AAAClient.cpp
@@ -37,17 +37,22 @@ aaa::add_sessions_request create_add_sessions_req(
       if (!session->is_radius_cwf_session()) {
         continue;
       }
-      auto config = session->get_config();
+      const auto& config = session->get_config();
+      if (!config.rat_specific_context.has_wlan_context()) {
+        MLOG(MWARNING) << "Session " << session->get_session_id() << " does not"
+                       << " have WLAN specific session context";
+        continue;
+      }
+      const auto& wlan_context = config.rat_specific_context.wlan_context();
       magma::SessionState::SessionInfo session_info;
       session->get_session_info(session_info);
       ctx.set_imsi(session_info.imsi);
-      ctx.set_session_id(config.radius_session_id);
+      ctx.set_session_id(wlan_context.radius_session_id());
       ctx.set_acct_session_id(session->get_session_id());
-      ctx.set_mac_addr(config.mac_addr);
+      ctx.set_mac_addr(wlan_context.mac_addr());
       ctx.set_msisdn(config.common_context.msisdn());
       ctx.set_apn(config.common_context.apn());
-      auto mutable_sessions = req.mutable_sessions();
-      mutable_sessions->Add()->CopyFrom(ctx);
+      req.mutable_sessions()->Add()->CopyFrom(ctx);
     }
   }
   return req;

--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -61,7 +61,7 @@ void ChargingGrant::receive_charging_grant(
   }
 
   // Expiry Time
-  auto delta_time_sec = p_credit.validity_time();
+  const auto delta_time_sec = p_credit.validity_time();
   if (delta_time_sec == 0) {
     expiry_time = std::numeric_limits<std::time_t>::max();
   } else {

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -31,10 +31,10 @@ namespace {
 
 std::chrono::milliseconds time_difference_from_now(
     const google::protobuf::Timestamp& timestamp) {
-  auto rule_time_sec =
+  const auto rule_time_sec =
       google::protobuf::util::TimeUtil::TimestampToSeconds(timestamp);
-  auto now   = time(NULL);
-  auto delta = std::max(rule_time_sec - now, 0L);
+  const auto now   = time(NULL);
+  const auto delta = std::max(rule_time_sec - now, 0L);
   std::chrono::seconds sec(delta);
   return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
 }
@@ -119,19 +119,18 @@ bool LocalEnforcer::setup(
   std::vector<std::string> ue_mac_addrs;
   std::vector<std::string> apn_mac_addrs;
   std::vector<std::string> apn_names;
-  auto cwf = false;
+  bool cwf = false;
   for (auto it = session_map.begin(); it != session_map.end(); it++) {
     for (const auto& session : it->second) {
       SessionState::SessionInfo session_info;
       session->get_session_info(session_info);
       session_infos.push_back(session_info);
-      auto ue_mac_addr = session->get_config().mac_addr;
-      ue_mac_addrs.push_back(ue_mac_addr);
-      auto msisdn = session->get_config().common_context.msisdn();
-      msisdns.push_back(msisdn);
+      const auto& config = session->get_config();
+      msisdns.push_back(config.common_context.msisdn());
+
       std::string apn_mac_addr;
       std::string apn_name;
-      auto apn = session->get_config().common_context.apn();
+      auto apn = config.common_context.apn();
       if (!parse_apn(apn, apn_mac_addr, apn_name)) {
         MLOG(MWARNING) << "Failed mac/name parsiong for apn " << apn;
         apn_mac_addr = "";
@@ -139,8 +138,12 @@ bool LocalEnforcer::setup(
       }
       apn_mac_addrs.push_back(apn_mac_addr);
       apn_names.push_back(apn_name);
+
       if (session->is_radius_cwf_session()) {
-        cwf                          = true;
+        cwf                      = true;
+        const auto& wlan_context = config.rat_specific_context.wlan_context();
+        const auto& ue_mac_addr  = wlan_context.mac_addr();
+        ue_mac_addrs.push_back(ue_mac_addr);
         SubscriberQuotaUpdate update = make_subscriber_quota_update(
             session_info.imsi, ue_mac_addr,
             session->get_subscriber_quota_state());
@@ -148,6 +151,7 @@ bool LocalEnforcer::setup(
       }
     }
   }
+  // TODO this assumption of CWF only deployments will not be relevant for long
   if (cwf) {
     return pipelined_client_->setup_cwf(
         session_infos, quota_updates, ue_mac_addrs, msisdns, apn_mac_addrs,
@@ -164,7 +168,7 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
   auto session_update = SessionStore::get_default_session_update(session_map);
   // Update the sessions so that their rules match the current timestamp
   for (auto& it : session_map) {
-    auto imsi = it.first;
+    const auto& imsi = it.first;
     for (auto& session : it.second) {
       auto& uc = session_update[it.first][session->get_session_id()];
       // Reschedule termination if it was pending before
@@ -177,12 +181,12 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
       if (trigger_it != triggers.end() &&
           triggers[REVALIDATION_TIMEOUT] == PENDING) {
         // the bool value indicates whether the trigger has been triggered
-        auto revalidation_time = session->get_revalidation_time();
+        const auto revalidation_time = session->get_revalidation_time();
         schedule_revalidation(imsi, *session, revalidation_time, uc);
       }
 
       session->sync_rules_to_time(current_time, uc);
-      auto ip_addr = session->get_config().common_context.ue_ipv4();
+      const auto& ip_addr = session->get_config().common_context.ue_ipv4();
 
       for (std::string rule_id : session->get_static_rules()) {
         auto lifetime = session->get_rule_lifetime(rule_id);
@@ -367,16 +371,18 @@ void LocalEnforcer::start_session_termination(
   MLOG(MINFO) << "Initiating session termination for " << session_id;
 
   remove_all_rules_for_termination(imsi, session, update_criteria);
-
+  
   session->set_fsm_state(SESSION_RELEASED, update_criteria);
-  auto config = session->get_config();
+  const auto& config         = session->get_config();
+  const auto& common_context = config.common_context;
   if (notify_access) {
     notify_termination_to_access_service(imsi, session_id, config);
   }
-  if (config.common_context.rat_type() == TGPP_WLAN) {
+  if (common_context.rat_type() == TGPP_WLAN) {
     MLOG(MDEBUG) << "Deleting UE MAC flow for subscriber " << imsi;
     pipelined_client_->delete_ue_mac_flow(
-        config.common_context.sid(), config.mac_addr);
+        common_context.sid(),
+        config.rat_specific_context.wlan_context().mac_addr());
   }
   if (terminate_on_wallet_exhaust()) {
     handle_subscriber_quota_state_change(
@@ -439,7 +445,8 @@ void LocalEnforcer::notify_termination_to_access_service(
   switch (common_context.rat_type()) {
     case TGPP_WLAN: {
       // tell AAA service to terminate radius session if necessary
-      auto radius_session_id = config.radius_session_id;
+      const auto& radius_session_id =
+          config.rat_specific_context.wlan_context().radius_session_id();
       MLOG(MDEBUG) << "Asking AAA service to terminate session with "
                    << "Radius ID: " << radius_session_id << ", IMSI: " << imsi;
       aaa_client_->terminate_session(radius_session_id, imsi);
@@ -448,7 +455,7 @@ void LocalEnforcer::notify_termination_to_access_service(
     case TGPP_LTE: {
       // Deleting the PDN session by triggering network issued default bearer
       // deactivation
-      auto lte_context = config.rat_specific_context.lte_context();
+      const auto& lte_context = config.rat_specific_context.lte_context();
       spgw_client_->delete_default_bearer(
           imsi, common_context.ue_ipv4(), lte_context.bearer_id());
       break;
@@ -962,7 +969,7 @@ bool LocalEnforcer::init_session_credit(
     session_map[imsi] = std::vector<std::unique_ptr<SessionState>>();
   }
   if (session_state->is_radius_cwf_session() == false) {
-    events_reporter_->session_created(session_state);
+    events_reporter_->session_created(imsi, session_id, cfg);
   }
   session_map[imsi].push_back(std::move(session_state));
 
@@ -987,7 +994,6 @@ bool LocalEnforcer::is_wallet_exhausted(SessionState& session_state) {
 void LocalEnforcer::handle_session_init_subscriber_quota_state(
     SessionMap& session_map, const std::string& imsi,
     SessionState& session_state) {
-  auto ue_mac_addr  = session_state.get_config().mac_addr;
   bool is_exhausted = is_wallet_exhausted(session_state);
 
   // This method only used for session creation and not updates, so
@@ -1071,7 +1077,7 @@ void LocalEnforcer::complete_termination(
       (*session_it)->complete_termination(*reporter_, update_criteria);
       // Send to eventd
       if ((*session_it)->is_radius_cwf_session() == false) {
-        events_reporter_->session_terminated(*session_it);
+        events_reporter_->session_terminated(imsi, *session_it);
       }
       // We break the loop below, but for extra code safety in case
       // someone removes the break in the future, adjust the iterator
@@ -1736,12 +1742,12 @@ void LocalEnforcer::create_bearer(
     const bool activate_success, const std::unique_ptr<SessionState>& session,
     const PolicyReAuthRequest& request,
     const std::vector<PolicyRule>& dynamic_rules) {
-  auto config = session->get_config();
+  const auto& config = session->get_config();
   if (!config.rat_specific_context.has_lte_context()) {
     MLOG(MWARNING) << "No LTE Session Context is specified for session";
     return;
   }
-  auto lte_context = config.rat_specific_context.lte_context();
+  const auto& lte_context = config.rat_specific_context.lte_context();
   if (!activate_success || !lte_context.has_qos_info() ||
       !request.has_qos_info()) {
     MLOG(MDEBUG) << "Not creating bearer";

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -87,7 +87,6 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
   // Before reporting and returning control to the event loop, increment the
   // request numbers stored for the sessions in SessionStore
   session_store_.sync_request_numbers(session_update);
-
   // report to cloud
   // NOTE: It is not possible to construct a std::function from a move-only type
   //       So because of this, we can't directly move session_map into the
@@ -183,28 +182,12 @@ bool LocalSessionManagerHandlerImpl::restart_pipelined(
 
 static CreateSessionRequest make_create_session_request(
     const SessionConfig& cfg, const std::string& sid) {
-  auto common       = cfg.common_context;
-  auto rat_specific = cfg.rat_specific_context;
-
   CreateSessionRequest create_request;
   create_request.set_session_id(sid);
-  create_request.mutable_common_context()->CopyFrom(common);
-  create_request.mutable_rat_specific_context()->CopyFrom(rat_specific);
+  create_request.mutable_common_context()->CopyFrom(cfg.common_context);
+  create_request.mutable_rat_specific_context()->CopyFrom(
+      cfg.rat_specific_context);
   return create_request;
-}
-
-SessionConfig LocalSessionManagerHandlerImpl::build_session_config(
-    const LocalCreateSessionRequest& request) {
-  SessionConfig cfg = {
-      .mac_addr          = convert_mac_addr_to_str(request.hardware_addr()),
-      .hardware_addr     = request.hardware_addr(),
-      .radius_session_id = request.radius_session_id()};
-
-  // TODO @themarwhal The fields above in SessionConfig will be replaced by
-  //  the bundled fields below
-  cfg.common_context       = request.common_context();
-  cfg.rat_specific_context = request.rat_specific_context();
-  return cfg;
 }
 
 void LocalSessionManagerHandlerImpl::CreateSession(
@@ -214,16 +197,16 @@ void LocalSessionManagerHandlerImpl::CreateSession(
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread(
       [this, context, response_callback, request_cpy]() {
-        auto imsi = request_cpy.sid().id();
-        auto sid  = id_gen_.gen_session_id(imsi);
-        auto apn  = request_cpy.apn();
+        const auto& imsi = request_cpy.sid().id();
+        const auto& sid  = id_gen_.gen_session_id(imsi);
+        const auto& apn  = request_cpy.apn();
         MLOG(MDEBUG) << "Received a CreateSessionRequest for " << imsi
                      << " apn: " << apn << " plmn_id: " << request_cpy.plmn_id()
                      << " imsi_plmn_id: " << request_cpy.imsi_plmn_id();
 
-        SessionConfig cfg = build_session_config(request_cpy);
-        auto session_map  = get_sessions_for_creation(imsi);
-        auto rat_type     = cfg.common_context.rat_type();
+        SessionConfig cfg(request_cpy);
+        auto session_map     = get_sessions_for_creation(imsi);
+        const auto& rat_type = cfg.common_context.rat_type();
         switch (rat_type) {
           case TGPP_WLAN:
             handle_create_session_cwf(
@@ -238,10 +221,10 @@ void LocalSessionManagerHandlerImpl::CreateSession(
             failure_stream << "Received an invalid RAT type " << rat_type;
             std::string failure_msg = failure_stream.str();
             MLOG(MERROR) << failure_msg;
-            events_reporter_->session_create_failure(
-                imsi, cfg.common_context.apn(), cfg.mac_addr, failure_msg);
-            auto status = Status(grpc::FAILED_PRECONDITION, "Invalid RAT type");
-            send_local_create_session_response(status, sid, response_callback);
+            events_reporter_->session_create_failure(imsi, cfg, failure_msg);
+            send_local_create_session_response(
+                Status(grpc::FAILED_PRECONDITION, "Invalid RAT type"), sid,
+                response_callback);
             return;
         }
       });
@@ -250,7 +233,7 @@ void LocalSessionManagerHandlerImpl::CreateSession(
 void LocalSessionManagerHandlerImpl::send_create_session(
     SessionMap& session_map, const std::string& sid, const SessionConfig& cfg,
     std::function<void(grpc::Status, LocalCreateSessionResponse)> cb) {
-  auto imsi       = cfg.common_context.sid().id();
+  const auto& imsi       = cfg.common_context.sid().id();
   auto create_req = make_create_session_request(cfg, sid);
   reporter_->report_create_session(
       create_req,
@@ -267,20 +250,21 @@ void LocalSessionManagerHandlerImpl::send_create_session(
             status = Status(
                 grpc::FAILED_PRECONDITION, "Failed to initialize session");
           } else {
-            auto lte_context   = cfg.rat_specific_context.lte_context();
+            std::string bearer_id = "";
+            if (cfg.rat_specific_context.has_lte_context()) {
+              bearer_id = cfg.rat_specific_context.lte_context().bearer_id();
+            }
             bool write_success = session_store_.create_sessions(
                 imsi, std::move((*session_map_ptr)[imsi]));
             if (write_success) {
               MLOG(MINFO) << "Successfully initialized new session " << sid
                           << " in sessiond for subscriber " << imsi
-                          << " with default bearer id "
-                          << lte_context.bearer_id();
+                          << " with default bearer id " << bearer_id;
               add_session_to_directory_record(imsi, sid);
             } else {
               MLOG(MINFO) << "Failed to initialize new session " << sid
                           << " in sessiond for subscriber " << imsi
-                          << " with default bearer id "
-                          << lte_context.bearer_id()
+                          << " with default bearer id " << bearer_id
                           << " due to failure writing to SessionStore."
                           << " An earlier update may have invalidated it.";
               status = Status(
@@ -295,8 +279,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
                          << status.error_message();
           std::string failure_msg = failure_stream.str();
           MLOG(MERROR) << failure_msg;
-          events_reporter_->session_create_failure(
-              imsi, cfg.common_context.apn(), cfg.mac_addr, failure_msg);
+          events_reporter_->session_create_failure(imsi, cfg, failure_msg);
         }
         send_local_create_session_response(status, sid, cb);
       });
@@ -527,7 +510,8 @@ void LocalSessionManagerHandlerImpl::report_session_update_event(
       auto updates    = session_update.find(it.first)->second;
       auto session_id = (*session)->get_session_id();
       if (updates.find(session_id) != updates.end()) {
-        events_reporter_->session_updated(*session);
+        events_reporter_->session_updated(
+            imsi, session_id, (*session)->get_config());
       }
       ++session;
     }
@@ -549,7 +533,8 @@ void LocalSessionManagerHandlerImpl::report_session_update_event_failure(
                        << failure_reason;
         std::string failure_msg = failure_stream.str();
         MLOG(MERROR) << failure_msg;
-        events_reporter_->session_update_failure(failure_msg, *session);
+        events_reporter_->session_update_failure(
+            imsi, session_id, (*session)->get_config(), failure_msg);
       }
       ++session;
     }

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -182,8 +182,6 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   void handle_setup_callback(
       const std::uint64_t& epoch, Status status, SetupFlowsResult resp);
 
-  SessionConfig build_session_config(const LocalCreateSessionRequest& request);
-
   /**
    * Get the most recently written state of sessions for Creation
    * Does not get any other sessions.

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -46,143 +46,130 @@ EventsReporterImpl::EventsReporterImpl(AsyncEventdClient& eventd_client)
     : eventd_client_(eventd_client) {}
 
 void EventsReporterImpl::session_created(
-    const std::unique_ptr<SessionState>& session) {
+    const std::string& imsi, const std::string& session_id,
+const SessionConfig& session_context) {
   auto event = magma::orc8r::Event();
-  auto session_cfg = session->get_config();
-  SessionState::SessionInfo session_info;
-  session->get_session_info(session_info);
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_CREATED_EV);
-  event.set_tag(session_info.imsi);
+  event.set_tag(imsi);
 
   folly::dynamic event_value = folly::dynamic::object;
-  event_value[IMSI] = session_info.imsi;
-  event_value[SESSION_ID] = session->get_session_id();
-  event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.common_context.apn();
+  event_value[IMSI]          = imsi;
+  event_value[SESSION_ID]    = session_id;
+  event_value[APN]           = session_context.common_context.apn();
+  event_value[MAC_ADDR]      = get_mac_addr(session_context);
+
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  eventd_client_.log_event(
-      event, [=](Status status, Void v) {
-      if (!status.ok()) {
-      MLOG(MERROR)
-      << "Could not log " << SESSION_CREATED_EV
-      << " event " << event_value_string
-      << ", Error Message: " << status.error_message();
-      }
-      });
+  eventd_client_.log_event(event, [=](Status status, Void v) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not log " << SESSION_CREATED_EV << " event "
+                   << event_value_string
+                   << ", Error Message: " << status.error_message();
+    }
+  });
 }
 
 void EventsReporterImpl::session_create_failure(
-    const std::string& imsi,
-    const std::string& apn,
-    const std::string& mac_addr,
+    const std::string& imsi, const SessionConfig& session_context,
     const std::string& failure_reason) {
   auto event = magma::orc8r::Event();
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_CREATE_FAILURE_EV);
   event.set_tag(imsi);
 
-  folly::dynamic event_value = folly::dynamic::object;
-  event_value[IMSI] = imsi;
-  event_value[APN] = apn;
-  event_value[MAC_ADDR] = mac_addr;
+  folly::dynamic event_value  = folly::dynamic::object;
+  event_value[IMSI]           = imsi;
+  event_value[APN]            = session_context.common_context.apn();
   event_value[FAILURE_REASON] = failure_reason;
+  event_value[MAC_ADDR]       = get_mac_addr(session_context);
+
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  eventd_client_.log_event(
-      event, [=](Status status, Void v) {
-        if (!status.ok()) {
-          MLOG(MERROR)
-          << "Could not log " << SESSION_CREATE_FAILURE_EV
-          << " event " << event_value_string
-          << ", Error Message: " << status.error_message();
-        }
-      });
-
+  eventd_client_.log_event(event, [=](Status status, Void v) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not log " << SESSION_CREATE_FAILURE_EV << " event "
+                   << event_value_string
+                   << ", Error Message: " << status.error_message();
+    }
+  });
 }
 
-void EventsReporterImpl::session_updated(std::unique_ptr<SessionState>& session) {
+void EventsReporterImpl::session_updated(
+    const std::string& imsi, const std::string& session_id,
+    const SessionConfig& session_context) {
   auto event = magma::orc8r::Event();
-  auto session_cfg = session->get_config();
-  SessionState::SessionInfo session_info;
-  session->get_session_info(session_info);
 
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_UPDATED_EV);
-  event.set_tag(session_info.imsi);
+  event.set_tag(imsi);
 
   folly::dynamic event_value = folly::dynamic::object;
-  event_value[IMSI] = session_info.imsi;
-  event_value[IP_ADDR] = session_info.ip_addr;
-  event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.common_context.apn();
+  event_value[IMSI]          = imsi;
+  event_value[SESSION_ID]    = session_id;
+  event_value[IP_ADDR]       = session_context.common_context.ue_ipv4();
+  event_value[APN]           = session_context.common_context.apn();
+  event_value[MAC_ADDR]      = get_mac_addr(session_context);
+
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  eventd_client_.log_event(
-      event, [=](Status status, Void v) {
-        if (!status.ok()) {
-          MLOG(MERROR)
-          << "Could not log "<< SESSION_UPDATED_EV
-          << " event " << event_value_string
-          << ", Error Message: " << status.error_message();
-        }
-      });
+  eventd_client_.log_event(event, [=](Status status, Void v) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not log " << SESSION_UPDATED_EV << " event "
+                   << event_value_string
+                   << ", Error Message: " << status.error_message();
+    }
+  });
 }
 
 void EventsReporterImpl::session_update_failure(
-    const std::string& failure_reason,
-    std::unique_ptr<SessionState>& session) {
+    const std::string& imsi, const std::string& session_id,
+    const SessionConfig& session_context, const std::string& failure_reason) {
   auto event = magma::orc8r::Event();
-  auto session_cfg = session->get_config();
-  SessionState::SessionInfo session_info;
-  session->get_session_info(session_info);
 
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_UPDATE_FAILURE_EV);
-  event.set_tag(session_info.imsi);
 
-  folly::dynamic event_value = folly::dynamic::object;
-  event_value[IMSI] = session_info.imsi;
-  event_value[IP_ADDR] = session_info.ip_addr;
-  event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.common_context.apn();
-  event_value[FAILURE_REASON] = failure_reason;
+  folly::dynamic event_value     = folly::dynamic::object;
+  event_value[IMSI]              = imsi;
+  event_value[SESSION_ID]        = session_id;
+  event_value[IP_ADDR]           = session_context.common_context.ue_ipv4();
+  event_value[MAC_ADDR]          = get_mac_addr(session_context);
+  event_value[APN]               = session_context.common_context.apn();
+  event_value[FAILURE_REASON]    = failure_reason;
+
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  eventd_client_.log_event(
-      event, [=](Status status, Void v) {
-        if (!status.ok()) {
-          MLOG(MERROR)
-          << "Could not log "<< SESSION_UPDATE_FAILURE_EV
-          << " event " << event_value_string
-          << ", Error Message: " << status.error_message();
+  eventd_client_.log_event(event, [=](Status status, Void v) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not log " << SESSION_UPDATE_FAILURE_EV << " event "
+                   << event_value_string
+                   << ", Error Message: " << status.error_message();
         }
       });
 
 }
 
 void EventsReporterImpl::session_terminated(
+    const std::string& imsi,
     const std::unique_ptr<SessionState>& session) {
-  auto event = magma::orc8r::Event();
+  auto event       = magma::orc8r::Event();
   auto session_cfg = session->get_config();
-  SessionState::SessionInfo session_info;
-  session->get_session_info(session_info);
 
   event.set_stream_name(SESSIOND_SERVICE_EV);
   event.set_event_type(SESSION_TERMINATED_EV);
-  event.set_tag(session_info.imsi);
+  event.set_tag(imsi);
 
-  folly::dynamic event_value = folly::dynamic::object;
-  event_value[IMSI] = session_info.imsi;
-  event_value[IP_ADDR] = session_info.ip_addr;
-  event_value[SESSION_ID] = session->get_session_id();
-  event_value[MAC_ADDR] = session_cfg.mac_addr;
-  event_value[APN] = session_cfg.common_context.apn();
+  folly::dynamic event_value           = folly::dynamic::object;
+  event_value[IMSI]                    = imsi;
+  event_value[IP_ADDR]                 = session_cfg.common_context.ue_ipv4();
+  event_value[SESSION_ID]              = session->get_session_id();
+  event_value[MAC_ADDR]                = get_mac_addr(session_cfg);
+  event_value[APN]                     = session_cfg.common_context.apn();
   SessionState::TotalCreditUsage usage = session->get_total_credit_usage();
   event_value[CHARGING_TX]             = usage.charging_tx;
   event_value[CHARGING_RX]             = usage.charging_rx;
@@ -191,15 +178,23 @@ void EventsReporterImpl::session_terminated(
   std::string event_value_string       = folly::toJson(event_value);
   event.set_value(event_value_string);
 
-  eventd_client_.log_event(
-      event, [=](Status status, Void v) {
-        if (!status.ok()) {
-          MLOG(MERROR)
-            << "Could not log "<< SESSION_TERMINATED_EV
-            << " event " << event_value_string
-            << ", Error Message: " << status.error_message();
-        }
-      });
+  eventd_client_.log_event(event, [=](Status status, Void v) {
+    if (!status.ok()) {
+      MLOG(MERROR) << "Could not log " << SESSION_TERMINATED_EV << " event "
+                   << event_value_string
+                   << ", Error Message: " << status.error_message();
+    }
+  });
+}
+
+std::string EventsReporterImpl::get_mac_addr(const SessionConfig& config) {
+  // MacAddr is only relevant for WLAN
+  const auto& rat_specific    = config.rat_specific_context;
+  std::string mac_addr = "";
+  if (rat_specific.has_wlan_context()) {
+    mac_addr = rat_specific.wlan_context().mac_addr();
+  }
+  return mac_addr;
 }
 
 }  // namespace lte

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -30,22 +30,24 @@ namespace lte {
 class EventsReporter {
  public:
   virtual void session_created(
-      const std::unique_ptr<SessionState>& session) {};
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& session_context){};
 
   virtual void session_create_failure(
-      const std::string& imsi,
-      const std::string& apn,
-      const std::string& mac_addr,
-      const std::string& failure_reason) {};
+      const std::string& imsi, const SessionConfig& session_context,
+      const std::string& failure_reason){};
 
-  virtual void session_updated(std::unique_ptr<SessionState>& session) {};
+  virtual void session_updated(
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& session_context){};
 
   virtual void session_update_failure(
-      const std::string& failure_reason,
-      std::unique_ptr<SessionState>& session) {};
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& session_context,
+      const std::string& failure_reason){};
 
   virtual void session_terminated(
-      const std::unique_ptr<SessionState>& session) {};
+      const std::string& imsi, const std::unique_ptr<SessionState>& session){};
 };
 
 /**
@@ -55,21 +57,27 @@ class EventsReporterImpl : public EventsReporter {
  public:
   EventsReporterImpl(AsyncEventdClient& eventd_client);
 
-  void session_created(const std::unique_ptr<SessionState>& session);
+  void session_created(
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& session_context);
 
   void session_create_failure(
-      const std::string& imsi,
-      const std::string& apn,
-      const std::string& mac_addr,
+      const std::string& imsi, const SessionConfig& session_context,
       const std::string& failure_reason);
 
-  void session_updated(std::unique_ptr<SessionState>& session);
+  void session_updated(
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& session_context);
 
   void session_update_failure(
-      const std::string& failure_reason,
-      std::unique_ptr<SessionState>& session);
+      const std::string& imsi, const std::string& session_id,
+      const SessionConfig& session_context, const std::string& failure_reason);
 
-  void session_terminated(const std::unique_ptr<SessionState>& session);
+  void session_terminated(
+      const std::string& imsi, const std::unique_ptr<SessionState>& session);
+
+ private:
+  std::string get_mac_addr(const SessionConfig& config);
 
  private:
   AsyncEventdClient& eventd_client_;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -425,9 +425,12 @@ void SessionState::add_common_fields_to_usage_monitor_update(
   req->set_request_number(request_number_);
   req->set_sid(imsi_);
   req->set_ue_ipv4(config_.common_context.ue_ipv4());
-  req->set_hardware_addr(config_.hardware_addr);
   req->set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req->mutable_tgpp_ctx());
+  if (config_.rat_specific_context.has_wlan_context()) {
+    const auto& wlan_context = config_.rat_specific_context.wlan_context();
+    req->set_hardware_addr(wlan_context.mac_addr_binary());
+  }
 }
 
 void SessionState::get_updates(
@@ -481,17 +484,20 @@ SessionTerminateRequest SessionState::make_termination_request(
   req.set_ue_ipv4(config_.common_context.ue_ipv4());
   req.set_msisdn(config_.common_context.msisdn());
   req.set_apn(config_.common_context.apn());
-  req.set_hardware_addr(config_.hardware_addr);
   req.set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req.mutable_tgpp_ctx());
   if (config_.rat_specific_context.has_lte_context()) {
-    auto lte_context = config_.rat_specific_context.lte_context();
+    const auto& lte_context = config_.rat_specific_context.lte_context();
     req.set_spgw_ipv4(lte_context.spgw_ipv4());
     req.set_imei(lte_context.imei());
     req.set_plmn_id(lte_context.plmn_id());
     req.set_imsi_plmn_id(lte_context.imsi_plmn_id());
     req.set_user_location(lte_context.user_location());
+  } else if (config_.rat_specific_context.has_wlan_context()) {
+    const auto& wlan_context = config_.rat_specific_context.wlan_context();
+    req.set_hardware_addr(wlan_context.mac_addr_binary());
   }
+
   // gx monitors
   for (auto& credit_pair : monitor_map_) {
     auto credit_uc = get_monitor_uc(credit_pair.first, update_criteria);
@@ -1086,16 +1092,18 @@ CreditUsageUpdate SessionState::make_credit_usage_update_req(
   req.set_msisdn(config_.common_context.msisdn());
   req.set_ue_ipv4(config_.common_context.ue_ipv4());
   req.set_apn(config_.common_context.apn());
-  req.set_hardware_addr(config_.hardware_addr);
   req.set_rat_type(config_.common_context.rat_type());
   fill_protos_tgpp_context(req.mutable_tgpp_ctx());
   if (config_.rat_specific_context.has_lte_context()) {
-    auto lte_context = config_.rat_specific_context.lte_context();
+    const auto& lte_context = config_.rat_specific_context.lte_context();
     req.set_spgw_ipv4(lte_context.spgw_ipv4());
     req.set_imei(lte_context.imei());
     req.set_plmn_id(lte_context.plmn_id());
     req.set_imsi_plmn_id(lte_context.imsi_plmn_id());
     req.set_user_location(lte_context.user_location());
+  } else if (config_.rat_specific_context.has_wlan_context()) {
+    const auto& wlan_context = config_.rat_specific_context.wlan_context();
+    req.set_hardware_addr(wlan_context.mac_addr_binary());
   }
   req.mutable_usage()->CopyFrom(usage);
   return req;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -17,6 +17,11 @@
 
 namespace magma {
 
+SessionConfig::SessionConfig(const LocalCreateSessionRequest& request) {
+  common_context = request.common_context();
+  rat_specific_context = request.rat_specific_context();
+}
+
 bool SessionConfig::operator==(const SessionConfig& config) const {
   auto common1 = common_context.SerializeAsString();
   auto common2 = config.common_context.SerializeAsString();
@@ -45,10 +50,6 @@ SessionStateUpdateCriteria get_default_update_criteria() {
 
 std::string serialize_stored_session_config(const SessionConfig& stored) {
   folly::dynamic marshaled       = folly::dynamic::object;
-  marshaled["mac_addr"]          = stored.mac_addr;
-  marshaled["hardware_addr"]     = stored.hardware_addr;
-  marshaled["radius_session_id"] = stored.radius_session_id;
-
   marshaled["common_context"] = stored.common_context.SerializeAsString();
   marshaled["rat_specific_context"] =
       stored.rat_specific_context.SerializeAsString();
@@ -62,10 +63,6 @@ SessionConfig deserialize_stored_session_config(const std::string& serialized) {
   folly::dynamic marshaled = folly::parseJson(folly_serialized);
 
   auto stored          = SessionConfig{};
-  stored.mac_addr      = marshaled["mac_addr"].getString();
-  stored.hardware_addr = marshaled["hardware_addr"].getString();
-  stored.radius_session_id = marshaled["radius_session_id"].getString();
-
   magma::lte::CommonSessionContext common_context;
   common_context.ParseFromString(marshaled["common_context"].getString());
   stored.common_context = common_context;

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -26,13 +26,11 @@
 
 namespace magma {
 struct SessionConfig {
-  std::string mac_addr;      // MAC Address for WLAN
-  std::string hardware_addr; // MAC Address for WLAN (binary)
-  std::string radius_session_id;
-  // TODO The fields above will be replaced by the bundled fields below
   CommonSessionContext common_context;
   RatSpecificContext rat_specific_context;
 
+  SessionConfig() {};
+  SessionConfig(const LocalCreateSessionRequest& request);
   bool operator== (const SessionConfig& config) const;
 };
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -15,40 +15,44 @@
 
 namespace magma {
 
-void build_common_context(
+CommonSessionContext build_common_context(
     const std::string& imsi,  // assumes IMSI prefix
     const std::string& ue_ipv4, const std::string& apn,
-    const std::string& msisdn, const RATType rat_type,
-    CommonSessionContext* common_context) {
-  common_context->mutable_sid()->set_id(imsi);
-  common_context->set_ue_ipv4(ue_ipv4);
-  common_context->set_apn(apn);
-  common_context->set_msisdn(msisdn);
-  common_context->set_rat_type(rat_type);
+    const std::string& msisdn, const RATType rat_type) {
+  CommonSessionContext common_context;
+  common_context.mutable_sid()->set_id(imsi);
+  common_context.set_ue_ipv4(ue_ipv4);
+  common_context.set_apn(apn);
+  common_context.set_msisdn(msisdn);
+  common_context.set_rat_type(rat_type);
+  return common_context;
 }
 
-void build_lte_context(
+LTESessionContext build_lte_context(
     const std::string& spgw_ipv4, const std::string& imei,
     const std::string& plmn_id, const std::string& imsi_plmn_id,
     const std::string& user_location, uint32_t bearer_id,
-    QosInformationRequest* qos_info, LTESessionContext* lte_context) {
-  lte_context->set_spgw_ipv4(spgw_ipv4);
-  lte_context->set_imei(imei);
-  lte_context->set_plmn_id(plmn_id);
-  lte_context->set_imsi_plmn_id(imsi_plmn_id);
-  lte_context->set_user_location(user_location);
-  lte_context->set_bearer_id(bearer_id);
+    QosInformationRequest* qos_info) {
+  LTESessionContext lte_context;
+  lte_context.set_spgw_ipv4(spgw_ipv4);
+  lte_context.set_imei(imei);
+  lte_context.set_plmn_id(plmn_id);
+  lte_context.set_imsi_plmn_id(imsi_plmn_id);
+  lte_context.set_user_location(user_location);
+  lte_context.set_bearer_id(bearer_id);
   if (qos_info != nullptr) {
-    lte_context->mutable_qos_info()->CopyFrom(*qos_info);
+    lte_context.mutable_qos_info()->CopyFrom(*qos_info);
   }
+  return lte_context;
 }
 
-void build_wlan_context(
+WLANSessionContext build_wlan_context(
     const std::string& mac_addr,
-    const std::string& radius_session_id,
-    WLANSessionContext* wlan_context) {
-  wlan_context->set_mac_addr(mac_addr);
-  wlan_context->set_radius_session_id(radius_session_id);
+    const std::string& radius_session_id) {
+  WLANSessionContext wlan_context;
+  wlan_context.set_mac_addr(mac_addr);
+  wlan_context.set_radius_session_id(radius_session_id);
+  return wlan_context;
 }
 
 void create_rule_record(

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -19,20 +19,18 @@
 namespace magma {
 using namespace lte;
 
-void build_common_context(
+CommonSessionContext build_common_context(
     const std::string& imsi, const std::string& ue_ipv4, const std::string& apn,
-    const std::string& msisdn, const RATType rat_type,
-    CommonSessionContext* common_context);
+    const std::string& msisdn, const RATType rat_type);
 
-void build_lte_context(
+LTESessionContext build_lte_context(
     const std::string& spgw_ipv4, const std::string& imei,
     const std::string& plmn_id, const std::string& imsi_plmn_id,
     const std::string& user_location, uint32_t bearer_id,
-    QosInformationRequest* qos_info, LTESessionContext* lte_context);
+    QosInformationRequest* qos_info);
 
-void build_wlan_context(
-    const std::string& mac_addr, const std::string& radius_session_id,
-    WLANSessionContext* wlan_context);
+WLANSessionContext build_wlan_context(
+    const std::string& mac_addr, const std::string& radius_session_id);
 
 void create_rule_record(
     const std::string& imsi, const std::string& rule_id, uint64_t bytes_rx,

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -256,20 +256,24 @@ public:
                     const std::vector<PolicyRule> &));
 };
 
-class MockEventsReporter : public EventsReporter{
+class MockEventsReporter : public EventsReporter {
  public:
-  MOCK_METHOD1(session_created,
-               void(const std::unique_ptr<SessionState> &));
-  MOCK_METHOD4(session_create_failure,
-               void(const std::string &, const std::string &,
-                   const std::string &, const std::string &));
-  MOCK_METHOD1(session_updated,
-               void(std::unique_ptr<SessionState> &));
-  MOCK_METHOD2(session_update_failure,
-               void(const std::string &,
-                   const std::unique_ptr<SessionState> &));
-  MOCK_METHOD1(session_terminated,
-               void(const std::unique_ptr<SessionState> &));
+  MOCK_METHOD3(
+      session_created,
+      void(const std::string&, const std::string&, const SessionConfig&));
+  MOCK_METHOD3(
+      session_create_failure,
+      void(const std::string&, const SessionConfig&, const std::string&));
+  MOCK_METHOD3(
+      session_updated,
+      void(const std::string&, const std::string&, const SessionConfig&));
+  MOCK_METHOD4(
+      session_update_failure, void(
+                                  const std::string&, const std::string&,
+                                  const SessionConfig&, const std::string&));
+  MOCK_METHOD2(
+      session_terminated,
+      void(const std::string&, const std::unique_ptr<SessionState>&));
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer_wallet_exhaust.cpp
@@ -118,8 +118,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_has_quota) {
 
   std::vector<std::string> static_rules{"static_1"};
   SessionConfig test_cwf_cfg;
-  build_common_context(
-      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
+  test_cwf_cfg.common_context =
+      build_common_context("IMSI1", "", "", "", TGPP_WLAN);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
 
@@ -145,8 +145,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_init_no_quota) {
 
   std::vector<std::string> static_rules{};  // no rule installs
   SessionConfig test_cwf_cfg;
-  build_common_context(
-      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
+  test_cwf_cfg.common_context =
+      build_common_context("IMSI1", "", "", "", TGPP_WLAN);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
 
@@ -168,8 +168,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_rar) {
 
   std::vector<std::string> static_rules{"static_1"};
   SessionConfig test_cwf_cfg;
-  build_common_context(
-      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
+  test_cwf_cfg.common_context =
+      build_common_context("IMSI1", "", "", "", TGPP_WLAN);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
   local_enforcer->init_session_credit(
@@ -203,8 +203,8 @@ TEST_F(LocalEnforcerTest, test_cwf_quota_exhaustion_on_update) {
 
   std::vector<std::string> static_rules{"static_1", "static_2"};
   SessionConfig test_cwf_cfg;
-  build_common_context(
-      "IMSI1", "", "", "", TGPP_WLAN, &test_cwf_cfg.common_context);
+  test_cwf_cfg.common_context =
+      build_common_context("IMSI1", "", "", "", TGPP_WLAN);
   CreateSessionResponse response;
   create_session_create_response("IMSI1", "m1", static_rules, &response);
   local_enforcer->init_session_credit(

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -85,15 +85,15 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     std::string radius_session_id =
         "AA-AA-AA-AA-AA-AA:TESTAP__"
         "0F-10-2E-12-3A-55";
-    std::string core_session_id = "asdf";
-    SessionConfig cfg           = {
-        .mac_addr          = "0f:10:2e:12:3a:55",
-        .hardware_addr     = hardware_addr_bytes,
-        .radius_session_id = radius_session_id};
-    auto tgpp_context           = TgppContext{};
-    auto session                = std::make_unique<SessionState>(
+    std::string mac_addr        = "0f:10:2e:12:3a:55";
+    SessionConfig cfg;
+    cfg.common_context =
+        build_common_context("", "128.0.0.1", "APN", msisdn, TGPP_WLAN);
+    const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+    cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
+    auto tgpp_context = TgppContext{};
+    return std::make_unique<SessionState>(
         imsi, session_id, cfg, *rule_store, tgpp_context);
-    return std::move(session);
   }
 
   UsageMonitoringUpdateResponse* get_monitoring_update() {

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -112,23 +112,19 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
 
   LocalCreateSessionRequest request;
   CreateSessionResponse response;
-  std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  std::string imsi                = "IMSI1";
-  std::string msisdn              = "5100001234";
-  std::string radius_session_id =
+  const std::string& hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
+  const std::string& imsi                = "IMSI1";
+  const std::string& msisdn              = "5100001234";
+  const std::string& radius_session_id =
       "AA-AA-AA-AA-AA-AA:TESTAP__"
       "0F-10-2E-12-3A-55";
-  std::string mac_addr = "0f:10:2e:12:3a:55";
-  auto sid             = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg    = {
-      .mac_addr          = mac_addr,
-      .hardware_addr     = hardware_addr_bytes,
-      .radius_session_id = radius_session_id};
-  build_common_context(
-      imsi, "", "apn1", msisdn, TGPP_WLAN, &cfg.common_context);
-  build_wlan_context(
-      mac_addr, radius_session_id,
-      cfg.rat_specific_context.mutable_wlan_context());
+  const std::string& mac_addr = "0f:10:2e:12:3a:55";
+  const auto& sid             = id_gen_.gen_session_id(imsi);
+  SessionConfig cfg;
+  cfg.common_context =
+      build_common_context(imsi, "", "apn1", msisdn, TGPP_WLAN);
+  const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+  cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   response.set_session_id(sid);
   // Only the active sessions are not recycled, to ensure that
@@ -159,11 +155,10 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   request.set_msisdn(msisdn);
   request.set_radius_session_id(radius_session_id);
   request.set_apn("apn2");  // Update APN
-  build_common_context(
-      imsi, "", "apn2", msisdn, TGPP_WLAN, request.mutable_common_context());
-  build_wlan_context(
-      mac_addr, radius_session_id,
-      request.mutable_rat_specific_context()->mutable_wlan_context());
+  auto common = build_common_context(imsi, "", "apn2", msisdn, TGPP_WLAN);
+  request.mutable_common_context()->CopyFrom(common);
+  request.mutable_rat_specific_context()->mutable_wlan_context()->CopyFrom(
+      wlan); // use same WLAN config as previous
 
   // Ensure session is not reported as its a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
@@ -194,10 +189,10 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   std::string msisdn = "5100001234";
   auto sid           = id_gen_.gen_session_id(imsi);
   SessionConfig cfg;
-  build_common_context(imsi, "", "apn1", msisdn, TGPP_LTE, &cfg.common_context);
-  build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr,
-      cfg.rat_specific_context.mutable_lte_context());
+  cfg.common_context = build_common_context(imsi, "", "apn1", msisdn, TGPP_LTE);
+  auto lte_context  = build_lte_context(
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+  cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
 
   response.set_session_id(sid);
   create_session_create_response(imsi, monitoring_key, static_rules, &response);
@@ -231,11 +226,12 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   request.set_imei("imei");
   request.set_plmn_id("plmn_id");
   request.set_imsi_plmn_id("imsi_plmn_id");
-  build_common_context(
-      imsi, "", "apn1", msisdn, TGPP_LTE, request.mutable_common_context());
-  build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr,
-      request.mutable_rat_specific_context()->mutable_lte_context());
+  auto common = build_common_context(imsi, "", "apn1", msisdn, TGPP_LTE);
+  request.mutable_common_context()->CopyFrom(common);
+  lte_context = build_lte_context(
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+  request.mutable_rat_specific_context()->mutable_lte_context()->CopyFrom(
+      lte_context);
 
   // Ensure session is not reported as its a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
@@ -269,12 +265,13 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   request2.set_rat_type(RATType::TGPP_LTE);
   request2.set_msisdn(msisdn + "magma :)");  // different msisdn
   request2.set_apn("apn1");
-  build_common_context(
-      imsi, "", "apn1", msisdn + "magma :)", TGPP_LTE,
-      request2.mutable_common_context());
-  build_lte_context(
-      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr,
-      request2.mutable_rat_specific_context()->mutable_lte_context());
+  common =
+      build_common_context(imsi, "", "apn1", msisdn + "magma :)", TGPP_LTE);
+  request2.mutable_common_context()->CopyFrom(common);
+  lte_context = build_lte_context(
+      "spgw_ip", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+  request2.mutable_rat_specific_context()->mutable_lte_context()->CopyFrom(
+      lte_context);
 
   // Ensure a create session for the new session is sent, the old one is
   // terminated
@@ -339,21 +336,19 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(
       "IMSI1", 1, 1025, response.mutable_credits()->Add());
-  std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  std::string imsi                = "IMSI1";
-  std::string msisdn              = "5100001234";
-  std::string radius_session_id =
-      "AA-AA-AA-AA-AA-AA:TESTAP__"
-      "0F-10-2E-12-3A-55";
-  auto sid          = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg = {
-      .mac_addr          = "0f:10:2e:12:3a:55",
-      .hardware_addr     = hardware_addr_bytes,
-      .radius_session_id = radius_session_id};
-
+  std::string imsi   = "IMSI1";
+  std::string msisdn = "5100001234";
+  auto sid           = id_gen_.gen_session_id(imsi);
+  SessionConfig cfg  = {};
+  cfg.common_context =
+      build_common_context("", "128.0.0.1", "APN", msisdn, TGPP_LTE);
+  const auto& lte_context = build_lte_context(
+      "127.0.0.1", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
+  cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
   SessionRead req  = {"IMSI1"};
   auto session_map = session_store->read_sessions(req);
-  EXPECT_CALL(*events_reporter, session_created(testing::_)).Times(1);
+  EXPECT_CALL(*events_reporter, session_created("IMSI1", sid, testing::_))
+      .Times(1);
   local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
   bool write_success =
       session_store->create_sessions(imsi, std::move(session_map[imsi]));
@@ -390,24 +385,19 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(
       "IMSI1", 1, 1025, response.mutable_credits()->Add());
-  std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  std::string imsi                = "IMSI1";
-  std::string msisdn              = "5100001234";
-  std::string radius_session_id =
+  const std::string& hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
+  const std::string& imsi                = "IMSI1";
+  const std::string& msisdn              = "5100001234";
+  const std::string& radius_session_id =
       "AA-AA-AA-AA-AA-AA:TESTAP__"
       "0F-10-2E-12-3A-55";
-  std::string apn   = "apn1";
-  std::string mac_addr = "0f:10:2e:12:3a:55";
-  auto sid          = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg = {
-      .mac_addr          = mac_addr,
-      .hardware_addr     = hardware_addr_bytes,
-      .radius_session_id = radius_session_id};
-
-  build_common_context(imsi, "", apn, msisdn, TGPP_WLAN, &cfg.common_context);
-  build_wlan_context(
-      mac_addr, radius_session_id,
-      cfg.rat_specific_context.mutable_wlan_context());
+  const std::string& apn      = "apn1";
+  const std::string& mac_addr = "0f:10:2e:12:3a:55";
+  auto sid                    = id_gen_.gen_session_id(imsi);
+  SessionConfig cfg;
+  cfg.common_context = build_common_context(imsi, "", apn, msisdn, TGPP_WLAN);
+  const auto& wlan          = build_wlan_context(mac_addr, radius_session_id);
+  cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   SessionRead req  = {"IMSI1"};
   auto session_map = session_store->read_sessions(req);

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -16,6 +16,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include "ProtobufCreators.h"
 #include "RuleStore.h"
 #include "SessionID.h"
 #include "SessionState.h"
@@ -64,15 +65,15 @@ class SessionStoreTest : public ::testing::Test {
     std::string radius_session_id =
         "AA-AA-AA-AA-AA-AA:TESTAP__"
         "0F-10-2E-12-3A-55";
-    std::string core_session_id = "asdf";
-    SessionConfig cfg           = {
-        .mac_addr          = "0f:10:2e:12:3a:55",
-        .hardware_addr     = hardware_addr_bytes,
-        .radius_session_id = radius_session_id};
-    auto tgpp_context           = TgppContext{};
-    auto session                = std::make_unique<SessionState>(
+    std::string mac_addr        = "0f:10:2e:12:3a:55";
+    SessionConfig cfg;
+    cfg.common_context =
+        build_common_context("", "128.0.0.1", "APN", msisdn, TGPP_WLAN);
+    const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+    cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
+    auto tgpp_context = TgppContext{};
+    return std::make_unique<SessionState>(
         imsi, session_id, cfg, *rule_store, tgpp_context);
-    return std::move(session);
   }
 
   UsageMonitoringUpdateResponse* get_monitoring_update() {

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -274,9 +274,11 @@ TEST_F(SessiondTest, end_to_end_success) {
         CreateSession(testing::_, CheckCreateSession("IMSI1"), testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
-          testing::SetArgPointee<2>(create_response),
-          testing::Return(grpc::Status::OK)));
-    EXPECT_CALL(*events_reporter, session_created(testing::_)).Times(1);
+            testing::SetArgPointee<2>(create_response),
+            testing::Return(grpc::Status::OK)));
+    EXPECT_CALL(
+        *events_reporter, session_created("IMSI1", testing::_, testing::_))
+        .Times(1);
 
     // Temporary fix for pipelined client in sessiond introduces separate calls
     // for static and dynamic rules. So here is the call for static rules.
@@ -290,7 +292,9 @@ TEST_F(SessiondTest, end_to_end_success) {
         ActivateFlows(testing::_, CheckActivateFlows("IMSI1", 0), testing::_))
         .Times(1);
 
-    EXPECT_CALL(*events_reporter, session_updated(testing::_)).Times(1);
+    EXPECT_CALL(
+        *events_reporter, session_updated("IMSI1", testing::_, testing::_))
+        .Times(1);
     CreditUsageUpdate expected_update;
     create_usage_update(
         "IMSI1", 1, 1024, 512, CreditUsage::QUOTA_EXHAUSTED, &expected_update);
@@ -321,9 +325,10 @@ TEST_F(SessiondTest, end_to_end_success) {
         TerminateSession(testing::_, CheckTerminate("IMSI1"), testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
-          testing::SetArgPointee<2>(terminate_response),
-          SetEndPromise(&end_promise, Status::OK)));
-    EXPECT_CALL(*events_reporter, session_terminated(testing::_)).Times(1);
+            testing::SetArgPointee<2>(terminate_response),
+            SetEndPromise(&end_promise, Status::OK)));
+    EXPECT_CALL(*events_reporter, session_terminated("IMSI1", testing::_))
+        .Times(1);
   }
 
   auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 
 #include "MemoryStoreClient.h"
+#include "ProtobufCreators.h"
 #include "RuleStore.h"
 #include "SessionID.h"
 #include "SessionState.h"
@@ -52,10 +53,11 @@ TEST_F(StoreClientTest, test_read_and_write) {
   auto sid                    = id_gen_.gen_session_id(imsi);
   auto sid2                   = id_gen_.gen_session_id(imsi2);
   auto sid3                   = id_gen_.gen_session_id(imsi3);
-  SessionConfig cfg           = {
-      .mac_addr          = "0f:10:2e:12:3a:55",
-      .hardware_addr     = hardware_addr_bytes,
-      .radius_session_id = radius_session_id};
+  SessionConfig cfg;
+  cfg.common_context =
+      build_common_context("", "128.0.0.1", "APN", msisdn, TGPP_WLAN);
+  const auto& wlan = build_wlan_context("0f:10:2e:12:3a:55", radius_session_id);
+  cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
   auto rule_store   = std::make_shared<StaticRuleStore>();
   auto tgpp_context = TgppContext{};
 

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -28,14 +28,12 @@ class StoredStateTest : public ::testing::Test {
  protected:
   SessionConfig get_stored_session_config() {
     SessionConfig stored;
-    stored.mac_addr          = "g";  // MAC Address for WLAN
-    stored.hardware_addr     = "h";  // MAC Address for WLAN (binary)
-    stored.radius_session_id = "i";
-    build_common_context(
-        "IMSI1", "ue_ipv4", "apn", "msisdn", TGPP_WLAN, &stored.common_context);
-    build_lte_context(
+    stored.common_context =
+        build_common_context("IMSI1", "ue_ipv4", "apn", "msisdn", TGPP_WLAN);
+    const auto& lte_context = build_lte_context(
         "192.168.0.2", "imei", "plmn_id", "imsi_plmn_id", "user_location", 321,
-        nullptr, stored.rat_specific_context.mutable_lte_context());
+        nullptr);
+    stored.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
     return stored;
   }
 
@@ -135,10 +133,6 @@ TEST_F(StoredStateTest, test_stored_session_config) {
 
   std::string serialized     = serialize_stored_session_config(stored);
   SessionConfig deserialized = deserialize_stored_session_config(serialized);
-
-  EXPECT_EQ(deserialized.mac_addr, "g");
-  EXPECT_EQ(deserialized.hardware_addr, "h");
-  EXPECT_EQ(deserialized.radius_session_id, "i");
 
   // compare the serialized objects
   auto original_common       = stored.common_context.SerializeAsString();
@@ -248,11 +242,6 @@ TEST_F(StoredStateTest, test_stored_session) {
 
   auto serialized   = serialize_stored_session(stored);
   auto deserialized = deserialize_stored_session(serialized);
-
-  auto config = deserialized.config;
-  EXPECT_EQ(config.mac_addr, "g");
-  EXPECT_EQ(config.hardware_addr, "h");
-  EXPECT_EQ(config.radius_session_id, "i");
 
   auto stored_charging_credit = deserialized.credit_map[CreditKey(1, 2)];
   // test charging grant fields


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR is a continuation of https://github.com/magma/magma/pull/2198 and https://github.com/magma/magma/pull/2238.

A recent change was made in https://github.com/magma/magma/pull/2063 and https://github.com/magma/magma/pull/2077 to consolidate common Non-RAT specific session context into `CommonSessionContext` and RAT specific ones into `WLANSessionContext` and `LTESessionContext`. 

This change migrates the WLAN fields to read from the new `WLANSessionContext`. As these fields are now deprecated, they are also removed from the `SessionConfig` structure. 

```
struct SessionConfig {
  std::string mac_addr;          <- covered in RatSpecificContext
  std::string hardware_addr;  <- covered in RatSpecificContext
  std::string radius_session_id; <- covered in RatSpecificContext
  CommonSessionContext common_context;
  RatSpecificContext rat_specific_context;
  bool operator== (const SessionConfig& config) const;
};
```
to 
```
struct SessionConfig {
  CommonSessionContext common_context;
  RatSpecificContext rat_specific_context;
  bool operator== (const SessionConfig& config) const;
};
```
I have also refactored the interface of EventReporter functions so take in the SessionConfig instead of the entire SessionState pointer, it is often cleaner this way.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD Unit Tests
CWF IntegTest
S1APTest
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
