### PR TITLE
pipelined: automate SGi management IP address assignment

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
+++ b/lte/gateway/deploy/roles/magma/files/magma_ifaces_gtp
@@ -41,7 +41,7 @@ iface patch-up inet manual
     ovs_extra set interface ${IFACE} ofport_request=2
 
 allow-ovs uplink_br0
-iface uplink_br0 inet dhcp
+iface uplink_br0 inet manual
     ovs_type OVSBridge
     ovs_ports dhcp0 patch-agw
 

--- a/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf
+++ b/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf
@@ -15,5 +15,5 @@ domain=ue_dns
 no-resolv
 bogus-priv
 
-dhcp-option=3,10.200.x.211
-dhcp-range=10.200.x.1,10.200.x.200,2m
+dhcp-option=3,10.x.211
+dhcp-range=10.x.1,10.x.200,2m

--- a/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
+++ b/lte/gateway/python/magma/mobilityd/scripts/setup-uplink-vlan-srv.sh
@@ -15,10 +15,15 @@
 
 br_name=$1
 tag=$2
+network_id=$3
+
+if [[ -z $network_id ]]; then
+        network_id="200"
+fi
 
 prefix="vt$tag"
-ip_addr="10.200.$tag.111/24"
-router_ip="10.200.$tag.211"
+ip_addr="10.$network_id.$tag.111/24"
+router_ip="10.$network_id.$tag.211"
 
 ip link del "$prefix"_port
 ip link add "$prefix"_port type veth peer name  "$prefix"_port1
@@ -42,7 +47,7 @@ then
 	kill "$PID"
 fi
 
-sed "s/.x./."$tag"./g" /home/vagrant/magma/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf > /tmp/dns."$tag".conf
+sed "s/.x./."$network_id.$tag"./g" /home/vagrant/magma/lte/gateway/python/magma/mobilityd/scripts/dnsd.x.conf > /tmp/dns."$tag".conf
 sleep 1
 ip netns exec "$prefix"_dhcp_srv  /usr/sbin/dnsmasq -q --conf-file=/tmp/dns."$tag".conf --log-queries --log-facility=/var/log/"$prefix"dnsmasq."$tag".test.log &
 

--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -11,6 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import subprocess
+import threading
 from collections import namedtuple
 
 from magma.pipelined.app.base import MagmaController, ControllerType
@@ -90,14 +91,13 @@ class UplinkBridgeController(MagmaController):
         self._delete_all_flows()
         self._add_eth_port()
         self._set_vlan_eth_port()
-        self._set_sgi_static_ip()
         self._setup_vlan_pop_dev()
         # flows to forward traffic between patch port to eth port
 
         # 1. DHCP traffic
         match = "in_port=%s,ip,udp,tp_dst=68" % self.config.uplink_eth_port_name
         actions = "output:%s,output:%s,output:LOCAL" % (self.config.dhcp_port,
-                                                     self.config.uplink_patch)
+                                                        self.config.uplink_patch)
         self._install_flow(flows.MAXIMUM_PRIORITY, match, actions)
 
         # 2.a. all egress traffic
@@ -146,6 +146,7 @@ class UplinkBridgeController(MagmaController):
 
         # everything else:
         self._install_flow(flows.MINIMUM_PRIORITY, "", "NORMAL")
+        self._set_sgi_ip_addr(self.config.uplink_bridge)
 
     def cleanup_on_disconnect(self, datapath):
         self._del_eth_port()
@@ -182,14 +183,16 @@ class UplinkBridgeController(MagmaController):
         if self.config.enable_nat is True or \
                 self.config.uplink_eth_port_name is None:
             return
-
+        self._cleanup_if(self.config.uplink_eth_port_name)
+        # Add eth interface to OVS.
         ovs_add_port = "ovs-vsctl --may-exist add-port %s %s" \
                        % (self.config.uplink_bridge, self.config.uplink_eth_port_name)
-        self.logger.info("Add uplink port: %s", ovs_add_port)
         try:
             subprocess.Popen(ovs_add_port, shell=True).wait()
         except subprocess.CalledProcessError as ex:
             raise Exception('Error: %s failed with: %s' % (ovs_add_port, ex))
