### PR TITLE
[SessionD] Get rid of termination_scheduled state

### DIFF
--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -82,8 +82,6 @@ std::string session_fsm_state_to_str(SessionFsmState state) {
       return "SESSION_ACTIVE";
     case SESSION_TERMINATED:
       return "SESSION_TERMINATED";
-    case SESSION_TERMINATION_SCHEDULED:
-      return "SESSION_TERMINATION_SCHEDULED";
     case SESSION_RELEASED:
       return "SESSION_RELEASED";
     default:

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -547,11 +547,6 @@ void SessionState::get_updates(
   get_event_trigger_updates(update_request_out, actions_out, update_criteria);
 }
 
-void SessionState::mark_as_awaiting_termination(
-    SessionStateUpdateCriteria& update_criteria) {
-  set_fsm_state(SESSION_TERMINATION_SCHEDULED, update_criteria);
-}
-
 SubscriberQuotaUpdate_Type SessionState::get_subscriber_quota_state() const {
   return subscriber_quota_state_;
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -133,13 +133,6 @@ class SessionState {
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& update_criteria);
 
-  /**
-   * mark_as_awaiting_termination transitions the session state from
-   * SESSION_ACTIVE to SESSION_TERMINATION_SCHEDULED
-   */
-  void mark_as_awaiting_termination(
-      SessionStateUpdateCriteria& update_criteria);
-
   bool is_terminating();
 
   /**

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -106,16 +106,11 @@ enum GrantTrackingType {
 
 /**
  * State transitions of a session:
- * SESSION_ACTIVE  ---------
- *       |                  \
- *       |                   \
- *       |                    \
- *       |                     \
- *       | (start_termination)  SESSION_TERMINATION_SCHEDULED
- *       |                      /
- *       |                     /
- *       |                    /
- *       V                   V
+ * SESSION_ACTIVE
+ *       |
+ *       |
+ *       |
+ *       V
  * SESSION_RELEASED
  *       |
  *       | (PipelineD enforcement flows get deleted OR forced timeout)
@@ -124,10 +119,9 @@ enum GrantTrackingType {
  * SESSION_TERMINATED
  */
 enum SessionFsmState {
-  SESSION_ACTIVE                = 0,
-  SESSION_TERMINATED            = 4,
-  SESSION_TERMINATION_SCHEDULED = 5,
-  SESSION_RELEASED              = 6,
+  SESSION_ACTIVE     = 0,
+  SESSION_TERMINATED = 4,
+  SESSION_RELEASED   = 6,
 };
 
 struct StoredSessionCredit {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Yet Another Session FSM State Cleanup!
This PR gets rid of the `SESSION_TERMINATION_RESCHEDULED` FSM state, since this state was only used for the SessionD restart case. Instead of maintaining a separate FSM state, we can simply re-evaluate whether the subscriber has a valid wallet on SessionD restart. 
Now the FSM states look nice and simple:
```
/**
 * State transitions of a session:
 * SESSION_ACTIVE 
 *       |
 *       |
 *       |
 *       V
 * SESSION_RELEASED
 *       |
 *       | (PipelineD enforcement flows get deleted OR forced timeout)
 *       |      -> complete_termination
 *       V
 * SESSION_TERMINATED
 */
```
Next step is to add the INACTIVE and CREATING fields.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD Unit Tests
CWF IntegTest
S1AP test

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
