### PR TITLE
[lte][agw] Adding persist_state_enabled check for s1ap_imsi_map

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state.cpp
@@ -99,7 +99,7 @@ uint64_t s1ap_get_comp_s1ap_id(
 }
 
 void put_s1ap_imsi_map() {
-  S1apStateManager::getInstance().put_s1ap_imsi_map();
+  S1apStateManager::getInstance().write_s1ap_imsi_map_to_db();
 }
 
 s1ap_imsi_map_t* get_s1ap_imsi_map() {

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -177,7 +177,7 @@ s1ap_imsi_map_t* S1apStateManager::get_s1ap_imsi_map() {
   return s1ap_imsi_map_;
 }
 
-void S1apStateManager::put_s1ap_imsi_map() {
+void S1apStateManager::write_s1ap_imsi_map_to_db() {
   if(!persist_state_enabled) {
     return;
   }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -150,10 +150,12 @@ void S1apStateManager::create_s1ap_imsi_map() {
   s1ap_imsi_map_->mme_ue_id_imsi_htbl =
       hashtable_uint64_ts_create(max_ues_, nullptr, nullptr);
 
-  oai::S1apImsiMap imsi_proto = oai::S1apImsiMap();
-  redis_client->read_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);
+  if(persist_state_enabled) {
+    oai::S1apImsiMap imsi_proto = oai::S1apImsiMap();
+    redis_client->read_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);
 
-  S1apStateConverter::proto_to_s1ap_imsi_map(imsi_proto, s1ap_imsi_map_);
+    S1apStateConverter::proto_to_s1ap_imsi_map(imsi_proto, s1ap_imsi_map_);
+  }
 }
 
 void S1apStateManager::clear_s1ap_imsi_map() {
@@ -163,6 +165,12 @@ void S1apStateManager::clear_s1ap_imsi_map() {
   hashtable_uint64_ts_destroy(s1ap_imsi_map_->mme_ue_id_imsi_htbl);
 
   free_wrapper((void**) &s1ap_imsi_map_);
+
+  if(persist_state_enabled) {
+    std::vector<std::string> keys_to_del;
+    keys_to_del.emplace_back(S1AP_IMSI_MAP_TABLE_NAME);
+    redis_client->clear_keys(keys_to_del);
+  }
 }
 
 s1ap_imsi_map_t* S1apStateManager::get_s1ap_imsi_map() {
@@ -170,6 +178,9 @@ s1ap_imsi_map_t* S1apStateManager::get_s1ap_imsi_map() {
 }
 
 void S1apStateManager::put_s1ap_imsi_map() {
+  if(!persist_state_enabled) {
+    return;
+  }
   oai::S1apImsiMap imsi_proto = oai::S1apImsiMap();
   S1apStateConverter::s1ap_imsi_map_to_proto(s1ap_imsi_map_, &imsi_proto);
   redis_client->write_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.h
@@ -80,7 +80,7 @@ class S1apStateManager
   /**
    * Serializes s1ap_imsi_map to proto and saves it into data store
    */
-  void put_s1ap_imsi_map();
+  void write_s1ap_imsi_map_to_db();
 
   /**
    * Returns a pointer to s1ap_imsi_map


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- s1ap_imsi_map (managed by s1ap task) was being persisted without checking stateless / stateful mode, this lead to issues on UE status identification with old records from database
- Adding persist_state_enabled check on s1ap_imsi_map read, write, clear operations

## Test Plan

- make test
- make integ_test
- verified on local setup that s1ap_imsi_map is not written on stateful mode, and is written on stateless mode

## Additional Information

- [ ] This change is backwards-breaking