### PR TITLE
[SessionD] 5G Session state manager and Enforcer code

### DIFF
--- a/lte/gateway/c/session_manager/AmfServiceClient.cpp
+++ b/lte/gateway/c/session_manager/AmfServiceClient.cpp
@@ -1,0 +1,85 @@
+#include "AmfServiceClient.h"
+#include "ServiceRegistrySingleton.h"
+#include "magma_logging.h"
+
+// using google::protobuf::RepeatedPtrField;
+using grpc::Status;
+
+namespace {
+
+void call_back_void_amf(grpc::Status, magma::SmContextVoid respvoid)
+{
+  //do nothinf but to only passing call back
+  //cout <<" Only for testing call back" << endl;
+}
+std::function<void(grpc::Status, magma::SmContextVoid)>callback  = call_back_void_amf;
+
+#if 0
+magma::SetSMSessionContextAccess create_set_smsess_access_req(
+    const std::string& imsi, const std::string& apn_ip_addr,
+    const uint32_t linked_bearer_id,
+    const std::vector<magma::PolicyRule>& flows) {
+  magma::SetSMSessionContextAccess sreq;
+  
+  auto *req =  sreq.mutable_rat_specific_context().mutable_m5g_session_context_rsp();
+
+  req.set_pdu_session_id();
+  req.set_pdu_session_type(magma::PduSessionType::IPV4);
+  req.set_selected_ssc_mode(magma::SscMode::SSC_MODE_1);
+  auto req_auth_qos_rules = req.mutable_authorized_qos_rules();
+  for (const auto& flow : flows) {
+    req_auth_qos_rules->Add()->CopyFrom(flow);
+  }
+  .
+  .
+  .
+
+ return req;
+}
+
+#endif
+}
+
+namespace magma {
+
+AsyncAmfServiceClient::AsyncAmfServiceClient(
+    std::shared_ptr<grpc::Channel> channel)
+    : stub_(SmfPduSessionSmContext::NewStub(channel)) {}
+
+AsyncAmfServiceClient::AsyncAmfServiceClient()
+    : AsyncAmfServiceClient(
+          ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+              "spgw_service", ServiceRegistrySingleton::LOCAL)) {}
+
+
+bool AsyncAmfServiceClient::handle_response_to_access(
+    const magma::SetSMSessionContextAccess& response) {
+  
+  MLOG(MINFO) << "Sending Set SM Session Response from SMF ";
+  #if 0
+  handle_response_to_access_rpc(
+      response, [](Status status, SmContextVoid resp) {
+        if (!status.ok()) {
+          MLOG(MERROR) << "Could not send Set SM Session Response from SMF" << imsi
+                       << apn_ip_addr << ": " << status.error_message();
+        }
+      });
+  #endif
+  handle_response_to_access_rpc(response, callback);
+  return true;
+}
+
+
+void AsyncAmfServiceClient::handle_response_to_access_rpc(
+    const SetSMSessionContextAccess& response,
+    std::function<void(Status, SmContextVoid)> callback) {
+	
+  std::cerr <<__LINE__ << " " << __FUNCTION__ 
+	         << " calling RPC of AMF SetSMFSessionContext and sending message" << "\n";
+  auto local_resp = new AsyncLocalResponse<SmContextVoid>(
+      std::move(callback), RESPONSE_TIMEOUT);
+  local_resp->set_response_reader(std::move(
+      stub_->AsyncSetSmfSessionContext(local_resp->get_context(), response, &queue_)));
+}
+
+}

--- a/lte/gateway/c/session_manager/AmfServiceClient.cpp
+++ b/lte/gateway/c/session_manager/AmfServiceClient.cpp
@@ -14,30 +14,6 @@ void call_back_void_amf(grpc::Status, magma::SmContextVoid respvoid)
 }
 std::function<void(grpc::Status, magma::SmContextVoid)>callback  = call_back_void_amf;
 
-#if 0
-magma::SetSMSessionContextAccess create_set_smsess_access_req(
-    const std::string& imsi, const std::string& apn_ip_addr,
-    const uint32_t linked_bearer_id,
-    const std::vector<magma::PolicyRule>& flows) {
-  magma::SetSMSessionContextAccess sreq;
-  
-  auto *req =  sreq.mutable_rat_specific_context().mutable_m5g_session_context_rsp();
-
-  req.set_pdu_session_id();
-  req.set_pdu_session_type(magma::PduSessionType::IPV4);
-  req.set_selected_ssc_mode(magma::SscMode::SSC_MODE_1);
-  auto req_auth_qos_rules = req.mutable_authorized_qos_rules();
-  for (const auto& flow : flows) {
-    req_auth_qos_rules->Add()->CopyFrom(flow);
-  }
-  .
-  .
-  .
-
- return req;
-}
-
-#endif
 }
 
 namespace magma {
@@ -56,15 +32,6 @@ bool AsyncAmfServiceClient::handle_response_to_access(
     const magma::SetSMSessionContextAccess& response) {
   
   MLOG(MINFO) << "Sending Set SM Session Response from SMF ";
-  #if 0
-  handle_response_to_access_rpc(
-      response, [](Status status, SmContextVoid resp) {
-        if (!status.ok()) {
-          MLOG(MERROR) << "Could not send Set SM Session Response from SMF" << imsi
-                       << apn_ip_addr << ": " << status.error_message();
-        }
-      });
-  #endif
   handle_response_to_access_rpc(response, callback);
   return true;
 }

--- a/lte/gateway/c/session_manager/AmfServiceClient.cpp
+++ b/lte/gateway/c/session_manager/AmfServiceClient.cpp
@@ -2,19 +2,17 @@
 #include "ServiceRegistrySingleton.h"
 #include "magma_logging.h"
 
-// using google::protobuf::RepeatedPtrField;
 using grpc::Status;
 
 namespace {
 
-void call_back_void_amf(grpc::Status, magma::SmContextVoid respvoid)
-{
-  //do nothinf but to only passing call back
-  //cout <<" Only for testing call back" << endl;
+void call_back_void_amf(grpc::Status, magma::SmContextVoid respvoid) {
+  // do nothinf but to only passing call back
 }
-std::function<void(grpc::Status, magma::SmContextVoid)>callback  = call_back_void_amf;
+std::function<void(grpc::Status, magma::SmContextVoid)> callback =
+    call_back_void_amf;
 
-}
+}  // namespace
 
 namespace magma {
 
@@ -27,26 +25,22 @@ AsyncAmfServiceClient::AsyncAmfServiceClient()
           ServiceRegistrySingleton::Instance()->GetGrpcChannel(
               "spgw_service", ServiceRegistrySingleton::LOCAL)) {}
 
-
 bool AsyncAmfServiceClient::handle_response_to_access(
     const magma::SetSMSessionContextAccess& response) {
-  
   MLOG(MINFO) << "Sending Set SM Session Response from SMF ";
   handle_response_to_access_rpc(response, callback);
   return true;
 }
 
-
 void AsyncAmfServiceClient::handle_response_to_access_rpc(
     const SetSMSessionContextAccess& response,
     std::function<void(Status, SmContextVoid)> callback) {
-	
-  std::cerr <<__LINE__ << " " << __FUNCTION__ 
-	         << " calling RPC of AMF SetSMFSessionContext and sending message" << "\n";
+  MLOG(MINFO) << "Calling RPC of AMF SetSMFSessionContext and sending message"
+              << "\n";
   auto local_resp = new AsyncLocalResponse<SmContextVoid>(
       std::move(callback), RESPONSE_TIMEOUT);
-  local_resp->set_response_reader(std::move(
-      stub_->AsyncSetSmfSessionContext(local_resp->get_context(), response, &queue_)));
+  local_resp->set_response_reader(std::move(stub_->AsyncSetSmfSessionContext(
+      local_resp->get_context(), response, &queue_)));
 }
 
-}
+}  // namespace magma

--- a/lte/gateway/c/session_manager/AmfServiceClient.h
+++ b/lte/gateway/c/session_manager/AmfServiceClient.h
@@ -40,14 +40,12 @@ class AsyncAmfServiceClient : public GRPCReceiver, public AmfServiceClient {
    public:
 
       AsyncAmfServiceClient();
-      //AsyncAmfServiceClient() {}  //TODO  For temorary compilation purpose and will take out
       AsyncAmfServiceClient(std::shared_ptr<grpc::Channel> amf_srv_channel);
 
       /* This will send response back to AMF for all three request messages
        * i.e. establish, modification and release messages
        */
       bool handle_response_to_access(const magma::SetSMSessionContextAccess& response);
-     //bool handle_response_to_access(const magma::SetSMSessionContextAccess& response) { return true;}
 
     private:
       static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds

--- a/lte/gateway/c/session_manager/AmfServiceClient.h
+++ b/lte/gateway/c/session_manager/AmfServiceClient.h
@@ -30,29 +30,34 @@ using namespace lte;
  * modification and release request message to AMF
  */
 class AmfServiceClient {
-   public:
-      virtual ~AmfServiceClient() {}
-      virtual bool handle_response_to_access(const magma::SetSMSessionContextAccess& response) = 0;
+ public:
+  virtual ~AmfServiceClient() {}
+  virtual bool handle_response_to_access(
+      const magma::SetSMSessionContextAccess& response) = 0;
 
-}; //end of abstract class
+};  // end of abstract class
 
 class AsyncAmfServiceClient : public GRPCReceiver, public AmfServiceClient {
-   public:
+ public:
+  AsyncAmfServiceClient();
+  // AsyncAmfServiceClient() {}  //TODO  For temorary compilation purpose and
+  // will take out
+  AsyncAmfServiceClient(std::shared_ptr<grpc::Channel> amf_srv_channel);
 
-      AsyncAmfServiceClient();
-      AsyncAmfServiceClient(std::shared_ptr<grpc::Channel> amf_srv_channel);
+  /* This will send response back to AMF for all three request messages
+   * i.e. establish, modification and release messages
+   */
+  bool handle_response_to_access(
+      const magma::SetSMSessionContextAccess& response);
+  // bool handle_response_to_access(const magma::SetSMSessionContextAccess&
+  // response) { return true;}
 
-      /* This will send response back to AMF for all three request messages
-       * i.e. establish, modification and release messages
-       */
-      bool handle_response_to_access(const magma::SetSMSessionContextAccess& response);
-
-    private:
-      static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
-      std::unique_ptr<SmfPduSessionSmContext::Stub> stub_;
-      void handle_response_to_access_rpc(const SetSMSessionContextAccess& response,
-		          std::function<void(Status, SmContextVoid)> callback);
-
+ private:
+  static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
+  std::unique_ptr<SmfPduSessionSmContext::Stub> stub_;
+  void handle_response_to_access_rpc(
+      const SetSMSessionContextAccess& response,
+      std::function<void(Status, SmContextVoid)> callback);
 };
 
