### PR TITLE
[lte][feg] Fix gw_cli argument parsing for go1.13+ 

### DIFF
--- a/feg/gateway/tools/gw_csfb_service_cli/main.go
+++ b/feg/gateway/tools/gw_csfb_service_cli/main.go
@@ -46,10 +46,6 @@ var marshallerMap = map[string]marshalFunc{
 	"VLRS":   marshalVLRStatus,
 }
 
-func init() {
-	flag.Parse()
-}
-
 func main() {
 	// setting up flags of the CLI
 	helpPtr := flag.Bool("help", false, "[optional] Display this help message")

--- a/feg/gateway/tools/gw_s6a_service_cli/main.go
+++ b/feg/gateway/tools/gw_s6a_service_cli/main.go
@@ -24,10 +24,6 @@ import (
 	"magma/feg/gateway/services/s6a_proxy"
 )
 
-func init() {
-	flag.Parse()
-}
-
 func main() {
 	// setting up flags of the CLI
 	helpPtr := flag.Bool("help", false, "[optional] Display this help message")


### PR DESCRIPTION
## Summary

In golang 1.13+ we shouldn't call `flags.Parse` in `init`. These scripts are
currently broken. 

## Test Plan

build feg, run gw_csfb_service_cli and gw_s6a_service_cli
