### PR TITLE
[AGW] pipelineD: inout: remove vlan header for ingress packets

### DIFF
--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
@@ -20,8 +20,9 @@ prefix="vt$tag"
 ip_addr="10.200.$tag.111/24"
 router_ip="10.200.$tag.211"
 
-ip link add "$prefix"_port0 type veth peer name  "$prefix"_port1
-ifconfig "$prefix"_port0 up
+ip link del "$prefix"_port
+ip link add "$prefix"_port type veth peer name  "$prefix"_port1
+ifconfig "$prefix"_port up
 
 mkdir -p /etc/netns/"$prefix"_dhcp_srv
 touch /etc/netns/"$prefix"_dhcp_srv/resolv.conf
@@ -47,4 +48,9 @@ ip netns exec "$prefix"_dhcp_srv  /usr/sbin/dnsmasq -q --conf-file=/tmp/dns."$ta
 
 logger "DHCP server started"
 
-ovs-vsctl --may-exist add-port "$br_name" "$prefix"_port0 tag="$tag"
+existing_br=$(sudo ovs-vsctl iface-to-br vt1_port)
+if [[ ! -z $existing_br ]]; then
+	ovs-vsctl del-port "$existing_br" "$prefix"_port
+fi
+
+ovs-vsctl --may-exist add-port "$br_name" "$prefix"_port tag="$tag"

--- a/lte/gateway/python/magma/pipelined/mobilityd_client.py
+++ b/lte/gateway/python/magma/pipelined/mobilityd_client.py
@@ -32,7 +32,7 @@ def get_mobilityd_gw_info() -> List[GWInfo]:
 
     client = MobilityServiceStub(chan)
     try:
-        return client.ListGatewayInfo(Void())
+        return client.ListGatewayInfo(Void()).gw_list
     except grpc.RpcError as err:
         logging.error(
             "ListGatewayInfo error[%s] %s",

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
@@ -3,5 +3,6 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x0000/0x1000 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x1000/0x1000 actions=strip_vlan,output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch.snapshot
@@ -5,4 +5,5 @@
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x100b/0x100b actions=set_field:b2:a0:cc:85:80:11->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:ff:ff:ff:ff:ff:ff->eth_dst,output:2
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x0000/0x1000 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x1000/0x1000 actions=strip_vlan,output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch2.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch2.snapshot
@@ -6,4 +6,5 @@
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1015/0x1015 actions=set_field:b2:a0:cc:85:80:21->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1016/0x1016 actions=set_field:b2:a0:cc:85:80:22->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:ff:ff:ff:ff:ff:ff->eth_dst,output:2
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x0000/0x1000 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x1000/0x1000 actions=strip_vlan,output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static1.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static1.snapshot
@@ -3,7 +3,8 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1016/0x1016 actions=set_field:22:33:44:55:66:77->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1015/0x1015 actions=set_field:b2:a0:cc:85:80:21->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1016/0x1016 actions=set_field:22:33:44:55:66:77->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:ff:ff:ff:ff:ff:ff->eth_dst,output:2
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x0000/0x1000 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x1000/0x1000 actions=strip_vlan,output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static2.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowVlanSnapshotMatch_static2.snapshot
@@ -3,7 +3,8 @@
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1020/0x1020 actions=set_field:22:33:44:55:66:77->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x101f/0x101f actions=set_field:11:33:44:55:66:77->eth_dst,output:2
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=12,reg1=0x1,vlan_tci=0x1020/0x1020 actions=set_field:22:33:44:55:66:77->eth_dst,output:2
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:00:33:44:55:66:77->eth_dst,output:2
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x0000/0x1000 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x1000/0x1000 actions=strip_vlan,output:32768

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -289,7 +289,7 @@ class InOutNonNatTest(unittest.TestCase):
     def testFlowVlanSnapshotMatch_static2(self):
         cls = self.__class__
         # setup network on unused vlan.
-        self.setUpNetworkAndController("1234")
+        self.setUpNetworkAndController("34")
         # statically configured config
 
         vlan1 = "31"


### PR DESCRIPTION
## Summary
In Multi APN setup, AGW support vlan network on SGi.
We need to remove this vlan header when transmitting packet over GTP. 

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


## Test Plan
`make test_python`
