### PR TITLE
[sessiond]Track PDP Start Time in Session Info

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -924,8 +924,11 @@ bool LocalEnforcer::init_session_credit(
     SessionMap& session_map, const std::string& imsi,
     const std::string& session_id, const SessionConfig& cfg,
     const CreateSessionResponse& response) {
+  auto now = std::chrono::system_clock::now();
+  uint64_t epoch = std::chrono::duration_cast<std::chrono::seconds>(
+    now.time_since_epoch()).count();
   auto session_state = std::make_unique<SessionState>(
-      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx());
+      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx(), epoch);
 
   std::unordered_set<uint32_t> charging_credits_received;
   for (const auto& credit : response.credits()) {

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -138,13 +138,14 @@ SessionState::SessionState(
 SessionState::SessionState(
     const std::string& imsi, const std::string& session_id,
     const SessionConfig& cfg, StaticRuleStore& rule_store,
-    const magma::lte::TgppContext& tgpp_context)
+    const magma::lte::TgppContext& tgpp_context, uint64_t pdp_start_time)
     : imsi_(imsi),
       session_id_(session_id),
       // Request number set to 1, because request 0 is INIT call
       request_number_(1),
       curr_state_(SESSION_ACTIVE),
       config_(cfg),
+      pdp_start_time_(pdp_start_time),
       tgpp_context_(tgpp_context),
       static_rules_(rule_store),
       credit_map_(4, &ccHash, &ccEqual) {}
@@ -605,6 +606,10 @@ void SessionState::fill_protos_tgpp_context(
 
 uint32_t SessionState::get_request_number() {
   return request_number_;
+}
+
+uint64_t SessionState::get_pdp_start_time() {
+  return pdp_start_time_;
 }
 
 void SessionState::increment_request_number(uint32_t incr) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -54,7 +54,8 @@ class SessionState {
   SessionState(
       const std::string& imsi, const std::string& session_id,
       const SessionConfig& cfg, StaticRuleStore& rule_store,
-      const magma::lte::TgppContext& tgpp_context);
+      const magma::lte::TgppContext& tgpp_context,
+      uint64_t pdp_start_time);
 
   SessionState(
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
@@ -170,6 +171,8 @@ class SessionState {
   bool active_monitored_rules_exist();
 
   uint32_t get_request_number();
+
+  uint64_t get_pdp_start_time();
 
   void increment_request_number(uint32_t incr);
 
@@ -339,6 +342,7 @@ class SessionState {
   uint32_t request_number_;
   SessionFsmState curr_state_;
   SessionConfig config_;
+  uint64_t pdp_start_time_;
   // Used to keep track of whether the subscriber has valid quota.
   // (only used for CWF at the moment)
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state_;

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -328,6 +328,7 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   std::string tgpp_context;
   stored.tgpp_context.SerializeToString(&tgpp_context);
   marshaled["tgpp_context"] = tgpp_context;
+  marshaled["pdp_start_time"] = std::to_string(stored.pdp_start_time);
 
   marshaled["pending_event_triggers"] =
       serialize_pending_event_triggers(stored.pending_event_triggers);
@@ -410,6 +411,9 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
 
   stored.request_number = static_cast<uint32_t>(
       std::stoul(marshaled["request_number"].getString()));
+
+  stored.pdp_start_time = static_cast<uint64_t>(
+      std::stoul(marshaled["pdp_start_time"].getString()));
 
   return stored;
 }

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -164,6 +164,7 @@ struct StoredSessionState {
   std::string session_level_key; // "" maps to nullptr
   std::string imsi;
   std::string session_id;
+  uint64_t pdp_start_time;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
   magma::lte::TgppContext tgpp_context;
   std::vector<std::string> static_rule_ids;

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -30,10 +30,11 @@ class SessionStateTest : public ::testing::Test {
   virtual void SetUp() {
     SessionConfig test_sstate_cfg;
     auto tgpp_ctx = TgppContext();
+    auto pdp_start_time = 12345;
     create_tgpp_context("gx.dest.com", "gy.dest.com", &tgpp_ctx);
     rule_store    = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
-        "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx);
+        "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx, pdp_start_time);
     update_criteria = get_default_update_criteria();
   }
   enum RuleType {

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -712,12 +712,13 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
 TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   const std::string imsi       = "IMSI1";
   const std::string session_id = "1234";
+  auto pdp_start_time = 12345;
   magma::lte::TgppContext tgpp_ctx;
   CreateSessionResponse response;
   create_credit_update_response(
       imsi, 1, 1024, true, response.mutable_credits()->Add());
   auto session_state =
-      new SessionState(imsi, session_id, test_cfg_, *rule_store, tgpp_ctx);
+      new SessionState(imsi, session_id, test_cfg_, *rule_store, tgpp_ctx, pdp_start_time);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -92,8 +92,9 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
     cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
     auto tgpp_context = TgppContext{};
+    auto pdp_start_time = 12345;
     return std::make_unique<SessionState>(
-        imsi, session_id, cfg, *rule_store, tgpp_context);
+        imsi, session_id, cfg, *rule_store, tgpp_context, pdp_start_time);
   }
 
   UsageMonitoringUpdateResponse* get_monitoring_update() {

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -72,8 +72,9 @@ class SessionStoreTest : public ::testing::Test {
     const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
     cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
     auto tgpp_context = TgppContext{};
+    auto pdp_start_time = 12345;
     return std::make_unique<SessionState>(
-        imsi, session_id, cfg, *rule_store, tgpp_context);
+        imsi, session_id, cfg, *rule_store, tgpp_context, pdp_start_time);
   }
 
   UsageMonitoringUpdateResponse* get_monitoring_update() {

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -60,6 +60,7 @@ TEST_F(StoreClientTest, test_read_and_write) {
   cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
   auto rule_store   = std::make_shared<StaticRuleStore>();
   auto tgpp_context = TgppContext{};
+  auto pdp_start_time = 12345;
 
   auto store_client = new MemoryStoreClient(rule_store);
 
@@ -69,11 +70,11 @@ TEST_F(StoreClientTest, test_read_and_write) {
 
   auto uc = get_default_update_criteria();
   auto session =
-      std::make_unique<SessionState>(imsi, sid, cfg, *rule_store, tgpp_context);
+      std::make_unique<SessionState>(imsi, sid, cfg, *rule_store, tgpp_context, pdp_start_time);
   auto session2 = std::make_unique<SessionState>(
-      imsi2, sid2, cfg, *rule_store, tgpp_context);
+      imsi2, sid2, cfg, *rule_store, tgpp_context, pdp_start_time);
   auto session3 = std::make_unique<SessionState>(
-      imsi3, sid3, cfg, *rule_store, tgpp_context);
+      imsi3, sid3, cfg, *rule_store, tgpp_context, pdp_start_time);
   EXPECT_EQ(session->get_session_id(), sid);
   EXPECT_EQ(session2->get_session_id(), sid2);
 

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -118,6 +118,7 @@ class StoredStateTest : public ::testing::Test {
     tgpp_context.set_gx_dest_host("gx");
     tgpp_context.set_gy_dest_host("gy");
     stored.tgpp_context = tgpp_context;
+    stored.pdp_start_time = 12345;
 
     stored.pending_event_triggers[REVALIDATION_TIMEOUT] = READY;
     stored.revalidation_time.set_seconds(32);
@@ -279,6 +280,7 @@ TEST_F(StoredStateTest, test_stored_session) {
   EXPECT_EQ(stored_monitor.level, MonitoringLevel::PCC_RULE_LEVEL);
 
   EXPECT_EQ(stored.imsi, "IMSI1");
+  EXPECT_EQ(stored.pdp_start_time, 12345);
   EXPECT_EQ(stored.session_id, "session_id");
   EXPECT_EQ(
       stored.subscriber_quota_state, SubscriberQuotaUpdate_Type_VALID_QUOTA);


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

For ipfix exporting we need to keep the pdp_start_time the same when we recycle sesssions, this means if we track it only when new session is init roaming won't affect it.

Initially I added pdp start time into the protobuf CommonSessionContext but I've realised that it becomes too convoluted as we use cfg comparison a lot in session recycling logic and introducing a new var breaks things

## Test Plan


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
