### PR TITLE
[lte][agw] Fixing copying of IMSI for DeleteBearer request

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -193,8 +193,16 @@ Status SpgwServiceImpl::DeleteBearer(
     DeleteBearerResult* response) {
   OAILOG_INFO(LOG_UTIL, "Received DeleteBearer GRPC request\n");
   itti_gx_nw_init_deactv_bearer_request_t itti_msg;
-  itti_msg.imsi_length = request->sid().id().size();
-  strcpy(itti_msg.imsi, request->sid().id().c_str());
+  std::string imsi = request->sid().id();
+  // If north bound is sessiond itself, IMSI prefix is used;
+  // in S1AP tests, IMSI prefix is not used
+  // Strip off any IMSI prefix
+  if (imsi.compare(0, 4, "IMSI") == 0) {
+    imsi = imsi.substr(4, std::string::npos);
+  }
+  itti_msg.imsi_length = imsi.size();
+  strcpy(itti_msg.imsi, imsi.c_str());
+
   itti_msg.lbi           = request->link_bearer_id();
   itti_msg.no_of_bearers = request->eps_bearer_ids_size();
   for (int i = 0; i < request->eps_bearer_ids_size() && i < BEARERS_PER_UE;


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Updating copying of IMSI on DeleteBearer request to strip IMSI prefix

## Test Plan

- Tested on local setup with policy rules applied and creation / deletion of dedicated bearers
- make integ_test 

## Additional Information

- [ ] This change is backwards-breaking

