### PR TITLE
[5G: MVC][SessionD] Rulestore and SessionState changes of 5g initial commit

### DIFF
--- a/lte/gateway/Makefile
+++ b/lte/gateway/Makefile
@@ -67,6 +67,8 @@ all: build
 
 build: build_python build_common build_oai build_sctpd build_session_manager ## Build all
 
+smf_build: build_session_manager  ## Build only sessionD component make smf_build
+
 test: test_python test_oai test_session_manager ## Run all tests
 
 clean: clean_python  ## Clean all builds

--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -154,8 +154,16 @@ add_library(SESSION_MANAGER
     MeteringReporter.h
     GrpcMagmaUtils.cpp
     GrpcMagmaUtils.h
+    SetMessageManagerHandler.h
+    SetMessageManagerHandler.cpp
+    SessionStateEnforcer.h
+    SessionStateEnforcer.cpp
+    AmfServiceClient.h
+    AmfServiceClient.cpp
     ${PROTO_SRCS}
     ${PROTO_HDRS})
+
+
 
 target_link_libraries(SESSION_MANAGER
   SERVICE303_LIB SERVICE_REGISTRY ASYNC_GRPC CONFIG POLICYDB EVENTD
@@ -175,8 +183,8 @@ if (CLANG_FORMAT)
 endif ()
 
 add_executable(sessiond ${PROJECT_SOURCE_DIR}/sessiond_main.cpp)
-
 target_link_libraries (sessiond SESSION_MANAGER)
+
 
 if (BUILD_TESTS)
   ENABLE_TESTING()

--- a/lte/gateway/c/session_manager/RuleStore.cpp
+++ b/lte/gateway/c/session_manager/RuleStore.cpp
@@ -245,4 +245,68 @@ bool PolicyRuleBiMap::get_rules(std::vector<PolicyRule>& rules_out) {
   return true;
 }
 
+void ConvergedRuleStore::insert_rule(uint32_t id, const SetGroupPDR& rule) {
+  auto rule_p = std::make_shared<SetGroupPDR>(rule);
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  rules_by_pdr_key_[id] = rule_p;
+}
+
+void ConvergedRuleStore::insert_rule(uint32_t id, const SetGroupFAR& rule) {
+  auto rule_p = std::make_shared<SetGroupFAR>(rule);
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  rules_by_far_key_[id] = rule_p;
+}
+
+bool ConvergedRuleStore::remove_rule(uint32_t rule_id, SetGroupPDR* rule_out) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  auto it = rules_by_pdr_key_.find(rule_id);
+  if (it != rules_by_pdr_key_.end()) {
+    auto rule_ptr = it->second;
+    if (rule_out != NULL) {
+      rule_out->CopyFrom(*rule_ptr);
+    }
+    rules_by_pdr_key_.erase(rule_id);
+    return true;
+  }
+  return false;
+}
+
+bool ConvergedRuleStore::remove_rule(uint32_t rule_id, SetGroupFAR* rule_out) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  auto it = rules_by_far_key_.find(rule_id);
+  if (it != rules_by_far_key_.end()) {
+    auto rule_ptr = it->second;
+    if (rule_out != NULL) {
+      rule_out->CopyFrom(*rule_ptr);
+    }
+    rules_by_far_key_.erase(rule_id);
+    return true;
+  }
+  return false;
+}
+
+bool ConvergedRuleStore::get_rule(uint32_t rule_id, SetGroupPDR* rule_out) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  auto it = rules_by_pdr_key_.find(rule_id);
+  if (it == rules_by_pdr_key_.end()) {
+    return false;
+  }
+  if (rule_out != NULL) {
+    rule_out->CopyFrom(*it->second);
+  }
+  return true;
+}
+
+bool ConvergedRuleStore::get_rule(uint32_t rule_id, SetGroupFAR* rule_out) {
+  std::lock_guard<std::mutex> lock(map_mutex_);
+  auto it = rules_by_far_key_.find(rule_id);
+  if (it == rules_by_far_key_.end()) {
+    return false;
+  }
+  if (rule_out != NULL) {
+    rule_out->CopyFrom(*it->second);
+  }
+  return true;
+}
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -48,10 +48,12 @@ std::unique_ptr<SessionState> SessionState::unmarshal(
 StoredSessionState SessionState::marshal() {
   StoredSessionState marshaled{};
 
-  marshaled.fsm_state              = curr_state_;
-  marshaled.config                 = config_;
-  marshaled.imsi                   = imsi_;
-  marshaled.session_id             = session_id_;
+  marshaled.fsm_state  = curr_state_;
+  marshaled.config     = config_;
+  marshaled.imsi       = imsi_;
+  marshaled.session_id = session_id_;
+  // 5G session version handling
+  marshaled.current_version        = current_version_;
   marshaled.subscriber_quota_state = subscriber_quota_state_;
   marshaled.tgpp_context           = tgpp_context_;
   marshaled.request_number         = request_number_;
@@ -112,6 +114,8 @@ SessionState::SessionState(
       config_(marshaled.config),
       pdp_start_time_(marshaled.pdp_start_time),
       pdp_end_time_(marshaled.pdp_end_time),
+      // 5G session version handlimg
+      current_version_(marshaled.current_version),
       subscriber_quota_state_(marshaled.subscriber_quota_state),
       tgpp_context_(marshaled.tgpp_context),
       static_rules_(rule_store),
@@ -169,6 +173,61 @@ SessionState::SessionState(
       tgpp_context_(tgpp_context),
       static_rules_(rule_store),
       credit_map_(4, &ccHash, &ccEqual) {}
+
+/*For 5G which doesn't have response context*/
+SessionState::SessionState(
+    const std::string& imsi, const std::string& session_ctx_id,
+    const SessionConfig& cfg, StaticRuleStore& rule_store)
+    : imsi_(imsi),
+      session_id_(session_ctx_id),
+      // Request number set to 1, because request 0 is INIT call
+      request_number_(1),
+      /*current state would be CREATING and version would be 0 */
+      curr_state_(CREATING),
+      config_(cfg),
+      current_version_(0),
+      static_rules_(rule_store) {}
+
+/* get-set methods of new messages  for 5G*/
+uint32_t SessionState::get_current_version() {
+  return current_version_;
+}
+
+void SessionState::set_current_version(int new_session_version) {
+  current_version_ = new_session_version;
+}
+/* Add PDR rule to this rules session list */
+void SessionState::insert_pdr(SetGroupPDR* rule) {
+  PdrList_.push_back(*rule);
+}
+
+/* Add FAR rule to this rules session list */
+void SessionState::insert_far(SetGroupFAR* rule) {
+  FarList_.push_back(*rule);
+}
+
+/* It gets all PDR rule list of the session */
+std::vector<SetGroupPDR>& SessionState::get_all_pdr_rules() {
+  return PdrList_;
+}
+
+/* It gets all FAR rule list of the session */
+std::vector<SetGroupFAR>& SessionState::get_all_far_rules() {
+  return FarList_;
+}
+
+/*temporary copy to be removed after upf node code completes */
+void SessionState::sess_infocopy(struct SessionInfo* info) {
+  // Static SessionInfo vlaue till UPF node value implementation
+  // gets stablized.
+  info->state               = magma::lte::Fsm_state_FsmState_CREATING;
+  info->sess_id             = "1122334455667788";
+  info->ver_no              = 1;
+  info->nodeId.node_id_type = SessionInfo::IPv4;
+  strcpy(info->nodeId.node_id, "192.168.2.1");
+  memcpy(&(info->Seid.Nid), &(info->nodeId), sizeof(SessionInfo::NodeId));
+  info->Seid.f_seid = 1122334455667788;
+}
 
 static UsageMonitorUpdate make_usage_monitor_update(
     const SessionCredit::Usage& usage_in, const std::string& monitoring_key,

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -77,14 +77,45 @@ struct BearerUpdate {
  */
 class SessionState {
  public:
+
   struct SessionInfo {
+    enum  upfNodeType {
+	   	IPv4 = 0,
+        IPv6 = 1,
+       FQDN = 2,
+    };
+
+    typedef struct tNodeId {
+      upfNodeType node_id_type;
+      char node_id[40];
+    }NodeId;
+
+    typedef struct  Fseid {
+	uint64_t  f_seid;
+	NodeId  Nid;
+    } FSid;
     std::string imsi;
     std::string ip_addr;
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
     std::vector<PolicyRule> gy_dynamic_rules;
     optional<AggregatedMaximumBitrate> ambr;
+    // 5G specific extensions
+    std::vector<SetGroupPDR> Pdr_rules_;
+    std::vector<SetGroupFAR> Far_rules_;
+    magma::lte::Fsm_state_FsmState state;
+    std::string sess_id;
+    uint32_t ver_no;
+    NodeId nodeId;
+    FSid Seid;
+    // 5G specific extension routines
   };
+
+  /* To remove below routine  once the UPF node core logic
+   * get completed
+   */
+  void sess_infocopy(struct SessionInfo*);
+
   struct TotalCreditUsage {
     uint64_t monitoring_tx;
     uint64_t monitoring_rx;
@@ -105,6 +136,24 @@ class SessionState {
       const StoredSessionState& marshaled, StaticRuleStore& rule_store);
 
   StoredSessionState marshal();
+
+  // 5G processing constructor without response contxt as set-interface msg
+  SessionState(
+      const std::string& imsi, const std::string& session_ctx_id,
+      const SessionConfig& cfg, StaticRuleStore& rule_store);
+
+  /* methods of new messages of 5G and handle other message*/
+  uint32_t get_current_version();
+
+  void set_current_version(int new_session_version);
+
+  void insert_pdr(SetGroupPDR* rule);
+
+  void insert_far(SetGroupFAR* rule);
+
+  std::vector<SetGroupPDR>& get_all_pdr_rules();
+
+  std::vector<SetGroupFAR>& get_all_far_rules();
 
   /**
    * Updates rules to be scheduled, active, or removed, depending on the
@@ -245,15 +294,15 @@ class SessionState {
       const PolicyRule& rule, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
-  void insert_gy_dynamic_rule(
-      const PolicyRule& rule, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
-
   /**
    * Add a static rule to the session which is currently active.
    */
   void activate_static_rule(
       const std::string& rule_id, RuleLifetime& lifetime,
+      SessionStateUpdateCriteria& update_criteria);
+
+  void insert_gy_dynamic_rule(
+      const PolicyRule& rule, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
   /**
@@ -450,6 +499,12 @@ class SessionState {
   SessionConfig config_;
   uint64_t pdp_start_time_;
   uint64_t pdp_end_time_;
+  /*5G related message to handle session state context */
+  uint32_t current_version_;  // To compare with incoming session version
+  // All 5G specific rules
+  // use as shared_ptr to check
+  std::vector<SetGroupPDR> PdrList_;
+  std::vector<SetGroupFAR> FarList_;
   // Used to keep track of whether the subscriber has valid quota.
   // (only used for CWF at the moment)
   magma::lte::SubscriberQuotaUpdate_Type subscriber_quota_state_;

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -172,6 +172,12 @@ int main(int argc, char* argv[]) {
   auto config =
       magma::ServiceConfigLoader{}.load_service_config(SESSIOND_SERVICE);
   magma::set_verbosity(get_log_verbosity(config, mconfig));
+  bool converged_access = false;
+  // Check converged sesiond is enebaled or not
+  if ((config["converged_access"].IsDefined()) &&
+      (config["converged_access"].as<bool>())) {
+    converged_access = true;
+  }
   MLOG(MINFO) << "Starting Session Manager";
   folly::EventBase* evb = folly::EventBaseManager::get()->getEventBase();
 
@@ -210,6 +216,9 @@ int main(int argc, char* argv[]) {
 
   std::shared_ptr<magma::AsyncSpgwServiceClient> spgw_client;
   std::shared_ptr<aaa::AsyncAAAClient> aaa_client;
+
+  //AMF service client to handle response message
+  auto amf_srv_client = std::make_shared<magma::AsyncAmfServiceClient>();
   // Case on config, setup the appropriate client for the access component
   std::thread access_response_handling_thread;
   if (config["support_carrier_wifi"].as<bool>()) {
@@ -283,9 +292,43 @@ int main(int argc, char* argv[]) {
   magma::SessionProxyResponderAsyncService proxy_service(
       server.GetNewCompletionQueue(), std::move(proxy_handler));
   server.AddServiceToServer(&local_service);
+  MLOG(MINFO) << "Add localservice";
   server.AddServiceToServer(&proxy_service);
+  MLOG(MINFO) << "Add proxyservice";
+  std::thread access_common_message_thread;
+  /* Initialize the main thread of session managment by folly event to handle
+   * logical component of 5G of SessionD
+   */
+  auto conv_session_enforcer = std::make_shared <magma::SessionStateEnforcer>(
+      rule_store, *session_store, pipelined_client, amf_srv_client, mconfig);
+  // 5G related async msg handler service framework creation
+  auto conv_set_message_handler = std::make_unique<magma::SetMessageManagerHandler>(
+      conv_session_enforcer, *session_store);
+  MLOG(MINFO) << "session enforcer";
+  // 5G specific services to handle set messages from AMF and mme
+  magma::AmfPduSessionSmContextAsyncService conv_set_message_service(
+      server.GetNewCompletionQueue(), std::move(conv_set_message_handler));
+  MLOG(MINFO) << "Amfpdusessionsmcontext set message started";
+  // 5G related services
+  if (converged_access) {
+    MLOG(MINFO) << "converged  GRPC Added";
+    server.AddServiceToServer(&conv_set_message_service);
+  }
   server.Start();
 
+  // 5G set message handling thread from access.
+  access_common_message_thread = std::thread([&]() {
+    if (converged_access) {
+      MLOG(MDEBUG) << "Started access message thread";
+      conv_set_message_service
+          .wait_for_requests();    // block here instead of on server
+      conv_set_message_service.stop();  // stop queue after server shutsdown
+    }
+  });
+  // 5G related SessionStateEnforcer main thread start to handled session state
+  conv_session_enforcer->attachEventBase(evb);
+  // session_enforcer->sync_sessions_on_restart(time(NULL));//not part of drop-1
+  // MVC
   std::thread local_thread([&]() {
     MLOG(MINFO) << "Started local service thread";
     local_service.wait_for_requests();  // block here instead of on server
@@ -296,11 +339,14 @@ int main(int argc, char* argv[]) {
     proxy_service.wait_for_requests();  // block here instead of on server
     proxy_service.stop();               // stop queue after server shuts down
   });
-
   // Block on main local_enforcer (to keep evb in this thread)
   local_enforcer->attachEventBase(evb);
+  MLOG(MDEBUG) << "local enforcer Attached EventBase to evb";
   local_enforcer->sync_sessions_on_restart(time(NULL));
-  local_enforcer->start();
+  MLOG(MDEBUG) << "Synced session on restart";
+  evb->loopForever();
+  MLOG(MINFO) << "Stoping.. session manager GRPC server";
+
   server.Stop();
 
   // Clean up threads & resources
@@ -312,6 +358,10 @@ int main(int argc, char* argv[]) {
   restart_handler_thread.join();
   policy_loader_thread.join();
   access_response_handling_thread.join();
+  if (converged_access) {
+    // 5G related thread join
+    access_common_message_thread.join();
+  }
   free(session_store);
 
   return 0;

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -52,3 +52,7 @@ support_stateless: false
 
 # Redis table name for session state.
 sessions_table: sessiond:sessions
+
+# Set to true if converged access set message support is required or 5g access
+# support is required
+converged_access: true


### PR DESCRIPTION
Signed-off-by: gurrapualt <venukumar.g@altencalsoftlabs.com>

<!--
    Tag  your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


## Summary

<!-- Enumerate changes you made and why you made them -->
Implemented  the following 
              -->5G  Rules association(PDR/FAR) to SessionState
              --> Invoking Pipelined (later it wud converted to UPFclient class) set method to send UPF.
              --> Setting all Set message common/header value with the help of static routine (sess_infocopy, this 
                      will removed/cleaned once UPF node GRPC implementation and Upfclient core functionality gets completed.
              --> SessionD main file changes to introduce/add new access thread, GRPC sever, and access message handler.

## Test Plan
Added new UT file in unit test frame work. This UT calls landing object of 5G sessionD and processing the message.
Added std::cerr to track the flow trace, and before to sending to Pipelined the log shows the values of GRPC individual fields of set message.
Testcase is part PR#2584
[RuleStore-test.log](https://github.com/magma/magma/files/5243467/RuleStore-test.log)


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
