### PR TITLE
[lte][agw] Fixing enb_name param in s1_setup_success event

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
@@ -94,7 +94,13 @@ int detach_success_event(imsi64_t imsi64, const char* action) {
 
 int s1_setup_success_event(const char* enb_name, uint32_t enb_id) {
   folly::dynamic event_value = folly::dynamic::object;
-  event_value["enb_name"]    = enb_name;
+
+  if(enb_name) {
+    event_value["enb_name"] = enb_name;
+  } else {
+    event_value["enb_name"] = "";
+  }
+
   event_value["enb_id"]      = enb_id;
 
   return report_event(event_value, S1_SETUP_SUCCESS, MME_STREAM_NAME, enb_name);


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- On logging s1_setup_success event, there's a bug / crash if the enb name is not specified, as per spec this param can be optional, this PR fixes it by checking for null ptr.

## Test Plan

- make test
- make integ_test

## Additional Information

- [ ] This change is backwards-breaking
