### PR TITLE
[AGW] mobilityd: configure internet GW addr and mac from API

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -127,7 +127,7 @@ class DHCPClient:
             self.dhcp_client_state[mac.as_redis_key(vlan)] = dhcp_desc
 
         pkt = Ether(src=str(mac), dst="ff:ff:ff:ff:ff:ff")
-        if vlan:
+        if vlan and vlan != "0":
             pkt /= Dot1Q(vlan=int(vlan))
         pkt /= IP(src="0.0.0.0", dst="255.255.255.255")
         pkt /= UDP(sport=68, dport=67)

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -184,7 +184,8 @@ class IPAddressManager:
 
         if self.static_ip_enabled:
             ip_allocator = IPAllocatorStaticWrapper(subscriberdb_rpc_stub=subscriberdb_rpc_stub,
-                                                    ip_allocator=ip_allocator)
+                                                    ip_allocator=ip_allocator,
+                                                    gw_info=self._dhcp_gw_info)
 
         if self.multi_apn:
             self.ip_allocator = IPAllocatorMultiAPNWrapper(subscriberdb_rpc_stub=subscriberdb_rpc_stub,

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -19,18 +19,21 @@ from __future__ import absolute_import, division, print_function, \
     unicode_literals
 
 from ipaddress import ip_address, ip_network
-from typing import List
+from typing import List, Optional
 
 from magma.mobilityd.ip_descriptor import IPDesc, IPState, IPType
 from magma.mobilityd.ip_allocator_base import IPAllocator
-from magma.mobilityd.subscriberdb_client import SubscriberDbClient
+from magma.mobilityd.subscriberdb_client import SubscriberDbClient, StaticIPInfo
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+import logging
 
 DEFAULT_IP_RECYCLE_INTERVAL = 15
 
 
 class IPAllocatorStaticWrapper(IPAllocator):
 
-    def __init__(self, subscriberdb_rpc_stub, ip_allocator: IPAllocator):
+    def __init__(self, subscriberdb_rpc_stub, ip_allocator: IPAllocator,
+                 gw_info: UplinkGatewayInfo):
         """ Initializes a static IP allocator
             This is wrapper around other configured Ip allocator. If subscriber
             does have static IP, it uses underlying IP allocator to allocate IP
@@ -38,6 +41,7 @@ class IPAllocatorStaticWrapper(IPAllocator):
         """
         self._subscriber_client = SubscriberDbClient(subscriberdb_rpc_stub)
         self._ip_allocator = ip_allocator
+        self._gw_info = gw_info
 
     def add_ip_block(self, ipblock: ip_network):
         """ Add a block of IP addresses to the free IP list
@@ -79,14 +83,23 @@ class IPAllocatorStaticWrapper(IPAllocator):
         if ip_desc.type != IPType.STATIC:
             self._ip_allocator.release_ip(ip_desc)
 
-    def _allocate_static_ip(self, sid: str) -> IPDesc:
+    def _allocate_static_ip(self, sid: str) -> Optional[IPDesc]:
         """
         Check if static IP allocation is enabled and then check
         subscriber DB for assigned static IP for the SID
         """
-        ip_addr = self._subscriber_client.get_subscriber_ip(sid)
-        if ip_addr is None:
+        ip_addr_info = self._subscriber_client.get_subscriber_ip(sid)
+        if ip_addr_info is None:
             return None
-        return IPDesc(ip=ip_addr, state=IPState.ALLOCATED,
-                      sid=sid, ip_block=ip_addr, ip_type=IPType.STATIC)
+        logging.debug("sid: %s ip_addr_info %s", sid, ip_addr_info)
+        # update gw info if available.
+        if ip_addr_info.gw_ip:
+            self._gw_info.update_ip(ip_addr_info.gw_ip, str(ip_addr_info.vlan))
+            # update mac if IP is present.
+            if ip_addr_info.gw_mac != "":
+                self._gw_info.update_mac(ip_addr_info.gw_ip,
+                                         ip_addr_info.gw_mac,
+                                         str(ip_addr_info.vlan))
 
+        return IPDesc(ip=ip_addr_info.ip, state=IPState.ALLOCATED,
+                      sid=sid, ip_block=ip_addr_info.ip, ip_type=IPType.STATIC)

--- a/lte/gateway/python/magma/mobilityd/ip_descriptor.py
+++ b/lte/gateway/python/magma/mobilityd/ip_descriptor.py
@@ -49,7 +49,9 @@ class IPDesc:
         self.state = state
         self.sid = sid
         self.type = ip_type
-        self.vlan_id = vlan_id
+        self.vlan_id = 0
+        if 0 < vlan_id < 4096:
+            self.vlan_id = vlan_id
 
     def __str__(self):
         as_str = '<mobilityd.IPDesc ' + \

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -14,18 +14,37 @@ limitations under the License.
 import ipaddress
 from typing import Optional
 from lte.protos.subscriberdb_pb2 import APNConfiguration
+from magma.subscriberdb.sid import SIDUtils
 
 import grpc
 import logging
 
-from magma.subscriberdb.sid import SIDUtils
+
+class StaticIPInfo:
+    """
+    Operator can configure Static GW IP and MAC.
+    This would be used by AGW services to generate networking
+    configuration.
+    """
+
+    def __init__(self, ip: str, gw_ip: str, gw_mac: str,
+                 vlan: str):
+        self.ip = ipaddress.ip_address(ip)
+        self.gw_mac = gw_mac
+        gw_ip_parsed = None
+        try:
+            gw_ip_parsed = ipaddress.ip_address(gw_ip)
+        except ValueError:
+            logging.debug("invalid internet gw ip: %s", gw_ip)
+        self.gw_ip = gw_ip_parsed
+        self.vlan = vlan
 
 
 class SubscriberDbClient:
     def __init__(self, subscriberdb_rpc_stub):
         self.subscriber_client = subscriberdb_rpc_stub
 
-    def get_subscriber_ip(self, sid: str) -> Optional[ipaddress.ip_address]:
+    def get_subscriber_ip(self, sid: str) -> Optional[StaticIPInfo]:
         """
         Make RPC call to 'GetSubscriberData' method of local SubscriberDB
         service to get assigned IP address if any.
@@ -37,18 +56,20 @@ class SubscriberDbClient:
             apn_config = self._find_ip_and_apn_config(sid)
             logging.debug("ip: Got APN: %s", apn_config)
             if apn_config:
-                return ipaddress.ip_address(apn_config.assigned_static_ip)
+                return StaticIPInfo(ip=apn_config.assigned_static_ip,
+                                    gw_ip=apn_config.resource.gateway_ip,
+                                    gw_mac=apn_config.resource.gateway_mac,
+                                    vlan=apn_config.resource.vlan_id)
 
         except ValueError:
             logging.warning("Invalid data for sid %s: ", sid)
-            return None
 
         except grpc.RpcError as err:
             logging.error(
                 "GetSubscriberData while reading static ip, error[%s] %s",
                 err.code(),
                 err.details())
-            return None
+        return None
 
     def get_subscriber_apn_vlan(self, sid: str) -> int:
         """
@@ -90,7 +111,7 @@ class SubscriberDbClient:
             for apn_config in data.non_3gpp.apn_config:
                 logging.debug("APN config: %s", apn_config)
                 if apn_config.assigned_static_ip is None or \
-                   apn_config.assigned_static_ip == "":
+                        apn_config.assigned_static_ip == "":
                     continue
                 try:
                     ipaddress.ip_address(apn_config.assigned_static_ip)
@@ -98,7 +119,7 @@ class SubscriberDbClient:
                     continue
                 if apn_config.service_selection == '*':
                     selected_apn_conf = apn_config
-                if apn_config.service_selection == apn_name:
+                elif apn_config.service_selection == apn_name:
                     selected_apn_conf = apn_config
                     break
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -13,12 +13,14 @@ limitations under the License.
 
 import ipaddress
 import unittest
+from typing import Optional
 
 from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 from magma.mobilityd.ip_descriptor import IPDesc, IPType
 from magma.mobilityd.ip_address_man import IPAddressManager, \
     IPNotInUseError, MappingNotFoundError
 from magma.mobilityd.tests.test_multi_apn_ip_alloc import MockedSubscriberDBStub
+from magma.mobilityd.uplink_gw import InvalidVlanId
 
 
 class StaticIPAllocationTests(unittest.TestCase):
@@ -55,6 +57,12 @@ class StaticIPAllocationTests(unittest.TestCase):
     def check_type(self, sid: str, type: IPType):
         ip_desc = self._allocator.sid_ips_map[sid]
         self.assertEqual(ip_desc.type, type)
+
+    def check_gw_info(self, vlan: Optional[int], gw_ip: str, gw_mac: Optional[str]):
+        gw_info_ip = self._allocator._dhcp_gw_info.get_gw_ip(vlan)
+        self.assertEqual(gw_info_ip, gw_ip)
+        gw_info_mac = self._allocator._dhcp_gw_info.get_gw_mac(vlan)
+        self.assertEqual(gw_info_mac, gw_mac)
 
     def test_get_ip_for_subscriber(self):
         """ test get_ip_for_sid without any assignment """
@@ -246,3 +254,173 @@ class StaticIPAllocationTests(unittest.TestCase):
         self.assertEqual(ip0, ip0_returned)
         self.assertEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
         self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_apn_with_gw(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = "1.2.3.1"
+        gw_mac = "11:22:33:11:77:28"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(None, gw_ip, gw_mac)
+
+    def test_get_ip_for_subscriber_with_only_wildcard_apn_gw(self):
+        """ test wildcard apn"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = "1.2.3.100"
+        gw_mac = "11:22:33:11:77:81"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn="*", ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_apn_with_gw_vlan(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = "1.2.3.1"
+        gw_mac = "11:22:33:11:77:44"
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, gw_ip, gw_mac)
+
+    def test_get_ip_for_subscriber_with_apn_with_gw_invalid_ip(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = "1.2.3.1333"
+        gw_mac = "11:22:33:11:77:76"
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, None, None)
+
+    def test_get_ip_for_subscriber_with_apn_with_gw_nul_ip(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = ""
+        gw_mac = "11:22:33:11:77:45"
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, None, None)
+
+    def test_get_ip_for_subscriber_with_apn_with_gw_nul_mac(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.24'
+        gw_ip = "1.2.3.55"
+        gw_mac = None
+        vlan = "200"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, gw_ip, "")
+
+    def test_get_ip_for_subscriber_with_wildcard_apn_gw(self):
+        """ test wildcard apn"""
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = "1.2.3.100"
+        gw_mac = "11:22:33:11:77:81"
+        vlan = "300"
+
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+
+        wildcard_assigned_ip = "20.20.20.20"
+        wildcard_gw_ip = "1.2.7.7"
+        wildcard_gw_mac = "11:22:33:88:77:99"
+        wildcard_vlan = "400"
+
+        MockedSubscriberDBStub.add_sub_ip(sid=imsi, apn="*", ip=wildcard_assigned_ip,
+                                          gw_ip=wildcard_gw_ip, gw_mac=wildcard_gw_mac,
+                                          vlan=wildcard_vlan)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+        self.check_gw_info(vlan, gw_ip, gw_mac)
+        self.check_gw_info(wildcard_vlan, None, None)
+
+    def test_get_ip_for_subscriber_with_apn_with_gw_invalid_vlan(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        gw_ip = "1.2.3.1"
+        gw_mac = "11:22:33:11:77:44"
+        vlan = "20000"
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip,
+                                       gw_ip=gw_ip, gw_mac=gw_mac, vlan=vlan)
+
+        with self.assertRaises(InvalidVlanId):
+            ip0, _ = self._allocator.alloc_ip_address(sid)

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -21,9 +21,9 @@ NO_VLAN = "NO_VLAN"
 
 
 def _get_vlan_key(vlan: Optional[str]) -> str:
-    if vlan is None or vlan == '' or vlan == NO_VLAN:
+    if vlan is None or vlan == '' or vlan == NO_VLAN or vlan == "0":
         return NO_VLAN
-    if int(vlan) < 0 or int(vlan) > 4096:
+    if int(vlan) < 0 or int(vlan) > 4095:
         raise InvalidVlanId("invalid vlan: " + vlan)
 
     return vlan
@@ -40,6 +40,7 @@ class UplinkGatewayInfo:
         """
         self._backing_map = gw_info_map
 
+    # TODO: change vlan_id type to int
     def get_gw_ip(self, vlan_id: Optional[str] = "") -> Optional[str]:
         vlan_key = _get_vlan_key(vlan_id)
         if vlan_key in self._backing_map:
@@ -81,11 +82,11 @@ class UplinkGatewayInfo:
         else:
             return None
 
-    def update_mac(self, ip: str, mac: str, vlan_id: Optional[str] = ""):
+    def update_mac(self, ip: str, mac: Optional[str], vlan_id: Optional[str] = ""):
         vlan_key = _get_vlan_key(vlan_id)
 
         # TODO: enhance check for MAC address sanity.
-        if ':' not in mac:
+        if mac is None or ':' not in mac:
             logging.error("Incorrect mac format: %s for IP %s (vlan_key %s)",
                           mac, ip, vlan_id)
             return


### PR DESCRIPTION
## Summary

in case of static IP allocation user can specify GW ip address
and mac address via API, this patch configures it in GW Info.
so that AGW services can consume it.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
