### PR TITLE
Add integ test jobs for PRs to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -864,6 +864,14 @@ workflows:
   agw:
     jobs:
       - lte-test
+      - lte-integ-test-pr-hold:
+          type: approval
+          context: "Magma Team"
+      - lte-integ-test:
+          name: pr-lte-integ-test
+          context: "Magma Team"
+          requires:
+            - lte-integ-test-pr-hold
       - lte-integ-test:
           <<: *master_and_develop
       - lte-agw-deploy:
@@ -881,6 +889,14 @@ workflows:
   cwag:
     jobs:
       - cwag-precommit
+      - cwf-integ-test-pr-hold:
+          type: approval
+          context: "Magma Team"
+      - cwf-integ-test:
+          name: pr-cwf-integ-test
+          context: "Magma Team"
+          requires:
+            - cwf-integ-test-pr-hold
       - cwf-integ-test:
           <<: *master_and_develop
       - xwfm-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -866,10 +866,10 @@ workflows:
       - lte-test
       - lte-integ-test-pr-hold:
           type: approval
-          context: "Magma Team"
+          context: Magma Team
       - lte-integ-test:
           name: pr-lte-integ-test
-          context: "Magma Team"
+          context: Magma Team
           requires:
             - lte-integ-test-pr-hold
       - lte-integ-test:
@@ -891,10 +891,10 @@ workflows:
       - cwag-precommit
       - cwf-integ-test-pr-hold:
           type: approval
-          context: "Magma Team"
+          context: Magma Team
       - cwf-integ-test:
           name: pr-cwf-integ-test
-          context: "Magma Team"
+          context: Magma Team
           requires:
             - cwf-integ-test-pr-hold
       - cwf-integ-test:

--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -61,7 +61,6 @@ def lte():
 
 def integ_test(repo: str = 'git@github.com:facebookincubator/magma.git',
                branch: str = '', sha1: str = '', tag: str = '',
-               pr_num: str = '',
                magma_root: str = '',
                node_ssh_key: str = 'ci_node.pem',
                api_url: str = 'https://api-staging.magma.etagecom.io',
@@ -88,7 +87,7 @@ def integ_test(repo: str = 'git@github.com:facebookincubator/magma.git',
 
     try:
         _set_host_for_lease(lease, node_ssh_key)
-        _checkout_code(repo, branch, sha1, tag, pr_num, magma_root)
+        _checkout_code(repo, branch, sha1, tag, magma_root)
         # Destroy all running vagrant VMs. If we use the same node to run integ
         # tests on more than one repo, Vagrant will complain about colliding
         # VM names.
@@ -174,7 +173,7 @@ def _acquire_node_lease(api_url: str,
     return NodeLease(resp_obj['id'], resp_obj['lease_id'], resp_obj['vpn_ip'])
 
 
-def _checkout_code(repo: str, branch: str, sha1: str, tag: str, pr_num: str,
+def _checkout_code(repo: str, branch: str, sha1: str, tag: str,
                    magma_root: str):
     repo_name = _get_repo_name(repo)
     if not exists(repo_name):
@@ -184,8 +183,6 @@ def _checkout_code(repo: str, branch: str, sha1: str, tag: str, pr_num: str,
             _run_git(f'git remote set-url origin "{repo}"', warn_only=True)
 
     # This logic comes from the CircleCI `checkout` step
-    # TODO: allow PR builds - or does circle set branch env var to
-    #  PR branch already?
     branch = branch or 'master'
     with cd(f'{repo_name}/{magma_root}'):
         _run_git('git clean -d -f')


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR adds the ability for a Magma team member to approve an integ test job (CWF or LTE) to run on a PR.
It turns out that the checkout code logic already supports checking out a PR, so I removed pr_num from
the fabfile since this was unused.

## Test Plan

circleCI tests