### PR TITLE
[nms] Move grafana ui code to magma

### DIFF
--- a/nms/app/packages/magmalte/app/components/Grafana.js
+++ b/nms/app/packages/magmalte/app/components/Grafana.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import React from 'react';
+
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+
+import {makeStyles} from '@material-ui/styles';
+import {useState} from 'react';
+
+const useStyles = makeStyles(() => ({
+  root: {
+    display: 'flex',
+    height: '100%',
+    flexGrow: 1,
+  },
+  dashboardsIframe: {
+    width: '100%',
+    border: 0,
+  },
+}));
+
+type Props = {
+  grafanaURL: string,
+};
+
+export default function GrafanaDashboards(props: Props) {
+  const classes = useStyles();
+  const [isLoading, setIsLoading] = useState(true);
+  return (
+    <>
+      {isLoading ? <LoadingFiller /> : null}
+      <div className={classes.root}>
+        <iframe
+          src={props.grafanaURL}
+          onLoad={() => setIsLoading(false)}
+          className={classes.dashboardsIframe}
+        />
+      </div>
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/components/cwf/CWFMetrics.js
+++ b/nms/app/packages/magmalte/app/components/cwf/CWFMetrics.js
@@ -18,7 +18,7 @@ import APMetrics from './APMetrics';
 import AppBar from '@material-ui/core/AppBar';
 import AppContext from '@fbcnms/ui/context/AppContext';
 import CWFNetworkMetrics from './CWFNetworkMetrics';
-import Grafana from '@fbcnms/ui/insights/Grafana';
+import Grafana from '../Grafana';
 import IMSIMetrics from './IMSIMetrics';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import React from 'react';

--- a/nms/app/packages/magmalte/app/components/lte/LteMetrics.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteMetrics.js
@@ -19,7 +19,7 @@ import type {MetricGraphConfig} from '@fbcnms/ui/insights/Metrics';
 import AppBar from '@material-ui/core/AppBar';
 import AppContext from '@fbcnms/ui/context/AppContext';
 import GatewayMetrics from '@fbcnms/ui/insights/GatewayMetrics';
-import Grafana from '@fbcnms/ui/insights/Grafana';
+import Grafana from '../Grafana';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import NetworkKPIs from './NetworkKPIs';
 import React, {useContext} from 'react';


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Continuing to move all grafana stuff into Magma itself, this takes the UI component that holds the Grafana iframe from fbcnms-ui.

## Test Plan
![image](https://user-images.githubusercontent.com/13274915/91747567-46370a00-eb73-11ea-8068-62b6cad4687e.png)
