### PR TITLE
[lte][agw] Updating mtr0 interface static ip to 10.1.0.1

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -19,7 +19,7 @@ iface gtp0 inet manual
 
 allow-gtp_br0 mtr0
 iface mtr0 inet static
-    address 10.0.2.10
+    address 10.1.0.1
     netmask 255.255.255.0
     ovs_bridge gtp_br0
     ovs_type OVSIntPort


### PR DESCRIPTION


Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Updating mtr0 interface static IP as previous one was colliding on ip routing with eNB ip allocation

## Test Plan

- provisioned magma VM to ensure mtr0 is up with new set IP

## Additional Information

- [ ] This change is backwards-breaking

