### PR TITLE
[orc8r] Fix push target in orchestrator.yml

### DIFF
--- a/orc8r/cloud/configs/metricsd.yml
+++ b/orc8r/cloud/configs/metricsd.yml
@@ -10,9 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-prometheusPushAddresses:
-  - "http://prometheus-cache:9091/metrics"
-
 prometheusQueryAddress: "http://prometheus:9090"
 
 alertmanagerApiURL: "http://alertmanager:9093/api/v2"

--- a/orc8r/cloud/configs/orchestrator.yml
+++ b/orc8r/cloud/configs/orchestrator.yml
@@ -11,4 +11,4 @@
 # limitations under the License.
 
 prometheusPushAddresses:
-  - "http://orc8r-prometheus-cache:9091/metrics"
+  - "http://prometheus-cache:9091/metrics"

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -93,14 +93,17 @@ resource "kubernetes_secret" "orc8r_configs" {
     "metricsd.yml" = yamlencode({
       "profile" : "prometheus",
       "prometheusQueryAddress" : format("http://%s-prometheus:9090", var.helm_deployment_name),
-      "prometheusPushAddresses" : [
-        format("http://%s-prometheus-cache:9091/metrics", var.helm_deployment_name),
-      ],
 
       "alertmanagerApiURL" : format("http://%s-alertmanager:9093/api/v2", var.helm_deployment_name),
       "prometheusConfigServiceURL" : format("http://%s-prometheus-configurer:9100", var.helm_deployment_name),
       "alertmanagerConfigServiceURL" : format("http://%s-alertmanager-configurer:9101", var.helm_deployment_name),
     })
+
+    "orchestrator.yml" = yamlencode({
+      "prometheusPushAddresses" : [
+        format("http://%s-prometheus-cache:9091/metrics", var.helm_deployment_name),
+      ],
+    }
 
     "elastic.yml" = yamlencode({
       "elasticHost" : var.elasticsearch_endpoint == null ? "elastic" : var.elasticsearch_endpoint

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.34
+version: 1.4.35
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create magma orchestrator secrets
 name: secrets
-version: 0.1.4
+version: 0.1.5
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -54,12 +54,13 @@ secret:
         profile: "prometheus"
 
         prometheusQueryAddress: "http://orc8r-prometheus:9090"
-        prometheusPushAddresses:
-          - "http://orc8r-prometheus-cache:9091/metrics"
 
         alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2/alerts"
         prometheusConfigServiceURL: "http://orc8r-config-manager:9100"
         alertmanagerConfigServiceURL: "http://orc8r-config-manager:9101"
+
+      orchestrator.yml: |-
+        prometheusPushAddresses: "http://orc8r-prometheus-cache:9091/metrics"
 
   # cwf:
   #   key: value

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: secrets
   repository: ""
-  version: 0.1.4
+  version: 0.1.5
 - name: metrics
   repository: ""
   version: 1.4.14

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -11,7 +11,7 @@
 
 dependencies:
   - name: secrets
-    version: 0.1.4
+    version: 0.1.5
     repository: ""
     condition: secrets.create
   - name: metrics


### PR DESCRIPTION
## Summary
The default `orchestrator.yaml` file has an entry for the push address of the pushgateway. It was set to `orc8r-prometheus-cache:9091` but that service name is only for helm managed deployments, and doesn't work for docker. This caused no metrics to work when following the quick-start guide.

## Test Plan
Spin up docker, push test metric via API, it appears in prometheus:
![image](https://user-images.githubusercontent.com/13274915/92020442-f68c4600-ed0c-11ea-9aea-379b4a0abdcb.png)