+
+        self.logger.info("Add uplink port: %s", ovs_add_port)
 
     def _set_vlan_eth_port(self):
         if self.config.uplink_bridge is None:
@@ -197,7 +200,7 @@ class UplinkBridgeController(MagmaController):
 
         if self.config.sgi_management_iface_vlan == '':
             vlan_cmd = "ovs-vsctl clear port %s tag" \
-                    % self.config.uplink_bridge
+                       % self.config.uplink_bridge
         else:
             vlan_cmd = "ovs-vsctl set port %s tag=%s" \
                        % (self.config.uplink_bridge,
@@ -210,42 +213,51 @@ class UplinkBridgeController(MagmaController):
             raise Exception('Error: %s failed with: %s' % (vlan_cmd, ex))
 
     def _del_eth_port(self):
+        self._cleanup_if(self.config.uplink_bridge)
+
         ovs_rem_port = "ovs-vsctl --if-exists del-port %s %s" \
                        % (self.config.uplink_bridge, self.config.uplink_eth_port_name)
-        self.logger.info("Remove ovs uplink port: %s", ovs_rem_port)
         try:
             subprocess.Popen(ovs_rem_port, shell=True).wait()
         except subprocess.CalledProcessError as ex:
             self.logger.debug("ignore port del error: %s ", ex)
+        self.logger.info("Remove ovs uplink port: %s", ovs_rem_port)
 
-    def _set_sgi_static_ip(self):
+        self._set_sgi_ip_addr(self.config.uplink_eth_port_name)
+
+    def _set_sgi_ip_addr(self, if_name: str):
         self.logger.debug("self.config.sgi_management_iface_ip_addr %s",
-                         self.config.sgi_management_iface_ip_addr)
+                          self.config.sgi_management_iface_ip_addr)
         if self.config.sgi_management_iface_ip_addr is None or \
                 self.config.sgi_management_iface_ip_addr == "":
+            self._restart_dhclient(if_name)
             return
 
         try:
             # Kill dhclient if running.
             pgrep_out = subprocess.Popen(["pgrep", "-f",
-                                          "dhclient.*" + self.config.uplink_bridge],
+                                          "dhclient.*" + if_name],
                                          stdout=subprocess.PIPE)
             for pid in pgrep_out.stdout.readlines():
                 subprocess.check_call(["kill", pid.strip()])
 
             flush_ip = ["ip", "addr", "flush",
-                        "dev" , self.config.uplink_bridge]
+                        "dev", if_name]
             subprocess.check_call(flush_ip)
 
             set_ip_cmd = ["ip",
                           "addr", "add",
                           self.config.sgi_management_iface_ip_addr,
                           "dev",
-                          self.config.uplink_bridge]
+                          if_name]
             subprocess.check_call(set_ip_cmd)
             self.logger.debug("SGi ip address config: [%s]", set_ip_cmd)
         except subprocess.SubprocessError as e:
             self.logger.warning("Error while setting SGi IP: %s", e)
+
+    def _restart_dhclient(self, if_name):
+        # restart DHCP client can take loooong time, process it in separate thread:
+        threading.Thread(target=self._restart_dhclient_if(if_name))
 
     def _setup_vlan_pop_dev(self):
         if self.config.ovs_vlan_workaround:
@@ -260,3 +272,32 @@ class UplinkBridgeController(MagmaController):
             BridgeTools.add_ovs_port(self.config.uplink_bridge,
                                      self.config.dev_vlan_out, "71")
 
+    def _cleanup_if(self, if_name):
+        # Release eth IP first.
+        release_eth_ip = ["dhclient", "-r", if_name]
+        try:
+            subprocess.check_call(release_eth_ip)
+        except subprocess.CalledProcessError as ex:
+            self.logger.info("could not release dhcp lease: %s, %s",
+                             release_eth_ip, ex)
+
+        flush_eth_ip = ["ip", "addr", "flush", "dev", if_name]
+        try:
+            subprocess.check_call(flush_eth_ip)
+        except subprocess.CalledProcessError as ex:
+            self.logger.info("could not flush ip addr: %s, %s",
+                             flush_eth_ip, ex)
+
+        self.logger.info("SGi DHCP: port [%s] ip removed", if_name)
+
+    def _restart_dhclient_if(self, if_name):
+        self._cleanup_if(if_name)
+
+        setup_dhclient = ["dhclient", if_name]
+        try:
+            subprocess.check_call(setup_dhclient)
+        except subprocess.CalledProcessError as ex:
+            self.logger.info("could not release dhcp lease: %s, %s",
+                             setup_dhclient, ex)
+
+        self.logger.info("SGi DHCP: restart for %s done", if_name)

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Test.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNatUplinkConnect_Test.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,8 @@
+ priority=0 actions=NORMAL
+ priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
+ priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
+ priority=100,ip,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
+ priority=100,in_port=70 actions=drop
+ priority=1,in_port=71 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -14,6 +14,8 @@ import subprocess
 import unittest
 import warnings
 from concurrent.futures import Future
