### PR TITLE
[feg][aaa] Adding MSISDN field to AAA server metrics 

### DIFF
--- a/feg/gateway/services/aaa/metrics/metrics.go
+++ b/feg/gateway/services/aaa/metrics/metrics.go
@@ -32,32 +32,32 @@ var (
 	Sessions = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "active_sessions",
-			Help: "Number of active user sessions partitioned by APN",
+			Help: "Number of active user sessions partitioned by APN, IMSI, SessionID, MSISDN",
 		},
-		[]string{"apn", "imsi", "id"},
+		[]string{"apn", "imsi", "id", "msisdn"},
 	)
 
 	SessionTimeouts = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "session_timeouts",
-			Help: "Session timeouts, partitioned by APN, IMSI",
+			Help: "Session timeouts, partitioned by APN, IMSI, MSISDN",
 		},
-		[]string{"apn", "imsi"},
+		[]string{"apn", "imsi", "msisdn"},
 	)
 
 	SessionStart = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "session_start",
-			Help: "Session start partitioned by APN, IMSI, SessionID",
+			Help: "Session start partitioned by APN, IMSI, SessionID, MSISDN",
 		},
-		[]string{"apn", "imsi", "id"},
+		[]string{"apn", "imsi", "id", "msisdn"},
 	)
 	SessionStop = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "session_stop",
-			Help: "Session stop partitioned by APN, IMSI, SessionID",
+			Help: "Session stop partitioned by APN, IMSI, SessionID, MSISDN",
 		},
-		[]string{"apn", "imsi", "id"},
+		[]string{"apn", "imsi", "id", "msisdn"},
 	)
 
 	// Latencies
@@ -71,40 +71,40 @@ var (
 	OctetsIn = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "octets_in",
-			Help: "Inboud data usage, partitioned by APN, IMSI",
+			Help: "Inboud data usage, partitioned by APN, IMSI, MSISDN",
 		},
-		[]string{"apn", "imsi"},
+		[]string{"apn", "imsi", "msisdn"},
 	)
 	OctetsOut = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "octets_out",
-			Help: "Outbound data usage, partitioned by APN, IMSI",
+			Help: "Outbound data usage, partitioned by APN, IMSI, MSISDN",
 		},
-		[]string{"apn", "imsi"},
+		[]string{"apn", "imsi", "msisdn"},
 	)
 
 	// Acct
 	AcctStop = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "accounting_stop",
-			Help: "Accounting Stop Calls, partitioned by APN, IMSI",
+			Help: "Accounting Stop Calls, partitioned by APN, IMSI, MSISDN",
 		},
-		[]string{"apn", "imsi"},
+		[]string{"apn", "imsi", "msisdn"},
 	)
 
 	SessionTerminate = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "session_manager_terminate",
-			Help: "Terminate Session Calls by Local Session Manager, partitioned by APN, IMSI",
+			Help: "Terminate Session Calls by Local Session Manager, partitioned by APN, IMSI, MSISDN",
 		},
-		[]string{"apn", "imsi"},
+		[]string{"apn", "imsi", "msisdn"},
 	)
 	EndSession = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "end_session",
-			Help: "EndSession Calls to Local Session Manager, partitioned by APN, IMSI",
+			Help: "EndSession Calls to Local Session Manager, partitioned by APN, IMSI, MSISDN",
 		},
-		[]string{"apn", "imsi"},
+		[]string{"apn", "imsi", "msisdn"},
 	)
 )
 

--- a/feg/gateway/services/aaa/servicers/accounting.go
+++ b/feg/gateway/services/aaa/servicers/accounting.go
@@ -101,8 +101,9 @@ func (srv *accountingService) InterimUpdate(_ context.Context, ur *protos.Update
 	srv.sessions.SetTimeout(sid, srv.sessionTout, srv.timeoutSessionNotifier)
 
 	imsi := metrics.DecorateIMSI(s.GetCtx().GetImsi())
-	metrics.OctetsIn.WithLabelValues(s.GetCtx().GetApn(), imsi).Add(float64(ur.GetOctetsIn()))
-	metrics.OctetsOut.WithLabelValues(s.GetCtx().GetApn(), imsi).Add(float64(ur.GetOctetsOut()))
+	msisdn := s.GetCtx().GetMsisdn()
+	metrics.OctetsIn.WithLabelValues(s.GetCtx().GetApn(), imsi, msisdn).Add(float64(ur.GetOctetsIn()))
+	metrics.OctetsOut.WithLabelValues(s.GetCtx().GetApn(), imsi, msisdn).Add(float64(ur.GetOctetsOut()))
 
 	return &protos.AcctResp{}, nil
 }
