### PR TITLE
[nms] add analytics dashboard

### DIFF
--- a/nms/app/packages/magmalte/grafana/dashboards/AnalyticsDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/AnalyticsDashboards.js
@@ -1,0 +1,167 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {apnTemplate} from './CWFDashboards';
+import {networkTemplate} from './Dashboards';
+import type {GrafanaDBData} from './Dashboards';
+
+export const AnalyticsDBData: GrafanaDBData = {
+  title: 'Aggregated Analyses',
+  description:
+    'Various KPIs aggregated and calculated from other existing metrics.',
+  templates: [networkTemplate, apnTemplate],
+  rows: [
+    {
+      title: 'Active Users',
+      panels: [
+        {
+          title: 'Active Users Over Time',
+          targets: [
+            {
+              expr: 'active_users_over_time{networkID=~"$networkID"}',
+              legendFormat: '{{networkID}} - Days: {{days}}',
+            },
+          ],
+          description: 'Number of unique active users over the past N days.',
+        },
+      ],
+    },
+    {
+      title: 'User Throughput',
+      panels: [
+        {
+          title: 'User Throughput (Download)',
+          targets: [
+            {
+              expr: 'user_throughput{direction="in",networkID=~"$networkID"}',
+              legendFormat: '{{networkID}} - Days: {{days}}',
+            },
+          ],
+          unit: 'Bps',
+          description:
+            'Average user download throughput over the network in the last N days.',
+        },
+        {
+          title: 'User Throughput (Upload)',
+          targets: [
+            {
+              expr: 'user_throughput{direction="out",networkID=~"$networkID"}',
+              legendFormat: '{{networkID}} - Days: {{days}}',
+            },
+          ],
+          unit: 'Bps',
+          description:
+            'Average user upload throughput over the network in the last N days.',
+        },
+        {
+          title: 'Throughput Per APN (Upload)',
+          targets: [
+            {
+              expr: 'throughput_per_ap{direction="out",apn=~"$apn"}',
+              legendFormat: '{{apn}}',
+            },
+          ],
+          unit: 'Bps',
+          description:
+            'Average user upload throughput for a given APN in the last N days',
+        },
+        {
+          title: 'Throughput Per APN (Download)',
+          targets: [
+            {
+              expr: 'throughput_per_ap{direction="in",apn=~"$apn"}',
+              legendFormat: '{{apn}}',
+            },
+          ],
+          unit: 'Bps',
+          description:
+            'Average user download throughput for a given APN in the last N days',
+        },
+      ],
+    },
+    {
+      title: 'User Consumption',
+      panels: [
+        {
+          title: 'User Consumption (Upload)',
+          targets: [
+            {
+              expr: 'user_consumption{direction="out",networkID=~"$networkID"}',
+              legendFormat: '{{networkID}} - Days: {{days}}',
+            },
+          ],
+          unit: 'decbytes',
+          description:
+            'Total user upload consumption over the network in the past N days.',
+        },
+        {
+          title: 'User Consumption (Download)',
+          targets: [
+            {
+              expr: 'user_consumption{direction="in",networkID=~"$networkID"}',
+              legendFormat: '{{networkID}} - Days: {{days}}',
+            },
+          ],
+          unit: 'decbytes',
+          description:
+            'Total user download consumption over the network in the past N days.',
+        },
+        {
+          title: 'User Consumption Hourly (Upload)',
+          targets: [
+            {
+              expr:
+                'user_consumption_hourly{direction="out",networkID=~"$networkID"}',
+              legendFormat: '{{networkID}}',
+            },
+          ],
+          unit: 'decbytes',
+          description:
+            'Total user upload consumption over the network in the past hour.',
+        },
+        {
+          title: 'User Consumption Hourly (Download)',
+          targets: [
+            {
+              expr:
+                'user_consumption_hourly{direction="in",networkID=~"$networkID"}',
+              legendFormat: '{{networkID}}',
+            },
+          ],
+          unit: 'decbytes',
+          description:
+            'Total user download consumption over the network in the past hour.',
+        },
+      ],
+    },
+    {
+      title: 'Authentications',
+      panels: [
+        {
+          title: 'Authentications Over Time',
+          targets: [
+            {
+              expr: 'authentications_over_time{networkID=~"$networkID"}',
+              legendFormat: '{{networkID}} - Code: {{code}}',
+            },
+          ],
+          description:
+            'Total number of authentication failures or successes in the network in the last N days.',
+        },
+      ],
+    },
+  ],
+};

--- a/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
@@ -25,7 +25,7 @@ const msisdnTemplate = variableTemplate({
   includeAll: false,
 });
 
-const apnTemplate = variableTemplate({
+export const apnTemplate = variableTemplate({
   labelName: 'apn',
   query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
   regex: `/.+/`,

--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -17,6 +17,7 @@
 import {isEqual, sortBy} from 'lodash';
 
 import MagmaV1API from '@fbcnms/platform-server/magma/index';
+import {AnalyticsDBData} from './dashboards/AnalyticsDashboards';
 import {
   CWFAccessPointDBData,
   CWFGatewayDBData,
@@ -490,13 +491,14 @@ export async function syncDashboards(
 
   // If an org contains CWF networks, add the CWF-specific dashboards
   if (await hasCWFNetwork(networks)) {
-    console.log('Creating cwf dashboards');
     posts.push(
       dashboardData(createDashboard(CWFNetworkDBData).generate()),
       dashboardData(createDashboard(CWFAccessPointDBData).generate()),
       dashboardData(createDashboard(CWFSubscriberDBData).generate()),
       dashboardData(createDashboard(CWFGatewayDBData).generate()),
     );
+    // Analytics Dashboard
+    posts.push(dashboardData(createDashboard(AnalyticsDBData).generate()));
   }
 
   for (const post of posts) {


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Adds a dashboard to display aggregated analyses performed by the cwf analytics service.

## Test Plan
![image](https://user-images.githubusercontent.com/13274915/92292992-f9399780-eed4-11ea-921e-89ae211ae7a5.png)
no data on staging, but all the queries work due to no errors on grafana.

