### PR TITLE
[SessionD] Deprecate unused session_map_ variable from LocalEnforcer

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -225,8 +225,6 @@ class LocalEnforcer {
   std::shared_ptr<EventsReporter> events_reporter_;
   std::shared_ptr<SpgwServiceClient> spgw_client_;
   std::shared_ptr<aaa::AAAClient> aaa_client_;
-  std::unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>
-      session_map_;
   SessionStore& session_store_;
   folly::EventBase* evb_;
   long session_force_termination_timeout_ms_;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This field was deprecated from the move to use SessionStore
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD builds/unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
