### PR TITLE
[pipelined] fix gy rules activation during redirection

### DIFF
--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -185,7 +185,7 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             self._service_manager.session_rule_version_mapper.update_version(
                 request.sid.id, rule.id)
 
-        res = self._activate_rules_in_gy(request.sid.id, request.ip_addr,
+        res = self._activate_rules_in_gy(request.sid.id, request.ip_addr, request.apn_ambr,
             request.rule_ids, request.dynamic_rules)
 
         fut.set_result(res)
@@ -218,10 +218,11 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
         return enforcement_res
 
     def _activate_rules_in_gy(self, imsi: str, ip_addr: str,
+                              apn_ambr: AggregatedMaximumBitrate,
                               static_rule_ids: List[str],
                               dynamic_rules: List[PolicyRule]
                               ) -> ActivateFlowsResult:
-        gy_res = self._gy_app.activate_rules(imsi, ip_addr, static_rule_ids,
+        gy_res = self._gy_app.activate_rules(imsi, ip_addr, apn_ambr, static_rule_ids,
                                              dynamic_rules)
         # TODO: add metrics
         return gy_res


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

ERROR:asyncio:Exception in callback PipelinedRpcServicer._activate_flows_gy(sid {
  id: "...
  type: GY
}
, <Future at 0x...state=pending>)
handle: <Handle PipelinedRpcServicer._activate_flows_gy(sid {
  id: "...
  type: GY
}
, <Future at 0x...state=pending>)>
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/events.py", line 127, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.5/dist-packages/magma/pipelined/rpc_servicer.py", line 189, in _activate_flows_gy
    request.rule_ids, request.dynamic_rules)
  File "/usr/local/lib/python3.5/dist-packages/magma/pipelined/rpc_servicer.py", line 225, in _activate_rules_in_gy
    dynamic_rules)
TypeError: activate_rules() missing 1 required positional argument: 'dynamic_rules'
DEBUG:root:Activating GY flows for IMSI184871355299879
ERROR:asyncio:Exception in callback PipelinedRpcServicer._activate_flows_gy(sid {
  id: "...
  type: GY
}
, <Future at 0x...state=pending>)
handle: <Handle PipelinedRpcServicer._activate_flows_gy(sid {
  id: "...
  type: GY
}
, <Future at 0x...state=pending>)>
Traceback (most recent call last):
  File "/usr/lib/python3.5/asyncio/events.py", line 127, in _run
    self._callback(*self._args)
  File "/usr/local/lib/python3.5/dist-packages/magma/pipelined/rpc_servicer.py", line 189, in _activate_flows_gy
    request.rule_ids, request.dynamic_rules)
  File "/usr/local/lib/python3.5/dist-packages/magma/pipelined/rpc_servicer.py", line 225, in _activate_rules_in_gy
    dynamic_rules)

## Test Plan

integration tests and unit tests