### PR TITLE
pipelineD: use flows for SGi vlan handling

### DIFF
--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -1,4 +1,4 @@
- priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,in_port=70 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
@@ -1,8 +1,10 @@
- priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65535,in_port=3,dl_vlan=100 actions=strip_vlan,LOCAL
+ priority=65535,in_port=LOCAL actions=mod_vlan_vid:100,output:3
+ priority=100,in_port=70 actions=drop
+ priority=1,in_port=71 actions=drop
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
  priority=100,ip,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
- priority=100,in_port=70 actions=drop
- priority=1,in_port=71 actions=drop
  priority=0 actions=NORMAL

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -1,8 +1,10 @@
- priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65535,in_port=3,dl_vlan=500 actions=strip_vlan,LOCAL
+ priority=65535,in_port=LOCAL actions=mod_vlan_vid:500,output:3
+ priority=100,in_port=70 actions=drop
+ priority=1,in_port=71 actions=drop
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
  priority=100,ip,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
- priority=100,in_port=70 actions=drop
- priority=1,in_port=71 actions=drop
  priority=0 actions=NORMAL

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -171,9 +171,6 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
 
         # dummy uplink interface
         vlan = "10"
-        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
-                          "tag=" + vlan]).wait()
-        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
 
         BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
                                           cls.UPLINK_DHCP, None)
@@ -197,7 +194,6 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
         cls = self.__class__
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
                                      include_stats=False)
-        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), '[]')
 
 
 class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
@@ -276,9 +272,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
         # validate vlan id set
         vlan = "10"
         BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
-        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
-                          "tag=" + vlan]).wait()
-        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
 
         BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
                                           cls.UPLINK_DHCP, None)
@@ -303,7 +296,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
                                      include_stats=False)
 
-        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), cls.VLAN_TAG)
 
 class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     BRIDGE = 'testing_br'
@@ -314,7 +306,7 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     UPLINK_DHCP = 'test_dhcp0'
     UPLINK_PATCH = 'test_patch_p2'
     UPLINK_ETH_PORT = 'test_eth3'
-    VLAN_TAG='100'
+    VLAN_TAG='500'
     SGi_IP="1.6.5.7"
 
     @classmethod
@@ -370,9 +362,6 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         # validate vlan id set
         vlan = "10"
         BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
-        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
-                          "tag=" + vlan]).wait()
-        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
 
         set_ip_cmd = ["ip",
                       "addr", "replace",
@@ -403,7 +392,6 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         cls = self.__class__
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
                                      include_stats=False)
-        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), cls.VLAN_TAG)
 
         self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.UPLINK_BRIDGE), "ip not found")
 
@@ -591,6 +579,7 @@ class UplinkBridgeTestNatIPAddr(unittest.TestCase):
 
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager)
         self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.BRIDGE_ETH_PORT), "ip not found")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

rather than using vlan tag for the port, use flows for processing
vlan packets.
This makes datapath simple to analyze  in production. This also
improves performance a bit.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
