### PR TITLE
[nms][metrics] Update Connected Subscribers chart metric

### DIFF
--- a/nms/app/packages/magmalte/app/components/lte/LteMetrics.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteMetrics.js
@@ -55,7 +55,7 @@ const CONFIGS: Array<MetricGraphConfig> = [
   {
     basicQueryConfigs: [
       {
-        metric: 'ue_connected',
+        metric: 'ue_registered',
         filters: [{name: 'service', value: 'mme'}],
       },
     ],


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Updating Connected Subscribers chart metric to use ue_registered instead of ue_connected

## Test Plan

- tested on local setup

## Additional Information

- [ ] This change is backwards-breaking

