### PR TITLE
[SessionD] Create PolicyID->BearerID mapping for bearer lifecycle management

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -920,6 +920,12 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   // when no rule is provided as the parameter.
   propagate_rule_updates_to_pipelined(
       imsi, config, rules_to_activate, rules_to_deactivate, true);
+
+  if (config.common_context.rat_type() == TGPP_LTE) {
+    const auto update = session_state.get_dedicated_bearer_updates(
+        rules_to_activate, rules_to_deactivate, uc);
+    propagate_bearer_updates_to_mme(update);
+  }
   return true;
 }
 
@@ -1206,6 +1212,7 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
 
     for (const auto& session : it->second) {
       auto& update_criteria = session_update[imsi][session->get_session_id()];
+      const auto& config    = session->get_config();
       session->receive_monitor(usage_monitor_resp, update_criteria);
       session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), update_criteria);
 
@@ -1222,8 +1229,7 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
           rules_to_activate, rules_to_deactivate, update_criteria);
       
       propagate_rule_updates_to_pipelined(
-          imsi, session->get_config(), rules_to_activate, rules_to_deactivate,
-          false);
+          imsi, config, rules_to_activate, rules_to_deactivate, false);
 
       if (terminate_on_wallet_exhaust() && is_wallet_exhausted(*session)) {
         subscribers_to_terminate.insert(imsi);
@@ -1242,6 +1248,12 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
         imsis_with_revalidation.insert(imsi);
         schedule_revalidation(
             imsi, *session, revalidation_time, update_criteria);
+      }
+
+      if (config.common_context.rat_type() == TGPP_LTE) {
+        const auto update = session->get_dedicated_bearer_updates(
+            rules_to_activate, rules_to_deactivate, update_criteria);
+        propagate_bearer_updates_to_mme(update);
       }
     }
   }
@@ -1446,7 +1458,7 @@ void LocalEnforcer::init_policy_reauth_for_session(
     start_session_termination(imsi, session, true, update_criteria);
     return;
   }
