### PR TITLE
[orc8r][sms] Add sms_ll package

### DIFF
--- a/cwf/cloud/go/go.sum
+++ b/cwf/cloud/go/go.sum
@@ -366,6 +366,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -503,6 +505,7 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -656,6 +659,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.3.1/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/fbinternal/cloud/go/go.sum
+++ b/fbinternal/cloud/go/go.sum
@@ -380,6 +380,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -523,6 +525,7 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -688,6 +691,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.3.1/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/feg/cloud/go/go.sum
+++ b/feg/cloud/go/go.sum
@@ -377,6 +377,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -520,6 +522,7 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -685,6 +688,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.3.1/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/lte/cloud/go/go.mod
+++ b/lte/cloud/go/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 	github.com/thoas/go-funk v0.7.0
+	github.com/warthog618/sms v0.3.0
 	golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e
 	google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55
 	google.golang.org/grpc v1.27.1

--- a/lte/cloud/go/go.sum
+++ b/lte/cloud/go/go.sum
@@ -371,6 +371,8 @@ github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8m
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223 h1:F9x/1yl3T2AeKLr2AMdilSD8+f9bvMnNN8VS5iDtovc=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
@@ -508,6 +510,8 @@ github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyC
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QINDnvyZuTaACm9ofY+PRh+5vFz4oxBZeF8=
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 github.com/vektra/mockery v0.0.0-20181123154057-e78b021dcbb5/go.mod h1:ppEjwdhyy7Y31EnHRDm1JkChoC7LXIJ7Ex0VYLWtZtQ=
+github.com/warthog618/sms v0.3.0 h1:LYAb5ngmu2qjNExgji3B7xi2tIZ9+DsuE9pC5xs4wwc=
+github.com/warthog618/sms v0.3.0/go.mod h1:+bYZGeBxu003sxD5xhzsrIPBAjPBzTABsRTwSpd7ld4=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20180616005107-d6fb6747feb6/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
@@ -661,6 +665,8 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/fsnotify/fsnotify.v1 v1.3.1/go.mod h1:Fyux9zXlo4rWoMSIzpn9fDAYjalPqJ/K1qJ27s+7ltE=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=

