### PR TITLE
[SessionD] Clean up LocalEnforcer

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -56,6 +56,7 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1295,38 +1295,6 @@ void LocalEnforcer::terminate_session(
   }
 }
 
-uint64_t LocalEnforcer::get_charging_credit(
-    SessionMap& session_map, const std::string& imsi,
-    const CreditKey& charging_key, Bucket bucket) const {
-  auto it = session_map.find(imsi);
-  if (it == session_map.end()) {
-    return 0;
-  }
-  for (const auto& session : it->second) {
-    uint64_t credit = session->get_charging_credit(charging_key, bucket);
-    if (credit > 0) {
-      return credit;
-    }
-  }
-  return 0;
-}
-
-uint64_t LocalEnforcer::get_monitor_credit(
-    SessionMap& session_map, const std::string& imsi, const std::string& mkey,
-    Bucket bucket) const {
-  auto it = session_map.find(imsi);
-  if (it == session_map.end()) {
-    return 0;
-  }
-  for (const auto& session : it->second) {
-    uint64_t credit = session->get_monitor(mkey, bucket);
-    if (credit > 0) {
-      return credit;
-    }
-  }
-  return 0;
-}
-
 void LocalEnforcer::handle_set_session_rules(
     SessionMap& session_map, const SessionRules& rules,
     SessionUpdate& session_update) {

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -38,6 +38,13 @@ std::chrono::milliseconds time_difference_from_now(
   std::chrono::seconds sec(delta);
   return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
 }
+
+uint64_t get_time_in_sec_since_epoch() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             now.time_since_epoch())
+      .count();
+}
 }  // namespace
 
 namespace magma {
@@ -49,12 +56,6 @@ using google::protobuf::util::TimeUtil;
 
 using namespace std::placeholders;
 
-// We will treat rule install/uninstall failures as all-or-nothing - that is,
-// if we get a bad response from the pipelined client, we'll mark all the rules
-// as failed in the response
-static void mark_rule_failures(
-    const bool activate_success, const bool deactivate_success,
-    const PolicyReAuthRequest& request, PolicyReAuthAnswer& answer_out);
 // For command level result codes, we will mark the subscriber to be terminated
 // if the result code indicates a permanent failure.
 static void handle_command_level_result_code(
@@ -294,11 +295,10 @@ void LocalEnforcer::complete_termination_for_released_sessions(
     }
   }
   for (const auto& imsi_sid_pair : imsi_to_terminate) {
-    auto imsi       = imsi_sid_pair.first;
-    auto session_id = imsi_sid_pair.second;
-    SessionStateUpdateCriteria& update_criteria =
-        session_update[imsi][session_id];
-    complete_termination(session_map, imsi, session_id, update_criteria);
+    auto imsi                      = imsi_sid_pair.first;
+    auto session_id                = imsi_sid_pair.second;
+    SessionStateUpdateCriteria& uc = session_update[imsi][session_id];
+    complete_termination(session_map, imsi, session_id, uc);
   }
 }
 
@@ -358,8 +358,8 @@ bool LocalEnforcer::find_and_terminate_session(
   }
   for (const auto& session : it->second) {
     if (session->get_session_id() == session_id) {
-      auto& uc = session_update[imsi][session_id];
-      start_session_termination(imsi, session, true, uc);
+      start_session_termination(
+          imsi, session, true, session_update[imsi][session_id]);
       return true;
     }
   }
