### PR TITLE
[feg][radius] Fix missing comma in radius config

### DIFF
--- a/feg/radius/src/config/samples/radius.ofpanalytics.config.json.template
+++ b/feg/radius/src/config/samples/radius.ofpanalytics.config.json.template
@@ -15,7 +15,7 @@
       "graph_url": "https://graph.facebook.com/scribe_logs",
       "access_token": "$SCUBA_ACCESS_TOKEN",
       "partner_shortname": "$PARTNER_SHORTNAME"
-    }
+    },
     "census": {
       "disable_stats": false,
       "stat_views": ["proc"]


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

A Recent merged PR was missing a comma, causing xwfm-test to fail in circleCI.

## Test Plan

Ensure radius doesn't crash locally.

