### PR TITLE
[sessiond] Added two different ways to stop an active monitor (Usage=…

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -25,8 +25,7 @@ ChargingGrant::ChargingGrant(const StoredChargingGrant& marshaled) {
   final_action_info.final_action = marshaled.final_action_info.final_action;
   final_action_info.redirect_server =
       marshaled.final_action_info.redirect_server;
-  final_action_info.restrict_rules =
-      marshaled.final_action_info.restrict_rules;
+  final_action_info.restrict_rules = marshaled.final_action_info.restrict_rules;
 
   reauth_state   = marshaled.reauth_state;
   service_state  = marshaled.service_state;
@@ -40,12 +39,11 @@ StoredChargingGrant ChargingGrant::marshal() {
   marshaled.final_action_info.final_action = final_action_info.final_action;
   marshaled.final_action_info.redirect_server =
       final_action_info.redirect_server;
-  marshaled.final_action_info.restrict_rules =
-    final_action_info.restrict_rules;
-  marshaled.reauth_state  = reauth_state;
-  marshaled.service_state = service_state;
-  marshaled.expiry_time   = expiry_time;
-  marshaled.credit        = credit.marshal();
+  marshaled.final_action_info.restrict_rules = final_action_info.restrict_rules;
+  marshaled.reauth_state                     = reauth_state;
+  marshaled.service_state                    = service_state;
+  marshaled.expiry_time                      = expiry_time;
+  marshaled.credit                           = credit.marshal();
   return marshaled;
 }
 
@@ -69,7 +67,7 @@ void ChargingGrant::receive_charging_grant(
           final_action_info.restrict_rules.push_back(rule);
         }
         break;
-      default: // do nothing
+      default:  // do nothing
         break;
     }
     log_final_action_info();
@@ -231,7 +229,7 @@ void ChargingGrant::log_final_action_info() const {
       case ChargingCredit_FinalAction_REDIRECT:
         final_action += ", redirect_server: ";
         final_action +=
-          final_action_info.redirect_server.redirect_server_address();
+            final_action_info.redirect_server.redirect_server_address();
         break;
       case ChargingCredit_FinalAction_RESTRICT_ACCESS:
         final_action += ", restrict_rules: { ";
@@ -240,7 +238,7 @@ void ChargingGrant::log_final_action_info() const {
         }
         final_action += "}";
         break;
-      default: // do nothing;
+      default:  // do nothing;
         break;
     }
   }

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -40,16 +40,20 @@ struct ChargingGrant {
   ReAuthState reauth_state;
 
   // Default states
-  ChargingGrant() : credit(), is_final_grant(false),
-    service_state(SERVICE_ENABLED), reauth_state(REAUTH_NOT_NEEDED) {}
+  ChargingGrant()
+      : credit(),
+        is_final_grant(false),
+        service_state(SERVICE_ENABLED),
+        reauth_state(REAUTH_NOT_NEEDED) {}
 
-  ChargingGrant(const StoredChargingGrant &marshaled);
+  ChargingGrant(const StoredChargingGrant& marshaled);
 
   // ChargingGrant -> StoredChargingGrant
   StoredChargingGrant marshal();
 
-  void receive_charging_grant(const magma::lte::ChargingCredit& credit,
-                              SessionCreditUpdateCriteria* uc=NULL);
+  void receive_charging_grant(
+      const magma::lte::ChargingCredit& credit,
+      SessionCreditUpdateCriteria* uc = NULL);
 
   // Returns a SessionCreditUpdateCriteria that reflects the current state
   SessionCreditUpdateCriteria get_update_criteria();
@@ -62,16 +66,19 @@ struct ChargingGrant {
 
   // get_action returns the action to take on the credit based on the last
   // update. If no action needs to take place, CONTINUE_SERVICE is returned.
-  ServiceActionType get_action(SessionCreditUpdateCriteria &update_criteria);
+  ServiceActionType get_action(SessionCreditUpdateCriteria& update_criteria);
 
   // Get unreported usage from credit and return as part of CreditUsage
   // The update_type is also included in CreditUsage
   // If the grant is final or is_terminate is true, we include all unreported
-  // usage, otherwise we only include unreported usage up to the allocated amount.
-  CreditUsage get_credit_usage(CreditUsage::UpdateType update_type,
-    SessionCreditUpdateCriteria& uc, bool is_terminate);
+  // usage, otherwise we only include unreported usage up to the allocated
+  // amount.
+  CreditUsage get_credit_usage(
+      CreditUsage::UpdateType update_type, SessionCreditUpdateCriteria& uc,
+      bool is_terminate);
 
-  // get_requested_units returns total, tx and rx needed to cover one worth of grant
+  // get_requested_units returns total, tx and rx needed to cover one worth of
+  // grant
   RequestedUnits get_requested_units();
 
   // Return true if the service needs to be deactivated
@@ -79,17 +86,20 @@ struct ChargingGrant {
 
   // Convert FinalAction enum to ServiceActionType
   ServiceActionType final_action_to_action(
-    const ChargingCredit_FinalAction action) const;
+      const ChargingCredit_FinalAction action) const;
 
   // Set is_final_grant and final_action_info values
   void set_final_action_info(
-    const magma::lte::ChargingCredit& credit, SessionCreditUpdateCriteria& uc);
+      const magma::lte::ChargingCredit& credit,
+      SessionCreditUpdateCriteria& uc);
 
   // Set the object and update criteria's reauth state to new_state.
-  void set_reauth_state(const ReAuthState new_state, SessionCreditUpdateCriteria &uc);
+  void set_reauth_state(
+      const ReAuthState new_state, SessionCreditUpdateCriteria& uc);
 
   // Set the object and update criteria's service state to new_state.
-  void set_service_state(const ServiceState new_service_state, SessionCreditUpdateCriteria &uc);
+  void set_service_state(
+      const ServiceState new_service_state, SessionCreditUpdateCriteria& uc);
 
   // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
   // and assign it to expiry_time

--- a/lte/gateway/c/session_manager/Monitor.h
+++ b/lte/gateway/c/session_manager/Monitor.h
@@ -44,8 +44,24 @@ struct Monitor {
     return marshaled;
   }
 
+  // Monitor will be deleted when the credit is exhausted and no more grants are received
+  // or when we receive the explicit action
   bool should_delete_monitor(){
     return credit.current_grant_contains_zero() && credit.is_quota_exhausted(1);
+  }
+
+  bool shoould_send_update(){
+    // update trigger by being the final report
+    if (credit.get_last_update()){
+      return true;
+    }
+    // updated trigger due to usage threshold (80%)
+    if (!credit.current_grant_contains_zero() &&
+        credit.is_quota_exhausted(SessionCredit::USAGE_REPORTING_THRESHOLD)){
+      // if grant contains zeros that means we are in final. Do no report
+      return true;
+    }
+    return false;
   }
 };
 

