### PR TITLE
pipelined: Config ARP cache for upstream APN vlan

### DIFF
--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
@@ -30,7 +30,7 @@ ip netns add "$prefix"_dhcp_srv
 
 ip link set dev  "$prefix"_port1 netns "$prefix"_dhcp_srv
 ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 "$ip_addr"
-ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 hw ether b2:a0:cc:85:80:7a
+ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 hw ether b2:a0:cc:85:80:$tag
 ip netns exec    "$prefix"_dhcp_srv   ip addr add $router_ip  dev "$prefix"_port1
 
 ip netns exec    "$prefix"_dhcp_srv   ifconfig  "$prefix"_port1 up

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -14,19 +14,19 @@ import ipaddress
 import threading
 
 from collections import namedtuple
-from ipaddress import IPv4Address
 
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 
 from scapy.arch import get_if_hwaddr, get_if_addr
-from scapy.data import ETHER_BROADCAST, ETH_P_ARP
+from scapy.data import ETHER_BROADCAST, ETH_P_ALL
 from scapy.error import Scapy_Exception
-from scapy.layers.l2 import ARP, Ether
+from scapy.layers.l2 import ARP, Ether, Dot1Q
 from scapy.sendrecv import srp1
 
 from .base import MagmaController
 from magma.pipelined.mobilityd_client import get_mobilityd_gw_info, \
     set_mobilityd_gw_info
+from lte.protos.mobilityd_pb2 import IPAddress
 
 from magma.pipelined.app.li_mirror import LIMirrorController
 from magma.pipelined.openflow import flows
@@ -91,7 +91,7 @@ class InOutController(MagmaController):
         self._egress_tbl_num = self._service_manager.get_table_num(EGRESS)
         # following fields are only used in Non Nat config
         self._gw_mac_monitor = None
-        self._current_upstream_mac = ""
+        self._current_upstream_mac_map = {}   # maps vlan to upstream gw mac
         self._datapath = None
 
     def _get_config(self, config_dict):
@@ -123,13 +123,12 @@ class InOutController(MagmaController):
             enable_nat=enable_nat,
             non_mat_gw_probe_frequency=non_mat_gw_probe_freq,
             non_nat_arp_egress_port=non_nat_arp_egress_port,
-            setup_type=setup_type,
-        )
+            setup_type=setup_type)
 
     def initialize_on_connect(self, datapath):
         self.delete_all_flows(datapath)
-        self._install_default_egress_flows(datapath)
         self._install_default_ingress_flows(datapath)
+        self._install_default_egress_flows(datapath)
         self._install_default_middle_flows(datapath)
         self._setup_non_nat_monitoring(datapath)
 
@@ -171,10 +170,13 @@ class InOutController(MagmaController):
                                   [], priority=flows.UE_FLOW_PRIORITY,
                                   output_port=self.config.mtr_port)
 
