### PR TITLE
SMF-UPF set interface proto definitions #2033

### DIFF
--- a/lte/protos/pipelined.proto
+++ b/lte/protos/pipelined.proto
@@ -198,6 +198,217 @@ message PacketDropTableId {
   int32 table_id = 1;
 }
 
+//-------------------------------------------------------------------------
+// SMF to UPF Proto
+//-------------------------------------------------------------------------
+
+
+
+message NodeID {
+  enum NodeIDType {
+    IPv4 = 0;
+    IPv6 = 1;
+    FQDN = 2;
+    }
+  NodeIDType node_id_type = 1;
+  string node_id = 2;
+}
+
+
+//CPFseid message
+message CpFSeid {
+  uint64 f_seid = 1;
+  NodeID node_id = 2;
+}
+
+message OuterHeadRemoval {                //conditional PDR Message Structures
+  uint32 o_hd_remo_descr = 1;
+}
+
+
+//message LocalFTeid {                      //not sure about the message structure
+ ///local_f_teid = ;                        //doubt
+//}
+
+
+
+message SdfFilters {                               //8.2.5
+
+  FlowDescriptor fd = 1;
+  bytes ttc = 2;
+  bytes spi = 3;
+  bytes fl = 4;
+  uint32 sdf_id = 5;
+}
+
+message FlowDescriptor {                //include
+FlowMatchNew match = 1;
+  enum Action {
+    PERMIT = 0;
+    DENY = 1;
+  }
+  Action action = 2;
+}
+
+message FlowMatchNew {
+  string ipv4_src = 1;
+  string ipv4_dst = 2;
+  uint32 tcp_src = 3;
+  uint32 tcp_dst = 4;
+  uint32 udp_src = 5;
+  uint32 udp_dst = 6;
+}
+
+message MacAddress {            //8.2.93
+  bytes mac_src_value = 1;
+  bytes mac_dst_value = 2;
+  bytes upper_mac_src_value = 3;
+  bytes upper_mac_dst_value = 4;
+}
+
+
+//Table 7.5.2.2-3: Ethernet Packet Filter IE within PFCP Session Establishment Request
+message EthPackFilter {
+  uint32 eth_filt_id = 1;
+  uint32 eth_filt_prop = 2;
+  MacAddress mac_addr = 3;
+  uint32 c_tag = 4;                                   //not verified the tag values
+  uint32 s_tag = 5;
+  SdfFilters sdf_filters = 6;
+  uint32 ethertype = 7;
+}
+
+
+message ApplyAction {               //8.2.26
+  enum Action{
+    DROP = 0;
+    FORW = 1;
+    //Below may be reqd. In future.
+    BUFF = 2;
+    NOCP = 3;
+    DUPL = 4;
+  }
+  repeated Action apply_action = 1;
+}
+
+
+message RedirectInfo {                //8.2.20    //doubt who gives the info to SMF
+  enum RedirectAddrType {
+    IPV4 = 0;
+    IPV6 = 1;
+    URL = 2;
+    SIPURI = 3;
+    IPV4V6 = 4;
+  }
+  RedirectAddrType red_add_type = 1;
+  string red_server_addr = 2;
+}
+
+message OuterHeaderCreation {
+ uint32 o_teid = 1;
+ string ipv4_adr = 2;
+ uint32 port_no = 3;
+}
+
+
+//Table 7.5.2.3-2: Forwarding Parameters IE in FAR
+message FwdParam {
+  uint32 dest_iface = 1;                        // need to add enums for dest. interface 8.2.24
+  string net_instace = 2;
+  RedirectInfo redirect_info = 3;
+  OuterHeaderCreation outr_head_cr = 4;                  //this has to be defined as per MVC // now created
+}
+
+
+//Table 7.5.2.3-3: Duplicating Parameters IE in FAR
+message DupParam {
+  uint32 dest_iface = 1;
+}
+
+
+//PDI Message Table 7.5.2.2-2: PDI IE within PFCP Session Establishment Request
+message PDI {
+  uint32 src_interface = 1;
+  // LocalFTeid local_f_teid = 2;        //optional and conditionals
+  string net_instance = 3;
+  string ue_ip_adr = 4;         //modified and added ueipv4 address
+  bytes tr_ep_id = 5;                //8.2.92
+  SdfFilters sdf_filters = 6;
+  string app_id = 7;
+}
+
+//Group Type messages - Currently Includes -> 1. PDR 2. FAR
+
+//PDR message Table 7.5.2.2-1: Create PDR IE within PFCP Session Establishment Request
+message SetGroupPDR {
+  uint32 pdr_id = 1;
+  int32 sess_ver_no = 2;
+  uint32 precedence = 3;
+  PDI pdi = 4;
+  OuterHeadRemoval o_h_remo_desc = 5;      
+  uint32 far_id = 6;
+  uint32 urr_id = 7;
+  uint32 qer_id = 8;
+  uint32 bar_id = 9;
+  string active_pred_rule = 10;     // modified and renamed     //8.2.72 Doubt
+}
+
+
+//FAR message Table 7.5.2.3-1: Create FAR IE within PFCP Session Establishment Request
+message SetGroupFAR {
+  uint32 far_id = 1;              //FAR ID should be less than 2^32
+  int32 sess_ver_no = 2;
+  ApplyAction apply_action = 3;
+  FwdParam fwd_parm = 4;
+  DupParam du_param = 5;     // might be required for 4G
+  uint32 bar_id = 6;
+}
+
+// ToDO  SetGroupQER   write
+// ToDo  SetGroupBAR   write
+
+
+
+
+//SET message - SMF to Upf Session Requests
+message SessionSet {
+  string seid = 1;
+  int32 sess_ver_no = 2;
+  NodeID node_id = 3;
+
+  enum SessionState {
+    // before 6 all values are already reserved for old FSM states
+    CREATING = 7;
+    CREATED =  8;
+    ACTIVE   =9;
+    INACTIVE =10;
+    RELEASE  =11;
+  }
+  SessionState session_state = 4;
+  CpFSeid f_seid = 5;
+  repeated SetGroupPDR set_gr_pdr = 6;
+  repeated SetGroupFAR set_gr_far = 7;
+  //repeated SetGroupQER set_gr_qer = 8;
+  //repeated SetGroupBAR set_gr_bar = 9;
+  //TrafficEndPoint tr_ep = 9;
+  //PdnType pdn_type = 10;
+  //UserPlId user_pl_id = 11;
+  //UserId user_id = 12;
+  //TraceInfo tr_info = 13;
+  //ApnDnn apn_dnn = 14;
+}
+
+
+message UpfRes {}
+
+service UPFServicesForSMF {
+     rpc SetSMFSessions(SessionSet) returns (UpfRes) {}
+}
+
+
+
+
+
 // --------------------------------------------------------------------------
 // Pipelined gateway RPC service
 // --------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: ronit-kumar-acl <ronit.k@altencalsoftlabs.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->
## Summary

Common set interface proto definitions for 5G. Contains SMF to UPF Proto definitions.
<!-- Enumerate changes you made and why you made them -->

## Test Plan

Compiled successfully inside AGW VM.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
