### PR TITLE
[lte][policydb] Add per-APN rule mappings stream to local PCRF

### DIFF
--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -28,6 +28,7 @@ services:
         network_wide_rules,
         policydb,
         rating_groups,
+        apn_rule_mappings,
         rule_mappings,
         subscriberdb,
 

--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -29,7 +29,6 @@ services:
         policydb,
         rating_groups,
         apn_rule_mappings,
-        rule_mappings,
         subscriberdb,
 
   subscriberdb:

--- a/lte/cloud/go/lte/const.go
+++ b/lte/cloud/go/lte/const.go
@@ -74,6 +74,7 @@ const (
 	SubscriberEntityType       = "subscriber"
 
 	// BaseNameStreamName etc. are streamer stream names.
+	ApnRuleMappingsStreamName  = "apn_rule_mappings"
 	BaseNameStreamName         = "base_names"
 	MappingsStreamName         = "rule_mappings"
 	NetworkWideRulesStreamName = "network_wide_rules"

--- a/lte/cloud/go/lte/const.go
+++ b/lte/cloud/go/lte/const.go
@@ -76,7 +76,6 @@ const (
 	// BaseNameStreamName etc. are streamer stream names.
 	ApnRuleMappingsStreamName  = "apn_rule_mappings"
 	BaseNameStreamName         = "base_names"
-	MappingsStreamName         = "rule_mappings"
 	NetworkWideRulesStreamName = "network_wide_rules"
 	PolicyStreamName           = "policydb"
 	RatingGroupStreamName      = "rating_groups"

--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -96,7 +96,6 @@ func (*LteOrchestratorPlugin) GetStreamerProviders() []providers.StreamProvider 
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.PolicyStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.ApnRuleMappingsStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.BaseNameStreamName),
-		providers.NewRemoteProvider(lte_service.ServiceName, lte.MappingsStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.NetworkWideRulesStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.RatingGroupStreamName),
 	}

--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -94,6 +94,7 @@ func (*LteOrchestratorPlugin) GetStreamerProviders() []providers.StreamProvider 
 	return []providers.StreamProvider{
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.SubscriberStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.PolicyStreamName),
+		providers.NewRemoteProvider(lte_service.ServiceName, lte.ApnRuleMappingsStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.BaseNameStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.MappingsStreamName),
 		providers.NewRemoteProvider(lte_service.ServiceName, lte.NetworkWideRulesStreamName),

