### PR TITLE
[orc8r][metricsd] add selector label to speed up label values queries

### DIFF
--- a/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/metricsd/obsidian/models/swagger.v1.yml
@@ -655,7 +655,7 @@ paths:
           name: start
           type: string
           description: start time of the requested range (UnixTime or RFC3339)
-          required: true
+          required: false
         - in: query
           name: end
           type: string

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -343,10 +343,6 @@ func getSeriesMatches(c echo.Context, matchParam string, queryRestrictor restric
  * We can't just proxy the request to Prometheus since this endpoint has no way
  * of restricting the query, so we have to simulate it by doing a series request
  * and then manipulating the result
- *
- * We have found that on large deployments the query time for `api/v1/series`
- * can take a very long time and fail after a while. To fix this, we set the
- * default start time to 3 hours ago, rather than having no limit.
  */
 func GetTenantPromValuesHandler(api v1.API) func(c echo.Context) error {
 	return func(c echo.Context) error {
@@ -362,13 +358,13 @@ func GetTenantPromValuesHandler(api v1.API) func(c echo.Context) error {
 		if err != nil {
 			return obsidian.HttpError(err, http.StatusInternalServerError)
 		}
-		seriesMatchers := []string{}
+
+		seriesMatchers := []string{fmt.Sprintf("{%s=~\".*\"}", labelName)}
 		for _, matcher := range queryRestrictor.Matchers() {
 			seriesMatchers = append(seriesMatchers, fmt.Sprintf("{%s}", matcher.String()))
 		}
 
-		defaultStartTime := time.Now().Add(-3 * time.Hour)
-		startTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeStart), &defaultStartTime)
+		startTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeStart), &minTime)
 		endTime, err := utils.ParseTime(c.QueryParam(utils.ParamRangeEnd), &maxTime)
 
 		// TODO: catch the warnings replacing _
@@ -397,7 +393,9 @@ func getSetOfValuesFromLabel(seriesList []model.LabelSet, labelName model.LabelN
 	}
 	ret := make([]string, 0)
 	for val := range values {
-		ret = append(ret, string(val))
+		if val != "" {
+			ret = append(ret, string(val))
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Pass in the label name we're looking for into the query for label values so we don't have make prometheus query every single metric. This is made possible due to improvements in the prometheus API in v2.20.1. 

Fixes a potentially weird issue where the labels in grafana only represent values from the last 3 hours and are missing values from earlier. That was a known problem with the original implementation, and it was made to solve the problem of queries timing out on large deployments, but now this is no longer an issue.

## Test Plan

```
curl -k --cert ~/magma/.cache/test_certs/admin_operator.pem --key ~/magma/.cache/test_certs/admin_operator.key.pem "https://localhost:9443/magma/v1/tenants/1/metrics/api/v1/label/cloudHost/values"
{"status":"success","data":["dev"]}
```


## Additional Information

- [ ] This change is backwards-breaking

DON'T MERGE until https://github.com/magma/magma/pull/2598 has also been merged
