### PR TITLE
[orc8r][obsidian] Fix QoS dangling apn_policy_profile ent

### DIFF
--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers.go
@@ -271,18 +271,13 @@ func CreateRule(c echo.Context) error {
 	writes = append(writes, createdEntity)
 
 	for _, tk := range rule.GetParentAssocs().Filter(lte.SubscriberEntityType) {
-		writes = append(writes, configurator.EntityUpdateCriteria{
+		w := configurator.EntityUpdateCriteria{
 			Type:              lte.SubscriberEntityType,
 			Key:               tk.Key,
 			AssociationsToAdd: []storage.TypeAndKey{{Type: lte.PolicyRuleEntityType, Key: createdEntity.Key}},
-		})
+		}
+		writes = append(writes, w)
 	}
-	childWrites := configurator.EntityUpdateCriteria{
-		Type:              createdEntity.Type,
-		Key:               createdEntity.Key,
-		AssociationsToAdd: rule.GetAssocs(),
-	}
-	writes = append(writes, childWrites)
 
 	if err := configurator.WriteEntities(networkID, writes...); err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "failed to create policy"), http.StatusInternalServerError)

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
@@ -562,7 +562,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 			Key:                "p1",
 			GraphID:            "2",
 			ParentAssociations: []storage.TypeAndKey{{Type: lte.SubscriberEntityType, Key: imsi2}, {Type: lte.SubscriberEntityType, Key: imsi1}},
-			Version:            1,
+			Version:            0,
 		},
 	)
 
@@ -587,7 +587,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 			Key:                "p1",
 			GraphID:            "2",
 			ParentAssociations: []storage.TypeAndKey{{Type: lte.SubscriberEntityType, Key: imsi3}},
-			Version:            2,
+			Version:            1,
 		},
 	)
 

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -123,12 +123,10 @@ func (m RuleNames) ToTKs() storage.TKs {
 
 func (m *PolicyRule) ToEntity() configurator.NetworkEntity {
 	ent := configurator.NetworkEntity{
-		Type:   lte.PolicyRuleEntityType,
-		Key:    string(m.ID),
-		Config: m.getConfig(),
-	}
-	if m.QosProfile != "" {
-		ent.Associations = append(ent.Associations, storage.TypeAndKey{Type: lte.PolicyQoSProfileEntityType, Key: m.QosProfile})
+		Type:         lte.PolicyRuleEntityType,
+		Key:          string(m.ID),
+		Config:       m.getConfig(),
+		Associations: m.GetAssocs(),
 	}
 	return ent
 }

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -164,6 +164,7 @@ func (m *MutableSubscriber) FromEnt(ent configurator.NetworkEntity) (*MutableSub
 		if err != nil {
 			return nil, err
 		}
+		model.ActivePoliciesByApn[apn.Key] = policymodels.PolicyIds{} // place apn key in map
 		for _, policyRuleAssoc := range p.Associations.Filter(lte.PolicyRuleEntityType) {
 			model.ActivePoliciesByApn[apn.Key] = append(model.ActivePoliciesByApn[apn.Key], policymodels.PolicyID(policyRuleAssoc.Key))
 		}


### PR DESCRIPTION
## Summary

An apn_policy_profile ent with zero policies attached would not get deleted when its owning subscriber was deleted.

This resulted in errors when re-creating the subscriber.

## Test Plan

- [x] make test, with added regression test

## Additional Information

- [ ] This change is backwards-breaking