### PR TITLE
[docs][lte] Updating UE metering doc to include ip_proto param in policy rule config

### DIFF
--- a/docs/readmes/orc8r/ue_metering.md
+++ b/docs/readmes/orc8r/ue_metering.md
@@ -79,12 +79,14 @@ policy to the subscriber you wish to meter for.
       "action": "PERMIT",
       "match": {
         "direction": "UPLINK",
+        "ip_proto": "IPPROTO_IP"
       }
     },
     {
       "action": "PERMIT",
       "match": {
         "direction": "DOWNLINK",
+        "ip_proto": "IPPROTO_IP"
       }
     }
   ],


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Adding IPPROTO entry to policy rule json config on the UE metering docs as this is a required parameter for the configuration

## Test Plan

- tested docusaurus locally 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