@@ -369,23 +369,19 @@ bool LocalEnforcer::find_and_terminate_session(
 // Terminates sessions that correspond to the given IMSI and session.
 void LocalEnforcer::start_session_termination(
     const std::string& imsi, const std::unique_ptr<SessionState>& session,
-    bool notify_access, SessionStateUpdateCriteria& update_criteria) {
+    bool notify_access, SessionStateUpdateCriteria& uc) {
   auto session_id = session->get_session_id();
   if (session->is_terminating()) {
     // If the session is terminating already, do nothing.
     MLOG(MINFO) << "Session " << session_id << " is already terminating, "
-                 << "ignoring termination request";
+                << "ignoring termination request";
     return;
   }
   MLOG(MINFO) << "Initiating session termination for " << session_id;
-  auto now = std::chrono::system_clock::now();
-  uint64_t epoch = std::chrono::duration_cast<std::chrono::seconds>(
-    now.time_since_epoch()).count();
-  update_criteria.updated_pdp_end_time = epoch;
+  session->set_pdp_end_time(get_time_in_sec_since_epoch());
 
-  remove_all_rules_for_termination(imsi, session, update_criteria);
-
-  session->set_fsm_state(SESSION_RELEASED, update_criteria);
+  remove_all_rules_for_termination(imsi, session, uc);
+  session->set_fsm_state(SESSION_RELEASED, uc);
   const auto& config         = session->get_config();
   const auto& common_context = config.common_context;
   if (notify_access) {
@@ -399,12 +395,14 @@ void LocalEnforcer::start_session_termination(
   }
   if (terminate_on_wallet_exhaust()) {
     handle_subscriber_quota_state_change(
-        imsi, *session, SubscriberQuotaUpdate_Type_TERMINATE, update_criteria);
+        imsi, *session, SubscriberQuotaUpdate_Type_TERMINATE, uc);
   }
   // The termination should be completed when aggregated usage record no
   // longer
   // includes the imsi. If this has not occurred after the timeout, force
   // terminate the session.
+  MLOG(MDEBUG) << "Scheduling a force termination timeout for " << session_id
+               << " in " << session_force_termination_timeout_ms_ << "ms";
   evb_->runAfterDelay(
       [this, imsi, session_id] {
         handle_force_termination_timeout(imsi, session_id);
@@ -414,38 +412,39 @@ void LocalEnforcer::start_session_termination(
 
 void LocalEnforcer::handle_force_termination_timeout(
     const std::string& imsi, const std::string& session_id) {
-  MLOG(MDEBUG) << "Checking if termination has to be forced for " << session_id;
-  SessionRead req     = {imsi};
-  auto session_map    = session_store_.read_sessions_for_deletion(req);
+  auto session_map    = session_store_.read_sessions_for_deletion({imsi});
   auto session_update = SessionStore::get_default_session_update(session_map);
-  if (session_update[imsi].find(session_id) != session_update[imsi].end()) {
-    auto& update_criteria = session_update[imsi][session_id];
-    complete_termination(session_map, imsi, session_id, update_criteria);
+  bool needs_termination =
+      session_update[imsi].find(session_id) != session_update[imsi].end();
+  MLOG(MDEBUG) << "Forced termination timeout! Checking if termination has to "
+               << "be forced for " << session_id << "... => "
+               << (needs_termination ? "YES" : "NO");
+  // If the session doesn't exist in the session_update, then the session was
+  // already terminated + removed
+  if (needs_termination) {
+    complete_termination(
+        session_map, imsi, session_id, session_update[imsi][session_id]);
     bool end_success = session_store_.update_sessions(session_update);
     if (end_success) {
-      MLOG(MDEBUG) << "Ended session " << imsi
-                   << " with session_id: " << session_id;
+      MLOG(MDEBUG) << "Updated session termination of " << session_id
+                   << " in to SessionStore";
     } else {
-      MLOG(MERROR) << "Failed to update SessionStore with ended session "
-                   << imsi << " and session_id: " << session_id;
+      MLOG(MDEBUG) << "Failed to update session termination of " << session_id
+                   << " in to SessionStore";
     }
-  } else {
-    MLOG(MDEBUG) << "Not forcing termination for session " << imsi
-                 << " and session_id: " << session_id
-                 << " as it has already terminated.";
   }
 }
 
 void LocalEnforcer::remove_all_rules_for_termination(
     const std::string& imsi, const std::unique_ptr<SessionState>& session,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria& uc) {
   RulesToProcess rules;
   populate_rules_from_session_to_remove(imsi, session, rules);
   for (const std::string& static_rule : rules.static_rules) {
-    update_criteria.static_rules_to_uninstall.insert(static_rule);
+    uc.static_rules_to_uninstall.insert(static_rule);
   }
   for (const PolicyRule& dynamic_rule : rules.dynamic_rules) {
-    update_criteria.dynamic_rules_to_uninstall.insert(dynamic_rule.id());
+    uc.dynamic_rules_to_uninstall.insert(dynamic_rule.id());
   }
   pipelined_client_->deactivate_flows_for_rules(
       imsi, rules.static_rules, rules.dynamic_rules, RequestOriginType::GX);
@@ -483,13 +482,12 @@ void LocalEnforcer::notify_termination_to_access_service(
 
 void LocalEnforcer::handle_subscriber_quota_state_change(
     const std::string& imsi, SessionState& session,
-    SubscriberQuotaUpdate_Type new_state,
-    SessionStateUpdateCriteria& update_criteria) {
+    SubscriberQuotaUpdate_Type new_state, SessionStateUpdateCriteria& uc) {
   auto config     = session.get_config();
   auto session_id = session.get_session_id();
   MLOG(MINFO) << session_id << " now has subscriber wallet status: "
               << wallet_state_to_str(new_state);
-  session.set_subscriber_quota_state(new_state, update_criteria);
+  session.set_subscriber_quota_state(new_state, uc);
   std::string ue_mac_addr = "";
   auto rat_specific       = config.rat_specific_context;
   if (rat_specific.has_wlan_context()) {
@@ -617,10 +615,10 @@ UpdateSessionRequest LocalEnforcer::collect_updates(
   UpdateSessionRequest request;
   for (const auto& session_pair : session_map) {
     for (const auto& session : session_pair.second) {
-      std::string imsi      = session_pair.first;
-      std::string sid       = session->get_session_id();
-      auto& update_criteria = session_update[imsi][sid];
-      session->get_updates(request, &actions, update_criteria);
+      std::string imsi = session_pair.first;
+      std::string sid  = session->get_session_id();
+      auto& uc         = session_update[imsi][sid];
+      session->get_updates(request, &actions, uc);
     }
   }
   return request;
@@ -892,11 +890,10 @@ void LocalEnforcer::filter_rule_installs(
   dynamic_installs.erase(end_of_valid_dy_rules, dynamic_installs.end());
 }
 
-bool LocalEnforcer::handle_session_init_rule_updates(
-    SessionMap& session_map, const std::string& imsi,
-    SessionState& session_state, const CreateSessionResponse& response,
+void LocalEnforcer::handle_session_init_rule_updates(
+    const std::string& imsi, SessionState& session_state,
+    const CreateSessionResponse& response,
     std::unordered_set<uint32_t>& charging_credits_received) {
-
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
 
@@ -926,18 +923,16 @@ bool LocalEnforcer::handle_session_init_rule_updates(
         rules_to_activate, rules_to_deactivate, uc);
     propagate_bearer_updates_to_mme(update);
   }
-  return true;
 }
 
-bool LocalEnforcer::init_session_credit(
+void LocalEnforcer::init_session_credit(
     SessionMap& session_map, const std::string& imsi,
     const std::string& session_id, const SessionConfig& cfg,
     const CreateSessionResponse& response) {
-  auto now = std::chrono::system_clock::now();
-  uint64_t epoch = std::chrono::duration_cast<std::chrono::seconds>(
-    now.time_since_epoch()).count();
-  auto session_state = std::make_unique<SessionState>(
-      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx(), epoch);
+  const auto time_since_epoch = get_time_in_sec_since_epoch();
+  auto session_state          = std::make_unique<SessionState>(
+      imsi, session_id, cfg, *rule_store_, response.tgpp_ctx(),
+      time_since_epoch);
 
   std::unordered_set<uint32_t> charging_credits_received;
   for (const auto& credit : response.credits()) {
@@ -955,15 +950,14 @@ bool LocalEnforcer::init_session_credit(
     session_state->receive_monitor(monitor, uc);
   }
 
-  auto rule_update_success = handle_session_init_rule_updates(
-      session_map, imsi, *session_state, response, charging_credits_received);
+  handle_session_init_rule_updates(
+      imsi, *session_state, response, charging_credits_received);
 
-  update_ipfix_flow(imsi, cfg, epoch);
+  update_ipfix_flow(imsi, cfg, time_since_epoch);
 
   if (session_state->is_radius_cwf_session()) {
     if (terminate_on_wallet_exhaust()) {
-      handle_session_init_subscriber_quota_state(
-          session_map, imsi, *session_state);
+      handle_session_init_subscriber_quota_state(imsi, *session_state);
     }
   }
 
@@ -986,8 +980,6 @@ bool LocalEnforcer::init_session_credit(
     events_reporter_->session_created(imsi, session_id, cfg, session_state);
   }
   session_map[imsi].push_back(std::move(session_state));
-
-  return rule_update_success;
 }
 
 bool LocalEnforcer::terminate_on_wallet_exhaust() {
@@ -1006,14 +998,11 @@ bool LocalEnforcer::is_wallet_exhausted(SessionState& session_state) {
 }
 
 void LocalEnforcer::handle_session_init_subscriber_quota_state(
-    SessionMap& session_map, const std::string& imsi,
-    SessionState& session_state) {
-  bool is_exhausted = is_wallet_exhausted(session_state);
-
-  // This method only used for session creation and not updates, so
+    const std::string& imsi, SessionState& session_state) {
+  // TODO This method only used for session creation and not updates, so
   // UpdateCriteria is unused.
   auto _ = get_default_update_criteria();
-  if (is_exhausted) {
+  if (is_wallet_exhausted(session_state)) {
     handle_subscriber_quota_state_change(
         imsi, session_state, SubscriberQuotaUpdate_Type_NO_QUOTA);
     // Schedule a session termination for a configured number of seconds after
@@ -1072,8 +1061,7 @@ void LocalEnforcer::report_subscriber_state_to_pipelined(
 
 void LocalEnforcer::complete_termination(
     SessionMap& session_map, const std::string& imsi,
-    const std::string& session_id,
-    SessionStateUpdateCriteria& update_criteria) {
+    const std::string& session_id, SessionStateUpdateCriteria& uc) {
   // If the session cannot be found in session_map, or a new session has
   // already begun, do nothing.
   auto it = session_map.find(imsi);
@@ -1087,8 +1075,14 @@ void LocalEnforcer::complete_termination(
   for (auto session_it = it->second.begin(); session_it != it->second.end();
        ++session_it) {
     if ((*session_it)->get_session_id() == session_id) {
-      // Complete session termination and remove session from session_map.
-      (*session_it)->complete_termination(*reporter_, update_criteria);
+      bool terminated = (*session_it)->complete_termination(uc);
+      if (!terminated) {
+        return;  // error is logged in SessionState's complete_termination
+      }
+      auto termination_req = (*session_it)->make_termination_request(uc);
+      auto logging_cb =
+          SessionReporter::get_terminate_logging_cb(termination_req);
+      reporter_->report_terminate_session(termination_req, logging_cb);
       // Send to eventd
       if ((*session_it)->is_radius_cwf_session() == false) {
         events_reporter_->session_terminated(imsi, *session_it);
@@ -1096,18 +1090,21 @@ void LocalEnforcer::complete_termination(
       // We break the loop below, but for extra code safety in case
       // someone removes the break in the future, adjust the iterator
       // after erasing the element
-      update_criteria.is_session_ended = true;
+      uc.is_session_ended = true;
       it->second.erase(session_it--);
-      MLOG(MDEBUG) << "Successfully terminated session for " << imsi
-                   << "session ID " << session_id;
+      MLOG(MDEBUG) << "Successfully terminated session " << session_id;
       // No session left for this IMSI
       if (it->second.size() == 0) {
         session_map.erase(imsi);
         MLOG(MDEBUG) << "All sessions terminated for " << imsi;
       }
-      break;
+      return;
     }
   }
+  // Session Not Found
+  MLOG(MDEBUG) << "Could not find session " << session_id
+               << "to complete termination.";
+  return;  // Session not found, so not terminated
 }
 
 bool LocalEnforcer::rules_to_process_is_not_empty(
@@ -1151,13 +1148,13 @@ void LocalEnforcer::update_charging_credits(
       continue;
     }
     for (const auto& session : it->second) {
-      std::string sid                             = session->get_session_id();
-      SessionStateUpdateCriteria& update_criteria = session_update[imsi][sid];
+      std::string sid                = session->get_session_id();
+      SessionStateUpdateCriteria& uc = session_update[imsi][sid];
       bool is_redirected =
           session->is_credit_state_redirected(CreditKey(credit_update_resp));
-      session->receive_charging_credit(credit_update_resp, update_criteria);
+      session->receive_charging_credit(credit_update_resp, uc);
 
-      session->set_tgpp_context(credit_update_resp.tgpp_ctx(), update_criteria);
+      session->set_tgpp_context(credit_update_resp.tgpp_ctx(), uc);
       SessionState::SessionInfo info;
 
       if (is_redirected) {
@@ -1211,22 +1208,22 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
     }
 
     for (const auto& session : it->second) {
-      auto& update_criteria = session_update[imsi][session->get_session_id()];
-      const auto& config    = session->get_config();
-      session->receive_monitor(usage_monitor_resp, update_criteria);
-      session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), update_criteria);
+      auto& uc           = session_update[imsi][session->get_session_id()];
+      const auto& config = session->get_config();
+      session->receive_monitor(usage_monitor_resp, uc);
+      session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), uc);
 
       RulesToProcess rules_to_activate;
       RulesToProcess rules_to_deactivate;
 
       process_rules_to_remove(
           imsi, session, usage_monitor_resp.rules_to_remove(),
-          rules_to_deactivate, update_criteria);
+          rules_to_deactivate, uc);
 
       process_rules_to_install(
           *session, imsi, to_vec(usage_monitor_resp.static_rules_to_install()),
           to_vec(usage_monitor_resp.dynamic_rules_to_install()),
-          rules_to_activate, rules_to_deactivate, update_criteria);
+          rules_to_activate, rules_to_deactivate, uc);
 
       propagate_rule_updates_to_pipelined(
           imsi, config, rules_to_activate, rules_to_deactivate, false);
@@ -1246,13 +1243,12 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
         // this IMSI
         auto revalidation_time = usage_monitor_resp.revalidation_time();
         imsis_with_revalidation.insert(imsi);
-        schedule_revalidation(
-            imsi, *session, revalidation_time, update_criteria);
+        schedule_revalidation(imsi, *session, revalidation_time, uc);
       }
 
       if (config.common_context.rat_type() == TGPP_LTE) {
         const auto update = session->get_dedicated_bearer_updates(
-            rules_to_activate, rules_to_deactivate, update_criteria);
+            rules_to_activate, rules_to_deactivate, uc);
         propagate_bearer_updates_to_mme(update);
       }
     }
@@ -1291,11 +1287,10 @@ void LocalEnforcer::terminate_session(
     auto config     = session->get_config();
     auto session_id = session->get_session_id();
     if (config.common_context.apn() == apn) {
-      SessionStateUpdateCriteria& update_criteria =
-          session_update[imsi][session_id];
+      SessionStateUpdateCriteria& uc = session_update[imsi][session_id];
       MLOG(MINFO) << "Starting externally triggered termination for "
                   << session_id;
-      start_session_termination(imsi, session, false, update_criteria);
+      start_session_termination(imsi, session, false, uc);
     }
   }
 }
@@ -1385,7 +1380,7 @@ ReAuthResult LocalEnforcer::init_charging_reauth(
                  << " during reauth";
     return ReAuthResult::SESSION_NOT_FOUND;
   }
-  SessionStateUpdateCriteria& update_criteria =
+  SessionStateUpdateCriteria& uc =
       session_update[request.sid()][request.session_id()];
   if (request.type() == ChargingReAuthRequest::SINGLE_SERVICE) {
     MLOG(MDEBUG) << "Initiating reauth of key " << request.charging_key()
@@ -1393,7 +1388,7 @@ ReAuthResult LocalEnforcer::init_charging_reauth(
                  << request.session_id();
     for (const auto& session : it->second) {
       if (session->get_session_id() == request.session_id()) {
-        return session->reauth_key(CreditKey(request), update_criteria);
+        return session->reauth_key(CreditKey(request), uc);
       }
     }
     MLOG(MERROR) << "Could not find session for subscriber " << request.sid()
@@ -1404,7 +1399,7 @@ ReAuthResult LocalEnforcer::init_charging_reauth(
                << request.sid() << " for session" << request.session_id();
   for (const auto& session : it->second) {
     if (session->get_session_id() == request.session_id()) {
-      return session->reauth_all(update_criteria);
+      return session->reauth_all(uc);
     }
   }
   MLOG(MERROR) << "Could not find session for subscriber " << request.sid()
@@ -1423,32 +1418,19 @@ void LocalEnforcer::init_policy_reauth(
     answer_out.set_result(ReAuthResult::SESSION_NOT_FOUND);
     return;
   }
-
-  bool deactivate_success = true;
-  bool activate_success   = true;
   // For empty session_id, apply changes to all sessions of subscriber
   // Changes are applied on a best-effort basis, so failures for one session
   // won't stop changes from being applied for subsequent sessions.
   if (request.session_id() == "") {
-    bool all_activated   = true;
-    bool all_deactivated = true;
     for (const auto& session : it->second) {
-      init_policy_reauth_for_session(
-          session_map, request, session, activate_success, deactivate_success,
-          session_update);
-      all_activated &= activate_success;
-      all_deactivated &= deactivate_success;
+      init_policy_reauth_for_session(request, session, session_update);
     }
-    // Treat activate/deactivate as all-or-nothing when reporting rule failures
-    mark_rule_failures(all_activated, all_deactivated, request, answer_out);
   } else {
     bool session_id_valid = false;
     for (const auto& session : it->second) {
       if (session->get_session_id() == request.session_id()) {
         session_id_valid = true;
-        init_policy_reauth_for_session(
-            session_map, request, session, activate_success, deactivate_success,
-            session_update);
+        init_policy_reauth_for_session(request, session, session_update);
       }
     }
     if (!session_id_valid) {
@@ -1458,53 +1440,46 @@ void LocalEnforcer::init_policy_reauth(
       answer_out.set_result(ReAuthResult::SESSION_NOT_FOUND);
       return;
     }
-    mark_rule_failures(
-        activate_success, deactivate_success, request, answer_out);
   }
   answer_out.set_result(ReAuthResult::UPDATE_INITIATED);
 }
 
 void LocalEnforcer::init_policy_reauth_for_session(
-    SessionMap& session_map, const PolicyReAuthRequest& request,
-    const std::unique_ptr<SessionState>& session, bool& activate_success,
-    bool& deactivate_success, SessionUpdate& session_update) {
+    const PolicyReAuthRequest& request,
+    const std::unique_ptr<SessionState>& session,
+    SessionUpdate& session_update) {
   std::string imsi = request.imsi();
-  SessionStateUpdateCriteria& update_criteria =
+  SessionStateUpdateCriteria& uc =
       session_update[imsi][session->get_session_id()];
 
-  activate_success   = true;
-  deactivate_success = true;
-  receive_monitoring_credit_from_rar(request, session, update_criteria);
+  receive_monitoring_credit_from_rar(request, session, uc);
 
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
 
   MLOG(MDEBUG) << "Processing policy reauth for subscriber " << request.imsi();
   if (revalidation_required(request.event_triggers())) {
-    schedule_revalidation(
-        imsi, *session, request.revalidation_time(), update_criteria);
+    schedule_revalidation(imsi, *session, request.revalidation_time(), uc);
   }
 
   process_rules_to_remove(
-      imsi, session, request.rules_to_remove(), rules_to_deactivate,
-      update_criteria);
+      imsi, session, request.rules_to_remove(), rules_to_deactivate, uc);
 
   process_rules_to_install(
       *session, imsi, to_vec(request.rules_to_install()),
       to_vec(request.dynamic_rules_to_install()), rules_to_activate,
-      rules_to_deactivate, update_criteria);
+      rules_to_deactivate, uc);
 
   propagate_rule_updates_to_pipelined(
       imsi, session->get_config(), rules_to_activate, rules_to_deactivate,
       false);
 
   if (terminate_on_wallet_exhaust() && is_wallet_exhausted(*session)) {
-    start_session_termination(imsi, session, true, update_criteria);
+    start_session_termination(imsi, session, true, uc);
     return;
   }
   if (session->get_config().common_context.rat_type() == TGPP_LTE) {
-    create_bearer(
-        activate_success, session, request, rules_to_activate.dynamic_rules);
+    create_bearer(session, request, rules_to_activate.dynamic_rules);
   }
 }
 
@@ -1537,7 +1512,7 @@ void LocalEnforcer::propagate_rule_updates_to_pipelined(
 void LocalEnforcer::receive_monitoring_credit_from_rar(
     const PolicyReAuthRequest& request,
     const std::unique_ptr<SessionState>& session,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria& uc) {
   UsageMonitoringUpdateResponse monitoring_credit;
   monitoring_credit.set_session_id(request.session_id());
   monitoring_credit.set_sid("IMSI" + request.session_id());
@@ -1547,7 +1522,7 @@ void LocalEnforcer::receive_monitoring_credit_from_rar(
   for (const auto& usage_monitoring_credit :
        request.usage_monitoring_credits()) {
     credit->CopyFrom(usage_monitoring_credit);
-    session->receive_monitor(monitoring_credit, update_criteria);
+    session->receive_monitor(monitoring_credit, uc);
   }
 }
 
@@ -1555,17 +1530,15 @@ void LocalEnforcer::process_rules_to_remove(
     const std::string& imsi, const std::unique_ptr<SessionState>& session,
     const google::protobuf::RepeatedPtrField<std::basic_string<char>>
         rules_to_remove,
-    RulesToProcess& rules_to_deactivate,
-    SessionStateUpdateCriteria& update_criteria) {
+    RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc) {
   for (const auto& rule_id : rules_to_remove) {
     // Try to remove as dynamic rule first
     PolicyRule dy_rule;
-    bool is_dynamic =
-        session->remove_dynamic_rule(rule_id, &dy_rule, update_criteria);
+    bool is_dynamic = session->remove_dynamic_rule(rule_id, &dy_rule, uc);
     if (is_dynamic) {
       rules_to_deactivate.dynamic_rules.push_back(dy_rule);
     } else {
-      if (!session->deactivate_static_rule(rule_id, update_criteria))
+      if (!session->deactivate_static_rule(rule_id, uc))
         MLOG(MWARNING) << "Could not find rule " << rule_id << "for IMSI "
                        << imsi << " during static rule removal";
       rules_to_deactivate.static_rules.push_back(rule_id);
@@ -1611,7 +1584,7 @@ void LocalEnforcer::process_rules_to_install(
     std::vector<StaticRuleInstall> static_rule_installs,
     std::vector<DynamicRuleInstall> dynamic_rule_installs,
     RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria& uc) {
   std::time_t current_time = time(NULL);
   std::string ip_addr      = session.get_config().common_context.ue_ipv4();
   for (const auto& rule_install : static_rule_installs) {
@@ -1631,17 +1604,17 @@ void LocalEnforcer::process_rules_to_install(
         .deactivation_time = std::time_t(deactivation_time),
     };
     if (activation_time > current_time) {
-      session.schedule_static_rule(id, lifetime, update_criteria);
+      session.schedule_static_rule(id, lifetime, uc);
       schedule_static_rule_activation(imsi, ip_addr, rule_install);
     } else {
-      session.activate_static_rule(id, lifetime, update_criteria);
+      session.activate_static_rule(id, lifetime, uc);
       rules_to_activate.static_rules.push_back(id);
     }
 
     if (deactivation_time > current_time) {
       schedule_static_rule_deactivation(imsi, rule_install);
     } else if (deactivation_time > 0) {  // 0: never scheduled to deactivate
-      if (!session.deactivate_static_rule(id, update_criteria)) {
+      if (!session.deactivate_static_rule(id, uc)) {
         MLOG(MWARNING) << "Could not find rule " << id << "for IMSI " << imsi
                        << " during static rule removal";
       }
@@ -1660,19 +1633,16 @@ void LocalEnforcer::process_rules_to_install(
         .deactivation_time = std::time_t(deactivation_time),
     };
     if (activation_time > current_time) {
-      session.schedule_dynamic_rule(
-          rule_install.policy_rule(), lifetime, update_criteria);
+      session.schedule_dynamic_rule(rule_install.policy_rule(), lifetime, uc);
       schedule_dynamic_rule_activation(imsi, ip_addr, rule_install);
     } else {
-      session.insert_dynamic_rule(
-          rule_install.policy_rule(), lifetime, update_criteria);
+      session.insert_dynamic_rule(rule_install.policy_rule(), lifetime, uc);
       rules_to_activate.dynamic_rules.push_back(rule_install.policy_rule());
     }
     if (deactivation_time > current_time) {
       schedule_dynamic_rule_deactivation(imsi, rule_install);
     } else if (deactivation_time > 0) {
-      session.remove_dynamic_rule(
-          rule_install.policy_rule().id(), NULL, update_criteria);
+      session.remove_dynamic_rule(rule_install.policy_rule().id(), NULL, uc);
       rules_to_deactivate.dynamic_rules.push_back(rule_install.policy_rule());
     }
   }
@@ -1688,10 +1658,10 @@ bool LocalEnforcer::revalidation_required(
 void LocalEnforcer::schedule_revalidation(
     const std::string& imsi, SessionState& session,
     const google::protobuf::Timestamp& revalidation_time,
-    SessionStateUpdateCriteria& update_criteria) {
+    SessionStateUpdateCriteria& uc) {
   // Add revalidation info to session and mark as pending
-  session.add_new_event_trigger(REVALIDATION_TIMEOUT, update_criteria);
-  session.set_revalidation_time(revalidation_time, update_criteria);
+  session.add_new_event_trigger(REVALIDATION_TIMEOUT, uc);
+  session.set_revalidation_time(revalidation_time, uc);
   auto session_id = session.get_session_id();
   SessionRead req = {imsi};
   auto delta      = time_difference_from_now(revalidation_time);
@@ -1708,9 +1678,9 @@ void LocalEnforcer::schedule_revalidation(
             for (const auto& session : session_pair.second) {
               std::string imsi = session_pair.first;
               if (session->get_session_id() == session_id) {
-                auto& update_criteria = update[imsi][session_id];
+                auto& uc = update[imsi][session_id];
                 session->mark_event_trigger_as_triggered(
-                    REVALIDATION_TIMEOUT, update_criteria);
+                    REVALIDATION_TIMEOUT, uc);
               }
             }
           }
@@ -1786,7 +1756,7 @@ void LocalEnforcer::handle_add_ue_mac_flow_callback(
 }
 
 void LocalEnforcer::create_bearer(
-    const bool activate_success, const std::unique_ptr<SessionState>& session,
+    const std::unique_ptr<SessionState>& session,
     const PolicyReAuthRequest& request,
     const std::vector<PolicyRule>& dynamic_rules) {
   const auto& config = session->get_config();
@@ -1795,8 +1765,7 @@ void LocalEnforcer::create_bearer(
     return;
   }
   const auto& lte_context = config.rat_specific_context.lte_context();
-  if (!activate_success || !lte_context.has_qos_info() ||
-      !request.has_qos_info()) {
+  if (!lte_context.has_qos_info() || !request.has_qos_info()) {
     MLOG(MDEBUG) << "Not creating bearer";
     return;
   }
@@ -1865,10 +1834,10 @@ void LocalEnforcer::handle_cwf_roaming(
   auto it = session_map.find(imsi);
   if (it != session_map.end()) {
     for (const auto& session : it->second) {
-      auto& update_criteria = session_update[imsi][session->get_session_id()];
+      auto& uc = session_update[imsi][session->get_session_id()];
       session->set_config(config);
-      update_criteria.is_config_updated = true;
-      update_criteria.updated_config    = session->get_config();
+      uc.is_config_updated = true;
+      uc.updated_config    = session->get_config();
       // TODO Check for event triggers and send updates to the core if needed
       update_ipfix_flow(imsi, config, session->get_pdp_start_time());
     }
@@ -1951,27 +1920,6 @@ static void handle_command_level_result_code(
     // only log transient errors for now
     MLOG(MERROR) << "Received result code: " << result_code << "for IMSI "
                  << imsi << "during update";
-  }
-}
-
-static void mark_rule_failures(
-    const bool activate_success, const bool deactivate_success,
-    const PolicyReAuthRequest& request, PolicyReAuthAnswer& answer_out) {
-  auto failed_rules = *answer_out.mutable_failed_rules();
-  if (!deactivate_success) {
-    for (const std::string& rule_id : request.rules_to_remove()) {
-      failed_rules[rule_id] = PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
-    }
-  }
-  if (!activate_success) {
-    for (const StaticRuleInstall rule : request.rules_to_install()) {
-      failed_rules[rule.rule_id()] = PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
-    }
-    for (const DynamicRuleInstall& d_rule :
-         request.dynamic_rules_to_install()) {
-      failed_rules[d_rule.policy_rule().id()] =
-          PolicyReAuthAnswer::GW_PCEF_MALFUNCTION;
-    }
   }
 }
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -157,14 +157,6 @@ class LocalEnforcer {
       SessionMap& session_map, const std::string& imsi, const std::string& apn,
       SessionUpdate& session_update);
 
-  uint64_t get_charging_credit(
-      SessionMap& session_map, const std::string& imsi,
-      const CreditKey& charging_key, Bucket bucket) const;
-
-  uint64_t get_monitor_credit(
-      SessionMap& session_map, const std::string& imsi, const std::string& mkey,
-      Bucket bucket) const;
-
   /**
    * Initialize reauth for a subscriber service. If the subscriber cannot be
    * found, the method returns SESSION_NOT_FOUND

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -120,18 +120,17 @@ class LocalEnforcer {
    * Perform any rule installs/removals that need to be executed given a
    * CreateSessionResponse.
    */
-  bool handle_session_init_rule_updates(
-      SessionMap& session_map, const std::string& imsi,
-      SessionState& session_state, const CreateSessionResponse& response,
+  void handle_session_init_rule_updates(
+      const std::string& imsi, SessionState& session_state,
+      const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
 
   /**
    * Initialize credit received from the cloud in the system. This adds all the
    * charging keys to the credit manager for tracking
    * @param credit_response - message from cloud containing initial credits
-   * @return true if init was successful
    */
-  bool init_session_credit(
+  void init_session_credit(
       SessionMap& session_map, const std::string& imsi,
       const std::string& session_id, const SessionConfig& cfg,
       const CreateSessionResponse& response);
@@ -311,8 +310,7 @@ class LocalEnforcer {
       const std::string& imsi, const std::unique_ptr<SessionState>& session,
       const google::protobuf::RepeatedPtrField<std::basic_string<char>>
           rules_to_remove,
-      RulesToProcess& rules_to_deactivate,
-      SessionStateUpdateCriteria& update_criteria);
+      RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc);
 
   /**
    * Populate existing rules from a specific session;
@@ -334,7 +332,7 @@ class LocalEnforcer {
       std::vector<StaticRuleInstall> static_rule_installs,
       std::vector<DynamicRuleInstall> dynamic_rule_installs,
       RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& uc);
 
   /**
    * propagate_rule_updates_to_pipelined calls the PipelineD RPC calls to
@@ -357,9 +355,9 @@ class LocalEnforcer {
    * Also create a bearer for the session.
    */
   void init_policy_reauth_for_session(
-      SessionMap& session_map, const PolicyReAuthRequest& request,
-      const std::unique_ptr<SessionState>& session, bool& activate_success,
-      bool& deactivate_success, SessionUpdate& session_update);
+      const PolicyReAuthRequest& request,
+      const std::unique_ptr<SessionState>& session,
+      SessionUpdate& session_update);
 
   /**
    * Completes the session termination and executes the callback function
@@ -374,8 +372,7 @@ class LocalEnforcer {
    */
   void complete_termination(
       SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id,
-      SessionStateUpdateCriteria& update_criteria);
+      const std::string& session_id, SessionStateUpdateCriteria& uc);
 
   void schedule_static_rule_activation(
       const std::string& imsi, const std::string& ip_addr,
@@ -398,14 +395,14 @@ class LocalEnforcer {
   void receive_monitoring_credit_from_rar(
       const PolicyReAuthRequest& request,
       const std::unique_ptr<SessionState>& session,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& uc);
 
   /**
    * Send bearer creation request through the PGW client if rules were
    * activated successfully in pipelined
    */
   void create_bearer(
-      const bool activate_success, const std::unique_ptr<SessionState>& session,
+      const std::unique_ptr<SessionState>& session,
       const PolicyReAuthRequest& request,
       const std::vector<PolicyRule>& dynamic_rules);
 
@@ -418,7 +415,7 @@ class LocalEnforcer {
   void schedule_revalidation(
       const std::string& imsi, SessionState& session,
       const google::protobuf::Timestamp& revalidation_time,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& uc);
 
   void handle_add_ue_mac_flow_callback(
       const SubscriberID& sid, const std::string& ue_mac_addr,
@@ -454,11 +451,11 @@ class LocalEnforcer {
    * @param session
    * @param notify_access: bool to determine whether the access component needs
    * notification
-   * @param update_criteria
+   * @param uc
    */
   void start_session_termination(
       const std::string& imsi, const std::unique_ptr<SessionState>& session,
-      bool notify_access, SessionStateUpdateCriteria& update_criteria);
+      bool notify_access, SessionStateUpdateCriteria& uc);
 
   /**
    * handle_force_termination_timeout is scheduled to run when a termination
@@ -475,11 +472,11 @@ class LocalEnforcer {
    * attached to the session
    * @param imsi
    * @param session
-   * @param update_criteria
+   * @param uc
    */
   void remove_all_rules_for_termination(
       const std::string& imsi, const std::unique_ptr<SessionState>& session,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& uc);
 
   /**
    * notify_termination_to_access_service cases on the session's rat type and
@@ -499,12 +496,11 @@ class LocalEnforcer {
    * @param imsi
    * @param session
    * @param new_state
-   * @param update_criteria
+   * @param uc
    */
   void handle_subscriber_quota_state_change(
       const std::string& imsi, SessionState& session,
-      SubscriberQuotaUpdate_Type new_state,
-      SessionStateUpdateCriteria& update_criteria);
+      SubscriberQuotaUpdate_Type new_state, SessionStateUpdateCriteria& uc);
 
   void handle_subscriber_quota_state_change(
       const std::string& imsi, SessionState& session,
@@ -546,15 +542,13 @@ class LocalEnforcer {
       const uint64_t pdp_start_time);
 
   /**
-   * [CWF-ONLY]
    * If the session has active monitored rules attached to it, then propagate
    * to pipelined that the subscriber has valid quota.
    * Otherwise, mark the subscriber as out of quota to pipelined, and schedule
    * the session to be terminated in a configured amount of time.
    */
   void handle_session_init_subscriber_quota_state(
-      SessionMap& session_map, const std::string& imsi,
-      SessionState& session_state);
+      const std::string& imsi, SessionState& session_state);
 
   bool is_wallet_exhausted(SessionState& session_state);
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -179,9 +179,9 @@ bool LocalSessionManagerHandlerImpl::restart_pipelined(
 }
 
 static CreateSessionRequest make_create_session_request(
-    const SessionConfig& cfg, const std::string& sid) {
+    const SessionConfig& cfg, const std::string& session_id) {
   CreateSessionRequest create_request;
-  create_request.set_session_id(sid);
+  create_request.set_session_id(session_id);
   create_request.mutable_common_context()->CopyFrom(cfg.common_context);
   create_request.mutable_rat_specific_context()->CopyFrom(
       cfg.rat_specific_context);
@@ -195,27 +195,21 @@ void LocalSessionManagerHandlerImpl::CreateSession(
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread(
       [this, context, response_callback, request_cpy]() {
-        const auto& imsi = request_cpy.common_context().sid().id();
-        const auto& sid  = id_gen_.gen_session_id(imsi);
-        const auto& apn  = request_cpy.common_context().apn();
-        std::string create_message =
-            "Received a CreateSessionRequest for " + imsi + " " + apn;
-        if (request_cpy.rat_specific_context().has_lte_context()) {
-          const auto& lte = request_cpy.rat_specific_context().lte_context();
-          create_message += " plmn_id " + lte.plmn_id() + " imsi_plmn_id " +
-                            lte.imsi_plmn_id();
-        }
-        MLOG(MINFO) << create_message;
-
+        const auto& imsi       = request_cpy.common_context().sid().id();
+        const auto& session_id = id_gen_.gen_session_id(imsi);
         SessionConfig cfg(request_cpy);
-        auto session_map     = get_sessions_for_creation(imsi);
+        log_create_session(cfg);
+
+        auto session_map     = session_store_.read_sessions({imsi});
         const auto& rat_type = cfg.common_context.rat_type();
         switch (rat_type) {
           case TGPP_WLAN:
-            handle_create_session_cwf(session_map, sid, cfg, response_callback);
+            handle_create_session_cwf(
+                session_map, session_id, cfg, response_callback);
             return;
           case TGPP_LTE:
-            handle_create_session_lte(session_map, sid, cfg, response_callback);
+            handle_create_session_lte(
+                session_map, session_id, cfg, response_callback);
             return;
           default:
             std::ostringstream failure_stream;
@@ -224,8 +218,8 @@ void LocalSessionManagerHandlerImpl::CreateSession(
             MLOG(MERROR) << failure_msg;
             events_reporter_->session_create_failure(imsi, cfg, failure_msg);
             send_local_create_session_response(
-                Status(grpc::FAILED_PRECONDITION, "Invalid RAT type"), sid,
-                response_callback);
+                Status(grpc::FAILED_PRECONDITION, "Invalid RAT type"),
+                session_id, response_callback);
             return;
         }
       });
@@ -237,6 +231,8 @@ void LocalSessionManagerHandlerImpl::send_create_session(
     std::function<void(grpc::Status, LocalCreateSessionResponse)> cb) {
   const auto& imsi = cfg.common_context.sid().id();
   auto create_req  = make_create_session_request(cfg, session_id);
+  MLOG(MINFO) << "Sending a CreateSessionRequest to fetch policies for "
+              << session_id;
   reporter_->report_create_session(
       create_req,
       [this, imsi, session_id, cfg, cb,
@@ -245,34 +241,30 @@ void LocalSessionManagerHandlerImpl::send_create_session(
         PrintGrpcMessage(
             static_cast<const google::protobuf::Message&>(response));
         if (status.ok()) {
+          MLOG(MINFO) << "Sending a CreateSessionResponse for " << session_id;
           enforcer_->init_session_credit(
               *session_map_ptr, imsi, session_id, cfg, response);
 
-          std::string bearer_id = "";
-          if (cfg.rat_specific_context.has_lte_context()) {
-            bearer_id = cfg.rat_specific_context.lte_context().bearer_id();
-          }
           bool write_success = session_store_.create_sessions(
               imsi, std::move((*session_map_ptr)[imsi]));
           if (write_success) {
             MLOG(MINFO) << "Successfully initialized new session " << session_id
-                        << " in SessionD for subscriber " << imsi
-                        << " with default bearer id " << bearer_id;
+                        << " in SessionD for subscriber " << imsi;
             add_session_to_directory_record(
                 imsi, session_id, cfg.common_context.msisdn());
           } else {
             MLOG(MINFO) << "Failed to initialize new session " << session_id
                         << " in SessionD for subscriber " << imsi
-                        << " with default bearer id " << bearer_id
                         << " due to failure writing to SessionStore."
                         << " An earlier update may have invalidated it.";
             status = Status(
-                grpc::ABORTED, "Failed to write session to sessiond storage.");
+                grpc::ABORTED, "Failed to write session to SessionD storage.");
           }
         } else {
           std::ostringstream failure_stream;
-          failure_stream << "Failed to initialize session in SessionProxy "
-                         << "for " << imsi << ": " << status.error_message();
+          failure_stream << "Failed to initialize session in SessionProxy for "
+                         << imsi << " APN " << cfg.common_context.apn() << ": "
+                         << status.error_message();
           std::string failure_msg = failure_stream.str();
           MLOG(MERROR) << failure_msg;
           events_reporter_->session_create_failure(imsi, cfg, failure_msg);
@@ -282,7 +274,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
 }
 
 void LocalSessionManagerHandlerImpl::handle_create_session_cwf(
-    SessionMap& session_map, const std::string& sid, SessionConfig cfg,
+    SessionMap& session_map, const std::string& session_id, SessionConfig cfg,
     std::function<void(Status, LocalCreateSessionResponse)> cb) {
   auto imsi = cfg.common_context.sid().id();
 
@@ -290,21 +282,17 @@ void LocalSessionManagerHandlerImpl::handle_create_session_cwf(
   if (it != session_map.end()) {
     for (const auto& session : it->second) {
       if (session->is_active()) {
-        recycle_cwf_session(imsi, sid, cfg, session_map, cb);
+        recycle_cwf_session(imsi, session_id, cfg, session_map, cb);
         return;
-      } else {
-        MLOG(MINFO) << "Found a non-active CWF session with the same IMSI "
-                    << imsi << ", requesting a new session";
       }
     }
   }
-  MLOG(MINFO) << "Requesting a new CWF session for" << imsi;
-  send_create_session(session_map, sid, cfg, cb);
+  send_create_session(session_map, session_id, cfg, cb);
 }
 
 void LocalSessionManagerHandlerImpl::recycle_cwf_session(
-    const std::string& imsi, const std::string& sid, const SessionConfig& cfg,
-    SessionMap& session_map,
+    const std::string& imsi, const std::string& session_id,
+    const SessionConfig& cfg, SessionMap& session_map,
     std::function<void(Status, LocalCreateSessionResponse)> cb) {
   // To recycle the session, it has to be active (i.e., not in
   // transition for termination).
@@ -317,30 +305,31 @@ void LocalSessionManagerHandlerImpl::recycle_cwf_session(
   enforcer_->handle_cwf_roaming(session_map, imsi, cfg, session_update);
   bool success = session_store_.update_sessions(session_update);
   if (!success) {
-    MLOG(MINFO) << "Failed to update session config for " << sid
+    MLOG(MINFO) << "Failed to update session config for " << session_id
                 << " in SessionD due to failure writing to SessionStore."
                 << " An earlier update may have invalidated it.";
     auto err_status = Status(grpc::ABORTED, "Failed to update SessionStore");
-    send_local_create_session_response(err_status, sid, cb);
+    send_local_create_session_response(err_status, session_id, cb);
     return;
   }
-  MLOG(MINFO) << "Successfully recycled an existing CWF session " << sid;
-  send_local_create_session_response(grpc::Status::OK, sid, cb);
+  MLOG(MINFO) << "Successfully recycled an existing CWF session " << session_id;
+  send_local_create_session_response(grpc::Status::OK, session_id, cb);
 }
 
 void LocalSessionManagerHandlerImpl::handle_create_session_lte(
-    SessionMap& session_map, const std::string& sid, SessionConfig cfg,
+    SessionMap& session_map, const std::string& session_id, SessionConfig cfg,
     std::function<void(Status, LocalCreateSessionResponse)> cb) {
   auto imsi = cfg.common_context.sid().id();
 
   // If there are no existing sessions for the IMSI, just create a new one
   auto it = session_map.find(imsi);
   if (it == session_map.end()) {
-    send_create_session(session_map, sid, cfg, cb);
+    send_create_session(session_map, session_id, cfg, cb);
     return;
   }
 
   for (const auto& session : it->second) {
+    const std::string& existing_session_id = session->get_session_id();
     if (cfg == session->get_config() && session->is_active()) {
       // To recycle the session, it has to be active (i.e., not in
       // transition for termination) AND it should have the exact same
@@ -348,8 +337,9 @@ void LocalSessionManagerHandlerImpl::handle_create_session_lte(
       MLOG(MINFO) << "Found an active completely duplicated session with IMSI "
                   << imsi << " and APN " << cfg.common_context.apn()
                   << ", and same configuration. Recycling the existing session "
-                  << sid;
-      send_local_create_session_response(grpc::Status::OK, sid, cb);
+                  << existing_session_id;
+      send_local_create_session_response(
+          grpc::Status::OK, existing_session_id, cb);
       return;  // Return early
     }
     auto apn = cfg.common_context.apn();
@@ -358,10 +348,10 @@ void LocalSessionManagerHandlerImpl::handle_create_session_lte(
         session->is_active()) {
       // If we have found an active session with the same IMSI+APN, but NOT
       // identical context, we should terminate the existing session.
-      MLOG(MINFO) << "Found an active session with the same IMSI " << imsi
-                  << " and APN " << apn << ", but different "
-                  << "configuration. Ending the existing session, "
-                  << "and requesting a new session";
+      MLOG(MINFO) << "Found an active session " << existing_session_id
+                  << " with same IMSI " << imsi << " and APN " << apn
+                  << ", but different configuration. Ending the existing "
+                  << "session, and requesting a new session";
       end_session(
           session_map, cfg.common_context.sid(), apn,
           [&](grpc::Status status, LocalEndSessionResponse response) {});
@@ -369,15 +359,15 @@ void LocalSessionManagerHandlerImpl::handle_create_session_lte(
       break;
     }
   }
-  send_create_session(session_map, sid, cfg, cb);
+  send_create_session(session_map, session_id, cfg, cb);
 }
 
 void LocalSessionManagerHandlerImpl::send_local_create_session_response(
-    Status status, const std::string& sid,
+    Status status, const std::string& session_id,
     std::function<void(Status, LocalCreateSessionResponse)> response_callback) {
   try {
     LocalCreateSessionResponse resp;
-    resp.set_session_id(sid);
+    resp.set_session_id(session_id);
     response_callback(status, resp);
   } catch (...) {
     std::exception_ptr ep = std::current_exception();
@@ -445,7 +435,7 @@ void LocalSessionManagerHandlerImpl::EndSession(
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
   enforcer_->get_event_base().runInEventBaseThread(
       [this, sid, apn, response_callback]() {
-        auto session_map = get_sessions_for_deletion(sid.id());
+        auto session_map = session_store_.read_sessions({sid.id()});
         end_session(session_map, sid, apn, response_callback);
       });
 }
@@ -473,29 +463,6 @@ void LocalSessionManagerHandlerImpl::end_session(
     Status status(grpc::FAILED_PRECONDITION, "Session not found");
     response_callback(status, LocalEndSessionResponse());
   }
-}
-
-SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_creation(
-    const std::string& imsi) {
-  SessionRead req = {imsi};
-  return session_store_.read_sessions(req);
-}
-
-SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_reporting(
-    const RuleRecordTable& records) {
-  SessionRead req = {};
-  for (const RuleRecord& record : records.records()) {
-    req.insert(record.sid());
-  }
-  return session_store_.read_sessions(req);
-}
-
-SessionMap LocalSessionManagerHandlerImpl::get_sessions_for_deletion(
-    const std::string& imsi) {
-  // Request numbers are not incremented here, but rather in the 5s delayed
-  // callback when reporting is done.
-  SessionRead req = {imsi};
-  return session_store_.read_sessions(req);
 }
 
 void LocalSessionManagerHandlerImpl::report_session_update_event(
@@ -596,6 +563,23 @@ void LocalSessionManagerHandlerImpl::SetSessionRules(
     }
   });
   response_callback(Status::OK, Void());
+}
+
+void LocalSessionManagerHandlerImpl::log_create_session(SessionConfig& cfg) {
+  const auto& imsi = cfg.common_context.sid().id();
+  const auto& apn  = cfg.common_context.apn();
+  std::string create_message =
+      "Received a LocalCreateSessionRequest for " + imsi + " with APN:" + apn;
+  if (cfg.rat_specific_context.has_lte_context()) {
+    const auto& lte = cfg.rat_specific_context.lte_context();
+    create_message += ", default bearer ID:" + std::to_string(lte.bearer_id()) +
+                      ", PLMN ID:" + lte.plmn_id() +
+                      ", IMSI PLMN ID:" + lte.imsi_plmn_id();
+  } else if (cfg.rat_specific_context.has_wlan_context()) {
+    create_message +=
+        ", MAC addr:" + cfg.rat_specific_context.wlan_context().mac_addr();
+  }
+  MLOG(MINFO) << create_message;
 }
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -211,33 +211,6 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
   void handle_setup_callback(
       const std::uint64_t& epoch, Status status, SetupFlowsResult resp);
 
-  /**
-   * Get the most recently written state of sessions for Creation
-   * Does not get any other sessions.
-   *
-   * NOTE: Call only from the main EventBase thread, otherwise there will
-   *       be undefined behavior.
-   */
-  SessionMap get_sessions_for_creation(const std::string& imsi);
-
-  /**
-   * Get the most recently written state of sessions for reporting usage.
-   * Does not get sessions that are not required for reporting.
-   *
-   * NOTE: Call only from the main EventBase thread, otherwise there will
-   *       be undefined behavior.
-   */
-  SessionMap get_sessions_for_reporting(const RuleRecordTable& request);
-
-  /**
-   * Get the most recently written state of the session that is to be deleted.
-   * Does not get any other sessions.
-   *
-   * NOTE: Call only from the main EventBase thread, otherwise there will
-   *       be undefined behavior.
-   */
-  SessionMap get_sessions_for_deletion(const std::string& imsi);
-
   void report_session_update_event(
       SessionMap& session_map, SessionUpdate& session_update);
 
@@ -249,6 +222,8 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
       Status status, const std::string& sid,
       std::function<void(Status, LocalCreateSessionResponse)>
           response_callback);
+
+  void log_create_session(SessionConfig& cfg);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -233,7 +233,7 @@ std::string EventsReporterImpl::get_imei(const SessionConfig& config) {
 }
 
 std::string EventsReporterImpl::get_spgw_ipv4(const SessionConfig& config) {
-  // IMEI is only relevant for LTE
+  // SPGW_IPV4 is only relevant for LTE
   const auto& rat_specific    = config.rat_specific_context;
   std::string spgw_ipv4 = "";
   if (rat_specific.has_lte_context()) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -143,19 +143,15 @@ class SessionState {
   bool is_terminating();
 
   /**
-   * complete_termination collects final usages for all credits into a
-   * SessionTerminateRequest and calls the on termination callback with the
-   * request.
-   * Note that complete_termination will forcefully complete the termination
-   * no matter the current state of the session. To properly complete the
-   * termination, this function should only be called when
-   * can_complete_termination returns true.
+   * complete_termination checks the FSM state and transitions the state to
+   * TERMINATED, if it can. If the state is ACTIVE or TERMINATED, it will not do
+   * anything.
+   * This function will return true if the termination happened successfully.
    */
-  void complete_termination(
-      SessionReporter& reporter, SessionStateUpdateCriteria& update_criteria);
+  bool complete_termination(SessionStateUpdateCriteria& update_criteria);
 
-  bool reset_reporting_charging_credit(const CreditKey &key,
-                              SessionStateUpdateCriteria &update_criteria);
+  bool reset_reporting_charging_credit(
+      const CreditKey& key, SessionStateUpdateCriteria& update_criteria);
 
   /**
    * Receive the credit grant if the credit update was successful
@@ -219,6 +215,9 @@ class SessionState {
   uint64_t get_pdp_end_time();
 
   void increment_request_number(uint32_t incr);
+
+  SessionTerminateRequest make_termination_request(
+      SessionStateUpdateCriteria& uc);
 
   // Methods related to the session's static and dynamic rules
   /**
@@ -530,9 +529,6 @@ class SessionState {
       const std::string &key, SessionCreditUpdateCriteria &update);
 
   void add_common_fields_to_usage_monitor_update(UsageMonitoringUpdateRequest* req);
-
-  SessionTerminateRequest make_termination_request(
-    SessionStateUpdateCriteria& update_criteria);
 
   /**
    * Returns true if the specified rule should be active at that time

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -95,7 +95,6 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
     subscriber_ids.insert(it.first);
   }
   auto session_map = store_client_->read_sessions(subscriber_ids);
-  MLOG(MDEBUG) << "Merging updates into existing sessions";
   // Now attempt to modify the state
   for (auto& it : session_map) {
     auto imsi = it.first;
@@ -120,7 +119,6 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
       ++it2;
     }
   }
-  MLOG(MDEBUG) << "Writing into session store";
   return store_client_->write_sessions(std::move(session_map));
 }
 

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -5,6 +5,7 @@ set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")
 include_directories("${PROJECT_SOURCE_DIR}")
 
 add_library(SESSIOND_TEST_LIB
+    Consts.h
     Matchers.h
     ProtobufCreators.cpp
     ProtobufCreators.h

--- a/lte/gateway/c/session_manager/test/Consts.h
+++ b/lte/gateway/c/session_manager/test/Consts.h
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define IMSI1 "imsi1"
+#define IMSI2 "imsi2"
+#define IMSI3 "imsi3"
+#define SESSION_ID_1 "IMSI1-SessionID"
+#define SESSION_ID_2 "IMSI2-SessionID"
+#define SECONDS_A_DAY 86400
+#define MSISDN "5100001234"
+#define RADIUS_SESSION_ID "AA-AA-AA-AA-AA-AA:TESTAP__0F-10-2E-12-3A-55"
+#define MAC_ADDR "0f:10:2e:12:3a:55"
+#define IP1 "127.0.0.1"
+#define IP2 "127.0.0.2"

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -531,17 +531,12 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
   local_enforcer->aggregate_records(session_map, empty_table, update);
   run_evb();
   run_evb();
+  bool success = session_store->update_sessions(update);
+  EXPECT_TRUE(success);
 
   // No longer in system
   session_map = session_store->read_sessions(SessionRead{"IMSI1"});
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      0);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 2, ALLOWED_TOTAL),
-      0);
+  EXPECT_EQ(session_map["IMSI1"].size(), 0);
 }
 
 TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
@@ -685,7 +680,8 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   create_credit_update_response(
       imsi, 1, 1024, true, response.mutable_credits()->Add());
   auto session_state =
-      new SessionState(imsi, session_id, test_cfg_, *rule_store, tgpp_ctx, pdp_start_time);
+      new SessionState(imsi, session_id, test_cfg_, *rule_store, tgpp_ctx,
+pdp_start_time);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;
@@ -1459,7 +1455,8 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
   SessionConfig test_volte_cfg;
   test_volte_cfg.common_context =
       build_common_context("", "127.0.0.1", "", "IMS", TGPP_LTE);
-  const auto& lte_context = build_lte_context("", "", "", "", "", 1, &test_qos_info);
+  const auto& lte_context = build_lte_context("", "", "", "", "", 1,
+&test_qos_info);
   test_volte_cfg.rat_specific_context.mutable_lte_context()->CopyFrom(
       lte_context);
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include <lte/protos/session_manager.grpc.pb.h>
 
+#include "Consts.h"
 #include "LocalEnforcer.h"
 #include "Matchers.h"
 #include "MagmaService.h"
@@ -62,12 +63,12 @@ class LocalEnforcerTest : public ::testing::Test {
 
   void initialize_lte_test_config() {
     test_cfg_.common_context =
-        build_common_context("", "127.0.0.1", "IMS", "", TGPP_LTE);
+        build_common_context("", IP1, "IMS", "", TGPP_LTE);
     QosInformationRequest qos_info;
     qos_info.set_apn_ambr_dl(32);
     qos_info.set_apn_ambr_dl(64);
     const auto& lte_context =
-        build_lte_context("128.0.0.1", "", "", "", "", 0, &qos_info);
+        build_lte_context(IP2, "", "", "", "", 0, &qos_info);
     test_cfg_.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
   }
 
@@ -94,23 +95,41 @@ class LocalEnforcerTest : public ::testing::Test {
   }
 
   void assert_charging_credit(
-      const std::string& imsi, Bucket bucket,
+      SessionMap& session_map, const std::string& imsi,
+      const std::string& session_id, Bucket bucket,
       const std::vector<std::pair<uint32_t, uint64_t>>& volumes) {
-    for (auto& volume_pair : volumes) {
-      auto volume_out = local_enforcer->get_charging_credit(
-          session_map, imsi, volume_pair.first, bucket);
-      EXPECT_EQ(volume_out, volume_pair.second);
+    EXPECT_TRUE(session_map.find(imsi) != session_map.end());
+    bool found = false;
+    for (const auto& session : session_map.find(imsi)->second) {
+      if (session->get_session_id() == session_id) {
+        found = true;
+        for (auto& volume_pair : volumes) {
+          EXPECT_EQ(
+              session->get_charging_credit(volume_pair.first, bucket),
+              volume_pair.second);
+        }
+      }
     }
+    EXPECT_TRUE(found);
   }
 
   void assert_monitor_credit(
-      const std::string& imsi, Bucket bucket,
+      SessionMap& session_map, const std::string& imsi,
+      const std::string& session_id, Bucket bucket,
       const std::vector<std::pair<std::string, uint64_t>>& volumes) {
-    for (auto& volume_pair : volumes) {
-      auto volume_out = local_enforcer->get_monitor_credit(
-          session_map, imsi, volume_pair.first, bucket);
-      EXPECT_EQ(volume_out, volume_pair.second);
+    EXPECT_TRUE(session_map.find(imsi) != session_map.end());
+    bool found = false;
+    for (const auto& session : session_map.find(imsi)->second) {
+      if (session->get_session_id() == session_id) {
+        found = true;
+        for (auto& volume_pair : volumes) {
+          EXPECT_EQ(
+              session->get_monitor(volume_pair.first, bucket),
+              volume_pair.second);
+        }
+      }
     }
+    EXPECT_TRUE(found);
   }
 
  protected:
@@ -133,35 +152,30 @@ TEST_F(LocalEnforcerTest, test_init_cwf_session_credit) {
 
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, 1024, credits->Add());
+  create_credit_update_response(IMSI1, 1, 1024, credits->Add());
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
-                             "IMSI1", testing::_, testing::_, CheckCount(0),
+                             IMSI1, testing::_, testing::_, CheckCount(0),
                              CheckCount(0), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 
   EXPECT_CALL(
-      *pipelined_client,
-      update_ipfix_flow(
-          testing::_, testing::_, testing::_, testing::_, testing::_,
-          testing::_))
+      *pipelined_client, update_ipfix_flow(
+                             testing::_, testing::_, testing::_, testing::_,
+                             testing::_, testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 
   SessionConfig test_cwf_cfg;
-  const auto& mac_addr          = "00:00:00:00:00:00";
-  const auto& radius_session_id = "1234567";
-  const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+  const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cwf_cfg, response);
+      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      1024);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}});
 }
 
 TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
@@ -169,7 +183,7 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
 
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, INFINITE_METERED, credits->Add());
+  create_credit_update_response(IMSI1, 1, INFINITE_METERED, credits->Add());
 
   StaticRuleInstall rule1;
   rule1.set_rule_id("rule1");
@@ -184,11 +198,9 @@ TEST_F(LocalEnforcerTest, test_init_infinite_metered_credit) {
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      0);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 0}});
 }
 
 TEST_F(LocalEnforcerTest, test_init_no_credit) {
@@ -196,7 +208,7 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
 
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, FINITE, credits->Add());
+  create_credit_update_response(IMSI1, 1, FINITE, credits->Add());
 
   StaticRuleInstall rule1;
   rule1.set_rule_id("rule1");
@@ -211,11 +223,9 @@ TEST_F(LocalEnforcerTest, test_init_no_credit) {
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      0);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 0}});
 }
 
 TEST_F(LocalEnforcerTest, test_init_session_credit) {
@@ -223,7 +233,7 @@ TEST_F(LocalEnforcerTest, test_init_session_credit) {
 
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, 1024, credits->Add());
+  create_credit_update_response(IMSI1, 1, 1024, credits->Add());
 
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
@@ -232,125 +242,108 @@ TEST_F(LocalEnforcerTest, test_init_session_credit) {
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      1024);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}});
 }
 
 TEST_F(LocalEnforcerTest, test_single_record) {
   // insert initial session credit
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 16, 32, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 16, 32, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
-
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX),
-      16);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX),
-      32);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      1024);
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 16}});
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 32}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}});
 
   EXPECT_EQ(update.size(), 1);
-  EXPECT_EQ(update["IMSI1"]["1234"].charging_credit_map.size(), 1);
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].charging_credit_map.size(), 1);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_RX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_RX],
       16);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_TX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_TX],
       32);
 }
 
 TEST_F(LocalEnforcerTest, test_aggregate_records) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
-      "IMSI1", 2, 1024, response.mutable_credits()->Add());
+      IMSI1, 2, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
   insert_static_rule(2, "", "rule3");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 5, 15, record_list->Add());
-  create_rule_record("IMSI1", "rule3", 100, 150, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 5, 15, record_list->Add());
+  create_rule_record(IMSI1, "rule3", 100, 150, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX),
-      15);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX),
-      35);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 2, USED_RX),
-      100);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 2, USED_TX),
-      150);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 15}, {2, 100}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 35}, {2, 150}});
 
-  EXPECT_EQ(update["IMSI1"]["1234"].charging_credit_map.size(), 2);
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].charging_credit_map.size(), 2);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_RX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_RX],
       15);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_TX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_TX],
       35);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[2].bucket_deltas[USED_RX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[2].bucket_deltas[USED_RX],
       100);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[2].bucket_deltas[USED_TX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[2].bucket_deltas[USED_TX],
       150);
 }
 
 TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
-      "IMSI1", 2, 1024, response.mutable_credits()->Add());
+      IMSI1, 2, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
   insert_static_rule(2, "", "rule3");
 
   auto update = SessionStore::get_default_session_update(session_map);
-  local_enforcer->terminate_session(session_map, "IMSI1", "IMS", update);
+  local_enforcer->terminate_session(session_map, IMSI1, "IMS", update);
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 5, 15, record_list->Add());
-  create_rule_record("IMSI1", "rule3", 100, 150, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 5, 15, record_list->Add());
+  create_rule_record(IMSI1, "rule3", 100, 150, record_list->Add());
 
   EXPECT_CALL(
       *reporter,
-      report_terminate_session(CheckTerminateRequestCount("IMSI1", 0, 2), _))
+      report_terminate_session(CheckTerminateRequestCount(IMSI1, 0, 2), _))
       .Times(1);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -361,9 +354,9 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
 TEST_F(LocalEnforcerTest, test_collect_updates) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 3072, response.mutable_credits()->Add());
+      IMSI1, 1, 3072, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   insert_static_rule(1, "", "rule1");
 
   std::vector<std::unique_ptr<ServiceAction>> actions;
@@ -375,7 +368,7 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
 
   local_enforcer->aggregate_records(session_map, table, update);
   actions.clear();
@@ -383,23 +376,19 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
       local_enforcer->collect_updates(session_map, actions, update);
   local_enforcer->execute_actions(session_map, actions, update);
   EXPECT_EQ(session_update.updates_size(), 1);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, REPORTING_RX),
-      1024);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, REPORTING_TX),
-      2048);
-  EXPECT_EQ(update["IMSI1"]["1234"].charging_credit_map.size(), 1);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_RX, {{1, 1024}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_TX, {{1, 2048}});
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].charging_credit_map.size(), 1);
   // UpdateCriteria does not store REPORTING_RX / REPORTING_TX
   EXPECT_EQ(
-      update["IMSI1"]["1234"]
+      update[IMSI1][SESSION_ID_1]
           .charging_credit_map[1]
           .bucket_deltas[REPORTING_RX],
       0);
   EXPECT_EQ(
-      update["IMSI1"]["1234"]
+      update[IMSI1][SESSION_ID_1]
           .charging_credit_map[1]
           .bucket_deltas[REPORTING_TX],
       0);
@@ -410,41 +399,38 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules) {
 
   CreateSessionResponse response;
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, 2048, credits->Add());
+  create_credit_update_response(IMSI1, 1, 2048, credits->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      2048);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 2048}});
 
   insert_static_rule(1, "1", "rule1");
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1024, 1024, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 1024, 1024, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
-  session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
+  session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
 
   UpdateSessionResponse update_response;
   auto credit_updates_response = update_response.mutable_responses();
-  create_credit_update_response("IMSI1", 1, 24, credit_updates_response->Add());
+  create_credit_update_response(IMSI1, 1, 24, credit_updates_response->Add());
 
   auto monitor_updates_response =
       update_response.mutable_usage_monitor_responses();
   create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 2048,
+      IMSI1, "1", MonitoringLevel::PCC_RULE_LEVEL, 2048,
       monitor_updates_response->Add());
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      2072);
+
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 2072}});
 }
 
 TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
@@ -458,74 +444,76 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
 
   auto monitor_updates = response.mutable_usage_monitors();
   create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
+      IMSI1, "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       monitor_updates->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1", test_cfg_, response);
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
-  assert_charging_credit("IMSI1", ALLOWED_TOTAL, {});
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{"1", 1024}});
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {});
 
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
-  assert_monitor_credit("IMSI1", USED_RX, {{"1", 10}});
-  assert_monitor_credit("IMSI1", USED_TX, {{"1", 20}});
+  assert_monitor_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{"1", 10}});
+  assert_monitor_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{"1", 20}});
 
   UpdateSessionResponse update_response;
   auto monitor_updates_responses =
       update_response.mutable_usage_monitor_responses();
   auto monitor_response = monitor_updates_responses->Add();
   create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 2048, monitor_response);
+      IMSI1, "1", MonitoringLevel::PCC_RULE_LEVEL, 2048, monitor_response);
   monitor_response->set_success(false);
   monitor_response->set_result_code(5001);  // USER_UNKNOWN permanent failure
 
   // expect all rules attached to this session should be removed
   EXPECT_CALL(
-      *pipelined_client, deactivate_flows_for_rules(
-                             "IMSI1", std::vector<std::string>{"rule1"},
-                             CheckCount(0), testing::_))
+      *pipelined_client,
+      deactivate_flows_for_rules(
+          IMSI1, std::vector<std::string>{"rule1"}, CheckCount(0), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 
   // expect no update to credit
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 1024}});
-  assert_charging_credit("IMSI1", ALLOWED_TOTAL, {});
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{"1", 1024}});
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {});
 }
 
 TEST_F(LocalEnforcerTest, test_terminate_credit) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
-      "IMSI1", 2, 2048, response.mutable_credits()->Add());
+      IMSI1, 2, 2048, response.mutable_credits()->Add());
   CreateSessionResponse response2;
   create_credit_update_response(
-      "IMSI2", 1, 4096, response2.mutable_credits()->Add());
+      IMSI2, 1, 4096, response2.mutable_credits()->Add());
 
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
-  session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
-  session_map = session_store->read_sessions(SessionRead{"IMSI2"});
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
+  session_map = session_store->read_sessions(SessionRead{IMSI2});
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "4321", test_cfg_, response2);
-  session_store->create_sessions("IMSI2", std::move(session_map["IMSI2"]));
+      session_map, IMSI2, "4321", test_cfg_, response2);
+  session_store->create_sessions(IMSI2, std::move(session_map[IMSI2]));
 
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   auto update = SessionStore::get_default_session_update(session_map);
 
   EXPECT_CALL(
       *reporter,
-      report_terminate_session(CheckTerminateRequestCount("IMSI1", 0, 2), _))
+      report_terminate_session(CheckTerminateRequestCount(IMSI1, 0, 2), _))
       .Times(1);
   local_enforcer->terminate_session(
-      session_map, "IMSI1", test_cfg_.common_context.apn(), update);
+      session_map, IMSI1, test_cfg_.common_context.apn(), update);
 
   RuleRecordTable empty_table;
   local_enforcer->aggregate_records(session_map, empty_table, update);
@@ -535,28 +523,28 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
   EXPECT_TRUE(success);
 
   // No longer in system
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
-  EXPECT_EQ(session_map["IMSI1"].size(), 0);
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
+  EXPECT_EQ(session_map[IMSI1].size(), 0);
 }
 
 TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 3072, response.mutable_credits()->Add());
+      IMSI1, 1, 3072, response.mutable_credits()->Add());
   create_credit_update_response(
-      "IMSI1", 2, 2048, response.mutable_credits()->Add());
+      IMSI1, 2, 2048, response.mutable_credits()->Add());
   create_monitor_update_response(
-      "IMSI1", "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
+      IMSI1, "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(2, "", "rule2");
 
   // Insert record for key 1
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -565,20 +553,18 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   auto usage_updates =
       local_enforcer->collect_updates(session_map, actions, update);
   local_enforcer->execute_actions(session_map, actions, update);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, REPORTING_RX),
-      1024);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_RX, {{1, 1024}});
 
-  session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
+  session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
 
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   // Collecting terminations should key 1 anyways during reporting
-  local_enforcer->terminate_session(session_map, "IMSI1", "IMS", update);
+  local_enforcer->terminate_session(session_map, IMSI1, "IMS", update);
 
   EXPECT_CALL(
       *reporter,
-      report_terminate_session(CheckTerminateRequestCount("IMSI1", 1, 2), _))
+      report_terminate_session(CheckTerminateRequestCount(IMSI1, 1, 2), _))
       .Times(1);
 
   RuleRecordTable empty_table;
@@ -587,28 +573,26 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
 }
 
 TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
-  const std::string imsi       = "IMSI1";
-  const std::string session_id = "1234";
   CreateSessionResponse response;
   create_credit_update_response(
-      imsi, 1, 1024, true, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, true, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
   insert_static_rule(1, "", "rule3");
   insert_static_rule(1, "", "rule4");
 
-  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
   bool success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
 
-  auto session_map_2 = session_store->read_sessions(SessionRead{imsi});
+  auto session_map_2 = session_store->read_sessions(SessionRead{IMSI1});
   auto session_update =
       session_store->get_default_session_update(session_map_2);
-  EXPECT_EQ(session_map_2[imsi].size(), 1);
+  EXPECT_EQ(session_map_2[IMSI1].size(), 1);
 
   RuleLifetime lifetime1 = {
       .activation_time   = std::time_t(0),
@@ -626,25 +610,22 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
       .activation_time   = std::time_t(15),
       .deactivation_time = std::time_t(20),
   };
-  auto& uc = session_update[imsi][session_id];
-  session_map_2[imsi].front()->activate_static_rule("rule1", lifetime1, uc);
-  session_map_2[imsi].front()->schedule_static_rule("rule2", lifetime2, uc);
-  session_map_2[imsi].front()->schedule_static_rule("rule3", lifetime3, uc);
-  session_map_2[imsi].front()->schedule_static_rule("rule4", lifetime4, uc);
+  auto& uc = session_update[IMSI1][SESSION_ID_1];
+  session_map_2[IMSI1].front()->activate_static_rule("rule1", lifetime1, uc);
+  session_map_2[IMSI1].front()->schedule_static_rule("rule2", lifetime2, uc);
+  session_map_2[IMSI1].front()->schedule_static_rule("rule3", lifetime3, uc);
+  session_map_2[IMSI1].front()->schedule_static_rule("rule4", lifetime4, uc);
 
-  PolicyRule d1;
+  PolicyRule d1, d2, d3, d4;
   d1.set_id("dynamic_rule1");
-  PolicyRule d2;
   d2.set_id("dynamic_rule2");
-  PolicyRule d3;
   d3.set_id("dynamic_rule3");
-  PolicyRule d4;
   d4.set_id("dynamic_rule4");
 
-  session_map_2[imsi].front()->insert_dynamic_rule(d1, lifetime1, uc);
-  session_map_2[imsi].front()->schedule_dynamic_rule(d2, lifetime2, uc);
-  session_map_2[imsi].front()->schedule_dynamic_rule(d3, lifetime3, uc);
-  session_map_2[imsi].front()->schedule_dynamic_rule(d4, lifetime4, uc);
+  session_map_2[IMSI1].front()->insert_dynamic_rule(d1, lifetime1, uc);
+  session_map_2[IMSI1].front()->schedule_dynamic_rule(d2, lifetime2, uc);
+  session_map_2[IMSI1].front()->schedule_dynamic_rule(d3, lifetime3, uc);
+  session_map_2[IMSI1].front()->schedule_dynamic_rule(d4, lifetime4, uc);
 
   EXPECT_EQ(uc.new_scheduled_static_rules.count("rule2"), 1);
   EXPECT_EQ(uc.new_scheduled_static_rules.count("rule3"), 1);
@@ -655,11 +636,11 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
 
   local_enforcer->sync_sessions_on_restart(std::time_t(12));
 
-  session_map_2  = session_store->read_sessions(SessionRead{imsi});
+  session_map_2  = session_store->read_sessions(SessionRead{IMSI1});
   session_update = session_store->get_default_session_update(session_map_2);
-  EXPECT_EQ(session_map_2[imsi].size(), 1);
+  EXPECT_EQ(session_map_2[IMSI1].size(), 1);
 
-  auto& session = session_map_2[imsi].front();
+  auto& session = session_map_2[IMSI1].front();
   EXPECT_FALSE(session->is_static_rule_installed("rule1"));
   EXPECT_FALSE(session->is_static_rule_installed("rule2"));
   EXPECT_TRUE(session->is_static_rule_installed("rule3"));
@@ -672,16 +653,13 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart) {
 }
 
 TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
-  const std::string imsi       = "IMSI1";
-  const std::string session_id = "1234";
   auto pdp_start_time = 12345;
   magma::lte::TgppContext tgpp_ctx;
   CreateSessionResponse response;
   create_credit_update_response(
-      imsi, 1, 1024, true, response.mutable_credits()->Add());
-  auto session_state =
-      new SessionState(imsi, session_id, test_cfg_, *rule_store, tgpp_ctx,
-pdp_start_time);
+      IMSI1, 1, 1024, true, response.mutable_credits()->Add());
+  auto session_state = new SessionState(
+      IMSI1, SESSION_ID_1, test_cfg_, *rule_store, tgpp_ctx, pdp_start_time);
 
   // manually place revalidation timer
   SessionStateUpdateCriteria uc;
@@ -692,13 +670,13 @@ pdp_start_time);
   time.set_seconds(0);
   session_state->set_revalidation_time(time, uc);
 
-  session_map[imsi] = std::vector<std::unique_ptr<SessionState>>();
-  session_map[imsi].push_back(
+  session_map[IMSI1] = std::vector<std::unique_ptr<SessionState>>();
+  session_map[IMSI1].push_back(
       std::move(std::unique_ptr<SessionState>(session_state)));
 
-  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
   bool success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
 
   local_enforcer->sync_sessions_on_restart(std::time_t(0));
@@ -707,10 +685,10 @@ pdp_start_time);
   evb->loopOnce();
   evb->loopOnce();
   // We expect that the event trigger will now be marked as ready to be acted on
-  auto session_map_2 = session_store->read_sessions(SessionRead{imsi});
-  EXPECT_EQ(session_map_2[imsi].size(), 1);
+  auto session_map_2 = session_store->read_sessions(SessionRead{IMSI1});
+  EXPECT_EQ(session_map_2[IMSI1].size(), 1);
 
-  auto& session = session_map_2[imsi].front();
+  auto& session = session_map_2[IMSI1].front();
   auto events   = session->get_event_triggers();
   EXPECT_EQ(events[REVALIDATION_TIMEOUT], true);
 }
@@ -720,29 +698,27 @@ pdp_start_time);
 TEST_F(LocalEnforcerTest, test_termination_scheduling_on_sync_sessions) {
   CreateSessionResponse response;
   std::vector<std::string> rules_to_install;
-  const std::string imsi       = "IMSI1";
-  const std::string session_id = "1234";
   rules_to_install.push_back("rule1");
   insert_static_rule(0, "m1", "rule1");
 
   // Create a CreateSessionResponse with one Gx monitor:m1 and one rule:rule1
-  create_session_create_response(imsi, "m1", rules_to_install, &response);
+  create_session_create_response(IMSI1, "m1", rules_to_install, &response);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
-  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
   bool success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
 
-  auto session_map    = session_store->read_sessions(SessionRead{imsi});
+  auto session_map    = session_store->read_sessions(SessionRead{IMSI1});
   auto session_update = session_store->get_default_session_update(session_map);
-  EXPECT_EQ(session_map[imsi].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
 
   // Update session to have SESSION_TERMINATION_SCHEDULED
-  auto& uc = session_update[imsi][session_id];
-  session_map[imsi].front()->mark_as_awaiting_termination(uc);
+  auto& uc = session_update[IMSI1][SESSION_ID_1];
+  session_map[IMSI1].front()->mark_as_awaiting_termination(uc);
   EXPECT_EQ(uc.is_fsm_updated, true);
   EXPECT_EQ(uc.updated_fsm_state, SESSION_TERMINATION_SCHEDULED);
 
@@ -758,30 +734,30 @@ TEST_F(LocalEnforcerTest, test_termination_scheduling_on_sync_sessions) {
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules(
-          "IMSI1", CheckCount(1), testing::_, RequestOriginType::GX));
+          IMSI1, CheckCount(1), testing::_, RequestOriginType::GX));
   evb->loopOnce();
 
   // At this point, the state should have transitioned from
   // SESSION_TERMINATION_SCHEDULED -> SESSION_TERMINATING_FLOW_ACTIVE
-  session_map            = session_store->read_sessions(SessionRead{imsi});
-  auto updated_fsm_state = session_map[imsi].front()->get_state();
+  session_map            = session_store->read_sessions(SessionRead{IMSI1});
+  auto updated_fsm_state = session_map[IMSI1].front()->get_state();
   EXPECT_EQ(updated_fsm_state, SESSION_RELEASED);
 }
 
 TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, true, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, true, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
 
   // Insert record for key 1
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -794,7 +770,7 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   // + FUA-Terminate), we expect MME to be notified to delete the bearer
   // created on session creation
   EXPECT_CALL(
-      *spgw_client, delete_default_bearer("IMSI1", testing::_, testing::_));
+      *spgw_client, delete_default_bearer(IMSI1, testing::_, testing::_));
   // call collect_updates to trigger actions
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto usage_updates =
@@ -805,11 +781,11 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
 TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, true, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, true, response.mutable_credits()->Add());
   auto monitors = response.mutable_usage_monitors();
   auto monitor  = monitors->Add();
   create_monitor_update_response(
-      "IMSI1", "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor);
+      IMSI1, "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor);
   StaticRuleInstall static_rule_install;
   static_rule_install.set_rule_id("rule3");
   response.mutable_static_rules()->Add()->CopyFrom(static_rule_install);
@@ -817,23 +793,21 @@ TEST_F(LocalEnforcerTest, test_cwf_final_unit_handling) {
   insert_static_rule(0, "m1", "rule3");
 
   SessionConfig test_cwf_cfg;
-  const auto& mac_addr          = "00:00:00:00:00:00";
-  const auto& radius_session_id = "1234567";
   test_cwf_cfg.common_context =
-      build_common_context("IMSI1", "", "", "", TGPP_WLAN);
-  const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+      build_common_context(IMSI1, "", "", "", TGPP_WLAN);
+  const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cwf_cfg, response);
+      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
   insert_static_rule(1, "", "rule1");
   insert_static_rule(1, "", "rule2");
 
   // Insert record for key 1
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -862,64 +836,52 @@ TEST_F(LocalEnforcerTest, test_all) {
   // insert initial session credit
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   CreateSessionResponse response2;
   create_credit_update_response(
-      "IMSI2", 2, 2048, response2.mutable_credits()->Add());
+      IMSI2, 2, 2048, response2.mutable_credits()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "4321", test_cfg_, response2);
+      session_map, IMSI2, SESSION_ID_2, test_cfg_, response2);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      1024);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI2", 2, ALLOWED_TOTAL),
-      2048);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, ALLOWED_TOTAL, {{2, 2048}});
 
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 10, 20, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 5, 15, record_list->Add());
-  create_rule_record("IMSI2", "rule3", 1024, 1024, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 5, 15, record_list->Add());
+  create_rule_record(IMSI2, "rule3", 1024, 1024, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX),
-      15);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX),
-      35);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI2", 2, USED_RX),
-      1024);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI2", 2, USED_TX),
-      1024);
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 15}});
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 35}});
+  assert_charging_credit(session_map, IMSI2, SESSION_ID_2, USED_RX, {{2, 1024}});
+  assert_charging_credit(session_map, IMSI2, SESSION_ID_2, USED_TX, {{2, 1024}});
 
   EXPECT_EQ(update.size(), 2);
 
-  EXPECT_EQ(update["IMSI1"]["1234"].charging_credit_map.size(), 1);
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].charging_credit_map.size(), 1);
   // UpdateCriteria does not store REPORTING_RX / REPORTING_TX
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_RX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_RX],
       15);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_TX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_TX],
       35);
 
-  EXPECT_EQ(update["IMSI2"]["4321"].charging_credit_map.size(), 1);
+  EXPECT_EQ(update[IMSI2][SESSION_ID_2].charging_credit_map.size(), 1);
   // UpdateCriteria does not store REPORTING_RX / REPORTING_TX
   EXPECT_EQ(
-      update["IMSI2"]["4321"].charging_credit_map[2].bucket_deltas[USED_RX],
+      update[IMSI2][SESSION_ID_2].charging_credit_map[2].bucket_deltas[USED_RX],
       1024);
   EXPECT_EQ(
-      update["IMSI2"]["4321"].charging_credit_map[2].bucket_deltas[USED_TX],
+      update[IMSI2][SESSION_ID_2].charging_credit_map[2].bucket_deltas[USED_TX],
       1024);
 
   // Collect updates for reporting
@@ -928,61 +890,51 @@ TEST_F(LocalEnforcerTest, test_all) {
       local_enforcer->collect_updates(session_map, actions, update);
   local_enforcer->execute_actions(session_map, actions, update);
   EXPECT_EQ(session_update.updates_size(), 1);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI2", 2, REPORTING_RX),
-      1024);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI2", 2, REPORTING_TX),
-      1024);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTED_TX),
-      0);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTED_RX),
-      0);
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTING_RX, {{2, 1024}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTING_TX, {{2, 1024}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTED_RX, {{2, 0}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTED_TX, {{2, 0}});
 
   // Add updated credit from cloud
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
-  create_credit_update_response("IMSI2", 2, 4096, updates->Add());
+  create_credit_update_response(IMSI2, 2, 4096, updates->Add());
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI2", 2, ALLOWED_TOTAL),
-      6144);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI2", 2, REPORTING_TX),
-      0);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI2", 2, REPORTING_RX),
-      0);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTED_TX),
-      1024);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI2", 2, REPORTED_RX),
-      1024);
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, ALLOWED_TOTAL, {{2, 6144}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTING_RX, {{2, 0}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTING_TX, {{2, 0}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTED_RX, {{2, 1024}});
+  assert_charging_credit(
+      session_map, IMSI2, SESSION_ID_2, REPORTED_TX, {{2, 1024}});
 
   EXPECT_EQ(
-      update["IMSI2"]["4321"].charging_credit_map[2].bucket_deltas[REPORTED_TX],
+      update[IMSI2][SESSION_ID_2]
+          .charging_credit_map[2]
+          .bucket_deltas[REPORTED_TX],
       1024);
   EXPECT_EQ(
-      update["IMSI2"]["4321"].charging_credit_map[2].bucket_deltas[REPORTED_RX],
+      update[IMSI2][SESSION_ID_2]
+          .charging_credit_map[2]
+          .bucket_deltas[REPORTED_RX],
       1024);
 
   // Terminate IMSI1
-  local_enforcer->terminate_session(session_map, "IMSI1", "IMS", update);
+  local_enforcer->terminate_session(session_map, IMSI1, "IMS", update);
 
   EXPECT_CALL(
       *reporter,
-      report_terminate_session(CheckTerminateRequestCount("IMSI1", 0, 1), _))
+      report_terminate_session(CheckTerminateRequestCount(IMSI1, 0, 1), _))
       .Times(1);
   run_evb();
 
@@ -994,11 +946,11 @@ TEST_F(LocalEnforcerTest, test_re_auth) {
   insert_static_rule(1, "", "rule1");
   CreateSessionResponse response;
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   ChargingReAuthRequest reauth;
-  reauth.set_sid("IMSI1");
-  reauth.set_session_id("1234");
+  reauth.set_sid(IMSI1);
+  reauth.set_session_id(SESSION_ID_1);
   reauth.set_charging_key(1);
   reauth.set_type(ChargingReAuthRequest::SINGLE_SERVICE);
   auto update = SessionStore::get_default_session_update(session_map);
@@ -1011,13 +963,13 @@ TEST_F(LocalEnforcerTest, test_re_auth) {
       local_enforcer->collect_updates(session_map, actions, update);
   local_enforcer->execute_actions(session_map, actions, update);
   EXPECT_EQ(update_req.updates_size(), 1);
-  EXPECT_EQ(update_req.updates(0).sid(), "IMSI1");
+  EXPECT_EQ(update_req.updates(0).sid(), IMSI1);
   EXPECT_EQ(update_req.updates(0).usage().type(), CreditUsage::REAUTH_REQUIRED);
 
   // Give credit after re-auth
   UpdateSessionResponse update_response;
   auto updates = update_response.mutable_responses();
-  create_credit_update_response("IMSI1", 1, 4096, updates->Add());
+  create_credit_update_response(IMSI1, 1, 4096, updates->Add());
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
 
@@ -1037,40 +989,34 @@ TEST_F(LocalEnforcerTest, test_re_auth) {
 TEST_F(LocalEnforcerTest, test_dynamic_rules) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   auto dynamic_rule = response.mutable_dynamic_rules()->Add();
   auto policy_rule  = dynamic_rule->mutable_policy_rule();
   policy_rule->set_id("rule1");
   policy_rule->set_rating_group(1);
   policy_rule->set_tracking_type(PolicyRule::ONLY_OCS);
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   insert_static_rule(1, "", "rule2");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 16, 32, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 8, 8, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 16, 32, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 8, 8, record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_RX),
-      24);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(session_map, "IMSI1", 1, USED_TX),
-      40);
-  EXPECT_EQ(
-      local_enforcer->get_charging_credit(
-          session_map, "IMSI1", 1, ALLOWED_TOTAL),
-      1024);
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 24}});
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 40}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}});
 
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_RX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_RX],
       24);
   EXPECT_EQ(
-      update["IMSI1"]["1234"].charging_credit_map[1].bucket_deltas[USED_TX],
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].bucket_deltas[USED_TX],
       40);
 }
 
@@ -1078,7 +1024,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
   CreateSessionResponse response;
   // with final action = terminate
   create_credit_update_response(
-      "IMSI1", 1, 1024, true, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, true, response.mutable_credits()->Add());
   auto dynamic_rule = response.mutable_dynamic_rules()->Add();
   auto policy_rule  = dynamic_rule->mutable_policy_rule();
   policy_rule->set_id("rule2");
@@ -1100,12 +1046,12 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
       .WillOnce(testing::Return(true));
 
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1024, 2048, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1124,7 +1070,7 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
 TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, true, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, true, response.mutable_credits()->Add());
 
   // add a dynamic rule without activation time
   auto dynamic_rule = response.mutable_dynamic_rules()->Add();
@@ -1175,7 +1121,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
   // static rules: rule4, rule6
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
-                             "IMSI1", testing::_, testing::_, CheckCount(2),
+                             IMSI1, testing::_, testing::_, CheckCount(2),
                              CheckCount(2), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
@@ -1183,7 +1129,7 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
   // static rules: rule5
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
-                             "IMSI1", testing::_, testing::_, CheckCount(1),
+                             IMSI1, testing::_, testing::_, CheckCount(1),
                              CheckCount(0), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
@@ -1191,14 +1137,14 @@ TEST_F(LocalEnforcerTest, test_installing_rules_with_activation_time) {
   // dynamic rules: rule2
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
-                             "IMSI1", testing::_, testing::_, CheckCount(0),
+                             IMSI1, testing::_, testing::_, CheckCount(0),
                              CheckCount(1), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   bool success =
-      session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
 }
 
@@ -1213,40 +1159,46 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   // insert initial session credit
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   create_credit_update_response(
-      "IMSI1", 2, 1024, response.mutable_credits()->Add());
+      IMSI1, 2, 1024, response.mutable_credits()->Add());
   create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
+      IMSI1, "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response.mutable_usage_monitors()->Add());
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 2048,
+      IMSI1, "3", MonitoringLevel::PCC_RULE_LEVEL, 2048,
       response.mutable_usage_monitors()->Add());
   create_monitor_update_response(
-      "IMSI1", "4", MonitoringLevel::SESSION_LEVEL, 2128,
+      IMSI1, "4", MonitoringLevel::SESSION_LEVEL, 2128,
       response.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
-  assert_charging_credit("IMSI1", ALLOWED_TOTAL, {{1, 1024}, {2, 1024}});
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL, {{1, 1024}, {2, 1024}});
   assert_monitor_credit(
-      "IMSI1", ALLOWED_TOTAL, {{"1", 1024}, {"3", 2048}, {"4", 2128}});
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL,
+      {{"1", 1024}, {"3", 2048}, {"4", 2128}});
 
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "both_rule", 10, 20, record_list->Add());
-  create_rule_record("IMSI1", "ocs_rule", 5, 15, record_list->Add());
-  create_rule_record("IMSI1", "pcrf_only", 1024, 1024, record_list->Add());
-  create_rule_record("IMSI1", "pcrf_split", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, "both_rule", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, "ocs_rule", 5, 15, record_list->Add());
+  create_rule_record(IMSI1, "pcrf_only", 1024, 1024, record_list->Add());
+  create_rule_record(IMSI1, "pcrf_split", 10, 20, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
-  assert_charging_credit("IMSI1", USED_RX, {{1, 10}, {2, 5}});
-  assert_charging_credit("IMSI1", USED_TX, {{1, 20}, {2, 15}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 10}, {2, 5}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 20}, {2, 15}});
   assert_monitor_credit(
-      "IMSI1", USED_RX, {{"1", 20}, {"3", 1024}, {"4", 1049}});
+      session_map, IMSI1, SESSION_ID_1, USED_RX,
+      {{"1", 20}, {"3", 1024}, {"4", 1049}});
   assert_monitor_credit(
-      "IMSI1", USED_TX, {{"1", 40}, {"3", 1024}, {"4", 1079}});
+      session_map, IMSI1, SESSION_ID_1, USED_TX,
+      {{"1", 40}, {"3", 1024}, {"4", 1079}});
 
   // Collect updates, should only have mkeys 3 and 4
   std::vector<std::unique_ptr<ServiceAction>> actions;
@@ -1255,7 +1207,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   local_enforcer->execute_actions(session_map, actions, update);
   EXPECT_EQ(session_update.usage_monitors_size(), 2);
   for (const auto& monitor : session_update.usage_monitors()) {
-    EXPECT_EQ(monitor.sid(), "IMSI1");
+    EXPECT_EQ(monitor.sid(), IMSI1);
     if (monitor.update().monitoring_key() == "3") {
       EXPECT_EQ(monitor.update().level(), MonitoringLevel::PCC_RULE_LEVEL);
       EXPECT_EQ(monitor.update().bytes_rx(), 1024);
@@ -1269,41 +1221,49 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
     }
   }
 
-  assert_charging_credit("IMSI1", REPORTING_RX, {{1, 0}, {2, 0}});
-  assert_charging_credit("IMSI1", REPORTING_TX, {{1, 0}, {2, 0}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_RX, {{1, 0}, {2, 0}});
+  assert_charging_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_TX, {{1, 0}, {2, 0}});
   assert_monitor_credit(
-      "IMSI1", REPORTING_RX, {{"1", 0}, {"3", 1024}, {"4", 1049}});
+      session_map, IMSI1, SESSION_ID_1, REPORTING_RX,
+      {{"1", 0}, {"3", 1024}, {"4", 1049}});
   assert_monitor_credit(
-      "IMSI1", REPORTING_TX, {{"1", 0}, {"3", 1024}, {"4", 1079}});
+      session_map, IMSI1, SESSION_ID_1, REPORTING_TX,
+      {{"1", 0}, {"3", 1024}, {"4", 1079}});
 
   UpdateSessionResponse update_response;
   auto monitor_updates = update_response.mutable_usage_monitor_responses();
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 2048,
+      IMSI1, "3", MonitoringLevel::PCC_RULE_LEVEL, 2048,
       monitor_updates->Add());
   create_monitor_update_response(
-      "IMSI1", "4", MonitoringLevel::SESSION_LEVEL, 2048,
-      monitor_updates->Add());
+      IMSI1, "4", MonitoringLevel::SESSION_LEVEL, 2048, monitor_updates->Add());
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
-  assert_monitor_credit("IMSI1", REPORTING_RX, {{"3", 0}, {"4", 0}});
-  assert_monitor_credit("IMSI1", REPORTING_TX, {{"3", 0}, {"4", 0}});
-  assert_monitor_credit("IMSI1", REPORTED_RX, {{"3", 1024}, {"4", 1049}});
-  assert_monitor_credit("IMSI1", REPORTED_TX, {{"3", 1024}, {"4", 1079}});
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"3", 4096}, {"4", 4176}});
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_RX, {{"3", 0}, {"4", 0}});
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTING_TX, {{"3", 0}, {"4", 0}});
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTED_RX, {{"3", 1024}, {"4", 1049}});
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, REPORTED_TX, {{"3", 1024}, {"4", 1079}});
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL,
+      {{"3", 4096}, {"4", 4176}});
 
   // Test rule removal in usage monitor response for CCA-Update
   update_response.Clear();
   monitor_updates = update_response.mutable_usage_monitor_responses();
   auto monitor_updates_response = monitor_updates->Add();
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 0,
-      monitor_updates_response);
+      IMSI1, "3", MonitoringLevel::PCC_RULE_LEVEL, 0, monitor_updates_response);
   monitor_updates_response->add_rules_to_remove("pcrf_only");
 
   EXPECT_CALL(
       *pipelined_client, deactivate_flows_for_rules(
-                             "IMSI1", std::vector<std::string>{"pcrf_only"},
+                             IMSI1, std::vector<std::string>{"pcrf_only"},
                              CheckCount(0), RequestOriginType::GX))
       .Times(1)
       .WillOnce(testing::Return(true));
@@ -1315,8 +1275,7 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   monitor_updates          = update_response.mutable_usage_monitor_responses();
   monitor_updates_response = monitor_updates->Add();
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 0,
-      monitor_updates_response);
+      IMSI1, "3", MonitoringLevel::PCC_RULE_LEVEL, 0, monitor_updates_response);
 
   StaticRuleInstall static_rule_install;
   static_rule_install.set_rule_id("pcrf_only");
@@ -1327,8 +1286,8 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   EXPECT_CALL(
       *pipelined_client,
       activate_flows_for_rules(
-          "IMSI1", testing::_, testing::_,
-          std::vector<std::string>{"pcrf_only"}, CheckCount(0), testing::_))
+          IMSI1, testing::_, testing::_, std::vector<std::string>{"pcrf_only"},
+          CheckCount(0), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
   local_enforcer->update_session_credits_and_rules(
@@ -1348,36 +1307,35 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   // insert initial session credit
   CreateSessionResponse response_1;
   create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
+      IMSI1, "1", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response_1.mutable_usage_monitors()->Add());
   create_monitor_update_response(
-      "IMSI1", "2", MonitoringLevel::SESSION_LEVEL, 1024,
+      IMSI1, "2", MonitoringLevel::SESSION_LEVEL, 1024,
       response_1.mutable_usage_monitors()->Add());
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 1024,
+      IMSI1, "3", MonitoringLevel::PCC_RULE_LEVEL, 1024,
       response_1.mutable_usage_monitors()->Add());
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response_1);
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL,
-                        {{"1", 1024}, {"2", 1024},{"3", 1024}});
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response_1);
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL,
+      {{"1", 1024}, {"2", 1024}, {"3", 1024}});
+
   // IMPORTANT: save the updates into store and reload
   bool success =
-      session_store->create_sessions("IMSI1", std::move(session_map["IMSI1"]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
-
+  session_map   = session_store->read_sessions(SessionRead{IMSI1});
+  auto update_1 = SessionStore::get_default_session_update(session_map);
 
   // Monitor credit usage #1
   // Use the quota to exhaust monitor 2 and 3 and assert that we send usage
   // reports for all monitors receive usages from pipelined
   RuleRecordTable table_1;
   auto record_list_1 = table_1.mutable_records();
+  create_rule_record(IMSI1, "pcrf_only_active", 2000, 0, record_list_1->Add());
   create_rule_record(
-      "IMSI1", "pcrf_only_active", 2000, 0, record_list_1->Add());
-  create_rule_record(
-  "IMSI1", "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
-
-  auto update_1 = SessionStore::get_default_session_update(session_map);
+      IMSI1, "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
   local_enforcer->aggregate_records(session_map, table_1, update_1);
 
   // Collect updates, should have updates since all monitors got 80% exhausted
@@ -1387,7 +1345,6 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   EXPECT_EQ(update_request_1.updates_size(), 0);
   EXPECT_EQ(update_request_1.usage_monitors_size(), 3);
 
-
   // Monitor credit addition #2
   // Receive an update with zero grant for mkey=3 & mkey=2, but with
   // credit for mkey=1. That means 3 and 2 will have to stop reporting when
@@ -1395,48 +1352,47 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   UpdateSessionResponse update_response_2;
   auto monitors_2 = update_response_2.mutable_usage_monitor_responses();
   create_monitor_update_response(
-      "IMSI1", "1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitors_2->Add());
+      IMSI1, "1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitors_2->Add());
   create_monitor_update_response(
-      "IMSI1", "2", MonitoringLevel::SESSION_LEVEL, 0, monitors_2->Add());
+      IMSI1, "2", MonitoringLevel::SESSION_LEVEL, 0, monitors_2->Add());
   create_monitor_update_response(
-      "IMSI1", "3", MonitoringLevel::PCC_RULE_LEVEL, 0, monitors_2->Add());
+      IMSI1, "3", MonitoringLevel::PCC_RULE_LEVEL, 0, monitors_2->Add());
   // Apply the updates
   auto update_2 = SessionStore::get_default_session_update(session_map);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response_2, update_2);
 
-  auto monitor_updates_2 = update_2["IMSI1"]["1234"].monitor_credit_map;
+  auto monitor_updates_2 = update_2[IMSI1][SESSION_ID_1].monitor_credit_map;
   EXPECT_FALSE(monitor_updates_2["1"].deleted);
   EXPECT_FALSE(monitor_updates_2["2"].deleted);
   EXPECT_FALSE(monitor_updates_2["3"].deleted);
   // Check updates for disabling session level monitoring key
-  EXPECT_TRUE(update_2["IMSI1"]["1234"].is_session_level_key_updated);
-  EXPECT_EQ(update_2["IMSI1"]["1234"].updated_session_level_key, "2");
+  EXPECT_TRUE(update_2[IMSI1][SESSION_ID_1].is_session_level_key_updated);
+  EXPECT_EQ(update_2[IMSI1][SESSION_ID_1].updated_session_level_key, "2");
   // note that we have gone over allowed, so we will reset ALLOWED_TOTAL
   // 3024 because used 2000 before (out of the initial 1024) plues we added 1024
   // 4000 because session level has used 2000 + 2000 from mkey 1 and 3
   // 2000 because mkey 3 have used 2000 but we haven't added any extra
-  assert_monitor_credit("IMSI1", ALLOWED_TOTAL, {{"1", 3024},
-      {"2", 4000},{"3", 2000}});
-
+  assert_monitor_credit(
+      session_map, IMSI1, SESSION_ID_1, ALLOWED_TOTAL,
+      {{"1", 3024}, {"2", 4000}, {"3", 2000}});
 
   // Monitor credit usage #2
   // Generate more traffic to see monitors 2 and 3 are not triggering update
   RuleRecordTable table_2;
   auto record_list2 = table_2.mutable_records();
+  create_rule_record(IMSI1, "pcrf_only_active", 2000, 0, record_list2->Add());
   create_rule_record(
-      "IMSI1", "pcrf_only_active", 2000, 0, record_list2->Add());
-  create_rule_record(
-      "IMSI1", "pcrf_only_to_be_disabled", 2000, 0, record_list2->Add());
+      IMSI1, "pcrf_only_to_be_disabled", 2000, 0, record_list2->Add());
 
   update_2 = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table_2, update_2);
-  monitor_updates_2 = update_2["IMSI1"]["1234"].monitor_credit_map;
+  monitor_updates_2 = update_2[IMSI1][SESSION_ID_1].monitor_credit_map;
   EXPECT_FALSE(monitor_updates_2["1"].deleted);
   EXPECT_TRUE(monitor_updates_2["2"].deleted);
   EXPECT_TRUE(monitor_updates_2["3"].deleted);
   // check session level key will be removed
-  EXPECT_EQ(update_2["IMSI1"]["1234"].updated_session_level_key, "");
+  EXPECT_EQ(update_2[IMSI1][SESSION_ID_1].updated_session_level_key, "");
 
   // Collect updates, should have NO updates
   std::vector<std::unique_ptr<ServiceAction>> actions_2;
@@ -1444,8 +1400,6 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
       local_enforcer->collect_updates(session_map, actions_2, update_2);
   EXPECT_EQ(update_request_2.updates_size(), 0);
   EXPECT_EQ(update_request_2.usage_monitors_size(), 1);
-
-
 }
 
 TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
@@ -1454,15 +1408,15 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
 
   SessionConfig test_volte_cfg;
   test_volte_cfg.common_context =
-      build_common_context("", "127.0.0.1", "", "IMS", TGPP_LTE);
-  const auto& lte_context = build_lte_context("", "", "", "", "", 1,
-&test_qos_info);
+      build_common_context("", IP1, "", "IMS", TGPP_LTE);
+  const auto& lte_context =
+      build_lte_context("", "", "", "", "", 1, &test_qos_info);
   test_volte_cfg.rat_specific_context.mutable_lte_context()->CopyFrom(
       lte_context);
 
   CreateSessionResponse response;
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_volte_cfg, response);
+      session_map, IMSI1, SESSION_ID_1, test_volte_cfg, response);
 
   PolicyReAuthRequest rar;
   std::vector<std::string> rules_to_remove;
@@ -1471,7 +1425,7 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
   std::vector<EventTrigger> event_triggers;
   std::vector<UsageMonitoringCredit> usage_monitoring_credits;
   create_policy_reauth_request(
-      "1234", "IMSI1", rules_to_remove, rules_to_install,
+      SESSION_ID_1, IMSI1, rules_to_remove, rules_to_install,
       dynamic_rules_to_install, event_triggers, time(NULL),
       usage_monitoring_credits, &rar);
   auto rar_qos_info = rar.mutable_qos_info();
@@ -1491,8 +1445,6 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
 // Simulate a policy->bearer mapping from MME, both success + failure.
 // Simulate additional rule updates to trigger dedicated bearer deletions
 TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
-  const std::string imsi           = "IMSI1";
-  const std::string session_id     = "1234";
   const uint32_t default_bearer_id = 5;
   const uint32_t bearer_1          = 6;
   const uint32_t bearer_2          = 7;
@@ -1504,7 +1456,7 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   insert_static_rule(0, "m1", "rule4");
 
   // test_cfg_ is initialized with QoSInfo field w/ QCI 5
-  test_cfg_.common_context.mutable_sid()->set_id(imsi);
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
   test_cfg_.common_context.set_apn("apn1");
   auto lte_context = test_cfg_.rat_specific_context.mutable_lte_context();
   lte_context->mutable_qos_info()->set_qos_class_id(5);
@@ -1519,30 +1471,30 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   // expect only 1 rule in the request since only rules with a QoS field
   // should be mapped to a bearer
   EXPECT_CALL(
-      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(imsi, 3)))
+      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 3)))
       .Times(1)
       .WillOnce(testing::Return(true));
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   // Write + Read in/from SessionStore
   bool write_success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
-  session_map = session_store->read_sessions({imsi});
+  session_map = session_store->read_sessions({IMSI1});
   auto update = SessionStore::get_default_session_update(session_map);
 
   // Test successful creation of dedicated bearer for rule1 + rule2
-  auto bearer_bind_req_success1 =
-      create_policy_bearer_bind_req(imsi, default_bearer_id, "rule1", bearer_1);
-  auto bearer_bind_req_success2 =
-      create_policy_bearer_bind_req(imsi, default_bearer_id, "rule2", bearer_2);
+  auto bearer_bind_req_success1 = create_policy_bearer_bind_req(
+      IMSI1, default_bearer_id, "rule1", bearer_1);
+  auto bearer_bind_req_success2 = create_policy_bearer_bind_req(
+      IMSI1, default_bearer_id, "rule2", bearer_2);
   std::unordered_set<std::string> rule_ids({"rule1", "rule2"});
   // Expect NO call to PipelineD for rule1
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules(
-          imsi, CheckSubset(rule_ids), CheckCount(0), testing::_))
+          IMSI1, CheckSubset(rule_ids), CheckCount(0), testing::_))
       .Times(0);
   local_enforcer->bind_policy_to_bearer(
       session_map, bearer_bind_req_success1, update);
@@ -1551,21 +1503,21 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
 
   // Test unsuccessful creation of dedicated bearer for rule3 (bearer_id = 0)
   auto bearer_bind_req_fail =
-      create_policy_bearer_bind_req(imsi, default_bearer_id, "rule3", 0);
+      create_policy_bearer_bind_req(IMSI1, default_bearer_id, "rule3", 0);
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules(
-          imsi, std::vector<std::string>{"rule3"}, CheckCount(0), testing::_))
+          IMSI1, std::vector<std::string>{"rule3"}, CheckCount(0), testing::_))
       .Times(1);
   local_enforcer->bind_policy_to_bearer(
       session_map, bearer_bind_req_fail, update);
   // Check update criteria has changes
-  EXPECT_TRUE(update[imsi][session_id].is_bearer_mapping_updated);
-  EXPECT_EQ(update[imsi][session_id].bearer_id_by_policy.size(), 2);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1].is_bearer_mapping_updated);
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].bearer_id_by_policy.size(), 2);
   // Write + Read in/from SessionStore
   write_success = session_store->update_sessions(update);
   EXPECT_TRUE(write_success);
-  session_map = session_store->read_sessions({imsi});
+  session_map = session_store->read_sessions({IMSI1});
   update      = SessionStore::get_default_session_update(session_map);
 
   // At this point we have rule1 -> bearer1, rule2 -> bearer2 rule3 -> deleted,
@@ -1573,17 +1525,17 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   // dedicated bearer request. Use the set rule interface to remove rule1.
   SessionRules session_rules;
   auto rule_set_per_sub = session_rules.mutable_rules_per_subscriber()->Add();
-  rule_set_per_sub->set_imsi(imsi);
+  rule_set_per_sub->set_imsi(IMSI1);
   rule_set_per_sub->mutable_rule_set()->Add()->CopyFrom(
       create_rule_set(false, "apn1", {"rule2", "rule4"}, {}));
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules(
-          imsi, std::vector<std::string>{"rule1"}, CheckCount(0), testing::_))
+          IMSI1, std::vector<std::string>{"rule1"}, CheckCount(0), testing::_))
       .Times(1);
   EXPECT_CALL(
       *spgw_client, delete_dedicated_bearer(CheckDeleteOneBearerReq(
-                        imsi, default_bearer_id, bearer_1)))
+                        IMSI1, default_bearer_id, bearer_1)))
       .Times(1);
   update = SessionStore::get_default_session_update(session_map);
   local_enforcer->handle_set_session_rules(session_map, session_rules, update);
@@ -1593,34 +1545,31 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   auto monitor_update =
       update_response.mutable_usage_monitor_responses()->Add();
   create_monitor_update_response(
-      imsi, "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor_update);
+      IMSI1, "m1", MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor_update);
   monitor_update->add_rules_to_remove("rule2");
 
   EXPECT_CALL(
       *pipelined_client,
       deactivate_flows_for_rules(
-          imsi, std::vector<std::string>{"rule2"}, CheckCount(0), testing::_))
+          IMSI1, std::vector<std::string>{"rule2"}, CheckCount(0), testing::_))
       .Times(1);
   EXPECT_CALL(
       *spgw_client, delete_dedicated_bearer(CheckDeleteOneBearerReq(
-                        imsi, default_bearer_id, bearer_2)))
+                        IMSI1, default_bearer_id, bearer_2)))
       .Times(1);
   local_enforcer->update_session_credits_and_rules(
       session_map, update_response, update);
   // Check update criteria has changes + no bearer left!
-  EXPECT_TRUE(update[imsi][session_id].is_bearer_mapping_updated);
-  EXPECT_EQ(update[imsi][session_id].bearer_id_by_policy.size(), 0);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1].is_bearer_mapping_updated);
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].bearer_id_by_policy.size(), 0);
 }
 
 // Test the handle_set_session_rules function to apply rules to sessions
 // We will test a case where a subscriber has 2 separate sessions
 TEST_F(LocalEnforcerTest, test_set_session_rules) {
   SessionConfig config1, config2;
-  const std::string imsi        = "IMSI1";
-  const std::string session_id1 = "1234";
-  const std::string session_id2 = "5678";
-  const std::string ip1         = "127.0.0.1";
-  const std::string ip2         = "127.0.0.2";
+  const std::string ip1 = IP1;
+  const std::string ip2 = "127.0.0.2";
 
   // Set Session1 + Session2 to be LTE session with default QoS
   QosInformationRequest qos_info;
@@ -1628,12 +1577,12 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
   qos_info.set_apn_ambr_dl(64);
   qos_info.set_qos_class_id(1);
   const auto& lte_context =
-      build_lte_context("128.0.0.1", "", "", "", "", 0, &qos_info);
+      build_lte_context(IP2, "", "", "", "", 0, &qos_info);
   config1.common_context =
-      build_common_context(imsi, ip1, "apn1", "msisdn1", TGPP_LTE);
+      build_common_context(IMSI1, ip1, "apn1", "msisdn1", TGPP_LTE);
   config1.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
   config2.common_context =
-      build_common_context(imsi, ip2, "apn2", "msisdn1", TGPP_LTE);
+      build_common_context(IMSI1, ip2, "apn2", "msisdn1", TGPP_LTE);
   config2.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
 
   // Initialize 3 static rules in RuleStore and create 2 dynamic rules
@@ -1652,16 +1601,16 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
       dynamic_1);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id1, config1, response);
+      session_map, IMSI1, SESSION_ID_1, config1, response);
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id2, config2, response);
+      session_map, IMSI1, SESSION_ID_2, config2, response);
   // Assert the rules exist
-  EXPECT_TRUE(session_map[imsi][0]->is_static_rule_installed("static1"));
-  EXPECT_TRUE(session_map[imsi][0]->is_static_rule_installed("static2"));
-  EXPECT_TRUE(session_map[imsi][0]->is_dynamic_rule_installed("dynamic1"));
+  EXPECT_TRUE(session_map[IMSI1][0]->is_static_rule_installed("static1"));
+  EXPECT_TRUE(session_map[IMSI1][0]->is_static_rule_installed("static2"));
+  EXPECT_TRUE(session_map[IMSI1][0]->is_dynamic_rule_installed("dynamic1"));
 
   bool success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
 
   // Apply a set rule of
@@ -1673,7 +1622,7 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
   // apn2 -> (add dynamic_2 + remove static2,dynamic_1)
   SessionRules session_rules;
   auto rule_set_per_sub = session_rules.mutable_rules_per_subscriber()->Add();
-  rule_set_per_sub->set_imsi(imsi);
+  rule_set_per_sub->set_imsi(IMSI1);
   rule_set_per_sub->mutable_rule_set()->Add()->CopyFrom(
       create_rule_set(false, "apn1", {"static1", "static3"}, {dynamic_2}));
   rule_set_per_sub->mutable_rule_set()->Add()->CopyFrom(
@@ -1685,7 +1634,7 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
   EXPECT_CALL(
       *pipelined_client,
       activate_flows_for_rules(
-          imsi, ip1, testing::_, std::vector<std::string>{"static3"},
+          IMSI1, ip1, testing::_, std::vector<std::string>{"static3"},
           CheckCount(1), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
@@ -1693,25 +1642,25 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
   EXPECT_CALL(
       *pipelined_client,
       activate_flows_for_rules(
-          imsi, ip2, testing::_, CheckCount(0), CheckCount(1), testing::_))
+          IMSI1, ip2, testing::_, CheckCount(0), CheckCount(1), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
   // For both Session1 + Session2
   EXPECT_CALL(
-      *pipelined_client,
-      deactivate_flows_for_rules(
-          imsi, std::vector<std::string>{"static2"}, CheckCount(1), testing::_))
+      *pipelined_client, deactivate_flows_for_rules(
+                             IMSI1, std::vector<std::string>{"static2"},
+                             CheckCount(1), testing::_))
       .Times(2)
       .WillOnce(testing::Return(true));
 
   // Since static3 is also a QoS rule with a new QCI (not equal to default), we
   // should also expect a create bearer request here
   EXPECT_CALL(
-      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(imsi, 1)))
+      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
       .Times(1)
       .WillOnce(testing::Return(true));
 
-  session_map = session_store->read_sessions(SessionRead{imsi});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->handle_set_session_rules(session_map, session_rules, update);
 }
@@ -1720,7 +1669,7 @@ TEST_F(LocalEnforcerTest, test_rar_session_not_found) {
   // verify session validity by passing in an invalid IMSI
   PolicyReAuthRequest rar;
   create_policy_reauth_request(
-      "session1", "IMSI1", {}, {}, {}, {}, time(NULL), {}, &rar);
+      "session1", IMSI1, {}, {}, {}, {}, time(NULL), {}, &rar);
   PolicyReAuthAnswer raa;
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->init_policy_reauth(session_map, rar, raa, update);
@@ -1730,15 +1679,13 @@ TEST_F(LocalEnforcerTest, test_rar_session_not_found) {
   // and an invalid session-id (session1)
   CreateSessionResponse response;
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "session0", test_cfg_, response);
+      session_map, IMSI1, "session0", test_cfg_, response);
   local_enforcer->init_policy_reauth(session_map, rar, raa, update);
   EXPECT_EQ(raa.result(), ReAuthResult::SESSION_NOT_FOUND);
 }
 
 TEST_F(LocalEnforcerTest, test_revalidation_timer_on_init) {
-  const std::string imsi       = "IMSI1";
-  const std::string session_id = "1234";
-  const std::string mkey       = "m1";
+  const std::string mkey = "m1";
   insert_static_rule(1, mkey, "rule1");
 
   // Create a CreateSessionResponse with one Gx monitor, PCC rule, and an event
@@ -1747,7 +1694,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_init) {
   auto monitor = response.mutable_usage_monitors()->Add();
   std::vector<EventTrigger> event_triggers{EventTrigger::REVALIDATION_TIMEOUT};
   create_monitor_update_response(
-      imsi, mkey, MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor);
+      IMSI1, mkey, MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor);
 
   response.add_event_triggers(EventTrigger::REVALIDATION_TIMEOUT);
   response.mutable_revalidation_time()->set_seconds(time(NULL));
@@ -1757,16 +1704,16 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_init) {
   response.mutable_static_rules()->Add()->CopyFrom(static_rule_install);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
   bool success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
   // schedule_revalidation puts two things on the event loop
   // updates the session's state with revalidation_requested_ set to true
   evb->loopOnce();
   evb->loopOnce();
   auto update = SessionStore::get_default_session_update(session_map);
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto updates = local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(updates.usage_monitors_size(), 1);
@@ -1779,28 +1726,26 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_rar) {
   std::vector<std::string> rules_to_install;
   std::vector<EventTrigger> event_triggers{EventTrigger::REVALIDATION_TIMEOUT};
 
-  const std::string imsi       = "IMSI1";
-  const std::string session_id = "1234";
-  const std::string mkey       = "m1";
+  const std::string mkey = "m1";
   rules_to_install.push_back("rule1");
   insert_static_rule(1, mkey, "rule1");
 
   // Create a CreateSessionResponse with one Gx monitor, PCC rule
-  create_session_create_response(imsi, mkey, rules_to_install, &response);
+  create_session_create_response(IMSI1, mkey, rules_to_install, &response);
 
   local_enforcer->init_session_credit(
-      session_map, imsi, session_id, test_cfg_, response);
-  EXPECT_EQ(session_map[imsi].size(), 1);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
 
   // Write and read into session store, assert success
   bool success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
 
   // Create a RaR with a REVALIDATION event trigger
   create_policy_reauth_request(
-      session_id, imsi, {}, {}, {}, event_triggers, time(NULL), {}, &rar);
+      SESSION_ID_1, IMSI1, {}, {}, {}, event_triggers, time(NULL), {}, &rar);
 
   auto update = SessionStore::get_default_session_update(session_map);
   // This should trigger a revalidation to be scheduled
@@ -1814,7 +1759,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_rar) {
   // updates the session's state with revalidation_requested_ set to true
   evb->loopOnce();
   evb->loopOnce();
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto updates = local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(updates.usage_monitors_size(), 1);
@@ -1830,49 +1775,43 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   rules_to_install.push_back("rule1");
   insert_static_rule(1, mkey1, "rule1");
 
-  // create two sessions
-  const std::string imsi1       = "IMSI1";
-  const std::string session_id1 = "1234";
-  const std::string imsi2       = "IMSI2";
-  const std::string session_id2 = "5678";
-
   // Create a CreateSessionResponse with one Gx monitor, PCC rule
   create_session_create_response(
-      imsi1, mkey1, rules_to_install, &create_response);
+      IMSI1, mkey1, rules_to_install, &create_response);
   local_enforcer->init_session_credit(
-      session_map, imsi1, session_id1, test_cfg_, create_response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, create_response);
 
   create_response.Clear();
   create_session_create_response(
-      imsi2, mkey1, rules_to_install, &create_response);
+      IMSI2, mkey1, rules_to_install, &create_response);
   local_enforcer->init_session_credit(
-      session_map, imsi2, session_id2, test_cfg_, create_response);
+      session_map, IMSI2, SESSION_ID_2, test_cfg_, create_response);
 
   // Write and read into session store, assert success
   bool success =
-      session_store->create_sessions(imsi1, std::move(session_map[imsi1]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
   success =
-      session_store->create_sessions(imsi2, std::move(session_map[imsi2]));
+      session_store->create_sessions(IMSI2, std::move(session_map[IMSI2]));
   EXPECT_TRUE(success);
-  session_map = session_store->read_sessions(SessionRead{imsi1, imsi2});
-  EXPECT_EQ(session_map[imsi1].size(), 1);
-  EXPECT_EQ(session_map[imsi2].size(), 1);
+  session_map = session_store->read_sessions(SessionRead{IMSI1, IMSI2});
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  EXPECT_EQ(session_map[IMSI2].size(), 1);
 
   auto revalidation_timer = time(NULL);
   // IMSI1 has two separate monitors with the same revalidation timer
   // IMSI2 does not have a revalidation timer
   auto monitor = update_response.mutable_usage_monitor_responses()->Add();
   create_monitor_update_response(
-      imsi1, mkey1, MonitoringLevel::PCC_RULE_LEVEL, 1024, event_triggers,
+      IMSI1, mkey1, MonitoringLevel::PCC_RULE_LEVEL, 1024, event_triggers,
       revalidation_timer, monitor);
   monitor = update_response.mutable_usage_monitor_responses()->Add();
   create_monitor_update_response(
-      imsi1, mkey2, MonitoringLevel::PCC_RULE_LEVEL, 1024, event_triggers,
+      IMSI1, mkey2, MonitoringLevel::PCC_RULE_LEVEL, 1024, event_triggers,
       revalidation_timer, monitor);
   monitor = update_response.mutable_usage_monitor_responses()->Add();
   create_monitor_update_response(
-      imsi1, mkey1, MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor);
+      IMSI1, mkey1, MonitoringLevel::PCC_RULE_LEVEL, 1024, monitor);
   auto update = SessionStore::get_default_session_update(session_map);
   // This should trigger a revalidation to be scheduled
   local_enforcer->update_session_credits_and_rules(
@@ -1886,7 +1825,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update) {
   evb->loopOnce();
   evb->loopOnce();
 
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto updates = local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(updates.usage_monitors_size(), 1);
@@ -1900,30 +1839,26 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update_no_monitor) {
   rule_install.set_rule_id("rule1");
   insert_static_rule(1, "m1", "rule1");
 
-  // create one sessions
-  const std::string imsi1       = "IMSI1";
-  const std::string session_id1 = "1234";
-
   // Create a CreateSessionResponse with Revalidation Timeout, PCC rule
   auto res = create_response.mutable_usage_monitors()->Add();
   res->set_success(true);
-  res->set_sid(imsi1);
+  res->set_sid(IMSI1);
   create_response.mutable_static_rules()->Add()->CopyFrom(rule_install);
   local_enforcer->init_session_credit(
-      session_map, imsi1, session_id1, test_cfg_, create_response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, create_response);
 
   // Write and read into session store, assert success
   bool success =
-      session_store->create_sessions(imsi1, std::move(session_map[imsi1]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(success);
 
-  session_map = session_store->read_sessions(SessionRead{imsi1});
-  EXPECT_EQ(session_map[imsi1].size(), 1);
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
 
   // IMSI1 has no monitor credit and a revalidation timeout
   auto monitor = update_response.mutable_usage_monitor_responses()->Add();
   monitor->set_success(true);
-  monitor->set_sid(imsi1);
+  monitor->set_sid(IMSI1);
   monitor->add_event_triggers(EventTrigger::REVALIDATION_TIMEOUT);
   monitor->mutable_revalidation_time()->set_seconds(time(NULL));
   auto update = SessionStore::get_default_session_update(session_map);
@@ -1939,7 +1874,7 @@ TEST_F(LocalEnforcerTest, test_revalidation_timer_on_update_no_monitor) {
   evb->loopOnce();
   evb->loopOnce();
 
-  session_map = session_store->read_sessions(SessionRead{"IMSI1"});
+  session_map = session_store->read_sessions(SessionRead{IMSI1});
   std::vector<std::unique_ptr<ServiceAction>> actions;
   auto updates = local_enforcer->collect_updates(session_map, actions, update);
   EXPECT_EQ(updates.usage_monitors_size(), 1);
@@ -1951,7 +1886,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
 
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   auto epoch        = 145;
   auto dynamic_rule = response.mutable_dynamic_rules()->Add();
   auto policy_rule  = dynamic_rule->mutable_policy_rule();
@@ -1962,16 +1897,15 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
   static_rule->set_rule_id("rule2");
   SessionConfig test_cwf_cfg1;
   test_cwf_cfg1.common_context = build_common_context(
-      "IMSI1", "127.0.0.1", "01-a1-20-c2-0f-bb:CWC_OFFLOAD", "msisdn1",
-      TGPP_WLAN);
+      IMSI1, IP1, "01-a1-20-c2-0f-bb:CWC_OFFLOAD", "msisdn1", TGPP_WLAN);
   const auto& wlan = build_wlan_context("11:22:00:00:22:11", "5555");
   test_cwf_cfg1.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cwf_cfg1, response);
+      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg1, response);
 
   CreateSessionResponse response2;
   create_credit_update_response(
-      "IMSI2", 1, 2048, response2.mutable_credits()->Add());
+      IMSI2, 1, 2048, response2.mutable_credits()->Add());
   auto dynamic_rule2 = response2.mutable_dynamic_rules()->Add();
   auto policy_rule2  = dynamic_rule2->mutable_policy_rule();
   policy_rule2->set_id("rule22");
@@ -1979,14 +1913,14 @@ TEST_F(LocalEnforcerTest, test_pipelined_cwf_setup) {
   policy_rule2->set_tracking_type(PolicyRule::ONLY_OCS);
   SessionConfig test_cwf_cfg2;
   test_cwf_cfg2.common_context = build_common_context(
-      "IMSI2", "127.0.0.1", "03-21-00-02-00-20:Magma", "msisdn2", TGPP_WLAN);
+      IMSI2, IP1, "03-21-00-02-00-20:Magma", "msisdn2", TGPP_WLAN);
   const auto& wlan2 = build_wlan_context("00:00:00:00:00:02", "5555");
   test_cwf_cfg2.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan2);
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "12345", test_cwf_cfg2, response2);
+      session_map, IMSI2, "12345", test_cwf_cfg2, response2);
 
-  std::vector<std::string> imsi_list       = {"IMSI2", "IMSI1"};
-  std::vector<std::string> ip_address_list = {"127.0.0.1", "127.0.0.1"};
+  std::vector<std::string> imsi_list                      = {IMSI2, IMSI1};
+  std::vector<std::string> ip_address_list                = {IP1, IP1};
   std::vector<std::vector<std::string>> static_rule_list  = {{}, {"rule2"}};
   std::vector<std::vector<std::string>> dynamic_rule_list = {
       {"rule22"}, {"rule1"}};
@@ -2017,7 +1951,7 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
 
   CreateSessionResponse response;
   create_credit_update_response(
-      "IMSI1", 1, 1024, response.mutable_credits()->Add());
+      IMSI1, 1, 1024, response.mutable_credits()->Add());
   auto epoch        = 145;
   auto dynamic_rule = response.mutable_dynamic_rules()->Add();
   auto policy_rule  = dynamic_rule->mutable_policy_rule();
@@ -2027,21 +1961,21 @@ TEST_F(LocalEnforcerTest, test_pipelined_lte_setup) {
   auto static_rule = response.mutable_static_rules()->Add();
   static_rule->set_rule_id("rule2");
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cfg_, response);
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
   CreateSessionResponse response2;
   create_credit_update_response(
-      "IMSI2", 1, 2048, response2.mutable_credits()->Add());
+      IMSI2, 1, 2048, response2.mutable_credits()->Add());
   auto dynamic_rule2 = response2.mutable_dynamic_rules()->Add();
   auto policy_rule2  = dynamic_rule2->mutable_policy_rule();
   policy_rule2->set_id("rule22");
   policy_rule2->set_rating_group(1);
   policy_rule2->set_tracking_type(PolicyRule::ONLY_OCS);
   local_enforcer->init_session_credit(
-      session_map, "IMSI2", "12345", test_cfg_, response2);
+      session_map, IMSI2, "12345", test_cfg_, response2);
 
-  std::vector<std::string> imsi_list       = {"IMSI2", "IMSI1"};
-  std::vector<std::string> ip_address_list = {"127.0.0.1", "127.0.0.1"};
+  std::vector<std::string> imsi_list                      = {IMSI2, IMSI1};
+  std::vector<std::string> ip_address_list                = {IP1, IP1};
   std::vector<std::vector<std::string>> static_rule_list  = {{}, {"rule2"}};
   std::vector<std::vector<std::string>> dynamic_rule_list = {
       {"rule22"}, {"rule1"}};
@@ -2073,30 +2007,28 @@ TEST_F(LocalEnforcerTest, test_valid_apn_parsing) {
       SessionStore::get_default_session_update(session_map);
 
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, 1024, credits->Add());
+  create_credit_update_response(IMSI1, 1, 1024, credits->Add());
 
   auto apn               = "03-21-00-02-00-20:Magma";
-  auto mac_addr          = "00:00:00:00:00:02";
-  auto radius_session_id = "5555";
   SessionConfig test_cwf_cfg;
   test_cwf_cfg.common_context =
-      build_common_context("IMSI1", "", apn, "msisdn", TGPP_WLAN);
-  const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+      build_common_context(IMSI1, "", apn, MSISDN, TGPP_WLAN);
+  const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cwf_cfg, response);
+      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
 
-  std::vector<std::string> ue_mac_addrs  = {"00:00:00:00:00:02"};
-  std::vector<std::string> msisdns       = {"msisdn"};
+  std::vector<std::string> ue_mac_addrs  = {MAC_ADDR};
+  std::vector<std::string> msisdns       = {MSISDN};
   std::vector<std::string> apn_mac_addrs = {"03-21-00-02-00-20"};
   std::vector<std::string> apn_names     = {"Magma"};
 
   EXPECT_CALL(
-      *pipelined_client, setup_cwf(
-                             testing::_, testing::_, ue_mac_addrs, msisdns,
-                             apn_mac_addrs, apn_names, testing::_, epoch,
-                             testing::_))
+      *pipelined_client,
+      setup_cwf(
+          testing::_, testing::_, ue_mac_addrs, msisdns, apn_mac_addrs,
+          apn_names, testing::_, epoch, testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 
@@ -2112,22 +2044,20 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
       SessionStore::get_default_session_update(session_map);
 
   auto credits = response.mutable_credits();
-  create_credit_update_response("IMSI1", 1, 1024, credits->Add());
+  create_credit_update_response(IMSI1, 1, 1024, credits->Add());
 
   auto apn               = "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay";
-  auto mac_addr          = "00:00:00:00:00:02";
-  auto radius_session_id = "5555";
   SessionConfig test_cwf_cfg;
   test_cwf_cfg.common_context =
-      build_common_context("IMSI1", "127.0.0.1", apn, "msisdn", TGPP_WLAN);
-  const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+      build_common_context(IMSI1, IP1, apn, MSISDN, TGPP_WLAN);
+  const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   test_cwf_cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
   local_enforcer->init_session_credit(
-      session_map, "IMSI1", "1234", test_cwf_cfg, response);
+      session_map, IMSI1, SESSION_ID_1, test_cwf_cfg, response);
 
-  std::vector<std::string> ue_mac_addrs  = {"00:00:00:00:00:02"};
-  std::vector<std::string> msisdns       = {"msisdn"};
+  std::vector<std::string> ue_mac_addrs  = {MAC_ADDR};
+  std::vector<std::string> msisdns       = {MSISDN};
   std::vector<std::string> apn_mac_addrs = {""};
   std::vector<std::string> apn_names     = {
       "03-0BLAHBLAH0-00-02-00-20:ThisIsNotOkay"};


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
**4** things are covered in this PR:
  1. **Logic refactor on the session termination flow**
This change was brought up because I was noticing this log all the time when observing SessionD logs. `[IMSI] Forcefully terminating session since it did not receive usage from pipelined in time`.  I initially thought there was a bug somewhere that was causing sessions to be terminated forcefully all the time. (As opposed to terminating itself after PipelineD's enforcement stats were cleared.) But it turns out the logs were inaccurate. 
This log comes from `SessionState`'s `complete_termination`, which is used in both force termination and regular termination. So the fix here is to update the logs to reflect the behavior.
Finally, while I was looking at the function, I noticed that `LocalEnforcer` passes the `SessionReporter` into the function, which is a bit of an anti-pattern since we do all reporting from either `LocalSessionManagerHandler` or `LocalEnforcer`. So I moved out the logic to `LocalEnforcer`.
  2. **Some cosmetic changes to rename variable `update_criteria` -> `uc`**
  3. **Light refactor to remove unused parameters/return values from LocalEnforcer**
There are to main changes. Many of the LocalEnforcer functions had 'session_map' as a parameter when it is not used at all. (This is probably left over from legacy code). Second, `PipelineDClient` always returns true as a result of making an asynchronous call, so there is no value in casing on its return value. 
 4. **test_local_enforcer clean up + deprecate test-only methods**
Remove `LocalEnforcer`'s `get_charging_credit` and `get_monitor_credit` since they are only used for testing. The functions also just have a questionable way to go from IMSI, bucket -> value. (Sessions are unique by IMSI+SessionID, not just IMSI). Instead, `assert_charging_credit` and `assert_monitor_credit` are used in `test_local_enforcer.cpp`. Additionally, instead of having hardcoded imsi/sessionID test values, migrate to a model where we use a predefined set of values.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests, s1ap test (ran it locally it passed)
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
