### PR TITLE
Support non-glog logging

### DIFF
--- a/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
+++ b/lte/gateway/c/session_manager/GrpcMagmaUtils.cpp
@@ -13,6 +13,7 @@
 
 #include <string>
 #include "magma_logging.h"
+#include <sstream>
 #include "GrpcMagmaUtils.h"
 
 #define MAGMA_PRINT_GRPC_PAYLOAD "MAGMA_PRINT_GRPC_PAYLOAD"

--- a/orc8r/gateway/c/common/logging/magma_logging.h
+++ b/orc8r/gateway/c/common/logging/magma_logging.h
@@ -57,13 +57,16 @@ static void init_logging(const char* service_name) {
 struct _MLOG_NEWLINE {
   ~_MLOG_NEWLINE() { std::cout << std::endl; }
 };
-#define MLOG(VERBOSITY) (_MLOG_NEWLINE(), \
-  std::cout << "[" << __FILE__ << ":" << __LINE__ << "] ")
+#define MLOG(VERBOSITY)                                                        \
+  (_MLOG_NEWLINE(), std::cout << "[" << __FILE__ << ":" << __LINE__ << "] ")
 
 namespace magma {
-// These functions do nothing without glog
 static void set_verbosity(uint32_t verbosity) {}
-static void init_logging(const char* service_name) {
+// get_verbosity gets the the global logging verbosity
+static uint32_t get_verbosity() {
+  return 0;
 }
-}
+static void init_logging(const char* service_name) {}
+
+}  // namespace magma
 #endif


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We support two modes of logging setup by an evironment variable: `LOG_WITH_GLOG`. Realized recently that we cannot compile without the environment variable set, so adding a function to make it compile.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
make build succeeds.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
