### PR TITLE
[XWF] Pull goradius instead of gateway_go when deploying

### DIFF
--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -82,7 +82,7 @@ services:
 
   radius:
     <<: *service
-    image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+    image: ${DOCKER_REGISTRY}goradius:${IMAGE_VERSION}
     container_name: radius
     environment:
       - ODS_ACCESS_TOKEN=${ODS_ACCESS_TOKEN}


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

This docker-compose file is used by ansible scripts to deploy xwfm gateway. In this case, we need to pull goradius image and not gateway_go.

## Test Plan

tested by deploying a gateway.