### PR TITLE
[agw] [mme] Free common procedure after failure notif

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/sap/EmmCommonProcedureInitiated.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/sap/EmmCommonProcedureInitiated.c
@@ -133,15 +133,16 @@ int EmmCommonProcedureInitiated(emm_reg_t* const evt) {
               emm_ctx, &evt->u.common.common_proc->emm_proc.base_proc);
         }
 
-        if (evt->free_proc) {
-          nas_delete_common_procedure(emm_ctx, &evt->u.common.common_proc);
-        }
-
         if ((rc != RETURNerror) && (emm_ctx) && (evt->notify) &&
             (evt->u.common.common_proc->emm_proc.base_proc.failure_notif)) {
           rc = (*evt->u.common.common_proc->emm_proc.base_proc.failure_notif)(
               emm_ctx);
         }
+
+        if (evt->free_proc) {
+          nas_delete_common_procedure(emm_ctx, &evt->u.common.common_proc);
+        }
+
       }
 
       break;

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_auth_mac_failure.py
@@ -1,0 +1,72 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+import s1ap_types
+
+from integ_tests.s1aptests import s1ap_wrapper
+
+
+class TestAuthMacFailure(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_auth_failure_cause_mac_failure(self):
+        """ Test authentication failure procedure with cause MAC failure"""
+        num_ues = 1
+
+        self._s1ap_wrapper.configUEDevice(num_ues)
+        print("************************* sending Attach Request for ue-id : 1")
+        attach_req = s1ap_types.ueAttachRequest_t()
+        attach_req.ue_Id = 1
+        sec_ctxt = s1ap_types.TFW_CREATE_NEW_SECURITY_CONTEXT
+        id_type = s1ap_types.TFW_MID_TYPE_IMSI
+        eps_type = s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH
+        pdn_type = s1ap_types.pdn_Type()
+        pdn_type.pres = True
+        pdn_type.pdn_type = 3
+        attach_req.mIdType = id_type
+        attach_req.epsAttachType = eps_type
+        attach_req.useOldSecCtxt = sec_ctxt
+        attach_req.pdnType_pr = pdn_type
+
+        print("Sending Attach Request for ue-id", attach_req.ue_Id)
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+        )
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value)
+        print("Received Authentication Request message ")
+
+        auth_failure = s1ap_types.ueAuthFailure_t()
+        auth_failure.ue_Id = 1
+        auth_failure.cause = s1ap_types.TFW_EMM_CAUSE_MAC_FAILURE
+        # sending random/zero auts value to simulate failure scenario
+        for idx1 in range(14):
+            auth_failure.auts[idx1] = 0
+        print("Sending Authentication Failure for ue-id", auth_failure.ue_Id)
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_AUTH_FAILURE, auth_failure
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertTrue(response, s1ap_types.tfwCmd.UE_AUTH_REJ_IND.value)
+        print("Received Authentication Reject message")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

As reported in https://github.com/magma/magma/issues/2404 the MME crashes with 'heap-use-after-free' error when UE sends a Authentication Failure with cause as MAC failure. This change fixes the logic to free the common procedures only after the failure notifications have been sent.

## Test Plan

Regression testing with S1ap integration tests
Added new test case for Auth failure with cause as MAC failure: test_attach_auth_mac_failure.py
