### PR TITLE
[NMS] Fix error handling for event table and gateway log table

### DIFF
--- a/nms/app/packages/magmalte/app/components/ActionTable.js
+++ b/nms/app/packages/magmalte/app/components/ActionTable.js
@@ -35,6 +35,7 @@ import MoreVertIcon from '@material-ui/icons/MoreVert';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
 import Paper from '@material-ui/core/Paper';
 import React, {useState} from 'react';
+import RefreshIcon from '@material-ui/icons/Refresh';
 import Remove from '@material-ui/icons/Remove';
 import SaveAlt from '@material-ui/icons/SaveAlt';
 import Search from '@material-ui/icons/Search';
@@ -58,6 +59,7 @@ const tableIcons = {
     <ChevronLeft {...props} ref={ref} />
   )),
   ResetSearch: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Retry: forwardRef((props, ref) => <RefreshIcon {...props} ref={ref} />),
   Search: forwardRef((props, ref) => <Search {...props} ref={ref} />),
   SortArrow: forwardRef((props, ref) => <ArrowDownward {...props} ref={ref} />),
   ThirdStateCheck: forwardRef((props, ref) => <Remove {...props} ref={ref} />),

--- a/nms/app/packages/magmalte/app/views/events/EventsTable.js
+++ b/nms/app/packages/magmalte/app/views/events/EventsTable.js
@@ -33,7 +33,6 @@ import {DateTimePicker} from '@material-ui/pickers';
 import {colors} from '../../theme/default';
 import {getStep} from '../../components/CustomMetrics';
 import {makeStyles} from '@material-ui/styles';
-import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useMemo, useRef, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -136,16 +135,7 @@ function ExpandEvent(props: EventDescriptionProps) {
   );
 }
 
-function handleEventQuery(
-  networkId,
-  streams,
-  tags,
-  q,
-  from,
-  start,
-  end,
-  enqueueSnackbar,
-) {
+function handleEventQuery(networkId, streams, tags, q, from, start, end) {
   return new Promise(async (resolve, reject) => {
     try {
       const eventCount = await MagmaV1API.getEventsByNetworkIdAboutCount({
@@ -189,8 +179,7 @@ function handleEventQuery(
         totalCount: eventCount,
       });
     } catch (e) {
-      enqueueSnackbar(e, {variant: 'error'});
-      reject(e);
+      reject(e?.message ?? 'error retrieving events');
     }
   });
 }
@@ -209,7 +198,6 @@ export default function EventsTable({
   const [endDate, setEndDate] = useState(moment());
   const [eventCount, setEventCount] = useState(0);
   const tableRef = useRef(null);
-  const enqueueSnackbar = useEnqueueSnackbar();
   const {match} = useRouter();
   const networkId = nullthrows(match.params.networkId);
   const streams =
@@ -287,7 +275,6 @@ export default function EventsTable({
               0,
               startDate,
               endDate,
-              enqueueSnackbar,
             );
           }}
           columns={[
@@ -322,7 +309,6 @@ export default function EventsTable({
               0,
               startDate,
               endDate,
-              enqueueSnackbar,
             );
           }}
           columns={[
@@ -376,7 +362,6 @@ export default function EventsTable({
                     0,
                     startDate,
                     endDate,
-                    enqueueSnackbar,
                   );
                 }}
                 columns={[


### PR DESCRIPTION
## Summary

Enqueue snackbar was not used properly and that caused the exception in the issue associated with the PR. This PR does a general cleanup of the error handling in the gateway logs and event table code. Instead of using snackbar for displaying errors, instead we display error in the table by rejecting the query. Following screenshots display this change for a mock error. Additionally cleaned up the promise then chain and used await instead.

## Test Plan
![Screen Shot 2020-08-24 at 3 03 27 PM](https://user-images.githubusercontent.com/8224854/91101405-d200e180-e61b-11ea-9af2-755f2d4bfa2e.png)
![Screen Shot 2020-08-24 at 3 04 18 PM](https://user-images.githubusercontent.com/8224854/91101407-d3caa500-e61b-11ea-9382-451ea585bcdf.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
