### PR TITLE
[lte][migration_required] Modify handlers for swapped assoc directions between base_name, subscriber, and policies

### DIFF
--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -135,11 +135,11 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 			NatEnabled:               swag.BoolValue(gwEpc.NatEnabled),
 		},
 		"pipelined": &lte_mconfig.PipelineD{
-			LogLevel:      protos.LogLevel_INFO,
-			UeIpBlock:     gwEpc.IPBlock,
-			NatEnabled:    swag.BoolValue(gwEpc.NatEnabled),
-			DefaultRuleId: nwEpc.DefaultRuleID,
-			Services:      pipelineDServices,
+			LogLevel:               protos.LogLevel_INFO,
+			UeIpBlock:              gwEpc.IPBlock,
+			NatEnabled:             swag.BoolValue(gwEpc.NatEnabled),
+			DefaultRuleId:          nwEpc.DefaultRuleID,
+			Services:               pipelineDServices,
 			SgiManagementIfaceVlan: gwEpc.SgiManagementIfaceVlan,
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -203,7 +203,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 	}
 	lteGW := configurator.NetworkEntity{
 		Type: lte.CellularGatewayEntityType, Key: "gw1",
-                Config:             newGatewayConfigNonNat(""),
+		Config:             newGatewayConfigNonNat(""),
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
 	graph := configurator.EntityGraph{
@@ -331,7 +331,7 @@ func TestBuilder_Build_NonNat(t *testing.T) {
 	// validate SGi vlan tag mconfig
 	lteGW = configurator.NetworkEntity{
 		Type: lte.CellularGatewayEntityType, Key: "gw1",
-                Config:             newGatewayConfigNonNat("30"),
+		Config:             newGatewayConfigNonNat("30"),
 		ParentAssociations: []storage.TypeAndKey{gw.GetTypeAndKey()},
 	}
 	graph = configurator.EntityGraph{
@@ -637,8 +637,8 @@ func newGatewayConfigNonNat(vlan string) *lte_models.GatewayCellularConfigs {
 			TransmitEnabled: swag.Bool(true),
 		},
 		Epc: &lte_models.GatewayEpcConfigs{
-			NatEnabled: swag.Bool(false),
-			IPBlock:    "192.168.128.0/24",
+			NatEnabled:             swag.Bool(false),
+			IPBlock:                "192.168.128.0/24",
 			SgiManagementIfaceVlan: vlan,
 		},
 		NonEpsService: &lte_models.GatewayNonEpsConfigs{

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
@@ -643,7 +643,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 			Type:      lte.BaseNameEntityType,
 			Key:       "b1",
 			GraphID:   "10",
-			Associations: []storage.TypeAndKey{
+			ParentAssociations: []storage.TypeAndKey{
 				{Type: lte.PolicyRuleEntityType, Key: "p1"},
 				{Type: lte.SubscriberEntityType, Key: imsi2},
 				{Type: lte.SubscriberEntityType, Key: imsi1},
@@ -675,11 +675,11 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 			Type:      lte.BaseNameEntityType,
 			Key:       "b1",
 			GraphID:   "10",
-			Associations: []storage.TypeAndKey{
+			ParentAssociations: []storage.TypeAndKey{
 				{Type: lte.PolicyRuleEntityType, Key: "p2"},
 				{Type: lte.SubscriberEntityType, Key: imsi3},
 			},
-			Version: 1,
+			Version: 0,
 		},
 	)
 
@@ -707,14 +707,14 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 			Type:      lte.BaseNameEntityType,
 			Key:       "b1",
 			GraphID:   "10",
-			Associations: []storage.TypeAndKey{
+			ParentAssociations: []storage.TypeAndKey{
 				{Type: lte.PolicyRuleEntityType, Key: "p1"},
 				{Type: lte.PolicyRuleEntityType, Key: "p2"},
 				{Type: lte.SubscriberEntityType, Key: imsi2},
 				{Type: lte.SubscriberEntityType, Key: imsi3},
 				{Type: lte.SubscriberEntityType, Key: imsi1},
 			},
-			Version: 2,
+			Version: 0,
 		},
 	)
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
@@ -561,11 +561,11 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 		t, e, getPolicy,
 		expectedP1,
 		configurator.NetworkEntity{
-			NetworkID:    "n1",
-			Type:         lte.PolicyRuleEntityType,
-			Key:          "p1",
-			GraphID:      "2",
-			Associations: []storage.TypeAndKey{{Type: lte.SubscriberEntityType, Key: imsi2}, {Type: lte.SubscriberEntityType, Key: imsi1}},
+			NetworkID:          "n1",
+			Type:               lte.PolicyRuleEntityType,
+			Key:                "p1",
+			GraphID:            "2",
+			ParentAssociations: []storage.TypeAndKey{{Type: lte.SubscriberEntityType, Key: imsi2}, {Type: lte.SubscriberEntityType, Key: imsi1}},
 		},
 	)
 
@@ -585,12 +585,12 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 		t, e, getPolicy,
 		expectedP1,
 		configurator.NetworkEntity{
-			NetworkID:    "n1",
-			Type:         lte.PolicyRuleEntityType,
-			Key:          "p1",
-			GraphID:      "2",
-			Associations: []storage.TypeAndKey{{Type: lte.SubscriberEntityType, Key: imsi3}},
-			Version:      1,
+			NetworkID:          "n1",
+			Type:               lte.PolicyRuleEntityType,
+			Key:                "p1",
+			GraphID:            "2",
+			ParentAssociations: []storage.TypeAndKey{{Type: lte.SubscriberEntityType, Key: imsi3}},
+			Version:            1,
 		},
 	)
 

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -67,15 +67,16 @@ func (m *BaseNames) ToUpdateCriteria(network configurator.Network) (configurator
 
 func (m *BaseNameRecord) ToEntity() configurator.NetworkEntity {
 	return configurator.NetworkEntity{
-		Type:         lte.BaseNameEntityType,
-		Key:          string(m.Name),
-		Associations: m.getAssociations(),
+		Type: lte.BaseNameEntityType,
+		Key:  string(m.Name),
+		// This field is considered read-only by configurator
+		ParentAssociations: m.GetParentAssociations(),
 	}
 }
 
 func (m *BaseNameRecord) FromEntity(ent configurator.NetworkEntity) *BaseNameRecord {
 	m.Name = BaseName(ent.Key)
-	for _, tk := range ent.Associations {
+	for _, tk := range ent.ParentAssociations {
 		if tk.Type == lte.PolicyRuleEntityType {
 			m.RuleNames = append(m.RuleNames, tk.Key)
 		} else if tk.Type == lte.SubscriberEntityType {
@@ -85,15 +86,7 @@ func (m *BaseNameRecord) FromEntity(ent configurator.NetworkEntity) *BaseNameRec
 	return m
 }
 
-func (m *BaseNameRecord) ToEntityUpdateCriteria() configurator.EntityUpdateCriteria {
-	return configurator.EntityUpdateCriteria{
-		Type:              lte.BaseNameEntityType,
-		Key:               string(m.Name),
-		AssociationsToSet: m.getAssociations(),
-	}
-}
-
-func (m *BaseNameRecord) getAssociations() []storage.TypeAndKey {
+func (m *BaseNameRecord) GetParentAssociations() []storage.TypeAndKey {
 	allAssocs := make([]storage.TypeAndKey, 0, len(m.RuleNames)+len(m.AssignedSubscribers))
 	allAssocs = append(allAssocs, m.RuleNames.ToAssocs()...)
 	for _, sid := range m.AssignedSubscribers {

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -110,8 +110,9 @@ func (m *PolicyRule) ToEntity() configurator.NetworkEntity {
 		Key:    string(m.ID),
 		Config: m.getConfig(),
 	}
+	// ParentAssociations treated as read-only by configurator
 	for _, sid := range m.AssignedSubscribers {
-		ret.Associations = append(ret.Associations, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: string(sid)})
+		ret.ParentAssociations = append(ret.Associations, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: string(sid)})
 	}
 	return ret
 }
@@ -119,7 +120,7 @@ func (m *PolicyRule) ToEntity() configurator.NetworkEntity {
 func (m *PolicyRule) FromEntity(ent configurator.NetworkEntity) *PolicyRule {
 	m.ID = PolicyID(ent.Key)
 	m.fillFromConfig(ent.Config)
-	for _, assoc := range ent.Associations {
+	for _, assoc := range ent.ParentAssociations {
 		if assoc.Type == lte.SubscriberEntityType {
 			m.AssignedSubscribers = append(m.AssignedSubscribers, SubscriberID(assoc.Key))
 		}
@@ -133,10 +134,15 @@ func (m *PolicyRule) ToEntityUpdateCriteria() configurator.EntityUpdateCriteria 
 		Key:       string(m.ID),
 		NewConfig: m.getConfig(),
 	}
-	for _, sid := range m.AssignedSubscribers {
-		ret.AssociationsToSet = append(ret.AssociationsToSet, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: string(sid)})
-	}
 	return ret
+}
+
+func (m *PolicyRule) GetParentAssociations() []storage.TypeAndKey {
+	allAssocs := []storage.TypeAndKey{}
+	for _, sid := range m.AssignedSubscribers {
+		allAssocs = append(allAssocs, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: string(sid)})
+	}
+	return allAssocs
 }
 
 func (m *PolicyRule) getConfig() *PolicyRuleConfig {

--- a/lte/cloud/go/services/policydb/servicers/assignments.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments.go
@@ -108,19 +108,19 @@ func getRuleUpdateForDisableRule(ruleID string, subscriberID string) configurato
 
 func getBaseNameUpdateForEnable(baseName string, subscriberID string) configurator.EntityUpdateCriteria {
 	ret := configurator.EntityUpdateCriteria{
-		Type: lte.BaseNameEntityType,
-		Key:  baseName,
+		Type:              lte.SubscriberEntityType,
+		Key:               subscriberID,
+		AssociationsToAdd: []storage.TypeAndKey{{Type: lte.BaseNameEntityType, Key: baseName}},
 	}
-	ret.AssociationsToAdd = append(ret.AssociationsToAdd, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: subscriberID})
 	return ret
 }
 
 func getBaseNameUpdateForDisable(baseName string, subscriberID string) configurator.EntityUpdateCriteria {
 	ret := configurator.EntityUpdateCriteria{
-		Type: lte.BaseNameEntityType,
-		Key:  baseName,
+		Type:                 lte.SubscriberEntityType,
+		Key:                  subscriberID,
+		AssociationsToDelete: []storage.TypeAndKey{{Type: lte.BaseNameEntityType, Key: baseName}},
 	}
-	ret.AssociationsToDelete = append(ret.AssociationsToDelete, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: subscriberID})
 	return ret
 }
 

--- a/lte/cloud/go/services/policydb/servicers/assignments.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments.go
@@ -90,19 +90,19 @@ func doesSubscriberAndRulesExist(networkID string, subscriberID string, ruleIDs 
 
 func getRuleUpdateForEnable(ruleID string, subscriberID string) configurator.EntityUpdateCriteria {
 	ret := configurator.EntityUpdateCriteria{
-		Type: lte.PolicyRuleEntityType,
-		Key:  ruleID,
+		Type:              lte.SubscriberEntityType,
+		Key:               subscriberID,
+		AssociationsToAdd: []storage.TypeAndKey{{Type: lte.PolicyRuleEntityType, Key: ruleID}},
 	}
-	ret.AssociationsToAdd = append(ret.AssociationsToAdd, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: subscriberID})
 	return ret
 }
 
 func getRuleUpdateForDisableRule(ruleID string, subscriberID string) configurator.EntityUpdateCriteria {
 	ret := configurator.EntityUpdateCriteria{
-		Type: lte.PolicyRuleEntityType,
-		Key:  ruleID,
+		Type:                 lte.SubscriberEntityType,
+		Key:                  subscriberID,
+		AssociationsToDelete: []storage.TypeAndKey{{Type: lte.PolicyRuleEntityType, Key: ruleID}},
 	}
-	ret.AssociationsToDelete = append(ret.AssociationsToDelete, storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: subscriberID})
 	return ret
 }
 

--- a/lte/cloud/go/services/policydb/streamer/providers.go
+++ b/lte/cloud/go/services/policydb/streamer/providers.go
@@ -142,7 +142,7 @@ func (p *BaseNamesProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]
 	bnEnts, err := configurator.LoadAllEntitiesInNetwork(
 		gwEnt.NetworkID,
 		lte.BaseNameEntityType,
-		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsToThis: true},
 	)
 	if err != nil {
 		return nil, err

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -180,6 +180,25 @@ func TestPolicyStreamers(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
+	_, err = configurator.UpdateEntities("n1", []configurator.EntityUpdateCriteria{
+		{
+			Type:              lte.PolicyRuleEntityType,
+			Key:               "r1",
+			AssociationsToAdd: []storage.TypeAndKey{{Type: lte.BaseNameEntityType, Key: "b1"}},
+		},
+		{
+			Type:              lte.PolicyRuleEntityType,
+			Key:               "r2",
+			AssociationsToAdd: []storage.TypeAndKey{{Type: lte.BaseNameEntityType, Key: "b1"}},
+		},
+		{
+			Type:              lte.PolicyRuleEntityType,
+			Key:               "r3",
+			AssociationsToAdd: []storage.TypeAndKey{{Type: lte.BaseNameEntityType, Key: "b2"}},
+		},
+	})
+	assert.NoError(t, err)
+
 	expectedProtos := []*lte_protos.PolicyRule{
 		{
 			Id:            "r1",

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -652,6 +652,9 @@ func DoesEntityExist(networkID, entityType, entityKey string) (bool, error) {
 // DoEntitiesExist returns a boolean that indicated whether all entities
 // specified exist in the network
 func DoEntitiesExist(networkID string, ids []storage2.TypeAndKey) (bool, error) {
+	if len(ids) == 0 {
+		return true, nil
+	}
 	found, _, err := LoadEntities(
 		networkID,
 		nil, nil, nil,


### PR DESCRIPTION
## Summary

See https://github.com/magma/magma/pull/2452 for db migration to swap assoc directions.

Enforces the following assoc directions through API handler changes.
```
base_name -> policy_rule
base_name -> subscriber
subscriber -> policy_rule
```

## Test Plan

- Unit tests were modified and passed
- Verified that creation and update to `base_name` type through the API still functioned correctly. Changes were made to both assigned subscribers and assigned policies
- Verified that creation and update to `policy` type through the API still functioned correctly. Changes were made to  assigned subscribers

## Additional Information

- [x] This change is backwards-breaking

To complete the required change, run the m012_policy_edge data migration.
