### PR TITLE
[AGW] Add ovs dependency to solve apt upgrade

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -126,11 +126,17 @@ OAI_DEPS=(
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
+    "oai-gtp >= 4.9.5"
     )
 
 # OVS runtime dependencies
 OVS_DEPS=(
     "magma-libfluid >= 0.1.0.4"
+    "openvswitch-common >= 2.8.9"
+    "libopenvswitch >= 2.8.9"
+    "openvswitch-switch >= 2.8.9"
+    "openvswitch-datapath-source-4.9.0-9 >= 2.8.9"
+    "openvswitch-datapath-dkms >= 2.8.9"
     )
 
 # generate string for FPM


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

## Summary

We changed ovs version. However when we `apt upgrade magma` as ovs is not registered as a magma dependency when we build magma using fpm. It doesn't upgrade those. and break the latest magma version

## Test Plan

Let CI build the latest version of magma and then `apt upgrade magma`

## Additional Information

- [X ] This change is backwards-breaking