### PR TITLE
[orc8r] Upgrade prometheus

### DIFF
--- a/orc8r/cloud/docker/docker-compose.metrics.yml
+++ b/orc8r/cloud/docker/docker-compose.metrics.yml
@@ -10,7 +10,7 @@ services:
     restart: always
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v2.20.1
     ports:
       - 9090:9090/tcp
     volumes:

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.34
+version: 1.4.36
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.14
+version: 1.4.15
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -46,7 +46,7 @@ prometheus:
 
   image:
     repository: docker.io/prom/prometheus
-    tag: v2.12.0
+    tag: v2.20.1
     pullPolicy: IfNotPresent
 
   resources: {}

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.4
 - name: metrics
   repository: ""
-  version: 1.4.14
+  version: 1.4.15
 - name: nms
   repository: ""
   version: 0.1.6

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.14
+    version: 1.4.15
     repository: ""
     condition: metrics.enabled
   - name: nms


### PR DESCRIPTION
## Summary
Upgrade prometheus to v2.20.1

This version includes some improvements to the API that will allow us to in turn improve our own API for metrics.
Important change: You can query the `/series` API with a selector like `{labelName=~".*"}` and get all the series for which a label with that labelName exists.

## Test Plan

Tag works with docker

## Additional Information
We will need to do a little bit of manual helm hand-holding when we upgrade with this. Just turn the replicas of prometheus to 0, wait for it to die, then scale back to 1

