### PR TITLE
[SPGW] X2-hand-over: fix gtp-end marker generation

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/OpenflowController.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/OpenflowController.cpp
@@ -66,6 +66,8 @@ void OpenflowController::message_callback(
   } else if (type == OFPT_ERROR) {
     dispatch_event(
         ErrorEvent(ofconn, reinterpret_cast<struct ofp_error_msg*>(data)));
+  } else {
+    OAILOG_DEBUG(LOG_GTPV1U, "Openflow controller unknown callback %d\n", type);
   }
 }
 
@@ -92,7 +94,8 @@ void OpenflowController::dispatch_event(const ControllerEvent& ev) {
 void OpenflowController::inject_external_event(
     std::shared_ptr<ExternalEvent> ev, void* (*cb)(std::shared_ptr<void>) ) {
   if (latest_ofconn_ == NULL) {
-    throw std::runtime_error("Controller not connected to switch\n");
+    OAILOG_ERROR(LOG_GTPV1U, "Null connection on event type %d", ev->get_type());
+    throw std::runtime_error("Controller not connected to switch:\n");
   }
   ev->set_of_connection(latest_ofconn_);
   latest_ofconn_->add_immediate_event(cb, ev);

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -112,7 +112,7 @@ int openflow_send_end_marker(struct in_addr enb, uint32_t tei) {
       "actions=load:%" PRIu32
       "->tun_id[0..31],"
       "set_field:%s->tun_dst,"
-      "set_field:0xfe->tun_gtp_msg_type,set_field:0x30->tun_gtp_flags,output:"
+      "set_field:0xfe->tun_gtpu_msgtype,set_field:0x30->tun_gtpu_flags,output:"
       "gtp0'",
       tei, inet_ntoa(enb));
 
@@ -125,6 +125,9 @@ int openflow_send_end_marker(struct in_addr enb, uint32_t tei) {
     OAILOG_ERROR(
         LOG_GTPV1U, "end marker cmd: [%s] failed: %d", end_marker_cmd, rc);
     end_marker_supported = false;
+  } else {
+    OAILOG_DEBUG(LOG_GTPV1U, "End marker sent: tei %" PRIu32
+        " tun_dst %s", tei, inet_ntoa(enb));
   }
   return rc;
 }


### PR DESCRIPTION
upstream OVS has different GTP header field names. This patch
uses them to avoid error on such OVS with GTP end marker support.
We will not be using older OVS packages so there is no need
to maintain any compatibility.
This patch also adds event logging, That would be useful for
debugging of-connection related issues.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Summary

`make test`

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
