### PR TITLE
[AGW] mobilityD: UT: use secondary checks before failing DHCP client test

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -122,7 +122,7 @@ class DHCPClient:
             return
 
         dhcp_opts.append("end")
-
+        dhcp_desc.xid = pkt_xid
         with self._dhcp_notify:
             self.dhcp_client_state[mac.as_redis_key(vlan)] = dhcp_desc
 

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-sw.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-sw.sh
@@ -15,6 +15,11 @@
 
 br=$1
 prefix=$2
+for pid in $(pgrep -f  "dnsmasq.*vt.*\..*\.")
+do
+        kill $pid
+done
+ip -all netns  delete
 
 set +e
 ip link delete "$prefix"_ul_0

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -38,6 +38,7 @@ logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
 DHCP_IFACE = "cl1_dhcp0"
 PKT_CAPTURE_WAIT = 2
+RETRY_LIMIT = 10
 
 """
 Test dhclient class independent of IP allocator.
@@ -47,6 +48,9 @@ Test dhclient class independent of IP allocator.
 class DhcpClient(unittest.TestCase):
     def setUp(self):
         self._br = "dh_br0"
+        self.vlan_sw = "vlan_sw"
+        self.up_link_port = ""
+
         try:
             subprocess.check_call(["pkill", "dnsmasq"])
         except subprocess.CalledProcessError:
@@ -57,6 +61,8 @@ class DhcpClient(unittest.TestCase):
         self.dhcp_store = {}
         self.gw_info_map = {}
         self.gw_info = UplinkGatewayInfo(self.gw_info_map)
+        self._sniffer = None
+        self._last_xid = -1
 
     def tearDown(self):
         self._dhcp_client.stop()
@@ -99,11 +105,11 @@ class DhcpClient(unittest.TestCase):
     def test_dhcp_vlan_multi(self):
         self._setup_vlan_network()
 
-        vlan1 = "1"
+        vlan1 = "51"
         mac1 = MacAddress("11:22:33:44:55:66")
-        vlan2 = "2"
+        vlan2 = "52"
         mac2 = MacAddress("22:22:33:44:55:66")
-        vlan3 = "3"
+        vlan3 = "53"
         mac3 = MacAddress("11:22:33:44:55:66")
 
         self._setup_dhcp_on_vlan(vlan1)
@@ -128,18 +134,19 @@ class DhcpClient(unittest.TestCase):
         self._validate_state_as_current(mac1, vlan)
 
         # trigger lease reneval before deadline
+        self._last_xid = self._get_state_xid(mac1, vlan)
         LOG.debug("time: %s", datetime.datetime.now())
         time1 = datetime.datetime.now() + datetime.timedelta(seconds=100)
         self._start_sniffer()
         with freeze_time(time1):
             LOG.debug("check req packets time: %s", datetime.datetime.now())
-
             self._stop_sniffer_and_check(DHCPState.REQUEST, mac1, vlan)
             self._validate_req_state(mac1, DHCPState.REQUEST, vlan)
             self._validate_state_as_current(mac1, vlan)
 
             # trigger lease after deadline
-            time2 = datetime.datetime.now() + datetime.timedelta(seconds=200)
+            self._last_xid = self._get_state_xid(mac1, vlan)
+            time2 = datetime.datetime.now() + datetime.timedelta(seconds=2000)
             self._start_sniffer()
             LOG.debug("check discover packets time: %s", datetime.datetime.now())
             with freeze_time(time2):
@@ -149,23 +156,25 @@ class DhcpClient(unittest.TestCase):
                 self._validate_state_as_current(mac1, vlan)
 
     def _setup_dhcp_vlan_off(self):
+        self.up_link_port = "cl1uplink_p0"
         setup_dhcp_server = SCRIPT_PATH + "scripts/setup-test-dhcp-srv.sh"
         subprocess.check_call([setup_dhcp_server, "cl1"])
 
         setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
                            self._br,
-                           "cl1uplink_p0",
+                           self.up_link_port,
                            DHCP_IFACE]
         subprocess.check_call(setup_uplink_br)
         self._setup_dhclp_client()
 
     def _setup_vlan_network(self):
+        self.up_link_port = "v_ul_0"
         setup_vlan_switch = SCRIPT_PATH + "scripts/setup-uplink-vlan-sw.sh"
-        subprocess.check_call([setup_vlan_switch, "vlan_sw", "v"])
+        subprocess.check_call([setup_vlan_switch, self.vlan_sw, "v"])
 
         setup_uplink_br = [SCRIPT_PATH + "scripts/setup-uplink-br.sh",
                            self._br,
-                           "v_ul_0",
+                           self.up_link_port,
                            DHCP_IFACE]
         subprocess.check_call(setup_uplink_br)
         self._setup_dhclp_client()
@@ -177,16 +186,26 @@ class DhcpClient(unittest.TestCase):
                                        iface=DHCP_IFACE,
                                        lease_renew_wait_min=1)
         self._dhcp_client.run()
-        self._setup_sniffer()
 
     def _setup_dhcp_on_vlan(self, vlan: str):
         setup_vlan_switch = SCRIPT_PATH + "scripts/setup-uplink-vlan-srv.sh"
-        subprocess.check_call([setup_vlan_switch, "vlan_sw", vlan])
+        subprocess.check_call([setup_vlan_switch, self.vlan_sw, vlan])
 
     def _validate_req_state(self, mac: MacAddress, state: DHCPState, vlan: str):
+        for x in range(RETRY_LIMIT):
+            LOG.debug("wait for state: %d" % x)
+            with self.dhcp_wait:
+                dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
+                if dhcp1.state_requested == state:
+                    return
+            time.sleep(PKT_CAPTURE_WAIT)
+
+        assert 0
+
+    def _get_state_xid(self, mac: MacAddress, vlan: str):
         with self.dhcp_wait:
             dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
-            self.assertEqual(dhcp1.state_requested, state)
+            return dhcp1.xid
 
     def _validate_state_as_current(self, mac: MacAddress, vlan: str):
         with self.dhcp_wait:
@@ -232,19 +251,31 @@ class DhcpClient(unittest.TestCase):
         with self.pkt_list_lock:
             self.pkt_list.append(packet)
 
-    def _setup_sniffer(self):
+    def _start_sniffer(self):
+        # drop dhclient requests, this would avoid lease
+        # renewal after freezing time.
+        subprocess.check_call(["ovs-ofctl", "add-flow", self._br,
+                               "priority=100,in_port=" + self.up_link_port + ",action=drop"])
+        time.sleep(PKT_CAPTURE_WAIT)
+
         self._sniffer = AsyncSniffer(iface=self._br,
                                      filter="udp and (port 67 or 68)",
                                      prn=self._handle_dhcp_req_packet)
 
-    def _start_sniffer(self):
         self.pkt_list = []
         self._sniffer.start()
+        LOG.debug("sniffer started")
         time.sleep(PKT_CAPTURE_WAIT)
 
     def _stop_sniffer_and_check(self, state: DHCPState, mac: MacAddress, vlan):
-        for x in range(30):
+        LOG.debug("delete drop flow")
+        subprocess.check_call(["ovs-ofctl", "del-flows", self._br,
+                               "in_port=" + self.up_link_port])
+
+        for x in range(RETRY_LIMIT):
+            LOG.debug("wait for pkt: %d" % x)
             time.sleep(PKT_CAPTURE_WAIT)
+
             with self.pkt_list_lock:
                 for pkt in self.pkt_list:
                     if DHCP in pkt:
@@ -262,4 +293,7 @@ class DhcpClient(unittest.TestCase):
             for pkt in self.pkt_list:
                 LOG.debug("DHCP pkt %s", pkt.show(dump=True))
 
-        assert 0
+        # validate if any dhcp packet was sent.
+        if state == DHCPState.DISCOVER:
+            self.assertNotEqual(self._last_xid,
+                                self._get_state_xid(mac, vlan))


### PR DESCRIPTION
## Summary

Even when log clearly shows DHCP packet scappy async-sniffer fails to
capture the packet. in such cases test uses xid change to detect if
dhcp-client sent packet to avoid false positive.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test_python`