--- a/lte/gateway/c/session_manager/Monitor.h
+++ b/lte/gateway/c/session_manager/Monitor.h
@@ -31,33 +31,33 @@ struct Monitor {
 
   Monitor() {}
 
-  Monitor(const StoredMonitor &marshaled) {
+  Monitor(const StoredMonitor& marshaled) {
     credit = SessionCredit(marshaled.credit);
-    level = marshaled.level;
+    level  = marshaled.level;
   }
 
   // Marshal into StoredMonitor structure used in SessionStore
   StoredMonitor marshal() {
     StoredMonitor marshaled{};
     marshaled.credit = credit.marshal();
-    marshaled.level = level;
+    marshaled.level  = level;
     return marshaled;
   }
 
-  // Monitor will be deleted when the credit is exhausted and no more grants are received
-  // or when we receive the explicit action
-  bool should_delete_monitor(){
+  // Monitor will be deleted when the credit is exhausted and no more grants are
+  // received or when we receive the explicit action
+  bool should_delete_monitor() {
     return credit.current_grant_contains_zero() && credit.is_quota_exhausted(1);
   }
 
-  bool shoould_send_update(){
+  bool should_send_update() {
     // update trigger by being the final report
-    if (credit.get_last_update()){
+    if (credit.is_report_last_credit()) {
       return true;
     }
     // updated trigger due to usage threshold (80%)
     if (!credit.current_grant_contains_zero() &&
-        credit.is_quota_exhausted(SessionCredit::USAGE_REPORTING_THRESHOLD)){
+        credit.is_quota_exhausted(SessionCredit::USAGE_REPORTING_THRESHOLD)) {
       // if grant contains zeros that means we are in final. Do no report
       return true;
     }

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -34,13 +34,15 @@ SessionCredit::SessionCredit(
     : buckets_{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
       reporting_(false),
       credit_limit_type_(credit_limit_type),
-      grant_tracking_type_(TRACKING_UNSET) {}
+      grant_tracking_type_(TRACKING_UNSET),
+      last_update_(false){}
 
 SessionCredit::SessionCredit(const StoredSessionCredit& marshaled) {
   reporting_              = marshaled.reporting;
   credit_limit_type_      = marshaled.credit_limit_type;
   grant_tracking_type_    = marshaled.grant_tracking_type;
   received_granted_units_ = marshaled.received_granted_units;
+  last_update_            = marshaled.last_update;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
@@ -56,6 +58,7 @@ StoredSessionCredit SessionCredit::marshal() {
   marshaled.credit_limit_type      = credit_limit_type_;
   marshaled.grant_tracking_type    = grant_tracking_type_;
   marshaled.received_granted_units = received_granted_units_;
+  marshaled.last_update            = last_update_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket             = static_cast<Bucket>(bucket_int);
@@ -69,6 +72,7 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
   uc.deleted                = false;
   uc.grant_tracking_type    = grant_tracking_type_;
   uc.received_granted_units = received_granted_units_;
+  uc.last_update            = last_update_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket            = static_cast<Bucket>(bucket_int);
@@ -459,6 +463,15 @@ void SessionCredit::set_received_granted_units(
     GrantedUnits& rgu, SessionCreditUpdateCriteria& uc) {
   received_granted_units_   = rgu;
   uc.received_granted_units = rgu;
+}
+
+void SessionCredit::set_last_update(bool last_update, SessionCreditUpdateCriteria& uc){
+  last_update_ = last_update;
+  uc.last_update = last_update;
+}
+
+bool SessionCredit::get_last_update() {
+  return last_update_;
 }
 
 void SessionCredit::add_credit(

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -35,14 +35,14 @@ SessionCredit::SessionCredit(
       reporting_(false),
       credit_limit_type_(credit_limit_type),
       grant_tracking_type_(TRACKING_UNSET),
-      last_update_(false){}
+      report_last_credit_(false) {}
 
 SessionCredit::SessionCredit(const StoredSessionCredit& marshaled) {
   reporting_              = marshaled.reporting;
   credit_limit_type_      = marshaled.credit_limit_type;
   grant_tracking_type_    = marshaled.grant_tracking_type;
   received_granted_units_ = marshaled.received_granted_units;
-  last_update_            = marshaled.last_update;
+  report_last_credit_     = marshaled.report_last_credit;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
@@ -58,7 +58,7 @@ StoredSessionCredit SessionCredit::marshal() {
   marshaled.credit_limit_type      = credit_limit_type_;
   marshaled.grant_tracking_type    = grant_tracking_type_;
   marshaled.received_granted_units = received_granted_units_;
-  marshaled.last_update            = last_update_;
+  marshaled.report_last_credit     = report_last_credit_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket             = static_cast<Bucket>(bucket_int);
@@ -72,7 +72,7 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
   uc.deleted                = false;
   uc.grant_tracking_type    = grant_tracking_type_;
   uc.received_granted_units = received_granted_units_;
-  uc.last_update            = last_update_;
+  uc.report_last_credit     = report_last_credit_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket            = static_cast<Bucket>(bucket_int);
@@ -122,19 +122,19 @@ void SessionCredit::receive_credit(
   if (grant_tracking_type_ == TRACKING_UNSET) {
     grant_tracking_type_ = determine_grant_tracking_type(gsu);
   }
-  received_granted_units_ = gsu;
+  received_granted_units_    = gsu;
   uint64_t bucket_used_total = buckets_[USED_TX] + buckets_[USED_RX];
 
   // Floor represent the previous value of ALLOWED counters before grant is
   // applied They will only be updated if a valid grant is received
-  // In case we have overused (used > allowed) we will reset allowed_floor to used
-  uint64_t delta_allowed_floor_total =
-      calculate_delta_allowed_floor(gsu.total(),
-             ALLOWED_TOTAL, ALLOWED_FLOOR_TOTAL, bucket_used_total);
-  uint64_t delta_allowed_floor_tx = calculate_delta_allowed_floor(gsu.total(),
-             ALLOWED_TX, ALLOWED_FLOOR_TX,buckets_[USED_TX]);
-  uint64_t delta_allowed_floor_rx = calculate_delta_allowed_floor(gsu.total(),
-             ALLOWED_RX, ALLOWED_FLOOR_RX,buckets_[USED_RX]);
+  // In case we have overused (used > allowed) we will reset allowed_floor to
+  // used
+  uint64_t delta_allowed_floor_total = calculate_delta_allowed_floor(
+      gsu.total(), ALLOWED_TOTAL, ALLOWED_FLOOR_TOTAL, bucket_used_total);
+  uint64_t delta_allowed_floor_tx = calculate_delta_allowed_floor(
+      gsu.total(), ALLOWED_TX, ALLOWED_FLOOR_TX, buckets_[USED_TX]);
+  uint64_t delta_allowed_floor_rx = calculate_delta_allowed_floor(
+      gsu.total(), ALLOWED_RX, ALLOWED_FLOOR_RX, buckets_[USED_RX]);
 
   buckets_[ALLOWED_FLOOR_TOTAL] += delta_allowed_floor_total;
   buckets_[ALLOWED_FLOOR_TX] += delta_allowed_floor_tx;
@@ -145,13 +145,14 @@ void SessionCredit::receive_credit(
   uint64_t tx_volume    = gsu.tx().is_valid() ? gsu.tx().volume() : 0;
   uint64_t rx_volume    = gsu.rx().is_valid() ? gsu.rx().volume() : 0;
 
-  // in case we have overused (used > allowed) we will reset allowed to used + gsu_volume
+  // in case we have overused (used > allowed) we will reset allowed to used +
+  // gsu_volume
   uint64_t delta_allowed_total =
-      calculate_delta_allowed(total_volume,ALLOWED_TOTAL, bucket_used_total);
+      calculate_delta_allowed(total_volume, ALLOWED_TOTAL, bucket_used_total);
   uint64_t delta_allowed_tx =
-      calculate_delta_allowed(tx_volume,ALLOWED_TX, buckets_[USED_TX]);
+      calculate_delta_allowed(tx_volume, ALLOWED_TX, buckets_[USED_TX]);
   uint64_t delta_allowed_rx =
-      calculate_delta_allowed(rx_volume,ALLOWED_RX, buckets_[USED_RX]);
+      calculate_delta_allowed(rx_volume, ALLOWED_RX, buckets_[USED_RX]);
 
   // Update allowed bytes
   buckets_[ALLOWED_TOTAL] += delta_allowed_total;
@@ -214,8 +215,8 @@ uint64_t SessionCredit::calculate_delta_allowed_floor(
   }
 }
 
-uint64_t SessionCredit::calculate_delta_allowed(uint64_t gsu_volume,
-                                                Bucket allowed, uint64_t volume_used) {
+uint64_t SessionCredit::calculate_delta_allowed(
+    uint64_t gsu_volume, Bucket allowed, uint64_t volume_used) {
   if (volume_used > buckets_[allowed]) {
     // if we overused and received a grant that means that credit was already
     // counted.
@@ -276,7 +277,8 @@ bool SessionCredit::is_quota_exhausted(float threshold) const {
                    << " grant is totally exhausted";
     } else {
       MLOG(MDEBUG) << grant_type_to_str(grant_tracking_type_)
-                   << " grant is partially exhausted (threshold " << threshold << ")";
+                   << " grant is partially exhausted (threshold " << threshold
+                   << ")";
     }
   }
   return is_exhausted;
@@ -310,19 +312,19 @@ SessionCredit::Usage SessionCredit::get_usage_for_reporting(
 
 RequestedUnits SessionCredit::get_requested_credits_units() {
   RequestedUnits requestedUnits;
-  uint64_t buckets_used_total =buckets_[USED_TX] + buckets_[USED_RX];
+  uint64_t buckets_used_total = buckets_[USED_TX] + buckets_[USED_RX];
 
   uint64_t total_requested = calculate_requested_unit(
-      received_granted_units_.total(),
-      ALLOWED_TOTAL, ALLOWED_FLOOR_TOTAL, buckets_used_total);
+      received_granted_units_.total(), ALLOWED_TOTAL, ALLOWED_FLOOR_TOTAL,
+      buckets_used_total);
 
   uint64_t tx_requested = calculate_requested_unit(
-      received_granted_units_.tx(),
-      ALLOWED_TX, ALLOWED_FLOOR_TX, buckets_[USED_TX]);
+      received_granted_units_.tx(), ALLOWED_TX, ALLOWED_FLOOR_TX,
+      buckets_[USED_TX]);
 
   uint64_t rx_requested = calculate_requested_unit(
-      received_granted_units_.rx(),
-      ALLOWED_RX, ALLOWED_FLOOR_RX, buckets_[USED_RX]);
+      received_granted_units_.rx(), ALLOWED_RX, ALLOWED_FLOOR_RX,
+      buckets_[USED_RX]);
 
   requestedUnits.set_total(total_requested);
   requestedUnits.set_tx(tx_requested);
@@ -334,14 +336,15 @@ RequestedUnits SessionCredit::get_requested_credits_units() {
 // returns either the last grant, or the difference between the last grant
 // and the credit remaining. Prevents over requesting in case we still have
 // credit available from the previous request
-uint64_t SessionCredit:: calculate_requested_unit(
-    CreditUnit cu, Bucket allowed,Bucket allowed_floor, uint64_t used){
-  if (cu.is_valid() == false){
+uint64_t SessionCredit::calculate_requested_unit(
+    CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used) {
+  if (cu.is_valid() == false) {
     return 0;
   }
   // get the current volume grant, or infer it in case of 0
-  int64_t grant = cu.volume()!=0 ? cu.volume() :
-                                   buckets_[allowed]-buckets_[allowed_floor];
+  int64_t grant = cu.volume() != 0 ?
+                      cu.volume() :
+                      buckets_[allowed] - buckets_[allowed_floor];
   int64_t remaining = buckets_[allowed] - used;
   if (remaining >= 0 && grant >= remaining) {
     // request just partial of a grant since we still have some credit left
@@ -349,7 +352,6 @@ uint64_t SessionCredit:: calculate_requested_unit(
   }
   return grant;
 }
-
 
 // Take the minimum of (grant - reported) and (reported - used)
 void SessionCredit::apply_reporting_limits(SessionCredit::Usage& usage) {
@@ -465,13 +467,14 @@ void SessionCredit::set_received_granted_units(
   uc.received_granted_units = rgu;
 }
 
-void SessionCredit::set_last_update(bool last_update, SessionCreditUpdateCriteria& uc){
-  last_update_ = last_update;
-  uc.last_update = last_update;
+void SessionCredit::set_report_last_credit(
+    bool report_last_credit, SessionCreditUpdateCriteria& uc) {
+  report_last_credit_ = report_last_credit;
+  uc.report_last_credit = report_last_credit;
 }
 
-bool SessionCredit::get_last_update() {
-  return last_update_;
+bool SessionCredit::is_report_last_credit() {
+  return report_last_credit_;
 }
 
 void SessionCredit::add_credit(
@@ -484,9 +487,9 @@ void SessionCredit::add_credit(
 // Determine the grant's tracking type by looking at which values are valid.
 GrantTrackingType SessionCredit::determine_grant_tracking_type(
     const GrantedUnits& grant) {
-  bool total_valid = grant.total().is_valid() && grant.total().volume() !=0;
-  bool tx_valid    = grant.tx().is_valid() && grant.tx().volume() !=0;
-  bool rx_valid    = grant.rx().is_valid() && grant.rx().volume() !=0;
+  bool total_valid = grant.total().is_valid() && grant.total().volume() != 0;
+  bool tx_valid    = grant.tx().is_valid() && grant.tx().volume() != 0;
+  bool rx_valid    = grant.rx().is_valid() && grant.rx().volume() != 0;
 
   if (total_valid && tx_valid && rx_valid) {
     return ALL_TOTAL_TX_RX;
@@ -512,10 +515,9 @@ bool SessionCredit::current_grant_contains_zero() const {
     case ALL_TOTAL_TX_RX:
       // Monitors should not have this mode enabled
       MLOG(MWARNING) << "Possible monitor with ALL_TOTAL_TX_RX enabled";
-      return
-          is_received_grented_unit_zero(received_granted_units_.total()) ||
-          is_received_grented_unit_zero(received_granted_units_.tx()) ||
-          is_received_grented_unit_zero(received_granted_units_.rx());
+      return is_received_grented_unit_zero(received_granted_units_.total()) ||
+             is_received_grented_unit_zero(received_granted_units_.tx()) ||
+             is_received_grented_unit_zero(received_granted_units_.rx());
       break;
     case RX_ONLY:
       return is_received_grented_unit_zero(received_granted_units_.rx());
@@ -524,8 +526,7 @@ bool SessionCredit::current_grant_contains_zero() const {
       return is_received_grented_unit_zero(received_granted_units_.tx());
       break;
     case TX_AND_RX:
-      return
-             is_received_grented_unit_zero(received_granted_units_.tx()) ||
+      return is_received_grented_unit_zero(received_granted_units_.tx()) ||
              is_received_grented_unit_zero(received_granted_units_.rx());
       break;
     case TOTAL_ONLY:
@@ -540,15 +541,15 @@ bool SessionCredit::current_grant_contains_zero() const {
   }
 }
 
-bool SessionCredit::is_received_grented_unit_zero(const CreditUnit& cu) const{
-  if (!cu.is_valid() || cu.volume() == 0){
+bool SessionCredit::is_received_grented_unit_zero(const CreditUnit& cu) const {
+  if (!cu.is_valid() || cu.volume() == 0) {
     return true;
   }
   return false;
 }
 
 void SessionCredit::log_quota_and_usage() const {
-  if (magma::get_verbosity() != MDEBUG){
+  if (magma::get_verbosity() != MDEBUG) {
     return;
   }
   MLOG(MDEBUG) << "===> Used     Tx: " << buckets_[USED_TX]
@@ -563,12 +564,18 @@ void SessionCredit::log_quota_and_usage() const {
   MLOG(MDEBUG) << "===> A_Floor  Tx: " << buckets_[ALLOWED_FLOOR_TX]
                << " Rx: " << buckets_[ALLOWED_FLOOR_RX]
                << " Total: " << buckets_[ALLOWED_FLOOR_TOTAL];
-  MLOG(MDEBUG) << "===> (%used)  Tx: " << get_percentage_usage(
-          buckets_[ALLOWED_TX], buckets_[ALLOWED_FLOOR_TX], buckets_[USED_TX])
-               << " Rx: " << get_percentage_usage(
-          buckets_[ALLOWED_RX], buckets_[ALLOWED_FLOOR_RX], buckets_[USED_RX])
-               << " Total: " << get_percentage_usage(
-          buckets_[ALLOWED_TOTAL], buckets_[ALLOWED_FLOOR_TOTAL], buckets_[USED_TX]+buckets_[USED_RX]);
+  MLOG(MDEBUG) << "===> (%used)  Tx: "
+               << get_percentage_usage(
+                      buckets_[ALLOWED_TX], buckets_[ALLOWED_FLOOR_TX],
+                      buckets_[USED_TX])
+               << " Rx: "
+               << get_percentage_usage(
+                      buckets_[ALLOWED_RX], buckets_[ALLOWED_FLOOR_RX],
+                      buckets_[USED_RX])
+               << " Total: "
+               << get_percentage_usage(
+                      buckets_[ALLOWED_TOTAL], buckets_[ALLOWED_FLOOR_TOTAL],
+                      buckets_[USED_TX] + buckets_[USED_RX]);
 
   MLOG(MDEBUG) << "===> Grant tracking type "
                << grant_type_to_str(grant_tracking_type_)
@@ -577,26 +584,27 @@ void SessionCredit::log_quota_and_usage() const {
 
   MLOG(MDEBUG) << "===> Last Granted Units Received (tx/rx/total) "
                << received_granted_units_.tx().volume() << "/"
-               << received_granted_units_.rx().volume()<< "/"
+               << received_granted_units_.rx().volume() << "/"
                << received_granted_units_.total().volume();
 }
 
-std::string SessionCredit::get_percentage_usage(uint64_t allowed, uint64_t floor, uint64_t used) const {
+std::string SessionCredit::get_percentage_usage(
+    uint64_t allowed, uint64_t floor, uint64_t used) const {
   if (allowed <= floor) {
     return "_%";
   }
   int64_t currentGrant = allowed - floor;
   int64_t currentUsage = used - floor;
-  int currentPercent = int(100*currentUsage/currentGrant);
+  int currentPercent   = int(100 * currentUsage / currentGrant);
   // cap % in case it grows too much
-  if(abs(currentPercent) >=1000){
-    currentPercent = 999*currentPercent/abs(currentPercent);
+  if (abs(currentPercent) >= 1000) {
+    currentPercent = 999 * currentPercent / abs(currentPercent);
   }
-  return std::to_string(currentPercent) +"%";
+  return std::to_string(currentPercent) + "%";
 }
 
 void SessionCredit::log_usage_report(SessionCredit::Usage usage) const {
-  if (magma::get_verbosity() != MDEBUG){
+  if (magma::get_verbosity() != MDEBUG) {
     return;
   }
   MLOG(MDEBUG) << "===> Amount reporting for this report:"

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -35,7 +35,7 @@ class SessionCredit {
 
   SessionCredit(ServiceState start_state, CreditLimitType limit_type);
 
-  SessionCredit(const StoredSessionCredit &marshaled);
+  SessionCredit(const StoredSessionCredit& marshaled);
 
   StoredSessionCredit marshal();
 
@@ -103,9 +103,9 @@ class SessionCredit {
   void set_received_granted_units(
       GrantedUnits& rgu, SessionCreditUpdateCriteria& uc);
 
-  void set_last_update(bool last_update, SessionCreditUpdateCriteria& uc);
+  void set_report_last_credit(bool report_last_credit, SessionCreditUpdateCriteria& uc);
 
-  bool get_last_update();
+  bool is_report_last_credit();
 
   /**
    * Add credit to the specified bucket. This does not necessarily correspond
@@ -137,7 +137,6 @@ class SessionCredit {
    */
   bool is_quota_exhausted(float usage_reporting_threshold) const;
 
-
   bool current_grant_contains_zero() const;
 
   /**
@@ -163,12 +162,13 @@ class SessionCredit {
   GrantTrackingType grant_tracking_type_;
   // stores the granted credits we received the last
   GrantedUnits received_granted_units_;
-  bool last_update_;
+  bool report_last_credit_;
 
  private:
   void log_quota_and_usage() const;
 
-  std::string get_percentage_usage(uint64_t allowed, uint64_t floor, uint64_t used) const;
+  std::string get_percentage_usage(
+      uint64_t allowed, uint64_t floor, uint64_t used) const;
 
   bool is_received_grented_unit_zero(const CreditUnit& cu) const;
 
@@ -178,7 +178,8 @@ class SessionCredit {
 
   GrantTrackingType determine_grant_tracking_type(const GrantedUnits& grant);
 
-  uint64_t  calculate_requested_unit(CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used);
+  uint64_t calculate_requested_unit(
+      CreditUnit cu, Bucket allowed, Bucket allowed_floor, uint64_t used);
 
   bool compute_quota_exhausted(
       const uint64_t allowed, const uint64_t used, float threshold_ratio,
@@ -189,11 +190,11 @@ class SessionCredit {
 
   void apply_reporting_limits(SessionCredit::Usage& usage);
 
-  uint64_t calculate_delta_allowed_floor(CreditUnit cu,
-                           Bucket allowed, Bucket floor, uint64_t volume_used);
+  uint64_t calculate_delta_allowed_floor(
+      CreditUnit cu, Bucket allowed, Bucket floor, uint64_t volume_used);
 
-  uint64_t calculate_delta_allowed(uint64_t gsu_volume,
-                           Bucket allowed, uint64_t volume_used);
+  uint64_t calculate_delta_allowed(
+      uint64_t gsu_volume, Bucket allowed, uint64_t volume_used);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -103,6 +103,10 @@ class SessionCredit {
   void set_received_granted_units(
       GrantedUnits& rgu, SessionCreditUpdateCriteria& uc);
 
+  void set_last_update(bool last_update, SessionCreditUpdateCriteria& uc);
+
+  bool get_last_update();
+
   /**
    * Add credit to the specified bucket. This does not necessarily correspond
    * to allowed or used credit.
@@ -159,6 +163,7 @@ class SessionCredit {
   GrantTrackingType grant_tracking_type_;
   // stores the granted credits we received the last
   GrantedUnits received_granted_units_;
+  bool last_update_;
 
  private:
   void log_quota_and_usage() const;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -119,8 +119,9 @@ class SessionState {
   /**
    * add_rule_usage adds used TX/RX bytes to a particular rule
    */
-  void add_rule_usage( const std::string& rule_id, uint64_t used_tx,
-    uint64_t used_rx, SessionStateUpdateCriteria& update_criteria);
+  void add_rule_usage(
+      const std::string& rule_id, uint64_t used_tx, uint64_t used_rx,
+      SessionStateUpdateCriteria& update_criteria);
 
   /**
    * get_updates collects updates and adds them to a UpdateSessionRequest
@@ -164,18 +165,21 @@ class SessionState {
    *         a success. Also it must either be an infinite credit rating group,
    *         or have associated credit grant.
    */
-  bool receive_charging_credit(const CreditUpdateResponse &update,
-                               SessionStateUpdateCriteria &update_criteria);
+  bool receive_charging_credit(
+      const CreditUpdateResponse& update,
+      SessionStateUpdateCriteria& update_criteria);
 
-  uint64_t get_charging_credit(const CreditKey &key, Bucket bucket) const;
+  uint64_t get_charging_credit(const CreditKey& key, Bucket bucket) const;
 
-  ReAuthResult reauth_key(const CreditKey &charging_key,
-                               SessionStateUpdateCriteria &update_criteria);
+  ReAuthResult reauth_key(
+      const CreditKey& charging_key,
+      SessionStateUpdateCriteria& update_criteria);
 
-  ReAuthResult reauth_all(SessionStateUpdateCriteria &update_criteria);
+  ReAuthResult reauth_all(SessionStateUpdateCriteria& update_criteria);
 
-  void set_charging_credit(const CreditKey &key,
-    ChargingGrant charging_grant, SessionStateUpdateCriteria &uc);
+  void set_charging_credit(
+      const CreditKey& key, ChargingGrant charging_grant,
+      SessionStateUpdateCriteria& uc);
 
   /**
    * get_total_credit_usage returns the tx and rx of the session,
@@ -271,7 +275,7 @@ class SessionState {
       SessionStateUpdateCriteria& update_criteria);
 
   bool remove_gy_dynamic_rule(
-      const std::string& rule_id, PolicyRule *rule_out,
+      const std::string& rule_id, PolicyRule* rule_out,
       SessionStateUpdateCriteria& update_criteria);
 
   /**
@@ -285,7 +289,6 @@ class SessionState {
    */
   bool deactivate_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
-
 
   bool deactivate_scheduled_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
@@ -334,54 +337,58 @@ class SessionState {
 
   uint32_t get_credit_key_count();
 
-  void set_fsm_state(
-    SessionFsmState new_state, SessionStateUpdateCriteria& uc);
+  void set_fsm_state(SessionFsmState new_state, SessionStateUpdateCriteria& uc);
 
   StaticRuleInstall get_static_rule_install(
-    const std::string& rule_id, const RuleLifetime& lifetime);
+      const std::string& rule_id, const RuleLifetime& lifetime);
 
   DynamicRuleInstall get_dynamic_rule_install(
-    const std::string& rule_id, const RuleLifetime& lifetime);
+      const std::string& rule_id, const RuleLifetime& lifetime);
 
   SessionFsmState get_state();
 
   // Event Triggers
   void add_new_event_trigger(
-  magma::lte::EventTrigger trigger,
-  SessionStateUpdateCriteria& update_criteria);
+      magma::lte::EventTrigger trigger,
+      SessionStateUpdateCriteria& update_criteria);
 
   void mark_event_trigger_as_triggered(
-    magma::lte::EventTrigger trigger,
-    SessionStateUpdateCriteria& update_criteria);
+      magma::lte::EventTrigger trigger,
+      SessionStateUpdateCriteria& update_criteria);
 
   void set_event_trigger(
-    magma::lte::EventTrigger trigger, const EventTriggerState value,
-    SessionStateUpdateCriteria& update_criteria);
+      magma::lte::EventTrigger trigger, const EventTriggerState value,
+      SessionStateUpdateCriteria& update_criteria);
 
-  void remove_event_trigger(magma::lte::EventTrigger trigger,
-    SessionStateUpdateCriteria& update_criteria);
+  void remove_event_trigger(
+      magma::lte::EventTrigger trigger,
+      SessionStateUpdateCriteria& update_criteria);
 
-  void set_revalidation_time(const google::protobuf::Timestamp& time,
-                             SessionStateUpdateCriteria& update_criteria);
+  void set_revalidation_time(
+      const google::protobuf::Timestamp& time,
+      SessionStateUpdateCriteria& update_criteria);
 
-  google::protobuf::Timestamp get_revalidation_time() {return revalidation_time_;}
+  google::protobuf::Timestamp get_revalidation_time() {
+    return revalidation_time_;
+  }
 
-  EventTriggerStatus get_event_triggers() {return pending_event_triggers_;}
+  EventTriggerStatus get_event_triggers() { return pending_event_triggers_; }
 
-  bool is_credit_in_final_unit_state(const CreditKey &charging_key) const;
+  bool is_credit_in_final_unit_state(const CreditKey& charging_key) const;
 
   void get_final_action_restrict_rules(
-      const CreditKey &charging_key,
-      std::vector<std::string> &restrict_rules);
+      const CreditKey& charging_key, std::vector<std::string>& restrict_rules);
 
   // Monitors
-  bool receive_monitor(const UsageMonitoringUpdateResponse &update,
-                       SessionStateUpdateCriteria & session_uc);
+  bool receive_monitor(
+      const UsageMonitoringUpdateResponse& update,
+      SessionStateUpdateCriteria& session_uc);
 
-  uint64_t get_monitor(const std::string &key, Bucket bucket) const;
+  uint64_t get_monitor(const std::string& key, Bucket bucket) const;
 
-  bool add_to_monitor(const std::string &key, uint64_t used_tx,
-                      uint64_t used_rx, SessionStateUpdateCriteria &uc);
+  bool add_to_monitor(
+      const std::string& key, uint64_t used_tx, uint64_t used_rx,
+      SessionStateUpdateCriteria& uc);
 
   void set_monitor(
       const std::string& key, Monitor monitor, SessionStateUpdateCriteria& uc);
@@ -499,7 +506,7 @@ class SessionState {
       SessionStateUpdateCriteria& uc);
 
   void apply_charging_credit_update(
-      const CreditKey &key, SessionCreditUpdateCriteria & credit_uc);
+      const CreditKey& key, SessionCreditUpdateCriteria& credit_uc);
 
   /**
    * Receive the credit grant if the credit update was successful
@@ -512,7 +519,7 @@ class SessionState {
    *         or have associated credit grant.
    */
   bool init_charging_credit(
-    const CreditUpdateResponse &update, SessionStateUpdateCriteria &uc);
+      const CreditUpdateResponse& update, SessionStateUpdateCriteria& uc);
 
   /**
    * Return true if any credit unit is valid and has non-zero volume
@@ -539,11 +546,12 @@ class SessionState {
    * @param key : monitoring key for the update
    * @param update : the diff that needs to be applied
    */
-  void apply_monitor_updates(const std::string& key,
-                             SessionStateUpdateCriteria& session_uc,
-                             SessionCreditUpdateCriteria& credit_uc);
+  void apply_monitor_updates(
+      const std::string& key, SessionStateUpdateCriteria& session_uc,
+      SessionCreditUpdateCriteria& credit_uc);
 
-  void add_common_fields_to_usage_monitor_update(UsageMonitoringUpdateRequest* req);
+  void add_common_fields_to_usage_monitor_update(
+      UsageMonitoringUpdateRequest* req);
 
   /**
    * Returns true if the specified rule should be active at that time
@@ -556,20 +564,20 @@ class SessionState {
   bool should_rule_be_deactivated(const std::string& rule_id, std::time_t time);
 
   SessionCreditUpdateCriteria* get_credit_uc(
-    const CreditKey &key, SessionStateUpdateCriteria &uc);
+      const CreditKey& key, SessionStateUpdateCriteria& uc);
 
   CreditUsageUpdate make_credit_usage_update_req(CreditUsage& usage) const;
 
   bool init_new_monitor(
-    const UsageMonitoringUpdateResponse &update,
-    SessionStateUpdateCriteria &update_criteria);
+      const UsageMonitoringUpdateResponse& update,
+      SessionStateUpdateCriteria& update_criteria);
 
   void update_session_level_key(
-    const UsageMonitoringUpdateResponse &update,
-    SessionStateUpdateCriteria &update_criteria);
+      const UsageMonitoringUpdateResponse& update,
+      SessionStateUpdateCriteria& update_criteria);
 
   SessionCreditUpdateCriteria* get_monitor_uc(
-    const std::string &key, SessionStateUpdateCriteria &uc);
+      const std::string& key, SessionStateUpdateCriteria& uc);
 
   void fill_protos_tgpp_context(magma::lte::TgppContext* tgpp_context) const;
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -376,7 +376,7 @@ class SessionState {
 
   // Monitors
   bool receive_monitor(const UsageMonitoringUpdateResponse &update,
-                       SessionStateUpdateCriteria &uc);
+                       SessionStateUpdateCriteria & session_uc);
 
   uint64_t get_monitor(const std::string &key, Bucket bucket) const;
 
@@ -499,7 +499,7 @@ class SessionState {
       SessionStateUpdateCriteria& uc);
 
   void apply_charging_credit_update(
-      const CreditKey &key, SessionCreditUpdateCriteria &credit_update);
+      const CreditKey &key, SessionCreditUpdateCriteria & credit_uc);
 
   /**
    * Receive the credit grant if the credit update was successful
@@ -539,8 +539,9 @@ class SessionState {
    * @param key : monitoring key for the update
    * @param update : the diff that needs to be applied
    */
-  void apply_monitor_updates(
-      const std::string &key, SessionCreditUpdateCriteria &update);
+  void apply_monitor_updates(const std::string& key,
+                             SessionStateUpdateCriteria& session_uc,
+                             SessionCreditUpdateCriteria& credit_uc);
 
   void add_common_fields_to_usage_monitor_update(UsageMonitoringUpdateRequest* req);
 

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -171,7 +171,7 @@ std::string serialize_stored_session_credit(StoredSessionCredit& stored) {
       static_cast<int>(stored.grant_tracking_type);
   marshaled["received_granted_units"] =
       stored.received_granted_units.SerializeAsString();
-  marshaled["last_update"] = stored.last_update;
+  marshaled["report_last_credit"] = stored.report_last_credit;
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
     marshaled["buckets"][std::to_string(bucket_int)] =
@@ -197,7 +197,7 @@ StoredSessionCredit deserialize_stored_session_credit(
   GrantedUnits received_granted_units;
   received_granted_units.ParseFromString(marshaled["received_granted_units"].getString());
   stored.received_granted_units = received_granted_units;
-  stored.last_update = marshaled["last_update"].getBool();
+  stored.report_last_credit     = marshaled["report_last_credit"].getBool();
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket          = static_cast<Bucket>(bucket_int);

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -171,6 +171,7 @@ std::string serialize_stored_session_credit(StoredSessionCredit& stored) {
       static_cast<int>(stored.grant_tracking_type);
   marshaled["received_granted_units"] =
       stored.received_granted_units.SerializeAsString();
+  marshaled["last_update"] = stored.last_update;
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
     marshaled["buckets"][std::to_string(bucket_int)] =
@@ -196,6 +197,7 @@ StoredSessionCredit deserialize_stored_session_credit(
   GrantedUnits received_granted_units;
   received_granted_units.ParseFromString(marshaled["received_granted_units"].getString());
   stored.received_granted_units = received_granted_units;
+  stored.last_update = marshaled["last_update"].getBool();
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket          = static_cast<Bucket>(bucket_int);

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -138,7 +138,7 @@ struct StoredSessionCredit {
   std::unordered_map<Bucket, uint64_t> buckets;
   GrantTrackingType grant_tracking_type;
   GrantedUnits received_granted_units;
-  bool last_update;
+  bool report_last_credit;
 };
 
 struct StoredMonitor {
@@ -237,7 +237,7 @@ struct SessionCreditUpdateCriteria {
   std::unordered_map<Bucket, uint64_t> bucket_deltas;
 
   bool deleted;
-  bool last_update;
+  bool report_last_credit;
 };
 
 struct SessionStateUpdateCriteria {

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -138,6 +138,7 @@ struct StoredSessionCredit {
   std::unordered_map<Bucket, uint64_t> buckets;
   GrantTrackingType grant_tracking_type;
   GrantedUnits received_granted_units;
+  bool last_update;
 };
 
 struct StoredMonitor {
@@ -236,6 +237,7 @@ struct SessionCreditUpdateCriteria {
   std::unordered_map<Bucket, uint64_t> bucket_deltas;
 
   bool deleted;
+  bool last_update;
 };
 
 struct SessionStateUpdateCriteria {

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1474,9 +1474,9 @@ TEST_F(LocalEnforcerTest, test_usage_monitor_disable) {
   update_2 = SessionStore::get_default_session_update(session_map);
   local_enforcer->aggregate_records(session_map, table_2, update_2);
   monitor_updates_2 = update_2[IMSI1][SESSION_ID_1].monitor_credit_map;
-  EXPECT_FALSE(monitor_updates_2["1"].last_update);
-  EXPECT_TRUE(monitor_updates_2["2"].last_update);
-  EXPECT_TRUE(monitor_updates_2["3"].last_update);
+  EXPECT_FALSE(monitor_updates_2["1"].report_last_credit);
+  EXPECT_TRUE(monitor_updates_2["2"].report_last_credit);
+  EXPECT_TRUE(monitor_updates_2["3"].report_last_credit);
   // check session level key will be removed
   EXPECT_EQ(update_2[IMSI1][SESSION_ID_1].updated_session_level_key, "");
 

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -399,7 +399,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   session_state->add_rule_usage("rule1", 1001, 1, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 6001);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2001);
-  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].last_update);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
 
   // check final update will be sent
   UpdateSessionRequest update_2;
@@ -954,7 +954,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
-  EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].last_update);
+  EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].report_last_credit);
   EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].deleted);
 
   // receive a grant with total = 0 (meaning there is no more cuota left and monitor
@@ -965,7 +965,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 4000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2000);
-  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].last_update);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
   EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].deleted);
 
   // Get the updates that will be sent to core
@@ -977,7 +977,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   EXPECT_EQ(update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_TX], 4000);
   EXPECT_EQ(update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 2000);
   EXPECT_EQ(update_criteria.monitor_credit_map["m1"].service_state, SERVICE_ENABLED);
-  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].last_update);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].deleted);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].reporting);
 

--- a/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
+++ b/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
@@ -49,25 +49,44 @@ TEST_F(SessionStateTest, test_remove_monitor) {
   EXPECT_EQ(update_criteria.static_rules_to_install.size(), 0);
   insert_rule(0, "m1", "rule1", STATIC, 0, 0);
 
-  receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
-  EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1024);
+  receive_credit_from_pcrf("m1", 1000, MonitoringLevel::PCC_RULE_LEVEL);
+  EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1000);
   EXPECT_EQ(
       update_criteria.monitor_credit_to_install["m1"]
           .credit.buckets[ALLOWED_TOTAL],
-      1024);
+      1000);
+
+  session_state->add_rule_usage("rule1", 1000, 0, update_criteria);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1000);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
 
   // UsageMonitorResponse with 0 credit will mark the monitor to be DISABLED
   receive_credit_from_pcrf("m1", 0, MonitoringLevel::PCC_RULE_LEVEL);
 
   update_criteria = get_default_update_criteria();
-  // add usage to trigger the quota exhaustion
-  session_state->add_rule_usage("rule1", 1024, 0, update_criteria);
-  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1024);
-  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
 
-  // add usage to see that the rule will be deleted due to reporting a value over quota
-  session_state->add_rule_usage("rule1", 1024, 0, update_criteria);
+  // add usage to trigger the quota exhaustion
+  session_state->add_rule_usage("rule1", 1, 0, update_criteria);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1001);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].last_update);
+
+  // check last update will be sent
+  UpdateSessionRequest update;
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  session_state->get_updates(update, &actions, update_criteria);
+  EXPECT_EQ(actions.size(), 0);
+  EXPECT_EQ(update.usage_monitors_size(), 1);
+  auto& single_update = update.usage_monitors(0).update();
+  EXPECT_EQ(single_update.level(), MonitoringLevel::PCC_RULE_LEVEL);
+  EXPECT_EQ(single_update.bytes_tx(), 1001);
+  EXPECT_EQ(single_update.bytes_rx(), 0);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].deleted);
+
+  // check the deletion with apply_update_criteria
+  session_state->apply_update_criteria(update_criteria);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 0);
+  EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
 }
 
 int main(int argc, char** argv) {

--- a/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
+++ b/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
@@ -69,7 +69,7 @@ TEST_F(SessionStateTest, test_remove_monitor) {
   session_state->add_rule_usage("rule1", 1, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1001);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
-  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].last_update);
+  EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
 
   // check last update will be sent
   UpdateSessionRequest update;


### PR DESCRIPTION
…Monitoring-Support AVP)

Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

**NOTE**: check commit 1 since commit 2 has only clang changes
[https://github.com/magma/magma/pull/2863/commits/bd450b7b68991264e8d0afa66534e457754be4a7](https://github.com/magma/magma/pull/2863/commits/bd450b7b68991264e8d0afa66534e457754be4a7)

This PR includes:

1- Monitors are terminated **after** sending a last update: so far the monitors were either terminated before sending last update (last update to the core was never sent) or they were removed after the next credit received (which was leaving a monitor to be deleted in case no more credit was sent). With this PR, we have introduced a `last_update` field on credit object. That field will indicate that the session must report its last update. After that report is sent, then we can terminate (or redirect/reselect...). Note we may need to do the same for Gy (`last_update` field can be used there too since it is at credit level)

2- Implements `Usage-Monitoring-Support AVP` support: now when we receive that AVP, feg will set `UsageMonitoringCredit` as `Disabled` (done on a previous PR).  Sessiond will then terminate the session immediately, no matter the credit

## Test Plan

make test on agw
test on teravm (lots)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
