### PR TITLE
[AGW] pipelineD: reduce number of required config points

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -136,13 +136,12 @@ ovs_gtp_port_number: 32768
 # Internal port for monitoring service
 ovs_mtr_port_number: 15577
 
-# define enable_nat for here debugging only.
-# enable_nat: True
 # Be careful changing these default values
+# enable_nat: True
 non_nat_gw_probe_frequency: 20
 # non_nat_arp_egress_port: dhcp0
 ovs_uplink_port_name: patch-up
-virtual_mac: '02:ff:bb:cc:dd:ee'
+# virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
 uplink_eth_port_name: uplink_p0
 uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -130,12 +130,12 @@ ovs_gtp_port_number: 32768
 # Internal port for monitoring service
 ovs_mtr_port_number: 15577
 
-# define enable_nat for here debugging only.
+# Be careful changing these default values
 # enable_nat: True
 non_nat_gw_probe_frequency: 20
-non_nat_arp_egress_port: dhcp0
+# non_nat_arp_egress_port: dhcp0
 ovs_uplink_port_name: patch-up
-virtual_mac: '02:ff:bb:cc:dd:ee'
+# virtual_mac: '02:ff:bb:cc:dd:ee'
 uplink_bridge: uplink_br0
 uplink_eth_port_name: eth0
 uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'

--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -63,7 +63,8 @@ class InOutController(MagmaController):
          'setup_type', 'uplink_gw_mac'],
     )
     ARP_PROBE_FREQUENCY = 300
-    NON_NAT_ARP_EGRESS_PORT = 'uplink_br0'
+    NON_NAT_ARP_EGRESS_PORT = 'dhcp0'
+    UPLINK_OVS_BRIDGE_NAME = 'uplink_br0'
 
     def __init__(self, *args, **kwargs):
         super(InOutController, self).__init__(*args, **kwargs)
@@ -111,8 +112,14 @@ class InOutController(MagmaController):
         enable_nat = config_dict.get('enable_nat', True)
         non_nat_gw_probe_freq = config_dict.get('non_nat_gw_probe_frequency',
                                                 self.ARP_PROBE_FREQUENCY)
-        non_nat_arp_egress_port = config_dict.get('non_nat_arp_egress_port',
-                                                  self.NON_NAT_ARP_EGRESS_PORT)
+        # In case of vlan tag on uplink_bridge, use separate port.
+        sgi_vlan = config_dict.get('sgi_management_iface_vlan', "")
+        if not sgi_vlan:
+            non_nat_arp_egress_port = config_dict.get('non_nat_arp_egress_port',
+                                                      self.UPLINK_OVS_BRIDGE_NAME)
+        else:
+            non_nat_arp_egress_port = config_dict.get('non_nat_arp_egress_port',
+                                                      self.NON_NAT_ARP_EGRESS_PORT)
         uplink_gw_mac = config_dict.get('uplink_gw_mac',
                                         "ff:ff:ff:ff:ff:ff")
         return self.InOutConfig(

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -23,6 +23,7 @@ import threading
 import aioeventlet
 from ryu import cfg
 from ryu.base.app_manager import AppManager
+from scapy.arch import get_if_hwaddr
 
 from magma.common.misc_utils import call_process
 from magma.common.service import MagmaService
@@ -55,6 +56,7 @@ def main():
     cfg.CONF.ofp_listen_host = "127.0.0.1"
 
     # override mconfig using local config.
+    # TODO: move config compilation to separate module.
     enable_nat = service.config.get('enable_nat', service.mconfig.nat_enabled)
     service.config['enable_nat'] = enable_nat
     logging.info("Nat: %s", enable_nat)
@@ -65,6 +67,9 @@ def main():
     sgi_ip = service.config.get('sgi_management_iface_ip_addr',
                                   service.mconfig.sgi_management_iface_ip_addr)
     service.config['sgi_management_iface_ip_addr'] = sgi_ip
+
+    if 'virtual_mac' not in service.config:
+        service.config['virtual_mac'] = get_if_hwaddr(service.config.get('bridge_name'))
 
     # Load the ryu apps
     service_manager = ServiceManager(service)


### PR DESCRIPTION
## Summary

Following patch automatically detect config value
during pipelineD startup.
non_nat_arp_egress_port,virtual_mac are no longer
required parameters.
Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
pipelineD tests, manually verified flows on magma-dev.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
