### PR TITLE
[CWF IntegTest] Assert on total rx+tx and not only tx value for GxReAuth 

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -48,7 +48,7 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
                gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml",
                transfer_images=False, destroy_vm=False, no_build=False,
                tests_to_run="all", skip_unit_tests=False, test_re=None,
-               run_tests=True):
+               count="1", run_tests=True):
     """
     Run the integration tests. This defaults to running on local vagrant
     machines, but can also be pointed to an arbitrary host (e.g. amazon) by
@@ -141,7 +141,7 @@ def integ_test(gateway_host=None, test_host=None, trf_host=None,
               "You can now run the tests manually from cwag_test")
         sys.exit(0)
 
-    execute(_run_integ_tests, test_host, trf_host, tests_to_run, test_re)
+    execute(_run_integ_tests, test_host, trf_host, tests_to_run, count, test_re)
 
     # If we got here means everything work well!!
     if not test_host and not trf_host:
@@ -368,7 +368,7 @@ def _add_docker_host_remote_network_envvar():
         "echo 'DOCKER_API_VERSION=1.40' >> /etc/environment" % (CWAG_IP, CWAG_IP))
 
 
-def _run_integ_tests(test_host, trf_host, tests_to_run: SubTests,
+def _run_integ_tests(test_host, trf_host, tests_to_run: SubTests, count,
                      test_re=None):
     """ Run the integration tests """
     # add docker host environment as well
@@ -382,6 +382,7 @@ def _run_integ_tests(test_host, trf_host, tests_to_run: SubTests,
     # QOS take a while to run. Increasing the timeout to 20m
     go_test_cmd = "gotestsum --format=standard-verbose --"
     go_test_cmd += " -test.short -timeout 20m" # go test args
+    go_test_cmd += " -count " + count
     go_test_cmd += " -tags=" + tests_to_run.value
     if test_re:
         go_test_cmd += " -run=" + test_re

--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -56,6 +56,7 @@ require (
 	golang.org/x/net v0.0.0-20200625001655-4c5254603344
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000

--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -111,7 +111,7 @@ func TestAuthenticateFail(t *testing.T) {
 	tr.AssertAllGxExpectationsMetNoError()
 
 	// Since CCR/A-I failed, pipelined should see no rules installed
-	tr.AssertPolicyEnforcementRecordIsNil(imsi)
+	tr.AssertEnforcementRecordIsEmptyForSub(imsi)
 
 	// ----- Gx CCR-I success && Gy CCR-I fail -> Authentication fails -----
 	imsi = ues[1].GetImsi()
@@ -133,7 +133,7 @@ func TestAuthenticateFail(t *testing.T) {
 	tr.AssertAllGyExpectationsMetNoError()
 
 	// Since CCR/A-I failed, pipelined should see no rules installed
-	tr.AssertPolicyEnforcementRecordIsNil(imsi)
+	tr.AssertEnforcementRecordIsEmptyForSub(imsi)
 }
 
 // - Set an expectation for a CCR-I to be sent up to PCRF, to which it will

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -509,7 +509,7 @@ func TestGyCreditUpdateCommandLevelFail(t *testing.T) {
 	// Assert that a CCR-I/U/T was sent to OCS
 	tr.AssertAllGyExpectationsMetNoError()
 
-	tr.AssertPolicyEnforcementRecordIsNil(ue.GetImsi())
+	tr.AssertEnforcementRecordIsEmptyForSub(ue.GetImsi())
 }
 
 // This test verifies the abort session request

--- a/cwf/gateway/integ_tests/rule_manager.go
+++ b/cwf/gateway/integ_tests/rule_manager.go
@@ -171,7 +171,7 @@ func (manager *RuleManager) RemoveInstalledRules() error {
 // AddUsageMonitor constructs a usage monitor according to the parameters and
 // inserts it into PCRF
 func (manager *RuleManager) AddUsageMonitor(imsi, monitoringKey string, volume, bytesPerGrant uint64) error {
-	fmt.Printf("************************* Adding PCRF Usage Monitor for UE with IMSI: %s\n", imsi)
+	fmt.Printf("************************* Adding PCRF Usage Monitor for UE with IMSI: %s with TotalGrant: %v, Incremental grant %v\n", imsi, volume, bytesPerGrant)
 	usageMonitor := makeUsageMonitor(imsi, monitoringKey, volume, bytesPerGrant)
 	err := addPCRFUsageMonitorsPerInstance(manager.pcrfInstance, usageMonitor)
 	if err != nil {

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -66,6 +66,7 @@ const (
 	KiloBytes                = 1024
 	MegaBytes                = 1024 * KiloBytes
 	Buffer                   = 100 * KiloBytes
+	BufferMultiplier         = 1.2 // 20% error
 	RevalidationTimeoutEvent = 17
 
 	ReAuthMaxUsageBytes   = 5 * MegaBytes
@@ -276,7 +277,7 @@ func (tr *TestRunner) GetPolicyUsage() (RecordByIMSI, error) {
 		return recordsBySubID, err
 	}
 	for _, record := range table.Records {
-		fmt.Printf("Record %v\n", record)
+		fmt.Printf("Record %vtotal:%v\n", record, record.BytesTx+record.BytesRx)
 		_, exists := recordsBySubID[record.Sid]
 		if !exists {
 			recordsBySubID[record.Sid] = map[string]*lteprotos.RuleRecord{}


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- Added -count flag to the fabfile so we can run the test suite multiple times. (Hopefully will help with discovering flakiness)
- Added several assertion functions to assert on the contents of policy usage table
- Modified Gx RAR tests to assert on the total usage instead of Tx only. We configure a usage monitor that tracks the total usage for these tests, so it is more helpful.
  - I think that maybe other tests should assert on the Tx+Rx if the credit is configured that way. But will focus only on the GxReAuth tests for this PR.
- Since Iperf3's volume specification is not 100% accurate, we have a buffer const to allow for some error. For these tests, I am trying out a error multiplier instead of a const value so that we scale the error with the amount of traffic 
- Improving and adding logs

## Test Plan
Ran `fab integ_test:no_build=True,skip_unit_tests=True,test_re=TestGxReAuth,count=10`
```
[vagrant@127.0.0.1:2201] out: PASS
[vagrant@127.0.0.1:2201] out: ok  	magma/cwf/gateway/integ_tests	932.698s
[vagrant@127.0.0.1:2201] out:
[vagrant@127.0.0.1:2201] out: DONE 50 tests in 938.136s
[vagrant@127.0.0.1:2201] out:
```
## Additional Information
- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
