### PR TITLE
[SessionD] Handle set interface from PolicyDB to update session rules

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -12,6 +12,7 @@
  */
 #pragma once
 
+#include <experimental/optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -204,6 +205,18 @@ class LocalEnforcer {
   void execute_actions(
       SessionMap& session_map,
       const std::vector<std::unique_ptr<ServiceAction>>& actions,
+      SessionUpdate& session_update);
+
+  /**
+   * handle_set_session_rules takes SessionRules, which is a set message that
+   * reflects the desired rule state, and apply the changes. The changes should
+   * be propagated to PipelineD and MME if the session is 4G.
+   * @param session_map
+   * @param updates
+   * @param session_update
+   */
+  void handle_set_session_rules(
+      SessionMap& session_map, const SessionRules& rules,
       SessionUpdate& session_update);
 
   static uint32_t REDIRECT_FLOW_PRIORITY;

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -119,6 +119,8 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
 
   /**
    * Update active rules for session
+   * Get the SessionMap for the updates, apply the set rules and update the
+   * store. The rule updates should be also propagated to PipelineD
    */
   void SetSessionRules(
       ServerContext* context, const SessionRules* request,

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -28,14 +28,38 @@
 #include "ChargingGrant.h"
 
 namespace magma {
-typedef std::unordered_map<CreditKey, std::unique_ptr<ChargingGrant>,
-                 decltype(&ccHash), decltype(&ccEqual)> CreditMap;
+typedef std::unordered_map<
+    CreditKey, std::unique_ptr<ChargingGrant>, decltype(&ccHash),
+    decltype(&ccEqual)>
+    CreditMap;
 typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
 static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 
 struct RulesToProcess {
   std::vector<std::string> static_rules;
   std::vector<PolicyRule> dynamic_rules;
+};
+
+// Used to transform the proto message RuleSet into a more useful structure
+struct RuleSetToApply {
+  std::unordered_map<std::string, PolicyRule> dynamic_rules;
+  std::unordered_set<std::string> static_rules;
+
+  RuleSetToApply() {}
+  RuleSetToApply(const magma::lte::RuleSet& rule_set);
+  void combine_rule_set(const RuleSetToApply& other);
+};
+
+// Used to transform the proto message RulesPerSubscriber into a more useful
+// structure
+struct RuleSetBySubscriber {
+  std::string imsi;
+  std::unordered_map<std::string, RuleSetToApply> rule_set_by_apn;
+  std::experimental::optional<RuleSetToApply> subscriber_wide_rule_set;
+
+  RuleSetBySubscriber(const RulesPerSubscriber& rules_per_subscriber);
+  std::experimental::optional<RuleSetToApply> get_combined_rule_set_for_apn(
+      const std::string& apn);
 };
 
 struct BearerUpdate {
@@ -225,7 +249,7 @@ class SessionState {
    * Remove a currently active dynamic rule to mark it as deactivated.
    *
    * @param rule_id ID of the rule to be removed.
-   * @param rule_out Will point to the removed rule.
+   * @param rule_out Will point to the removed rule if it is not nullptr
    * @param update_criteria Tracks updates to the session. To be passed back to
    *                        the SessionStore to resolve issues of concurrent
    *                        updates to a session.
@@ -370,6 +394,17 @@ class SessionState {
   BearerUpdate get_dedicated_bearer_updates(
       RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
       SessionStateUpdateCriteria& uc);
+
+  /**
+   *
+   * @param rule_set
+   * @param subscriber_wide_rule_set
+   * @param rules_to_activate
+   * @param rules_to_deactivate
+   */
+  void apply_session_rule_set(
+      RuleSetToApply& rule_set, RulesToProcess& rules_to_activate,
+      RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc);
 
  private:
   std::string imsi_;
@@ -519,6 +554,18 @@ class SessionState {
   bool is_static_rule_scheduled(const std::string& rule_id);
 
   bool is_dynamic_rule_scheduled(const std::string& rule_id);
+
+  /** apply static_rules which is the desired state for the session's rules **/
+  void apply_session_static_rule_set(
+      std::unordered_set<std::string> static_rules,
+      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+      SessionStateUpdateCriteria& uc);
+
+  /** apply dynamic_rules which is the desired state for the session's rules **/
+  void apply_session_dynamic_rule_set(
+      std::unordered_map<std::string, PolicyRule> dynamic_rules,
+      RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
+      SessionStateUpdateCriteria& uc);
 
   /**
    * Check if a new bearer has to be created for the given policy. If a creation

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -47,12 +47,28 @@ LTESessionContext build_lte_context(
 }
 
 WLANSessionContext build_wlan_context(
-    const std::string& mac_addr,
-    const std::string& radius_session_id) {
+    const std::string& mac_addr, const std::string& radius_session_id) {
   WLANSessionContext wlan_context;
   wlan_context.set_mac_addr(mac_addr);
   wlan_context.set_radius_session_id(radius_session_id);
   return wlan_context;
+}
+
+RuleSet create_rule_set(
+    const bool apply_subscriber_wide, const std::string& apn,
+    std::vector<std::string> static_rules,
+    std::vector<PolicyRule> dynamic_rules) {
+  RuleSet rule_set;
+  rule_set.set_apply_subscriber_wide(apply_subscriber_wide);
+  rule_set.set_apn(apn);
+  for (const auto& rule : static_rules) {
+    rule_set.mutable_static_rules()->Add()->set_rule_id(rule);
+  }
+  for (const auto& rule : dynamic_rules) {
+    rule_set.mutable_dynamic_rules()->Add()->mutable_policy_rule()->CopyFrom(
+        rule);
+  }
+  return rule_set;
 }
 
 void create_rule_record(

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -32,6 +32,11 @@ LTESessionContext build_lte_context(
 WLANSessionContext build_wlan_context(
     const std::string& mac_addr, const std::string& radius_session_id);
 
+RuleSet create_rule_set(
+    const bool apply_subscriber_wide, const std::string& apn,
+    std::vector<std::string> static_rules,
+    std::vector<PolicyRule> dynamic_rules);
+
 void create_rule_record(
     const std::string& imsi, const std::string& rule_id, uint64_t bytes_rx,
     uint64_t bytes_tx, RuleRecord* rule_record);

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -34,13 +34,22 @@ class SessionStateTest : public ::testing::Test {
     create_tgpp_context("gx.dest.com", "gy.dest.com", &tgpp_ctx);
     rule_store    = std::make_shared<StaticRuleStore>();
     session_state = std::make_shared<SessionState>(
-        "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx, pdp_start_time);
+        "imsi", "session", test_sstate_cfg, *rule_store, tgpp_ctx,
+        pdp_start_time);
     update_criteria = get_default_update_criteria();
   }
   enum RuleType {
     STATIC  = 0,
     DYNAMIC = 1,
   };
+
+  void insert_static_rule_into_store(
+      uint32_t rating_group, const std::string& m_key,
+      const std::string& rule_id) {
+    PolicyRule rule;
+    create_policy_rule(rule_id, m_key, rating_group, &rule);
+    rule_store->insert_rule(rule);
+  }
 
   void insert_rule(
       uint32_t rating_group, const std::string& m_key,

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -753,19 +753,33 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
   session_state->get_updates(update, &actions, update_criteria);
   EXPECT_EQ(actions.size(), 0);
   EXPECT_EQ(update.updates_size(), 1);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_TX], 4000);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_RX], 2000);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].service_state, SERVICE_ENABLED);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_TX],
+      4000);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[USED_RX],
+      2000);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)].service_state,
+      SERVICE_ENABLED);
   EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
   EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
 
   // recive final unit without grant
   receive_credit_from_ocs(1, 0, 0, 0, true);
   EXPECT_EQ(update_criteria.charging_credit_to_install.size(), 1);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[REPORTED_TX], 4000);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].bucket_deltas[REPORTED_RX], 2000);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)]
+          .bucket_deltas[REPORTED_TX],
+      4000);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)]
+          .bucket_deltas[REPORTED_RX],
+      2000);
   EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].service_state, SERVICE_ENABLED);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)].service_state,
+      SERVICE_ENABLED);
   EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
 
   // force to check for the state (no traffic sent)
@@ -773,8 +787,69 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
   EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
-  EXPECT_EQ(update_criteria.charging_credit_map[CreditKey(1)].service_state, SERVICE_NEEDS_DEACTIVATION);
+  EXPECT_EQ(
+      update_criteria.charging_credit_map[CreditKey(1)].service_state,
+      SERVICE_NEEDS_DEACTIVATION);
   EXPECT_FALSE(update_criteria.charging_credit_map[CreditKey(1)].reporting);
+}
+
+TEST_F(SessionStateTest, test_apply_session_rule_set) {
+  // populate rule store with 2 static and 2 dynamic rules
+  insert_rule(1, "", "rule-static-1", STATIC, 0, 0);
+  insert_rule(2, "m1", "rule-static-2", STATIC, 0, 0);
+  insert_rule(1, "", "rule-dynamic-1", DYNAMIC, 0, 0);
+  insert_rule(2, "m1", "rule-dynamic-2", DYNAMIC, 0, 0);
+
+  EXPECT_TRUE(session_state->is_static_rule_installed("rule-static-1"));
+  EXPECT_TRUE(session_state->is_static_rule_installed("rule-static-2"));
+  EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-1"));
+  EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-2"));
+
+  // Send a set rule update with
+  // 1 static rule addition: rule-static-3, 1 static rule removal: rule-static-1
+  // 1 dynamic rule removal: rule-dynamic-3, 1 static rule removal:
+  // rule-dynamic-1
+  insert_static_rule_into_store(3, "m2", "rule-static-3");
+  // Should contain all ACTIVE rules, not additional/removal
+  RuleSetToApply rules_to_apply;
+  rules_to_apply.static_rules.insert("rule-static-2");
+  rules_to_apply.static_rules.insert("rule-static-3");
+
+  PolicyRule dynamic_2, dynamic_3;
+  create_policy_rule("rule-dynamic-2", "m1", 2, &dynamic_2);
+  create_policy_rule("rule-dynamic-3", "m1", 3, &dynamic_3);
+  rules_to_apply.dynamic_rules["rule-dynamic-2"] = dynamic_2;
+  rules_to_apply.dynamic_rules["rule-dynamic-3"] = dynamic_3;
+
+  SessionStateUpdateCriteria uc;
+  RulesToProcess to_activate, to_deactivate;
+  session_state->apply_session_rule_set(
+      rules_to_apply, to_activate, to_deactivate, uc);
+
+  // First check the active rules in session
+  EXPECT_TRUE(!session_state->is_static_rule_installed("rule-static-1"));
+  EXPECT_TRUE(session_state->is_static_rule_installed("rule-static-2"));
+  EXPECT_TRUE(session_state->is_static_rule_installed("rule-static-3"));
+  EXPECT_TRUE(!session_state->is_dynamic_rule_installed("rule-dynamic-1"));
+  EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-2"));
+  EXPECT_TRUE(session_state->is_dynamic_rule_installed("rule-dynamic-3"));
+
+  // Check the RulesToProcess is properly filled out
+  EXPECT_EQ(to_activate.static_rules.size(), 1);
+  EXPECT_EQ(to_activate.static_rules[0], "rule-static-3");
+  EXPECT_EQ(to_deactivate.static_rules.size(), 1);
+  EXPECT_EQ(to_deactivate.static_rules[0], "rule-static-1");
+
+  EXPECT_EQ(to_activate.dynamic_rules.size(), 1);
+  EXPECT_EQ(to_activate.dynamic_rules[0].id(), "rule-dynamic-3");
+  EXPECT_EQ(to_deactivate.dynamic_rules.size(), 1);
+  EXPECT_EQ(to_deactivate.dynamic_rules[0].id(), "rule-dynamic-1");
+
+  // Finally assert the changes get applied to the update criteria
+  EXPECT_EQ(uc.static_rules_to_install.size(), 1);
+  EXPECT_EQ(uc.static_rules_to_uninstall.size(), 1);
+  EXPECT_EQ(uc.dynamic_rules_to_install.size(), 1);
+  EXPECT_EQ(uc.dynamic_rules_to_uninstall.size(), 1);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This diff includes the actual implementation to handle a set message of session->rules from PolicyDB.
The steps needed to accomplish this is the following:
1. Receive SetSessionRules request
2. Push a function into the event loop to handle the request. 
  a. Fetch the list of sessions mentioned in the request from SessionStore
  b. Go through each session and apply a combination of subscriber wide RuleSet and APN specific RuleSet
  c. Since this is a set message, we will want to install any rules in the set that does not already exist and remove any rules in the session that does not exist in the set.
  d. Propagate the rule change to PipelineD. If applicable, we will also create/delete dedicated bearers.
  e. Apply the updates back to SessionStore
3. Respond to PolicyDB with status OK

Since we need to do many looks up in the rule set we receive, I've defined two new structures to make that easier. By converting the received proto message to the following structures, we do not have to iterate through the rules every time.
```
struct RuleSetToApply {
  std::unordered_map<std::string, PolicyRule> dynamic_rules;
  std::unordered_set<std::string> static_rules;
};
struct RuleSetBySubscriber {
  std::string imsi;
  std::unordered_map<std::string, RuleSetToApply> rule_set_by_apn;
  std::experimental::optional<RuleSetToApply> subscriber_wide_rule_set;
};
```

Two additional unit tests were added to test the SessionState and LocalEnforcer layer.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
S1AP test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