-    def _install_default_egress_flows(self, dp, mac_addr: str = ""):
+    def _install_default_egress_flows(self, dp, mac_addr: str = "", vlan: str = ""):
         """
         Egress table is the last table that a packet touches in the pipeline.
         Output downlink traffic to gtp port, uplink trafic to LOCAL
+        Args:
+            mac_addr: In Non NAT mode, this is upstream internet GW mac address
+            vlan: in multi APN this is vlan_id of the upstream network.
 
         Raises:
             MagmaOFError if any of the default flows fail to install.
@@ -183,20 +185,41 @@ class InOutController(MagmaController):
         flows.add_output_flow(dp, self._egress_tbl_num, downlink_match, [],
                               output_port=self.config.gtp_port)
 
-        uplink_match = MagmaMatch(direction=Direction.OUT)
+        if vlan != "":
+            vid = 0x1000 | int(vlan)
+            uplink_match = MagmaMatch(direction=Direction.OUT,
+                                      vlan_vid=(vid, vid))
+        else:
+            uplink_match = MagmaMatch(direction=Direction.OUT)
+
         actions = []
         # avoid resetting mac address on switch connect event.
         if mac_addr == "":
-            mac_addr = self._current_upstream_mac
+            mac_addr = self._current_upstream_mac_map.get(vlan, "")
+        if mac_addr == "" and self.config.enable_nat is False:
+            mac_addr = "ff:ff:ff:ff:ff:ff"
 
         if mac_addr != "":
             parser = dp.ofproto_parser
-            actions.append(parser.NXActionRegLoad2(dst='eth_dst', value=mac_addr))
+            actions.append(parser.NXActionRegLoad2(dst='eth_dst',
+                                                   value=mac_addr))
+            if self._current_upstream_mac_map.get(vlan, "") != mac_addr:
+                self.logger.info("Using GW: mac: %s match %s actions: %s",
+                                 mac_addr,
+                                 str(uplink_match.ryu_match),
+                                 str(actions))
 
-            self.logger.info("Using GW: %s actions: %s", mac_addr, str(actions))
-            self._current_upstream_mac = mac_addr
+                self._current_upstream_mac_map[vlan] = mac_addr
+
+        if vlan != "":
+            priority = flows.UE_FLOW_PRIORITY
+        elif mac_addr != "":
+            priority = flows.DEFAULT_PRIORITY
+        else:
+            priority = flows.MINIMUM_PRIORITY
 
         flows.add_output_flow(dp, self._egress_tbl_num, uplink_match,
+                              priority=priority,
                               actions=actions,
                               output_port=self._uplink_port)
 
@@ -262,7 +285,7 @@ class InOutController(MagmaController):
                                                  match, actions=actions, priority=flows.DEFAULT_PRIORITY,
                                                  resubmit_table=next_table)
 
-    def _get_gw_mac_address(self, ip: IPv4Address) -> str:
+    def _get_gw_mac_address(self, ip: IPAddress, vlan: str = "") -> str:
         try:
             gw_ip = ipaddress.ip_address(ip.address)
             self.logger.debug("sending arp via egress: %s",
@@ -274,11 +297,13 @@ class InOutController(MagmaController):
                 psrc = egress_port_ip
 
             pkt = Ether(dst=ETHER_BROADCAST, src=eth_mac_src)
+            if vlan != "":
+                pkt /= Dot1Q(vlan=int(vlan))
             pkt /= ARP(op="who-has", pdst=gw_ip, hwsrc=eth_mac_src, psrc=psrc)
             self.logger.debug("ARP Req pkt %s", pkt.show(dump=True))
 
             res = srp1(pkt,
-                       type=ETH_P_ARP,
+                       type=ETH_P_ALL,
                        iface=self.config.non_nat_arp_egress_port,
                        timeout=1,
                        verbose=0,
@@ -287,7 +312,16 @@ class InOutController(MagmaController):
 
             if res is not None:
                 self.logger.debug("ARP Res pkt %s", res.show(dump=True))
-                mac = res[ARP].hwsrc
+                if str(res[ARP].psrc) != str(gw_ip):
+                    self.logger.warning("Unexpected ARP response. %s", res.show(dump=True))
+                    return ""
+                if vlan:
+                    if Dot1Q in res and str(res[Dot1Q].vlan) == vlan:
+                        mac = res[ARP].hwsrc
+                    else:
+                        self.logger.warning("Unexpected ARP response. %s", res.show(dump=True))
+                else:
+                    mac = res[ARP].hwsrc
                 return mac
             else:
                 self.logger.debug("Got Null response")
@@ -302,25 +336,24 @@ class InOutController(MagmaController):
 
     def _monitor_and_update(self):
         while True:
-            updated_info = get_mobilityd_gw_info()
-            if updated_info:
-                cached_gw_info = updated_info
-            if cached_gw_info and cached_gw_info.ip:
-                latest_mac_addr = self._get_gw_mac_address(cached_gw_info.ip)
-                if len(latest_mac_addr) == 17 and \
-                        self._current_upstream_mac != latest_mac_addr:
-                    self._install_default_egress_flows(self._datapath, latest_mac_addr)
-                    cached_gw_info.mac = latest_mac_addr
-                    set_gw_info = cached_gw_info
-                    set_mobilityd_gw_info(set_gw_info)
-                elif latest_mac_addr != "":
-                    self.logger.warning("invalid mac: %s", latest_mac_addr)
-            else:
-                self.logger.warning("No default GW found.")
+            gw_info_list = get_mobilityd_gw_info()
+            for gw_info in gw_info_list:
+                if gw_info and gw_info.ip:
+                    latest_mac_addr = self._get_gw_mac_address(gw_info.ip, gw_info.vlan)
+                    self.logger.debug("mac [%s] for vlan %s", latest_mac_addr, gw_info.vlan)
+                    if latest_mac_addr == "":
+                        latest_mac_addr = gw_info.mac
 
-            self.logger.info("non_mat_gw_probe_frequency: %s mac: [%s]",
-                             self.config.non_mat_gw_probe_frequency,
-                             self._current_upstream_mac)
+                    self._install_default_egress_flows(self._datapath,
+                                                       latest_mac_addr,
+                                                       gw_info.vlan)
+                    if latest_mac_addr != "":
+                        set_mobilityd_gw_info(gw_info.ip,
+                                              latest_mac_addr,
+                                              gw_info.vlan)
+                else:
+                    self.logger.warning("No default GW found.")
+
             hub.sleep(self.config.non_mat_gw_probe_frequency)
 
     def _setup_non_nat_monitoring(self, datapath):

--- a/lte/gateway/python/magma/pipelined/mobilityd_client.py
+++ b/lte/gateway/python/magma/pipelined/mobilityd_client.py
@@ -5,20 +5,21 @@ All rights reserved.
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
 """
