### PR TITLE
[NMS] Cleanup subscriber component

### DIFF
--- a/nms/app/packages/magmalte/app/components/DataGrid.js
+++ b/nms/app/packages/magmalte/app/components/DataGrid.js
@@ -223,7 +223,7 @@ export default function DataGrid(props: Props) {
   const dataGrid = props.data.map((row, i) => (
     <Grid key={i} container direction="row">
       {row.map((data, j) => (
-        <>
+        <React.Fragment key={`data-${i}-${j}`}>
           <Grid
             item
             container
@@ -271,7 +271,7 @@ export default function DataGrid(props: Props) {
               )}
             </Grid>
           </Grid>
-        </>
+        </React.Fragment>
       ))}
     </Grid>
   ));

--- a/nms/app/packages/magmalte/app/components/DateTimeMetricChart.js
+++ b/nms/app/packages/magmalte/app/components/DateTimeMetricChart.js
@@ -33,6 +33,7 @@ export type DateTimeMetricChartProps = {
   title: string,
   queries: Array<string>,
   legendLabels: Array<string>,
+  unit?: string,
 };
 
 const useStyles = makeStyles(_ => ({
@@ -131,7 +132,7 @@ export default function DateTimeMetricChart(props: DateTimeMetricChartProps) {
                 },
               }}
               label={`Frequency of ${props.title}`}
-              unit=""
+              unit={props.unit ?? ''}
               queries={props.queries}
               timeRange={'3_hours'}
               startEnd={[startDate, endDate]}

--- a/nms/app/packages/magmalte/app/components/EventAlertChart.js
+++ b/nms/app/packages/magmalte/app/components/EventAlertChart.js
@@ -43,14 +43,12 @@ type DatasetFetchProps = {
 
 async function getEventAlertDataset(props: DatasetFetchProps) {
   const {start, end, networkId} = props;
-  const [delta, unit, format] = getStep(start, end);
+  const [delta, unit] = getStep(start, end);
   let requestError = '';
   const queries = [];
-  const labels = [];
 
   let s = start.clone();
   while (end.diff(s) >= 0) {
-    labels.push(s.format(format));
     const e = s.clone();
     e.add(delta, unit);
     queries.push([s, e]);
@@ -85,7 +83,7 @@ async function getEventAlertDataset(props: DatasetFetchProps) {
           };
         }
         return {
-          t: s.unix(),
+          t: s.unix() * 1000,
           y: r,
         };
       });
@@ -95,43 +93,37 @@ async function getEventAlertDataset(props: DatasetFetchProps) {
       return [];
     });
 
+  const alertsData = [];
+  try {
+    const alertPromResp = await MagmaV1API.getNetworksByNetworkIdPrometheusQueryRange(
+      {
+        networkId: networkId,
+        start: start.toISOString(),
+        end: end.toISOString(),
+        step: getStepString(delta, unit),
+        query: 'sum(ALERTS)',
+      },
+    );
+    alertPromResp.data.result.forEach(it =>
+      it['values']?.map(i => {
+        alertsData.push({
+          t: parseInt(i[0]) * 1000,
+          y: parseFloat(i[1]),
+        });
+      }),
+    );
+  } catch (error) {
+    requestError = error;
+    return [];
+  }
+
   if (requestError) {
     props.enqueueSnackbar('Error getting event counts', {
       variant: 'error',
     });
   }
 
-  const alertPromResp = await MagmaV1API.getNetworksByNetworkIdPrometheusQueryRange(
-    {
-      networkId: networkId,
-      start: start.toISOString(),
-      end: end.toISOString(),
-      step: getStepString(delta, unit),
-      query: 'sum(ALERTS)',
-    },
-  );
-
-  const alertsData = [];
-  alertPromResp.data.result.forEach(it =>
-    it['values']?.map(i => {
-      alertsData.push({
-        t: parseInt(i[0]) * 1000,
-        y: parseFloat(i[1]),
-      });
-    }),
-  );
-
   return [
-    {
-      label: 'Events',
-      fill: false,
-      backgroundColor: colors.secondary.dodgerBlue,
-      borderColor: colors.secondary.dodgerBlue,
-      borderWidth: 1,
-      hoverBackgroundColor: colors.secondary.dodgerBlue,
-      hoverBorderColor: 'black',
-      data: eventData,
-    },
     {
       label: 'Alerts',
       fill: false,
@@ -145,7 +137,16 @@ async function getEventAlertDataset(props: DatasetFetchProps) {
       hoverBorderColor: 'black',
       data: alertsData,
     },
-    labels,
+    {
+      label: 'Events',
+      fill: false,
+      backgroundColor: colors.secondary.dodgerBlue,
+      borderColor: colors.secondary.dodgerBlue,
+      borderWidth: 1,
+      hoverBackgroundColor: colors.secondary.dodgerBlue,
+      hoverBorderColor: 'black',
+      data: eventData,
+    },
   ];
 }
 
