### PR TITLE
[NMS] Add custom line chart to custom metrics

### DIFF
--- a/nms/app/packages/magmalte/app/components/CustomMetrics.js
+++ b/nms/app/packages/magmalte/app/components/CustomMetrics.js
@@ -17,7 +17,11 @@
 import React from 'react';
 import moment from 'moment';
 
-import {Bar} from 'react-chartjs-2';
+import {Bar, Line} from 'react-chartjs-2';
+
+export function getStepString(delta: number, unit: string) {
+  return delta.toString() + unit[0];
+}
 
 export function getStep(start: moment, end: moment): [number, string, string] {
   const d = moment.duration(end.diff(start));
@@ -45,6 +49,11 @@ export function getStep(start: moment, end: moment): [number, string, string] {
   return [1, 'months', 'DD-MM-YYYY'];
 }
 
+export type DatasetType = {
+  t: number,
+  y: number,
+};
+
 export type Dataset = {
   label: string,
   borderWidth: number,
@@ -52,15 +61,15 @@ export type Dataset = {
   borderColor: string,
   hoverBorderColor: string,
   hoverBackgroundColor: string,
-  data: Array<number>,
+  data: Array<DatasetType>,
 };
 
-type HistogramProps = {
+type Props = {
   labels: Array<string>,
   dataset: Array<Dataset>,
 };
 
-export default function CustomHistogram(props: HistogramProps) {
+export default function CustomHistogram(props: Props) {
   return (
     <>
       <Bar
@@ -87,6 +96,82 @@ export default function CustomHistogram(props: HistogramProps) {
                 },
               },
             ],
+          },
+        }}
+      />
+    </>
+  );
+}
+
+export function CustomLineChart(props: Props) {
+  return (
+    <>
+      <Line
+        height={300}
+        data={{
+          labels: props.labels,
+          datasets: props.dataset,
+        }}
+        legend={{
+          display: true,
+          position: 'bottom',
+          align: 'center',
+          labels: {
+            boxWidth: 12,
+          },
+        }}
+        options={{
+          maintainAspectRatio: false,
+          scaleShowValues: true,
+          scales: {
+            xAxes: {
+              gridLines: {
+                display: true,
+              },
+              ticks: {
+                maxTicksLimit: 10,
+              },
+              type: 'time',
+              time: {
+                round: 'second',
+                tooltipFormat: 'YYYY/MM/DD h:mm:ss a',
+              },
+              scaleLabel: {
+                display: true,
+                labelString: 'Date',
+              },
+            },
+            yAxes: [
+              {
+                gridLines: {
+                  drawBorder: true,
+                },
+                ticks: {
+                  maxTicksLimit: 3,
+                },
+                scaleLabel: {
+                  display: true,
+                  labelString: '',
+                },
+                position: 'left',
+              },
+            ],
+          },
+          tooltips: {
+            enabled: true,
+            mode: 'nearest',
+            callbacks: {
+              label: (tooltipItem, data) => {
+                const x =
+                  data.datasets[tooltipItem.datasetIndex].label +
+                  ': ' +
+                  tooltipItem.yLabel +
+                  ' ' +
+                  (data.datasets[tooltipItem.datasetIndex].unit ?? '');
+                console.log('tooltip ', x);
+                return x;
+              },
+            },
           },
         }}
       />

--- a/nms/app/packages/magmalte/app/components/EventAlertChart.js
+++ b/nms/app/packages/magmalte/app/components/EventAlertChart.js
@@ -13,88 +13,204 @@
  * @flow strict-local
  * @format
  */
-import type {ChartStyle} from '@fbcnms/ui/insights/AsyncMetric';
+import type {Dataset} from './CustomMetrics';
+import type {network_id} from '@fbcnms/magma-api';
 
-import AsyncMetric from '@fbcnms/ui/insights/AsyncMetric';
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
-import Grid from '@material-ui/core/Grid';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import React from 'react';
-import Text from '../theme/design-system/Text';
 import moment from 'moment';
+import nullthrows from '@fbcnms/util/nullthrows';
 
+import {CustomLineChart, getStep, getStepString} from './CustomMetrics';
 import {colors} from '../theme/default';
+import {useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useRouter} from '@fbcnms/ui/hooks';
 
 type Props = {
   startEnd: [moment, moment],
 };
-const CHART_COLORS = [
-  colors.secondary.dodgerBlue,
-  colors.data.flamePea,
-  'green',
-  'yellow',
-  'purple',
-  'black',
-];
 
-const isValid = (start, end): boolean => {
-  return start.isValid() && end.isValid() && moment.min(start, end) === start;
+type DatasetFetchProps = {
+  networkId: network_id,
+  start: moment,
+  end: moment,
+  enqueueSnackbar: (msg: string, cfg: {}) => ?(string | number),
 };
 
-export default function ({startEnd}: Props) {
-  const [start, end] = startEnd;
-  const state = {
-    title: 'Frequency of Alerts and Events',
-    legendLabels: ['Alerts', 'Events'],
-  };
-  const chartStyle: ChartStyle = {
-    data: {
+async function getEventAlertDataset(props: DatasetFetchProps) {
+  const {start, end, networkId} = props;
+  const [delta, unit, format] = getStep(start, end);
+  let requestError = '';
+  const queries = [];
+  const labels = [];
+
+  let s = start.clone();
+  while (end.diff(s) >= 0) {
+    labels.push(s.format(format));
+    const e = s.clone();
+    e.add(delta, unit);
+    queries.push([s, e]);
+    s = e.clone();
+  }
+
+  const requests = queries.map(async (query, _) => {
+    try {
+      const [s, e] = query;
+      const response = await MagmaV1API.getEventsByNetworkIdAboutCount({
+        networkId: networkId,
+        start: s.toISOString(),
+        end: e.toISOString(),
+      });
+      return response;
+    } catch (error) {
+      requestError = error;
+    }
+    return null;
+  });
+
+  // get events data
+  const eventData = await Promise.all(requests)
+    .then(allResponses => {
+      return allResponses.map((r, index) => {
+        const [s] = queries[index];
+
+        if (r === null || r === undefined) {
+          return {
+            t: s.unix(),
+            y: 0,
+          };
+        }
+        return {
+          t: s.unix(),
+          y: r,
+        };
+      });
+    })
+    .catch(error => {
+      requestError = error;
+      return [];
+    });
+
+  if (requestError) {
+    props.enqueueSnackbar('Error getting event counts', {
+      variant: 'error',
+    });
+  }
+
+  const alertPromResp = await MagmaV1API.getNetworksByNetworkIdPrometheusQueryRange(
+    {
+      networkId: networkId,
+      start: start.toISOString(),
+      end: end.toISOString(),
+      step: getStepString(delta, unit),
+      query: 'sum(ALERTS)',
+    },
+  );
+
+  const alertsData = [];
+  alertPromResp.data.result.forEach(it =>
+    it['values']?.map(i => {
+      alertsData.push({
+        t: parseInt(i[0]) * 1000,
+        y: parseFloat(i[1]),
+      });
+    }),
+  );
+
+  return [
+    {
+      label: 'Events',
+      fill: false,
+      backgroundColor: colors.secondary.dodgerBlue,
+      borderColor: colors.secondary.dodgerBlue,
+      borderWidth: 1,
+      hoverBackgroundColor: colors.secondary.dodgerBlue,
+      hoverBorderColor: 'black',
+      data: eventData,
+    },
+    {
+      label: 'Alerts',
+      fill: false,
       lineTension: 0.2,
+      pointHitRadius: 10,
       pointRadius: 0.1,
+      borderWidth: 2,
+      backgroundColor: colors.data.flamePea,
+      borderColor: colors.data.flamePea,
+      hoverBackgroundColor: colors.data.flamePea,
+      hoverBorderColor: 'black',
+      data: alertsData,
     },
-    options: {
-      xAxes: {
-        gridLines: {
-          display: false,
-        },
-        ticks: {
-          maxTicksLimit: 10,
-        },
-      },
-      yAxes: {
-        gridLines: {
-          drawBorder: true,
-        },
-        ticks: {
-          maxTicksLimit: 1,
-        },
-      },
-    },
-    legend: {
-      position: 'top',
-      align: 'end',
-    },
-  };
+    labels,
+  ];
+}
+
+export default function EventAlertChart(props: Props) {
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const [start, end] = props.startEnd;
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const [labels, setLabels] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  const [eventDataset, setEventDataset] = useState<Dataset>({
+    label: 'Events',
+    backgroundColor: colors.secondary.dodgerBlue,
+    borderColor: colors.secondary.dodgerBlue,
+    borderWidth: 1,
+    hoverBackgroundColor: colors.secondary.malibu,
+    hoverBorderColor: 'black',
+    data: [],
+    fill: false,
+  });
+
+  const [alertDataset, setAlertDataset] = useState<Dataset>({
+    label: 'Alerts',
+    backgroundColor: colors.data.flamePea,
+    borderColor: colors.data.flamePea,
+    borderWidth: 1,
+    hoverBackgroundColor: colors.data.flamePea,
+    hoverBorderColor: 'black',
+    data: [],
+    fill: false,
+  });
+
+  useEffect(() => {
+    // fetch queries
+    const fetchAllData = async () => {
+      const [eventDataset, alertDataset, labels] = await getEventAlertDataset({
+        start,
+        end,
+        networkId,
+        enqueueSnackbar,
+      });
+      setEventDataset(eventDataset);
+      setAlertDataset(alertDataset);
+      setLabels(labels);
+      setIsLoading(false);
+    };
+
+    fetchAllData();
+  }, [start, end, enqueueSnackbar, networkId]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
   return (
-    <Grid>
-      <Card elevation={0}>
-        <CardHeader
-          title={<Text variant="body2">{state.title}</Text>}
-          subheader={
-            <AsyncMetric
-              height={300}
-              style={chartStyle}
-              label={state.title}
-              unit=""
-              queries={['sum(ALERTS)']}
-              timeRange={'3_hours'}
-              startEnd={isValid(start, end) ? startEnd : undefined}
-              legendLabels={state.legendLabels}
-              chartColors={CHART_COLORS}
-            />
-          }
-        />
-      </Card>
-    </Grid>
+    <Card elevation={0}>
+      <CardHeader
+        subheader={
+          <CustomLineChart
+            dataset={[eventDataset, alertDataset]}
+            labels={labels}
+          />
+        }
+      />
+    </Card>
   );
 }

--- a/nms/app/packages/magmalte/app/components/__tests__/EventAlertChartTest.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/EventAlertChartTest.js
@@ -64,19 +64,19 @@ describe('<EventAlertChart/>', () => {
     {
       startDate: moment().subtract(2, 'hours'),
       endDate: moment(),
-      step: '30s',
+      step: '15m',
       valid: true,
     },
     {
       startDate: moment().subtract(10, 'day'),
       endDate: moment(),
-      step: '4h',
+      step: '1d',
       valid: true,
     },
     {
       startDate: moment(),
       endDate: moment().subtract(10, 'day'),
-      step: '4h',
+      step: '1d',
       valid: false,
     },
   ];
@@ -118,7 +118,7 @@ describe('<EventAlertChart/>', () => {
         ).toEqual(tc.step);
       } else {
         // negative test for invalid start end use default timerange
-        const defaultStep = '30s';
+        const defaultStep = '5m';
         expect(
           MagmaAPIBindings.getNetworksByNetworkIdPrometheusQueryRange.mock
             .calls[0][0].step,

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayLogChart.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayLogChart.js
@@ -13,11 +13,11 @@
  * @flow strict-local
  * @format
  */
-import type {Dataset} from '../../components/CustomHistogram';
+import type {Dataset, DatasetType} from '../../components/CustomMetrics';
 
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
-import CustomHistogram from '../../components/CustomHistogram';
+import CustomHistogram from '../../components/CustomMetrics';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import React from 'react';
@@ -89,11 +89,18 @@ export default function LogChart(props: Props) {
 
     Promise.all(requests)
       .then(allResponses => {
-        const logData: Array<number> = allResponses.map(r => {
+        const data: Array<DatasetType> = allResponses.map((r, index) => {
+          const [s] = queries[index];
           if (r === null || r === undefined) {
-            return 0;
+            return {
+              t: s.unix(),
+              y: 0,
+            };
           }
-          return r;
+          return {
+            t: s.unix(),
+            y: r,
+          };
         });
 
         const ds: Dataset = {
@@ -103,10 +110,10 @@ export default function LogChart(props: Props) {
           borderWidth: 1,
           hoverBackgroundColor: colors.secondary.dodgerBlue,
           hoverBorderColor: 'black',
-          data: logData,
+          data: data,
         };
         setDataset(ds);
-        setLogCount(logData.reduce((a, b) => a + b, 0));
+        setLogCount(data.reduce((a, b) => a + b.y, 0));
         setIsLoading(false);
       })
       .catch(error => {

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayLogs.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayLogs.js
@@ -31,7 +31,7 @@ import nullthrows from '@fbcnms/util/nullthrows';
 import {CsvBuilder} from 'filefy';
 import {DateTimePicker} from '@material-ui/pickers';
 import {colors} from '../../theme/default';
-import {getStep} from '../../components/CustomHistogram';
+import {getStep} from '../../components/CustomMetrics';
 import {makeStyles} from '@material-ui/styles';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useMemo, useRef, useState} from 'react';

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayLogsTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayLogsTest.js
@@ -15,7 +15,7 @@
  */
 import 'jest-dom/extend-expect';
 
-import * as customHistogram from '../../../components/CustomHistogram';
+import * as customHistogram from '../../../components/CustomMetrics';
 import GatewayLogs from '../GatewayLogs';
 import MagmaAPIBindings from '@fbcnms/magma-api';
 import MomentUtils from '@date-io/moment';

--- a/nms/app/packages/magmalte/app/views/events/EventChart.js
+++ b/nms/app/packages/magmalte/app/views/events/EventChart.js
@@ -13,11 +13,11 @@
  * @flow strict-local
  * @format
  */
-import type {Dataset} from '../../components/CustomHistogram';
+import type {Dataset, DatasetType} from '../../components/CustomMetrics';
 
 import Card from '@material-ui/core/Card';
 import CardHeader from '@material-ui/core/CardHeader';
-import CustomHistogram from '../../components/CustomHistogram';
+import CustomHistogram from '../../components/CustomMetrics';
 import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import React from 'react';
@@ -91,11 +91,18 @@ export default function EventChart(props: Props) {
 
     Promise.all(requests)
       .then(allResponses => {
-        const logData: Array<number> = allResponses.map(r => {
+        const data: Array<DatasetType> = allResponses.map((r, index) => {
+          const [s] = queries[index];
           if (r === null || r === undefined) {
-            return 0;
+            return {
+              t: s.unix(),
+              y: 0,
+            };
           }
-          return r;
+          return {
+            t: s.unix(),
+            y: r,
+          };
         });
 
         const ds: Dataset = {
@@ -105,10 +112,10 @@ export default function EventChart(props: Props) {
           borderWidth: 1,
           hoverBackgroundColor: colors.secondary.dodgerBlue,
           hoverBorderColor: 'black',
-          data: logData,
+          data: data,
         };
         setDataset(ds);
-        setEventCount(logData.reduce((a, b) => a + b, 0));
+        setEventCount(data.reduce((a, b) => a + b.y, 0));
         setIsLoading(false);
       })
       .catch(error => {

--- a/nms/app/packages/magmalte/app/views/events/EventsTable.js
+++ b/nms/app/packages/magmalte/app/views/events/EventsTable.js
@@ -31,7 +31,7 @@ import nullthrows from '@fbcnms/util/nullthrows';
 
 import {DateTimePicker} from '@material-ui/pickers';
 import {colors} from '../../theme/default';
-import {getStep} from '../../components/CustomHistogram';
+import {getStep} from '../../components/CustomMetrics';
 import {makeStyles} from '@material-ui/styles';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useMemo, useRef, useState} from 'react';


### PR DESCRIPTION
#1398  Summary
- Added custom linechart to custom metrics component
- This enables us to query from prometheus and also query events directly and show them on the same chart across similar intervals
- Cleaned up other associated components

## Test Plan
- yarn test succeeds
![event_alert_gif](https://user-images.githubusercontent.com/8224854/90273493-e5d66780-de13-11ea-805b-761c829a2f78.gif)