+import logging
+from ryu.lib import hub
 
 from magma.pipelined.tests.app.start_pipelined import (
     TestSetup,
@@ -35,7 +37,7 @@ class UplinkBridgeTest(unittest.TestCase):
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
 
-    UPLINK_BRIDGE = 'up_br0'
+    UPLINK_BRIDGE = 'upt_br0'
 
     @classmethod
     def setUpClass(cls):
@@ -99,7 +101,7 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
 
-    UPLINK_BRIDGE = 'up_br0'
+    UPLINK_BRIDGE = 'upt_br0'
     UPLINK_DHCP = 'test_dhcp0'
     UPLINK_PATCH = 'test_patch_p2'
     UPLINK_ETH_PORT = 'test_eth3'
@@ -148,6 +150,7 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
                 'dev_vlan_in': cls.VLAN_DEV_IN,
                 'dev_vlan_out': cls.VLAN_DEV_OUT,
                 'ovs_vlan_workaround': False,
+                'sgi_management_iface_ip_addr': '1.1.11.1',
             },
             mconfig=None,
             loop=None,
@@ -202,7 +205,7 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
 
-    UPLINK_BRIDGE = 'ut_up_br0'
+    UPLINK_BRIDGE = 'upt_br0'
     UPLINK_DHCP = 'test_dhcp0'
     UPLINK_PATCH = 'test_patch_p2'
     UPLINK_ETH_PORT = 'test_eth3'
@@ -251,6 +254,7 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
                 'sgi_management_iface_vlan': cls.VLAN_TAG,
                 'dev_vlan_in': cls.VLAN_DEV_IN,
                 'dev_vlan_out': cls.VLAN_DEV_OUT,
+                'sgi_management_iface_ip_addr': '1.1.11.1',
             },
             mconfig=None,
             loop=None,
@@ -306,7 +310,7 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     MAC_DEST = "5e:cc:cc:b1:49:4b"
     BRIDGE_IP = '192.168.128.1'
 
-    UPLINK_BRIDGE = 'ut_up_br0'
+    UPLINK_BRIDGE = 'upt_br0'
     UPLINK_DHCP = 'test_dhcp0'
     UPLINK_PATCH = 'test_patch_p2'
     UPLINK_ETH_PORT = 'test_eth3'
