### PR TITLE
[events] Apply network ID filter to multi stream event query endpoint

### DIFF
--- a/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers.go
+++ b/orc8r/cloud/go/services/eventd/obsidian/handlers/event_handlers.go
@@ -309,7 +309,7 @@ type multiStreamEventQueryParams struct {
 }
 
 func (m multiStreamEventQueryParams) toElasticBoolQuery() *elastic.BoolQuery {
-	ret := elastic.NewBoolQuery()
+	ret := elastic.NewBoolQuery().Filter(elastic.NewTermQuery(elasticFilterNetworkID, m.networkID))
 	if !funk.IsEmpty(m.streams) {
 		ret.Filter(elastic.NewTermsQuery(elasticFilterStreamName, stringsToInterfaces(m.streams)...))
 	}


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- We weren't applying the network ID so this endpoint was showing events across all networks (oops)

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

- #m testinprod

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
