### PR TITLE
fix the controller ip on reboot

### DIFF
--- a/xwf/gateway/deploy/roles/xwfm/templates/ifcfg-downlink
+++ b/xwf/gateway/deploy/roles/xwfm/templates/ifcfg-downlink
@@ -4,3 +4,4 @@ DEVICETYPE=ovs
 TYPE=OVSPort
 OVS_BRIDGE=uplink_br0
 BOOTPROTO=none
+OVS_EXTRA="set interface $DEVICE ofport=10"

--- a/xwf/gateway/deploy/roles/xwfm/templates/ifcfg-gw0
+++ b/xwf/gateway/deploy/roles/xwfm/templates/ifcfg-gw0
@@ -13,3 +13,4 @@ DEVICETYPE=ovs
 OVS_BRIDGE=uplink_br0
 BOOTPROTO=none
 HOTPLUG=no
+OVS_EXTRA="set interface $DEVICE ofport=1"

--- a/xwf/gateway/deploy/roles/xwfm/templates/ifcfg-uplink_br0
+++ b/xwf/gateway/deploy/roles/xwfm/templates/ifcfg-uplink_br0
@@ -4,4 +4,4 @@ DEVICETYPE=ovs
 TYPE=OVSBridge
 BOOTPROTO=static
 HOTPLUG=no
-OVS_EXTRA="set-fail-mode $DEVICE secure"
+OVS_EXTRA="set-fail-mode $DEVICE secure -- set-controller $DEVICE tcp:{{ xwf_ctrl_ip }}:6653"


### PR DESCRIPTION
Signed-off-by: Benno Joy <bennojoy@fb.com>

[xwfm] add persistent contoller for ovs

## Summary
Current if the gateway reboots the controller is not added to the switch, This diff makes sure the when gateway reboots
the switch connects to the controller.

## Test Plan

tested in staging servers.

## Additional Information