+from typing import List
 
 import grpc
 import logging
 
 from magma.common.service_registry import ServiceRegistry
 from orc8r.protos.common_pb2 import Void
-from lte.protos.mobilityd_pb2 import GWInfo
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceStub
+from lte.protos.mobilityd_pb2 import IPAddress, GWInfo
 
 SERVICE_NAME = "mobilityd"
 IPV4_ADDR_KEY = "ipv4_addr"
 
 
-def get_mobilityd_gw_info() -> GWInfo:
+def get_mobilityd_gw_info() -> List[GWInfo]:
     """
     Make RPC call to 'GetGatewayInfo' method of local mobilityD service
     """
@@ -31,15 +32,16 @@ def get_mobilityd_gw_info() -> GWInfo:
 
     client = MobilityServiceStub(chan)
     try:
-        return client.GetGatewayInfo(Void())
+        return client.ListGatewayInfo(Void())
     except grpc.RpcError as err:
         logging.error(
-            "GetGatewayInfoRequest error[%s] %s",
+            "ListGatewayInfo error[%s] %s",
             err.code(),
             err.details())
+        return []
 
 
-def set_mobilityd_gw_info(gwinfo: GWInfo):
+def set_mobilityd_gw_info(ip: IPAddress, mac: str, vlan: str):
     """
     Make RPC call to 'SetGatewayInfo' method of local mobilityD service
     """
@@ -52,9 +54,10 @@ def set_mobilityd_gw_info(gwinfo: GWInfo):
 
     client = MobilityServiceStub(chan)
     try:
+        gwinfo = GWInfo(ip=ip, mac=mac, vlan=vlan)
         client.SetGatewayInfo(gwinfo)
     except grpc.RpcError as err:
         logging.error(
-            "GetGatewayInfoRequest error[%s] %s",
+            "SetGatewayInfo error[%s] %s",
             err.code(),
             err.details())

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -34,6 +34,7 @@ from magma.pipelined.tests.app.exceptions import BadConfigError, \
 from magma.pipelined.tests.app.flow_query import RyuDirectFlowQuery
 from magma.pipelined.tests.app.start_pipelined import StartThread
 from magma.pipelined.app.base import global_epoch
