### PR TITLE
[nms] add alerts tab to cwf networks

### DIFF
--- a/nms/app/packages/magmalte/app/components/cwf/CWFSections.js
+++ b/nms/app/packages/magmalte/app/components/cwf/CWFSections.js
@@ -15,6 +15,8 @@
  */
 import type {SectionsConfigs} from '@fbcnms/magmalte/app/components/layout/Section';
 
+import AlarmIcon from '@material-ui/icons/Alarm';
+import Alarms from '@fbcnms/ui/insights/Alarms/Alarms';
 import CWFConfigure from './CWFConfigure';
 import CWFGateways from './CWFGateways';
 import CWFMetrics from './CWFMetrics';
@@ -42,6 +44,12 @@ export function getCWFSections(): SectionsConfigs {
       label: 'Metrics',
       icon: <ShowChartIcon />,
       component: CWFMetrics,
+    },
+    {
+      path: 'alerts',
+      label: 'Alerts',
+      icon: <AlarmIcon />,
+      component: Alarms,
     },
   ];
 

--- a/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
+++ b/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
@@ -82,11 +82,11 @@ const testCases: {[string]: TestCase} = {
   },
   carrier_wifi_network: {
     default: 'gateways',
-    sections: ['gateways', 'configure', 'metrics'],
+    sections: ['gateways', 'configure', 'metrics', 'alerts'],
   },
   xwfm: {
     default: 'gateways',
-    sections: ['gateways', 'configure', 'metrics'],
+    sections: ['gateways', 'configure', 'metrics', 'alerts'],
   },
 };
 


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
No reason to not have this tab for CWF networks.

## Test Plan
Alerts tab shows up on CWF networks and creating an alert works
![image](https://user-images.githubusercontent.com/13274915/93385183-b9e74100-f81a-11ea-9265-385d01ce5db5.png)

