### PR TITLE
[sessiond] not send requested unit service on final unit action

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -116,9 +116,11 @@ CreditUsage ChargingGrant::get_credit_usage(
   p_usage.set_bytes_rx(credit_usage.bytes_rx);
   p_usage.set_type(update_type);
 
-  // add the Requested-Service-Unit
-  RequestedUnits requestedUnits = credit.get_requested_credits_units();
-  p_usage.mutable_requested_units()->CopyFrom(requestedUnits);
+  // add the Requested-Service-Unit only if we are not on final grant
+  if (!is_final_grant) {
+    RequestedUnits requestedUnits = credit.get_requested_credits_units();
+    p_usage.mutable_requested_units()->CopyFrom(requestedUnits);
+  }
   return p_usage;
 }
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

In case we are on final unit indication, we should not request more quota. This PR will not calculate the value of Granted Unit Service, so GRPC will default its values to 0

This will be confirmed with teraVM to make sure this is what we required. More test will be added then

## Test Plan

make test on agw

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