--- a/lte/cloud/go/sms_ll/sms_cp.go
+++ b/lte/cloud/go/sms_ll/sms_cp.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package sms_ll
+
+import (
+	"fmt"
+)
+
+func smsCpError(field string) error {
+	return fmt.Errorf("smscp: %s", field)
+}
+
+// Handles creation of SMS-CM messages (3GPP TS 24.011 7.2)
+
+// CP Message represents
+type cpMessage struct {
+	// Contains Transaction ID and Protocol Disc
+	firstOctet byte
+
+	// CP-DATA, CP-ACK, or CP-ERROR
+	messageType byte
+
+	// Only present for CP-ERROR
+	cause byte
+
+	// Only present for CP-DATA
+	length byte
+
+	// Only present for CP-DATA
+	rpdu []byte
+}
+
+func createCpMessage(txID byte, messageType byte, rpdu []byte) (cpMessage, error) {
+	if int(txID) < 0 || int(txID) > 15 {
+		return cpMessage{}, smsCpError(fmt.Sprintf("Transaction ID must be 0-15: %x", txID))
+	}
+
+	switch messageType {
+	case CpData, CpError, CpAck:
+		// do nothing
+	default:
+		return cpMessage{}, smsCpError(fmt.Sprintf("Invalid CP Message Type: 0x%x", messageType))
+	}
+
+	// Set txID and protocol disc
+	fo := byte(0x0)
+	fo |= (txID << 4)
+	fo |= CpProtocolDisc
+
+	rpduCopy := make([]byte, len(rpdu))
+	copy(rpduCopy, rpdu)
+
+	return cpMessage{
+		firstOctet: fo,
+		messageType: messageType,
+		length: byte(len(rpduCopy)),
+		rpdu: rpduCopy,
+	}, nil
+}
+
+func (cpm cpMessage) marshalBinary() []byte {
+	b := []byte{cpm.firstOctet, cpm.messageType}
+
+	switch cpm.messageType {
+	case CpData:
+		b = append(b, cpm.length)
+		b = append(b, cpm.rpdu...)
+	case CpError:
+		b = append(b, cpm.cause)
+	case CpAck:
+		// No additional data, do nothing
+	}
+	return b
+}
+
+func (cpm *cpMessage) unmarshalBinary(input []byte) error {
+	// must be at least two octets long
+	if len(input) < 2 {
+		return smsCpError("Message too short")
+	}
+
+	cpm.firstOctet = input[0]
+	cpm.messageType = input[1]
+
+	switch cpm.messageType {
+	case CpData:
+		cpm.length = input[2]
+		cpm.rpdu = make([]byte, len(input[3:]))
+		copy(cpm.rpdu, input[3:])
+	case CpError:
+		if _, ok := CpCauseStr[input[2]]; ok {
+			cpm.cause = input[2]
+		} else {
+			return smsCpError(fmt.Sprintf("Invalid cause: %x", cpm.cause))
+		}
+	case CpAck:
+		// Do nothing -- no more data
+	default:
+		return smsCpError(fmt.Sprintf("Invalid IE type: %x", cpm.messageType))
+	}
+
+	return nil
+}
+
+func (cpm cpMessage) GetTransactionId() byte {
+	return cpm.firstOctet >> 4
+}
+
+func (cpm cpMessage) GetProtocolDisc() byte {
+	return cpm.firstOctet & 0xf
+}
+
+const (
+	// CP Message bit fields
+
+	// Protocol discriminator (3GPP TS 24.007 11.2.3.1.1)
+	// For SMS-related messages, this is always 0x9 (half-octet)
+	CpProtocolDisc = 0x9
+
+	// Message types
+	CpData  = 0x1
+	CpAck   = 0x3
+	CpError = 0x5
+
+	// IE Types
+	CpIeiUser  = 0x1
+	CpIeiCause = 0x2
+)
+
+const (
+	// CP Cause error types (24.011 8.1.4.2, Table 8.2)
+	CpCauseNetworkFailure                = 0x11
+	CpCauseCongestion                     = 0x16
+	CpCauseInvalidTi                     = 0x51
+	CpCauseSemanticallyIncorrect         = 0x5f
+	CpCauseInvalidMandantoryInformation = 0x60
+	CpCauseMessageTypeNonexistant       = 0x61
+	CpCauseMessageNotCompatible         = 0x62
+	CpCauseInfoElementNonexistant       = 0x63
+	CpCauseProtocolError                 = 0x6f
+)
+
+var CpCauseStr = map[byte]string{
+	CpCauseNetworkFailure:                "Network failure",
+	CpCauseCongestion:                     "Congestion",
+	CpCauseInvalidTi:                     "Invalid Transaction Identifier value",
+	CpCauseSemanticallyIncorrect:         "Semantically incorrect message",
+	CpCauseInvalidMandantoryInformation: "Invalid mandantory information",
+	CpCauseMessageTypeNonexistant:       "Message type non-existent or not implemented",
+	CpCauseMessageNotCompatible:         "Message not compatible with the short message protocol state",
+	CpCauseInfoElementNonexistant:       "Information element non-existent or not implemented",
+	CpCauseProtocolError:                 "Protocol error, unspecified",
+}

