### PR TITLE
[AGW] mobilityd: add support for vlan to dhcp client

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -22,7 +22,7 @@ from typing import Optional, MutableMapping
 from ipaddress import IPv4Network, ip_address
 from scapy.all import AsyncSniffer
 from scapy.layers.dhcp import BOOTP, DHCP
-from scapy.layers.l2 import Ether
+from scapy.layers.l2 import Ether, Dot1Q
 from scapy.layers.inet import IP, UDP
 from scapy.sendrecv import sendp
 from threading import Condition
@@ -82,7 +82,8 @@ class DHCPClient:
         self._sniffer.stop()
         self._monitor_thread_event.set()
 
-    def send_dhcp_packet(self, mac: MacAddress, state: DHCPState,
+    def send_dhcp_packet(self, mac: MacAddress, vlan: str,
+                         state: DHCPState,
                          dhcp_desc: DHCPDescriptor = None):
         """
         Send DHCP packet and record state in dhcp_client_state.
@@ -98,7 +99,7 @@ class DHCPClient:
         # generate DHCP request packet
         if state == DHCPState.DISCOVER:
             dhcp_opts = [("message-type", "discover")]
-            dhcp_desc = DHCPDescriptor(mac=mac, ip="",
+            dhcp_desc = DHCPDescriptor(mac=mac, ip="", vlan=vlan,
                                        state_requested=DHCPState.DISCOVER)
             self._msg_xid = self._msg_xid + 1
             pkt_xid = self._msg_xid
@@ -123,9 +124,11 @@ class DHCPClient:
         dhcp_opts.append("end")
 
         with self._dhcp_notify:
-            self.dhcp_client_state[mac.as_redis_key()] = dhcp_desc
+            self.dhcp_client_state[mac.as_redis_key(vlan)] = dhcp_desc
 
         pkt = Ether(src=str(mac), dst="ff:ff:ff:ff:ff:ff")
+        if vlan:
+            pkt /= Dot1Q(vlan=int(vlan))
         pkt /= IP(src="0.0.0.0", dst="255.255.255.255")
         pkt /= UDP(sport=68, dport=67)
         pkt /= BOOTP(op=1, chaddr=mac.as_hex(), xid=pkt_xid, ciaddr=ciaddr)
@@ -134,37 +137,39 @@ class DHCPClient:
 
         sendp(pkt, iface=self._dhcp_interface, verbose=0)
 
-    def get_dhcp_desc(self, mac: MacAddress) -> Optional[DHCPDescriptor]:
+    def get_dhcp_desc(self, mac: MacAddress, vlan: str) -> Optional[DHCPDescriptor]:
         """
                 Get DHCP description for given MAC.
         Args:
             mac: Mac address of the client
+            vlan: vlan id if the IP allocated in a VLAN
 
         Returns: Current DHCP info.
         """
 
-        key = mac.as_redis_key()
+        key = mac.as_redis_key(vlan)
         if key in self.dhcp_client_state:
             return self.dhcp_client_state[key]
 
-        LOG.debug("lookup error for %s", str(mac))
+        LOG.debug("lookup error for %s", str(key))
         return None
 
-    def release_ip_address(self, mac: MacAddress):
+    def release_ip_address(self, mac: MacAddress, vlan: str):
         """
                 Release DHCP allocated IP.
         Args:
             mac: MAC address of the IP allocated.
+            vlan: vlan id if the IP allocated in a VLAN
 
         Returns: None
         """
-
-        if mac.as_redis_key() not in self.dhcp_client_state:
-            LOG.error("Unallocated DHCP release for MAC: %s", str(mac))
+        key = mac.as_redis_key(vlan)
+        if key not in self.dhcp_client_state:
+            LOG.error("Unallocated DHCP release for MAC: %s", key)
             return
 
-        dhcp_desc = self.dhcp_client_state[mac.as_redis_key()]
-        self.send_dhcp_packet(mac, DHCPState.RELEASE, dhcp_desc)
+        dhcp_desc = self.dhcp_client_state[key]
+        self.send_dhcp_packet(mac, dhcp_desc.vlan, DHCPState.RELEASE, dhcp_desc)
 
     def _monitor_dhcp_state(self):
         """
@@ -174,7 +179,7 @@ class DHCPClient:
             wait_time = self._lease_renew_wait_min
             with self._dhcp_notify:
                 for dhcp_record in self.dhcp_client_state.values():
-                    logging.debug("monitor state: %s", dhcp_record)
+                    logging.debug("monitor: %s", dhcp_record)
                     # Only process active records.
                     if dhcp_record.state != DHCPState.ACK and \
                        dhcp_record.state != DHCPState.REQUEST:
@@ -191,8 +196,10 @@ class DHCPClient:
 
                     if now >= dhcp_record.lease_renew_deadline:
                         logging.debug("sending lease renewal")
-                        self.send_dhcp_packet(dhcp_record.mac, request_state, dhcp_record)
+                        self.send_dhcp_packet(dhcp_record.mac, dhcp_record.vlan,
+                                              request_state, dhcp_record)
                     else:
+                        # Find next renewal wait time.
                         time_to_renew = dhcp_record.lease_renew_deadline - now
                         wait_time = min(wait_time, time_to_renew.total_seconds())
 
@@ -212,7 +219,10 @@ class DHCPClient:
 
     def _process_dhcp_pkt(self, packet, state: DHCPState):
         mac_addr = create_mac_from_sid(packet[Ether].dst)
-        mac_addr_key = mac_addr.as_redis_key()
+        vlan = ""
+        if Dot1Q in packet:
+            vlan = str(packet[Dot1Q].vlan)
+        mac_addr_key = mac_addr.as_redis_key(vlan)
 
         with self._dhcp_notify:
             if mac_addr_key in self.dhcp_client_state:
@@ -234,13 +244,14 @@ class DHCPClient:
                 dhcp_state = DHCPDescriptor(mac=mac_addr,
                                              ip=ip_offered,
                                              state=state,
+                                             vlan=vlan,
                                              state_requested=state_requested,
                                              subnet=str(ip_subnet),
                                              server_ip=packet[IP].src,
                                              router_ip=router_ip_addr,
                                              lease_expiration_time=lease_expiration_time,
                                              xid=packet[BOOTP].xid)
-                LOG.info("Record mac %s IP %s", mac_addr_key, dhcp_state)
+                LOG.info("Record DHCP for: %s state: %s", mac_addr_key, dhcp_state)
 
                 self.dhcp_client_state[mac_addr_key] = dhcp_state
 
@@ -250,7 +261,7 @@ class DHCPClient:
                 if state == DHCPState.OFFER:
                     #  let other thread work on fulfilling IP allocation request.
                     threading.Event().wait(self.THREAD_YIELD_TIME)
-                    self.send_dhcp_packet(mac_addr, DHCPState.REQUEST, dhcp_state)
+                    self.send_dhcp_packet(mac_addr, vlan, DHCPState.REQUEST, dhcp_state)
             else:
                 LOG.debug("Unknown MAC: %s " % packet.summary())
                 return

--- a/lte/gateway/python/magma/mobilityd/dhcp_desc.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_desc.py
@@ -36,7 +36,7 @@ class DHCPState(IntEnum):
 
 class DHCPDescriptor:
     def __init__(self, mac: MacAddress, ip: str,
-                 state_requested: DHCPState,
+                 state_requested: DHCPState, vlan: str,
                  state: DHCPState = DHCPState.UNKNOWN,
                  subnet: str = None, server_ip: str = None,
                  router_ip: str = None, lease_expiration_time: int = 0,
@@ -50,6 +50,7 @@ class DHCPDescriptor:
             ip: Allocated IP if IP is assigned by DHCP server
             state: Last known protocol state on server
             state_requested: Last requested state by client
+            vlan: track vlan id if MAC is allocated in a VLAN
             subnet: subnet of IP from DHCP offer or ACK
             server_ip: DHCP server IP address
             router_ip: GW IP address
@@ -58,6 +59,7 @@ class DHCPDescriptor:
         """
         self.mac = mac
         self.ip = ip
+        self.vlan = vlan
         self.subnet = subnet
         self.state = state
         self.state_requested = state_requested
@@ -72,13 +74,13 @@ class DHCPDescriptor:
             self.lease_renew_deadline = datetime.now()
 
     def __str__(self):
-        return "state: {:8s} requested state: {:8s} mac {} ip {} subnet {}" \
+        return "state: {:8s} requested state: {:8s} mac {} ip {} subnet {} " \
                "DHCP: {} router {} " \
-               "lease time {}, renew {} xid {}" \
+               "lease time {}, renew {} xid {} vlan {}" \
             .format(self.state.name, self.state_requested.name,
                     str(self.mac), self.ip, self.subnet,
                     self.server_ip, self.router_ip, self.lease_expiration_time,
-                    self.lease_renew_deadline, self.xid)
+                    self.lease_renew_deadline, self.xid, self.vlan)
 
     def get_ip_address(self) -> Optional[str]:
         """

--- a/lte/gateway/python/magma/mobilityd/mac.py
+++ b/lte/gateway/python/magma/mobilityd/mac.py
@@ -28,14 +28,17 @@ class MacAddress:
 
         return bytes.fromhex(self.mac_address.replace(':', ''))
 
-    def as_redis_key(self) -> str:
+    def as_redis_key(self, vlan: str) -> str:
         """
         Convert MAC address string to redis key. Redis does not
         allow ':' in the key, so use '_' instead
         Returns: str to make redis happy
         """
-
-        return str(self.mac_address).replace(':', '_').lower()
+        key = str(self.mac_address).replace(':', '_').lower()
+        if vlan:
+            return vlan + "." + key
+        else:
+            return key
 
     def __str__(self):
         return self.mac_address

--- a/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf
+++ b/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf
@@ -1,0 +1,19 @@
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+domain=ue_dns
+no-resolv
+bogus-priv
+
+dhcp-option=3,10.200.x.211
+dhcp-range=10.200.x.1,10.200.x.200,2m

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -x
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+br_name=$1
+tag=$2
+
+prefix="vt$tag"
+ip_addr="10.200.$tag.111/24"
+router_ip="10.200.$tag.211"
+
+ip link add "$prefix"_port0 type veth peer name  "$prefix"_port1
+ifconfig "$prefix"_port0 up
+
+mkdir -p /etc/netns/"$prefix"_dhcp_srv
+touch /etc/netns/"$prefix"_dhcp_srv/resolv.conf
+
+ip netns add "$prefix"_dhcp_srv
+
+ip link set dev  "$prefix"_port1 netns "$prefix"_dhcp_srv
+ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 "$ip_addr"
+ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 hw ether b2:a0:cc:85:80:7a
+ip netns exec    "$prefix"_dhcp_srv   ip addr add $router_ip  dev "$prefix"_port1
+
+ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 up
+
+PID=$(pgrep -f "dnsmasq.*mobilityd.*$prefix")
+if [[ -n "$PID" ]]
+then
+	kill "$PID"
+fi
+
+sed "s/.x./."$tag"./g" /home/vagrant/magma/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf > /tmp/dns."$tag".conf
+sleep 1
+ip netns exec "$prefix"_dhcp_srv  /usr/sbin/dnsmasq -q --conf-file=/tmp/dns."$tag".conf --log-queries --log-facility=/var/log/"$prefix"dnsmasq."$tag".test.log &
+
+logger "DHCP server started"
+
+ovs-vsctl --may-exist add-port "$br_name" "$prefix"_port0 tag="$tag"

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-sw.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-sw.sh
@@ -1,0 +1,37 @@
+#!/bin/bash -ex
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# of patent rights can be found in the PATENTS file in the same directory.
+#
+
+br=$1
+prefix=$2
+
+set +e
+ip link delete "$prefix"_ul_0
+set -e
+
+ip link add "$prefix"_ul_0 type veth peer name  "$prefix"_ul_1
+ifconfig "$prefix"_ul_0 up
+ifconfig "$prefix"_ul_1 up
+
+
+# setup bridge
+
+ovs-vsctl --if-exist del-br "$br"
+ovs-vsctl add-br "$br"
+ovs-vsctl --may-exist add-port "$br" "$prefix"_ul_1
+
+ifconfig "$br" up
+
+#ovs-vsctl set Bridge "$br" fail_mode=secure
+

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -91,7 +91,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         # wait for DHCP release
         threading.Event().wait(7)
         mac1 = create_mac_from_sid(sid1)
-        dhcp_state1 = dhcp_store.get(mac1.as_redis_key())
+        dhcp_state1 = dhcp_store.get(mac1.as_redis_key(None))
 
         self.assertEqual(dhcp_state1.state_requested, DHCPState.RELEASE)
 
@@ -132,7 +132,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         # wait for DHCP release
         threading.Event().wait(7)
         mac4 = create_mac_from_sid(sid4)
-        dhcp_state = dhcp_store.get(mac4.as_redis_key())
+        dhcp_state = dhcp_store.get(mac4.as_redis_key(None))
 
         self.assertEqual(dhcp_state.state_requested, DHCPState.RELEASE)
         ip4_2 = self._dhcp_allocator.alloc_ip_address(sid4)

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import datetime
+import ipaddress
 import logging
 import os
 import subprocess
@@ -27,7 +28,7 @@ from magma.mobilityd.mac import MacAddress
 from magma.mobilityd.dhcp_desc import DHCPState, DHCPDescriptor
 from magma.mobilityd.uplink_gw import UplinkGatewayInfo
 from scapy.layers.dhcp import DHCP
-from scapy.layers.l2 import Ether
+from scapy.layers.l2 import Ether, Dot1Q
 from scapy.sendrecv import AsyncSniffer
 
 LOG = logging.getLogger('mobilityd.dhcp.test')
@@ -51,6 +52,103 @@ class DhcpClient(unittest.TestCase):
         except subprocess.CalledProcessError:
             pass
 
+        self.dhcp_wait = threading.Condition()
+        self.pkt_list_lock = threading.Condition()
+        self.dhcp_store = {}
+        self.gw_info_map = {}
+        self.gw_info = UplinkGatewayInfo(self.gw_info_map)
+
+    def tearDown(self):
+        self._dhcp_client.stop()
+        BridgeTools.destroy_bridge(self._br)
+
+    @unittest.skipIf(os.getuid(), reason="needs root user")
+    def test_dhcp_lease1(self):
+        self._setup_dhcp_vlan_off()
+
+        mac1 = MacAddress("11:22:33:44:55:66")
+        self._validate_dhcp_alloc_renew(mac1, None)
+
+    """
+    Network diagram of vlan test setup                                    VETH pair        +---------------------+
+    ==================================                                                     |  Namespace 1 with   |
+                                                                      +--------------------+  DHCP server        |
+                                                                      |                    |                     |
+                                                                      |                    +---------------------+
+                                                                      |
+    +----------------+  Patch   +--------------+  uplink-    +--------+-------+            +---------------------+
+    |                |  Port    |              |  iface      |                | VETH Pair  |  Namespace 2 with   |
+    |  GTP_BR0       +----------+  UPLINK_BR0  +-------------+    VLAN_SW     +------------+  DHCP server        |
+    |                |          |              |             |                |            |                     |
+    +----------------+          +--------------+             +----------------+            +---------------------+
+    """
+
+    @unittest.skipIf(os.getuid(), reason="needs root user")
+    def test_dhcp_vlan(self):
+        vlan1 = "2"
+        mac1 = MacAddress("11:22:33:44:55:66")
+
+        self._setup_vlan_network()
+        self._setup_dhcp_on_vlan(vlan1)
+
+        self._validate_dhcp_alloc_renew(mac1, vlan1)
+        self._validate_ip_subnet(mac1, vlan1)
+        self._release_ip(mac1, vlan1)
+
+    @unittest.skipIf(os.getuid(), reason="needs root user")
+    def test_dhcp_vlan_multi(self):
+        self._setup_vlan_network()
+
+        vlan1 = "1"
+        mac1 = MacAddress("11:22:33:44:55:66")
+        vlan2 = "2"
+        mac2 = MacAddress("22:22:33:44:55:66")
+        vlan3 = "3"
+        mac3 = MacAddress("11:22:33:44:55:66")
+
+        self._setup_dhcp_on_vlan(vlan1)
+        self._setup_dhcp_on_vlan(vlan2)
+        self._setup_dhcp_on_vlan(vlan3)
+
+        self._validate_dhcp_alloc_renew(mac1, vlan1)
+        self._validate_dhcp_alloc_renew(mac2, vlan2)
+        self._validate_dhcp_alloc_renew(mac3, vlan3)
+
+        self._validate_ip_subnet(mac1, vlan1)
+        self._validate_ip_subnet(mac2, vlan2)
+        self._validate_ip_subnet(mac3, vlan3)
+
+        self._release_ip(mac1, vlan1)
+        self._release_ip(mac2, vlan2)
+        self._release_ip(mac3, vlan3)
+
+    def _validate_dhcp_alloc_renew(self, mac1: MacAddress, vlan: str):
+        self._alloc_ip_address_from_dhcp(mac1, vlan)
+        self._validate_req_state(mac1, DHCPState.REQUEST, vlan)
+        self._validate_state_as_current(mac1, vlan)
+
+        # trigger lease reneval before deadline
+        LOG.debug("time: %s", datetime.datetime.now())
+        time1 = datetime.datetime.now() + datetime.timedelta(seconds=100)
+        self._start_sniffer()
+        with freeze_time(time1):
+            LOG.debug("check req packets time: %s", datetime.datetime.now())
+
+            self._stop_sniffer_and_check(DHCPState.REQUEST, mac1, vlan)
+            self._validate_req_state(mac1, DHCPState.REQUEST, vlan)
+            self._validate_state_as_current(mac1, vlan)
+
+            # trigger lease after deadline
+            time2 = datetime.datetime.now() + datetime.timedelta(seconds=200)
+            self._start_sniffer()
+            LOG.debug("check discover packets time: %s", datetime.datetime.now())
+            with freeze_time(time2):
+                LOG.debug("check discover after lease loss")
+                self._stop_sniffer_and_check(DHCPState.DISCOVER, mac1, vlan)
+                self._validate_req_state(mac1, DHCPState.REQUEST, vlan)
+                self._validate_state_as_current(mac1, vlan)
+
+    def _setup_dhcp_vlan_off(self):
         setup_dhcp_server = SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
         subprocess.check_call([setup_dhcp_server, "cl1"])
 
@@ -59,77 +157,74 @@ class DhcpClient(unittest.TestCase):
                            "cl1uplink_p0",
                            DHCP_IFACE]
         subprocess.check_call(setup_uplink_br)
+        self._setup_dhclp_client()
 
-        self.dhcp_wait = threading.Condition()
-        self.dhcp_store = {}
-        self.gw_info_map = {}
-        self.gw_info = UplinkGatewayInfo(self.gw_info_map)
+    def _setup_vlan_network(self):
+        setup_vlan_switch = SCRIPT_PATH + "scripts/setup-uplink-vlan-sw.sh"
+        subprocess.check_call([setup_vlan_switch, "vlan_sw", "v"])
+
+        setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
+                           self._br,
+                           "v_ul_0",
+                           DHCP_IFACE]
+        subprocess.check_call(setup_uplink_br)
+        self._setup_dhclp_client()
+
+    def _setup_dhclp_client(self):
         self._dhcp_client = DHCPClient(dhcp_wait=self.dhcp_wait,
                                        dhcp_store=self.dhcp_store,
                                        gw_info=self.gw_info,
                                        iface=DHCP_IFACE,
                                        lease_renew_wait_min=1)
         self._dhcp_client.run()
