### PR TITLE
[XWF] Add radiusd to xwf-m

### DIFF
--- a/xwf/gateway/configs/gateway.mconfig
+++ b/xwf/gateway/configs/gateway.mconfig
@@ -4,10 +4,6 @@
       "@type": "type.googleapis.com/magma.mconfig.ControlProxy",
       "logLevel": "INFO"
     },
-    "directoryd": {
-      "@type": "type.googleapis.com/magma.mconfig.DirectoryD",
-      "logLevel": "INFO"
-    },
     "magmad": {
       "@type": "type.googleapis.com/magma.mconfig.MagmaD",
       "logLevel": "INFO",
@@ -27,19 +23,6 @@
       "services": [],
       "allowedGrePeers": [],
       "liUes": {}
-    },
-    "policydb": {
-      "@type": "type.googleapis.com/magma.mconfig.PolicyDB",
-      "logLevel": "INFO"
-    },
-    "sessiond": {
-      "@type": "type.googleapis.com/magma.mconfig.SessionD",
-      "logLevel": "INFO",
-      "relayEnabled": true
-    },
-    "redirectd": {
-      "@type": "type.googleapis.com/magma.mconfig.RedirectD",
-      "logLevel": "INFO"
     },
     "radiusd": {
       "@type": "type.googleapis.com/magma.mconfig.RadiusdConfig",

--- a/xwf/gateway/configs/magmad.yml
+++ b/xwf/gateway/configs/magmad.yml
@@ -16,10 +16,13 @@ log_level: INFO
 magma_services:
   - control_proxy
   - pipelined
+  - radiusd
+  - radius
 
 # List of services that don't provide service303 interface
 non_service303_services:
   - control_proxy
+  - radius
 
 # list of services that are required to have meta before checking in
 # (meta = data gathered via MagmaService.register_get_status_callback())
@@ -52,6 +55,7 @@ mconfig_modules:
   - orc8r.protos.mconfig.mconfigs_pb2
   - lte.protos.mconfig.mconfigs_pb2
   - feg.protos.mconfig.mconfigs_pb2
+  - cwf.protos.mconfig.mconfigs_pb2
 
 metricsd:
   log_level: INFO
@@ -69,3 +73,4 @@ metricsd:
   services:
     - magmad
     - pipelined
+    - radiusd

--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -94,3 +94,9 @@ services:
       - PARTNER_SHORTNAME=${PARTNER_SHORTNAME}
     command: >
       /bin/sh -c "./docker-entrypoint.sh"
+
+  radiusd:
+    <<: *service
+    image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
+    container_name: radiusd
+    command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

Enable Radiusd to allow fetching metrics from the running radius server and exporting them

## Test Plan

Tested on xwfmqa1

## Additional Information
