### PR TITLE
[xwfm][CI] Fix CI DNS

### DIFF
--- a/xwf/gateway/integ_tests/gw/entrypoint.sh
+++ b/xwf/gateway/integ_tests/gw/entrypoint.sh
@@ -27,6 +27,7 @@ echo "run XWF ansible"
 ANSIBLE_CONFIG=xwf/gateway/ansible.cfg ansible-playbook -e xwf_ctrl_ip="${CtrlIP}" xwf/gateway/deploy/xwf.yml -i "localhost," --skip-tags "install,install_docker,no_ci" -c local -v
 
 echo "run DNS server"
+echo "nameserver 8.8.8.8" >> /etc/resolv.conf
 dnsmasq
 
 echo "run DHCP server"


### PR DESCRIPTION
[xwfm][CI] Fix CI DNS

## Summary

CircleCI docker DNS is not working proper with the new centos docker image, adding 8.8.8.8 as DNS host solve this issue

## Test Plan

Run it manually on circleci env works

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
