### PR TITLE
[nms] add msisdn as label in CWF Subscribers dashboard

### DIFF
--- a/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
@@ -17,19 +17,20 @@
 import {gatewayTemplate, networkTemplate, variableTemplate} from './Dashboards';
 import type {GrafanaDBData} from './Dashboards';
 
-const imsiTemplate = variableTemplate({
-  labelName: 'imsi',
-  query: `label_values(imsi)`,
+const msisdnTemplate = variableTemplate({
+  labelName: 'msisdn',
+  query: `label_values(msisdn)`,
   regex: `/.+/`,
   sort: 'num-asc',
+  includeAll: false,
 });
 
 const apnTemplate = variableTemplate({
   labelName: 'apn',
-  query: `label_values(apn)`,
   query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
   regex: `/.+/`,
   sort: 'alpha-insensitive-asc',
+  includeAll: true,
 });
 
 const dbDescription =
@@ -38,7 +39,7 @@ const dbDescription =
 export const CWFSubscriberDBData: GrafanaDBData = {
   title: 'CWF - Subscribers',
   description: dbDescription,
-  templates: [imsiTemplate],
+  templates: [msisdnTemplate],
   rows: [
     {
       title: 'Traffic',
@@ -47,8 +48,8 @@ export const CWFSubscriberDBData: GrafanaDBData = {
           title: 'Traffic In',
           targets: [
             {
-              expr: 'sum(octets_in{imsi=~"$imsi"}) by (imsi)',
-              legendFormat: '{{imsi}}',
+              expr: 'sum(octets_in{msisdn=~"$msisdn"}) by (imsi, msisdn)',
+              legendFormat: '{{imsi}}, MSISDN: {{msisdn}}',
             },
           ],
           unit: 'decbytes',
@@ -58,8 +59,9 @@ export const CWFSubscriberDBData: GrafanaDBData = {
           title: 'Throughput In',
           targets: [
             {
-              expr: 'avg(rate(octets_in{imsi=~"$imsi"}[5m])) by (imsi)',
-              legendFormat: '{{imsi}}',
+              expr:
+                'avg(rate(octets_in{msisdn=~"$msisdn"}[5m])) by (imsi, msisdn)',
+              legendFormat: '{{imsi}}, MSISDN: {{msisdn}}',
             },
           ],
           unit: 'Bps',
@@ -70,8 +72,8 @@ export const CWFSubscriberDBData: GrafanaDBData = {
           title: 'Traffic Out',
           targets: [
             {
-              expr: 'sum(octets_out{imsi=~"$imsi"}) by (imsi)',
-              legendFormat: '{{imsi}}',
+              expr: 'sum(octets_out{msisdn=~"$msisdn"}) by (imsi, msisdn)',
+              legendFormat: '{{imsi}}, MSISDN: {{msisdn}}',
             },
           ],
           unit: 'decbytes',
@@ -81,8 +83,9 @@ export const CWFSubscriberDBData: GrafanaDBData = {
           title: 'Throughput Out',
           targets: [
             {
-              expr: 'avg(rate(octets_out{imsi=~"$imsi"}[5m])) by (imsi)',
-              legendFormat: '{{imsi}}',
+              expr:
+                'avg(rate(octets_out{msisdn=~"$msisdn"}[5m])) by (imsi, msisdn)',
+              legendFormat: '{{imsi}}, MSISDN: {{msisdn}}',
             },
           ],
           unit: 'Bps',
@@ -98,9 +101,9 @@ export const CWFSubscriberDBData: GrafanaDBData = {
           title: 'Active Sessions',
           targets: [
             {
-              expr: 'active_sessions{imsi=~"$imsi"}',
+              expr: 'active_sessions{msisdn=~"$msisdn"}',
               legendFormat:
-                '{{imsi}} Session: {{id}} -- Network: {{networkID}} -- Gateway: {{gatewayID}}',
+                '{{imsi}} -- MSISDN: {{msisdn}} -- Session: {{id}} -- Network: {{networkID}} -- Gateway: {{gatewayID}}',
             },
           ],
           description:

--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -35,6 +35,7 @@ export const networkTemplate: TemplateConfig = variableTemplate({
   query: `label_values(${netIDVar})`,
   regex: `/.+/`,
   sort: 'alpha-insensitive-asc',
+  includeAll: true,
 });
 
 // This templating schema will produce a variable in the dashboard
@@ -47,6 +48,7 @@ export const gatewayTemplate: TemplateConfig = variableTemplate({
   query: `label_values({networkID=~"$networkID",gatewayID=~".+"}, ${gwIDVar})`,
   regex: `/.+/`,
   sort: 'alpha-insensitive-asc',
+  includeAll: true,
 });
 
 export const NetworkDBData: GrafanaDBData = {
@@ -474,6 +476,7 @@ export type TemplateParams = {
   query: string,
   regex: string,
   sort?: VariableSortOption,
+  includeAll: boolean,
 };
 
 type VariableSortOption =
@@ -490,7 +493,7 @@ export function variableTemplate(params: TemplateParams): TemplateConfig {
     allValue: '.+',
     definition: params.query,
     hide: 0,
-    includeAll: true,
+    includeAll: params.includeAll,
     allFormat: 'glob',
     multi: true,
     name: params.labelName,


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Partner wanted MSISDN in addition to IMSI in the Subscribers dashboard. The way grafana variables work, we can only do one or the other, not both, but we can still display both. 
* Use MSISDN as the selector variable
* Add MSISDN to the legend of all graphs
* Make this work with many users by getting rid of the ability to select "all" MSISDNs from the grafana variable. This will show 1 by default. It means you have to select the user or users you want to see, but I think this is a much better experience than before.

## Test Plan
![image](https://user-images.githubusercontent.com/13274915/92045310-1172b080-ed35-11ea-9a32-4f265afad6b5.png)