-
-    def tearDown(self):
-        self._dhcp_client.stop()
-        BridgeTools.destroy_bridge(self._br)
-
-    @unittest.skipIf(os.getuid(), reason="needs root user")
-    def test_dhcp_lease1(self):
-        self.pkt_list_lock = threading.Condition()
-
         self._setup_sniffer()
-        mac1 = MacAddress("11:22:33:44:55:66")
-        self._alloc_ip_address_from_dhcp(mac1)
-        self._validate_req_state(mac1, DHCPState.REQUEST)
-        self._validate_state_as_current(mac1)
 
-        # trigger lease reneval before deadline
-        time1 = datetime.datetime.now() + datetime.timedelta(seconds=100)
-        self._start_sniffer()
-        with freeze_time(time1):
-            self._stop_sniffer_and_check(DHCPState.REQUEST, mac1)
-            self._validate_req_state(mac1, DHCPState.REQUEST)
-            self._validate_state_as_current(mac1)
+    def _setup_dhcp_on_vlan(self, vlan: str):
+        setup_vlan_switch = SCRIPT_PATH + "scripts/setup-uplink-vlan-srv.sh"
+        subprocess.check_call([setup_vlan_switch, "vlan_sw", vlan])
 
-            # trigger lease after deadline
-            time2 = datetime.datetime.now() + datetime.timedelta(seconds=200)
-            self._start_sniffer()
-            with freeze_time(time2):
-                LOG.debug("check discover after lease loss")
-                self._stop_sniffer_and_check(DHCPState.DISCOVER, mac1)
-                self._validate_req_state(mac1, DHCPState.REQUEST)
-                self._validate_state_as_current(mac1)
-
-        self._dhcp_client.release_ip_address(mac1)
-        time.sleep(PKT_CAPTURE_WAIT)
-        self._validate_req_state(mac1, DHCPState.RELEASE)
-
-    def _validate_req_state(self, mac: MacAddress, state: DHCPState):
+    def _validate_req_state(self, mac: MacAddress, state: DHCPState, vlan: str):
         with self.dhcp_wait:
