### PR TITLE
[lte][mme] Add complete ECGI back to ULI

### DIFF
--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -228,7 +228,12 @@ static int get_uli_from_session_req(
            ((saved_req->uli.s.ecgi.mcc[2] & 0xf));
   uli[8] = ((saved_req->uli.s.ecgi.mnc[1] & 0xf) << 4) |
            ((saved_req->uli.s.ecgi.mnc[0] & 0xf));
-  uli[9] = '\0';
+  uli[9] = (saved_req->uli.s.ecgi.cell_identity.enb_id >> 16) & 0xf;
+  uli[10] = (saved_req->uli.s.ecgi.cell_identity.enb_id >> 8) & 0xff;
+  uli[11] = saved_req->uli.s.ecgi.cell_identity.enb_id & 0xff;
+  uli[12] = saved_req->uli.s.ecgi.cell_identity.cell_id & 0xff;
+  uli[13] = '\0';
+
   return 1;
 }
 


### PR DESCRIPTION
## Summary

We are no longer including the full ECGI (eNB ID and Cell ID in User Location Information after a recent merge with OAI. This adds these identifiers back to the ULI. Closes #2720.

## Test Plan

- `make build_oai` and `make build_oai FEATURE=mme` compile cleanly
- Integration tests work on both

Signed-off-by: Shaddi Hasan <shasan@fb.com>

