### PR TITLE
[nms][lte] Adding Subscribers dashboard with UE data traffic panels on Grafana

### DIFF
--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
@@ -72,12 +72,12 @@ async function getDatasets(props: DatasetFetchProps) {
 
   const queries = [
     {
-      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+      q: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
       color: colors.secondary.dodgerBlue,
       label: 'download',
     },
     {
-      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="up"}[${step}]))`,
+      q: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="up"}[${step}]))`,
       color: colors.data.flamePea,
       label: 'upload',
     },
@@ -156,7 +156,7 @@ function SubscriberDataKPI() {
           const result = await MagmaV1API.getNetworksByNetworkIdPrometheusQuery(
             {
               networkId,
-              query: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+              query: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
             },
           );
           const [value, unit] = getLabelUnit(getPromValue(result));

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
@@ -72,12 +72,12 @@ async function getDatasets(props: DatasetFetchProps) {
 
   const queries = [
     {
-      q: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
       color: colors.secondary.dodgerBlue,
       label: 'download',
     },
     {
-      q: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="up"}[${step}]))`,
+      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="up"}[${step}]))`,
       color: colors.data.flamePea,
       label: 'upload',
     },
@@ -156,7 +156,7 @@ function SubscriberDataKPI() {
           const result = await MagmaV1API.getNetworksByNetworkIdPrometheusQuery(
             {
               networkId,
-              query: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+              query: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
             },
           );
           const [value, unit] = getLabelUnit(getPromValue(result));

--- a/nms/app/packages/magmalte/grafana/dashboards/AnalyticsDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/AnalyticsDashboards.js
@@ -14,8 +14,7 @@
  * @format
  */
 
-import {apnTemplate} from './CWFDashboards';
-import {getNetworkTemplate} from './Dashboards';
+import {apnTemplate, getNetworkTemplate} from './Dashboards';
 import type {GrafanaDBData} from './Dashboards';
 
 export const AnalyticsDBData = (networkIDs: Array<string>): GrafanaDBData => {

--- a/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
@@ -18,24 +18,10 @@ import {
   gatewayTemplate,
   getNetworkTemplate,
   variableTemplate,
+  apnTemplate,
+  msisdnTemplate,
 } from './Dashboards';
 import type {GrafanaDBData} from './Dashboards';
-
-const msisdnTemplate = variableTemplate({
-  name: 'msisdn',
-  query: `label_values(msisdn)`,
-  regex: `/.+/`,
-  sort: 'num-asc',
-  includeAll: false,
-});
-
-export const apnTemplate = variableTemplate({
-  name: 'apn',
-  query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
-  regex: `/.+/`,
-  sort: 'alpha-insensitive-asc',
-  includeAll: true,
-});
 
 const dbDescription =
   'Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.';

--- a/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
@@ -15,10 +15,9 @@
  */
 
 import {
+  apnTemplate,
   gatewayTemplate,
   getNetworkTemplate,
-  variableTemplate,
-  apnTemplate,
   msisdnTemplate,
 } from './Dashboards';
 import type {GrafanaDBData} from './Dashboards';

--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -342,7 +342,7 @@ export const SubscriberDBData: GrafanaDBData = {
   title: 'Subscribers',
   description:
     'Metrics relevant to subscribers. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
-  templates: [networkTemplate, imsiTemplate, apnTemplate, msisdnTemplate],
+  templates: [networkTemplate, msisdnTemplate],
   rows: [
     {
       title: '',
@@ -352,7 +352,7 @@ export const SubscriberDBData: GrafanaDBData = {
           targets: [
             {
               expr:
-                'sum(ue_reported_usage{IMSI=~"$imsi", direction="down"}) by (IMSI, apn, msisdn)',
+                'sum(ue_reported_usage{msisdn=~"$msisdn", direction="down"}) by (IMSI, apn, msisdn)',
               legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
             },
           ],
@@ -364,7 +364,7 @@ export const SubscriberDBData: GrafanaDBData = {
           targets: [
             {
               expr:
-                'sum(ue_reported_usage{IMSI=~"$imsi", direction="up"}) by (IMSI, apn, msisdn)',
+                'sum(ue_reported_usage{msisdn=~"$msisdn", direction="up"}) by (IMSI, apn, msisdn)',
               legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
             },
           ],
@@ -376,7 +376,7 @@ export const SubscriberDBData: GrafanaDBData = {
           targets: [
             {
               expr:
-                'avg(rate(ue_reported_usage{IMSI=~"$imsi", direction="down"}[5m])) by (IMSI, apn, msisdn)',
+                'avg(rate(ue_reported_usage{msisdn=~"$msisdn", direction="down"}[5m])) by (IMSI, apn, msisdn)',
               legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
             },
           ],
@@ -389,7 +389,7 @@ export const SubscriberDBData: GrafanaDBData = {
           targets: [
             {
               expr:
-                'avg(rate(ue_reported_usage{IMSI=~"$imsi", direction="up"}[5m])) by (IMSI, apn, msisdn)',
+                'avg(rate(ue_reported_usage{msisdn=~"$msisdn", direction="up"}[5m])) by (IMSI, apn, msisdn)',
               legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
             },
           ],

--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -55,6 +55,22 @@ export const gatewayTemplate: TemplateConfig = variableTemplate({
   includeAll: true,
 });
 
+export const imsiTemplate = variableTemplate({
+  labelName: 'imsi',
+  query: `label_values({networkID=~"$networkID",IMSI=~".+"}, IMSI)`,
+  regex: `/.+/`,
+  sort: 'alpha-insensitive-asc',
+  includeAll: true,
+});
+
+export const apnTemplate = variableTemplate({
+  labelName: 'apn',
+  query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
+  regex: `/.+/`,
+  sort: 'alpha-insensitive-asc',
+  includeAll: true,
+});
+
 export const NetworkDBData = (networkIDs: Array<string>): GrafanaDBData => {
   return {
     title: 'Networks',
@@ -313,6 +329,69 @@ export const GatewayDBData = (networkIDs: Array<string>): GrafanaDBData => {
       },
     ],
   };
+
+export const SubscriberDBData: GrafanaDBData = {
+  title: 'Subscribers',
+  description:
+    'Metrics relevant to subscribers. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
+  templates: [networkTemplate, imsiTemplate, apnTemplate],
+  rows: [
+    {
+      title: '',
+      panels: [
+        {
+          title: 'UE Data Usage In',
+          targets: [
+            {
+              expr:
+                'sum(ue_reported_usage{IMSI=~"$imsi", direction="down"}) by (IMSI, apn, msisdn)',
+              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+            },
+          ],
+          unit: 'decbytes',
+          description: 'Inbound data per subscriber measured in bytes.',
+        },
+        {
+          title: 'UE Data Usage Out',
+          targets: [
+            {
+              expr:
+                'sum(ue_reported_usage{IMSI=~"$imsi", direction="up"}) by (IMSI, apn, msisdn)',
+              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+            },
+          ],
+          unit: 'decbytes',
+          description: 'Outbound data per subscriber measured in bytes.',
+        },
+        {
+          title: 'Throughput In',
+          targets: [
+            {
+              expr:
+                'avg(rate(ue_reported_usage{IMSI=~"$imsi", direction="down"}[5m])) by (IMSI, apn, msisdn)',
+              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+            },
+          ],
+          unit: 'Bps',
+          description:
+            'Inbound data rate per subscriber measured in bytes/second.',
+        },
+        {
+          title: 'Throughput Out',
+          targets: [
+            {
+              expr:
+                'avg(rate(ue_reported_usage{IMSI=~"$imsi", direction="up"}[5m])) by (IMSI, apn, msisdn)',
+              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+            },
+          ],
+          unit: 'Bps',
+          description:
+            'Outbound data rate per subscriber measured in bytes/second.',
+        },
+      ],
+    },
+  ],
 };
 
 export const InternalDBData = (networkIDs: Array<string>): GrafanaDBData => {

--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -55,16 +55,8 @@ export const gatewayTemplate: TemplateConfig = variableTemplate({
   includeAll: true,
 });
 
-export const imsiTemplate = variableTemplate({
-  labelName: 'imsi',
-  query: `label_values({networkID=~"$networkID",IMSI=~".+"}, IMSI)`,
-  regex: `/.+/`,
-  sort: 'alpha-insensitive-asc',
-  includeAll: true,
-});
-
 export const msisdnTemplate = variableTemplate({
-  labelName: 'msisdn',
+  name: 'msisdn',
   query: `label_values(msisdn)`,
   regex: `/.+/`,
   sort: 'num-asc',
@@ -72,7 +64,7 @@ export const msisdnTemplate = variableTemplate({
 });
 
 export const apnTemplate = variableTemplate({
-  labelName: 'apn',
+  name: 'apn',
   query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
   regex: `/.+/`,
   sort: 'alpha-insensitive-asc',
@@ -337,69 +329,72 @@ export const GatewayDBData = (networkIDs: Array<string>): GrafanaDBData => {
       },
     ],
   };
+};
 
-export const SubscriberDBData: GrafanaDBData = {
-  title: 'Subscribers',
-  description:
-    'Metrics relevant to subscribers. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
-  templates: [networkTemplate, msisdnTemplate],
-  rows: [
-    {
-      title: '',
-      panels: [
-        {
-          title: 'UE Data Usage In',
-          targets: [
-            {
-              expr:
-                'sum(ue_reported_usage{msisdn=~"$msisdn", direction="down"}) by (IMSI, apn, msisdn)',
-              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
-            },
-          ],
-          unit: 'decbytes',
-          description: 'Inbound data per subscriber measured in bytes.',
-        },
-        {
-          title: 'UE Data Usage Out',
-          targets: [
-            {
-              expr:
-                'sum(ue_reported_usage{msisdn=~"$msisdn", direction="up"}) by (IMSI, apn, msisdn)',
-              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
-            },
-          ],
-          unit: 'decbytes',
-          description: 'Outbound data per subscriber measured in bytes.',
-        },
-        {
-          title: 'Throughput In',
-          targets: [
-            {
-              expr:
-                'avg(rate(ue_reported_usage{msisdn=~"$msisdn", direction="down"}[5m])) by (IMSI, apn, msisdn)',
-              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
-            },
-          ],
-          unit: 'Bps',
-          description:
-            'Inbound data rate per subscriber measured in bytes/second.',
-        },
-        {
-          title: 'Throughput Out',
-          targets: [
-            {
-              expr:
-                'avg(rate(ue_reported_usage{msisdn=~"$msisdn", direction="up"}[5m])) by (IMSI, apn, msisdn)',
-              legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
-            },
-          ],
-          unit: 'Bps',
-          description:
-            'Outbound data rate per subscriber measured in bytes/second.',
-        },
-      ],
-    },
-  ],
+export const SubscriberDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'Subscribers',
+    description:
+      'Metrics relevant to subscribers. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
+    templates: [getNetworkTemplate(networkIDs), msisdnTemplate],
+    rows: [
+      {
+        title: '',
+        panels: [
+          {
+            title: 'UE Data Usage In',
+            targets: [
+              {
+                expr:
+                  'sum(ue_reported_usage{msisdn=~"$msisdn", direction="down"}) by (IMSI, apn, msisdn)',
+                legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+              },
+            ],
+            unit: 'decbytes',
+            description: 'Inbound data per subscriber measured in bytes.',
+          },
+          {
+            title: 'UE Data Usage Out',
+            targets: [
+              {
+                expr:
+                  'sum(ue_reported_usage{msisdn=~"$msisdn", direction="up"}) by (IMSI, apn, msisdn)',
+                legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+              },
+            ],
+            unit: 'decbytes',
+            description: 'Outbound data per subscriber measured in bytes.',
+          },
+          {
+            title: 'Throughput In',
+            targets: [
+              {
+                expr:
+                  'avg(rate(ue_reported_usage{msisdn=~"$msisdn", direction="down"}[5m])) by (IMSI, apn, msisdn)',
+                legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+              },
+            ],
+            unit: 'Bps',
+            description:
+              'Inbound data rate per subscriber measured in bytes/second.',
+          },
+          {
+            title: 'Throughput Out',
+            targets: [
+              {
+                expr:
+                  'avg(rate(ue_reported_usage{msisdn=~"$msisdn", direction="up"}[5m])) by (IMSI, apn, msisdn)',
+                legendFormat: '{{IMSI}}, MSISDN: {{msisdn}}, APN: {{apn}}',
+              },
+            ],
+            unit: 'Bps',
+            description:
+              'Outbound data rate per subscriber measured in bytes/second.',
+          },
+        ],
+      },
+    ],
+  };
 };
 
 export const InternalDBData = (networkIDs: Array<string>): GrafanaDBData => {

--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -63,6 +63,14 @@ export const imsiTemplate = variableTemplate({
   includeAll: true,
 });
 
+export const msisdnTemplate = variableTemplate({
+  labelName: 'msisdn',
+  query: `label_values(msisdn)`,
+  regex: `/.+/`,
+  sort: 'num-asc',
+  includeAll: false,
+});
+
 export const apnTemplate = variableTemplate({
   labelName: 'apn',
   query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
@@ -334,7 +342,7 @@ export const SubscriberDBData: GrafanaDBData = {
   title: 'Subscribers',
   description:
     'Metrics relevant to subscribers. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
-  templates: [networkTemplate, imsiTemplate, apnTemplate],
+  templates: [networkTemplate, imsiTemplate, apnTemplate, msisdnTemplate],
   rows: [
     {
       title: '',

--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -483,17 +483,10 @@ export async function syncDashboards(
 
   // Basic dashboards
   const posts = [
-<<<<<<< HEAD
     dashboardData(createDashboard(NetworkDBData(networks)).generate()),
     dashboardData(createDashboard(GatewayDBData(networks)).generate()),
     dashboardData(createDashboard(InternalDBData(networks)).generate()),
-=======
-    dashboardData(createDashboard(NetworkDBData).generate()),
-    dashboardData(createDashboard(GatewayDBData).generate()),
-    dashboardData(createDashboard(SubscriberDBData).generate()),
-    dashboardData(createDashboard(InternalDBData).generate()),
-    dashboardData(createDashboard(TemplateDBData).generate()),
->>>>>>> Adding Subscribers dashboard with UE data traffic panels on Grafana
+    dashboardData(createDashboard(SubscriberDBData(networks)).generate()),
   ];
 
   // If an org contains CWF networks, add the CWF-specific dashboards

--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -28,6 +28,7 @@ import {
   GatewayDBData,
   InternalDBData,
   NetworkDBData,
+  SubscriberDBData,
   createDashboard,
 } from './dashboards/Dashboards';
 import {Organization} from '@fbcnms/sequelize-models';
@@ -482,9 +483,17 @@ export async function syncDashboards(
 
   // Basic dashboards
   const posts = [
+<<<<<<< HEAD
     dashboardData(createDashboard(NetworkDBData(networks)).generate()),
     dashboardData(createDashboard(GatewayDBData(networks)).generate()),
     dashboardData(createDashboard(InternalDBData(networks)).generate()),
+=======
+    dashboardData(createDashboard(NetworkDBData).generate()),
+    dashboardData(createDashboard(GatewayDBData).generate()),
+    dashboardData(createDashboard(SubscriberDBData).generate()),
+    dashboardData(createDashboard(InternalDBData).generate()),
+    dashboardData(createDashboard(TemplateDBData).generate()),
+>>>>>>> Adding Subscribers dashboard with UE data traffic panels on Grafana
   ];
 
   // If an org contains CWF networks, add the CWF-specific dashboards


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Adding Subscribers dashboard for FWA
- Including Data in / out, Throughput in / out, labeled by imsi, apn and msisdn
- Adding template for imsi, apn to filter by this label

## Test Plan

- Running local setup with NMS, Orc8r and enb with UE to validate metrics display correctly

![image](https://user-images.githubusercontent.com/6800940/92790498-acd0da80-f360-11ea-975d-512f772e91c5.png)


## Additional Information

- [ ] This change is backwards-breaking