--- a/lte/cloud/go/services/lte/servicers/provider_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer.go
@@ -38,6 +38,8 @@ func (s *providerServicer) GetUpdates(ctx context.Context, req *protos.StreamReq
 		streamer = &subscriber_streamer.SubscribersProvider{}
 	case lte.PolicyStreamName:
 		streamer = &policydb_streamer.PoliciesProvider{}
+	case lte.ApnRuleMappingsStreamName:
+		streamer = &policydb_streamer.ApnRuleMappingsProvider{}
 	case lte.BaseNameStreamName:
 		streamer = &policydb_streamer.BaseNamesProvider{}
 	case lte.MappingsStreamName:

--- a/lte/cloud/go/services/lte/servicers/provider_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer.go
@@ -42,8 +42,6 @@ func (s *providerServicer) GetUpdates(ctx context.Context, req *protos.StreamReq
 		streamer = &policydb_streamer.ApnRuleMappingsProvider{}
 	case lte.BaseNameStreamName:
 		streamer = &policydb_streamer.BaseNamesProvider{}
-	case lte.MappingsStreamName:
-		streamer = &policydb_streamer.RuleMappingsProvider{}
 	case lte.NetworkWideRulesStreamName:
 		streamer = &policydb_streamer.NetworkWideRulesProvider{}
 	case lte.RatingGroupStreamName:

--- a/lte/cloud/go/services/lte/test_init/test_service_init.go
+++ b/lte/cloud/go/services/lte/test_init/test_service_init.go
@@ -32,7 +32,6 @@ func StartTestService(t *testing.T) {
 		lte.PolicyStreamName,
 		lte.BaseNameStreamName,
 		lte.ApnRuleMappingsStreamName,
-		lte.MappingsStreamName,
 		lte.NetworkWideRulesStreamName,
 		lte.RatingGroupStreamName,
 	}

--- a/lte/cloud/go/services/lte/test_init/test_service_init.go
+++ b/lte/cloud/go/services/lte/test_init/test_service_init.go
@@ -31,6 +31,7 @@ func StartTestService(t *testing.T) {
 		lte.SubscriberStreamName,
 		lte.PolicyStreamName,
 		lte.BaseNameStreamName,
+		lte.ApnRuleMappingsStreamName,
 		lte.MappingsStreamName,
 		lte.NetworkWideRulesStreamName,
 		lte.RatingGroupStreamName,

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -17,6 +17,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"strings"
 
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/protos"
@@ -227,6 +228,13 @@ func (m PolicyIdsByApn) ToEntities(subscriberID string) []configurator.NetworkEn
 		ents = append(ents, ent)
 	}
 	return ents
+}
+
+func GetAPN(apnPolicyProfileKey string) (string, error) {
+	if !strings.Contains(apnPolicyProfileKey, magicNamespaceSeparator) {
+		return "", errors.New("incorrectly formatted APNPolicyProfile key")
+	}
+	return strings.Split(apnPolicyProfileKey, magicNamespaceSeparator)[1], nil
 }
 
 func makeAPNPolicyKey(subscriberID, apnName string) string {

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -22,6 +22,7 @@ import (
 	lte_test_init "magma/lte/cloud/go/services/lte/test_init"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/lte/cloud/go/services/policydb/streamer"
+	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -237,6 +238,147 @@ func TestPolicyStreamers(t *testing.T) {
 	actual, err = bnPro.GetUpdates("hw1", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
+}
+
+func TestApnRuleMappingsProvider(t *testing.T) {
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &lte_plugin.LteOrchestratorPlugin{})) // load remote providers
+	lte_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+
+	provider, err := providers.GetStreamProvider(lte.ApnRuleMappingsStreamName)
+	assert.NoError(t, err)
+
+	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	assert.NoError(t, err)
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{Type: lte.PolicyRuleEntityType, Key: "r1"},
+			{Type: lte.PolicyRuleEntityType, Key: "r2"},
+			{Type: lte.PolicyRuleEntityType, Key: "r4"},
+
+			{Type: lte.BaseNameEntityType, Key: "b1"},
+			{Type: lte.BaseNameEntityType, Key: "b3"},
+
+			{
+				Type: lte.APNEntityType, Key:  "apn1",
+				Config: &lte_models.ApnConfiguration{
+					Ambr: &lte_models.AggregatedMaximumBitrate{
+						MaxBandwidthDl: swag.Uint32(42),
+						MaxBandwidthUl: swag.Uint32(100),
+					},
+					QosProfile: &lte_models.QosProfile{
+						ClassID:                 swag.Int32(1),
+						PreemptionCapability:    swag.Bool(true),
+						PreemptionVulnerability: swag.Bool(true),
+						PriorityLevel:           swag.Uint32(1),
+					},
+				},
+			},
+			{
+				Type: lte.APNEntityType, Key:  "apn2",
+				Config: &lte_models.ApnConfiguration{
+					Ambr: &lte_models.AggregatedMaximumBitrate{
+						MaxBandwidthDl: swag.Uint32(42),
+						MaxBandwidthUl: swag.Uint32(100),
+					},
+					QosProfile: &lte_models.QosProfile{
+						ClassID:                 swag.Int32(1),
+						PreemptionCapability:    swag.Bool(true),
+						PreemptionVulnerability: swag.Bool(true),
+						PriorityLevel:           swag.Uint32(1),
+					},
+				},
+			},
+		},
+	)
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: lte.APNPolicyProfileEntityType, Key:  "s1___apn1",
+				Associations: []storage.TypeAndKey{
+					{Type: lte.APNEntityType, Key: "apn1"},
+					{Type: lte.PolicyRuleEntityType, Key: "r4"},
+				},
+			},
+			{
+				Type: lte.APNPolicyProfileEntityType, Key:  "s1___apn2",
+				Associations: []storage.TypeAndKey{
+					{Type: lte.APNEntityType, Key: "apn2"},
+				},
+			},
+		},
+	)
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: lte.SubscriberEntityType, Key: "s1",
+				Associations: []storage.TypeAndKey{
+					{Type: lte.PolicyRuleEntityType, Key: "r1"},
+					{Type: lte.BaseNameEntityType, Key: "b1"},
+					{Type: lte.APNPolicyProfileEntityType, Key: "s1___apn1"},
+				},
+			},
+			{
+				Type: lte.SubscriberEntityType, Key: "s2",
+				Associations: []storage.TypeAndKey{
+					{Type: lte.PolicyRuleEntityType, Key: "r2"},
+					{Type: lte.BaseNameEntityType, Key: "b3"},
+				},
+			},
+			{Type: lte.SubscriberEntityType, Key: "s3"},
+		},
+	)
+	assert.NoError(t, err)
+
+	expectedProtos := []*lte_protos.SubscriberPolicySet{
+		{
+			GlobalBaseNames: []string{"b1"},
+			GlobalPolicies:  []string{"r1"},
+			RulesPerApn: []*lte_protos.ApnPolicySet{
+				{
+					Apn: "apn1",
+					AssignedPolicies: []string{"r4"},
+				},
+			},
+		},
+		{
+			GlobalBaseNames: []string{"b3"},
+			GlobalPolicies:  []string{"r2"},
+			RulesPerApn: []*lte_protos.ApnPolicySet{},
+		},
+		{
+			GlobalBaseNames: []string{},
+			GlobalPolicies:  []string{},
+			RulesPerApn: []*lte_protos.ApnPolicySet{},
+		},
+	}
+	expected := funk.Map(
+		expectedProtos,
+		func(ap *lte_protos.SubscriberPolicySet) *protos.DataUpdate {
+			data, err := proto.Marshal(ap)
+			assert.NoError(t, err)
+			return &protos.DataUpdate{Value: data}
+		},
+	).([]*protos.DataUpdate)
+	expected[0].Key, expected[1].Key, expected[2].Key = "s1", "s2", "s3"
+
+	actual, err := provider.GetUpdates("hw1", nil)
+	assert.NoError(t, err)
+	for i, update := range actual {
+		subPolicySet := &lte_protos.SubscriberPolicySet{}
+		_ = proto.Unmarshal(update.Value, subPolicySet)
+		assert.True(t, proto.Equal(subPolicySet, expectedProtos[i]))
+	}
 }
 
 func TestRuleMappingsProvider(t *testing.T) {

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -16,7 +16,7 @@ lte:
       orc8r.io/obsidian_handlers: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte,/magma/v1/lte/:network_id"
-      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,apn_rule_mappings,rule_mappings,subscriberdb,rating_groups"
+      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,apn_rule_mappings,subscriberdb,rating_groups"
 
 policydb:
   service:

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -16,7 +16,7 @@ lte:
       orc8r.io/obsidian_handlers: "true"
     annotations:
       orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte,/magma/v1/lte/:network_id"
-      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,rule_mappings,subscriberdb,rating_groups"
+      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,apn_rule_mappings,rule_mappings,subscriberdb,rating_groups"
 
 policydb:
   service:

--- a/orc8r/cloud/go/services/configurator/client_api.go
+++ b/orc8r/cloud/go/services/configurator/client_api.go
@@ -584,6 +584,7 @@ func GetNetworkAndEntityIDForPhysicalID(physicalID string) (string, string, erro
 // LoadEntities loads entities specified by the parameters.
 // typeFilter, keyFilter, physicalID, and ids are all used to define a filter to
 // filter out results - if they are all nil, it will return all network entities
+// If ids is empty, all entities will be returned
 func LoadEntities(
 	networkID string,
 	typeFilter *string,


### PR DESCRIPTION
#2437  Summary

This revision adds the `ApnRuleMappingsProvider` to stream to the local PCRF per-APN rule mappings for each subscriber. 

## Test Plan

- Modified unit tests
- Ran local orc8r development instance
- Checked that a local orc8r with local AGW will get the per-apn mappings streamed to the AGW and update local Redis instance

## Additional Information

- [ ] This change is backwards-breaking
