### PR TITLE
[AGW] mobilityD: static IP: handle APN name with dot.

### DIFF
--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -33,7 +33,7 @@ class SubscriberDbClient:
         ip_addr = None
         try:
             if '.' in sid:
-                imsi, apn_name = sid.split('.')
+                imsi, apn_name = sid.split('.', maxsplit=1)
             else:
                 imsi, apn_name = sid, ''
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -256,3 +256,20 @@ class StaticIPAllocationTests(unittest.TestCase):
         self.assertEqual(ip0, ip0_returned)
         self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
         self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_apn_dot(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma.ipv4'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+


### PR DESCRIPTION
Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Test Plan

`make test`