### PR TITLE
Replace way to set up eth0 in agw_install.sh

### DIFF
--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -36,7 +36,8 @@ if [[ ! $INTERFACES == *'eth0'*  ]] || [[ ! $INTERFACES == *'eth1'* ]] || ! grep
   sed -i 's/GRUB_CMDLINE_LINUX=""/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0"/g' /etc/default/grub
   # changing interface name
   grub-mkconfig -o /boot/grub/grub.cfg
-  sed -i 's/enp1s0/eth0/g' /etc/network/interfaces
+  echo "auto eth0
+  iface eth0 inet dhcp" > /etc/network/interfaces.d/eth0
   # configuring eth1
   echo "auto eth1
   iface eth1 inet static

--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -1,13 +1,13 @@
 # ovs version on github default v2.8.1
-ovs_version: "v2.8.1"
+ovs_version: "v2.8.9"
 # Patches you want to apply
 packages:
   - "oai-gtp_4.9-5_amd64.deb"
-  - "libopenvswitch_2.8.1-1_amd64.deb"
-  - "openvswitch-datapath-dkms_2.8.1-1_all.deb"
-  - "openvswitch-datapath-source_2.8.1-1_all.deb"
-  - "openvswitch-common_2.8.1-1_amd64.deb"
-  - "openvswitch-switch_2.8.1-1_amd64.deb"
+  - "libopenvswitch_2.8.9-1_amd64.deb"
+  - "openvswitch-datapath-dkms_2.8.9-1_all.deb"
+  - "openvswitch-datapath-source_2.8.9-1_all.deb"
+  - "openvswitch-common_2.8.9-1_amd64.deb"
+  - "openvswitch-switch_2.8.9-1_amd64.deb"
 
 private_package: "deb http://packages.magma.etagecom.io stretch-stable main"
 source_name: "packages_magma_etagecom_io"


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

## Summary

Replace way to set up eth0 in agw_install.sh

## Test Plan

sh agw_install.sh

## Additional Information

- [ ] This change is backwards-breaking

