### PR TITLE
[agw] Add prometheus target scraping to magmad

### DIFF
--- a/orc8r/gateway/configs/magmad.yml
+++ b/orc8r/gateway/configs/magmad.yml
@@ -68,6 +68,17 @@ metricsd:
   services:
     - magmad
 
+  # List of prometheus scrape targets (not magma services) to poll
+  #  url: url of the metrics source
+  #  name: name to tag metrics with {scrape_target=<name>}
+  #  interval: time (in seconds) between scrapes
+  #
+  # Example:
+  # metric_scrape_targets:
+  #   - url: http://localhost:9091/metrics
+  #     name: node_exporter
+  #     interval: 5
+
 generic_command_config:
   module: magma.magmad.generic_command.shell_command_executor
   class: ShellCommandExecutor

--- a/orc8r/gateway/python/magma/magmad/main.py
+++ b/orc8r/gateway/python/magma/magmad/main.py
@@ -31,7 +31,7 @@ from .bootstrap_manager import BootstrapManager
 from .config_manager import CONFIG_STREAM_NAME, ConfigManager
 from .gateway_status import GatewayStatusFactory, KernelVersionsPoller
 from .metrics import metrics_collection_loop, monitor_unattended_upgrade_status
-from .metrics_collector import MetricsCollector
+from .metrics_collector import MetricsCollector, ScrapeTarget
 from .rpc_servicer import MagmadRpcServicer
 from .service_manager import ServiceManager
 from .service_poller import ServicePoller
@@ -76,6 +76,10 @@ def main():
     queue_length = metrics_config['queue_length']
     metrics_post_processor_fn = metrics_config.get('post_processing_fn')
 
+    metric_scrape_targets = map(lambda x: ScrapeTarget(x['url'], x['name'],
+                                                       x['interval']),
+                                metrics_config.get('metric_scrape_targets', []))
+
     # Create local metrics collector
     metrics_collector = MetricsCollector(
         services=metrics_services,
@@ -87,6 +91,7 @@ def main():
         loop=service.loop,
         post_processing_fn=
         get_metrics_postprocessor_fn(metrics_post_processor_fn),
+        scrape_targets=metric_scrape_targets
     )
 
     # Poll and sync the metrics collector loops

--- a/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
+++ b/orc8r/gateway/python/magma/magmad/tests/collector_tests.py
@@ -16,15 +16,19 @@ import time
 import unittest
 import unittest.mock
 
+import prometheus_client
+import metrics_pb2
 from magma.common.service_registry import ServiceRegistry
 from magma.magmad.metrics_collector import MetricsCollector
 from metrics_pb2 import Metric, MetricFamily
 from orc8r.protos import metricsd_pb2
 from orc8r.protos.metricsd_pb2 import MetricsContainer
 
-
 # Allow access to protected variables for unit testing
 # pylint: disable=protected-access
+from magma.magmad.metrics_collector import \
+    _counter_to_proto, _summary_to_proto, _gauge_to_proto, _untyped_to_proto, \
+    _histogram_to_proto
 
 
 class MockFuture(object):
@@ -58,8 +62,8 @@ class MetricsCollectorTests(unittest.TestCase):
     def setUp(self):
         ServiceRegistry.add_service('test', '0.0.0.0', 0)
         ServiceRegistry._PROXY_CONFIG = {'local_port': 1234,
-                'cloud_address': 'test',
-                'proxy_cloud_connections': True}
+                                         'cloud_address': 'test',
+                                         'proxy_cloud_connections': True}
 
         self._services = ['test']
         self.gateway_id = "2876171d-bf38-4254-b4da-71a713952904"
@@ -171,8 +175,159 @@ class MetricsCollectorTests(unittest.TestCase):
         mock.exception.side_effect = [False]
         try:
             self._collector.collect_done('test', mock)
-        except Exception:   # pylint: disable=broad-except
+        except Exception:  # pylint: disable=broad-except
             self.fail("Collection with empty metric should not have failed")
