### PR TITLE
{WIP} [agw] [stateless] Add systemd defaults in /lib and overrides in /etc

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 SRC_DIR=/usr/local/bin
-SERVICE_LIST=("mme" "mobilityd" "pipelined" "sctpd" "sessiond")
+SERVICE_LIST=("mme" "mobilityd" "pipelined" "sessiond" "sctpd")
 RETURN_STATELESS=0
 RETURN_STATEFUL=1
 RETURN_CORRUPT=2

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_utils.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_utils.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+RETURN_STATELESS=0
+RETURN_STATEFUL=1
+
+function check_systemd_file {
+  service_name=$1
+  dep_service_name=$2
+  systemd_file=/lib/systemd/system/"$dep_service_name".service
+  override_file=/etc/systemd/system/"$dep_service_name".service
+  if [ -f "$override_file" ]; then
+    systemd_file=$override_file
+  fi
+
+  if grep -q "^ *PartOf=$service_name" "$systemd_file"; then
+    echo "The $dep_service_name service will restart with $service_name," \
+      "i.e. stateful."
+    exit $RETURN_STATEFUL
+  else
+    return $RETURN_STATELESS
+  fi
+}
+
+function add_systemd_override {
+  service_name=$1
+  dep_service_name=$2
+  # create override systemd service file, if it does not exist
+  sudo /bin/cp -n /lib/systemd/system/"$dep_service_name".service \
+    /etc/systemd/system/"$dep_service_name".service
+  sudo sed -e "/PartOf=$service_name/ s/^#*/#/" -i \
+    /etc/systemd/system/"$dep_service_name".service
+}
+
+function remove_systemd_override {
+  dep_service_name=$1
+  sudo rm -f /etc/systemd/system/"$dep_service_name".service
+}

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: Copy magma service files
   copy:
     src: "systemd/magma_{{ item }}.service"
-    dest: "/etc/systemd/system/magma@{{ item }}.service"
+    dest: "/lib/systemd/system/magma@{{ item }}.service"
   with_items:
     # Magma Python services
     - magmad
@@ -34,7 +34,7 @@
 - name: Copy sctpd service file
   copy:
     src: systemd/sctpd.service
-    dest: /etc/systemd/system/sctpd.service
+    dest: /lib/systemd/system/sctpd.service
   when: full_provision
 
 - name: Copy logrotate config file
@@ -75,6 +75,7 @@
     - pipelined
     - sctpd
     - sessiond
+    - utils
 
 - name: Create symlink for sctpd binary
   file: src='{{ c_build }}/sctpd/sctpd' path=/usr/local/sbin/sctpd state=link force=yes follow=no

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -286,7 +286,7 @@ BUILDCMD="fpm \
 --exclude '*/.ignoreme' \
 ${SCTPD_BUILD}/sctpd=/usr/local/sbin/ \
 ${SCTPD_VERSION_FILE}=/usr/local/share/sctpd/version \
-$(glob_files "${SERVICE_DIR}/sctpd.service" /etc/systemd/system/sctpd.service)"
+$(glob_files "${SERVICE_DIR}/sctpd.service" /lib/systemd/system/sctpd.service)"
 
 eval "$BUILDCMD"
 
@@ -309,18 +309,18 @@ ${SYSTEM_DEPS} \
 ${OAI_BUILD}/oai_mme/mme=/usr/local/bin/ \
 ${SESSIOND_BUILD}/sessiond=/usr/local/bin/ \
 ${SCTPD_MIN_VERSION_FILE}=/usr/local/share/magma/sctpd_min_version \
