### PR TITLE
[nms] Show subscriber name in detail view if it exists

### DIFF
--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -101,11 +101,16 @@ export default function SubscriberDetail() {
   const classes = useStyles();
   const {relativePath, relativeUrl, match} = useRouter();
   const subscriberId: string = nullthrows(match.params.subscriberId);
+  const ctx = useContext(SubscriberContext);
+  // TODO: render a "Not found" component if the IMSI is not found
+  const subscriberInfo = ctx.state?.[subscriberId] || {};
 
   return (
     <>
       <div className={classes.topBar}>
-        <Text variant="body2">Subscriber/{subscriberId}</Text>
+        <Text variant="body2">
+          Subscriber/{subscriberInfo.name ?? subscriberId}
+        </Text>
       </div>
 
       <AppBar position="static" color="default" className={classes.tabBar}>
@@ -208,7 +213,7 @@ function Info(props: {subscriberInfo: subscriber}) {
   const kpiData: DataRows[] = [
     [
       {
-        value: props.subscriberInfo.id,
+        value: props.subscriberInfo.name ?? props.subscriberInfo.id,
         statusCircle: false,
       },
     ],


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Updates subscriber detail view to show name instead of IMSI on header and info table if it's specified on the entity.

## Test Plan

![Screen Shot 2020-09-01 at 4 47 52 PM](https://user-images.githubusercontent.com/3249794/91924405-6fe15580-ec87-11ea-8428-6584b96dc23d.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
