### PR TITLE
[Sessiond] Add LocalEnforcer final state activation/canceling test + minor fix

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1286,8 +1286,8 @@ void LocalEnforcer::update_charging_credits(
       const auto& credit_key(credit_update_resp);
       // We need to retrive restrict_rules and is_final_action_state
       // prior to receiving charging credit as they will be updated.
-      auto restrict_rules =
-          session->get_final_action_restrict_rules(credit_key);
+      std::vector<std::string> restrict_rules;
+      session->get_final_action_restrict_rules(credit_key, restrict_rules);
       bool is_final_action_state =
           session->is_credit_in_final_unit_state(credit_key);
       session->receive_charging_credit(credit_update_resp, uc);

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1630,7 +1630,7 @@ std::vector<std::string> SessionState::get_final_action_restrict_rules(
     const CreditKey& charging_key) const {
   std::vector<std::string> restrict_rules;
   auto it = credit_map_.find(charging_key);
-  if (it != credit_map_.end()) {
+  if (it == credit_map_.end()) {
     return restrict_rules;
   }
   restrict_rules = it->second->final_action_info.restrict_rules;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1626,15 +1626,14 @@ bool SessionState::is_credit_in_final_unit_state(
           it->second->service_state == SERVICE_RESTRICTED);
 }
 
-std::vector<std::string> SessionState::get_final_action_restrict_rules(
-    const CreditKey& charging_key) const {
-  std::vector<std::string> restrict_rules;
+void SessionState::get_final_action_restrict_rules(
+    const CreditKey& charging_key,
+    std::vector<std::string> &restrict_rules) {
   auto it = credit_map_.find(charging_key);
   if (it == credit_map_.end()) {
-    return restrict_rules;
+    return;
   }
   restrict_rules = it->second->final_action_info.restrict_rules;
-  return restrict_rules;
 }
 
 // QoS/Bearer Management

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -370,8 +370,9 @@ class SessionState {
 
   bool is_credit_in_final_unit_state(const CreditKey &charging_key) const;
 
-  std::vector<std::string> get_final_action_restrict_rules(
-      const CreditKey &charging_key) const;
+  void get_final_action_restrict_rules(
+      const CreditKey &charging_key,
+      std::vector<std::string> &restrict_rules);
 
   // Monitors
   bool receive_monitor(const UsageMonitoringUpdateResponse &update,

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -97,6 +97,18 @@ void create_charging_credit(
   credit->set_is_final(is_final);
 }
 
+void create_charging_credit(
+    uint64_t volume, ChargingCredit_FinalAction action,
+    std::string redirect_server, std::string restrict_rule,
+    ChargingCredit* credit) {
+  create_granted_units(&volume, NULL, NULL, credit->mutable_granted_units());
+  credit->set_type(ChargingCredit::BYTES);
+  credit->set_is_final(true);
+  credit->set_final_action(action);
+  credit->mutable_redirect_server()->set_redirect_server_address(redirect_server);
+  credit->add_restrict_rules(restrict_rule);
+}
+
 void create_credit_update_response(
   const std::string& imsi,
   const std::string session_id,
@@ -118,11 +130,25 @@ void create_credit_update_response(
   create_credit_update_response(imsi, session_id, charging_key, volume, false, response);
 }
 
+
 void create_credit_update_response(
     const std::string& imsi, const std::string session_id,
     uint32_t charging_key, uint64_t volume, bool is_final,
     CreditUpdateResponse* response) {
   create_charging_credit(volume, is_final, response->mutable_credit());
+  response->set_success(true);
+  response->set_sid(imsi);
+  response->set_session_id(session_id);
+  response->set_charging_key(charging_key);
+}
+
+void create_credit_update_response(
+    const std::string& imsi, const std::string session_id,
+    uint32_t charging_key, uint64_t volume, ChargingCredit_FinalAction action,
+    std::string redirect_server, std::string restrict_rule,
+    CreditUpdateResponse* response) {
+  create_charging_credit(volume, action,
+      redirect_server, restrict_rule, response->mutable_credit());
   response->set_success(true);
   response->set_sid(imsi);
   response->set_session_id(session_id);

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -58,6 +58,11 @@ void create_credit_update_response(
     uint32_t charging_key, uint64_t volume,
     CreditUpdateResponse* response);
 
+void create_credit_update_response(
+    const std::string& imsi, const std::string session_id,
+    uint32_t charging_key, uint64_t volume, ChargingCredit_FinalAction action,
+    std::string redirect_server, std::string restrict_rule,
+    CreditUpdateResponse* response);
 
 void create_credit_update_response(
     const std::string& imsi, const std::string session_id,
@@ -73,6 +78,11 @@ void create_credit_update_response(
 void create_charging_credit(
     uint64_t total_volume, uint64_t tx_volume, uint64_t rx_volume,
     bool is_final, ChargingCredit* credit);
+
+void create_charging_credit(
+    uint64_t volume, ChargingCredit_FinalAction action,
+    std::string redirect_server, std::string restrict_rule,
+    ChargingCredit* credit);
 
 void create_monitor_credit(
     const std::string& m_key, MonitoringLevel level, uint64_t volume,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -132,6 +132,19 @@ class LocalEnforcerTest : public ::testing::Test {
     EXPECT_TRUE(found);
   }
 
+  void assert_session_is_in_final_state(
+    SessionMap& session_map, const std::string& imsi,
+    const std::string& session_id, const CreditKey &charging_key,
+    bool is_final) {
+    EXPECT_TRUE(session_map.find(imsi) != session_map.end());
+    for (const auto& session : session_map.find(imsi)->second) {
+      if (session->get_session_id() == session_id) {
+        EXPECT_EQ(session->is_credit_in_final_unit_state(charging_key), is_final);
+      }
+    }
+}
+
+
  protected:
   std::shared_ptr<MockSessionReporter> reporter;
   std::shared_ptr<StaticRuleStore> rule_store;
@@ -2228,6 +2241,109 @@ TEST_F(LocalEnforcerTest, test_invalid_apn_parsing) {
 
   local_enforcer->setup(
       session_map, epoch, [](Status status, SetupFlowsResult resp) {});
+}
+
+TEST_F(LocalEnforcerTest, test_final_unit_activation_and_canceling) {
+  CreateSessionResponse response;
+  create_credit_update_response(
+      IMSI1, SESSION_ID_1, 1, 1024, ChargingCredit_FinalAction_RESTRICT_ACCESS,
+      "", "rule1", response.mutable_credits()->Add());
+
+  auto dynamic_rule = response.mutable_dynamic_rules()->Add();
+  auto policy_rule  = dynamic_rule->mutable_policy_rule();
+  policy_rule->set_id("rule2");
+  policy_rule->set_rating_group(1);
+  policy_rule->set_tracking_type(PolicyRule::ONLY_OCS);
+  auto static_rule = response.mutable_static_rules()->Add();
+  static_rule->set_rule_id("rule1");
+  static_rule = response.mutable_static_rules()->Add();
+  static_rule->set_rule_id("rule3");
+
+  insert_static_rule(1, "", "rule1");
+  insert_static_rule(1, "", "rule3");
+
+  // The activation for the static rules (rule1,rule3) and dynamic rule (rule2)
+  EXPECT_CALL(
+      *pipelined_client, activate_flows_for_rules(
+      testing::_, testing::_, testing::_, CheckCount(2),
+      CheckCount(1), testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+
+  EXPECT_CALL(
+      *pipelined_client, update_ipfix_flow(
+      testing::_, testing::_, testing::_, testing::_,
+      testing::_, testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+
+  // Insert record and aggreagate thems
+  RuleRecordTable table;
+  auto& ip = test_cfg_.common_context.ue_ipv4();
+  auto record_list = table.mutable_records();
+  create_rule_record(IMSI1, ip, "rule1", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, ip, "rule2", 1024, 2048, record_list->Add());
+  create_rule_record(IMSI1, ip, "rule3", 1024, 2048, record_list->Add());
+  auto update = SessionStore::get_default_session_update(session_map);
+  local_enforcer->aggregate_records(session_map, table, update);
+
+  // Collect actions and verify that restrict action is in the list
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto usage_updates =
+      local_enforcer->collect_updates(session_map, actions, update);
+  EXPECT_EQ(actions.size(), 1);
+  EXPECT_EQ(actions[0]->get_type(), RESTRICT_ACCESS);
+  EXPECT_EQ(actions[0]->get_restrict_rules()[0], "rule1");
+
+  // Execute actions and asset final action state
+  local_enforcer->execute_actions(session_map, actions, update);
+
+  const CreditKey& credit_key(1);
+  assert_session_is_in_final_state(session_map, IMSI1, SESSION_ID_1, credit_key, true);
+
+  // Send a ReAuth request
+  ChargingReAuthRequest reauth;
+  reauth.set_sid(IMSI1);
+  reauth.set_session_id(SESSION_ID_1);
+  reauth.set_charging_key(1);
+  reauth.set_type(ChargingReAuthRequest::SINGLE_SERVICE);
+  update = SessionStore::get_default_session_update(session_map);
+  auto result =
+      local_enforcer->init_charging_reauth(session_map, reauth, update);
+  EXPECT_EQ(result, ReAuthResult::UPDATE_INITIATED);
+
+  actions.clear();
+  auto update_req =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(update_req.updates_size(), 1);
+  EXPECT_EQ(update_req.updates(0).sid(), IMSI1);
+  EXPECT_EQ(update_req.updates(0).usage().type(), CreditUsage::REAUTH_REQUIRED);
+
+  // Give credit after ReAuth
+  UpdateSessionResponse update_response;
+  auto updates = update_response.mutable_responses();
+  create_credit_update_response(IMSI1, SESSION_ID_1, 1, 4096, updates->Add());
+  local_enforcer->update_session_credits_and_rules(
+      session_map, update_response, update);
+
+  // when next update is collected, this should trigger an action to activate
+  // the flow in pipelined
+  EXPECT_CALL(
+      *pipelined_client, activate_flows_for_rules(
+      testing::_, testing::_, testing::_, testing::_,
+      testing::_, testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  actions.clear();
+  local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+
+  // Assert that we exited final action state
+  assert_session_is_in_final_state(session_map, IMSI1, SESSION_ID_1, credit_key, false);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

Add LocalEnforcer final state activation/cancelling test
Fix restrict rules retrieval.

## Test Plan

ninja: Entering directory `/home/vagrant/build/c//session_manager'
[2/2] Linking CXX executable test/local_enforcer_test
cd  /home/vagrant/build/c//session_manager && ctest --output-on-failure
Test project /home/vagrant/build/c/session_manager
      Start  1: test_session_credit
 1/14 Test  #1: test_session_credit ..................   Passed    0.01 sec
      Start  2: test_local_enforcer
 2/14 Test  #2: test_local_enforcer ..................   Passed    2.53 sec
      Start  3: test_cloud_reporter
 3/14 Test  #3: test_cloud_reporter ..................   Passed    0.04 sec
      Start  4: test_session_manager_handler
 4/14 Test  #4: test_session_manager_handler .........   Passed    0.02 sec
      Start  5: test_sessiond_integ
 5/14 Test  #5: test_sessiond_integ ..................   Passed    0.70 sec
      Start  6: test_session_state
 6/14 Test  #6: test_session_state ...................   Passed    0.01 sec
      Start  7: test_session_store
 7/14 Test  #7: test_session_store ...................   Passed    0.01 sec
      Start  8: test_store_client
 8/14 Test  #8: test_store_client ....................   Passed    0.01 sec
      Start  9: test_stored_state
 9/14 Test  #9: test_stored_state ....................   Passed    0.01 sec
      Start 10: test_proxy_responder_handler
10/14 Test #10: test_proxy_responder_handler .........   Passed    0.01 sec
      Start 11: test_metering_reporter
11/14 Test #11: test_metering_reporter ...............   Passed    0.01 sec
      Start 12: test_local_enforcer_wallet_exhaust
12/14 Test #12: test_local_enforcer_wallet_exhaust ...   Passed    0.02 sec
      Start 13: test_charging_grant
13/14 Test #13: test_charging_grant ..................   Passed    0.01 sec
      Start 14: test_usage_monitor
14/14 Test #14: test_usage_monitor ...................   Passed    0.01 sec

100% tests passed, 0 tests failed out of 14

Total Test time (real) =   3.41 sec
