### PR TITLE
[agw][dev VMs] Use setuptools version less than 50.0.0

### DIFF
--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -42,7 +42,7 @@ $(PYTHON_BUILD):
 	mkdir -p $(PYTHON_BUILD)
 
 $(SITE_PACKAGES_DIR)/setuptools: install_virtualenv
-	$(VIRT_ENV_PIP_INSTALL) "setuptools>=41.0.1"
+	$(VIRT_ENV_PIP_INSTALL) "setuptools==49.6.0"  # newer than 41.0.1
 
 swagger:: swagger_prereqs $(SWAGGER_LIST)
 swagger_prereqs:

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -56,6 +56,7 @@ setup(
         'scripts/show_gateway_info.py',
     ],
     install_requires=[
+        'setuptools==49.6.0',
         'Cython>=0.29.1',
         'pystemd==0.5.0',
         'docker>=4.0.2',

--- a/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
+++ b/orc8r/tools/ansible/roles/python_dev/tasks/main.yml
@@ -100,7 +100,7 @@
 
 - name: install the package, force reinstall to the latest version
   pip:
-    name: setuptools
+    name: setuptools==49.6.0
     state: forcereinstall
     executable: pip3
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The latest setuptools version 50.0.0 is breaking the dev VMs due to the issue reported in https://github.com/pypa/setuptools/issues/2352. This change

- forces install of setuptools version 49.6.0 on dev VMs at the time of provisioning
- modified the setuptools version in python.mk 
- add setuptools version 49.6.0 in the "install_requires" list in setup.py

## Test Plan

Destroy and re-provision magma_dev, magma_test VMs, then run 
- `make test` on dev VM
- `make integ_test` on test VM 