### PR TITLE
[SessionD] FUA-Restrict Support in SessionD

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -58,16 +58,19 @@ void ChargingGrant::receive_charging_grant(
   is_final_grant = p_credit.is_final();
   if (is_final_grant) {
     final_action_info.final_action = p_credit.final_action();
-    if (p_credit.final_action() == ChargingCredit_FinalAction_REDIRECT) {
-      final_action_info.redirect_server = p_credit.redirect_server();
-    }
-    else if (p_credit.final_action() ==
-        ChargingCredit_FinalAction_RESTRICT_ACCESS) {
-      // Clear the previous restrict rules
-      final_action_info.restrict_rules.clear();
-      for (auto rule : p_credit.restrict_rules()) {
-        final_action_info.restrict_rules.push_back(rule);
-      }
+    switch (final_action_info.final_action) {
+      case ChargingCredit_FinalAction_REDIRECT:
+        final_action_info.redirect_server = p_credit.redirect_server();
+        break;
+      case ChargingCredit_FinalAction_RESTRICT_ACCESS:
+        // Clear the previous restrict rules
+        final_action_info.restrict_rules.clear();
+        for (auto rule : p_credit.restrict_rules()) {
+          final_action_info.restrict_rules.push_back(rule);
+        }
+        break;
+      default: // do nothing
+        break;
     }
     log_final_action_info();
   }
@@ -218,17 +221,21 @@ void ChargingGrant::log_final_action_info() const {
   if (is_final_grant) {
     final_action += "final action: ";
     final_action += final_action_to_str(final_action_info.final_action);
-    if (final_action_info.final_action == ChargingCredit_FinalAction_REDIRECT) {
-      final_action += ", redirect_server: ";
-      final_action +=
+    switch (final_action_info.final_action) {
+      case ChargingCredit_FinalAction_REDIRECT:
+        final_action += ", redirect_server: ";
+        final_action +=
           final_action_info.redirect_server.redirect_server_address();
-    }
-    else if (final_action_info.final_action ==
-        ChargingCredit_FinalAction_RESTRICT_ACCESS) {
-      final_action += ", restrict_rules: ";
-      for (auto rule : final_action_info.restrict_rules) {
-        final_action += rule + ", ";
-      }
+        break;
+      case ChargingCredit_FinalAction_RESTRICT_ACCESS:
+        final_action += ", restrict_rules: { ";
+        for (auto rule : final_action_info.restrict_rules) {
+          final_action += rule + " ";
+        }
+        final_action += "}";
+        break;
+      default: // do nothing;
+        break;
     }
   }
   MLOG(MINFO) << "This is a final credit, with " << final_action;

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -162,6 +162,4 @@ std::string service_action_type_to_str(ServiceActionType action) {
       return "INVALID ACTION TYPE";
   }
 }
-
-
 }  // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -145,4 +145,23 @@ std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state) {
       return "INVALID";
   }
 }
+
+std::string service_action_type_to_str(ServiceActionType action) {
+  switch (action) {
+    case CONTINUE_SERVICE:
+      return "CONTINUE_SERVICE";
+    case TERMINATE_SERVICE:
+      return "TERMINATE_SERVICE";
+    case ACTIVATE_SERVICE:
+      return "ACTIVATE_SERVICE";
+    case REDIRECT:
+      return "REDIRECT";
+    case RESTRICT_ACCESS:
+      return "RESTRICT_ACCESS";
+    default:
+      return "INVALID ACTION TYPE";
+  }
+}
+
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include "StoredState.h"
+#include "ServiceAction.h"
 
 namespace magma {
 std::string reauth_state_to_str(ReAuthState state);
@@ -30,4 +31,6 @@ std::string credit_update_type_to_str(CreditUsage::UpdateType update);
 std::string raa_result_to_str(ReAuthResult res);
 
 std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state);
