### PR TITLE
[CWF] Add Integration test case for FUA Restrict

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -648,14 +648,11 @@ func TestGyAbortSessionRequest(t *testing.T) {
 //   Generate traffic and assert the CCR-I is received.
 // - Generate 5M traffic to exceed 100% of the quota to trigger service restriction.
 // - Assert that UE flows are NOT deleted and data was passed.
-// - Generate an additional 2M traffic and assert that only Gy flows matched. Gx flows stats
-//   remains unchanged.
+// - Generate an additional 2M traffic and assert that only Gy flows matched.
 // - Send a Charging ReAuth request to top up quota and assert that the
 //   response is successful
 // - Assert that CCR-U was is generated
 // - Generate 2M traffic and assert that UE flows are NOT deleted and data was passed.
-// NOTE : Once Gy rules statistics will be fully supported, we can assert amount of data
-// passed by gy flows..
 func TestGyCreditExhaustionRestrict(t *testing.T) {
 	fmt.Println("\nRunning TestGyCreditExhaustionRestrict...")
 
@@ -726,8 +723,8 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
 
-	// Check that UE mac flow was not removed and no extra data hit gx rules
-	verifyPolicyUsage(t, tr, ue.GetImsi(), "static-pass-all-ocs2", 4*MegaBytes, 5*MegaBytes)
+	// Check that UE mac flow was not removed and flow data hit restrict rule
+	verifyPolicyUsage(t, tr, ue.GetImsi(), "restrict-pass-user", 0, 2*MegaBytes)
 
 	// Send ReAuth Request to update quota
 	raa, err := sendChargingReAuthRequest(ue.GetImsi(), 1)

--- a/cwf/gateway/integ_tests/static_rules.go
+++ b/cwf/gateway/integ_tests/static_rules.go
@@ -29,49 +29,12 @@ func getUsageInformation(monitorKey string, quota uint64) *protos.UsageMonitorin
 	}
 }
 
+const MATCH_ALL = "0.0.0.0/0"
+
 func getStaticPassAll(
 	ruleID string, monitoringKey string, ratingGroup uint32, trackingType string, priority uint32, qos *lteProtos.FlowQos,
 ) *lteProtos.PolicyRule {
-	rule := &models.PolicyRuleConfig{
-		FlowList: []*models.FlowDescription{
-			{
-				Action: swag.String("PERMIT"),
-				Match: &models.FlowMatch{
-					Direction: swag.String("UPLINK"),
-					IPProto:   swag.String("IPPROTO_IP"),
-					IPDst:     &models.IPAddress{
-						Version: models.IPAddressVersionIPV4,
-						Address: "0.0.0.0/0",
-					},
-					IPSrc:     &models.IPAddress{
-						Version: models.IPAddressVersionIPV4,
-						Address: "0.0.0.0/0",
-					},
-				},
-			},
-			{
-				Action: swag.String("PERMIT"),
-				Match: &models.FlowMatch{
-					Direction: swag.String("DOWNLINK"),
-					IPProto:   swag.String("IPPROTO_IP"),
-					IPDst:     &models.IPAddress{
-						Version: models.IPAddressVersionIPV4,
-						Address: "0.0.0.0/0",
-					},
-					IPSrc:     &models.IPAddress{
-						Version: models.IPAddressVersionIPV4,
-						Address: "0.0.0.0/0",
-					},
-				},
-			},
-		},
-		MonitoringKey: monitoringKey,
-		Priority:      swag.Uint32(priority),
-		TrackingType:  trackingType,
-		RatingGroup:   ratingGroup,
-	}
-
-	return rule.ToProto(ruleID, qos)
+	return getStaticPassTraffic(ruleID, MATCH_ALL, MATCH_ALL, monitoringKey, ratingGroup, trackingType, priority, qos)
 }
 
 func getStaticDenyAll(ruleID string, monitoringKey string, ratingGroup uint32, trackingType string, priority uint32) *lteProtos.PolicyRule {
@@ -115,4 +78,50 @@ func getStaticDenyAll(ruleID string, monitoringKey string, ratingGroup uint32, t
 	}
 
 	return rule.ToProto(ruleID, nil)
+}
+
+func getStaticPassTraffic(
+	ruleID string, srcIP string, dstIP string, monitoringKey string, ratingGroup uint32, trackingType string, priority uint32, qos *lteProtos.FlowQos,
+) *lteProtos.PolicyRule {
+	rule := &models.PolicyRuleConfig{
+		FlowList: []*models.FlowDescription{
+			{
+				Action: swag.String("PERMIT"),
+				Match: &models.FlowMatch{
+					Direction: swag.String("UPLINK"),
+					IPProto:   swag.String("IPPROTO_IP"),
+					IPDst:     &models.IPAddress{
+						Version: models.IPAddressVersionIPV4,
+						Address: dstIP,
+					},
+					IPSrc:     &models.IPAddress{
+						Version: models.IPAddressVersionIPV4,
+						Address: srcIP,
+					},
+					IPV4Dst:   dstIP,
+					IPV4Src:   srcIP,
+				},
+			},
+			{
+				Action: swag.String("PERMIT"),
+				Match: &models.FlowMatch{
+					Direction: swag.String("DOWNLINK"),
+					IPProto:   swag.String("IPPROTO_IP"),
+					IPDst:     &models.IPAddress{
+						Version: models.IPAddressVersionIPV4,
+						Address: srcIP,
+					},
+					IPSrc:     &models.IPAddress{
+						Version: models.IPAddressVersionIPV4,
+						Address: dstIP,
+					},
+				},
+			},
+		},
+		MonitoringKey: monitoringKey,
+		Priority:      swag.Uint32(priority),
+		TrackingType:  trackingType,
+		RatingGroup:   ratingGroup,
+	}
+	return rule.ToProto(ruleID, qos)
 }


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

Adding a test case for FinalUnitAction Restrict Access.

## Test Plan

Unit Tests and Running Integration Tests (Needs a pipelined support as well)
