### PR TITLE
[orc8r][easy] Clarify LTE's configurator entity graph

### DIFF
--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd.go
@@ -406,7 +406,7 @@ func configEnodeb(stateNumber int, successState string, machine *enodebdE2ETestS
 	pretext := fmt.Sprintf(reconfigPretextFmt, *config.EnodebSN, "SUCCEEDED")
 	fallback := "Reconfig enodeb notification"
 	_, err := configurator.UpdateEntity(*config.NetworkID, configurator.EntityUpdateCriteria{
-		Type:      lte.CellularEnodebType,
+		Type:      lte.CellularEnodebEntityType,
 		Key:       *config.EnodebSN,
 		NewConfig: config.EnodebConfig,
 	})

--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
@@ -827,7 +827,7 @@ func RegisterAGW(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: "t1"}},
 			},
 			{
-				Type:       lte.CellularEnodebType,
+				Type:       lte.CellularEnodebEntityType,
 				Key:        "1202000038269KP0037",
 				PhysicalID: "1202000038269KP0037",
 				Config: &ltemodels.EnodebConfiguration{

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
@@ -608,10 +608,10 @@ func TestFederatedLteNetworks(t *testing.T) {
 		Name:        "updated foobar",
 		Description: "Updated Foo Bar",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType:     models3.NewDefaultFDDNetworkConfig(),
-			feg.FederatedNetworkType:    models2.NewDefaultFederatedNetworkConfigs(),
-			orc8r.DnsdNetworkType:       payloadN1.DNS,
-			orc8r.NetworkFeaturesConfig: payloadN1.Features,
+			lte.CellularNetworkConfigType: models3.NewDefaultFDDNetworkConfig(),
+			feg.FederatedNetworkType:      models2.NewDefaultFederatedNetworkConfigs(),
+			orc8r.DnsdNetworkType:         payloadN1.DNS,
+			orc8r.NetworkFeaturesConfig:   payloadN1.Features,
 		},
 		Version: 1,
 	}
@@ -698,10 +698,10 @@ func seedFederatedLteNetworks(t *testing.T) {
 				Name:        "foobar",
 				Description: "Foo Bar",
 				Configs: map[string]interface{}{
-					feg.FederatedNetworkType:    models2.NewDefaultFederatedNetworkConfigs(),
-					lte.CellularNetworkType:     models3.NewDefaultTDDNetworkConfig(),
-					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+					feg.FederatedNetworkType:      models2.NewDefaultFederatedNetworkConfigs(),
+					lte.CellularNetworkConfigType: models3.NewDefaultTDDNetworkConfig(),
+					orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
+					orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
 				},
 			},
 			{

--- a/feg/cloud/go/services/feg/obsidian/models/conversion.go
+++ b/feg/cloud/go/services/feg/obsidian/models/conversion.go
@@ -109,10 +109,10 @@ func (m *FegLteNetwork) ToConfiguratorNetwork() configurator.Network {
 		Name:        string(m.Name),
 		Description: string(m.Description),
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType:     m.Cellular,
-			feg.FederatedNetworkType:    m.Federation,
-			orc8r.DnsdNetworkType:       m.DNS,
-			orc8r.NetworkFeaturesConfig: m.Features,
+			lte.CellularNetworkConfigType: m.Cellular,
+			feg.FederatedNetworkType:      m.Federation,
+			orc8r.DnsdNetworkType:         m.DNS,
+			orc8r.NetworkFeaturesConfig:   m.Features,
 		},
 	}
 }
@@ -123,10 +123,10 @@ func (m *FegLteNetwork) ToUpdateCriteria() configurator.NetworkUpdateCriteria {
 		NewName:        swag.String(string(m.Name)),
 		NewDescription: swag.String(string(m.Description)),
 		ConfigsToAddOrUpdate: map[string]interface{}{
-			lte.CellularNetworkType:     m.Cellular,
-			feg.FederatedNetworkType:    m.Federation,
-			orc8r.DnsdNetworkType:       m.DNS,
-			orc8r.NetworkFeaturesConfig: m.Features,
+			lte.CellularNetworkConfigType: m.Cellular,
+			feg.FederatedNetworkType:      m.Federation,
+			orc8r.DnsdNetworkType:         m.DNS,
+			orc8r.NetworkFeaturesConfig:   m.Features,
 		},
 	}
 }
@@ -138,7 +138,7 @@ func (m *FegLteNetwork) FromConfiguratorNetwork(n configurator.Network) interfac
 	if cfg := n.Configs[feg.FederatedNetworkType]; cfg != nil {
 		m.Federation = cfg.(*FederatedNetworkConfigs)
 	}
-	if cfg := n.Configs[lte.CellularNetworkType]; cfg != nil {
+	if cfg := n.Configs[lte.CellularNetworkConfigType]; cfg != nil {
 		m.Cellular = cfg.(*lteModels.NetworkCellularConfigs)
 	}
 	if cfg := n.Configs[orc8r.DnsdNetworkType]; cfg != nil {

--- a/lte/cloud/go/lte/const.go
+++ b/lte/cloud/go/lte/const.go
@@ -11,39 +11,64 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+	File const.go provides constants used across the LTE module.
+
+	A number of the constants refer to configurator network entities. These
+	are reproduced and annotated below.
+	Note: starred Swagger models also have mutable versions of the model.
+
+	Configurator type    Swagger model       Edges out           Notes
+	-----------------    -------------       ---------           -----
+	apn                  apn                                     Stored as apn_configuration
+	base_name            base_name_record    policy, subscriber
+	cellular_enodeb      enodeb                                  Stored as enodeb_configuration
+	cellular_gateway     *lte_gateway        cellular_enodeb     Stored as gateway_cellular_configs
+	policy               policy_rule         subscriber          Stored as policy_rule_config
+	rating_group         *rating_group
+	subscriber           *subscriber         apn
+
+	Resulting DAG
+
+	cellular_gateway -> cellular_enodeb
+	base_name -> (policy ->) subscriber -> apn
+*/
+
 package lte
 
 const ModuleName = "lte"
 
 const (
+	// NetworkType identifies managed networks as LTE networks.
 	NetworkType = "lte"
 
-	CellularNetworkType         = "cellular_network"
-	CellularGatewayType         = "cellular_gateway"
-	CellularEnodebType          = "cellular_enodeb"
+	// CellularNetworkConfigType etc. are keys to network-level configs stored
+	// in configurator.
+	CellularNetworkConfigType   = "cellular_network"
 	NetworkSubscriberConfigType = "network_subscriber_config"
 
-	EnodebStateType      = "single_enodeb"
-	SubscriberEntityType = "subscriber"
-	ICMPStateType        = "icmp_monitoring"
+	// APNEntityType etc. are configurator network entity types.
+	APNEntityType             = "apn"
+	BaseNameEntityType        = "base_name"
+	CellularEnodebEntityType  = "cellular_enodeb"
+	CellularGatewayEntityType = "cellular_gateway"
+	PolicyRuleEntityType      = "policy"
+	RatingGroupEntityType     = "rating_group"
+	SubscriberEntityType      = "subscriber"
 
-	BaseNameEntityType   = "base_name"
-	PolicyRuleEntityType = "policy"
-
-	RatingGroupEntityType = "rating_group"
-
-	ApnEntityType = "apn"
-
-	SubscriberStreamName       = "subscriberdb"
-	PolicyStreamName           = "policydb"
+	// BaseNameStreamName etc. are streamer stream names.
 	BaseNameStreamName         = "base_names"
 	MappingsStreamName         = "rule_mappings"
 	NetworkWideRulesStreamName = "network_wide_rules"
+	PolicyStreamName           = "policydb"
 	RatingGroupStreamName      = "rating_groups"
+	SubscriberStreamName       = "subscriberdb"
 
-	// Replicated states from AGW
-	SPGWStateType      = "SPGW"
+	// EnodebStateType etc. are denote types of state replicated from AGWs
+	EnodebStateType    = "single_enodeb"
+	ICMPStateType      = "icmp_monitoring"
 	MMEStateType       = "MME"
-	S1APStateType      = "S1AP"
 	MobilitydStateType = "mobilityd_ipdesc_record"
+	S1APStateType      = "S1AP"
+	SPGWStateType      = "SPGW"
 )

--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -59,10 +59,10 @@ func (*LteOrchestratorPlugin) GetSerdes() []serde.Serde {
 		state.NewStateSerde(lte.MobilitydStateType, &state.ArbitraryJSON{}),
 
 		// Configurator serdes
-		configurator.NewNetworkConfigSerde(lte.CellularNetworkType, &lte_models.NetworkCellularConfigs{}),
+		configurator.NewNetworkConfigSerde(lte.CellularNetworkConfigType, &lte_models.NetworkCellularConfigs{}),
 		configurator.NewNetworkConfigSerde(lte.NetworkSubscriberConfigType, &policydb_models.NetworkSubscriberConfig{}),
-		configurator.NewNetworkEntityConfigSerde(lte.CellularGatewayType, &lte_models.GatewayCellularConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(lte.CellularEnodebType, &lte_models.EnodebConfiguration{}),
+		configurator.NewNetworkEntityConfigSerde(lte.CellularGatewayEntityType, &lte_models.GatewayCellularConfigs{}),
+		configurator.NewNetworkEntityConfigSerde(lte.CellularEnodebEntityType, &lte_models.EnodebConfiguration{}),
 
 		configurator.NewNetworkEntityConfigSerde(lte.PolicyRuleEntityType, &policydb_models.PolicyRuleConfig{}),
 		configurator.NewNetworkEntityConfigSerde(lte.BaseNameEntityType, &policydb_models.BaseNameRecord{}),
@@ -70,7 +70,7 @@ func (*LteOrchestratorPlugin) GetSerdes() []serde.Serde {
 
 		configurator.NewNetworkEntityConfigSerde(lte.RatingGroupEntityType, &policydb_models.RatingGroup{}),
 
-		configurator.NewNetworkEntityConfigSerde(lte.ApnEntityType, &lte_models.ApnConfiguration{}),
+		configurator.NewNetworkEntityConfigSerde(lte.APNEntityType, &lte_models.ApnConfiguration{}),
 	}
 }
 

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -86,12 +86,12 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageNetworkDNSRecordByDomainPath, Methods: obsidian.PUT, HandlerFunc: handlers.UpdateDNSRecord},
 		{Path: ManageNetworkDNSRecordByDomainPath, Methods: obsidian.DELETE, HandlerFunc: handlers.DeleteDNSRecord},
 
-		handlers.GetListGatewaysHandler(ListGatewaysPath, lte.CellularGatewayType, makeLTEGateways),
+		handlers.GetListGatewaysHandler(ListGatewaysPath, lte.CellularGatewayEntityType, makeLTEGateways),
 		{Path: ListGatewaysPath, Methods: obsidian.POST, HandlerFunc: createGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
 		{Path: ManageGatewayStatePath, Methods: obsidian.GET, HandlerFunc: handlers.GetStateHandler},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
-		handlers.GetDeleteGatewayHandler(ManageGatewayPath, lte.CellularGatewayType),
+		handlers.GetDeleteGatewayHandler(ManageGatewayPath, lte.CellularGatewayEntityType),
 
 		{Path: ListEnodebsPath, Methods: obsidian.GET, HandlerFunc: listEnodebs},
 		{Path: ListEnodebsPath, Methods: obsidian.POST, HandlerFunc: createEnodeb},
@@ -120,7 +120,7 @@ func GetHandlers() []obsidian.Handler {
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8r_models.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSPath, &orc8r_models.NetworkDNSConfig{}, orc8r.DnsdNetworkType)...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSRecordsPath, new(orc8r_models.NetworkDNSRecords), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularPath, &lte_models.NetworkCellularConfigs{}, lte.CellularNetworkType)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularPath, &lte_models.NetworkCellularConfigs{}, lte.CellularNetworkConfigType)...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularEpcPath, &lte_models.NetworkEpcConfigs{}, "")...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularRanPath, &lte_models.NetworkRanConfigs{}, "")...)
 	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularFegNetworkID, new(lte_models.FegNetworkID), "")...)
