### PR TITLE
[AGW] pipelined: inout: tighten check for flow generation.

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -204,7 +204,8 @@ class InOutController(MagmaController):
         # avoid resetting mac address on switch connect event.
         if mac_addr == "":
             mac_addr = self._current_upstream_mac_map.get(vlan, "")
-        if mac_addr == "" and self.config.enable_nat is False:
+        if mac_addr == "" and self.config.enable_nat is False and \
+            self.config.setup_type == 'LTE':
             mac_addr = self.config.uplink_gw_mac
 
         if mac_addr != "":

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
@@ -3,4 +3,4 @@
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768
- cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:11:22:33:44:55:66->eth_dst,LOCAL
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=LOCAL


### PR DESCRIPTION
## Summary

XWF has enable_nat flag even though it does NAT on the AGW. so we can
not just check for enable_nat flag for bridged mode. This patch
adds check for setup_type LTE.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran pipelineD unit tests.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
