### PR TITLE
[orc8r][agw] Updating metrics collection gRPC message size limit / making it configurable

### DIFF
--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -79,7 +79,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
-  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
+  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -79,6 +79,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
+  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -66,6 +66,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 10 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
+  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
   # List of services for metricsd to poll
   services:
     - magmad

--- a/feg/gateway/configs/magmad.yml
+++ b/feg/gateway/configs/magmad.yml
@@ -66,7 +66,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 10 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
-  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
+  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
   # List of services for metricsd to poll
   services:
     - magmad

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -103,6 +103,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
+  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/lte/gateway/configs/magmad.yml
+++ b/lte/gateway/configs/magmad.yml
@@ -103,7 +103,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
-  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
+  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -88,6 +88,9 @@ http {
       grpc_set_header x-magma-client-cert-serial $ssl_client_serial;
       grpc_set_header Host $srv-{{ backend }}:$srvport;
     }
+
+    # Setting max allowed size for client requests body to 50MB
+    client_max_body_size 50M;
   }
 
   # Server block for bootstrapper and any other non-clientcert services

--- a/orc8r/cloud/go/services/metricsd/metricsd/main.go
+++ b/orc8r/cloud/go/services/metricsd/metricsd/main.go
@@ -29,14 +29,20 @@ import (
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_model/go"
+	"google.golang.org/grpc"
 )
 
 const (
 	CloudMetricsCollectInterval = time.Second * 20
+	// Setting Max Received Message gRPC size to 50MB
+	CloudMetricsCollectMaxMsgSize = 50 * 1024 * 1024
 )
 
 func main() {
-	srv, err := service.NewOrchestratorService(orc8r.ModuleName, metricsd.ServiceName)
+	srv, err := service.NewOrchestratorService(orc8r.ModuleName,
+		metricsd.ServiceName,
+		grpc.MaxRecvMsgSize(CloudMetricsCollectMaxMsgSize))
+
 	if err != nil {
 		glog.Fatalf("Error creating orc8r service for metricsd: %s", err)
 	}

--- a/orc8r/gateway/configs/magmad.yml
+++ b/orc8r/gateway/configs/magmad.yml
@@ -58,7 +58,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
-  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
+  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/orc8r/gateway/configs/magmad.yml
+++ b/orc8r/gateway/configs/magmad.yml
@@ -58,6 +58,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
+  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/orc8r/gateway/python/magma/common/service_registry.py
+++ b/orc8r/gateway/python/magma/common/service_registry.py
@@ -104,7 +104,8 @@ class ServiceRegistry:
         return create_grpc_channel(ip, port, authority, ssl_creds)
 
     @staticmethod
-    def get_rpc_channel(service, destination, proxy_cloud_connections=True):
+    def get_rpc_channel(service, destination, proxy_cloud_connections=True,
+                        grpc_options=None):
         """
         Returns a RPC channel to the service. The connection params
         are obtained from the service registry and used.
@@ -115,6 +116,7 @@ class ServiceRegistry:
             service (string): Name of the service
             destination (string): ServiceRegistry.LOCAL or ServiceRegistry.CLOUD
             proxy_cloud_connections (bool): Override to connect direct to cloud
+            grpc_options (list): list of gRPC options params for the channel
         Returns:
             grpc channel
         Raises:
@@ -146,7 +148,7 @@ class ServiceRegistry:
         if destination == ServiceRegistry.LOCAL:
             # Connect to the local service directly
             (ip, port) = ServiceRegistry.get_service_address(service)
-            channel = create_grpc_channel(ip, port, authority)
+            channel = create_grpc_channel(ip, port, authority, grpc_options)
         elif should_use_proxy:
             # Connect to the cloud via local control proxy
             try:
@@ -155,14 +157,14 @@ class ServiceRegistry:
             except ValueError as err:
                 logging.error(err)
                 (ip, port) = ('127.0.0.1', proxy_config['local_port'])
-            channel = create_grpc_channel(ip, port, authority)
+            channel = create_grpc_channel(ip, port, authority, grpc_options)
         else:
             # Connect to the cloud directly
             ip = proxy_config['cloud_address']
             port = proxy_config['cloud_port']
             ssl_creds = get_ssl_creds()
-            channel = create_grpc_channel(ip, port, authority, ssl_creds)
-
+            channel = create_grpc_channel(ip, port, authority, ssl_creds,
+                                          grpc_options)
         if should_reuse_channel:
             ServiceRegistry._CHANNELS_CACHE[authority] = channel
         return channel
@@ -243,7 +245,7 @@ def get_ssl_creds():
     return ssl_creds
 
 
-def create_grpc_channel(ip, port, authority, ssl_creds=None):
+def create_grpc_channel(ip, port, authority, ssl_creds=None, options=None):
     """
     Helper function to create a grpc channel.
 
@@ -252,17 +254,21 @@ def create_grpc_channel(ip, port, authority, ssl_creds=None):
        port: port of the remote endpoint
        authority: HTTP header that control proxy uses for routing
        ssl_creds: Enables SSL
+       options: configuration options for gRPC channel
     Returns:
         grpc channel
     """
+    grpc_options = [('grpc.default_authority', authority)]
+    if options is not None:
+        grpc_options.extend(options)
     if ssl_creds is not None:
         set_grpc_cipher_suites()
         channel = grpc.secure_channel(
-            '%s:%s' % (ip, port),
-            ssl_creds,
-            options=[('grpc.default_authority', authority)])
+            target='%s:%s' % (ip, port),
+            credentials=ssl_creds,
+            options=[grpc_options])
     else:
         channel = grpc.insecure_channel(
-            '%s:%s' % (ip, port),
-            options=[('grpc.default_authority', authority)])
+            target='%s:%s' % (ip, port),
+            options=[grpc_options])
     return channel

--- a/orc8r/gateway/python/magma/common/service_registry.py
+++ b/orc8r/gateway/python/magma/common/service_registry.py
@@ -148,7 +148,8 @@ class ServiceRegistry:
         if destination == ServiceRegistry.LOCAL:
             # Connect to the local service directly
             (ip, port) = ServiceRegistry.get_service_address(service)
-            channel = create_grpc_channel(ip, port, authority, grpc_options)
+            channel = create_grpc_channel(ip, port, authority,
+                                          options=grpc_options)
         elif should_use_proxy:
             # Connect to the cloud via local control proxy
             try:
@@ -157,14 +158,15 @@ class ServiceRegistry:
             except ValueError as err:
                 logging.error(err)
                 (ip, port) = ('127.0.0.1', proxy_config['local_port'])
-            channel = create_grpc_channel(ip, port, authority, grpc_options)
+            channel = create_grpc_channel(ip, port, authority,
+                                          options=grpc_options)
         else:
             # Connect to the cloud directly
             ip = proxy_config['cloud_address']
             port = proxy_config['cloud_port']
             ssl_creds = get_ssl_creds()
             channel = create_grpc_channel(ip, port, authority, ssl_creds,
-                                          grpc_options)
+                                          options=grpc_options)
         if should_reuse_channel:
             ServiceRegistry._CHANNELS_CACHE[authority] = channel
         return channel
@@ -266,9 +268,9 @@ def create_grpc_channel(ip, port, authority, ssl_creds=None, options=None):
         channel = grpc.secure_channel(
             target='%s:%s' % (ip, port),
             credentials=ssl_creds,
-            options=[grpc_options])
+            options=grpc_options)
     else:
         channel = grpc.insecure_channel(
             target='%s:%s' % (ip, port),
-            options=[grpc_options])
+            options=grpc_options)
     return channel

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -71,13 +71,20 @@ def main():
     collect_interval = metrics_config['collect_interval']
     sync_interval = metrics_config['sync_interval']
     grpc_timeout = metrics_config['grpc_timeout']
+    grpc_msg_size = metrics_config.get('grpc_msg_size', 4)
     queue_length = metrics_config['queue_length']
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 
     # Create local metrics collector
     metrics_collector = MetricsCollector(
-        metrics_services, collect_interval, sync_interval,
-        grpc_timeout, queue_length, service.loop,
+        services=metrics_services,
+        collect_interval=collect_interval,
+        sync_interval=sync_interval,
+        grpc_timeout=grpc_timeout,
+        grpc_msg_size=grpc_msg_size,
+        queue_length=queue_length,
+        loop=service.loop,
+        post_processing_fn=
         get_metrics_postprocessor_fn(metrics_post_processor_fn),
     )
 

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -71,7 +71,7 @@ def main():
     collect_interval = metrics_config['collect_interval']
     sync_interval = metrics_config['sync_interval']
     grpc_timeout = metrics_config['grpc_timeout']
-    grpc_msg_size = metrics_config.get('grpc_msg_size', 4)
+    grpc_msg_size = metrics_config.get('grpc_max_msg_size_mb', 4)
     queue_length = metrics_config['queue_length']
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 
@@ -81,7 +81,7 @@ def main():
         collect_interval=collect_interval,
         sync_interval=sync_interval,
         grpc_timeout=grpc_timeout,
-        grpc_msg_size=grpc_msg_size,
+        grpc_max_msg_size_mb=grpc_msg_size,
         queue_length=queue_length,
         loop=service.loop,
         post_processing_fn=

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -192,8 +192,10 @@ def _get_metrics_chan_grpc_options(msg_size: int):
     :param msg_size: msg size in MBs
     :return:
     """
-    return [('grpc.max_send_message_length', msg_size * 1024 * 1024),
-            ('grpc.max_receive_message_length', msg_size * 1024 * 1024)]
+    grpc_max_msg_size_bytes = msg_size * 1024 * 1024
+    logging.debug('Setting metricsd gRPC chan Max Message Size to: %s bytes',
+                  grpc_max_msg_size_bytes)
+    return [('grpc.max_send_message_length', grpc_max_msg_size_bytes)]
 
 
 def example_metrics_postprocessor_fn(

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -63,7 +63,8 @@ class MetricsCollector(object):
         """
         if self._samples:
             chan = ServiceRegistry.get_rpc_channel('metricsd',
-                                                   ServiceRegistry.CLOUD)
+                                                   ServiceRegistry.CLOUD,
+                                                   grpc_options=self._grpc_options)
             client = MetricsControllerStub(chan)
             if self.post_processing_fn:
                 # If services wants to, let it run a postprocessing function
@@ -94,7 +95,7 @@ class MetricsCollector(object):
             logging.error("Metrics upload error! [%s] %s",
                           err.code(), err.details())
         else:
-            logging.debug("Metrics upload success")
+            logging.info("Metrics upload success")
 
     def collect(self, service_name):
         """

--- a/orc8r/gateway/python/magma/magmad/metrics_collector.py
+++ b/orc8r/gateway/python/magma/magmad/metrics_collector.py
@@ -95,7 +95,7 @@ class MetricsCollector(object):
             logging.error("Metrics upload error! [%s] %s",
                           err.code(), err.details())
         else:
-            logging.info("Metrics upload success")
+            logging.debug("Metrics upload success")
 
     def collect(self, service_name):
         """

--- a/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
@@ -67,7 +67,7 @@ class MetricsCollectorTests(unittest.TestCase):
         self.timeout = 1
         self._collector = MetricsCollector(self._services, 5, 10,
                                            self.timeout,
-                                           grpc_msg_size=4,
+                                           grpc_max_msg_size_mb=4,
                                            queue_length=self.queue_length,
                                            loop=asyncio.new_event_loop())
 

--- a/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
@@ -67,6 +67,7 @@ class MetricsCollectorTests(unittest.TestCase):
         self.timeout = 1
         self._collector = MetricsCollector(self._services, 5, 10,
                                            self.timeout,
+                                           grpc_msg_size=4,
                                            queue_length=self.queue_length,
                                            loop=asyncio.new_event_loop())
 

--- a/xwf/gateway/configs/magmad.yml
+++ b/xwf/gateway/configs/magmad.yml
@@ -59,7 +59,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
-  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
+  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/xwf/gateway/configs/magmad.yml
+++ b/xwf/gateway/configs/magmad.yml
@@ -59,6 +59,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
+  grpc_msg_size: 4 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name


### PR DESCRIPTION
## Summary

- Adding max-send-message-size metrics_collector client gRPC channel parameter
- Adding grpc_max_size to magmad.yml configs to configure value (default to send is 4MB)
- Updating metricsd gRPC server to allow receiving messages up to 50MB (default to receive is 4MB)

## Test Plan

- Tested on mcp02, with cwf02 and feg setup
- Tested locally with local orc8r and agw, setting configurable value 

## Additional Information

- [ ] This change is backwards-breaking

