### PR TITLE
[AGW] mobilityd: Add validation for static IP

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -62,6 +62,7 @@ from .ip_allocator_dhcp import IPAllocatorDHCP
 from .ip_allocator_pool import IpAllocatorPool
 from .ip_allocator_static import IPAllocatorStaticWrapper
 from .ip_allocator_multi_apn import IPAllocatorMultiAPNWrapper
+from .ip_allocator_base import DuplicateIPAssignmentError
 
 from .ip_descriptor_map import IpDescriptorMap
 from .uplink_gw import UplinkGatewayInfo
@@ -476,10 +477,3 @@ class MappingNotFoundError(Exception):
     """ Exception thrown when releasing a non-exising SID-IP mapping """
     pass
 
-
-class DuplicateIPAssignmentError(Exception):
-    """ Exception thrown when underlying IP allocator assigns duplicate
-    Ip address to two different SID. This also catches dup IP across
-    two different APNs.
-    """
-    pass

--- a/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_base.py
@@ -76,3 +76,11 @@ class DuplicatedIPAllocationError(Exception):
     """ Exception thrown when an IP has already been allocated to a UE
     """
     pass
+
+
+class DuplicateIPAssignmentError(Exception):
+    """ Exception thrown when underlying IP allocator assigns duplicate
+    Ip address to two different SID. This also catches dup IP across
+    two different APNs or overlaps in IP-POOL.
+    """
+    pass

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -24,7 +24,8 @@ from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import return_void
 from magma.subscriberdb.sid import SIDUtils
 from .ip_address_man import IPAddressManager, IPNotInUseError, \
-    MappingNotFoundError, DuplicateIPAssignmentError
+    MappingNotFoundError
+from .ip_allocator_base import DuplicateIPAssignmentError
 
 from .ip_allocator_pool import IPBlockNotFoundError, NoAvailableIPError, \
     OverlappedIPBlocksError

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -48,7 +48,7 @@ class StaticIPAllocationTests(unittest.TestCase):
         self._allocator.add_ip_block(self._block)
 
     def setUp(self):
-        self._block = ipaddress.ip_network('192.168.0.0/28')
+        self._block = ipaddress.ip_network('192.168.0.0/24')
         self._new_ip_allocator(self.RECYCLING_INTERVAL_SECONDS)
 
     def tearDown(self):
@@ -482,3 +482,14 @@ class StaticIPAllocationTests(unittest.TestCase):
         self.assertEqual(ip1, ip1_returned)
         self.assertEqual(ip1, ipaddress.ip_address(assigned_ip1))
         self.check_type(sid, IPType.STATIC)
+
+    def test_get_ip_for_subscriber_with_apn_overlap_ip_pool(self):
+        """ test get_ip_for_sid with static IP """
+        apn = 'magma'
+        imsi = 'IMSI110'
+        sid = imsi + '.' + apn
+        assigned_ip = '192.168.0.10'
+        MockedSubscriberDBStub.add_sub(sid=imsi, apn=apn, ip=assigned_ip)
+
+        with self.assertRaises(DuplicateIPAssignmentError):
+            ip0, _ = self._allocator.alloc_ip_address(sid)


### PR DESCRIPTION
## Summary

Statically assigned IP which overlaps with IP-POOL
is not supported. This patch adds exception handling
for same.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
mobility related tests and modified integ-test.

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
