### PR TITLE
[CWAG][HA] Update CWF operator to support transport failover

### DIFF
--- a/cwf/k8s/cwf_operator/cmd/manager/main.go
+++ b/cwf/k8s/cwf_operator/cmd/manager/main.go
@@ -26,7 +26,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 package main
 

--- a/cwf/k8s/cwf_operator/deploy/crds/magma.cwf.k8s_haclusters_crd.yaml
+++ b/cwf/k8s/cwf_operator/deploy/crds/magma.cwf.k8s_haclusters_crd.yaml
@@ -66,8 +66,16 @@ spec:
               maxItems: 2
               minItems: 1
               type: array
+            maxConsecutiveActiveErrors:
+              description: MaxConsecutiveActiveErrors denotes the maximum number of
+                errors the HACluster's active can have fetching health status before
+                a failover occurs
+              maximum: 5
+              minimum: 1
+              type: integer
           required:
           - gatewayResourceNames
+          - maxConsecutiveActiveErrors
           type: object
         status:
           description: HAClusterStatus defines the observed state of HACluster
@@ -80,6 +88,16 @@ spec:
               description: ActiveInitState denotes the initialization state of the
                 active in the HACluster
               type: string
+            consecutiveActiveErrors:
+              description: ConsecutiveActiveErrors denotes the number of consecutive
+                errors that have occurred when the active has been called for health
+                status
+              type: integer
+            consecutiveStandbyErrors:
+              description: ConsecutiveStandbyErrors denotes the number of consecutive
+                errors that have occurred when the standby has been called for health
+                status
+              type: integer
             standbyInitState:
               description: StandbyInitState denotes the initialization state of the
                 standby in the HACluster
@@ -87,6 +105,8 @@ spec:
           required:
           - active
           - activeInitState