@@ -160,7 +160,7 @@ func getGateway(c echo.Context) error {
 	}
 
 	ent, err := configurator.LoadEntity(
-		nid, lte.CellularGatewayType, gid,
+		nid, lte.CellularGatewayEntityType, gid,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
 	)
 	if err != nil {
@@ -181,7 +181,7 @@ func getGateway(c echo.Context) error {
 	}
 
 	for _, tk := range ent.Associations {
-		if tk.Type == lte.CellularEnodebType {
+		if tk.Type == lte.CellularEnodebEntityType {
 			ret.ConnectedEnodebSerials = append(ret.ConnectedEnodebSerials, tk.Key)
 		}
 	}
@@ -219,7 +219,7 @@ func makeLTEGateways(
 		switch ent.Type {
 		case orc8r.MagmadGatewayType:
 			existing.magmadGateway = ent
-		case lte.CellularGatewayType:
+		case lte.CellularGatewayEntityType:
 			existing.cellularGateway = ent
 		}
 	}
@@ -243,7 +243,7 @@ func listEnodebs(c echo.Context) error {
 	}
 
 	ents, err := configurator.LoadAllEntitiesInNetwork(
-		nid, lte.CellularEnodebType,
+		nid, lte.CellularEnodebEntityType,
 		configurator.EntityLoadCriteria{LoadMetadata: true, LoadConfig: true, LoadAssocsToThis: true},
 	)
 	if err != nil {
@@ -275,7 +275,7 @@ func createEnodeb(c echo.Context) error {
 	}
 
 	_, err := configurator.CreateEntity(nid, configurator.NetworkEntity{
-		Type:        lte.CellularEnodebType,
+		Type:        lte.CellularEnodebEntityType,
 		Key:         payload.Serial,
 		Name:        payload.Name,
 		Description: payload.Description,
@@ -296,7 +296,7 @@ func getEnodeb(c echo.Context) error {
 	}
 
 	ent, err := configurator.LoadEntity(
-		nid, lte.CellularEnodebType, eid,
+		nid, lte.CellularEnodebEntityType, eid,
 		configurator.EntityLoadCriteria{LoadMetadata: true, LoadConfig: true, LoadAssocsToThis: true},
 	)
 	switch {
@@ -343,7 +343,7 @@ func deleteEnodeb(c echo.Context) error {
 		return nerr
 	}
 
-	err := configurator.DeleteEntity(nid, lte.CellularEnodebType, eid)
+	err := configurator.DeleteEntity(nid, lte.CellularEnodebEntityType, eid)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -420,7 +420,7 @@ func listApns(c echo.Context) error {
 		return nerr
 	}
 
-	ents, err := configurator.LoadAllEntitiesInNetwork(networkID, lte.ApnEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
+	ents, err := configurator.LoadAllEntitiesInNetwork(networkID, lte.APNEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -447,7 +447,7 @@ func createApn(c echo.Context) error {
 	}
 
 	_, err := configurator.CreateEntity(networkID, configurator.NetworkEntity{
-		Type:   lte.ApnEntityType,
+		Type:   lte.APNEntityType,
 		Key:    string(payload.ApnName),
 		Config: payload.ApnConfiguration,
 	})
@@ -464,7 +464,7 @@ func getApnConfiguration(c echo.Context) error {
 		return nerr
 	}
 
-	ent, err := configurator.LoadEntity(networkID, lte.ApnEntityType, apnName, configurator.EntityLoadCriteria{LoadConfig: true})
+	ent, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{LoadConfig: true})
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
@@ -490,7 +490,7 @@ func updateApnConfiguration(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	_, err := configurator.LoadEntity(networkID, lte.ApnEntityType, apnName, configurator.EntityLoadCriteria{})
+	_, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{})
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
@@ -498,7 +498,7 @@ func updateApnConfiguration(c echo.Context) error {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load existing APN"), http.StatusInternalServerError)
 	}
 
-	err = configurator.CreateOrUpdateEntityConfig(networkID, lte.ApnEntityType, apnName, payload.ApnConfiguration)
+	err = configurator.CreateOrUpdateEntityConfig(networkID, lte.APNEntityType, apnName, payload.ApnConfiguration)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -511,7 +511,7 @@ func deleteApnConfiguration(c echo.Context) error {
 		return nerr
 	}
 
-	err := configurator.DeleteEntity(networkID, lte.ApnEntityType, apnName)
+	err := configurator.DeleteEntity(networkID, lte.APNEntityType, apnName)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -143,9 +143,9 @@ func TestCreateNetwork(t *testing.T) {
 		Name:        "foobar",
 		Description: "Foo Bar",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType:     lteModels.NewDefaultTDDNetworkConfig(),
-			orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
-			orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+			lte.CellularNetworkConfigType: lteModels.NewDefaultTDDNetworkConfig(),
+			orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
+			orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
 		},
 	}
 	assert.Equal(t, expected, actual)
@@ -327,9 +327,9 @@ func TestUpdateNetwork(t *testing.T) {
 		Name:        "updated foobar",
 		Description: "Updated Foo Bar",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType:     lteModels.NewDefaultFDDNetworkConfig(),
-			orc8r.DnsdNetworkType:       payloadN1.DNS,
-			orc8r.NetworkFeaturesConfig: payloadN1.Features,
+			lte.CellularNetworkConfigType: lteModels.NewDefaultFDDNetworkConfig(),
+			orc8r.DnsdNetworkType:         payloadN1.DNS,
+			orc8r.NetworkFeaturesConfig:   payloadN1.Features,
 		},
 		Version: 1,
 	}
@@ -505,7 +505,7 @@ func TestCellularPartialGet(t *testing.T) {
 		{
 			ID: "n1",
 			ConfigsToAddOrUpdate: map[string]interface{}{
-				lte.CellularNetworkType: cellularConfig,
+				lte.CellularNetworkConfigType: cellularConfig,
 			},
 		},
 	})
@@ -565,7 +565,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 		Name:        "foobar",
 		Description: "Foo Bar",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType: lteModels.NewDefaultFDDNetworkConfig(),
+			lte.CellularNetworkConfigType: lteModels.NewDefaultFDDNetworkConfig(),
 		},
 		Version: 1,
 	}
@@ -618,7 +618,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 
 	actualN2, err = configurator.LoadNetwork("n2", true, true)
 	assert.NoError(t, err)
-	expected.Configs[lte.CellularNetworkType].(*lteModels.NetworkCellularConfigs).Epc = epcConfig
+	expected.Configs[lte.CellularNetworkConfigType].(*lteModels.NetworkCellularConfigs).Epc = epcConfig
 	expected.Version = 2
 	assert.Equal(t, expected, actualN2)
 
@@ -664,7 +664,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 	actualN2, err = configurator.LoadNetwork("n2", true, true)
 	assert.NoError(t, err)
-	expected.Configs[lte.CellularNetworkType].(*lteModels.NetworkCellularConfigs).Ran = ranConfig
+	expected.Configs[lte.CellularNetworkConfigType].(*lteModels.NetworkCellularConfigs).Ran = ranConfig
 	expected.Version = 3
 	assert.Equal(t, expected, actualN2)
 
@@ -718,7 +718,7 @@ func TestCellularDelete(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err := configurator.LoadNetworkConfig("n1", lte.CellularNetworkType)
+	_, err := configurator.LoadNetworkConfig("n1", lte.CellularNetworkConfigType)
 	assert.EqualError(t, err, "Not found")
 }
 
@@ -1036,7 +1036,7 @@ func TestCreateGateway(t *testing.T) {
 		"n1",
 		[]configurator.NetworkEntity{
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
-			{Type: lte.CellularEnodebType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
 		},
 	)
 	assert.NoError(t, err)
@@ -1087,7 +1087,7 @@ func TestCreateGateway(t *testing.T) {
 		"n1", nil, nil, nil,
 		[]storage.TypeAndKey{
 			{Type: orc8r.MagmadGatewayType, Key: "g1"},
-			{Type: lte.CellularGatewayType, Key: "g1"},
+			{Type: lte.CellularGatewayEntityType, Key: "g1"},
 		},
 		configurator.FullEntityLoadCriteria(),
 	)
@@ -1097,10 +1097,10 @@ func TestCreateGateway(t *testing.T) {
 
 	expectedEnts := configurator.NetworkEntities{
 		{
-			NetworkID: "n1", Type: lte.CellularGatewayType, Key: "g1",
+			NetworkID: "n1", Type: lte.CellularGatewayEntityType, Key: "g1",
 			Name: string(payload.Name), Description: string(payload.Description),
 			Config:             payload.Cellular,
-			Associations:       []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: "enb1"}},
+			Associations:       []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: "enb1"}},
 			ParentAssociations: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: "g1"}},
 			GraphID:            "2",
 		},
