### PR TITLE
[orc8r][api] Restrict label queries

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -56,7 +56,6 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -29,13 +29,8 @@ module magma/cwf/k8s/cwf_operator
 go 1.13
 
 require (
-	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/go-logr/glogr v0.1.0
 	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/hashicorp/go-msgpack v0.5.4 // indirect
-	github.com/hashicorp/go-uuid v1.0.1 // indirect
-	github.com/miekg/dns v1.1.10 // indirect
-	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/feg/radius/lib/go/oc/go.mod
+++ b/feg/radius/lib/go/oc/go.mod
@@ -15,7 +15,6 @@ require (
 	contrib.go.opencensus.io/exporter/prometheus v0.1.0
 	fbc/lib/go/http v0.0.0
 	fbc/lib/go/oc/helpers v0.0.0
-	github.com/gogo/protobuf v1.2.0 // indirect
 	github.com/jessevdk/go-flags v1.4.1-0.20181221193153-c0795c8afcf4
 	github.com/kelseyhightower/envconfig v1.3.0
 	github.com/pkg/errors v0.8.1

--- a/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
+++ b/orc8r/cloud/go/services/metricsd/prometheus/handlers/promo_handlers.go
@@ -359,7 +359,12 @@ func GetTenantPromValuesHandler(api v1.API) func(c echo.Context) error {
 			return obsidian.HttpError(err, http.StatusInternalServerError)
 		}
 
-		seriesMatchers := []string{fmt.Sprintf("{%s=~\".*\"}", labelName)}
+		restrictedQuery, err := queryRestrictor.RestrictQuery(fmt.Sprintf("{%s=~\".+\"}", labelName))
+		if err != nil {
+			return obsidian.HttpError(err, http.StatusInternalServerError)
+		}
+
+		seriesMatchers := []string{restrictedQuery}
 		for _, matcher := range queryRestrictor.Matchers() {
 			seriesMatchers = append(seriesMatchers, fmt.Sprintf("{%s}", matcher.String()))
 		}


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

When prometheus upgraded to 2.20.1 it included changes to the API that enabled https://github.com/magma/magma/pull/2599. It also changed the API use the less restrictive series matcher instead of the more restrictive one. This led to label values being returned that were not properly restricted based on the tenant. 
This fixes the problem by always restricting the label request query.

## Test Plan

Endpoint doesn't return networks that don't belong to tenant
![image](https://user-images.githubusercontent.com/13274915/92977701-8e431000-f442-11ea-802b-23f2260dfa00.png)