### PR TITLE
[docs] Remove outdated contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,34 +2,9 @@
 We want to make contributing to this project as easy and transparent as
 possible.
 
-## Pull Requests
-We actively welcome your pull requests.
+Please refer to the [Governance](https://github.com/magma/community)
+and [Contribution](https://github.com/magma/community/blob/main/CONTRIBUTING.md)
+model to get started.
 
-1. Fork the repo and create your branch from `master`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
-6. If you haven't already, complete the Contributor License Agreement ("CLA").
-
-## Contributor License Agreement ("CLA")
-In order to accept your pull request, we need you to submit a CLA. You only need
-to do this once to work on any of Facebook's open source projects.
-
-Complete your CLA here: <https://code.facebook.com/cla>
-
-## Issues
-We use GitHub issues to track public bugs. Please ensure your description is
-clear and has sufficient instructions to be able to reproduce the issue.
-
-Facebook has a [bounty program](https://www.facebook.com/whitehat/) for the safe
-disclosure of security bugs. In those cases, please go through the process
-outlined on that page and do not file a public issue.
-
-## Coding Style  
-* 2 spaces for indentation rather than tabs
-* 80 character line length
-
-## License
-By contributing to Magma, you agree that your contributions will be licensed
-under the LICENSE file in the root directory of this source tree.
+The [Wiki](https://github.com/magma/magma/wiki) outlines
+language specific guidelines.


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Contributing to Magma does not require CLA any more. This change updates the contributing document to refer to the latest documents related to contributors and governance.

## Test Plan

Not applicable

