### PR TITLE
[CWF] Fix flaky CWF Qos tests

### DIFF
--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -23,6 +23,7 @@ import (
 	fegProtos "magma/feg/cloud/go/protos"
 	lteProtos "magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
+	"strings"
 
 	"math"
 	"math/rand"
@@ -134,6 +135,19 @@ func TestGxUplinkTrafficQosEnforcement(t *testing.T) {
 	time.Sleep(3 * time.Second)
 }
 
+func checkIfRuleInstalled(tr *TestRunner, ruleName string) bool {
+	cmdList := [][]string{
+		{"pipelined_cli.py", "debug", "display_flows"},
+	}
+	cmdOutputList, err := tr.RunCommandInContainer("pipelined", cmdList)
+	if err != nil || len(cmdList) != 1 {
+		fmt.Printf("error dumping pipelined state %v", err)
+		return false
+	}
+
+	return strings.Contains(cmdOutputList[0].output, ruleName)
+}
+
 //TestGxDownlinkTrafficQosEnforcement
 // This test verifies the QOS configuration(downlink) present in the rules
 // - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
@@ -188,6 +202,13 @@ func TestGxDownlinkTrafficQosEnforcement(t *testing.T) {
 		Volume:      &wrappers.StringValue{Value: *swag.String("5M")},
 		Timeout:     60,
 	}
+
+	// wait for rule to be installed
+	waitForRuleToBeInstalled := func() bool {
+		return checkIfRuleInstalled(tr, ruleKey)
+	}
+	assert.Eventually(t, waitForRuleToBeInstalled, time.Minute, 2*time.Second)
+
 	verifyEgressRate(t, tr, req, float64(downlinkBwMax))
 
 	// Assert that enforcement_stats rules are properly installed and the right

--- a/cwf/gateway/integ_tests/gx_qos_restart_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_restart_test.go
@@ -18,15 +18,14 @@ package integration
 import (
 	"fmt"
 	"io/ioutil"
-	"math/rand"
-	"os"
-	"testing"
-	"time"
-
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/feg/cloud/go/protos"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
+	"math/rand"
+	"os"
+	"testing"
+	"time"
 
 	"github.com/fiorix/go-diameter/v4/diam"
 	"github.com/go-openapi/swag"
@@ -125,6 +124,12 @@ func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg strin
 		Imsi:   imsi,
 		Volume: &wrappers.StringValue{Value: *swag.String("500k")},
 	}
+	// wait for rule to be installed
+	waitForRuleToBeInstalled := func() bool {
+		return checkIfRuleInstalled(tr, ruleKey)
+	}
+	assert.Eventually(t, waitForRuleToBeInstalled, time.Minute, 2*time.Second)
+
 	verifyEgressRate(t, tr, req, float64(uplinkBwMax))
 
 	// Assert that enforcement_stats rules are properly installed and the right


### PR DESCRIPTION
- We need this flag for pipelined to check for redis health prior to startup.
- Additionally ensure that rules are installed in ovs prior to running traffic tests

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