--- a/lte/cloud/go/sms_ll/sms_ll.go
+++ b/lte/cloud/go/sms_ll/sms_ll.go
@@ -1,0 +1,153 @@
+package sms_ll
+
+import (
+	"github.com/warthog618/sms"
+	"github.com/warthog618/sms/encoding/tpdu"
+	"time"
+	"fmt"
+)
+
+// Generate fully encoded SMS PDUs for delivery to a UE (MS). Will handle
+// encoding and chunking of messages as appropriate. We first generate TPDUs,
+// then RP-DATA headers, and finally CP-DATA headers, resulting in a set of
+// byte arrays that can be directly delivered to a UE (MS).
+// Inputs:
+// 	message: A UTF-8 string representing the SMS.
+//	from_num: A E.164 encoded source number.
+//	timestamp: The sender timestamp for the SMS (generally, use current server time)
+//	references: An array of references for the messages we'll generate. Must match number of PDUs generated.
+// Outputs:
+//	- Array of byte array representing the set of fully-encoded CP-DATA(RP-DATA(TPDU)) messages generated
+//	- Error	(if any)
+func GenerateSmsDelivers(message string, from_num string, timestamp time.Time, references []uint8) ([][]byte, error) {
+	tpdus := createTpdus(message, from_num, timestamp)
+	if len(references) != len(tpdus) {
+		return nil, fmt.Errorf("Insufficient references for generated TPDU (have %d, need %d)", len(references), len(tpdus))
+	}
+
+	output := make([][]byte, 0)
+
+	for i := range tpdus {
+		tp, err := tpdus[i].MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		rpm, err := createRpDataMessage(RpMtiMtData, references[i], tp)
+		if err != nil {
+			return nil, err
+		}
+
+		marshaledRPM := rpm.marshalBinary()
+		cp_id := references[i] & 0xf // low order bits become the cp_id
+		cpm, err := createCpDataMessage(marshaledRPM, cp_id)
+		if err != nil {
+			return nil, err
+		}
+
+		marshaledCPM := cpm.marshalBinary()
+
+		output = append(output, marshaledCPM)
+	}
+
+	return output, nil
+}
+
+// Return the number of SMS PDUs that will be generated for a given string,
+// after taking TPDU encoding into account.
+// Inputs:
+// 	message: A UTF-8 string representing the SMS
+// Outputs:
+//	- An integer representing the number of SMS messages the input will
+//	need to be split across after encoding.
+func GetMessageCount(message string) int {
+	// Number of SMS is determined only by the message content, not the
+	// timestamp or number.
+	return len(createTpdus(message, "123456", time.Now()))
+}
+
+// Decodes an SMS-DELIVERY-REPORT message.
+// Inputs:
+//	input: A byte array representing a fully encoded SMS delivered from a UE
+// Outputs:
+//	- uint8: Reference number representing the SMS
+//	- bool: true if the message was successfully delivered
+//	- string: descriptive delivery status (only present for failures)
+//	- error: if the message received is not an SMS-DELIVERY-REPORT.
+func Decode(input []byte) (uint8, bool, string, error) {
+	// A message is a delivery report iff we receive a CP-DATA(RP-ACK(TPDU)). We can ignore everything else.
+	cpm := new(cpMessage)
+	err := cpm.unmarshalBinary(input)
+	if err != nil {
+		return 0, false, "", err
+	}
+
+	// Valid CPM, check type
+	if cpm.messageType != CpData {
+		return 0, false, "", fmt.Errorf("Not a CP-DATA message: %x", cpm.messageType)
+	}
+
+	rpm := new(rpMessage)
+	err = rpm.unmarshalBinary(cpm.rpdu)
+	if err != nil {
+		return 0, false, "", err
+	}
+
+	// Valid RPM, must be of type RP-ERROR or RP-ACK
+	msg_type, _ := rpm.msgType()
+	switch msg_type {
+	case RpAck: // success! get reference
+		return uint8(rpm.reference), true, "", nil
+	case RpError: // failure, get cause
+		return uint8(rpm.reference), false, rpm.cause.cause_str, nil
+	default:
+		return 0, false, "", fmt.Errorf("RP-DATA message, ignoring")
+	}
+}
+
+func createTpdus(message string, from_num string, timestamp time.Time) []tpdu.TPDU {
+	tpdus, _ := sms.Encode([]byte(message), sms.AsDeliver, sms.From(from_num))
+	for i := range tpdus {
+		tpdus[i].FirstOctet |= tpdu.FoMMS // Android won't accept if this bit isn't set.
+		tpdus[i].FirstOctet |= tpdu.FoSRI // Request a delivery report.
+		tpdus[i].SCTS = tpdu.Timestamp{Time: timestamp}
+	}
+
+	return tpdus
+}
+
+// Helper for creating a RP-DATA message.
+func createRpDataMessage(mti byte, reference byte, data []byte) (rpMessage, error) {
+	msg_type, err := rpMessage{mti: mti}.msgType()
+	if msg_type != RpData {
+		return rpMessage{}, smsRpError(fmt.Sprintf("MTI isn't RP-DATA: %x", mti))
+	} else if err != nil {
+		return rpMessage{}, err
+	}
+
+	ud, err := createRpUserElement(data)
+	if err != nil {
+		return rpMessage{}, err
+	}
+
+	rpm := rpMessage{
+		mti: mti,
+		reference: reference,
+		userData: ud,
+	}
+
+	if rpm.direction() == RpMt { // MT-SMS should have empty dest address
+		rpm.originatorAddress, rpm.destinationAddress = newFakeRpAddressElement(), rpAddressElement{length: 0}
+	} else { // MO-SMS should have empty orig address
+		rpm.originatorAddress, rpm.destinationAddress = rpAddressElement{length: 0}, newFakeRpAddressElement()
+	}
+
+	return rpm, nil
+}
+
+func createCpDataMessage(rpdu []byte, txID byte) (cpMessage, error) {
+	cpm, err := createCpMessage(txID, CpData, rpdu)
+	if err != nil {
+		return cpm, err
+	}
+	return cpm, nil
+}

