### PR TITLE
mobilityD : handle duplicate IP address assignment

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -175,17 +175,21 @@ class IPAddressManager:
         elif self.allocator_type == MobilityD.DHCP:
             iface = config.get('dhcp_iface', 'dhcp0')
             retry_limit = config.get('retry_limit', 300)
-            ip_allocator = IPAllocatorDHCP(self._assigned_ip_blocks,
-                                           self.ip_state_map,
+            ip_allocator = IPAllocatorDHCP(assigned_ip_blocks=self._assigned_ip_blocks,
+                                           ip_state_map=self.ip_state_map,
                                            iface=iface,
                                            retry_limit=retry_limit,
                                            dhcp_store=self._dhcp_store,
                                            gw_info=self._dhcp_gw_info)
+        else:
+            raise ValueError("Unknown IP allocator type: %s" % self.allocator_type)
 
         if self.static_ip_enabled:
             ip_allocator = IPAllocatorStaticWrapper(subscriberdb_rpc_stub=subscriberdb_rpc_stub,
                                                     ip_allocator=ip_allocator,
-                                                    gw_info=self._dhcp_gw_info)
+                                                    gw_info=self._dhcp_gw_info,
+                                                    assigned_ip_blocks=self._assigned_ip_blocks,
+                                                    ip_state_map=self.ip_state_map)
 
         if self.multi_apn:
             self.ip_allocator = IPAllocatorMultiAPNWrapper(subscriberdb_rpc_stub=subscriberdb_rpc_stub,
@@ -290,7 +294,6 @@ class IPAddressManager:
         with self._lock:
             # if an IP is reserved for the UE, this IP could be in the state of
             # ALLOCATED, RELEASED or REAPED.
-
             if sid in self.sid_ips_map:
                 old_ip_desc = self.sid_ips_map[sid]
                 if self.ip_state_map.test_ip_state(old_ip_desc.ip, IPState.ALLOCATED):
@@ -327,9 +330,19 @@ class IPAddressManager:
 
             # Now try to allocate it from underlying allocator.
             ip_desc = self.ip_allocator.alloc_ip_address(sid, 0)
+            existing_sid = self.get_sid_for_ip(ip_desc.ip)
+            if existing_sid:
+                error_msg = "Dup IP: {} for SID: {}, which already is " \
+                            "assigned to SID: {}".format(ip_desc.ip,
+                                                         sid,
+                                                         existing_sid)
+                logging.error(error_msg)
+                raise DuplicateIPAssignmentError(error_msg)
+
             self.ip_state_map.add_ip_to_state(ip_desc.ip, ip_desc, IPState.ALLOCATED)
             self.sid_ips_map[sid] = ip_desc
 
+            logging.debug("Allocating New IP: %s", str(ip_desc))
             IP_ALLOCATED_TOTAL.inc()
             return ip_desc.ip, ip_desc.vlan_id
 
@@ -377,7 +390,9 @@ class IPAddressManager:
             if not (sid in self.sid_ips_map and ip ==
                     self.sid_ips_map[sid].ip):
                 logging.error(
-                    "Releasing unknown <SID, IP> pair: <%s, %s>", sid, ip)
+                    "Releasing unknown <SID, IP> pair: <%s, %s> "
+                    "sid_ips_map[%s]: %s",
+                    sid, ip, sid, self.sid_ips_map.get(sid, ""))
                 raise MappingNotFoundError(
                     "(%s, %s) pair is not found", sid, str(ip))
             if not self.ip_state_map.test_ip_state(ip, IPState.ALLOCATED):
@@ -412,6 +427,8 @@ class IPAddressManager:
         with self._lock:
             for ip in self.ip_state_map.list_ips(IPState.REAPED):
                 ip_desc = self.ip_state_map.mark_ip_state(ip, IPState.FREE)
+                logging.debug("Release Reaped IP: %s", ip_desc)
+
                 self.ip_allocator.release_ip(ip_desc)
                 # update SID-IP map
                 del self.sid_ips_map[ip_desc.sid]
@@ -457,4 +474,12 @@ class IPNotInUseError(Exception):
 
 class MappingNotFoundError(Exception):
     """ Exception thrown when releasing a non-exising SID-IP mapping """
