### PR TITLE
[orc8r][policydb] Fix policydb streamer nil dereference

### DIFF
--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -423,9 +423,11 @@ func (m *PolicyQosProfile) ToProto() *protos.FlowQos {
 	proto := &protos.FlowQos{
 		MaxReqBwUl: swag.Uint32Value(m.MaxReqBwUl),
 		MaxReqBwDl: swag.Uint32Value(m.MaxReqBwDl),
-		GbrUl:      swag.Uint32Value(m.Gbr.Uplink),
-		GbrDl:      swag.Uint32Value(m.Gbr.Downlink),
 		Qci:        protos.FlowQos_Qci(m.ClassID),
+	}
+	if m.Gbr != nil {
+		proto.GbrUl = swag.Uint32Value(m.Gbr.Uplink)
+		proto.GbrDl = swag.Uint32Value(m.Gbr.Downlink)
 	}
 	if m.Arp != nil {
 		arp := &protos.QosArp{PriorityLevel: swag.Uint32Value(m.Arp.PriorityLevel)}

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -122,6 +122,14 @@ func TestPolicyStreamers(t *testing.T) {
 	// create the rules first otherwise base names can't associate to them
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{
+			Type: lte.PolicyQoSProfileEntityType,
+			Key:  "p1",
+			Config: &models.PolicyQosProfile{
+				ClassID: 42,
+				ID:      "p1",
+			},
+		},
+		{
 			Type: lte.PolicyRuleEntityType,
 			Key:  "r1",
 			Config: &models.PolicyRuleConfig{
@@ -137,6 +145,9 @@ func TestPolicyStreamers(t *testing.T) {
 					},
 				},
 				MonitoringKey: "foo",
+			},
+			Associations: []storage.TypeAndKey{
+				{Type: lte.PolicyQoSProfileEntityType, Key: "p1"},
 			},
 		},
 		{
@@ -196,6 +207,7 @@ func TestPolicyStreamers(t *testing.T) {
 					Action: lte_protos.FlowDescription_PERMIT,
 				},
 			},
+			Qos: &lte_protos.FlowQos{Qci: 42},
 		},
 		{
 			Id:       "r2",


### PR DESCRIPTION
## Summary

When a PolicyRule model has an associated PolicyQosProfile model, but that PolicyQosProfile.Gbr was nil, the policydb streamer was trying to access PolicyQosProfile.Gbr.Uplink (and .Downlink). This resulted in a nil pointer dereference, causing policydb streamer to fail.

## Test Plan

First added regression test to repro. Then added fix, which passed the regression test.

- [x] make test with added regression test

## Additional Information

- [ ] This change is backwards-breaking