### PR TITLE
[NMS] Add tooltips across various pages and fixed multiple minor issues 

### DIFF
--- a/nms/app/packages/magmalte/app/components/EnodebKPIs.js
+++ b/nms/app/packages/magmalte/app/components/EnodebKPIs.js
@@ -37,14 +37,17 @@ export default function EnodebKPIs() {
       {
         category: 'Severe Events',
         value: 0,
+        tooltip: 'Severe Events reported by the eNodeB',
       },
       {
         category: 'Total',
         value: total || 0,
+        tooltip: 'Total number of eNodeBs',
       },
       {
         category: 'Transmitting',
         value: transmitting || 0,
+        tooltip: 'Number of eNodeBs with active transmit status',
       },
     ],
   ];

--- a/nms/app/packages/magmalte/app/components/GatewayKPIs.js
+++ b/nms/app/packages/magmalte/app/components/GatewayKPIs.js
@@ -50,14 +50,17 @@ export default function GatewayKPIs() {
       {
         category: 'Severe Events',
         value: 0,
+        tooltip: 'Severe Events reported by the gateway',
       },
       {
         category: 'Connected',
         value: upCount || 0,
+        tooltip: 'Number of gateways checked in within last 5 minutes',
       },
       {
         category: 'Disconnected',
         value: downCount || 0,
+        tooltip: 'Number of gateways not checked in within last 5 minutes',
       },
     ],
   ];

--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
@@ -54,12 +54,16 @@ export function EnodebStatus() {
         value: isEnbHealthy ? 'Good' : 'Bad',
         statusCircle: true,
         status: isEnbHealthy,
+        tooltip: isEnbHealthy
+          ? 'eNodeB transmit config and status match'
+          : 'mismatch in eNodeB transmit config and status',
       },
       {
         category: 'Transmit Enabled',
         value: enbInfo.enb.config.transmit_enabled ? 'Enabled' : 'Disabled',
         statusCircle: true,
         status: enbInfo.enb.config.transmit_enabled,
+        tooltip: 'current transmit configuration on the eNodeB',
       },
     ],
     [

--- a/nms/app/packages/magmalte/app/views/equipment/EquipmentGateway.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EquipmentGateway.js
@@ -237,7 +237,6 @@ function GatewayTableRaw(props: WithAlert) {
               title: 'Hardware ID',
               field: 'hardwareId',
               editable: 'never',
-              width: 250,
             },
             {
               title: 'Current Version',

--- a/nms/app/packages/magmalte/app/views/equipment/EquipmentGatewayKPIs.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EquipmentGatewayKPIs.js
@@ -100,12 +100,31 @@ export default function EquipmentGatewayKPIs() {
 
   const kpiData: DataRows[] = [
     [
-      {category: 'Max Latency', value: maxLatency, unit: 'ms'},
-      {category: 'Min Latency', value: minLatency, unit: 'ms'},
-      {category: 'Avg Latency', value: avgLatency, unit: 'ms'},
+      {
+        category: 'Max Latency',
+        value: maxLatency,
+        unit: 'ms',
+        tooltip:
+          'Max ping latency(for host 8.8.8.8) observed across all gateways',
+      },
+      {
+        category: 'Min Latency',
+        value: minLatency,
+        unit: 'ms',
+        tooltip:
+          'Min ping latency(for host 8.8.8.8) observed across all gateways',
+      },
+      {
+        category: 'Avg Latency',
+        value: avgLatency,
+        unit: 'ms',
+        tooltip:
+          'Avg ping latency(for host 8.8.8.8) observed across all gateways',
+      },
       {
         category: '% Healthy Gateways',
         value: pctHealthyGw,
+        tooltip: '% of gateways which have checked in within last 5 minutes',
       },
     ],
   ];

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailStatus.js
@@ -60,13 +60,17 @@ export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
     !!gwInfo.magmad.dynamic_services &&
     gwInfo.magmad.dynamic_services.includes('eventd');
 
+  const isHealthy = isGatewayHealthy(gwInfo);
   const data: DataRows[] = [
     [
       {
         category: 'Health',
-        value: isGatewayHealthy(gwInfo) ? 'Good' : 'Bad',
+        value: isHealthy ? 'Good' : 'Bad',
         statusCircle: true,
         status: isGatewayHealthy(gwInfo),
+        tooltip: isHealthy
+          ? 'Gateway checked in recently'
+          : "Gateway hasn't checked in within last 5 minutes",
       },
       {
         category: 'Last Check in',
@@ -93,6 +97,7 @@ export default function GatewayDetailStatus({gwInfo}: {gwInfo: lte_gateway}) {
         unit:
           cpuPercent?.data?.result?.[0]?.values?.[0]?.[1] ?? false ? '%' : '',
         statusCircle: false,
+        tooltip: 'Current Gateway CPU %',
       },
     ],
   ];

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayLogs.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayLogs.js
@@ -44,9 +44,9 @@ import {useRouter} from '@fbcnms/ui/hooks';
 const MAX_PAGE_ROW_COUNT = 10000;
 const EXPORT_DELIMITER = ',';
 const LOG_COLUMNS = [
-  {title: 'Date', field: 'date', type: 'datetime'},
-  {title: 'Service', field: 'service'},
-  {title: 'Type', field: 'logType'},
+  {title: 'Date', field: 'date', type: 'datetime', width: 200},
+  {title: 'Service', field: 'service', width: 200},
+  {title: 'Type', field: 'logType', width: 200},
   {title: 'Output', field: 'output'},
 ];
 

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberAddDialog.js
@@ -154,8 +154,8 @@ function parseSubscriberFile(fileObj: File) {
             imsi: items[1],
             authKey: items[2],
             authOpc: items[3],
-            dataPlan: items[4],
-            state: items[5] === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
+            state: items[4] === 'ACTIVE' ? 'ACTIVE' : 'INACTIVE',
+            dataPlan: items[5],
             apns: items[6]
               .split('|')
               .map(item => item.trim())

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -247,11 +247,13 @@ function Status({subscriberInfo}: {subscriberInfo: subscriber}) {
         category: 'Gateway ID',
         value: gwId,
         statusCircle: false,
+        tooltip: 'latest gateway connected to the subscriber',
       },
       {
         category: 'eNodeB SN',
         value: featureUnsupported,
         statusCircle: false,
+        tooltip: 'not supported',
       },
     ],
     [
@@ -259,10 +261,12 @@ function Status({subscriberInfo}: {subscriberInfo: subscriber}) {
         category: 'Connection Status',
         value: statusUnknown,
         statusCircle: false,
+        tooltip: 'not supported',
       },
       {
         category: 'UE Latency',
-        value: statusUnknown,
+        value: subscriberInfo.monitoring?.icmp?.latency_ms ?? statusUnknown,
+        unit: subscriberInfo.monitoring?.icmp?.latency_ms ? 'ms' : '',
         statusCircle: false,
       },
     ],


### PR DESCRIPTION
## Summary

- Added tooltips across various datagrids in NMS
- Removed hardcoded UE latency value and made it dependent on icmp status
- Fixed bulk subscriber issue where csv parsing code  expected dataplan to come prior
to service state
- Fixed fit log table width to the content issue as well. 

## Test Plan

![Screen Shot 2020-09-03 at 1 56 44 PM](https://user-images.githubusercontent.com/8224854/92166483-85708f80-eded-11ea-89a0-9174ca0f5e46.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