-  if (!session->is_radius_cwf_session()) {
+  if (session->get_config().common_context.rat_type() == TGPP_LTE) {
     create_bearer(
         activate_success, session, request, rules_to_activate.dynamic_rules);
   }
@@ -1629,7 +1641,6 @@ bool LocalEnforcer::revalidation_required(
   return it != event_triggers.end();
 }
 
-// Todo support scheduling revalidation for different sessions for a IMSI
 void LocalEnforcer::schedule_revalidation(
     const std::string& imsi, SessionState& session,
     const google::protobuf::Timestamp& revalidation_time,
@@ -1748,9 +1759,16 @@ void LocalEnforcer::create_bearer(
   auto default_qci = QCI(lte_context.qos_info().qos_class_id());
   if (request.qos_info().qci() != default_qci) {
     MLOG(MDEBUG) << "QCI sent in RAR is different from default QCI";
-    spgw_client_->create_dedicated_bearer(
-        request.imsi(), config.common_context.ue_ipv4(),
-        lte_context.bearer_id(), dynamic_rules);
+    CreateBearerRequest req;
+    req.mutable_sid()->CopyFrom(config.common_context.sid());
+    req.set_ip_addr(config.common_context.ue_ipv4());
+    req.set_link_bearer_id(lte_context.bearer_id());
+
+    auto req_policy_rules = req.mutable_policy_rules();
+    for (const auto& rule : dynamic_rules) {
+      req_policy_rules->Add()->CopyFrom(rule);
+    }
+    spgw_client_->create_dedicated_bearer(req);
   }
   return;
 }
@@ -1758,29 +1776,40 @@ void LocalEnforcer::create_bearer(
 void LocalEnforcer::update_ipfix_flow(
     const std::string& imsi, const SessionConfig& config,
     const uint64_t pdp_start_time) {
-    MLOG(MDEBUG) << "Updating IPFIX flow for subscriber " << imsi;
-    SubscriberID sid;
-    sid.set_id(imsi);
-    std::string apn_mac_addr;
-    std::string apn_name;
-    if (!parse_apn(config.common_context.apn(), apn_mac_addr, apn_name)) {
-      MLOG(MWARNING) << "Failed mac/name parsiong for apn " << config.common_context.apn();
-      apn_mac_addr = "";
-      apn_name     = config.common_context.apn();
-    }
+  MLOG(MDEBUG) << "Updating IPFIX flow for subscriber " << imsi;
+  SubscriberID sid;
+  sid.set_id(imsi);
+  std::string apn_mac_addr;
+  std::string apn_name;
+  if (!parse_apn(config.common_context.apn(), apn_mac_addr, apn_name)) {
+    MLOG(MWARNING) << "Failed mac/name parsiong for apn "
+                   << config.common_context.apn();
+    apn_mac_addr = "";
+    apn_name     = config.common_context.apn();
+  }
 
-    // MacAddr is only relevant for WLAN
-    const auto& rat_specific = config.rat_specific_context;
-    std::string ue_mac_addr = "11:11:11:11:11:11";
-    if (rat_specific.has_wlan_context()) {
-      ue_mac_addr = rat_specific.wlan_context().mac_addr();
-    }
-    bool update_ipfix_flow_success = pipelined_client_->update_ipfix_flow(
-        sid, ue_mac_addr, config.common_context.msisdn(), apn_mac_addr,
-        apn_name, pdp_start_time);
-    if (!update_ipfix_flow_success) {
-      MLOG(MERROR) << "Failed to update IPFIX flow for subscriber " << imsi;
-    }
+  // MacAddr is only relevant for WLAN
+  const auto& rat_specific = config.rat_specific_context;
+  std::string ue_mac_addr  = "11:11:11:11:11:11";
+  if (rat_specific.has_wlan_context()) {
+    ue_mac_addr = rat_specific.wlan_context().mac_addr();
+  }
+  bool update_ipfix_flow_success = pipelined_client_->update_ipfix_flow(
+      sid, ue_mac_addr, config.common_context.msisdn(), apn_mac_addr, apn_name,
+      pdp_start_time);
+  if (!update_ipfix_flow_success) {
+    MLOG(MERROR) << "Failed to update IPFIX flow for subscriber " << imsi;
+  }
+}
+
+void LocalEnforcer::propagate_bearer_updates_to_mme(
+    const BearerUpdate& updates) {
+  if (updates.needs_creation) {
+    spgw_client_->create_dedicated_bearer(updates.create_req);
+  }
+  if (updates.needs_deletion) {
+    spgw_client_->delete_dedicated_bearer(updates.delete_req);
+  }
 }
 
 void LocalEnforcer::handle_cwf_roaming(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -209,10 +209,6 @@ class LocalEnforcer {
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
  private:
-  struct RulesToProcess {
-    std::vector<std::string> static_rules;
-    std::vector<PolicyRule> dynamic_rules;
-  };
   struct RedirectInstallInfo {
     std::string imsi;
     std::string session_id;
@@ -542,6 +538,8 @@ class LocalEnforcer {
   bool terminate_on_wallet_exhaust();
 
   void schedule_termination(std::unordered_set<std::string>& imsis);
+
+  void propagate_bearer_updates_to_mme(const BearerUpdate& updates);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -184,6 +184,11 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
       }
     }
   }
+  // QoS Management
+  if (uc.is_bearer_mapping_updated) {
+    bearer_id_by_policy_ = uc.bearer_id_by_policy;
+  }
+
   // Config
   if (uc.is_config_updated) {
     config_ = uc.updated_config;
@@ -1335,6 +1340,30 @@ void SessionState::set_session_level_key(const std::string new_key) {
   session_level_key_ = new_key;
 }
 
+BearerUpdate SessionState::get_dedicated_bearer_updates(
+    RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+    SessionStateUpdateCriteria& uc) {
+  BearerUpdate update;
+  // Rule Installs
+  for (const auto& rule_id : rules_to_activate.static_rules) {
+    update_bearer_creation_req(STATIC, rule_id, config_, update);
+  }
+  for (const auto& rule : rules_to_activate.dynamic_rules) {
+    const auto& rule_id = rule.id();
+    update_bearer_creation_req(DYNAMIC, rule_id, config_, update);
+  }
+
+  // Rule Removals
+  for (const auto& rule_id : rules_to_deactivate.static_rules) {
+    update_bearer_deletion_req(STATIC, rule_id, config_, update, uc);
+  }
+  for (const auto& rule : rules_to_deactivate.dynamic_rules) {
+    const auto& rule_id = rule.id();
+    update_bearer_deletion_req(DYNAMIC, rule_id, config_, update, uc);
+  }
+  return update;
+}
+
 SessionCreditUpdateCriteria* SessionState::get_monitor_uc(
     const std::string& key, SessionStateUpdateCriteria& uc) {
   if (uc.monitor_credit_map.find(key) == uc.monitor_credit_map.end()) {
@@ -1419,5 +1448,86 @@ bool SessionState::is_credit_state_redirected(
     return false;
   }
   return it->second->service_state == SERVICE_REDIRECTED;
+}
+
+// QoS/Bearer Management
+bool SessionState::policy_has_qos(
+    const PolicyType policy_type, const std::string& rule_id,
+    PolicyRule* rule_out) {
+  if (policy_type == STATIC) {
+    bool exists = static_rules_.get_rule(rule_id, rule_out);
+    return exists && rule_out->has_qos();
+  }
+  if (policy_type == DYNAMIC) {
+    bool exists = dynamic_rules_.get_rule(rule_id, rule_out);
+    return exists && rule_out->has_qos();
+  }
+  return false;
+}
+
+void SessionState::update_bearer_creation_req(
+    const PolicyType policy_type, const std::string& rule_id,
+    const SessionConfig& config, BearerUpdate& update) {
+  if (!config.rat_specific_context.has_lte_context()) {
+    return;
+  }
+  if (bearer_id_by_policy_.find(PolicyID(policy_type, rule_id)) !=
+      bearer_id_by_policy_.end()) {
+    // Policy already has a bearer
+    return;
+  }
+  PolicyRule rule;
+  if (!policy_has_qos(policy_type, rule_id, &rule)) {
+    // Only create a bearer for policies with QoS
+    return;
+  }
+  auto default_qci = FlowQos_Qci(
+      config.rat_specific_context.lte_context().qos_info().qos_class_id());
+  if (rule.qos().qci() == default_qci) {
+    // This QCI is already covered by the default bearer
+    return;
+  }
+
+  // If it is first time filling in the CreationReq, fill in other info
+  if (!update.needs_creation) {
+    update.needs_creation = true;
+    update.create_req.mutable_sid()->CopyFrom(config.common_context.sid());
+    update.create_req.set_ip_addr(config.common_context.ue_ipv4());
+    update.create_req.set_link_bearer_id(
+        config.rat_specific_context.lte_context().bearer_id());
+  }
+  update.create_req.mutable_policy_rules()->Add()->CopyFrom(rule);
+  // We will add the new policyID to bearerID association, once we receive a
+  // message from SGW.
+}
+
+void SessionState::update_bearer_deletion_req(
+    const PolicyType policy_type, const std::string& rule_id,
+    const SessionConfig& config, BearerUpdate& update,
+    SessionStateUpdateCriteria& uc) {
+  if (!config.rat_specific_context.has_lte_context()) {
+    return;
+  }
+  if (bearer_id_by_policy_.find(PolicyID(policy_type, rule_id)) ==
+      bearer_id_by_policy_.end()) {
+    return;
+  }
+
+  // map change needs to be propagated to the store
+  bearer_id_by_policy_.erase(PolicyID(policy_type, rule_id));
+  uc.is_bearer_mapping_updated = true;
+  uc.bearer_id_by_policy       = bearer_id_by_policy_;
+
+  // If it is first time filling in the DeletionReq, fill in other info
+  if (!update.needs_deletion) {
+    update.needs_deletion = true;
+    auto& req             = update.delete_req;
+    req.mutable_sid()->CopyFrom(config.common_context.sid());
+    req.set_ip_addr(config.common_context.ue_ipv4());
+    req.set_link_bearer_id(
+        config.rat_specific_context.lte_context().bearer_id());
+  }
+  update.delete_req.mutable_eps_bearer_ids()->Add(
+      bearer_id_by_policy_[PolicyID(policy_type, rule_id)]);
 }
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include <lte/protos/session_manager.grpc.pb.h>
+#include <lte/protos/spgw_service.grpc.pb.h>
 
 #include "RuleStore.h"
 #include "SessionReporter.h"
@@ -31,6 +32,20 @@ typedef std::unordered_map<CreditKey, std::unique_ptr<ChargingGrant>,
                  decltype(&ccHash), decltype(&ccEqual)> CreditMap;
 typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
 static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
+
+struct RulesToProcess {
+  std::vector<std::string> static_rules;
+  std::vector<PolicyRule> dynamic_rules;
+};
+
+struct BearerUpdate {
+  bool needs_creation;
+  CreateBearerRequest create_req;  // only valid if needs_creation is true
+  bool needs_deletion;
+  DeleteBearerRequest delete_req;  // only valid if needs_deletion is true
+  BearerUpdate() : needs_creation(false), needs_deletion(false) {}
+};
+
 /**
  * SessionState keeps track of a current UE session in the PCEF, recording
  * usage and allowance for all charging keys
@@ -56,8 +71,7 @@ class SessionState {
   SessionState(
       const std::string& imsi, const std::string& session_id,
       const SessionConfig& cfg, StaticRuleStore& rule_store,
-      const magma::lte::TgppContext& tgpp_context,
-      uint64_t pdp_start_time);
+      const magma::lte::TgppContext& tgpp_context, uint64_t pdp_start_time);
 
   SessionState(
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
@@ -337,11 +351,26 @@ class SessionState {
       const std::string& key, Monitor monitor, SessionStateUpdateCriteria& uc);
 
   bool reset_reporting_monitor(
-    const std::string &key, SessionStateUpdateCriteria &uc);
+      const std::string& key, SessionStateUpdateCriteria& uc);
 
   void set_session_level_key(const std::string new_key);
 
   bool apply_update_criteria(SessionStateUpdateCriteria& uc);
+
+  // QoS Management
+  /**
+   * get_dedicated_bearer_updates processes the two rule update inputs and
+   * produces a BearerUpdate based on whether a bearer has to be create/deleted.
+   * @param rules_to_activate
+   * @param rules_to_deactivate
+   * @param uc: update criteria needs to be updated if the bearer mapping is
+   * modified
+   * @return BearerUpdate with Create/DeleteBearerRequest
+   */
+  BearerUpdate get_dedicated_bearer_updates(
+      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+      SessionStateUpdateCriteria& uc);
+
  private:
   std::string imsi_;
   std::string session_id_;
@@ -380,14 +409,17 @@ class SessionState {
   // reschedule triggers
   google::protobuf::Timestamp revalidation_time_;
   /*
-  * ChargingCreditPool manages a pool of credits for OCS-based charging. It is
-  * keyed by rating groups & service Identity (uint32, [uint32]) and receives
-  * CreditUpdateResponses to update
-  * credit
-  */
+   * ChargingCreditPool manages a pool of credits for OCS-based charging. It is
+   * keyed by rating groups & service Identity (uint32, [uint32]) and receives
+   * CreditUpdateResponses to update
+   * credit
+   */
   CreditMap credit_map_;
   MonitorMap monitor_map_;
   std::string session_level_key_;
+
+  // PolicyID->DedicatedBearerID used for 4G bearer/QoS management
+  BearerIDByPolicyID bearer_id_by_policy_;
 
  private:
   /**
@@ -480,13 +512,52 @@ class SessionState {
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 
   void get_event_trigger_updates(
-    UpdateSessionRequest& update_request_out,
-    std::vector<std::unique_ptr<ServiceAction>>* actions_out,
-    SessionStateUpdateCriteria& update_criteria);
+      UpdateSessionRequest& update_request_out,
+      std::vector<std::unique_ptr<ServiceAction>>* actions_out,
+      SessionStateUpdateCriteria& update_criteria);
 
   bool is_static_rule_scheduled(const std::string& rule_id);
 
   bool is_dynamic_rule_scheduled(const std::string& rule_id);
+
+  /**
+   * Check if a new bearer has to be created for the given policy. If a creation
+   * is needed, fill in the BearerUpdate with required info.
+   * @param policy_type
+   * @param rule_id
+   * @param update
+   */
+  void update_bearer_creation_req(
+      const PolicyType policy_type, const std::string& rule_id,
+      const SessionConfig& config, BearerUpdate& update);
+
+  /**
+   * Check if a bearer has to be deleted for the given policy. If a deletion is
+   * needed, fill in the BearerUpdate with required info.
+   * @param policy_type
+   * @param rule_id
+   * @param update
+   */
+  void update_bearer_deletion_req(
+      const PolicyType policy_type, const std::string& rule_id,
+      const SessionConfig& config, BearerUpdate& update,
+      SessionStateUpdateCriteria& uc);
+
+  /**
+   * Set bearer_id_by_policy_ to the input
+   * @param bearer_id_by_policy
+   */
+  void set_bearer_map(BearerIDByPolicyID bearer_id_by_policy) {
+    bearer_id_by_policy_ = bearer_id_by_policy;
+  }
+  /**
+   * @param policy_type
+   * @param rule_id
+   * @return true if the policy definition includes a QoS field
+   */
+  bool policy_has_qos(
+      const PolicyType policy_type, const std::string& rule_id,
+      PolicyRule* rule_out);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SpgwServiceClient.cpp
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.cpp
@@ -15,7 +15,6 @@
 #include "ServiceRegistrySingleton.h"
 #include "magma_logging.h"
 
-// using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace {  // anonymous
@@ -78,24 +77,41 @@ bool AsyncSpgwServiceClient::delete_default_bearer(
 }
 
 bool AsyncSpgwServiceClient::delete_dedicated_bearer(
-    const std::string& imsi, const std::string& apn_ip_addr,
-    const uint32_t linked_bearer_id,
-    const std::vector<uint32_t>& eps_bearer_ids) {
-  MLOG(MINFO) << "Deleting dedicated bearer IMSI: " << imsi << " APN IP addr "
-              << apn_ip_addr << " Bearer ID " << linked_bearer_id;
-  return delete_bearer(imsi, apn_ip_addr, linked_bearer_id, eps_bearer_ids);
+    const magma::DeleteBearerRequest& request) {
+  std::string bearer_ids = "{";
+  for (const auto& bearer_id : request.eps_bearer_ids()) {
+    bearer_ids += bearer_id + " ";
+  }
+  bearer_ids += "}";
+  MLOG(MINFO) << "Deleting dedicated bearers for " << request.sid().id() << ", "
+              << request.ip_addr()
+              << ", default bearer id=" << request.link_bearer_id()
+              << ", dedicated bearer ids=" << bearer_ids;
+  delete_bearer_rpc(request, [request](Status status, DeleteBearerResult resp) {
+    if (!status.ok()) {
+      // only log error for now
+      MLOG(MERROR) << "Could not delete bearer" << request.sid().id() << ", "
+                   << request.ip_addr() << ": " << status.error_message();
+    }
+  });
+  return true;
 }
 
 bool AsyncSpgwServiceClient::create_dedicated_bearer(
-    const std::string& imsi, const std::string& apn_ip_addr,
-    const uint32_t linked_bearer_id, const std::vector<PolicyRule>& flows) {
-  auto req = create_add_bearer_req(imsi, apn_ip_addr, linked_bearer_id, flows);
-  MLOG(MINFO) << "creating dedicated bearer " << imsi << apn_ip_addr;
+    const magma::CreateBearerRequest& request) {
+  std::string rule_ids = "{";
+  for (const auto& rule : request.policy_rules()) {
+    rule_ids += rule.id() + " ";
+  }
+  rule_ids += "}";
+  MLOG(MINFO) << "Creating dedicated bearers for " << request.sid().id() << ", "
+              << request.ip_addr() << ", rules=" << rule_ids;
   create_dedicated_bearer_rpc(
-      req, [imsi, apn_ip_addr](Status status, CreateBearerResult resp) {
+      request, [request](Status status, CreateBearerResult resp) {
         if (!status.ok()) {
-          MLOG(MERROR) << "Could not create dedicated bearer" << imsi
-                       << apn_ip_addr << ": " << status.error_message();
+          MLOG(MERROR) << "Could not create dedicated bearer"
+                       << request.sid().id() << ", " << request.ip_addr()
+                       << ": " << status.error_message();
         }
       });
   return true;

--- a/lte/gateway/c/session_manager/SpgwServiceClient.h
+++ b/lte/gateway/c/session_manager/SpgwServiceClient.h
@@ -43,31 +43,19 @@ public:
 
   /**
    * Delete a dedicated bearer
-   * @param imsi - msi to identify a UE
-   * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param linked_bearer_id - identifier for link bearer
-   * @param eps_bearer_ids - ids of bearers to delete
-   * @return true if the operation was successful
+   * @param DeleteBearerRequest
+   * @return always returns true
    */
-  virtual bool
-  delete_dedicated_bearer(const std::string &imsi,
-                          const std::string &apn_ip_addr,
-                          const uint32_t linked_bearer_id,
-                          const std::vector<uint32_t> &eps_bearer_ids) = 0;
+  virtual bool delete_dedicated_bearer(
+      const magma::DeleteBearerRequest& request) = 0;
 
   /**
    * Create a dedicated bearer
-   * @param imsi - msi to identify a UE
-   * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param linked_bearer_id - identifier for link bearer
-   * @param flows - flow information required for a dedicated bearer
-   * @return true if the operation was successful
+   * @param CreateBearerRequest
+   * @return always returns true
    */
-  virtual bool
-  create_dedicated_bearer(const std::string &imsi,
-                          const std::string &apn_ip_addr,
-                          const uint32_t linked_bearer_id,
-                          const std::vector<PolicyRule> &flows) = 0;
+  virtual bool create_dedicated_bearer(
+      const magma::CreateBearerRequest& request) = 0;
 };
 
 /**
@@ -92,45 +80,34 @@ public:
 
   /**
    * Delete a dedicated bearer
-   * @param imsi - msi to identify a UE
-   * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param linked_bearer_id - identifier for link bearer
-   * @param flows - flow information required for a dedicated bearer
-   * @return true if the operation was successful
+   * @param DeleteBearerRequest
+   * @return always returns true
    */
-  bool delete_dedicated_bearer(const std::string &imsi,
-                               const std::string &apn_ip_addr,
-                               const uint32_t linked_bearer_id,
-                               const std::vector<uint32_t> &eps_bearer_ids);
+  bool delete_dedicated_bearer(const magma::DeleteBearerRequest& request);
 
   /**
    * Create a dedicated bearer
-   * @param imsi - msi to identify a UE
-   * @param apn_ip_addr - imsi and apn_ip_addrs identify a default bearer
-   * @param linked_bearer_id - identifier for link bearer
-   * @param flows - flow information required for a dedicated bearer
-   * @return true if the operation was successful
+   * @param CreateBearerRequest
+   * @return always returns true
    */
-  bool create_dedicated_bearer(const std::string &imsi,
-                               const std::string &apn_ip_addr,
-                               const uint32_t linked_bearer_id,
-                               const std::vector<PolicyRule> &flows);
+  bool create_dedicated_bearer(const magma::CreateBearerRequest& request);
 
-private:
-  static const uint32_t RESPONSE_TIMEOUT = 6; // seconds
+ private:
+  static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
   std::unique_ptr<SpgwService::Stub> stub_;
 
-private:
-  bool delete_bearer(const std::string &imsi, const std::string &apn_ip_addr,
-                     const uint32_t linked_bearer_id,
-                     const std::vector<uint32_t> &eps_bearer_ids);
+ private:
+  bool delete_bearer(
+      const std::string& imsi, const std::string& apn_ip_addr,
+      const uint32_t linked_bearer_id,
+      const std::vector<uint32_t>& eps_bearer_ids);
 
-  void
-  delete_bearer_rpc(const DeleteBearerRequest &request,
-                    std::function<void(Status, DeleteBearerResult)> callback);
+  void delete_bearer_rpc(
+      const DeleteBearerRequest& request,
+      std::function<void(Status, DeleteBearerResult)> callback);
 
   void create_dedicated_bearer_rpc(
-      const CreateBearerRequest &request,
+      const CreateBearerRequest& request,
       std::function<void(Status, CreateBearerResult)> callback);
 };
 

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -58,6 +58,7 @@ SessionStateUpdateCriteria get_default_update_criteria() {
       CreditKey, SessionCreditUpdateCriteria, decltype(&ccHash),
       decltype(&ccEqual)>(4, &ccHash, &ccEqual);
   uc.is_session_level_key_updated = false;
+  uc.is_bearer_mapping_updated = false;
   return uc;
 }
 
@@ -324,6 +325,34 @@ std::string serialize_pending_event_triggers(
   return serialized;
 }
 
+BearerIDByPolicyID deserialize_bearer_id_by_policy(std::string& serialized) {
+  auto folly_serialized    = folly::StringPiece(serialized);
+  folly::dynamic marshaled = folly::parseJson(folly_serialized);
+
+  auto stored = BearerIDByPolicyID{};
+  for (auto& bearer_id_by_policy : marshaled) {
+    PolicyType policy_type = PolicyType(bearer_id_by_policy["type"].getInt());
+    std::string rule_id    = bearer_id_by_policy["rule_id"].getString();
+    stored[PolicyID(policy_type, rule_id)] =
+        static_cast<uint32_t>(bearer_id_by_policy["bearer_id"].getInt());
+  }
+  return stored;
+}
+
+std::string serialize_bearer_id_by_policy(BearerIDByPolicyID bearer_map) {
+  folly::dynamic marshaled = folly::dynamic::array;
+
+  for (auto& pair : bearer_map) {
+    folly::dynamic bearer_id_by_policy = folly::dynamic::object;
+    bearer_id_by_policy["type"] = static_cast<int>(pair.first.policy_type);
+    bearer_id_by_policy["rule_id"]   = pair.first.rule_id;
+    bearer_id_by_policy["bearer_id"] = static_cast<int>(pair.second);
+    marshaled.push_back(bearer_id_by_policy);
+  }
+  std::string serialized = folly::toJson(marshaled);
+  return serialized;
+}
+
 std::string serialize_stored_session(StoredSessionState& stored) {
   folly::dynamic marshaled = folly::dynamic::object;
   marshaled["fsm_state"]   = static_cast<int>(stored.fsm_state);
@@ -348,6 +377,9 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   std::string revalidation_time;
   stored.revalidation_time.SerializeToString(&revalidation_time);
   marshaled["revalidation_time"] = revalidation_time;
+
+  marshaled["bearer_id_by_policy"] =
+      serialize_bearer_id_by_policy(stored.bearer_id_by_policy);
 
   folly::dynamic static_rule_ids = folly::dynamic::array;
   for (const auto& rule_id : stored.static_rule_ids) {
@@ -401,6 +433,9 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
   stored.revalidation_time      = revalidation_time;
   stored.pending_event_triggers = deserialize_pending_event_triggers(
       marshaled["pending_event_triggers"].getString());
+
+  stored.bearer_id_by_policy = deserialize_bearer_id_by_policy(
+      marshaled["bearer_id_by_policy"].getString());
 
   magma::lte::TgppContext tgpp_context;
   tgpp_context.ParseFromString(marshaled["tgpp_context"].getString());

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -88,4 +88,10 @@ MATCHER_P(CheckEventType, expectedEventType, "") {
   return (arg.event_type() == expectedEventType);
 }
 
+MATCHER_P2(CheckCreateBearerReq, imsi, rule_count, "") {
+  auto request = static_cast<const CreateBearerRequest>(arg);
+  return request.sid().id() == imsi &&
+         request.policy_rules().size() == rule_count;
+}
+
 };  // namespace magma

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -241,20 +241,15 @@ class MockSpgwServiceClient : public SpgwServiceClient {
 public:
   MockSpgwServiceClient() {
     ON_CALL(*this, delete_default_bearer(_, _, _)).WillByDefault(Return(true));
-    ON_CALL(*this, delete_dedicated_bearer(_, _, _, _))
-        .WillByDefault(Return(true));
-    ON_CALL(*this, create_dedicated_bearer(_, _, _, _))
-        .WillByDefault(Return(true));
+    ON_CALL(*this, delete_dedicated_bearer(_)).WillByDefault(Return(true));
+    ON_CALL(*this, create_dedicated_bearer(_)).WillByDefault(Return(true));
   }
-  MOCK_METHOD3(delete_default_bearer,
-               bool(const std::string &, const std::string &, const uint32_t));
+  MOCK_METHOD3(
+      delete_default_bearer,
+      bool(const std::string&, const std::string&, const uint32_t));
 
-  MOCK_METHOD4(delete_dedicated_bearer,
-               bool(const std::string &, const std::string &, const uint32_t,
-                    const std::vector<uint32_t> &));
-  MOCK_METHOD4(create_dedicated_bearer,
-               bool(const std::string &, const std::string &, const uint32_t,
-                    const std::vector<PolicyRule> &));
+  MOCK_METHOD1(delete_dedicated_bearer, bool(const DeleteBearerRequest&));
+  MOCK_METHOD1(create_dedicated_bearer, bool(const CreateBearerRequest&));
 };
 
 class MockEventsReporter : public EventsReporter {

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -102,6 +102,13 @@ class StoredStateTest : public ::testing::Test {
     return stored;
   }
 
+  BearerIDByPolicyID get_bearer_id_by_policy() {
+    BearerIDByPolicyID stored;
+    stored[PolicyID(DYNAMIC, "rule1")] = 32;
+    stored[PolicyID(STATIC, "rule1")]  = 64;
+    return stored;
+  }
+
   StoredSessionState get_stored_session() {
     StoredSessionState stored;
 
@@ -122,6 +129,8 @@ class StoredStateTest : public ::testing::Test {
 
     stored.pending_event_triggers[REVALIDATION_TIMEOUT] = READY;
     stored.revalidation_time.set_seconds(32);
+
+    stored.bearer_id_by_policy = get_bearer_id_by_policy();
 
     stored.request_number = 1;
 
@@ -161,6 +170,20 @@ TEST_F(StoredStateTest, test_stored_final_action_info) {
   EXPECT_EQ(
       deserialized.redirect_server.redirect_server_address(),
       "redirect_server_address");
+}
+
+TEST_F(StoredStateTest, test_stored_bearer_id_by_policy) {
+  auto stored       = get_bearer_id_by_policy();
+  auto serialized   = serialize_bearer_id_by_policy(stored);
+  auto deserialized = deserialize_bearer_id_by_policy(serialized);
+  EXPECT_EQ(stored[PolicyID(DYNAMIC, "rule1")], 32);
+  EXPECT_EQ(stored.size(), deserialized.size());
+  EXPECT_EQ(
+      stored[PolicyID(DYNAMIC, "rule1")],
+      deserialized[PolicyID(DYNAMIC, "rule1")]);
+  EXPECT_EQ(
+      stored[PolicyID(STATIC, "rule1")],
+      deserialized[PolicyID(STATIC, "rule1")]);
 }
 
 TEST_F(StoredStateTest, test_stored_session_credit) {
@@ -279,21 +302,24 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(stored_monitor.credit.buckets[ALLOWED_TOTAL], 54321);
   EXPECT_EQ(stored_monitor.level, MonitoringLevel::PCC_RULE_LEVEL);
 
-  EXPECT_EQ(stored.imsi, "IMSI1");
   EXPECT_EQ(stored.pdp_start_time, 12345);
-  EXPECT_EQ(stored.session_id, "session_id");
+  EXPECT_EQ(deserialized.imsi, "IMSI1");
+  EXPECT_EQ(deserialized.session_id, "session_id");
   EXPECT_EQ(
-      stored.subscriber_quota_state, SubscriberQuotaUpdate_Type_VALID_QUOTA);
-  EXPECT_EQ(stored.fsm_state, SESSION_RELEASED);
+      deserialized.subscriber_quota_state,
+      SubscriberQuotaUpdate_Type_VALID_QUOTA);
+  EXPECT_EQ(deserialized.fsm_state, SESSION_RELEASED);
 
-  EXPECT_EQ(stored.tgpp_context.gx_dest_host(), "gx");
-  EXPECT_EQ(stored.tgpp_context.gy_dest_host(), "gy");
+  EXPECT_EQ(deserialized.tgpp_context.gx_dest_host(), "gx");
+  EXPECT_EQ(deserialized.tgpp_context.gy_dest_host(), "gy");
 
-  EXPECT_EQ(stored.pending_event_triggers.size(), 1);
-  EXPECT_EQ(stored.pending_event_triggers[REVALIDATION_TIMEOUT], READY);
-  EXPECT_EQ(stored.revalidation_time.seconds(), 32);
+  EXPECT_EQ(deserialized.pending_event_triggers.size(), 1);
+  EXPECT_EQ(deserialized.pending_event_triggers[REVALIDATION_TIMEOUT], READY);
+  EXPECT_EQ(deserialized.revalidation_time.seconds(), 32);
 
-  EXPECT_EQ(stored.request_number, 1);
+  EXPECT_EQ(deserialized.bearer_id_by_policy.size(), 2);
+
+  EXPECT_EQ(deserialized.request_number, 1);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR includes changes needed to add dedicated bearer lifecycle management in SessionD. 
* Added a `QoSManager` class which maintains a map from PolicyID to dedicated bearer ID. It has various interfaces exposed so that given a policyID, we can determine whether a bearer needs to be created or deleted. 
* This object is maintained for every session by SessionState. SessionState exposes a public endpoint `get_dedicated_bearer_updates` that can be called by LocalEnforcer. LocalEnforcer will gather this info on every session creation / update and send a request to MME. Once we have the PolicyDB->SessionD rule modification endpoint complete, we will also do a similar thing in that handler.
* I've modified the `create_dedicated_bearer` and `delete_dedicated_bearer` interfaces to just take in the Create/DeleteBearerRequest, instead of individual fields. This makes the logic slightly cleaner.
* Other necessary changes in the serialization/deserialization of the map to support the stateless feature for this.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF integ test
S1AP tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
