### PR TITLE
[orc8r][fbinternal] Allow category_id for fbinternal exporter to be configurable via envvar

### DIFF
--- a/fbinternal/cloud/go/go.sum
+++ b/fbinternal/cloud/go/go.sum
@@ -8,6 +8,7 @@ github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFD
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73 h1:+cRmVBz3H/U19fwW85uY+vS+EweAj7cPdhlP4b7vrE4=
 github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73/go.mod h1:yaPeOnPG5ZRwL9oKdTsO/prlkPbXWZlRVMQ/gGlzIuA=
+github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/OneOfOne/xxhash v1.2.5/go.mod h1:eZbhyaAYD41SGSSsnmcpxVoRiQ/MPUTjUdIIOT9Um7Q=
@@ -72,6 +73,9 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/docker v1.13.1/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
@@ -307,6 +311,7 @@ github.com/olivere/elastic/v7 v7.0.6/go.mod h1:nut831m8vw5KQbQxX1oXjj3/buiDpDZc5
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opentracing-contrib/go-stdlib v0.0.0-20170113013457-1de4cc2120e7/go.mod h1:PLldrQSroqzH70Xl+1DQcGnefIbqsKR7UDaiux3zV+w=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -385,6 +390,7 @@ github.com/shurcooL/vfsgen v0.0.0-20180711163814-62bca832be04/go.mod h1:TrYk7fJV
 github.com/shurcooL/vfsgen v0.0.0-20180825020608-02ddb050ef6b/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.4.1/go.mod h1:ni0Sbl8bgC9z8RoU9G6nDWqqs/fq4eDPysMBDgk/93Q=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9/go.mod h1:SnhjPscd9TpLiy1LpzGSKh3bXCfxxXuqd9xmQJy3slM=
@@ -492,6 +498,7 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd h1:r7DufRZuZbWB7j439YfAzP8RPDa9unLkpwQKUYbIMPI=
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47 h1:/XfQ9z7ib8eEJX2hdgFTZJ/ntt0swNk5oYBziWeTCvY=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=

--- a/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
+++ b/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
@@ -21,6 +21,7 @@ import (
 	"magma/fbinternal/cloud/go/services/fbinternal/servicers"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/metricsd/protos"
+	"magma/orc8r/lib/go/definitions"
 
 	"github.com/golang/glog"
 )
@@ -34,13 +35,7 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating orc8r service for fbinternal: %s", err)
 	}
