### PR TITLE
[nms] Use magma api to get networks for dashboard templates

### DIFF
--- a/nms/app/packages/magmalte/grafana/dashboards/AnalyticsDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/AnalyticsDashboards.js
@@ -15,153 +15,158 @@
  */
 
 import {apnTemplate} from './CWFDashboards';
-import {networkTemplate} from './Dashboards';
+import {getNetworkTemplate} from './Dashboards';
 import type {GrafanaDBData} from './Dashboards';
 
-export const AnalyticsDBData: GrafanaDBData = {
-  title: 'Aggregated Analyses',
-  description:
-    'Various KPIs aggregated and calculated from other existing metrics.',
-  templates: [networkTemplate, apnTemplate],
-  rows: [
-    {
-      title: 'Active Users',
-      panels: [
-        {
-          title: 'Active Users Over Time',
-          targets: [
-            {
-              expr: 'active_users_over_time{networkID=~"$networkID"}',
-              legendFormat: '{{networkID}} - Days: {{days}}',
-            },
-          ],
-          description: 'Number of unique active users over the past N days.',
-        },
-      ],
-    },
-    {
-      title: 'User Throughput',
-      panels: [
-        {
-          title: 'User Throughput (Download)',
-          targets: [
-            {
-              expr: 'user_throughput{direction="in",networkID=~"$networkID"}',
-              legendFormat: '{{networkID}} - Days: {{days}}',
-            },
-          ],
-          unit: 'Bps',
-          description:
-            'Average user download throughput over the network in the last N days.',
-        },
-        {
-          title: 'User Throughput (Upload)',
-          targets: [
-            {
-              expr: 'user_throughput{direction="out",networkID=~"$networkID"}',
-              legendFormat: '{{networkID}} - Days: {{days}}',
-            },
-          ],
-          unit: 'Bps',
-          description:
-            'Average user upload throughput over the network in the last N days.',
-        },
-        {
-          title: 'Throughput Per APN (Upload)',
-          targets: [
-            {
-              expr: 'throughput_per_ap{direction="out",apn=~"$apn"}',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          unit: 'Bps',
-          description:
-            'Average user upload throughput for a given APN in the last N days',
-        },
-        {
-          title: 'Throughput Per APN (Download)',
-          targets: [
-            {
-              expr: 'throughput_per_ap{direction="in",apn=~"$apn"}',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          unit: 'Bps',
-          description:
-            'Average user download throughput for a given APN in the last N days',
-        },
-      ],
-    },
-    {
-      title: 'User Consumption',
-      panels: [
-        {
-          title: 'User Consumption (Upload)',
-          targets: [
-            {
-              expr: 'user_consumption{direction="out",networkID=~"$networkID"}',
-              legendFormat: '{{networkID}} - Days: {{days}}',
-            },
-          ],
-          unit: 'decbytes',
-          description:
-            'Total user upload consumption over the network in the past N days.',
-        },
-        {
-          title: 'User Consumption (Download)',
-          targets: [
-            {
-              expr: 'user_consumption{direction="in",networkID=~"$networkID"}',
-              legendFormat: '{{networkID}} - Days: {{days}}',
-            },
-          ],
-          unit: 'decbytes',
-          description:
-            'Total user download consumption over the network in the past N days.',
-        },
-        {
-          title: 'User Consumption Hourly (Upload)',
-          targets: [
-            {
-              expr:
-                'user_consumption_hourly{direction="out",networkID=~"$networkID"}',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 'decbytes',
-          description:
-            'Total user upload consumption over the network in the past hour.',
-        },
-        {
-          title: 'User Consumption Hourly (Download)',
-          targets: [
-            {
-              expr:
-                'user_consumption_hourly{direction="in",networkID=~"$networkID"}',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 'decbytes',
-          description:
-            'Total user download consumption over the network in the past hour.',
-        },
-      ],
-    },
-    {
-      title: 'Authentications',
-      panels: [
-        {
-          title: 'Authentications Over Time',
-          targets: [
-            {
-              expr: 'authentications_over_time{networkID=~"$networkID"}',
-              legendFormat: '{{networkID}} - Code: {{code}}',
-            },
-          ],
-          description:
-            'Total number of authentication failures or successes in the network in the last N days.',
-        },
-      ],
-    },
-  ],
+export const AnalyticsDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'Aggregated Analyses',
+    description:
+      'Various KPIs aggregated and calculated from other existing metrics.',
+    templates: [getNetworkTemplate(networkIDs), apnTemplate],
+    rows: [
+      {
+        title: 'Active Users',
+        panels: [
+          {
+            title: 'Active Users Over Time',
+            targets: [
+              {
+                expr: 'active_users_over_time{networkID=~"$networkID"}',
+                legendFormat: '{{networkID}} - Days: {{days}}',
+              },
+            ],
+            description: 'Number of unique active users over the past N days.',
+          },
+        ],
+      },
+      {
+        title: 'User Throughput',
+        panels: [
+          {
+            title: 'User Throughput (Download)',
+            targets: [
+              {
+                expr: 'user_throughput{direction="in",networkID=~"$networkID"}',
+                legendFormat: '{{networkID}} - Days: {{days}}',
+              },
+            ],
+            unit: 'Bps',
+            description:
+              'Average user download throughput over the network in the last N days.',
+          },
+          {
+            title: 'User Throughput (Upload)',
+            targets: [
+              {
+                expr:
+                  'user_throughput{direction="out",networkID=~"$networkID"}',
+                legendFormat: '{{networkID}} - Days: {{days}}',
+              },
+            ],
+            unit: 'Bps',
+            description:
+              'Average user upload throughput over the network in the last N days.',
+          },
+          {
+            title: 'Throughput Per APN (Upload)',
+            targets: [
+              {
+                expr: 'throughput_per_ap{direction="out",apn=~"$apn"}',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            unit: 'Bps',
+            description:
+              'Average user upload throughput for a given APN in the last N days',
+          },
+          {
+            title: 'Throughput Per APN (Download)',
+            targets: [
+              {
+                expr: 'throughput_per_ap{direction="in",apn=~"$apn"}',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            unit: 'Bps',
+            description:
+              'Average user download throughput for a given APN in the last N days',
+          },
+        ],
+      },
+      {
+        title: 'User Consumption',
+        panels: [
+          {
+            title: 'User Consumption (Upload)',
+            targets: [
+              {
+                expr:
+                  'user_consumption{direction="out",networkID=~"$networkID"}',
+                legendFormat: '{{networkID}} - Days: {{days}}',
+              },
+            ],
+            unit: 'decbytes',
+            description:
+              'Total user upload consumption over the network in the past N days.',
+          },
+          {
+            title: 'User Consumption (Download)',
+            targets: [
+              {
+                expr:
+                  'user_consumption{direction="in",networkID=~"$networkID"}',
+                legendFormat: '{{networkID}} - Days: {{days}}',
+              },
+            ],
+            unit: 'decbytes',
+            description:
+              'Total user download consumption over the network in the past N days.',
+          },
+          {
+            title: 'User Consumption Hourly (Upload)',
+            targets: [
+              {
+                expr:
+                  'user_consumption_hourly{direction="out",networkID=~"$networkID"}',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 'decbytes',
+            description:
+              'Total user upload consumption over the network in the past hour.',
+          },
+          {
+            title: 'User Consumption Hourly (Download)',
+            targets: [
+              {
+                expr:
+                  'user_consumption_hourly{direction="in",networkID=~"$networkID"}',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 'decbytes',
+            description:
+              'Total user download consumption over the network in the past hour.',
+          },
+        ],
+      },
+      {
+        title: 'Authentications',
+        panels: [
+          {
+            title: 'Authentications Over Time',
+            targets: [
+              {
+                expr: 'authentications_over_time{networkID=~"$networkID"}',
+                legendFormat: '{{networkID}} - Code: {{code}}',
+              },
+            ],
+            description:
+              'Total number of authentication failures or successes in the network in the last N days.',
+          },
+        ],
+      },
+    ],
+  };
 };

--- a/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/CWFDashboards.js
@@ -14,11 +14,15 @@
  * @format
  */
 
-import {gatewayTemplate, networkTemplate, variableTemplate} from './Dashboards';
+import {
+  gatewayTemplate,
+  getNetworkTemplate,
+  variableTemplate,
+} from './Dashboards';
 import type {GrafanaDBData} from './Dashboards';
 
 const msisdnTemplate = variableTemplate({
-  labelName: 'msisdn',
+  name: 'msisdn',
   query: `label_values(msisdn)`,
   regex: `/.+/`,
   sort: 'num-asc',
@@ -26,7 +30,7 @@ const msisdnTemplate = variableTemplate({
 });
 
 export const apnTemplate = variableTemplate({
-  labelName: 'apn',
+  name: 'apn',
   query: `label_values({networkID=~"$networkID",apn=~".+"},apn)`,
   regex: `/.+/`,
   sort: 'alpha-insensitive-asc',
@@ -116,892 +120,904 @@ export const CWFSubscriberDBData: GrafanaDBData = {
   ],
 };
 
-export const CWFAccessPointDBData: GrafanaDBData = {
-  title: 'CWF - Access Points',
-  description: dbDescription,
-  templates: [networkTemplate, apnTemplate],
-  rows: [
-    {
-      title: 'Message Stats',
-      panels: [
-        {
-          title: 'Accounting Stops',
-          targets: [
-            {
-              expr: 'sum(accounting_stop{apn=~"$apn"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          description: 'Radius accounting stops received from AP/WLC',
-        },
-        {
-          title: 'Authorization',
-          targets: [
-            {
-              expr: 'sum(eap_auth{apn=~"$apn"}) by (code, apn)',
-              legendFormat: '{{apn}}-{{code}}',
-            },
-          ],
-          description:
-            'EAP Authorization responses, partitioned by response type (Failure, Success) where request is the sum of success and failures',
-        },
-      ],
-    },
-    {
-      title: 'Traffic',
-      panels: [
-        {
-          title: 'Traffic In',
-          targets: [
-            {
-              expr:
-                'sum(ue_reported_usage{apn=~"$apn", direction="down"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          unit: 'decbytes',
-          description: 'Inbound data measured in bytes.',
-        },
-        {
-          title: 'Traffic Out',
-          targets: [
-            {
-              expr:
-                'sum(ue_reported_usage{apn=~"$apn", direction="up"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          unit: 'decbytes',
-          description: 'Outbound data measured in bytes.',
-        },
-        {
-          title: 'Throughput In',
-          targets: [
-            {
-              expr:
-                'avg(rate(ue_reported_usage{apn=~"$apn", direction="down"}[5m])) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          unit: 'Bps',
-          description: 'Inbound data rate measured in bytes/second.',
-        },
-        {
-          title: 'Throughput Out',
-          targets: [
-            {
-              expr:
-                'avg(rate(ue_reported_usage{apn=~"$apn", direction="up"}[5m])) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          unit: 'Bps',
-          description: 'Outbound data rate measured in bytes/second.',
-        },
-      ],
-    },
-    {
-      title: 'Session',
-      panels: [
-        {
-          title: 'Active Sessions',
-          targets: [
-            {
-              expr: 'sum(active_sessions{apn=~"$apn"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          description: 'Number of active user sessions in the network',
-        },
-        {
-          title: 'Session Stop',
-          targets: [
-            {
-              expr: 'sum(session_stop{apn=~"$apn"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          description: 'Number of sessions removed for any reason',
-        },
-        {
-          title: 'Session Timeout',
-          targets: [
-            {
-              expr: 'sum(session_timeouts{apn=~"$apn"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          description:
-            'Subset of session_stop. Count of any session that times out from aaa server',
-        },
-        {
-          title: 'Session Terminate',
-          targets: [
-            {
-              expr: 'sum(session_manager_terminate{apn=~"$apn"}) by (apn)',
-              legendFormat: '{{apn}}',
-            },
-          ],
-          description: 'Session terminations initiated by sessiond',
-        },
-      ],
-    },
-  ],
+export const CWFAccessPointDBData = (
+  networkIDs: Array<string>,
+): GrafanaDBData => {
+  return {
+    title: 'CWF - Access Points',
+    description: dbDescription,
+    templates: [getNetworkTemplate(networkIDs), apnTemplate],
+    rows: [
+      {
+        title: 'Message Stats',
+        panels: [
+          {
+            title: 'Accounting Stops',
+            targets: [
+              {
+                expr: 'sum(accounting_stop{apn=~"$apn"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            description: 'Radius accounting stops received from AP/WLC',
+          },
+          {
+            title: 'Authorization',
+            targets: [
+              {
+                expr: 'sum(eap_auth{apn=~"$apn"}) by (code, apn)',
+                legendFormat: '{{apn}}-{{code}}',
+              },
+            ],
+            description:
+              'EAP Authorization responses, partitioned by response type (Failure, Success) where request is the sum of success and failures',
+          },
+        ],
+      },
+      {
+        title: 'Traffic',
+        panels: [
+          {
+            title: 'Traffic In',
+            targets: [
+              {
+                expr:
+                  'sum(ue_reported_usage{apn=~"$apn", direction="down"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            unit: 'decbytes',
+            description: 'Inbound data measured in bytes.',
+          },
+          {
+            title: 'Traffic Out',
+            targets: [
+              {
+                expr:
+                  'sum(ue_reported_usage{apn=~"$apn", direction="up"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            unit: 'decbytes',
+            description: 'Outbound data measured in bytes.',
+          },
+          {
+            title: 'Throughput In',
+            targets: [
+              {
+                expr:
+                  'avg(rate(ue_reported_usage{apn=~"$apn", direction="down"}[5m])) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            unit: 'Bps',
+            description: 'Inbound data rate measured in bytes/second.',
+          },
+          {
+            title: 'Throughput Out',
+            targets: [
+              {
+                expr:
+                  'avg(rate(ue_reported_usage{apn=~"$apn", direction="up"}[5m])) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            unit: 'Bps',
+            description: 'Outbound data rate measured in bytes/second.',
+          },
+        ],
+      },
+      {
+        title: 'Session',
+        panels: [
+          {
+            title: 'Active Sessions',
+            targets: [
+              {
+                expr: 'sum(active_sessions{apn=~"$apn"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            description: 'Number of active user sessions in the network',
+          },
+          {
+            title: 'Session Stop',
+            targets: [
+              {
+                expr: 'sum(session_stop{apn=~"$apn"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            description: 'Number of sessions removed for any reason',
+          },
+          {
+            title: 'Session Timeout',
+            targets: [
+              {
+                expr: 'sum(session_timeouts{apn=~"$apn"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            description:
+              'Subset of session_stop. Count of any session that times out from aaa server',
+          },
+          {
+            title: 'Session Terminate',
+            targets: [
+              {
+                expr: 'sum(session_manager_terminate{apn=~"$apn"}) by (apn)',
+                legendFormat: '{{apn}}',
+              },
+            ],
+            description: 'Session terminations initiated by sessiond',
+          },
+        ],
+      },
+    ],
+  };
 };
 
-export const CWFNetworkDBData: GrafanaDBData = {
-  title: 'CWF - Networks',
-  description: dbDescription,
-  templates: [networkTemplate],
-  rows: [
-    {
-      title: 'Message Stats',
-      panels: [
-        {
-          title: 'Authorization',
-          targets: [
-            {
-              expr:
-                'sum(eap_auth{networkID=~"$networkID"}) by (code, networkID)',
-              legendFormat: '{{networkID}}-{{code}}',
-            },
-          ],
-          description:
-            'EAP Authorization responses, partitioned by response type (Failure, Success) where request is the sum of success and failures',
-        },
-        {
-          title: 'Accounting Stops',
-          targets: [
-            {
-              expr:
-                'sum(accounting_stop{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Radius accounting stops received from AP/WLC',
-        },
-      ],
-    },
-    {
-      title: 'Traffic',
-      panels: [
-        {
-          title: 'Traffic In',
-          targets: [
-            {
-              expr:
-                'sum(ue_reported_usage{networkID=~"$networkID", direction="down"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 'decbytes',
-          description: 'Inbound data measured in bytes.',
-        },
-        {
-          title: 'Traffic Out',
-          targets: [
-            {
-              expr:
-                'sum(ue_reported_usage{networkID=~"$networkID", direction="up"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 'decbytes',
-          description: 'Outbound data measured in bytes.',
-        },
-        {
-          title: 'Throughput In',
-          targets: [
-            {
-              expr:
-                'avg(rate(ue_reported_usage{networkID=~"$networkID", direction="down"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 'Bps',
-          description: 'Inbound data rate measured in bytes/second.',
-        },
-        {
-          title: 'Throughput Out',
-          targets: [
-            {
-              expr:
-                'avg(rate(ue_reported_usage{networkID=~"$networkID", direction="up"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 'Bps',
-          description: 'Outbound data rate measured in bytes/second.',
-        },
-      ],
-    },
-    {
-      title: 'Latency',
-      panels: [
-        {
-          title: 'Session Create Latency',
-          targets: [
-            {
-              expr:
-                'avg(create_session_lat{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 's',
-          description:
-            'Average time taken to create a session over the network.',
-        },
-      ],
-    },
-    {
-      title: 'Session',
-      panels: [
-        {
-          title: 'Active Sessions',
-          targets: [
-            {
-              expr:
-                'sum(active_sessions{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Number of active user sessions in the network',
-        },
-        {
-          title: 'Session Stop',
-          targets: [
-            {
-              expr: 'sum(session_stop{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Number of sessions removed for any reason',
-        },
-        {
-          title: 'Session Timeouts',
-          targets: [
-            {
-              expr:
-                'sum(session_timeouts{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Subset of session_stop. Count of any session that times out from aaa server',
-        },
-        {
-          title: 'Session Terminate',
-          targets: [
-            {
-              expr:
-                'sum(session_manager_terminate{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Session terminations initiated by sessiond',
-        },
-      ],
-    },
-    {
-      title: 'Diameter Result Codes',
-      panels: [
-        {
-          title: 'Gx Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gx_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
-              legendFormat: '{{networkID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of Gx responses segmented by code',
-        },
-        {
-          title: 'Gy Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gy_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
-              legendFormat: '{{networkID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of Gy responses segmented by code',
-        },
-        {
-          title: 'SWX Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(swx_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
-              legendFormat: '{{networkID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of SWx responses segmented by diameter base code',
-        },
-        {
-          title: 'SWX Experimental Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(swx_experimental_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
-              legendFormat: '{{networkID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of SWx responses segmented by SWx-specific code',
-        },
-      ],
-    },
-    {
-      title: 'Diameter Timeouts',
-      panels: [
-        {
-          title: 'Gx Timeouts (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gx_timeouts_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gx requests that did not receive a response (and thus timed out)',
-        },
-        {
-          title: 'Gy Timeouts (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gy_timeouts_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gy requests that did not receive a response (and thus timed out)',
-        },
-        {
-          title: 'SWX Timeouts (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(swx_timeouts_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of SWx requests that did not receive a response (and thus timed out)',
-        },
-      ],
-    },
-    {
-      title: 'OCS CCR Requests',
-      panels: [
-        {
-          title: 'Initializations (Rate)',
-          targets: [
-            {
-              expr: 'sum(rate(ocs_ccr_init_requests_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of Gy CCR-I requests',
-        },
-        {
-          title: 'Terminations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_terminate_requests_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of Gy CCR-T requests',
-        },
-        {
-          title: 'Updates (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_update_requests_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of Gy CCR-U requests',
-        },
-      ],
-    },
-    {
-      title: 'OCS Send Failures',
-      panels: [
-        {
-          title: 'Initialization Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_init_send_failures_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gy CCR-I messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Temination Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_terminate_send_failures_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gy CCR-T messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Update Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_update_send_failures_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gy CCR-U messages that were unable to be sent due to diameter connection errors',
-        },
-      ],
-    },
-    {
-      title: 'PCRF CCR Requests',
-      panels: [
-        {
-          title: 'Initializations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_init_requests_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of Gx CCR-I requests',
-        },
-        {
-          title: 'Teminations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_terminate_requests_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of Gx CCR-T requests',
-        },
-        {
-          title: 'Updates (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_update_requests_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of Gx CCR-U requests',
-        },
-      ],
-    },
-    {
-      title: 'PCRF CCR Send Failures',
-      panels: [
-        {
-          title: 'Initialization Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_init_send_failures_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gx CCR-I messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Temination Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_terminate_send_failures_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gx CCR-T messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Update Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_update_send_failures_total[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description:
-            'Rate of Gx CCR-U messages that were unable to be sent due to diameter connection errors',
-        },
-      ],
-    },
-    {
-      title: 'HSS Requests/Failures',
-      panels: [
-        {
-          title: 'MAR Requests (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(mar_requests_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of SWx MAR requests',
-        },
-        {
-          title: 'SAR Requests (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(sar_requests_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of SWx SAR requests',
-        },
-        {
-          title: 'MAR Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(mar_send_failures_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of SWx MAR request failures',
-        },
-        {
-          title: 'SAR Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(sar_send_failures_total{networkID=~"$networkID"}[5m])) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          description: 'Rate of SWx SAR request failures',
-        },
-      ],
-    },
-  ],
+export const CWFNetworkDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'CWF - Networks',
+    description: dbDescription,
+    templates: [getNetworkTemplate(networkIDs)],
+    rows: [
+      {
+        title: 'Message Stats',
+        panels: [
+          {
+            title: 'Authorization',
+            targets: [
+              {
+                expr:
+                  'sum(eap_auth{networkID=~"$networkID"}) by (code, networkID)',
+                legendFormat: '{{networkID}}-{{code}}',
+              },
+            ],
+            description:
+              'EAP Authorization responses, partitioned by response type (Failure, Success) where request is the sum of success and failures',
+          },
+          {
+            title: 'Accounting Stops',
+            targets: [
+              {
+                expr:
+                  'sum(accounting_stop{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Radius accounting stops received from AP/WLC',
+          },
+        ],
+      },
+      {
+        title: 'Traffic',
+        panels: [
+          {
+            title: 'Traffic In',
+            targets: [
+              {
+                expr:
+                  'sum(ue_reported_usage{networkID=~"$networkID", direction="down"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 'decbytes',
+            description: 'Inbound data measured in bytes.',
+          },
+          {
+            title: 'Traffic Out',
+            targets: [
+              {
+                expr:
+                  'sum(ue_reported_usage{networkID=~"$networkID", direction="up"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 'decbytes',
+            description: 'Outbound data measured in bytes.',
+          },
+          {
+            title: 'Throughput In',
+            targets: [
+              {
+                expr:
+                  'avg(rate(ue_reported_usage{networkID=~"$networkID", direction="down"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 'Bps',
+            description: 'Inbound data rate measured in bytes/second.',
+          },
+          {
+            title: 'Throughput Out',
+            targets: [
+              {
+                expr:
+                  'avg(rate(ue_reported_usage{networkID=~"$networkID", direction="up"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 'Bps',
+            description: 'Outbound data rate measured in bytes/second.',
+          },
+        ],
+      },
+      {
+        title: 'Latency',
+        panels: [
+          {
+            title: 'Session Create Latency',
+            targets: [
+              {
+                expr:
+                  'avg(create_session_lat{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 's',
+            description:
+              'Average time taken to create a session over the network.',
+          },
+        ],
+      },
+      {
+        title: 'Session',
+        panels: [
+          {
+            title: 'Active Sessions',
+            targets: [
+              {
+                expr:
+                  'sum(active_sessions{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Number of active user sessions in the network',
+          },
+          {
+            title: 'Session Stop',
+            targets: [
+              {
+                expr:
+                  'sum(session_stop{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Number of sessions removed for any reason',
+          },
+          {
+            title: 'Session Timeouts',
+            targets: [
+              {
+                expr:
+                  'sum(session_timeouts{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Subset of session_stop. Count of any session that times out from aaa server',
+          },
+          {
+            title: 'Session Terminate',
+            targets: [
+              {
+                expr:
+                  'sum(session_manager_terminate{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Session terminations initiated by sessiond',
+          },
+        ],
+      },
+      {
+        title: 'Diameter Result Codes',
+        panels: [
+          {
+            title: 'Gx Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gx_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
+                legendFormat: '{{networkID}} - {{code}}',
+              },
+            ],
+            description: 'Rate of Gx responses segmented by code',
+          },
+          {
+            title: 'Gy Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gy_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
+                legendFormat: '{{networkID}} - {{code}}',
+              },
+            ],
+            description: 'Rate of Gy responses segmented by code',
+          },
+          {
+            title: 'SWX Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(swx_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
+                legendFormat: '{{networkID}} - {{code}}',
+              },
+            ],
+            description:
+              'Rate of SWx responses segmented by diameter base code',
+          },
+          {
+            title: 'SWX Experimental Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(swx_experimental_result_codes{networkID=~"$networkID"}[5m])) by (networkID, code)',
+                legendFormat: '{{networkID}} - {{code}}',
+              },
+            ],
+            description: 'Rate of SWx responses segmented by SWx-specific code',
+          },
+        ],
+      },
+      {
+        title: 'Diameter Timeouts',
+        panels: [
+          {
+            title: 'Gx Timeouts (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gx_timeouts_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gx requests that did not receive a response (and thus timed out)',
+          },
+          {
+            title: 'Gy Timeouts (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gy_timeouts_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gy requests that did not receive a response (and thus timed out)',
+          },
+          {
+            title: 'SWX Timeouts (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(swx_timeouts_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of SWx requests that did not receive a response (and thus timed out)',
+          },
+        ],
+      },
+      {
+        title: 'OCS CCR Requests',
+        panels: [
+          {
+            title: 'Initializations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_init_requests_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of Gy CCR-I requests',
+          },
+          {
+            title: 'Terminations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_terminate_requests_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of Gy CCR-T requests',
+          },
+          {
+            title: 'Updates (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_update_requests_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of Gy CCR-U requests',
+          },
+        ],
+      },
+      {
+        title: 'OCS Send Failures',
+        panels: [
+          {
+            title: 'Initialization Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_init_send_failures_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gy CCR-I messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Temination Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_terminate_send_failures_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gy CCR-T messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Update Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_update_send_failures_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gy CCR-U messages that were unable to be sent due to diameter connection errors',
+          },
+        ],
+      },
+      {
+        title: 'PCRF CCR Requests',
+        panels: [
+          {
+            title: 'Initializations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_init_requests_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of Gx CCR-I requests',
+          },
+          {
+            title: 'Teminations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_terminate_requests_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of Gx CCR-T requests',
+          },
+          {
+            title: 'Updates (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_update_requests_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of Gx CCR-U requests',
+          },
+        ],
+      },
+      {
+        title: 'PCRF CCR Send Failures',
+        panels: [
+          {
+            title: 'Initialization Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_init_send_failures_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gx CCR-I messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Temination Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_terminate_send_failures_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gx CCR-T messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Update Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_update_send_failures_total[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description:
+              'Rate of Gx CCR-U messages that were unable to be sent due to diameter connection errors',
+          },
+        ],
+      },
+      {
+        title: 'HSS Requests/Failures',
+        panels: [
+          {
+            title: 'MAR Requests (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(mar_requests_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of SWx MAR requests',
+          },
+          {
+            title: 'SAR Requests (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(sar_requests_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of SWx SAR requests',
+          },
+          {
+            title: 'MAR Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(mar_send_failures_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of SWx MAR request failures',
+          },
+          {
+            title: 'SAR Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(sar_send_failures_total{networkID=~"$networkID"}[5m])) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            description: 'Rate of SWx SAR request failures',
+          },
+        ],
+      },
+    ],
+  };
 };
 
-export const CWFGatewayDBData: GrafanaDBData = {
-  title: 'CWF - Gateways',
-  description: dbDescription,
-  templates: [networkTemplate, gatewayTemplate],
-  rows: [
-    {
-      title: 'Diameter Result Codes',
-      panels: [
-        {
-          title: 'Gx Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gx_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
-              legendFormat: '{{gatewayID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of Gx responses segmented by code',
-        },
-        {
-          title: 'Gy Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gy_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
-              legendFormat: '{{gatewayID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of Gy responses segmented by code',
-        },
-        {
-          title: 'SWX Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(swx_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
-              legendFormat: '{{gatewayID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of SWx responses segmented by diameter base code',
-        },
-        {
-          title: 'SWX Experimental Result Codes (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(swx_experimental_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
-              legendFormat: '{{gatewayID}} - {{code}}',
-            },
-          ],
-          description: 'Rate of SWx responses segmented by SWx-specific code',
-        },
-      ],
-    },
-    {
-      title: 'Diameter Timeouts',
-      panels: [
-        {
-          title: 'Gx Timeouts (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gx_timeouts_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gx requests that did not receive a response (and thus timed out)',
-        },
-        {
-          title: 'Gy Timeouts (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(gy_timeouts_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gy requests that did not receive a response (and thus timed out)',
-        },
-        {
-          title: 'SWX Timeouts (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(swx_timeouts_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of SWx requests that did not receive a response (and thus timed out)',
-        },
-      ],
-    },
-    {
-      title: 'OCS CCR Requests',
-      panels: [
-        {
-          title: 'Initializations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_init_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of Gy CCR-I requests',
-        },
-        {
-          title: 'Terminations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_terminate_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of Gy CCR-T requests',
-        },
-        {
-          title: 'Updates (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_update_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of Gy CCR-U requests',
-        },
-      ],
-    },
-    {
-      title: 'OCS Send Failures (Rate)',
-      panels: [
-        {
-          title: 'Initialization Failures',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_init_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gy CCR-I messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Termination Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_terminate_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gy CCR-T messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Update Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(ocs_ccr_update_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gy CCR-U messages that were unable to be sent due to diameter connection errors',
-        },
-      ],
-    },
-    {
-      title: 'PCRF CCR Requests',
-      panels: [
-        {
-          title: 'Initializations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_init_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of Gx CCR-I requests',
-        },
-        {
-          title: 'Terminations (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_terminate_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of Gx CCR-T requests',
-        },
-        {
-          title: 'Updates (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_update_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of Gx CCR-U requests',
-        },
-      ],
-    },
-    {
-      title: 'PCRF CCR Send Failures',
-      panels: [
-        {
-          title: 'Initialization Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_init_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gx CCR-I messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Termination Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_terminate_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description:
-            'Rate of Gx CCR-T messages that were unable to be sent due to diameter connection errors',
-        },
-        {
-          title: 'Update Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(pcrf_ccr_update_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-        },
-      ],
-      description:
-        'Rate of Gx CCR-U messages that were unable to be sent due to diameter connection errors',
-    },
-    {
-      title: 'HSS Requests/Failures',
-      panels: [
-        {
-          title: 'MAR Requests (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(mar_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of SWx MAR requests',
-        },
-        {
-          title: 'SAR Requests (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(sar_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of SWx SAR requests',
-        },
-        {
-          title: 'MAR Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(mar_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of SWx MAR request failures',
-        },
-        {
-          title: 'SAR Failures (Rate)',
-          targets: [
-            {
-              expr:
-                'sum(rate(sar_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          description: 'Rate of SWx SAR request failures',
-        },
-      ],
-    },
-  ],
+export const CWFGatewayDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'CWF - Gateways',
+    description: dbDescription,
+    templates: [getNetworkTemplate(networkIDs), gatewayTemplate],
+    rows: [
+      {
+        title: 'Diameter Result Codes',
+        panels: [
+          {
+            title: 'Gx Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gx_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
+                legendFormat: '{{gatewayID}} - {{code}}',
+              },
+            ],
+            description: 'Rate of Gx responses segmented by code',
+          },
+          {
+            title: 'Gy Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gy_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
+                legendFormat: '{{gatewayID}} - {{code}}',
+              },
+            ],
+            description: 'Rate of Gy responses segmented by code',
+          },
+          {
+            title: 'SWX Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(swx_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
+                legendFormat: '{{gatewayID}} - {{code}}',
+              },
+            ],
+            description:
+              'Rate of SWx responses segmented by diameter base code',
+          },
+          {
+            title: 'SWX Experimental Result Codes (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(swx_experimental_result_codes{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID, code)',
+                legendFormat: '{{gatewayID}} - {{code}}',
+              },
+            ],
+            description: 'Rate of SWx responses segmented by SWx-specific code',
+          },
+        ],
+      },
+      {
+        title: 'Diameter Timeouts',
+        panels: [
+          {
+            title: 'Gx Timeouts (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gx_timeouts_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gx requests that did not receive a response (and thus timed out)',
+          },
+          {
+            title: 'Gy Timeouts (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(gy_timeouts_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gy requests that did not receive a response (and thus timed out)',
+          },
+          {
+            title: 'SWX Timeouts (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(swx_timeouts_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of SWx requests that did not receive a response (and thus timed out)',
+          },
+        ],
+      },
+      {
+        title: 'OCS CCR Requests',
+        panels: [
+          {
+            title: 'Initializations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_init_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of Gy CCR-I requests',
+          },
+          {
+            title: 'Terminations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_terminate_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of Gy CCR-T requests',
+          },
+          {
+            title: 'Updates (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_update_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of Gy CCR-U requests',
+          },
+        ],
+      },
+      {
+        title: 'OCS Send Failures (Rate)',
+        panels: [
+          {
+            title: 'Initialization Failures',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_init_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gy CCR-I messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Termination Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_terminate_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gy CCR-T messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Update Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(ocs_ccr_update_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gy CCR-U messages that were unable to be sent due to diameter connection errors',
+          },
+        ],
+      },
+      {
+        title: 'PCRF CCR Requests',
+        panels: [
+          {
+            title: 'Initializations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_init_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of Gx CCR-I requests',
+          },
+          {
+            title: 'Terminations (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_terminate_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of Gx CCR-T requests',
+          },
+          {
+            title: 'Updates (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_update_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of Gx CCR-U requests',
+          },
+        ],
+      },
+      {
+        title: 'PCRF CCR Send Failures',
+        panels: [
+          {
+            title: 'Initialization Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_init_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gx CCR-I messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Termination Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_terminate_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description:
+              'Rate of Gx CCR-T messages that were unable to be sent due to diameter connection errors',
+          },
+          {
+            title: 'Update Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(pcrf_ccr_update_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+          },
+        ],
+        description:
+          'Rate of Gx CCR-U messages that were unable to be sent due to diameter connection errors',
+      },
+      {
+        title: 'HSS Requests/Failures',
+        panels: [
+          {
+            title: 'MAR Requests (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(mar_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of SWx MAR requests',
+          },
+          {
+            title: 'SAR Requests (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(sar_requests_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of SWx SAR requests',
+          },
+          {
+            title: 'MAR Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(mar_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of SWx MAR request failures',
+          },
+          {
+            title: 'SAR Failures (Rate)',
+            targets: [
+              {
+                expr:
+                  'sum(rate(sar_send_failures_total{networkID=~"$networkID", gatewayID=~"$gatewayID"}[5m])) by (gatewayID)',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            description: 'Rate of SWx SAR request failures',
+          },
+        ],
+      },
+    ],
+  };
 };

--- a/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/Dashboards.js
@@ -30,13 +30,17 @@ const variableSortNumbers: {[VariableSortOption]: number} = {
   'alpha-insensitive-desc': 6,
 };
 
-export const networkTemplate: TemplateConfig = variableTemplate({
-  labelName: netIDVar,
-  query: `label_values(${netIDVar})`,
-  regex: `/.+/`,
-  sort: 'alpha-insensitive-asc',
-  includeAll: true,
-});
+export const getNetworkTemplate = (
+  networkIDs: Array<string>,
+): TemplateConfig => {
+  return customVariableTemplate({
+    name: netIDVar,
+    type: 'custom',
+    options: networkIDs,
+    sort: 'alpha-insensitive-asc',
+    includeAll: true,
+  });
+};
 
 // This templating schema will produce a variable in the dashboard
 // named gatewayID which is a multi-selectable option of all the
@@ -44,366 +48,351 @@ export const networkTemplate: TemplateConfig = variableTemplate({
 // currently selected $networkID. $networkID variable must also
 // be configured for this dashboard in order for it to work
 export const gatewayTemplate: TemplateConfig = variableTemplate({
-  labelName: gwIDVar,
+  name: gwIDVar,
   query: `label_values({networkID=~"$networkID",gatewayID=~".+"}, ${gwIDVar})`,
   regex: `/.+/`,
   sort: 'alpha-insensitive-asc',
   includeAll: true,
 });
 
-export const NetworkDBData: GrafanaDBData = {
-  title: 'Networks',
-  description:
-    'Metrics relevant to the whole network. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
-  templates: [networkTemplate],
-  rows: [
-    {
-      title: '',
-      panels: [
-        {
-          title: 'Number of Connected UEs',
-          targets: [
-            {
-              expr: 'sum(ue_connected{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          aggregates: {avg: true, max: true},
-        },
-        {
-          title: 'Number of Registered UEs',
-          targets: [
-            {
-              expr:
-                'sum(ue_registered{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          aggregates: {avg: true, max: true},
-        },
-        {
-          title: 'Number of Connected eNBs',
-          targets: [
-            {
-              expr:
-                'sum(enb_connected{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          aggregates: {avg: true, max: true},
-        },
-        {
-          title: 'S1 Setup',
-          targets: [
-            {
-              expr: 'sum(s1_setup{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Total: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(s1_setup{networkID=~"$networkID",result="success"}) by (networkID)',
-              legendFormat: 'Success: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(s1_setup{networkID=~"$networkID"})by(networkID)-sum(s1_setup{result="success",networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Failure: {{networkID}}',
-            },
-          ],
-        },
-        {
-          title: 'Attach/Reg Attempts',
-          targets: [
-            {
-              expr: 'sum(ue_attach{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Total: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(ue_attach{networkID=~"$networkID",result="attach_proc_successful"}) by (networkID)',
-              legendFormat: 'Success: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(ue_attach{networkID=~"$networkID"}) by (networkID) -sum(s1_setup{result="attach_proc_successful",networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Failure: {{networkID}}',
-            },
-          ],
-        },
-        {
-          title: 'Detach/Dereg Attempts',
-          targets: [
-            {
-              expr: 'sum(ue_detach{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Total: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(ue_detach{networkID=~"$networkID",result="attach_proc_successful"}) by (networkID)',
-              legendFormat: 'Success: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(ue_detach{networkID=~"$networkID"}) by (networkID) -sum(s1_setup{result="attach_proc_successful",networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Failure: {{networkID}}',
-            },
-          ],
-        },
-        {
-          title: 'GPS Connection Uptime',
-          targets: [
-            {
-              expr:
-                'avg(enodeb_gps_connected{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-          unit: 's',
-        },
-        {
-          title: 'Device Transmitting Status',
-          targets: [
-            {
-              expr:
-                'avg(enodeb_rf_tx_enabled{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: '{{networkID}}',
-            },
-          ],
-        },
-        {
-          title: 'Service Requests',
-          targets: [
-            {
-              expr:
-                'sum(service_request{networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Total: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(service_request{networkID=~"$networkID",result="success"}) by (networkID)',
-              legendFormat: 'Success: {{networkID}}',
-            },
-            {
-              expr:
-                'sum(service_request{networkID=~"$networkID"}) by (networkID)-sum(s1_setup{result="success",networkID=~"$networkID"}) by (networkID)',
-              legendFormat: 'Failure: {{networkID}}',
-            },
-          ],
-        },
-      ],
-    },
-  ],
+export const NetworkDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'Networks',
+    description:
+      'Metrics relevant to the whole network. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
+    templates: [getNetworkTemplate(networkIDs)],
+    rows: [
+      {
+        title: '',
+        panels: [
+          {
+            title: 'Number of Connected UEs',
+            targets: [
+              {
+                expr:
+                  'sum(ue_connected{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            aggregates: {avg: true, max: true},
+          },
+          {
+            title: 'Number of Registered UEs',
+            targets: [
+              {
+                expr:
+                  'sum(ue_registered{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            aggregates: {avg: true, max: true},
+          },
+          {
+            title: 'Number of Connected eNBs',
+            targets: [
+              {
+                expr:
+                  'sum(enb_connected{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            aggregates: {avg: true, max: true},
+          },
+          {
+            title: 'S1 Setup',
+            targets: [
+              {
+                expr: 'sum(s1_setup{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Total: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(s1_setup{networkID=~"$networkID",result="success"}) by (networkID)',
+                legendFormat: 'Success: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(s1_setup{networkID=~"$networkID"})by(networkID)-sum(s1_setup{result="success",networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Failure: {{networkID}}',
+              },
+            ],
+          },
+          {
+            title: 'Attach/Reg Attempts',
+            targets: [
+              {
+                expr: 'sum(ue_attach{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Total: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(ue_attach{networkID=~"$networkID",result="attach_proc_successful"}) by (networkID)',
+                legendFormat: 'Success: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(ue_attach{networkID=~"$networkID"}) by (networkID) -sum(s1_setup{result="attach_proc_successful",networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Failure: {{networkID}}',
+              },
+            ],
+          },
+          {
+            title: 'Detach/Dereg Attempts',
+            targets: [
+              {
+                expr: 'sum(ue_detach{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Total: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(ue_detach{networkID=~"$networkID",result="attach_proc_successful"}) by (networkID)',
+                legendFormat: 'Success: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(ue_detach{networkID=~"$networkID"}) by (networkID) -sum(s1_setup{result="attach_proc_successful",networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Failure: {{networkID}}',
+              },
+            ],
+          },
+          {
+            title: 'GPS Connection Uptime',
+            targets: [
+              {
+                expr:
+                  'avg(enodeb_gps_connected{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+            unit: 's',
+          },
+          {
+            title: 'Device Transmitting Status',
+            targets: [
+              {
+                expr:
+                  'avg(enodeb_rf_tx_enabled{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: '{{networkID}}',
+              },
+            ],
+          },
+          {
+            title: 'Service Requests',
+            targets: [
+              {
+                expr:
+                  'sum(service_request{networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Total: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(service_request{networkID=~"$networkID",result="success"}) by (networkID)',
+                legendFormat: 'Success: {{networkID}}',
+              },
+              {
+                expr:
+                  'sum(service_request{networkID=~"$networkID"}) by (networkID)-sum(s1_setup{result="success",networkID=~"$networkID"}) by (networkID)',
+                legendFormat: 'Failure: {{networkID}}',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
 };
 
-export const GatewayDBData: GrafanaDBData = {
-  title: 'Gateways',
-  description:
-    'Metrics relevant to the gateways. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
-  templates: [networkTemplate, gatewayTemplate],
-  rows: [
-    {
-      title: '',
-      panels: [
-        {
-          title: 'E-Node B Status',
-          targets: [
-            {
-              expr:
-                'enodeb_rf_tx_enabled{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-        },
-        {
-          title: 'Connected Subscribers',
-          targets: [
-            {
-              expr:
-                'ue_connected{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-        },
-        {
-          title: 'Download Throughput',
-          targets: [
-            {
-              expr:
-                'pdcp_user_plane_bytes_dl{gatewayID=~"$gatewayID",service="enodebd",networkID=~"$networkID"}/1000',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 'Bps',
-        },
-        {
-          title: 'Upload Throughput',
-          targets: [
-            {
-              expr:
-                'pdcp_user_plane_bytes_ul{gatewayID=~"$gatewayID",service="enodebd",networkID=~"$networkID"}/1000',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 'Bps',
-        },
-        {
-          title: 'Latency',
-          targets: [
-            {
-              expr:
-                'magmad_ping_rtt_ms{gatewayID=~"$gatewayID",networkID=~"$networkID",metric="rtt_ms"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 's',
-        },
-        {
-          title: 'Gateway CPU %',
-          targets: [
-            {
-              expr:
-                'cpu_percent{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 'percent',
-        },
-        {
-          title: 'Temperature',
-          targets: [
-            {
-              expr:
-                'temperature{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}} - {{sensor}}',
-            },
-          ],
-          yMin: null,
-          unit: 'celsius',
-        },
-        {
-          title: 'Disk %',
-          targets: [
-            {
-              expr:
-                'disk_percent{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 'percent',
-        },
-        {
-          title: 's6a Auth Failure',
-          targets: [
-            {
-              expr:
-                's6a_auth_failure{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-        },
-      ],
-    },
-  ],
+export const GatewayDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'Gateways',
+    description:
+      'Metrics relevant to the gateways. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
+    templates: [getNetworkTemplate(networkIDs), gatewayTemplate],
+    rows: [
+      {
+        title: '',
+        panels: [
+          {
+            title: 'E-Node B Status',
+            targets: [
+              {
+                expr:
+                  'enodeb_rf_tx_enabled{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+          },
+          {
+            title: 'Connected Subscribers',
+            targets: [
+              {
+                expr:
+                  'ue_connected{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+          },
+          {
+            title: 'Download Throughput',
+            targets: [
+              {
+                expr:
+                  'pdcp_user_plane_bytes_dl{gatewayID=~"$gatewayID",service="enodebd",networkID=~"$networkID"}/1000',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 'Bps',
+          },
+          {
+            title: 'Upload Throughput',
+            targets: [
+              {
+                expr:
+                  'pdcp_user_plane_bytes_ul{gatewayID=~"$gatewayID",service="enodebd",networkID=~"$networkID"}/1000',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 'Bps',
+          },
+          {
+            title: 'Latency',
+            targets: [
+              {
+                expr:
+                  'magmad_ping_rtt_ms{gatewayID=~"$gatewayID",networkID=~"$networkID",metric="rtt_ms"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 's',
+          },
+          {
+            title: 'Gateway CPU %',
+            targets: [
+              {
+                expr:
+                  'cpu_percent{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 'percent',
+          },
+          {
+            title: 'Temperature',
+            targets: [
+              {
+                expr:
+                  'temperature{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}} - {{sensor}}',
+              },
+            ],
+            yMin: null,
+            unit: 'celsius',
+          },
+          {
+            title: 'Disk %',
+            targets: [
+              {
+                expr:
+                  'disk_percent{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 'percent',
+          },
+          {
+            title: 's6a Auth Failure',
+            targets: [
+              {
+                expr:
+                  's6a_auth_failure{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
 };
 
-export const InternalDBData: GrafanaDBData = {
-  title: 'Internal',
-  description:
-    'Metrics relevant to the internals of gateways. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
-  templates: [networkTemplate, gatewayTemplate],
-  rows: [
-    {
-      title: '',
-      panels: [
-        {
-          title: 'Physical Memory Utilization Percent',
-          targets: [
-            {
-              expr:
-                'mem_free{gatewayID=~"$gatewayID"}/mem_total{gatewayID=~"$gatewayID",networkID=~"$networkID"} * 100',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-        },
-        {
-          title: 'Temperature',
-          targets: [
-            {
-              expr:
-                'temperature{gatewayID=~"$gatewayID",sensor="coretemp_0",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}} - {{sensor}}',
-            },
-          ],
-          unit: 'percent',
-        },
-        {
-          title: 'Virtual Memory Percent',
-          targets: [
-            {
-              expr:
-                'virtual_memory_percent{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 'percent',
-        },
-        {
-          title: 'Backhaul Latency',
-          targets: [
-            {
-              expr:
-                'magmad_ping_rtt_ms{gatewayID=~"$gatewayID",service="magmad",host="8.8.8.8",metric="rtt_ms",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}',
-            },
-          ],
-          unit: 's',
-        },
-        {
-          title: 'System Uptime',
-          targets: [
-            {
-              expr:
-                'process_uptime_seconds{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}-{{service}}',
-            },
-          ],
-          unit: 's',
-        },
-        {
-          title: 'Number of Service Restarts',
-          targets: [
-            {
-              expr:
-                'unexpected_service_restarts{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
-              legendFormat: '{{gatewayID}}-{{service_name}}',
-            },
-          ],
-        },
-      ],
-    },
-  ],
-};
-
-export const TemplateDBData: GrafanaDBData = {
-  title: 'Variable Demo',
-  description:
-    'Template dashboard with network and gateway variables preconfigured. Copy from this template to create a new dashboard which includes the networkID and gatewayID variables.',
-  templates: [networkTemplate, gatewayTemplate],
-  rows: [
-    {
-      title: '',
-      panels: [
-        {
-          title: 'Variable Demo',
-          targets: [
-            {
-              expr: `cpu_percent{networkID=~"$networkID",gatewayID=~"$gatewayID"}`,
-            },
-          ],
-        },
-      ],
-    },
-  ],
+export const InternalDBData = (networkIDs: Array<string>): GrafanaDBData => {
+  return {
+    title: 'Internal',
+    description:
+      'Metrics relevant to the internals of gateways. Do not edit: edits will be overwritten. Save this dashboard under another name to copy and edit.',
+    templates: [getNetworkTemplate(networkIDs), gatewayTemplate],
+    rows: [
+      {
+        title: '',
+        panels: [
+          {
+            title: 'Physical Memory Utilization Percent',
+            targets: [
+              {
+                expr:
+                  'mem_free{gatewayID=~"$gatewayID"}/mem_total{gatewayID=~"$gatewayID",networkID=~"$networkID"} * 100',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+          },
+          {
+            title: 'Temperature',
+            targets: [
+              {
+                expr:
+                  'temperature{gatewayID=~"$gatewayID",sensor="coretemp_0",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}} - {{sensor}}',
+              },
+            ],
+            unit: 'percent',
+          },
+          {
+            title: 'Virtual Memory Percent',
+            targets: [
+              {
+                expr:
+                  'virtual_memory_percent{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 'percent',
+          },
+          {
+            title: 'Backhaul Latency',
+            targets: [
+              {
+                expr:
+                  'magmad_ping_rtt_ms{gatewayID=~"$gatewayID",service="magmad",host="8.8.8.8",metric="rtt_ms",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}',
+              },
+            ],
+            unit: 's',
+          },
+          {
+            title: 'System Uptime',
+            targets: [
+              {
+                expr:
+                  'process_uptime_seconds{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}-{{service}}',
+              },
+            ],
+            unit: 's',
+          },
+          {
+            title: 'Number of Service Restarts',
+            targets: [
+              {
+                expr:
+                  'unexpected_service_restarts{gatewayID=~"$gatewayID",networkID=~"$networkID"}',
+                legendFormat: '{{gatewayID}}-{{service_name}}',
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
 };
 
 export function createDashboard(dbdata: GrafanaDBData) {
@@ -420,6 +409,14 @@ export function createDashboard(dbdata: GrafanaDBData) {
     rows,
   });
   db.state.editable = false;
+
+  // Necessary to make custom templates display "all" option
+  for (const template of db.state?.templating?.list) {
+    if (template.type === 'custom' && template.includeAll) {
+      template.options.unshift({selected: true, text: 'All', value: '$__all'});
+    }
+    template.current = template.options[0];
+  }
   return db;
 }
 
@@ -472,11 +469,13 @@ function newPanel(params: PanelParams) {
 }
 
 export type TemplateParams = {
-  labelName: string,
-  query: string,
-  regex: string,
+  name: string,
+  query?: string,
+  options?: Array<string>,
+  regex?: string,
   sort?: VariableSortOption,
   includeAll: boolean,
+  type?: string,
 };
 
 type VariableSortOption =
@@ -496,27 +495,40 @@ export function variableTemplate(params: TemplateParams): TemplateConfig {
     includeAll: params.includeAll,
     allFormat: 'glob',
     multi: true,
-    name: params.labelName,
-    query: params.query,
+    name: params.name,
+    query: params.query ?? '',
+    options: params.options ?? [],
     regex: params.regex,
-    type: 'query',
+    type: params.type ?? 'query',
     refresh: true,
     useTags: false,
     sort: params.sort ? variableSortNumbers[params.sort] : 0,
   };
 }
 
+export function customVariableTemplate(params: TemplateParams): TemplateConfig {
+  return {
+    options: params.options ?? [],
+    includeAll: true,
+    name: params.name,
+    multi: true,
+    allFormat: 'glob',
+    allValue: '.+',
+  };
+}
+
 export type TemplateConfig = {
   allValue: string,
-  definition: string,
-  hide: number,
+  definition?: string,
+  hide?: number,
   includeAll: boolean,
   allFormat: string,
   multi: boolean,
   name: string,
-  query: string,
-  regex: string,
-  type: string,
-  refresh: boolean,
-  useTags: boolean,
+  query?: string,
+  options: Array<string>,
+  regex?: string,
+  type?: string,
+  refresh?: boolean,
+  useTags?: boolean,
 };

--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -28,7 +28,6 @@ import {
   GatewayDBData,
   InternalDBData,
   NetworkDBData,
-  TemplateDBData,
   createDashboard,
 } from './dashboards/Dashboards';
 import {Organization} from '@fbcnms/sequelize-models';
@@ -483,22 +482,23 @@ export async function syncDashboards(
 
   // Basic dashboards
   const posts = [
-    dashboardData(createDashboard(NetworkDBData).generate()),
-    dashboardData(createDashboard(GatewayDBData).generate()),
-    dashboardData(createDashboard(InternalDBData).generate()),
-    dashboardData(createDashboard(TemplateDBData).generate()),
+    dashboardData(createDashboard(NetworkDBData(networks)).generate()),
+    dashboardData(createDashboard(GatewayDBData(networks)).generate()),
+    dashboardData(createDashboard(InternalDBData(networks)).generate()),
   ];
 
   // If an org contains CWF networks, add the CWF-specific dashboards
   if (await hasCWFNetwork(networks)) {
     posts.push(
-      dashboardData(createDashboard(CWFNetworkDBData).generate()),
-      dashboardData(createDashboard(CWFAccessPointDBData).generate()),
+      dashboardData(createDashboard(CWFNetworkDBData(networks)).generate()),
+      dashboardData(createDashboard(CWFAccessPointDBData(networks)).generate()),
       dashboardData(createDashboard(CWFSubscriberDBData).generate()),
-      dashboardData(createDashboard(CWFGatewayDBData).generate()),
+      dashboardData(createDashboard(CWFGatewayDBData(networks)).generate()),
     );
     // Analytics Dashboard
-    posts.push(dashboardData(createDashboard(AnalyticsDBData).generate()));
+    posts.push(
+      dashboardData(createDashboard(AnalyticsDBData(networks)).generate()),
+    );
   }
 
   for (const post of posts) {


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Previously we used a "query" variable type to get the list of networkIDs from prometheus by querying for all metrics with a networkID and then getting the unique set out of that. This works, but it's kinda slow and we already have this data available in the NMS itself via the magma /networks api.

* Will do the same for `gatewayID` in another diff


## Test Plan
Dashboard loads instantly
Checked all other dashboards to ensure no side effects

![image](https://user-images.githubusercontent.com/13274915/92966419-5e890d80-f42c-11ea-9634-1cba220316ac.png)

