### PR TITLE
[lte][agw] Bug fix for UE tp port matching in DL flow installation

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1911,10 +1911,10 @@ static void _generate_dl_flow(
       TRAFFIC_FLOW_TEMPLATE_SINGLE_LOCAL_PORT_FLAG) {
     if (dlflow->ip_proto == IPPROTO_TCP) {
       dlflow->set_params |= TCP_DST_PORT;
-      dlflow->tcp_dst_port = packet_filter->singleremoteport;
+      dlflow->tcp_dst_port = packet_filter->singlelocalport;
     } else if (dlflow->ip_proto == IPPROTO_UDP) {
       dlflow->set_params |= UDP_DST_PORT;
-      dlflow->udp_dst_port = packet_filter->singleremoteport;
+      dlflow->udp_dst_port = packet_filter->singlelocalport;
     }
   }
 }

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -676,7 +676,7 @@ class SpgwUtil(object):
                         FlowDescription(
                             match=FlowMatch(
                                 ipv4_src="",
-                                tcp_src=5002,
+                                tcp_dst=5002,
                                 ip_proto=FlowMatch.IPPROTO_TCP,
                                 direction=FlowMatch.DOWNLINK,
                             ),


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

When policy flow rules include transport port match on the UE side, DL flows in Table-0 were passed remote server transport number instead of UE transport port number. This PR fixes the bug.

## Test Plan

Run integ tests for regression.
Modified default flow rules in the test utility and manually verified the rules:
` cookie=0x0, duration=4.744s, table=0, n_packets=0, n_bytes=0, idle_age=4, priority=65535,tcp,in_port=LOCAL,nw_dst=192.168.128.241,tp_dst=5002 actions=load:0xa000130->NXM_NX_TUN_ID[],load:0xc0a83c8d->NXM_NX_TUN_IPV4_DST[],load:0x7594587a00d->OXM_OF_METADATA[],resubmit(,1)
`

## Additional Information

We have other PRs in the works for refactoring existing test utility and verify OVS rules in new/updated tests. 
