### PR TITLE
fix for uplink interface

### DIFF
--- a/xwf/gateway/deploy/roles/containers/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/containers/tasks/main.yml
@@ -99,6 +99,7 @@
   copy: 
    src: xwfm_update.sh
    dest: /var/opt/magma/docker/
+   mode: '0755'
 
 - name: place the cron file
   copy:

--- a/xwf/gateway/deploy/roles/xwfm/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/xwfm/tasks/main.yml
@@ -83,35 +83,43 @@
     - name: Install network config  file for passthrough
       become: true
       template: src=ifcfg-gw0 dest=/etc/sysconfig/network-scripts/ifcfg-{{ uplink_if }}
-      when: uplink_if is defined 
+      when: uplink_if is not none
 
     - name: bring up uplink interface
       become: true
       shell: ifup {{ item }}
       with_items:
         - "{{ uplink_if }}"
-      when: uplink_if is defined 
+      when: uplink_if is not none
 
     - name: bring up uplink patch 
       become: true
       shell: ifup uplink_patch
-      when: downlink_if is not defined
+      when: downlink_if is none
 
     - name: Install downlink file
       become: true
       template: src=ifcfg-downlink dest=/etc/sysconfig/network-scripts/ifcfg-{{ downlink_if }}
-      when: downlink_if is defined
+      when: downlink_if is not none
 
     - name: bring up downlink interface
       become: true
       shell: ifup {{ item }}
       with_items:
         - "{{ downlink_if }}"
-      when: downlink_if is defined 
+      when: downlink_if is not none
 
 - name: Enable IP forwarding
   become: true
   sysctl: name="net.ipv4.ip_forward" value=1 sysctl_set=yes state=present reload=yes
+
+- name: Add kernel paramters for arp
+  become: true
+  sysctl: name={{ item }} value=32768 sysctl_set=yes state=present reload=yes
+  with_items:
+     - "net.ipv4.neigh.default.gc_thresh1"
+     - "net.ipv4.neigh.default.gc_thresh2"
+     - "net.ipv4.neigh.default.gc_thresh3"
 
 - name: Load TLS PKI for XWF bridge
   block:

--- a/xwf/gateway/deploy/roles/xwfm/templates/setup_uplink.j2
+++ b/xwf/gateway/deploy/roles/xwfm/templates/setup_uplink.j2
@@ -25,6 +25,6 @@ sudo ovs-vsctl --may-exist add-port uplink_br0 uplink_patch \
   -- --may-exist add-port cwag_br0 cwag_patch \
   -- set Interface cwag_patch type=patch  options:peer=uplink_patch
 
-{% if downlink_if is defined %}
+{% if downlink_if is not none %}
 sudo ovs-vsctl --may-exist add-port uplink_br0 {{ downlink_if }}
 {% endif %}

--- a/xwf/gateway/deploy/xwf.yml
+++ b/xwf/gateway/deploy/xwf.yml
@@ -29,7 +29,7 @@
          - install
     - role: xwfm
     - role: dhcpd
-      when: uplink_if is not defined
+      when: uplink_if is none
     - role: docker
       tags:
          - install_docker


### PR DESCRIPTION
Signed-off-by: Benno Joy <bennojoy@fb.com>
  
     [xwfm] fix couple if bugs.


## Summary

This fixes the below things.
1) if uplink_if is null and the variable exists, the deployment fails to add dhcp server since it thinks we have an uplink interface.
2) the update job didnt have execute permission hence couldnt be run.
3) added the arp kernel parameters so that it can scale beyond 1k users.


## Test Plan

tested in my devserver.


## Additional Information
