### PR TITLE
[NMS] Move alarm component to the end

### DIFF
--- a/nms/app/packages/magmalte/app/components/lte/LteSections.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteSections.js
@@ -338,7 +338,7 @@ export function getLteSectionsV2(
     ],
   ];
   if (alertsEnabled) {
-    sections[1].splice(2, 0, {
+    sections[1].push({
       path: 'alerts',
       label: 'Alerts',
       icon: <AlarmIcon />,


### PR DESCRIPTION
## Summary

Currently alarm component is incorrectly spliced between equipment and network. Moving this towards the end

## Test Plan
![Screen Shot 2020-08-27 at 5 34 10 PM](https://user-images.githubusercontent.com/8224854/91508197-a7b55b00-e88b-11ea-9c29-548a79166d9a.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
