### PR TITLE
[AAA][metrics] Include session timeouts in session stop metric

### DIFF
--- a/feg/gateway/services/aaa/store/in_memory.go
+++ b/feg/gateway/services/aaa/store/in_memory.go
@@ -301,5 +301,6 @@ func updateSessionMetricsForRemovedSession(apn string, imsi string, sid string, 
 func updateSessionMetricsForTimedOutSession(apn string, imsi string, sid string, msisdn string) {
 	imsi = metrics.DecorateIMSI(imsi)
 	metrics.Sessions.WithLabelValues(apn, imsi, sid, msisdn).Dec()
+	metrics.SessionStop.WithLabelValues(apn, imsi, sid, msisdn).Inc()
 	metrics.SessionTimeouts.WithLabelValues(apn, imsi, msisdn).Inc()
 }


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This change increments session stop on session timeout. Previously removed sessions
were shown as session stops + session timeouts. Now session stop represents all removed
sessions. This will allow us to display metrics in the NMS in a more visually understandable way
(i.e. Active Sessions = Session Start - Session Stop).

## Test Plan

Tested locally and in lab to ensure grafana checks out