### PR TITLE
[SessionD] Properly persist bearerID mapping to SessionStore

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -59,6 +59,7 @@ StoredSessionState SessionState::marshal() {
   marshaled.pdp_end_time           = pdp_end_time_;
   marshaled.pending_event_triggers = pending_event_triggers_;
   marshaled.revalidation_time      = revalidation_time_;
+  marshaled.bearer_id_by_policy = bearer_id_by_policy_;
 
   marshaled.monitor_map = StoredMonitorMap();
   for (auto& monitor_pair : monitor_map_) {
@@ -115,7 +116,8 @@ SessionState::SessionState(
       static_rules_(rule_store),
       pending_event_triggers_(marshaled.pending_event_triggers),
       revalidation_time_(marshaled.revalidation_time),
-      credit_map_(4, &ccHash, &ccEqual) {
+      credit_map_(4, &ccHash, &ccEqual),
+      bearer_id_by_policy_(marshaled.bearer_id_by_policy) {
   session_level_key_ = marshaled.session_level_key;
   for (auto it : marshaled.monitor_map) {
     Monitor monitor;


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
When testing the set policy update -> bearer lifecycle management, it became clear that SessionD was not calling a delete bearer request on a rule removal. After investigating, it was because the bearer mapping change was not properly propagated into SessionStore. More specifically, the bearer mapping was not translated to/from StoredSessionStore. 
The modified unit test failed before the fix and now it passes.

A todo here is to add some documentation on ALL the places we need to modify when we make changes to SessionState. (until we come up with a more automated way to serialize, at least)
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Updated Unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
