### PR TITLE
[agw] [stateless] [s1ap tests] Add delay when AGW changes from stateless to stateful

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -101,4 +101,11 @@ sudo service sctpd restart
 echo "Config complete"
 
 check_stateless_agw; ret_check=$?
+
+if [[ $ret_check -eq 1 ]]; then
+  sudo service magma@magmad start
+  # Sleep for a bit so OVS and Magma services come up before proceeding
+  sleep 15
+fi
+
 exit $ret_check


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The connection between MME and Openvswitch takes some time to establish after the service restarts. The recent changes in https://github.com/magma/magma/pull/2339 removed the 15 sec wait time when the AGW config is changed from stateless to stateful as part of the last integ test. This change re-adds the wait time, when AGW is switched back to stateful mode.

## Test Plan

S1ap integration tests
