### PR TITLE
[AGW] mobilityD: plug in multi apn allocator

### DIFF
--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -109,8 +109,8 @@ static itti_sgi_create_end_point_response_t handle_allocate_ipv4_address_status(
     sgi_create_endpoint_resp.paa.pdn_type     = IPv4;
     sgi_create_endpoint_resp.paa.vlan         = vlan;
     OAILOG_DEBUG(
-        LOG_UTIL, "Allocated IPv4 address for imsi <%s>, apn <%s>\n", imsi,
-        apn);
+        LOG_UTIL, "Allocated IPv4 address for imsi <%s>, apn <%s> vlan %d\n", imsi,
+        apn, vlan);
     sgi_create_endpoint_resp.status = SGI_STATUS_OK;
   } else {
     if (status.error_code() == RPC_STATUS_ALREADY_EXISTS) {

--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -5,7 +5,8 @@
       "logLevel": "INFO",
       "ipBlock": "192.168.128.0/24",
       "ip_allocator_type": "IP_POOL",
-      "static_ip_enabled": true
+      "static_ip_enabled": true,
+      "multi_apn_ip_alloc": true
     },
     "mme": {
       "@type": "type.googleapis.com/magma.mconfig.MME",

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -136,14 +136,15 @@ class IPAddressManager:
         persist_to_redis = config.get('persist_to_redis', True)
         redis_port = config.get('redis_port', 6379)
 
-        self.multi_apn = config.get('multi_apn', False)
+        self.multi_apn = config.get('multi_apn', mconfig.multi_apn_ip_alloc)
+        self.static_ip_enabled = config.get('static_ip', mconfig.static_ip_enabled)
+
         self.allocator_type = mconfig.ip_allocator_type
         logging.debug('Persist to Redis: %s', persist_to_redis)
         self._lock = threading.RLock()  # re-entrant locks
 
         self._recycle_timer = None  # reference to recycle timer
         self._recycling_interval_seconds = recycling_interval
-        self.static_ip_enabled = mconfig.static_ip_enabled
 
         if not persist_to_redis:
             self._assigned_ip_blocks = set()  # {ip_block}
@@ -161,8 +162,10 @@ class IPAddressManager:
             self._dhcp_store = store.MacToIP()  # mac => DHCP_State
 
         self.ip_state_map = IpDescriptorMap(persist_to_redis, redis_port)
-        logging.info("Using allocator: %s static ip: %s",
-                     self.allocator_type, self.static_ip_enabled)
+        logging.info("Using allocator: %s static ip: %s multi_apn %s",
+                     self.allocator_type,
+                     self.static_ip_enabled,
+                     self.multi_apn)
 
         if self.allocator_type == MobilityD.IP_POOL:
             self._dhcp_gw_info.read_default_gw()
@@ -266,7 +269,7 @@ class IPAddressManager:
             res = self.ip_allocator.list_allocated_ips(ipblock)
         return res
 
-    def alloc_ip_address(self, sid: str) -> ip_address:
+    def alloc_ip_address(self, sid: str) -> Tuple[ip_address, int]:
         """ Allocate an IP address from the free list
 
         Assumption: one-to-one mappings between SID and IP.
@@ -319,7 +322,7 @@ class IPAddressManager:
                 logging.info("Allocating the same IP %s for sid %s",
                              old_ip_desc.ip, sid)
                 IP_ALLOCATED_TOTAL.inc()
-                return old_ip_desc.ip
+                return old_ip_desc.ip, old_ip_desc.vlan_id
 
             # Now try to allocate it from underlying allocator.
             ip_desc = self.ip_allocator.alloc_ip_address(sid, 0)
@@ -327,7 +330,7 @@ class IPAddressManager:
             self.sid_ips_map[sid] = ip_desc
 
             IP_ALLOCATED_TOTAL.inc()
-            return ip_desc.ip
+            return ip_desc.ip, ip_desc.vlan_id
 
     def get_sid_ip_table(self) -> List[Tuple[str, ip_address]]:
         """ Return list of tuples (sid, ip) """

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -169,12 +169,13 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 if request.apn:
                     composite_sid = composite_sid + "." + request.apn
 
-                ip = self._ipv4_allocator.alloc_ip_address(composite_sid)
+                ip, vlan = self._ipv4_allocator.alloc_ip_address(composite_sid)
                 logging.info("Allocated IPv4 %s for sid %s for apn %s"
                              % (ip, SIDUtils.to_str(request.sid), request.apn))
                 ip_addr.version = IPAddress.IPV4
                 ip_addr.address = ip.packed
-                return AllocateIPAddressResponse(ip_addr=ip_addr)
+                return AllocateIPAddressResponse(ip_addr=ip_addr,
+                                                 vlan=str(vlan))
             except NoAvailableIPError:
                 context.set_details('No free IPv4 IP available')
                 context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)

--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -80,7 +80,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
     @unittest.skipIf(os.getuid(), reason="needs root user")
     def test_ip_alloc(self):
         sid1 = "IMSI02917"
-        ip1 = self._dhcp_allocator.alloc_ip_address(sid1)
+        ip1, _ = self._dhcp_allocator.alloc_ip_address(sid1)
         threading.Event().wait(2)
         dhcp_gw_info = self._dhcp_allocator._dhcp_gw_info
         dhcp_store = self._dhcp_allocator._dhcp_store
@@ -95,7 +95,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
 
         self.assertEqual(dhcp_state1.state_requested, DHCPState.RELEASE)
 
-        ip1_1 = self._dhcp_allocator.alloc_ip_address(sid1)
+        ip1_1, _ = self._dhcp_allocator.alloc_ip_address(sid1)
         threading.Event().wait(2)
         self.assertEqual(str(ip1), str(ip1_1))
 
@@ -103,15 +103,15 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         threading.Event().wait(5)
         self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(), [])
 
-        ip1 = self._dhcp_allocator.alloc_ip_address("IMSI02918")
+        ip1, _ = self._dhcp_allocator.alloc_ip_address("IMSI02918")
         self.assertEqual(str(ip1), "192.168.128.146")
         self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(),
                          [ip_network('192.168.128.0/24')])
 
-        ip2 = self._dhcp_allocator.alloc_ip_address("IMSI029192")
+        ip2, _ = self._dhcp_allocator.alloc_ip_address("IMSI029192")
         self.assertNotEqual(ip1, ip2)
 
-        ip3 = self._dhcp_allocator.alloc_ip_address("IMSI0432")
+        ip3, _ = self._dhcp_allocator.alloc_ip_address("IMSI0432")
         self.assertNotEqual(ip1, ip3)
         self.assertNotEqual(ip2, ip3)
         # release unallocated IP of SID
@@ -123,7 +123,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
                          [ip_network('192.168.128.0/24')])
 
         sid4 = "IMSI54321"
-        ip4 = self._dhcp_allocator.alloc_ip_address(sid4)
+        ip4, _ = self._dhcp_allocator.alloc_ip_address(sid4)
         threading.Event().wait(1)
         self._dhcp_allocator.release_ip_address(sid4, ip4)
         self.assertEqual(self._dhcp_allocator.list_added_ip_blocks(),
@@ -135,7 +135,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         dhcp_state = dhcp_store.get(mac4.as_redis_key(None))
 
         self.assertEqual(dhcp_state.state_requested, DHCPState.RELEASE)
-        ip4_2 = self._dhcp_allocator.alloc_ip_address(sid4)
+        ip4_2, _ = self._dhcp_allocator.alloc_ip_address(sid4)
         self.assertEqual(ip4, ip4_2)
 
         try:

--- a/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_allocator_tests.py
@@ -85,12 +85,12 @@ class IPAllocatorTests(unittest.TestCase):
 
     def test_alloc_ip_address(self):
         """ test alloc_ip_address """
-        ip0 = self._allocator.alloc_ip_address('SID0')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
         self.assertTrue(ip0 in [self._ip0, self._ip1, self._ip2])
         self.assertTrue(ip0 in self._allocator.list_allocated_ips(self._block))
         self.assertEqual(self._allocator.get_sid_ip_table(), [('SID0', ip0)])
 
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
         self.assertTrue(ip1 in [self._ip0, self._ip1, self._ip2])
         self.assertNotEqual(ip1, ip0)
         self.assertEqual({ip0, ip1},
@@ -98,7 +98,7 @@ class IPAllocatorTests(unittest.TestCase):
         self.assertEqual(set(self._allocator.get_sid_ip_table()),
                          {('SID0', ip0), ('SID1', ip1)})
 
-        ip2 = self._allocator.alloc_ip_address('SID2')
+        ip2, _ = self._allocator.alloc_ip_address('SID2')
         self.assertTrue(ip2 in [self._ip0, self._ip1, self._ip2])
         self.assertNotEqual(ip2, ip0)
         self.assertNotEqual(ip2, ip1)
@@ -113,9 +113,9 @@ class IPAllocatorTests(unittest.TestCase):
 
     def test_release_ip_address(self):
         """ test release_ip_address """
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
-        ip2 = self._allocator.alloc_ip_address('SID2')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
+        ip2, _ = self._allocator.alloc_ip_address('SID2')
 
         # release ip
         self._allocator.release_ip_address('SID0', ip0)
@@ -140,8 +140,8 @@ class IPAllocatorTests(unittest.TestCase):
 
     def test_get_ip_for_subscriber(self):
         """ test get_ip_for_sid """
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         ip0_returned = self._allocator.get_ip_for_sid('SID0')
         ip1_returned = self._allocator.get_ip_for_sid('SID1')
@@ -156,8 +156,8 @@ class IPAllocatorTests(unittest.TestCase):
 
     def test_get_sid_for_ip(self):
         """ test get_sid_for_ip """
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         sid0_returned = self._allocator.get_sid_for_ip(ip0)
         sid1_returned = self._allocator.get_sid_for_ip(ip1)
@@ -172,40 +172,40 @@ class IPAllocatorTests(unittest.TestCase):
 
     def test_allocate_allocate(self):
         """ Duplicated IP requests for the same UE returns same IP """
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID0')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID0')
         self.assertEqual(ip0, ip1)
 
     def test_allocated_release_allocate(self):
         """ Immediate allocation after releasing get the same IP """
-        ip0 = self._allocator.alloc_ip_address('SID0')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
         self._allocator.release_ip_address('SID0', ip0)
-        ip2 = self._allocator.alloc_ip_address('SID0')
+        ip2, _ = self._allocator.alloc_ip_address('SID0')
         self.assertEqual(ip0, ip2)
 
     def test_allocate_release_recycle_allocate(self):
         """ Allocation after recycling should get different IPs """
-        ip0 = self._allocator.alloc_ip_address('SID0')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
         self._allocator.release_ip_address('SID0', ip0)
 
         # Wait for auto-recycler to kick in
         time.sleep(1.2 * self.RECYCLING_INTERVAL_SECONDS)
 
-        ip1 = self._allocator.alloc_ip_address('SID1')
-        ip2 = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
+        ip2, _ = self._allocator.alloc_ip_address('SID0')
         self.assertNotEqual(ip1, ip2)
 
     def test_recycle_tombstone_ip_on_timer(self):
         """ test recycle tombstone IP on interval loop """
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
-        ip2 = self._allocator.alloc_ip_address('SID2')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
+        ip2, _ = self._allocator.alloc_ip_address('SID2')
         self._allocator.release_ip_address('SID0', ip0)
 
         # Wait for auto-recycler to kick in
         time.sleep(2 * self.RECYCLING_INTERVAL_SECONDS)
 
-        ip3 = self._allocator.alloc_ip_address('SID3')
+        ip3, _ = self._allocator.alloc_ip_address('SID3')
         self.assertEqual(ip0, ip3)
 
         self._allocator.release_ip_address('SID1', ip1)
@@ -213,7 +213,7 @@ class IPAllocatorTests(unittest.TestCase):
         # Wait for auto-recycler to kick in
         time.sleep(2 * self.RECYCLING_INTERVAL_SECONDS)
 
-        ip4 = self._allocator.alloc_ip_address('SID4')
+        ip4, _ = self._allocator.alloc_ip_address('SID4')
         self.assertEqual(ip1, ip4)
 
         self._allocator.release_ip_address('SID2', ip2)
@@ -221,12 +221,12 @@ class IPAllocatorTests(unittest.TestCase):
         # Wait for auto-recycler to kick in
         time.sleep(2 * self.RECYCLING_INTERVAL_SECONDS)
 
-        ip5 = self._allocator.alloc_ip_address('SID5')
+        ip5, _ = self._allocator.alloc_ip_address('SID5')
         self.assertEqual(ip2, ip5)
 
     def test_allocate_unrecycled_IP(self):
         """ Allocation should fail before IP recycling """
-        ip0 = self._allocator.alloc_ip_address('SID0')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
         self._allocator.alloc_ip_address('SID1')
         self._allocator.alloc_ip_address('SID2')
         self._allocator.release_ip_address('SID0', ip0)
@@ -237,19 +237,19 @@ class IPAllocatorTests(unittest.TestCase):
         """ test recycle tombstone IP """
         self._new_ip_allocator(0)
 
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
-        ip2 = self._allocator.alloc_ip_address('SID2')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
+        ip2, _ = self._allocator.alloc_ip_address('SID2')
         self._allocator.release_ip_address('SID0', ip0)
-        ip3 = self._allocator.alloc_ip_address('SID3')
+        ip3, _ = self._allocator.alloc_ip_address('SID3')
         self.assertEqual(ip0, ip3)
 
         self._allocator.release_ip_address('SID1', ip1)
-        ip4 = self._allocator.alloc_ip_address('SID4')
+        ip4, _ = self._allocator.alloc_ip_address('SID4')
         self.assertEqual(ip1, ip4)
 
         self._allocator.release_ip_address('SID2', ip2)
-        ip5 = self._allocator.alloc_ip_address('SID5')
+        ip5, _ = self._allocator.alloc_ip_address('SID5')
         self.assertEqual(ip2, ip5)
 
     def test_remove_unallocated_block(self):
@@ -279,8 +279,8 @@ class IPAllocatorTests(unittest.TestCase):
         """ removing after releasing all allocated addresses """
         self._new_ip_allocator(0)  # Immediately recycle
 
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         self.assertEqual(
             set(), self._allocator.remove_ip_blocks(self._block, force=False))
@@ -296,8 +296,8 @@ class IPAllocatorTests(unittest.TestCase):
         """ removing after releasing all allocated addresses """
         self._new_ip_allocator(0)  # Immediately recycle
 
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         self.assertEqual(
             set(), self._allocator.remove_ip_blocks(self._block, force=False))
@@ -320,15 +320,15 @@ class IPAllocatorTests(unittest.TestCase):
         recycling_interval_seconds = 1  # plenty of time to set up
         self._new_ip_allocator(recycling_interval_seconds)
 
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
         self._allocator.release_ip_address('SID0', ip0)
         self.assertEqual(
             {self._block},
             self._allocator.remove_ip_blocks(self._block, force=True))
         self._allocator.add_ip_block(self._block)
-        ip0 = self._allocator.alloc_ip_address('SID0')
-        ip1 = self._allocator.alloc_ip_address('SID1')
+        ip0, _ = self._allocator.alloc_ip_address('SID0')
+        ip1, _ = self._allocator.alloc_ip_address('SID1')
 
         # Wait for auto-recycler to kick in
         time.sleep(recycling_interval_seconds)

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -129,7 +129,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
     def test_get_ip_vlan_for_subscriber(self):
         """ test get_ip_for_sid without any assignment """
         sid = 'IMSI11'
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
 
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
@@ -146,7 +146,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         vlan = 132
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -164,7 +164,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         vlan = 188
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="xyz", ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -183,7 +183,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -206,7 +206,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=wild_assigned_ip, vlan=vlan_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -225,7 +225,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -246,7 +246,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="abc", ip=assigned_ip, vlan=vlan_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -262,7 +262,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         sid = imsi + '.' + apn
         MockedSubscriberDBStub.add_incomplete_sub(sid=imsi)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -279,7 +279,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -298,7 +298,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -321,7 +321,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=wild_assigned_ip, vlan=vlan_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -343,7 +343,7 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=wild_assigned_ip, vlan=vlan_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None, vlan=vlan)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -59,7 +59,7 @@ class StaticIPAllocationTests(unittest.TestCase):
     def test_get_ip_for_subscriber(self):
         """ test get_ip_for_sid without any assignment """
         sid = 'IMSI11'
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
 
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
@@ -75,7 +75,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -91,7 +91,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="xyz", ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -107,7 +107,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -125,7 +125,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -141,7 +141,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.hh'
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -159,7 +159,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="abc", ip=assigned_ip_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -174,7 +174,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         sid = imsi + '.' + apn
         MockedSubscriberDBStub.add_incomplete_sub(sid=imsi)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -188,7 +188,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -204,7 +204,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         assigned_ip = '1.2.3.4'
         MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -222,7 +222,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="xyz", ip=assigned_ip)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated
@@ -239,7 +239,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip_wild)
         MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn=apn, ip=None)
 
-        ip0 = self._allocator.alloc_ip_address(sid)
+        ip0, _ = self._allocator.alloc_ip_address(sid)
         ip0_returned = self._allocator.get_ip_for_sid(sid)
 
         # check if retrieved ip is the same as the one allocated


### PR DESCRIPTION
This code uses mobility config to enable multi_apn_ip_allocator.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
`make test`
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
