### PR TITLE
[bug fix] [agw] [stateless mme] Fix null pointer reference for protocol config options in state conve…

### DIFF
--- a/lte/gateway/c/oai/include/mme_app_ue_context.h
+++ b/lte/gateway/c/oai/include/mme_app_ue_context.h
@@ -579,8 +579,6 @@ void mme_remove_ue_context(
  **/
 ue_mm_context_t* mme_create_new_ue_context(void);
 
-void mme_app_free_pdn_connection(pdn_context_t** const pdn_connection);
-
 void mme_app_ue_context_free_content(ue_mm_context_t* const mme_ue_context_p);
 
 /**

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -46,6 +46,7 @@
 #include "enum_string.h"
 #include "mme_app_ue_context.h"
 #include "mme_app_bearer_context.h"
+#include "mme_app_pdn_context.h"
 #include "mme_app_defs.h"
 #include "mme_app_itti_messaging.h"
 #include "mme_app_procedures.h"
@@ -229,14 +230,6 @@ void mme_app_ue_sgs_context_free_content(
 }
 
 //------------------------------------------------------------------------------
-void mme_app_free_pdn_connection(pdn_context_t** const pdn_connection) {
-  bdestroy_wrapper(&(*pdn_connection)->apn_in_use);
-  bdestroy_wrapper(&(*pdn_connection)->apn_oi_replacement);
-  bdestroy_wrapper(&(*pdn_connection)->apn_subscribed);
-  free_wrapper((void**) pdn_connection);
-}
-
-//------------------------------------------------------------------------------
 void mme_app_ue_context_free_content(ue_mm_context_t* const ue_context_p) {
   bdestroy_wrapper(&ue_context_p->msisdn);
   bdestroy_wrapper(&ue_context_p->ue_radio_capability);
@@ -334,7 +327,7 @@ void mme_app_ue_context_free_content(ue_mm_context_t* const ue_context_p) {
   ue_context_p->hss_initiated_detach  = false;
   for (int i = 0; i < MAX_APN_PER_UE; i++) {
     if (ue_context_p->pdn_contexts[i]) {
-      mme_app_free_pdn_connection(&ue_context_p->pdn_contexts[i]);
+      mme_app_free_pdn_context(&ue_context_p->pdn_contexts[i]);
     }
   }
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_pdn_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_pdn_context.c
@@ -42,19 +42,10 @@ static void mme_app_pdn_context_init(
 
 //------------------------------------------------------------------------------
 void mme_app_free_pdn_context(pdn_context_t** const pdn_context) {
-  if ((*pdn_context)->apn_in_use) {
-    bdestroy_wrapper(&(*pdn_context)->apn_in_use);
-  }
-  if ((*pdn_context)->apn_subscribed) {
-    bdestroy_wrapper(&(*pdn_context)->apn_subscribed);
-  }
-  if ((*pdn_context)->apn_oi_replacement) {
-    bdestroy_wrapper(&(*pdn_context)->apn_oi_replacement);
-  }
-  if ((*pdn_context)->pco) {
-    free_protocol_configuration_options(&(*pdn_context)->pco);
-  }
-
+  bdestroy_wrapper(&(*pdn_context)->apn_in_use);
+  bdestroy_wrapper(&(*pdn_context)->apn_subscribed);
+  bdestroy_wrapper(&(*pdn_context)->apn_oi_replacement);
+  free_protocol_configuration_options(&(*pdn_context)->pco);
   free_wrapper((void**) pdn_context);
 }
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -474,6 +474,8 @@ void MmeNasStateConverter::proto_to_pdn_context(
   proto_to_esm_pdn(pdn_context_proto.esm_data(), &state_pdn_context->esm_data);
   state_pdn_context->is_active = pdn_context_proto.is_active();
   if (pdn_context_proto.has_pco()) {
+    state_pdn_context->pco = (protocol_configuration_options_t*) calloc(
+        1, sizeof(protocol_configuration_options_t));
     NasStateConverter::proto_to_protocol_configuration_options(
         pdn_context_proto.pco(), state_pdn_context->pco);
   }


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

With real UE, stateless MME is crashing while reading the protocol configuration options from Redis as there is no memory allocated in PDN context. While making this fix, also removed duplicate function for freeing pdn_context for each UE.

## Test Plan

- Regression testing with S1AP integration tests
- Functional testing in testbed with AGW on bare metal connected to physical eNB and COTS UE
--- Set AGW to stateless mode
--- Attach UE to AGW
--- Restart MME service on AGW and confirm that there is no Segmentation fault while restarting
--- Detach UE and stop the MME service to verify there is no memory leak from this change