### PR TITLE
[SessionD] Schedule bearer creation for Session Create

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -41,8 +41,8 @@ std::chrono::milliseconds time_difference_from_now(
 }  // namespace
 
 namespace magma {
-
-uint32_t LocalEnforcer::REDIRECT_FLOW_PRIORITY = 2000;
+uint32_t LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 2000;
+uint32_t LocalEnforcer::REDIRECT_FLOW_PRIORITY                = 2000;
 
 using google::protobuf::RepeatedPtrField;
 using google::protobuf::util::TimeUtil;
@@ -896,12 +896,8 @@ bool LocalEnforcer::handle_session_init_rule_updates(
     SessionMap& session_map, const std::string& imsi,
     SessionState& session_state, const CreateSessionResponse& response,
     std::unordered_set<uint32_t>& charging_credits_received) {
-
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
-
-  // Can use a default UpdateCriteria since SessionStore's create and update
-  // methods are separate.
   std::vector<StaticRuleInstall> static_rule_installs =
       to_vec(response.static_rules());
   std::vector<DynamicRuleInstall> dynamic_rule_installs =
@@ -909,24 +905,94 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   filter_rule_installs(
       static_rule_installs, dynamic_rule_installs, charging_credits_received);
 
-  auto uc = get_default_update_criteria();
+  auto uc = get_default_update_criteria();  // TODO remove unused UC
   process_rules_to_install(
       session_state, imsi, static_rule_installs, dynamic_rule_installs,
       rules_to_activate, rules_to_deactivate, uc);
 
-  const auto& config = session_state.get_config();
-  // activate_flows_for_rules() should be called even if there is no rule to
-  // activate, because pipelined activates a "drop all packet" rule
+  // activate_flows_for_rules() should be called even if there is no rule
+  // to activate, because pipelined activates a "drop all packet" rule
   // when no rule is provided as the parameter.
+  const auto& config = session_state.get_config();
   propagate_rule_updates_to_pipelined(
       imsi, config, rules_to_activate, rules_to_deactivate, true);
 
   if (config.common_context.rat_type() == TGPP_LTE) {
-    const auto update = session_state.get_dedicated_bearer_updates(
+    auto bearer_updates = session_state.get_dedicated_bearer_updates(
         rules_to_activate, rules_to_deactivate, uc);
-    propagate_bearer_updates_to_mme(update);
+    if (bearer_updates.needs_creation) {
+      // If a bearer creation is needed, we need to delay this by a few seconds
+      // so that the attach fully completes before.
+      schedule_session_init_bearer_creations(
+          imsi, session_state.get_session_id(), bearer_updates);
+    }
   }
   return true;
+}
+
+void LocalEnforcer::schedule_session_init_bearer_creations(
+    const std::string& imsi, const std::string& session_id,
+    BearerUpdate& bearer_updates) {
+  MLOG(MINFO) << "Scheduling a bearer creation request for newly created "
+              << session_id << " in "
+              << LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT << " ms";
+  evb_->runAfterDelay(
+      [this, imsi, session_id, bearer_updates]() mutable {
+        auto session_map = session_store_.read_sessions({imsi});
+        auto it          = session_map.find(imsi);
+        if (it == session_map.end()) {
+          MLOG(MWARNING) << "Ignoring dedicated bearer creations from session "
+                            "creation for "
+                         << session_id << " since it no longer exists";
+          return;
+        }
+        for (auto& session : it->second) {
+          if (session->get_session_id() != session_id) {
+            continue;
+          }
+          // Skip bearer update if it is no longer ACTIVE
+          if (session->get_state() != SESSION_ACTIVE) {
+            MLOG(MWARNING) << "Ignoring dedicated bearer create request from"
+                           << " session creation for " << session_id
+                           << " since the session is no longer active";
+            return;
+          }
+          // Check that the policies are still installed and needs a
+          // bearer
+          auto rules = bearer_updates.create_req.mutable_policy_rules();
+          auto it    = rules->begin();
+          while (it != rules->end()) {
+            auto policy_type = session->get_policy_type(it->id());
+            if (!policy_type) {
+              MLOG(MWARNING) << "Ignoring dedicated bearer create request from"
+                             << " session creation for " << session_id
+                             << " policy ID: " << it->id()
+                             << " since the policy is no longer active in the "
+                                "session";
+              it = rules->erase(it);
+              continue;
+            }
+            if (!session->policy_needs_bearer_creation(
+                    *policy_type, it->id(), session->get_config())) {
+              MLOG(MWARNING) << "Ignoring dedicated bearer create request from "
+                             << "session creation for " << session_id
+                             << " and policy ID: " << it->id()
+                             << " since the policy no longer needs a bearer";
+              it = rules->erase(it);
+              continue;
+            }
+            ++it;
+          }
+          if (rules->size() > 0) {
+            propagate_bearer_updates_to_mme(bearer_updates);
+          }
+          return;
+        }
+        // No need to update session store for bearer creations.
+        // SessionStore will be updated once the bearer binding
+        // completes/fails.
+      },
+      LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT);
 }
 
 bool LocalEnforcer::init_session_credit(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -125,6 +125,10 @@ class LocalEnforcer {
       SessionState& session_state, const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
 
+  void schedule_session_init_bearer_creations(
+      const std::string& imsi, const std::string& session_id,
+      BearerUpdate& update);
+
   /**
    * Initialize credit received from the cloud in the system. This adds all the
    * charging keys to the credit manager for tracking
@@ -230,6 +234,7 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   static uint32_t REDIRECT_FLOW_PRIORITY;
+  static uint32_t BEARER_CREATION_DELAY_ON_SESSION_INIT;
 
  private:
   struct RedirectInstallInfo {

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -246,6 +246,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
         PrintGrpcMessage(
             static_cast<const google::protobuf::Message&>(response));
         if (status.ok()) {
+          MLOG(MINFO) << "Received a CreateSessionResponse for " << sid;
           bool success = enforcer_->init_session_credit(
               *session_map_ptr, imsi, sid, cfg, response);
           if (!success) {
@@ -548,10 +549,11 @@ void LocalSessionManagerHandlerImpl::BindPolicy2Bearer(
         response_callback) {
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
-  MLOG(INFO) << "imsi: " << request->sid().id()
-             << " default bearer: " << request->linked_bearer_id()
-             << " policy rule: " << request->policy_rule_id()
-             << " created bearer: " << request->bearer_id();
+  MLOG(INFO) << "Received a BindPolicy2Bearer request for "
+             << request->sid().id()
+             << " with default bearerID: " << request->linked_bearer_id()
+             << " policyID: " << request->policy_rule_id()
+             << " created dedicated bearerID: " << request->bearer_id();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = session_store_.read_sessions({request_cpy.sid().id()});
     SessionUpdate update =

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -51,9 +51,9 @@ magma::ActivateFlowsRequest create_activate_req(
   req.mutable_request_origin()->set_type(origin_type);
   if (ambr) {
     // TODO remove log once feature is stable
-    MLOG(MINFO) << "Sending AMBR info for " << imsi << " ip addr " << ip_addr
-                 << "dl " << ambr->max_bandwidth_dl() << "ul "
-                 << ambr->max_bandwidth_ul();
+    MLOG(MINFO) << "Sending AMBR info for " << imsi << ", ip addr=" << ip_addr
+                << ", dl=" << ambr->max_bandwidth_dl()
+                << ", ul=" << ambr->max_bandwidth_ul();
     req.mutable_apn_ambr()->CopyFrom(*ambr);
   }
   auto ids = req.mutable_rule_ids();
@@ -232,8 +232,8 @@ bool AsyncPipelinedClient::activate_flows_for_rules(
     const std::vector<PolicyRule>& dynamic_rules,
     std::function<void(Status status, ActivateFlowsResult)> callback) {
   MLOG(MDEBUG) << "Activating " << static_rules.size() << " static rules and "
-               << dynamic_rules.size() << " dynamic rules for subscriber "
-               << imsi;
+               << dynamic_rules.size() << " dynamic rules for " << imsi
+               << " and ip " << ip_addr;
   // Activate static rules and dynamic rules separately until bug is fixed in
   // pipelined which crashes if activated at the same time
   auto static_req = create_activate_req(

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -402,7 +402,16 @@ class SessionState {
   BearerUpdate get_dedicated_bearer_updates(
       RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
       SessionStateUpdateCriteria& uc);
-
+  /**
+   * Determine whether a policy with type+ID needs a bearer to be created
+   * @param policy_type
+   * @param rule_id
+   * @param config
+   * @return an optional wrapped PolicyRule if creation is needed, {} otherwise
+   */
+  std::experimental::optional<PolicyRule> policy_needs_bearer_creation(
+      const PolicyType policy_type, const std::string& rule_id,
+      const SessionConfig& config);
   /**
    *
    * @param rule_set

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -100,7 +100,7 @@ static uint32_t get_log_verbosity(
   }
 }
 
-void set_session_credit_consts(const YAML::Node& config) {
+void set_consts(const YAML::Node& config) {
   auto reporting_threshold = config["usage_reporting_threshold"].as<float>();
   if (reporting_threshold <= MIN_USAGE_REPORTING_THRESHOLD ||
       reporting_threshold >= MAX_USAGE_REPORTING_THRESHOLD) {
@@ -114,6 +114,11 @@ void set_session_credit_consts(const YAML::Node& config) {
 
   magma::SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED =
       config["terminate_service_when_quota_exhausted"].as<bool>();
+
+  if (config["bearer_creation_delay_on_session_init"].IsDefined()) {
+    magma::LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT =
+        config["bearer_creation_delay_on_session_init"].as<uint32_t>();
+  }
 }
 
 magma::SessionStore* create_session_store(
@@ -231,7 +236,7 @@ int main(int argc, char* argv[]) {
   magma::SessionStore* session_store = create_session_store(config, rule_store);
 
   // Some setup work for the SessionCredit class
-  set_session_credit_consts(config);
+  set_consts(config);
   // Initialize the main logical component of SessionD
   auto local_enforcer = std::make_shared<magma::LocalEnforcer>(
       reporter, rule_store, *session_store, pipelined_client, directoryd_client,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1453,6 +1453,93 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
   EXPECT_EQ(raa.result(), ReAuthResult::UPDATE_INITIATED);
 }
 
+// This test covers some edge cases for the dedicated bearer creation scheduling
+// for a new session. For session creation, we delay the actual call to create
+// bearer by a few seconds. (BEARER_CREATION_DELAY_ON_SESSION_INIT)
+// But since we could have a case where the rule state is modified during the
+// scheduling and the actual call, we want to ensure that we do not create
+// bearers if:
+// 1. Policy is no longer installed.
+// 2. Policy no longer needs a bearer for some reason. One case of this could be
+// that it is already tied to a bearer.
+// The success case where the creation takes place is covered by another test
+// "test_dedicated_bearer_lifecycle"
+TEST_F(LocalEnforcerTest, test_dedicated_bearer_creation_on_session_init) {
+  CreateSessionResponse response1, response2;
+  const std::string IMSI1 = "IMSI1";
+  const std::string IMSI2 = "IMSI2";
+  const std::string SESSION_ID_1 = "SESSION_ID_1";
+  const std::string SESSION_ID_2 = "SESSION_ID_2";
+  const uint32_t default_bearer_id = 5;
+  const uint32_t bearer_1          = 6;
+  insert_static_rule_with_qos(0, "m1", "rule1", 1);             // QCI=1
+  LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 1000;  // 1 sec
+
+  // test_cfg_ is initialized with QoSInfo field w/ QCI 5
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
+  test_cfg_.common_context.set_apn("apn1");
+  auto lte_context = test_cfg_.rat_specific_context.mutable_lte_context();
+  lte_context->mutable_qos_info()->set_qos_class_id(5);
+  lte_context->set_bearer_id(default_bearer_id);  // linked_bearer_id
+
+  // CASE 1: policy has a bearer by the time the scheduled function is executed
+  response1.mutable_static_rules()->Add()->set_rule_id("rule1");
+  // Schedules default bearer install in 1 sec
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response1);
+  // Write + Read in/from SessionStore
+  bool write_success =
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
+  EXPECT_TRUE(write_success);
+
+  // Before we hit the 1 second, simulate a case where another call triggered
+  // the policy to be tied a bearer already
+  session_map = session_store->read_sessions({IMSI1});
+  auto update = SessionStore::get_default_session_update(session_map);
+  auto bearer_bind_req_success1 = create_policy_bearer_bind_req(
+      IMSI1, default_bearer_id, "rule1", bearer_1);
+  local_enforcer->bind_policy_to_bearer(
+      session_map, bearer_bind_req_success1, update);
+  // Write + Read in/from SessionStore
+  write_success = session_store->update_sessions(update);
+  EXPECT_TRUE(write_success);
+  // Since the policy is already tied to a bearer, we should not see an
+  // additional create bearer request when the scheduled creation happens
+  EXPECT_CALL(
+      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
+      .Times(0);
+  evb->loopOnce();
+
+  // CASE 2: policy has been removed
+  session_map = session_store->read_all_sessions();
+  response2.mutable_static_rules()->Add()->set_rule_id("rule1");
+  // Schedules default bearer install in 1 sec
+  local_enforcer->init_session_credit(
+      session_map, IMSI2, SESSION_ID_2, test_cfg_, response2);
+
+  // Write + Read in/from SessionStore
+  write_success =
+      session_store->create_sessions(IMSI2, std::move(session_map[IMSI2]));
+  EXPECT_TRUE(write_success);
+  // Before we hit the 1 second, remove the policy
+  session_map = session_store->read_sessions({IMSI2});
+  update      = SessionStore::get_default_session_update(session_map);
+  SessionRules session_rules;
+  auto rule_set_per_sub = session_rules.mutable_rules_per_subscriber()->Add();
+  rule_set_per_sub->set_imsi(IMSI2);
+  rule_set_per_sub->mutable_rule_set()->Add()->CopyFrom(
+      create_rule_set(false, "apn1", {}, {}));  // Remove all rules
+  local_enforcer->handle_set_session_rules(session_map, session_rules, update);
+  // Write + Read in/from SessionStore
+  write_success = session_store->update_sessions(update);
+  EXPECT_TRUE(write_success);
+  // Rule is removed, expect no bearer creation
+  EXPECT_CALL(
+      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
+      .Times(0);
+  evb->loopOnce();
+}
+
 // Create multiple rules with QoS and assert dedicated bearers are created
 // Simulate a policy->bearer mapping from MME, both success + failure.
 // Simulate additional rule updates to trigger dedicated bearer deletions
@@ -1488,7 +1575,8 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
       *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(imsi, 3)))
       .Times(1)
       .WillOnce(testing::Return(true));
-
+  // For testing change the delay to 0 ms.
+  LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 0;
   local_enforcer->init_session_credit(
       session_map, imsi, session_id, test_cfg_, response);
   // Write + Read in/from SessionStore
@@ -1497,7 +1585,8 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   EXPECT_TRUE(write_success);
   session_map = session_store->read_sessions({imsi});
   auto update = SessionStore::get_default_session_update(session_map);
-
+  // Progress the loop to run the scheduled bearer creation request
+  evb->loopOnce();
   // Test successful creation of dedicated bearer for rule1 + rule2
   auto bearer_bind_req_success1 =
       create_policy_bearer_bind_req(imsi, default_bearer_id, "rule1", bearer_1);
@@ -1621,6 +1710,8 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
       session_map, imsi, session_id1, config1, response);
   local_enforcer->init_session_credit(
       session_map, imsi, session_id2, config2, response);
+  evb->loopOnce();
+  evb->loopOnce();
   // Assert the rules exist
   EXPECT_TRUE(session_map[imsi][0]->is_static_rule_installed("static1"));
   EXPECT_TRUE(session_map[imsi][0]->is_static_rule_installed("static2"));

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -38,6 +38,11 @@ support_carrier_wifi: false
 # quota.
 cwf_quota_exhaustion_termination_on_init_ms: 30000
 
+# On session creation, we want to delay the bearer creation requests to after
+# the attach has completed. This value indicates how many ms to wait before
+# sending the bearer create request.
+bearer_creation_delay_on_session_init: 2000
+
 # Set to true to store session state in Redis for persistence.
 support_stateless: false
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
This PR adds a change to delay dedicated bearer creation by a configured amount of time for session creation. This is needed since, we need to send the bearer request after UE attach is completed.

When we process the create session response, if a bearer creation is needed we schedule the request to be sent in the event loop. When the function is called, we double check that the request is still valid before making the request. The conditions we check are:
1. The session is exists
2. The session is active
3. The rule exists in the session
4. A bearer creation is still needed -> meaning that the rule still has a qos / is not already tied to a bearer etc.

This amount is configured in `sessiond.yml` under : `bearer_creation_delay_on_session_init`. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Additional SessionD unit tests to cover the edge cases
SessionD unit tests + S1AP tests
Also did some manual testing by modifying the dynamic rule PolicyDB returns on SessionCreation to include a QoS field and running an `attach-detach` test. I've set ` bearer_creation_delay_on_session_init: 1000`
```
def get_allow_all_policy_rule(
    subscriber_id: str,
    apn: str,
) -> PolicyRule:
    policy_id = _get_allow_all_rule_id(subscriber_id, apn)
    return PolicyRule(
        id=policy_id,
        priority=2,
        flow_list=_get_allow_all_flows(),
        tracking_type=PolicyRule.TrackingType.Value("NO_TRACKING"),
        qos = FlowQos(
            qci=5,  # qci value [1 to 9]
            max_req_bw_ul=10000000,  # MAX bw Uplink
            max_req_bw_dl=15000000,  # MAX bw Downlink
            gbr_ul=1000000,  # GBR Uplink
            gbr_dl=2000000,  # GBR Downlink
            arp=QosArp(
                priority_level=15,  # ARP priority
                pre_capability=1,  # pre-emption capability
                pre_vulnerability=1,  # pre-emption vulnerability
            ),
        ),
    )
```
Here is the logs from SessionD, the important lines are "Scheduling a bearer creation request for newly created IMSI001010000000001-623138 in 1000 ms" @ Sep 11 12:38:48 and "Creating dedicated bearers for IMSI001010000000001, 192.168.128.13, rules={ allowlist_sid-IMSI001010000000001-magma.ipv4 }" @ Sep 11 12:38:49.

```Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.831861 12503 LocalSessionManagerHandler.cpp:583] Received a LocalCreateSessionRequest for IMSI001010000000001 with APN:magma.ipv4, default bearer ID:5, PLMN ID:00101, IMSI PLMN ID:00101
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.831985 12503 LocalSessionManagerHandler.cpp:234] Sending a CreateSessionRequest to fetch policies for IMSI001010000000001-623138
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.834321 12503 GrpcMagmaUtils.cpp:37]
Sep 11 12:38:48 magma-dev sessiond[12503]:   magma.lte.CreateSessionResponse {
Sep 11 12:38:48 magma-dev sessiond[12503]:       dynamic_rules {
Sep 11 12:38:48 magma-dev sessiond[12503]:         policy_rule {
Sep 11 12:38:48 magma-dev sessiond[12503]:           id: "allowlist_sid-IMSI001010000000001-magma.ipv4"
Sep 11 12:38:48 magma-dev sessiond[12503]:           priority: 2
Sep 11 12:38:48 magma-dev sessiond[12503]:           flow_list {
Sep 11 12:38:48 magma-dev sessiond[12503]:             match {
Sep 11 12:38:48 magma-dev sessiond[12503]:             }
Sep 11 12:38:48 magma-dev sessiond[12503]:           }
Sep 11 12:38:48 magma-dev sessiond[12503]:           flow_list {
Sep 11 12:38:48 magma-dev sessiond[12503]:             match {
Sep 11 12:38:48 magma-dev sessiond[12503]:               direction: DOWNLINK
Sep 11 12:38:48 magma-dev sessiond[12503]:             }
Sep 11 12:38:48 magma-dev sessiond[12503]:           }
Sep 11 12:38:48 magma-dev sessiond[12503]:           qos {
Sep 11 12:38:48 magma-dev sessiond[12503]:             max_req_bw_ul: 10000000
Sep 11 12:38:48 magma-dev sessiond[12503]:             max_req_bw_dl: 15000000
Sep 11 12:38:48 magma-dev sessiond[12503]:             gbr_ul: 1000000
Sep 11 12:38:48 magma-dev sessiond[12503]:             gbr_dl: 2000000
Sep 11 12:38:48 magma-dev sessiond[12503]:             qci: QCI_5
Sep 11 12:38:48 magma-dev sessiond[12503]:             arp {
Sep 11 12:38:48 magma-dev sessiond[12503]:               priority_level: 15
Sep 11 12:38:48 magma-dev sessiond[12503]:               pre_capability: PRE_CAP_DISABLED
Sep 11 12:38:48 magma-dev sessiond[12503]:               pre_vulnerability: PRE_VUL_DISABLED
Sep 11 12:38:48 magma-dev sessiond[12503]:             }
Sep 11 12:38:48 magma-dev sessiond[12503]:           }
Sep 11 12:38:48 magma-dev sessiond[12503]:           tracking_type: NO_TRACKING
Sep 11 12:38:48 magma-dev sessiond[12503]:         }
Sep 11 12:38:48 magma-dev sessiond[12503]:       }
Sep 11 12:38:48 magma-dev sessiond[12503]:       session_id: "IMSI001010000000001-623138"
Sep 11 12:38:48 magma-dev sessiond[12503]:   }
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.834350 12503 LocalSessionManagerHandler.cpp:244] Received a CreateSessionResponse for IMSI001010000000001-623138
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.834468 12503 LocalEnforcer.cpp:695] Activating untracked rule allowlist_sid-IMSI001010000000001-magma.ipv4
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.834828 12503 PipelinedClient.cpp:54] Sending AMBR info for IMSI001010000000001, ip addr=192.168.128.13, dl=100000000, ul=200000000
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.835069 12503 GrpcMagmaUtils.cpp:37]
Sep 11 12:38:48 magma-dev sessiond[12503]:   magma.lte.ActivateFlowsRequest {
Sep 11 12:38:48 magma-dev sessiond[12503]:       sid {
Sep 11 12:38:48 magma-dev sessiond[12503]:         id: "IMSI001010000000001"
Sep 11 12:38:48 magma-dev sessiond[12503]:       }
Sep 11 12:38:48 magma-dev sessiond[12503]:       ip_addr: "192.168.128.13"
Sep 11 12:38:48 magma-dev sessiond[12503]:       dynamic_rules {
Sep 11 12:38:48 magma-dev sessiond[12503]:         id: "allowlist_sid-IMSI001010000000001-magma.ipv4"
Sep 11 12:38:48 magma-dev sessiond[12503]:         priority: 2
Sep 11 12:38:48 magma-dev eventd[12819]: DEBUG:root:Logging event: stream_name: "sessiond"
Sep 11 12:38:48 magma-dev sessiond[12503]:         flow_list {
Sep 11 12:38:48 magma-dev sessiond[12503]:           match {
Sep 11 12:38:48 magma-dev sessiond[12503]:           }
Sep 11 12:38:48 magma-dev sessiond[12503]:         }
Sep 11 12:38:48 magma-dev sessiond[12503]:         flow_list {
Sep 11 12:38:48 magma-dev sessiond[12503]:           match {
Sep 11 12:38:48 magma-dev sessiond[12503]:             direction: DOWNLINK
Sep 11 12:38:48 magma-dev sessiond[12503]:           }
Sep 11 12:38:48 magma-dev sessiond[12503]:         }
Sep 11 12:38:48 magma-dev sessiond[12503]:         qos {
Sep 11 12:38:48 magma-dev sessiond[12503]:           max_req_bw_ul: 10000000
Sep 11 12:38:48 magma-dev sessiond[12503]:           max_req_bw_dl: 15000000
Sep 11 12:38:48 magma-dev sessiond[12503]:           gbr_ul: 1000000
Sep 11 12:38:48 magma-dev sessiond[12503]:           gbr_dl: 2000000
Sep 11 12:38:48 magma-dev sessiond[12503]:           qci: QCI_5
Sep 11 12:38:48 magma-dev sessiond[12503]:           arp {
Sep 11 12:38:48 magma-dev sessiond[12503]:             priority_level: 15
Sep 11 12:38:48 magma-dev sessiond[12503]:             pre_capability: PRE_CAP_DISABLED
Sep 11 12:38:48 magma-dev sessiond[12503]:             pre_vulnerability: PRE_VUL_DISABLED
Sep 11 12:38:48 magma-dev sessiond[12503]:           }
Sep 11 12:38:48 magma-dev sessiond[12503]:         }
Sep 11 12:38:48 magma-dev sessiond[12503]:         tracking_type: NO_TRACKING
Sep 11 12:38:48 magma-dev sessiond[12503]:       }
Sep 11 12:38:48 magma-dev sessiond[12503]:       request_origin {
Sep 11 12:38:48 magma-dev sessiond[12503]:       }
Sep 11 12:38:48 magma-dev sessiond[12503]:       apn_ambr {
Sep 11 12:38:48 magma-dev sessiond[12503]:         max_bandwidth_ul: 200000000
Sep 11 12:38:48 magma-dev sessiond[12503]:         max_bandwidth_dl: 100000000
Sep 11 12:38:48 magma-dev sessiond[12503]:       }
Sep 11 12:38:48 magma-dev sessiond[12503]:   }
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.835448 12503 LocalEnforcer.cpp:933] Scheduling a bearer creation request for newly created IMSI001010000000001-623138 in 1000 ms
Sep 11 12:38:48 magma-dev sessiond[12503]: I0911 12:38:48.836154 12503 LocalSessionManagerHandler.cpp:251] Successfully initialized new session IMSI001010000000001-623138 in SessionD for subscriber IMSI001010000000001
Sep 11 12:38:49 magma-dev sessiond[12503]: I0911 12:38:49.836793 12503 SpgwServiceClient.cpp:107] Creating dedicated bearers for IMSI001010000000001, 192.168.128.13, rules={ allowlist_sid-IMSI001010000000001-magma.ipv4 }
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
