### PR TITLE
[orc8r][tf] Save rootCA.key to Secretsmanager

### DIFF
--- a/orc8r/cloud/deploy/scripts/self_sign_certs.sh
+++ b/orc8r/cloud/deploy/scripts/self_sign_certs.sh
@@ -54,9 +54,3 @@ echo "###########################"
 echo "Deleting intermediate files"
 echo "###########################"
 rm -f controller.csr rootCA.srl
-
-echo ""
-echo "####################"
-echo "Deleting root CA key"
-echo "####################"
-rm -f rootCA.key

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/scripts/create_orc8r_secrets.py
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/scripts/create_orc8r_secrets.py
@@ -20,6 +20,7 @@ import boto3
 
 ORC8R_CERTS = [
     'rootCA.pem',
+    'rootCA.key',
     'controller.key',
     'controller.crt',
     'certifier.key',


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Store the rootCA private key in Secretesmanager but don't put it in the k8s secret

## Test Plan

- n/a

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
