### PR TITLE
[orc8r][policydb] Fix policydb streamer bug for dangling QoS profiles

### DIFF
--- a/lte/cloud/go/services/policydb/streamer/providers.go
+++ b/lte/cloud/go/services/policydb/streamer/providers.go
@@ -124,13 +124,13 @@ func loadQosProfiles(networkID string) (map[string]configurator.NetworkEntity, e
 		return nil, err
 	}
 
+	// Select all attached QoS profiles
 	byPolicyID := map[string]configurator.NetworkEntity{}
 	for _, prof := range profiles {
 		tk, err := prof.ParentAssociations.GetFirst(lte.PolicyRuleEntityType)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			byPolicyID[tk.Key] = prof
 		}
-		byPolicyID[tk.Key] = prof
 	}
 
 	return byPolicyID, nil

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -121,12 +121,22 @@ func TestPolicyStreamers(t *testing.T) {
 
 	// create the rules first otherwise base names can't associate to them
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
+		// Attached qos profile
 		{
 			Type: lte.PolicyQoSProfileEntityType,
 			Key:  "p1",
 			Config: &models.PolicyQosProfile{
 				ClassID: 42,
 				ID:      "p1",
+			},
+		},
+		// Dangling qos profile
+		{
+			Type: lte.PolicyQoSProfileEntityType,
+			Key:  "p2",
+			Config: &models.PolicyQosProfile{
+				ClassID: 420,
+				ID:      "p2",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Policydb streaming would fail when there was a dangling policy_qos_profile. This is incorrect behavior, as we allow dangling QoS profiles (profiles with no attached policy rule).

This PR adds a regression test and fixes the bug.

## Test Plan

- [x] make test with updated (regression) test

## Additional Information

- [ ] This change is backwards-breaking