### PR TITLE
[orc8r][subscriberdb] Fix subscriberdb not streaming apn_resource

### DIFF
--- a/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
@@ -76,6 +76,8 @@ func initSubscriber(t *testing.T, hwID string) {
 
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: hwID})
 	assert.NoError(t, err)
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"})
+	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
 		{

--- a/lte/cloud/go/services/subscriberdb/streamer/providers_test.go
+++ b/lte/cloud/go/services/subscriberdb/streamer/providers_test.go
@@ -22,6 +22,7 @@ import (
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	lte_test_init "magma/lte/cloud/go/services/lte/test_init"
 	"magma/lte/cloud/go/services/subscriberdb/obsidian/models"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/services/configurator"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
@@ -45,7 +46,9 @@ func TestSubscriberdbStreamer(t *testing.T) {
 
 	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
 	assert.NoError(t, err)
-	gw, err := configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1", PhysicalID: "hw1"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
+	assert.NoError(t, err)
+	gw, err := configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"})
 	assert.NoError(t, err)
 
 	// 1 sub without a profile on the backend (should fill as "default"), the


### PR DESCRIPTION
## Summary

The subscriberdb stream provider grabbed the magmad_gateway and treated it as a cellular_gateway. This passed the tests because the test code didn't accurately reflect the relationship between a magmad_gateway and cellular_gateway.

Now, subscriberdb stream provider correctly acts on the cellular_gateway.

## Test Plan

- [x] make test with added regression test
- [x] local e2e test with gw

## Additional Information

- [ ] This change is backwards-breaking