@@ -154,7 +155,6 @@ export default function EventAlertChart(props: Props) {
   const networkId: string = nullthrows(match.params.networkId);
   const [start, end] = props.startEnd;
   const enqueueSnackbar = useEnqueueSnackbar();
-  const [labels, setLabels] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
 
   const [eventDataset, setEventDataset] = useState<Dataset>({
@@ -182,7 +182,7 @@ export default function EventAlertChart(props: Props) {
   useEffect(() => {
     // fetch queries
     const fetchAllData = async () => {
-      const [eventDataset, alertDataset, labels] = await getEventAlertDataset({
+      const [eventDataset, alertDataset] = await getEventAlertDataset({
         start,
         end,
         networkId,
@@ -190,7 +190,6 @@ export default function EventAlertChart(props: Props) {
       });
       setEventDataset(eventDataset);
       setAlertDataset(alertDataset);
-      setLabels(labels);
       setIsLoading(false);
     };
 
@@ -207,7 +206,7 @@ export default function EventAlertChart(props: Props) {
         subheader={
           <CustomLineChart
             dataset={[eventDataset, alertDataset]}
-            labels={labels}
+            yLabel={'count'}
           />
         }
       />

--- a/nms/app/packages/magmalte/app/components/TopBar.js
+++ b/nms/app/packages/magmalte/app/components/TopBar.js
@@ -112,7 +112,13 @@ export default function TopBar(props: Props) {
             </Tabs>
           </Grid>
           {props.tabs.map((tab, i) => (
-            <>{currentTab === i ? <Grid item>{tab.filters}</Grid> : null}</>
+            <>
+              {currentTab === i ? (
+                <Grid key={i} item>
+                  {tab.filters}
+                </Grid>
+              ) : null}
+            </>
           ))}
         </Grid>
       </AppBar>

--- a/nms/app/packages/magmalte/app/components/__tests__/EventAlertChartTest.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/EventAlertChartTest.js
@@ -70,13 +70,13 @@ describe('<EventAlertChart/>', () => {
     {
       startDate: moment().subtract(10, 'day'),
       endDate: moment(),
-      step: '1d',
+      step: '24h',
       valid: true,
     },
     {
       startDate: moment(),
       endDate: moment().subtract(10, 'day'),
-      step: '1d',
+      step: '24h',
       valid: false,
     },
   ];

--- a/nms/app/packages/magmalte/app/components/context/SubscriberContext.js
+++ b/nms/app/packages/magmalte/app/components/context/SubscriberContext.js
@@ -17,8 +17,14 @@ import type {subscriber} from '@fbcnms/magma-api';
 
 import React from 'react';
 
+export type Metrics = {
+  currentUsage: string,
+  dailyAvg: string,
+};
+
 export type SubscriberContextType = {
   state: {[string]: subscriber},
+  metrics: {[string]: Metrics},
   setState: (key: string, val: subscriber) => Promise<void>,
 };
 

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayLogChart.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayLogChart.js
@@ -44,7 +44,6 @@ export default function LogChart(props: Props) {
   const gatewayId: string = nullthrows(match.params.gatewayId);
   const {start, end, delta, format, unit, setLogCount} = props;
   const enqueueSnackbar = useEnqueueSnackbar();
-  const [labels, setLabels] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [dataset, setDataset] = useState<Dataset>({
     label: 'Log Counts',
@@ -60,16 +59,13 @@ export default function LogChart(props: Props) {
     // build queries
     let requestError = '';
     const queries = [];
-    const logLabels = [];
     let s = start.clone();
     while (end.diff(s) >= 0) {
-      logLabels.push(s.format(format));
       const e = s.clone();
       e.add(delta, unit);
       queries.push([s, e]);
       s = e.clone();
     }
-    setLabels(logLabels);
 
     const requests = queries.map(async (query, _) => {
       try {
@@ -93,12 +89,12 @@ export default function LogChart(props: Props) {
           const [s] = queries[index];
           if (r === null || r === undefined) {
             return {
-              t: s.unix(),
+              t: s.unix() * 1000,
               y: 0,
             };
           }
           return {
-            t: s.unix(),
+            t: s.unix() * 1000,
             y: r,
           };
         });
@@ -144,9 +140,7 @@ export default function LogChart(props: Props) {
 
   return (
     <Card elevation={0}>
-      <CardHeader
-        subheader={<CustomHistogram dataset={[dataset]} labels={labels} />}
-      />
+      <CardHeader subheader={<CustomHistogram dataset={[dataset]} />} />
     </Card>
   );
 }

--- a/nms/app/packages/magmalte/app/views/events/EventChart.js
+++ b/nms/app/packages/magmalte/app/views/events/EventChart.js
@@ -45,7 +45,6 @@ export default function EventChart(props: Props) {
   const networkId: string = nullthrows(match.params.networkId);
   const {start, end, delta, format, unit, streams, tags, setEventCount} = props;
   const enqueueSnackbar = useEnqueueSnackbar();
-  const [labels, setLabels] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [dataset, setDataset] = useState<Dataset>({
     label: 'Event Counts',
@@ -61,16 +60,13 @@ export default function EventChart(props: Props) {
     // build queries
     let requestError = '';
     const queries = [];
-    const logLabels = [];
     let s = start.clone();
     while (end.diff(s) >= 0) {
-      logLabels.push(s.format(format));
       const e = s.clone();
       e.add(delta, unit);
       queries.push([s, e]);
       s = e.clone();
     }
-    setLabels(logLabels);
 
     const requests = queries.map(async (query, _) => {
       try {
@@ -95,12 +91,12 @@ export default function EventChart(props: Props) {
           const [s] = queries[index];
           if (r === null || r === undefined) {
             return {
-              t: s.unix(),
+              t: s.unix() * 1000,
               y: 0,
             };
           }
           return {
-            t: s.unix(),
+            t: s.unix() * 1000,
             y: r,
           };
         });
@@ -147,9 +143,7 @@ export default function EventChart(props: Props) {
 
   return (
     <Card elevation={0}>
-      <CardHeader
-        subheader={<CustomHistogram dataset={[dataset]} labels={labels} />}
-      />
+      <CardHeader subheader={<CustomHistogram dataset={[dataset]} />} />
     </Card>
   );
 }

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
@@ -1,0 +1,283 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {DataRows} from '../../components/DataGrid';
+import type {Dataset} from '../../components/CustomMetrics';
+import type {network_id, subscriber_id} from '@fbcnms/magma-api';
+
+import Card from '@material-ui/core/Card';
+import CardHeader from '@material-ui/core/CardHeader';
+import CardTitleRow from '../../components/layout/CardTitleRow';
+import CustomHistogram from '../../components/CustomMetrics';
+import Divider from '@material-ui/core/Divider';
+
+import DataGrid from '../../components/DataGrid';
+import DataUsageIcon from '@material-ui/icons/DataUsage';
+import Grid from '@material-ui/core/Grid';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import React from 'react';
+import Text from '../../theme/design-system/Text';
+import moment from 'moment';
+import nullthrows from '@fbcnms/util/nullthrows';
+
+import {DateTimePicker} from '@material-ui/pickers';
+import {colors} from '../../theme/default';
+import {getLabelUnit, getPromValue} from './SubscriberUtils';
+import {getStep, getStepString} from '../../components/CustomMetrics';
+import {makeStyles} from '@material-ui/styles';
+import {useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
+
+export type DateTimeMetricChartProps = {
+  title: string,
+  queries: Array<string>,
+  legendLabels: Array<string>,
+  unit?: string,
+};
+
+const useStyles = makeStyles(_ => ({
+  dateTimeText: {
+    color: colors.primary.comet,
+  },
+}));
+
+type DatasetFetchProps = {
+  networkId: network_id,
+  subscriberId: subscriber_id,
+  start: moment,
+  end: moment,
+  enqueueSnackbar: (msg: string, cfg: {}) => ?(string | number),
+};
+
+async function getDatasets(props: DatasetFetchProps) {
+  const {start, end, networkId, subscriberId} = props;
+  const [delta, unit] = getStep(start, end);
+  let requestError = '';
+  const step = getStepString(delta, unit);
+  const toolTipHint = delta + ' ' + unit;
+
+  const queries = [
+    {
+      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+      color: colors.secondary.dodgerBlue,
+      label: 'download',
+    },
+    {
+      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="up"}[${step}]))`,
+      color: colors.data.flamePea,
+      label: 'upload',
+    },
+  ];
+  const allDatasets = [];
+  const requests = queries.map(async (query, index) => {
+    try {
+      const resp = await MagmaV1API.getNetworksByNetworkIdPrometheusQueryRange({
+        networkId,
+        start: start.toISOString(),
+        end: end.toISOString(),
+        step: getStepString(delta, unit),
+        query: query.q,
+      });
+
+      const data = [];
+      resp.data.result.forEach(it =>
+        it['values']?.map(i => {
+          data.push({
+            t: parseInt(i[0]) * 1000,
+            y: parseFloat(i[1]),
+          });
+        }),
+      );
+
+      allDatasets.push({
+        datasetKeyProvider: index.toString(),
+        label: query.label,
+        fill: false,
+        barPercentage: 0.7,
+
+        borderWidth: 2,
+        backgroundColor: query.color,
+        borderColor: query.color,
+        hoverBackgroundColor: query.color,
+        hoverBorderColor: 'black',
+        data: data,
+        unit: 'bytes',
+      });
+    } catch (error) {
+      requestError = error;
+      return [];
+    }
+  });
+
+  await Promise.all(requests);
+  if (requestError) {
+    props.enqueueSnackbar('Error getting event counts', {
+      variant: 'error',
+    });
+  }
+  return {allDatasets, unit, toolTipHint};
+}
+
+function SubscriberDataKPI() {
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const subscriberId: string = nullthrows(match.params.subscriberId);
+  const [kpiRows, setKpiRows] = useState<DataRows[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    // fetch queries
+    const fetchAllData = async () => {
+      const stepCategoryMap = {
+        '1h': 'Last 1 Hour',
+        '24h': 'Last 1 Day',
+        '7d': 'Last 1 Week',
+        '30d': 'Last 1 Month',
+      };
+
+      const queries = Object.keys(stepCategoryMap).map(async step => {
+        const category = stepCategoryMap[step];
+        try {
+          const result = await MagmaV1API.getNetworksByNetworkIdPrometheusQuery(
+            {
+              networkId,
+              query: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+            },
+          );
+          const [value, unit] = getLabelUnit(getPromValue(result));
+          return {value, unit, category};
+        } catch (e) {
+          enqueueSnackbar('Error getting subscriber KPIs', {variant: 'error'});
+          return {value: '-', unit: '', category};
+        }
+      });
+
+      Promise.all(queries).then(allResponses => setKpiRows([allResponses]));
+      // setKpiRows(kpiRows);
+      setIsLoading(false);
+    };
+
+    fetchAllData();
+  }, [enqueueSnackbar, networkId, subscriberId]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+  return <DataGrid data={kpiRows} />;
+}
+
+export default function SubscriberChart() {
+  const classes = useStyles();
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const subscriberId: string = nullthrows(match.params.subscriberId);
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const [datasets, setDatasets] = useState<Array<Dataset>>([]);
+  const [toolTipHint, setToolTipHint] = useState('');
+  const [unit, setUnit] = useState('');
+  const [start, setStart] = useState(moment().subtract(3, 'hours'));
+  const [end, setEnd] = useState(moment());
+  const [isLoading, setIsLoading] = useState(true);
+
+  function Filter() {
+    return (
+      <Grid container justify="flex-end" alignItems="center" spacing={1}>
+        <Grid item>
+          <Text variant="body3" className={classes.dateTimeText}>
+            Filter By Date
+          </Text>
+        </Grid>
+        <Grid item>
+          <DateTimePicker
+            autoOk
+            variant="outlined"
+            inputVariant="outlined"
+            maxDate={end}
+            disableFuture
+            value={start}
+            onChange={setStart}
+          />
+        </Grid>
+        <Grid item>
+          <Text variant="body3" className={classes.dateTimeText}>
+            to
+          </Text>
+        </Grid>
+        <Grid item>
+          <DateTimePicker
+            autoOk
+            variant="outlined"
+            inputVariant="outlined"
+            disableFuture
+            value={end}
+            onChange={setEnd}
+          />
+        </Grid>
+      </Grid>
+    );
+  }
+  useEffect(() => {
+    // fetch queries
+    const fetchAllData = async () => {
+      const {allDatasets, unit, toolTipHint} = await getDatasets({
+        start,
+        end,
+        networkId,
+        subscriberId,
+        enqueueSnackbar,
+      });
+      setDatasets(allDatasets);
+      setToolTipHint(toolTipHint);
+      setIsLoading(false);
+      setUnit(unit);
+    };
+
+    fetchAllData();
+  }, [start, end, enqueueSnackbar, networkId, subscriberId]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <>
+      <CardTitleRow icon={DataUsageIcon} label={'Data Usage'} filter={Filter} />
+      <Card elevation={0}>
+        <CardHeader
+          title={<Text variant="body2">Data Usage Pattern</Text>}
+          subheader={
+            <CustomHistogram
+              dataset={datasets}
+              unit={unit}
+              yLabel={'Bytes'}
+              tooltipHandler={(tooltipItem, data) => {
+                const [val, units] = getLabelUnit(tooltipItem.yLabel);
+                return (
+                  data.datasets[tooltipItem.datasetIndex].label +
+                  ` ${val}${units} in last ${toolTipHint}s`
+                );
+              }}
+            />
+          }
+        />
+      </Card>
+      <Divider />
+      <SubscriberDataKPI />
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -20,7 +20,6 @@ import AppBar from '@material-ui/core/AppBar';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DataGrid from '../../components/DataGrid';
-import DateTimeMetricChart from '../../components/DateTimeMetricChart';
 import EventsTable from '../../views/events/EventsTable';
 import GraphicEqIcon from '@material-ui/icons/GraphicEq';
 import Grid from '@material-ui/core/Grid';
@@ -29,20 +28,22 @@ import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import PersonIcon from '@material-ui/icons/Person';
 import React from 'react';
 import SettingsIcon from '@material-ui/icons/Settings';
+import SubscriberChart from './SubscriberChart';
+import SubscriberContext from '../../components/context/SubscriberContext';
 import SubscriberDetailConfig from './SubscriberDetailConfig';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Text from '../../theme/design-system/Text';
 import nullthrows from '@fbcnms/util/nullthrows';
-import {SubscriberJsonConfig} from './SubscriberDetailConfig';
 
 import {DetailTabItems, GetCurrentTabPos} from '../../components/TabUtils.js';
 import {Redirect, Route, Switch} from 'react-router-dom';
+import {SubscriberJsonConfig} from './SubscriberDetailConfig';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
-const CHART_TITLE = 'Data Usage';
 const useStyles = makeStyles(theme => ({
   dashboardRoot: {
     margin: theme.spacing(3),
@@ -96,16 +97,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-export default function SubscriberDetail(props: {
-  subscriberMap: ?{[string]: subscriber},
-}) {
+export default function SubscriberDetail() {
   const classes = useStyles();
   const {relativePath, relativeUrl, match} = useRouter();
   const subscriberId: string = nullthrows(match.params.subscriberId);
-  const subscriberInfo = props.subscriberMap?.[subscriberId];
-  if (!subscriberInfo) {
-    return null;
-  }
 
   return (
     <>
@@ -154,22 +149,13 @@ export default function SubscriberDetail(props: {
         />
         <Route
           path={relativePath('/config')}
-          render={() => (
-            <SubscriberDetailConfig subscriberInfo={subscriberInfo} />
-          )}
+          render={() => <SubscriberDetailConfig />}
         />
-        <Route
-          path={relativePath('/overview')}
-          render={() => <Overview subscriberInfo={subscriberInfo} />}
-        />
+        <Route path={relativePath('/overview')} render={() => <Overview />} />
         <Route
           path={relativePath('/event')}
           render={() => (
-            <EventsTable
-              sz="lg"
-              eventStream="SUBSCRIBER"
-              tags={subscriberInfo.id}
-            />
+            <EventsTable sz="lg" eventStream="SUBSCRIBER" tags={subscriberId} />
           )}
         />
         <Redirect to={relativeUrl('/overview')} />
@@ -178,38 +164,38 @@ export default function SubscriberDetail(props: {
   );
 }
 
-function Overview(props: {subscriberInfo: subscriber}) {
+function Overview() {
   const classes = useStyles();
+  const {match} = useRouter();
+  const subscriberId: string = nullthrows(match.params.subscriberId);
+  const ctx = useContext(SubscriberContext);
+  const subscriberInfo = ctx.state?.[subscriberId];
+  if (!subscriberInfo) {
+    return null;
+  }
 
   return (
     <div className={classes.dashboardRoot}>
       <Grid container spacing={4}>
         <Grid item xs={12}>
           <Grid container spacing={4}>
-            <Grid item xs={12} md={6} alignItems="center">
+            <Grid item xs={12} md={6}>
               <CardTitleRow icon={PersonIcon} label="Subscriber" />
-              <Info subscriberInfo={props.subscriberInfo} />
+              <Info subscriberInfo={subscriberInfo} />
             </Grid>
-            <Grid item xs={12} md={6} alignItems="center">
+            <Grid item xs={12} md={6}>
               <CardTitleRow icon={GraphicEqIcon} label="Status" />
-              <Status subscriberInfo={props.subscriberInfo} />
+              <Status subscriberInfo={subscriberInfo} />
             </Grid>
           </Grid>
         </Grid>
         <Grid item xs={12}>
-          <DateTimeMetricChart
-            title={CHART_TITLE}
-            queries={[
-              `ue_traffic{IMSI="${props.subscriberInfo.id}",direction="down"}`,
-              `ue_traffic{IMSI="${props.subscriberInfo.id}",direction="up"}`,
-            ]}
-            legendLabels={['Download', 'Upload']}
-          />
+          <SubscriberChart />
         </Grid>
         <Grid item xs={12}>
           <EventsTable
             eventStream="SUBSCRIBER"
-            tags={props.subscriberInfo.id}
+            tags={subscriberInfo.id}
             sz="md"
           />
         </Grid>

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetailConfig.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetailConfig.js
@@ -14,7 +14,6 @@
  * @format
  */
 import type {DataRows} from '../../components/DataGrid';
-import type {subscriber} from '@fbcnms/magma-api';
 
 import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
@@ -80,13 +79,10 @@ export function SubscriberJsonConfig() {
   );
 }
 
-export default function SubscriberDetailConfig({
-  subscriberInfo,
-}: {
-  subscriberInfo: subscriber,
-}) {
+export default function SubscriberDetailConfig() {
   const classes = useStyles();
   const {history, relativeUrl} = useRouter();
+
   function TrafficFilter() {
     return <Button variant="text">Edit</Button>;
   }
@@ -117,18 +113,12 @@ export default function SubscriberDetailConfig({
           <Grid container spacing={4}>
             <Grid item xs={12} md={6}>
               <CardTitleRow label="Subscriber" filter={EditSubscriberButton} />
-              <SubscriberInfoConfig
-                readOnly={true}
-                subscriberInfo={subscriberInfo}
-              />
+              <SubscriberInfoConfig />
             </Grid>
 
             <Grid item xs={12} md={6}>
               <CardTitleRow label="Traffic Policy" filter={TrafficFilter} />
-              <SubscriberConfigTrafficPolicy
-                readOnly={true}
-                subscriberInfo={subscriberInfo}
-              />
+              <SubscriberConfigTrafficPolicy />
             </Grid>
           </Grid>
         </Grid>
@@ -137,11 +127,12 @@ export default function SubscriberDetailConfig({
   );
 }
 
-function SubscriberConfigTrafficPolicy({
-  subscriberInfo,
-}: {
-  subscriberInfo: subscriber,
-}) {
+function SubscriberConfigTrafficPolicy() {
+  const {match} = useRouter();
+  const subscriberId = nullthrows(match.params.subscriberId);
+  const ctx = useContext(SubscriberContext);
+  const subscriberInfo = ctx.state?.[subscriberId];
+
   function CollapseItems(props) {
     const data: DataRows[] = [
       [
@@ -190,7 +181,12 @@ function SubscriberConfigTrafficPolicy({
   return <DataGrid data={trafficPolicyData} />;
 }
 
-function SubscriberInfoConfig({subscriberInfo}: {subscriberInfo: subscriber}) {
+function SubscriberInfoConfig() {
+  const {match} = useRouter();
+  const subscriberId = nullthrows(match.params.subscriberId);
+  const ctx = useContext(SubscriberContext);
+  const subscriberInfo = ctx.state?.[subscriberId];
+
   const [authKey, _setAuthKey] = useState(subscriberInfo.lte.auth_key);
   const [authOPC, _setAuthOPC] = useState(subscriberInfo.lte.auth_opc ?? false);
   const [dataPlan, _setDataPlan] = useState(subscriberInfo.lte.sub_profile);

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberOverview.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberOverview.js
@@ -13,7 +13,8 @@
  * @flow strict-local
  * @format
  */
-import type {subscriber} from '@fbcnms/magma-api';
+import type {Metrics} from '../../components/context/SubscriberContext';
+import type {network_id, subscriber} from '@fbcnms/magma-api';
 
 import ActionTable from '../../components/ActionTable';
 import AddSubscriberButton from './SubscriberAddDialog';
@@ -29,12 +30,13 @@ import SubscriberContext from '../../components/context/SubscriberContext';
 import SubscriberDetail from './SubscriberDetail';
 import TopBar from '../../components/TopBar';
 import nullthrows from '@fbcnms/util/nullthrows';
-import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
 
 import {Redirect, Route, Switch} from 'react-router-dom';
 import {colors, typography} from '../../theme/default';
+import {getLabelUnit} from './SubscriberUtils';
 import {makeStyles} from '@material-ui/styles';
-import {useCallback, useState} from 'react';
+import {useContext, useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const TITLE = 'Subscribers';
@@ -61,28 +63,96 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+type InitSubscriberStateProps = {
+  networkId: network_id,
+  setSubscriberMap: ({[string]: subscriber}) => void,
+  setSubscriberMetrics: ({[string]: Metrics}) => void,
+  enqueueSnackbar: (msg: string, cfg: {}) => ?(string | number),
+};
+
+async function InitSubscriberState(props: InitSubscriberStateProps) {
+  const {
+    networkId,
+    setSubscriberMap,
+    setSubscriberMetrics,
+    enqueueSnackbar,
+  } = props;
+
+  let subscribers = {};
+  try {
+    subscribers = await MagmaV1API.getLteByNetworkIdSubscribers({networkId});
+  } catch (e) {
+    enqueueSnackbar('failed fetching subscriber information', {
+      variant: 'error',
+    });
+    return [];
+  }
+  setSubscriberMap(subscribers);
+
+  const subscriberMetrics = {};
+  const queries = {
+    dailyAvg: 'avg (avg_over_time(ue_traffic[24h])) by (IMSI)',
+    currentUsage: 'sum (ue_traffic) by (IMSI)',
+  };
+
+  const requests = Object.keys(queries).map(async (queryType: string) => {
+    try {
+      const resp = await MagmaV1API.getNetworksByNetworkIdPrometheusQuery({
+        networkId,
+        query: queries[queryType],
+      });
+
+      resp?.data?.result?.filter(Boolean).forEach(item => {
+        const imsi = Object.values(item?.metric)?.[0];
+        if (typeof imsi === 'string') {
+          const [value, unit] = getLabelUnit(parseFloat(item?.value?.[1]));
+          if (!(imsi in subscriberMetrics)) {
+            subscriberMetrics[imsi] = {};
+          }
+          subscriberMetrics[imsi][queryType] = `${value}${unit}`;
+        }
+      });
+    } catch (e) {
+      enqueueSnackbar('failed fetching current usage information', {
+        variant: 'error',
+      });
+    }
+  });
+  await Promise.all(requests);
+  setSubscriberMetrics(subscriberMetrics);
+}
+
 export default function SubscriberDashboard() {
   const {match, relativePath, relativeUrl} = useRouter();
   const networkId: string = nullthrows(match.params.networkId);
   const [subscriberMap, setSubscriberMap] = useState({});
-  const {isLoading} = useMagmaAPI(
-    MagmaV1API.getLteByNetworkIdSubscribers,
-    {
-      networkId: networkId,
-    },
-    useCallback(response => setSubscriberMap(response), []),
-  );
+  const [subscriberMetrics, setSubscriberMetrics] = useState({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchData = async () => {
+      await InitSubscriberState({
+        networkId,
+        setSubscriberMap,
+        setSubscriberMetrics,
+        enqueueSnackbar,
+      });
+      setIsLoading(false);
+    };
+    fetchData();
+  }, [networkId, enqueueSnackbar]);
 
   const updateSubscriberMap = async (key: string, val: subscriber) => {
     if (key in subscriberMap) {
       await MagmaV1API.putLteByNetworkIdSubscribersBySubscriberId({
-        networkId: networkId,
+        networkId,
         subscriber: val,
         subscriberId: key,
       });
     } else {
       await MagmaV1API.postLteByNetworkIdSubscribers({
-        networkId: networkId,
+        networkId,
         subscriber: val,
       });
     }
@@ -93,18 +163,20 @@ export default function SubscriberDashboard() {
     return <LoadingFiller />;
   }
 
+  const subscriberCtx = {
+    state: subscriberMap,
+    metrics: subscriberMetrics,
+    setState: updateSubscriberMap,
+  };
+
   return (
     <Switch>
       <Route
         path={relativePath('/overview/:subscriberId')}
         render={() => {
           return (
-            <SubscriberContext.Provider
-              value={{
-                state: subscriberMap ?? {},
-                setState: updateSubscriberMap,
-              }}>
-              <SubscriberDetail subscriberMap={subscriberMap} />
+            <SubscriberContext.Provider value={subscriberCtx}>
+              <SubscriberDetail />
             </SubscriberContext.Provider>
           );
         }}
@@ -114,12 +186,8 @@ export default function SubscriberDashboard() {
         path={relativePath('/overview')}
         render={() => {
           return (
-            <SubscriberContext.Provider
-              value={{
-                state: subscriberMap ?? {},
-                setState: updateSubscriberMap,
-              }}>
-              <SubscriberDashboardInternal subscriberMap={subscriberMap} />
+            <SubscriberContext.Provider value={subscriberCtx}>
+              <SubscriberDashboardInternal />
             </SubscriberContext.Provider>
           );
         }}
@@ -138,14 +206,13 @@ type SubscriberRowType = {
   lastReportedTime: Date,
 };
 
-function SubscriberDashboardInternal({
-  subscriberMap,
-}: {
-  subscriberMap: ?{[string]: subscriber} | void,
-}) {
+function SubscriberDashboardInternal() {
   const classes = useStyles();
   const {history, relativeUrl} = useRouter();
   const [currRow, setCurrRow] = useState<SubscriberRowType>({});
+  const ctx = useContext(SubscriberContext);
+  const subscriberMap = ctx.state;
+  const subscriberMetrics = ctx.metrics;
 
   return (
     <>
@@ -192,12 +259,13 @@ function SubscriberDashboardInternal({
               <ActionTable
                 data={Object.keys(subscriberMap).map((imsi: string) => {
                   const subscriberInfo = subscriberMap[imsi];
+                  const metrics = subscriberMetrics[`${imsi}`];
                   return {
                     name: subscriberInfo.name ?? imsi,
                     imsi: imsi,
                     service: subscriberInfo.lte.state,
-                    currentUsage: '0',
-                    dailyAvg: '0',
+                    currentUsage: metrics?.currentUsage ?? 0,
+                    dailyAvg: metrics?.dailyAvg ?? 0,
                     lastReportedTime: new Date(
                       subscriberInfo.monitoring?.icmp?.last_reported_time ?? 0,
                     ),

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberUtils.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberUtils.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {promql_return_object} from '@fbcnms/magma-api';
+
+const mBIT = 1000000;
+const kBIT = 1000;
+export function getLabelUnit(val: number) {
+  if (val > mBIT) {
+    return [(val / mBIT).toFixed(2), 'mb'];
+  } else if (val > kBIT) {
+    return [(val / kBIT).toFixed(2), 'kb'];
+  }
+  return [val.toFixed(2), 'bytes'];
+}
+
+export function getPromValue(resp: promql_return_object) {
+  const respArr = resp?.data?.result
+    ?.map(item => {
+      return parseFloat(item?.value?.[1]);
+    })
+    .filter(Boolean);
+  return respArr && respArr.length ? respArr[0] : 0;
+}


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>

## Summary

- Use subscriber context consistently across the subscriber components

- Add current usage and daily average metrics to the subscriber overview page

- Display the subscriber usage metrics as a stacked bar chart

- Add additional subscriber data KPIs to the detail page


## Test Plan
- yarn test succeeds
![subscriber_usage_gif](https://user-images.githubusercontent.com/8224854/90306507-bf034a00-de82-11ea-96d5-b6fcf52fa483.gif)


stacked histogram
![stacked_gif](https://user-images.githubusercontent.com/8224854/90649403-88fdf700-e1ef-11ea-8f31-32826b6fe21e.gif)

![Screen Shot 2020-08-19 at 8 50 05 AM](https://user-images.githubusercontent.com/8224854/90659288-5822bf80-e1f9-11ea-92bd-0749eaa825fc.png)