### PR TITLE
[ci][jenkins]Uncomment integration traffic tests and fix routing issue for traffic…

### DIFF
--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -260,7 +260,6 @@ pipeline {
             script {
                 myShCmdWithLog('cd lte/gateway && vagrant destroy --force magma_test && vagrant up magma_test', 'archives/magma_vagrant_test_up.log', new_host_flag, new_host_user, new_host)
                 // The Traffic Testcases are disabled from the Mandatory suite --> will be run manually
-                // myShCmd('sed -i -f ci-scripts/removeLastUlTestCases.sed lte/gateway/python/integ_tests/defs.mk', new_host_flag, new_host_user, new_host)
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"', 'archives/magma_vagrant_test_make1.log', new_host_flag, new_host_user, new_host)
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"', 'archives/magma_vagrant_test_make2.log', new_host_flag, new_host_user, new_host)
             }
@@ -311,32 +310,32 @@ pipeline {
 
                 echo "Starting the integration Tests - S1AP Tester"
                 // We have removed the traffic testcases from mandatory suite.
-                timeout (time: 45, unit: 'MINUTES') {
+                timeout (time: 30, unit: 'MINUTES') {
                   myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                 }
                 // Adding a few tests not in the mandatory suite and the UL traffic scenarios (launched manually)
-                timeout (time: 45, unit: 'MINUTES') {
+                timeout (time: 45, unit: 'SECONDS') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_ul_udp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_ul_udp_data testcase may fail"
                   }
                 }
-                timeout (time: 45, unit: 'MINUTES') {
+                timeout (time: 45, unit: 'SECONDS') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_ul_tcp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_ul_tcp_data testcase may fail"
                   }
                 }
-                timeout (time: 45, unit: 'MINUTES') {
+                timeout (time: 45, unit: 'SECONDS') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_udp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_dl_udp_data testcase may fail"
                   }
                 }