+    pass
+
+
+class DuplicateIPAssignmentError(Exception):
+    """ Exception thrown when underlying IP allocator assigns duplicate
+    Ip address to two different SID. This also catches dup IP across
+    two different APNs.
+    """
     pass

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_dhcp.py
@@ -57,7 +57,7 @@ class IPAllocatorDHCP(IPAllocator):
             assigned_ip_blocks: set of IP blocks, populated from DHCP.
             ip_state_map: maintains state of IP allocation to UE.
             dhcp_store: maintains DHCP transaction for each active MAC address
-            gw_info_map: maintains uplink GW info
+            gw_info: maintains uplink GW info
             retry_limit: try DHCP request
             iface: DHCP interface.
         """
@@ -111,10 +111,9 @@ class IPAllocatorDHCP(IPAllocator):
             NoAvailableIPError: if run out of available IP addresses
         """
         mac = create_mac_from_sid(sid)
-        LOG.debug("allocate IP for %s mac %s", sid, mac)
 
         dhcp_desc = self._dhcp_client.get_dhcp_desc(mac, vlan)
-        LOG.debug("got IP from redis: %s", dhcp_desc)
+        LOG.debug("allocate IP for %s mac %s dhcp_desc %s", sid, mac, dhcp_desc)
 
         if dhcp_allocated_ip(dhcp_desc) is not True:
             dhcp_desc = self._alloc_ip_address_from_dhcp(mac, vlan)
@@ -122,13 +121,13 @@ class IPAllocatorDHCP(IPAllocator):
         if dhcp_allocated_ip(dhcp_desc):
             ip_block = ip_network(dhcp_desc.subnet)
             ip_desc = IPDesc(ip=ip_address(dhcp_desc.ip), state=IPState.ALLOCATED,
-                             sid=sid, ip_block=ip_block, ip_type=IPType.DHCP)
-            LOG.debug("Got IP after sending DHCP requests: %s", ip_desc)
+                             sid=sid, ip_block=ip_block, ip_type=IPType.DHCP, vlan_id=vlan)
             self._assigned_ip_blocks.add(ip_block)
 
             return ip_desc
         else:
-            raise NoAvailableIPError("No available IP addresses From DHCP")
+            msg = "No available IP addresses From DHCP for SID: {} MAC {}".format(sid, mac)
+            raise NoAvailableIPError(msg)
 
     def release_ip(self, ip_desc: IPDesc):
         """

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_multi_apn.py
@@ -38,7 +38,6 @@ class IPAllocatorMultiAPNWrapper(IPAllocator):
             IP address by underlying IP allocator. For DHCP it means using
             vlan tag for DHCP request, for IP pool allocator it does not change
             behaviour.
-            TODO: Add support of per APN IP-POOL
         """
         self._subscriber_client = SubscriberDbClient(subscriberdb_rpc_stub)
         self._ip_allocator = ip_allocator
@@ -71,19 +70,11 @@ class IPAllocatorMultiAPNWrapper(IPAllocator):
         once we have APN specific info use IP allocator to assign an IP.
         """
         vlan_id = self._subscriber_client.get_subscriber_apn_vlan(sid)
-        logging.info("got vlan: [%s]", vlan_id)
-        ip_desc = self._ip_allocator.alloc_ip_address(sid, vlan_id)
-
-        if ip_desc:
-            ip_desc.vlan_id = vlan_id
-        logging.info("sid %s vlan %s", sid, vlan_id)
-
-        return ip_desc
+        return self._ip_allocator.alloc_ip_address(sid, vlan_id)
 
     def release_ip(self, ip_desc: IPDesc):
         """
         Multi APN allocated IPs do not need to do any update on
         ip release, let actual IP allocator release the IP.
         """
-        if ip_desc.type != IPType.STATIC:
-            self._ip_allocator.release_ip(ip_desc)
+        self._ip_allocator.release_ip(ip_desc)

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_pool.py
@@ -195,6 +195,7 @@ class IpAllocatorPool(IPAllocator):
             NoAvailableIPError: if run out of available IP addresses
             DuplicatedIPAllocationError: if an IP has been allocated to a UE
                 with the same IMSI
+        TODO: Add support of per APN IP-POOL
         """
         # if an IP is not yet allocated for the UE, allocate a new IP
         if self._ip_state_map.get_ip_count(IPState.FREE):

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -23,7 +23,8 @@ from lte.protos.mobilityd_pb2_grpc import MobilityServiceServicer, \
 from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import return_void
 from magma.subscriberdb.sid import SIDUtils
