### PR TITLE
[agw] [S1ap test] Add test case for sctpd restart

### DIFF
--- a/lte/gateway/deploy/roles/magma_test/files/update_package.sh
+++ b/lte/gateway/deploy/roles/magma_test/files/update_package.sh
@@ -33,10 +33,13 @@ popd
 # Link the build binaries again
 $SCRIPT_DIR/build_s1_tester.sh
 
+echo "Install pyparsing"
 # Re-generate the s1ap_types.py
 pip3 show pyparsing 1>/dev/null
 if [ $? != 0 ]; then
    echo "Installing pyparsing"
    pip3 install pyparsing
 fi
+
+echo "Regenerating s1ap_types.py"
 /usr/bin/python3.5 $SCRIPT_DIR/c_parser.py

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -121,6 +121,7 @@ s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
+s1aptests/test_attach_detach_with_sctpd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_sctpd_restart.py
@@ -1,0 +1,99 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import time
+import unittest
+
+import s1ap_types
+import s1ap_wrapper
+from s1ap_utils import (
+    MagmadUtil,
+    S1ApUtil
+)
+
+
+class TestAttachDetachWithSctpdRestart(unittest.TestCase):
+
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_detach(self):
+        """
+        Attach/detach test with two UEs, where Sctpd restarts after each attach,
+        so a new attach has to happen before detach
+        """
+        num_ues = 2
+        detach_type = [s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value,
+                       s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value]
+        wait_for_s1 = [True, False]
+        self._s1ap_wrapper.configUEDevice(num_ues)
+
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            print("************************* Running End to End attach for ",
+                  "UE id ", req.ue_id)
+            # Now actually complete the attach
+            self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t)
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            print("************************* Restarting Sctpd service on",
+                  "gateway")
+
+            # The Sctpd service is not managed by magmad, hence needs to be
+            # restarted explicitly
+            self._s1ap_wrapper.magmad_util.exec_command(
+                "sudo service sctpd restart")
+
+            for j in range(60):
+                print("Waiting for", j, "seconds")
+                time.sleep(1)
+
+            # Re-establish S1 connection between eNB and MME
+            self._s1ap_wrapper._s1setup()
+
+            break
+            """
+            # Repeat the attach
+            self._s1ap_wrapper._s1_util.attach(
+                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t)
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+            # Now detach the UE
+            print("************************* Running UE detach for UE id ",
+                  req.ue_id)
+            self._s1ap_wrapper.s1_util.detach(
+                req.ue_id, detach_type[i], wait_for_s1[i])
+
+            if i == 0:
+                break
+
+            for j in range(15):
+                print("Connecting next UE in", 15 - j, "seconds")
+                time.sleep(1)
+            """
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

As discussed in #3594 , adding a new test case for sctpd service restart when the AGW is in stateless mode. For two UEs, an attach is completed, then Sctpd service is restarted (which clears on Redis state) and the UE needs to attach again before it can detach.

Also added the test case to the sanity test suite.

## Test Plan

`make integ_test TESTS=s1aptests/test_attach_detach_with_sctpd_restart.py`

`make integ_test`
