### PR TITLE
 [xwfm][ci] - remove app from docker-compose services

### DIFF
--- a/xwf/docker/docker-compose.override.yml
+++ b/xwf/docker/docker-compose.override.yml
@@ -11,9 +11,6 @@ services:
   ofredirector:
     image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/ofredirector
 
-  app:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/app
-
   httpserver:
     image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/httpserver
 

--- a/xwf/docker/docker-compose.yml
+++ b/xwf/docker/docker-compose.yml
@@ -78,18 +78,6 @@ services:
       - ODS_CLUSTER=${XWF_PARTNER_SHORT_NAME}.${ENV}
       - ODS_ENTITY=ofredirector
     logging: *logging_anchor
-  app:
-    container_name: ofapp
-    privileged: true
-    environment:
-      - DEBUG=1
-      - PORT=80
-      - HOST=0.0.0.0
-      - DHCP=${DHCP}
-      - METER=1
-    networks:
-      - control
-    logging: *logging_anchor
   httpserver:
     container_name: httpserver
     ports:


### PR DESCRIPTION

   [xwfm][ci] - remove redundant docker service  

## Summary

remove this service from the ci - it is not used

## Test Plan

CI

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
