### PR TITLE
[xwf][ofpanalytics] Fixing logline for access response + sync to compose

### DIFF
--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -128,8 +128,12 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 	}
 	defer resp.Body.Close()
 	rc.Logger.Debug("got response", zap.String("status", resp.Status),
-		zap.ByteString("full_msg", encodedMsg), zap.String("url", resp.Request.URL.String()),
-		zap.Any("request", r.Packet.Attributes))
+		zap.String("url", resp.Request.URL.String()),
+		zap.Any("request", r.Packet.Attributes),
+		zap.String("Called-Station-Id", rfc2865.CalledStationID_GetString(r.Packet)),
+		zap.String("Calling-Station-Id", rfc2865.CallingStationID_GetString(r.Packet)),
+		zap.String("NAS-Identifier", rfc2865.NASIdentifier_GetString(r.Packet)),
+		zap.String("XWF-C-Version", analyticsVersion))
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("error processing message by endpoint. Response status %d", resp.StatusCode)

--- a/xwf/docker/docker-compose.yml
+++ b/xwf/docker/docker-compose.yml
@@ -16,10 +16,10 @@ services:
     ports:
       - "24224:24224"
     healthcheck:
-      test: ["CMD", "nc", "-vz", "localhost", "24224"]
-      interval: 30s
-      timeout: 10s
-      retries: 15
+        test: ["CMD", "nc", "-vz", "localhost", "24224"]
+        interval: 30s
+        timeout: 10s
+        retries: 15
     environment:
       - SCRIBE_ACCESS_TOKEN=${XWF_SCUBA_ACCESS_TOKEN}
       - SCUBA_TABLE=perfpipe_xwf_openflow_compose_logs
@@ -131,6 +131,8 @@ services:
       /bin/sh -c "./docker-entrypoint.sh"
     networks:
       - control
+    ports:
+      - "1812:1812/udp"
     logging:
       driver: "json-file"
       options:
@@ -276,4 +278,4 @@ networks:
   control:
     ipam:
       config:
-        - subnet: 10.0.12.0/24
+      - subnet: 10.0.12.0/24


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

The logline before had json encoding issues.
Also i have opened port 1812 in compose file to be able to debug radius requests.

## Test Plan

I have run the compose files using the following commands:
```
$ MAGMA_BASE="~/magma/xwf/docker/" ./run magma build
$ MAGMA_BASE="~/magma/xwf/docker/" ./run magma init --extra_env MAGMA_BASE "~/magma/xwf/docker/"

$ export MAC="74:81:14:52:21:c1"
$ echo "Calling-Station-Id = $MAC, Called-Station-Id = 11:11:11:11:11:12, User-Name = $MAC, NAS-IP-Address = 192.168.1.1, NAS-Identifier = blabla" | radclient -x 127.0.0.1:1812 auth 123456
Sent Access-Request Id 48 from 0.0.0.0:53131 to 127.0.0.1:1812 length 91
	Calling-Station-Id = "74:81:14:52:21:c1"
	Called-Station-Id = "11:11:11:11:11:12"
	User-Name = "74:81:14:52:21:c1"
	NAS-IP-Address = 192.168.1.1
	NAS-Identifier = "blabla"
Received Access-Accept Id 48 from 127.0.0.1:1812 to 127.0.0.1:53131 length 20
```

checked docker logs:

```
{"level":"debug","ts":1600011704.1988342,"caller":"ofpanalytics/ofpanalytics.go:130","msg":"got response","host":"6068aaf9ac57","partner_shortname":"ofpqa1-gh","app_version":"1.0.0","correlation":2854263694,"status":"200 OK","url":"https://graph.expresswifi.com/radius/authorization","request":{"1":["NzQ6ODE6MTQ6NTI6MjE6YzE="],"30":["MTE6MTE6MTE6MTE6MTE6MTI="],"31":["NzQ6ODE6MTQ6NTI6MjE6YzE="],"32":["YmxhYmxh"],"4":["wKgBAQ=="]},"Called-Station-Id":"11:11:11:11:11:12","Calling-Station-Id":"74:81:14:52:21:c1","NAS-Identifier":"blabla","XWF-C-Version":"v1.1"}
```
## Additional Information

- [ ] This change is backwards-breaking

