### PR TITLE
[xwf][radiussevrer] logs to fluentbit vs to scribe via service template

### DIFF
--- a/feg/radius/src/config/samples/radius.ofpanalytics.config.json.template
+++ b/feg/radius/src/config/samples/radius.ofpanalytics.config.json.template
@@ -8,14 +8,6 @@
       "unique_entity": true,
       "debug_prints": true
     },
-    "scuba": {
-      "message_queue_size": 2000,
-      "flush_interval_sec": 2,
-      "batch_size": 15,
-      "graph_url": "https://graph.facebook.com/scribe_logs",
-      "access_token": "$SCUBA_ACCESS_TOKEN",
-      "partner_shortname": "$PARTNER_SHORTNAME"
-    },
     "census": {
       "disable_stats": false,
       "stat_views": ["proc"]

--- a/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
+++ b/feg/radius/src/modules/ofpanalytics/ofpanalytics.go
@@ -128,8 +128,12 @@ func Handle(m modules.Context, rc *modules.RequestContext, r *radius.Request, _ 
 	}
 	defer resp.Body.Close()
 	rc.Logger.Debug("got response", zap.String("status", resp.Status),
-		zap.ByteString("full_msg", encodedMsg), zap.String("url", resp.Request.URL.String()),
-		zap.Any("request", r.Packet.Attributes))
+		zap.String("url", resp.Request.URL.String()),
+		zap.Any("request", r.Packet.Attributes),
+		zap.String("Called-Station-Id", rfc2865.CalledStationID_GetString(r.Packet)),
+		zap.String("Calling-Station-Id", rfc2865.CallingStationID_GetString(r.Packet)),
+		zap.String("NAS-Identifier", rfc2865.NASIdentifier_GetString(r.Packet)),
+		zap.String("XWF-C-Version", analyticsVersion))
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("error processing message by endpoint. Response status %d", resp.StatusCode)

--- a/xwf/docker/docker-compose.yml
+++ b/xwf/docker/docker-compose.yml
@@ -16,10 +16,10 @@ services:
     ports:
       - "24224:24224"
     healthcheck:
-      test: ["CMD", "nc", "-vz", "localhost", "24224"]
-      interval: 30s
-      timeout: 10s
-      retries: 15
+        test: ["CMD", "nc", "-vz", "localhost", "24224"]
+        interval: 30s
+        timeout: 10s
+        retries: 15
     environment:
       - SCRIBE_ACCESS_TOKEN=${XWF_SCUBA_ACCESS_TOKEN}
       - SCUBA_TABLE=perfpipe_xwf_openflow_compose_logs
@@ -131,6 +131,8 @@ services:
       /bin/sh -c "./docker-entrypoint.sh"
     networks:
       - control
+    ports:
+      - "1812:1812/udp"
     logging:
       driver: "json-file"
       options:
@@ -276,4 +278,4 @@ networks:
   control:
     ipam:
       config:
-        - subnet: 10.0.12.0/24
+      - subnet: 10.0.12.0/24

--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -111,7 +111,7 @@ services:
 
   logrouter:
     <<: *service
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/logrouter
+    image: ${DOCKER_REGISTRY}logrouter
     container_name: local_fluentbit
     ports:
       - "24224:24224"

--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -7,6 +7,13 @@ x-logging: &logging_anchor
     max-size: "10mb"
     max-file: "10"
 
+# fluentbit logging for special services
+x-logging: &fluentd_anchor
+  driver: "fluentd"
+  options:
+    fluentd-address: "localhost:24224"
+    fluentd-async-connect: "true"
+
 # Standard volumes mounted
 x-standard-volumes: &volumes_anchor
   - ${ROOTCA_PATH}:/var/opt/magma/certs/rootCA.pem
@@ -94,9 +101,26 @@ services:
       - PARTNER_SHORTNAME=${PARTNER_SHORTNAME}
     command: >
       /bin/sh -c "./docker-entrypoint.sh"
+    logging: *fluentd_anchor
 
   radiusd:
     <<: *service
     image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
     container_name: radiusd
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
+
+  logrouter:
+    <<: *service
+    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/logrouter
+    container_name: local_fluentbit
+    ports:
+      - "24224:24224"
+    healthcheck:
+      test: ["CMD", "nc", "-vz", "localhost", "24224"]
+      interval: 30s
+      timeout: 10s
+      retries: 15
+    environment:
+      - SCRIBE_ACCESS_TOKEN=${SCUBA_ACCESS_TOKEN}
+      - SCUBA_TABLE=perfpipe_xwf_xwfm_logs
+      - PARTNER_SHORTNAME=${PARTNER_SHORTNAME}


### PR DESCRIPTION
<!--
[xwf][radiussevrer] logs to fluentbit vs to scribe via service template
-->

## Summary

We would like to have generic solution to collect logs from xwfm containers

## Test Plan

tested on xwfm gateway box by using this PR in roles and checking for logs in my scuba dataset.
```
vi ./roles/containers/tasks/main.yml
- name: Clone the git repo
  git:
   repo: "https://github.com/AyliD/magma.git"
   clone: yes
   force: yes
   dest: "/opt/magma"
   version: "{{ image_version }}"

- name: branching
  shell: git checkout origin/fluentbit
  args:
   chdir: "/opt/magma"

```

got the logs in scuba https://fburl.com/scuba/xwf_xwfm_logs/orlideeo



## Additional Information

- [ ] This change is backwards-breaking


