### PR TITLE
[SessionD] Handle Policy->BearerID bindings from MME

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1872,6 +1872,68 @@ void LocalEnforcer::handle_cwf_roaming(
   }
 }
 
+bool LocalEnforcer::bind_policy_to_bearer(
+    SessionMap& session_map, const PolicyBearerBindingRequest& request,
+    SessionUpdate& session_update) {
+  const auto& imsi = request.sid().id();
+  auto it          = session_map.find(imsi);
+  if (it == session_map.end()) {
+    MLOG(MERROR) << "Could not bind policy to bearer: session for " << imsi
+                 << " is not found";
+    return false;
+  }
+  for (const auto& session : it->second) {
+    const auto& config = session->get_config();
+    if (!config.rat_specific_context.has_lte_context()) {
+      continue;  // not LTE
+    }
+    const auto& lte_context = config.rat_specific_context.lte_context();
+    if (lte_context.bearer_id() != request.linked_bearer_id()) {
+      continue;
+    }
+    auto& uc = session_update[imsi][session->get_session_id()];
+    if (request.bearer_id() != 0) {
+      session->bind_policy_to_bearer(request, uc);
+      return true;
+    }
+    // if bearer_id is 0, the rule needs to be removed since we cannot honor the
+    // QoS request
+    remove_rule_due_to_bearer_creation_failure(
+        imsi, *session, request.policy_rule_id(), uc);
+  }
+  return false;
+}
+
+void LocalEnforcer::remove_rule_due_to_bearer_creation_failure(
+    const std::string& imsi, SessionState& session, const std::string& rule_id,
+    SessionStateUpdateCriteria& uc) {
+  MLOG(MINFO) << "Removing " << rule_id
+              << " since we failed to create a dedicated bearer for it";
+  auto policy_type = session.get_policy_type(rule_id);
+  if (!policy_type) {
+    MLOG(MERROR) << "Unable to remove rule " << rule_id
+                 << " since it is not found";
+    return;
+  }
+  std::vector<std::string> static_rule_to_remove;
+  std::vector<PolicyRule> dynamic_rule_to_remove;
+
+  switch (*policy_type) {
+    case STATIC:
+      session.deactivate_static_rule(rule_id, uc);
+      static_rule_to_remove.push_back(rule_id);
+      break;
+    case DYNAMIC: {
+      PolicyRule rule;
+      session.remove_dynamic_rule(rule_id, &rule, uc);
+      dynamic_rule_to_remove.push_back(rule);
+    }
+  }
+  pipelined_client_->deactivate_flows_for_rules(
+      imsi, static_rule_to_remove, dynamic_rule_to_remove,
+      RequestOriginType::GX);
+}
+
 static void handle_command_level_result_code(
     const std::string& imsi, const uint32_t result_code,
     std::unordered_set<std::string>& subscribers_to_terminate) {

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -219,6 +219,16 @@ class LocalEnforcer {
       SessionMap& session_map, const SessionRules& rules,
       SessionUpdate& session_update);
 
+  /**
+   * Check if PolicyBearerBindingRequest has a non-zero dedicated bearer ID:
+   * Update the policy to bearer map if non-zero
+   * Delete the policy rule if zero
+   * @return true if successfully processed the request
+   */
+  bool bind_policy_to_bearer(
+      SessionMap& session_map, const PolicyBearerBindingRequest& request,
+      SessionUpdate& session_update);
+
   static uint32_t REDIRECT_FLOW_PRIORITY;
 
  private:
@@ -553,6 +563,16 @@ class LocalEnforcer {
   void schedule_termination(std::unordered_set<std::string>& imsis);
 
   void propagate_bearer_updates_to_mme(const BearerUpdate& updates);
+
+  /**
+   * Remove the specified rule from the session and propagate the change to
+   * PipelineD
+   * @param rule_id rule to be deleted
+   * @param uc
+   */
+  void remove_rule_due_to_bearer_creation_failure(
+      const std::string& imsi, SessionState& session,
+      const std::string& rule_id, SessionStateUpdateCriteria& uc);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1441,6 +1441,34 @@ BearerUpdate SessionState::get_dedicated_bearer_updates(
   return update;
 }
 
+void SessionState::bind_policy_to_bearer(
+    const PolicyBearerBindingRequest& request, SessionStateUpdateCriteria& uc) {
+  const std::string& rule_id = request.policy_rule_id();
+  auto policy_type           = get_policy_type(rule_id);
+  if (!policy_type) {
+    MLOG(MDEBUG) << "Policy " << rule_id
+                 << " not found, when trying to bind to bearerID "
+                 << request.bearer_id();
+    return;
+  }
+  MLOG(MINFO) << session_id_ << " now has policy " << rule_id
+              << " tied to bearerID " << request.bearer_id();
+  bearer_id_by_policy_[PolicyID(*policy_type, rule_id)] = request.bearer_id();
+  uc.is_bearer_mapping_updated = true;
+  uc.bearer_id_by_policy       = bearer_id_by_policy_;
+}
+
+std::experimental::optional<PolicyType> SessionState::get_policy_type(
+    const std::string& rule_id) {
+  if (is_static_rule_installed(rule_id)) {
+    return STATIC;
+  } else if (is_dynamic_rule_installed(rule_id)) {
+    return DYNAMIC;
+  } else {
+    return {};
+  }
+}
+
 SessionCreditUpdateCriteria* SessionState::get_monitor_uc(
     const std::string& key, SessionStateUpdateCriteria& uc) {
   if (uc.monitor_credit_map.find(key) == uc.monitor_credit_map.end()) {
@@ -1589,8 +1617,9 @@ void SessionState::update_bearer_deletion_req(
       bearer_id_by_policy_.end()) {
     return;
   }
-
   // map change needs to be propagated to the store
+  const auto bearer_id_to_delete =
+      bearer_id_by_policy_[PolicyID(policy_type, rule_id)];
   bearer_id_by_policy_.erase(PolicyID(policy_type, rule_id));
   uc.is_bearer_mapping_updated = true;
   uc.bearer_id_by_policy       = bearer_id_by_policy_;
@@ -1604,8 +1633,7 @@ void SessionState::update_bearer_deletion_req(
     req.set_link_bearer_id(
         config.rat_specific_context.lte_context().bearer_id());
   }
-  update.delete_req.mutable_eps_bearer_ids()->Add(
-      bearer_id_by_policy_[PolicyID(policy_type, rule_id)]);
+  update.delete_req.mutable_eps_bearer_ids()->Add(bearer_id_to_delete);
 }
 
 RuleSetToApply::RuleSetToApply(const magma::lte::RuleSet& rule_set) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -221,6 +221,14 @@ class SessionState {
   void increment_request_number(uint32_t incr);
 
   // Methods related to the session's static and dynamic rules
+  /**
+   * Infer the policy's type (STATIC or DYNAMIC)
+   * @param rule_id
+   * @return the type if the rule exists, {} otherwise.
+   */
+  std::experimental::optional<PolicyType> get_policy_type(
+      const std::string& rule_id);
+
   bool is_dynamic_rule_installed(const std::string& rule_id);
 
   bool is_gy_dynamic_rule_installed(const std::string& rule_id);
@@ -405,6 +413,14 @@ class SessionState {
   void apply_session_rule_set(
       RuleSetToApply& rule_set, RulesToProcess& rules_to_activate,
       RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc);
+
+  /**
+   * Add the association of policy -> bearerID into bearer_id_by_policy_
+   * This assumes the bearerID is not 0
+   */
+  void bind_policy_to_bearer(
+      const PolicyBearerBindingRequest& request,
+      SessionStateUpdateCriteria& uc);
 
  private:
   std::string imsi_;

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -94,4 +94,23 @@ MATCHER_P2(CheckCreateBearerReq, imsi, rule_count, "") {
          request.policy_rules().size() == rule_count;
 }
 
+MATCHER_P3(CheckDeleteOneBearerReq, imsi, link_bearer_id, eps_bearer_id, "") {
+  auto request = static_cast<const DeleteBearerRequest>(arg);
+
+  return request.sid().id() == imsi &&
+         request.link_bearer_id() == uint32_t(link_bearer_id) &&
+         request.eps_bearer_ids_size() == 1 &&
+         request.eps_bearer_ids(0) == uint32_t(eps_bearer_id);
+}
+
+MATCHER_P(CheckSubset, ids, "") {
+  auto request = static_cast<const std::vector<std::string>>(arg);
+  for (size_t i = 0; i < request.size(); i++) {
+    if (ids.find(request[i]) != ids.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 };  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -296,4 +296,15 @@ magma::mconfig::SessionD get_default_mconfig() {
   wallet_config->set_terminate_on_exhaust(false);
   return mconfig;
 }
+
+PolicyBearerBindingRequest create_policy_bearer_bind_req(
+    const std::string& imsi, const uint32_t linked_bearer_id,
+    const std::string& rule_id, const uint32_t bearer_id) {
+  PolicyBearerBindingRequest bearer_bind_req;
+  bearer_bind_req.mutable_sid()->set_id(imsi);
+  bearer_bind_req.set_linked_bearer_id(linked_bearer_id);
+  bearer_bind_req.set_policy_rule_id(rule_id);
+  bearer_bind_req.set_bearer_id(bearer_id);
+  return bearer_bind_req;
+}
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -115,4 +115,8 @@ void create_granted_units(
     uint64_t* total, uint64_t* tx, uint64_t* rx, GrantedUnits* gsu);
 
 magma::mconfig::SessionD get_default_mconfig();
+
+PolicyBearerBindingRequest create_policy_bearer_bind_req(
+    const std::string& imsi, const uint32_t linked_bearer_id,
+    const std::string& rule_id, const uint32_t bearer_id);
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR includes changes necessary to handle Policy->Bearer bindings from MME.
When we receive a `PolicyBearerBindingRequest` request, there are two main cases:
1. bearer_id is NOT 0: This means the bearer creation was successful, so the mapping should be propagated to the policy bearer map in SessionState.
2. bearer_id is 0: This means that the bearer creation did not happen, so the corresponding rule must be removed. 

A bug fix in `update_bearer_deletion_req` is also included. The previous implementation was removing the policy->bearerID mapping before grabbing the bearerID. The bearer deletion flow is now tested in the added unit test.

TODO: now that the core changes in SessionD are done, we need to add some integration tests for both PolicyDB <-> SessionD and SessionD <-> MME. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
S1AP test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
