### PR TITLE
[NMS] Add checks to ensure that we err out when we attempt to add existing

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -234,7 +234,7 @@ function GatewayEditDialog(props: DialogProps) {
       </Tabs>
       {tabPos === 0 && (
         <ConfigEdit
-          saveButtonTitle={editProps ? 'Save' : 'Save And Continue'}
+          isAdd={!editProps}
           gateway={
             Object.keys(gateway).length != 0 ? gateway : ctx.state[gatewayId]
           }
@@ -251,7 +251,7 @@ function GatewayEditDialog(props: DialogProps) {
       )}
       {tabPos === 1 && (
         <AggregationEdit
-          saveButtonTitle={editProps ? 'Save' : 'Save And Add Gateway'}
+          isAdd={!editProps}
           gateway={
             Object.keys(gateway).length != 0 ? gateway : ctx.state[gatewayId]
           }
@@ -268,7 +268,7 @@ function GatewayEditDialog(props: DialogProps) {
       )}
       {tabPos === 2 && (
         <EPCEdit
-          saveButtonTitle={editProps ? 'Save' : 'Save And Continue'}
+          isAdd={!editProps}
           gateway={
             Object.keys(gateway).length != 0 ? gateway : ctx.state[gatewayId]
           }
@@ -285,7 +285,7 @@ function GatewayEditDialog(props: DialogProps) {
       )}
       {tabPos === 3 && (
         <RanEdit
-          saveButtonTitle={editProps ? 'Save' : 'Save And Close'}
+          isAdd={!editProps}
           gateway={
             Object.keys(gateway).length != 0 ? gateway : ctx.state[gatewayId]
           }
@@ -304,7 +304,7 @@ function GatewayEditDialog(props: DialogProps) {
 }
 
 type Props = {
-  saveButtonTitle: string,
+  isAdd: boolean,
   gateway?: lte_gateway,
   onClose: () => void,
   onSave: lte_gateway => void,
@@ -351,6 +351,14 @@ export function ConfigEdit(props: Props) {
         },
         device: {...gatewayDevice, key: challengeKey},
       };
+      if (props.isAdd) {
+        // check if it is not a modify during add i.e we aren't switching tabs back
+        // during add and modifying the information other than the serial number
+        if (gateway.id in ctx.state && gateway.id !== props.gateway?.id) {
+          setError(`Gateway ${gateway.id} already exists`);
+          return;
+        }
+      }
       await ctx.setState(gateway.id, gatewayInfos);
       enqueueSnackbar('Gateway saved successfully', {
         variant: 'success',
@@ -366,7 +374,9 @@ export function ConfigEdit(props: Props) {
         <List>
           {error !== '' && (
             <AltFormField label={''}>
-              <FormLabel error>{error}</FormLabel>
+              <FormLabel data-testid="configEditError" error>
+                {error}
+              </FormLabel>
             </AltFormField>
           )}
           <AltFormField label={'Gateway Name'}>
@@ -439,7 +449,7 @@ export function ConfigEdit(props: Props) {
           Cancel
         </Button>
         <Button onClick={onSave} variant="contained" color="primary">
-          {props.saveButtonTitle}
+          {props.isAdd ? 'Save And Continue' : 'Save'}
         </Button>
       </DialogActions>
     </>
@@ -515,7 +525,7 @@ export function AggregationEdit(props: Props) {
 
   return (
     <>
-      <DialogContent data-testid="aggregation">
+      <DialogContent data-testid="aggregationEdit">
         <List>
           {error !== '' && (
             <AltFormField label={''}>
@@ -547,7 +557,7 @@ export function AggregationEdit(props: Props) {
           Cancel
         </Button>
         <Button onClick={onSave} variant="contained" color="primary">
-          {props.saveButtonTitle}
+          {props.isAdd ? 'Save And Continue' : 'Save'}
         </Button>
       </DialogActions>
     </>
@@ -642,7 +652,7 @@ export function EPCEdit(props: Props) {
           Cancel
         </Button>
         <Button onClick={onSave} variant="contained" color="primary">
-          {props.saveButtonTitle}
+          {props.isAdd ? 'Save And Continue' : 'Save'}
         </Button>
       </DialogActions>
     </>
@@ -749,7 +759,7 @@ export function RanEdit(props: Props) {
           Cancel
         </Button>
         <Button onClick={onSave} variant="contained" color="primary">
-          {props.saveButtonTitle}
+          {props.isAdd ? 'Save And Close' : 'Save'}
         </Button>
       </DialogActions>
     </>

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebConfigTest.js
@@ -88,7 +88,7 @@ describe('<AddEditEnodeButton />', () => {
   });
 
   const AddWrapper = () => {
-    const [enbInf, setEnbInfo] = useState({});
+    const [enbInf, setEnbInfo] = useState({testEnodebSerial0: enbInfo});
     return (
       <MemoryRouter initialEntries={['/nms/test/enode']} initialIndex={0}>
         <MuiThemeProvider theme={defaultTheme}>
@@ -188,6 +188,21 @@ describe('<AddEditEnodeButton />', () => {
     let enbName = getByTestId('name').firstChild;
     let enbDesc = getByTestId('description').firstChild;
 
+    // test adding an existing enodeb
+    if (enbSerial instanceof HTMLInputElement) {
+      fireEvent.change(enbSerial, {target: {value: 'testEnodebSerial0'}});
+    } else {
+      throw 'invalid type';
+    }
+
+    fireEvent.click(getByText('Save And Continue'));
+    await wait();
+
+    expect(getByTestId('configEditError')).toHaveTextContent(
+      'eNodeB testEnodebSerial0 already exists',
+    );
+
+    // test adding new enodeb
     if (
       enbSerial instanceof HTMLInputElement &&
       enbName instanceof HTMLInputElement &&

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -1,0 +1,226 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {lte_gateway} from '@fbcnms/magma-api';
+
+import 'jest-dom/extend-expect';
+
+import AddEditGatewayButton from '../GatewayDetailConfigEdit';
+import GatewayContext from '../../../components/context/GatewayContext';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import defaultTheme from '../../../theme/default.js';
+
+import {MemoryRouter, Route} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {SetGatewayState} from '../../../state/EquipmentState';
+import {cleanup, fireEvent, render, wait} from '@testing-library/react';
+import {useState} from 'react';
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+jest.mock('@fbcnms/ui/hooks/useSnackbar');
+afterEach(cleanup);
+const enqueueSnackbarMock = jest.fn();
+jest
+  .spyOn(require('@fbcnms/ui/hooks/useSnackbar'), 'useEnqueueSnackbar')
+  .mockReturnValue(enqueueSnackbarMock);
+
+const mockGw0: lte_gateway = {
+  id: ' testGatewayId0',
+  name: ' testGateway0',
+  description: ' testGateway0',
+  tier: 'default',
+  device: {
+    key: {key: '', key_type: 'SOFTWARE_ECDSA_SHA256'},
+    hardware_id: '',
+  },
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'tier2',
+  },
+  connected_enodeb_serials: [],
+  cellular: {
+    epc: {
+      ip_block: '192.168.0.1/24',
+      nat_enabled: true,
+    },
+    ran: {
+      pci: 620,
+      transmit_enabled: true,
+    },
+  },
+  status: {
+    checkin_time: 0,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+describe('<AddEditGatewayButton />', () => {
+  afterEach(() => {
+    MagmaAPIBindings.postLteByNetworkIdGateways.mockClear();
+  });
+
+  const AddWrapper = () => {
+    const [lteGateways, setLteGateways] = useState({testGatewayId0: mockGw0});
+    return (
+      <MemoryRouter initialEntries={['/nms/test/gateway']} initialIndex={0}>
+        <MuiThemeProvider theme={defaultTheme}>
+          <MuiStylesThemeProvider theme={defaultTheme}>
+            <GatewayContext.Provider
+              value={{
+                state: lteGateways,
+                setState: async (key, value?) =>
+                  SetGatewayState({
+                    lteGateways: lteGateways,
+                    setLteGateways: setLteGateways,
+                    networkId: 'test',
+                    key: key,
+                    value: value,
+                  }),
+                updateGateway: async () => {},
+              }}>
+              <Route
+                path="/nms/:networkId/gateway"
+                render={props => (
+                  <AddEditGatewayButton
+                    {...props}
+                    title="Add Gateway"
+                    isLink={false}
+                  />
+                )}
+              />
+            </GatewayContext.Provider>
+          </MuiStylesThemeProvider>
+        </MuiThemeProvider>
+      </MemoryRouter>
+    );
+  };
+
+  it('Verify Gateway Add', async () => {
+    const {getByTestId, getByText, queryByTestId} = render(<AddWrapper />);
+    await wait();
+    expect(queryByTestId('editDialog')).toBeNull();
+
+    fireEvent.click(getByText('Add Gateway'));
+    await wait();
+
+    // check if only first tab (config) is active
+    expect(queryByTestId('configEdit')).not.toBeNull();
+    expect(queryByTestId('aggregationEdit')).toBeNull();
+    expect(queryByTestId('ranEdit')).toBeNull();
+    expect(queryByTestId('epcEdit')).toBeNull();
+
+    const gatewayID = getByTestId('id').firstChild;
+    const gatewayName = getByTestId('name').firstChild;
+    const hwId = getByTestId('hardwareId').firstChild;
+    const version = getByTestId('version').firstChild;
+    const description = getByTestId('description').firstChild;
+    const challengeKey = getByTestId('challengeKey').firstChild;
+
+    // test adding an existing gateway
+    if (gatewayID instanceof HTMLInputElement) {
+      fireEvent.change(gatewayID, {target: {value: 'testGatewayId0'}});
+    } else {
+      throw 'invalid type';
+    }
+
+    fireEvent.click(getByText('Save And Continue'));
+    await wait();
+
+    expect(getByTestId('configEditError')).toHaveTextContent(
+      'Gateway testGatewayId0 already exists',
+    );
+
+    if (
+      gatewayID instanceof HTMLInputElement &&
+      gatewayName instanceof HTMLInputElement &&
+      hwId instanceof HTMLInputElement &&
+      version instanceof HTMLInputElement &&
+      challengeKey instanceof HTMLInputElement &&
+      description instanceof HTMLInputElement
+    ) {
+      fireEvent.change(gatewayID, {target: {value: 'testGatewayID1'}});
+      fireEvent.change(gatewayName, {target: {value: 'testGatewayName'}});
+      fireEvent.change(description, {
+        target: {value: 'Test Gateway Description'},
+      });
+      fireEvent.change(challengeKey, {target: {value: 'testChallenge'}});
+      fireEvent.change(hwId, {target: {value: 'testHwId'}});
+      fireEvent.change(version, {target: {value: '1.0'}});
+    } else {
+      throw 'invalid type';
+    }
+
+    fireEvent.click(getByText('Save And Continue'));
+    await wait();
+    expect(MagmaAPIBindings.postLteByNetworkIdGateways).toHaveBeenCalledWith({
+      gateway: {
+        id: 'testGatewayID1',
+        name: 'testGatewayName',
+        cellular: {
+          epc: {
+            dns_primary: '',
+            dns_secondary: '',
+            ip_block: '192.168.128.0/24',
+            nat_enabled: true,
+          },
+          ran: {
+            pci: 260,
+            transmit_enabled: true,
+          },
+        },
+        connected_enodeb_serials: [],
+        description: 'Test Gateway Description',
+        device: {
+          hardware_id: 'testHwId',
+          key: {
+            key: 'testChallenge',
+            key_type: 'SOFTWARE_ECDSA_SHA256',
+          },
+        },
+
+        magmad: {
+          autoupgrade_enabled: true,
+          autoupgrade_poll_interval: 60,
+          checkin_interval: 60,
+          checkin_timeout: 30,
+          dynamic_services: [],
+        },
+        status: {
+          platform_info: {
+            packages: [
+              {
+                version: '1.0',
+              },
+            ],
+          },
+        },
+        tier: 'default',
+      },
+      networkId: 'test',
+    });
+  });
+});


### PR DESCRIPTION
gateways and enodeBs

Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>

## Summary

Fix to err out when we attempt to add existing gateways and enodebs.

## Test Plan
Added a new GatewayConfigTest to verify this case
and enhanced EnodebConfigTest to verify this.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
