### PR TITLE
[lte][agw] Updating DeleteBearer request for multiple bearers

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -202,14 +202,13 @@ Status SpgwServiceImpl::DeleteBearer(
   }
   itti_msg.imsi_length = imsi.size();
   strcpy(itti_msg.imsi, imsi.c_str());
-
   itti_msg.lbi           = request->link_bearer_id();
-  itti_msg.no_of_bearers = request->eps_bearer_ids_size();
+  itti_msg.no_of_bearers = 1;
   for (int i = 0; i < request->eps_bearer_ids_size() && i < BEARERS_PER_UE;
        i++) {
-    itti_msg.ebi[i] = request->eps_bearer_ids(i);
+    itti_msg.ebi[0] = request->eps_bearer_ids(i);
+    send_deactivate_bearer_request_itti(&itti_msg);
   }
-  send_deactivate_bearer_request_itti(&itti_msg);
   return Status::OK;
 }
 


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- For multiple bearers being deleted in one request, previous implementation only deleted the first on list, we now separate them and delete multiples in separate request as a work-around

## Test Plan

- Tested on local setup with VM agw and eNB, with QoS enforcement and multiple policy rules


## Additional Information

- [ ] This change is backwards-breaking
