### PR TITLE
{WIP} [agw] [stateless] Move statelss config to override YML

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -6,6 +6,27 @@ RETURN_STATEFUL=1
 RETURN_CORRUPT=2
 RETURN_INVALID=3
 
+function set_override_flag {
+  service_name=$1
+  flag=$2
+  value=$3
+  override_file=/var/opt/magma/configs/$service_name.yml
+
+# check if override file exists
+  if [ ! -f "$override_file" ]; then
+    sudo mkdir -p /var/opt/magma/configs && touch $override_file
+  fi
+
+# check if the setting exists and set the correct value
+  if ! grep -q "$flag" $override_file; then
+    echo "$flag: $value" >> $override_file
+  else
+    if ! grep -q "$flag: $value" $override_file; then
+      sed -e "/$flag/ s/.*/$flag:\ $value/" -i $override_file
+    fi
+  fi
+}
+
 function check_stateless_agw {
   echo "Checking stateless AGW config"
   num_stateful=0

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SRC_DIR=/usr/local/bin
-SERVICE_LIST=("mme" "mobilityd" "pipelined" "sctpd" "sessiond")
+SERVICE_LIST=("mme" "mobilityd" "pipelined" "sessiond" "sctpd")
 RETURN_STATELESS=0
 RETURN_STATEFUL=1
 RETURN_CORRUPT=2

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -6,27 +6,6 @@ RETURN_STATEFUL=1
 RETURN_CORRUPT=2
 RETURN_INVALID=3
 
-function set_override_flag {
-  service_name=$1
-  flag=$2
-  value=$3
-  override_file=/var/opt/magma/configs/$service_name.yml
-
-# check if override file exists
-  if [ ! -f "$override_file" ]; then
-    sudo mkdir -p /var/opt/magma/configs && touch $override_file
-  fi
-
-# check if the setting exists and set the correct value
-  if ! grep -q "$flag" $override_file; then
-    echo "$flag: $value" >> $override_file
-  else
-    if ! grep -q "$flag: $value" $override_file; then
-      sed -e "/$flag/ s/.*/$flag:\ $value/" -i $override_file
-    fi
-  fi
-}
-
 function check_stateless_agw {
   echo "Checking stateless AGW config"
   num_stateful=0

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_mme.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_mme.sh
@@ -10,8 +10,9 @@ if [[ $1 == "check" ]]; then
     check_systemd_file "magma@mme" "$dep_service_name"
   done
 
-  #check service config
-  if ! grep -q "use_stateless.*true" /etc/magma/mme.yml; then
+  # check service config
+  check_stateless_flag mme use_stateless; ret_check=$?
+  if [[ $ret_check -eq $RETURN_STATEFUL ]]; then
     echo "MME config file is stateful."
     exit 1
   fi
@@ -27,7 +28,7 @@ elif [[ $1 == "disable" ]]; then
   done
 
   # change use_stateless setting in mme.yml
-  sed -e '/use_stateless/ s/true/false/' -i /etc/magma/mme.yml
+  disable_stateless_flag mme use_stateless
 elif [[ $1 == "enable" ]]; then
   echo "Enabling stateless MME config"
   # stop other services from restarting when MME restarts
@@ -37,7 +38,7 @@ elif [[ $1 == "enable" ]]; then
   done
 
   # change use_stateless setting in mme.yml
-  sed -e '/use_stateless/ s/false/true/' -i /etc/magma/mme.yml
+  enable_stateless_flag mme use_stateless true
 else
   echo "Invalid argument. Use one of the following"
   echo "check: Run a check whether MME is stateless or not"

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_mobilityd.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_mobilityd.sh
@@ -10,8 +10,9 @@ if [[ $1 == "check" ]]; then
     check_systemd_file "magma@mobilityd" "$dep_service_name"
   done
 
-  #check service config
-  if ! grep -q "persist_to_redis.*true" /etc/magma/mobilityd.yml; then
+  # check service config
+  check_stateless_flag mobilityd persist_to_redis; ret_check=$?
+  if [[ $ret_check -eq $RETURN_STATEFUL ]]; then
     echo "Mobilityd config file is stateful."
     exit 1
   fi
@@ -27,7 +28,7 @@ elif [[ $1 == "disable" ]]; then
   done
 
   # change persist_to_redis setting in mobilityd.yml
-  sed -e '/persist_to_redis/ s/true/false/' -i /etc/magma/mobilityd.yml
+  disable_stateless_flag mobilityd persist_to_redis
 elif [[ $1 == "enable" ]]; then
   echo "Enabling stateless mobilityd config"
   # remove restart dependencies between mobilityd and other services
@@ -37,7 +38,7 @@ elif [[ $1 == "enable" ]]; then
   done
 
   # change persist_to_redis setting in mobilityd.yml
-  sed -e '/persist_to_redis/ s/false/true/' -i /etc/magma/mobilityd.yml
+  enable_stateless_flag mobilityd persist_to_redis true
 else
   echo "Invalid argument. Use one of the following"
   echo "check: Run a check whether Mobilityd is stateless or not"

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_pipelined.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_pipelined.sh
@@ -5,8 +5,9 @@ if [[ $1 == "check" ]]; then
   # check dependency in systemd files of other services
   check_systemd_file "magma@pipelined" "magma@mme"
 
-  #check service config
-  if ! grep -q "clean_restart.*false" /etc/magma/pipelined.yml; then
+  # check service config
+  check_stateless_flag pipelined clean_restart; ret_check=$?
+  if [[ $ret_check -eq $RETURN_STATEFUL ]]; then
     echo "Pipelined config file is stateful."
     exit 1
   fi
@@ -19,14 +20,14 @@ elif [[ $1 == "disable" ]]; then
   remove_systemd_override "magma@mme"
 
   # change clean_restart setting in pipelined.yml
-  sed -e '/clean_restart/ s/false/true/' -i /etc/magma/pipelined.yml
+  disable_stateless_flag pipelined clean_restart
 elif [[ $1 == "enable" ]]; then
   echo "Enabling stateless pipelined config"
   # remove restart dependencies between pipelined and other services
   add_systemd_override "magma@pipelined" "magma@mme"
 
   # change clean_restart setting in pipelined.yml
-  sed -e '/clean_restart/ s/true/false/' -i /etc/magma/pipelined.yml
+  enable_stateless_flag pipelined clean_restart false
 else
   echo "Invalid argument. Use one of the following"
   echo "check: Run a check whether Pipelined is stateless or not"

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_sessiond.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_sessiond.sh
@@ -5,8 +5,9 @@ if [[ $1 == "check" ]]; then
   # check dependency in systemd files of other services
   check_systemd_file "magma@sessiond" "magma@mme"
 
-  #check service config
-  if ! grep -q "support_stateless.*true" /etc/magma/sessiond.yml; then
+  # check service config
+  check_stateless_flag sessiond support_stateless; ret_check=$?
+  if [[ $ret_check -eq $RETURN_STATEFUL ]]; then
     echo "Sessiond config file is stateful."
     exit 1
   fi
@@ -19,14 +20,14 @@ elif [[ $1 == "disable" ]]; then
   remove_systemd_override "magma@mme"
 
   # change support_stateless setting in sessiond.yml
-  sed -e '/support_stateless/ s/true/false/' -i /etc/magma/sessiond.yml
+  disable_stateless_flag sessiond support_stateless
 elif [[ $1 == "enable" ]]; then
   echo "Enabling stateless sessiond config"
   # remove restart dependencies between sessiond and other services
   add_systemd_override "magma@sessiond" "magma@mme"
 
   # change support_stateless setting in sessiond.yml
-  sed -e '/support_stateless/ s/false/true/' -i /etc/magma/sessiond.yml
+  enable_stateless_flag sessiond support_stateless true
 else
   echo "Invalid argument. Use one of the following"
   echo "check: Run a check whether Sessiond is stateless or not"

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_utils.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_utils.sh
@@ -34,3 +34,65 @@ function remove_systemd_override {
   dep_service_name=$1
   sudo rm -f /etc/systemd/system/"$dep_service_name".service
 }
+
+function check_stateless_flag {
+  service_name=$1
+  flag=$2
+  value=false  # stateful
+  override_file=/var/opt/magma/configs/$service_name.yml
+  if [[ $service_name == "pipelined" ]]; then
+    value=true # pipelined has a reverse logic compared to other services
+  fi
+
+  # check if stateless_flag config exists in override file
+  if grep -s -q "$flag" "$override_file"; then
+    if grep -q "$flag: $value" "$override_file"; then
+      return $RETURN_STATEFUL
+    else
+      return $RETURN_STATELESS
+    fi
+  fi
+
+  # check in regular file
+  if grep -q "$flag: $value" /etc/magma/"$service_name".yml; then
+    return $RETURN_STATEFUL
+  else
+    return $RETURN_STATELESS
+  fi
+}
+
+function enable_stateless_flag {
+  service_name=$1
+  flag=$2
+  value=$3
+  override_file=/var/opt/magma/configs/$service_name.yml
+
+  # check if override file exists
+  if [ ! -f "$override_file" ]; then
+    sudo mkdir -p /var/opt/magma/configs && touch "$override_file"
+  fi
+
+  # check if the setting exists and set the correct value
+  if ! grep -q "$flag" "$override_file"; then
+    echo "$flag: $value" >> "$override_file"
+  elif ! grep -q "$flag: $value" "$override_file"; then
+    sed -e "/$flag/ s/.*/$flag:\ $value/" -i "$override_file"
+  fi
+}
+
+function disable_stateless_flag {
+  service_name=$1
+  flag=$2
+  override_file=/var/opt/magma/configs/$service_name.yml
+
+  # check if override file exists
+  if [ -f "$override_file" ]; then
+    # remove the stateless config override as default is always stateful
+    sed -i "/$flag/d" "$override_file"
+
+    # delete override file if it is empty
+    if [ ! -s "$override_file" ]; then
+      sudo rm -f "$override_file"
+    fi
+  fi
+}

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_utils.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_utils.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+RETURN_STATELESS=0
+RETURN_STATEFUL=1
+
+function check_systemd_file {
+  service_name=$1
+  dep_service_name=$2
+  systemd_file=/lib/systemd/system/"$dep_service_name".service
+  override_file=/etc/systemd/system/"$dep_service_name".service
+  if [ -f "$override_file" ]; then
+    systemd_file=$override_file
+  fi
+
+  if grep -q "^ *PartOf=$service_name" "$systemd_file"; then
+    echo "The $dep_service_name service will restart with $service_name," \
+      "i.e. stateful."
+    exit $RETURN_STATEFUL
+  else
+    return $RETURN_STATELESS
+  fi
+}
+
+function add_systemd_override {
+  service_name=$1
+  dep_service_name=$2
+  # create override systemd service file, if it does not exist
+  sudo /bin/cp -n /lib/systemd/system/"$dep_service_name".service \
+    /etc/systemd/system/"$dep_service_name".service
+  sudo sed -e "/PartOf=$service_name/ s/^#*/#/" -i \
+    /etc/systemd/system/"$dep_service_name".service
+}
+
+function remove_systemd_override {
+  dep_service_name=$1
+  sudo rm -f /etc/systemd/system/"$dep_service_name".service
+}

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Copy magma service files
   copy:
     src: "systemd/magma_{{ item }}.service"
-    dest: "/etc/systemd/system/magma@{{ item }}.service"
+    dest: "/lib/systemd/system/magma@{{ item }}.service"
   with_items:
     # Magma Python services
     - magmad
@@ -34,7 +34,7 @@
 - name: Copy sctpd service file
   copy:
     src: systemd/sctpd.service
-    dest: /etc/systemd/system/sctpd.service
+    dest: /lib/systemd/system/sctpd.service
   when: full_provision
 
 - name: Copy logrotate config file
@@ -75,6 +75,7 @@
     - pipelined
     - sctpd
     - sessiond
+    - utils
 
 - name: Create symlink for sctpd binary
   file: src='{{ c_build }}/sctpd/sctpd' path=/usr/local/sbin/sctpd state=link force=yes follow=no

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -286,7 +286,7 @@ BUILDCMD="fpm \
 --exclude '*/.ignoreme' \
 ${SCTPD_BUILD}/sctpd=/usr/local/sbin/ \
 ${SCTPD_VERSION_FILE}=/usr/local/share/sctpd/version \
-$(glob_files "${SERVICE_DIR}/sctpd.service" /etc/systemd/system/sctpd.service)"
+$(glob_files "${SERVICE_DIR}/sctpd.service" /lib/systemd/system/sctpd.service)"
 
 eval "$BUILDCMD"
 
@@ -309,18 +309,18 @@ ${SYSTEM_DEPS} \
 ${OAI_BUILD}/oai_mme/mme=/usr/local/bin/ \
 ${SESSIOND_BUILD}/sessiond=/usr/local/bin/ \
 ${SCTPD_MIN_VERSION_FILE}=/usr/local/share/magma/sctpd_min_version \
-$(glob_files "${SERVICE_DIR}/magma@.service" /etc/systemd/system/magma@.service) \
-$(glob_files "${SERVICE_DIR}/magma@control_proxy.service" /etc/systemd/system/magma@control_proxy.service) \
-$(glob_files "${SERVICE_DIR}/magma@magmad.service" /etc/systemd/system/magma@magmad.service) \
-$(glob_files "${SERVICE_DIR}/magma@mme.service" /etc/systemd/system/magma@mme.service) \
-$(glob_files "${SERVICE_DIR}/magma@sessiond.service" /etc/systemd/system/magma@sessiond.service) \
-$(glob_files "${SERVICE_DIR}/magma@mobilityd.service" /etc/systemd/system/magma@mobilityd.service) \
-$(glob_files "${SERVICE_DIR}/magma@pipelined.service" /etc/systemd/system/magma@pipelined.service) \
-$(glob_files "${SERVICE_DIR}/magma@redirectd.service" /etc/systemd/system/magma@redirectd.service) \
-$(glob_files "${SERVICE_DIR}/magma@dnsd.service" /etc/systemd/system/magma@dnsd.service) \
-$(glob_files "${SERVICE_DIR}/magma@lighttpd.service" /etc/systemd/system/magma@lighttpd.service) \
-$(glob_files "${SERVICE_DIR}/magma@redis.service" /etc/systemd/system/magma@redis.service) \
-$(glob_files "${SERVICE_DIR}/magma@td-agent-bit.service" /etc/systemd/system/magma@td-agent-bit.service) \
+$(glob_files "${SERVICE_DIR}/magma@.service" /lib/systemd/system/magma@.service) \
+$(glob_files "${SERVICE_DIR}/magma@control_proxy.service" /lib/systemd/system/magma@control_proxy.service) \
+$(glob_files "${SERVICE_DIR}/magma@magmad.service" /lib/systemd/system/magma@magmad.service) \
+$(glob_files "${SERVICE_DIR}/magma@mme.service" /lib/systemd/system/magma@mme.service) \
+$(glob_files "${SERVICE_DIR}/magma@sessiond.service" /lib/systemd/system/magma@sessiond.service) \
+$(glob_files "${SERVICE_DIR}/magma@mobilityd.service" /lib/systemd/system/magma@mobilityd.service) \
+$(glob_files "${SERVICE_DIR}/magma@pipelined.service" /lib/systemd/system/magma@pipelined.service) \
+$(glob_files "${SERVICE_DIR}/magma@redirectd.service" /lib/systemd/system/magma@redirectd.service) \
+$(glob_files "${SERVICE_DIR}/magma@dnsd.service" /lib/systemd/system/magma@dnsd.service) \
+$(glob_files "${SERVICE_DIR}/magma@lighttpd.service" /lib/systemd/system/magma@lighttpd.service) \
+$(glob_files "${SERVICE_DIR}/magma@redis.service" /lib/systemd/system/magma@redis.service) \
+$(glob_files "${SERVICE_DIR}/magma@td-agent-bit.service" /lib/systemd/system/magma@td-agent-bit.service) \
 ${CERT_FILE}=/var/opt/magma/certs/rootCA.pem \
 $(glob_files "${MAGMA_ROOT}/lte/gateway/configs/!(control_proxy.yml|pipelined.yml|sessiond.yml)" /etc/magma/) \
 $(glob_files "${MAGMA_ROOT}/lte/gateway/configs/pipelined.yml_prod" /etc/magma/pipelined.yml) \

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -259,7 +259,7 @@ if [ -f ${BUILD_PATH} ]; then
   rm ${BUILD_PATH}
 fi
 
-SERVICE_DIR="/etc/systemd/system/"
+SERVICE_DIR="/lib/systemd/system/"
 ANSIBLE_FILES="${MAGMA_ROOT}/lte/gateway/deploy/roles/magma/files"
 
 SCTPD_VERSION_FILE=$(mktemp)


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The current scripts to configure stateless AGW mode edit the Yaml configs in /etc/magma, which is overwritten at the time of software upgrade. This change adds the stateless config as an override Yaml config in /var/opt/magma/configs/ by:
- Adding new utility functions to check/enable/disable stateless flag in config_stateless_utils.sh
- Modifying the check/enable/disable logic in config_stateless_<service>.sh for mme, mobilityd, pipelined and sessiond services

## Test Plan

- Feature agw_of: tested with S1AP integration tests
- Feature mme: to be tested in Jenkins CI pipeline
