### PR TITLE
[sessiond] Adding quota exhaustion algo to sessiond README

### DIFF
--- a/docs/readmes/lte/sessiond.md
+++ b/docs/readmes/lte/sessiond.md
@@ -80,3 +80,73 @@ On SessionD restart, session state will be synced to MME service, which
 it will use as the source of truth for active sessions. 
 Based on the active sessions, PipelineD will be instructed to 
 allow/disallow traffic.
+
+## Enforcement algorithm 
+Sessiond can report credit to PCRF (Gx) and OCS (Gy). In both cases it is up to 
+PCRF or OCS to determine when the user is out of quota. Sessiond will only receive, 
+count, report and execute actions from the core. The algorithms here described 
+are mainly related how to interpret the orders received by PCRF and OCS and how
+in advance we will report to the core to prevent to hit the exhaustion prematurely.
+Sessiond will not execute any action unless receiving an explicit order from 
+PCRF and OCS.
+
+Gx reporting will be identified with monitoring key, while Gy reporting will be 
+identified by charging key. 
+
+Both Gx and Gy reporting have some commonalities on its algorithm:
+1. PCRF/OCS will send an initial grant with allowed credit to be reported. 
+2. Sessiond will count the credits used but it will not report back anything yet
+3. When a specific percentage of that grant is reached, Sessiond will send a 
+report to OCS or PCRF with used units (by default 80% and can be changed at 
+`sessiond.yml` using parameter `sessiond_readme_quota_exhaustion`) 
+4. PCRF/OCS will then send back another grant, which will be added to the still
+remaining grant. 
+5. PCRF/OCS can also include an indication to let SessionD know that there is 
+no more quota available for that user. So SessionD will only have a small 
+percentage left (around 20%) until is exhausted and execute an specific
+action
+
+See that PCRF or OCS can request to track the credit using Tx only, Rx only, Tx and Rx,
+TX, RX and Total. The tracking type will be determined by the very first grant received
+and will remain the same for the entire session for that specific monitor key (Gx reporting)
+or charging key (Gy reporting)
+
+To better understand the exhaustion algorithm refer to `SessionCredit::is_quota_exhausted`
+
+Below you have some differences on how SessionD deals with GX and Gy reporting 
+
+### PCRF (Gx reporting) 
+Gx reporting will not cause a session termination. Gx reporting will report credit
+back to PCRF until quota is exhausted. Once quota is exhausted, the monitor will be
+deleted from SessionD (stop reporting) but the session or the policy related with 
+that monitoring key will not be removed.
+
+Monitor removal will be triggered by PCRF sending a grant with one of its components
+(tx, rx or total) set to 0 (or not set). Note that this component (tx, rx or total) 
+must be one of the tracked types. So if we are tracking TX and RX, the deletion of
+the monitor will be triggered if we receive either a 0 on Tx or Rx 
+(total component will be ignored).
+
+When SessionD receives a 0 on one of its tracked components of the last received
+grant, the monitor will not be deleted immediately. Sessiond will exhaust the remaining 
+credit still left (remember we still have around 20% left of the previous grant), and 
+then stop reporting removing the monitoring key.
+
+### OCS (Gy reporting) 
+Gy reporting will cause session termination, redirection or restriction. Gy reporting will 
+report credit back to OCS until quota is exhausted. Then, and depending on 
+Final Unit Action, the session may be terminated, redirected or restricted.
+In all cases, this will have impact on the whole session, not on a specific policy of 
+that session
+
+Session action will be triggered by OCS sending a grant which must include AVP 
+Final Action Indication. If this AVP is not included, SessionD will keep tracking
+and reporting to OCS, even if quota is exhausted, but it will not take any action. 
+The reason for that is that we don't want to trigger an early termination of the 
+session due to OCS being too slow to provide a grant. Also, Per 3gpp 
+Final Unit Indication AVP is needed to trigger any action by SessionD.
+
+Note when SessionD receives a grant which includes Final Unit Indicaton, it 
+will continue tracking this charging key until any of its quotas is exhausted. 
+Once it is exhausted, Final Unit Action (termnate, redirect, restrict) 
+will be executed.


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>


## Summary

Added a description of how Gx and Gy counting algorithm works on sessiond and the differences between them

## Test Plan
NA
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
