### PR TITLE
Using circleci_tag as argument to docker build to log what version is…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -818,7 +818,7 @@ jobs:
           name: Build xwf go radius
           command: |
             cd ${MAGMA_ROOT}/feg
-            docker build --tag goradius -f radius/src/Dockerfile ./
+            docker build --build-arg BUILD_NUM=${CIRCLE_SHA1:0:8} --tag goradius -f radius/src/Dockerfile ./
       - tag-push-docker:
           images: 'goradius'
           tag: <<parameters.tag>>


### PR DESCRIPTION
… running

Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>


[circleci][xwfm][radius] Using circleci_tag ad argument to docker build to log what version is running


## Summary

We would like to see new column in our logs including the container tag.

## Test Plan

Built and run docker locally:

$ CIRCLE_SHA1=abcdef
$ docker build --build-arg BUILD_NUM=${CIRCLE_SHA1} --tag goradius -f radius/src/Dockerfile ./
$ docker run -ti -p 1812:1812/udp --env-file=/Users/ayeletrd/radius_env_file -e TEMPLATE_ENV=radius.ofpanalytics.config.json.template goradius:latest
/app # ./docker-entrypoint.sh

{"level":"info","ts":1597658971.8441799,"caller":"server/server.go:234","msg":"created memory config","host":"16b148effc8f","partner_shortname":"ayelet_test","app_version":"abcdef"}
{"level":"info","ts":1597658971.84542,"caller":"server/server.go:101","msg":"allocate new server","host":"16b148effc8f","partner_shortname":"ayelet_test","app_version":"abcdef","num_listeners":1,"num_filters":0}
{"level":"info","ts":1597658971.8455381,"caller":"server/server.go:165","msg":"loading module","host":"16b148effc8f","partner_shortname":"ayelet_test","app_version":"abcdef","module_name":"ofpanalytics"}
{"level":"info","ts":1597658971.8459456,"caller":"loader/static_loader.go:102","msg":"creating module","host":"16b148effc8f","partner_shortname":"ayelet_test","app_version":"abcdef","module_name":"ofpanalytics"}
{"level":"debug","ts":1597658971.8459961,"caller":"server/server.go:173","msg":"Module loaded successfully","host":"16b148effc8f","partner_shortname":"ayelet_test","app_version":"abcdef","module_name":"ofpanalytics","precedence":0}
{"level":"debug","ts":1597658971.8460324,"caller":"server/server.go:180","msg":"Initializing module","host":"16b148effc8f","partner_shortname":"ayelet_test","app_version":"abcdef","module_name":"ofpanalytics"}



I cannot test circleCI itself except the validity of it.


$ circleci config validate ~/magma/.circleci/config.yml

Config file at /Users/ayeletrd/magma/.circleci/config.yml is valid.

## Additional Information
