### PR TITLE
Modified the partial reset test cases to send enb_ue_s1ap_id and mme_ue_s1ap_id from test script

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_con_dereg.py
@@ -114,14 +114,14 @@ class TestEnbPartialReset(unittest.TestCase):
         reset_req.r = s1ap_types.R()
         reset_req.r.partialRst = s1ap_types.PartialReset()
         reset_req.r.partialRst.numOfConn = num_ues
-        reset_req.r.partialRst.ueIdLst = (
-            ctypes.c_ubyte * reset_req.r.partialRst.numOfConn
+        reset_req.r.partialRst.ueS1apIdPairList  = (
+            (s1ap_types.UeS1apIdPair) * reset_req.r.partialRst.numOfConn
         )()
         for indx in range(reset_req.r.partialRst.numOfConn):
-            reset_req.r.partialRst.ueIdLst[indx] = ue_ids[indx]
+            reset_req.r.partialRst.ueS1apIdPairList[indx].ueId = ue_ids[indx]
             print(
-                "Reset_req.r.partialRst.ueIdLst[indx]",
-                reset_req.r.partialRst.ueIdLst[indx],
+                "Reset_req.r.partialRst.ueS1apIdPairList[indx].ueId",
+                reset_req.r.partialRst.ueS1apIdPairList[indx].ueId,
                 indx,
             )
         print("ue_ids", ue_ids)

--- a/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
@@ -63,10 +63,20 @@ class TestEnbPartialReset(unittest.TestCase):
         )()
         for indx in range(reset_req.r.partialRst.numOfConn):
             reset_req.r.partialRst.ueS1apIdPairList[indx].ueId = ue_ids[indx]
+            '''Known Issue: if enbUeS1apId is getting changed, Detach Request is
+             not sent from s1ap tester.
+             Due to other high priority tasks, working on this issue is de-prioritized
+            '''
+
+            #reset_req.r.partialRst.ueS1apIdPairList[indx].enbUeS1apId = ue_ids[indx] + 20
+            reset_req.r.partialRst.ueS1apIdPairList[indx].mmeUeS1apId = ue_ids[indx] + 20
             print(
-                "Reset_req.r.partialRst.ueS1apIdPairList[indx].ueId",
+                "Reset_req.r.partialRst.ueS1apIdPairList[indx].ueId"
+                " enbUeS1apId: mmeUeS1apId:",
                 reset_req.r.partialRst.ueS1apIdPairList[indx].ueId,
                 indx,
+                reset_req.r.partialRst.ueS1apIdPairList[indx].enbUeS1apId,
+                reset_req.r.partialRst.ueS1apIdPairList[indx].mmeUeS1apId
             )
         print("ue_ids", ue_ids)
         self._s1ap_wrapper.s1_util.issue_cmd(s1ap_types.tfwCmd.RESET_REQ, reset_req)

--- a/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_multi_enb_partial_reset.py
@@ -87,14 +87,14 @@ class TestMultipleEnbPartialReset(unittest.TestCase):
         reset_req.r = s1ap_types.R()
         reset_req.r.partialRst = s1ap_types.PartialReset()
         reset_req.r.partialRst.numOfConn = num_ues
-        reset_req.r.partialRst.ueIdLst = (
-            ctypes.c_ubyte * reset_req.r.partialRst.numOfConn
+        reset_req.r.partialRst.ueS1apIdPairList = (
+            (s1ap_types.UeS1apIdPair) * reset_req.r.partialRst.numOfConn
         )()
         for indx in range(reset_req.r.partialRst.numOfConn):
-            reset_req.r.partialRst.ueIdLst[indx] = ue_ids[indx]
+            reset_req.r.partialRst.ueS1apIdPairList[indx].ueId = ue_ids[indx]
             print(
-                "Reset_req.r.partialRst.ueIdLst[indx]",
-                reset_req.r.partialRst.ueIdLst[indx],
+                "Reset_req.r.partialRst.ueS1apIdPairList[indx].ueId",
+                reset_req.r.partialRst.ueS1apIdPairList[indx].ueId,
                 indx,
             )
         print("ue_ids", ue_ids)


### PR DESCRIPTION
## Title : [lte] Added and modified Partial reset test cases
## Summary
Added new test case to send unknown ue_s1ap_id in S1ap-Partial Reset message.
Since data structure for Partial Reset is changed, in accordance to data structure modified the Partial Reset test cases
## Test Plan
Added test case, test_enb_partial_reset_with_unknown_ue_s1ap_ids.py
The script is provisioned to give unknown ue_s1ap_id, MME detects invalid ue_s1ap_ids and includes them in Reset-Ack message. Verified through the Wireshark capture.

## Additional Information
Known issue: On modifying enb_ue_s1ap_id,  the modified enb_ue_s1ap_id is included in both S1ap-Reset and S1ap-Reset Ack message.
After completion of Reset procedure, sending Detach Request is included, But Detach Request is not sent out from S1ap stack. Due to other high priority tasks, this debugging on this is deprioritized.
Signed-off-by: rashmi <rashmi.sarwad@radisys.com>