### PR TITLE
pipelineD: add config for default uplink internet GW mac address

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -145,3 +145,4 @@ ovs_uplink_port_name: patch-up
 virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
 uplink_eth_port_name: uplink_p0
+uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -138,3 +138,4 @@ ovs_uplink_port_name: patch-up
 virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
 uplink_eth_port_name: eth0
+uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
@@ -53,4 +53,8 @@ if [[ ! -z $existing_br ]]; then
 	ovs-vsctl del-port "$existing_br" "$prefix"_port
 fi
 
-ovs-vsctl --may-exist add-port "$br_name" "$prefix"_port tag="$tag"
+ovs-vsctl --may-exist add-port "$br_name" "$prefix"_port
+if [[ "$tag" -ne "0" ]]
+then
+	ovs-vsctl set port "$prefix"_port tag="$tag"
+fi

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -60,7 +60,7 @@ class InOutController(MagmaController):
         'InOutConfig',
         ['gtp_port', 'uplink_port_name', 'mtr_ip', 'mtr_port', 'li_port_name',
          'enable_nat', 'non_mat_gw_probe_frequency', 'non_nat_arp_egress_port',
-         'setup_type'],
+         'setup_type', 'uplink_gw_mac'],
     )
     ARP_PROBE_FREQUENCY = 300
     NON_NAT_ARP_EGRESS_PORT = 'uplink_br0'
@@ -113,7 +113,8 @@ class InOutController(MagmaController):
                                                 self.ARP_PROBE_FREQUENCY)
         non_nat_arp_egress_port = config_dict.get('non_nat_arp_egress_port',
                                                   self.NON_NAT_ARP_EGRESS_PORT)
-
+        uplink_gw_mac = config_dict.get('uplink_gw_mac',
+                                        "ff:ff:ff:ff:ff:ff")
         return self.InOutConfig(
             gtp_port=config_dict['ovs_gtp_port_number'],
             uplink_port_name=port_name,
@@ -123,7 +124,8 @@ class InOutController(MagmaController):
             enable_nat=enable_nat,
             non_mat_gw_probe_frequency=non_mat_gw_probe_freq,
             non_nat_arp_egress_port=non_nat_arp_egress_port,
-            setup_type=setup_type)
+            setup_type=setup_type,
+            uplink_gw_mac=uplink_gw_mac)
 
     def initialize_on_connect(self, datapath):
         self.delete_all_flows(datapath)
@@ -203,7 +205,7 @@ class InOutController(MagmaController):
         if mac_addr == "":
             mac_addr = self._current_upstream_mac_map.get(vlan, "")
         if mac_addr == "" and self.config.enable_nat is False:
-            mac_addr = "ff:ff:ff:ff:ff:ff"
+            mac_addr = self.config.uplink_gw_mac
 
         if mac_addr != "":
             parser = dp.ofproto_parser

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,6 @@
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:11:22:33:44:55:66->eth_dst,LOCAL

--- a/lte/gateway/python/magma/pipelined/tests/test_inout.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout.py
@@ -67,6 +67,7 @@ class InOutTest(unittest.TestCase):
                 'ovs_gtp_port_number': 32768,
                 'clean_restart': True,
                 'enable_nat': True,
+                'uplink_gw_mac': '11:22:33:44:55:66'
             },
             mconfig=None,
             loop=None,

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -32,7 +32,8 @@ from magma.pipelined.tests.pipelined_test_util import (
     start_ryu_app_thread,
     stop_ryu_app_thread,
     create_service_manager,
-    SnapshotVerifier
+    SnapshotVerifier,
+    assert_bridge_snapshot_match,
 )
 
 from magma.pipelined.app import inout
@@ -100,7 +101,8 @@ class InOutNonNatTest(unittest.TestCase):
         subprocess.check_call([setup_vlan_switch, cls.UPLINK_VLAN_SW, vlan])
 
     def setUpNetworkAndController(self, vlan: str = "",
-                                  non_nat_arp_egress_port: str = None):
+                                  non_nat_arp_egress_port: str = None,
+                                  gw_mac_addr="ff:ff:ff:ff:ff:ff"):
         """
         Starts the thread which launches ryu apps
 
@@ -152,7 +154,8 @@ class InOutNonNatTest(unittest.TestCase):
                 'enable_nat': False,
                 'non_mat_gw_probe_frequency': .2,
                 'non_nat_arp_egress_port': non_nat_arp_egress_port,
-                'ovs_uplink_port_name': 'patch-up'
+                'ovs_uplink_port_name': 'patch-up',
+                'uplink_gw_mac': gw_mac_addr
             },
             mconfig=None,
             loop=None,
@@ -177,7 +180,8 @@ class InOutNonNatTest(unittest.TestCase):
 
     def testFlowSnapshotMatch(self):
         cls = self.__class__
-        self.setUpNetworkAndController(non_nat_arp_egress_port=cls.UPLINK_BR)
+        self.setUpNetworkAndController(non_nat_arp_egress_port=cls.UPLINK_BR,
+                                       gw_mac_addr="33:44:55:ff:ff:ff")
         # wait for atleast one iteration of the ARP probe.
 
         ip_addr = ipaddress.ip_address("192.168.128.211")
@@ -324,6 +328,67 @@ class InOutNonNatTest(unittest.TestCase):
         self.assertEqual(gw_info_map[vlan1].mac, '11:33:44:55:66:77')
         self.assertEqual(gw_info_map[vlan2].mac, '22:33:44:55:66:77')
         self.assertEqual(gw_info_map[""].mac, '00:33:44:55:66:77')
+
+class InOutTestNonNATBasicFlows(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(InOutTestNonNATBasicFlows, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        inout_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.InOut,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.InOut:
+                    inout_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': False,
+                'uplink_gw_mac': '11:22:33:44:55:66'
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.inout_controller = inout_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+
+    def testFlowSnapshotMatch(self):
+        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

This would be useful in Non NAT setup when ARP for
upstream internet GW is not configured
Signed-off-by: Pravin B Shelar <pbshelar@fb.com>



<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test_python`

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
