### PR TITLE
[e2e] Fix testcontroller traffic test logic

### DIFF
--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
@@ -403,15 +403,15 @@ func Test_EnodebdE2ETestStateMachine_TrafficScript(t *testing.T) {
 
 	mockMagmad.On("GenerateTraffic", "n1", "g2", "magmawifi", "magmamagma").Return(mockGenericCommandResp, nil)
 	mockGenericCommandResp.Response.Fields = map[string]*structpb.Value{
-		"result": {Kind: &structpb.Value_NumberValue{NumberValue: float64(1)}},
-		"stdout": {Kind: &structpb.Value_StringValue{StringValue: ""}},
-		"stderr": {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"returncode": {Kind: &structpb.Value_NumberValue{NumberValue: float64(1)}},
+		"stdout":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"stderr":     {Kind: &structpb.Value_StringValue{StringValue: "unable to connect to magmawifi"}},
 	}
 	// ---
 	// Traffic test 1 fails, traffic script failing
 	// ---
 	actualState, actualDuration, err = sm.Run("traffic_test1_1", testConfig, nil)
-	assert.EqualError(t, err, "Traffic script failed")
+	assert.EqualError(t, err, "Traffic script failed. Return Code: 1, Stdout: , Stderr: unable to connect to magmawifi")
 	assert.Equal(t, "traffic_test1_2", actualState)
 	assert.Equal(t, time.Minute, actualDuration)
 
@@ -424,7 +424,7 @@ func Test_EnodebdE2ETestStateMachine_TrafficScript(t *testing.T) {
 	// Traffic test 2 fails, traffic script failing
 	// ---
 	actualState, actualDuration, err = sm.Run("traffic_test2_1", testConfig, nil)
-	assert.EqualError(t, err, "Traffic script failed")
+	assert.EqualError(t, err, "Traffic script failed. Return Code: 1, Stdout: , Stderr: unable to connect to magmawifi")
 	assert.Equal(t, "traffic_test2_2", actualState)
 	assert.Equal(t, time.Minute, actualDuration)
 
@@ -434,9 +434,9 @@ func Test_EnodebdE2ETestStateMachine_TrafficScript(t *testing.T) {
 	assert.Equal(t, time.Minute, actualDuration)
 
 	mockGenericCommandResp.Response.Fields = map[string]*structpb.Value{
-		"result": {Kind: &structpb.Value_NumberValue{NumberValue: float64(0)}},
-		"stdout": {Kind: &structpb.Value_StringValue{StringValue: ""}},
-		"stderr": {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"returncode": {Kind: &structpb.Value_NumberValue{NumberValue: float64(0)}},
+		"stdout":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"stderr":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
 	}
 	// ---
 	// Traffic Test 1
@@ -555,16 +555,16 @@ func Test_EnodebdE2ETestStateMachine_ReconfigEnb(t *testing.T) {
 	mockMagmad.On("GenerateTraffic", "n1", "g2", "magmawifi", "magmamagma").Return(mockGenericCommandResp, nil)
 	testConfig.EnodebConfig.Pci = 261
 	mockGenericCommandResp.Response.Fields = map[string]*structpb.Value{
-		"result": {Kind: &structpb.Value_NumberValue{NumberValue: float64(1)}},
-		"stdout": {Kind: &structpb.Value_StringValue{StringValue: ""}},
-		"stderr": {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"returncode": {Kind: &structpb.Value_NumberValue{NumberValue: float64(1)}},
+		"stdout":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"stderr":     {Kind: &structpb.Value_StringValue{StringValue: "unable to connect to magmawifi"}},
 	}
 
 	// ---
 	// Traffic Test 3 fails, traffic script failing
 	// ---
 	actualState, actualDuration, err = sm.Run("traffic_test3_1", testConfig, nil)
-	assert.EqualError(t, err, "Traffic script failed")
+	assert.EqualError(t, err, "Traffic script failed. Return Code: 1, Stdout: , Stderr: unable to connect to magmawifi")
 	assert.Equal(t, "traffic_test3_2", actualState)
 	assert.Equal(t, time.Minute, actualDuration)
 
@@ -577,7 +577,7 @@ func Test_EnodebdE2ETestStateMachine_ReconfigEnb(t *testing.T) {
 	// Traffic Test 4 fails, traffic script failing
 	// ---
 	actualState, actualDuration, err = sm.Run("traffic_test4_1", testConfig, nil)
-	assert.EqualError(t, err, "Traffic script failed")
+	assert.EqualError(t, err, "Traffic script failed. Return Code: 1, Stdout: , Stderr: unable to connect to magmawifi")
 	assert.Equal(t, "traffic_test4_2", actualState)
 	assert.Equal(t, time.Minute, actualDuration)
 
@@ -587,9 +587,9 @@ func Test_EnodebdE2ETestStateMachine_ReconfigEnb(t *testing.T) {
 	assert.Equal(t, time.Minute, actualDuration)
 
 	mockGenericCommandResp.Response.Fields = map[string]*structpb.Value{
-		"result": {Kind: &structpb.Value_NumberValue{NumberValue: float64(0)}},
-		"stdout": {Kind: &structpb.Value_StringValue{StringValue: ""}},
-		"stderr": {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"returncode": {Kind: &structpb.Value_NumberValue{NumberValue: float64(0)}},
+		"stdout":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"stderr":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
 	}
 
 	// ---
@@ -735,15 +735,15 @@ func Test_EnodebdE2ETestStateMachine_SubscriberState(t *testing.T) {
 	assert.Equal(t, time.Minute, actualDuration)
 
 	mockGenericCommandResp.Response.Fields = map[string]*structpb.Value{
-		"result": {Kind: &structpb.Value_NumberValue{NumberValue: float64(1)}},
-		"stdout": {Kind: &structpb.Value_StringValue{StringValue: ""}},
-		"stderr": {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"returncode": {Kind: &structpb.Value_NumberValue{NumberValue: float64(1)}},
+		"stdout":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
+		"stderr":     {Kind: &structpb.Value_StringValue{StringValue: "unable to connect to magmawifi"}},
 	}
 	// ---
 	// Traffic test 6 fail, traffic script failing
 	// ---
 	actualState, actualDuration, err = sm.Run("traffic_test6_1", testConfig, nil)
-	assert.EqualError(t, err, "Traffic script failed")
+	assert.EqualError(t, err, "Traffic script failed. Return Code: 1, Stdout: , Stderr: unable to connect to magmawifi")
 	assert.Equal(t, "traffic_test6_2", actualState)
 	assert.Equal(t, time.Minute, actualDuration)
 
@@ -897,9 +897,9 @@ func GetMockObjects() (*mockMagmadClient, *protos.GenericCommandResponse) {
 	mockMagmad := &mockMagmadClient{}
 	mockResponse := &structpb.Struct{
 		Fields: map[string]*structpb.Value{
-			"result": {Kind: &structpb.Value_NumberValue{NumberValue: float64(0)}},
-			"stdout": {Kind: &structpb.Value_StringValue{StringValue: ""}},
-			"stderr": {Kind: &structpb.Value_StringValue{StringValue: ""}},
+			"returncode": {Kind: &structpb.Value_NumberValue{NumberValue: float64(0)}},
+			"stdout":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
+			"stderr":     {Kind: &structpb.Value_StringValue{StringValue: ""}},
 		},
 	}
 	mockGenericCommandResp := &protos.GenericCommandResponse{

--- a/orc8r/gateway/docker/Dockerfile
+++ b/orc8r/gateway/docker/Dockerfile
@@ -68,7 +68,8 @@ RUN apt-get -y update && apt-get -y install \
   python-cffi \
   python3-pip \
   python3.5-dev \
-  redis-server
+  redis-server \
+  network-manager
 
 RUN curl -sSL https://get.docker.com/ > /tmp/get_docker.sh && \
     sh /tmp/get_docker.sh && \

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -54,6 +54,7 @@ setup(
         'scripts/service_util.py',
         'scripts/service303_cli.py',
         'scripts/show_gateway_info.py',
+        'scripts/traffic_cli.py',
     ],
     install_requires=[
         'setuptools==49.6.0',


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

Traffic test for the e2e LTE tests have been broken. This diff updates the
test to work correctly. It also ensures that error message contains the reason
why the test failed.

## Test Plan

`make precommit`. Ran locally with orc8r <-> lte agw