+from magma.pipelined.openflow import flows
 
 """
 Pipelined test util functions can be used for testing pipelined, the usage of
@@ -414,7 +415,14 @@ def assert_bridge_snapshot_match(test_case: TestCase, bridge_name: str,
                                                     service_manager,
                                                     include_stats=include_stats)
 
-    def fail(err_msg: str):
+    def fail(err_msg: str, _bridge_name: str):
+        ofctl_cmd = "sudo ovs-ofctl dump-flows %s" % _bridge_name
+        p = subprocess.Popen([ofctl_cmd],
+                             stdout=subprocess.PIPE,
+                             shell=True)
+        ofctl_dump = p.stdout.read().decode("utf-8").strip()
+        logging.error("cmd ofctl_dump: %s", ofctl_dump)
+
         msg = 'Snapshot mismatch with error:\n' \
               '{}\n' \
               'To fix the error, update "{}" to the current snapshot:\n' \
@@ -428,17 +436,19 @@ def assert_bridge_snapshot_match(test_case: TestCase, bridge_name: str,
             for line in file:
                 prev_snapshot.append(line.rstrip('\n'))
     except OSError as e:
-        fail(str(e))
+        fail(str(e), bridge_name)
         return
     if set(current_snapshot) != set(prev_snapshot):
         fail('\n'.join(list(unified_diff(prev_snapshot, current_snapshot,
                                          fromfile='previous snapshot',
-                                         tofile='current snapshot'))))
+                                         tofile='current snapshot'))),
+             bridge_name)
 
 
 def wait_for_snapshots(bridge_name: str,
                        service_manager: ServiceManager,
-                       wait_time: int = 1, max_sleep_time: int = 20):
+                       wait_time: int = 1, max_sleep_time: int = 20,
+                       datapath=None):
     """
     Wait after checking ovs snapshot as new changes might still come in,
 
