### PR TITLE
[CWAG][health] Update health service to use transport VIP

### DIFF
--- a/cwf/gateway/docker/go/Dockerfile
+++ b/cwf/gateway/docker/go/Dockerfile
@@ -109,7 +109,7 @@ RUN make -C $MAGMA_ROOT/cwf/gateway build
 FROM ubuntu:bionic AS cwag_go
 
 # Install envdir.
-RUN apt-get -y update && apt-get -y install daemontools curl iptables
+RUN apt-get -y update && apt-get -y install daemontools curl arping
 
 # Copy the build artifacts.
 COPY --from=builder /var/opt/magma/bin /var/opt/magma/bin

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -38,6 +38,8 @@ require (
 	fbc/cwf/radius v0.0.0
 	fbc/lib/go/radius v0.0.0-00010101000000-000000000000
 	github.com/coreos/go-iptables v0.4.5
+	github.com/Microsoft/go-winio v0.4.14 // indirect
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/fiorix/go-diameter/v4 v4.0.1-0.20200120193412-55a1c21738f9
 	github.com/go-openapi/swag v0.19.5
@@ -50,6 +52,10 @@ require (
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
 	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
+	github.com/vishvananda/netlink v1.1.0
+	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 // indirect
+	golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7
+	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -75,7 +75,6 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/etcd v3.3.12+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-iptables v0.4.5 h1:DpHb9vJrZQEFMcVLFKAAGMUVX0XoRC0ptCthinRYm38=
-github.com/coreos/go-iptables v0.4.5/go.mod h1:/mVI274lEDI2ns62jHCDnCyBF9Iwsmekav8Dbxlm1MU=
 github.com/coreos/go-oidc v2.1.0+incompatible/go.mod h1:CgnwVTmzoESiwO9qyAFEMiHoZ1nMCKZlZ9V6mm3/LKc=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
@@ -527,6 +526,10 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/vishvananda/netlink v1.1.0 h1:1iyaYNBLmP6L0220aDnYQpo1QEV4t4hJ+xEEhhJH8j0=
+github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df h1:OviZH7qLw/7ZovXvuNyL3XQl8UFofeikI1NW1Gypu7k=
+github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -621,6 +624,7 @@ golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190502145724-3ef323f4f1fd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190606203320-7fc4e5ec1444/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190616124812-15dcb6c0061f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190907184412-d223b2b6db03/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/cwf/gateway/services/gateway_health/gateway_health/main.go
+++ b/cwf/gateway/services/gateway_health/gateway_health/main.go
@@ -16,6 +16,7 @@ package main
 import (
 	"flag"
 	"net"
+	"os"
 	"strings"
 
 	mconfigprotos "magma/cwf/cloud/go/protos/mconfig"
@@ -40,7 +41,7 @@ const (
 	defaultCpuUtilPct       = 0.9
 	defaultGREProbeInterval = 10
 	defaultICMPPktCount     = 3
-	defaultICMPInterface    = "eth1"
+	defaultInterface        = "eth1"
 )
 
 func main() {
@@ -51,7 +52,15 @@ func main() {
 	}
 	cfg := getHealthMconfig()
 	probe := gre_probe.NewICMPProbe(cfg.GrePeers, cfg.GreProbeInterval, int(cfg.IcmpProbePktCount))
-	systemHealth, err := system_health.NewCWAGSystemHealthProvider(defaultICMPInterface)
+
+	// TODO: Use mconfig VIP
+	transportVIP := os.Getenv("TRANSPORT_VIP")
+	if len(transportVIP) == 0 {
+		glog.Warningf("No transport VIP has been specified. If running with HA enabled, this is a critical error!")
+	} else if _, _, err := net.ParseCIDR(transportVIP); err != nil {
+		glog.Fatalf("Transport VIP must be specified with a subnet (i.e. 10.10.10.10/24)")
+	}
+	systemHealth, err := system_health.NewCWAGSystemHealthProvider(defaultInterface, transportVIP)
 	if err != nil {
 		glog.Fatalf("Error creating CWAGServiceHealthProvider: %s", err)
 	}
@@ -104,7 +113,6 @@ func getHealthMconfig() *mconfigprotos.CwfGatewayHealthConfig {
 func removeSubnetEndpoints(endpoints []*mconfigprotos.CwfGatewayHealthConfigGrePeer) []*mconfigprotos.CwfGatewayHealthConfigGrePeer {
 	ret := []*mconfigprotos.CwfGatewayHealthConfigGrePeer{}
 	for _, endpoint := range endpoints {
-		_, _, err := net.ParseCIDR(endpoint.Ip)
 		parsedIP, _, err := net.ParseCIDR(endpoint.Ip)
 		if err != nil {
 			ret = append(ret, endpoint)


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR updates the CWAG's health service to function using
a virtual IP. The idea is that the active CWAG will hold the VIP. 
This eliminates the need for the WLC/AP to support redundant
transport features.

The implementation functions using netlink to add/remove the VIP and update
the route to use the proper source IP. 

This change also allows us to run the GRE ICMP probe on both the active
and standby gateway, as we no longer need to block ICMP on eth1.
Additionally, we no longer need to stop the RADIUS server on the 
standby. This allows us to eliminate the weird logic we had employed
to determine healthy services.

## Test Plan

Added unit tests.
Tested locally to ensure proper IP mechanism updates.
Tested in the lab to ensure session continuity on failover.

## Additional Information

- [ ] This change is backwards-breaking

This change will break existing HA deployments for CWF. This is because
the HA mechanism now relies on having a VIP configured. To handle this,
add the following to /var/opt/magma/docker/docker-compose.yml to the `health`
service:

```
 health:
    ...
    environment:
      - TRANSPORT_VIP=10.10.10.10/24 #(insert your VIP here)
   volumes:
      ...
```
The VIP should be an unused IP in the same subnet as the eth1 interfaces
of your CWAGs.

Given that the only known deployments with CWAG HA enabled are lab environments,
this should not be too disruptive of a change.
