### PR TITLE
[SessionD] Apply data usage per-session

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -247,58 +247,60 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
 void LocalEnforcer::aggregate_records(
     SessionMap& session_map, const RuleRecordTable& records,
     SessionUpdate& session_update) {
-  // TODO We should have a more granular identifier for sessions here
-  // Insert the IMSIs for which we received a rule record into a set for easy
-  // access
-  std::unordered_set<std::string> sessions_with_active_flows;
+  // Insert the IMSI+SessionID for sessions we received a rule record into a set
+  // for easy access
+  std::unordered_set<ImsiAndSessionID> sessions_with_active_flows;
   for (const RuleRecord& record : records.records()) {
-    auto it = session_map.find(record.sid());
-    if (it == session_map.end()) {
-      MLOG(MERROR) << "Could not find session for " << record.sid()
+    const std::string &imsi = record.sid(), &ip = record.ue_ipv4();
+    SessionSearchCriteria criteria(imsi, IMSI_AND_UE_IPV4, ip);
+    auto session_it = session_store_.find_session(session_map, criteria);
+    if (!session_it) {
+      MLOG(MERROR) << "Could not find session for " << imsi << " and " << ip
                    << " during record aggregation";
       continue;
     }
-    sessions_with_active_flows.insert(record.sid());
+    auto& session          = **session_it;
+    const auto& session_id = session->get_session_id();
     if (record.bytes_tx() > 0 || record.bytes_rx() > 0) {
-      MLOG(MINFO) << record.sid() << " used " << record.bytes_tx()
+      MLOG(MINFO) << session_id << " used " << record.bytes_tx()
                   << " tx bytes and " << record.bytes_rx()
                   << " rx bytes for rule " << record.rule_id();
     }
-    // Update sessions
-    for (const auto& session : it->second) {
-      SessionStateUpdateCriteria& uc =
-          session_update[record.sid()][session->get_session_id()];
-      session->add_rule_usage(
-          record.rule_id(), record.bytes_tx(), record.bytes_rx(), uc);
-    }
+    SessionStateUpdateCriteria& uc = session_update[imsi][session_id];
+    session->add_rule_usage(
+        record.rule_id(), record.bytes_tx(), record.bytes_rx(), uc);
+    sessions_with_active_flows.insert(ImsiAndSessionID(imsi, session_id));
   }
   complete_termination_for_released_sessions(
       session_map, sessions_with_active_flows, session_update);
 }
 
 void LocalEnforcer::complete_termination_for_released_sessions(
-    SessionMap& session_map, std::unordered_set<std::string> sessions_with_active_flows,
+    SessionMap& session_map,
+    std::unordered_set<ImsiAndSessionID> sessions_with_active_flows,
     SessionUpdate& session_update) {
   // Iterate through sessions and notify that report has finished. Terminate any
   // sessions that can be terminated.
-  std::vector<std::pair<std::string, std::string>> imsi_to_terminate;
+  std::vector<ImsiAndSessionID> sessions_to_terminate;
   for (const auto& session_pair : session_map) {
     const std::string imsi = session_pair.first;
     for (const auto& session : session_pair.second) {
       const std::string session_id = session->get_session_id();
       // If we did not receive a rule record for the session, this means
       // PipelineD has reported all usage for the session
+      auto imsi_and_session_id = ImsiAndSessionID(imsi, session_id);
       if (session->get_state() == SESSION_RELEASED &&
-          sessions_with_active_flows.find(imsi) == sessions_with_active_flows.end()) {
-        imsi_to_terminate.push_back(std::make_pair(imsi, session_id));
+          sessions_with_active_flows.find(imsi_and_session_id) ==
+              sessions_with_active_flows.end()) {
+        sessions_to_terminate.push_back(imsi_and_session_id);
       }
     }
   }
-  for (const auto& imsi_sid_pair : imsi_to_terminate) {
-    auto imsi                      = imsi_sid_pair.first;
-    auto session_id                = imsi_sid_pair.second;
-    SessionStateUpdateCriteria& uc = session_update[imsi][session_id];
-    complete_termination(session_map, imsi, session_id, uc);
+  // Do the actual termination in a separate loop since this can modify the
+  // session map structure
+  for (const auto& pair : sessions_to_terminate) {
+    const auto &imsi = pair.first, &session_id = pair.second;
+    complete_termination(session_map, imsi, session_id, session_update);
   }
 }
 
@@ -424,8 +426,7 @@ void LocalEnforcer::handle_force_termination_timeout(
   // If the session doesn't exist in the session_update, then the session was
   // already terminated + removed
   if (needs_termination) {
-    complete_termination(
-        session_map, imsi, session_id, session_update[imsi][session_id]);
+    complete_termination(session_map, imsi, session_id, session_update);
     bool end_success = session_store_.update_sessions(session_update);
     if (end_success) {
       MLOG(MDEBUG) << "Updated session termination of " << session_id
@@ -1184,7 +1185,7 @@ void LocalEnforcer::report_subscriber_state_to_pipelined(
 
 void LocalEnforcer::complete_termination(
     SessionMap& session_map, const std::string& imsi,
-    const std::string& session_id, SessionStateUpdateCriteria& uc) {
+    const std::string& session_id, SessionUpdate& session_update) {
   // If the session cannot be found in session_map, or a new session has
   // already begun, do nothing.
   auto it = session_map.find(imsi);
@@ -1195,6 +1196,7 @@ void LocalEnforcer::complete_termination(
                  << ". Skipping termination.";
     return;
   }
+  auto& uc = session_update[imsi][session_id];
   for (auto session_it = it->second.begin(); session_it != it->second.end();
        ++session_it) {
     if ((*session_it)->get_session_id() == session_id) {

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -35,6 +35,7 @@
 
 namespace magma {
 using std::experimental::optional;
+typedef std::pair<std::string, std::string> ImsiAndSessionID;
 class SessionNotFound : public std::exception {
  public:
   SessionNotFound() = default;
@@ -265,7 +266,7 @@ class LocalEnforcer {
    */
   void complete_termination_for_released_sessions(
       SessionMap& session_map,
-      std::unordered_set<std::string> sessions_with_active_flows,
+      std::unordered_set<ImsiAndSessionID> sessions_with_active_flows,
       SessionUpdate& session_update);
 
   void filter_rule_installs(
@@ -372,7 +373,7 @@ class LocalEnforcer {
    */
   void complete_termination(
       SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id, SessionStateUpdateCriteria& uc);
+      const std::string& session_id, SessionUpdate& session_update);
 
   void schedule_static_rule_activation(
       const std::string& imsi, const std::string& ip_addr,

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -44,6 +44,10 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
     ServerContext* context, const RuleRecordTable* request,
     std::function<void(Status, Void)> response_callback) {
   auto& request_cpy = *request;
+  if (request_cpy.records_size() > 0) {
+    PrintGrpcMessage(
+        static_cast<const google::protobuf::Message&>(request_cpy));
+  }
   MLOG(MDEBUG) << "Aggregating " << request_cpy.records_size() << " records";
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = session_store_.read_all_sessions();

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -139,9 +139,13 @@ optional<SessionVector::iterator> SessionStore::find_session(
             criteria.secondary_key) {
           return it;
         }
-      default:
-        continue;
+      case IMSI_AND_UE_IPV4:
+        if ((*it)->get_config().common_context.ue_ipv4() ==
+            criteria.secondary_key) {
+          return it;
+        }
     }
+    continue;
   }
   return {};
 }

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -38,6 +38,7 @@ typedef std::unordered_map<
 enum SessionSearchCriteriaType {
   IMSI_AND_APN        = 0,
   IMSI_AND_SESSION_ID = 1,
+  IMSI_AND_UE_IPV4    = 2,
 };
 
 struct SessionSearchCriteria {
@@ -143,7 +144,7 @@ class SessionStore {
    * optional of the iterator. Otherwise, it returns an empty value.
    *
    * Usage Example
-   * SessionSearchCriteriaType criteria(IMSI1, IMSI_AND_SESSION_ID,
+   * SessionSearchCriteria criteria(IMSI1, IMSI_AND_SESSION_ID,
    * SESSION_ID_1);
    * auto session_it = session_store_.find_session(session_map,
    * id);

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -34,6 +34,15 @@ MATCHER_P2(CheckUpdateRequestCount, monitorCount, chargingCount, "") {
          req.usage_monitors().size() == monitorCount;
 }
 
+MATCHER_P(CheckUpdateRequestNumber, request_number, "") {
+  auto request = static_cast<const UpdateSessionRequest&>(arg);
+  for (const auto& credit_usage_update : request.updates()) {
+    int req_number = credit_usage_update.request_number();
+    return req_number == request_number;
+  }
+  return false;
+}
+
 MATCHER_P3(CheckTerminateRequestCount, imsi, monitorCount, chargingCount, "") {
   auto req = static_cast<const SessionTerminateRequest>(arg);
   return req.sid() == imsi && req.credit_usages().size() == chargingCount &&

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -80,6 +80,16 @@ void create_rule_record(
   rule_record->set_bytes_tx(bytes_tx);
 }
 
+void create_rule_record(
+    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    uint64_t bytes_rx, uint64_t bytes_tx, RuleRecord* rule_record) {
+  rule_record->set_sid(imsi);
+  rule_record->set_rule_id(rule_id);
+  rule_record->set_bytes_rx(bytes_rx);
+  rule_record->set_bytes_tx(bytes_tx);
+  rule_record->set_ue_ipv4(ip);
+}
+
 void create_charging_credit(
     uint64_t volume, bool is_final, ChargingCredit* credit) {
   create_granted_units(&volume, NULL, NULL, credit->mutable_granted_units());

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -41,12 +41,15 @@ void create_rule_record(
     const std::string& imsi, const std::string& rule_id, uint64_t bytes_rx,
     uint64_t bytes_tx, RuleRecord* rule_record);
 
+void create_rule_record(
+    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    uint64_t bytes_rx, uint64_t bytes_tx, RuleRecord* rule_record);
+
 void create_charging_credit(
     uint64_t volume, bool is_final, ChargingCredit* credit);
 
 void create_credit_update_response(
-    const std::string& imsi,
-    const std::string sessiond_id,
+    const std::string& imsi, const std::string sessiond_id,
     uint32_t charging_key, CreditLimitType limit_type,
     CreditUpdateResponse* response);
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -259,7 +259,9 @@ TEST_F(LocalEnforcerTest, test_single_record) {
   insert_static_rule(1, "", "rule1");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 16, 32, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 16, 32,
+      record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
@@ -292,9 +294,15 @@ TEST_F(LocalEnforcerTest, test_aggregate_records) {
   insert_static_rule(2, "", "rule3");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 5, 15, record_list->Add());
-  create_rule_record(IMSI1, "rule3", 100, 150, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
+      record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 5, 15,
+      record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule3", 100, 150,
+      record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
@@ -368,7 +376,9 @@ TEST_F(LocalEnforcerTest, test_collect_updates) {
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      record_list->Add());
 
   local_enforcer->aggregate_records(session_map, table, update);
   actions.clear();
@@ -469,7 +479,9 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
+      record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
   assert_monitor_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{"1", 10}});
@@ -560,7 +572,9 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
   // Insert record for key 1
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -773,8 +787,12 @@ TEST_F(LocalEnforcerTest, test_final_unit_handling) {
   // Insert record for key 1
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 1024, 2048,
+      record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -872,9 +890,15 @@ TEST_F(LocalEnforcerTest, test_all) {
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 10, 20, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 5, 15, record_list->Add());
-  create_rule_record(IMSI2, "rule3", 1024, 1024, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
+      record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 5, 15,
+      record_list->Add());
+  create_rule_record(
+      IMSI2, test_cfg_.common_context.ue_ipv4(), "rule3", 1024, 1024,
+      record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1022,8 +1046,12 @@ TEST_F(LocalEnforcerTest, test_dynamic_rules) {
   insert_static_rule(1, "", "rule2");
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 16, 32, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 8, 8, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 16, 32,
+      record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 8, 8,
+      record_list->Add());
 
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
@@ -1061,8 +1089,8 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
   // The activation for the static rules (rule1,rule3) and dynamic rule (rule2)
   EXPECT_CALL(
       *pipelined_client, activate_flows_for_rules(
-      testing::_, testing::_, testing::_, CheckCount(2),
-      CheckCount(1), testing::_))
+                             testing::_, testing::_, testing::_, CheckCount(2),
+                             CheckCount(1), testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
 
@@ -1071,8 +1099,12 @@ TEST_F(LocalEnforcerTest, test_dynamic_rule_actions) {
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "rule1", 1024, 2048, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 1024, 2048,
+      record_list->Add());
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule2", 1024, 2048,
+      record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1203,10 +1235,11 @@ TEST_F(LocalEnforcerTest, test_usage_monitors) {
   // receive usages from pipelined
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(IMSI1, "both_rule", 10, 20, record_list->Add());
-  create_rule_record(IMSI1, "ocs_rule", 5, 15, record_list->Add());
-  create_rule_record(IMSI1, "pcrf_only", 1024, 1024, record_list->Add());
-  create_rule_record(IMSI1, "pcrf_split", 10, 20, record_list->Add());
+  auto& ip         = test_cfg_.common_context.ue_ipv4();
+  create_rule_record(IMSI1, ip, "both_rule", 10, 20, record_list->Add());
+  create_rule_record(IMSI1, ip, "ocs_rule", 5, 15, record_list->Add());
+  create_rule_record(IMSI1, ip, "pcrf_only", 1024, 1024, record_list->Add());
+  create_rule_record(IMSI1, ip, "pcrf_split", 10, 20, record_list->Add());
   auto update = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table, update);
 
@@ -1359,9 +1392,11 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   // reports for all monitors receive usages from pipelined
   RuleRecordTable table_1;
   auto record_list_1 = table_1.mutable_records();
-  create_rule_record(IMSI1, "pcrf_only_active", 2000, 0, record_list_1->Add());
+  auto ip            = test_cfg_.common_context.ue_ipv4();
   create_rule_record(
-      IMSI1, "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
+      IMSI1, ip, "pcrf_only_active", 2000, 0, record_list_1->Add());
+  create_rule_record(
+      IMSI1, ip, "pcrf_only_to_be_disabled", 2000, 0, record_list_1->Add());
   local_enforcer->aggregate_records(session_map, table_1, update_1);
 
   // Collect updates, should have updates since all monitors got 80% exhausted
@@ -1407,9 +1442,10 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   // Generate more traffic to see monitors 2 and 3 are not triggering update
   RuleRecordTable table_2;
   auto record_list2 = table_2.mutable_records();
-  create_rule_record(IMSI1, "pcrf_only_active", 2000, 0, record_list2->Add());
   create_rule_record(
-      IMSI1, "pcrf_only_to_be_disabled", 2000, 0, record_list2->Add());
+      IMSI1, ip, "pcrf_only_active", 2000, 0, record_list2->Add());
+  create_rule_record(
+      IMSI1, ip, "pcrf_only_to_be_disabled", 2000, 0, record_list2->Add());
 
   update_2 = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table_2, update_2);

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -20,6 +20,7 @@
 #include "Consts.h"
 #include "LocalEnforcer.h"
 #include "MagmaService.h"
+#include "Matchers.h"
 #include "ProtobufCreators.h"
 #include "RuleStore.h"
 #include "ServiceRegistrySingleton.h"
@@ -92,20 +93,6 @@ class SessionManagerHandlerTest : public ::testing::Test {
   SessionMap session_map_;
 };
 
-MATCHER_P(CheckCreateSession, imsi, "") {
-  auto req = static_cast<const CreateSessionRequest*>(arg);
-  return req->common_context().sid().id() == imsi;
-}
-
-MATCHER_P(CheckUpdateSessionRequest, request_number, "") {
-  auto request = static_cast<const UpdateSessionRequest&>(arg);
-  for (const auto& credit_usage_update : request.updates()) {
-    int req_number = credit_usage_update.request_number();
-    return req_number == request_number;
-  }
-  return false;
-}
-
 TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   // 1) Insert the entry for a rule
   insert_static_rule(rule_store, monitoring_key, 1, "rule1");
@@ -114,47 +101,40 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   LocalCreateSessionRequest request;
   CreateSessionResponse response;
   const std::string& hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  const std::string& imsi                = "IMSI1";
-  const std::string& session_id          = "1234";
-  const std::string& msisdn              = "5100001234";
-  const std::string& radius_session_id =
-      "AA-AA-AA-AA-AA-AA:TESTAP__"
-      "0F-10-2E-12-3A-55";
-  const std::string& mac_addr = "0f:10:2e:12:3a:55";
-  const auto& sid             = id_gen_.gen_session_id(imsi);
   SessionConfig cfg;
   cfg.common_context =
-      build_common_context(imsi, "", "apn1", msisdn, TGPP_WLAN);
-  const auto& wlan = build_wlan_context(mac_addr, radius_session_id);
+      build_common_context(IMSI1, "", "apn1", MSISDN, TGPP_WLAN);
+  const auto& wlan = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
-  response.set_session_id(sid);
+  response.set_session_id(SESSION_ID_1);
   // Only the active sessions are not recycled, to ensure that
   // this session is not automatically scheduled for termination
   // when RAT Type is WLAN, it needs monitoring keys...
-  create_session_create_response(imsi, session_id, monitoring_key, static_rules, &response);
+  create_session_create_response(
+      IMSI1, SESSION_ID_1, monitoring_key, static_rules, &response);
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(
-      imsi, session_id, 1, 1536, response.mutable_credits()->Add());
+      IMSI1, SESSION_ID_1, 1, 1536, response.mutable_credits()->Add());
 
-  SessionRead req  = {"IMSI1"};
-  auto session_map = session_store->read_sessions(req);
-  local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
+  auto session_map = session_store->read_sessions({IMSI1});
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, cfg, response);
   bool write_success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
-  session_map = session_store->read_sessions(req);
-  auto it     = session_map.find("IMSI1");
+  session_map = session_store->read_sessions({IMSI1});
+  auto it     = session_map.find(IMSI1);
   EXPECT_FALSE(it == session_map.end());
-  EXPECT_EQ(session_map["IMSI1"].size(), 1);
-  auto& session = session_map["IMSI1"][0];
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  auto& session = session_map[IMSI1][0];
   EXPECT_EQ(session->get_config().common_context.apn(), "apn1");
 
   grpc::ServerContext create_context;
-  auto common = build_common_context(imsi, "", "apn2", msisdn, TGPP_WLAN);
+  auto common = build_common_context(IMSI1, "", "apn2", MSISDN, TGPP_WLAN);
   request.mutable_common_context()->CopyFrom(common);
   request.mutable_rat_specific_context()->mutable_wlan_context()->CopyFrom(
-      wlan); // use same WLAN config as previous
+      wlan);  // use same WLAN config as previous
 
   // Ensure session is not reported as its a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(0);
@@ -167,11 +147,11 @@ TEST_F(SessionManagerHandlerTest, test_create_session_cfg) {
   evb->loopOnce();
 
   // Assert the internal session config is updated to the new one
-  session_map = session_store->read_sessions(req);
-  it          = session_map.find("IMSI1");
+  session_map = session_store->read_sessions({IMSI1});
+  it          = session_map.find(IMSI1);
   EXPECT_FALSE(it == session_map.end());
-  EXPECT_EQ(session_map["IMSI1"].size(), 1);
-  auto& session_apn2 = session_map["IMSI1"][0];
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
+  auto& session_apn2 = session_map[IMSI1][0];
   EXPECT_EQ(session_apn2->get_config().common_context.apn(), "apn2");
 }
 
@@ -271,13 +251,11 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
 TEST_F(SessionManagerHandlerTest, test_create_session) {
   // 1) Create the session
   LocalCreateSessionRequest request;
-  std::string imsi                = "IMSI1";
-  std::string msisdn              = "5100001234";
 
   grpc::ServerContext server_context;
-  request.mutable_common_context()->mutable_sid()->set_id(imsi);
+  request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
   request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
-  request.mutable_common_context()->set_msisdn(msisdn);
+  request.mutable_common_context()->set_msisdn(MSISDN);
 
   CreateSessionResponse create_response;
   create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
@@ -287,9 +265,9 @@ TEST_F(SessionManagerHandlerTest, test_create_session) {
   create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
       "rule3");
   create_credit_update_response(
-        "IMSI1", "1234", 1, 1536, create_response.mutable_credits()->Add());
+      IMSI1, "1234", 1, 1536, create_response.mutable_credits()->Add());
   create_credit_update_response(
-        "IMSI1", "1234", 2, 1024, create_response.mutable_credits()->Add());
+      IMSI1, "1234", 2, 1024, create_response.mutable_credits()->Add());
 
   // Ensure session is reported as it is not a duplicate
   EXPECT_CALL(*reporter, report_create_session(_, _)).Times(1);
@@ -311,45 +289,43 @@ TEST_F(SessionManagerHandlerTest, test_report_rule_stats) {
   CreateSessionResponse response;
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(
-        "IMSI1", "1234", 1, 1025, response.mutable_credits()->Add());
-  std::string imsi   = "IMSI1";
-  std::string msisdn = "5100001234";
-  auto sid           = id_gen_.gen_session_id(imsi);
-  SessionConfig cfg  = {};
+      IMSI1, SESSION_ID_1, 1, 1025, response.mutable_credits()->Add());
+  SessionConfig cfg = {};
   cfg.common_context =
-      build_common_context("", "128.0.0.1", "APN", msisdn, TGPP_LTE);
+      build_common_context(IMSI1, IP1, "APN", MSISDN, TGPP_LTE);
   const auto& lte_context = build_lte_context(
       "127.0.0.1", "imei", "plmn_id", "imsi_plmn_id", "user_loc", 1, nullptr);
   cfg.rat_specific_context.mutable_lte_context()->CopyFrom(lte_context);
-  SessionRead req  = {"IMSI1"};
-  auto session_map = session_store->read_sessions(req);
-  EXPECT_CALL(*events_reporter, session_created("IMSI1", sid, testing::_,
-      testing::_))
+  auto session_map = session_store->read_sessions({IMSI1});
+  EXPECT_CALL(
+      *events_reporter,
+      session_created(IMSI1, SESSION_ID_1, testing::_, testing::_))
       .Times(1);
-  local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, cfg, response);
   bool write_success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
 
   // Check the request number
-  auto session_map_2 = session_store->read_sessions(SessionRead{imsi});
-  EXPECT_EQ(session_map_2[imsi].front()->get_request_number(), 1);
+  auto session_map_2 = session_store->read_sessions(SessionRead{IMSI1});
+  EXPECT_EQ(session_map_2[IMSI1].front()->get_request_number(), 1);
   // 2) ReportRuleStats
   grpc::ServerContext server_context;
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record("IMSI1", "rule1", 512, 512, record_list->Add());
+  create_rule_record(IMSI1, IP1, "rule1", 512, 512, record_list->Add());
 
   EXPECT_CALL(
-      *reporter, report_updates(CheckUpdateSessionRequest(1), testing::_))
+      *reporter, report_updates(CheckUpdateRequestNumber(1), testing::_))
       .Times(1);
   session_manager->ReportRuleStats(
       &server_context, &table,
       [this](grpc::Status status, orc8r::Void response_out) {});
   evb->loopOnce();
 
-  session_map_2 = session_store->read_sessions(SessionRead{imsi});
-  EXPECT_EQ(session_map_2[imsi].front()->get_request_number(), 2);
+  session_map_2 = session_store->read_sessions(SessionRead{IMSI1});
+  EXPECT_EQ(session_map_2[IMSI1].front()->get_request_number(), 2);
   evb->loopOnce();
 }
 
@@ -361,33 +337,26 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
   CreateSessionResponse response;
   response.mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
   create_credit_update_response(
-        "IMSI1", "1234", 1, 1025, response.mutable_credits()->Add());
+      IMSI1, SESSION_ID_1, 1, 1025, response.mutable_credits()->Add());
   const std::string& hardware_addr_bytes = {0x0f, 0x10, 0x2e, 0x12, 0x3a, 0x55};
-  const std::string& imsi                = "IMSI1";
-  const std::string& msisdn              = "5100001234";
-  const std::string& radius_session_id =
-      "AA-AA-AA-AA-AA-AA:TESTAP__"
-      "0F-10-2E-12-3A-55";
-  const std::string& apn      = "apn1";
-  const std::string& mac_addr = "0f:10:2e:12:3a:55";
-  auto sid                    = id_gen_.gen_session_id(imsi);
+  const std::string& apn                 = "apn1";
   SessionConfig cfg;
-  cfg.common_context = build_common_context(imsi, "", apn, msisdn, TGPP_WLAN);
-  const auto& wlan          = build_wlan_context(mac_addr, radius_session_id);
+  cfg.common_context = build_common_context(IMSI1, "", apn, MSISDN, TGPP_WLAN);
+  const auto& wlan   = build_wlan_context(MAC_ADDR, RADIUS_SESSION_ID);
   cfg.rat_specific_context.mutable_wlan_context()->CopyFrom(wlan);
 
-  SessionRead req  = {"IMSI1"};
-  auto session_map = session_store->read_sessions(req);
-  local_enforcer->init_session_credit(session_map, imsi, sid, cfg, response);
+  auto session_map = session_store->read_sessions({IMSI1});
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, cfg, response);
   bool write_success =
-      session_store->create_sessions(imsi, std::move(session_map[imsi]));
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
   EXPECT_TRUE(write_success);
 
   // 3) EndSession
-  session_map = session_store->read_sessions(req);
-  EXPECT_EQ(session_map["IMSI1"].size(), 1);
+  session_map = session_store->read_sessions({IMSI1});
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
   LocalEndSessionRequest end_request;
-  end_request.mutable_sid()->set_id("IMSI1");
+  end_request.mutable_sid()->set_id(IMSI1);
   end_request.set_apn("apn1");
   grpc::ServerContext server_context;
 
@@ -396,13 +365,13 @@ TEST_F(SessionManagerHandlerTest, test_end_session) {
       &server_context, &end_request,
       [this](grpc::Status status, LocalEndSessionResponse response_out) {});
   evb->loopOnce();
-  session_map = session_store->read_sessions(req);
-  EXPECT_EQ(session_map["IMSI1"].size(), 1);
+  session_map = session_store->read_sessions({IMSI1});
+  EXPECT_EQ(session_map[IMSI1].size(), 1);
 
   evb->loopOnce();
 
-  session_map = session_store->read_sessions(req);
-  EXPECT_EQ(session_map["IMSI1"].size(), 0);
+  session_map = session_store->read_sessions({IMSI1});
+  EXPECT_EQ(session_map[IMSI1].size(), 0);
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -527,6 +527,12 @@ TEST_F(SessionStoreTest, test_get_session) {
   EXPECT_TRUE(optional_it2);
   auto& found_session2 = **optional_it2;
   EXPECT_EQ(found_session2->get_config().common_context.apn(), "APN2");
+  // Happy Path! IMSI+UE IPv4
+  SessionSearchCriteria id1_success_ip(IMSI1, IMSI_AND_UE_IPV4, IP2);
+  auto optional_it3 = session_store.find_session(session_map, id1_success_ip);
+  EXPECT_TRUE(optional_it3);
+  auto& found_session3 = **optional_it3;
+  EXPECT_EQ(found_session3->get_config().common_context.ue_ipv4(), IP2);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We recently made a change in PipelineD->SessionD's usage reporting to also include the IP address of the usage. (https://github.com/magma/magma/pull/2699) This now means that for each usage record, we can uniquely identify a session for which the usage should be applied towards. 

Before this change, since we could not uniquely identify a session from the record, if we received a record for a certain IMSI, we apply the usage to all sessions with the subscriber. 

This PR includes the change on SessionD's side to apply the usage correctly. For each record, we look up a session with the IP+IMSI, and add the usage into the session. 

## Test Plan
SessionD Unit Tests
Checked for regression by running CWF Integ Test
Ran S1AP tests 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