@@ -453,6 +463,8 @@ def wait_for_snapshots(bridge_name: str,
     sleep_time = 0
     old_snapshot = _get_current_bridge_snapshot(bridge_name, service_manager)
     while True:
+        if datapath:
+            flows.set_barrier(datapath)
         hub.sleep(wait_time)
 
         new_snapshot = _get_current_bridge_snapshot(bridge_name,
@@ -478,7 +490,9 @@ class SnapshotVerifier:
     def __init__(self, test_case: TestCase, bridge_name: str,
                  service_manager: ServiceManager,
                  snapshot_name: Optional[str] = None,
-                 include_stats: bool = True):
+                 include_stats: bool = True,
+                 max_sleep_time: int = 20,
+                 datapath=None):
         """
         These arguments are used to call assert_bridge_snapshot_match on exit.
 
@@ -495,6 +509,8 @@ class SnapshotVerifier:
         self._service_manager = service_manager
         self._snapshot_name = snapshot_name
         self._include_stats = include_stats
+        self._max_sleep_time = max_sleep_time
+        self._datapath = datapath
 
     def __enter__(self):
         pass
@@ -504,8 +520,16 @@ class SnapshotVerifier:
         Runs after finishing 'with' (Verify snapshot)
         """
         try:
-            wait_for_snapshots(self._bridge_name, self._service_manager)
+            wait_for_snapshots(self._bridge_name, self._service_manager,
+                               max_sleep_time=self._max_sleep_time,
+                               datapath=self._datapath)
         except WaitTimeExceeded as e:
+            ofctl_cmd = "sudo ovs-ofctl dump-flows %s".format(self._bridge_name)
+            p = subprocess.Popen([ofctl_cmd],
+                                 stdout=subprocess.PIPE,
+                                 shell=True)
+            ofctl_dump = p.stdout.read().decode("utf-8").strip()
+            logging.error("ofctl_dump: %s", ofctl_dump)
             TestCase().fail(e)
         assert_bridge_snapshot_match(self._test_case, self._bridge_name,
                                      self._service_manager,

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch.snapshot
@@ -3,5 +3,6 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x100b/0x100b actions=set_field:b2:a0:cc:85:80:11->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:ff:ff:ff:ff:ff:ff->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch2.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch2.snapshot
@@ -3,5 +3,7 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1015/0x1015 actions=set_field:b2:a0:cc:85:80:21->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1016/0x1016 actions=set_field:b2:a0:cc:85:80:22->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:ff:ff:ff:ff:ff:ff->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static1.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static1.snapshot
@@ -3,5 +3,7 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1016/0x1016 actions=set_field:22:33:44:55:66:77->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1015/0x1015 actions=set_field:b2:a0:cc:85:80:21->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:ff:ff:ff:ff:ff:ff->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static2.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static2.snapshot
@@ -3,5 +3,7 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1020/0x1020 actions=set_field:22:33:44:55:66:77->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x101f/0x101f actions=set_field:11:33:44:55:66:77->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:00:33:44:55:66:77->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -12,10 +12,14 @@ limitations under the License.
 """
 import ipaddress
 import subprocess
+import time
 import threading
 import unittest
 import warnings
 from concurrent.futures import Future
+import logging
+from typing import List
+from ryu.lib import hub
 
 from lte.protos.mobilityd_pb2 import IPAddress, GWInfo, IPBlock
 
@@ -33,18 +37,26 @@ from magma.pipelined.tests.pipelined_test_util import (
 
 from magma.pipelined.app import inout
 
-gw_info = GWInfo()
+gw_info_map = {}
+gw_info_lock = threading.RLock()  # re-entrant locks
 
 
-def mocked_get_mobilityd_gw_info() -> GWInfo:
-    global gw_info
-    return gw_info
+def mocked_get_mobilityd_gw_info() -> List[GWInfo]:
+    global gw_info_map
+    global gw_info_lock
+
+    with gw_info_lock:
+        return gw_info_map.values()
 
 
-def mocked_set_mobilityd_gw_info(updated_gw_info: GWInfo) -> GWInfo:
-    global gw_info
-    gw_info = updated_gw_info
+def mocked_set_mobilityd_gw_info(ip: IPAddress, mac: str, vlan: str):
+    global gw_info_map
+    global gw_info_lock
 
+    with gw_info_lock:
+        gw_info = GWInfo(ip=ip, mac=mac, vlan=vlan)
+        gw_info_map[vlan] = gw_info
+    
 
 class InOutNonNatTest(unittest.TestCase):
     BRIDGE = 'testing_br'
@@ -52,9 +64,10 @@ class InOutNonNatTest(unittest.TestCase):
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
     SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
-    UPLINK_BR = "up_inout_br0"
     NON_NAT_ARP_EGRESS_PORT = "tinouplink_p0"
+    UPLINK_BR = "up_inout_br0"
     DHCP_PORT = "tino_dhcp"
+    UPLINK_VLAN_SW = "vlan_inout"
 
     @classmethod
     def setup_uplink_br(cls):
@@ -67,10 +80,27 @@ class InOutNonNatTest(unittest.TestCase):
                            cls.NON_NAT_ARP_EGRESS_PORT,
                            cls.DHCP_PORT]
         subprocess.check_call(setup_uplink_br)
-        inout.get_mobilityd_gw_info = mocked_get_mobilityd_gw_info
-        inout.set_mobilityd_gw_info = mocked_set_mobilityd_gw_info
 
-    def setUp(self):
+    @classmethod
+    def _setup_vlan_network(cls, vlan: str):
+        setup_vlan_switch = cls.SCRIPT_PATH + "scripts/setup-uplink-vlan-sw.sh"
+        subprocess.check_call([setup_vlan_switch, cls.UPLINK_VLAN_SW, "inout"])
+
+        setup_uplink_br = [cls.SCRIPT_PATH + "scripts/setup-uplink-br.sh",
+                           cls.UPLINK_BR,
+                           "inout_ul_0",
+                           cls.DHCP_PORT]
+
+        subprocess.check_call(setup_uplink_br)
+        cls._setup_vlan(vlan)
+
+    @classmethod
+    def _setup_vlan(cls, vlan):
+        setup_vlan_switch = cls.SCRIPT_PATH + "scripts/setup-uplink-vlan-srv.sh"
+        subprocess.check_call([setup_vlan_switch, cls.UPLINK_VLAN_SW, vlan])
+
+    def setUpNetworkAndController(self, vlan: str = "",
+                                  non_nat_arp_egress_port: str = None):
         """
         Starts the thread which launches ryu apps
 
@@ -78,16 +108,29 @@ class InOutNonNatTest(unittest.TestCase):
         launch the ryu apps for testing pipelined. Gets the references
         to apps launched by using futures.
         """
+        global gw_info_map
+        gw_info_map.clear()
+        hub.sleep(2)
 
         cls = self.__class__
         super(InOutNonNatTest, cls).setUpClass()
-        warnings.simplefilter('ignore')
+        inout.get_mobilityd_gw_info = mocked_get_mobilityd_gw_info
+        inout.set_mobilityd_gw_info = mocked_set_mobilityd_gw_info
 
+        warnings.simplefilter('ignore')
         cls.setup_uplink_br()
+
+        if vlan != "":
+            cls._setup_vlan_network(vlan)
+
         cls.service_manager = create_service_manager([])
 
         inout_controller_reference = Future()
         testing_controller_reference = Future()
+
+        if non_nat_arp_egress_port is None:
+            non_nat_arp_egress_port = cls.DHCP_PORT
+
         test_setup = TestSetup(
             apps=[PipelinedController.InOut,
                   PipelinedController.Testing,
@@ -108,7 +151,7 @@ class InOutNonNatTest(unittest.TestCase):
                 'clean_restart': True,
                 'enable_nat': False,
                 'non_mat_gw_probe_frequency': .2,
-                'non_nat_arp_egress_port': cls.UPLINK_BR,
+                'non_nat_arp_egress_port': non_nat_arp_egress_port,
                 'ovs_uplink_port_name': 'patch-up'
             },
             mconfig=None,
@@ -120,31 +163,167 @@ class InOutNonNatTest(unittest.TestCase):
         BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
         subprocess.Popen(["ifconfig", cls.UPLINK_BR, "192.168.128.41"]).wait()
         cls.thread = start_ryu_app_thread(test_setup)
-
         cls.inout_controller = inout_controller_reference.result()
+
         cls.testing_controller = testing_controller_reference.result()
 
-    @classmethod
-    def tearDownClass(cls):
+    def tearDown(self):
+        cls = self.__class__
         stop_ryu_app_thread(cls.thread)
-        BridgeTools.destroy_bridge(cls.BRIDGE)
+        subprocess.Popen(["ovs-ofctl", "del-flows", cls.BRIDGE]).wait()
+        subprocess.Popen(["ovs-vsctl", "del-br", cls.UPLINK_BR]).wait()
+
+        hub.sleep(1)
 
     def testFlowSnapshotMatch(self):
+        cls = self.__class__
+        self.setUpNetworkAndController(non_nat_arp_egress_port=cls.UPLINK_BR)
         # wait for atleast one iteration of the ARP probe.
-        global gw_info
-        ip_addr = ipaddress.ip_address("192.168.128.211")
-        gw_info.ip.version = IPBlock.IPV4
-        gw_info.ip.address = ip_addr.packed
 
-        while gw_info.mac is None or gw_info.mac == '':
-            threading.Event().wait(0.1)
+        ip_addr = ipaddress.ip_address("192.168.128.211")
+        vlan = ""
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "", vlan)
+        hub.sleep(2)
+        while gw_info_map[vlan].mac is None or gw_info_map[vlan].mac == '':
+            threading.Event().wait(.5)
 
         snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
-                                             self.service_manager)
+                                             self.service_manager,
+                                             max_sleep_time=40,
+                                             datapath=cls.inout_controller._datapath)
         with snapshot_verifier:
             pass
-        assert gw_info.mac == 'b2:a0:cc:85:80:7a'
+        self.assertEqual(gw_info_map[vlan].mac, 'b2:a0:cc:85:80:7a')
 
+    def testFlowVlanSnapshotMatch(self):
+        cls = self.__class__
+        vlan = "11"
+        self.setUpNetworkAndController(vlan)
+        # wait for atleast one iteration of the ARP probe.
+
+        ip_addr = ipaddress.ip_address("10.200.11.211")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "", vlan)
+        hub.sleep(2)
+        while gw_info_map[vlan].mac is None or gw_info_map[vlan].mac == '':
+            threading.Event().wait(.5)
+
+        logging.info("done waiting for vlan: %s", vlan)
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager,
+                                             max_sleep_time=40,
+                                             datapath=cls.inout_controller._datapath)
+
+        with snapshot_verifier:
+            pass
+        self.assertEqual(gw_info_map[vlan].mac, 'b2:a0:cc:85:80:11')
+
+    def testFlowVlanSnapshotMatch2(self):
+        cls = self.__class__
+        vlan1 = "21"
+        self.setUpNetworkAndController(vlan1)
+        vlan2 = "22"
+        cls._setup_vlan(vlan2)
+
+        ip_addr = ipaddress.ip_address("10.200.21.211")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "", vlan1)
+
+        ip_addr = ipaddress.ip_address("10.200.22.211")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "", vlan2)
+
+        hub.sleep(2)
+        while gw_info_map[vlan2].mac is None or gw_info_map[vlan2].mac == '':
+            threading.Event().wait(.5)
+
+        logging.info("done waiting for vlan: %s", vlan1)
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager,
+                                             max_sleep_time=40,
+                                             datapath=cls.inout_controller._datapath)
+
+        with snapshot_verifier:
+            pass
+        self.assertEqual(gw_info_map[vlan1].mac, 'b2:a0:cc:85:80:21')
+        self.assertEqual(gw_info_map[vlan2].mac, 'b2:a0:cc:85:80:22')
+
+    def testFlowVlanSnapshotMatch_static1(self):
+        cls = self.__class__
+        # setup network on unused vlan.
+        vlan1 = "21"
+        self.setUpNetworkAndController(vlan1)
+        # statically configured config
+        vlan2 = "22"
+
+        ip_addr = ipaddress.ip_address("10.200.21.211")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "11:33:44:55:66:77", vlan1)
+
+        ip_addr = ipaddress.ip_address("10.200.22.211")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "22:33:44:55:66:77", vlan2)
+
+        hub.sleep(2)
+        while gw_info_map[vlan2].mac is None or gw_info_map[vlan2].mac == '':
+            threading.Event().wait(.5)
+
+        logging.info("done waiting for vlan: %s", vlan1)
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager,
+                                             max_sleep_time=20,
+                                             datapath=cls.inout_controller._datapath)
+
+        with snapshot_verifier:
+            pass
+        self.assertEqual(gw_info_map[vlan1].mac, 'b2:a0:cc:85:80:21')
+        self.assertEqual(gw_info_map[vlan2].mac, '22:33:44:55:66:77')
+
+    def testFlowVlanSnapshotMatch_static2(self):
+        cls = self.__class__
+        # setup network on unused vlan.
+        self.setUpNetworkAndController("1234")
+        # statically configured config
+
+        vlan1 = "31"
+        ip_addr = ipaddress.ip_address("10.200.21.100")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "11:33:44:55:66:77", vlan1)
+
+        vlan2 = "32"
+        ip_addr = ipaddress.ip_address("10.200.22.200")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "22:33:44:55:66:77", vlan2)
+
+        ip_addr = ipaddress.ip_address("10.200.22.10")
+        mocked_set_mobilityd_gw_info(IPAddress(address=ip_addr.packed,
+                                               version=IPBlock.IPV4),
+                                     "00:33:44:55:66:77", "")
+
+        hub.sleep(2)
+        while gw_info_map[vlan2].mac is None or gw_info_map[vlan2].mac == '':
+            threading.Event().wait(.5)
+
+        logging.info("done waiting for vlan: %s", vlan1)
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager,
+                                             max_sleep_time=20,
+                                             datapath=cls.inout_controller._datapath)
+
+        with snapshot_verifier:
+            pass
+        self.assertEqual(gw_info_map[vlan1].mac, '11:33:44:55:66:77')
+        self.assertEqual(gw_info_map[vlan2].mac, '22:33:44:55:66:77')
+        self.assertEqual(gw_info_map[""].mac, '00:33:44:55:66:77')
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Following patch uses mobilityD GWInfo API to get Internet GW Ip address.
The it periodically probe internet GW mac address using ARP. This way pipelineD
can get MAC address of upstream GW.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>