### PR TITLE
[nms] remove transitive dependencies from flow

### DIFF
--- a/nms/app/.flowconfig
+++ b/nms/app/.flowconfig
@@ -1,5 +1,7 @@
 [ignore]
 
+<PROJECT_ROOT>/node_modules/.*/node_modules/.*
+
 ; Ignore components that we dont care if they match our flow
 .*/node_modules/bcryptjs/.*
 .*/node_modules/config-chain/test/.*


### PR DESCRIPTION
## Summary

By doing this, we reduce the number of files flow has to parse
from ~40k to ~27k.  Since they are used in package-of-packages,
and we never import those directly, we can safely ignore them

## Test Plan

run `flow` before and after this change.  Verify no flow errors, and
that parsing has sped up

Signed-off-by: Josh Braegger <jbraeg@fb.com>