### PR TITLE
Move the network, policy and apn state upto LteContext

### DIFF
--- a/nms/app/packages/magmalte/app/components/context/ApnContext.js
+++ b/nms/app/packages/magmalte/app/components/context/ApnContext.js
@@ -13,19 +13,14 @@
  * @flow strict-local
  * @format
  */
-import type {UpdateGatewayProps} from '../../state/lte/EquipmentState';
-import type {
-  gateway_id,
-  lte_gateway,
-  mutable_lte_gateway,
-} from '@fbcnms/magma-api';
+'use strict';
+import type {apn} from '@fbcnms/magma-api';
 
 import React from 'react';
 
-export type GatewayContextType = {
-  state: {[string]: lte_gateway},
-  setState: (key: gateway_id, val?: mutable_lte_gateway) => Promise<void>,
-  updateGateway: (props: $Shape<UpdateGatewayProps>) => Promise<void>,
+export type ApnContextType = {
+  state: {[string]: apn},
+  setState: (key: string, val?: apn) => Promise<void>,
 };
 
-export default React.createContext<GatewayContextType>({});
+export default React.createContext<ApnContextType>({});

--- a/nms/app/packages/magmalte/app/components/context/LteNetworkContext.js
+++ b/nms/app/packages/magmalte/app/components/context/LteNetworkContext.js
@@ -13,19 +13,15 @@
  * @flow strict-local
  * @format
  */
-import type {UpdateGatewayProps} from '../../state/lte/EquipmentState';
-import type {
-  gateway_id,
-  lte_gateway,
-  mutable_lte_gateway,
-} from '@fbcnms/magma-api';
+'use strict';
+import type {UpdateNetworkProps} from '../../state/lte/NetworkState';
+import type {lte_network} from '@fbcnms/magma-api';
 
 import React from 'react';
 
-export type GatewayContextType = {
-  state: {[string]: lte_gateway},
-  setState: (key: gateway_id, val?: mutable_lte_gateway) => Promise<void>,
-  updateGateway: (props: $Shape<UpdateGatewayProps>) => Promise<void>,
+export type LteNetworkContextType = {
+  state: lte_network,
+  updateNetworks: (props: $Shape<UpdateNetworkProps>) => Promise<void>,
 };
 
-export default React.createContext<GatewayContextType>({});
+export default React.createContext<LteNetworkContextType>({});

--- a/nms/app/packages/magmalte/app/components/context/NetworkContext.js
+++ b/nms/app/packages/magmalte/app/components/context/NetworkContext.js
@@ -14,7 +14,6 @@
  * @format
  */
 'use strict';
-
 import React from 'react';
 
 export type NetworkContextType = {

--- a/nms/app/packages/magmalte/app/components/context/PolicyContext.js
+++ b/nms/app/packages/magmalte/app/components/context/PolicyContext.js
@@ -13,19 +13,14 @@
  * @flow strict-local
  * @format
  */
-import type {UpdateGatewayProps} from '../../state/lte/EquipmentState';
-import type {
-  gateway_id,
-  lte_gateway,
-  mutable_lte_gateway,
-} from '@fbcnms/magma-api';
+'use strict';
+import type {policy_id, policy_rule} from '@fbcnms/magma-api';
 
 import React from 'react';
 
-export type GatewayContextType = {
-  state: {[string]: lte_gateway},
-  setState: (key: gateway_id, val?: mutable_lte_gateway) => Promise<void>,
-  updateGateway: (props: $Shape<UpdateGatewayProps>) => Promise<void>,
+export type PolicyContextType = {
+  state: {[string]: policy_rule},
+  setState: (key: policy_id, val?: policy_rule) => Promise<void>,
 };
 
-export default React.createContext<GatewayContextType>({});
+export default React.createContext<PolicyContextType>({});

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -1,0 +1,379 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import * as React from 'react';
+import ApnContext from '../context/ApnContext';
+import EnodebContext from '../context/EnodebContext';
+import GatewayContext from '../context/GatewayContext';
+import GatewayTierContext from '../context/GatewayTierContext';
+import InitSubscriberState from '../../state/lte/SubscriberState';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import LteNetworkContext from '../context/LteNetworkContext';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import PolicyContext from '../context/PolicyContext';
+import SubscriberContext from '../context/SubscriberContext';
+
+import {
+  InitEnodeState,
+  InitTierState,
+  SetEnodebState,
+  SetGatewayState,
+  SetTierState,
+  UpdateGateway,
+} from '../../state/lte/EquipmentState';
+import {SetApnState} from '../../state/lte/ApnState';
+import {SetPolicyState} from '../../state/lte/PolicyState';
+import {UpdateNetworkState} from '../../state/lte/NetworkState';
+import {
+  getSubscriberGatewayMap,
+  setSubscriberState,
+} from '../../state/lte/SubscriberState';
+import {useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import type {EnodebInfo} from '../lte/EnodebUtils';
+import type {
+  apn,
+  lte_gateway,
+  lte_network,
+  mutable_subscriber,
+  network_id,
+  network_ran_configs,
+  policy_rule,
+  subscriber_id,
+  tier,
+} from '@fbcnms/magma-api';
+
+type Props = {
+  networkId: network_id,
+  children: React.Node,
+};
+
+export function GatewayContextProvider(props: Props) {
+  const {networkId} = props;
+  const [lteGateways, setLteGateways] = useState<{[string]: lte_gateway}>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchState = async () => {
+      const lteGateways = await MagmaV1API.getLteByNetworkIdGateways({
+        networkId,
+      });
+      setLteGateways(lteGateways);
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <GatewayContext.Provider
+      value={{
+        state: lteGateways,
+        setState: (key, value?) => {
+          return SetGatewayState({
+            lteGateways,
+            setLteGateways,
+            networkId,
+            key,
+            value,
+          });
+        },
+        updateGateway: props =>
+          UpdateGateway({networkId, setLteGateways, ...props}),
+      }}>
+      {props.children}
+    </GatewayContext.Provider>
+  );
+}
+
+export function EnodebContextProvider(props: Props) {
+  const {networkId} = props;
+  const [enbInfo, setEnbInfo] = useState<{[string]: EnodebInfo}>({});
+  const [lteRanConfigs, setLteRanConfigs] = useState<network_ran_configs>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchState = async () => {
+      if (networkId == null) {
+        return;
+      }
+      const [lteRanConfigsResp] = await Promise.allSettled([
+        MagmaV1API.getLteByNetworkIdCellularRan({networkId}),
+        InitEnodeState({networkId, setEnbInfo, enqueueSnackbar}),
+      ]);
+      if (lteRanConfigsResp.value) {
+        setLteRanConfigs(lteRanConfigsResp.value);
+      }
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+  return (
+    <EnodebContext.Provider
+      value={{
+        state: {enbInfo},
+        lteRanConfigs: lteRanConfigs,
+        setState: (key, value?) =>
+          SetEnodebState({enbInfo, setEnbInfo, networkId, key, value}),
+        setLteRanConfigs: lteRanConfigs => setLteRanConfigs(lteRanConfigs),
+      }}>
+      {props.children}
+    </EnodebContext.Provider>
+  );
+}
+
+export function SubscriberContextProvider(props: Props) {
+  const {networkId} = props;
+  const [subscriberMap, setSubscriberMap] = useState({});
+  const [subscriberMetrics, setSubscriberMetrics] = useState({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchLteState = async () => {
+      if (networkId == null) {
+        return;
+      }
+      await InitSubscriberState({
+        networkId,
+        setSubscriberMap,
+        setSubscriberMetrics,
+        enqueueSnackbar,
+      }),
+        setIsLoading(false);
+    };
+    fetchLteState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <SubscriberContext.Provider
+      value={{
+        state: subscriberMap,
+        metrics: subscriberMetrics,
+        gwSubscriberMap: getSubscriberGatewayMap(subscriberMap),
+        setState: (key: subscriber_id, value?: mutable_subscriber) =>
+          setSubscriberState({
+            networkId,
+            subscriberMap,
+            setSubscriberMap,
+            key,
+            value,
+          }),
+      }}>
+      {props.children}
+    </SubscriberContext.Provider>
+  );
+}
+
+export function GatewayTierContextProvider(props: Props) {
+  const {networkId} = props;
+  const [tiers, setTiers] = useState<{[string]: tier}>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const [supportedVersions, setSupportedVersions] = useState<Array<string>>([]);
+
+  useEffect(() => {
+    const fetchState = async () => {
+      if (networkId == null) {
+        return;
+      }
+      const [stableChannelResp] = await Promise.allSettled([
+        MagmaV1API.getChannelsByChannelId({channelId: 'stable'}),
+        InitTierState({networkId, setTiers, enqueueSnackbar}),
+      ]);
+      if (stableChannelResp.value) {
+        setSupportedVersions(
+          stableChannelResp.value.supported_versions.reverse(),
+        );
+      }
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <GatewayTierContext.Provider
+      value={{
+        state: {supportedVersions, tiers},
+        setState: (key, value?) =>
+          SetTierState({tiers, setTiers, networkId, key, value}),
+      }}>
+      {props.children}
+    </GatewayTierContext.Provider>
+  );
+}
+
+export function PolicyProvider(props: Props) {
+  const {networkId} = props;
+  const [policies, setPolicies] = useState<{[string]: policy_rule}>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchState = async () => {
+      setPolicies(
+        await MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull({
+          networkId,
+        }),
+      );
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <PolicyContext.Provider
+      value={{
+        state: policies,
+        setState: (key, value?) => {
+          return SetPolicyState({
+            policies,
+            setPolicies,
+            networkId,
+            key,
+            value,
+          });
+        },
+      }}>
+      {props.children}
+    </PolicyContext.Provider>
+  );
+}
+
+export function ApnProvider(props: Props) {
+  const {networkId} = props;
+  const [apns, setApns] = useState<{[string]: apn}>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchState = async () => {
+      setApns(
+        await MagmaV1API.getLteByNetworkIdApns({
+          networkId,
+        }),
+      );
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <ApnContext.Provider
+      value={{
+        state: apns,
+        setState: (key, value?) => {
+          return SetApnState({
+            apns,
+            setApns,
+            networkId,
+            key,
+            value,
+          });
+        },
+      }}>
+      {props.children}
+    </ApnContext.Provider>
+  );
+}
+
+export function LteNetworkContextProvider(props: Props) {
+  const {networkId} = props;
+  const [lteNetwork, setLteNetwork] = useState<lte_network>({});
+  const [isLoading, setIsLoading] = useState(true);
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  useEffect(() => {
+    const fetchState = async () => {
+      const lteNetwork = await MagmaV1API.getLteByNetworkId({
+        networkId,
+      });
+      setLteNetwork(lteNetwork);
+      setIsLoading(false);
+    };
+    fetchState();
+  }, [networkId, enqueueSnackbar]);
+
+  if (isLoading) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <LteNetworkContext.Provider
+      value={{
+        state: lteNetwork,
+        updateNetworks: props => {
+          let refreshState = true;
+          if (networkId !== props.networkId) {
+            refreshState = false;
+          }
+          return UpdateNetworkState({
+            networkId,
+            setLteNetwork,
+            refreshState,
+            ...props,
+          });
+        },
+      }}>
+      {props.children}
+    </LteNetworkContext.Provider>
+  );
+}
+
+export function LteContextProvider(props: Props) {
+  const {networkId} = props;
+  return (
+    <LteNetworkContextProvider networkId={networkId}>
+      <PolicyProvider networkId={networkId}>
+        <ApnProvider networkId={networkId}>
+          <SubscriberContextProvider networkId={networkId}>
+            <GatewayTierContextProvider networkId={networkId}>
+              <EnodebContextProvider networkId={networkId}>
+                <GatewayContextProvider networkId={networkId}>
+                  {props.children}
+                </GatewayContextProvider>
+              </EnodebContextProvider>
+            </GatewayTierContextProvider>
+          </SubscriberContextProvider>
+        </ApnProvider>
+      </PolicyProvider>
+    </LteNetworkContextProvider>
+  );
+}

--- a/nms/app/packages/magmalte/app/components/lte/LteSections.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteSections.js
@@ -13,36 +13,22 @@
  * @flow strict-local
  * @format
  */
-import type {EnodebInfo} from '../lte/EnodebUtils';
 import type {SectionsConfigs} from '../layout/Section';
-import type {
-  lte_gateway,
-  mutable_subscriber,
-  network_id,
-  network_ran_configs,
-  subscriber_id,
-  tier,
-} from '@fbcnms/magma-api';
 
 import * as React from 'react';
 import AlarmIcon from '@material-ui/icons/Alarm';
 import Alarms from '@fbcnms/ui/insights/Alarms/Alarms';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DashboardIcon from '@material-ui/icons/Dashboard';
-import EnodebContext from '../../components/context/EnodebContext';
 import Enodebs from './Enodebs';
 import EquipmentDashboard from '../../views/equipment/EquipmentDashboard';
-import GatewayContext from '../../components/context/GatewayContext';
-import GatewayTierContext from '../../components/context/GatewayTierContext';
 import Gateways from '../Gateways';
-import InitSubscriberState from '../../state/SubscriberState';
 import Insights from '@fbcnms/ui/insights/Insights';
 import ListIcon from '@material-ui/icons/List';
 import Logs from '@fbcnms/ui/insights/Logs/Logs';
 import LteConfigure from '../LteConfigure';
 import LteDashboard from './LteDashboard';
 import LteMetrics from './LteMetrics';
-import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import NetworkCheckIcon from '@material-ui/icons/NetworkCheck';
 import NetworkDashboard from '../../views/network/NetworkDashboard';
 import PeopleIcon from '@material-ui/icons/People';
@@ -51,219 +37,10 @@ import RouterIcon from '@material-ui/icons/Router';
 import SettingsCellIcon from '@material-ui/icons/SettingsCell';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
-import SubscriberContext from '../context/SubscriberContext';
 import SubscriberDashboard from '../../views/subscriber/SubscriberOverview';
 import Subscribers from '../Subscribers';
 import TrafficDashboard from '../../views/traffic/TrafficOverview';
 import WifiTetheringIcon from '@material-ui/icons/WifiTethering';
-
-import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
-import {
-  InitEnodeState,
-  InitTierState,
-  SetEnodebState,
-  SetGatewayState,
-  SetTierState,
-  UpdateGateway,
-} from '../../state/EquipmentState';
-import {
-  getSubscriberGatewayMap,
-  setSubscriberState,
-} from '../../state/SubscriberState';
-import {useEffect, useState} from 'react';
-import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
-
-type GatewayProviderProps = {
-  networkId: network_id,
-  children: React.Node,
-};
-
-export function GatewayContextProvider(props: GatewayProviderProps) {
-  const {networkId} = props;
-  const [lteGateways, setLteGateways] = useState<{[string]: lte_gateway}>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const enqueueSnackbar = useEnqueueSnackbar();
-
-  useEffect(() => {
-    const fetchState = async () => {
-      const lteGateways = await MagmaV1API.getLteByNetworkIdGateways({
-        networkId,
-      });
-      setLteGateways(lteGateways);
-      setIsLoading(false);
-    };
-    fetchState();
-  }, [networkId, enqueueSnackbar]);
-
-  if (isLoading) {
-    return <LoadingFiller />;
-  }
-
-  return (
-    <GatewayContext.Provider
-      value={{
-        state: lteGateways,
-        setState: (key, value?) => {
-          return SetGatewayState({
-            lteGateways,
-            setLteGateways,
-            networkId,
-            key,
-            value,
-          });
-        },
-        updateGateway: props =>
-          UpdateGateway({networkId, setLteGateways, ...props}),
-      }}>
-      {props.children}
-    </GatewayContext.Provider>
-  );
-}
-
-type EnodebProviderProps = {
-  networkId: network_id,
-  children: React.Node,
-};
-
-export function EnodebContextProvider(props: EnodebProviderProps) {
-  const {networkId} = props;
-  const [enbInfo, setEnbInfo] = useState<{[string]: EnodebInfo}>({});
-  const [lteRanConfigs, setLteRanConfigs] = useState<network_ran_configs>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const enqueueSnackbar = useEnqueueSnackbar();
-
-  useEffect(() => {
-    const fetchState = async () => {
-      if (networkId == null) {
-        return;
-      }
-      const [lteRanConfigsResp] = await Promise.allSettled([
-        MagmaV1API.getLteByNetworkIdCellularRan({networkId}),
-        InitEnodeState({networkId, setEnbInfo, enqueueSnackbar}),
-      ]);
-      if (lteRanConfigsResp.value) {
-        setLteRanConfigs(lteRanConfigsResp.value);
-      }
-      setIsLoading(false);
-    };
-    fetchState();
-  }, [networkId, enqueueSnackbar]);
-
-  if (isLoading) {
-    return <LoadingFiller />;
-  }
-  return (
-    <EnodebContext.Provider
-      value={{
-        state: {enbInfo},
-        lteRanConfigs: lteRanConfigs,
-        setState: (key, value?) =>
-          SetEnodebState({enbInfo, setEnbInfo, networkId, key, value}),
-        setLteRanConfigs: lteRanConfigs => setLteRanConfigs(lteRanConfigs),
-      }}>
-      {props.children}
-    </EnodebContext.Provider>
-  );
-}
-
-type SubscriberProviderProps = {
-  networkId: network_id,
-  children: React.Node,
-};
-
-export function SubscriberContextProvider(props: SubscriberProviderProps) {
-  const {networkId} = props;
-  const [subscriberMap, setSubscriberMap] = useState({});
-  const [subscriberMetrics, setSubscriberMetrics] = useState({});
-  const [isLoading, setIsLoading] = useState(true);
-  const enqueueSnackbar = useEnqueueSnackbar();
-
-  useEffect(() => {
-    const fetchLteState = async () => {
-      if (networkId == null) {
-        return;
-      }
-      await InitSubscriberState({
-        networkId,
-        setSubscriberMap,
-        setSubscriberMetrics,
-        enqueueSnackbar,
-      }),
-        setIsLoading(false);
-    };
-    fetchLteState();
-  }, [networkId, enqueueSnackbar]);
-
-  if (isLoading) {
-    return <LoadingFiller />;
-  }
-
-  return (
-    <SubscriberContext.Provider
-      value={{
-        state: subscriberMap,
-        metrics: subscriberMetrics,
-        gwSubscriberMap: getSubscriberGatewayMap(subscriberMap),
-        setState: (key: subscriber_id, value?: mutable_subscriber) =>
-          setSubscriberState({
-            networkId,
-            subscriberMap,
-            setSubscriberMap,
-            key,
-            value,
-          }),
-      }}>
-      {props.children}
-    </SubscriberContext.Provider>
-  );
-}
-
-type GatewayTierProviderProps = {
-  networkId: network_id,
-  children: React.Node,
-};
-
-export function GatewayTierContextProvider(props: GatewayTierProviderProps) {
-  const {networkId} = props;
-  const [tiers, setTiers] = useState<{[string]: tier}>({});
-  const [isLoading, setIsLoading] = useState(true);
-  const enqueueSnackbar = useEnqueueSnackbar();
-  const [supportedVersions, setSupportedVersions] = useState<Array<string>>([]);
-
-  useEffect(() => {
-    const fetchState = async () => {
-      if (networkId == null) {
-        return;
-      }
-      const [stableChannelResp] = await Promise.allSettled([
-        MagmaV1API.getChannelsByChannelId({channelId: 'stable'}),
-        InitTierState({networkId, setTiers, enqueueSnackbar}),
-      ]);
-      if (stableChannelResp.value) {
-        setSupportedVersions(
-          stableChannelResp.value.supported_versions.reverse(),
-        );
-      }
-      setIsLoading(false);
-    };
-    fetchState();
-  }, [networkId, enqueueSnackbar]);
-
-  if (isLoading) {
-    return <LoadingFiller />;
-  }
-
-  return (
-    <GatewayTierContext.Provider
-      value={{
-        state: {supportedVersions, tiers},
-        setState: (key, value?) =>
-          SetTierState({tiers, setTiers, networkId, key, value}),
-      }}>
-      {props.children}
-    </GatewayTierContext.Provider>
-  );
-}
 
 export function getLteSections(
   alertsEnabled: boolean,

--- a/nms/app/packages/magmalte/app/components/main/Index.js
+++ b/nms/app/packages/magmalte/app/components/main/Index.js
@@ -15,13 +15,9 @@
  */
 
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
-import {
-  EnodebContextProvider,
-  GatewayContextProvider,
-  GatewayTierContextProvider,
-  SubscriberContextProvider,
-} from '@fbcnms/magmalte/app/components/lte/LteSections';
+
 import {FEG_LTE, LTE, coalesceNetworkType} from '@fbcnms/types/network';
+import {LteContextProvider} from '../lte/LteContext';
 import type {NetworkType} from '@fbcnms/types/network';
 import type {Theme} from '@material-ui/core';
 
@@ -57,26 +53,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     ...theme.mixins.toolbar,
   },
 }));
-
-type LteContextProviderProps = {
-  networkId: string,
-  children: React.Node,
-};
-
-function LteContextProvider(props: LteContextProviderProps) {
-  const {networkId} = props;
-  return (
-    <SubscriberContextProvider networkId={networkId}>
-      <GatewayTierContextProvider networkId={networkId}>
-        <EnodebContextProvider networkId={networkId}>
-          <GatewayContextProvider networkId={networkId}>
-            {props.children}
-          </GatewayContextProvider>
-        </EnodebContextProvider>
-      </GatewayTierContextProvider>
-    </SubscriberContextProvider>
-  );
-}
 
 export default function Index() {
   const classes = useStyles();

--- a/nms/app/packages/magmalte/app/state/lte/ApnState.js
+++ b/nms/app/packages/magmalte/app/state/lte/ApnState.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+import type {apn, network_id} from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+type Props = {
+  networkId: network_id,
+  apns: {[string]: apn},
+  setApns: ({[string]: apn}) => void,
+  key: string,
+  value?: apn,
+};
+
+export async function SetApnState(props: Props) {
+  const {networkId, apns, setApns, key, value} = props;
+  if (value != null) {
+    if (!(key in apns)) {
+      await MagmaV1API.postLteByNetworkIdApns({
+        networkId: networkId,
+        apn: value,
+      });
+      setApns({...apns, [key]: value});
+    } else {
+      await MagmaV1API.putLteByNetworkIdApnsByApnName({
+        networkId: networkId,
+        apnName: key,
+        apn: value,
+      });
+      setApns({...apns, [key]: value});
+    }
+    const apn = await MagmaV1API.getLteByNetworkIdApnsByApnName({
+      networkId: networkId,
+      apnName: key,
+    });
+    if (apn) {
+      const newPolicies = {...apns, [key]: apn};
+      setApns(newPolicies);
+    }
+  } else {
+    await MagmaV1API.deleteLteByNetworkIdApnsByApnName({
+      networkId: networkId,
+      apnName: key,
+    });
+    const newApns = {...apns};
+    delete newApns[key];
+    setApns(newApns);
+  }
+}

--- a/nms/app/packages/magmalte/app/state/lte/EquipmentState.js
+++ b/nms/app/packages/magmalte/app/state/lte/EquipmentState.js
@@ -14,7 +14,7 @@
  * @format
  */
 
-import type {EnodebInfo} from '../components/lte/EnodebUtils';
+import type {EnodebInfo} from '../../components/lte/EnodebUtils';
 import type {
   enodeb_serials,
   gateway_epc_configs,

--- a/nms/app/packages/magmalte/app/state/lte/NetworkState.js
+++ b/nms/app/packages/magmalte/app/state/lte/NetworkState.js
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {
+  lte_network,
+  network_dns_config,
+  network_epc_configs,
+  network_id,
+  network_ran_configs,
+} from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+export type UpdateNetworkProps = {
+  networkId: network_id,
+  lteNetwork?: lte_network,
+  epcConfigs?: network_epc_configs,
+  lteRanConfigs?: network_ran_configs,
+  lteDnsConfig?: network_dns_config,
+  setLteNetwork: lte_network => void,
+  refreshState: boolean,
+};
+
+export async function UpdateNetworkState(props: UpdateNetworkProps) {
+  const {networkId, setLteNetwork} = props;
+  const requests = [];
+  if (props.lteNetwork !== undefined) {
+    requests.push(
+      await MagmaV1API.putLteByNetworkId({
+        networkId: networkId,
+        lteNetwork: {
+          ...props.lteNetwork,
+        },
+      }),
+    );
+  }
+
+  if (props.epcConfigs !== undefined) {
+    requests.push(
+      await MagmaV1API.putLteByNetworkIdCellularEpc({
+        networkId: props.networkId,
+        config: props.epcConfigs,
+      }),
+    );
+  }
+  if (props.lteRanConfigs !== undefined) {
+    requests.push(
+      await MagmaV1API.putLteByNetworkIdCellularRan({
+        networkId: props.networkId,
+        config: props.lteRanConfigs,
+      }),
+    );
+  }
+  if (props.lteDnsConfig !== undefined) {
+    requests.push(
+      await MagmaV1API.putLteByNetworkIdDns({
+        networkId: props.networkId,
+        config: props.lteDnsConfig,
+      }),
+    );
+  }
+
+  await Promise.all(requests);
+  if (props.refreshState) {
+    setLteNetwork(await MagmaV1API.getLteByNetworkId({networkId}));
+  }
+}

--- a/nms/app/packages/magmalte/app/state/lte/PolicyState.js
+++ b/nms/app/packages/magmalte/app/state/lte/PolicyState.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {network_id, policy_id, policy_rule} from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+type Props = {
+  networkId: network_id,
+  policies: {[string]: policy_rule},
+  setPolicies: ({[string]: policy_rule}) => void,
+  key: policy_id,
+  value?: policy_rule,
+};
+
+export async function SetPolicyState(props: Props) {
+  const {networkId, policies, setPolicies, key, value} = props;
+  if (value != null) {
+    if (!(key in policies)) {
+      await MagmaV1API.postNetworksByNetworkIdPoliciesRules({
+        networkId: networkId,
+        policyRule: value,
+      });
+      setPolicies({...policies, [key]: value});
+    } else {
+      await MagmaV1API.putNetworksByNetworkIdPoliciesRulesByRuleId({
+        networkId: networkId,
+        ruleId: key,
+        policyRule: value,
+      });
+      setPolicies({...policies, [key]: value});
+    }
+    const policyRule = await MagmaV1API.getNetworksByNetworkIdPoliciesRulesByRuleId(
+      {
+        networkId: networkId,
+        ruleId: key,
+      },
+    );
+    if (policyRule) {
+      const newPolicies = {...policies, [key]: policyRule};
+      setPolicies(newPolicies);
+    }
+  } else {
+    await MagmaV1API.deleteNetworksByNetworkIdPoliciesRulesByRuleId({
+      networkId: networkId,
+      ruleId: key,
+    });
+    const newPolicies = {...policies};
+    delete newPolicies[key];
+    setPolicies(newPolicies);
+  }
+}

--- a/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
@@ -13,16 +13,15 @@
  * @flow strict-local
  * @format
  */
-import type {Metrics} from '../components/context/SubscriberContext';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+import {getLabelUnit} from '../../views/subscriber/SubscriberUtils';
+import type {Metrics} from '../../components/context/SubscriberContext';
 import type {
   mutable_subscriber,
   network_id,
   subscriber,
 } from '@fbcnms/magma-api';
-
-import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
-
-import {getLabelUnit} from '../views/subscriber/SubscriberUtils';
 
 type InitSubscriberStateProps = {
   networkId: network_id,

--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -34,7 +34,7 @@ import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 import {EnodebJsonConfig} from './EnodebDetailConfig';
 import {EnodebStatus, EnodebSummary} from './EnodebDetailSummaryStatus';
 import {Redirect, Route, Switch} from 'react-router-dom';
-import {RunGatewayCommands} from '../../state/EquipmentState';
+import {RunGatewayCommands} from '../../state/lte/EquipmentState';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext} from 'react';

--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailMain.js
@@ -43,7 +43,7 @@ import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {GatewayJsonConfig} from './GatewayDetailConfig';
 import {Redirect, Route, Switch} from 'react-router-dom';
-import {RunGatewayCommands} from '../../state/EquipmentState';
+import {RunGatewayCommands} from '../../state/lte/EquipmentState';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext} from 'react';

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebConfigTest.js
@@ -25,7 +25,7 @@ import defaultTheme from '../../../theme/default.js';
 
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {SetEnodebState} from '../../../state/EquipmentState';
+import {SetEnodebState} from '../../../state/lte/EquipmentState';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
 import {useState} from 'react';
 

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -26,7 +26,7 @@ import defaultTheme from '../../../theme/default.js';
 
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
-import {SetGatewayState} from '../../../state/EquipmentState';
+import {SetGatewayState} from '../../../state/lte/EquipmentState';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
 import {useState} from 'react';
 

--- a/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
@@ -13,25 +13,22 @@
  * @flow strict-local
  * @format
  */
-import type {
-  lte_network,
-  network_epc_configs,
-  network_id,
-  network_ran_configs,
-} from '@fbcnms/magma-api';
+import type {lte_network, network_epc_configs} from '@fbcnms/magma-api';
 
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '../../theme/design-system/DialogTitle';
+import LteNetworkContext from '../../components/context/LteNetworkContext';
 import React from 'react';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
+
 import {NetworkEpcEdit} from './NetworkEpc';
 import {NetworkInfoEdit} from './NetworkInfo';
 import {NetworkRanEdit} from './NetworkRanConfig';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useState} from 'react';
+import {useContext, useState} from 'react';
 
 const NETWORK_TITLE = 'Network';
 const EPC_TITLE = 'Epc';
@@ -65,12 +62,6 @@ const EditTableType = {
 
 type EditProps = {
   editTable: $Keys<typeof EditTableType>,
-  lteNetwork: lte_network,
-  epcConfigs: network_epc_configs,
-  lteRanConfigs: network_ran_configs,
-  onSaveNetworkInfo: lte_network => void,
-  onSaveEpcConfigs: network_epc_configs => void,
-  onSaveLteRanConfigs: network_ran_configs => void,
 };
 
 type DialogProps = {
@@ -126,20 +117,23 @@ export default function AddEditNetworkButton(props: ButtonProps) {
 export function NetworkEditDialog(props: DialogProps) {
   const {open, editProps} = props;
   const classes = useStyles();
-  const [networkId, setNetworkId] = useState<network_id>(
-    editProps?.lteNetwork?.id || '',
+  const ctx = useContext(LteNetworkContext);
+
+  const [lteNetwork, setLteNetwork] = useState<lte_network>(
+    editProps ? ctx.state : {},
   );
-  const [lteNetwork, setLteNetwork] = useState<lte_network>({});
-  const [epcConfigs, setEpcConfigs] = useState<network_epc_configs>({});
+  const [epcConfigs, setEpcConfigs] = useState<network_epc_configs>(
+    editProps ? ctx.state.cellular?.epc ?? {} : {},
+  );
+  const lteRanConfigs = editProps ? ctx.state.cellular?.ran : undefined;
 
   const [tabPos, setTabPos] = React.useState(
     editProps ? EditTableType[editProps.editTable] : 0,
   );
-
   const onClose = () => {
     setLteNetwork({});
     setEpcConfigs({});
-    setNetworkId('');
+    setTabPos(0);
     props.onClose();
   };
 
@@ -158,14 +152,14 @@ export function NetworkEditDialog(props: DialogProps) {
         <Tab
           key="epc"
           data-testid="epcTab"
-          disabled={networkId ? false : true}
+          disabled={editProps ? false : true}
           label={EPC_TITLE}
         />
         ;
         <Tab
           key="ran"
           data-testid="ranTab"
-          disabled={networkId ? false : true}
+          disabled={editProps ? false : true}
           label={RAN_TITLE}
         />
         ;
@@ -173,19 +167,13 @@ export function NetworkEditDialog(props: DialogProps) {
       {tabPos === 0 && (
         <NetworkInfoEdit
           saveButtonTitle={editProps ? 'Save' : 'Save And Continue'}
-          lteNetwork={
-            Object.keys(lteNetwork).length != 0
-              ? lteNetwork
-              : editProps?.lteNetwork
-          }
+          lteNetwork={lteNetwork}
           onClose={onClose}
           onSave={(lteNetwork: lte_network) => {
             setLteNetwork(lteNetwork);
             if (editProps) {
-              editProps.onSaveNetworkInfo(lteNetwork);
               onClose();
             } else {
-              setNetworkId(lteNetwork.id);
               setTabPos(tabPos + 1);
             }
           }}
@@ -194,17 +182,12 @@ export function NetworkEditDialog(props: DialogProps) {
       {tabPos === 1 && (
         <NetworkEpcEdit
           saveButtonTitle={editProps ? 'Save' : 'Save And Continue'}
-          networkId={networkId}
-          epcConfigs={
-            Object.keys(epcConfigs).length != 0
-              ? epcConfigs
-              : editProps?.epcConfigs
-          }
+          networkId={lteNetwork.id}
+          epcConfigs={epcConfigs}
           onClose={onClose}
           onSave={epcConfigs => {
             setEpcConfigs(epcConfigs);
             if (editProps) {
-              editProps.onSaveEpcConfigs(epcConfigs);
               onClose();
             } else {
               setTabPos(tabPos + 1);
@@ -215,13 +198,10 @@ export function NetworkEditDialog(props: DialogProps) {
       {tabPos === 2 && (
         <NetworkRanEdit
           saveButtonTitle={editProps ? 'Save' : 'Save And Add Network'}
-          networkId={networkId}
-          lteRanConfigs={editProps?.lteRanConfigs}
+          networkId={lteNetwork.id}
+          lteRanConfigs={lteRanConfigs}
           onClose={onClose}
-          onSave={lteRanConfigs => {
-            editProps?.onSaveLteRanConfigs(lteRanConfigs);
-            onClose();
-          }}
+          onSave={onClose}
         />
       )}
     </Dialog>

--- a/nms/app/packages/magmalte/app/views/network/NetworkKPIs.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkKPIs.js
@@ -14,14 +14,15 @@
  * @format
  */
 import type {DataRows} from '../../components/DataGrid';
-import type {apn, rule_id} from '@fbcnms/magma-api';
 
+import ApnContext from '../../components/context/ApnContext';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import DataGrid from '../../components/DataGrid';
 import EnodebContext from '../../components/context/EnodebContext';
 import GatewayContext from '../../components/context/GatewayContext';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
 import PeopleIcon from '@material-ui/icons/People';
+import PolicyContext from '../../components/context/PolicyContext';
 import React from 'react';
 import RssFeedIcon from '@material-ui/icons/RssFeed';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
@@ -29,15 +30,12 @@ import SubscriberContext from '../../components/context/SubscriberContext';
 
 import {useContext} from 'react';
 
-type Props = {
-  policyRules: ?Array<rule_id>,
-  apns: ?{[string]: apn},
-};
-
-export default function NetworkKPI(props: Props) {
+export default function NetworkKPI() {
   const gwCtx = useContext(GatewayContext);
   const enbCtx = useContext(EnodebContext);
   const subscriberCtx = useContext(SubscriberContext);
+  const apnCtx = useContext(ApnContext);
+  const policyCtx = useContext(PolicyContext);
 
   const kpiData: DataRows[] = [
     [
@@ -59,12 +57,12 @@ export default function NetworkKPI(props: Props) {
       {
         icon: LibraryBooksIcon,
         category: 'Policies',
-        value: props.policyRules ? props.policyRules.length : 0,
+        value: Object.keys(policyCtx.state).length,
       },
       {
         icon: RssFeedIcon,
         category: 'APNs',
-        value: props.apns ? Object.keys(props.apns).length : 0,
+        value: Object.keys(apnCtx.state).length,
       },
     ],
   ];

--- a/nms/app/packages/magmalte/app/views/network/__tests__/NetworkTest.js
+++ b/nms/app/packages/magmalte/app/views/network/__tests__/NetworkTest.js
@@ -15,11 +15,14 @@
  */
 import 'jest-dom/extend-expect';
 
+import ApnContext from '../../../components/context/ApnContext';
 import EnodebContext from '../../../components/context/EnodebContext';
 import GatewayContext from '../../../components/context/GatewayContext';
+import LteNetworkContext from '../../../components/context/LteNetworkContext';
 import MagmaAPIBindings from '@fbcnms/magma-api';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import NetworkDashboard from '../NetworkDashboard';
+import PolicyContext from '../../../components/context/PolicyContext';
 import React from 'react';
 import SubscriberContext from '../../../components/context/SubscriberContext';
 import axiosMock from 'axios';
@@ -27,6 +30,7 @@ import defaultTheme from '../../../theme/default.js';
 
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
+import {UpdateNetworkState} from '../../../state/lte/NetworkState';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
@@ -43,6 +47,11 @@ describe('<NetworkDashboard />', () => {
     description: 'Test Network Description',
     id: 'test_network',
     name: 'Test Network',
+    dns: {
+      enable_caching: false,
+      local_ttl: 0,
+      records: [],
+    },
   };
 
   const epc = {
@@ -152,7 +161,28 @@ describe('<NetworkDashboard />', () => {
     },
   };
 
-  const rules = ['test1', 'test2'];
+  const policies = {
+    test1: {
+      flow_list: [],
+      id: 'test',
+      priority: 10,
+      redirect: {
+        address_type: 'IPv4',
+        server_address: 'http://localhost:8080',
+        support: 'ENABLED',
+      },
+    },
+    test2: {
+      flow_list: [],
+      id: 'test',
+      priority: 10,
+      redirect: {
+        address_type: 'IPv4',
+        server_address: 'http://localhost:8080',
+        support: 'ENABLED',
+      },
+    },
+  };
 
   const subscribers = {
     IMSI00000000001002: {
@@ -211,15 +241,6 @@ describe('<NetworkDashboard />', () => {
   };
 
   beforeEach(() => {
-    MagmaAPIBindings.getLteByNetworkId.mockResolvedValue(testNetwork);
-    MagmaAPIBindings.getLteByNetworkIdCellularEpc.mockResolvedValue(epc);
-    MagmaAPIBindings.getLteByNetworkIdCellularRan.mockResolvedValue(ran);
-    // eslint-disable-next-line max-len
-    MagmaAPIBindings.getNetworksByNetworkIdPoliciesRules.mockResolvedValue(
-      rules,
-    );
-    MagmaAPIBindings.getLteByNetworkIdApns.mockResolvedValue(apns);
-
     axiosMock.post.mockImplementation(() =>
       Promise.resolve({data: {success: true}}),
     );
@@ -232,19 +253,30 @@ describe('<NetworkDashboard />', () => {
     MagmaAPIBindings.putLteByNetworkIdCellularRan.mockImplementation(() =>
       Promise.resolve({data: {success: true}}),
     );
+    MagmaAPIBindings.putLteByNetworkIdDns.mockImplementation(() =>
+      Promise.resolve({data: {success: true}}),
+    );
   });
 
   afterEach(() => {
     axiosMock.get.mockClear();
+    MagmaAPIBindings.getLteByNetworkId.mockClear();
     MagmaAPIBindings.getNetworksByNetworkId.mockClear();
     MagmaAPIBindings.putLteByNetworkId.mockClear();
-    MagmaAPIBindings.getLteByNetworkIdCellularEpc.mockClear();
     MagmaAPIBindings.putLteByNetworkIdCellularEpc.mockClear();
-    MagmaAPIBindings.getLteByNetworkIdCellularRan.mockClear();
     MagmaAPIBindings.putLteByNetworkIdCellularRan.mockClear();
+    MagmaAPIBindings.putLteByNetworkIdDns.mockClear();
   });
 
   const Wrapper = () => {
+    const apnCtx = {
+      state: apns,
+      setState: async () => {},
+    };
+    const policyCtx = {
+      state: policies,
+      setState: async () => {},
+    };
     const enodebCtx = {
       state: {enbInfo},
       setState: async () => {},
@@ -261,20 +293,43 @@ describe('<NetworkDashboard />', () => {
       gwSubscriberMap: {},
     };
 
+    const networkCtx = {
+      state: {
+        ...testNetwork,
+        cellular: {
+          epc: epc,
+          ran: ran,
+        },
+      },
+      updateNetworks: async props => {
+        return UpdateNetworkState({
+          setLteNetwork: () => {},
+          refreshState: testNetwork.id === props.networkId,
+          ...props,
+        });
+      },
+    };
+
     return (
       <MemoryRouter initialEntries={['/nms/test/network']} initialIndex={0}>
         <MuiThemeProvider theme={defaultTheme}>
           <MuiStylesThemeProvider theme={defaultTheme}>
-            <GatewayContext.Provider value={gatewayCtx}>
-              <EnodebContext.Provider value={enodebCtx}>
-                <SubscriberContext.Provider value={subscriberCtx}>
-                  <Route
-                    path="/nms/:networkId/network"
-                    component={NetworkDashboard}
-                  />
-                </SubscriberContext.Provider>
-              </EnodebContext.Provider>
-            </GatewayContext.Provider>
+            <LteNetworkContext.Provider value={networkCtx}>
+              <PolicyContext.Provider value={policyCtx}>
+                <ApnContext.Provider value={apnCtx}>
+                  <GatewayContext.Provider value={gatewayCtx}>
+                    <EnodebContext.Provider value={enodebCtx}>
+                      <SubscriberContext.Provider value={subscriberCtx}>
+                        <Route
+                          path="/nms/:networkId/network"
+                          component={NetworkDashboard}
+                        />
+                      </SubscriberContext.Provider>
+                    </EnodebContext.Provider>
+                  </GatewayContext.Provider>
+                </ApnContext.Provider>
+              </PolicyContext.Provider>
+            </LteNetworkContext.Provider>
           </MuiStylesThemeProvider>
         </MuiThemeProvider>
       </MemoryRouter>
@@ -284,21 +339,6 @@ describe('<NetworkDashboard />', () => {
   it('Verify Network Dashboard', async () => {
     const {getByTestId, getByLabelText} = render(<Wrapper />);
     await wait();
-
-    expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledTimes(1);
-    // eslint-disable-next-line max-len
-    expect(MagmaAPIBindings.getLteByNetworkIdCellularEpc).toHaveBeenCalledTimes(
-      1,
-    );
-    // eslint-disable-next-line max-len
-    expect(MagmaAPIBindings.getLteByNetworkIdCellularRan).toHaveBeenCalledTimes(
-      1,
-    );
-    // eslint-disable-next-line max-len
-    expect(
-      MagmaAPIBindings.getNetworksByNetworkIdPoliciesRules,
-    ).toHaveBeenCalledTimes(1);
-    expect(MagmaAPIBindings.getLteByNetworkIdApns).toHaveBeenCalledTimes(1);
 
     const info = getByTestId('info');
     expect(info).toHaveTextContent('Test Network');
@@ -506,6 +546,7 @@ describe('<NetworkDashboard />', () => {
       },
       networkId: 'testNetworkID',
     });
+    expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledTimes(0);
   });
 
   it('Verify Network Edit Info', async () => {
@@ -551,13 +592,13 @@ describe('<NetworkDashboard />', () => {
       lteNetwork: {
         ...testNetwork,
         description: 'Edit LTE test network description',
+        cellular: {
+          epc: epc,
+          ran: ran,
+        },
       },
     });
-
-    // verify that info component is updated with edited info
-    expect(getByTestId('info')).toHaveTextContent(
-      'Edit LTE test network description',
-    );
+    expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledTimes(1);
   });
 
   it('Verify Network Edit EPC', async () => {
@@ -585,9 +626,7 @@ describe('<NetworkDashboard />', () => {
       config: {...epc, mnc: '03'},
       networkId: 'test_network',
     });
-
-    // verify epc component is updated with edited epc
-    expect(getByTestId('epc')).toHaveTextContent('03');
+    expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledTimes(1);
   });
 
   it('Verify Network Edit Ran', async () => {
@@ -621,8 +660,6 @@ describe('<NetworkDashboard />', () => {
       },
       networkId: 'test_network',
     });
-
-    // verify ran component is updated with edited ran info
-    expect(getByTestId('ran')).toHaveTextContent('40000');
+    expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledTimes(1);
   });
 });

--- a/nms/app/packages/magmalte/app/views/traffic/PolicyOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/PolicyOverview.js
@@ -21,18 +21,17 @@ import Button from '@material-ui/core/Button';
 import Grid from '@material-ui/core/Grid';
 import JsonEditor from '../../components/JsonEditor';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
-import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import PolicyContext from '../../components/context/PolicyContext';
 import React from 'react';
 import Text from '@fbcnms/ui/components/design-system/Text';
 import TextField from '@material-ui/core/TextField';
-import nullthrows from '@fbcnms/util/nullthrows';
 import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
+import {useContext, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
-import {useState} from 'react';
 
 const POLICY_TITLE = 'Policies';
 const DEFAULT_POLICY_CONFIG = {
@@ -114,20 +113,16 @@ type PolicyRowType = {
   trackingType: string,
 };
 
-type Props = WithAlert & {
-  policies: {[string]: policy_rule},
-  onDelete?: string => void,
-};
-
-export function PolicyOverview(props: Props) {
+export function PolicyOverview(props: WithAlert) {
   const classes = useStyles();
   const enqueueSnackbar = useEnqueueSnackbar();
   const [currRow, setCurrRow] = useState<PolicyRowType>({});
-  const {history, match, relativeUrl} = useRouter();
-  const networkId: string = nullthrows(match.params.networkId);
-  const policyRows: Array<PolicyRowType> = props.policies
-    ? Object.keys(props.policies).map((policyID: string) => {
-        const policyRule = props.policies[policyID];
+  const {history, relativeUrl} = useRouter();
+  const ctx = useContext(PolicyContext);
+  const policies = ctx.state;
+  const policyRows: Array<PolicyRowType> = policies
+    ? Object.keys(policies).map((policyID: string) => {
+        const policyRule = policies[policyID];
         return {
           policyID: policyRule.id,
           numFlows: policyRule.flow_list.length,
@@ -224,13 +219,8 @@ export function PolicyOverview(props: Props) {
                       }
 
                       try {
-                        await MagmaV1API.deleteNetworksByNetworkIdPoliciesRulesByRuleId(
-                          {
-                            networkId: networkId,
-                            ruleId: currRow.policyID,
-                          },
-                        );
-                        props.onDelete?.(currRow.policyID);
+                        // trigger deletion
+                        ctx.setState(currRow.policyID);
                       } catch (e) {
                         enqueueSnackbar(
                           'failed deleting policy ' + currRow.policyID,
@@ -253,43 +243,26 @@ export function PolicyOverview(props: Props) {
     </div>
   );
 }
-type JsonConfigType = {
-  policies: {[string]: policy_rule},
-  onSave?: policy_rule => void,
-};
-export function PolicyJsonConfig(props: JsonConfigType) {
+
+export function PolicyJsonConfig() {
   const {match, history} = useRouter();
   const [error, setError] = useState('');
-  const networkId: string = nullthrows(match.params.networkId);
   const policyID: string = match.params.policyId;
   const enqueueSnackbar = useEnqueueSnackbar();
-  const policy: policy_rule = props.policies[policyID] || DEFAULT_POLICY_CONFIG;
+  const ctx = useContext(PolicyContext);
+  const policies = ctx.state;
+  const policy: policy_rule = policies[policyID] || DEFAULT_POLICY_CONFIG;
   return (
     <JsonEditor
       content={policy}
       error={error}
       onSave={async policy => {
         try {
-          if (policyID) {
-            await MagmaV1API.putNetworksByNetworkIdPoliciesRulesByRuleId({
-              networkId: networkId,
-              ruleId: policyID,
-              policyRule: (policy: policy_rule),
-            });
-            enqueueSnackbar('Policy saved successfully', {
-              variant: 'success',
-            });
-          } else {
-            await MagmaV1API.postNetworksByNetworkIdPoliciesRules({
-              networkId: networkId,
-              policyRule: (policy: policy_rule),
-            });
-            enqueueSnackbar('Policy added successfully', {
-              variant: 'success',
-            });
-          }
+          ctx.setState(policyID, policy);
+          enqueueSnackbar('Policy saved successfully', {
+            variant: 'success',
+          });
           setError('');
-          props.onSave?.(policy);
           history.goBack();
         } catch (e) {
           setError(e.response?.data?.message ?? e.message);

--- a/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
@@ -13,52 +13,21 @@
  * @flow strict-local
  * @format
  */
-import type {apn, policy_rule} from '@fbcnms/magma-api';
-
 import ApnOverview from './ApnOverview';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
-import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
-import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import PolicyOverview from './PolicyOverview';
 import React from 'react';
 import RssFeedIcon from '@material-ui/icons/RssFeed';
 import TopBar from '../../components/TopBar';
-import nullthrows from '@fbcnms/util/nullthrows';
-import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
 
 import {ApnJsonConfig} from './ApnOverview';
 import {PolicyJsonConfig} from './PolicyOverview';
 import {Redirect, Route, Switch} from 'react-router-dom';
-import {useCallback, useState} from 'react';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 export default function TrafficDashboard() {
-  const {relativePath, relativeUrl, match} = useRouter();
-  const networkId: string = nullthrows(match.params.networkId);
-  const [policies, setPolicies] = useState<{[string]: policy_rule}>({});
-  const [apns, setApns] = useState<{[string]: apn}>({});
-  const {isLoading: policyLoading} = useMagmaAPI(
-    MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull,
-    {
-      networkId: networkId,
-    },
-    useCallback(response => {
-      setPolicies(response);
-    }, []),
-  );
+  const {relativePath, relativeUrl} = useRouter();
 
-  const {isLoading: apnLoading} = useMagmaAPI(
-    MagmaV1API.getLteByNetworkIdApns,
-    {
-      networkId: networkId,
-    },
-    useCallback(response => {
-      setApns(response);
-    }, []),
-  );
-  if (policyLoading || apnLoading) {
-    return <LoadingFiller />;
-  }
   return (
     <>
       <TopBar
@@ -80,67 +49,19 @@ export default function TrafficDashboard() {
       <Switch>
         <Route
           path={relativePath('/policy/:policyId/json')}
-          render={() => (
-            <PolicyJsonConfig
-              policies={policies}
-              onSave={policy => setPolicies({...policies, [policy.id]: policy})}
-            />
-          )}
+          component={PolicyJsonConfig}
         />
         <Route
           path={relativePath('/policy/json')}
-          render={() => (
-            <PolicyJsonConfig
-              policies={policies}
-              onSave={policy => setPolicies({...policies, [policy.id]: policy})}
-            />
-          )}
+          component={PolicyJsonConfig}
         />
         <Route
           path={relativePath('/apn/:apnId/json')}
-          render={() => (
-            <ApnJsonConfig
-              apns={apns}
-              onSave={apn => setApns({...apns, [apn.apn_name]: apn})}
-            />
-          )}
+          component={ApnJsonConfig}
         />
-        <Route
-          path={relativePath('/apn/json')}
-          render={() => (
-            <ApnJsonConfig
-              apns={apns}
-              onSave={apn => setApns({...apns, [apn.apn_name]: apn})}
-            />
-          )}
-        />
-        <Route
-          path={relativePath('/policy')}
-          render={() => (
-            <PolicyOverview
-              policies={policies}
-              onDelete={policyId => {
-                const {
-                  [policyId]: _deletedPolicy,
-                  ...updatedPolicies
-                } = policies;
-                setPolicies(updatedPolicies);
-              }}
-            />
-          )}
-        />
-        <Route
-          path={relativePath('/apn')}
-          render={() => (
-            <ApnOverview
-              apns={apns}
-              onDelete={apnId => {
-                const {[apnId]: _deletedApn, ...updatedApns} = apns;
-                setApns(updatedApns);
-              }}
-            />
-          )}
-        />
+        <Route path={relativePath('/apn/json')} component={ApnJsonConfig} />
+        <Route path={relativePath('/policy')} component={PolicyOverview} />
+        <Route path={relativePath('/apn')} component={ApnOverview} />
         <Redirect to={relativeUrl('/policy')} />
       </Switch>
     </>

--- a/nms/app/packages/magmalte/mock/db.json
+++ b/nms/app/packages/magmalte/mock/db.json
@@ -1404,6 +1404,75 @@
       }
     }
   },
+  "policies" : {
+    "test1": {
+      "flow_list": [],
+      "id": "test",
+      "priority": 10,
+      "redirect": {
+        "address_type": "IPv4",
+        "server_address": "http://localhost:8080",
+        "support": "ENABLED"
+      }
+    },
+    "test2": {
+      "flow_list": [],
+      "id": "test",
+      "priority": 10,
+      "redirect": {
+        "address_type": "IPv4",
+        "server_address": "http://localhost:8080",
+        "support": "ENABLED"
+      }
+    }
+  },
+  "apns" : {
+    "internet": {
+      "apn_configuration": {
+        "ambr": {
+          "max_bandwidth_dl": 200000000,
+          "max_bandwidth_ul": 100000000
+        },
+        "qos_profile": {
+          "class_id": 9,
+          "preemption_capability": true,
+          "preemption_vulnerability": false,
+          "priority_level": 15
+        }
+      },
+      "apn_name": "internet"
+    },
+    "magma.ipv4": {
+      "apn_configuration": {
+        "ambr": {
+          "max_bandwidth_dl": 200000000,
+          "max_bandwidth_ul": 100000000
+        },
+        "qos_profile": {
+          "class_id": 9,
+          "preemption_capability": false,
+          "preemption_vulnerability": false,
+          "priority_level": 15
+        }
+      },
+      "apn_name": "magma.ipv4"
+    },
+    "oai.ipv4": {
+      "apn_configuration": {
+        "ambr": {
+          "max_bandwidth_dl": 200000000,
+          "max_bandwidth_ul": 100000000
+        },
+        "qos_profile": {
+          "class_id": 9,
+          "preemption_capability": true,
+          "preemption_vulnerability": false,
+          "priority_level": 15
+        }
+      },
+      "apn_name": "oai.ipv4"
+    }
+  },
   "networksFull": {
     "test" : {
       "type": "lte",

--- a/nms/app/packages/magmalte/scripts/mockServer.js
+++ b/nms/app/packages/magmalte/scripts/mockServer.js
@@ -18,9 +18,9 @@ const jsonServer = require('json-server');
 const https = require('https');
 const fs = require('fs');
 
-const certFile = process.env.API_CERT_FILENAME ?? 'mock/.cache/mock_server.key';
+const certFile = process.env.API_CERT_FILENAME ?? '.cache/mock_server.cert';
 const keyFile =
-  process.env.API_PRIVATE_KEY_FILENAME ?? 'mock/.cache/mock_server.cert';
+  process.env.API_PRIVATE_KEY_FILENAME ?? '.cache/mock_server.key';
 
 const server = jsonServer.create();
 const router = jsonServer.router('./mock/db.json');
@@ -31,6 +31,12 @@ const buffer = fs.readFileSync('./mock/db.json', 'utf-8');
 const db = JSON.parse(buffer);
 
 // add custom route handlers
+server.get('/magma/v1/lte/test', (req, res) => {
+  if (req.method === 'GET') {
+    res.status(200).jsonp(db['networksFull']['test']);
+  }
+});
+
 server.get('/magma/v1/networks/test/gateways', (req, res) => {
   if (req.method === 'GET') {
     res.status(200).jsonp(db['networksFull']['test']['gateways']);
@@ -98,6 +104,17 @@ server.get(
     }
   },
 );
+server.get('/magma/v1/networks/test/policies/rules', (req, res) => {
+  if (req.method === 'GET') {
+    res.status(200).jsonp(db['policies']);
+  }
+});
+
+server.get('/magma/v1/networks/test/apns', (req, res) => {
+  if (req.method === 'GET') {
+    res.status(200).jsonp(db['apns']);
+  }
+});
 server.use('/magma/v1', router);
 
 https


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <karthikshyam@gmail.com>

## Summary
- Moved network, policy and apn related state to LteContext.
- Moved all context related code to LteContext (https://github.com/magma/magma/pull/2606#pullrequestreview-482028465)
- Moved all state related code to lte/state directory
- Modified Network and Traffic test to use context

## Test Plan
yarn test works fine. Modified the test to accommodate new context changes


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
