### PR TITLE
add default repositories for facebookincubator containers

### DIFF
--- a/orc8r/cloud/docker/docker-compose.metrics.yml
+++ b/orc8r/cloud/docker/docker-compose.metrics.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   prometheus-cache:
-    image: facebookincubator/prometheus-edge-hub:latest
+    image: facebookincubator/prometheus-edge-hub:1.1.0
     ports:
       - 9091:9091/tcp
     command:

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.34
+version: 1.4.35
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.14
+version: 1.4.15
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -111,8 +111,8 @@ prometheusConfigurer:
   prometheusURL: "orc8r-prometheus:9090"
 
   image:
-    repository:
-    tag:
+    repository: docker.io/facebookincubator/prometheus-configurer
+    tag: 1.0.0
     pullPolicy: IfNotPresent
 
   resources: {}
@@ -150,8 +150,8 @@ alertmanagerConfigurer:
   alertmanagerURL: "orc8r-alertmanager:9093"
 
   image:
-    repository:
-    tag:
+    repository: docker.io/facebookincubator/alertmanager-configurer
+    tag: 1.0.0
     pullPolicy: IfNotPresent
 
   resources: {}
@@ -183,8 +183,8 @@ prometheusCache:
         targetPort: 9091
 
   image:
-    repository:
-    tag:
+    repository: docker.io/facebookincubator/prometheus-edge-hub
+    tag: 1.1.0
     pullPolicy: IfNotPresent
 
   # Maximum number of datapoints in the cache at one time. Unlimited if <= 0.
@@ -238,8 +238,8 @@ grafana:
         emptyDir: {}
 
   image:
-    repository:
-    tag:
+    repository: grafana/grafana
+    tag: 6.6.2
     pullPolicy: IfNotPresent
 
   # Number of metrics replicas desired

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.4
 - name: metrics
   repository: ""
-  version: 1.4.14
+  version: 1.4.15
 - name: nms
   repository: ""
   version: 0.1.6

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.14
+    version: 1.4.15
     repository: ""
     condition: metrics.enabled
   - name: nms


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Added default repos for facebookincubator containers (configmanager, edge-hub) since they're now publicly hosted. 
Also pin prometheus-edge-hub to 1.1.0 which is a new version

## Test Plan

Didn't test with Helm because the helm charts don't work out of the box like they should :)
I trust that this will be fine since the only thing that's changing are default values so current deployments won't be affected. Additionally I know I'm referencing existing images since they work on docker.
