### PR TITLE
[nms] add default unit to grafana dashboards

### DIFF
--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -452,9 +452,10 @@ function newPanel(params: PanelParams) {
   // Have to add this after to avoid grafana-dash-gen from forcing the target
   // into a Graphite format
   pan.state.targets = params.targets;
-  if (params.unit !== null) {
-    pan.state.y_formats[0] = params.unit;
-  }
+
+  // "short" is the default unit for grafana (no unit)
+  pan.state.y_formats[0] = params.unit ?? 'short';
+
   // yMin should be 0 at minimum unless otherwise specified.
   // null is used to indicate 'auto' in grafana
   if (params.yMin === null) {


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Somehow `null` was making its way into the unit field of grafana dashboards making a lot of them not show up. This ensures that "short" (the default grafana unit) is used instead.

## Test Plan
![image](https://user-images.githubusercontent.com/13274915/91890704-c24d5280-ec44-11ea-9527-0cce8fa931f9.png)
