### PR TITLE
SPGW: GTP_APP: multi APN: handle vlan id

### DIFF
--- a/lte/gateway/c/oai/common/common_types.h
+++ b/lte/gateway/c/oai/common/common_types.h
@@ -209,6 +209,7 @@ typedef struct paa_s {
   struct in6_addr ipv6_address;
   /* Note in rel.8 the ipv6 prefix length has a fixed value of /64 */
   uint8_t ipv6_prefix_length;
+  int vlan;
 } paa_t;
 
 void copy_paa(paa_t* paa_dst, paa_t* paa_src);

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -89,10 +89,26 @@ void ExternalEvent::set_of_connection(fluid_base::OFConnection* ofconn) {
   ofconn_ = ofconn;
 }
 
-AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip, const struct in_addr enb_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const char* imsi)
+UeNetworkInfo::UeNetworkInfo(const struct in_addr ue_ip)
     : ue_ip_(ue_ip),
+      vlan_(0) {}
+
+UeNetworkInfo::UeNetworkInfo(const struct in_addr ue_ip, int vlan)
+    : ue_ip_(ue_ip),
+      vlan_(vlan) {}
+
+const struct in_addr& UeNetworkInfo::get_ip() const {
+  return ue_ip_;
+}
+
+const int UeNetworkInfo::get_vlan() const {
+  return vlan_;
+}
+
+AddGTPTunnelEvent::AddGTPTunnelEvent(
+    const struct in_addr ue_ip, int vlan, const struct in_addr enb_ip,
+    const uint32_t in_tei, const uint32_t out_tei, const char* imsi)
+    : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       in_tei_(in_tei),
       out_tei_(out_tei),
@@ -103,10 +119,10 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       ExternalEvent(EVENT_ADD_GTP_TUNNEL) {}
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip, const struct in_addr enb_ip,
+    const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
     const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
     const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence)
-    : ue_ip_(ue_ip),
+    : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       in_tei_(in_tei),
       out_tei_(out_tei),
@@ -117,7 +133,11 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       ExternalEvent(EVENT_ADD_GTP_TUNNEL) {}
 
 const struct in_addr& AddGTPTunnelEvent::get_ue_ip() const {
-  return ue_ip_;
+  return ue_info_.get_ip();
+}
+
+const struct UeNetworkInfo& AddGTPTunnelEvent::get_ue_info() const {
+  return ue_info_;
 }
 
 const struct in_addr& AddGTPTunnelEvent::get_enb_ip() const {
@@ -151,7 +171,7 @@ const uint32_t AddGTPTunnelEvent::get_dl_flow_precedence() const {
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct in_addr ue_ip, const uint32_t in_tei,
     const struct ipv4flow_dl* dl_flow)
-    : ue_ip_(ue_ip),
+    : ue_info_(ue_ip),
       in_tei_(in_tei),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
@@ -159,14 +179,14 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct in_addr ue_ip, const uint32_t in_tei)
-    : ue_ip_(ue_ip),
+    : ue_info_(ue_ip),
       in_tei_(in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
       ExternalEvent(EVENT_DELETE_GTP_TUNNEL) {}
 
 const struct in_addr& DeleteGTPTunnelEvent::get_ue_ip() const {
-  return ue_ip_;
+  return ue_info_.get_ip();
 }
 
 const uint32_t DeleteGTPTunnelEvent::get_in_tei() const {
@@ -185,17 +205,18 @@ HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
     const struct in_addr ue_ip, const uint32_t in_tei,
     const ControllerEventType event_type, const struct ipv4flow_dl* dl_flow,
     const uint32_t dl_flow_precedence)
-    : ue_ip_(ue_ip),
+    : ue_info_(ue_ip),
       in_tei_(in_tei),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
       dl_flow_precedence_(dl_flow_precedence),
       ExternalEvent(event_type) {}
 
+
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
     const struct in_addr ue_ip, const uint32_t in_tei,
     const ControllerEventType event_type)
