### PR TITLE
[orc8r] Copy labels explicitly to avoid rare overwriting in metric conversion to gauges

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -56,7 +56,6 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -29,13 +29,8 @@ module magma/cwf/k8s/cwf_operator
 go 1.13
 
 require (
-	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/go-logr/glogr v0.1.0
 	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/hashicorp/go-msgpack v0.5.4 // indirect
-	github.com/hashicorp/go-uuid v1.0.1 // indirect
-	github.com/miekg/dns v1.1.10 // indirect
-	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,7 +15,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -20,6 +20,7 @@ replace (
 require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73
+	github.com/davecgh/go-spew v1.1.1
 	github.com/emakeev/snowflake v0.0.0-20200206205012-767080b052fe
 	github.com/facebookincubator/ent v0.0.0-20191128071424-29c7b0a0d805
 	github.com/facebookincubator/prometheus-configmanager v0.0.0-20200717220759-a8282767b087


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>


## Summary
I'll be honest I really don't know why this is necessary.
* While testing getting new stats from AGWs, I noticed summaries from the AGW were only coming through with the {quantile="1"} metric (while there were 4 other quantiles)
* It seemed like a pretty clear issue of pointers being overwritten in a loop in `gaugeconverter.go`, although I still don't really know how that was happening
* What's even weirder is that this was only happening on metrics from the AGW, and there were quite a few summaries that originated in the cloud where this error never occurred (basically identical metrics too)
* EVEN weirder is that I cannot replicate this in tests
* I fixed the problem by just messing around until something worked and now it works so I give up trying to understand

## Test Plan
* Test by pushing a summary through the pipeline, all expected labels show up.
* No other metrics were affected
![image](https://user-images.githubusercontent.com/13274915/92664417-ca4a6980-f2b8-11ea-972e-c981ba487cc2.png)
