### PR TITLE
[AGW] inject ovs and oai-gtp as magma  dep

### DIFF
--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -4,10 +4,11 @@ ovs_version: "v2.8.9"
 packages:
   - "oai-gtp_4.9-5_amd64.deb"
   - "libopenvswitch_2.8.9-1_amd64.deb"
-  - "openvswitch-datapath-dkms_2.8.9-1_all.deb"
+  - "openvswitch-datapath-module-4.9.0-9-amd64_2.8.9-1_amd64.deb"
   - "openvswitch-datapath-source_2.8.9-1_all.deb"
   - "openvswitch-common_2.8.9-1_amd64.deb"
   - "openvswitch-switch_2.8.9-1_amd64.deb"
+  - "python-openvswitch_2.8.9-1_all.deb"
 
 private_package: "deb http://packages.magma.etagecom.io stretch-test main"
 source_name: "packages_magma_etagecom_io"

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -126,11 +126,17 @@ OAI_DEPS=(
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
+    "oai-gtp >= 4.9.5"
     )
 
 # OVS runtime dependencies
 OVS_DEPS=(
     "magma-libfluid >= 0.1.0.4"
+    "openvswitch-common >= 2.8.9"
+    "libopenvswitch >= 2.8.9"
+    "openvswitch-switch >= 2.8.9"
+    "openvswitch-datapath-source-4.9.0-9 >= 2.8.9"
+    "openvswitch-datapath-dkms >= 2.8.9"
     )
 
 # generate string for FPM


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

## Summary

Inject ovs and oai-gtp as magma  dep

## Test Plan

2 scenarios :
 - Brand new install: `sh agw_install.sh`
 - On v1.1 install: `apt-get -f install magma`

## Additional Information

- [ ] This change is backwards-breaking
