### PR TITLE
[NMS] Change upgrade tier version input from select to autocomplete input

### DIFF
--- a/nms/app/packages/magmalte/app/components/ActionTable.js
+++ b/nms/app/packages/magmalte/app/components/ActionTable.js
@@ -17,6 +17,7 @@ import type {ComponentType} from 'react';
 
 import AddBox from '@material-ui/icons/AddBox';
 import ArrowDownward from '@material-ui/icons/ArrowDownward';
+import Autocomplete from '@material-ui/lab/Autocomplete';
 import CardTitleRow from './layout/CardTitleRow';
 import Check from '@material-ui/icons/Check';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
@@ -34,14 +35,25 @@ import MenuItem from '@material-ui/core/MenuItem';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import Paper from '@material-ui/core/Paper';
-import React, {useState} from 'react';
+import React from 'react';
 import RefreshIcon from '@material-ui/icons/Refresh';
 import Remove from '@material-ui/icons/Remove';
 import SaveAlt from '@material-ui/icons/SaveAlt';
 import Search from '@material-ui/icons/Search';
 import Select from '@material-ui/core/Select';
+import TextField from '@material-ui/core/TextField';
 
 import {forwardRef} from 'react';
+import {makeStyles} from '@material-ui/styles';
+import {useState} from 'react';
+
+const useStyles = makeStyles(_ => ({
+  inputRoot: {
+    '&.MuiOutlinedInput-root': {
+      padding: 0,
+    },
+  },
+}));
 
 const tableIcons = {
   Add: forwardRef((props, ref) => <AddBox {...props} ref={ref} />),
@@ -152,6 +164,30 @@ export function SelectEditComponent(props: SelectProps) {
         ))}
       </Select>
     </FormControl>
+  );
+}
+
+export function AutoCompleteEditComponent(props: SelectProps) {
+  const classes = useStyles();
+
+  return (
+    <Autocomplete
+      disableClearable
+      options={props.content}
+      freeSolo
+      value={props.value}
+      classes={{
+        inputRoot: classes.inputRoot,
+      }}
+      onChange={(_, newValue) => {
+        props.onChange(newValue);
+      }}
+      inputValue={props.value}
+      onInputChange={(_, newInputValue) => {
+        props.onChange(newInputValue);
+      }}
+      renderInput={(params: {}) => <TextField {...params} variant="outlined" />}
+    />
   );
 }
 

--- a/nms/app/packages/magmalte/app/views/equipment/UpgradeTiersDialog.js
+++ b/nms/app/packages/magmalte/app/views/equipment/UpgradeTiersDialog.js
@@ -33,8 +33,8 @@ import React from 'react';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Text from '@fbcnms/ui/components/design-system/Text';
+import {AutoCompleteEditComponent} from '../../components/ActionTable';
 
-import {SelectEditComponent} from '../../components/ActionTable';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext, useState} from 'react';
@@ -217,9 +217,8 @@ function UpgradeDetails(props: DialogProps) {
               title: 'Software Version',
               field: 'version',
               editComponent: props => (
-                <SelectEditComponent
+                <AutoCompleteEditComponent
                   {...props}
-                  defaultValue={props.value}
                   value={props.value}
                   content={ctx.state.supportedVersions}
                   onChange={value => props.onChange(value)}


### PR DESCRIPTION
## Summary

Only supported versions were the options available in the select box. Changing this to autocomplete (freesolo)input.
This provides us the option of both selecting, as well as entering arbitrary version numbers in here.

## Test Plan

![upgrade_gif](https://user-images.githubusercontent.com/8224854/91074347-3fe3e380-e5f1-11ea-8ca3-cccdfff58e35.gif)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
