### PR TITLE
[AGW] pipelineD: configure SGi management ip address.

### DIFF
--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -62,6 +62,10 @@ def main():
                                   service.mconfig.sgi_management_iface_vlan)
     service.config['sgi_management_iface_vlan'] = vlan_tag
 
+    sgi_ip = service.config.get('sgi_management_iface_ip_addr',
+                                  service.mconfig.sgi_management_iface_ip_addr)
+    service.config['sgi_management_iface_ip_addr'] = sgi_ip
+
     # Load the ryu apps
     service_manager = ServiceManager(service)
     service_manager.load()

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -15,6 +15,7 @@ import logging
 import os
 import re
 import subprocess
+import netifaces
 
 from collections import namedtuple
 from concurrent.futures import Future
@@ -543,12 +544,16 @@ def get_ovsdb_port_tag(port_name: str) -> str:
         if port_name not in str(port):
             continue
         try:
-            tokens = str(port).strip().split()
-            port_name = tokens[0]
-            tag = tokens[1]
-            if port_name == port_name:
-                return str(tag).split('\\')[0]
+            tokens = str(port.decode("utf-8")).strip('\"').split()
+            return tokens[1]
         except ValueError:
             pass
 
 
+def get_iface_ipv4(iface: str) -> List[str]:
+    virt_ifaddresses = netifaces.ifaddresses(iface)
+    ip_addr_list = []
+    for ip_rec in virt_ifaddresses[netifaces.AF_INET]:
+        ip_addr_list.append(ip_rec['addr'])
+
+    return ip_addr_list

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,4 @@
+ priority=2000,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=1000,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
+ priority=1000,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=100 actions=NORMAL

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -26,6 +26,7 @@ from magma.pipelined.tests.pipelined_test_util import (
     create_service_manager,
     assert_bridge_snapshot_match,
     get_ovsdb_port_tag,
+    get_iface_ipv4,
 )
 
 
@@ -273,6 +274,106 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
                                      include_stats=False)
 
         self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), cls.VLAN_TAG)
+
+class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+
+    UPLINK_BRIDGE = 'ut_up_br0'
+    UPLINK_DHCP = 'test_dhcp0'
+    UPLINK_PATCH = 'test_patch_p2'
+    UPLINK_ETH_PORT = 'test_eth3'
+    VLAN_TAG='100'
+    SGi_IP="1.6.5.7"
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UplinkBridgeWithNonNATTest_IP_VLAN, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        uplink_bridge_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.UplinkBridge,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.UplinkBridge:
+                    uplink_bridge_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': False,
+                'uplink_bridge': cls.UPLINK_BRIDGE,
+                'uplink_eth_port_name': cls.UPLINK_ETH_PORT,
+                'virtual_mac': '02:bb:5e:36:06:4b',
+                'uplink_patch': cls.UPLINK_PATCH,
+                'uplink_dhcp_port': cls.UPLINK_DHCP,
+                'sgi_management_iface_vlan': cls.VLAN_TAG,
+                'sgi_management_iface_ip_addr': cls.SGi_IP
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+        # validate vlan id set
+        vlan = "10"
+        BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
+        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
+                          "tag=" + vlan]).wait()
+        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
+
+        set_ip_cmd = ["ip",
+                      "addr", "replace",
+                      "2.33.44.6",
+                      "dev",
+                      cls.UPLINK_BRIDGE]
+        subprocess.check_call(set_ip_cmd)
+
+        BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
+                                          cls.UPLINK_DHCP, None)
+        BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
+                                          cls.UPLINK_PATCH, None)
+        BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
+                                          cls.UPLINK_ETH_PORT, None)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.uplink_br_controller = uplink_bridge_controller_reference.result()
+
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+        BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
+
+    def testFlowSnapshotMatch(self):
+        cls = self.__class__
+        assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
+                                     include_stats=False)
+        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), cls.VLAN_TAG)
+
+        self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.UPLINK_BRIDGE), "ip not found")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This allows operator to configure static IP address on
SGi for management traffic.
Only single IP is allowed.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
