### PR TITLE
[NMS] Force event table refresh when input start and end dates in lte dashb…

### DIFF
--- a/nms/app/packages/magmalte/app/views/events/EventsTable.js
+++ b/nms/app/packages/magmalte/app/views/events/EventsTable.js
@@ -33,7 +33,7 @@ import {DateTimePicker} from '@material-ui/pickers';
 import {colors} from '../../theme/default';
 import {getStep} from '../../components/CustomMetrics';
 import {makeStyles} from '@material-ui/styles';
-import {useMemo, useRef, useState} from 'react';
+import {useEffect, useMemo, useRef, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
@@ -238,6 +238,14 @@ export default function EventsTable(props: EventTableProps) {
       format: format,
     };
   }, [startDate, endDate]);
+
+  useEffect(() => {
+    if (props.inStartDate && props.inEndDate) {
+      if (tableRef.current) {
+        tableRef.current.onQueryChange();
+      }
+    }
+  }, [props.inStartDate, props.inEndDate]);
 
   function DateFilter() {
     return (


### PR DESCRIPTION

## Summary

Event table wasn't refreshing when the start and end dates in Lte dashboard changed.

## Test Plan

![eventtable_refresh](https://user-images.githubusercontent.com/8224854/91935284-3e29b800-eca2-11ea-91e5-878bf964fb08.gif)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