+          - consecutiveActiveErrors
+          - consecutiveStandbyErrors
           - standbyInitState
           type: object
       type: object

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -29,8 +29,14 @@ module magma/cwf/k8s/cwf_operator
 go 1.13
 
 require (
+	github.com/OneOfOne/xxhash v1.2.5 // indirect
+	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/go-logr/glogr v0.1.0
 	github.com/gorilla/mux v1.7.4 // indirect
+	github.com/hashicorp/go-msgpack v0.5.4 // indirect
+	github.com/hashicorp/go-uuid v1.0.1 // indirect
+	github.com/miekg/dns v1.1.10 // indirect
+	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/cwf/k8s/cwf_operator/go.mod
+++ b/cwf/k8s/cwf_operator/go.mod
@@ -29,14 +29,9 @@ module magma/cwf/k8s/cwf_operator
 go 1.13
 
 require (
-	github.com/OneOfOne/xxhash v1.2.5 // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/go-logr/glogr v0.1.0
 	github.com/gorilla/mux v1.7.4 // indirect
-	github.com/hashicorp/go-msgpack v0.5.4 // indirect
-	github.com/hashicorp/go-uuid v1.0.1 // indirect
-	github.com/miekg/dns v1.1.10 // indirect
-	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.4.0

--- a/cwf/k8s/cwf_operator/go.sum
+++ b/cwf/k8s/cwf_operator/go.sum
@@ -263,6 +263,8 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-metrics v0.0.0-20180209012529-399ea8c73916/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82 h1:X0fj836zx99zFu83v/M79DuBn84IL/Syx1SY6Y5ZEMA=
 github.com/docker/go-metrics v0.0.0-20181218153428-b84716841b82/go.mod h1:/u0gXw0Gay3ceNrsHubL3BtdOL2fHf93USgMTe0W5dI=
+github.com/docker/go-metrics v0.0.1 h1:AgB/0SvBxihN0X8OR4SjsblXkbMvalQ8cjmtKQ2rQV8=
+github.com/docker/go-metrics v0.0.1/go.mod h1:cG1hvH2utMXtqgqqYE9plW6lDxS3/5ayHzueweSI3Vw=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=

--- a/cwf/k8s/cwf_operator/pkg/apis/magma/v1alpha1/hacluster_types.go
+++ b/cwf/k8s/cwf_operator/pkg/apis/magma/v1alpha1/hacluster_types.go
@@ -39,9 +39,6 @@ type CarrierWifiAccessGatewayHealthCondition string
 type CarrierWifiAccessGatewayInitState string
 
 const (
-	Healthy   CarrierWifiAccessGatewayHealthCondition = "Healthy"
-	Unhealthy CarrierWifiAccessGatewayHealthCondition = "Unhealthy"
-
 	Initialized   HAClusterInitState = "Initialized"
 	Uninitialized HAClusterInitState = "Uninitialized"
 )
@@ -50,10 +47,18 @@ const (
 
 // HAClusterSpec defines the desired state of HACluster
 type HAClusterSpec struct {
-	// GatewayResourceNames denotes the list of all gateway resource names in the HACluster
+	// GatewayResourceNames denotes the list of all gateway resource names in
+	// the HACluster
 	// +kubebuilder:validation:MaxItems=2
 	// +kubebuilder:validation:MinItems=1
 	GatewayResourceNames []string `json:"gatewayResourceNames"`
+
+	// MaxConsecutiveActiveErrors denotes the maximum number of errors the
+	// HACluster's active can have fetching health status before a failover
+	// occurs
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Maximum=5
+	MaxConsecutiveActiveErrors int `json:"maxConsecutiveActiveErrors"`
 	// Important: Run "make gen" to regenerate code after modifying this file
 }
 
@@ -69,6 +74,14 @@ type HAClusterStatus struct {
 	// StandbyInitState denotes the initialization state of the standby in
 	// the HACluster
 	StandbyInitState HAClusterInitState `json:"standbyInitState"`
+
+	// ConsecutiveActiveErrors denotes the number of consecutive errors
+	// that have occurred when the active has been called for health status
+	ConsecutiveActiveErrors int `json:"consecutiveActiveErrors"`
+
+	// ConsecutiveStandbyErrors denotes the number of consecutive errors
+	// that have occurred when the standby has been called for health status
+	ConsecutiveStandbyErrors int `json:"consecutiveStandbyErrors"`
 	// Important: Run "make gen" to regenerate code after modifying this file
 }
 

--- a/cwf/k8s/cwf_operator/pkg/apis/magma/v1alpha1/hacluster_types.go
+++ b/cwf/k8s/cwf_operator/pkg/apis/magma/v1alpha1/hacluster_types.go
@@ -26,7 +26,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 package v1alpha1
 

--- a/cwf/k8s/cwf_operator/pkg/controller/hacluster/hacluster_controller.go
+++ b/cwf/k8s/cwf_operator/pkg/controller/hacluster/hacluster_controller.go
@@ -60,6 +60,7 @@ const (
 	cwfAppSelectorValue    = "cwf"
 	cwfInstanceSelectorKey = "app.kubernetes.io/instance"
 	reconcilePeriod        = 15 * time.Second
+	retryPeriod            = 5 * time.Second
 	gatewayHealthService   = "health"
 )
 
@@ -110,9 +111,13 @@ type ReconcileHACluster struct {
 // Reconcile monitors gateway resources defined in the HACluster's spec
 // and updates the HACluster's status, taking remediation steps if the
 // the active gateway becomes unhealthy.
+//
 // Note:
-// The Controller will requeue the Request to be processed again if the returned error is non-nil or
-// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+// The Controller will requeue the Request to be processed again if the
+// returned error is non-nil or  Result.Requeue is true, otherwise upon
+// completion it will remove the work from the queue. Returned errors should be
+// reserved for scenarios that are unexpected as k8s will reduce scheduling
+// the workload after consecutive errors.
 func (r *ReconcileHACluster) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling Cluster")
@@ -147,14 +152,32 @@ func (r *ReconcileHACluster) Reconcile(request reconcile.Request) (reconcile.Res
 
 	activeHealth, err := r.getGatewayHealthStatus(activeGateway, request.Namespace)
 	if err != nil {
-		reqLogger.Error(err, "An error occurred while fetching active health status")
+		reqLogger.Error(
+			err,
+			"An error occurred while fetching active health status",
+			"consecutive error count",
+			hacluster.Status.ConsecutiveActiveErrors,
+			"max consecutive errors for failover",
+			hacluster.Spec.MaxConsecutiveActiveErrors,
+		)
+		hacluster.Status.ConsecutiveActiveErrors = hacluster.Status.ConsecutiveActiveErrors + 1
+		if hacluster.Status.ConsecutiveActiveErrors < hacluster.Spec.MaxConsecutiveActiveErrors {
+			updateErr := r.client.Status().Update(context.TODO(), hacluster)
+			if updateErr != nil {
+				reqLogger.Error(updateErr, "An error occurred while updating consecutive error total for active")
+			}
+			return reconcile.Result{RequeueAfter: retryPeriod}, updateErr
+		}
 	} else {
+		hacluster.Status.ConsecutiveActiveErrors = 0
 		reqLogger.Info("Fetched active health status", "health", activeHealth.Health.String(), "message", activeHealth.HealthMessage)
 	}
 	standbyHealth, err := r.getGatewayHealthStatus(standbyGateway, request.Namespace)
 	if err != nil {
+		hacluster.Status.ConsecutiveStandbyErrors = hacluster.Status.ConsecutiveStandbyErrors + 1
 		reqLogger.Error(err, "An error occurring while fetching standby health status")
 	} else {
+		hacluster.Status.ConsecutiveStandbyErrors = 0
 		reqLogger.Info("Fetched standby health status", "health", standbyHealth.Health.String(), "message", standbyHealth.HealthMessage)
 	}
 
@@ -162,32 +185,40 @@ func (r *ReconcileHACluster) Reconcile(request reconcile.Request) (reconcile.Res
 	var initErr error
 	var updatedStatus magmav1alpha1.HAClusterStatus
 	if activeHealth.Health == protos.HealthStatus_HEALTHY {
-		updatedStatus, initErr = r.initCluster(activeGateway, standbyGateway, request.Namespace, hacluster.Status)
+		updatedStatus, initErr = r.initCluster(activeGateway, standbyGateway, request.Namespace, hacluster.Status, false)
 	} else if activeHealth.Health == protos.HealthStatus_UNHEALTHY && standbyHealth.Health == protos.HealthStatus_HEALTHY {
-		failover = true
 		reqLogger.Info("Promoting standby due to unhealthy active", "promoted active", standbyGateway)
 		hacluster.Status.ActiveInitState = magmav1alpha1.Uninitialized
 		hacluster.Status.StandbyInitState = magmav1alpha1.Uninitialized
-		updatedStatus, initErr = r.initCluster(standbyGateway, activeGateway, request.Namespace, hacluster.Status)
+		hacluster.Status.ConsecutiveActiveErrors = 0
+		hacluster.Status.ConsecutiveStandbyErrors = 0
+		updatedStatus, initErr = r.initCluster(standbyGateway, activeGateway, request.Namespace, hacluster.Status, true)
 	} else {
 		reqLogger.Info("Both gateways are detected to be unhealthy")
-		updatedStatus, initErr = r.initCluster(activeGateway, standbyGateway, request.Namespace, hacluster.Status)
+		// If both gateways are unhealthy, there is a chance that a restart
+		// occurred, rendering the gateway(s) uninitialized. As a precaution,
+		// update the status to uninitialized and re-init. If the gateways are
+		// already initialized, this will be a no-op
+		hacluster.Status.ActiveInitState = magmav1alpha1.Uninitialized
+		hacluster.Status.StandbyInitState = magmav1alpha1.Uninitialized
+		updatedStatus, initErr = r.initCluster(activeGateway, standbyGateway, request.Namespace, hacluster.Status, false)
 	}
 
 	if initErr != nil {
-		reqLogger.Error(initErr, "failover occurred", strconv.FormatBool(failover))
+		reqLogger.Error(initErr, "did failover occur", strconv.FormatBool(failover))
 	}
 	hacluster.Status = updatedStatus
 	updateErr := r.client.Status().Update(context.TODO(), hacluster)
 	if updateErr != nil && failover {
-		err = fmt.Errorf("Updating hacluster status with promoted active %s failed; %s", standbyGateway, updateErr)
-		return reconcile.Result{RequeueAfter: r.reconcilePeriod}, updateErr
+		reqLogger.Error(updateErr, "Updating hacluster status with promoted active failed", "promoted active", standbyGateway)
+		return reconcile.Result{}, updateErr
 	} else if updateErr != nil {
-		return reconcile.Result{RequeueAfter: r.reconcilePeriod}, updateErr
+		reqLogger.Error(updateErr, "Updating hacluster status failed")
+		return reconcile.Result{}, updateErr
 	}
 
 	reqLogger.Info("Reconciled request")
-	return reconcile.Result{RequeueAfter: r.reconcilePeriod}, initErr
+	return reconcile.Result{RequeueAfter: r.reconcilePeriod}, nil
 }
 
 // getGatewayHealthStatus fetches the health status for the provided gateway.
@@ -220,32 +251,43 @@ func (r ReconcileHACluster) getGatewayHealthStatus(gateway string, namespace str
 	return health, err
 }
 
-func (r ReconcileHACluster) initCluster(active string, standby string, namespace string, status magmav1alpha1.HAClusterStatus) (magmav1alpha1.HAClusterStatus, error) {
+func (r ReconcileHACluster) initCluster(active string, standby string, namespace string, status magmav1alpha1.HAClusterStatus, didFailover bool) (magmav1alpha1.HAClusterStatus, error) {
 	ret := magmav1alpha1.HAClusterStatus{
-		Active:           active,
-		ActiveInitState:  status.ActiveInitState,
-		StandbyInitState: status.StandbyInitState,
+		Active:                   active,
+		ActiveInitState:          status.ActiveInitState,
+		StandbyInitState:         status.StandbyInitState,
+		ConsecutiveActiveErrors:  status.ConsecutiveActiveErrors,
+		ConsecutiveStandbyErrors: status.ConsecutiveStandbyErrors,
 	}
 	var initActiveErr error
 	var initStandbyErr error
-	if status.ActiveInitState != magmav1alpha1.Initialized {
-		ret.ActiveInitState, initActiveErr = r.initGatewayWithRole(active, namespace, true)
-	}
+	var recreateGateway bool
+
+	// Init standby first to avoid potential dual-ownership of VIP
 	if status.StandbyInitState != magmav1alpha1.Initialized {
-		ret.StandbyInitState, initStandbyErr = r.initGatewayWithRole(standby, namespace, false)
+		ret.StandbyInitState, recreateGateway, initStandbyErr = r.initGatewayWithRole(standby, namespace, false)
+		// If we are unable to disable the standby after failover, recreate the
+		// gateway to ensure the VIP is transferred properly to the active
+		if didFailover && recreateGateway {
+			r.recreateGateway(standby, namespace)
+		}
 	}
+	if status.ActiveInitState != magmav1alpha1.Initialized {
+		ret.ActiveInitState, _, initActiveErr = r.initGatewayWithRole(active, namespace, true)
+	}
+
 	return ret, r.constructAggregateClusterError(initActiveErr, initStandbyErr)
 }
 
-func (r ReconcileHACluster) initGatewayWithRole(gateway string, namespace string, active bool) (magmav1alpha1.HAClusterInitState, error) {
+func (r ReconcileHACluster) initGatewayWithRole(gateway string, namespace string, active bool) (magmav1alpha1.HAClusterInitState, bool, error) {
 	// Get pod first to avoid sending an RPC that will timeout
 	_, err := r.getPodNamespacedNameForGateway(gateway, namespace)
 	if err != nil {
-		return magmav1alpha1.Uninitialized, err
+		return magmav1alpha1.Uninitialized, false, err
 	}
 	svc, port, err := r.getHealthServiceAddressForResource(gateway, namespace)
 	if err != nil {
-		return magmav1alpha1.Uninitialized, err
+		return magmav1alpha1.Uninitialized, false, err
 	}
 	if active {
 		err = r.healthClient.Enable(svc, port)
@@ -253,9 +295,22 @@ func (r ReconcileHACluster) initGatewayWithRole(gateway string, namespace string
 		err = r.healthClient.Disable(svc, port)
 	}
 	if err != nil {
-		return magmav1alpha1.Uninitialized, err
+		return magmav1alpha1.Uninitialized, true, err
 	}
-	return magmav1alpha1.Initialized, nil
+	return magmav1alpha1.Initialized, false, nil
+}
+
+func (r ReconcileHACluster) recreateGateway(gateway string, namespace string) error {
+	podName, err := r.getPodNamespacedNameForGateway(gateway, namespace)
+	if err != nil {
+		return err
+	}
+	pod := &corev1.Pod{}
+	err = r.client.Get(context.TODO(), *podName, pod)
+	if err != nil {
+		return err
+	}
+	return r.client.Delete(context.TODO(), pod)
 }
 
 func (r ReconcileHACluster) getPodNamespacedNameForGateway(gateway string, namespace string) (*types.NamespacedName, error) {

--- a/cwf/k8s/cwf_operator/pkg/controller/hacluster/hacluster_controller_test.go
+++ b/cwf/k8s/cwf_operator/pkg/controller/hacluster/hacluster_controller_test.go
@@ -136,15 +136,13 @@ func TestHAClusterControllerTwoGateways(t *testing.T) {
 	mockCluster := &magmav1alpha1.HACluster{}
 	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
 	assert.NoError(t, err)
-	assert.Equal(t, gw, mockCluster.Status.Active)
-	assert.Equal(t, magmav1alpha1.Uninitialized, mockCluster.Status.ActiveInitState)
-	assert.Equal(t, magmav1alpha1.Uninitialized, mockCluster.Status.StandbyInitState)
+	assertClusterStatus(t, gw, magmav1alpha1.Uninitialized, magmav1alpha1.Uninitialized, 0, 0, mockCluster.Status)
 
 	// Test proper error handling if a configured gateway doesn't actually exist
 	mockServicer.On("GetHealthStatus", mock.Anything, mock.Anything).Return(healthyStatus, nil).Once()
 	mockServicer.On("Enable", mock.Anything, mock.Anything).Return(void, nil).Once()
 	_, err = r.Reconcile(req)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	mockServicer.AssertExpectations(t)
 
 	// Create gw2 resource
@@ -161,15 +159,13 @@ func TestHAClusterControllerTwoGateways(t *testing.T) {
 	assert.NoError(t, err)
 	mockServicer.AssertExpectations(t)
 	mockServicer2.AssertExpectations(t)
-	mockcluster := &magmav1alpha1.HACluster{}
-	err = r.client.Get(context.Background(), req.NamespacedName, mockcluster)
+	mockCluster = &magmav1alpha1.HACluster{}
+	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
 	assert.NoError(t, err)
-	assert.Equal(t, gw, mockcluster.Status.Active)
-	assert.Equal(t, magmav1alpha1.Initialized, mockcluster.Status.ActiveInitState)
-	assert.Equal(t, magmav1alpha1.Initialized, mockcluster.Status.StandbyInitState)
+	assertClusterStatus(t, gw, magmav1alpha1.Initialized, magmav1alpha1.Initialized, 0, 0, mockCluster.Status)
 
 	// Test successful failover
-	mockServicer.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, fmt.Errorf("err connecting")).Once()
+	mockServicer.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, nil).Once()
 	mockServicer2.On("GetHealthStatus", mock.Anything, mock.Anything).Return(healthyStatus, nil).Once()
 	mockServicer2.On("Enable", mock.Anything, mock.Anything).Return(void, nil).Once()
 	mockServicer.On("Disable", mock.Anything, mock.Anything).Return(void, nil).Once()
@@ -180,9 +176,7 @@ func TestHAClusterControllerTwoGateways(t *testing.T) {
 	mockCluster = &magmav1alpha1.HACluster{}
 	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
 	assert.NoError(t, err)
-	assert.Equal(t, gw2, mockCluster.Status.Active)
-	assert.Equal(t, magmav1alpha1.Initialized, mockCluster.Status.ActiveInitState)
-	assert.Equal(t, magmav1alpha1.Initialized, mockCluster.Status.StandbyInitState)
+	assertClusterStatus(t, gw2, magmav1alpha1.Initialized, magmav1alpha1.Initialized, 0, 0, mockCluster.Status)
 
 	// Test failover and active init failure
 	mockServicer2.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, nil).Once()
@@ -190,20 +184,19 @@ func TestHAClusterControllerTwoGateways(t *testing.T) {
 	mockServicer.On("Enable", mock.Anything, mock.Anything).Return(void, fmt.Errorf("session restart failed")).Once()
 	mockServicer2.On("Disable", mock.Anything, mock.Anything).Return(void, nil).Once()
 	_, err = r.Reconcile(req)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 	mockServicer.AssertExpectations(t)
 	mockServicer2.AssertExpectations(t)
 	mockCluster = &magmav1alpha1.HACluster{}
 	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
 	assert.NoError(t, err)
-	assert.Equal(t, gw, mockCluster.Status.Active)
-	assert.Equal(t, magmav1alpha1.Uninitialized, mockCluster.Status.ActiveInitState)
-	assert.Equal(t, magmav1alpha1.Initialized, mockCluster.Status.StandbyInitState)
+	assertClusterStatus(t, gw, magmav1alpha1.Uninitialized, magmav1alpha1.Initialized, 0, 0, mockCluster.Status)
 
-	// Test both unhealthy, but active uninitialized
+	// Test both unhealthy, both should be re-initialized
 	mockServicer.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, nil).Once()
 	mockServicer2.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, nil).Once()
 	mockServicer.On("Enable", mock.Anything, mock.Anything).Return(void, nil).Once()
+	mockServicer2.On("Disable", mock.Anything, mock.Anything).Return(void, nil).Once()
 	_, err = r.Reconcile(req)
 	assert.NoError(t, err)
 	mockServicer.AssertExpectations(t)
@@ -211,9 +204,54 @@ func TestHAClusterControllerTwoGateways(t *testing.T) {
 	mockCluster = &magmav1alpha1.HACluster{}
 	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
 	assert.NoError(t, err)
-	assert.Equal(t, gw, mockCluster.Status.Active)
-	assert.Equal(t, magmav1alpha1.Initialized, mockCluster.Status.ActiveInitState)
-	assert.Equal(t, magmav1alpha1.Initialized, mockCluster.Status.StandbyInitState)
+	assertClusterStatus(t, gw, magmav1alpha1.Initialized, magmav1alpha1.Initialized, 0, 0, mockCluster.Status)
+
+	// Test active unreachable, first error
+	mockServicer.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, fmt.Errorf("err connecting")).Once()
+	_, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	mockServicer.AssertExpectations(t)
+	mockCluster = &magmav1alpha1.HACluster{}
+	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
+	assert.NoError(t, err)
+	assertClusterStatus(t, gw, magmav1alpha1.Initialized, magmav1alpha1.Initialized, 1, 0, mockCluster.Status)
+
+	// Test active unreachable, second error causes failover, disable fails
+	mockServicer.On("GetHealthStatus", mock.Anything, mock.Anything).Return(unhealthyStatus, fmt.Errorf("err connecting")).Once()
+	mockServicer2.On("GetHealthStatus", mock.Anything, mock.Anything).Return(healthyStatus, nil).Once()
+	mockServicer2.On("Enable", mock.Anything, mock.Anything).Return(void, nil).Once()
+	mockServicer.On("Disable", mock.Anything, mock.Anything).Return(void, fmt.Errorf("Unavailable")).Once()
+	_, err = r.Reconcile(req)
+	assert.NoError(t, err)
+	mockServicer.AssertExpectations(t)
+	mockServicer2.AssertExpectations(t)
+	mockCluster = &magmav1alpha1.HACluster{}
+	err = r.client.Get(context.Background(), req.NamespacedName, mockCluster)
+	assert.NoError(t, err)
+	assertClusterStatus(t, gw2, magmav1alpha1.Initialized, magmav1alpha1.Uninitialized, 0, 0, mockCluster.Status)
+
+	// Ensure standby got deleted due to failed init
+	podlist := &corev1.PodList{}
+	err = r.client.List(context.TODO(), podlist)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(podlist.Items))
+	assert.Equal(t, gwPod2.Name, podlist.Items[0].Name)
+}
+
+func assertClusterStatus(
+	t *testing.T,
+	expectedActive string,
+	expectedActiveInit magmav1alpha1.HAClusterInitState,
+	expectedStandbyInit magmav1alpha1.HAClusterInitState,
+	expectedActiveFailures int,
+	expectedStandbyFailures int,
+	actualStatus magmav1alpha1.HAClusterStatus,
+) {
+	assert.Equal(t, expectedActive, actualStatus.Active)
+	assert.Equal(t, expectedActiveInit, actualStatus.ActiveInitState)
+	assert.Equal(t, expectedStandbyInit, actualStatus.StandbyInitState)
+	assert.Equal(t, expectedActiveFailures, actualStatus.ConsecutiveActiveErrors)
+	assert.Equal(t, expectedStandbyFailures, actualStatus.ConsecutiveStandbyErrors)
 }
 
 func initTestReconciler(gateways []string, name string, namespace string, svcsToAddrs map[string]string) *ReconcileHACluster {
@@ -224,7 +262,8 @@ func initTestReconciler(gateways []string, name string, namespace string, svcsTo
 			Namespace: namespace,
 		},
 		Spec: magmav1alpha1.HAClusterSpec{
-			GatewayResourceNames: gateways,
+			GatewayResourceNames:       gateways,
+			MaxConsecutiveActiveErrors: 2,
 		},
 	}
 	// Objects to track in the fake client.

--- a/cwf/k8s/cwf_operator/version/version.go
+++ b/cwf/k8s/cwf_operator/version/version.go
@@ -26,7 +26,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+*/
 
 package version
 

--- a/cwf/k8s/cwf_operator/version/version.go
+++ b/cwf/k8s/cwf_operator/version/version.go
@@ -31,5 +31,5 @@
 package version
 
 var (
-	Version = "0.0.1"
+	Version = "0.1.0"
 )


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR implements a few changes to the CWF Operator to better support HA for CWAGs:

- Track consecutive failures when fetching health status. This ensures that a transient connection failure won't cause an unnecessary failover
- Don't return errors unless it is unexpected (i.e. failure from operator to K8s API). This ensures the CWF operator will continued to be scheduled as k8s will not schedule controller workloads that are consistently returning the same error.
- Update the operator to work properly with the transport failover implementation: 
   - Delete unresponsive standbys to ensure VIP is transferred
   - Disable standby before enabling active
   - Re-init gateways when both unhealthy

## Test Plan

- Updated Unit Tests
- Tested in lab to ensure we properly delete unresponsive gateways to ensure VIP transfer

## Additional Information

- [x ] This change is backwards-breaking

This changes will break existing HACluster's. In practice this only affects HA deployments. 
To upgrade:
`kubectl -n  magma delete -f <old_cluster_definition.yaml>`
`kubectl -n magma create -f <magma.cwf.k8s_v1alpha1_hacluster_cr.yaml>`