### PR TITLE
[orc8r][easy] Fix go.mod

### DIFF
--- a/orc8r/lib/go/protos/go.mod
+++ b/orc8r/lib/go/protos/go.mod
@@ -7,9 +7,6 @@ require (
 	github.com/golang/protobuf v1.3.3
 	github.com/prometheus/client_model v0.2.0
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3 // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
-	golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135 // indirect
 	google.golang.org/grpc v1.27.1
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 )


### PR DESCRIPTION
## Summary

Ran `./build.py -g` to regenerate files. `go.mod` was out of sync

## Test Plan

N/A


## Additional Information

- [ ] This change is backwards-breaking