-	var categoryID string
-	categoryIDEnv := os.Getenv("FACEBOOK_APP_CATEGORY_ID")
-	if len(categoryIDEnv) != 0 {
-		categoryID = categoryIDEnv
-	} else {
-		categoryID = defaultCategoryID
-	}
+	categoryID := definitions.GetEnvWithDefault("FACEBOOK_APP_CATEGORY_ID", defaultCategoryID)
 	exporterServicer := servicers.NewExporterServicer(
 		os.Getenv("METRIC_EXPORT_URL"),
 		os.Getenv("FACEBOOK_APP_ID"),

--- a/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
+++ b/fbinternal/cloud/go/services/fbinternal/fbinternal/main.go
@@ -25,16 +25,27 @@ import (
 	"github.com/golang/glog"
 )
 
+const (
+	defaultCategoryID = "magma"
+)
+
 func main() {
 	srv, err := service.NewOrchestratorService(fbinternal.ModuleName, fbinternal_service.ServiceName)
 	if err != nil {
 		glog.Fatalf("Error creating orc8r service for fbinternal: %s", err)
 	}
-
+	var categoryID string
+	categoryIDEnv := os.Getenv("FACEBOOK_APP_CATEGORY_ID")
+	if len(categoryIDEnv) != 0 {
+		categoryID = categoryIDEnv
+	} else {
+		categoryID = defaultCategoryID
+	}
 	exporterServicer := servicers.NewExporterServicer(
 		os.Getenv("METRIC_EXPORT_URL"),
 		os.Getenv("FACEBOOK_APP_ID"),
 		os.Getenv("FACEBOOK_APP_SECRET"),
+		categoryID,
 		os.Getenv("METRICS_PREFIX"),
 		servicers.ODSMetricsQueueLength,
 		servicers.ODSMetricsExportInterval,

--- a/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer.go
+++ b/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer.go
@@ -50,7 +50,6 @@ const (
 	deviceIDLabelName = "deviceID"
 	serviceLabelName  = "service"
 	tagsLabelName     = "tags"
-	categoryName      = "magma"
 )
 
 var (
@@ -70,6 +69,7 @@ type HTTPClient interface {
 
 type ExporterServicer struct {
 	odsURL         string
+	categoryID     string
 	queue          []exporters.Sample
 	queueMu        sync.Mutex
 	maxQueueLength int
@@ -82,12 +82,14 @@ func NewExporterServicer(
 	baseUrl string,
 	appId string,
 	appSecret string,
+	categoryID string,
 	metricsPrefix string,
 	maxQueueLength int,
 	exportInterval time.Duration,
 ) protos.MetricsExporterServer {
 	srv := &ExporterServicer{
 		odsURL:         fmt.Sprintf("%s?access_token=%s|%s", baseUrl, appId, appSecret),
+		categoryID:     categoryID,
 		maxQueueLength: maxQueueLength,
 		exportInterval: exportInterval,
 		metricsPrefix:  metricsPrefix,
@@ -171,7 +173,7 @@ func (s *ExporterServicer) write(client HTTPClient, samples []exporters.Sample) 
 	if err != nil {
 		return err
 	}
-	resp, err := client.PostForm(s.odsURL, url.Values{"datapoints": {string(datapointsJson)}, "category": {categoryName}})
+	resp, err := client.PostForm(s.odsURL, url.Values{"datapoints": {string(datapointsJson)}, "category": {s.categoryID}})
 	if err != nil {
 		return err
 	}

--- a/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer_test.go
+++ b/fbinternal/cloud/go/services/fbinternal/servicers/exporter_servicer_test.go
@@ -41,6 +41,7 @@ func TestODSSubmit(t *testing.T) {
 		"",
 		"",
 		"magma",
+		"magma",
 		2,
 		time.Second*10,
 	)
@@ -71,6 +72,7 @@ func TestExport(t *testing.T) {
 		"",
 		"",
 		"",
+		"100",
 		"magma",
 		2,
 		time.Second*10,
@@ -101,7 +103,7 @@ func TestExport(t *testing.T) {
 	expectedDatapoints := `[{"entity":"magma.testId1.testId2","key":"test","value":"0","time":0,"tags":["Tag1","Tag2"]}]`
 	assert.Equal(t, expectedDatapoints, string(datapointsJson))
 
-	client.On("PostForm", mock.AnythingOfType("string"), url.Values{"datapoints": {string(datapointsJson)}, "category": {"magma"}}).Return(resp, nil)
+	client.On("PostForm", mock.AnythingOfType("string"), url.Values{"datapoints": {string(datapointsJson)}, "category": {"100"}}).Return(resp, nil)
 
 	// Export called on empty queue
 	err = exporterSrv.Export(client)
@@ -127,7 +129,7 @@ func TestExport(t *testing.T) {
 	datapoints = append(datapoints, datapoints...)
 	datapointsJson, err = json.Marshal(datapoints)
 	assert.NoError(t, err)
-	client.On("PostForm", mock.Anything, url.Values{"datapoints": {string(datapointsJson)}, "category": {"magma"}}).Return(resp, nil)
+	client.On("PostForm", mock.Anything, url.Values{"datapoints": {string(datapointsJson)}, "category": {"100"}}).Return(resp, nil)
 
 	err = exporterSrv.Export(client)
 	assert.NoError(t, err)

--- a/fbinternal/cloud/go/services/fbinternal/test_init/test_service_init.go
+++ b/fbinternal/cloud/go/services/fbinternal/test_init/test_service_init.go
@@ -29,6 +29,7 @@ func StartTestService(t *testing.T) {
 		os.Getenv("METRIC_EXPORT_URL"),
 		os.Getenv("FACEBOOK_APP_ID"),
 		os.Getenv("FACEBOOK_APP_SECRET"),
+		"magma",
 		os.Getenv("METRICS_PREFIX"),
 		servicers.ODSMetricsQueueLength,
 		servicers.ODSMetricsExportInterval,


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This diff allows the default category_id for fbinternal's exporter to be
overridden via the env var FACEBOOK_APP_CATEGORY_ID. This change
is needed for the xwf-m orc8r's as this uses a different category_id than
magma.

## Test Plan

Updated unit test. Ran locally to ensure that category id was configured
properly when env-var was set.