-from .ip_address_man import IPAddressManager, IPNotInUseError, MappingNotFoundError
+from .ip_address_man import IPAddressManager, IPNotInUseError, \
+    MappingNotFoundError, DuplicateIPAssignmentError
 
 from .ip_allocator_pool import IPBlockNotFoundError, NoAvailableIPError, \
     OverlappedIPBlocksError
@@ -181,6 +182,9 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
                 context.set_code(grpc.StatusCode.RESOURCE_EXHAUSTED)
             except DuplicatedIPAllocationError:
                 context.set_details('IP has been allocated for this subscriber')
+                context.set_code(grpc.StatusCode.ALREADY_EXISTS)
+            except DuplicateIPAssignmentError:
+                context.set_details('IP has been allocated for other subscriber')
                 context.set_code(grpc.StatusCode.ALREADY_EXISTS)
         else:
             self._unimplemented_ip_version_error(context)

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -39,6 +39,12 @@ class StaticIPInfo:
         self.gw_ip = gw_ip_parsed
         self.vlan = vlan
 
+    def __str__(self):
+        return "IP: {} GW-IP: {} GW-MAC: {} VLAN: {}".format(self.ip,
+                                                             self.gw_ip,
+                                                             self.gw_mac,
+                                                             self.vlan)
+
 
 class SubscriberDbClient:
     def __init__(self, subscriberdb_rpc_stub):

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -18,7 +18,7 @@ from typing import Optional
 from lte.protos.mconfig.mconfigs_pb2 import MobilityD
 from magma.mobilityd.ip_descriptor import IPDesc, IPType
 from magma.mobilityd.ip_address_man import IPAddressManager, \
-    IPNotInUseError, MappingNotFoundError
+    IPNotInUseError, MappingNotFoundError, DuplicateIPAssignmentError
 from magma.mobilityd.tests.test_multi_apn_ip_alloc import MockedSubscriberDBStub
 from magma.mobilityd.uplink_gw import InvalidVlanId
 
@@ -57,6 +57,11 @@ class StaticIPAllocationTests(unittest.TestCase):
     def check_type(self, sid: str, type: IPType):
         ip_desc = self._allocator.sid_ips_map[sid]
         self.assertEqual(ip_desc.type, type)
+        if type == IPType.IP_POOL:
+            ip_block = self._block
+        else:
+            ip_block = ipaddress.ip_network(ip_desc.ip)
+        self.assertEqual(ip_desc.ip_block, ip_block)
 
     def check_gw_info(self, vlan: Optional[int], gw_ip: str, gw_mac: Optional[str]):
         gw_info_ip = self._allocator._dhcp_gw_info.get_gw_ip(vlan)
@@ -424,3 +429,56 @@ class StaticIPAllocationTests(unittest.TestCase):
 
         with self.assertRaises(InvalidVlanId):
             ip0, _ = self._allocator.alloc_ip_address(sid)
+
+    def test_get_ip_for_subscriber_with_apn_dup_assignment(self):
+        """ test duplicate static IPs """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+        apn = 'magma'
+        imsi = 'IMSI999'
+        sid = imsi + '.' + apn
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+        with self.assertRaises(DuplicateIPAssignmentError):
+            ip0, _ = self._allocator.alloc_ip_address(sid)
+
+    def test_get_ip_for_2_subscribers_with_apn(self):
+        """ test duplicate static IPs """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '1.2.3.4'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        ip0, _ = self._allocator.alloc_ip_address(sid)
+        ip0_returned = self._allocator.get_ip_for_sid(sid)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip0, ip0_returned)
+        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip))
+        self.check_type(sid, IPType.STATIC)
+
+        apn1 = 'magma'
+        imsi1 = 'IMSI999'
+        assigned_ip1 = '1.2.3.5'
+        sid1 = imsi1 + '.' + apn1
+        MockedSubscriberDBStub.add_sub(sid=imsi1, apn=apn1, ip=assigned_ip1)
+
+        ip1, _ = self._allocator.alloc_ip_address(sid1)
+        ip1_returned = self._allocator.get_ip_for_sid(sid1)
+
+        # check if retrieved ip is the same as the one allocated
+        self.assertEqual(ip1, ip1_returned)
+        self.assertEqual(ip1, ipaddress.ip_address(assigned_ip1))
+        self.check_type(sid, IPType.STATIC)


### PR DESCRIPTION
## Summary

If there is any duplicate IP assignments in subscriberDB via
configuration, MobilityD would throw exception.
This patch also improves ip-desc bookkeeping by setting
valid ip-block for static ip.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
mobilityD tests.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
