### PR TITLE
[NMS] Add tooltip support to DataGrid component

### DIFF
--- a/docs/readmes/nms/developer.md
+++ b/docs/readmes/nms/developer.md
@@ -163,6 +163,10 @@ Passes the state of the `statusCircle`. **True** renders a green status indicato
 #### statusInactive `boolean` **(Optional)**
 Passes the state of inactive to `statusCircle` rendering a gray status indicator. 
 <br />
+
+#### tooltip `string` **(Optional)**
+Passes a string that will be shown as a tooltip when hovering over a specific data entry. If the prop is not passed, the data entry `value` is displayed instead.
+<br />
 <br />
 
 ### Examples

--- a/nms/app/packages/magmalte/app/components/DataGrid.js
+++ b/nms/app/packages/magmalte/app/components/DataGrid.js
@@ -29,6 +29,7 @@ import Input from '@material-ui/core/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
+import Tooltip from '@material-ui/core/Tooltip';
 import React from 'react';
 import Visibility from '@material-ui/icons/Visibility';
 import VisibilityOff from '@material-ui/icons/VisibilityOff';
@@ -68,8 +69,8 @@ const useStyles = makeStyles(theme => ({
       props.hasStatus
         ? 'calc(100% - 16px)'
         : props.hasIcon
-        ? 'calc(100% - 32px)'
-        : '100%',
+          ? 'calc(100% - 32px)'
+          : '100%',
   },
   dataObscuredValue: {
     color: colors.primary.brightGray,
@@ -212,67 +213,74 @@ type Data = {
   statusCircle?: boolean,
   statusInactive?: boolean,
   status?: boolean,
+  tooltip?: string,
 };
 
 export type DataRows = Data[];
 
-type Props = {data: DataRows[], testID?: string};
+type Props = { data: DataRows[], testID?: string };
 
 export default function DataGrid(props: Props) {
   const classes = useStyles();
   const dataGrid = props.data.map((row, i) => (
     <Grid key={i} container direction="row">
-      {row.map((data, j) => (
-        <React.Fragment key={`data-${i}-${j}`}>
-          <Grid
-            item
-            container
-            alignItems="center"
-            xs={12}
-            md
-            key={`data-${i}-${j}`}
-            zeroMinWidth
-            className={classes.dataBlock}>
-            <Grid item xs={12}>
-              {data.collapse !== undefined && data.collapse !== false ? (
-                DataCollapse(data.category, data.value, data.collapse)
-              ) : (
-                <CardHeader
-                  data-testid={data.category}
-                  className={classes.dataBox}
-                  title={data.category}
-                  titleTypographyProps={{
-                    variant: 'caption',
-                    className: classes.dataLabel,
-                    title: data.category,
-                  }}
-                  subheaderTypographyProps={{
-                    variant: 'body1',
-                    className:
-                      data.obscure === true
-                        ? classes.dataObscuredValue
-                        : classes.dataValue,
-                    title: data.value + (data.unit ?? ''),
-                  }}
-                  subheader={
-                    data.statusCircle === true
-                      ? StatusIndicator(
-                          data.statusInactive || false,
-                          data.status || false,
-                          data.value + (data.unit ?? ''),
-                        )
-                      : data.icon
-                      ? DataIcon(data.icon, data.value + (data.unit ?? ''))
-                      : data.obscure === true
-                      ? DataObscure(data.value, data.category)
-                      : data.value + (data.unit ?? '')
-                  }
-                />
-              )}
+      {row.map((data, j) => {
+        const dataEntryValue = data.value + (data.unit ?? '');
+
+        return (
+          <React.Fragment key={`data-${i}-${j}`}>
+            <Grid
+              item
+              container
+              alignItems="center"
+              xs={12}
+              md
+              key={`data-${i}-${j}`}
+              zeroMinWidth
+              className={classes.dataBlock}>
+              <Grid item xs={12}>
+                {data.collapse !== undefined && data.collapse !== false ? (
+                  DataCollapse(data.category, data.value, data.collapse)
+                ) : (
+                    <Tooltip title={data.tooltip ?? dataEntryValue}>
+                      <CardHeader
+                        data-testid={data.category}
+                        className={classes.dataBox}
+                        title={data.category}
+                        titleTypographyProps={{
+                          variant: 'caption',
+                          className: classes.dataLabel,
+                          title: data.category,
+                        }}
+                        subheaderTypographyProps={{
+                          variant: 'body1',
+                          className:
+                            data.obscure === true
+                              ? classes.dataObscuredValue
+                              : classes.dataValue,
+                          title: dataEntryValue,
+                        }}
+                        subheader={
+                          data.statusCircle === true
+                            ? StatusIndicator(
+                              data.statusInactive || false,
+                              data.status || false,
+                              dataEntryValue,
+                            )
+                            : data.icon
+                              ? DataIcon(data.icon, dataEntryValue)
+                              : data.obscure === true
+                                ? DataObscure(data.value, data.category)
+                                : dataEntryValue
+                        }
+                      />
+                    </Tooltip>
+                  )}
+              </Grid>
             </Grid>
-          </Grid>
-        </React.Fragment>
-      ))}
+          </React.Fragment>
+        )
+      })}
     </Grid>
   ));
   return (

--- a/nms/app/packages/magmalte/app/components/DataGrid.js
+++ b/nms/app/packages/magmalte/app/components/DataGrid.js
@@ -69,8 +69,8 @@ const useStyles = makeStyles(theme => ({
       props.hasStatus
         ? 'calc(100% - 16px)'
         : props.hasIcon
-          ? 'calc(100% - 32px)'
-          : '100%',
+        ? 'calc(100% - 32px)'
+        : '100%',
   },
   dataObscuredValue: {
     color: colors.primary.brightGray,
@@ -218,7 +218,7 @@ type Data = {
 
 export type DataRows = Data[];
 
-type Props = { data: DataRows[], testID?: string };
+type Props = {data: DataRows[], testID?: string};
 
 export default function DataGrid(props: Props) {
   const classes = useStyles();
@@ -242,39 +242,37 @@ export default function DataGrid(props: Props) {
                 {data.collapse !== undefined && data.collapse !== false ? (
                   DataCollapse(data.category, data.value, data.collapse)
                 ) : (
-                    <Tooltip title={data.tooltip ?? dataEntryValue}>
-                      <CardHeader
-                        data-testid={data.category}
-                        className={classes.dataBox}
-                        title={data.category}
-                        titleTypographyProps={{
-                          variant: 'caption',
-                          className: classes.dataLabel,
-                          title: data.category,
-                        }}
-                        subheaderTypographyProps={{
-                          variant: 'body1',
-                          className:
-                            data.obscure === true
-                              ? classes.dataObscuredValue
-                              : classes.dataValue,
-                          title: dataEntryValue,
-                        }}
-                        subheader={
-                          data.statusCircle === true
-                            ? StatusIndicator(
-                              data.statusInactive || false,
-                              data.status || false,
-                              dataEntryValue,
-                            )
-                            : data.icon
-                              ? DataIcon(data.icon, dataEntryValue)
-                              : data.obscure === true
-                                ? DataObscure(data.value, data.category)
-                                : dataEntryValue
-                        }
-                      />
-                    </Tooltip>
+                    <CardHeader
+                      data-testid={data.category}
+                      className={classes.dataBox}
+                      title={data.category}
+                      titleTypographyProps={{
+                        variant: 'caption',
+                        className: classes.dataLabel,
+                        title: data.category,
+                      }}
+                      subheaderTypographyProps={{
+                        variant: 'body1',
+                        className:
+                        data.obscure === true
+                          ? classes.dataObscuredValue
+                          : classes.dataValue,
+                        title: data.tooltip ?? dataEntryValue,
+                      }}
+                      subheader={
+                        data.statusCircle === true
+                          ? StatusIndicator(
+                            data.statusInactive || false,
+                            data.status || false,
+                            dataEntryValue,
+                          )
+                          : data.icon
+                            ? DataIcon(data.icon, dataEntryValue)
+                            : data.obscure === true
+                              ? DataObscure(data.value, data.category)
+                              : dataEntryValue
+                      }
+                    />
                   )}
               </Grid>
             </Grid>

--- a/nms/app/packages/magmalte/app/components/DataGrid.js
+++ b/nms/app/packages/magmalte/app/components/DataGrid.js
@@ -29,7 +29,6 @@ import Input from '@material-ui/core/Input';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
-import Tooltip from '@material-ui/core/Tooltip';
 import React from 'react';
 import Visibility from '@material-ui/icons/Visibility';
 import VisibilityOff from '@material-ui/icons/VisibilityOff';
@@ -242,42 +241,42 @@ export default function DataGrid(props: Props) {
                 {data.collapse !== undefined && data.collapse !== false ? (
                   DataCollapse(data.category, data.value, data.collapse)
                 ) : (
-                    <CardHeader
-                      data-testid={data.category}
-                      className={classes.dataBox}
-                      title={data.category}
-                      titleTypographyProps={{
-                        variant: 'caption',
-                        className: classes.dataLabel,
-                        title: data.category,
-                      }}
-                      subheaderTypographyProps={{
-                        variant: 'body1',
-                        className:
+                  <CardHeader
+                    data-testid={data.category}
+                    className={classes.dataBox}
+                    title={data.category}
+                    titleTypographyProps={{
+                      variant: 'caption',
+                      className: classes.dataLabel,
+                      title: data.category,
+                    }}
+                    subheaderTypographyProps={{
+                      variant: 'body1',
+                      className:
                         data.obscure === true
                           ? classes.dataObscuredValue
                           : classes.dataValue,
-                        title: data.tooltip ?? dataEntryValue,
-                      }}
-                      subheader={
-                        data.statusCircle === true
-                          ? StatusIndicator(
+                      title: data.tooltip ?? dataEntryValue,
+                    }}
+                    subheader={
+                      data.statusCircle === true
+                        ? StatusIndicator(
                             data.statusInactive || false,
                             data.status || false,
                             dataEntryValue,
                           )
-                          : data.icon
-                            ? DataIcon(data.icon, dataEntryValue)
-                            : data.obscure === true
-                              ? DataObscure(data.value, data.category)
-                              : dataEntryValue
-                      }
-                    />
-                  )}
+                        : data.icon
+                        ? DataIcon(data.icon, dataEntryValue)
+                        : data.obscure === true
+                        ? DataObscure(data.value, data.category)
+                        : dataEntryValue
+                    }
+                  />
+                )}
               </Grid>
             </Grid>
           </React.Fragment>
-        )
+        );
       })}
     </Grid>
   ));

--- a/nms/app/packages/magmalte/app/components/__tests__/DataGrid-test.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/DataGrid-test.js
@@ -2,7 +2,7 @@ import 'jest-dom/extend-expect';
 import React from 'react';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import { MuiThemeProvider } from '@material-ui/core/styles';
-import { cleanup, render, waitFor, fireEvent } from '@testing-library/react';
+import { cleanup, render } from '@testing-library/react';
 import DataGrid, { DataRows } from '../DataGrid';
 import defaultTheme from '../../theme/default';
 
@@ -39,36 +39,25 @@ const Wrapper = () => {
 
 describe('<DataGrid />', () => {
   it('displays the passed tooltip', async () => {
-    const { getByTestId, getByRole } = render(<Wrapper />);
+    const { getByText } = render(<Wrapper />);
 
-    const dataEntryToHoverOver = getByTestId('Total');
-    fireEvent.mouseOver(dataEntryToHoverOver);
-
-    await waitFor(() => {
-      expect(getByRole('tooltip')).toHaveTextContent(data[0][0].tooltip);
-    });
+    const dataEntryElement = getByText(data[0][0].value);
+    expect(dataEntryElement).toHaveAttribute('title', data[0][0].tooltip);
   });
 
   it('defaults to the data entry value when the tooltip prop in not passed', async () => {
-    const { getByTestId, getByRole } = render(<Wrapper />);
+    const { getByText } = render(<Wrapper />);
 
-    const dataEntryToHoverOver = getByTestId('Severe Events');
-    fireEvent.mouseOver(dataEntryToHoverOver);
-
-    await waitFor(() => {
-      expect(getByRole('tooltip')).toHaveTextContent(data[0][1].value);
-    });
+    const dataEntryElement = getByText(data[0][1].value);
+    expect(dataEntryElement).toHaveAttribute('title', data[0][1].value);
   });
 
-  it('displays the data unit along with data value when unit prop is passed', async () => {
-    const { getByTestId, getByRole } = render(<Wrapper />);
-
-    const dataEntryToHoverOver = getByTestId('Max Latency');
-    fireEvent.mouseOver(dataEntryToHoverOver);
-
-    await waitFor(() => {
-      const { value, unit } = data[0][2];
-      expect(getByRole('tooltip')).toHaveTextContent(value + unit);
-    });
+  it('displays the data unit along with data value as the tooltip when unit prop is passed', async () => {
+    const { getByText } = render(<Wrapper />);
+    const { value, unit } = data[0][2];
+    const cellValue = value + unit;
+  
+    const dataEntryElement = getByText(cellValue);
+    expect(dataEntryElement).toHaveAttribute('title', cellValue);
   });
 });

--- a/nms/app/packages/magmalte/app/components/__tests__/DataGrid-test.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/DataGrid-test.js
@@ -1,10 +1,27 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
 import 'jest-dom/extend-expect';
-import React from 'react';
+import DataGrid from '../DataGrid';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
-import { MuiThemeProvider } from '@material-ui/core/styles';
-import { cleanup, render } from '@testing-library/react';
-import DataGrid, { DataRows } from '../DataGrid';
+import React from 'react';
 import defaultTheme from '../../theme/default';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {cleanup, render} from '@testing-library/react';
+import type {DataRows} from '../DataGrid';
 
 afterEach(cleanup);
 
@@ -22,7 +39,7 @@ const data: DataRows[] = [
     {
       category: 'Max Latency',
       value: 100,
-      unit: 'ms'
+      unit: 'ms',
     },
   ],
 ];
@@ -34,30 +51,31 @@ const Wrapper = () => {
         <DataGrid data={data} />
       </MuiStylesThemeProvider>
     </MuiThemeProvider>
-  )
-}
+  );
+};
 
 describe('<DataGrid />', () => {
   it('displays the passed tooltip', async () => {
-    const { getByText } = render(<Wrapper />);
+    const {getByText} = render(<Wrapper />);
 
-    const dataEntryElement = getByText(data[0][0].value);
-    expect(dataEntryElement).toHaveAttribute('title', data[0][0].tooltip);
+    const dataEntryElement = getByText('eNodeBs');
+    expect(dataEntryElement).toHaveAttribute('title', 'Tooltip text');
   });
 
   it('defaults to the data entry value when the tooltip prop in not passed', async () => {
-    const { getByText } = render(<Wrapper />);
+    const {getByText} = render(<Wrapper />);
 
-    const dataEntryElement = getByText(data[0][1].value);
-    expect(dataEntryElement).toHaveAttribute('title', data[0][1].value);
+    const dataEntryElement = getByText('Value used as a tooltip');
+    expect(dataEntryElement).toHaveAttribute(
+      'title',
+      'Value used as a tooltip',
+    );
   });
 
   it('displays the data unit along with data value as the tooltip when unit prop is passed', async () => {
-    const { getByText } = render(<Wrapper />);
-    const { value, unit } = data[0][2];
-    const cellValue = value + unit;
-  
-    const dataEntryElement = getByText(cellValue);
-    expect(dataEntryElement).toHaveAttribute('title', cellValue);
+    const {getByText} = render(<Wrapper />);
+
+    const dataEntryElement = getByText('100ms');
+    expect(dataEntryElement).toHaveAttribute('title', '100ms');
   });
 });

--- a/nms/app/packages/magmalte/app/components/__tests__/DataGrid-test.js
+++ b/nms/app/packages/magmalte/app/components/__tests__/DataGrid-test.js
@@ -1,0 +1,74 @@
+import 'jest-dom/extend-expect';
+import React from 'react';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import { MuiThemeProvider } from '@material-ui/core/styles';
+import { cleanup, render, waitFor, fireEvent } from '@testing-library/react';
+import DataGrid, { DataRows } from '../DataGrid';
+import defaultTheme from '../../theme/default';
+
+afterEach(cleanup);
+
+const data: DataRows[] = [
+  [
+    {
+      category: 'Total',
+      value: 'eNodeBs',
+      tooltip: 'Tooltip text',
+    },
+    {
+      category: 'Severe Events',
+      value: 'Value used as a tooltip',
+    },
+    {
+      category: 'Max Latency',
+      value: 100,
+      unit: 'ms'
+    },
+  ],
+];
+
+const Wrapper = () => {
+  return (
+    <MuiThemeProvider theme={defaultTheme}>
+      <MuiStylesThemeProvider theme={defaultTheme}>
+        <DataGrid data={data} />
+      </MuiStylesThemeProvider>
+    </MuiThemeProvider>
+  )
+}
+
+describe('<DataGrid />', () => {
+  it('displays the passed tooltip', async () => {
+    const { getByTestId, getByRole } = render(<Wrapper />);
+
+    const dataEntryToHoverOver = getByTestId('Total');
+    fireEvent.mouseOver(dataEntryToHoverOver);
+
+    await waitFor(() => {
+      expect(getByRole('tooltip')).toHaveTextContent(data[0][0].tooltip);
+    });
+  });
+
+  it('defaults to the data entry value when the tooltip prop in not passed', async () => {
+    const { getByTestId, getByRole } = render(<Wrapper />);
+
+    const dataEntryToHoverOver = getByTestId('Severe Events');
+    fireEvent.mouseOver(dataEntryToHoverOver);
+
+    await waitFor(() => {
+      expect(getByRole('tooltip')).toHaveTextContent(data[0][1].value);
+    });
+  });
+
+  it('displays the data unit along with data value when unit prop is passed', async () => {
+    const { getByTestId, getByRole } = render(<Wrapper />);
+
+    const dataEntryToHoverOver = getByTestId('Max Latency');
+    fireEvent.mouseOver(dataEntryToHoverOver);
+
+    await waitFor(() => {
+      const { value, unit } = data[0][2];
+      expect(getByRole('tooltip')).toHaveTextContent(value + unit);
+    });
+  });
+});


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Add `tooltip` prop to DataRow item. The tooltip is displayed when the cursor is over a cell. If `tooltip` prop is not passed, data entry `value` is used instead.

## Test Plan
![lll](https://user-images.githubusercontent.com/43514877/92013466-7f7b9f80-ed56-11ea-8abc-6119f514b90a.gif)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
