### PR TITLE
[orc8r] swagger: gateway-mconfig: sgi ip address

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/gateway_epc_configs_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/gateway_epc_configs_swaggergen.go
@@ -40,8 +40,7 @@ type GatewayEpcConfigs struct {
 	// IP address for management interface on the AGW, If not specified AGW uses DHCP to configure it.
 	// Max Length: 49
 	// Min Length: 5
-	// Format: ipv4
-	SgiManagementIfaceStaticIP strfmt.IPv4 `json:"sgi_management_iface_static_ip,omitempty"`
+	SgiManagementIfaceStaticIP string `json:"sgi_management_iface_static_ip,omitempty"`
 
 	// VLAN ID for management interface traffic on the AGW
 	// Max Length: 4
@@ -154,10 +153,6 @@ func (m *GatewayEpcConfigs) validateSgiManagementIfaceStaticIP(formats strfmt.Re
 	}
 
 	if err := validate.MaxLength("sgi_management_iface_static_ip", "body", string(m.SgiManagementIfaceStaticIP), 49); err != nil {
-		return err
-	}
-
-	if err := validate.FormatOf("sgi_management_iface_static_ip", "body", "ipv4", m.SgiManagementIfaceStaticIP.String(), formats); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -1693,7 +1693,7 @@ definitions:
         maxLength: 4
       sgi_management_iface_static_ip:
         type: string
-        format: ipv4
+        format: cidr
         description: IP address for management interface on the AGW, If not specified AGW uses DHCP to configure it.
         minLength: 5
         maxLength: 49

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -142,7 +142,7 @@ func (s *builderServicer) Build(ctx context.Context, request *builder_protos.Bui
 			DefaultRuleId:            nwEpc.DefaultRuleID,
 			Services:                 pipelineDServices,
 			SgiManagementIfaceVlan:   gwEpc.SgiManagementIfaceVlan,
-			SgiManagementIfaceIpAddr: gwEpc.SgiManagementIfaceStaticIP.String(),
+			SgiManagementIfaceIpAddr: gwEpc.SgiManagementIfaceStaticIP,
 		},
 		"subscriberdb": &lte_mconfig.SubscriberDB{
 			LogLevel:     protos.LogLevel_INFO,

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -31,7 +31,6 @@ import (
 	"magma/orc8r/cloud/go/storage"
 	"magma/orc8r/lib/go/protos"
 
-	strfmt "github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
@@ -685,7 +684,7 @@ func newGatewayConfigNonNat(vlan string, sgi_ip string) *lte_models.GatewayCellu
 			NatEnabled:                 swag.Bool(false),
 			IPBlock:                    "192.168.128.0/24",
 			SgiManagementIfaceVlan:     vlan,
-			SgiManagementIfaceStaticIP: strfmt.IPv4(sgi_ip),
+			SgiManagementIfaceStaticIP: sgi_ip,
 		},
 		NonEpsService: &lte_models.GatewayNonEpsConfigs{
 			CsfbMcc:              "001",


### PR DESCRIPTION
## Summary

This API need to take ip adddress CIDR to set subnet mask on AGW.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
mconfig UT: `go test builder_servicer_test.go`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