-} // namespace magma
+}  // namespace magma

--- a/lte/gateway/c/session_manager/AmfServiceClient.h
+++ b/lte/gateway/c/session_manager/AmfServiceClient.h
@@ -35,13 +35,11 @@ class AmfServiceClient {
   virtual bool handle_response_to_access(
       const magma::SetSMSessionContextAccess& response) = 0;
 
-};  // end of abstract class
+};// end of abstract class
 
 class AsyncAmfServiceClient : public GRPCReceiver, public AmfServiceClient {
  public:
   AsyncAmfServiceClient();
-  // AsyncAmfServiceClient() {}  //TODO  For temorary compilation purpose and
-  // will take out
   AsyncAmfServiceClient(std::shared_ptr<grpc::Channel> amf_srv_channel);
 
   /* This will send response back to AMF for all three request messages
@@ -49,8 +47,6 @@ class AsyncAmfServiceClient : public GRPCReceiver, public AmfServiceClient {
    */
   bool handle_response_to_access(
       const magma::SetSMSessionContextAccess& response);
-  // bool handle_response_to_access(const magma::SetSMSessionContextAccess&
-  // response) { return true;}
 
  private:
   static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds

--- a/lte/gateway/c/session_manager/AmfServiceClient.h
+++ b/lte/gateway/c/session_manager/AmfServiceClient.h
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <mutex>
+
+#include <grpc++/grpc++.h>
+#include <lte/protos/session_manager.pb.h>
+#include <lte/protos/session_manager.grpc.pb.h>
+
+#include "GRPCReceiver.h"
+
+using grpc::Status;
+
+namespace magma {
+using namespace lte;
+
+/**
+ * AmfServiceClient is the base class for responding on establish
+ * modification and release request message to AMF
+ */
+class AmfServiceClient {
+   public:
+      virtual ~AmfServiceClient() {}
+      virtual bool handle_response_to_access(const magma::SetSMSessionContextAccess& response) = 0;
+
+}; //end of abstract class
+
+class AsyncAmfServiceClient : public GRPCReceiver, public AmfServiceClient {
+   public:
+
+      AsyncAmfServiceClient();
+      //AsyncAmfServiceClient() {}  //TODO  For temorary compilation purpose and will take out
+      AsyncAmfServiceClient(std::shared_ptr<grpc::Channel> amf_srv_channel);
+
+      /* This will send response back to AMF for all three request messages
+       * i.e. establish, modification and release messages
+       */
+      bool handle_response_to_access(const magma::SetSMSessionContextAccess& response);
+     //bool handle_response_to_access(const magma::SetSMSessionContextAccess& response) { return true;}
+
+    private:
+      static const uint32_t RESPONSE_TIMEOUT = 6;  // seconds
+      std::unique_ptr<SmfPduSessionSmContext::Stub> stub_;
+      void handle_response_to_access_rpc(const SetSMSessionContextAccess& response,
+		          std::function<void(Status, SmContextVoid)> callback);
+
+};
+
+} // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -81,13 +81,19 @@ std::string grant_type_to_str(GrantTrackingType grant_type) {
 std::string session_fsm_state_to_str(SessionFsmState state) {
   switch (state) {
     case SESSION_ACTIVE:
+    case ACTIVE:
       return "SESSION_ACTIVE";
     case SESSION_TERMINATED:
       return "SESSION_TERMINATED";
     case SESSION_TERMINATION_SCHEDULED:
       return "SESSION_TERMINATION_SCHEDULED";
     case SESSION_RELEASED:
+    case RELEASE:
       return "SESSION_RELEASED";
+    case CREATING:
+      return "SESSION_CREATING";
+    case CREATED:
+      return "SESSION_CREATED";
     default:
       return "INVALID SESSION FSM STATE";
   }

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*****************************************************************************
+  Source      	SessionStateEnforcer.cpp
+  Version     	0.1
+  Date       	2020/08/08
+  Product     	SessionD
+  Subsystem   	5G managing & maintaining state & store of session of SessionD
+                Fanout message to Access and UPF through respective client obj
+  Author/Editor Sanjay Kumar Ojha
+  Description 	Objects run in main thread context invoked by folly event
+*****************************************************************************/
+
+#include <string>
+#include <time.h>
+#include <utility>
+#include <vector>
+
+#include <google/protobuf/repeated_field.h>
+#include <google/protobuf/timestamp.pb.h>
+#include <google/protobuf/util/time_util.h>
+#include <grpcpp/channel.h>
+#include "magma_logging.h"
+#include "EnumToString.h"
+#include "SessionStateEnforcer.h"
+
+namespace magma
+{
+//temp routine
+void call_back_void_upf(grpc::Status, magma::UpfRes response)
+{
+  //do nothinf but to only passing call back
+  //cout <<" Only for testing call back" << endl;
+}
+
+
+/*constructor*/
+SessionStateEnforcer::SessionStateEnforcer(
+    std::shared_ptr<StaticRuleStore> rule_store,
+    SessionStore& session_store,
+    std::shared_ptr<PipelinedClient> pipelined_client,
+    std::shared_ptr<AmfServiceClient> amf_srv_client,
+    magma::mconfig::SessionD mconfig)
+    : session_store_(session_store),
+      pipelined_client_(pipelined_client),
+      amf_srv_client_(amf_srv_client),
+      retry_timeout_(1),
+      mconfig_(mconfig)
+      //SmSession_Context_Send_Client_sp_(SmSession_Context_Send_Client)
+      //pipelined_client_(pipelined_client),
+        {
+			// for now this is the right place, need to move if find  anohter right place
+			static_rule_init();
+		}
+
+/*
+void SessionStateEnforcer::start() {
+   evb_->loopForever();
+}
+*/
+
+void SessionStateEnforcer::attachEventBase(folly::EventBase* evb) {
+   evb_ = evb;
+}
+
+void SessionStateEnforcer::stop() {
+   evb_->terminateLoopSoon();
+}
+
+folly::EventBase& SessionStateEnforcer::get_event_base() {
+   return *evb_;
+}
+
+bool SessionStateEnforcer::m5g_init_session_credit(SessionMap& session_map,
+		const std::string& imsi, const std::string& session_ctx_id,
+	       	const SessionConfig& cfg) {
+   /* creating SessionState object with state CREATING
+    * This calls constructor and allocates memory*/
+   std::cerr << __LINE__ << " " << __FUNCTION__ <<" New SessionState object getting created" 
+	                  << " with IMSI" << imsi <<"\n";
+   auto session_state = std::make_unique<SessionState>
+                        (imsi, session_ctx_id, cfg,*rule_store_);
+   MLOG(MINFO) << __LINE__ << " ACL_TAG New SessionState object created with IMSI: "
+	        << imsi <<" session context id : " << session_ctx_id;
+   handle_session_init_rule_updates(session_map,
+   		                            imsi, *session_state);
+
+   /* Find same UE or imsi already present, if not add
+    * TODO - Need to check if same DNN/APN already exist
+    */
+   auto exist_imsi = session_map.find(imsi);
+   if (exist_imsi == session_map.end()) {
+     // First time a session is created for IMSI in the SessionMap
+     MLOG(MDEBUG) << "First session for IMSI " << imsi
+                  << " with session context ID " << session_ctx_id;
+     session_map[imsi] = std::vector<std::unique_ptr<SessionState>>();
+   }
+   else {//TODO IMP to remove the comment, as session_state is not filled properly
+      //session_map[imsi].push_back(std::move(session_state));
+   }
+   /*Check if version missmatch, adapt AMF version as it is new session*/
+   if((session_state->get_current_version()) !=
+		   cfg.common_context.sm_session_version()) {
+      //MLOG(MDEBUG) << "New SessionState with different version ID received "
+      MLOG(MINFO) << "New SessionState with different version ID received "
+	           << "Aligned version number of session of AMF and SessionD "
+		   << "IMSI " << imsi;
+      std::cerr << __LINE__ << " " << __FUNCTION__ <<" updating session_state->set_current_version\n";
+      session_state->set_current_version(
+		      cfg.common_context.sm_session_version());
+   }
+   return true; // for compilation only.
+}
+
+bool SessionStateEnforcer::handle_session_init_rule_updates(
+		SessionMap& session_map, const std::string& imsi,
+   		SessionState&  session_state)
+{
+
+   std::cerr <<__LINE__ << " " << __FUNCTION__ <<" imsi "<< imsi <<"\n";
+   auto itp = pdr_map_.equal_range(imsi);
+   for ( auto itr = itp.first;  itr!= itp.second; itr++) {
+	/* Get the PDR numbers, now  get the rules from global static rule 
+         * list
+         */
+        SetGroupPDR rule;
+		GlobalRuleList.get_rule(itr->second,&rule);
+        std::cerr <<__LINE__ << " " << __FUNCTION__ <<" for imsi " << imsi
+			 << "matched  pdr no "   <<rule.pdr_id()<< "\n";
+		session_state.insert_with_static_rules (&rule);
+	}
+   auto itf = far_map_.equal_range(imsi);
+   for ( auto itr = itf.first;  itr!= itf.second; itr++) {
+	/* Get the PDR numbers, now  get the rules from global static rule 
+         * list
+         */
+        SetGroupFAR rule;
+	GlobalRuleList.get_rule(itr->second,&rule);
+        std::cerr <<__LINE__ << " " << __FUNCTION__ <<" for imsi "<< imsi
+					<<"matched far no " <<rule.far_id()<<"\n";
+        // Add to the the session vector
+	session_state.insert_with_static_rules (&rule);
+    }
+#if 1
+    //auto ip_addr = session_state.get_config().common_context.ue_ipv4();
+    auto ip_addr = session_state.get_config().rat_specific_context.
+               m5gsm_session_context().pdu_address().redirect_server_address();
+    SessionState::SessionCommonInfo  sess_comm_info;
+    sess_comm_info.imsi_ = imsi;
+    sess_comm_info.ip_addr_ = ip_addr;
+    sess_comm_info.Pdr_rules_ = session_state.get_5g_static_pdr_rules();
+    sess_comm_info.Far_rules_ = session_state.get_5g_static_far_rules();
+
+    /* session_state elments are filled with rules. State needs to be 
+     * moved to CREATED and sending message to UPF.
+     * Note: charging and credit related info not taken care in drop-1  
+     */
+    auto update_criteria = get_default_update_criteria();
+    session_state.set_fsm_state(CREATED, update_criteria);
+    MLOG(MDEBUG) << "State of session changed to "
+                 << session_fsm_state_to_str(session_state.get_state());
+    std::cerr <<__LINE__ << " " << __FUNCTION__ <<" changed the state to "
+              << session_fsm_state_to_str(session_state.get_state())
+              << " IP_Address ipv4 " << ip_addr << "of IMSI " << imsi << "\n";
+
+    std::cerr <<__LINE__ << " " << __FUNCTION__ <<" Beofre calling set_upf_session" <<"\n";
+    /* Update the m5gsm_cause and prepare for respone along with actual cause*/
+    prepare_response_to_access(imsi, session_state, 
+		    magma::lte::M5GSMCause::OPERATION_SUCCESS);
+    pipelined_client_->set_upf_session(sess_comm_info,call_back_void_upf);
+#endif
+return true;
+}
+
+/* To send response back to AMF 
+ * Fill the response structure from session context message 
+ * and call rpc of AmfServiceClient
+ * TODO  const std::vector<magma::PolicyRule>& flows 
+ *            ==> related to AuthorizedQosRules authorized_qos_rules.
+ */
+void SessionStateEnforcer::prepare_response_to_access(
+		    const std::string& imsi,
+		    SessionState& session_state,
+		    const magma::lte::M5GSMCause m5gsm_cause)
+{
+   magma::SetSMSessionContextAccess response;
+   const auto& config = session_state.get_config();
+
+   if (!config.rat_specific_context.has_m5gsm_session_context()) {
+       MLOG(MWARNING) << "No M5G SM Session Context is specified for session";
+       std::cerr <<__LINE__ << " " << __FUNCTION__ 
+	         << " No M5G SM Session Context is specified for session" << "\n";
+       return;
+   }
+   std::cerr <<__LINE__ << " " << __FUNCTION__ 
+	         << " Filling Response messages to be passed through AMFClientClient" << "\n";
+
+   /* Filing response proto message*/
+   auto *rsp = response.mutable_rat_specific_context()->mutable_m5g_session_context_rsp();
+   auto *rsp_cmn = response.mutable_common_context();
+
+   rsp->set_pdu_session_id(config.rat_specific_context.
+		   m5gsm_session_context().pdu_session_id());
+   rsp->set_pdu_session_type(config.rat_specific_context.
+		   m5gsm_session_context().pdu_session_type());
+   rsp->set_selected_ssc_mode(config.rat_specific_context.
+		   m5gsm_session_context().ssc_mode());
+   rsp->set_allowed_ssc_mode(config.rat_specific_context.
+		   m5gsm_session_context().ssc_mode());
+   rsp->set_m5gsm_cause(m5gsm_cause);
+   rsp->set_always_on_pdu_session_indication(config.rat_specific_context.
+		   m5gsm_session_context().pdu_session_req_always_on());
+   rsp->set_m5gsm_congetion_re_attempt_indicator(true);
+   //rsp->set_sm_session_state(config.rat_specific_context.
+   //		   m5gsm_session_context().sm_session_state());
+   //rsp->set_sm_session_version(config.rat_specific_context.
+   //		   m5gsm_session_context().sm_session_version());
+   rsp->mutable_pdu_address()->set_redirect_address_type(
+		   config.rat_specific_context.
+		   m5gsm_session_context().pdu_address().redirect_address_type());
+   rsp->mutable_pdu_address()->set_redirect_server_address(
+		   config.rat_specific_context.m5gsm_session_context().
+		   pdu_address().redirect_server_address());
+   ///TODO after AMF completes config firl ambr to be implemeted. 
+   //Deferring QoS for now. Once implemted will be adapted.
+   //AggregatedMaximumBitrate session_ambr
+   //AuthorizedQosRules authorized_qos_rules
+
+   rsp_cmn->mutable_sid()->CopyFrom(config.common_context.sid());  //imsi
+   rsp_cmn->set_sm_session_state(config.common_context.sm_session_state());
+   rsp_cmn->set_sm_session_version(config.common_context.sm_session_version());
+
+   //Send message to AMF gRPC client handler.
+   amf_srv_client_->handle_response_to_access(response);
+}
+
+bool SessionStateEnforcer:: static_rule_init () {
+// Static PDR, FAR, QDR, URR and BAR mapping  and also
+//  Define 1 PDR and FAR
+   SetGroupPDR reqpdr1,reqpdr2;
+   SetGroupFAR reqf;
+   magma::PDI pdireq;
+#if 0
+   //req.set_seid("0x12345678");
+   req.set_sess_ver_no(0x01);
+   //req.mutable_node_id()->set_node_id("100");
+   req.set_session_state("Created");
+   //cpfseid to be addeid
+#endif
+   reqpdr1.set_pdr_id(1);
+   reqpdr1.set_sess_ver_no(2);
+   reqpdr1.set_precedence(5);
+   reqpdr1.set_far_id(1);
+   pdireq.set_src_interface(3);
+   pdireq.set_net_instance("downlink");
+   pdireq.set_ue_ip_adr("10.10.1.1");
+   //pdireq.set_tr_ep_id(0x234035);
+   //mutable_pdi()
+   //reqp.mutable_pdi()->set_pdi(pdireq);
+   //PdrGlobalList.policy_count();
+   GlobalRuleList.insert_rule(1,reqpdr1); 
+   reqpdr2.set_pdr_id(2);
+   reqpdr2.set_sess_ver_no(1);
+   reqpdr2.set_precedence(2);
+   reqpdr2.set_far_id(2);
+   pdireq.set_src_interface(3);
+   pdireq.set_net_instance("uplink");
+   pdireq.set_ue_ip_adr("10.10.1.2");
+   GlobalRuleList.insert_rule(2,reqpdr2);
+   SetGroupFAR  far1;
+   far1.set_far_id(1);
+   far1.set_sess_ver_no (4);
+   far1.set_bar_id(6);
+   //ApplyAction_Action  far_act =::magma::lte::ApplyAction_Action_FORW;
+   //far1.mutable_apply_action()->set_apply_action(far_act);
+   GlobalRuleList.insert_rule(1,far1);
+
+   //subscriber Id 1 to PDR 1 and FAR 1
+   pdr_map_.insert(std::pair<std::string,uint32_t>("IMSI00000001",1));
+   far_map_.insert(std::pair<std::string,uint32_t>("IMSI00000001",1));
+   //subscriber Id 2  PDR list shud 2 and 4, far list also 2 and 4
+   pdr_map_.insert(std::pair<std::string,uint32_t>("IMSI00000002",2));
+   far_map_.insert(std::pair<std::string,uint32_t>("IMSI00000002",2));
+   #if 0
+   for ( auto local_it = pdr_map_.begin(); local_it!= pdr_map_.end(); ++local_it )
+      std::cout << " first" << local_it->first << ":" << local_it->second;
+    std::cout << std::endl;
+
+   for (auto itr =far_map_.begin(); itr!= far_map_.end(); ++itr)  {
+      std::cout << " first" << itr->first << ":" << itr->second;
+   }
+   #endif
+   return true;
+}
+} //end namespace magma

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.cpp
@@ -33,20 +33,15 @@
 #include "EnumToString.h"
 #include "SessionStateEnforcer.h"
 
-namespace magma
-{
-//temp routine
-void call_back_void_upf(grpc::Status, magma::UpfRes response)
-{
-  //do nothinf but to only passing call back
-  //cout <<" Only for testing call back" << endl;
+namespace magma {
+// temp routine
+void call_back_void_upf(grpc::Status, magma::UpfRes response) {
+  // do nothinf but to only passing call back
 }
-
 
 /*constructor*/
 SessionStateEnforcer::SessionStateEnforcer(
-    std::shared_ptr<StaticRuleStore> rule_store,
-    SessionStore& session_store,
+    std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
     std::shared_ptr<PipelinedClient> pipelined_client,
     std::shared_ptr<AmfServiceClient> amf_srv_client,
     magma::mconfig::SessionD mconfig)
@@ -55,216 +50,196 @@ SessionStateEnforcer::SessionStateEnforcer(
       amf_srv_client_(amf_srv_client),
       retry_timeout_(1),
       mconfig_(mconfig)
-      //SmSession_Context_Send_Client_sp_(SmSession_Context_Send_Client)
-      //pipelined_client_(pipelined_client),
-      {
-	  // for now this is the right place, need to move if find  anohter right place
-          static_rule_init();
-      }
+{
+  // for now this is the right place, need to move if find  anohter right place
+  static_rule_init();
+}
 
 void SessionStateEnforcer::attachEventBase(folly::EventBase* evb) {
-   evb_ = evb;
+  evb_ = evb;
 }
 
 void SessionStateEnforcer::stop() {
-   evb_->terminateLoopSoon();
+  evb_->terminateLoopSoon();
 }
 
 folly::EventBase& SessionStateEnforcer::get_event_base() {
-   return *evb_;
+  return *evb_;
 }
 
-bool SessionStateEnforcer::m5g_init_session_credit(SessionMap& session_map,
-		const std::string& imsi, const std::string& session_id,
-	       	const SessionConfig& cfg) {
-   /* creating SessionState object with state CREATING
-    * This calls constructor and allocates memory*/
-   std::cerr << __LINE__ << " " << __FUNCTION__ <<" New SessionState object getting created" 
-	                  << " with IMSI" << imsi <<"\n";
-   auto session_state = std::make_unique<SessionState>
-                        (imsi, session_id, cfg,*rule_store_);
-   MLOG(MINFO) << __LINE__ << " New SessionState object created with IMSI: "
-	        << imsi <<" session context id : " << session_id;
-   handle_session_init_rule_updates(session_map,
-   		                            imsi, *session_state);
+bool SessionStateEnforcer::m5g_init_session_credit(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, const SessionConfig& cfg) {
+  /* creating SessionState object with state CREATING
+   * This calls constructor and allocates memory*/
+  auto session_state =
+      std::make_unique<SessionState>(imsi, session_id, cfg, *rule_store_);
+  MLOG(MINFO) << " New SessionState object created with IMSI: " << imsi
+              << " session context id : " << session_id;
+  handle_session_init_rule_updates(session_map, imsi, *session_state);
 
-   /* Find same UE or imsi already present, if not add
-    * TODO - Need to check if same DNN/APN already exist
-    */
-   auto exist_imsi = session_map.find(imsi);
-   if (exist_imsi == session_map.end()) {
-     // First time a session is created for IMSI in the SessionMap
-     MLOG(MDEBUG) << "First session for IMSI " << imsi
-                  << " with session context ID " << session_id;
-     session_map[imsi] = std::vector<std::unique_ptr<SessionState>>();
-   }
-   else {//TODO IMP to remove the comment, as session_state is not filled properly
-      //session_map[imsi].push_back(std::move(session_state));
-   }
-   /*Check if version missmatch, adapt AMF version as it is new session*/
-   if((session_state->get_current_version()) !=
-		   cfg.common_context.sm_session_version()) {
-      //MLOG(MDEBUG) << "New SessionState with different version ID received "
-      MLOG(MINFO) << "New SessionState with different version ID received "
-	           << "Aligned version number of session of AMF and SessionD "
-		   << "IMSI " << imsi;
-      std::cerr << __LINE__ << " " << __FUNCTION__ <<" updating session_state->set_current_version\n";
-      session_state->set_current_version(
-		      cfg.common_context.sm_session_version());
-   }
-   return true; // for compilation only.
+  /* Find same UE or imsi already present, if not add
+   * TODO - Need to check if same DNN/APN already exist
+   */
+  auto exist_imsi = session_map.find(imsi);
+  if (exist_imsi == session_map.end()) {
+    // First time a session is created for IMSI in the SessionMap
+    MLOG(MDEBUG) << "First session for IMSI " << imsi
+                 << " with session context ID " << session_id;
+    session_map[imsi] = std::vector<std::unique_ptr<SessionState>>();
+  } else {
+    MLOG(MINFO) << "Sanjay inside else session exist session for IMSI " << imsi;
+    session_map[imsi].push_back(std::move(session_state));
+  }
+  return true;
 }
 
-bool SessionStateEnforcer::handle_session_init_rule_updates(
-		SessionMap& session_map, const std::string& imsi,
-   		SessionState&  session_state)
-{
-
-   std::cerr <<__LINE__ << " " << __FUNCTION__ <<" imsi "<< imsi <<"\n";
-   auto itp = pdr_map_.equal_range(imsi);
-   for ( auto itr = itp.first;  itr!= itp.second; itr++) {
-	/* Get the PDR numbers, now  get the rules from global static rule 
-         * list
-         */
-        SetGroupPDR rule;
-		GlobalRuleList.get_rule(itr->second,&rule);
-        std::cerr <<__LINE__ << " " << __FUNCTION__ <<" for imsi " << imsi
-			 << "matched  pdr no "   <<rule.pdr_id()<< "\n";
-		session_state.insert_with_static_rules (&rule);
-	}
-   auto itf = far_map_.equal_range(imsi);
-   for ( auto itr = itf.first;  itr!= itf.second; itr++) {
-	/* Get the PDR numbers, now  get the rules from global static rule 
-         * list
-         */
-        SetGroupFAR rule;
-	GlobalRuleList.get_rule(itr->second,&rule);
-        std::cerr <<__LINE__ << " " << __FUNCTION__ <<" for imsi "<< imsi
-					<<"matched far no " <<rule.far_id()<<"\n";
-        // Add to the the session vector
-	session_state.insert_with_static_rules (&rule);
-    }
-    auto ip_addr = session_state.get_config().rat_specific_context.
-               m5gsm_session_context().pdu_address().redirect_server_address();
-    SessionState::SessionInfo  sess_info;
-    sess_info.imsi = imsi;
-    sess_info.ip_addr = ip_addr;
-    sess_info.Pdr_rules_ = session_state.get_5g_static_pdr_rules();
-    sess_info.Far_rules_ = session_state.get_5g_static_far_rules();
-    session_state.sess_infocopy(&sess_info);
-
-    /* session_state elments are filled with rules. State needs to be 
-     * moved to CREATED and sending message to UPF.
-     * Note: charging and credit related info not taken care in drop-1  
+void SessionStateEnforcer::handle_session_init_rule_updates(
+    SessionMap& session_map, const std::string& imsi,
+    SessionState& session_state) {
+  auto itp = pdr_map_.equal_range(imsi);
+  for (auto itr = itp.first; itr != itp.second; itr++) {
+    /* Get the PDR numbers, now  get the rules from global static rule
+     * list
      */
-    auto update_criteria = get_default_update_criteria();
-    session_state.set_fsm_state(CREATED, update_criteria);
-    MLOG(MDEBUG) << "State of session changed to "
-                 << session_fsm_state_to_str(session_state.get_state());
-    std::cerr <<__LINE__ << " " << __FUNCTION__ <<" changed the state to "
-              << session_fsm_state_to_str(session_state.get_state())
-              << " IP_Address ipv4 " << ip_addr << "of IMSI " << imsi << "\n";
+    SetGroupPDR rule;
+    GlobalRuleList.get_rule(itr->second, &rule);
+    session_state.insert_with_static_rules(&rule);
+  }
+  auto itf = far_map_.equal_range(imsi);
+  for (auto itr = itf.first; itr != itf.second; itr++) {
+    /* Get the PDR numbers, now  get the rules from global static rule
+     * list
+     */
+    SetGroupFAR rule;
+    GlobalRuleList.get_rule(itr->second, &rule);
+    // Add to the the session vector
+    session_state.insert_with_static_rules(&rule);
+  }
+  auto ip_addr = session_state.get_config()
+                     .rat_specific_context.m5gsm_session_context()
+                     .pdu_address()
+                     .redirect_server_address();
+  SessionState::SessionInfo sess_info;
+  sess_info.imsi       = imsi;
+  sess_info.ip_addr    = ip_addr;
+  sess_info.Pdr_rules_ = session_state.get_5g_static_pdr_rules();
+  sess_info.Far_rules_ = session_state.get_5g_static_far_rules();
+  session_state.sess_infocopy(&sess_info);
 
-    std::cerr <<__LINE__ << " " << __FUNCTION__ <<" Beofre calling set_upf_session" <<"\n";
-    /* Update the m5gsm_cause and prepare for respone along with actual cause*/
-    prepare_response_to_access(imsi, session_state, 
-		    magma::lte::M5GSMCause::OPERATION_SUCCESS);
-    pipelined_client_->set_upf_session(sess_info,call_back_void_upf);
-return true;
+  /* session_state elments are filled with rules. State needs to be
+   * moved to CREATED and sending message to UPF.
+   * Note: charging and credit related info not taken care in drop-1
+   *
+   * TODO - will be taken care later
+   * Thinking of adding the created session into session store after step
+   * CREATING state and before rules are add to session. And adding the logic
+   * of implementing policy rules into the event loop. This way, when PCF
+   * component is introduced an asynchronous call into PCF (PolicyDB) can be
+   * handled easily later on.
+   *
+   */
+  auto update_criteria = get_default_update_criteria();
+  session_state.set_fsm_state(CREATED, update_criteria);
+  MLOG(MDEBUG) << "State of session changed to "
+               << session_fsm_state_to_str(session_state.get_state());
+  /* Update the m5gsm_cause and prepare for respone along with actual cause*/
+  prepare_response_to_access(
+      imsi, session_state, magma::lte::M5GSMCause::OPERATION_SUCCESS);
+  pipelined_client_->set_upf_session(sess_info, call_back_void_upf);
+  return;
 }
 
-/* To send response back to AMF 
- * Fill the response structure from session context message 
+/* To send response back to AMF
+ * Fill the response structure from session context message
  * and call rpc of AmfServiceClient
- * TODO  const std::vector<magma::PolicyRule>& flows 
+ * TODO  const std::vector<magma::PolicyRule>& flows
  *            ==> related to AuthorizedQosRules authorized_qos_rules.
  */
 void SessionStateEnforcer::prepare_response_to_access(
-		    const std::string& imsi,
-		    SessionState& session_state,
-		    const magma::lte::M5GSMCause m5gsm_cause)
-{
-   magma::SetSMSessionContextAccess response;
-   const auto& config = session_state.get_config();
+    const std::string& imsi, SessionState& session_state,
+    const magma::lte::M5GSMCause m5gsm_cause) {
+  magma::SetSMSessionContextAccess response;
+  const auto& config = session_state.get_config();
 
-   if (!config.rat_specific_context.has_m5gsm_session_context()) {
-       MLOG(MWARNING) << "No M5G SM Session Context is specified for session";
-       std::cerr <<__LINE__ << " " << __FUNCTION__ 
-	         << " No M5G SM Session Context is specified for session" << "\n";
-       return;
-   }
-   std::cerr <<__LINE__ << " " << __FUNCTION__ 
-	         << " Filling Response messages to be passed through AMFClientClient" << "\n";
+  if (!config.rat_specific_context.has_m5gsm_session_context()) {
+    MLOG(MWARNING) << "No M5G SM Session Context is specified for session";
+    return;
+  }
 
-   /* Filing response proto message*/
-   auto *rsp = response.mutable_rat_specific_context()->mutable_m5g_session_context_rsp();
-   auto *rsp_cmn = response.mutable_common_context();
+  /* Filing response proto message*/
+  auto* rsp = response.mutable_rat_specific_context()
+                  ->mutable_m5g_session_context_rsp();
+  auto* rsp_cmn = response.mutable_common_context();
 
-   rsp->set_pdu_session_id(config.rat_specific_context.
-		   m5gsm_session_context().pdu_session_id());
-   rsp->set_pdu_session_type(config.rat_specific_context.
-		   m5gsm_session_context().pdu_session_type());
-   rsp->set_selected_ssc_mode(config.rat_specific_context.
-		   m5gsm_session_context().ssc_mode());
-   rsp->set_allowed_ssc_mode(config.rat_specific_context.
-		   m5gsm_session_context().ssc_mode());
-   rsp->set_m5gsm_cause(m5gsm_cause);
-   rsp->set_always_on_pdu_session_indication(config.rat_specific_context.
-		   m5gsm_session_context().pdu_session_req_always_on());
-   rsp->set_m5gsm_congetion_re_attempt_indicator(true);
-   rsp->mutable_pdu_address()->set_redirect_address_type(
-		   config.rat_specific_context.
-		   m5gsm_session_context().pdu_address().redirect_address_type());
-   rsp->mutable_pdu_address()->set_redirect_server_address(
-		   config.rat_specific_context.m5gsm_session_context().
-		   pdu_address().redirect_server_address());
-   ///TODO after AMF completes config firl ambr to be implemeted. 
-   //Deferring QoS for now. Once implemted will be adapted.
-   //AggregatedMaximumBitrate session_ambr
-   //AuthorizedQosRules authorized_qos_rules
+  rsp->set_pdu_session_id(
+      config.rat_specific_context.m5gsm_session_context().pdu_session_id());
+  rsp->set_pdu_session_type(
+      config.rat_specific_context.m5gsm_session_context().pdu_session_type());
+  rsp->set_selected_ssc_mode(
+      config.rat_specific_context.m5gsm_session_context().ssc_mode());
+  rsp->set_allowed_ssc_mode(
+      config.rat_specific_context.m5gsm_session_context().ssc_mode());
+  rsp->set_m5gsm_cause(m5gsm_cause);
+  rsp->set_always_on_pdu_session_indication(
+      config.rat_specific_context.m5gsm_session_context()
+          .pdu_session_req_always_on());
+  rsp->set_m5gsm_congetion_re_attempt_indicator(true);
+  rsp->mutable_pdu_address()->set_redirect_address_type(
+      config.rat_specific_context.m5gsm_session_context()
+          .pdu_address()
+          .redirect_address_type());
+  rsp->mutable_pdu_address()->set_redirect_server_address(
+      config.rat_specific_context.m5gsm_session_context()
+          .pdu_address()
+          .redirect_server_address());
+  /* TODO AMBR and QoS will be implemented later.
+   * AMBR value need to compared from AMF and PCF, then fill the required
+   * values and sent to AMF.
+   */
 
-   rsp_cmn->mutable_sid()->CopyFrom(config.common_context.sid());  //imsi
-   rsp_cmn->set_sm_session_state(config.common_context.sm_session_state());
-   rsp_cmn->set_sm_session_version(config.common_context.sm_session_version());
+  rsp_cmn->mutable_sid()->CopyFrom(config.common_context.sid());  // imsi
+  rsp_cmn->set_sm_session_state(config.common_context.sm_session_state());
+  rsp_cmn->set_sm_session_version(config.common_context.sm_session_version());
 
-   //Send message to AMF gRPC client handler.
-   amf_srv_client_->handle_response_to_access(response);
+  // Send message to AMF gRPC client handler.
+  amf_srv_client_->handle_response_to_access(response);
 }
 
-bool SessionStateEnforcer:: static_rule_init () {
-// Static PDR, FAR, QDR, URR and BAR mapping  and also
-//  Define 1 PDR and FAR
-   SetGroupPDR reqpdr1,reqpdr2;
-   SetGroupFAR reqf;
-   magma::PDI pdireq;
-   reqpdr1.set_pdr_id(1);
-   reqpdr1.set_sess_ver_no(2);
-   reqpdr1.set_precedence(5);
-   reqpdr1.set_far_id(1);
-   pdireq.set_src_interface(3);
-   pdireq.set_net_instance("downlink");
-   pdireq.set_ue_ip_adr("10.10.1.1");
-   GlobalRuleList.insert_rule(1,reqpdr1); 
-   reqpdr2.set_pdr_id(2);
-   reqpdr2.set_sess_ver_no(1);
-   reqpdr2.set_precedence(2);
-   reqpdr2.set_far_id(2);
-   pdireq.set_src_interface(3);
-   pdireq.set_net_instance("uplink");
-   pdireq.set_ue_ip_adr("10.10.1.2");
-   GlobalRuleList.insert_rule(2,reqpdr2);
-   SetGroupFAR  far1;
-   far1.set_far_id(1);
-   far1.set_sess_ver_no (4);
-   far1.set_bar_id(6);
-   GlobalRuleList.insert_rule(1,far1);
+bool SessionStateEnforcer::static_rule_init() {
+  // Static PDR, FAR, QDR, URR and BAR mapping  and also
+  //  Define 1 PDR and FAR
+  SetGroupPDR reqpdr1, reqpdr2;
+  SetGroupFAR reqf;
+  magma::PDI pdireq;
+  reqpdr1.set_pdr_id(1);
+  reqpdr1.set_sess_ver_no(2);
+  reqpdr1.set_precedence(5);
+  reqpdr1.set_far_id(1);
+  pdireq.set_src_interface(3);
+  pdireq.set_net_instance("downlink");
+  pdireq.set_ue_ip_adr("10.10.1.1");
+  GlobalRuleList.insert_rule(1, reqpdr1);
+  reqpdr2.set_pdr_id(2);
+  reqpdr2.set_sess_ver_no(1);
+  reqpdr2.set_precedence(2);
+  reqpdr2.set_far_id(2);
+  pdireq.set_src_interface(3);
+  pdireq.set_net_instance("uplink");
+  pdireq.set_ue_ip_adr("10.10.1.2");
+  GlobalRuleList.insert_rule(2, reqpdr2);
+  SetGroupFAR far1;
+  far1.set_far_id(1);
+  far1.set_sess_ver_no(4);
+  far1.set_bar_id(6);
+  GlobalRuleList.insert_rule(1, far1);
 
-   //subscriber Id 1 to PDR 1 and FAR 1
-   pdr_map_.insert(std::pair<std::string,uint32_t>("IMSI00000001",1));
-   far_map_.insert(std::pair<std::string,uint32_t>("IMSI00000001",1));
-   //subscriber Id 2  PDR list shud 2 and 4, far list also 2 and 4
-   pdr_map_.insert(std::pair<std::string,uint32_t>("IMSI00000002",2));
-   far_map_.insert(std::pair<std::string,uint32_t>("IMSI00000002",2));
-   return true;
+  // subscriber Id 1 to PDR 1 and FAR 1
+  pdr_map_.insert(std::pair<std::string, uint32_t>("IMSI00000001", 1));
+  far_map_.insert(std::pair<std::string, uint32_t>("IMSI00000001", 1));
+  // subscriber Id 2  PDR list shud 2 and 4, far list also 2 and 4
+  pdr_map_.insert(std::pair<std::string, uint32_t>("IMSI00000002", 2));
+  far_map_.insert(std::pair<std::string, uint32_t>("IMSI00000002", 2));
+  return true;
 }
-} //end namespace magma
+}  // end namespace magma

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -30,8 +30,8 @@ limitations under the License.
 #include <folly/io/async/EventBaseManager.h>
 #include <lte/protos/mconfig/mconfigs.pb.h>
 #include <lte/protos/policydb.pb.h>
-#include "RuleStore.h"
 #include "PipelinedClient.h"
+#include "RuleStore.h"
 #include "SessionState.h"
 #include "SessionStore.h"
 #include "AmfServiceClient.h"

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -1,0 +1,114 @@
+/*
+Copyright 2020 The Magma Authors.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*****************************************************************************
+  Source      	SessionStateEnforcer.h
+  Version     	0.1
+  Date       	2020/08/08
+  Product     	SessionD
+  Subsystem   	5G managing & maintaining state & store of session of SessionD
+                Fanout message to Access and UPF through respective client obj
+  Author/Editor Sanjay Kumar Ojha
+  Description 	Objects run in main thread context invoked by folly event
+*****************************************************************************/
+
+#pragma once
+
+#include <unordered_map>
+#include <map>
+#include <unordered_set>
+#include <vector>
+
+#include <folly/io/async/EventBaseManager.h>
+#include <lte/protos/mconfig/mconfigs.pb.h>
+#include <lte/protos/policydb.pb.h>
+#include "RuleStore.h"
+#include "PipelinedClient.h"
+#include "SessionState.h"
+#include "SessionStore.h"
+#include "AmfServiceClient.h"
+
+
+namespace magma
+{
+class SmSessionContextSendClient {};
+
+//Object flow calss for 5G and composed from 4G LocalEnforcer.
+class SessionStateEnforcer
+{
+   public:
+
+      SessionStateEnforcer(
+      std::shared_ptr<StaticRuleStore> rule_store,
+      SessionStore& session_store,
+      /*M5G specific parameter new objects to communicate UPF and response to AMF*/
+      std::shared_ptr<PipelinedClient> pipelined_client,
+      std::shared_ptr<AmfServiceClient> amf_srv_client,
+      magma::mconfig::SessionD mconfig);
+      //std::shared_ptr<SmSessionContextSendClient> SmSession_Context_Send_Client, //Revisit on sending msg back
+      //std::shared_ptr<SpgwServiceClient> spgw_client,
+      //long session_force_termination_timeout_ms,
+
+      ~SessionStateEnforcer() {}
+
+      void attachEventBase(folly::EventBase* evb);
+
+      // starts the event base thread with loop
+      //void start();//moved to global and get started for both 4G and 5G
+
+      void stop();
+
+      folly::EventBase& get_event_base();
+
+      /*Member functions*/
+      bool m5g_init_session_credit(SessionMap& session_map,
+		      const std::string& imsi, const std::string& session_ctx_id,
+		      const SessionConfig& cfg);
+      /*Charging & rule related*/
+      bool handle_session_init_rule_updates( SessionMap& session_map,
+		      const std::string& imsi, SessionState& session_state);
+   private:
+    std::vector<std::string> static_rules;
+    //std::vector<PolicyRule> dynamic_rules;
+
+    ConvergedRuleStore  GlobalRuleList;
+    std::unordered_multimap<std::string,uint32_t> pdr_map_;
+    std::unordered_multimap<std::string,uint32_t> far_map_;
+
+    std::shared_ptr<StaticRuleStore> rule_store_;
+    //AsyncEventdClient& eventd_client_;
+    SessionStore& session_store_;
+    // Two new objects are responsible to communicate UPF and AMF 
+    //std::shared_ptr<UpfClient> upf_client_;
+    std::shared_ptr<PipelinedClient> pipelined_client_;
+    std::shared_ptr<SmSessionContextSendClient> SmSession_Context_Send_Client_;
+    std::shared_ptr<AmfServiceClient> amf_srv_client_;
+    //std::unordered_map<std::string, std::vector<std::unique_ptr<SessionState>>>
+    //                  session_map_;
+    folly::EventBase* evb_;
+    std::chrono::seconds retry_timeout_;
+    magma::mconfig::SessionD mconfig_;  // Is this really reqd ?
+    bool static_rule_init();
+    /* To send response back to AMF 
+     * Fill the response structure and call rpc of AmfServiceClient */
+    void prepare_response_to_access(
+		    const std::string& imsi,
+		    SessionState& session_state,
+		    //const std::vector<magma::PolicyRule>& flows,TODO
+		    const magma::lte::M5GSMCause m5gsmcause);
+
+    //long session_force_termination_timeout_ms_;
+    //std::shared_ptr<PipelinedClient> pipelined_client_;
+ }; //End of class SessionStateEnforcer
+
+} //end namespace magma
+
+

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*****************************************************************************
+  Source      	SetMessageManagerHandler.cpp
+  Version     	0.1
+  Date       	2020/08/08
+  Product     	SessionD
+  Subsystem   	5G Landing object in SessionD
+  Author/Editor Sanjay Kumar Ojha
+  Description 	Acts as 5G Landing object in SessionD & start 5G related flow
+*****************************************************************************/
+#include <chrono>
+#include <thread>
+
+#include <google/protobuf/util/time_util.h>
+
+#include "SetMessageManagerHandler.h"
+#include "magma_logging.h"
+#include "GrpcMagmaUtils.h"
+
+using grpc::Status;
+
+namespace magma
+{
+
+/**
+ * SetMessageManagerHandler processes gRPC requests for the sessionD
+ * This composites the earlier LocalSessionManagerHandlerImpl and uses the
+ * exiting functionalities.
+ */
+
+/*Constructor*/
+SetMessageManagerHandler::SetMessageManagerHandler(
+    std::shared_ptr<SessionStateEnforcer> m5genforcer, SessionStore& session_store)
+    : session_store_(session_store),
+      m5g_enforcer_(m5genforcer) {}
+
+/*Building session config with required parameters*/  //TODO on SubscriberID how to assigne or manage
+SessionConfig SetMessageManagerHandler::m5g_build_session_config(
+              const SetSMSessionContext& request) {
+  SessionConfig cfg ;
+  /*copying pnly 5G specific data to respective elements*/
+  cfg.common_context         = request.common_context();
+  cfg.rat_specific_context   = request.rat_specific_context();
+
+  return cfg;
+}
+
+/* Handling set message from AMF
+ * check if it is INITIAL_REQUEST or EXISTING_PDU_SESSION
+ * if it is INITIAL_REQUEST need to create the session context in SessionMap
+ * and write to memory by SessionStore
+ * If EXISTING_PDU_SESSION, check on incoming session state and version
+ * accordingly take action.
+ * As per ASYNC method, response_callback is included but not functional
+ * */
+
+void SetMessageManagerHandler::SetAmfSessionContext(
+		ServerContext* context,
+		const SetSMSessionContext* request,
+		std::function<void(Status, SmContextVoid)> response_callback)
+{
+   auto& request_cpy = *request;
+   //Print the message from AMF
+   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
+   response_callback(Status::OK, SmContextVoid());
+   /*The Event Based main_thread invocation and runs to handle session state*/ 
+   m5g_enforcer_->get_event_base().runInEventBaseThread (
+      [this, context, response_callback, request_cpy]() {
+   std::cerr << __LINE__ << " ACL_TAG entered event loop therad " << __FUNCTION__ << " processing message \n";
+   //extract values from proto
+   auto  imsi = request_cpy.common_context().sid().id();
+   std::string dnn = request_cpy.common_context().apn(); //may not required for demo-1
+   std::string session_ctx_id = id_gen_.gen_session_id(imsi);
+
+   MLOG(MDEBUG) << "Requested imsi from UE: " << imsi
+                 << " Generated sessioncontext ID" << session_ctx_id;
+   std::cerr << __LINE__ << " ACL_TAG Requested imsi from UE " << imsi << "\n";
+   /*reach complete message from proto message*/
+   SessionConfig cfg = m5g_build_session_config(request_cpy);
+   std::cerr << __LINE__ << " ACL_TAG m5g_build_session_config called \n";
+
+   /*check if it's initial message*/
+   if((cfg.rat_specific_context.m5gsm_session_context().rquest_type() == INITIAL_REQUEST) &&
+      (cfg.common_context.sm_session_state() == CREATING_0)) {
+      /*it's new UE establisment request and need to create the session context*/
+      	 MLOG(MDEBUG) << "AMF request type INITIAL_REQUEST and session state CREATING";
+      	 std::cerr << __LINE__ << " ACL_TAG AMF request type INITIAL_REQUEST and session state CREATING \n";
+         /* read the SessionMap from global session_store 
+	  * if not found it will add this imsi
+	  */
+	 SessionRead req = {imsi};
+         auto session_map = session_store_.read_sessions(req);
+	 send_create_session(session_map, imsi, session_ctx_id, cfg);
+    }
+  });
+}
+
+/* Creeate respective SessionState and context*/
+void SetMessageManagerHandler::send_create_session(
+		   SessionMap& session_map,
+		   const std::string& imsi,
+		   const std::string& session_ctx_id,
+		   const SessionConfig& cfg)
+{
+   auto session_map_ptr = std::make_shared<SessionMap>(std::move(session_map));
+   /* initialization of SessionState for IMSI by SessionStateEnforcer*/
+   bool success = m5g_enforcer_->m5g_init_session_credit(*session_map_ptr,
+		                                 imsi, session_ctx_id, cfg);
+   std::cerr << __LINE__ << " " << __FUNCTION__ << " successfully handled m5g_enforcer \n" ;
+   if(!success) {
+      MLOG(MERROR) << "Failed to initialize SessionState for IMSI " << imsi;
+   }
+   else {
+      /* writing of SessionMap in memory through SessionStore object*/
+      if(session_store_.create_sessions(
+                imsi, std::move((*session_map_ptr)[imsi]))) {
+	  std::cerr << __LINE__ << " ACL_TAG Successfully initialized 5G session for "
+		    << "subscriber and stored by session_store_.create_sessions \n";
+	  MLOG(MINFO) << "Successfully initialized 5G session for subscriber "
+		          << cfg.common_context.sid().id()
+                          << " with PDU session ID "
+			  << cfg.rat_specific_context.m5gsm_session_context().pdu_session_id();
+      }
+      else {
+	  MLOG(MERROR) << "Failed to initialize 5G session for subscriber"
+		          << cfg.common_context.sid().id()
+                          << " with PDU session ID "
+			  << cfg.rat_specific_context.m5gsm_session_context().pdu_session_id()
+                          << " due to failure writing to SessionStore.";
+      }
+
+   }
+}
+
+
+}//end namespace magma
+
+

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.cpp
@@ -81,7 +81,7 @@ void SetMessageManagerHandler::SetAmfSessionContext(
             request_cpy.common_context().apn();  // may not required for demo-1
         std::string session_id = id_gen_.gen_session_id(imsi);
 
-        MLOG(MDEBUG) << "Requested imsi from UE: " << imsi
+        MLOG(MDEBUG) << "Requested session from UE with IMSI: " << imsi
                      << " Generated sessioncontext ID" << session_id;
         /*reach complete message from proto message*/
         SessionConfig cfg = m5g_build_session_config(request_cpy);
@@ -95,8 +95,8 @@ void SetMessageManagerHandler::SetAmfSessionContext(
            */
           MLOG(MDEBUG)
               << "AMF request type INITIAL_REQUEST and session state CREATING";
-          /* read the SessionMap from global session_store
-           * if not found it will add this imsi
+          /* Read the SessionMap from global session_store,
+           * if it is not found, it will be added w.r.t imsi
            */
           auto session_map = session_store_.read_sessions({imsi});
           send_create_session(session_map, imsi, session_id, cfg);
@@ -113,8 +113,8 @@ void SetMessageManagerHandler::send_create_session(
   bool success = m5g_enforcer_->m5g_init_session_credit(
       *session_map_ptr, imsi, session_id, cfg);
   if (!success) {
-    MLOG(MERROR) << "Failed to initialize SessionState for IMSI and returing"
-                 << imsi;
+     MLOG(MERROR) << "Failed to initialize SessionStore for 5G session " 
+	                   << session_id <<" IMSI "<< " imsi";
     return;
   } else {
     /* writing of SessionMap in memory through SessionStore object*/

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.h
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*****************************************************************************
+  Source      	SetMessageManagerHandler.h
+  Version     	0.1
+  Date       	2020/08/08
+  Product     	SessionD
+  Subsystem   	5G Landing object in SessionD
+  Author/Editor Sanjay Kumar Ojha
+  Description 	Defines Access and Mobility Management Messages
+*****************************************************************************/
+#pragma once
+#include <functional>
+
+#include <grpc++/grpc++.h>
+#include <lte/protos/session_manager.grpc.pb.h>
+
+#include "SessionStateEnforcer.h"
+#include "SessionID.h"
+//#include "SessionReporter.h"
+//#include "SessionStore.h"
+
+using grpc::Server;
+using grpc::ServerContext;
+using grpc::Status;
+namespace magma {
+using namespace orc8r;
+/* SetMessageManagerHandler processes gRPC requests for the sessionD
+ * This composites the earlier LocalSessionManagerHandlerImpl and uses the
+ * exiting functionalities.
+ */
+
+/* This the landing object of 5G gRPC call by set message*/
+class SetMessageManager
+{
+ public:
+
+ virtual ~SetMessageManager() {}
+
+   /* RPC call from AMF "rpc SetAmfSessionContext (SetSMSessionContext) returns (SmContextVoid);" 
+    * as its set-interface API, no need to send response back, response is void and gRPC
+    * will take care on acknowledgement 
+    */
+   //void SetAmfSessionContext(ServerContext* context, const SetSMSessionContext* request);
+   virtual void SetAmfSessionContext(ServerContext* context, const SetSMSessionContext* request,
+		          std::function<void(Status, SmContextVoid)> response_callback) = 0;
+}; //end of abstract class
+class SetMessageManagerHandler: public SetMessageManager {
+public:
+      SetMessageManagerHandler(	//recheck on the attributes of constructor TODO.
+      std::shared_ptr<SessionStateEnforcer> m5G_monitor,
+      /*SessionReporter* reporter,
+      std::shared_ptr<AsyncDirectorydClient> directoryd_client,*/
+      SessionStore& session_store);
+      ~SetMessageManagerHandler() {}
+
+      virtual void SetAmfSessionContext(ServerContext* context, const SetSMSessionContext* request,
+		          std::function<void(Status, SmContextVoid)> response_callback);
+    /*
+    * Send session creation related request to the CentralSessionController.
+    * which is policy/QoS related. On successful, creates and populate, 
+    * session_map in memoery and response set message to AMF by gRPC.
+    * It uses SessionStateEnforcer object to create new session state.
+    */
+   //void send_create_session
+   /*void send_create_session(SessionMap& session_map,
+		   const SetSMSessionContext& request,
+		   const std::string& imsi, const std::string& session_ctx_id,
+		   const SessionConfig& cfg);*/
+   /*initialize the session message from proto message
+   SessionConfig m5g_build_session_config(const SetSMSessionContext& request);*/
+
+private:
+   SessionStore& session_store_;
+   std::shared_ptr<SessionStateEnforcer> m5g_enforcer_;
+   SessionIDGenerator id_gen_;
+
+   void send_create_session(SessionMap& session_map,
+                   /*const SetSMSessionContext& request,*/
+                   const std::string& imsi, const std::string& session_ctx_id,
+                   const SessionConfig& cfg);
+   /*initialize the session message from proto message*/
+   SessionConfig m5g_build_session_config(const SetSMSessionContext& request);
+
+
+}; // of class SetMessageManagerHandlerImpl
+}//end namespace magma
+
+
+

--- a/lte/gateway/c/session_manager/SetMessageManagerHandler.h
+++ b/lte/gateway/c/session_manager/SetMessageManagerHandler.h
@@ -25,74 +25,60 @@
 
 #include "SessionStateEnforcer.h"
 #include "SessionID.h"
-//#include "SessionReporter.h"
-//#include "SessionStore.h"
 
 using grpc::Server;
 using grpc::ServerContext;
 using grpc::Status;
 namespace magma {
 using namespace orc8r;
+
 /* SetMessageManagerHandler processes gRPC requests for the sessionD
  * This composites the earlier LocalSessionManagerHandlerImpl and uses the
  * exiting functionalities.
  */
 
 /* This the landing object of 5G gRPC call by set message*/
-class SetMessageManager
-{
+class SetMessageManager {
  public:
+  virtual ~SetMessageManager() {}
 
- virtual ~SetMessageManager() {}
+  /* RPC call from AMF "rpc SetAmfSessionContext (SetSMSessionContext) returns
+   * (SmContextVoid);" as its set-interface API, no need to send response back,
+   * response is void and gRPC will take care on acknowledgement
+   */
+  virtual void SetAmfSessionContext(
+      ServerContext* context, const SetSMSessionContext* request,
+      std::function<void(Status, SmContextVoid)> response_callback) = 0;
+};  // end of abstract class
 
-   /* RPC call from AMF "rpc SetAmfSessionContext (SetSMSessionContext) returns (SmContextVoid);" 
-    * as its set-interface API, no need to send response back, response is void and gRPC
-    * will take care on acknowledgement 
-    */
-   //void SetAmfSessionContext(ServerContext* context, const SetSMSessionContext* request);
-   virtual void SetAmfSessionContext(ServerContext* context, const SetSMSessionContext* request,
-		          std::function<void(Status, SmContextVoid)> response_callback) = 0;
-}; //end of abstract class
-class SetMessageManagerHandler: public SetMessageManager {
-public:
-      SetMessageManagerHandler(	//recheck on the attributes of constructor TODO.
+class SetMessageManagerHandler : public SetMessageManager {
+ public:
+  SetMessageManagerHandler(
       std::shared_ptr<SessionStateEnforcer> m5G_monitor,
-      /*SessionReporter* reporter,
-      std::shared_ptr<AsyncDirectorydClient> directoryd_client,*/
       SessionStore& session_store);
-      ~SetMessageManagerHandler() {}
+  ~SetMessageManagerHandler() {}
 
-      virtual void SetAmfSessionContext(ServerContext* context, const SetSMSessionContext* request,
-		          std::function<void(Status, SmContextVoid)> response_callback);
-    /*
-    * Send session creation related request to the CentralSessionController.
-    * which is policy/QoS related. On successful, creates and populate, 
-    * session_map in memoery and response set message to AMF by gRPC.
-    * It uses SessionStateEnforcer object to create new session state.
-    */
-   //void send_create_session
-   /*void send_create_session(SessionMap& session_map,
-		   const SetSMSessionContext& request,
-		   const std::string& imsi, const std::string& session_ctx_id,
-		   const SessionConfig& cfg);*/
-   /*initialize the session message from proto message
-   SessionConfig m5g_build_session_config(const SetSMSessionContext& request);*/
+  virtual void SetAmfSessionContext(
+      ServerContext* context, const SetSMSessionContext* request,
+      std::function<void(Status, SmContextVoid)> response_callback);
 
-private:
-   SessionStore& session_store_;
-   std::shared_ptr<SessionStateEnforcer> m5g_enforcer_;
-   SessionIDGenerator id_gen_;
+ private:
+  SessionStore& session_store_;
+  std::shared_ptr<SessionStateEnforcer> m5g_enforcer_;
+  SessionIDGenerator id_gen_;
 
-   void send_create_session(SessionMap& session_map,
-                   /*const SetSMSessionContext& request,*/
-                   const std::string& imsi, const std::string& session_ctx_id,
-                   const SessionConfig& cfg);
-   /*initialize the session message from proto message*/
-   SessionConfig m5g_build_session_config(const SetSMSessionContext& request);
+  /*
+   * Send session creation related request to the CentralSessionController.
+   * which is policy/QoS related. On successful, creates and populate,
+   * session_map in memoery and response set message to AMF by gRPC.
+   * It uses SessionStateEnforcer object to create new session state.
+   */
+  void send_create_session(
+      SessionMap& session_map, const std::string& imsi,
+      const std::string& session_ctx_id, const SessionConfig& cfg);
+  /*initialize the session message from proto message*/
+  SessionConfig m5g_build_session_config(const SetSMSessionContext& request);
 
+};  // of class SetMessageManagerHandlerImpl
 
-}; // of class SetMessageManagerHandlerImpl
-}//end namespace magma
-
-
-
+}  // end namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -130,6 +130,11 @@ enum SessionFsmState {
   SESSION_TERMINATED            = 4,
   SESSION_TERMINATION_SCHEDULED = 5,
   SESSION_RELEASED              = 6,
+  CREATING	                        = 7,
+  CREATED	                        = 8,
+  ACTIVE	                        = 9,
+  INACTIVE	                        = 10,
+  RELEASE	                        = 11,
 };
 
 struct StoredSessionCredit {
@@ -205,6 +210,8 @@ struct StoredSessionState {
   std::string session_id;
   uint64_t pdp_start_time;
   uint64_t pdp_end_time;
+  //5G session version handling
+  uint32_t current_version;
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state;
   magma::lte::TgppContext tgpp_context;
   std::vector<std::string> static_rule_ids;

--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -19,7 +19,7 @@ foreach (session_test session_credit local_enforcer cloud_reporter
     session_manager_handler sessiond_integ session_state
     session_store store_client stored_state proxy_responder_handler
     metering_reporter local_enforcer_wallet_exhaust charging_grant
-    usage_monitor)
+    usage_monitor set_session_manager_handler)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)
   add_test(test_${session_test} ${session_test}_test)

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -70,11 +70,14 @@ public:
        .WillByDefault(Return(true));
    ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _, _))
        .WillByDefault(Return(true));
-   ON_CALL(*this, delete_ue_mac_flow(_, _)).WillByDefault(Return(true));
+   ON_CALL(*this, delete_ue_mac_flow(_, _))
+	   .WillByDefault(Return(true));
    ON_CALL(*this, update_ipfix_flow(_, _, _, _, _, _))
        .WillByDefault(Return(true));
    ON_CALL(*this, add_gy_final_action_flow(_, _, _, _))
        .WillByDefault(Return(true));
+   ON_CALL(*this, set_upf_session(_, _))
+	.WillByDefault(Return(true));
    ON_CALL(*this, update_subscriber_quota_state(_)).WillByDefault(Return(true));
  }
 
@@ -120,11 +123,6 @@ public:
       const std::string &ap_mac_addr,
       const std::string &ap_name,
       std::function<void(Status status, FlowResponse)> callback));
-  MOCK_METHOD2(
-    delete_ue_mac_flow,
-    bool(
-      const SubscriberID &sid,
-      const std::string &ue_mac_addr));
   MOCK_METHOD6(
     update_ipfix_flow,
     bool(
@@ -134,6 +132,15 @@ public:
       const std::string &ap_mac_addr,
       const std::string &ap_name,
       const uint64_t &pdp_start_time));
+  MOCK_METHOD1(
+    update_subscriber_quota_state,
+    bool(
+      const std::vector<SubscriberQuotaUpdate>& updates));
+  MOCK_METHOD2(
+    delete_ue_mac_flow,
+    bool(
+      const SubscriberID &sid,
+      const std::string &ue_mac_addr));
   MOCK_METHOD4(
     add_gy_final_action_flow,
     bool(
@@ -141,9 +148,11 @@ public:
       const std::string &ip_addr,
       const std::vector<std::string> &static_rules,
       const std::vector<PolicyRule> &dynamic_rules));
-  MOCK_METHOD1(
-    update_subscriber_quota_state,
-    bool(const std::vector<SubscriberQuotaUpdate>& updates));
+  MOCK_METHOD2(
+    set_upf_session,
+    bool(
+	 const SessionState::SessionInfo info,
+	 std::function<void(Status status, UpfRes)> callback));
 };
 
 class MockDirectorydClient : public AsyncDirectorydClient {

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -17,7 +17,10 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
-#include "SetMessageManagerHandler.h" //session_manager.grpc.pb.h and SessionStateEnforcer.h included
+/* session_manager.grpc.pb.h and SessionStateEnforcer.h
+ * included in "SetMessageManagerHandler.h"
+ */
+#include "SetMessageManagerHandler.h"
 #include "MagmaService.h"
 #include "ProtobufCreators.h"
 #include "RuleStore.h"
@@ -35,39 +38,37 @@ using ::testing::Test;
 namespace magma {
 
 class SessionManagerHandlerTest : public ::testing::Test {
- //protected:
+  // protected:
  public:
   virtual void SetUp() {
-
-    rule_store             = std::make_shared<StaticRuleStore>();
-    session_store          = std::make_shared<SessionStore>(rule_store);
-    //pipelined_client     = std::make_shared<MockPipelinedClient>();
-    auto pipelined_client  = std::make_shared<magma::AsyncPipelinedClient>();
-    amf_srv_client         = std::make_shared<magma::AsyncAmfServiceClient>();
+    rule_store    = std::make_shared<StaticRuleStore>();
+    session_store = std::make_shared<SessionStore>(rule_store);
+    //TODO recheck on MockPipelinedClient
+    // pipelined_client     = std::make_shared<MockPipelinedClient>();
+    auto pipelined_client = std::make_shared<magma::AsyncPipelinedClient>();
+    amf_srv_client        = std::make_shared<magma::AsyncAmfServiceClient>();
 
     magma::mconfig::SessionD mconfig;
     mconfig.set_log_level(magma::orc8r::LogLevel::INFO);
     mconfig.set_relay_enabled(false);
 
-   auto session_enforcer = std::make_shared<magma::SessionStateEnforcer>(
-          rule_store, *session_store, pipelined_client,
-	  amf_srv_client, mconfig);
+    auto session_enforcer = std::make_shared<magma::SessionStateEnforcer>(
+        rule_store, *session_store, pipelined_client, amf_srv_client, mconfig);
 
     evb = new folly::EventBase();
     std::thread([&]() {
-      std::cerr << "Started event loop thread\n";
       folly::EventBaseManager::get()->setEventBase(evb, 0);
     })
         .detach();
 
     session_enforcer->attachEventBase(evb);
     session_map_ = SessionMap{};
-    //creating landing object and invoking contructor
+    // creating landing object and invoking contructor
     set_session_manager = std::make_shared<SetMessageManagerHandler>(
         session_enforcer, *session_store);
   }
 
- //protected:
+  // protected:
  public:
   std::shared_ptr<SessionStore> session_store;
   std::shared_ptr<StaticRuleStore> rule_store;
@@ -78,42 +79,42 @@ class SessionManagerHandlerTest : public ::testing::Test {
   SessionIDGenerator id_gen_;
   folly::EventBase* evb;
   SessionMap session_map_;
-};  //End of class
+};  // End of class
 
 TEST_F(SessionManagerHandlerTest, test_SetAmfSessionContext) {
-    magma::SetSMSessionContext request;
-    auto *req =  request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
-    auto *reqcmn = request.mutable_common_context();
-    req->set_pdu_session_id({0x5});
-    req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
-    req->mutable_pdu_address()->set_redirect_address_type(magma::RedirectServer::IPV4);
-    req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
-    req->set_priority_access(magma::priorityaccess::High);
-    req->set_access_type(magma::AccessType::M_3GPP_ACCESS_3GPP);
-    //req->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
-    req->set_imei("123456789012345");
-    req->set_gpsi("9876543210");
-    req->set_pcf_id("1357924680123456");
+  magma::SetSMSessionContext request;
+  auto* req =
+      request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+  auto* reqcmn = request.mutable_common_context();
+  req->set_pdu_session_id({0x5});
+  req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+  req->mutable_pdu_address()->set_redirect_address_type(
+      magma::RedirectServer::IPV4);
+  req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
+  req->set_priority_access(magma::priorityaccess::High);
+  req->set_access_type(magma::AccessType::M_3GPP_ACCESS_3GPP);
+  // req->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+  req->set_imei("123456789012345");
+  req->set_gpsi("9876543210");
+  req->set_pcf_id("1357924680123456");
 
-    reqcmn->mutable_sid()->set_id("IMSI00000001");
-    reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+  reqcmn->mutable_sid()->set_id("IMSI00000001");
+  reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
 
-  /*To redirect the std::cerr to a file written in ~/build/c/session_manager/test*/
-  freopen( "ACL_TAG_error.txt", "w", stderr );
+  /* To redirect the std::cerr to a file written in
+   * ~/build/c/session_manager/test
+   */
+  freopen("ACL_TAG_error.txt", "w", stderr);
 
   grpc::ServerContext server_context;
 
-   std::cerr << " all values filled and triggering SetAmfSessionContext\n";
 
   set_session_manager->SetAmfSessionContext(
       &server_context, &request,
       [this](grpc::Status status, SmContextVoid Void) {});
 
-   std::cerr << " END triggerred SetAmfSessionContext\n";
   // Run session creation in the EventBase loop
   evb->loopOnce();
-  //evb->loopOnce();
-  //evb->loopOnce();
 }
 
 int main(int argc, char** argv) {
@@ -122,5 +123,3 @@ int main(int argc, char** argv) {
 }
 
 }  // namespace magma
-
-

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -38,13 +38,10 @@ using ::testing::Test;
 namespace magma {
 
 class SessionManagerHandlerTest : public ::testing::Test {
-  // protected:
  public:
   virtual void SetUp() {
     rule_store    = std::make_shared<StaticRuleStore>();
     session_store = std::make_shared<SessionStore>(rule_store);
-    //TODO recheck on MockPipelinedClient
-    // pipelined_client     = std::make_shared<MockPipelinedClient>();
     auto pipelined_client = std::make_shared<magma::AsyncPipelinedClient>();
     amf_srv_client        = std::make_shared<magma::AsyncAmfServiceClient>();
 
@@ -68,7 +65,6 @@ class SessionManagerHandlerTest : public ::testing::Test {
         session_enforcer, *session_store);
   }
 
-  // protected:
  public:
   std::shared_ptr<SessionStore> session_store;
   std::shared_ptr<StaticRuleStore> rule_store;
@@ -93,18 +89,12 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionContext) {
   req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
   req->set_priority_access(magma::priorityaccess::High);
   req->set_access_type(magma::AccessType::M_3GPP_ACCESS_3GPP);
-  // req->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
   req->set_imei("123456789012345");
   req->set_gpsi("9876543210");
   req->set_pcf_id("1357924680123456");
 
   reqcmn->mutable_sid()->set_id("IMSI00000001");
   reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
-
-  /* To redirect the std::cerr to a file written in
-   * ~/build/c/session_manager/test
-   */
-  freopen("ACL_TAG_error.txt", "w", stderr);
 
   grpc::ServerContext server_context;
 

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -1,0 +1,126 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <memory>
+
+#include <folly/io/async/EventBaseManager.h>
+#include <glog/logging.h>
+#include <gtest/gtest.h>
+
+#include "SetMessageManagerHandler.h" //session_manager.grpc.pb.h and SessionStateEnforcer.h included
+#include "MagmaService.h"
+#include "ProtobufCreators.h"
+#include "RuleStore.h"
+#include "ServiceRegistrySingleton.h"
+#include "SessionState.h"
+#include "SessionStore.h"
+#include "SessiondMocks.h"
+#include "StoredState.h"
+#include "magma_logging.h"
+#include "PipelinedClient.h"
+#include "AmfServiceClient.h"
+
+using ::testing::Test;
+
+namespace magma {
+
+class SessionManagerHandlerTest : public ::testing::Test {
+ //protected:
+ public:
+  virtual void SetUp() {
+
+    rule_store             = std::make_shared<StaticRuleStore>();
+    session_store          = std::make_shared<SessionStore>(rule_store);
+    //pipelined_client     = std::make_shared<MockPipelinedClient>();
+    auto pipelined_client  = std::make_shared<magma::AsyncPipelinedClient>();
+    amf_srv_client         = std::make_shared<magma::AsyncAmfServiceClient>();
+
+    magma::mconfig::SessionD mconfig;
+    mconfig.set_log_level(magma::orc8r::LogLevel::INFO);
+    mconfig.set_relay_enabled(false);
+
+   auto session_enforcer = std::make_shared<magma::SessionStateEnforcer>(
+          rule_store, *session_store, pipelined_client,
+	  amf_srv_client, mconfig);
+
+    evb = new folly::EventBase();
+    std::thread([&]() {
+      std::cerr << "Started event loop thread\n";
+      folly::EventBaseManager::get()->setEventBase(evb, 0);
+    })
+        .detach();
+
+    session_enforcer->attachEventBase(evb);
+    session_map_ = SessionMap{};
+    //creating landing object and invoking contructor
+    set_session_manager = std::make_shared<SetMessageManagerHandler>(
+        session_enforcer, *session_store);
+  }
+
+ //protected:
+ public:
+  std::shared_ptr<SessionStore> session_store;
+  std::shared_ptr<StaticRuleStore> rule_store;
+  std::shared_ptr<SetMessageManagerHandler> set_session_manager;
+  std::shared_ptr<MockPipelinedClient> pipelined_client;
+  std::shared_ptr<SessionStateEnforcer> session_enforcer;
+  std::shared_ptr<AsyncAmfServiceClient> amf_srv_client;
+  SessionIDGenerator id_gen_;
+  folly::EventBase* evb;
+  SessionMap session_map_;
+};  //End of class
+
+TEST_F(SessionManagerHandlerTest, test_SetAmfSessionContext) {
+    magma::SetSMSessionContext request;
+    auto *req =  request.mutable_rat_specific_context()->mutable_m5gsm_session_context();
+    auto *reqcmn = request.mutable_common_context();
+    req->set_pdu_session_id({0x5});
+    req->set_rquest_type(magma::RequestType::INITIAL_REQUEST);
+    req->mutable_pdu_address()->set_redirect_address_type(magma::RedirectServer::IPV4);
+    req->mutable_pdu_address()->set_redirect_server_address("10.20.30.40");
+    req->set_priority_access(magma::priorityaccess::High);
+    req->set_access_type(magma::AccessType::M_3GPP_ACCESS_3GPP);
+    //req->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+    req->set_imei("123456789012345");
+    req->set_gpsi("9876543210");
+    req->set_pcf_id("1357924680123456");
+
+    reqcmn->mutable_sid()->set_id("IMSI00000001");
+    reqcmn->set_sm_session_state(magma::SMSessionFSMState::CREATING_0);
+
+  /*To redirect the std::cerr to a file written in ~/build/c/session_manager/test*/
+  freopen( "ACL_TAG_error.txt", "w", stderr );
+
+  grpc::ServerContext server_context;
+
+   std::cerr << "ACL_TAG all values filled and triggering SetAmfSessionContext\n";
+
+  set_session_manager->SetAmfSessionContext(
+      &server_context, &request,
+      [this](grpc::Status status, SmContextVoid Void) {});
+
+   std::cerr << "ACL_TAG END triggerred SetAmfSessionContext\n";
+  // Run session creation in the EventBase loop
+  evb->loopOnce();
+  //evb->loopOnce();
+  //evb->loopOnce();
+}
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+}  // namespace magma
+
+

--- a/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_set_session_manager_handler.cpp
@@ -103,13 +103,13 @@ TEST_F(SessionManagerHandlerTest, test_SetAmfSessionContext) {
 
   grpc::ServerContext server_context;
 
-   std::cerr << "ACL_TAG all values filled and triggering SetAmfSessionContext\n";
+   std::cerr << " all values filled and triggering SetAmfSessionContext\n";
 
   set_session_manager->SetAmfSessionContext(
       &server_context, &request,
       [this](grpc::Status status, SmContextVoid Void) {});
 
-   std::cerr << "ACL_TAG END triggerred SetAmfSessionContext\n";
+   std::cerr << " END triggerred SetAmfSessionContext\n";
   // Run session creation in the EventBase loop
   evb->loopOnce();
   //evb->loopOnce();


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Implementation on message handling from AMF and state management. 
UT file included as well.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Added new UT file in unit test frame work. This UT calls landing object of 5G sessionD and processing the message.
Added std::cerr to track the flow trace and will be removed while committing to master.
[UT_Log_by_Test_frame_work.txt](https://github.com/magma/magma/files/5238990/UT_Log_by_Test_frame_work.txt)
[UT_Log_by_AMF_Client_Python_Script.txt](https://github.com/magma/magma/files/5238991/UT_Log_by_AMF_Client_Python_Script.txt)



## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