--- a/lte/cloud/go/sms_ll/sms_ll_test.go
+++ b/lte/cloud/go/sms_ll/sms_ll_test.go
@@ -1,0 +1,179 @@
+package sms_ll
+
+import (
+	"encoding/hex"
+	"testing"
+	"time"
+	"reflect"
+)
+
+// Test cases:
+// 1) Marshal a specific SMS-Deliver and ensure the binary matches what we expect
+// 2) Marshal a long SMS and ensure binary matches what we expect
+// 3) Given a delivery report, decode the TPDU
+
+// Pick a consistent timestamp for tests
+
+func TestEncodeSingleSMS(t *testing.T) {
+	msg := "Here's a test."
+	ts := time.Date(2020, 9, 14, 16, 30, 50, 12345, time.UTC)
+	num := "18658675309"
+	ref := []byte{7}
+	expected := "790127010702b9110020240b918156685703f90000029041610305000ec8b2bc7c9a83c2207a794e7701"
+	b, e := GenerateSmsDelivers(msg, num, ts, ref)
+	if e != nil {
+		t.Errorf("Error: %s", e)
+	}
+
+	if GetMessageCount(msg) != 1 || len(b) != 1 {
+		t.Errorf("Incorrect number of PDUs generated")
+	}
+	if hex.EncodeToString(b[0]) != expected {
+		t.Errorf("Incorrect PDU generated/wanted:\n%s\n%s", hex.EncodeToString(b[0]), expected)
+	}
+
+}
+
+func TestEncodingMultipleSMS(t *testing.T) {
+	msg := "Here's a test of a veeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeerrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrryyyyyyyyyyyyyyyyyy long message that's super super long."
+	ts := time.Date(2020, 9, 14, 16, 30, 50, 12345, time.UTC)
+	num := "18658675309"
+	ref := []byte{1,2}
+	expected := []string{"1901a6010102b911009f640b918156685703f9000002904161030500a0050003010201906579f934078541f4f29c0e7a9b416190bd5c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c96cbe572b95c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c2e97cbe572b95c2ecfe7f3f97c3e9fcfe7f3f97c3e9fcfe741ecb7fb0c6a97e7f3f0b90ca2a3c3", "290133010202b911002c640b918156685703f90000029041610305001c050003010202e8a739685e8797e5a0791d5e9683d86ff7d905"}
+
+	b, e := GenerateSmsDelivers(msg, num, ts, ref)
+	if e != nil {
+		t.Errorf("Error: %s", e)
+	}
+	if GetMessageCount(msg) != 2 || len(b) != 2 {
+		t.Errorf("Wrong number of PDUs generated")
+	}
+	for i := range b {
+		if hex.EncodeToString(b[i]) != expected[i] {
+			t.Errorf("Incorrect PDU generated/wanted:\n%s\n%s", hex.EncodeToString(b[i]), expected[i])
+		}
+	}
+}
+
+func TestDecode(t *testing.T) {
+	type decodeResult struct {
+		ref uint8
+		res bool
+		cause string
+		err bool // true if we get an error
+	}
+
+	tests := []struct {
+		name string
+		input string
+		want decodeResult
+	}{
+		{name: "deliver-success", input: "d90106020141020000", want: decodeResult{1, true, "", false}},
+		{name: "deliver-fail", input: "d9010404040160", want: decodeResult{4, false, "Invalid mandantory information", false}},
+		{name: "giberish", input: "209491c192c912ca1010", want: decodeResult{0, false, "", true}},
+		{name: "data", input: "790127010702b9110020240b918156685703f90000029041610305000ec8b2bc7c9a83c2207a794e7701", want: decodeResult{0, false, "", true}},
+	}
+
+	for _, tc := range tests {
+		msg, _ := hex.DecodeString(tc.input)
+		ref, res, cause, err := Decode(msg)
+		result := decodeResult{ref, res, cause, err != nil}
+		if !reflect.DeepEqual(tc.want, result) {
+			t.Errorf("Decode failed (want: %v, got %v)", tc.want, result)
+		}
+	}
+}
+
+func TestPiecewiseDecodeDeliveryFailure(t *testing.T) {
+	input := "d9010404010160"
+	cp_hex, _ := hex.DecodeString(input)
+	cpm := new(cpMessage)
+	err := cpm.unmarshalBinary(cp_hex)
+	if err != nil {
+		t.Errorf("Failed to decode valid CP-DATA")
+	}
+	if cpm.messageType != CpData {
+		t.Errorf("Failed to decode valid CP-DATA")
+	}
+	if int(cpm.length) != 4 || len(cpm.rpdu) != 4 {
+		t.Errorf("CP-DATA length incorrect")
+	}
+	if cpm.cause != 0x0 {
+		t.Errorf("CP-DATA has cause set to non-zero")
+	}
+
+	rpm := new(rpMessage)
+	err = rpm.unmarshalBinary(cpm.rpdu)
+	if err != nil {
+		t.Errorf("Failed to decode valid RP-ERROR")
+	}
+	msg_type, err := rpm.msgType()
+	if err != nil {
+		t.Errorf("Failed to decode valid RP-ERROR")
+	}
+	if msg_type != RpError || rpm.cause.cause != RpCauseInvalidMandantoryInfo {
+		t.Errorf("Failed to decode valid RP-ERROR")
+	}
+}
+
+func TestPiecewiseDecodeDeliveryReport(t *testing.T) {
+	input := "d90106020141020000"
+	cp_hex, _ := hex.DecodeString(input)
+	cpm := new(cpMessage)
+	err := cpm.unmarshalBinary(cp_hex)
+	if err != nil {
+		t.Errorf("Failed to decode valid CP-DATA")
+	}
+	if cpm.messageType != CpData {
+		t.Errorf("Failed to decode valid CP-DATA")
+	}
+	if int(cpm.length) != 6 && len(cpm.rpdu) != 6 {
+		t.Errorf("CP-DATA length incorrect")
+	}
+	if cpm.cause != 0x0 {
+		t.Errorf("CP-DATA has cause set to non-zero")
+	}
+
+	rpm := new(rpMessage)
+	err = rpm.unmarshalBinary(cpm.rpdu)
+	if err != nil {
+		t.Errorf("Failed to decode valid RP-ACK")
+	}
+	msg_type, err := rpm.msgType()
+	if err != nil {
+		t.Errorf("Failed to decode valid RP-ACK")
+	}
+	if msg_type != RpAck {
+		t.Errorf("Failed to decode valid RP-ACK")
+	}
+	if rpm.userData.iei != RpUdeIei {
+		t.Errorf("Failed to decode valid RP-ACK User Data IEI")
+	}
+	if rpm.userData.length != byte(2) {
+		t.Errorf("Failed to decode valid RP-ACK User Data Length")
+	}
+	if len(rpm.userData.tpdu) != int(rpm.userData.length) {
+		t.Errorf("RP-ACK user data length doesn't match payload")
+	}
+}
+
+func TestUnmarshalAddressElement(t *testing.T) {
+	input := "0b911605935713f2"
+	rpadde_hex, _ := hex.DecodeString(input)
+	rpadde := new(rpAddressElement)
+	l, err := rpadde.unmarshalBinary(rpadde_hex)
+	if err != nil {
+		t.Errorf("Failed to decode RP Address Element")
+	}
+
+	if l != 8 || rpadde.length != 0x0b {
+		t.Errorf("RPAddressElement incorrect length")
+	}
+	if rpadde.numberInfo != 0x91 {
+		t.Errorf("RPAddressElement incorrect number info")
+	}
+	num, _ := hex.DecodeString("1605935713f2")
+	if !reflect.DeepEqual(rpadde.number, num) {
+		t.Errorf("RPAddressElement incorrect number. Have:\n%s\nwant\n%s", hex.Dump(rpadde.number), hex.Dump(num))
+	}
+}