-            dhcp1 = self.dhcp_store.get(mac.as_redis_key())
+            dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
             self.assertEqual(dhcp1.state_requested, state)
 
-    def _validate_state_as_current(self, mac: MacAddress):
+    def _validate_state_as_current(self, mac: MacAddress, vlan: str):
         with self.dhcp_wait:
-            dhcp1 = self.dhcp_store.get(mac.as_redis_key())
-            assert (dhcp1.state == DHCPState.OFFER or dhcp1.state == DHCPState.ACK)
+            dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
+            self.assert_(dhcp1.state == DHCPState.OFFER or dhcp1.state == DHCPState.ACK)
 
-    def _alloc_ip_address_from_dhcp(self, mac: MacAddress) -> DHCPDescriptor:
+    def _alloc_ip_address_from_dhcp(self, mac: MacAddress, vlan: str) -> DHCPDescriptor:
         retry_count = 0
         with self.dhcp_wait:
             dhcp_desc = None
             while (retry_count < 60 and (dhcp_desc is None or
                                          dhcp_desc.ip_is_allocated() is not True)):
                 if retry_count % 5 == 0:
-                    self._dhcp_client.send_dhcp_packet(mac, DHCPState.DISCOVER)
+                    self._dhcp_client.send_dhcp_packet(mac, vlan,
+                                                       DHCPState.DISCOVER)
 
                 self.dhcp_wait.wait(timeout=1)
