### PR TITLE
[lte][policydb][sessiond] Fix issue where SetSessionRules is never handled

### DIFF
--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -56,6 +56,7 @@ void LocalSessionManagerAsyncService::init_call_data() {
   new CreateSessionCallData(cq_.get(), *this, *handler_);
   new EndSessionCallData(cq_.get(), *this, *handler_);
   new BindPolicy2BearerCallData(cq_.get(), *this, *handler_);
+  new SetSessionRulesCallData(cq_.get(), *this, *handler_);
 }
 
 SessionProxyResponderAsyncService::SessionProxyResponderAsyncService(

--- a/lte/gateway/c/session_manager/SessionManagerServer.h
+++ b/lte/gateway/c/session_manager/SessionManagerServer.h
@@ -305,6 +305,38 @@ class BindPolicy2BearerCallData :
 };
 
 /**
+ * Class to handle SetSessionRules requests
+ */
+class SetSessionRulesCallData :
+  public AsyncGRPCRequest<
+    LocalSessionManager::AsyncService,
+    SessionRules,
+    Void> {
+ public:
+  SetSessionRulesCallData(
+    ServerCompletionQueue *cq,
+    LocalSessionManager::AsyncService &service,
+    LocalSessionManagerHandler &handler):
+    AsyncGRPCRequest(cq, service),
+    handler_(handler)
+  {
+    service_.RequestSetSessionRules(
+      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+  }
+
+ protected:
+  void clone() override { new SetSessionRulesCallData(cq_, service_, handler_); }
+
+  void process() override
+  {
+    handler_.SetSessionRules(&ctx_, &request_, get_finish_callback());
+  }
+
+ private:
+  LocalSessionManagerHandler &handler_;
+};
+
+/**
  * Class to handle ChargingReauth requests
  */
 class ChargingReAuthCallData :

--- a/lte/gateway/python/magma/policydb/streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/streamer_callback.py
@@ -133,9 +133,9 @@ class ApnRuleMappingsStreamerCallback(StreamerClient.Callback):
         update = SessionRules(rules_per_subscriber=all_subscriber_rules)
 
         try:
-            self._session_mgr_stub.SetSessionRules(update)
-        except grpc.RpcError:
-            logging.error('Unable to apply apn->policy updates')
+            self._session_mgr_stub.SetSessionRules(update, timeout=5)
+        except grpc.RpcError as e:
+            logging.error('Unable to apply apn->policy updates %s', str(e))
 
     def _are_sub_policies_updated(
         self,

--- a/lte/gateway/python/magma/policydb/tests/mock_stubs.py
+++ b/lte/gateway/python/magma/policydb/tests/mock_stubs.py
@@ -22,7 +22,7 @@ class MockLocalSessionManagerStub:
     def __init__(self):
         pass
 
-    def SetSessionRules(self, _: SessionRules) -> Void:
+    def SetSessionRules(self, _: SessionRules, timeout: float) -> Void:
         return Void()
 
 

--- a/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
+++ b/lte/gateway/python/magma/policydb/tests/test_streamer_callback.py
@@ -257,7 +257,7 @@ class RuleMappingsStreamerCallbackTest(unittest.TestCase):
 def get_SetSessionRules_side_effect(
     called_with: List[SessionRules],
 ) -> Callable[[SessionRules], Void]:
-    def side_effect(session_rules: SessionRules) -> Void:
+    def side_effect(session_rules: SessionRules, timeout: float) -> Void:
         called_with.append(session_rules)
         return Void()
     return side_effect


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

This pull request fixes two related issues.

First, on `policydb`, when calls are made to `sessiond` for `SetSessionRules`, because a timeout is never specified, then the `ApnRuleMappingsStreamerCallback` can hang, and no other streamer callbacks run. A timeout has been added, and gRPC error messages will now be logged.

Second, on `sessiond`, calls to `SetSessionRules` are never handled. This is due to a missing registration of `SetSessionRulesCallData` in the `SessionManagerServer`.

## Test Plan

Checking that `policydb` will not hang if `sessiond` does not respond with the added timeout:
```
Sep 01 06:25:51 magma-dev policydb[24733]: ERROR:root:Unable to apply apn->policy updates <_Rendezvous of RPC that terminated with:
Sep 01 06:25:51 magma-dev policydb[24733]:         status = StatusCode.DEADLINE_EXCEEDED
Sep 01 06:25:51 magma-dev policydb[24733]:         details = "Deadline Exceeded"
Sep 01 06:25:51 magma-dev policydb[24733]:         debug_error_string = "{"created":"@1598941551.764833636","description":"Error received from peer","file":"src/core/lib/surface/call.cc","file_line":1017,"grpc_message":"Deadline Exceeded","grpc_status":4}"
Sep 01 06:25:51 magma-dev policydb[24733]: >
```

Checking that `sessiond` receives and processes `SetSessionRules` calls from `policydb` in a test setup where both are running locally, along with orc8r which is streaming per-APN rule mappings to the gateway:
`sessiond`
```
...
Sep 01 07:01:21 magma-dev sessiond[11720]: I0901 07:01:21.149061 11720 LocalEnforcer.cpp:240] Successfully synced sessions after restart
Sep 01 07:01:22 magma-dev sessiond[11720]: [/home/vagrant/magma/orc8r/gateway/c/common/config/ServiceConfigLoader.cpp:34] Override file not found for service redis
Sep 01 07:01:22 magma-dev sessiond[11720]: I0901 07:01:22.031155 11739 PolicyLoader.cpp:55] Connected to redis server
Sep 01 07:01:22 magma-dev sessiond[11720]: I0901 07:01:22.031868 11739 PolicyLoader.cpp:64] 2 rules synced
Sep 01 07:01:22 magma-dev sessiond[11720]: I0901 07:01:22.368149 11766 LocalSessionManagerHandler.cpp:582] Received session <-> rule associations
Sep 01 07:01:22 magma-dev sessiond[11720]: I0901 07:01:22.368645 11720 SessionStore.cpp:98] Merging updates into existing sessions
Sep 01 07:01:22 magma-dev sessiond[11720]: I0901 07:01:22.368672 11720 SessionStore.cpp:123] Writing into session store
Sep 01 07:01:22 magma-dev sessiond[11720]: I0901 07:01:22.368685 11720 LocalSessionManagerHandler.cpp:595] Succeeded in updating SessionStore after processing session rules set
```
`policydb` (Note that no gRPC error was logged, so success is silent)
```
Sep 01 07:01:20 magma-dev systemd[1]: Started Magma policydb service.
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Streamer reconnect pause: 60
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Streamer timeout: 150
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Starting policydb...
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Listening on address 127.0.0.1:50068
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Processing 0 rating group updates
Sep 01 07:01:22 magma-dev policydb[11718]: ERROR:root:Error! Streaming from the cloud failed! [StatusCode.UNAVAILABLE] stream rule_mappings does not exist
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Processing 1 SID -> apn -> policy updates
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Updating 1 IMSIs with new APN->policy assignments
Sep 01 07:01:22 magma-dev policydb[11718]: INFO:root:Processing 2 policy updates (resync=True)
```



## Additional Information

- [ ] This change is backwards-breaking
