### PR TITLE
[SessionD] Add `find_session` function to `SessionStore` for easier searching 

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1097,7 +1097,7 @@ void LocalEnforcer::init_session_credit(
     // First time a session is created for IMSI
     MLOG(MDEBUG) << "First session for IMSI " << imsi << " with session ID "
                  << session_id;
-    session_map[imsi] = std::vector<std::unique_ptr<SessionState>>();
+    session_map[imsi] = SessionVector();
   }
   if (session_state->is_radius_cwf_session() == false) {
     events_reporter_->session_created(imsi, session_id, cfg, session_state);
@@ -1788,7 +1788,7 @@ void LocalEnforcer::schedule_revalidation(
 
 void LocalEnforcer::handle_activate_ue_flows_callback(
     const std::string& imsi, const std::string& ip_addr,
-    std::experimental::optional<AggregatedMaximumBitrate> ambr,
+    optional<AggregatedMaximumBitrate> ambr,
     const std::vector<std::string>& static_rules,
     const std::vector<PolicyRule>& dynamic_rules, Status status,
     ActivateFlowsResult resp) {

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -34,6 +34,7 @@
 #include "SpgwServiceClient.h"
 
 namespace magma {
+using std::experimental::optional;
 class SessionNotFound : public std::exception {
  public:
   SessionNotFound() = default;
@@ -425,7 +426,7 @@ class LocalEnforcer {
 
   void handle_activate_ue_flows_callback(
       const std::string& imsi, const std::string& ip_addr,
-      std::experimental::optional<AggregatedMaximumBitrate> ambr,
+      optional<AggregatedMaximumBitrate> ambr,
       const std::vector<std::string>& static_rules,
       const std::vector<PolicyRule>& dynamic_rules, Status status,
       ActivateFlowsResult resp);

--- a/lte/gateway/c/session_manager/MemoryStoreClient.cpp
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.cpp
@@ -26,7 +26,7 @@ SessionMap MemoryStoreClient::read_sessions(
     std::set<std::string> subscriber_ids) {
   auto session_map = SessionMap{};
   for (const auto& subscriber_id : subscriber_ids) {
-    auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+    auto sessions = SessionVector{};
     if (session_map_.find(subscriber_id) != session_map_.end()) {
       for (auto& stored_session : session_map_[subscriber_id]) {
         auto session = SessionState::unmarshal(stored_session, *rule_store_);
@@ -41,7 +41,7 @@ SessionMap MemoryStoreClient::read_sessions(
 SessionMap MemoryStoreClient::read_all_sessions() {
   auto session_map = SessionMap{};
   for (auto& it : session_map_) {
-    auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+    auto sessions = SessionVector{};
     for (auto& stored_session : it.second) {
       auto session = SessionState::unmarshal(stored_session, *rule_store_);
       sessions.push_back(std::move(session));

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -21,6 +21,7 @@
 using grpc::Status;
 
 namespace {  // anonymous
+using std::experimental::optional;
 
 magma::DeactivateFlowsRequest create_deactivate_req(
     const std::string& imsi, const std::string& ip_addr,
@@ -43,7 +44,7 @@ magma::DeactivateFlowsRequest create_deactivate_req(
 
 magma::ActivateFlowsRequest create_activate_req(
     const std::string& imsi, const std::string& ip_addr,
-    const std::experimental::optional<magma::AggregatedMaximumBitrate>& ambr,
+    const optional<magma::AggregatedMaximumBitrate>& ambr,
     const std::vector<std::string>& static_rules,
     const std::vector<magma::PolicyRule>& dynamic_rules,
     const magma::RequestOriginType_OriginType origin_type) {
@@ -231,7 +232,7 @@ bool AsyncPipelinedClient::deactivate_flows_for_rules(
 
 bool AsyncPipelinedClient::activate_flows_for_rules(
     const std::string& imsi, const std::string& ip_addr,
-    const std::experimental::optional<AggregatedMaximumBitrate>& ambr,
+    const optional<AggregatedMaximumBitrate>& ambr,
     const std::vector<std::string>& static_rules,
     const std::vector<PolicyRule>& dynamic_rules,
     std::function<void(Status status, ActivateFlowsResult)> callback) {

--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -27,6 +27,7 @@ using grpc::Status;
 
 namespace magma {
 using namespace lte;
+using std::experimental::optional;
 
 /**
  * PipelinedClient is the base class for managing rules and their activations.
@@ -83,12 +84,11 @@ class PipelinedClient {
    * Activate all rules for the specified rules, using a normal vector
    */
   virtual bool activate_flows_for_rules(
-    const std::string& imsi,
-    const std::string& ip_addr,
-    const std::experimental::optional<AggregatedMaximumBitrate>& ambr,
-    const std::vector<std::string>& static_rules,
-    const std::vector<PolicyRule>& dynamic_rules,
-    std::function<void(Status status, ActivateFlowsResult)> callback) = 0;
+      const std::string& imsi, const std::string& ip_addr,
+      const optional<AggregatedMaximumBitrate>& ambr,
+      const std::vector<std::string>& static_rules,
+      const std::vector<PolicyRule>& dynamic_rules,
+      std::function<void(Status status, ActivateFlowsResult)> callback) = 0;
 
   /**
    * Send the MAC address of UE and the subscriberID
@@ -197,12 +197,11 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
    * Activate all rules for the specified rules, using a normal vector
    */
   bool activate_flows_for_rules(
-    const std::string& imsi,
-    const std::string& ip_addr,
-    const std::experimental::optional<AggregatedMaximumBitrate>& ambr,
-    const std::vector<std::string>& static_rules,
-    const std::vector<PolicyRule>& dynamic_rules,
-    std::function<void(Status status, ActivateFlowsResult)> callback);
+      const std::string& imsi, const std::string& ip_addr,
+      const optional<AggregatedMaximumBitrate>& ambr,
+      const std::vector<std::string>& static_rules,
+      const std::vector<PolicyRule>& dynamic_rules,
+      std::function<void(Status status, ActivateFlowsResult)> callback);
 
   /**
    * Send the MAC address of UE and the subscriberID

--- a/lte/gateway/c/session_manager/RedisStoreClient.cpp
+++ b/lte/gateway/c/session_manager/RedisStoreClient.cpp
@@ -69,12 +69,12 @@ SessionMap RedisStoreClient::read_sessions(
     auto reply = futures[key].get();
     if (reply.is_null()) {
       // value just doesn't exist
-      session_map[key] = std::vector<std::unique_ptr<SessionState>>{};
+      session_map[key] = SessionVector{};
     } else if (reply.is_error()) {
       MLOG(MERROR) << "RedisStoreClient: Unable to get value for key " << key;
       throw RedisReadFailed();
     } else if (!reply.is_string()) {
-      session_map[key] = std::vector<std::unique_ptr<SessionState>>{};
+      session_map[key] = SessionVector{};
     } else {
       session_map[key] = std::move(deserialize_session_vec(reply.as_string()));
     }
@@ -109,7 +109,7 @@ SessionMap RedisStoreClient::read_all_sessions() {
     auto value_reply = array[i + 1];
     if (!value_reply.is_string()) {
       MLOG(MERROR) << "RedisStoreClient: Unable to get value for key " << key;
-      session_map[key] = std::vector<std::unique_ptr<SessionState>>{};
+      session_map[key] = SessionVector{};
     } else {
       session_map[key] =
           std::move(deserialize_session_vec(value_reply.as_string()));
@@ -161,7 +161,7 @@ bool RedisStoreClient::write_sessions(SessionMap session_map) {
 }
 
 std::string RedisStoreClient::serialize_session_vec(
-    std::vector<std::unique_ptr<SessionState>>& session_vec) {
+    SessionVector& session_vec) {
   folly::dynamic marshaled = folly::dynamic::array;
   for (auto& session_ptr : session_vec) {
     auto stored_session = session_ptr->marshal();
@@ -171,9 +171,8 @@ std::string RedisStoreClient::serialize_session_vec(
   return serialized;
 }
 
-std::vector<std::unique_ptr<SessionState>>
-RedisStoreClient::deserialize_session_vec(std::string serialized) {
-  std::vector<std::unique_ptr<SessionState>> session_vec;
+SessionVector RedisStoreClient::deserialize_session_vec(std::string serialized) {
+  SessionVector session_vec;
   auto folly_serialized = folly::StringPiece(serialized);
   try {
     folly::dynamic marshaled = folly::parseJson(folly_serialized);

--- a/lte/gateway/c/session_manager/RedisStoreClient.h
+++ b/lte/gateway/c/session_manager/RedisStoreClient.h
@@ -62,11 +62,9 @@ class RedisStoreClient final : public StoreClient {
   std::shared_ptr<StaticRuleStore> rule_store_;
 
  private:
-  std::string serialize_session_vec(
-      std::vector<std::unique_ptr<SessionState>>& session_vec);
+  std::string serialize_session_vec(SessionVector& session_vec);
 
-  std::vector<std::unique_ptr<SessionState>> deserialize_session_vec(
-      std::string serialized);
+  SessionVector deserialize_session_vec(std::string serialized);
 };
 
 }  // namespace lte

--- a/lte/gateway/c/session_manager/ServiceAction.h
+++ b/lte/gateway/c/session_manager/ServiceAction.h
@@ -21,6 +21,7 @@
 
 namespace magma {
 using namespace lte;
+using std::experimental::optional;
 
 enum ServiceActionType {
   CONTINUE_SERVICE = 0,
@@ -69,8 +70,7 @@ class ServiceAction {
     return *this;
   }
 
-  ServiceAction& set_ambr(
-      const std::experimental::optional<AggregatedMaximumBitrate> ambr) {
+  ServiceAction& set_ambr(const optional<AggregatedMaximumBitrate> ambr) {
     ambr_ = ambr;
     return *this;
   }
@@ -120,9 +120,7 @@ class ServiceAction {
     return *redirect_server_;
   }
 
-  const std::experimental::optional<AggregatedMaximumBitrate> get_ambr() const {
-    return ambr_;
-  }
+  const optional<AggregatedMaximumBitrate> get_ambr() const { return ambr_; }
 
   /**
    * get_mutable_restrict_rules returns a mutable list of the associated restrict
@@ -149,7 +147,7 @@ class ServiceAction {
   std::vector<std::string> rule_ids_;
   std::vector<PolicyRule> rule_definitions_;
   std::unique_ptr<RedirectServer> redirect_server_;
-  std::experimental::optional<AggregatedMaximumBitrate> ambr_;
+  optional<AggregatedMaximumBitrate> ambr_;
   std::vector<std::string> restrict_rules_;
 };
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1529,8 +1529,7 @@ void SessionState::bind_policy_to_bearer(
   uc.bearer_id_by_policy       = bearer_id_by_policy_;
 }
 
-std::experimental::optional<PolicyType> SessionState::get_policy_type(
-    const std::string& rule_id) {
+optional<PolicyType> SessionState::get_policy_type(const std::string& rule_id) {
   if (is_static_rule_installed(rule_id)) {
     return STATIC;
   } else if (is_dynamic_rule_installed(rule_id)) {
@@ -1762,8 +1761,7 @@ RuleSetBySubscriber::RuleSetBySubscriber(
   }
 }
 
-std::experimental::optional<RuleSetToApply>
-RuleSetBySubscriber::get_combined_rule_set_for_apn(const std::string& apn) {
+optional<RuleSetToApply> RuleSetBySubscriber::get_combined_rule_set_for_apn(const std::string& apn) {
   const bool apn_rule_set_exists =
       rule_set_by_apn.find(apn) != rule_set_by_apn.end();
   // Apply subscriber wide rule set if it exists. Also apply per-APN rule

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -28,6 +28,7 @@
 #include "ChargingGrant.h"
 
 namespace magma {
+using std::experimental::optional;
 typedef std::unordered_map<
     CreditKey, std::unique_ptr<ChargingGrant>, decltype(&ccHash),
     decltype(&ccEqual)>
@@ -55,10 +56,10 @@ struct RuleSetToApply {
 struct RuleSetBySubscriber {
   std::string imsi;
   std::unordered_map<std::string, RuleSetToApply> rule_set_by_apn;
-  std::experimental::optional<RuleSetToApply> subscriber_wide_rule_set;
+  optional<RuleSetToApply> subscriber_wide_rule_set;
 
   RuleSetBySubscriber(const RulesPerSubscriber& rules_per_subscriber);
-  std::experimental::optional<RuleSetToApply> get_combined_rule_set_for_apn(
+  optional<RuleSetToApply> get_combined_rule_set_for_apn(
       const std::string& apn);
 };
 
@@ -82,7 +83,7 @@ class SessionState {
     std::vector<std::string> static_rules;
     std::vector<PolicyRule> dynamic_rules;
     std::vector<PolicyRule> gy_dynamic_rules;
-    std::experimental::optional<AggregatedMaximumBitrate> ambr;
+    optional<AggregatedMaximumBitrate> ambr;
   };
   struct TotalCreditUsage {
     uint64_t monitoring_tx;
@@ -225,8 +226,7 @@ class SessionState {
    * @param rule_id
    * @return the type if the rule exists, {} otherwise.
    */
-  std::experimental::optional<PolicyType> get_policy_type(
-      const std::string& rule_id);
+  optional<PolicyType> get_policy_type(const std::string& rule_id);
 
   bool is_dynamic_rule_installed(const std::string& rule_id);
 

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -80,8 +80,7 @@ SessionMap SessionStore::read_sessions_for_deletion(const SessionRead& req) {
 }
 
 bool SessionStore::create_sessions(
-    const std::string& subscriber_id,
-    std::vector<std::unique_ptr<SessionState>> sessions) {
+    const std::string& subscriber_id, SessionVector sessions) {
   auto session_map           = SessionMap{};
   session_map[subscriber_id] = std::move(sessions);
   store_client_->write_sessions(std::move(session_map));
@@ -120,6 +119,31 @@ bool SessionStore::update_sessions(const SessionUpdate& update_criteria) {
     }
   }
   return store_client_->write_sessions(std::move(session_map));
+}
+
+optional<SessionVector::iterator> SessionStore::find_session(
+    SessionMap& session_map, SessionSearchCriteria criteria) {
+  auto it = session_map.find(criteria.imsi);
+  if (it == session_map.end()) {
+    return {};
+  }
+  auto& sessions = it->second;
+  for (auto it = sessions.begin(); it != sessions.end(); ++it) {
+    switch (criteria.search_type) {
+      case IMSI_AND_SESSION_ID:
+        if ((*it)->get_session_id() == criteria.secondary_key) {
+          return it;
+        }
+      case IMSI_AND_APN:
+        if ((*it)->get_config().common_context.apn() ==
+            criteria.secondary_key) {
+          return it;
+        }
+      default:
+        continue;
+    }
+  }
+  return {};
 }
 
 SessionUpdate SessionStore::get_default_session_update(

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -13,6 +13,7 @@
 #pragma once
 
 #include <memory>
+#include <experimental/optional>
 
 #include <lte/protos/session_manager.grpc.pb.h>
 #include <folly/io/async/EventBaseManager.h>
@@ -26,15 +27,29 @@
 
 namespace magma {
 namespace lte {
+using std::experimental::optional;
 
-typedef std::unordered_map<
-    std::string, std::vector<std::unique_ptr<SessionState>>>
-    SessionMap;
 // Value int represents the request numbers needed for requests to PCRF
 typedef std::set<std::string> SessionRead;
 typedef std::unordered_map<
     std::string, std::unordered_map<std::string, SessionStateUpdateCriteria>>
     SessionUpdate;
+
+enum SessionSearchCriteriaType {
+  IMSI_AND_APN        = 0,
+  IMSI_AND_SESSION_ID = 1,
+};
+
+struct SessionSearchCriteria {
+  std::string imsi;
+  SessionSearchCriteriaType search_type;
+  std::string secondary_key;
+  SessionSearchCriteria(
+      const std::string p_imsi, SessionSearchCriteriaType p_type,
+      const std::string p_secondary_key)
+      : imsi(p_imsi), search_type(p_type), secondary_key(p_secondary_key) {}
+};
+
 /**
  * SessionStore acts as a broker to storage of sessiond state.
  *
@@ -109,8 +124,7 @@ class SessionStore {
    * @return true if successful, otherwise the update to storage is discarded.
    */
   bool create_sessions(
-      const std::string& subscriber_id,
-      std::vector<std::unique_ptr<SessionState>> sessions);
+      const std::string& subscriber_id, SessionVector sessions);
 
   /**
    * Attempt to update sessions with update criteria. If any update to any of
@@ -121,6 +135,23 @@ class SessionStore {
    * @return true if successful, otherwise the update to storage is discarded.
    */
   bool update_sessions(const SessionUpdate& update_criteria);
+
+  /**
+   * @param session_map
+   * @param id
+   * @return If the session that meets the criteria is found, then it returns an
+   * optional of the iterator. Otherwise, it returns an empty value.
+   *
+   * Usage Example
+   * SessionSearchCriteriaType criteria(IMSI1, IMSI_AND_SESSION_ID,
+   * SESSION_ID_1);
+   * auto session_it = session_store_.find_session(session_map,
+   * id);
+   * if (!session_it) { // Log session not found };
+   * auto& session = **session_it; // First deference optional, then iterator
+   */
+  optional<SessionVector::iterator> find_session(
+      SessionMap& session_map, SessionSearchCriteria criteria);
 
  private:
   std::shared_ptr<StaticRuleStore> rule_store_;

--- a/lte/gateway/c/session_manager/StoreClient.h
+++ b/lte/gateway/c/session_manager/StoreClient.h
@@ -21,9 +21,8 @@
 namespace magma {
 namespace lte {
 
-typedef std::unordered_map<
-    std::string, std::vector<std::unique_ptr<SessionState>>>
-    SessionMap;
+typedef std::vector<std::unique_ptr<SessionState>> SessionVector;
+typedef std::unordered_map<std::string, SessionVector> SessionMap;
 
 /**
  * StoreClient is responsible for reading/writing sessions to/from storage.

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -686,7 +686,7 @@ TEST_F(LocalEnforcerTest, test_sync_sessions_on_restart_revalidation_timer) {
   time.set_seconds(0);
   session_state->set_revalidation_time(time, uc);
 
-  session_map[IMSI1] = std::vector<std::unique_ptr<SessionState>>();
+  session_map[IMSI1] = SessionVector();
   session_map[IMSI1].push_back(
       std::move(std::unique_ptr<SessionState>(session_state)));
 

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -198,7 +198,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   EXPECT_EQ(session->get_monitor(monitoring_key, USED_RX), 333);
 
   // 3) Commit session for IMSI1 into SessionStore
-  auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+  auto sessions = SessionVector{};
   EXPECT_EQ(sessions.size(), 0);
   sessions.push_back(std::move(session));
   EXPECT_EQ(sessions.size(), 1);

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -16,6 +16,7 @@
 #include <glog/logging.h>
 #include <gtest/gtest.h>
 
+#include "Consts.h"
 #include "ProtobufCreators.h"
 #include "RuleStore.h"
 #include "SessionID.h"
@@ -36,11 +37,7 @@ class SessionStoreTest : public ::testing::Test {
 
  protected:
   virtual void SetUp() {
-    imsi              = "IMSI1";
-    imsi2             = "IMSI2";
-    sid               = id_gen_.gen_session_id(imsi);
-    sid2              = id_gen_.gen_session_id(imsi2);
-    sid3              = id_gen_.gen_session_id(imsi2);
+    session_id_3      = id_gen_.gen_session_id(IMSI2);
     monitoring_key    = "mk1";
     monitoring_key2   = "mk2";
     rule_id_1         = "test_rule_1";
@@ -59,19 +56,21 @@ class SessionStoreTest : public ::testing::Test {
   }
 
   std::unique_ptr<SessionState> get_session(
-      std::string session_id, std::shared_ptr<StaticRuleStore> rule_store) {
+      const std::string& imsi, std::string session_id,
+      std::shared_ptr<StaticRuleStore> rule_store) {
+    return get_session(imsi, session_id, "APN", rule_store);
+  }
+
+  std::unique_ptr<SessionState> get_session(
+      const std::string& imsi, std::string session_id, const std::string& apn,
+      std::shared_ptr<StaticRuleStore> rule_store) {
     std::string hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-    std::string msisdn              = "5100001234";
-    std::string radius_session_id =
-        "AA-AA-AA-AA-AA-AA:TESTAP__"
-        "0F-10-2E-12-3A-55";
-    std::string mac_addr        = "0f:10:2e:12:3a:55";
     SessionConfig cfg;
     cfg.common_context =
-        build_common_context("", "128.0.0.1", "APN", msisdn, TGPP_WLAN);
-    const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+        build_common_context(imsi, IP2, apn, MSISDN, TGPP_WLAN);
+    const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
     cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
-    auto tgpp_context = TgppContext{};
+    auto tgpp_context   = TgppContext{};
     auto pdp_start_time = 12345;
     return std::make_unique<SessionState>(
         imsi, session_id, cfg, *rule_store, tgpp_context, pdp_start_time);
@@ -181,11 +180,7 @@ class SessionStoreTest : public ::testing::Test {
   }
 
  protected:
-  std::string imsi;
-  std::string imsi2;
-  std::string sid;
-  std::string sid2;
-  std::string sid3;
+  std::string session_id_3;
   std::string monitoring_key;
   std::string monitoring_key2;
   std::string rule_id_1;
@@ -201,13 +196,13 @@ TEST_F(SessionStoreTest, test_metering_reporting) {
   auto session_store = new SessionStore(rule_store);
 
   // 2) Create a single session and write it into the store
-  auto session1    = get_session(sid, rule_store);
-  auto session_vec = std::vector<std::unique_ptr<SessionState>>{};
+  auto session1    = get_session(IMSI1, SESSION_ID_1, rule_store);
+  auto session_vec = SessionVector{};
   session_vec.push_back(std::move(session1));
-  session_store->create_sessions(imsi, std::move(session_vec));
+  session_store->create_sessions(IMSI1, std::move(session_vec));
 
   // 3) Try to update the session in SessionStore with a rule installation
-  auto session_map    = session_store->read_sessions(SessionRead{imsi});
+  auto session_map    = session_store->read_sessions(SessionRead{IMSI1});
   auto session_update = SessionStore::get_default_session_update(session_map);
 
   auto uc = get_default_update_criteria();
@@ -229,7 +224,7 @@ TEST_F(SessionStoreTest, test_metering_reporting) {
   credit_uc.bucket_deltas[USED_RX]      = DOWNLOADED_BYTES;
   uc.monitor_credit_map[monitoring_key] = credit_uc;
 
-  session_update[imsi][sid] = uc;
+  session_update[IMSI1][SESSION_ID_1] = uc;
 
   auto update_success = session_store->update_sessions(session_update);
   EXPECT_TRUE(update_success);
@@ -281,14 +276,14 @@ TEST_F(SessionStoreTest, test_read_and_write) {
   auto session_store = new SessionStore(rule_store);
 
   // 2) Create bare-bones session for IMSI1
-  auto session = get_session(sid, rule_store);
+  auto session = get_session(IMSI1, SESSION_ID_1, rule_store);
   auto uc      = get_default_update_criteria();
   RuleLifetime lifetime{
       .activation_time   = std::time_t(0),
       .deactivation_time = std::time_t(0),
   };
   session->activate_static_rule(rule_id_3, lifetime, uc);
-  EXPECT_EQ(session->get_session_id(), sid);
+  EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
   EXPECT_EQ(session->is_static_rule_installed(rule_id_3), true);
 
@@ -302,29 +297,29 @@ TEST_F(SessionStoreTest, test_read_and_write) {
   EXPECT_EQ(session->get_monitor(monitoring_key, USED_RX), 333);
 
   // 3) Commit session for IMSI1 into SessionStore
-  auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+  auto sessions = SessionVector{};
   EXPECT_EQ(sessions.size(), 0);
   sessions.push_back(std::move(session));
   EXPECT_EQ(sessions.size(), 1);
-  session_store->create_sessions(imsi, std::move(sessions));
+  session_store->create_sessions(IMSI1, std::move(sessions));
 
   // 4) Read session for IMSI1 from SessionStore
   SessionRead read_req = {};
-  read_req.insert(imsi);
+  read_req.insert(IMSI1);
   auto session_map = session_store->read_sessions(read_req);
 
   // 5) Verify that state was written for IMSI1 and has been retrieved.
   EXPECT_EQ(session_map.size(), 1);
-  EXPECT_EQ(session_map[imsi].size(), 1);
-  EXPECT_EQ(session_map[imsi].front()->get_request_number(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].front()->get_request_number(), 1);
 
   // 6) Make updates to session via SessionUpdateCriteria
   auto update_req = SessionUpdate{};
-  update_req[imsi] =
+  update_req[IMSI1] =
       std::unordered_map<std::string, SessionStateUpdateCriteria>{};
-  auto update_criteria  = get_update_criteria();
+  auto update_criteria                 = get_update_criteria();
   update_criteria.updated_pdp_end_time = 156789;
-  update_req[imsi][sid] = update_criteria;
+  update_req[IMSI1][SESSION_ID_1]      = update_criteria;
 
   // 7) Commit updates to SessionStore
   auto success = session_store->update_sessions(update_req);
@@ -333,67 +328,68 @@ TEST_F(SessionStoreTest, test_read_and_write) {
   // 8) Read in session for IMSI1 again to check that the update was successful
   session_map = session_store->read_sessions(read_req);
   EXPECT_EQ(session_map.size(), 1);
-  EXPECT_EQ(session_map[imsi].size(), 1);
-  EXPECT_EQ(session_map[imsi].front()->get_session_id(), sid);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].front()->get_session_id(), SESSION_ID_1);
   // Check installed rules
   EXPECT_EQ(
-      session_map[imsi].front()->is_static_rule_installed(rule_id_1), true);
+      session_map[IMSI1].front()->is_static_rule_installed(rule_id_1), true);
   EXPECT_EQ(
-      session_map[imsi].front()->is_static_rule_installed(rule_id_3), true);
+      session_map[IMSI1].front()->is_static_rule_installed(rule_id_3), true);
   EXPECT_EQ(
-      session_map[imsi].front()->is_static_rule_installed(rule_id_2), false);
+      session_map[IMSI1].front()->is_static_rule_installed(rule_id_2), false);
   EXPECT_EQ(
-      session_map[imsi].front()->is_dynamic_rule_installed(dynamic_rule_id_1),
+      session_map[IMSI1].front()->is_dynamic_rule_installed(dynamic_rule_id_1),
       true);
   EXPECT_EQ(
-      session_map[imsi].front()->is_dynamic_rule_installed(dynamic_rule_id_2),
+      session_map[IMSI1].front()->is_dynamic_rule_installed(dynamic_rule_id_2),
       false);
 
   // Check for installation of new monitoring credit
-  session_map[imsi].front()->set_monitor(
+  session_map[IMSI1].front()->set_monitor(
       monitoring_key2,
-      Monitor(update_criteria.monitor_credit_to_install[monitoring_key2]),
-      uc);
+      Monitor(update_criteria.monitor_credit_to_install[monitoring_key2]), uc);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key2, USED_TX), 100);
+      session_map[IMSI1].front()->get_monitor(monitoring_key2, USED_TX), 100);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key2, USED_RX), 200);
+      session_map[IMSI1].front()->get_monitor(monitoring_key2, USED_RX), 200);
 
   // Check monitoring credit usage
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, USED_TX), 222);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, USED_TX), 222);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, USED_RX), 666);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, USED_RX), 666);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, ALLOWED_TOTAL),
+      session_map[IMSI1].front()->get_monitor(monitoring_key, ALLOWED_TOTAL),
       1002);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, ALLOWED_TX), 1003);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, ALLOWED_TX),
+      1003);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, ALLOWED_RX), 1004);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, ALLOWED_RX),
+      1004);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, REPORTING_TX), 5);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, REPORTING_TX), 5);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, REPORTING_RX), 6);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, REPORTING_RX), 6);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, REPORTED_TX), 7);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, REPORTED_TX), 7);
   EXPECT_EQ(
-      session_map[imsi].front()->get_monitor(monitoring_key, REPORTED_RX), 8);
+      session_map[IMSI1].front()->get_monitor(monitoring_key, REPORTED_RX), 8);
 
   // Check pdp end time update
-  EXPECT_EQ(session_map[imsi].front()->get_pdp_end_time(), 156789);
+  EXPECT_EQ(session_map[IMSI1].front()->get_pdp_end_time(), 156789);
 
   // 11) Delete sessions for IMSI1
   update_req                       = SessionUpdate{};
   update_criteria                  = SessionStateUpdateCriteria{};
   update_criteria.is_session_ended = true;
-  update_req[imsi][sid]            = update_criteria;
+  update_req[IMSI1][SESSION_ID_1]  = update_criteria;
   session_store->update_sessions(update_req);
 
   // 12) Verify that IMSI1 no longer has a session
   session_map = session_store->read_sessions(read_req);
   EXPECT_EQ(session_map.size(), 1);
-  EXPECT_EQ(session_map[imsi].size(), 0);
+  EXPECT_EQ(session_map[IMSI1].size(), 0);
 }
 
 TEST_F(SessionStoreTest, test_sync_request_numbers) {
@@ -402,33 +398,33 @@ TEST_F(SessionStoreTest, test_sync_request_numbers) {
   auto session_store = new SessionStore(rule_store);
 
   // 2) Create bare-bones session for IMSI1
-  auto session = get_session(sid, rule_store);
+  auto session = get_session(IMSI1, SESSION_ID_1, rule_store);
   auto uc      = get_default_update_criteria();
 
   // 3) Commit session for IMSI1 into SessionStore
-  auto sessions = std::vector<std::unique_ptr<SessionState>>{};
+  auto sessions = SessionVector{};
   EXPECT_EQ(sessions.size(), 0);
   sessions.push_back(std::move(session));
   EXPECT_EQ(sessions.size(), 1);
-  session_store->create_sessions(imsi, std::move(sessions));
+  session_store->create_sessions(IMSI1, std::move(sessions));
 
   // 4) Read session for IMSI1 from SessionStore
   SessionRead read_req = {};
-  read_req.insert(imsi);
+  read_req.insert(IMSI1);
   auto session_map = session_store->read_sessions(read_req);
 
   // 5) Verify that state was written for IMSI1 and has been retrieved.
   EXPECT_EQ(session_map.size(), 1);
-  EXPECT_EQ(session_map[imsi].size(), 1);
-  EXPECT_EQ(session_map[imsi].front()->get_request_number(), 1);
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  EXPECT_EQ(session_map[IMSI1].front()->get_request_number(), 1);
 
   // 6) Make updates to session via SessionUpdateCriteria
   auto update_req = SessionUpdate{};
-  update_req[imsi] =
+  update_req[IMSI1] =
       std::unordered_map<std::string, SessionStateUpdateCriteria>{};
   auto update_criteria                     = get_update_criteria();
   update_criteria.request_number_increment = 3;
-  update_req[imsi][sid]                    = update_criteria;
+  update_req[IMSI1][SESSION_ID_1]          = update_criteria;
 
   // 7) Sync updated request_numbers to SessionStore
   session_store->sync_request_numbers(update_req);
@@ -440,31 +436,31 @@ TEST_F(SessionStoreTest, test_sync_request_numbers) {
   // 8) Read in session for IMSI1 again to check that the update was successful
   auto session_map_2 = session_store->read_sessions(read_req);
   EXPECT_EQ(session_map_2.size(), 1);
-  EXPECT_EQ(session_map_2[imsi].size(), 1);
-  EXPECT_EQ(session_map_2[imsi].front()->get_session_id(), sid);
-  EXPECT_EQ(session_map_2[imsi].front()->get_request_number(), 4);
+  EXPECT_EQ(session_map_2[IMSI1].size(), 1);
+  EXPECT_EQ(session_map_2[IMSI1].front()->get_session_id(), SESSION_ID_1);
+  EXPECT_EQ(session_map_2[IMSI1].front()->get_request_number(), 4);
 }
 
 TEST_F(SessionStoreTest, test_get_default_session_update) {
   // 1) Create a SessionMap with a few sessions
   auto rule_store        = std::make_shared<StaticRuleStore>();
   SessionMap session_map = {};
-  auto session1          = get_session(sid, rule_store);
-  auto session2          = get_session(sid2, rule_store);
-  auto session3          = get_session(sid3, rule_store);
+  auto session1          = get_session(IMSI1, SESSION_ID_1, rule_store);
+  auto session2          = get_session(IMSI2, SESSION_ID_2, rule_store);
+  auto session3          = get_session(IMSI2, session_id_3, rule_store);
 
-  session_map[imsi]  = std::vector<std::unique_ptr<SessionState>>{};
-  session_map[imsi2] = std::vector<std::unique_ptr<SessionState>>{};
+  session_map[IMSI1] = SessionVector{};
+  session_map[IMSI2] = SessionVector{};
 
-  session_map[imsi].push_back(std::move(session1));
-  session_map[imsi2].push_back(std::move(session2));
-  session_map[imsi2].push_back(std::move(session3));
+  session_map[IMSI1].push_back(std::move(session1));
+  session_map[IMSI2].push_back(std::move(session2));
+  session_map[IMSI2].push_back(std::move(session3));
 
   // 2) Build SessionUpdate
   auto update = SessionStore::get_default_session_update(session_map);
   EXPECT_EQ(update.size(), 2);
-  EXPECT_EQ(update[imsi].size(), 1);
-  EXPECT_EQ(update[imsi2].size(), 2);
+  EXPECT_EQ(update[IMSI1].size(), 1);
+  EXPECT_EQ(update[IMSI2].size(), 2);
 }
 
 TEST_F(SessionStoreTest, test_update_session_rules) {
@@ -473,13 +469,13 @@ TEST_F(SessionStoreTest, test_update_session_rules) {
   auto session_store = new SessionStore(rule_store);
 
   // 2) Create a single session and write it into the store
-  auto session1    = get_session(sid, rule_store);
-  auto session_vec = std::vector<std::unique_ptr<SessionState>>{};
+  auto session1    = get_session(IMSI1, SESSION_ID_1, rule_store);
+  auto session_vec = SessionVector{};
   session_vec.push_back(std::move(session1));
-  session_store->create_sessions(imsi, std::move(session_vec));
+  session_store->create_sessions(IMSI1, std::move(session_vec));
 
   // 3) Try to update the session in SessionStore with a rule installation
-  auto session_map    = session_store->read_sessions(SessionRead{imsi});
+  auto session_map    = session_store->read_sessions(SessionRead{IMSI1});
   auto session_update = SessionStore::get_default_session_update(session_map);
 
   auto uc = get_default_update_criteria();
@@ -488,11 +484,49 @@ TEST_F(SessionStoreTest, test_update_session_rules) {
       .activation_time   = std::time_t(0),
       .deactivation_time = std::time_t(0),
   };
-  uc.new_rule_lifetimes["RULE_asdf"] = lifetime;
-  session_update[imsi][sid]          = uc;
+  uc.new_rule_lifetimes["RULE_asdf"]  = lifetime;
+  session_update[IMSI1][SESSION_ID_1] = uc;
 
   auto update_success = session_store->update_sessions(session_update);
   EXPECT_TRUE(update_success);
+}
+
+TEST_F(SessionStoreTest, test_get_session) {
+  // 1) Create a SessionMap with a few sessions
+  auto rule_store = std::make_shared<StaticRuleStore>();
+  SessionStore session_store(rule_store);
+  SessionMap session_map = {};
+  auto session1          = get_session(IMSI1, SESSION_ID_1, "APN1", rule_store);
+  auto session2          = get_session(IMSI1, SESSION_ID_2, "APN2", rule_store);
+  session_map[IMSI1]     = SessionVector{};
+  session_map[IMSI1].push_back(std::move(session1));
+  session_map[IMSI1].push_back(std::move(session2));
+
+  // Non-existing subscriber: IMSI3
+  SessionSearchCriteria id1_fail1(IMSI3, IMSI_AND_SESSION_ID, SESSION_ID_1);
+  SessionSearchCriteria id1_fail2(IMSI3, IMSI_AND_APN, "NON-EXISTING");
+  EXPECT_FALSE(session_store.find_session(session_map, id1_fail1));
+  EXPECT_FALSE(session_store.find_session(session_map, id1_fail2));
+
+  // Existing subscriber, but non-existing APN/SESSION_ID
+  SessionSearchCriteria id1_fail3(IMSI1, IMSI_AND_SESSION_ID, "NON-EXISTING");
+  SessionSearchCriteria id1_fail4(IMSI1, IMSI_AND_APN, "NON-EXISTING");
+  EXPECT_FALSE(session_store.find_session(session_map, id1_fail3));
+  EXPECT_FALSE(session_store.find_session(session_map, id1_fail4));
+
+  // Happy Path! IMSI+SessionID
+  SessionSearchCriteria id1_success_sid(
+      IMSI1, IMSI_AND_SESSION_ID, SESSION_ID_1);
+  auto optional_it1 = session_store.find_session(session_map, id1_success_sid);
+  EXPECT_TRUE(optional_it1);
+  auto& found_session1 = **optional_it1;
+  EXPECT_EQ(found_session1->get_session_id(), SESSION_ID_1);
+  // Happy Path! IMSI+APN
+  SessionSearchCriteria id1_success_apn(IMSI1, IMSI_AND_APN, "APN2");
+  auto optional_it2 = session_store.find_session(session_map, id1_success_apn);
+  EXPECT_TRUE(optional_it2);
+  auto& found_session2 = **optional_it2;
+  EXPECT_EQ(found_session2->get_config().common_context.apn(), "APN2");
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_store_client.cpp
+++ b/lte/gateway/c/session_manager/test/test_store_client.cpp
@@ -89,7 +89,7 @@ TEST_F(StoreClientTest, test_read_and_write) {
 
   // Since the grant was not given with R/W permission for subscriber IMSI2,
   // The session for IMSI2 should not be saved into the store
-  session_map[imsi2] = std::vector<std::unique_ptr<SessionState>>();
+  session_map[imsi2] = SessionVector();
   session_map[imsi2].push_back(std::move(session2));
   EXPECT_EQ(session_map.size(), 2);
   EXPECT_EQ(session_map[imsi2].size(), 1);


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The main change in this PR is in `SessionStore.cpp/h` and `test_session_store.cpp`. Those include the definition/unit tests for the new `get_session` function. This function takes in a session map and a search criteria, `SessionSearchCriteria` and returns an iterator to the session object if a matching session exists. Otherwise, it returns a an empty optional. The typing is weird here because: 

1. Can't return a reference because references don't support null values
2. Can't return the unique pointer, since it has to be unique :p 
So I settled with an optional of the session vector iterator. 

Some minor changes included are:
1. `test_session_store.cpp` clean up. (Using consts, etc)
2. Some type aliases. `std::vector<std::unique_ptr<SessionState>>`->`SessionVector`, `std::experimental::optional`->`optional`

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests, and this function is not used in existing code yet
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
