### PR TITLE
[NMS] Fix the incomplete bucket chart issue and minor bugs

### DIFF
--- a/nms/app/packages/magmalte/app/components/TopBar.js
+++ b/nms/app/packages/magmalte/app/components/TopBar.js
@@ -18,13 +18,15 @@ import type {ComponentType} from 'react';
 import AppBar from '@material-ui/core/AppBar';
 import Grid from '@material-ui/core/Grid';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
-import React, {useState} from 'react';
+import React from 'react';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import Text from '../theme/design-system/Text';
 
+import {GetCurrentTabPos} from './TabUtils';
 import {colors} from '../theme/default';
 import {makeStyles} from '@material-ui/styles';
+import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
   topBar: {
@@ -68,8 +70,11 @@ type Props = {header: string, tabs: BarLabel[]};
 
 export default function TopBar(props: Props) {
   const classes = useStyles();
-  const [currentTab, setCurrentTab] = useState(0);
-
+  const {match} = useRouter();
+  const currentTab = GetCurrentTabPos(
+    match.url,
+    props.tabs.map(tab => tab.to.slice(1)),
+  );
   function tabLabel(label, icon) {
     const Icon = icon;
 
@@ -80,7 +85,6 @@ export default function TopBar(props: Props) {
       </div>
     );
   }
-
   return (
     <>
       <div className={classes.topBar}>
@@ -99,9 +103,8 @@ export default function TopBar(props: Props) {
               TabIndicatorProps={{style: {height: '5px'}}}
               textColor="inherit"
               className={classes.tabs}>
-              {props.tabs.map((tab, i) => (
+              {props.tabs.map(tab => (
                 <Tab
-                  onClick={() => setCurrentTab(i)}
                   key={tab.key ?? tab.label}
                   component={NestedRouteLink}
                   label={tabLabel(tab.label, tab.icon)}

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayCheckinChart.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayCheckinChart.js
@@ -39,6 +39,8 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+const CHART_COLORS = [colors.secondary.dodgerBlue, colors.data.flamePea];
+
 export default function () {
   const classes = useStyles();
   const [timeRange, setTimeRange] = useState<TimeRange>('3_hours');
@@ -115,6 +117,7 @@ export default function () {
               timeRange={timeRange}
               startEnd={undefined}
               legendLabels={state.legendLabels}
+              chartColors={CHART_COLORS}
             />
           }
         />

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayLogChart.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayLogChart.js
@@ -25,6 +25,7 @@ import moment from 'moment';
 import nullthrows from '@fbcnms/util/nullthrows';
 
 import {colors} from '../../theme/default';
+import {getQueryRanges} from '../../components/CustomMetrics';
 import {useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
@@ -58,15 +59,7 @@ export default function LogChart(props: Props) {
   useEffect(() => {
     // build queries
     let requestError = '';
-    const queries = [];
-    let s = start.clone();
-    while (end.diff(s) >= 0) {
-      const e = s.clone();
-      e.add(delta, unit);
-      queries.push([s, e]);
-      s = e.clone();
-    }
-
+    const queries = getQueryRanges(start, end, delta, unit);
     const requests = queries.map(async (query, _) => {
       try {
         const [s, e] = query;
@@ -86,15 +79,15 @@ export default function LogChart(props: Props) {
     Promise.all(requests)
       .then(allResponses => {
         const data: Array<DatasetType> = allResponses.map((r, index) => {
-          const [s] = queries[index];
+          const [_, e] = queries[index];
           if (r === null || r === undefined) {
             return {
-              t: s.unix() * 1000,
+              t: e.unix() * 1000,
               y: 0,
             };
           }
           return {
-            t: s.unix() * 1000,
+            t: e.unix() * 1000,
             y: r,
           };
         });


### PR DESCRIPTION

## Summary
1. This PR fixes the issue where we might be displaying data for incomplete buckets towards the end. This behavior is similar to response of prometheus query (which doesn't return incomplete buckets either). We mimic that behavior in the building charts for event and log table charts.
2. minor fix to set the color of gateway checkin chart with the new theme
3. minor fix to ensure that tabs get selected properly when we directly go to the url. Erik's TopBar changes broke this. This fix addresses that bug. 

## Test Plan

Yarn test passes successfully
![chart_gif](https://user-images.githubusercontent.com/8224854/91501762-353c7f00-e87b-11ea-9eee-ba63151dd2e7.gif)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
