### PR TITLE
[agw][lte] Fixing parsing of sessiond redis values on state cli

### DIFF
--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -27,12 +27,13 @@ from lte.protos.oai.spgw_state_pb2 import SpgwState, S11BearerContext
 from lte.protos.oai.s1ap_state_pb2 import S1apState, UeDescription
 
 
-def _deserialize_session_json(serialized_json_str: str) -> str:
+def _deserialize_session_json(serialized_json_str: bytes) -> str:
     """
     Helper function to deserialize sessiond:sessions hash list values
     :param serialized_json_str
     """
     session_json_values = []
+    serialized_json_str = str(serialized_json_str, 'utf-8', 'ignore')
     session_values = jsonpickle.decode(serialized_json_str)
     for value in session_values:
         session_json = json.loads(value)


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Updating parsing of sessiond:sessions key as it was failing due to missing conversion of bytes str value

## Test Plan

- Tested using S1ap integ tests to generate state on redis:

```
IMSI001010000000016
{
  "bearer_id_by_policy": "[]",
  "charging_pool": "{\"credit_map\":{},\"credit_keys\":[]}",
  "config": "{\"rat_specific_context\":\"\\u00012\\n\\u000e192.168.60.142\\u001a\\u000500101\\\"\\u0005001012\\u0010\\b/\\u0010_\\u0018\\u000f \\u00010\\t8\\u0005\",\"common_context\":\"\\n\\u0015\\n\\u0013IMSI001010000000016\\u001a\\u000e192.168.128.87\\\"\\nmagma.ipv4\"}",
  "dynamic_rules": [
    "\n,allowlist_sid-IMSI001010000000016-magma.ipv4\u0018\u0002:\u0002\n\u0000:\u0004\n\u0002@\u0001P\u0003"
  ],
  "fsm_state": 0,
  "gy_dynamic_rules": [],
  "imsi": "IMSI001010000000016",
  "monitor_map": "{\"monitor_map\":{},\"monitor_keys\":[]}",
  "pdp_end_time": "0",
  "pdp_start_time": "1600331220",
  "pending_event_triggers": "{\"event_trigger_map\":{},\"event_trigger_keys\":[]}",
  "request_number": "1",
  "revalidation_time": "",
  "session_id": "IMSI001010000000016-164827",
  "session_level_key": "",
  "static_rule_ids": [],
  "subscriber_quota_state": -1094795586,
  "tgpp_context": ""
}
```

## Additional Information

- [ ] This change is backwards-breaking
