### PR TITLE
[xwfm][ci] copy xwfm docker config files from orc8r and cwf

### DIFF
--- a/xwf/gateway/integ_tests/gw/Dockerfile
+++ b/xwf/gateway/integ_tests/gw/Dockerfile
@@ -26,6 +26,8 @@ COPY xwf/gateway/deploy ./xwf/gateway/deploy
 RUN ANSANSIBLE_CONFIG=xwf/gateway/ansible.cfg ansible-playbook xwf/gateway/deploy/xwf.yml -i "localhost," -c local --tags "install" -v
 
 COPY xwf ./xwf
+COPY orc8r ./orc8r
+COPY cwf ./cwf
 
 # Create snowflake to be mounted into containers
 RUN touch /etc/snowflake

--- a/xwf/gateway/integ_tests/gw/entrypoint.sh
+++ b/xwf/gateway/integ_tests/gw/entrypoint.sh
@@ -15,7 +15,9 @@ ovsdb-server --pidfile /etc/openvswitch/conf.db -vconsole:emer -vsyslog:err -vfi
 # Copy files to /etc/magma it must be here and not in dockerfile because the volume
 # are shared and may be taint on the local host
 echo "copy config file"
+cp cwf/gateway/configs/* /etc/magma/
 cp xwf/gateway/configs/* /etc/magma/
+cp orc8r/gateway/configs/templates/* /etc/magma/
 
 echo "get xwfwhoami"
 curl -X POST  https://graph.expresswifi.com/openflow/configxwfm?access_token=$ACCESSTOKEN | jq -r .configxwfm > /etc/xwfwhoami


### PR DESCRIPTION
Signed-off-by: aharonnovo <aharonnovo@gmail.com>

[xwfm][ci] 

## Summary

Fixing the CI - copy xwfm docker config files from orc8r and cwf. There is probably some config file missing in xwfm configuration file. Fixing it now by copy configuration from other places, will look into it later.

## Test Plan

check the result on CircleCI machine

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