@@ -123,6 +124,7 @@ func (srv *accountingService) Stop(_ context.Context, req *protos.StopRequest) (
 	s.Lock()
 	sessionImsi := s.GetCtx().GetImsi()
 	apn := s.GetCtx().GetApn()
+	msisdn := s.GetCtx().GetMsisdn()
 	s.Unlock()
 
 	imsi := metrics.DecorateIMSI(sessionImsi)
@@ -136,14 +138,14 @@ func (srv *accountingService) Stop(_ context.Context, req *protos.StopRequest) (
 		if err != nil {
 			err = Error(codes.Unavailable, err)
 		}
-		metrics.EndSession.WithLabelValues(apn, imsi).Inc()
+		metrics.EndSession.WithLabelValues(apn, imsi, msisdn).Inc()
 	} else {
 		deleteRequest := &orcprotos.DeleteRecordRequest{
 			Id: sessionImsi,
 		}
 		directoryd.DeleteRecord(deleteRequest)
 	}
-	metrics.AcctStop.WithLabelValues(apn, imsi)
+	metrics.AcctStop.WithLabelValues(apn, imsi, msisdn)
 
 	if err != nil && srv.config.GetEventLoggingEnabled() {
 		events.LogSessionTerminationFailedEvent(req.GetCtx(), events.AccountingStop, err.Error())
@@ -195,9 +197,10 @@ func (srv *accountingService) TerminateSession(
 	sctx := s.GetCtx()
 	imsi := sctx.GetImsi()
 	apn := sctx.GetApn()
+	msisdn := sctx.GetMsisdn()
 	s.Unlock()
 
-	metrics.SessionTerminate.WithLabelValues(apn, metrics.DecorateIMSI(imsi)).Inc()
+	metrics.SessionTerminate.WithLabelValues(apn, metrics.DecorateIMSI(imsi), msisdn).Inc()
 
 	if !strings.HasPrefix(imsi, imsiPrefix) {
 		imsi = imsiPrefix + imsi
@@ -231,7 +234,7 @@ func (srv *accountingService) EndTimedOutSession(aaaCtx *protos.Context) error {
 			Apn: aaaCtx.GetApn(),
 		}
 		_, err = session_manager.EndSession(req)
-		metrics.EndSession.WithLabelValues(aaaCtx.GetApn(), metrics.DecorateIMSI(aaaCtx.GetImsi())).Inc()
+		metrics.EndSession.WithLabelValues(aaaCtx.GetApn(), metrics.DecorateIMSI(aaaCtx.GetImsi()), aaaCtx.GetMsisdn()).Inc()
 	} else {
 		deleteRequest := &orcprotos.DeleteRecordRequest{
 			Id: aaaCtx.GetImsi(),

--- a/feg/gateway/services/aaa/servicers/responders.go
+++ b/feg/gateway/services/aaa/servicers/responders.go
@@ -102,7 +102,7 @@ func (srv *accountingService) AbortSession(
 			Apn: sctx.GetApn(),
 		}
 		session_manager.EndSession(req)
-		metrics.EndSession.WithLabelValues(sctx.GetApn(), metrics.DecorateIMSI(sctx.GetImsi())).Inc()
+		metrics.EndSession.WithLabelValues(sctx.GetApn(), metrics.DecorateIMSI(sctx.GetImsi()), sctx.GetMsisdn()).Inc()
 	} else {
 		deleteRequest := &orcprotos.DeleteRecordRequest{
 			Id: imsi,
@@ -191,7 +191,7 @@ func (srv *accountingService) TerminateRegistration(
 			Apn: sctx.GetApn(),
 		}
 		session_manager.EndSession(req)
-		metrics.EndSession.WithLabelValues(sctx.GetApn(), sid.Id).Inc()
+		metrics.EndSession.WithLabelValues(sctx.GetApn(), sid.Id, sctx.GetMsisdn()).Inc()
 	}
 
 	srv.sessions.RemoveSession(sid)

--- a/feg/gateway/services/aaa/store/in_memory.go
+++ b/feg/gateway/services/aaa/store/in_memory.go
@@ -111,6 +111,7 @@ func (st *memSessionTable) AddSession(
 	}
 
 	imsi := pc.GetImsi()
+	msisdn := pc.GetMsisdn()
 	s := &memSession{Context: pc, imsi: imsi}
 	st.rwl.Lock()
 
@@ -131,7 +132,7 @@ func (st *memSessionTable) AddSession(
 					if oldSid, ok := st.sids[oldImsi]; ok && oldSid == sid {
 						delete(st.sids, oldImsi)
 					}
-					updateSessionMetricsForRemovedSession(oldSession.GetApn(), oldImsi, sid)
+					updateSessionMetricsForRemovedSession(oldSession.GetApn(), oldImsi, sid, msisdn)
 				}
 			}
 		} else {
@@ -146,7 +147,7 @@ func (st *memSessionTable) AddSession(
 				oldImsiSession.StopTimeout()
 			}
 			delete(st.sids, oldSessionId)
-			updateSessionMetricsForRemovedSession(oldImsiSession.GetApn(), imsi, oldSessionId)
+			updateSessionMetricsForRemovedSession(oldImsiSession.GetApn(), imsi, oldSessionId, msisdn)
 			glog.Infof("old session with SID: %s found for IMSI: %s, will remove", oldSessionId, imsi)
 		}
 	}
@@ -158,7 +159,7 @@ func (st *memSessionTable) AddSession(
 	glog.V(1).Infof("setting timeout of %f seconds for session: %s", tout.Seconds(), sid)
 	setTimeoutUnsafe(st, sid, tout, s, notifier)
 	if !isExistingSession {
-		updateSessionMetricsForNewSession(apn, imsi, sid)
+		updateSessionMetricsForNewSession(apn, imsi, sid, msisdn)
 	}
 	return s, nil
 }
@@ -204,10 +205,10 @@ func (st *memSessionTable) RemoveSession(sid string) aaa.Session {
 			found bool
 			s     *memSession
 		)
-		var apn, imsi string
+		var apn, imsi, msisdn string
 		st.rwl.Lock()
 		if s, found = st.sm[sid]; found {
-			apn, imsi = s.GetApn(), s.GetImsi()
+			apn, imsi, msisdn = s.GetApn(), s.GetImsi(), s.GetMsisdn()
 			delete(st.sm, sid)
 			if oldSid, ok := st.sids[s.imsi]; ok && oldSid == sid {
 				delete(st.sids, s.imsi)
@@ -216,7 +217,7 @@ func (st *memSessionTable) RemoveSession(sid string) aaa.Session {
 		st.rwl.Unlock()
 		if found {
 			s.StopTimeout()
-			updateSessionMetricsForRemovedSession(apn, imsi, sid)
+			updateSessionMetricsForRemovedSession(apn, imsi, sid, msisdn)
 			return s
 		}
 	}
@@ -280,25 +281,25 @@ func cleanupTimer(ctx *cleanupTimerCtx) {
 				"Timed out session '%s' for SessionId: %s; IMSI: %s; Identity: %s; MAC: %s; IP: %s; notify result: %v",
 				ctx.sidKey, s.GetSessionId(), s.GetImsi(), s.GetIdentity(), s.GetMacAddr(), s.GetIpAddr(), notifyResult)
 
-			updateSessionMetricsForTimedOutSession(s.GetApn(), s.GetImsi(), s.GetSessionId())
+			updateSessionMetricsForTimedOutSession(s.GetApn(), s.GetImsi(), s.GetSessionId(), s.GetMsisdn())
 		}
 	}
 }
 
-func updateSessionMetricsForNewSession(apn string, imsi string, sid string) {
+func updateSessionMetricsForNewSession(apn string, imsi string, sid string, msisdn string) {
 	imsi = metrics.DecorateIMSI(imsi)
-	metrics.Sessions.WithLabelValues(apn, imsi, sid).Inc()
-	metrics.SessionStart.WithLabelValues(apn, imsi, sid).Inc()
+	metrics.Sessions.WithLabelValues(apn, imsi, sid, msisdn).Inc()
+	metrics.SessionStart.WithLabelValues(apn, imsi, sid, msisdn).Inc()
 }
 
-func updateSessionMetricsForRemovedSession(apn string, imsi string, sid string) {
+func updateSessionMetricsForRemovedSession(apn string, imsi string, sid string, msisdn string) {
 	imsi = metrics.DecorateIMSI(imsi)
-	metrics.Sessions.WithLabelValues(apn, imsi, sid).Dec()
-	metrics.SessionStop.WithLabelValues(apn, imsi, sid).Inc()
+	metrics.Sessions.WithLabelValues(apn, imsi, sid, msisdn).Dec()
+	metrics.SessionStop.WithLabelValues(apn, imsi, sid, msisdn).Inc()
 }
 
-func updateSessionMetricsForTimedOutSession(apn string, imsi string, sid string) {
+func updateSessionMetricsForTimedOutSession(apn string, imsi string, sid string, msisdn string) {
 	imsi = metrics.DecorateIMSI(imsi)
-	metrics.Sessions.WithLabelValues(apn, imsi, sid).Dec()
-	metrics.SessionTimeouts.WithLabelValues(apn, imsi).Inc()
+	metrics.Sessions.WithLabelValues(apn, imsi, sid, msisdn).Dec()
+	metrics.SessionTimeouts.WithLabelValues(apn, imsi, msisdn).Inc()
 }


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Adding msisdn label to `Sessions, SessionTimeouts, SessionStart, SessionStop, SessionTerminate, OctetsIn, OctetsOut, AcctStop, EndSession` metrics under aaa_server
- Updating usages of given metrics to include msisdn field

## Test Plan

- Ran cwf integ tests 
- Validated metrics with service303_cli.py to check msisdn label
```
metric {
  label {
    name: "apn"
    value: "98-DE-D0-84-B5-47:CWF-TP-LINK_B547_5G"
  }
  label {
    name: "imsi"
    value: "IMSI889231951507381"
  }
  label {
    name: "msisdn"
    value: "5100001234"
  }
  counter {
    value: 1.0
  }
  timestamp_ms: 1597790619892
}
```
- make test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
