### PR TITLE
Add CODEOWNERS for XWF Magma integrations

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,6 +24,10 @@ lte/gateway/python/integ_tests @ssanadhya @ulaskozat
 **/*.pb.go @magma/entire-org
 **/*_swaggergen.go @magma/entire-org
 
+# xwf Magma integrations
+xwf/ @AyliD @aharonnovo @r-i-g
+feg/radius @AyliD @aharonnovo @r-i-g @themarwhal @mpgermano @uri200 @emakeev
+
 nms/ @karthiksubraveti @andreilee @xjtian @Scott8440
 
 CODEOWNERS @xjtian @amarpad


### PR DESCRIPTION
## Summary

Add the owners of XWF<->Magma integrations as CODEOWNERS to Magma

## Test Plan

Visually validated

## Additional Information

- [ ] This change is backwards-breaking