@@ -404,5 +408,226 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.UPLINK_BRIDGE), "ip not found")
 
 
+
+class UplinkBridgeWithNonNatUplinkConnect_Test(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+    SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
+    NET_SW_BR = "net_sw_up1"
+    UPLINK_DHCP = "tino_dhcp"
+    SCRIPT_PATH = "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/"
+    UPLINK_ETH_PORT = "upb_ul_0"
+    UPLINK_BRIDGE = 'upt_br0'
+    UPLINK_PATCH = 'test_patch_p2'
+    ROUTER_IP = "10.55.0.211"
+
+
+    @classmethod
+    def _setup_vlan_network(cls, vlan: str):
+        setup_vlan_switch = cls.SCRIPT_PATH + "scripts/setup-uplink-vlan-sw.sh"
+        subprocess.check_call([setup_vlan_switch, cls.NET_SW_BR, "upb"])
+        cls._setup_vlan(vlan)
+
+    @classmethod
+    def _setup_vlan(cls, vlan):
+        setup_vlan_switch = cls.SCRIPT_PATH + "scripts/setup-uplink-vlan-srv.sh"
+        subprocess.check_call([setup_vlan_switch, cls.NET_SW_BR, vlan, "55"])
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UplinkBridgeWithNonNatUplinkConnect_Test, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        cls._setup_vlan_network("0")
+
+        BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
+        BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
+                                          cls.UPLINK_DHCP, None)
+        BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
+                                          cls.UPLINK_PATCH, None)
+
+        check_connectivity(cls.ROUTER_IP, cls.UPLINK_ETH_PORT)
+
+        # this is setup after AGW boot up in NATed mode.
+        uplink_bridge_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.UplinkBridge,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.UplinkBridge:
+                    uplink_bridge_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': False,
+                'uplink_bridge': cls.UPLINK_BRIDGE,
+                'uplink_eth_port_name': cls.UPLINK_ETH_PORT,
+                'virtual_mac': '02:bb:5e:36:06:4b',
+                'uplink_patch': cls.UPLINK_PATCH,
+                'uplink_dhcp_port': cls.UPLINK_DHCP,
+                'sgi_management_iface_vlan': "",
+                'ovs_vlan_workaround': True,
+                'dev_vlan_in': "testv1_in",
+                'dev_vlan_out': "testv1_out",
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.uplink_br_controller = uplink_bridge_controller_reference.result()
+
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+        BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
+        BridgeTools.destroy_bridge(cls.NET_SW_BR)
+
+    # TODO this test updates resolve.conf, once that is fixed turn-on the test
+    @unittest.skip
+    def testFlowSnapshotMatch(self):
+        cls = self.__class__
+        assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
+                                     include_stats=False)
+        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), '[]')
+        # after Non NAT init, router shld be accessible.
+        # manually start DHCP client on up-br
+        check_connectivity(cls.ROUTER_IP, cls.UPLINK_BRIDGE)
+
+
+class UplinkBridgeTestNatIPAddr(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+    BRIDGE_ETH_PORT = "eth_t1"
+    UPLINK_BRIDGE = 'upt_br0'
+    SGi_IP="1.6.5.77"
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(UplinkBridgeTestNatIPAddr, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        uplink_bridge_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.UplinkBridge,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.UplinkBridge:
+                    uplink_bridge_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': True,
+                'uplink_bridge': cls.UPLINK_BRIDGE,
+                'sgi_management_iface_ip_addr': cls.SGi_IP,
+                'uplink_eth_port_name': cls.BRIDGE_ETH_PORT,
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.BRIDGE)
+        BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
+        BridgeTools.create_internal_iface(cls.BRIDGE,
+                                          cls.BRIDGE_ETH_PORT, '2.2.2.2')
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.uplink_br_controller = uplink_bridge_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+        BridgeTools.destroy_bridge(cls.UPLINK_BRIDGE)
+
+    def testFlowSnapshotMatch(self):
+        cls = self.__class__
+
+        assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager)
+        self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.BRIDGE_ETH_PORT), "ip not found")
+
 if __name__ == "__main__":
     unittest.main()
+
+
+def check_connectivity(dst: str, dev_name: str):
+    try:
+        ifdown_if = ["dhclient", dev_name]
+        subprocess.check_call(ifdown_if)
+    except subprocess.SubprocessError as e:
+        logging.warning("Error while setting dhcl IP: %s: %s",
+                        dev_name, e)
+        return
+    hub.sleep(1)
+
+    try:
+        ping_cmd = ["ping", "-c", "3", dst]
+        subprocess.check_call(ping_cmd)
+    except subprocess.SubprocessError as e:
+        logging.warning("Error while ping: %s", e)
+        # for now dont assert here.
+
+    validate_routing_table(dst, dev_name)
+
+
+def validate_routing_table(dst: str, dev_name: str) -> str:
+    dump1 = subprocess.Popen(["ip", "r", "get", dst],
+                             stdout=subprocess.PIPE)
+    for line in dump1.stdout.readlines():
+        if "dev" not in str(line):
+            continue
+        try:
+            if dev_name in str(line):
+                return
+        except ValueError:
+            pass
+    logging.error("could not find route to %s via %s", dst, dev_name)
+    logging.error("dump1: %s", str(dump1))
+    assert 0
+


### PR DESCRIPTION
## Summary

When switching between NAT and Bridged mode AGW SGi iface could loose IP,
This patch cleanup ip config and sets ip when switching between these modes.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test` and validated on lab setup.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
