### PR TITLE
[MME] Include bearer_id as part of the LTESessionContext sent to SessionD

### DIFF
--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -67,9 +67,9 @@ static void pcef_fill_create_session_req(
   sreq->mutable_sid()->set_id("IMSI" + imsi);
   sreq->set_rat_type(magma::RATType::TGPP_LTE);
   sreq->set_ue_ipv4(ip);
-  sreq->set_bearer_id(eps_bearer_id);
   sreq->set_apn(session_data->apn);
   sreq->set_msisdn(session_data->msisdn, session_data->msisdn_len);
+  sreq->set_bearer_id(eps_bearer_id);
   sreq->set_spgw_ipv4(session_data->sgw_ip);
   sreq->set_plmn_id(session_data->mcc_mnc, session_data->mcc_mnc_len);
   sreq->set_imsi_plmn_id(
@@ -103,11 +103,11 @@ static void pcef_fill_create_session_req(
   // LTE Context
   auto lte_context =
       sreq->mutable_rat_specific_context()->mutable_lte_context();
+  lte_context->set_bearer_id(eps_bearer_id);
   lte_context->set_spgw_ipv4(session_data->sgw_ip);
   lte_context->set_plmn_id(session_data->mcc_mnc, session_data->mcc_mnc_len);
   lte_context->set_imsi_plmn_id(
       session_data->imsi_mcc_mnc, session_data->imsi_mcc_mnc_len);
-
   if (session_data->imeisv_exists) {
     lte_context->set_imei(session_data->imeisv, IMEISV_DIGITS_MAX);
   }


### PR DESCRIPTION

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A previous (https://github.com/magma/magma/pull/2063) made the change to include LTE specific Session context into LTESessionContext field. BearerID was missed from this change. This was causing the `test_attach_detach_rar_tcp_data.py` test to fail, as the bearerID was never properly set in SessionD.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run S1AP test. (test_attach_detach_rar_tcp_data.py is now passing)
SessionD unit tests

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
