### PR TITLE
[sessiond] add lazy loging to some functions

### DIFF
--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -492,6 +492,9 @@ bool SessionCredit::is_received_grented_unit_zero(const CreditUnit& cu) const{
 }
 
 void SessionCredit::log_quota_and_usage() const {
+  if (magma::get_verbosity() != MDEBUG){
+    return;
+  }
   MLOG(MDEBUG) << "===> Used     Tx: " << buckets_[USED_TX]
                << " Rx: " << buckets_[USED_RX]
                << " Total: " << buckets_[USED_TX] + buckets_[USED_RX];
@@ -537,6 +540,9 @@ std::string SessionCredit::get_percentage_usage(uint64_t allowed, uint64_t floor
 }
 
 void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {
+  if (magma::get_verbosity() != MDEBUG){
+    return;
+  }
   MLOG(MDEBUG) << "===> Amount reporting for this report:"
                << " tx=" << usage.bytes_tx << " rx=" << usage.bytes_rx;
   MLOG(MDEBUG) << "===> The total amount currently being reported:"

--- a/orc8r/gateway/c/common/logging/magma_logging.h
+++ b/orc8r/gateway/c/common/logging/magma_logging.h
@@ -34,6 +34,11 @@ static void set_verbosity(uint32_t verbosity) {
   FLAGS_v = verbosity;
 }
 
+// get_verbosity gets the the global logging verbosity
+static google::int32 get_verbosity(){
+  return FLAGS_v;
+}
+
 // init_logging initializes glog, sets logging to use std::err, and sets the
 // initial verbosity
 static void init_logging(const char* service_name) {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added lazy logging to some functions that may cause overhead. So better not to even execute them if logging `DEBUG` is not enabled

## Test Plan
make test agw
tested in teravm 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