+
+    def test_counter_to_proto(self):
+        test_counter = prometheus_client.core.CounterMetricFamily(
+            "test",
+            "",
+            labels=["testLabel"],
+        )
+        test_counter.add_metric(["val"], 1.23)
+        test_counter.add_metric(["val2"], 2.34)
+
+        proto = _counter_to_proto(test_counter)
+        self.assertEqual(proto.name, test_counter.name)
+        self.assertEqual(proto.type, metrics_pb2.COUNTER)
+
+        self.assertEqual(2, len(proto.metric))
+        self.assertEqual("val", proto.metric[0].label[0].value)
+        self.assertEqual(1.23, proto.metric[0].counter.value)
+        self.assertEqual("val2", proto.metric[1].label[0].value)
+        self.assertEqual(2.34, proto.metric[1].counter.value)
+
+    def test_gauge_to_proto(self):
+        test_gauge = prometheus_client.core.GaugeMetricFamily(
+            "test",
+            "",
+            labels=["testLabel"],
+        )
+        test_gauge.add_metric(["val"], 1.23)
+        test_gauge.add_metric(["val2"], 2.34)
+
+        proto = _gauge_to_proto(test_gauge)
+        self.assertEqual(proto.name, test_gauge.name)
+        self.assertEqual(proto.type, metrics_pb2.GAUGE)
+
+        self.assertEqual(2, len(proto.metric))
+        self.assertEqual("val", proto.metric[0].label[0].value)
+        self.assertEqual(1.23, proto.metric[0].gauge.value)
+        self.assertEqual("val2", proto.metric[1].label[0].value)
+        self.assertEqual(2.34, proto.metric[1].gauge.value)
+
+    def test_untyped_to_proto(self):
+        test_untyped = prometheus_client.core.UntypedMetricFamily(
+            "test",
+            "",
+            labels=["testLabel"],
+        )
+        test_untyped.add_metric(["val"], 1.23)
+        test_untyped.add_metric(["val2"], 2.34)
+
+        proto = _untyped_to_proto(test_untyped)
+        self.assertEqual(proto.name, test_untyped.name)
+        self.assertEqual(proto.type, metrics_pb2.UNTYPED)
+
+        self.assertEqual(2, len(proto.metric))
+        self.assertEqual("val", proto.metric[0].label[0].value)
+        self.assertEqual(1.23, proto.metric[0].untyped.value)
+        self.assertEqual("val2", proto.metric[1].label[0].value)
+        self.assertEqual(2.34, proto.metric[1].untyped.value)
+
+    def test_summary_to_proto(self):
+        test_summary = prometheus_client.core.SummaryMetricFamily(
+            "test",
+            "",
+            labels=["testLabel"],
+        )
+        # Add first unique labelset metrics
+        test_summary.add_metric(["val1"], 10, 0.1)
+        test_summary.add_sample("test",
+                                {"quantile": "0.0", "testLabel": "val1"}, 0.01)
+        test_summary.add_sample("test",
+                                {"quantile": "0.5", "testLabel": "val1"}, 0.02)
+        test_summary.add_sample("test",
+                                {"quantile": "1.0", "testLabel": "val1"}, 0.03)
+
+        # Add second unique labelset metrics
+        test_summary.add_metric(["val2"], 20, 0.2)
+        test_summary.add_sample("test",
+                                {"quantile": "0.0", "testLabel": "val2"}, 0.02)
+        test_summary.add_sample("test",
+                                {"quantile": "0.5", "testLabel": "val2"}, 0.04)
+        test_summary.add_sample("test",
+                                {"quantile": "1.0", "testLabel": "val2"}, 0.06)
+
+        protos = _summary_to_proto(test_summary)
+        self.assertEqual(2, len(protos))
+
+        for proto in protos:
+            self.assertEqual(proto.name, test_summary.name)
+            self.assertEqual(proto.type, metrics_pb2.SUMMARY)
+            if proto.metric[0].label[0].value == "val1":
+                self.assertEqual(1, len(proto.metric))
+                self.assertEqual(10, proto.metric[0].summary.sample_count)
+                self.assertEqual(0.1, proto.metric[0].summary.sample_sum)
+                self.assertEqual(3, len(proto.metric[0].summary.quantile))
+                self.assertEqual(0.01,
+                                 proto.metric[0].summary.quantile[0].value)
+                self.assertEqual(0.02,
+                                 proto.metric[0].summary.quantile[1].value)
+                self.assertEqual(0.03,
+                                 proto.metric[0].summary.quantile[2].value)
+            else:
+                self.assertEqual(1, len(proto.metric))
+                self.assertEqual(20, proto.metric[0].summary.sample_count)
+                self.assertEqual(0.2, proto.metric[0].summary.sample_sum)
+                self.assertEqual(3, len(proto.metric[0].summary.quantile))
+                self.assertEqual(0.02,
+                                 proto.metric[0].summary.quantile[0].value)
+                self.assertEqual(0.04,
+                                 proto.metric[0].summary.quantile[1].value)
+                self.assertEqual(0.06,
+                                 proto.metric[0].summary.quantile[2].value)
+
+    def test_histogram_to_proto(self):
+        test_hist = prometheus_client.core.HistogramMetricFamily(
+            "test",
+            "",
+            labels=["testLabel"],
+        )
+        # Add first unique labelset metrics
+        test_hist.add_metric(["val1"], [(1, 1), (10, 2), (100, 3)], 6)
+
+        # Add second unique labelset metrics
+        test_hist.add_metric(["val2"], [(1, 2), (10, 3), (100, 4)], 9)
+
+        protos = _histogram_to_proto(test_hist)
+        self.assertEqual(2, len(protos))
+
+        for proto in protos:
+            self.assertEqual(proto.name, test_hist.name)
+            self.assertEqual(proto.type, metrics_pb2.HISTOGRAM)
+            if proto.metric[0].label[0].value == "val1":
+                self.assertEqual(1, len(proto.metric))
+                self.assertEqual(3, proto.metric[0].histogram.sample_count)
+                self.assertEqual(6, proto.metric[0].histogram.sample_sum)
+                self.assertEqual(3, len(proto.metric[0].histogram.bucket))
+                self.assertEqual(1, proto.metric[0].histogram.bucket[
+                    0].cumulative_count)
+                self.assertEqual(2, proto.metric[0].histogram.bucket[
+                    1].cumulative_count)
+                self.assertEqual(3, proto.metric[0].histogram.bucket[
+                    2].cumulative_count)
+            else:
+                self.assertEqual(1, len(proto.metric))
+                self.assertEqual(4, proto.metric[0].histogram.sample_count)
+                self.assertEqual(9, proto.metric[0].histogram.sample_sum)
+                self.assertEqual(3, len(proto.metric[0].histogram.bucket))
+                self.assertEqual(2, proto.metric[0].histogram.bucket[
+                    0].cumulative_count)
+                self.assertEqual(3, proto.metric[0].histogram.bucket[
+                    1].cumulative_count)
+                self.assertEqual(4, proto.metric[0].histogram.bucket[
+                    2].cumulative_count)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
This adds functionality into magmad to scrape arbitrary prometheus metrics targets (http endpoints that expose metrics in the prometheus text exposition format)
* The prometheus python client parser does not support parsing into protobuf types, so the majority of the code here is just handling that conversion + unit tests for all of it
* Scrape targets are configured in the `magmad.yml` file with url, name, and scrape interval

## Test Plan
* Unit tests to test conversion on python client type to protobuf
* Run multiple services on local gateway, see that both are scraped and metrics are sent to prometheus with correct tags:
![image](https://user-images.githubusercontent.com/13274915/92832415-77da7d00-f38c-11ea-88e2-46255b783fb8.png)
