### PR TITLE
[NMS] Add context for FEG_LTE network as well

### DIFF
--- a/nms/app/packages/magmalte/app/components/main/Index.js
+++ b/nms/app/packages/magmalte/app/components/main/Index.js
@@ -21,7 +21,7 @@ import {
   GatewayTierContextProvider,
   SubscriberContextProvider,
 } from '@fbcnms/magmalte/app/components/lte/LteSections';
-import {LTE, coalesceNetworkType} from '@fbcnms/types/network';
+import {FEG_LTE, LTE, coalesceNetworkType} from '@fbcnms/types/network';
 import type {NetworkType} from '@fbcnms/types/network';
 import type {Theme} from '@material-ui/core';
 
@@ -104,6 +104,7 @@ export default function Index() {
     return <LoadingFiller />;
   }
 
+  const lteNetwork = networkType === LTE || networkType === FEG_LTE;
   return (
     <NetworkContext.Provider value={{networkId, networkType}}>
       <div className={classes.root}>
@@ -118,7 +119,7 @@ export default function Index() {
           user={user}
         />
         <AppContent>
-          {networkType === LTE ? (
+          {lteNetwork ? (
             <LteContextProvider networkId={networkId}>
               <SectionRoutes />
             </LteContextProvider>


### PR DESCRIPTION
## Summary

Currently feg_lte network fails due to lack of context information. This change ensures feg_lte network gets displayed properly. However support for feg_lte network in NMS is currently buggy. We don't use any FegLte based APIs. We use regular LTE network APIs.


## Test Plan

yarn test passes fine

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
