### PR TITLE
Add reboot button

### DIFF
--- a/nms/app/packages/magmalte/app/state/EquipmentState.js
+++ b/nms/app/packages/magmalte/app/state/EquipmentState.js
@@ -341,7 +341,7 @@ export async function RunGatewayCommands(props: GatewayCommandProps) {
 
     default:
       if (props.params != null) {
-        return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandReboot(
+        return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric(
           {networkId, gatewayId, parameters: props.params},
         );
       }

--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -13,6 +13,9 @@
  * @flow strict-local
  * @format
  */
+import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
+
+import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DateTimeMetricChart from '../../components/DateTimeMetricChart';
@@ -26,17 +29,34 @@ import SettingsIcon from '@material-ui/icons/Settings';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import TopBar from '../../components/TopBar';
 import nullthrows from '@fbcnms/util/nullthrows';
+import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {EnodebJsonConfig} from './EnodebDetailConfig';
 import {EnodebStatus, EnodebSummary} from './EnodebDetailSummaryStatus';
 import {Redirect, Route, Switch} from 'react-router-dom';
+import {RunGatewayCommands} from '../../state/EquipmentState';
+import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
   dashboardRoot: {
     margin: theme.spacing(5),
+  },
+  appBarBtn: {
+    color: colors.primary.white,
+    background: colors.primary.comet,
+    fontFamily: typography.button.fontFamily,
+    fontWeight: typography.button.fontWeight,
+    fontSize: typography.button.fontSize,
+    lineHeight: typography.button.lineHeight,
+    letterSpacing: typography.button.letterSpacing,
+
+    '&:hover': {
+      background: colors.primary.mirage,
+    },
   },
 }));
 const CHART_TITLE = 'Bandwidth Usage';
@@ -56,11 +76,13 @@ export function EnodebDetail() {
             label: 'Overview',
             to: '/overview',
             icon: DashboardIcon,
+            filters: <EnodebRebootButton />,
           },
           {
             label: 'Config',
             to: '/config',
             icon: SettingsIcon,
+            filters: <EnodebRebootButton />,
           },
         ]}
       />
@@ -78,6 +100,64 @@ export function EnodebDetail() {
     </>
   );
 }
+
+function EnodebRebootButtonInternal(props: WithAlert) {
+  const classes = useStyles();
+  const ctx = useContext(EnodebContext);
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const enodebSerial: string = nullthrows(match.params.enodebSerial);
+  const enbInfo = ctx.state.enbInfo[enodebSerial];
+  const gatewayId = enbInfo?.enb_state?.reporting_gateway_id;
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  const handleClick = () => {
+    if (gatewayId == null) {
+      enqueueSnackbar('Unable to trigger reboot, reporting gateway not found', {
+        variant: 'error',
+      });
+      return;
+    }
+
+    props
+      .confirm(`Are you sure you want to reboot ${enodebSerial}?`)
+      .then(async confirmed => {
+        if (!confirmed) {
+          return;
+        }
+        const params = {
+          command: 'reboot_enodeb',
+          params: {shell_params: {[enodebSerial]: {}}},
+        };
+
+        try {
+          await RunGatewayCommands({
+            networkId,
+            gatewayId,
+            command: 'generic',
+            params,
+          });
+          enqueueSnackbar('eNodeB reboot triggered successfully', {
+            variant: 'success',
+          });
+        } catch (e) {
+          enqueueSnackbar(e.response?.data?.message ?? e.message, {
+            variant: 'error',
+          });
+        }
+      });
+  };
+
+  return (
+    <Button
+      variant="contained"
+      className={classes.appBarBtn}
+      onClick={handleClick}>
+      Reboot
+    </Button>
+  );
+}
+const EnodebRebootButton = withAlert(EnodebRebootButtonInternal);
 
 function Overview() {
   const ctx = useContext(EnodebContext);


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>

## Summary

Add the missing reboot button in eNodeB detail page

## Test Plan

<img width="1669" alt="Screen Shot 2020-09-08 at 4 24 08 PM" src="https://user-images.githubusercontent.com/8224854/92539229-b689ff00-f1f5-11ea-9498-a047189af03f.png">
<img width="1677" alt="Screen Shot 2020-09-08 at 4 24 29 PM" src="https://user-images.githubusercontent.com/8224854/92539234-b8ec5900-f1f5-11ea-9ff0-08979f251392.png">
<img width="1679" alt="Screen Shot 2020-09-08 at 4 25 25 PM" src="https://user-images.githubusercontent.com/8224854/92539237-b984ef80-f1f5-11ea-8117-da9a3c91d423.png">

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
