### PR TITLE
[lte][agw]Fixed bug in setting APN AMBR information in create session request

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -236,12 +236,6 @@ int mme_app_send_s11_create_session_req(
     session_request_p->msisdn.length = 0;
   }
   session_request_p->rat_type = RAT_EUTRAN;
-  /*
-   * Copy the subscribed ambr to the sgw create session request message
-   */
-  memcpy(
-      &session_request_p->ambr, &ue_mm_context->subscribed_ue_ambr,
-      sizeof(ambr_t));
 
   // default bearer already created by NAS
   bearer_context_t* bc = mme_app_get_bearer_context(
@@ -296,6 +290,13 @@ int mme_app_send_s11_create_session_req(
   memcpy(
       session_request_p->apn, selected_apn_config_p->service_selection,
       selected_apn_config_p->service_selection_length);
+
+  /*
+   * Copy the APN AMBR to the sgw create session request message
+   */
+  memcpy(
+      &session_request_p->ambr, &selected_apn_config_p->ambr,
+      sizeof(ambr_t));
   /*
    * Set PDN type for pdn_type and PAA even if this IE is redundant
    */

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
@@ -293,7 +293,7 @@ int mme_app_handle_s6a_update_location_ans(
   ue_mm_context->access_restriction_data =
       ula_pP->subscription_data.access_restriction;
   /*
-   * Copy the subscribed ambr to the sgw create session request message
+   * Copy the subscribed UE AMBR (comes from data plan) to UE context
    */
   memcpy(
       &ue_mm_context->subscribed_ue_ambr,


### PR DESCRIPTION
## Summary

APN AMBR information in create session request towards SPGW task was copied from the subscriber ambr information that is the same as UE AMBR. This PR corrects this bug and pulls the information from the APN configuration instead.

## Test Plan

Printed the RAT context data at sessiond, manually changes the default APN configuration in S1AP testing, and cross-checked if the information  in syslog prints matched to the manually configured changes.

Run sanity tests.