-$(glob_files "${SERVICE_DIR}/magma@.service" /etc/systemd/system/magma@.service) \
-$(glob_files "${SERVICE_DIR}/magma@control_proxy.service" /etc/systemd/system/magma@control_proxy.service) \
-$(glob_files "${SERVICE_DIR}/magma@magmad.service" /etc/systemd/system/magma@magmad.service) \
-$(glob_files "${SERVICE_DIR}/magma@mme.service" /etc/systemd/system/magma@mme.service) \
-$(glob_files "${SERVICE_DIR}/magma@sessiond.service" /etc/systemd/system/magma@sessiond.service) \
-$(glob_files "${SERVICE_DIR}/magma@mobilityd.service" /etc/systemd/system/magma@mobilityd.service) \
-$(glob_files "${SERVICE_DIR}/magma@pipelined.service" /etc/systemd/system/magma@pipelined.service) \
-$(glob_files "${SERVICE_DIR}/magma@redirectd.service" /etc/systemd/system/magma@redirectd.service) \
-$(glob_files "${SERVICE_DIR}/magma@dnsd.service" /etc/systemd/system/magma@dnsd.service) \
-$(glob_files "${SERVICE_DIR}/magma@lighttpd.service" /etc/systemd/system/magma@lighttpd.service) \
-$(glob_files "${SERVICE_DIR}/magma@redis.service" /etc/systemd/system/magma@redis.service) \
-$(glob_files "${SERVICE_DIR}/magma@td-agent-bit.service" /etc/systemd/system/magma@td-agent-bit.service) \
+$(glob_files "${SERVICE_DIR}/magma@.service" /lib/systemd/system/magma@.service) \
+$(glob_files "${SERVICE_DIR}/magma@control_proxy.service" /lib/systemd/system/magma@control_proxy.service) \
+$(glob_files "${SERVICE_DIR}/magma@magmad.service" /lib/systemd/system/magma@magmad.service) \
+$(glob_files "${SERVICE_DIR}/magma@mme.service" /lib/systemd/system/magma@mme.service) \
+$(glob_files "${SERVICE_DIR}/magma@sessiond.service" /lib/systemd/system/magma@sessiond.service) \
+$(glob_files "${SERVICE_DIR}/magma@mobilityd.service" /lib/systemd/system/magma@mobilityd.service) \
+$(glob_files "${SERVICE_DIR}/magma@pipelined.service" /lib/systemd/system/magma@pipelined.service) \
+$(glob_files "${SERVICE_DIR}/magma@redirectd.service" /lib/systemd/system/magma@redirectd.service) \
+$(glob_files "${SERVICE_DIR}/magma@dnsd.service" /lib/systemd/system/magma@dnsd.service) \
+$(glob_files "${SERVICE_DIR}/magma@lighttpd.service" /lib/systemd/system/magma@lighttpd.service) \
+$(glob_files "${SERVICE_DIR}/magma@redis.service" /lib/systemd/system/magma@redis.service) \
+$(glob_files "${SERVICE_DIR}/magma@td-agent-bit.service" /lib/systemd/system/magma@td-agent-bit.service) \
 ${CERT_FILE}=/var/opt/magma/certs/rootCA.pem \
 $(glob_files "${MAGMA_ROOT}/lte/gateway/configs/!(control_proxy.yml|pipelined.yml|sessiond.yml)" /etc/magma/) \
 $(glob_files "${MAGMA_ROOT}/lte/gateway/configs/pipelined.yml_prod" /etc/magma/pipelined.yml) \

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -259,7 +259,7 @@ if [ -f ${BUILD_PATH} ]; then
   rm ${BUILD_PATH}
 fi
 
-SERVICE_DIR="/etc/systemd/system/"
+SERVICE_DIR="/lib/systemd/system/"
 ANSIBLE_FILES="${MAGMA_ROOT}/lte/gateway/deploy/roles/magma/files"
 
 SCTPD_VERSION_FILE=$(mktemp)


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The default systemd config in Magma AGW package is always stateful. For stateless AGWs, we need a systemd override which persists across package upgrades. This change moves the default "stateful" systemd configs to /lib/systemd/system directory, and creates the override config in /etc/systemd/system.

This change is backwards breaking:
- In production networks, remove the service files in /etc/systemd/system for stateful AGWs after the new package version is installed
- In dev-setup, re-provision magma dev VM

## Test Plan

- vagrant provision magma
- S1ap integration tests

## Additional Information

- [x] This change is backwards-breaking

-- In production networks, remove the service files in /etc/systemd/system for stateful AGWs after the new package version is installed
-- Re-provision Magma dev VM to get the systemd files in the new location, i.e. /lib/