### PR TITLE
Fixing typo on name of param for max grpc msg size

### DIFF
--- a/cwf/gateway/configs/magmad.yml
+++ b/cwf/gateway/configs/magmad.yml
@@ -79,7 +79,7 @@ metricsd:
   sync_interval: 60 # How frequently to sync to cloud in seconds
   grpc_timeout: 30 # Timeout in seconds
   queue_length: 1000 # Number of failed samples to enqueue for resend
-  max_grpc_msg_size_mb: 4 # Max message size for gRPC channel in MBs
+  max_grpc_msg_size_mb: 40 # Max message size for gRPC channel in MBs
 
   # An optional function  to mutate metrics before they are sent to the cloud
   # A string in the form path.to.module.fn_name

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -72,7 +72,7 @@ def main():
     collect_interval = metrics_config['collect_interval']
     sync_interval = metrics_config['sync_interval']
     grpc_timeout = metrics_config['grpc_timeout']
-    grpc_msg_size = metrics_config.get('grpc_max_msg_size_mb', 4)
+    grpc_msg_size = metrics_config.get('max_grpc_msg_size_mb', 4)
     queue_length = metrics_config['queue_length']
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- magmad had invalid param name for metrics collector max msg param, this fixes it
- increasing default value for cwf on magmad.yml based on mcp tests

## Test Plan

- tested on mcp2 setup

## Additional Information

- [ ] This change is backwards-breaking
