### PR TITLE
pipelined: Non-NAT: ARP request: use src IP if available.

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -138,8 +138,9 @@ ovs_mtr_port_number: 15577
 
 # define enable_nat for here debugging only.
 # enable_nat: True
+# Be careful changing these default values
 non_mat_gw_probe_frequency: 60
-non_nat_arp_egress_port: dhcp0
+# non_nat_arp_egress_port: dhcp0
 ovs_uplink_port_name: patch-up
 virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -18,7 +18,7 @@ from ipaddress import IPv4Address
 
 from ryu.ofproto.ofproto_v1_4 import OFPP_LOCAL
 
-from scapy.arch import get_if_hwaddr
+from scapy.arch import get_if_hwaddr, get_if_addr
 from scapy.data import ETHER_BROADCAST, ETH_P_ARP
 from scapy.error import Scapy_Exception
 from scapy.layers.l2 import ARP, Ether
@@ -268,9 +268,13 @@ class InOutController(MagmaController):
             self.logger.debug("sending arp via egress: %s",
                               self.config.non_nat_arp_egress_port)
             eth_mac_src = get_if_hwaddr(self.config.non_nat_arp_egress_port)
+            psrc = "0.0.0.0"
+            egress_port_ip = get_if_addr(self.config.non_nat_arp_egress_port)
+            if egress_port_ip:
+                psrc = egress_port_ip
 
             pkt = Ether(dst=ETHER_BROADCAST, src=eth_mac_src)
-            pkt /= ARP(op="who-has", pdst=gw_ip, hwsrc=eth_mac_src, psrc="0.0.0.0")
+            pkt /= ARP(op="who-has", pdst=gw_ip, hwsrc=eth_mac_src, psrc=psrc)
             self.logger.debug("ARP Req pkt %s", pkt.show(dump=True))
 
             res = srp1(pkt,

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -118,6 +118,7 @@ class InOutNonNatTest(unittest.TestCase):
         )
 
         BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
+        subprocess.Popen(["ifconfig", cls.UPLINK_BR, "192.168.128.41"]).wait()
         cls.thread = start_ryu_app_thread(test_setup)
 
         cls.inout_controller = inout_controller_reference.result()


### PR DESCRIPTION
## Summary

In some network uplink router might not respond to
ARP request with broadcast IP address. Use egress
interface IP if available.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