@@ -1109,7 +1109,7 @@ func TestCreateGateway(t *testing.T) {
 			Name: string(payload.Name), Description: string(payload.Description),
 			PhysicalID:         "hw1",
 			Config:             payload.Magmad,
-			Associations:       []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations:       []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			ParentAssociations: []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: "t1"}},
 			GraphID:            "2",
 			Version:            1,
@@ -1154,7 +1154,7 @@ func TestCreateGateway(t *testing.T) {
 		"n1", nil, nil, nil,
 		[]storage.TypeAndKey{
 			{Type: orc8r.MagmadGatewayType, Key: "g3"},
-			{Type: lte.CellularGatewayType, Key: "g3"},
+			{Type: lte.CellularGatewayEntityType, Key: "g3"},
 		},
 		configurator.FullEntityLoadCriteria(),
 	)
@@ -1237,24 +1237,24 @@ func TestListAndGetGateways(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
-			{Type: lte.CellularEnodebType, Key: "enb2"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 			{
-				Type: lte.CellularGatewayType, Key: "g1",
+				Type: lte.CellularGatewayEntityType, Key: "g1",
 				Config: &lteModels.GatewayCellularConfigs{
 					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
 					Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				},
 			},
 			{
-				Type: lte.CellularGatewayType, Key: "g2",
+				Type: lte.CellularGatewayEntityType, Key: "g2",
 				Config: &lteModels.GatewayCellularConfigs{
 					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
 					Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				},
 				Associations: []storage.TypeAndKey{
-					{Type: lte.CellularEnodebType, Key: "enb1"},
-					{Type: lte.CellularEnodebType, Key: "enb2"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 				},
 			},
 			{
@@ -1267,7 +1267,7 @@ func TestListAndGetGateways(t *testing.T) {
 					CheckinInterval:         15,
 					CheckinTimeout:          5,
 				},
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 			{
 				Type: orc8r.MagmadGatewayType, Key: "g2",
@@ -1279,7 +1279,7 @@ func TestListAndGetGateways(t *testing.T) {
 					CheckinInterval:         15,
 					CheckinTimeout:          5,
 				},
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g2"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g2"}},
 			},
 			{
 				Type: orc8r.UpgradeTierEntityType, Key: "t1",
@@ -1428,18 +1428,18 @@ func TestUpdateGateway(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
-			{Type: lte.CellularEnodebType, Key: "enb2"},
-			{Type: lte.CellularEnodebType, Key: "enb3"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb2"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb3"},
 			{
-				Type: lte.CellularGatewayType, Key: "g1",
+				Type: lte.CellularGatewayEntityType, Key: "g1",
 				Config: &lteModels.GatewayCellularConfigs{
 					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
 					Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				},
 				Associations: []storage.TypeAndKey{
-					{Type: lte.CellularEnodebType, Key: "enb1"},
-					{Type: lte.CellularEnodebType, Key: "enb2"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 				},
 			},
 			{
@@ -1452,7 +1452,7 @@ func TestUpdateGateway(t *testing.T) {
 					CheckinInterval:         15,
 					CheckinTimeout:          5,
 				},
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 			{
 				Type: orc8r.UpgradeTierEntityType, Key: "t1",
@@ -1511,7 +1511,7 @@ func TestUpdateGateway(t *testing.T) {
 		"n1", nil, nil, nil,
 		[]storage.TypeAndKey{
 			{Type: orc8r.MagmadGatewayType, Key: "g1"},
-			{Type: lte.CellularGatewayType, Key: "g1"},
+			{Type: lte.CellularGatewayEntityType, Key: "g1"},
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
 		configurator.FullEntityLoadCriteria(),
@@ -1522,13 +1522,13 @@ func TestUpdateGateway(t *testing.T) {
 
 	expectedEnts := configurator.NetworkEntities{
 		{
-			NetworkID: "n1", Type: lte.CellularGatewayType, Key: "g1",
+			NetworkID: "n1", Type: lte.CellularGatewayEntityType, Key: "g1",
 			Name: string(payload.Name), Description: string(payload.Description),
 			Config:             payload.Cellular,
 			ParentAssociations: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: "g1"}},
 			Associations: []storage.TypeAndKey{
-				{Type: lte.CellularEnodebType, Key: "enb1"},
-				{Type: lte.CellularEnodebType, Key: "enb3"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb3"},
 			},
 			GraphID: "10",
 			Version: 1,
@@ -1538,7 +1538,7 @@ func TestUpdateGateway(t *testing.T) {
 			Name: string(payload.Name), Description: string(payload.Description),
 			PhysicalID:         "hw1",
 			Config:             payload.Magmad,
-			Associations:       []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations:       []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			ParentAssociations: []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: "t1"}},
 			GraphID:            "10",
 			Version:            1,
@@ -1572,17 +1572,17 @@ func TestDeleteGateway(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
-			{Type: lte.CellularEnodebType, Key: "enb2"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 			{
-				Type: lte.CellularGatewayType, Key: "g1",
+				Type: lte.CellularGatewayEntityType, Key: "g1",
 				Config: &lteModels.GatewayCellularConfigs{
 					Epc: &lteModels.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
 					Ran: &lteModels.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
 				},
 				Associations: []storage.TypeAndKey{
-					{Type: lte.CellularEnodebType, Key: "enb1"},
-					{Type: lte.CellularEnodebType, Key: "enb2"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 				},
 			},
 			{
@@ -1595,7 +1595,7 @@ func TestDeleteGateway(t *testing.T) {
 					CheckinInterval:         15,
 					CheckinTimeout:          5,
 				},
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 			{
 				Type: orc8r.UpgradeTierEntityType, Key: "t1",
@@ -1623,7 +1623,7 @@ func TestDeleteGateway(t *testing.T) {
 		"n1", nil, nil, nil,
 		[]storage.TypeAndKey{
 			{Type: orc8r.MagmadGatewayType, Key: "g1"},
-			{Type: lte.CellularGatewayType, Key: "g1"},
+			{Type: lte.CellularGatewayEntityType, Key: "g1"},
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
 		configurator.FullEntityLoadCriteria(),
@@ -1660,21 +1660,21 @@ func TestGetCellularGatewayConfig(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
-			{Type: lte.CellularEnodebType, Key: "enb2"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 			{
-				Type: lte.CellularGatewayType, Key: "g1",
+				Type: lte.CellularGatewayEntityType, Key: "g1",
 				Config: newDefaultGatewayConfig(),
 				Associations: []storage.TypeAndKey{
-					{Type: lte.CellularEnodebType, Key: "enb1"},
-					{Type: lte.CellularEnodebType, Key: "enb2"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 				},
 			},
 			{
 				Type: orc8r.MagmadGatewayType, Key: "g1",
 				Name: "foobar", Description: "foo bar",
 				PhysicalID:   "hw1",
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 		},
 	)
@@ -1772,12 +1772,12 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
-			{Type: lte.CellularEnodebType, Key: "enb2"},
-			{Type: lte.CellularGatewayType, Key: "g1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb2"},
+			{Type: lte.CellularGatewayEntityType, Key: "g1"},
 			{
 				Type: orc8r.MagmadGatewayType, Key: "g1",
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 		},
 	)
@@ -1798,13 +1798,13 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "6",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  newDefaultGatewayConfig(),
 			GraphID: "6",
 			Version: 1,
@@ -1832,13 +1832,13 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "6",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "6",
 			Version: 2,
@@ -1864,13 +1864,13 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "6",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "6",
 			Version: 3,
@@ -1912,13 +1912,13 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "6",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "6",
 			Version: 4,
@@ -1944,19 +1944,19 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "2",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "2",
 			Version: 5,
 			Associations: []storage.TypeAndKey{
-				{Type: lte.CellularEnodebType, Key: "enb1"},
-				{Type: lte.CellularEnodebType, Key: "enb2"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 			},
 		},
 	}
@@ -1964,7 +1964,7 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.ToEntitiesByID())
 
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularEnodebType, Key: "enb3"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularEnodebEntityType, Key: "enb3"})
 	assert.NoError(t, err)
 
 	// happy case
@@ -1983,20 +1983,20 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "10",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "10",
 			Version: 6,
 			Associations: []storage.TypeAndKey{
-				{Type: lte.CellularEnodebType, Key: "enb1"},
-				{Type: lte.CellularEnodebType, Key: "enb2"},
-				{Type: lte.CellularEnodebType, Key: "enb3"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb2"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb3"},
 			},
 		},
 	}
@@ -2020,19 +2020,19 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "10",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "10",
 			Version: 7,
 			Associations: []storage.TypeAndKey{
-				{Type: lte.CellularEnodebType, Key: "enb1"},
-				{Type: lte.CellularEnodebType, Key: "enb2"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+				{Type: lte.CellularEnodebEntityType, Key: "enb2"},
 			},
 		},
 	}
@@ -2056,13 +2056,13 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		storage.TypeAndKey{Type: orc8r.MagmadGatewayType, Key: "g1"}: {
 			NetworkID: "n1",
 			Type:      orc8r.MagmadGatewayType, Key: "g1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: "g1"}},
+			Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			GraphID:      "10",
 			Version:      0,
 		},
-		storage.TypeAndKey{Type: lte.CellularGatewayType, Key: "g1"}: {
+		storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: "g1"}: {
 			NetworkID: "n1",
-			Type:      lte.CellularGatewayType, Key: "g1",
+			Type:      lte.CellularGatewayEntityType, Key: "g1",
 			Config:  modifiedCellularConfig,
 			GraphID: "10",
 			Version: 8,
@@ -2091,7 +2091,7 @@ func TestListAndGetEnodebs(t *testing.T) {
 
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{
-			Type:        lte.CellularEnodebType,
+			Type:        lte.CellularEnodebEntityType,
 			Key:         "abcdefg",
 			Name:        "abc enodeb",
 			Description: "abc enodeb description",
@@ -2109,7 +2109,7 @@ func TestListAndGetEnodebs(t *testing.T) {
 			},
 		},
 		{
-			Type:        lte.CellularEnodebType,
+			Type:        lte.CellularEnodebEntityType,
 			Key:         "vwxyz",
 			Name:        "xyz enodeb",
 			Description: "xyz enodeb description",
@@ -2127,8 +2127,8 @@ func TestListAndGetEnodebs(t *testing.T) {
 			},
 		},
 		{
-			Type: lte.CellularGatewayType, Key: "gw1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: "abcdefg"}},
+			Type: lte.CellularGatewayEntityType, Key: "gw1",
+			Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: "abcdefg"}},
 		},
 	})
 	assert.NoError(t, err)
@@ -2254,11 +2254,11 @@ func TestCreateEnodeb(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebType, "abcdef", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdef", configurator.FullEntityLoadCriteria())
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
-		Type:      lte.CellularEnodebType, Key: "abcdef",
+		Type:      lte.CellularEnodebEntityType, Key: "abcdef",
 		Name:        "foobar",
 		Description: "foobar description",
 		PhysicalID:  "abcdef",
@@ -2322,7 +2322,7 @@ func TestUpdateEnodeb(t *testing.T) {
 
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{
-			Type:        lte.CellularEnodebType,
+			Type:        lte.CellularEnodebEntityType,
 			Key:         "abcdefg",
 			Name:        "abc enodeb",
 			Description: "abc enodeb description",
@@ -2368,11 +2368,11 @@ func TestUpdateEnodeb(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebType, "abcdefg", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdefg", configurator.FullEntityLoadCriteria())
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
-		Type:      lte.CellularEnodebType, Key: "abcdefg",
+		Type:      lte.CellularEnodebEntityType, Key: "abcdefg",
 		Name:        "foobar",
 		Description: "new description",
 		PhysicalID:  "abcdefg",
@@ -2436,7 +2436,7 @@ func TestDeleteEnodeb(t *testing.T) {
 
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{
-			Type:       lte.CellularEnodebType,
+			Type:       lte.CellularEnodebEntityType,
 			Key:        "abcdefg",
 			Name:       "abc enodeb",
 			PhysicalID: "abcdefg",
@@ -2465,7 +2465,7 @@ func TestDeleteEnodeb(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.LoadEntity("n1", lte.CellularEnodebType, "abcdefg", configurator.FullEntityLoadCriteria())
+	_, err = configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdefg", configurator.FullEntityLoadCriteria())
 	assert.EqualError(t, err, "Not found")
 }
 
@@ -2488,13 +2488,13 @@ func TestGetEnodebState(t *testing.T) {
 	_, err = configurator.CreateEntities("n1",
 		[]configurator.NetworkEntity{
 			{
-				Type: lte.CellularEnodebType, Key: "serial1",
+				Type: lte.CellularEnodebEntityType, Key: "serial1",
 				PhysicalID: "serial1",
 			},
 			{
 				Type: orc8r.MagmadGatewayType, Key: "gw1",
 				PhysicalID:   "hwid1",
-				Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: "serial1"}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: "serial1"}},
 			},
 		})
 	assert.NoError(t, err)
@@ -2574,11 +2574,11 @@ func TestCreateApn(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.ApnEntityType, "foo", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.APNEntityType, "foo", configurator.FullEntityLoadCriteria())
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
-		Type:      lte.ApnEntityType,
+		Type:      lte.APNEntityType,
 		Key:       "foo",
 		Config:    payload.ApnConfiguration,
 		GraphID:   "2",
@@ -2614,7 +2614,7 @@ func TestListApns(t *testing.T) {
 		"n1",
 		[]configurator.NetworkEntity{
 			{
-				Type: lte.ApnEntityType, Key: "oai.ipv4",
+				Type: lte.APNEntityType, Key: "oai.ipv4",
 				Config: &lteModels.ApnConfiguration{
 					Ambr: &lteModels.AggregatedMaximumBitrate{
 						MaxBandwidthDl: swag.Uint32(200),
@@ -2629,7 +2629,7 @@ func TestListApns(t *testing.T) {
 				},
 			},
 			{
-				Type: lte.ApnEntityType, Key: "oai.ims",
+				Type: lte.APNEntityType, Key: "oai.ims",
 				Config: &lteModels.ApnConfiguration{
 					Ambr: &lteModels.AggregatedMaximumBitrate{
 						MaxBandwidthDl: swag.Uint32(100),
@@ -2717,7 +2717,7 @@ func TestGetApn(t *testing.T) {
 	_, err = configurator.CreateEntity(
 		"n1",
 		configurator.NetworkEntity{
-			Type: lte.ApnEntityType, Key: "oai.ipv4",
+			Type: lte.APNEntityType, Key: "oai.ipv4",
 			Config: &lteModels.ApnConfiguration{
 				Ambr: &lteModels.AggregatedMaximumBitrate{
 					MaxBandwidthDl: swag.Uint32(200),
@@ -2806,7 +2806,7 @@ func TestUpdateApn(t *testing.T) {
 	_, err = configurator.CreateEntity(
 		"n1",
 		configurator.NetworkEntity{
-			Type: lte.ApnEntityType, Key: "oai.ipv4",
+			Type: lte.APNEntityType, Key: "oai.ipv4",
 			Config: &lteModels.ApnConfiguration{
 				Ambr: &lteModels.AggregatedMaximumBitrate{
 					MaxBandwidthDl: swag.Uint32(200),
@@ -2834,11 +2834,11 @@ func TestUpdateApn(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.ApnEntityType, "oai.ipv4", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.APNEntityType, "oai.ipv4", configurator.FullEntityLoadCriteria())
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
-		Type:      lte.ApnEntityType,
+		Type:      lte.APNEntityType,
 		Key:       "oai.ipv4",
 		Config:    payload.ApnConfiguration,
 		GraphID:   "2",
@@ -2864,7 +2864,7 @@ func TestDeleteApn(t *testing.T) {
 		"n1",
 		[]configurator.NetworkEntity{
 			{
-				Type: lte.ApnEntityType, Key: "oai.ipv4",
+				Type: lte.APNEntityType, Key: "oai.ipv4",
 				Config: &lteModels.ApnConfiguration{
 					Ambr: &lteModels.AggregatedMaximumBitrate{
 						MaxBandwidthDl: swag.Uint32(200),
@@ -2879,7 +2879,7 @@ func TestDeleteApn(t *testing.T) {
 				},
 			},
 			{
-				Type: lte.ApnEntityType, Key: "oai.ims",
+				Type: lte.APNEntityType, Key: "oai.ims",
 				Config: &lteModels.ApnConfiguration{
 					Ambr: &lteModels.AggregatedMaximumBitrate{
 						MaxBandwidthDl: swag.Uint32(100),
@@ -2907,12 +2907,12 @@ func TestDeleteApn(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadAllEntitiesInNetwork("n1", lte.ApnEntityType, configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadAllEntitiesInNetwork("n1", lte.APNEntityType, configurator.FullEntityLoadCriteria())
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(actual))
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
-		Type:      lte.ApnEntityType,
+		Type:      lte.APNEntityType,
 		Key:       "oai.ims",
 		Config: &lteModels.ApnConfiguration{
 			Ambr: &lteModels.AggregatedMaximumBitrate{
@@ -2962,9 +2962,9 @@ func seedNetworks(t *testing.T) {
 				Name:        "foobar",
 				Description: "Foo Bar",
 				Configs: map[string]interface{}{
-					lte.CellularNetworkType:     lteModels.NewDefaultTDDNetworkConfig(),
-					orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
-					orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+					lte.CellularNetworkConfigType: lteModels.NewDefaultTDDNetworkConfig(),
+					orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
+					orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
 				},
 			},
 			{

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -44,9 +44,9 @@ func (m *LteNetwork) ToConfiguratorNetwork() configurator.Network {
 		Name:        string(m.Name),
 		Description: string(m.Description),
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType:     m.Cellular,
-			orc8r.DnsdNetworkType:       m.DNS,
-			orc8r.NetworkFeaturesConfig: m.Features,
+			lte.CellularNetworkConfigType: m.Cellular,
+			orc8r.DnsdNetworkType:         m.DNS,
+			orc8r.NetworkFeaturesConfig:   m.Features,
 		},
 	}
 }
@@ -57,9 +57,9 @@ func (m *LteNetwork) ToUpdateCriteria() configurator.NetworkUpdateCriteria {
 		NewName:        swag.String(string(m.Name)),
 		NewDescription: swag.String(string(m.Description)),
 		ConfigsToAddOrUpdate: map[string]interface{}{
-			lte.CellularNetworkType:     m.Cellular,
-			orc8r.DnsdNetworkType:       m.DNS,
-			orc8r.NetworkFeaturesConfig: m.Features,
+			lte.CellularNetworkConfigType: m.Cellular,
+			orc8r.DnsdNetworkType:         m.DNS,
+			orc8r.NetworkFeaturesConfig:   m.Features,
 		},
 	}
 }
@@ -68,7 +68,7 @@ func (m *LteNetwork) FromConfiguratorNetwork(n configurator.Network) interface{}
 	m.ID = models.NetworkID(n.ID)
 	m.Name = models.NetworkName(n.Name)
 	m.Description = models.NetworkDescription(n.Description)
-	if cfg := n.Configs[lte.CellularNetworkType]; cfg != nil {
+	if cfg := n.Configs[lte.CellularNetworkConfigType]; cfg != nil {
 		m.Cellular = cfg.(*NetworkCellularConfigs)
 	}
 	if cfg := n.Configs[orc8r.DnsdNetworkType]; cfg != nil {
@@ -84,24 +84,24 @@ func (m *LteNetwork) FromConfiguratorNetwork(n configurator.Network) interface{}
 }
 
 func (m *NetworkCellularConfigs) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
-	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkType, m), nil
+	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkConfigType, m), nil
 }
 
 func (m *NetworkCellularConfigs) GetFromNetwork(network configurator.Network) interface{} {
-	return orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	return orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 }
 
 func (m FegNetworkID) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
-	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 	if iCellularConfig == nil {
 		return configurator.NetworkUpdateCriteria{}, fmt.Errorf("No cellular network config found")
 	}
 	iCellularConfig.(*NetworkCellularConfigs).FegNetworkID = m
-	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkType, iCellularConfig), nil
+	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkConfigType, iCellularConfig), nil
 }
 
 func (m FegNetworkID) GetFromNetwork(network configurator.Network) interface{} {
-	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 	if iCellularConfig == nil {
 		return nil
 	}
@@ -109,16 +109,16 @@ func (m FegNetworkID) GetFromNetwork(network configurator.Network) interface{} {
 }
 
 func (m *NetworkEpcConfigs) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
-	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 	if iCellularConfig == nil {
 		return configurator.NetworkUpdateCriteria{}, fmt.Errorf("No cellular network config found")
 	}
 	iCellularConfig.(*NetworkCellularConfigs).Epc = m
-	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkType, iCellularConfig), nil
+	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkConfigType, iCellularConfig), nil
 }
 
 func (m *NetworkEpcConfigs) GetFromNetwork(network configurator.Network) interface{} {
-	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 	if iCellularConfig == nil {
 		return nil
 	}
@@ -126,16 +126,16 @@ func (m *NetworkEpcConfigs) GetFromNetwork(network configurator.Network) interfa
 }
 
 func (m *NetworkRanConfigs) ToUpdateCriteria(network configurator.Network) (configurator.NetworkUpdateCriteria, error) {
-	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 	if iCellularConfig == nil {
 		return configurator.NetworkUpdateCriteria{}, fmt.Errorf("No cellular network config found")
 	}
 	iCellularConfig.(*NetworkCellularConfigs).Ran = m
-	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkType, iCellularConfig), nil
+	return orc8rModels.GetNetworkConfigUpdateCriteria(network.ID, lte.CellularNetworkConfigType, iCellularConfig), nil
 }
 
 func (m *NetworkRanConfigs) GetFromNetwork(network configurator.Network) interface{} {
-	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkType)
+	iCellularConfig := orc8rModels.GetNetworkConfig(network, lte.CellularNetworkConfigType)
 	if iCellularConfig == nil {
 		return nil
 	}
@@ -160,7 +160,7 @@ func (m *LteGateway) FromBackendModels(
 		m.Cellular = cellularGateway.Config.(*GatewayCellularConfigs)
 	}
 	for _, tk := range cellularGateway.Associations {
-		if tk.Type == lte.CellularEnodebType {
+		if tk.Type == lte.CellularEnodebEntityType {
 			m.ConnectedEnodebSerials = append(m.ConnectedEnodebSerials, tk.Key)
 		}
 	}
@@ -202,14 +202,14 @@ func (m *MutableLteGateway) GetMagmadGateway() *orc8rModels.MagmadGateway {
 
 func (m *MutableLteGateway) GetAdditionalWritesOnCreate() []configurator.EntityWriteOperation {
 	ent := configurator.NetworkEntity{
-		Type:        lte.CellularGatewayType,
+		Type:        lte.CellularGatewayEntityType,
 		Key:         string(m.ID),
 		Name:        string(m.Name),
 		Description: string(m.Description),
 		Config:      m.Cellular,
 	}
 	for _, enbSerial := range m.ConnectedEnodebSerials {
-		ent.Associations = append(ent.Associations, storage.TypeAndKey{Type: lte.CellularEnodebType, Key: enbSerial})
+		ent.Associations = append(ent.Associations, storage.TypeAndKey{Type: lte.CellularEnodebEntityType, Key: enbSerial})
 	}
 
 	return []configurator.EntityWriteOperation{
@@ -217,13 +217,13 @@ func (m *MutableLteGateway) GetAdditionalWritesOnCreate() []configurator.EntityW
 		configurator.EntityUpdateCriteria{
 			Type:              orc8r.MagmadGatewayType,
 			Key:               string(m.ID),
-			AssociationsToAdd: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: string(m.ID)}},
+			AssociationsToAdd: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: string(m.ID)}},
 		},
 	}
 }
 
 func (m *MutableLteGateway) GetAdditionalEntitiesToLoadOnUpdate(gatewayID string) []storage.TypeAndKey {
-	return []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: gatewayID}}
+	return []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: gatewayID}}
 }
 
 func (m *MutableLteGateway) GetAdditionalWritesOnUpdate(
@@ -231,13 +231,13 @@ func (m *MutableLteGateway) GetAdditionalWritesOnUpdate(
 	loadedEntities map[storage.TypeAndKey]configurator.NetworkEntity,
 ) ([]configurator.EntityWriteOperation, error) {
 	ret := []configurator.EntityWriteOperation{}
-	existingEnt, ok := loadedEntities[storage.TypeAndKey{Type: lte.CellularGatewayType, Key: gatewayID}]
+	existingEnt, ok := loadedEntities[storage.TypeAndKey{Type: lte.CellularGatewayEntityType, Key: gatewayID}]
 	if !ok {
 		return ret, merrors.ErrNotFound
 	}
 
 	entUpdate := configurator.EntityUpdateCriteria{
-		Type:      lte.CellularGatewayType,
+		Type:      lte.CellularGatewayEntityType,
 		Key:       string(m.ID),
 		NewConfig: m.Cellular,
 	}
@@ -249,7 +249,7 @@ func (m *MutableLteGateway) GetAdditionalWritesOnUpdate(
 	}
 
 	for _, enbSerial := range m.ConnectedEnodebSerials {
-		entUpdate.AssociationsToSet = append(entUpdate.AssociationsToSet, storage.TypeAndKey{Type: lte.CellularEnodebType, Key: enbSerial})
+		entUpdate.AssociationsToSet = append(entUpdate.AssociationsToSet, storage.TypeAndKey{Type: lte.CellularEnodebEntityType, Key: enbSerial})
 	}
 
 	ret = append(ret, entUpdate)
@@ -257,7 +257,7 @@ func (m *MutableLteGateway) GetAdditionalWritesOnUpdate(
 }
 
 func (m *GatewayCellularConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	cellularConfig, err := configurator.LoadEntityConfig(networkID, lte.CellularGatewayType, gatewayID)
+	cellularConfig, err := configurator.LoadEntityConfig(networkID, lte.CellularGatewayEntityType, gatewayID)
 	if err != nil {
 		return err
 	}
@@ -268,7 +268,7 @@ func (m *GatewayCellularConfigs) FromBackendModels(networkID string, gatewayID s
 func (m *GatewayCellularConfigs) ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
 	return []configurator.EntityUpdateCriteria{
 		{
-			Type: lte.CellularGatewayType, Key: gatewayID,
+			Type: lte.CellularGatewayEntityType, Key: gatewayID,
 			NewConfig: m,
 		},
 	}, nil
@@ -335,13 +335,13 @@ func (m *GatewayNonEpsConfigs) ToUpdateCriteria(networkID string, gatewayID stri
 }
 
 func (m *EnodebSerials) FromBackendModels(networkID string, gatewayID string) error {
-	cellularGatewayEntity, err := configurator.LoadEntity(networkID, lte.CellularGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
+	cellularGatewayEntity, err := configurator.LoadEntity(networkID, lte.CellularGatewayEntityType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
 	if err != nil {
 		return err
 	}
 	enodebSerials := EnodebSerials{}
 	for _, assoc := range cellularGatewayEntity.Associations {
-		if assoc.Type == lte.CellularEnodebType {
+		if assoc.Type == lte.CellularEnodebEntityType {
 			enodebSerials = append(enodebSerials, assoc.Key)
 		}
 	}
@@ -352,11 +352,11 @@ func (m *EnodebSerials) FromBackendModels(networkID string, gatewayID string) er
 func (m *EnodebSerials) ToUpdateCriteria(networkID string, gatewayID string) ([]configurator.EntityUpdateCriteria, error) {
 	enodebSerials := []storage.TypeAndKey{}
 	for _, enodebSerial := range *m {
-		enodebSerials = append(enodebSerials, storage.TypeAndKey{Type: lte.CellularEnodebType, Key: enodebSerial})
+		enodebSerials = append(enodebSerials, storage.TypeAndKey{Type: lte.CellularEnodebEntityType, Key: enodebSerial})
 	}
 	return []configurator.EntityUpdateCriteria{
 		{
-			Type:              lte.CellularGatewayType,
+			Type:              lte.CellularGatewayEntityType,
 			Key:               gatewayID,
 			AssociationsToSet: enodebSerials,
 		},
@@ -365,15 +365,15 @@ func (m *EnodebSerials) ToUpdateCriteria(networkID string, gatewayID string) ([]
 
 func (m *EnodebSerials) ToDeleteUpdateCriteria(networkID, gatewayID, enodebID string) configurator.EntityUpdateCriteria {
 	return configurator.EntityUpdateCriteria{
-		Type: lte.CellularGatewayType, Key: gatewayID,
-		AssociationsToDelete: []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: enodebID}},
+		Type: lte.CellularGatewayEntityType, Key: gatewayID,
+		AssociationsToDelete: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: enodebID}},
 	}
 }
 
 func (m *EnodebSerials) ToCreateUpdateCriteria(networkID, gatewayID, enodebID string) configurator.EntityUpdateCriteria {
 	return configurator.EntityUpdateCriteria{
-		Type: lte.CellularGatewayType, Key: gatewayID,
-		AssociationsToAdd: []storage.TypeAndKey{{Type: lte.CellularEnodebType, Key: enodebID}},
+		Type: lte.CellularGatewayEntityType, Key: gatewayID,
+		AssociationsToAdd: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: enodebID}},
 	}
 }
 
@@ -385,7 +385,7 @@ func (m *Enodeb) FromBackendModels(ent configurator.NetworkEntity) *Enodeb {
 		m.Config = ent.Config.(*EnodebConfiguration)
 	}
 	for _, tk := range ent.ParentAssociations {
-		if tk.Type == lte.CellularGatewayType {
+		if tk.Type == lte.CellularGatewayEntityType {
 			m.AttachedGatewayID = tk.Key
 		}
 	}
@@ -394,7 +394,7 @@ func (m *Enodeb) FromBackendModels(ent configurator.NetworkEntity) *Enodeb {
 
 func (m *Enodeb) ToEntityUpdateCriteria() configurator.EntityUpdateCriteria {
 	return configurator.EntityUpdateCriteria{
-		Type:           lte.CellularEnodebType,
+		Type:           lte.CellularEnodebEntityType,
 		Key:            m.Serial,
 		NewName:        swag.String(m.Name),
 		NewDescription: swag.String(m.Description),
@@ -412,7 +412,7 @@ func (m ApnList) ToAssocs() []storage.TypeAndKey {
 	return funk.Map(
 		m,
 		func(rn string) storage.TypeAndKey {
-			return storage.TypeAndKey{Type: lte.ApnEntityType, Key: rn}
+			return storage.TypeAndKey{Type: lte.APNEntityType, Key: rn}
 		},
 	).([]storage.TypeAndKey)
 }

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -54,13 +54,13 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 	}
 
 	// Only build an mconfig if cellular network and gateway configs exist
-	inwConfig, found := network.Configs[lte.CellularNetworkType]
+	inwConfig, found := network.Configs[lte.CellularNetworkConfigType]
 	if !found || inwConfig == nil {
 		return ret, nil
 	}
 	cellularNwConfig := inwConfig.(*lte_models.NetworkCellularConfigs)
 
-	cellGW, err := graph.GetEntity(lte.CellularGatewayType, request.GatewayId)
+	cellGW, err := graph.GetEntity(lte.CellularGatewayEntityType, request.GatewayId)
 	if err == merrors.ErrNotFound {
 		return ret, nil
 	}
@@ -76,7 +76,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 		return nil, err
 	}
 
-	enodebs, err := graph.GetAllChildrenOfType(cellGW, lte.CellularEnodebType)
+	enodebs, err := graph.GetAllChildrenOfType(cellGW, lte.CellularEnodebEntityType)
 	if err != nil {
 		return nil, err
 	}

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -44,7 +44,7 @@ func TestBuilder_Build(t *testing.T) {
 	nw := configurator.Network{
 		ID: "n1",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType: lte_models.NewDefaultTDDNetworkConfig(),
+			lte.CellularNetworkConfigType: lte_models.NewDefaultTDDNetworkConfig(),
 			orc8r.DnsdNetworkType: &models.NetworkDNSConfig{
 				EnableCaching: swag.Bool(true),
 			},
@@ -53,19 +53,19 @@ func TestBuilder_Build(t *testing.T) {
 	gw := configurator.NetworkEntity{
 		Type: orc8r.MagmadGatewayType, Key: "gw1",
 		Associations: []storage.TypeAndKey{
-			{Type: lte.CellularGatewayType, Key: "gw1"},
+			{Type: lte.CellularGatewayEntityType, Key: "gw1"},
 		},
 	}
 	lteGW := configurator.NetworkEntity{
-		Type: lte.CellularGatewayType, Key: "gw1",
+		Type: lte.CellularGatewayEntityType, Key: "gw1",
 		Config: newDefaultGatewayConfig(),
 		Associations: []storage.TypeAndKey{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
 		},
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
 	enb := configurator.NetworkEntity{
-		Type: lte.CellularEnodebType, Key: "enb1",
+		Type: lte.CellularEnodebEntityType, Key: "enb1",
 		Config:             newDefaultEnodebConfig(),
 		ParentAssociations: []storage.TypeAndKey{lteGW.GetTypeAndKey()},
 	}
@@ -191,17 +191,17 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 	nw := configurator.Network{
 		ID: "n1",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType: lte_models.NewDefaultTDDNetworkConfig(),
+			lte.CellularNetworkConfigType: lte_models.NewDefaultTDDNetworkConfig(),
 		},
 	}
 	gw := configurator.NetworkEntity{
 		Type: orc8r.MagmadGatewayType, Key: "gw1",
 		Associations: []storage.TypeAndKey{
-			{Type: lte.CellularGatewayType, Key: "gw1"},
+			{Type: lte.CellularGatewayEntityType, Key: "gw1"},
 		},
 	}
 	lteGW := configurator.NetworkEntity{
-		Type: lte.CellularGatewayType, Key: "gw1",
+		Type: lte.CellularGatewayEntityType, Key: "gw1",
 		Config:             newGatewayConfigNonNat(),
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
@@ -337,17 +337,17 @@ func TestBuilder_Build_BaseCase(t *testing.T) {
 	nw := configurator.Network{
 		ID: "n1",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType: lte_models.NewDefaultTDDNetworkConfig(),
+			lte.CellularNetworkConfigType: lte_models.NewDefaultTDDNetworkConfig(),
 		},
 	}
 	gw := configurator.NetworkEntity{
 		Type: orc8r.MagmadGatewayType, Key: "gw1",
 		Associations: []storage.TypeAndKey{
-			{Type: lte.CellularGatewayType, Key: "gw1"},
+			{Type: lte.CellularGatewayEntityType, Key: "gw1"},
 		},
 	}
 	lteGW := configurator.NetworkEntity{
-		Type: lte.CellularGatewayType, Key: "gw1",
+		Type: lte.CellularGatewayEntityType, Key: "gw1",
 		Config:             newDefaultGatewayConfig(),
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
@@ -437,7 +437,7 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 	nw := configurator.Network{
 		ID: "n1",
 		Configs: map[string]interface{}{
-			lte.CellularNetworkType: lte_models.NewDefaultTDDNetworkConfig(),
+			lte.CellularNetworkConfigType: lte_models.NewDefaultTDDNetworkConfig(),
 			orc8r.DnsdNetworkType: &models.NetworkDNSConfig{
 				EnableCaching: swag.Bool(true),
 			},
@@ -446,19 +446,19 @@ func TestBuilder_BuildInheritedProperties(t *testing.T) {
 	gw := configurator.NetworkEntity{
 		Type: orc8r.MagmadGatewayType, Key: "gw1",
 		Associations: []storage.TypeAndKey{
-			{Type: lte.CellularGatewayType, Key: "gw1"},
+			{Type: lte.CellularGatewayEntityType, Key: "gw1"},
 		},
 	}
 	lteGW := configurator.NetworkEntity{
-		Type: lte.CellularGatewayType, Key: "gw1",
+		Type: lte.CellularGatewayEntityType, Key: "gw1",
 		Config: newDefaultGatewayConfig(),
 		Associations: []storage.TypeAndKey{
-			{Type: lte.CellularEnodebType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
 		},
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
 	enb := configurator.NetworkEntity{
-		Type: lte.CellularEnodebType, Key: "enb1",
+		Type: lte.CellularEnodebEntityType, Key: "enb1",
 		Config: &lte_models.EnodebConfiguration{
 			CellID:          swag.Uint32(42),
 			DeviceClass:     "Baicells ID TDD/FDD",
@@ -637,20 +637,20 @@ func newDefaultEnodebConfig() *lte_models.EnodebConfiguration {
 }
 
 func setEPCNetworkServices(services []string, nw *configurator.Network) {
-	inwConfig := nw.Configs[lte.CellularNetworkType]
+	inwConfig := nw.Configs[lte.CellularNetworkConfigType]
 	cellularNwConfig := inwConfig.(*lte_models.NetworkCellularConfigs)
 	cellularNwConfig.Epc.NetworkServices = services
 
-	nw.Configs[lte.CellularNetworkType] = cellularNwConfig
+	nw.Configs[lte.CellularNetworkConfigType] = cellularNwConfig
 }
 
 func setEPCNetworkIPAllocator(nw *configurator.Network, mode string, static_ip bool) {
-	inwConfig := nw.Configs[lte.CellularNetworkType]
+	inwConfig := nw.Configs[lte.CellularNetworkConfigType]
 	cellularNwConfig := inwConfig.(*lte_models.NetworkCellularConfigs)
 	cellularNwConfig.Epc.Mobility = &lte_models.NetworkEpcConfigsMobility{
 		IPAllocationMode:          mode,
 		EnableStaticIPAssignments: static_ip,
 	}
 
-	nw.Configs[lte.CellularNetworkType] = cellularNwConfig
+	nw.Configs[lte.CellularNetworkConfigType] = cellularNwConfig
 }

--- a/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
@@ -79,7 +79,7 @@ func initSubscriber(t *testing.T, hwID string) {
 
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{
-			Type: lte.ApnEntityType, Key: "apn1",
+			Type: lte.APNEntityType, Key: "apn1",
 			Config: &lte_models.ApnConfiguration{
 				Ambr: &lte_models.AggregatedMaximumBitrate{
 					MaxBandwidthDl: swag.Uint32(42),
@@ -94,7 +94,7 @@ func initSubscriber(t *testing.T, hwID string) {
 			},
 		},
 		{
-			Type: lte.ApnEntityType, Key: "apn2",
+			Type: lte.APNEntityType, Key: "apn2",
 			Config: &lte_models.ApnConfiguration{
 				Ambr: &lte_models.AggregatedMaximumBitrate{
 					MaxBandwidthDl: swag.Uint32(42),
@@ -118,7 +118,7 @@ func initSubscriber(t *testing.T, hwID string) {
 				},
 				StaticIps: map[string]strfmt.IPv4{"apn1": "192.168.100.1"},
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: "apn1"}, {Type: lte.ApnEntityType, Key: "apn2"}},
+			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: "apn1"}, {Type: lte.APNEntityType, Key: "apn2"}},
 		},
 		{Type: lte.SubscriberEntityType, Key: "IMSI67890", Config: &models.SubscriberConfig{Lte: &models.LteSubscription{State: "INACTIVE", SubProfile: "foo"}}},
 	})

--- a/lte/cloud/go/services/policydb/servicers/assignments_test.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments_test.go
@@ -82,7 +82,7 @@ func TestAssignmentsServicer(t *testing.T) {
 				},
 			},
 			{
-				Type: lte.CellularGatewayType, Key: testGwLogicalId,
+				Type: lte.CellularGatewayEntityType, Key: testGwLogicalId,
 				Config: newDefaultGatewayConfig(),
 				Associations: []storage.TypeAndKey{
 					{Type: lte.SubscriberEntityType, Key: testSubscriberId},
@@ -92,7 +92,7 @@ func TestAssignmentsServicer(t *testing.T) {
 				Type: orc8r.MagmadGatewayType, Key: testGwLogicalId,
 				Name: "foobar", Description: "foo bar",
 				PhysicalID:   testGwHwId,
-				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayType, Key: testGwLogicalId}},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: testGwLogicalId}},
 			},
 		},
 	)

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -283,7 +283,7 @@ func validateSubscriberProfile(networkID string, sub *subscribermodels.LteSubscr
 	// Check the sub profiles available on the network if sub profile is not
 	// default (which is always available)
 	if sub.SubProfile != "default" {
-		netConf, err := configurator.LoadNetworkConfig(networkID, lte.CellularNetworkType)
+		netConf, err := configurator.LoadNetworkConfig(networkID, lte.CellularNetworkConfigType)
 		switch {
 		case err == merrors.ErrNotFound:
 			return obsidian.HttpError(errors.New("no cellular config found for network"), http.StatusInternalServerError)

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -60,8 +60,8 @@ func TestCreateSubscriber(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -105,7 +105,7 @@ func TestCreateSubscriber(t *testing.T) {
 			StaticIps: payload.StaticIps,
 		},
 		GraphID:      "2",
-		Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+		Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 	}
 	assert.Equal(t, expected, actual)
 
@@ -138,7 +138,7 @@ func TestCreateSubscriber(t *testing.T) {
 
 	// nonexistent sub profile should be 400
 	err = configurator.UpdateNetworkConfig(
-		"n1", lte.CellularNetworkType,
+		"n1", lte.CellularNetworkConfigType,
 		&lteModels.NetworkCellularConfigs{
 			Epc: &lteModels.NetworkEpcConfigs{
 				SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
@@ -244,8 +244,8 @@ func TestListSubscribers(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -275,7 +275,7 @@ func TestListSubscribers(t *testing.T) {
 					},
 					StaticIps: subscriberModels.SubscriberStaticIps{apn1: "192.168.100.1", apn2: "10.10.10.5"},
 				},
-				Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+				Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 			},
 			{
 				Type: lte.SubscriberEntityType, Key: "IMSI0987654321",
@@ -288,7 +288,7 @@ func TestListSubscribers(t *testing.T) {
 						SubProfile: "foo",
 					},
 				},
-				Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn1}},
+				Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn1}},
 			},
 		},
 	)
@@ -476,8 +476,8 @@ func TestGetSubscriber(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -508,7 +508,7 @@ func TestGetSubscriber(t *testing.T) {
 				},
 				StaticIps: subscriberModels.SubscriberStaticIps{apn1: "192.168.100.1"},
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 		},
 	)
 	assert.NoError(t, err)
@@ -651,8 +651,8 @@ func TestUpdateSubscriber(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -683,7 +683,7 @@ func TestUpdateSubscriber(t *testing.T) {
 
 	// Happy path
 	err = configurator.UpdateNetworkConfig(
-		"n1", lte.CellularNetworkType,
+		"n1", lte.CellularNetworkConfigType,
 		&lteModels.NetworkCellularConfigs{
 			Epc: &lteModels.NetworkEpcConfigs{
 				SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
@@ -708,7 +708,7 @@ func TestUpdateSubscriber(t *testing.T) {
 					SubProfile: "default",
 				},
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}},
+			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}},
 		},
 	)
 	assert.NoError(t, err)
@@ -747,7 +747,7 @@ func TestUpdateSubscriber(t *testing.T) {
 		Config:       &subscriberModels.SubscriberConfig{Lte: payload.Lte, StaticIps: payload.StaticIps},
 		GraphID:      "2",
 		Version:      1,
-		Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+		Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 	}
 	assert.Equal(t, expected, actual)
 
@@ -785,8 +785,8 @@ func TestDeleteSubscriber(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -801,7 +801,7 @@ func TestDeleteSubscriber(t *testing.T) {
 				AuthOpc:  []byte("\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11\x11"),
 				State:    "ACTIVE",
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 		},
 	)
 	assert.NoError(t, err)
@@ -840,8 +840,8 @@ func TestActivateDeactivateSubscriber(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -856,7 +856,7 @@ func TestActivateDeactivateSubscriber(t *testing.T) {
 				State:    "ACTIVE",
 			},
 		},
-		Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+		Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 	}
 	_, err = configurator.CreateEntity("n1", expected)
 	assert.NoError(t, err)
@@ -918,7 +918,7 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
 	assert.NoError(t, err)
 	err = configurator.UpdateNetworkConfig(
-		"n1", lte.CellularNetworkType,
+		"n1", lte.CellularNetworkConfigType,
 		&lteModels.NetworkCellularConfigs{
 			Epc: &lteModels.NetworkEpcConfigs{
 				SubProfiles: map[string]lteModels.NetworkEpcConfigsSubProfilesAnon{
@@ -937,8 +937,8 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 	_, err = configurator.CreateEntities(
 		"n1",
 		[]configurator.NetworkEntity{
-			{Type: lte.ApnEntityType, Key: apn1},
-			{Type: lte.ApnEntityType, Key: apn2},
+			{Type: lte.APNEntityType, Key: apn1},
+			{Type: lte.APNEntityType, Key: apn2},
 		},
 	)
 	assert.NoError(t, err)
@@ -955,7 +955,7 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 					SubProfile: "default",
 				},
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 		},
 	)
 	assert.NoError(t, err)
@@ -1020,7 +1020,7 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 		},
 		GraphID:      "2",
 		Version:      1,
-		Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+		Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 	}
 	assert.Equal(t, expected, actual)
 
@@ -1050,7 +1050,7 @@ func TestUpdateSubscriberProfile(t *testing.T) {
 		},
 		GraphID:      "2",
 		Version:      2,
-		Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: apn2}, {Type: lte.ApnEntityType, Key: apn1}},
+		Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: apn2}, {Type: lte.APNEntityType, Key: apn1}},
 	}
 	assert.Equal(t, expected, actual)
 }

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -50,7 +50,7 @@ func (m *Subscriber) FromBackendModels(ent configurator.NetworkEntity, statesByI
 		m.Lte.SubProfile = "default"
 	}
 	for _, tk := range ent.Associations {
-		if tk.Type == lte.ApnEntityType {
+		if tk.Type == lte.APNEntityType {
 			m.ActiveApns = append(m.ActiveApns, tk.Key)
 		}
 	}
@@ -178,7 +178,7 @@ func (m ApnList) ToAssocs() []storage.TypeAndKey {
 	return funk.Map(
 		m,
 		func(rn string) storage.TypeAndKey {
-			return storage.TypeAndKey{Type: lte.ApnEntityType, Key: rn}
+			return storage.TypeAndKey{Type: lte.APNEntityType, Key: rn}
 		},
 	).([]storage.TypeAndKey)
 }

--- a/lte/cloud/go/services/subscriberdb/streamer/providers.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers.go
@@ -45,7 +45,7 @@ func (p *SubscribersProvider) GetUpdates(gatewayId string, extraArgs *any.Any) (
 		return nil, err
 	}
 	// Collect all APNs in one RPC call
-	apnEnts, err := configurator.LoadAllEntitiesInNetwork(ent.NetworkID, lte.ApnEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
+	apnEnts, err := configurator.LoadAllEntitiesInNetwork(ent.NetworkID, lte.APNEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
 	// Create a map to avoid for loops in function calls to populate subscriber data from subscriber associations
 	apnConfigMap := make(map[string]*lte_models.ApnConfiguration, len(apnEnts))
 	for _, apnEnt := range apnEnts {

--- a/lte/cloud/go/services/subscriberdb/streamer/providers_test.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers_test.go
@@ -55,7 +55,7 @@ func TestSubscriberdbStreamer(t *testing.T) {
 	// other without
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{
-			Type: lte.ApnEntityType, Key: "apn1",
+			Type: lte.APNEntityType, Key: "apn1",
 			Config: &lte_models.ApnConfiguration{
 				Ambr: &lte_models.AggregatedMaximumBitrate{
 					MaxBandwidthDl: swag.Uint32(42),
@@ -70,7 +70,7 @@ func TestSubscriberdbStreamer(t *testing.T) {
 			},
 		},
 		{
-			Type: lte.ApnEntityType, Key: "apn2",
+			Type: lte.APNEntityType, Key: "apn2",
 			Config: &lte_models.ApnConfiguration{
 				Ambr: &lte_models.AggregatedMaximumBitrate{
 					MaxBandwidthDl: swag.Uint32(42),
@@ -94,7 +94,7 @@ func TestSubscriberdbStreamer(t *testing.T) {
 				},
 				StaticIps: models.SubscriberStaticIps{"apn1": "192.168.100.1"},
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.ApnEntityType, Key: "apn1"}, {Type: lte.ApnEntityType, Key: "apn2"}},
+			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: "apn1"}, {Type: lte.APNEntityType, Key: "apn2"}},
 		},
 		{Type: lte.SubscriberEntityType, Key: "IMSI67890", Config: &models.SubscriberConfig{Lte: &models.LteSubscription{State: "INACTIVE", SubProfile: "foo"}}},
 	})

--- a/orc8r/cloud/go/services/configurator/doc.go
+++ b/orc8r/cloud/go/services/configurator/doc.go
@@ -11,8 +11,56 @@
  * limitations under the License.
  */
 
-// Package configurator contains the Configurator service which manages
-// configuration of and relationships between logical network entities.
+/*
+	Package configurator supports configuration management and dynamic
+	generation by manipulating a graph of network entities.
+
+	Entity graph
+
+	Configurator manages a directed acyclic graph (DAG) of network-partitioned
+	entities. Callers can define their graph via the following three types
+		- Network
+			- Network-level configs
+			- Network-level metadata
+		- Network entity (vertices)
+			- Type
+			- Key (ID)
+			- Config (serialized)
+		- Edge (directed edge)
+			- Connect two network entities
+	Each network provides an isolated graph, with network-level configs and
+	metadata. Network entities represent logical entities within a network
+	such as a gateway, subscriber, or APN. Edges connect two network
+	entities with a directed edge.
+
+	Code calling configurator should take care to define entity types and
+	relations which would invariably result in an acyclic graph.
+
+	Generating configs
+
+	Configurator provides two interfaces: northbound and southbound. The
+	northbound interface manipulates the entity graphs according to requests
+	from the Orchestrator REST API and from other Orchestrator services. The
+	southbound interface synthesizes the entity graph into mconfigs for
+	particular gateways.
+
+	Configurator generates these gateway mconfigs ("Magma" configs) by
+	outsourcing config generation to a dynamic set of mconfig builders.
+	Configurator sends each registered builder the gateway ID for which to
+	build a config, along with the encompassing entity graph and network.
+	With this information, each builder can traverse the graph as-necessary to
+	dynamically build a config for the requesting gateway.
+
+	Configurator assembles the set of partial configs from each mconfig builder
+	into a complete config. Before returning, it adds metadata such as
+	time of creation and hash/digest of the configs.
+
+	Mconfig builders are Orchestrator services registering an MconfigBuilder
+	under their gRPC endpoint. Any Orchestrator service can provide its own
+	builder servicer. Configurator discovers mconfig builders using K8s labels.
+	Any service with the label "orc8r.io/mconfig_builder" will be assumed to
+	provide an mconfig builder servicer.
+*/
 package configurator
 
 const (
@@ -24,6 +72,4 @@ const (
 
 	// NetworkEntitySerdeDomain is the Serde domain for network entity configs
 	NetworkEntitySerdeDomain = "configurator_entity_configs"
-
-	GatewayEntityType = "gateway"
 )

--- a/orc8r/cloud/go/services/metricsd/doc.go
+++ b/orc8r/cloud/go/services/metricsd/doc.go
@@ -11,31 +11,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package metricsd supports metrics collection, augmentation, and export,
-// as well as providing REST API endpoints for viewing metrics and
-// managing alerts.
-//
-// A metrics profile defines the manner and extent to which metrics are
-// consumed and exported.
-//
-// Metrics profiles are registered with the profile registry. The metricsd
-// service consumes profiles from the registry and kicks off their respective
-// collect/export loops.
-//
-// Only one metrics profile can be active at a time. The active profile is
-// determined by a service-level config value, and changing the active profile
-// requires a metricsd service restart. Each exporter in the active profile
-// receives metrics from every collector.
-//
-// Available exporters include export to a custom Prometheus push gateway, as
-// well as support for more time-series-oriented endpoints.
-//
-// The metricsd service provides gRPC endpoints to accept metrics pushed
-// via the REST API, as well as metrics collected (reported) from non-local
-// services such as those on AGWs.
-//
-// The obsidian REST API handlers provide endpoints to query metrics, as well
-// as view, configure, and silence alerts.
+/*
+	Package metricsd supports metrics collection, augmentation, and export,
+	as well as providing REST API endpoints for viewing metrics and
+	managing alerts.
+
+	A metrics profile defines the manner and extent to which metrics are
+	consumed and exported.
+
+	Metrics profiles are registered with the profile registry. The metricsd
+	service consumes profiles from the registry and kicks off their respective
+	collect/export loops.
+
+	Only one metrics profile can be active at a time. The active profile is
+	determined by a service-level config value, and changing the active profile
+	requires a metricsd service restart. Each exporter in the active profile
+	receives metrics from every collector.
+
+	Available exporters include export to a custom Prometheus push gateway, as
+	well as support for more time-series-oriented endpoints.
+
+	The metricsd service provides gRPC endpoints to accept metrics pushed
+	via the REST API, as well as metrics collected (reported) from non-local
+	services such as those on AGWs.
+
+	The obsidian REST API handlers provide endpoints to query metrics, as well
+	as view, configure, and silence alerts.
+*/
 package metricsd
 
 const (

--- a/orc8r/cloud/go/services/state/indexer/doc.go
+++ b/orc8r/cloud/go/services/state/indexer/doc.go
@@ -11,112 +11,114 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package indexer provides tools to define, use, and update state indexers.
-//
-// State service
-//
-// The state service stores gateway state as keyed blobs.
-// Examples
-//	- IMSI -> directory record blob
-//	- HWID -> gateway status blob
-//
-// Since state values are stored as arbitrary serialized blobs, the state
-// service has no semantic understanding of stored values. This means searching
-// over stored values would otherwise require an O(n) operation.
-// Examples
-//	- Find IMSI with given IP -- must load all directory records into memory
-//	- Find all gateways that haven't checked in recently -- must load all
-//	  gateway statuses into memory
-//
-// Derived state
-//
-// The solution is to provide customizable, online mechanisms for generating
-// derived state based on existing state. Existing, "primary" state is stored
-// in the state service, and derived, "secondary" state is stored in whichever
-// service owns the derived state.
-// Examples
-//	- Reverse map of directory records
-//		- Primary state: IMSI -> directory record
-//		- Secondary state: IP -> IMSI (stored in e.g. directoryd)
-//	- Reverse map of gateway checkin time
-//		- Primary state: HWID -> gateway status
-//		- Secondary state: checkin time -> HWID (stored in e.g. metricsd)
-//	- List all gateways with multiple kernel versions installed
-//		- Primary state: HWID -> gateway status
-//		-  Secondary state: list of gateways (stored in e.g. bootstrapper)
-//
-// State indexers
-//
-// State indexers are Orchestrator services registering an IndexerServer under
-// their gRPC endpoint. Any Orchestrator service can provide its own indexer
-// servicer.
-//
-// The state service discovers indexers using K8s labels. Any service with the
-// label "orc8r.io/state_indexer" will be assumed to provide an indexer
-// servicer.
-//
-// Indexers provide two additional pieces of metadata -- version and types.
-//	- version: positive integer indicating when the indexer requires reindexing
-//	- types: list of state types the indexer subscribes to
-// These metadata are indicated by K8s annotations
-//	- orc8r.io/state_indexer_version -- positive integer
-//	- orc8r.io/state_indexer_types -- comma-separated list of state types
-//
-// Reindexing
-//
-// When an indexer's implementation changes, its derived state needs to be
-// refreshed. This is accomplished by sending all existing state (of desired
-// types) through the now-updated indexer.
-//
-// An indexer indicates it needs to undergo a reindex by incrementing its
-// version (exposed via the above-mentioned annotation). From there, the state
-// service automatically handles the reindexing process.
-//
-// Metrics and logging are available to track long-running reindex processes,
-// as well an indexers CLI which reports desired and current indexer versions.
-//
-// Implementing a custom indexer
-//
-// To create a custom indexer, attach an IndexerServer to a new or existing
-// Orchestrator service.
-//
-// A service can only attach a single indexer. However, that indexer can choose
-// to multiplex its functionality over any desired number of "logical"
-// indexers.
-//
-// See the orchestrator service for an example custom indexer.
-//
-// Notes
-//
-// The state indexer pattern currently provides no mechanism for connecting
-// primary and secondary state. This means secondary state can go stale.
-// Where relevant, consumers of secondary state should take this into account,
-// generally by checking the primary state to ensure it agrees with the
-// secondary state.
-// Examples
-//	- Reverse map of directory records
-//		- Get IMSI from IP -> IMSI map (secondary state)
-//		- Ensure the directory record in the IMSI -> directory map contains
-//		  the desired IP (primary state)
-//	- Reverse map of gateway checkin time
-//		- Get HWIDs from checkin time -> HWID map (secondary state)
-//		- For each HWID, ensure the gateway status in the HWID -> gateway
-//		  status map contains the relevant checkin time (primary state)
-//
-// Automatic reindexing is only supported with Postgres. Deployments targeting
-// Maria will need to use the indexer CLI to manually trigger reindex
-// operations.
-//
-// There is a trivial but existent race condition during the reindex process.
-// Since the index and reindex operations but use the Index gRPC method,
-// and the index and reindex operations operate in parallel, it's possible for
-// an indexer to receive an outdated piece of state from the reindexer.
-// However, this requires
-//	- reindexer read old state
-//	- new state reported, indexer read new state
-//	- indexer Index call completed
-//	- reindexer Index call completed
-// If this race condition is intolerable to the desired use case, the solution
-// is to separate out the Index call into Index and Reindex methods. This is
-// not currently implemented as we don't have a concrete use-case for it yet.
+/*
+	Package indexer provides tools to define, use, and update state indexers.
+
+	State service
+
+	The state service stores gateway state as keyed blobs.
+	Examples
+		- IMSI -> directory record blob
+		- HWID -> gateway status blob
+
+	Since state values are stored as arbitrary serialized blobs, the state
+	service has no semantic understanding of stored values. This means searching
+	over stored values would otherwise require an O(n) operation.
+	Examples
+		- Find IMSI with given IP -- must load all directory records into memory
+		- Find all gateways that haven't checked in recently -- must load all
+		  gateway statuses into memory
+
+	Derived state
+
+	The solution is to provide customizable, online mechanisms for generating
+	derived state based on existing state. Existing, "primary" state is stored
+	in the state service, and derived, "secondary" state is stored in whichever
+	service owns the derived state.
+	Examples
+		- Reverse map of directory records
+			- Primary state: IMSI -> directory record
+			- Secondary state: IP -> IMSI (stored in e.g. directoryd)
+		- Reverse map of gateway checkin time
+			- Primary state: HWID -> gateway status
+			- Secondary state: checkin time -> HWID (stored in e.g. metricsd)
+		- List all gateways with multiple kernel versions installed
+			- Primary state: HWID -> gateway status
+			-  Secondary state: list of gateways (stored in e.g. bootstrapper)
+
+	State indexers
+
+	State indexers are Orchestrator services registering an IndexerServer under
+	their gRPC endpoint. Any Orchestrator service can provide its own indexer
+	servicer.
+
+	The state service discovers indexers using K8s labels. Any service with the
+	label "orc8r.io/state_indexer" will be assumed to provide an indexer
+	servicer.
+
+	Indexers provide two additional pieces of metadata -- version and types.
+		- version: positive integer indicating when the indexer requires reindexing
+		- types: list of state types the indexer subscribes to
+	These metadata are indicated by K8s annotations
+		- orc8r.io/state_indexer_version -- positive integer
+		- orc8r.io/state_indexer_types -- comma-separated list of state types
+
+	Reindexing
+
+	When an indexer's implementation changes, its derived state needs to be
+	refreshed. This is accomplished by sending all existing state (of desired
+	types) through the now-updated indexer.
+
+	An indexer indicates it needs to undergo a reindex by incrementing its
+	version (exposed via the above-mentioned annotation). From there, the state
+	service automatically handles the reindexing process.
+
+	Metrics and logging are available to track long-running reindex processes,
+	as well an indexers CLI which reports desired and current indexer versions.
+
+	Implementing a custom indexer
+
+	To create a custom indexer, attach an IndexerServer to a new or existing
+	Orchestrator service.
+
+	A service can only attach a single indexer. However, that indexer can choose
+	to multiplex its functionality over any desired number of "logical"
+	indexers.
+
+	See the orchestrator service for an example custom indexer.
+
+	Notes
+
+	The state indexer pattern currently provides no mechanism for connecting
+	primary and secondary state. This means secondary state can go stale.
+	Where relevant, consumers of secondary state should take this into account,
+	generally by checking the primary state to ensure it agrees with the
+	secondary state.
+	Examples
+		- Reverse map of directory records
+			- Get IMSI from IP -> IMSI map (secondary state)
+			- Ensure the directory record in the IMSI -> directory map contains
+			  the desired IP (primary state)
+		- Reverse map of gateway checkin time
+			- Get HWIDs from checkin time -> HWID map (secondary state)
+			- For each HWID, ensure the gateway status in the HWID -> gateway
+			  status map contains the relevant checkin time (primary state)
+
+	Automatic reindexing is only supported with Postgres. Deployments targeting
+	Maria will need to use the indexer CLI to manually trigger reindex
+	operations.
+
+	There is a trivial but existent race condition during the reindex process.
+	Since the index and reindex operations but use the Index gRPC method,
+	and the index and reindex operations operate in parallel, it's possible for
+	an indexer to receive an outdated piece of state from the reindexer.
+	However, this requires
+		- reindexer read old state
+		- new state reported, indexer read new state
+		- indexer Index call completed
+		- reindexer Index call completed
+	If this race condition is intolerable to the desired use case, the solution
+	is to separate out the Index call into Index and Reindex methods. This is
+	not currently implemented as we don't have a concrete use-case for it yet.
+*/
 package indexer


### PR DESCRIPTION
## Summary

Spent time planning #2257 by reading through configurator and LTE's models/entities. There was a lack of clarity, to me at least, on (a) which types were configs vs. entities and (b) the DAG of entity types. These were both rememdied by some light const renaming as well as a comment in const.go explaining the set of model-entity relationships and the edges between entity types.

## Test Plan

- [x] make test

## Additional Information

- [ ] This change is backwards-breaking