### PR TITLE
adds .nms suffix to org name in versioned docs

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.2.0/nms/organizations.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/nms/organizations.md
@@ -42,7 +42,7 @@ organization.
 
 We use [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) to
 automatically set up an AWS Route53 DNS record that points
-`*.nms.youdomain.com` to the NMS application. If you're managing your
+`*.nms.yourdomain.com` to the NMS application. If you're managing your
 domain name outside of Route53, you'll have to add an NS record `<org>.nms.`
 for every new organization you add to the NMS. The list of nameservers to set
 can be found in the AWS console for the Route53 zone or as the `nameservers`
@@ -54,7 +54,7 @@ output of the `orc8r-aws` Terraform module.
 
 Create one organization and give it access to all networks. This is essentially
 the same as v1.0 when there was no tenancy support. The only difference is that
-the NMS is accessible from the URL `magma-test.youdomain.com`
+the NMS is accessible from the URL `magma-test.nms.yourdomain.com`
 
 ![Org with access to all networks](assets/nms/org_all_networks.png)
 
@@ -69,6 +69,6 @@ to the network `mpk_test`. Create a user in this organization to use it
 
 ![Add user to org](assets/nms/org_add_user.png)
 
-When you log in to `magma-test.youdomain.com` you will only be able to see the
-network `mpk_test`. If you log into `fb-test.yourdomain.com`, you will
+When you log in to `magma-test.nms.yourdomain.com` you will only be able to see the
+network `mpk_test`. If you log into `fb-test.nms.yourdomain.com`, you will
 have access to all networks.


### PR DESCRIPTION
Signed-off-by: Sudhi Kandi <sudhikan@fb.com>

[nms][organizations]
## Summary

Add .nms suffix to the org name so that the url matches what's in route 53; updated on master but forgot to do it in versioned docs. 

## Test Plan

na; documentation only. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