-                timeout (time: 45, unit: 'MINUTES') {
+                timeout (time: 45, unit: 'SECONDS') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_tcp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
@@ -469,6 +468,7 @@ stage ("Deploy SPGW-CUPS") {
           steps {
             script {
               myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip addr add 192.168.61.128/26 dev eth0"', new_host_flag, new_host_user, new_host)
+              myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route del 192.168.128.0/24 via 192.168.129.1 dev eth2"', new_host_flag, new_host_user, new_host)
               myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route add 192.168.128.0/24 via 192.168.61.131 dev eth0"', new_host_flag, new_host_user, new_host)
                 echo "Starting the Traffic server in foreground"
                 try {
@@ -485,7 +485,7 @@ stage ("Deploy SPGW-CUPS") {
               // making sure the TRF server is up
               sh "sleep 60"
                 echo "Starting the integration Tests - S1AP Tester"
-                timeout (time: 45, unit: 'MINUTES') {
+                timeout (time: 10, unit: 'MINUTES') {
                   myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
                   myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
                   myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)

--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -485,7 +485,7 @@ stage ("Deploy SPGW-CUPS") {
               // making sure the TRF server is up
               sh "sleep 60"
                 echo "Starting the integration Tests - S1AP Tester"
-                timeout (time: 10, unit: 'MINUTES') {
+                timeout (time: 20, unit: 'MINUTES') {
                   myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
                   myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
                   myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)

--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -260,7 +260,7 @@ pipeline {
             script {
                 myShCmdWithLog('cd lte/gateway && vagrant destroy --force magma_test && vagrant up magma_test', 'archives/magma_vagrant_test_up.log', new_host_flag, new_host_user, new_host)
                 // The Traffic Testcases are disabled from the Mandatory suite --> will be run manually
-                myShCmd('sed -i -f ci-scripts/removeLastUlTestCases.sed lte/gateway/python/integ_tests/defs.mk', new_host_flag, new_host_user, new_host)
+                // myShCmd('sed -i -f ci-scripts/removeLastUlTestCases.sed lte/gateway/python/integ_tests/defs.mk', new_host_flag, new_host_user, new_host)
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"', 'archives/magma_vagrant_test_make1.log', new_host_flag, new_host_user, new_host)
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"', 'archives/magma_vagrant_test_make2.log', new_host_flag, new_host_user, new_host)
             }
@@ -277,6 +277,7 @@ pipeline {
                   echo "Known issue with magma-custom.io public key?"
                 }
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo apt install --yes psmisc net-tools iproute"', 'archives/magma_vagrant_trfserver_killall_install.log', new_host_flag, new_host_user, new_host)
+                myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route add 192.168.128.0/24 via 192.168.129.1 dev eth2"', new_host_flag, new_host_user, new_host)
             }
           }
         }

--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -311,32 +311,32 @@ pipeline {
 
                 echo "Starting the integration Tests - S1AP Tester"
                 // We have removed the traffic testcases from mandatory suite.
-                timeout (time: 20, unit: 'MINUTES') {
+                timeout (time: 45, unit: 'MINUTES') {
                   myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                 }
                 // Adding a few tests not in the mandatory suite and the UL traffic scenarios (launched manually)
-                timeout (time: 45, unit: 'SECONDS') {
+                timeout (time: 45, unit: 'MINUTES') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_ul_udp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_ul_udp_data testcase may fail"
                   }
                 }
-                timeout (time: 45, unit: 'SECONDS') {
+                timeout (time: 45, unit: 'MINUTES') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_ul_tcp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_ul_tcp_data testcase may fail"
                   }
                 }
-                timeout (time: 45, unit: 'SECONDS') {
+                timeout (time: 45, unit: 'MINUTES') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_udp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_dl_udp_data testcase may fail"
                   }
                 }
-                timeout (time: 45, unit: 'SECONDS') {
+                timeout (time: 45, unit: 'MINUTES') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_tcp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                   } catch (Exception e) {
@@ -485,7 +485,7 @@ stage ("Deploy SPGW-CUPS") {
               // making sure the TRF server is up
               sh "sleep 60"
                 echo "Starting the integration Tests - S1AP Tester"
-                timeout (time: 20, unit: 'MINUTES') {
+                timeout (time: 45, unit: 'MINUTES') {
                   myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
                   myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
                   myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)

--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -77,7 +77,7 @@ pipeline {
     stage ("Retrieve and Prepare Source Code") {
       steps {
         script {
-            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: "https://{{GIT_URL}}.git"]]]    
+            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: "https://" + GIT_URL + ".git"]]]
             GIT_COMMIT = sh returnStdout: true, script: 'git log -1 --pretty="%H"'
             sh "git clean -x -d -e .cache -e lte/gateway/.vagrant -f > /dev/null 2>&1"
             TEMP_COMMIT = sh returnStdout: true, script: 'git log -n1 --pretty=format:"%H"'

--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -369,9 +369,9 @@ pipeline {
                 }
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"', 'archives/magma_vagrant_make_stop.log', new_host_flag, new_host_user, new_host)
                 // Retrieving the sys logs and mme log for more debugging.
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/syslog"', 'archives/magma_dev_syslog.log', new_host_flag, new_host_user, new_host)
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/mme.log"', 'archives/magma_dev_mme.log', new_host_flag, new_host_user, new_host)
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "sudo cat /var/log/syslog"', 'archives/magma_test_syslog.log', new_host_flag, new_host_user, new_host)
+                myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/syslog archives/magma_dev_syslog.log"', new_host_flag, new_host_user, new_host)
+                myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/mme.log archives/magma_dev_mme.log"', new_host_flag, new_host_user, new_host)
+                myShCmd('cd lte/gateway && vagrant ssh magma_test -c "sudo cp /var/log/syslog archives/magma_test_syslog.log"', new_host_flag, new_host_user, new_host)
               }
             }
             success {
@@ -519,13 +519,14 @@ stage ("Deploy SPGW-CUPS") {
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"', 'archives/magma_vagrant_make_stop2.log', new_host_flag, new_host_user, new_host)
 
                 // Retrieving the sys logs and mme log for more debugging.
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/syslog"', 'archives/magma_dev_syslog_s11.log', new_host_flag, new_host_user, new_host)
+                myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/syslog archives/magma_dev_syslog_s11.log"', new_host_flag, new_host_user, new_host)
                 try {
-                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/mme.log"', 'archives/magma_dev_mme_s11.log', new_host_flag, new_host_user, new_host)
+                  myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/mme.log archives/magma_dev_mme_s11.log"', new_host_flag, new_host_user, new_host)
+                  myShCmd('docker cp magma-oai-spgwc:/openair-spgwc/spgwc_check_run.log archives', new_host_flag, new_host_user, new_host)
                 } catch (Exception e) {
                   echo "MME log may not be available"
                 }
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "sudo cat /var/log/syslog"', 'archives/magma_test_syslog_s11.log', new_host_flag, new_host_user, new_host)
+                myShCmd('cd lte/gateway && vagrant ssh magma_test -c "sudo cp /var/log/syslog archives/magma_test_syslog_s11.log"', new_host_flag, new_host_user, new_host)
                 // Retrieving the container logs
                 myShCmd('docker cp magma-oai-spgwc:/openair-spgwc/spgwc_check_run.log archives', new_host_flag, new_host_user, new_host)
                 myShCmd('docker cp magma-oai-spgwu-tiny:/openair-spgwu-tiny/spgwu_check_run.log archives', new_host_flag, new_host_user, new_host)

--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -259,7 +259,6 @@ pipeline {
           steps {
             script {
                 myShCmdWithLog('cd lte/gateway && vagrant destroy --force magma_test && vagrant up magma_test', 'archives/magma_vagrant_test_up.log', new_host_flag, new_host_user, new_host)
-                // The Traffic Testcases are disabled from the Mandatory suite --> will be run manually
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"', 'archives/magma_vagrant_test_make1.log', new_host_flag, new_host_user, new_host)
                 myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"', 'archives/magma_vagrant_test_make2.log', new_host_flag, new_host_user, new_host)
             }
@@ -313,7 +312,6 @@ pipeline {
                 timeout (time: 30, unit: 'MINUTES') {
                   myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
                 }
-                // Adding a few tests not in the mandatory suite and the UL traffic scenarios (launched manually)
                 timeout (time: 45, unit: 'SECONDS') {
                   try {
                     myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_ul_udp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)


### PR DESCRIPTION
Signed-off-by: Vitalii <vitalij.kostenko@gmail.com>

## Summary
[skipJenkins] 
This PR removes "comment integration tests" instruction and fix routing for traffic tests

## Test Plan

Run Jenkins tests for the PRs

## Additional Information

added according to the @ssanadhya request