### PR TITLE
[NMS] Add support for feg_lte networks.

### DIFF
--- a/nms/app/packages/magmalte/app/components/JsonEditor.js
+++ b/nms/app/packages/magmalte/app/components/JsonEditor.js
@@ -15,12 +15,12 @@
  */
 
 import Button from '@material-ui/core/Button';
+import CardTitleRow from './layout/CardTitleRow';
 import FormLabel from '@material-ui/core/FormLabel';
 import Grid from '@material-ui/core/Grid';
 import React from 'react';
 import ReactJson from 'react-json-view';
 import SettingsIcon from '@material-ui/icons/Settings';
-import Text from '@fbcnms/ui/components/design-system/Text';
 
 import {colors, typography} from '../theme/default';
 import {makeStyles} from '@material-ui/styles';
@@ -73,6 +73,7 @@ const useStyles = makeStyles(theme => ({
 type Props<T> = {
   content: T,
   error: string,
+  customFilter?: React$Node,
   onSave: T => Promise<void>,
 };
 
@@ -89,40 +90,46 @@ export default function JsonEditor<T>(props: Props<T>) {
     setContent(data.updated_src);
   };
 
+  const JsonFilter = () => {
+    return (
+      <Grid container alignItems="center">
+        {props.customFilter}
+        <Grid item>
+          <Button
+            className={classes.appBarBtnSecondary}
+            onClick={() => {
+              setContent(props.content);
+              setError('');
+            }}>
+            Clear
+          </Button>
+        </Grid>
+        <Grid item>
+          <Button
+            className={classes.appBarBtn}
+            onClick={() => {
+              try {
+                props.onSave(content);
+              } catch (e) {
+                setError(e.message);
+              }
+            }}>
+            Save
+          </Button>
+        </Grid>
+      </Grid>
+    );
+  };
+
   return (
     <div className={classes.dashboardRoot}>
       <Grid container spacing={3}>
-        <Grid container item xs={12}>
-          <Grid item xs={6}>
-            <Text>
-              <SettingsIcon /> JSON Config
-            </Text>
-          </Grid>
-          <Grid container item justify="flex-end" xs={6}>
-            <Grid item>
-              <Button
-                className={classes.appBarBtnSecondary}
-                onClick={() => {
-                  setContent(props.content);
-                  setError('');
-                }}>
-                Cancel
-              </Button>
-            </Grid>
-            <Grid item>
-              <Button
-                className={classes.appBarBtn}
-                onClick={() => {
-                  try {
-                    props.onSave(content);
-                  } catch (e) {
-                    setError(e.message);
-                  }
-                }}>
-                Save
-              </Button>
-            </Grid>
-          </Grid>
+        <Grid item xs={12}>
+          <CardTitleRow
+            icon={SettingsIcon}
+            label="JSON Config"
+            filter={JsonFilter}
+          />
         </Grid>
 
         <Grid

--- a/nms/app/packages/magmalte/app/components/admin/AddNetworkDialog.js
+++ b/nms/app/packages/magmalte/app/components/admin/AddNetworkDialog.js
@@ -32,7 +32,7 @@ import axios from 'axios';
 
 import nullthrows from '@fbcnms/util/nullthrows';
 import {AllNetworkTypes} from '@fbcnms/types/network';
-import {CWF, FEG} from '@fbcnms/types/network';
+import {CWF, FEG, FEG_LTE} from '@fbcnms/types/network';
 import {makeStyles} from '@material-ui/styles';
 import {useState} from 'react';
 
@@ -121,7 +121,7 @@ export default function NetworkDialog(props: Props) {
             ))}
           </Select>
         </FormControl>
-        {networkType === CWF && (
+        {(networkType === CWF || networkType === FEG_LTE) && (
           <TextField
             name="fegNetworkID"
             label="Federation Network ID"

--- a/nms/app/packages/magmalte/app/components/context/LteNetworkContext.js
+++ b/nms/app/packages/magmalte/app/components/context/LteNetworkContext.js
@@ -14,14 +14,17 @@
  * @format
  */
 'use strict';
-import type {UpdateNetworkProps} from '../../state/lte/NetworkState';
-import type {lte_network} from '@fbcnms/magma-api';
+import type {UpdateNetworkProps as FegLteUpdateNetworkProps} from '../../state/feg_lte/NetworkState';
+import type {UpdateNetworkProps as LteUpdateNetworkProps} from '../../state/lte/NetworkState';
+import type {feg_lte_network, lte_network} from '@fbcnms/magma-api';
 
 import React from 'react';
 
 export type LteNetworkContextType = {
-  state: lte_network,
-  updateNetworks: (props: $Shape<UpdateNetworkProps>) => Promise<void>,
+  state: $Shape<lte_network & feg_lte_network>,
+  updateNetworks: (
+    props: $Shape<LteUpdateNetworkProps & FegLteUpdateNetworkProps>,
+  ) => Promise<void>,
 };
 
 export default React.createContext<LteNetworkContextType>({});

--- a/nms/app/packages/magmalte/app/components/context/PolicyContext.js
+++ b/nms/app/packages/magmalte/app/components/context/PolicyContext.js
@@ -20,7 +20,11 @@ import React from 'react';
 
 export type PolicyContextType = {
   state: {[string]: policy_rule},
-  setState: (key: policy_id, val?: policy_rule) => Promise<void>,
+  setState: (
+    key: policy_id,
+    val?: policy_rule,
+    isNetworkWide?: boolean,
+  ) => Promise<void>,
 };
 
 export default React.createContext<PolicyContextType>({});

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -13,38 +13,11 @@
  * @flow strict-local
  * @format
  */
-import * as React from 'react';
-import ApnContext from '../context/ApnContext';
-import EnodebContext from '../context/EnodebContext';
-import GatewayContext from '../context/GatewayContext';
-import GatewayTierContext from '../context/GatewayTierContext';
-import InitSubscriberState from '../../state/lte/SubscriberState';
-import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
-import LteNetworkContext from '../context/LteNetworkContext';
-import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
-import PolicyContext from '../context/PolicyContext';
-import SubscriberContext from '../context/SubscriberContext';
-
-import {
-  InitEnodeState,
-  InitTierState,
-  SetEnodebState,
-  SetGatewayState,
-  SetTierState,
-  UpdateGateway,
-} from '../../state/lte/EquipmentState';
-import {SetApnState} from '../../state/lte/ApnState';
-import {SetPolicyState} from '../../state/lte/PolicyState';
-import {UpdateNetworkState} from '../../state/lte/NetworkState';
-import {
-  getSubscriberGatewayMap,
-  setSubscriberState,
-} from '../../state/lte/SubscriberState';
-import {useEffect, useState} from 'react';
-import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import type {EnodebInfo} from '../lte/EnodebUtils';
 import type {
   apn,
+  feg_lte_network,
+  feg_network,
   lte_gateway,
   lte_network,
   mutable_subscriber,
@@ -54,6 +27,40 @@ import type {
   subscriber_id,
   tier,
 } from '@fbcnms/magma-api';
+
+import * as React from 'react';
+import ApnContext from '../context/ApnContext';
+import EnodebContext from '../context/EnodebContext';
+import GatewayContext from '../context/GatewayContext';
+import GatewayTierContext from '../context/GatewayTierContext';
+import InitSubscriberState from '../../state/lte/SubscriberState';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import LteNetworkContext from '../context/LteNetworkContext';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import NetworkContext from '../../components/context/NetworkContext';
+import PolicyContext from '../context/PolicyContext';
+import SubscriberContext from '../context/SubscriberContext';
+
+import {FEG_LTE} from '@fbcnms/types/network';
+import {
+  InitEnodeState,
+  InitTierState,
+  SetEnodebState,
+  SetGatewayState,
+  SetTierState,
+  UpdateGateway,
+} from '../../state/lte/EquipmentState';
+import {SetApnState} from '../../state/lte/ApnState';
+import {SetPolicyState} from '../../state/PolicyState';
+import {UpdateNetworkState as UpdateFegLteNetworkState} from '../../state/feg_lte/NetworkState';
+import {UpdateNetworkState as UpdateFegNetworkState} from '../../state/feg/NetworkState';
+import {UpdateNetworkState as UpdateLteNetworkState} from '../../state/lte/NetworkState';
+import {
+  getSubscriberGatewayMap,
+  setSubscriberState,
+} from '../../state/lte/SubscriberState';
+import {useContext, useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 
 type Props = {
   networkId: network_id,
@@ -68,10 +75,16 @@ export function GatewayContextProvider(props: Props) {
 
   useEffect(() => {
     const fetchState = async () => {
-      const lteGateways = await MagmaV1API.getLteByNetworkIdGateways({
-        networkId,
-      });
-      setLteGateways(lteGateways);
+      try {
+        const lteGateways = await MagmaV1API.getLteByNetworkIdGateways({
+          networkId,
+        });
+        setLteGateways(lteGateways);
+      } catch (e) {
+        enqueueSnackbar?.('failed fetching gateway information', {
+          variant: 'error',
+        });
+      }
       setIsLoading(false);
     };
     fetchState();
@@ -111,15 +124,21 @@ export function EnodebContextProvider(props: Props) {
 
   useEffect(() => {
     const fetchState = async () => {
-      if (networkId == null) {
-        return;
-      }
-      const [lteRanConfigsResp] = await Promise.allSettled([
-        MagmaV1API.getLteByNetworkIdCellularRan({networkId}),
-        InitEnodeState({networkId, setEnbInfo, enqueueSnackbar}),
-      ]);
-      if (lteRanConfigsResp.value) {
-        setLteRanConfigs(lteRanConfigsResp.value);
+      try {
+        if (networkId == null) {
+          return;
+        }
+        const [lteRanConfigsResp] = await Promise.allSettled([
+          MagmaV1API.getLteByNetworkIdCellularRan({networkId}),
+          InitEnodeState({networkId, setEnbInfo, enqueueSnackbar}),
+        ]);
+        if (lteRanConfigsResp.value) {
+          setLteRanConfigs(lteRanConfigsResp.value);
+        }
+      } catch (e) {
+        enqueueSnackbar?.('failed fetching enodeb information', {
+          variant: 'error',
+        });
       }
       setIsLoading(false);
     };
@@ -199,17 +218,23 @@ export function GatewayTierContextProvider(props: Props) {
 
   useEffect(() => {
     const fetchState = async () => {
-      if (networkId == null) {
-        return;
-      }
-      const [stableChannelResp] = await Promise.allSettled([
-        MagmaV1API.getChannelsByChannelId({channelId: 'stable'}),
-        InitTierState({networkId, setTiers, enqueueSnackbar}),
-      ]);
-      if (stableChannelResp.value) {
-        setSupportedVersions(
-          stableChannelResp.value.supported_versions.reverse(),
-        );
+      try {
+        if (networkId == null) {
+          return;
+        }
+        const [stableChannelResp] = await Promise.allSettled([
+          MagmaV1API.getChannelsByChannelId({channelId: 'stable'}),
+          InitTierState({networkId, setTiers, enqueueSnackbar}),
+        ]);
+        if (stableChannelResp.value) {
+          setSupportedVersions(
+            stableChannelResp.value.supported_versions.reverse(),
+          );
+        }
+      } catch (e) {
+        enqueueSnackbar?.('failed fetching tier information', {
+          variant: 'error',
+        });
       }
       setIsLoading(false);
     };
@@ -234,17 +259,41 @@ export function GatewayTierContextProvider(props: Props) {
 
 export function PolicyProvider(props: Props) {
   const {networkId} = props;
+  const networkCtx = useContext(NetworkContext);
+  const lteNetworkCtx = useContext(LteNetworkContext);
   const [policies, setPolicies] = useState<{[string]: policy_rule}>({});
+  const [fegNetwork, setFegNetwork] = useState<feg_network>({});
+  const [fegPolicies, setFegPolicies] = useState<{[string]: policy_rule}>({});
   const [isLoading, setIsLoading] = useState(true);
+  const networkType = networkCtx.networkType;
   const enqueueSnackbar = useEnqueueSnackbar();
 
   useEffect(() => {
     const fetchState = async () => {
-      setPolicies(
-        await MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull({
-          networkId,
-        }),
-      );
+      try {
+        setPolicies(
+          await MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull({
+            networkId,
+          }),
+        );
+        if (networkType === FEG_LTE) {
+          const fegNetworkId = lteNetworkCtx.state?.federation.feg_network_id;
+          if (fegNetworkId != null && fegNetworkId !== '') {
+            setFegNetwork(
+              await MagmaV1API.getFegByNetworkId({networkId: fegNetworkId}),
+            );
+            setFegPolicies(
+              await MagmaV1API.getNetworksByNetworkIdPoliciesRulesViewFull({
+                networkId: fegNetworkId,
+              }),
+            );
+          }
+        }
+      } catch (e) {
+        enqueueSnackbar?.('failed fetching policy information', {
+          variant: 'error',
+        });
+      }
       setIsLoading(false);
     };
     fetchState();
@@ -258,14 +307,140 @@ export function PolicyProvider(props: Props) {
     <PolicyContext.Provider
       value={{
         state: policies,
-        setState: (key, value?) => {
-          return SetPolicyState({
-            policies,
-            setPolicies,
-            networkId,
-            key,
-            value,
-          });
+        setState: async (key, value?, isNetworkWide?) => {
+          if (networkType === FEG_LTE) {
+            const fegNetworkID = lteNetworkCtx.state?.federation.feg_network_id;
+            await SetPolicyState({
+              policies,
+              setPolicies,
+              networkId,
+              key,
+              value,
+            });
+
+            // duplicate the policy on feg_network as well
+            if (fegNetworkID != null) {
+              await SetPolicyState({
+                policies: fegPolicies,
+                setPolicies: setFegPolicies,
+                networkId: fegNetworkID,
+                key,
+                value,
+              });
+            }
+          } else {
+            await SetPolicyState({
+              policies,
+              setPolicies,
+              networkId,
+              key,
+              value,
+            });
+          }
+          if (isNetworkWide === true) {
+            // we only support isNetworkWide rules now(and not basenames)
+            let ruleNames = [];
+            let fegRuleNames = [];
+
+            if (value != null) {
+              ruleNames =
+                lteNetworkCtx.state?.subscriber_config
+                  ?.network_wide_rule_names ?? [];
+              if (!ruleNames.includes(key)) {
+                ruleNames.push(key);
+              }
+              fegRuleNames =
+                fegNetwork.subscriber_config?.network_wide_rule_names ?? [];
+              if (!fegRuleNames.includes(key)) {
+                fegRuleNames.push(key);
+              }
+            } else {
+              // this is a delete operation
+              const oldRuleNames =
+                lteNetworkCtx.state?.subscriber_config
+                  ?.network_wide_rule_names ?? [];
+              const oldFegRuleNames =
+                fegNetwork.subscriber_config?.network_wide_rule_names ?? [];
+
+              ruleNames = oldRuleNames.filter(function (
+                ruleId,
+                _unused0,
+                _unused1,
+              ) {
+                return ruleId !== key;
+              });
+              fegRuleNames = oldFegRuleNames.filter(function (
+                ruleId,
+                _unused0,
+                _unused1,
+              ) {
+                return ruleId !== key;
+              });
+            }
+            lteNetworkCtx.updateNetworks({
+              networkId,
+              subscriberConfig: {
+                network_wide_base_names:
+                  lteNetworkCtx.state?.subscriber_config
+                    ?.network_wide_base_names,
+                network_wide_rule_names: ruleNames,
+              },
+            });
+            UpdateFegNetworkState({
+              networkId: fegNetwork.id,
+              subscriberConfig: {
+                network_wide_base_names:
+                  fegNetwork.subscriber_config?.network_wide_base_names,
+                network_wide_rule_names: fegRuleNames,
+              },
+              setFegNetwork,
+              refreshState: true,
+            });
+          } else {
+            // delete network wide rules for the key
+            console.log('DELETING NETWORK WIDE RULES FOR ', key);
+            let ruleNames = [];
+            let fegRuleNames = [];
+            const oldRuleNames =
+              lteNetworkCtx.state?.subscriber_config?.network_wide_rule_names ??
+              [];
+            const oldFegRuleNames =
+              fegNetwork.subscriber_config?.network_wide_rule_names ?? [];
+
+            ruleNames = oldRuleNames.filter(function (
+              ruleId,
+              _unused0,
+              _unused1,
+            ) {
+              return ruleId !== key;
+            });
+            fegRuleNames = oldFegRuleNames.filter(function (
+              ruleId,
+              _unused0,
+              _unused1,
+            ) {
+              return ruleId !== key;
+            });
+            lteNetworkCtx.updateNetworks({
+              networkId,
+              subscriberConfig: {
+                network_wide_base_names:
+                  lteNetworkCtx.state?.subscriber_config
+                    ?.network_wide_base_names,
+                network_wide_rule_names: ruleNames,
+              },
+            });
+            UpdateFegNetworkState({
+              networkId: fegNetwork.id,
+              subscriberConfig: {
+                network_wide_base_names:
+                  fegNetwork.subscriber_config?.network_wide_base_names,
+                network_wide_rule_names: fegRuleNames,
+              },
+              setFegNetwork,
+              refreshState: true,
+            });
+          }
         },
       }}>
       {props.children}
@@ -281,11 +456,17 @@ export function ApnProvider(props: Props) {
 
   useEffect(() => {
     const fetchState = async () => {
-      setApns(
-        await MagmaV1API.getLteByNetworkIdApns({
-          networkId,
-        }),
-      );
+      try {
+        setApns(
+          await MagmaV1API.getLteByNetworkIdApns({
+            networkId,
+          }),
+        );
+      } catch (e) {
+        enqueueSnackbar?.('failed fetching APN information', {
+          variant: 'error',
+        });
+      }
       setIsLoading(false);
     };
     fetchState();
@@ -316,16 +497,39 @@ export function ApnProvider(props: Props) {
 
 export function LteNetworkContextProvider(props: Props) {
   const {networkId} = props;
-  const [lteNetwork, setLteNetwork] = useState<lte_network>({});
+  const networkCtx = useContext(NetworkContext);
+  const [lteNetwork, setLteNetwork] = useState<
+    $Shape<lte_network & feg_lte_network>,
+  >({});
   const [isLoading, setIsLoading] = useState(true);
   const enqueueSnackbar = useEnqueueSnackbar();
 
   useEffect(() => {
     const fetchState = async () => {
-      const lteNetwork = await MagmaV1API.getLteByNetworkId({
-        networkId,
-      });
-      setLteNetwork(lteNetwork);
+      try {
+        if (networkCtx.networkType === FEG_LTE) {
+          const [
+            fegLteResp,
+            fegLteSubscriberConfigResp,
+          ] = await Promise.allSettled([
+            MagmaV1API.getFegLteByNetworkId({networkId}),
+            MagmaV1API.getFegLteByNetworkIdSubscriberConfig({networkId}),
+          ]);
+          if (fegLteResp.value) {
+            let subscriber_config = {};
+            if (fegLteSubscriberConfigResp.value) {
+              subscriber_config = fegLteSubscriberConfigResp.value;
+            }
+            setLteNetwork({...fegLteResp.value, subscriber_config});
+          }
+        } else {
+          setLteNetwork(await MagmaV1API.getLteByNetworkId({networkId}));
+        }
+      } catch (e) {
+        enqueueSnackbar?.('failed fetching network information', {
+          variant: 'error',
+        });
+      }
       setIsLoading(false);
     };
     fetchState();
@@ -344,12 +548,21 @@ export function LteNetworkContextProvider(props: Props) {
           if (networkId !== props.networkId) {
             refreshState = false;
           }
-          return UpdateNetworkState({
-            networkId,
-            setLteNetwork,
-            refreshState,
-            ...props,
-          });
+          if (networkCtx.networkType === FEG_LTE) {
+            return UpdateFegLteNetworkState({
+              networkId,
+              setLteNetwork,
+              refreshState,
+              ...props,
+            });
+          } else {
+            return UpdateLteNetworkState({
+              networkId,
+              setLteNetwork,
+              refreshState,
+              ...props,
+            });
+          }
         },
       }}>
       {props.children}

--- a/nms/app/packages/magmalte/app/state/PolicyState.js
+++ b/nms/app/packages/magmalte/app/state/PolicyState.js
@@ -34,14 +34,12 @@ export async function SetPolicyState(props: Props) {
         networkId: networkId,
         policyRule: value,
       });
-      setPolicies({...policies, [key]: value});
     } else {
       await MagmaV1API.putNetworksByNetworkIdPoliciesRulesByRuleId({
         networkId: networkId,
         ruleId: key,
         policyRule: value,
       });
-      setPolicies({...policies, [key]: value});
     }
     const policyRule = await MagmaV1API.getNetworksByNetworkIdPoliciesRulesByRuleId(
       {
@@ -49,6 +47,7 @@ export async function SetPolicyState(props: Props) {
         ruleId: key,
       },
     );
+
     if (policyRule) {
       const newPolicies = {...policies, [key]: policyRule};
       setPolicies(newPolicies);

--- a/nms/app/packages/magmalte/app/state/feg/NetworkState.js
+++ b/nms/app/packages/magmalte/app/state/feg/NetworkState.js
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {
+  feg_network,
+  network_id,
+  network_subscriber_config,
+} from '@fbcnms/magma-api';
+
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+
+export type UpdateNetworkProps = {
+  networkId: network_id,
+  subscriberConfig?: network_subscriber_config,
+  setFegNetwork: feg_network => void,
+  refreshState: boolean,
+};
+
+export async function UpdateNetworkState(props: UpdateNetworkProps) {
+  const {networkId, setFegNetwork} = props;
+  const requests = [];
+  if (props.subscriberConfig) {
+    requests.push(
+      await MagmaV1API.putFegByNetworkIdSubscriberConfig({
+        networkId: props.networkId,
+        record: props.subscriberConfig,
+      }),
+    );
+  }
+  await Promise.all(requests);
+  if (props.refreshState) {
+    setFegNetwork(await MagmaV1API.getFegByNetworkId({networkId}));
+  }
+}

--- a/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
@@ -28,7 +28,7 @@ import {NetworkInfoEdit} from './NetworkInfo';
 import {NetworkRanEdit} from './NetworkRanConfig';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useContext, useState} from 'react';
+import {useContext, useEffect, useState} from 'react';
 
 const NETWORK_TITLE = 'Network';
 const EPC_TITLE = 'Epc';
@@ -130,9 +130,12 @@ export function NetworkEditDialog(props: DialogProps) {
   const [tabPos, setTabPos] = React.useState(
     editProps ? EditTableType[editProps.editTable] : 0,
   );
+  useEffect(() => {
+    setLteNetwork(editProps ? ctx.state : {});
+    setEpcConfigs(editProps ? ctx.state.cellular?.epc ?? {} : {});
+  }, [open]);
+
   const onClose = () => {
-    setLteNetwork({});
-    setEpcConfigs({});
     setTabPos(0);
     props.onClose();
   };

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -26,7 +26,7 @@ import defaultTheme from '@fbcnms/ui/theme/default';
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SetApnState} from '../../../state/lte/ApnState';
-import {SetPolicyState} from '../../../state/lte/PolicyState';
+import {SetPolicyState} from '../../../state/PolicyState';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
 
 jest.mock('axios');
@@ -175,21 +175,21 @@ describe('<TrafficDashboard />', () => {
     expect(rowItemsPolicy[1]).toHaveTextContent('0');
     expect(rowItemsPolicy[1]).toHaveTextContent('1');
     expect(rowItemsPolicy[1]).toHaveTextContent('0');
-    expect(rowItemsPolicy[1]).toHaveTextContent('not found');
+    expect(rowItemsPolicy[1]).toHaveTextContent('Not Found');
     expect(rowItemsPolicy[1]).toHaveTextContent('NO_TRACKING');
 
     expect(rowItemsPolicy[2]).toHaveTextContent('policy_1');
     expect(rowItemsPolicy[2]).toHaveTextContent('2');
     expect(rowItemsPolicy[2]).toHaveTextContent('1');
     expect(rowItemsPolicy[2]).toHaveTextContent('0');
-    expect(rowItemsPolicy[2]).toHaveTextContent('not found');
+    expect(rowItemsPolicy[2]).toHaveTextContent('Not Found');
     expect(rowItemsPolicy[2]).toHaveTextContent('NO_TRACKING');
 
     expect(rowItemsPolicy[3]).toHaveTextContent('policy_2');
     expect(rowItemsPolicy[3]).toHaveTextContent('0');
     expect(rowItemsPolicy[3]).toHaveTextContent('10');
     expect(rowItemsPolicy[3]).toHaveTextContent('0');
-    expect(rowItemsPolicy[3]).toHaveTextContent('not found');
+    expect(rowItemsPolicy[3]).toHaveTextContent('Not Found');
     expect(rowItemsPolicy[3]).toHaveTextContent('NO_TRACKING');
 
     // click the actions button for policy 0

--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -67,6 +67,7 @@
     "postcss-loader": "^3.0.0",
     "react-hot-loader": "^4.8.0",
     "react-test-renderer": "^16.12.0",
+    "sqlite3": "^5.0.0",
     "style-loader": "^1.2.1",
     "terser-webpack-plugin": "^1.2.3",
     "url-loader": "^1.1.2",

--- a/nms/app/packages/magmalte/server/apicontroller/__tests__/proxy-test.js
+++ b/nms/app/packages/magmalte/server/apicontroller/__tests__/proxy-test.js
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {networkIdFilter, networksResponseDecorator} from '../routes';
+
+// $FlowIgnore Ignoring error for tests.
+const testNetworkIdFilter = async req => await networkIdFilter(req);
+
+const testNetworksResponseDecorator = async (
+  proxyResponse,
+  proxyResponseData,
+  userRequest,
+  {},
+) =>
+  await networksResponseDecorator(
+    // $FlowIgnore Ignoring error for tests.
+    proxyResponse,
+    proxyResponseData,
+    // $FlowIgnore Ignoring error for tests.
+    userRequest,
+    // $FlowIgnore Ignoring error for tests.
+    {}, // userResponse
+  );
+
+const createData = (
+  controllerNetworks: Array<string>,
+  orgNetworks: Array<string>,
+  userNetworks: Array<string>,
+  isSuperUser: boolean,
+) => {
+  const proxyResponse = {statusCode: 200};
+  const proxyResponseData = new Buffer(
+    JSON.stringify(controllerNetworks),
+    'utf8',
+  );
+
+  const userRequest = {
+    organization: async () => ({networkIDs: orgNetworks}),
+    user: {isSuperUser, networkIDs: userNetworks},
+  };
+
+  return {proxyResponse, proxyResponseData, userRequest};
+};
+
+const createDataNoOrg = (
+  controllerNetworks: Array<string>,
+  userNetworks: Array<string>,
+  isSuperUser: boolean,
+) => {
+  const proxyResponse = {statusCode: 200};
+  const proxyResponseData = new Buffer(
+    JSON.stringify(controllerNetworks),
+    'utf8',
+  );
+
+  const userRequest = {
+    user: {isSuperUser, networkIDs: userNetworks},
+  };
+
+  return {proxyResponse, proxyResponseData, userRequest};
+};
+
+describe('Proxy test', () => {
+  describe('networkIdFilter', () => {
+    const params = {
+      networkID: 'test',
+    };
+
+    it('allows superuser access to org network', async () => {
+      const req = {
+        params,
+        organization: () => ({
+          networkIDs: ['test'],
+        }),
+        user: {
+          isSuperUser: true,
+          networkIDs: [],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(true);
+    });
+
+    it('allows superuser access no org', async () => {
+      const req = {
+        params,
+        user: {
+          isSuperUser: true,
+          networkIDs: [],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(true);
+    });
+
+    it('disallows superuser access to non-org network', async () => {
+      const req = {
+        params,
+        organization: () => ({
+          networkIDs: ['not-test'],
+        }),
+        user: {
+          isSuperUser: true,
+          networkIDs: [],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(false);
+    });
+
+    it('allows user with access to network on specific org', async () => {
+      const req = {
+        params,
+        organization: () => ({
+          networkIDs: ['test'],
+        }),
+        user: {
+          isSuperUser: false,
+          networkIDs: ['test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(true);
+    });
+
+    it('allows user with access to network no org', async () => {
+      const req = {
+        params,
+        user: {
+          isSuperUser: false,
+          networkIDs: ['test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(true);
+    });
+
+    it('disallows user with access to network but not org', async () => {
+      const req = {
+        params,
+        organization: () => ({
+          networkIDs: ['not-test'],
+        }),
+        user: {
+          isSuperUser: false,
+          networkIDs: ['test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(false);
+    });
+
+    it('disallows user without access to network', async () => {
+      const req = {
+        params,
+        organization: () => ({
+          networkIDs: ['test', 'not-test'],
+        }),
+        user: {
+          isSuperUser: false,
+          networkIDs: ['not-test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(false);
+    });
+
+    it('disallows user without access to network no org', async () => {
+      const req = {
+        params,
+        user: {
+          isSuperUser: false,
+          networkIDs: ['not-test'],
+        },
+      };
+      const isAllowed = await testNetworkIdFilter(req);
+      expect(isAllowed).toBe(false);
+    });
+  });
+
+  describe('networksResponseDecorator', () => {
+    it('allows normal user access to her network only', async () => {
+      const {proxyResponse, proxyResponseData, userRequest} = createData(
+        ['network1', 'network2'],
+        ['network2'],
+        ['network2'],
+        false, // isSuperUser
+      );
+
+      const result = await testNetworksResponseDecorator(
+        proxyResponse,
+        proxyResponseData,
+        userRequest,
+        {}, // userResponse
+      );
+
+      expect(JSON.parse(result)).toEqual(['network2']);
+    });
+
+    it('allows super user access to all org networks', async () => {
+      const {proxyResponse, proxyResponseData, userRequest} = createData(
+        ['network1', 'network2', 'network3'],
+        ['network1', 'network2'],
+        [],
+        true, // isSuperUser
+      );
+
+      const result = await testNetworksResponseDecorator(
+        proxyResponse,
+        proxyResponseData,
+        userRequest,
+        {}, // userResponse
+      );
+
+      expect(JSON.parse(result)).toEqual(['network1', 'network2']);
+    });
+
+    it('denies normal user access to a network not in the org', async () => {
+      const {proxyResponse, proxyResponseData, userRequest} = createData(
+        ['network1', 'network2', 'network3'],
+        ['network1', 'network2'],
+        ['network1', 'network3', 'network4'],
+        false, // isSuperUser
+      );
+
+      const result = await testNetworksResponseDecorator(
+        proxyResponse,
+        proxyResponseData,
+        userRequest,
+        {}, // userResponse
+      );
+
+      expect(JSON.parse(result)).toEqual(['network1']);
+    });
+
+    it('denies super user access to a network not in the controller', async () => {
+      const {proxyResponse, proxyResponseData, userRequest} = createData(
+        ['network1', 'network2', 'network3'],
+        ['network1', 'network2', 'network4'],
+        [],
+        true, // isSuperUser
+      );
+
+      const result = await testNetworksResponseDecorator(
+        proxyResponse,
+        proxyResponseData,
+        userRequest,
+        {}, // userResponse
+      );
+
+      expect(JSON.parse(result)).toEqual(['network1', 'network2']);
+    });
+
+    describe('no organization', () => {
+      it('filters user access when no access to networks', async () => {
+        const {proxyResponse, proxyResponseData, userRequest} = createDataNoOrg(
+          ['network1', 'network2', 'network3'],
+          [],
+          false, // isSuperUser
+        );
+
+        const result = await testNetworksResponseDecorator(
+          proxyResponse,
+          proxyResponseData,
+          userRequest,
+          {}, // userResponse
+        );
+
+        expect(result).toEqual('[]');
+      });
+
+      it('filters user access to networks allowed', async () => {
+        const {proxyResponse, proxyResponseData, userRequest} = createDataNoOrg(
+          ['network1', 'network2', 'network3'],
+          ['network1', 'network4', 'network5'],
+          false, // isSuperUser
+        );
+
+        const result = await testNetworksResponseDecorator(
+          proxyResponse,
+          proxyResponseData,
+          userRequest,
+          {}, // userResponse
+        );
+
+        expect(JSON.parse(result)).toEqual(['network1']);
+      });
+
+      it('superuser access to all networks', async () => {
+        const {proxyResponse, proxyResponseData, userRequest} = createDataNoOrg(
+          ['network1', 'network2', 'network3'],
+          [],
+          true, // isSuperUser
+        );
+
+        const result = await testNetworksResponseDecorator(
+          proxyResponse,
+          proxyResponseData,
+          userRequest,
+          {}, // userResponse
+        );
+
+        expect(JSON.parse(result)).toEqual([
+          'network1',
+          'network2',
+          'network3',
+        ]);
+      });
+    });
+  });
+});

--- a/nms/app/packages/magmalte/server/apicontroller/auditLoggingDecorator.js
+++ b/nms/app/packages/magmalte/server/apicontroller/auditLoggingDecorator.js
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import type {ExpressResponse} from 'express';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+
+const url = require('url');
+import pathToRegexp from 'path-to-regexp';
+
+import {AuditLogEntry} from '@fbcnms/sequelize-models';
+const logger = require('@fbcnms/logging').getLogger(module);
+
+const defaultResolver = (req: FBCNMSRequest, type: string) => {
+  const {search} = url.parse(req.originalUrl);
+  const params = new URLSearchParams(search ?? '');
+  return [params.get('requested_id'), type];
+};
+
+const PATHS: Array<{
+  path: string,
+  type?: string,
+  resolver?: (FBCNMSRequest, string[]) => [?string, ?string],
+}> = [
+  {
+    path: '/magma/networks/:networkId/gateways',
+    resolver: (req: FBCNMSRequest) => defaultResolver(req, 'gateway'),
+  },
+  {
+    path: '/magma/networks/:networkId/configs/devices',
+    resolver: (req: FBCNMSRequest) => defaultResolver(req, 'device'),
+  },
+  {
+    path: '/magma/networks/:networkId/gateways/:objectId',
+    type: 'gateway',
+  },
+  {
+    path: '/magma/networks/:networkId/gateways/:objectId/configs/cellular',
+    type: 'gateway cellular config',
+  },
+  {
+    path: '/magma/networks/:networkId/gateways/:objectId/configs/wifi',
+    type: 'gateway wifi config',
+  },
+  {
+    path: '/magma/networks/:networkId/gateways/:objectId/configs/tarazed',
+    type: 'gateway tarazed config',
+  },
+  {
+    path: '/magma/networks/:networkId/gateways/:objectId/configs/devmand',
+    type: 'gateway devmand config',
+  },
+  {
+    path: '/magma/networks/:networkId/gateways/:objectId/configs',
+    type: 'gateway config',
+  },
+  {
+    path: '/magma/networks/:networkId/subscribers/:objectId',
+    type: 'subscriber',
+  },
+  {
+    path: '/magma/networks/:networkId/subscribers',
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'subscriber'],
+  },
+  {
+    path: '/magma/networks/:networkId/tiers/:objectId',
+    type: 'network tier',
+  },
+  {
+    path: '/magma/networks/:networkId/tiers',
+    resolver: (req: FBCNMSRequest) => [req.body.id, 'network tier'],
+  },
+  {
+    path: '/magma/networks/:networkId/configs/cellular',
+    resolver: (_, params) => [params[2], 'network cellular configs'],
+  },
+  {
+    path: '/magma/networks/:networkId/configs/wifi',
+    resolver: (_, params) => [params[2], 'network wifi configs'],
+  },
+  {
+    path: '/magma/v1/networks/:networkId',
+    resolver: (_, params) => [params[1], 'network'],
+  },
+  {
+    path: '/magma/v1/cwf/:networkId/gateways',
+    resolver: req => [req.body.id, 'carrier wifi gateway'],
+  },
+  {
+    path: '/magma/v1/cwf/:networkId/gateways/:objectId',
+    resolver: (_, params) => [params[2], 'carrier wifi gateway'],
+  },
+  {
+    path: '/magma/v1/feg/:networkId/gateways',
+    resolver: req => [req.body.id, 'federation gateway'],
+  },
+  {
+    path: '/magma/v1/feg/:networkId/gateways/:objectId',
+    resolver: (_, params) => [params[2], 'federation gateway'],
+  },
+  {
+    path: '/magma/v1/feg/:networkId/gateways/:objectId/federation',
+    resolver: (_, params) => [params[2], 'federation gateway config'],
+  },
+  {
+    path: '/magma/v1/networks/:networkId/rules/policies',
+    resolver: req => [req.body.id, 'policy'],
+  },
+  {
+    path: '/magma/v1/networks/:networkId/policies/rules/:objectId',
+    resolver: (_, params) => [params[2], 'policy'],
+  },
+];
+
+const MUTATION_TYPE_MAP = {
+  POST: 'CREATE',
+  PUT: 'UPDATE',
+  DELETE: 'DELETE',
+};
+
+function getObjectIdAndType(req: FBCNMSRequest): [?string, ?string] {
+  const parsed = url.parse(
+    req.originalUrl.replace(/^\/nms\/apicontroller/, ''),
+  );
+  for (let i = 0; i < PATHS.length; i++) {
+    const params = pathToRegexp(PATHS[i].path).exec(parsed.pathname);
+    if (params) {
+      return PATHS[i].resolver
+        ? PATHS[i].resolver(req, params)
+        : [params[2], PATHS[i].type];
+    }
+  }
+
+  return [null, null];
+}
+
+export default async function auditLoggingDecorator(
+  proxyRes: ExpressResponse,
+  proxyResData: Buffer,
+  userReq: FBCNMSRequest,
+  _userRes: ExpressResponse,
+) {
+  if (!MUTATION_TYPE_MAP[userReq.method]) {
+    return proxyResData;
+  }
+
+  const [objectId, objectType] = getObjectIdAndType(userReq);
+  if (!objectId || !objectType) {
+    return proxyResData;
+  }
+
+  let organizationName = '';
+  if (userReq.organization) {
+    const organization = await userReq.organization();
+    organizationName = organization.name;
+  }
+
+  const data = {
+    actingUserId: userReq.user.id,
+    actingUserEmail: userReq.user.email,
+    organization: organizationName,
+    mutationType: MUTATION_TYPE_MAP[userReq.method],
+    objectId,
+    objectType,
+    objectDisplayName: objectId,
+    mutationData: userReq.body,
+    url: userReq.originalUrl,
+    ipAddress: userReq.ip,
+    status: proxyRes.statusCode < 300 ? 'SUCCESS' : 'FAILURE',
+    statusCode: `${proxyRes.statusCode}`,
+  };
+
+  try {
+    await AuditLogEntry.create(data);
+  } catch (error) {
+    logger.error('Error creating AuditLogEntry', error);
+  }
+  return proxyResData;
+}

--- a/nms/app/packages/magmalte/server/apicontroller/routes.js
+++ b/nms/app/packages/magmalte/server/apicontroller/routes.js
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import type {ExpressResponse} from 'express';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+
+const express = require('express');
+const proxy = require('express-http-proxy');
+const HttpsProxyAgent = require('https-proxy-agent');
+const url = require('url');
+const {apiCredentials, API_HOST} = require('@fbcnms/platform-server/config');
+import auditLoggingDecorator from './auditLoggingDecorator';
+
+import {intersection} from 'lodash';
+
+const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
+
+const PROXY_TIMEOUT_MS = 30000;
+
+let agent = null;
+if (process.env.HTTPS_PROXY) {
+  const options = url.parse(process.env.HTTPS_PROXY);
+  agent = new HttpsProxyAgent(options);
+}
+const PROXY_OPTIONS = {
+  https: true,
+  memoizeHost: false,
+  timeout: PROXY_TIMEOUT_MS,
+  proxyReqOptDecorator: (proxyReqOpts, _originalReq) => {
+    return {
+      ...proxyReqOpts,
+      agent: agent,
+      cert: apiCredentials().cert,
+      key: apiCredentials().key,
+      rejectUnauthorized: false,
+    };
+  },
+  proxyReqPathResolver: req =>
+    req.originalUrl.replace(/^\/nms\/apicontroller/, ''),
+};
+
+export async function networkIdFilter(req: FBCNMSRequest): Promise<boolean> {
+  if (req.organization) {
+    const organization = await req.organization();
+
+    // If the request isn't an organization network, block
+    // the request
+    const isOrganizationAllowed = containsNetworkID(
+      organization.networkIDs,
+      req.params.networkID,
+    );
+    if (!isOrganizationAllowed) {
+      return false;
+    }
+  }
+
+  // super users on standalone deployments
+  // have access to all proxied API requests
+  // for the organization
+  if (req.user.isSuperUser) {
+    return true;
+  }
+  return containsNetworkID(req.user.networkIDs, req.params.networkID);
+}
+
+export async function networksResponseDecorator(
+  _proxyRes: ExpressResponse,
+  proxyResData: Buffer,
+  userReq: FBCNMSRequest,
+  _userRes: ExpressResponse,
+) {
+  let result = JSON.parse(proxyResData.toString('utf8'));
+  if (userReq.organization) {
+    const organization = await userReq.organization();
+    result = intersection(result, organization.networkIDs);
+  }
+  if (!userReq.user.isSuperUser) {
+    // the list of networks is further restricted to what the user
+    // is allowed to see
+    result = intersection(result, userReq.user.networkIDs);
+  }
+  return JSON.stringify(result);
+}
+
+const containsNetworkID = function (
+  allowedNetworkIDs: string[],
+  networkID: string,
+): boolean {
+  return (
+    allowedNetworkIDs.indexOf(networkID) !== -1 ||
+    // Remove secondary condition after T34404422 is addressed. Reason:
+    //   Request needs to be lower cased otherwise calling
+    //   MagmaAPIUrls.gateways() potentially returns missing devices.
+    allowedNetworkIDs
+      .map(id => id.toString().toLowerCase())
+      .indexOf(networkID.toString().toLowerCase()) !== -1
+  );
+};
+
+const proxyErrorHandler = (err, res, next) => {
+  if (err.code === 'ENOTFOUND') {
+    res.status(503).send('Cannot reach Orchestrator server');
+  } else {
+    next();
+  }
+};
+
+router.use(
+  /^\/magma\/v1\/networks$/,
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    userResDecorator: networksResponseDecorator,
+    proxyErrorHandler,
+  }),
+);
+
+router.use(
+  '/magma/v1/networks/:networkID',
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: networkIdFilter,
+    userResDecorator: auditLoggingDecorator,
+    proxyErrorHandler,
+  }),
+);
+
+const networkTypeRegex = '(cwf|feg|lte|feg_lte|symphony|wifi)';
+router.use(
+  `/magma/v1/:networkType(${networkTypeRegex})/:networkID`,
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: networkIdFilter,
+    userResDecorator: auditLoggingDecorator,
+    proxyErrorHandler,
+  }),
+);
+
+router.use(
+  '/magma/channels/:channel',
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: (req, _res) => req.method === 'GET',
+  }),
+);
+
+router.use(
+  '/magma/v1/channels/:channel',
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: (req, _res) => req.method === 'GET',
+  }),
+);
+
+router.use(
+  '/magma/v1/events/:networkID',
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: networkIdFilter,
+    proxyErrorHandler,
+  }),
+);
+
+router.use(
+  '/magma/v1/events/:networkID/:streamName',
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: networkIdFilter,
+    proxyErrorHandler,
+  }),
+);
+
+router.use('', (req: FBCNMSRequest, res: ExpressResponse) => {
+  res.status(404).send('Not Found');
+});
+
+export default router;

--- a/nms/app/packages/magmalte/server/magma/index.js
+++ b/nms/app/packages/magmalte/server/magma/index.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import axios from 'axios';
+import https from 'https';
+import nullthrows from '@fbcnms/util/nullthrows';
+import {API_HOST, apiCredentials} from '@fbcnms/platform-server/config';
+
+const httpsAgent = new https.Agent({
+  cert: apiCredentials().cert,
+  key: apiCredentials().key,
+  rejectUnauthorized: false,
+});
+
+function apiUrl(): string {
+  return !/^https?\:\/\//.test(nullthrows(API_HOST))
+    ? `https://${nullthrows(API_HOST)}/magma/v1`
+    : `${nullthrows(API_HOST)}/magma/v1`;
+}
+
+export default class NodeClient extends MagmaAPIBindings {
+  static async request(
+    path: string,
+    method: 'POST' | 'GET' | 'PUT' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH',
+    query: {[string]: mixed},
+    // eslint-disable-next-line flowtype/no-weak-types
+    body?: any,
+  ) {
+    const response = await axios({
+      baseURL: apiUrl(),
+      url: path,
+      method: (method: string),
+      params: query,
+      data: body,
+      headers: {'content-type': 'application/json'},
+      httpsAgent,
+    });
+
+    return response.data;
+  }
+}

--- a/nms/app/packages/magmalte/server/main/routes.js
+++ b/nms/app/packages/magmalte/server/main/routes.js
@@ -18,18 +18,19 @@ import type {AppContextAppData} from '@fbcnms/ui/context/AppContext';
 import type {ExpressResponse} from 'express';
 import type {FBCNMSRequest} from '@fbcnms/auth/access';
 
+import apiControllerRoutes from '../apicontroller/routes';
 import asyncHandler from '@fbcnms/util/asyncHandler';
 import express from 'express';
+import networkRoutes from '../network/routes';
 import staticDist from '@fbcnms/webpack-config/staticDist';
 import userMiddleware from '@fbcnms/auth/express';
 import {AccessRoles} from '@fbcnms/auth/roles';
 import {MAPBOX_ACCESS_TOKEN} from '@fbcnms/platform-server/config';
 
+import {TABS} from '@fbcnms/types/tabs';
 import {access} from '@fbcnms/auth/access';
 import {getEnabledFeatures} from '@fbcnms/platform-server/features';
 import {masterOrgMiddleware} from '@fbcnms/platform-server/master/middleware';
-
-import {TABS} from '@fbcnms/types/tabs';
 
 const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
 
@@ -75,14 +76,8 @@ router.use(
   require('@fbcnms/platform-server/admin/routes').default,
 );
 router.get('/admin*', access(AccessRoles.SUPERUSER), handleReact('admin'));
-router.use(
-  '/nms/apicontroller',
-  require('@fbcnms/platform-server/apicontroller/routes').default,
-);
-router.use(
-  '/nms/network',
-  require('@fbcnms/platform-server/network/routes').default,
-);
+router.use('/nms/apicontroller', apiControllerRoutes);
+router.use('/nms/network', networkRoutes);
 
 router.use('/logger', require('@fbcnms/platform-server/logger/routes'));
 router.use('/test', require('@fbcnms/platform-server/test/routes'));

--- a/nms/app/packages/magmalte/server/network/routes.js
+++ b/nms/app/packages/magmalte/server/network/routes.js
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import type {ExpressResponse} from 'express';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+import type {
+  network_cellular_configs,
+  network_dns_config,
+  tier,
+} from '@fbcnms/magma-api';
+
+import asyncHandler from '@fbcnms/util/asyncHandler';
+import express from 'express';
+
+import MagmaV1API from '../magma';
+import {AccessRoles} from '@fbcnms/auth/roles';
+import {CWF, FEG, FEG_LTE, LTE, SYMPHONY, XWFM} from '@fbcnms/types/network';
+import {access} from '@fbcnms/auth/access';
+import {difference} from 'lodash';
+
+const logger = require('@fbcnms/logging').getLogger(module);
+
+const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
+
+const DEFAULT_CELLULAR_CONFIG: network_cellular_configs = {
+  epc: {
+    cloud_subscriberdb_enabled: false,
+    default_rule_id: 'default_rule_1',
+    lte_auth_amf: 'gAA=',
+    lte_auth_op: 'EREREREREREREREREREREQ==',
+    mcc: '001',
+    mnc: '01',
+    network_services: ['policy_enforcement'],
+    relay_enabled: false,
+    sub_profiles: {},
+    tac: 1,
+  },
+  feg_network_id: '',
+  ran: {
+    bandwidth_mhz: 20,
+    // TODO: Add option in UI for either fdd or tdd
+    // plus config values
+    // fdd_config: {
+    //   earfcndl: 44590,
+    //   earfcnul: 18000,
+    // },
+    tdd_config: {
+      earfcndl: 44590,
+      special_subframe_pattern: 7,
+      subframe_assignment: 2,
+    },
+  },
+};
+
+// A placeholder due to bug in serialization
+const NETWORK_FEATURES = {
+  features: {
+    features: {
+      placeholder: 'true',
+    },
+  },
+};
+
+const DEFAULT_DNS_CONFIG: network_dns_config = {
+  enable_caching: false,
+  local_ttl: 0,
+  records: [],
+};
+
+const DEFAULT_UPGRADE_TIER: tier = {
+  gateways: [],
+  id: 'default',
+  images: [],
+  name: 'Default Tier',
+  version: '0.0.0-0',
+};
+
+router.post(
+  '/create',
+  access(AccessRoles.SUPERUSER),
+  asyncHandler(async (req: FBCNMSRequest, res) => {
+    const {networkID, data} = req.body;
+    const {name, description} = data;
+    const commonField = {
+      name,
+      description,
+      id: networkID,
+      ...NETWORK_FEATURES,
+    };
+
+    let resp;
+    try {
+      if (data.networkType === LTE) {
+        resp = await MagmaV1API.postLte({
+          lteNetwork: {
+            ...commonField,
+            cellular: DEFAULT_CELLULAR_CONFIG,
+            dns: DEFAULT_DNS_CONFIG,
+          },
+        });
+      } else if (data.networkType === FEG_LTE) {
+        resp = await MagmaV1API.postFegLte({
+          lteNetwork: {
+            ...commonField,
+            cellular: {
+              ...DEFAULT_CELLULAR_CONFIG,
+              feg_network_id: data.fegNetworkID,
+            },
+            dns: DEFAULT_DNS_CONFIG,
+            federation: {feg_network_id: data.fegNetworkID},
+          },
+        });
+      } else if (data.networkType === CWF) {
+        resp = await MagmaV1API.postCwf({
+          cwfNetwork: {
+            ...commonField,
+            dns: DEFAULT_DNS_CONFIG,
+            federation: {feg_network_id: data.fegNetworkID},
+            carrier_wifi: {
+              aaa_server: {
+                accounting_enabled: true,
+                create_session_on_auth: true,
+                idle_session_timeout_ms: 500000,
+              },
+              default_rule_id: '',
+              eap_aka: {},
+              network_services: ['policy_enforcement', 'dpi'],
+            },
+          },
+        });
+      } else if (data.networkType === XWFM) {
+        resp = await MagmaV1API.postCwf({
+          cwfNetwork: {
+            ...commonField,
+            dns: DEFAULT_DNS_CONFIG,
+            federation: {feg_network_id: data.fegNetworkID},
+            carrier_wifi: {
+              aaa_server: {
+                accounting_enabled: true,
+                create_session_on_auth: true,
+                idle_session_timeout_ms: 500000,
+              },
+              default_rule_id: '',
+              eap_aka: {},
+              network_services: [],
+            },
+          },
+        });
+      } else if (data.networkType === FEG) {
+        resp = await MagmaV1API.postFeg({
+          fegNetwork: {
+            ...commonField,
+            dns: DEFAULT_DNS_CONFIG,
+            federation: {
+              aaa_server: {},
+              csfb: {},
+              eap_aka: {},
+              gx: {},
+              gy: {},
+              health: {},
+              hss: {},
+              s6a: {},
+              served_network_ids: data.servedNetworkIDs.split(','),
+              swx: {},
+            },
+          },
+        });
+      } else if (data.networkType === SYMPHONY) {
+        resp = await MagmaV1API.postSymphony({
+          symphonyNetwork: {
+            ...commonField,
+          },
+        });
+      } else {
+        await MagmaV1API.postNetworks({
+          network: {
+            ...commonField,
+            type: data.networkType,
+            dns: DEFAULT_DNS_CONFIG,
+          },
+        });
+      }
+
+      MagmaV1API.postNetworksByNetworkIdTiers({
+        networkId: networkID,
+        tier: DEFAULT_UPGRADE_TIER,
+      });
+
+      // Add network to organization
+      if (req.organization) {
+        const organization = await req.organization();
+        const networkIDs = [...organization.networkIDs, networkID];
+        await organization.update({networkIDs});
+      }
+    } catch (e) {
+      logger.error(e, {
+        response: e.response?.data,
+      });
+      res
+        .status(200)
+        .send({
+          success: false,
+          message: e.response?.data.message || e.toString(),
+          apiResponse: e.response?.data,
+        })
+        .end();
+      return;
+    }
+
+    res
+      .status(200)
+      .send({
+        success: true,
+        apiResponse: resp,
+      })
+      .end();
+  }),
+);
+
+router.post(
+  '/delete',
+  access(AccessRoles.SUPERUSER),
+  asyncHandler(async (req: FBCNMSRequest, res) => {
+    const {networkID} = req.body;
+
+    try {
+      await MagmaV1API.deleteNetworksByNetworkId({
+        networkId: networkID,
+      });
+
+      // Remove network from organization
+      if (req.organization) {
+        const organization = await req.organization();
+
+        const networkIDs = difference(organization.networkIDs, [networkID]);
+        await organization.update({networkIDs});
+      }
+    } catch (e) {
+      logger.error(e, {
+        response: e.response?.data,
+      });
+      res
+        .status(200)
+        .send({
+          success: false,
+        })
+        .end();
+      return;
+    }
+
+    res
+      .status(200)
+      .send({
+        success: true,
+      })
+      .end();
+  }),
+);
+export default router;


### PR DESCRIPTION
## Summary

Following describes the main changes done as a part of this PR
1. Added a state directory for feg_lte networks and moved the feg_lte specific API there. 
2. Moved the platform-server magma specific routes to magma repo. Discussed with @a8m and realized that only magma currently uses the magma specific routes and moved that here. Will cleanup the code in fbc-js-core repo.
3. Added support to add "federation_network_id" when adding feg_lte networks.
4. Added support to view/edit federation network ID for feg_lte networks. 
5. Added support to duplicate policies to feg_network
6. Add support for pushing omnipresent rules and duplicating omnipresent rules to feg network

## Test Plan
yarn test passes
- Working on adding tests to verify this feature. 

![Screen Shot 2020-09-21 at 9 32 22 PM](https://user-images.githubusercontent.com/8224854/93845044-413a1780-fc54-11ea-9172-8da708a0a670.png)

![feg_lte_add](https://user-images.githubusercontent.com/8224854/94079000-3d70d700-fdb3-11ea-871f-7138e13c356b.gif)
![edit_feg_lte](https://user-images.githubusercontent.com/8224854/94079122-4a8dc600-fdb3-11ea-9905-d6e0aead25d9.gif)
![policy_duplication](https://user-images.githubusercontent.com/8224854/94079320-57121e80-fdb3-11ea-9905-a5a51309c492.gif)
![Screen Shot 2020-09-23 at 3 36 39 PM](https://user-images.githubusercontent.com/8224854/94079479-62654a00-fdb3-11ea-840d-09c898097b42.png)

[skipJenkins]
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