-                dhcp_desc = self._dhcp_client.get_dhcp_desc(mac)
+                dhcp_desc = self._dhcp_client.get_dhcp_desc(mac, vlan)
                 retry_count = retry_count + 1
 
             return dhcp_desc
+
+    def _validate_ip_subnet(self, mac: MacAddress, vlan: str):
+        # vlan is configured with subnet : 10.200.x.1
+        # router IP is 10.200.x.211
+        # x is vlan id
+        exptected_subnet = ipaddress.ip_network("10.200.%s.0/24" % vlan)
+        exptected_router_ip = ipaddress.ip_address("10.200.%s.211" % vlan)
+        with self.dhcp_wait:
+            dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
+            self.assertEqual(dhcp1.subnet, str(exptected_subnet))
+            self.assertEqual(dhcp1.router_ip, exptected_router_ip)
+            self.assert_(ipaddress.ip_address(dhcp1.ip) in exptected_subnet)
+
+    def _release_ip(self, mac: MacAddress, vlan: str):
+        self._dhcp_client.release_ip_address(mac, vlan)
+        time.sleep(PKT_CAPTURE_WAIT)
+        self._validate_req_state(mac, DHCPState.RELEASE, vlan)
 
     def _handle_dhcp_req_packet(self, packet):
         if DHCP not in packet:
@@ -138,7 +233,7 @@ class DhcpClient(unittest.TestCase):
             self.pkt_list.append(packet)
 
     def _setup_sniffer(self):
-        self._sniffer = AsyncSniffer(iface=DHCP_IFACE,
+        self._sniffer = AsyncSniffer(iface=self._br,
                                      filter="udp and (port 67 or 68)",
                                      prn=self._handle_dhcp_req_packet)
 
@@ -147,16 +242,24 @@ class DhcpClient(unittest.TestCase):
         self._sniffer.start()
         time.sleep(PKT_CAPTURE_WAIT)
 
-    def _stop_sniffer_and_check(self, state: DHCPState, mac: MacAddress):
+    def _stop_sniffer_and_check(self, state: DHCPState, mac: MacAddress, vlan):
         for x in range(30):
             time.sleep(PKT_CAPTURE_WAIT)
             with self.pkt_list_lock:
                 for pkt in self.pkt_list:
-                    LOG.debug("DHCP pkt %s", pkt.show(dump=True))
                     if DHCP in pkt:
+                        if vlan and (Dot1Q not in pkt or
+                                     vlan != str(pkt[Dot1Q].vlan)):
+                            continue
+
                         if pkt[DHCP].options[0][1] == int(state) and \
                                 pkt[Ether].src == str(mac):
                             self._sniffer.stop()
-                            return None
+                            return
+
+        LOG.debug("Failed check for dhcp packet: %s", state)
+        with self.pkt_list_lock:
+            for pkt in self.pkt_list:
+                LOG.debug("DHCP pkt %s", pkt.show(dump=True))
 
         assert 0


### PR DESCRIPTION
## Summary

This adds vlan tag to DHCP client. UT added in test_dhcp_client.py
to validate multi vlan network.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Test Plan
`make test` 