--- a/lte/cloud/go/sms_ll/sms_rp.go
+++ b/lte/cloud/go/sms_ll/sms_rp.go
@@ -1,0 +1,347 @@
+package sms_ll
+
+import (
+	"fmt"
+)
+
+func smsRpError(field string) error {
+	return fmt.Errorf("smsrp: %s", field)
+}
+
+// Used for both RP-Destination and RP-Originator Address, since it's the
+// same layout (TS 24.011 8.2.5.1 and 8.2.5.2). Note that while 8.2.5.1-2
+// suggest that the first octet is an IEI, 7.3.1 notes that this is a Type
+// 4 LV IE, which means there's no IEI present -- just a length and values.
+type rpAddressElement struct {
+	length     byte // of the number in half-octets!
+	numberInfo byte // octet 3
+	number     []byte
+}
+
+// The length field of an RP Address Element is the number of half-octets in
+// the number. This converts to a byte length of the number itself.
+func (rpadde rpAddressElement) getNumberOctets() int {
+	l := int(rpadde.length)
+	if l%2 == 0 {
+		return l/2
+	} else {
+		return (l+1)/2 // last half-octet is padded with 0xf
+	}
+}
+
+func (rpadde rpAddressElement) marshalBinary() []byte {
+	if rpadde.length == 0x0 {
+		return []byte{rpadde.length}
+	}
+
+	b := []byte{rpadde.length, rpadde.numberInfo}
+	b = append(b, rpadde.number...)
+	return b
+}
+
+// Decode an address element. Returns the length of the address element if present.
+func (rpadde *rpAddressElement) unmarshalBinary(input []byte) (int, error) {
+	// Empty addresses will be one byte long with a zero value length
+	if len(input) == 1 {
+		if input[0] != 0x0 {
+			return -1, smsRpError("Invalid RP Address of length 1")
+		} else {
+			rpadde.length = input[0]
+			return 1, nil
+		}
+	} else if len(input) < 3 { // if it's not zero length, we must have at least 3 octets
+		return -1, smsRpError("Invalid RP Address")
+	}
+
+	rpadde.length = input[0]
+	rpadde.numberInfo = input[1]
+
+	num_bytes := rpadde.getNumberOctets()
+	rpadde.number = make([]byte, num_bytes)
+	copy(rpadde.number, input[2:num_bytes+2])
+
+	return num_bytes + 2, nil
+}
+
+// The RP-Address-Element refers to the number of the SMSC. In our case, we
+// generally don't use an SMSC, so we just set the number to 11.
+func newFakeRpAddressElement() rpAddressElement {
+	return rpAddressElement{
+		numberInfo: 0xb9, // network specific number, private numbering plan
+		number: []byte{0x11}, // 1 1
+		length: 0x2,
+	}
+}
+
+// RP-User data element (TS 24.011 8.2.5.3)
+type rpUserElement struct {
+	iei    byte // Not present for RP-DATA
+	length byte
+	tpdu   []byte
+}
+
+func createRpUserElement(data []byte) (rpUserElement, error) {
+	if len(data) > 232 { // TS24.011 8.2.5.3
+		return rpUserElement{}, smsRpError("UserData-Element too long (>232 bytes)")
+	}
+
+	return rpUserElement{
+		iei: RpUdeIei,
+		length: byte(len(data)),
+		tpdu: data,
+	}, nil
+
+}
+
+func (rpue rpUserElement) marshalBinary(msgType byte) []byte {
+	rpu_len := len(rpue.tpdu) + 1
+	b := make([]byte, 0, rpu_len)
+	if msgType == RpAck || msgType == RpError { // these start with IEI
+		b = append(b, rpue.iei)
+	}
+	b = append(b, rpue.length)
+	b = append(b, rpue.tpdu...)
+	return b
+}
+
+func (rpue *rpUserElement) unmarshalBinary(msgType byte, input []byte) int {
+	idx := 0
+	if msgType == RpAck || msgType == RpError { // these start with IEI
+		rpue.iei = input[idx]
+		idx++
+	}
+	rpue.length = input[idx]
+	idx++
+
+	end := idx + int(rpue.length)
+	rpue.tpdu = make([]byte, rpue.length)
+	copy(rpue.tpdu, input[idx:end])
+	return end
+}
+
+// RP-Cause element (TS 24.011 8.2.5.4)
+type rpCauseElement struct {
+	iei        byte // Never serialized
+	length     byte
+	cause      byte
+	diagnostic byte // Optional
+	cause_str  string // Derived
+}
+
+func (rpce rpCauseElement) marshalBinary() []byte {
+	b := []byte{rpce.length, rpce.cause}
+	if int(rpce.length) == 2 {
+		b = append(b, rpce.diagnostic)
+	}
+	return b
+}
+
+func (rpce *rpCauseElement) unmarshalBinary(input []byte) (int, error) {
+	if cs, ok := RpCauseStr[input[1]]; ok {
+		rpce.cause = input[1]
+		rpce.cause_str = cs
+	} else {
+		return 0, smsRpError(fmt.Sprintf("Invalid cause: %x", rpce.cause))
+	}
+
+	rpce.length = input[0]
+	if int(rpce.length) == 2 {
+		rpce.diagnostic = input[2]
+		return 3, nil
+	}
+	return 2, nil
+}
+
+type rpMessage struct {
+	mti       byte
+	reference byte
+
+	// Mandantory. If UE->Network, must be length 0
+	originatorAddress rpAddressElement
+
+	// Mandantory. If Network->UE, must be length 0
+	destinationAddress rpAddressElement
+
+	// Mandantory for RP-DATA, includes tpdu. If RP-ACK or RP-ERROR, must
+	// include IEI.
+	userData rpUserElement
+
+	// Mandantory for RP-ERROR
+	cause rpCauseElement
+}
+
+func (rpm rpMessage) marshalBinary() []byte {
+	b := []byte{rpm.mti, rpm.reference}
+
+	rpmt, _ := rpm.msgType()
+
+	switch rpmt {
+	case RpData:
+		b = append(b, rpm.originatorAddress.marshalBinary()...)
+		b = append(b, rpm.destinationAddress.marshalBinary()...)
+		b = append(b, rpm.userData.marshalBinary(RpData)...)
+	case RpError:
+		b = append(b, rpm.cause.marshalBinary()...)
+	case RpAck:
+		// Do nothing
+	}
+
+	return b
+}
+
+func (rpm *rpMessage) unmarshalBinary(input []byte) error {
+	if len(input) < 2 {
+		return smsRpError("SMS-RP Message too short")
+	}
+
+	idx := 0
+	rpm.mti = input[idx]
+	idx++ // 1
+	rpm.reference = input[idx]
+	idx++ // 2
+
+	rpmt, err := rpm.msgType()
+	if err != nil {
+		return err
+	}
+
+	switch rpmt {
+	case RpData:
+		// The next two IEs should be adddresses in this case. So, get the lengths and pass to unmarshal
+		n, _ := rpm.originatorAddress.unmarshalBinary(input[idx:])
+		if rpm.direction() == RpMo && n != 1 {
+			return smsRpError("SMS-RP-DATA is MO, but OA length != 1")
+		}
+		idx += n
+		n, _ = rpm.destinationAddress.unmarshalBinary(input[idx:])
+		if rpm.direction() == RpMt && n != 1 {
+			return smsRpError("SMS-RP-DATA is MT, but DA length != 1")
+		}
+		idx += n
+
+		rpm.userData.unmarshalBinary(RpData, input[idx:])
+	case RpAck:
+		// RP-ACK and RP-ERROR may optionally contain an RP-User-Data
+		// element (TS24.001 7.3.3). If this is the case, it will be a
+		// TLV IE, with the first octet starting with the RP-User-Data
+		// IE ID (0x41).
+		if len(input) > 2 && input[idx] == RpUdeIei {
+			rpm.userData.unmarshalBinary(RpAck, input[idx:])
+		}
+	case RpError:
+		// Do nothing
+		_, err := rpm.cause.unmarshalBinary(input[idx:])
+		if err != nil {
+			return err
+		}
+		// TODO: Add support for optional UserData TLV element.
+	default:
+		return smsRpError(fmt.Sprintf("Invalid RP-SMS MTI: 0x%08b", rpm.mti))
+	}
+
+	return nil
+}
+
+// If MTI is even, message is UE->Network
+func (rpm rpMessage) direction() byte {
+	if rpm.mti&0x1 == 0 {
+		return RpMo
+	}
+	return RpMt
+}
+
+func (rpm rpMessage) msgType() (byte, error) {
+	switch rpm.mti {
+	case RpMtiMoData, RpMtiMtData:
+		return RpData, nil
+	case RpMtiMoErr, RpMtiMtErr:
+		return RpError, nil
+	case RpMtiMoAck, RpMtiMtAck:
+		return RpAck, nil
+	default:
+		return RpInvalid, smsRpError(fmt.Sprintf("Invalid RP-SMS MTI: 0x%08b", rpm.mti))
+	}
+}
+
+const (
+	RpData = iota
+	RpError
+	RpAck
+	RpInvalid // error type
+	RpMo      // UE/MS->Network
+	RpMt      // Network->UE/MS
+)
+
+const (
+	// RP Message fields
+
+	//RP-MTI (TS24.011 8.2.2) is technically defined as a 3 bit field in
+	//the low order bits of the first octet of the RPDU. However, the five
+	//high order bits are defined to always be 0, so here we treat these
+	//fields as a full octet.
+	RpMtiMoData = 0x0
+	RpMtiMoAck  = 0x2
+	RpMtiMoErr  = 0x4
+	RpMtiMoSmma = 0x6
+	RpMtiMtData = 0x1
+	RpMtiMtAck  = 0x3
+	RpMtiMtErr  = 0x5
+
+	RpUdeIei   = 0x41
+	RpCauseIei = 0x42
+)
+
+const (
+	// RP Cause types (TS24.011 Table 8.4)
+	RpCauseUnassigned               = 0x1
+	RpCauseOpBarred                = 0x8
+	RpCauseCallBarred              = 0xa
+	RpCauseReserved                 = 0xb
+	RpCauseSmTransferRejected     = 0x15
+	RpCauseMemExceeded             = 0x16
+	RpCauseDestOutOfOrder        = 0x1b
+	RpCauseUnidentifiedSub         = 0x1c
+	RpCauseFacilityRejected        = 0x1d
+	RpCauseUnknownSub              = 0x1e
+	RpCauseNetOutOfOrder         = 0x26
+	RpCauseTempFailure             = 0x29
+	RpCauseCongestion               = 0x2a
+	RpCauseResourceUnavailable     = 0x2f
+	RpCauseRequestedFacNotSub    = 0x32
+	RpCauseRequestedFacNotImpl   = 0x45
+	RpCauseInvalidSmTransRef     = 0x51
+	RpCauseSemIncorrectMessage    = 0x5f
+	RpCauseInvalidMandantoryInfo  = 0x60
+	RpCauseMsgTypeNotImpl        = 0x61
+	RpCauseMsgTypeNotCompatible  = 0x62
+	RpCauseInfoElementNonexistant = 0x63
+	RpCauseProtocolError           = 0x6f
+	RpCauseInterworking             = 0x7f
+)
+
+var RpCauseStr = map[byte]string{
+	RpCauseUnassigned:               "Unassigned (unallocated) number",
+	RpCauseOpBarred:                "Operator determined barring",
+	RpCauseCallBarred:              "Call barred",
+	RpCauseReserved:                 "Reserved",
+	RpCauseSmTransferRejected:     "Short message transfer rejected",
+	RpCauseMemExceeded:             "Memory capacity exceeded",
+	RpCauseDestOutOfOrder:        "Destination out of order",
+	RpCauseUnidentifiedSub:         "Unidentified subscriber",
+	RpCauseFacilityRejected:        "Facility rejected",
+	RpCauseUnknownSub:              "Unknown subscriber",
+	RpCauseNetOutOfOrder:         "Network out of order",
+	RpCauseTempFailure:             "Temporary failure",
+	RpCauseCongestion:               "Congestion",
+	RpCauseResourceUnavailable:     "Resources unavailable, unspecified",
+	RpCauseRequestedFacNotSub:    "Requested facility not subscribed",
+	RpCauseRequestedFacNotImpl:   "Requested facility not implemented",
+	RpCauseInvalidSmTransRef:     "Invalid short message transfer reference value",
+	RpCauseSemIncorrectMessage:    "Semantically incorrect message",
+	RpCauseInvalidMandantoryInfo:  "Invalid mandantory information",
+	RpCauseMsgTypeNotImpl:        "Message type not non-existent or not implemented",
+	RpCauseMsgTypeNotCompatible:  "Message not compatible with short message protocol state",
+	RpCauseInfoElementNonexistant: "Information element non-existent or not implemented",
+	RpCauseProtocolError:           "Protocol error, unspecified",
+	RpCauseInterworking:             "Interworking, unspecified",
+}

--- a/orc8r/cloud/go/go.mod
+++ b/orc8r/cloud/go/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.3.3
 	github.com/Masterminds/squirrel v1.1.1-0.20190513200039-d13326f0be73
 	github.com/Microsoft/go-winio v0.4.14 // indirect
-	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect


### PR DESCRIPTION
## Summary

sms_ll is a package for handling low-level encoding/decoding of SMS PDUs
(specifically SM-RP and SM-CP protocols). This package is currently focused on
providing support for MT-SMS from orc8r to AGW and handling delivery reports
from UEs.

## Test Plan

- `go test`
- Manual testing with physical UE (Pixel 3) and comparison with Wireshark traces.