### PR TITLE
[lte][agw] Fix handle_failed_create_bearer_response for multiple bearers

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1811,8 +1811,6 @@ static void _handle_failed_create_bearer_response(
     pgw_ni_cbr_proc = pgw_get_procedure_create_bearer(spgw_context);
     if (((pgw_ni_cbr_proc) &&
          (!LIST_EMPTY(pgw_ni_cbr_proc->pending_eps_bearers)))) {
-      pgw_base_proc_t* base_proc1 = LIST_FIRST(
-          spgw_context->sgw_eps_bearer_context_information.pending_procedures);
       sgw_eps_bearer_entry_p = LIST_FIRST(pgw_ni_cbr_proc->pending_eps_bearers);
       while (sgw_eps_bearer_entry_p) {
         if (teid == sgw_eps_bearer_entry_p->sgw_eps_bearer_entry
@@ -1831,11 +1829,18 @@ static void _handle_failed_create_bearer_response(
         }
         sgw_eps_bearer_entry_p = LIST_NEXT(sgw_eps_bearer_entry_p, entries);
       }
-      LIST_REMOVE(base_proc1, entries);
-      free_wrapper((void**) &spgw_context->sgw_eps_bearer_context_information
-                       .pending_procedures);
-      free_wrapper((void**) &pgw_ni_cbr_proc->pending_eps_bearers);
-      pgw_free_procedure_create_bearer((pgw_ni_cbr_proc_t**) &pgw_ni_cbr_proc);
+      if (pgw_ni_cbr_proc &&
+          (LIST_EMPTY(pgw_ni_cbr_proc->pending_eps_bearers))) {
+        pgw_base_proc_t* base_proc1 =
+            LIST_FIRST(spgw_context->sgw_eps_bearer_context_information
+                           .pending_procedures);
+        LIST_REMOVE(base_proc1, entries);
+        free_wrapper((void**) &spgw_context->sgw_eps_bearer_context_information
+                         .pending_procedures);
+        free_wrapper((void**) &pgw_ni_cbr_proc->pending_eps_bearers);
+        pgw_free_procedure_create_bearer(
+            (pgw_ni_cbr_proc_t**) &pgw_ni_cbr_proc);
+      }
     }
   }
   int rc = spgw_send_nw_init_activate_bearer_rsp(


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Fixing handle_failed_create_bearer_response, adding check for pending_eps_bearers list

## Test plan

- Tested on local ue and enb setup with qos debugging and creation and deletion of multiple policy rules

## Additional Information

- [ ] This change is backwards-breaking

