### PR TITLE
[agw] [stateless] Make stateless config scripts available in Magma AGW package

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SRC_DIR=$MAGMA_ROOT/lte/gateway/deploy/roles/magma/files
+SRC_DIR=/usr/local/bin
 SERVICE_LIST=("mme" "mobilityd" "pipelined" "sctpd" "sessiond")
 RETURN_STATELESS=0
 RETURN_STATEFUL=1

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_sctpd.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_sctpd.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SRC_DIR=$MAGMA_ROOT/lte/gateway/deploy/roles/magma/files
+SRC_DIR=/usr/local/bin
 PRE_START_CMD="ExecStartPre=$SRC_DIR/config_stateless_agw.sh\ sctpd_pre"
 POST_START_CMD="ExecStartPost=$SRC_DIR/config_stateless_agw.sh\ sctpd_post"
 SYS_FILE=/etc/systemd/system/sctpd.service

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -66,6 +66,16 @@
     - generate_oai_config.py
   when: full_provision
 
+- name: Create symlink for stateless scripts
+  file: src="{{ magma_root }}/lte/gateway/deploy/roles/magma/files/config_stateless_{{ item }}.sh" path="/usr/local/bin/config_stateless_{{ item }}.sh" state=link force=yes follow=no
+  with_items:
+    - agw
+    - mobilityd
+    - mme
+    - pipelined
+    - sctpd
+    - sessiond
+
 - name: Create symlink for sctpd binary
   file: src='{{ c_build }}/sctpd/sctpd' path=/usr/local/sbin/sctpd state=link force=yes follow=no
   when: full_provision

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -444,13 +444,10 @@ class MagmadUtil(object):
 
         """
 
-        config_stateless_script = (
-            "/home/vagrant/magma/lte/gateway/deploy/roles/magma/files/"
-            "config_stateless_agw.sh"
-        )
+        config_stateless_script = "/usr/local/bin/config_stateless_agw.sh"
 
         ret_code = self.exec_command(
-            "sudo -E " + config_stateless_script + " " + cmd.name.lower()
+            "sudo " + config_stateless_script + " " + cmd.name.lower()
         )
 
         if ret_code == 0:

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -334,6 +334,7 @@ ${MAGMA_ROOT}/orc8r/tools/ansible/roles/fluent_bit/files/60-fluent-bit.conf=/etc
 ${PY_PROTOS}=${PY_DEST} \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/${PKGNAME}*" ${PY_DEST}) \
 $(glob_files "${PY_TMP_BUILD}/${PY_TMP_BUILD_SUFFIX}/*.egg-info" ${PY_DEST}) \
-$(glob_files "${PY_TMP_BUILD}/usr/bin/*" /usr/local/bin/)"
+$(glob_files "${PY_TMP_BUILD}/usr/bin/*" /usr/local/bin/) \
+$(glob_files "${ANSIBLE_FILES}/config_stateless_*.sh" /usr/local/bin/)"
 
 eval "$BUILDCMD"


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

This change makes 
- all the stateless configuration files available as part of the Magma AGW release package
- adds a symbolic link to config stateless scripts from /usr/local/bin in the gateway VM, so it follows the same script path as the release package

## Test Plan

- Functional testing with S1AP integration tests
- Package contents:
-- On host, from magma/lte/gateway, run `fab dev package:git` to generate the package. 
-- On gateway VM, the generated package is located in `~/magmapackages/magma_<version>_<timestamp>_<hash>_amd64.deb`. 
-- Check contents with `dpkg -c <package file>`

`vagrant@magma-dev:~/magma-packages$ dpkg -c magma_1.1.0-1598044387-1f487fb4_amd64.deb | grep config_stateless
-rwxr-xr-x 0/0            1532 2020-07-21 06:50 ./usr/local/bin/config_stateless_sessiond.sh
-rwxr-xr-x 0/0            1889 2020-08-21 04:54 ./usr/local/bin/config_stateless_sctpd.sh
-rwxr-xr-x 0/0            1543 2020-07-21 06:50 ./usr/local/bin/config_stateless_mobilityd.sh
-rwxr-xr-x 0/0            1788 2020-08-14 17:35 ./usr/local/bin/config_stateless_mme.sh
-rwxr-xr-x 0/0            3026 2020-08-21 04:48 ./usr/local/bin/config_stateless_agw.sh
-rwxr-xr-x 0/0            1529 2020-07-21 06:50 ./usr/local/bin/config_stateless_pipelined.sh`