### PR TITLE
[AGW] typo in oai-gtp dep -5 instead of .5

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -126,7 +126,7 @@ OAI_DEPS=(
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
-    "oai-gtp >= 4.9.5"
+    "oai-gtp >= 4.9-5"
     )
 
 # OVS runtime dependencies


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW] typo in oai-gtp dep -5 instead of .5

## Summary

Typo in oai-gtp dep -5 instead of .5

## Test Plan

Let CI built magma and then 

`apt -f install magma`

## Additional Information

My bad I made a typo 
