### PR TITLE
[xwfm] fix CI to be able to run without cert

### DIFF
--- a/xwf/gateway/integ_tests/gw/entrypoint.sh
+++ b/xwf/gateway/integ_tests/gw/entrypoint.sh
@@ -27,7 +27,7 @@ cp xwf/gateway/configs/* /etc/magma/
 cp orc8r/gateway/configs/templates/* /etc/magma/
 
 echo "get xwfwhoami"
-curl -X POST  https://graph.expresswifi.com/openflow/configxwfm?access_token=$ACCESSTOKEN | jq -r .configxwfm > /etc/xwfwhoami
+curl -X POST -k https://graph.expresswifi.com/openflow/configxwfm?access_token=$ACCESSTOKEN | jq -r .configxwfm > /etc/xwfwhoami
 sed -i '/^uplink_if/d'  /etc/xwfwhoami # TODO: remove this
 
 echo "run XWF ansible"


### PR DESCRIPTION
[xwfm][ci]

## Summary

Don't validate SSL certificate against facebook servers on CI. This is needed in order to test CI against dev machines without signed certificates.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