-    : ue_ip_(ue_ip),
+    : ue_info_(ue_ip),
       in_tei_(in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
@@ -203,7 +224,7 @@ HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
       ExternalEvent(event_type) {}
 
 const struct in_addr& HandleDataOnGTPTunnelEvent::get_ue_ip() const {
-  return ue_ip_;
+  return ue_info_.get_ip();
 }
 
 const uint32_t HandleDataOnGTPTunnelEvent::get_in_tei() const {
@@ -223,17 +244,17 @@ const uint32_t HandleDataOnGTPTunnelEvent::get_dl_flow_precedence() const {
 }
 
 AddPagingRuleEvent::AddPagingRuleEvent(const struct in_addr ue_ip)
-    : ue_ip_(ue_ip), ExternalEvent(EVENT_ADD_PAGING_RULE) {}
+    : ue_info_(ue_ip), ExternalEvent(EVENT_ADD_PAGING_RULE) {}
 
 const struct in_addr& AddPagingRuleEvent::get_ue_ip() const {
-  return ue_ip_;
+  return ue_info_.get_ip();
 }
 
 DeletePagingRuleEvent::DeletePagingRuleEvent(const struct in_addr ue_ip)
-    : ue_ip_(ue_ip), ExternalEvent(EVENT_DELETE_PAGING_RULE) {}
+    : ue_info_(ue_ip), ExternalEvent(EVENT_DELETE_PAGING_RULE) {}
 
 const struct in_addr& DeletePagingRuleEvent::get_ue_ip() const {
-  return ue_ip_;
+  return ue_info_.get_ip();
 }
 
 }  // namespace openflow

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -139,19 +139,38 @@ class ExternalEvent : public ControllerEvent {
 };
 
 /*
+ * This object contains info about UE IP and vlan.
+ * Together this uniquely identifies a UE.
+ */
+
+class UeNetworkInfo {
+ public:
+  UeNetworkInfo(const struct in_addr ue_ip);
+  UeNetworkInfo(const struct in_addr ue_ip, int vlan);
+
+  const struct in_addr& get_ip() const;
+  const int get_vlan() const;
+
+ private:
+  const struct in_addr ue_ip_;
+  const int vlan_;
+};
+
+/*
  * Event triggered by SPGW to add a GTP tunnel for a UE
  */
 class AddGTPTunnelEvent : public ExternalEvent {
  public:
   AddGTPTunnelEvent(
-      const struct in_addr ue_ip, const struct in_addr enb_ip,
+      const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
       const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
       const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence);
 
   AddGTPTunnelEvent(
-      const struct in_addr ue_ip, const struct in_addr enb_ip,
+      const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
       const uint32_t in_tei, const uint32_t out_tei, const char* imsi);
 
+  const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const struct in_addr& get_enb_ip() const;
   const uint32_t get_in_tei() const;
@@ -162,7 +181,7 @@ class AddGTPTunnelEvent : public ExternalEvent {
   const uint32_t get_dl_flow_precedence() const;
 
  private:
-  const struct in_addr ue_ip_;
+  const UeNetworkInfo ue_info_;
   const struct in_addr enb_ip_;
   const uint32_t in_tei_;
   const uint32_t out_tei_;
@@ -182,13 +201,14 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
       const struct ipv4flow_dl* dl_flow);
   DeleteGTPTunnelEvent(const struct in_addr ue_ip, const uint32_t in_tei);
 
+  const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
   const bool is_dl_flow_valid() const;
   const struct ipv4flow_dl& get_dl_flow() const;
 
  private:
-  const struct in_addr ue_ip_;
+  const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
   const struct ipv4flow_dl dl_flow_;
   const bool dl_flow_valid_;
@@ -211,6 +231,7 @@ class HandleDataOnGTPTunnelEvent : public ExternalEvent {
       const struct in_addr ue_ip, const uint32_t in_tei,
       const ControllerEventType event_type);
 
+  const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
   const bool is_dl_flow_valid() const;
@@ -218,7 +239,7 @@ class HandleDataOnGTPTunnelEvent : public ExternalEvent {
   const uint32_t get_dl_flow_precedence() const;
 
  private:
-  const struct in_addr ue_ip_;
+  const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
   const struct ipv4flow_dl dl_flow_;
   const bool dl_flow_valid_;
@@ -233,10 +254,11 @@ class AddPagingRuleEvent : public ExternalEvent {
  public:
   AddPagingRuleEvent(const struct in_addr ue_ip);
 
+  const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
 
  private:
-  const struct in_addr ue_ip_;
+  const UeNetworkInfo ue_info_;
 };
 
 /*
@@ -247,10 +269,11 @@ class DeletePagingRuleEvent : public ExternalEvent {
  public:
   DeletePagingRuleEvent(const struct in_addr ue_ip);
 
+  const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
 
  private:
-  const struct in_addr ue_ip_;
+  const UeNetworkInfo ue_info_;
 };
 
 }  // namespace openflow

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -82,16 +82,16 @@ static void* external_event_callback(std::shared_ptr<void> data) {
 }
 
 int openflow_controller_add_gtp_tunnel(
-    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     const char* imsi, struct ipv4flow_dl* flow_dl,
     uint32_t flow_precedence_dl) {
   if (flow_dl) {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
+        ue, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   } else {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, enb, i_tei, o_tei, imsi);
+        ue, vlan, enb, i_tei, o_tei, imsi);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   }
   return 0;

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
@@ -30,7 +30,7 @@ int start_of_controller(bool persist_state);
 int stop_of_controller(void);
 
 int openflow_controller_add_gtp_tunnel(
-    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     const char* imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
 
 int openflow_controller_del_gtp_tunnel(

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -33,6 +33,7 @@ using namespace fluid_msg;
 namespace openflow {
 
 const std::string GTPApplication::GTP_PORT_MAC = "02:00:00:00:00:01";
+const std:: uint16_t OFPVID_PRESENT = 0x1000;
 
 GTPApplication::GTPApplication(
     const std::string& uplink_mac, uint32_t gtp_port_num, uint32_t mtr_port_num,
@@ -116,6 +117,15 @@ void GTPApplication::add_uplink_tunnel_flow(
   of13::SetFieldAction set_eth_dst(new of13::EthDst(uplink_port));
   apply_ul_inst.add_action(set_eth_dst);
 
+  int vlan_id = ev.get_ue_info().get_vlan();
+  if (vlan_id > 0) {
+    of13::PushVLANAction push_vlan(0x8100);
+    apply_ul_inst.add_action(push_vlan);
+
+    uint16_t vid = OFPVID_PRESENT | vlan_id;
+    of13::SetFieldAction set_vlan(new of13::VLANVid(vid));
+    apply_ul_inst.add_action(set_vlan);
+  }
   // add imsi to packet metadata to pass to other tables
   add_imsi_metadata(apply_ul_inst, imsi);
 
@@ -127,6 +137,7 @@ void GTPApplication::add_uplink_tunnel_flow(
 
   // Finally, send flow mod
   messenger.send_of_msg(uplink_fm, ev.get_connection());
+
   OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "Uplink flow added\n");
 }
 

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
@@ -149,7 +149,7 @@ int libgtpnl_reset(void) {
 }
 
 int libgtpnl_add_tunnel(
-    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     Imsi_t imsi, struct ipv4flow_dl* flow_dl) {
   struct gtp_tunnel* t;
   int ret;

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -53,10 +53,10 @@ int openflow_reset(void) {
 }
 
 int openflow_add_tunnel(
-    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl) {
   return openflow_controller_add_gtp_tunnel(
-      ue, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
+      ue, vlan, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
       flow_precedence_dl);
 }
 

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -127,7 +127,7 @@ struct gtp_tunnel_ops {
   int (*uninit)(void);
   int (*reset)(void);
   int (*add_tunnel)(
-      struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+      struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
       Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
   int (*del_tunnel)(
       struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
@@ -150,6 +150,6 @@ const struct gtp_tunnel_ops* gtp_tunnel_ops_init_libgtpnl(void);
 #endif
 
 int gtpv1u_add_tunnel(
-    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
 #endif /* FILE_GTPV1_U_SEEN */

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
@@ -166,7 +166,7 @@ int gtpv1u_init(
 }
 
 int gtpv1u_add_tunnel(
-    struct in_addr ue, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl) {
   OAILOG_DEBUG(LOG_GTPV1U, "Add tunnel ue %s", inet_ntoa(ue));
 
@@ -196,7 +196,7 @@ int gtpv1u_add_tunnel(
   }
 
   return gtp_tunnel_ops->add_tunnel(
-      ue, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
+      ue, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -489,7 +489,9 @@ int sgw_handle_sgi_endpoint_updated(
       ;
 
       struct in_addr ue = {.s_addr = 0};
-      ue.s_addr         = eps_bearer_ctxt_p->paa.ipv4_address.s_addr;
+      ue.s_addr = eps_bearer_ctxt_p->paa.ipv4_address.s_addr;
+      int vlan = eps_bearer_ctxt_p->paa.vlan;
+
       Imsi_t imsi =
           new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi;
       /* UE is switching back to EPS services after the CS Fallback
@@ -508,7 +510,7 @@ int sgw_handle_sgi_endpoint_updated(
         }
       } else {
         rv = gtpv1u_add_tunnel(
-            ue, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+            ue, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
             eps_bearer_ctxt_p->enb_teid_S1u, imsi, NULL, DEFAULT_PRECEDENCE);
         if (rv < 0) {
           OAILOG_ERROR_UE(
@@ -1433,7 +1435,8 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
           enb.s_addr = eps_bearer_ctxt_entry_p->enb_ip_address_S1u.address
                            .ipv4_address.s_addr;
           struct in_addr ue = {.s_addr = 0};
-          ue.s_addr         = eps_bearer_ctxt_entry_p->paa.ipv4_address.s_addr;
+          int vlan = eps_bearer_ctxt_entry_p->paa.vlan;
+          ue.s_addr = eps_bearer_ctxt_entry_p->paa.ipv4_address.s_addr;
           Imsi_t imsi = spgw_context->sgw_eps_bearer_context_information.imsi;
           strcpy(policy_rule_name, eps_bearer_ctxt_entry_p->policy_rule_name);
           // Iterate of packet filter rules
@@ -1509,7 +1512,7 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
               }
             }
             rc = gtpv1u_add_tunnel(
-                ue, enb, eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,
+                ue, vlan, enb, eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,
                 eps_bearer_ctxt_entry_p->enb_teid_S1u, imsi, &dlflow,
                 eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
                     .eval_precedence);

--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -151,7 +151,8 @@ TEST_F(GTPApplicationTest, TestAddTunnel) {
   uint32_t in_tei  = 1;
   uint32_t out_tei = 2;
   char imsi[]      = "001010000000013";
-  AddGTPTunnelEvent add_tunnel(ue_ip, enb_ip, in_tei, out_tei, imsi);
+  int vlan = 0;
+  AddGTPTunnelEvent add_tunnel(ue_ip, vlan, enb_ip, in_tei, out_tei, imsi);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -269,6 +270,7 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlow) {
   char imsi[]      = "001010000000013";
   struct ipv4flow_dl dl_flow;
   uint32_t dl_flow_precedence = 0;
+  int vlan = 0;
 
   dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
   dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
@@ -279,7 +281,7 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlow) {
       SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
 
   AddGTPTunnelEvent add_tunnel(
-      ue_ip, enb_ip, in_tei, out_tei, imsi, &dl_flow, dl_flow_precedence);
+      ue_ip, vlan, enb_ip, in_tei, out_tei, imsi, &dl_flow, dl_flow_precedence);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -409,6 +411,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlow) {
 
   controller->dispatch_event(del_tunnel);
 }
+
 int main(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
In Multi APN configuration, we support configuring VLAN-id
for each APN. This patch adds support for setting vlan id
to uplink flow.
Eventually this functionality would be moved to pipelined.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Summary

`make test`
`make ingteg_tests`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