+
+std::string service_action_type_to_str(ServiceActionType action);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -314,12 +314,22 @@ void LocalEnforcer::execute_actions(
         handle_activate_service_action(session_map, action_p, session_update);
         break;
       case REDIRECT:
-        // This is GY based REDIRECT, GX redirect will come in as a regular rule
-        start_redirect_flow_install(session_map, action_p, session_update);
-        break;
       case RESTRICT_ACCESS:
-        MLOG(MWARNING) << "RESTRICT_ACCESS mode is unsupported"
-                       << ", will just terminate the service.";
+        {
+          // Bundle up all info into this struct so that we don't have to pass around
+          // unique pointers
+          FinalActionInstallInfo fua_info{
+            .imsi              = action_p->get_imsi(),
+            .session_id        = action_p->get_session_id(),
+            .action_type       = action_p->get_type(),
+            .restrict_rule_ids = action_p->get_restrict_rule_ids(),
+          };
+          if (action_p->is_redirect_server_set()) {
+            fua_info.redirect_server = action_p->get_redirect_server();
+          }
+          start_final_unit_action_flows_install(session_map, fua_info, session_update);
+          break;
+        }
       case TERMINATE_SERVICE: {
         bool terminated = find_and_terminate_session(
             session_map, imsi, session_id, session_update);
@@ -523,7 +533,7 @@ static RedirectInformation_AddressType address_type_converter(
 }
 
 PolicyRule LocalEnforcer::create_redirect_rule(
-    const RedirectInstallInfo& info) {
+    const FinalActionInstallInfo& info) {
   PolicyRule redirect_rule;
   redirect_rule.set_id("redirect");
   redirect_rule.set_priority(LocalEnforcer::REDIRECT_FLOW_PRIORITY);
@@ -539,38 +549,28 @@ PolicyRule LocalEnforcer::create_redirect_rule(
   return redirect_rule;
 }
 
-void LocalEnforcer::start_redirect_flow_install(
-    SessionMap& session_map, const std::unique_ptr<ServiceAction>& action_p,
+void LocalEnforcer::start_final_unit_action_flows_install(
+    SessionMap& session_map, const FinalActionInstallInfo fua_info,
     SessionUpdate& session_update) {
-  // Bundle up all info into this struct so that we don't have to pass around
-  // unique pointers
-  RedirectInstallInfo redirect_info{
-      .imsi            = action_p->get_imsi(),
-      .session_id      = action_p->get_session_id(),
-      .redirect_server = action_p->get_redirect_server(),
-  };
-
   MLOG(MDEBUG) << "Fetching Subscriber IP address from DirectoryD for "
-               << redirect_info.session_id;
+               << fua_info.session_id;
   directoryd_client_->get_directoryd_ip_field(
-      redirect_info.imsi,
-      [this, redirect_info](Status status, DirectoryField resp) {
+      fua_info.imsi,
+      [this, fua_info](Status status, DirectoryField resp) {
         // This call back gets executed in the DirectoryD client thread, but
         // we want to run the session update logic in the main thread.
-        evb_->runInEventBaseThread([this, redirect_info, status, resp]() {
-          complete_redirect_flow_install(status, resp, redirect_info);
+        evb_->runInEventBaseThread([this, fua_info, status, resp]() {
+          complete_final_unit_action_flows_install(status, resp, fua_info);
         });
       });
 }
 
-void LocalEnforcer::complete_redirect_flow_install(
+void LocalEnforcer::complete_final_unit_action_flows_install(
     Status status, DirectoryField resp,
-    const RedirectInstallInfo redirect_info) {
+    const FinalActionInstallInfo fua_info) {
   RuleLifetime lifetime{};
-  std::vector<std::string> static_rules;
-  auto rule       = create_redirect_rule(redirect_info);
-  auto imsi       = redirect_info.imsi;
-  auto session_id = redirect_info.session_id;
+  auto imsi         = fua_info.imsi;
+  auto session_id   = fua_info.session_id;
 
   MLOG(MDEBUG) << "Received response from DirectoryD on IP addr for "
                << session_id;
@@ -589,23 +589,33 @@ void LocalEnforcer::complete_redirect_flow_install(
     return;
   }
   auto session_update = session_store_.get_default_session_update(session_map);
-
-  // check if the rule has been installed already.
   for (const auto& session : it->second) {
-    if (session->get_session_id() == session_id &&
-        !session->is_dynamic_rule_installed(rule.id())) {
-      MLOG(MDEBUG) << "Install redirect GY flow in pipelined for "
-                   << session_id;
-      pipelined_client_->add_gy_final_action_flow(
-          imsi, ip, static_rules, {rule});
-
-      auto& uc = session_update[imsi][session_id];
-      session->insert_gy_dynamic_rule(rule, lifetime, uc);
+    if (session->get_session_id() == session_id) {
+      if (fua_info.action_type == REDIRECT) {
+        // This is GY based REDIRECT, GX redirect will come in as a regular rule
+        std::vector<std::string> static_rules;
+        auto rule = create_redirect_rule(fua_info);
+        // check if the rule has been installed already.
+        if (session->is_dynamic_rule_installed(rule.id())) {
+          MLOG(MDEBUG) << "Install redirect GY flow in pipelined for "
+                     << session_id;
+          pipelined_client_->add_gy_final_action_flow(
+              imsi, ip, static_rules, {rule});
+          auto& uc = session_update[imsi][session_id];
+          session->insert_gy_dynamic_rule(rule, lifetime, uc);
+        }
+      }
+      else if (fua_info.action_type == RESTRICT_ACCESS) {
+        MLOG(MDEBUG) << "Install restricted GY flow in pipelined for "
+                     << session_id;
+        pipelined_client_->add_gy_final_action_flow(
+            imsi, ip, fua_info.restrict_rule_ids, {});
+      }
     }
   }
   auto success = session_store_.update_sessions(session_update);
   if (!success) {
-    MLOG(MERROR) << "Failed to store redirect flow update for " << session_id;
+    MLOG(MERROR) << "Failed to store final unit action flows update for " << session_id;
   }
 }
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -535,6 +535,7 @@ class LocalEnforcer {
    */
   void cancelling_final_unit_action(
       const std::unique_ptr<SessionState>& session,
+      const std::vector<std::string> &restrict_rules,
       SessionStateUpdateCriteria& uc);
 
   /**

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -228,9 +228,11 @@ class LocalEnforcer {
   static uint32_t BEARER_CREATION_DELAY_ON_SESSION_INIT;
 
  private:
-  struct RedirectInstallInfo {
+  struct FinalActionInstallInfo {
     std::string imsi;
     std::string session_id;
+    ServiceActionType action_type;
+    std::vector<std::string> restrict_rule_ids;
     magma::lte::RedirectServer redirect_server;
   };
   std::shared_ptr<SessionReporter> reporter_;
@@ -520,15 +522,16 @@ class LocalEnforcer {
   /**
    * Install flow for redirection through pipelined
    */
-  void start_redirect_flow_install(
-      SessionMap& session_map, const std::unique_ptr<ServiceAction>& action,
+  void start_final_unit_action_flows_install(
+      SessionMap& session_map, const FinalActionInstallInfo info,
       SessionUpdate& session_update);
 
-  void complete_redirect_flow_install(
+  void complete_final_unit_action_flows_install(
       Status status, DirectoryField resp,
-      const RedirectInstallInfo redirect_info);
+      const FinalActionInstallInfo info);
 
-  PolicyRule create_redirect_rule(const RedirectInstallInfo& info);
+
+  PolicyRule create_redirect_rule(const FinalActionInstallInfo& info);
 
   bool rules_to_process_is_not_empty(const RulesToProcess& rules_to_process);
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -232,7 +232,7 @@ class LocalEnforcer {
     std::string imsi;
     std::string session_id;
     ServiceActionType action_type;
-    std::vector<std::string> restrict_rule_ids;
+    std::vector<std::string> restrict_rules;
     magma::lte::RedirectServer redirect_server;
   };
   std::shared_ptr<SessionReporter> reporter_;

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -520,7 +520,7 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   /**
-   * Install flow for redirection through pipelined
+   * Install final action flows through pipelined
    */
   void start_final_unit_action_flows_install(
       SessionMap& session_map, const FinalActionInstallInfo info,
@@ -530,8 +530,25 @@ class LocalEnforcer {
       Status status, DirectoryField resp,
       const FinalActionInstallInfo info);
 
+  /**
+   * Remove final action flows through pipelined
+   */
+  void cancelling_final_unit_action(
+      const std::unique_ptr<SessionState>& session,
+      SessionStateUpdateCriteria& uc);
 
+  /**
+   * Create redirection rule
+   */
   PolicyRule create_redirect_rule(const FinalActionInstallInfo& info);
+
+  /**
+   * Populate FinalActionInstallInfo structure with all info
+   * needed to complete final action flows installation.
+   */
+  void populate_final_action_install_info(
+      FinalActionInstallInfo &info,
+      const std::unique_ptr<ServiceAction>& action);
 
   bool rules_to_process_is_not_empty(const RulesToProcess& rules_to_process);
 

--- a/lte/gateway/c/session_manager/ServiceAction.h
+++ b/lte/gateway/c/session_manager/ServiceAction.h
@@ -102,6 +102,14 @@ class ServiceAction {
     return rule_definitions_;
   }
 
+  /**
+   * get_restrict_rule_ids returns the associated restrict rules
+   * for the RESTRICT action
+   */
+  const std::vector<std::string> &get_restrict_rule_ids() const {
+    return restrict_rule_ids_;
+  }
+
   std::vector<std::string>* get_mutable_rule_ids() { return &rule_ids_; }
 
   std::vector<PolicyRule>* get_mutable_rule_definitions() {
@@ -116,6 +124,22 @@ class ServiceAction {
     return ambr_;
   }
 
+  /**
+   * get_mutable_restrict_rule_ids returns a mutable list of the associated restrict
+   * rules
+   */
+  std::vector<std::string>* get_mutable_restrict_rule_ids() {
+    return &restrict_rule_ids_;
+  }
+
+  /**
+   * is_redirect_server_set returns true if redirect server is set,
+   * false otherwise.
+   */
+  bool is_redirect_server_set() const {
+    return (redirect_server_ != NULL);
+  }
+
  private:
   ServiceActionType action_type_;
   std::unique_ptr<std::string> imsi_;
@@ -126,6 +150,7 @@ class ServiceAction {
   std::vector<PolicyRule> rule_definitions_;
   std::unique_ptr<RedirectServer> redirect_server_;
   std::experimental::optional<AggregatedMaximumBitrate> ambr_;
+  std::vector<std::string> restrict_rule_ids_;
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/ServiceAction.h
+++ b/lte/gateway/c/session_manager/ServiceAction.h
@@ -103,11 +103,11 @@ class ServiceAction {
   }
 
   /**
-   * get_restrict_rule_ids returns the associated restrict rules
+   * get_restrict_rules returns the associated restrict rules
    * for the RESTRICT action
    */
-  const std::vector<std::string> &get_restrict_rule_ids() const {
-    return restrict_rule_ids_;
+  const std::vector<std::string> &get_restrict_rules() const {
+    return restrict_rules_;
   }
 
   std::vector<std::string>* get_mutable_rule_ids() { return &rule_ids_; }
@@ -125,11 +125,11 @@ class ServiceAction {
   }
 
   /**
-   * get_mutable_restrict_rule_ids returns a mutable list of the associated restrict
+   * get_mutable_restrict_rules returns a mutable list of the associated restrict
    * rules
    */
-  std::vector<std::string>* get_mutable_restrict_rule_ids() {
-    return &restrict_rule_ids_;
+  std::vector<std::string>* get_mutable_restrict_rules() {
+    return &restrict_rules_;
   }
 
   /**
@@ -150,7 +150,7 @@ class ServiceAction {
   std::vector<PolicyRule> rule_definitions_;
   std::unique_ptr<RedirectServer> redirect_server_;
   std::experimental::optional<AggregatedMaximumBitrate> ambr_;
-  std::vector<std::string> restrict_rule_ids_;
+  std::vector<std::string> restrict_rules_;
 };
 
 } // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -871,10 +871,9 @@ bool SessionState::deactivate_static_rule(
   return true;
 }
 
-bool SessionState::clear_restrict_rules(SessionStateUpdateCriteria& update_criteria) {
+void SessionState::clear_restrict_rules(SessionStateUpdateCriteria& update_criteria) {
   restrict_rules_.clear();
   update_criteria.restrict_rules.clear();
-  return true;
 }
 
 bool SessionState::deactivate_scheduled_static_rule(
@@ -1323,14 +1322,14 @@ void SessionState::get_charging_updates(
       } break;
       case REDIRECT:
         if (grant->service_state == SERVICE_REDIRECTED) {
-          MLOG(MDEBUG) << "Redirection already activated.";
+          MLOG(MDEBUG) << "Redirection already activated for " << session_id_ ;
           continue;
         }
         grant->set_service_state(SERVICE_REDIRECTED, *credit_uc);
         action->set_redirect_server(grant->final_action_info.redirect_server);
       case RESTRICT_ACCESS: {
         if (grant->service_state == SERVICE_RESTRICTED) {
-          MLOG(MDEBUG) << "Service Restriction is already activated.";
+          MLOG(MDEBUG) << "Restriction already activated for " << session_id_;
           continue;
         }
         auto restrict_rules = action->get_mutable_restrict_rules();
@@ -1355,7 +1354,8 @@ void SessionState::get_charging_updates(
         actions_out->push_back(std::move(action));
         break;
       default:
-        MLOG(MWARNING) << "Unexpected action type " << action_type;
+        MLOG(MWARNING) << "Unexpected action type " << action_type
+                       << " for " << session_id_;
         break;
     }
   }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -367,7 +367,7 @@ class SessionState {
 
   EventTriggerStatus get_event_triggers() {return pending_event_triggers_;}
 
-  bool is_credit_state_redirected(const CreditKey &charging_key) const;
+  bool is_credit_in_final_unit_state(const CreditKey &charging_key) const;
 
   // Monitors
   bool receive_monitor(const UsageMonitoringUpdateResponse &update,

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -82,7 +82,6 @@ class SessionState {
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
     std::vector<PolicyRule> gy_dynamic_rules;
-    std::vector<std::string> restrict_rules;
     std::experimental::optional<AggregatedMaximumBitrate> ambr;
   };
   struct TotalCreditUsage {
@@ -235,7 +234,6 @@ class SessionState {
 
   bool is_static_rule_installed(const std::string& rule_id);
 
-  bool is_restrict_rule_installed(const std::string& rule_id);
   /**
    * Add a dynamic rule to the session which is currently active.
    */
@@ -251,13 +249,6 @@ class SessionState {
    * Add a static rule to the session which is currently active.
    */
   void activate_static_rule(
-      const std::string& rule_id, RuleLifetime& lifetime,
-      SessionStateUpdateCriteria& update_criteria);
-
-  /**
-   * Add a restrict rule to the session which is currently active.
-   */
-  void insert_restrict_rule(
       const std::string& rule_id, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
@@ -299,11 +290,6 @@ class SessionState {
   bool deactivate_scheduled_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
 
-  /**
-   * Remove all currently active restrict rules.
-   */
-  void clear_restrict_rules(SessionStateUpdateCriteria& update_criteria);
-
   std::vector<std::string>& get_static_rules();
 
   std::set<std::string>& get_scheduled_static_rules();
@@ -312,7 +298,6 @@ class SessionState {
 
   DynamicRuleStore& get_scheduled_dynamic_rules();
 
-  std::vector<std::string>& get_restrict_rules();
   /**
    * Schedule a dynamic rule for activation in the future.
    */
@@ -384,6 +369,9 @@ class SessionState {
   EventTriggerStatus get_event_triggers() {return pending_event_triggers_;}
 
   bool is_credit_in_final_unit_state(const CreditKey &charging_key) const;
+
+  std::vector<std::string> get_final_action_restrict_rules(
+      const CreditKey &charging_key) const;
 
   // Monitors
   bool receive_monitor(const UsageMonitoringUpdateResponse &update,
@@ -467,8 +455,6 @@ class SessionState {
   DynamicRuleStore dynamic_rules_;
   // Dynamic GY rules that are currently installed for the session
   DynamicRuleStore gy_dynamic_rules_;
-  // Restrict rules that are currently installed for the session
-  std::vector<std::string> restrict_rules_;
 
   // Static rules that are scheduled for installation for the session
   std::set<std::string> scheduled_static_rules_;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -82,6 +82,7 @@ class SessionState {
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
     std::vector<PolicyRule> gy_dynamic_rules;
+    std::vector<std::string> restrict_rules;
     std::experimental::optional<AggregatedMaximumBitrate> ambr;
   };
   struct TotalCreditUsage {
@@ -234,10 +235,15 @@ class SessionState {
 
   bool is_static_rule_installed(const std::string& rule_id);
 
+  bool is_restrict_rule_installed(const std::string& rule_id);
   /**
    * Add a dynamic rule to the session which is currently active.
    */
   void insert_dynamic_rule(
+      const PolicyRule& rule, RuleLifetime& lifetime,
+      SessionStateUpdateCriteria& update_criteria);
+
+  void insert_gy_dynamic_rule(
       const PolicyRule& rule, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
@@ -248,8 +254,11 @@ class SessionState {
       const std::string& rule_id, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
-  void insert_gy_dynamic_rule(
-      const PolicyRule& rule, RuleLifetime& lifetime,
+  /**
+   * Add a restrict rule to the session which is currently active.
+   */
+  void insert_restrict_rule(
+      const std::string& rule_id, RuleLifetime& lifetime,
       SessionStateUpdateCriteria& update_criteria);
 
   /**
@@ -270,6 +279,10 @@ class SessionState {
       const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& update_criteria);
 
+  bool remove_gy_dynamic_rule(
+      const std::string& rule_id, PolicyRule *rule_out,
+      SessionStateUpdateCriteria& update_criteria);
+
   /**
    * Remove a currently active static rule to mark it as deactivated.
    *
@@ -282,12 +295,14 @@ class SessionState {
   bool deactivate_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
 
-  bool remove_gy_dynamic_rule(
-      const std::string& rule_id, PolicyRule *rule_out,
-      SessionStateUpdateCriteria& update_criteria);
 
   bool deactivate_scheduled_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
+
+  /**
+   * Remove all currently active restrict rules.
+   */
+  bool clear_restrict_rules(SessionStateUpdateCriteria& update_criteria);
 
   std::vector<std::string>& get_static_rules();
 
@@ -297,6 +312,7 @@ class SessionState {
 
   DynamicRuleStore& get_scheduled_dynamic_rules();
 
+  std::vector<std::string>& get_restrict_rules();
   /**
    * Schedule a dynamic rule for activation in the future.
    */
@@ -451,6 +467,8 @@ class SessionState {
   DynamicRuleStore dynamic_rules_;
   // Dynamic GY rules that are currently installed for the session
   DynamicRuleStore gy_dynamic_rules_;
+  // Restrict rules that are currently installed for the session
+  std::vector<std::string> restrict_rules_;
 
   // Static rules that are scheduled for installation for the session
   std::set<std::string> scheduled_static_rules_;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -302,7 +302,7 @@ class SessionState {
   /**
    * Remove all currently active restrict rules.
    */
-  bool clear_restrict_rules(SessionStateUpdateCriteria& update_criteria);
+  void clear_restrict_rules(SessionStateUpdateCriteria& update_criteria);
 
   std::vector<std::string>& get_static_rules();
 

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -98,6 +98,12 @@ std::string serialize_stored_final_action_info(const FinalActionInfo& stored) {
   stored.redirect_server.SerializeToString(&redirect_server);
   marshaled["redirect_server"] = redirect_server;
 
+  folly::dynamic restrict_rules = folly::dynamic::array;
+  for (const auto& rule_id : stored.restrict_rules) {
+    restrict_rules.push_back(rule_id);
+  }
+  marshaled["restrict_rules"] = restrict_rules;
+
   std::string serialized = folly::toJson(marshaled);
   return serialized;
 }
@@ -114,6 +120,10 @@ FinalActionInfo deserialize_stored_final_action_info(
   magma::lte::RedirectServer redirect_server;
   redirect_server.ParseFromString(marshaled["redirect_server"].getString());
   stored.redirect_server = redirect_server;
+
+  for (auto& rule_id : marshaled["restrict_rules"]) {
+    stored.restrict_rules.push_back(rule_id.getString());
+  }
 
   return stored;
 }

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -124,7 +124,6 @@ FinalActionInfo deserialize_stored_final_action_info(
   for (auto& rule_id : marshaled["restrict_rules"]) {
     stored.restrict_rules.push_back(rule_id.getString());
   }
-
   return stored;
 }
 
@@ -422,6 +421,12 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   }
   marshaled["gy_dynamic_rules"] = gy_dynamic_rules;
 
+  folly::dynamic restrict_rules = folly::dynamic::array;
+  for (const auto& rule_id : stored.restrict_rules) {
+    restrict_rules.push_back(rule_id);
+  }
+  marshaled["restrict_rules"] = restrict_rules;
+
   marshaled["request_number"] = std::to_string(stored.request_number);
 
   std::string serialized = folly::toJson(marshaled);
@@ -474,6 +479,10 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
     PolicyRule policy_rule;
     policy_rule.ParseFromString(policy.getString());
     stored.gy_dynamic_rules.push_back(policy_rule);
+  }
+
+  for (auto& rule_id : marshaled["restrict_rules"]) {
+    stored.restrict_rules.push_back(rule_id.getString());
   }
 
   stored.request_number = static_cast<uint32_t>(

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -421,12 +421,6 @@ std::string serialize_stored_session(StoredSessionState& stored) {
   }
   marshaled["gy_dynamic_rules"] = gy_dynamic_rules;
 
-  folly::dynamic restrict_rules = folly::dynamic::array;
-  for (const auto& rule_id : stored.restrict_rules) {
-    restrict_rules.push_back(rule_id);
-  }
-  marshaled["restrict_rules"] = restrict_rules;
-
   marshaled["request_number"] = std::to_string(stored.request_number);
 
   std::string serialized = folly::toJson(marshaled);
@@ -479,10 +473,6 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
     PolicyRule policy_rule;
     policy_rule.ParseFromString(policy.getString());
     stored.gy_dynamic_rules.push_back(policy_rule);
-  }
-
-  for (auto& rule_id : marshaled["restrict_rules"]) {
-    stored.restrict_rules.push_back(rule_id.getString());
   }
 
   stored.request_number = static_cast<uint32_t>(

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -40,6 +40,7 @@ struct SessionConfig {
 struct FinalActionInfo {
   ChargingCredit_FinalAction final_action;
   RedirectServer redirect_server;
+  std::set<std::string> restrict_rules;
 };
 
 enum EventTriggerState {

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -40,7 +40,7 @@ struct SessionConfig {
 struct FinalActionInfo {
   ChargingCredit_FinalAction final_action;
   RedirectServer redirect_server;
-  std::set<std::string> restrict_rules;
+  std::vector<std::string> restrict_rules;
 };
 
 enum EventTriggerState {

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -212,7 +212,6 @@ struct StoredSessionState {
   std::set<std::string> scheduled_static_rules;
   std::vector<PolicyRule> scheduled_dynamic_rules;
   std::unordered_map<std::string, RuleLifetime> rule_lifetimes;
-  std::vector<std::string> restrict_rules;
   uint32_t request_number;
   EventTriggerStatus pending_event_triggers;
   google::protobuf::Timestamp revalidation_time;
@@ -262,7 +261,6 @@ struct SessionStateUpdateCriteria {
   std::set<std::string> dynamic_rules_to_uninstall;
   std::set<std::string> gy_dynamic_rules_to_uninstall;
   std::vector<PolicyRule> new_scheduled_dynamic_rules;
-  std::set<std::string> restrict_rules;
   std::unordered_map<std::string, RuleLifetime> new_rule_lifetimes;
   StoredChargingCreditMap charging_credit_to_install;
   std::unordered_map<

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -212,6 +212,7 @@ struct StoredSessionState {
   std::set<std::string> scheduled_static_rules;
   std::vector<PolicyRule> scheduled_dynamic_rules;
   std::unordered_map<std::string, RuleLifetime> rule_lifetimes;
+  std::vector<std::string> restrict_rules;
   uint32_t request_number;
   EventTriggerStatus pending_event_triggers;
   google::protobuf::Timestamp revalidation_time;
@@ -261,6 +262,7 @@ struct SessionStateUpdateCriteria {
   std::set<std::string> dynamic_rules_to_uninstall;
   std::set<std::string> gy_dynamic_rules_to_uninstall;
   std::vector<PolicyRule> new_scheduled_dynamic_rules;
+  std::set<std::string> restrict_rules;
   std::unordered_map<std::string, RuleLifetime> new_rule_lifetimes;
   StoredChargingCreditMap charging_credit_to_install;
   std::unordered_map<

--- a/lte/gateway/c/session_manager/test/test_stored_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_stored_state.cpp
@@ -37,7 +37,7 @@ class StoredStateTest : public ::testing::Test {
     return stored;
   }
 
-  FinalActionInfo get_stored_final_action_info() {
+  FinalActionInfo get_stored_redirect_final_action_info() {
     FinalActionInfo stored;
     stored.final_action =
         ChargingCredit_FinalAction::ChargingCredit_FinalAction_REDIRECT;
@@ -46,6 +46,14 @@ class StoredStateTest : public ::testing::Test {
             RedirectServer_RedirectAddressType_IPV6);
     stored.redirect_server.set_redirect_server_address(
         "redirect_server_address");
+    return stored;
+  }
+
+  FinalActionInfo get_stored_restrict_final_action_info() {
+    FinalActionInfo stored;
+    stored.final_action =
+        ChargingCredit_FinalAction::ChargingCredit_FinalAction_RESTRICT_ACCESS;
+    stored.restrict_rules.push_back("restrict_rule");
     return stored;
   }
 
@@ -155,8 +163,8 @@ TEST_F(StoredStateTest, test_stored_session_config) {
   EXPECT_EQ(original_rat_specific, recovered_rat_specific);
 }
 
-TEST_F(StoredStateTest, test_stored_final_action_info) {
-  auto stored = get_stored_final_action_info();
+TEST_F(StoredStateTest, test_stored_redirect_final_action_info) {
+  auto stored = get_stored_redirect_final_action_info();
 
   auto serialized   = serialize_stored_final_action_info(stored);
   auto deserialized = deserialize_stored_final_action_info(serialized);
@@ -171,6 +179,21 @@ TEST_F(StoredStateTest, test_stored_final_action_info) {
   EXPECT_EQ(
       deserialized.redirect_server.redirect_server_address(),
       "redirect_server_address");
+}
+
+TEST_F(StoredStateTest, test_stored_restrict_final_action_info) {
+  auto stored = get_stored_restrict_final_action_info();
+
+  auto serialized   = serialize_stored_final_action_info(stored);
+  auto deserialized = deserialize_stored_final_action_info(serialized);
+
+  EXPECT_EQ(
+      deserialized.final_action,
+      ChargingCredit_FinalAction::ChargingCredit_FinalAction_RESTRICT_ACCESS);
+
+  std::vector<std::string> restrict_rules = {"restrict_rule"};
+  EXPECT_EQ(
+      deserialized.restrict_rules, restrict_rules);
 }
 
 TEST_F(StoredStateTest, test_stored_bearer_id_by_policy) {


### PR DESCRIPTION
## Summary

This PR add the support of FUA restrict to SessionD.

## Test Plan

Unit tests and CwF Integration tests

Test project /home/vagrant/build/c/session_manager
      Start  1: test_session_credit
 1/14 Test  #1: test_session_credit ..................   Passed    0.11 sec
      Start  2: test_local_enforcer
 2/14 Test  #2: test_local_enforcer ..................   Passed    0.62 sec
      Start  3: test_cloud_reporter
 3/14 Test  #3: test_cloud_reporter ..................   Passed    0.05 sec
      Start  4: test_session_manager_handler
 4/14 Test  #4: test_session_manager_handler .........   Passed    0.02 sec
      Start  5: test_sessiond_integ
 5/14 Test  #5: test_sessiond_integ ..................   Passed    0.46 sec
      Start  6: test_session_state
 6/14 Test  #6: test_session_state ...................   Passed    0.01 sec
      Start  7: test_session_store
 7/14 Test  #7: test_session_store ...................   Passed    0.01 sec
      Start  8: test_store_client
 8/14 Test  #8: test_store_client ....................   Passed    0.01 sec
      Start  9: test_stored_state
 9/14 Test  #9: test_stored_state ....................   Passed    0.01 sec
      Start 10: test_proxy_responder_handler
10/14 Test #10: test_proxy_responder_handler .........   Passed    0.02 sec
      Start 11: test_metering_reporter
11/14 Test #11: test_metering_reporter ...............   Passed    0.03 sec
      Start 12: test_local_enforcer_wallet_exhaust
12/14 Test #12: test_local_enforcer_wallet_exhaust ...   Passed    0.02 sec
      Start 13: test_charging_grant
13/14 Test #13: test_charging_grant ..................   Passed    0.03 sec
      Start 14: test_usage_monitor
14/14 Test #14: test_usage_monitor ...................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 14


[vagrant@127.0.0.1:2202] out:     ipfix_test.go:46: Skipping test due to DPI changes
[vagrant@127.0.0.1:2202] out: 
[vagrant@127.0.0.1:2202] out: 
[vagrant@127.0.0.1:2202] out: DONE 34 tests, 4 skipped in 798.812s
[vagrant@127.0.0.1:2202] out: 

===== Integ Tests

[vagrant@127.0.0.1:2202] Executing task '_clean_up'
[vagrant@127.0.0.1:2202] run: pkill go
[localhost] local: pwd
[localhost] local: vagrant status magma_trfserver
[localhost] local: vagrant ssh-config magma_trfserver
[vagrant@127.0.0.1:2201] run: pkill iperf3 > /dev/null &
Integration Test Passed for "all"!
Disconnecting from vagrant@127.0.0.1:2200... done.
Disconnecting from vagrant@127.0.0.1:2201... done.
Disconnecting from vagrant@127.0.0.1:2202... done.

## Additional Information
