### PR TITLE
[sessiond] New monitor credit algorithm 

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -176,7 +176,7 @@ func TestGxMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	assert.NoError(t, setPCRFExpectations(expectations, defaultUpdateAnswer))
 
 	tr.AuthenticateAndAssertSuccess(imsi)
-
+	tr.WaitForEnforcementStatsToSync()
 	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "250K"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -106,7 +106,7 @@ func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 	finalQuotaGrant := &fegprotos.QuotaGrant{
 		RatingGroup: 1,
 		GrantedServiceUnit: &fegprotos.Octets{
-			TotalOctets: 2 * MegaBytes,
+			TotalOctets: 3 * MegaBytes,
 		},
 		IsFinalCredit:   true,
 		FinalUnitAction: fegprotos.FinalUnitAction_Terminate,
@@ -136,7 +136,7 @@ func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 	if record != nil {
 		// We should not be seeing > 1024k data here
 		assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
-		assert.True(t, record.BytesTx <= uint64(math.Round(4.5*MegaBytes+Buffer)), fmt.Sprintf("policy usage: %v", record))
+		assert.True(t, record.BytesTx <= uint64(math.Round(5*MegaBytes+Buffer)), fmt.Sprintf("policy usage: %v", record))
 	}
 
 	// Assert that a CCR-I and at least one CCR-U were sent up to the OCS
@@ -150,7 +150,7 @@ func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 	assert.NoError(t, setOCSExpectations(expectations, nil))
 
 	// We need to generate over 100% of the quota to trigger a session termination
-	req = &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("5.5M")}}
+	req = &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("10M")}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -61,6 +61,8 @@ std::string final_action_to_str(ChargingCredit_FinalAction final_action) {
 
 std::string grant_type_to_str(GrantTrackingType grant_type) {
   switch (grant_type) {
+    case TRACKING_UNSET:
+      return "TRACKING_UNSET";
     case ALL_TOTAL_TX_RX:
       return "ALL_TOTAL_TX_RX";
     case TOTAL_ONLY:

--- a/lte/gateway/c/session_manager/Monitor.h
+++ b/lte/gateway/c/session_manager/Monitor.h
@@ -43,6 +43,10 @@ struct Monitor {
     marshaled.level = level;
     return marshaled;
   }
+
+  bool should_delete_monitor(){
+    return credit.current_grant_contains_zero() && credit.is_quota_exhausted(1);
+  }
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -94,6 +94,9 @@ class SessionCredit {
   void set_grant_tracking_type(
       GrantTrackingType g_type, SessionCreditUpdateCriteria& uc);
 
+  void set_received_granted_units(
+      GrantedUnits& rgu, SessionCreditUpdateCriteria& uc);
+
   /**
    * Add credit to the specified bucket. This does not necessarily correspond
    * to allowed or used credit.
@@ -124,6 +127,9 @@ class SessionCredit {
    */
   bool is_quota_exhausted(float usage_reporting_threshold) const;
 
+
+  bool current_grant_contains_zero() const;
+
   /**
    * A threshold represented as a ratio for triggering usage update before
    * an user completely used up the quota
@@ -145,9 +151,13 @@ class SessionCredit {
   bool reporting_;
   CreditLimitType credit_limit_type_;
   GrantTrackingType grant_tracking_type_;
+  // stores the granted credits we received the last
+  GrantedUnits received_granted_units_;
 
  private:
   void log_quota_and_usage() const;
+
+  bool is_received_grented_unit_zero(const CreditUnit& cu) const;
 
   SessionCredit::Usage get_unreported_usage() const;
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -157,6 +157,8 @@ class SessionCredit {
  private:
   void log_quota_and_usage() const;
 
+  std::string get_percentage_usage(uint64_t allowed, uint64_t floor, uint64_t used) const;
+
   bool is_received_grented_unit_zero(const CreditUnit& cu) const;
 
   SessionCredit::Usage get_unreported_usage() const;
@@ -174,7 +176,11 @@ class SessionCredit {
 
   void apply_reporting_limits(SessionCredit::Usage& usage);
 
-  uint64_t calculate_delta_allowed_floor(CreditUnit cu, Bucket allowed, Bucket floor);
+  uint64_t calculate_delta_allowed_floor(CreditUnit cu,
+                           Bucket allowed, Bucket floor, uint64_t volume_used);
+
+  uint64_t calculate_delta_allowed(uint64_t gsu_volume,
+                           Bucket allowed, uint64_t volume_used);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -505,7 +505,16 @@ void SessionState::get_monitor_updates(
   for (auto& monitor_pair : monitor_map_) {
     auto mkey    = monitor_pair.first;
     auto& credit = monitor_pair.second->credit;
-    if (!credit.is_quota_exhausted(SessionCredit::USAGE_REPORTING_THRESHOLD)) {
+
+    bool is_partially_exhausted = credit.is_quota_exhausted(
+        SessionCredit::USAGE_REPORTING_THRESHOLD);
+    bool is_totally_exhausted = credit.is_quota_exhausted(1);
+
+    if (!is_partially_exhausted ||
+        (!is_totally_exhausted && credit.current_grant_contains_zero())){
+      // The update will be skipped in case we havent used enough data yet
+      // OR in the case the monitor got a 0 grant and it is not exhausted
+      // (we will only send the last update when it is totally exhausted)
       continue;
     }
     MLOG(MDEBUG) << "Session " << session_id_ << " monitoring key " << mkey
@@ -1180,6 +1189,8 @@ void SessionState::apply_charging_credit_update(
   // Credit merging
   credit.set_grant_tracking_type(
       credit_update.grant_tracking_type, credit_update);
+  credit.set_received_granted_units(credit_update.received_granted_units,
+                                    credit_update);
   for (int i = USED_TX; i != MAX_VALUES; i++) {
     Bucket bucket = static_cast<Bucket>(i);
     credit.add_credit(
@@ -1193,6 +1204,7 @@ void SessionState::apply_charging_credit_update(
   charging_grant->expiry_time       = credit_update.expiry_time;
   charging_grant->reauth_state      = credit_update.reauth_state;
   charging_grant->service_state     = credit_update.service_state;
+
 }
 
 void SessionState::set_charging_credit(
@@ -1306,6 +1318,17 @@ bool SessionState::receive_monitor(
   }
   auto mkey = update.credit().monitoring_key();
   auto it = monitor_map_.find(mkey);
+
+  if (update_criteria.monitor_credit_map.find(mkey) !=
+      update_criteria.monitor_credit_map.end() &&
+      update_criteria.monitor_credit_map[mkey].deleted){
+    // This will only happen if the PCRF responds back with more credit when
+    // the monitor has already been set to be terminated
+    MLOG(MDEBUG) <<"Ignoring Monitor update" << mkey << " update because it "
+                                                  "has been set for deletion";
+    return false;
+  }
+
   if (it == monitor_map_.end()) {
     // new credit
     return init_new_monitor(update, update_criteria);
@@ -1316,15 +1339,9 @@ bool SessionState::receive_monitor(
     return false;
   }
 
-  if (update.credit().action() == UsageMonitoringCredit::DISABLE) {
-    MLOG(MINFO) << "Erasing monitor " << mkey << " from DISABLE instruction";
-    monitor_map_.erase(mkey);
-    credit_uc->deleted = true;
-  } else {
-    MLOG(MINFO) << session_id_ << " Received monitor credit for " << mkey;
-    const auto& gsu = update.credit().granted_units();
-    it->second->credit.receive_credit(gsu, credit_uc);
-  }
+  MLOG(MINFO) << session_id_ << " Received monitor credit for " << mkey;
+  const auto& gsu = update.credit().granted_units();
+  it->second->credit.receive_credit(gsu, credit_uc);
   return true;
 }
 
@@ -1334,10 +1351,11 @@ void SessionState::apply_monitor_updates(
   if (it == monitor_map_.end()) {
     return;
   }
-  if (update.deleted) {
-    monitor_map_.erase(key);
-    return;
-  }
+
+  auto& credit = it->second->credit;
+  // Credit merging
+  credit.set_grant_tracking_type(update.grant_tracking_type, update);
+  credit.set_received_granted_units(update.received_granted_units,update);
   for (int i = USED_TX; i != MAX_VALUES; i++) {
     Bucket bucket = static_cast<Bucket>(i);
     it->second->credit.add_credit(
@@ -1363,8 +1381,20 @@ bool SessionState::add_to_monitor(
                  << " not found, not adding the usage";
     return false;
   }
+
   auto credit_uc = get_monitor_uc(key, uc);
-  it->second->credit.add_used_credit(used_tx, used_rx, *credit_uc);
+  // add credit or delete monitor
+  if (it->second->should_delete_monitor() ){
+    MLOG(MINFO) << "Erasing monitor " << key << " due to quota exhausted";
+    if (it->second->level == MonitoringLevel::SESSION_LEVEL){
+      uc.is_session_level_key_updated = true;
+      uc.updated_session_level_key = "";
+    }
+    credit_uc->deleted = true;
+    monitor_map_.erase(key);
+  } else {
+    it->second->credit.add_used_credit(used_tx, used_rx, *credit_uc);
+  }
   return true;
 }
 

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -160,6 +160,8 @@ std::string serialize_stored_session_credit(StoredSessionCredit& stored) {
   marshaled["buckets"]           = folly::dynamic::object();
   marshaled["grant_tracking_type"] =
       static_cast<int>(stored.grant_tracking_type);
+  marshaled["received_granted_units"] =
+      stored.received_granted_units.SerializeAsString();
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
     marshaled["buckets"][std::to_string(bucket_int)] =
@@ -181,6 +183,11 @@ StoredSessionCredit deserialize_stored_session_credit(
       static_cast<CreditLimitType>(marshaled["credit_limit_type"].getInt());
   stored.grant_tracking_type =
       static_cast<GrantTrackingType>(marshaled["grant_tracking_type"].getInt());
+
+  GrantedUnits received_granted_units;
+  received_granted_units.ParseFromString(marshaled["received_granted_units"].getString());
+  stored.received_granted_units = received_granted_units;
+
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket          = static_cast<Bucket>(bucket_int);
     stored.buckets[bucket] = static_cast<uint64_t>(std::stoul(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -97,6 +97,7 @@ enum ServiceState {
 };
 
 enum GrantTrackingType {
+  TRACKING_UNSET  = -1,
   TOTAL_ONLY      = 0,
   TX_ONLY         = 1,
   RX_ONLY         = 2,
@@ -135,6 +136,7 @@ struct StoredSessionCredit {
   CreditLimitType credit_limit_type;
   std::unordered_map<Bucket, uint64_t> buckets;
   GrantTrackingType grant_tracking_type;
+  GrantedUnits received_granted_units;
 };
 
 struct StoredMonitor {
@@ -227,6 +229,8 @@ struct SessionCreditUpdateCriteria {
   // Maintained by SessionCredit
   bool reporting;
   GrantTrackingType grant_tracking_type;
+  GrantedUnits received_granted_units;
+
   // Do not mark REPORTING buckets, but do mark REPORTED
   std::unordered_map<Bucket, uint64_t> bucket_deltas;
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -158,15 +158,36 @@ void create_usage_update(
 void create_monitor_credit(
     const std::string& m_key, MonitoringLevel level, uint64_t volume,
     UsageMonitoringCredit* credit) {
-  if (volume == 0) {
-    credit->set_action(UsageMonitoringCredit::DISABLE);
-  } else {
-    credit->set_action(UsageMonitoringCredit::CONTINUE);
-  }
-  credit->mutable_granted_units()->mutable_total()->set_volume(volume);
+  create_monitor_credit(m_key, level, volume, 0 , 0, credit);
+}
+
+void create_monitor_credit(
+    const std::string& m_key, MonitoringLevel level,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    UsageMonitoringCredit* credit) {
+  credit->mutable_granted_units()->mutable_total()->set_volume(total_volume);
   credit->mutable_granted_units()->mutable_total()->set_is_valid(true);
+  credit->mutable_granted_units()->mutable_tx()->set_volume(tx_volume);
+  credit->mutable_granted_units()->mutable_tx()->set_is_valid(true);
+  credit->mutable_granted_units()->mutable_rx()->set_volume(rx_volume);
+  credit->mutable_granted_units()->mutable_rx()->set_is_valid(true);
   credit->set_level(level);
   credit->set_monitoring_key(m_key);
+}
+
+
+void create_monitor_update_response(
+    const std::string& imsi, const std::string& m_key, MonitoringLevel level,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    UsageMonitoringUpdateResponse* response) {
+  std::vector<EventTrigger> event_triggers;
+  create_monitor_update_response(
+      imsi, m_key, level, total_volume, tx_volume, rx_volume,
+      event_triggers, 0, response);
 }
 
 void create_monitor_update_response(
@@ -182,7 +203,21 @@ void create_monitor_update_response(
     uint64_t volume, const std::vector<EventTrigger>& event_triggers,
     const uint64_t revalidation_time_unix_ts,
     UsageMonitoringUpdateResponse* response) {
-  create_monitor_credit(m_key, level, volume, response->mutable_credit());
+  create_monitor_update_response(
+      imsi, m_key, level, volume, 0, 0,
+      event_triggers, revalidation_time_unix_ts, response);
+}
+
+void create_monitor_update_response(
+    const std::string& imsi, const std::string& m_key, MonitoringLevel level,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    const std::vector<EventTrigger>& event_triggers,
+    const uint64_t revalidation_time_unix_ts,
+    UsageMonitoringUpdateResponse* response) {
+  create_monitor_credit(m_key, level, total_volume, tx_volume, rx_volume,
+                        response->mutable_credit());
   response->set_success(true);
   response->set_sid(imsi);
   for (const auto& event_trigger : event_triggers) {

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -69,8 +69,20 @@ void create_monitor_credit(
     const std::string& m_key, MonitoringLevel level, uint64_t volume,
     UsageMonitoringCredit* response);
 
-// When volume = 0, the action for the monitoring credit will be set to DISABLE.
-// It is CONTINUE otherwise.
+void create_monitor_credit(
+    const std::string& m_key, MonitoringLevel level,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    UsageMonitoringCredit* credit);
+
+void create_monitor_update_response(
+    const std::string& imsi, const std::string& m_key, MonitoringLevel level,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    UsageMonitoringUpdateResponse* response);
+
 void create_monitor_update_response(
     const std::string& imsi, const std::string& m_key, MonitoringLevel level,
     uint64_t volume, UsageMonitoringUpdateResponse* response);
@@ -78,6 +90,15 @@ void create_monitor_update_response(
 void create_monitor_update_response(
     const std::string& imsi, const std::string& m_key, MonitoringLevel level,
     uint64_t volume, const std::vector<EventTrigger>& event_triggers,
+    const uint64_t revalidation_time_unix_ts,
+    UsageMonitoringUpdateResponse* response);
+
+void create_monitor_update_response(
+    const std::string& imsi, const std::string& m_key, MonitoringLevel level,
+    uint64_t total_volume,
+    uint64_t tx_volume,
+    uint64_t rx_volume,
+    const std::vector<EventTrigger>& event_triggers,
     const uint64_t revalidation_time_unix_ts,
     UsageMonitoringUpdateResponse* response);
 

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -153,7 +153,16 @@ class SessionStateTest : public ::testing::Test {
   void receive_credit_from_pcrf(
       const std::string& mkey, uint64_t volume, MonitoringLevel level) {
     UsageMonitoringUpdateResponse monitor_resp;
-    create_monitor_update_response("IMSI1", mkey, level, volume, &monitor_resp);
+    receive_credit_from_pcrf(mkey, volume, 0, 0, level);
+  }
+
+  void receive_credit_from_pcrf(
+      const std::string& mkey, uint64_t total_volume,
+      uint64_t tx_volume,uint64_t rx_volume, MonitoringLevel level) {
+    UsageMonitoringUpdateResponse monitor_resp;
+    create_monitor_update_response(
+        "IMSI1", mkey, level, total_volume,
+        tx_volume, rx_volume, &monitor_resp);
     session_state->receive_monitor(monitor_resp, update_criteria);
   }
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1416,8 +1416,12 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   // Check updates for disabling session level monitoring key
   EXPECT_TRUE(update_2["IMSI1"]["1234"].is_session_level_key_updated);
   EXPECT_EQ(update_2["IMSI1"]["1234"].updated_session_level_key, "2");
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 2048},
-      {"2", 1024},{"3", 1024}});
+  // note that we have gone over allowed, so we will reset ALLOWED_TOTAL
+  // 3024 because used 2000 before (out of the initial 1024) plues we added 1024
+  // 4000 because session level has used 2000 + 2000 from mkey 1 and 3
+  // 2000 because mkey 3 have used 2000 but we haven't added any extra
+  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 3024},
+      {"2", 4000},{"3", 2000}});
 
 
   // Monitor credit usage #2

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1348,71 +1348,104 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   insert_static_rule(0, "1", "pcrf_only_active");
   insert_static_rule(0, "3", "pcrf_only_to_be_disabled");
 
+  // Monitor credit addition #1
   // insert initial session credit
-  CreateSessionResponse response;
+  CreateSessionResponse response_1;
   create_monitor_update_response(
       "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
-      response.mutable_usage_monitors()->Add());
+      response_1.mutable_usage_monitors()->Add());
   create_monitor_update_response(
       "IMSI1", "2", MonitoringLevel::SESSION_LEVEL, 1024,
-      response.mutable_usage_monitors()->Add());
+      response_1.mutable_usage_monitors()->Add());
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 2048,
-      response.mutable_usage_monitors()->Add());
+      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 1024,
+      response_1.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}, {"3", 2048}});
-
+      session_map, "IMSI1", "1234", test_cfg_, response_1);
+  assert_monitor_credit("IMSI1", ALLOWED_TOTAL,
+                        {{"1", 1024}, {"2", 1024},{"3", 1024}});
   // IMPORTANT: save the updates into store and reload
   bool success =
       session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
   EXPECT_TRUE(success);
   session_map = session_store->read_sessions(SessionRead{"IMSI1"});
 
-  // Receive an update with DISABLE for mkey=3 & mkey=2, CONTINUE for mkey=1
-  UpdateSessionResponse update_response;
-  auto monitors = update_response.mutable_usage_monitor_responses();
-  create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitors->Add());
-  create_monitor_update_response(
-      "IMSI1", "2", MonitoringLevel::SESSION_LEVEL, 0, monitors->Add());
-  create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 0, monitors->Add());
-  // Apply the updates
-  auto update = SessionStore::get_default_session_update(session_map);
-  local_enforcer->update_session_credits_and_rules(
-      session_map, update_response, update);
-  // Check the UC's deleted field, as that will be applied to SessionStore
-  auto monitor_updates = update["IMSI1"]["1234"].monitor_credit_map;
-  EXPECT_FALSE(monitor_updates["1"].deleted);
-  EXPECT_TRUE(monitor_updates["2"].deleted);
-  EXPECT_TRUE(monitor_updates["3"].deleted);
-  // Check updates for disabling session level monitoring key
-  EXPECT_TRUE(update["IMSI1"]["1234"].is_session_level_key_updated);
-  EXPECT_EQ(update["IMSI1"]["1234"].updated_session_level_key, "");
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 2048}, {"3", 0}});
 
-  // IMPORTANT: this step will sync the updates into session store and re-read
-  // the session_map.
-  success = session_store->update_sessions(update);
-  EXPECT_TRUE(success);
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
-
-  // Assert that we don't send usage reports for deleted monitors
-  // receive usages from pipelined
-  RuleRecordTable table;
-  auto record_list = table.mutable_records();
+  // Monitor credit usage #1
+  // Use the quota to exhaust monitor 2 and 3 and assert that we send usage
+  // reports for all monitors receive usages from pipelined
+  RuleRecordTable table_1;
+  auto record_list_1 = table_1.mutable_records();
   create_rule_record(
-      "IMSI1", "pcrf_only_to_be_disabled", 5000, 5000, record_list->Add());
-  update = SessionStore::get_default_session_update(session_map);
-  local_enforcer->aggregate_records(session_map, table, update);
+      "IMSI1", "pcrf_only_active", 2000, 0, record_list_1->Add());
+  create_rule_record(
+  "IMSI1", "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
+
+  auto update_1 = SessionStore::get_default_session_update(session_map);
+  local_enforcer->aggregate_records(session_map, table_1, update_1);
+
+  // Collect updates, should have updates since all monitors got 80% exhausted
+  std::vector<std::unique_ptr<ServiceAction>> actions_1;
+  auto update_request_1 =
+      local_enforcer->collect_updates(session_map, actions_1, update_1);
+  EXPECT_EQ(update_request_1.updates_size(), 0);
+  EXPECT_EQ(update_request_1.usage_monitors_size(), 3);
+
+
+  // Monitor credit addition #2
+  // Receive an update with zero grant for mkey=3 & mkey=2, but with
+  // credit for mkey=1. That means 3 and 2 will have to stop reporting when
+  // their quotas are exhausted
+  UpdateSessionResponse update_response_2;
+  auto monitors_2 = update_response_2.mutable_usage_monitor_responses();
+  create_monitor_update_response(
+      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitors_2->Add());
+  create_monitor_update_response(
+      "IMSI1", "2", MonitoringLevel::SESSION_LEVEL, 0, monitors_2->Add());
+  create_monitor_update_response(
+      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 0, monitors_2->Add());
+  // Apply the updates
+  auto update_2 = SessionStore::get_default_session_update(session_map);
+  local_enforcer->update_session_credits_and_rules(
+      session_map, update_response_2, update_2);
+
+  auto monitor_updates_2 = update_2["IMSI1"]["1234"].monitor_credit_map;
+  EXPECT_FALSE(monitor_updates_2["1"].deleted);
+  EXPECT_FALSE(monitor_updates_2["2"].deleted);
+  EXPECT_FALSE(monitor_updates_2["3"].deleted);
+  // Check updates for disabling session level monitoring key
+  EXPECT_TRUE(update_2["IMSI1"]["1234"].is_session_level_key_updated);
+  EXPECT_EQ(update_2["IMSI1"]["1234"].updated_session_level_key, "2");
+  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 2048},
+      {"2", 1024},{"3", 1024}});
+
+
+  // Monitor credit usage #2
+  // Generate more traffic to see monitors 2 and 3 are not triggering update
+  RuleRecordTable table_2;
+  auto record_list2 = table_2.mutable_records();
+  create_rule_record(
+      "IMSI1", "pcrf_only_active", 2000, 0, record_list2->Add());
+  create_rule_record(
+      "IMSI1", "pcrf_only_to_be_disabled", 2000, 0, record_list2->Add());
+
+  update_2 = SessionStore::get_default_session_update(session_map);
+  local_enforcer->aggregate_records(session_map, table_2, update_2);
+  monitor_updates_2 = update_2["IMSI1"]["1234"].monitor_credit_map;
+  EXPECT_FALSE(monitor_updates_2["1"].deleted);
+  EXPECT_TRUE(monitor_updates_2["2"].deleted);
+  EXPECT_TRUE(monitor_updates_2["3"].deleted);
+  // check session level key will be removed
+  EXPECT_EQ(update_2["IMSI1"]["1234"].updated_session_level_key, "");
 
   // Collect updates, should have NO updates
-  std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto update_request =
-      local_enforcer->collect_updates(session_map, actions, update);
-  EXPECT_EQ(update_request.updates_size(), 0);
-  EXPECT_EQ(update_request.usage_monitors_size(), 0);
+  std::vector<std::unique_ptr<ServiceAction>> actions_2;
+  auto update_request_2 =
+      local_enforcer->collect_updates(session_map, actions_2, update_2);
+  EXPECT_EQ(update_request_2.updates_size(), 0);
+  EXPECT_EQ(update_request_2.usage_monitors_size(), 1);
+
+
 }
 
 TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {

--- a/lte/gateway/c/session_manager/test/test_session_credit.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_credit.cpp
@@ -223,7 +223,7 @@ TEST(test_counting_algorithm, test_session_credit) {
   SessionCredit credit;
   SessionCreditUpdateCriteria uc{};
   GrantedUnits gsu;
-  uint64_t total_grant = 300;
+  uint64_t total_grant = 1000;
   uint64_t tx_grant    = 100;
   uint64_t rx_grant    = 200;
   create_granted_units(&total_grant, &tx_grant, &rx_grant, &gsu);
@@ -231,6 +231,13 @@ TEST(test_counting_algorithm, test_session_credit) {
   // receive total = 300 tx = 100, rx = 200
   credit.receive_credit(gsu, &uc);
   EXPECT_EQ(uc.grant_tracking_type, ALL_TOTAL_TX_RX);
+  EXPECT_EQ(0, credit.get_credit(ALLOWED_FLOOR_TOTAL));
+  EXPECT_EQ(0, credit.get_credit(ALLOWED_FLOOR_TX));
+  EXPECT_EQ(0, credit.get_credit(ALLOWED_FLOOR_RX));
+  EXPECT_EQ(1000, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(100, credit.get_credit(ALLOWED_TX)); // 250 because we overused so 150 + 100
+  EXPECT_EQ(200, credit.get_credit(ALLOWED_RX));
+
   // use tx and rx = 99 + 150 = 249
   credit.add_used_credit(99, 150, uc);
   EXPECT_TRUE(credit.is_quota_exhausted(0.8));
@@ -243,11 +250,11 @@ TEST(test_counting_algorithm, test_session_credit) {
   // cumulative: total = 600 tx = 200, rx = 400
   credit.receive_credit(gsu, &uc);
   EXPECT_EQ(uc.grant_tracking_type, ALL_TOTAL_TX_RX);
-  EXPECT_EQ(600, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(2000, credit.get_credit(ALLOWED_TOTAL));
   EXPECT_EQ(200, credit.get_credit(ALLOWED_TX));
   EXPECT_EQ(400, credit.get_credit(ALLOWED_RX));
-  EXPECT_EQ(300, credit.get_credit(ALLOWED_FLOOR_TOTAL));
-  EXPECT_EQ(100, credit.get_credit(ALLOWED_FLOOR_TX));
+  EXPECT_EQ(1000, credit.get_credit(ALLOWED_FLOOR_TOTAL));
+  EXPECT_EQ(100, credit.get_credit(ALLOWED_FLOOR_TX)); // 150 because we overused so 150
   EXPECT_EQ(200, credit.get_credit(ALLOWED_FLOOR_RX));
   EXPECT_EQ(99, credit.get_credit(USED_TX));
   EXPECT_EQ(150, credit.get_credit(USED_RX));
@@ -281,10 +288,10 @@ TEST(test_counting_algorithm, test_session_credit) {
   create_granted_units(&total_grant, &tx_grant, &rx_grant, &gsu);
   credit.receive_credit(gsu, &uc);
   EXPECT_EQ(uc.grant_tracking_type, ALL_TOTAL_TX_RX);
-  EXPECT_EQ(600, credit.get_credit(ALLOWED_TOTAL));
+  EXPECT_EQ(2000, credit.get_credit(ALLOWED_TOTAL));
   EXPECT_EQ(200, credit.get_credit(ALLOWED_TX));
   EXPECT_EQ(400, credit.get_credit(ALLOWED_RX));
-  EXPECT_EQ(300, credit.get_credit(ALLOWED_FLOOR_TOTAL));
+  EXPECT_EQ(1000, credit.get_credit(ALLOWED_FLOOR_TOTAL));
   EXPECT_EQ(100, credit.get_credit(ALLOWED_FLOOR_TX));
   EXPECT_EQ(200, credit.get_credit(ALLOWED_FLOOR_RX));
   EXPECT_EQ(200, credit.get_credit(USED_TX));

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -370,6 +370,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   EXPECT_TRUE(update_criteria.is_session_level_key_updated);
   EXPECT_EQ(update_criteria.updated_session_level_key, "m1");
 
+  // add usage to go over quota
   session_state->add_rule_usage("rule1", 5000, 3000, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 5000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 3000);
@@ -379,6 +380,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   EXPECT_EQ(
       update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 3000);
 
+  // check no updates will be sent
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
   session_state->get_updates(update, &actions, update_criteria);
@@ -389,12 +391,31 @@ TEST_F(SessionStateTest, test_session_level_key) {
   EXPECT_EQ(single_update.bytes_rx(), 3000);
   EXPECT_EQ(single_update.bytes_tx(), 5000);
 
-  // Disable session level monitor with 0 grant. Monitor should get deleted and
-  // session level key updated.
+  // Disable session level monitor with 0 grant. Monitor should get deleted
+  // once credit is exhausted and session level key updated.
   receive_credit_from_pcrf("m1", 0, MonitoringLevel::SESSION_LEVEL);
+
+  // add usage to see that the rule will be set as disabled
+  session_state->add_rule_usage("rule1", 5000, 3000, update_criteria);
+  // check monitor has been deleted (=0)
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 0);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
+  EXPECT_EQ(
+      update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_TX], 5000);
+  EXPECT_EQ(
+      update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 3000);
+
   EXPECT_TRUE(update_criteria.is_session_level_key_updated);
   EXPECT_EQ(update_criteria.updated_session_level_key, "");
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].deleted);
+
+  // check no updates will be sent
+  UpdateSessionRequest update_2;
+  std::vector<std::unique_ptr<ServiceAction>> actions_2;
+  session_state->get_updates(update_2, &actions_2, update_criteria);
+  EXPECT_EQ(actions_2.size(), 0);
+  EXPECT_EQ(update_2.updates_size(), 0);
+  EXPECT_EQ(update_2.usage_monitors_size(), 0);
 }
 
 TEST_F(SessionStateTest, test_reauth_key) {
@@ -705,8 +726,8 @@ TEST_F(SessionStateTest, test_empty_credit_grant) {
       ChargingCredit_FinalAction_TERMINATE);
 
   // At this point, the charging credit for RG=1 should have no available quota
-  // and the tracking should be the default, TOTAL_ONLY
-  EXPECT_EQ(u_credit.credit.grant_tracking_type, TOTAL_ONLY);
+  // and the tracking should be TRACKING_UNSET
+  EXPECT_EQ(u_credit.credit.grant_tracking_type, TRACKING_UNSET);
   EXPECT_EQ(u_credit.credit.buckets[ALLOWED_TOTAL], 0);
   EXPECT_EQ(u_credit.credit.buckets[ALLOWED_TX], 0);
   EXPECT_EQ(u_credit.credit.buckets[ALLOWED_RX], 0);
@@ -728,15 +749,19 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
 
   receive_credit_from_ocs(1, 3000, 2000, 2000, false);
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
+  EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)]
           .credit.buckets[ALLOWED_TOTAL],3000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
+  EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)]
           .credit.buckets[ALLOWED_TX],2000);
-  EXPECT_EQ(
-      update_criteria.charging_credit_to_install[CreditKey(1)]
+  EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)]
           .credit.buckets[ALLOWED_RX],2000);
+  // received granted units
+  EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)].
+          credit.received_granted_units.total().volume(),3000);
+  EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)].
+          credit.received_granted_units.tx().volume(),2000);
+  EXPECT_EQ(update_criteria.charging_credit_to_install[CreditKey(1)].
+          credit.received_granted_units.rx().volume(),2000);
 
   // add usage for 2 times to go over quota
   session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
@@ -781,6 +806,13 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
       update_criteria.charging_credit_map[CreditKey(1)].service_state,
       SERVICE_ENABLED);
   EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
+  // received granted units
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].
+            received_granted_units.total().volume(),0);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].
+          received_granted_units.tx().volume(),0);
+  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].
+          received_granted_units.rx().volume(),0);
 
   // force to check for the state (no traffic sent)
   session_state->add_rule_usage("rule1", 0, 0, update_criteria);
@@ -850,6 +882,94 @@ TEST_F(SessionStateTest, test_apply_session_rule_set) {
   EXPECT_EQ(uc.static_rules_to_uninstall.size(), 1);
   EXPECT_EQ(uc.dynamic_rules_to_install.size(), 1);
   EXPECT_EQ(uc.dynamic_rules_to_uninstall.size(), 1);
+}
+
+TEST_F(SessionStateTest, test_monitor_cycle) {
+  // add one rule with credits
+  insert_rule(1, "m1", "rule1", STATIC, 0, 0);
+  EXPECT_TRUE(
+      std::find(
+          update_criteria.static_rules_to_install.begin(),
+          update_criteria.static_rules_to_install.end(),
+          "rule1") != update_criteria.static_rules_to_install.end());
+
+  receive_credit_from_pcrf("m1", 3000, 2000, 2000, MonitoringLevel::PCC_RULE_LEVEL);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install.size(), 1);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"]
+                .credit.buckets[ALLOWED_TOTAL],3000);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"]
+                .credit.buckets[ALLOWED_TX],2000);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"]
+                .credit.buckets[ALLOWED_RX],2000);
+  // received granted units
+  EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"].
+      credit.received_granted_units.total().volume(),3000);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"].
+      credit.received_granted_units.tx().volume(),2000);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install["m1"].
+      credit.received_granted_units.rx().volume(),2000);
+
+  // reset update_criteria (before any add_rule_usage)
+  update_criteria = get_default_update_criteria();
+  // add usage for 2 times to go over quota
+  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
+
+  // reset update_criteria (before any add_rule_usage)
+  update_criteria = get_default_update_criteria();
+  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 4000);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2000);
+
+  // check if we need to report the usage
+  UpdateSessionRequest update;
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  session_state->get_updates(update, &actions, update_criteria);
+  EXPECT_EQ(actions.size(), 0);
+  EXPECT_EQ(update.usage_monitors_size(), 1);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_TX], 2000);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 1000);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].service_state, SERVICE_ENABLED);
+  EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].deleted);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].reporting);
+
+  // recive a grant with total = 0 (meaning there is no more cuota left and monitor
+  // needs to be removed once quota is exhausted
+  receive_credit_from_pcrf("m1", 0, 100, 200, MonitoringLevel::PCC_RULE_LEVEL);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install.size(), 0);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].bucket_deltas[REPORTED_TX], 4000);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].bucket_deltas[REPORTED_RX], 2000);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].service_state, SERVICE_ENABLED);
+  EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].reporting);
+  // received granted units
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].
+      received_granted_units.total().volume(),0);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].
+      received_granted_units.tx().volume(),100);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].
+      received_granted_units.rx().volume(),200);
+
+  // reset update_criteria (before any add_rule_usage)
+  update_criteria = get_default_update_criteria();
+  // force to check for the state (no traffic sent)
+  session_state->add_rule_usage("rule1", 1000, 2000, update_criteria);
+  // at this poing the monitor should be deleted, so lusage should be 0
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 0);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].deleted);
+  EXPECT_EQ(update_criteria.monitor_credit_map["m1"].service_state, SERVICE_ENABLED);
+  EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].reporting);
+
+  UpdateSessionRequest update2;
+  std::vector<std::unique_ptr<ServiceAction>> actions2;
+  session_state->get_updates(update2, &actions2, update_criteria);
+  EXPECT_EQ(actions2.size(), 0);
+  EXPECT_EQ(update2.usage_monitors_size(), 0);
+
+
+  receive_credit_from_pcrf("m1", 0, 100, 200, MonitoringLevel::PCC_RULE_LEVEL);
+  EXPECT_EQ(update_criteria.monitor_credit_to_install.size(), 0);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>


## Summary

The current monitor algorithm stops reporting as soon as it receives a 0 grant. Since we report the update request at 80% of quota, that means that 20% of the quota will not be utilized when 0 is received. This PR changes how the GX (monitors) that and allows the monitor to finish any quota left when receiving a 0 grant

The changes are
- Addition of `received_granted_units` which will record the last grant received. With that we will cal be able to calculate `should_disable_monitor`

- Change on the logic of monitor reporting: when 0 grant is received, we will only report when quota is totally exhausted (we will not report at 80% since we already know that there is no more quota left). Also quen quota is exhausted we will mark the monitor as deleted. But the delete action will not be performed until the next iteration when we get some more traffic for that monitor. The reason for that is we want to report the last chucnk of data, so we can not delete the monitor when we detect it. We could delete the monitor when doing `update_session_credits_and_rules` or `update_sessions`, but to me it made more sense to force it until the next iteration and keep the deletion at `SessionState`

- Change of some related unit test and add new ones. Note that the changes on the unit test forces that last iteration to see if the monitor is deleted and doesn't trigger any update.



## Test Plan

Tested different version on terra VM. 
make test on AGW
cwag_integ_test

Yet, it is very difficult to assure all the edge cases. So we will have to monitor for possible bugs

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
