### PR TITLE
[SessionD] Support ASR/ASA in FWA by handling it in Sessiond

### DIFF
--- a/feg/gateway/policydb/flow_parser.go
+++ b/feg/gateway/policydb/flow_parser.go
@@ -84,11 +84,11 @@ func getFlowDescriptionFromSplit(matches []string) (*protos.FlowDescription, err
 		Match: &protos.FlowMatch{
 			Direction: direction,
 			IpProto:   proto,
-			IpSrc:     &protos.IPAddress{
+			IpSrc: &protos.IPAddress{
 				Version: protos.IPAddress_IPV4,
 				Address: []byte(src.ip),
 			},
-			IpDst:     &protos.IPAddress{
+			IpDst: &protos.IPAddress{
 				Version: protos.IPAddress_IPV4,
 				Address: []byte(dst.ip),
 			},

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -139,6 +139,23 @@ std::string raa_result_to_str(ReAuthResult res) {
   }
 }
 
+std::string asr_result_to_str(AbortSessionResult_Code res) {
+  switch (res) {
+    case AbortSessionResult_Code_SESSION_REMOVED:
+      return "SESSION_REMOVED";
+    case AbortSessionResult_Code_SESSION_NOT_FOUND:
+      return "SESSION_NOT_FOUND";
+    case AbortSessionResult_Code_USER_NOT_FOUND:
+      return "USER_NOT_FOUND";
+    case AbortSessionResult_Code_GATEWAY_NOT_FOUND:
+      return "GATEWAY_NOT_FOUND";
+    case AbortSessionResult_Code_RADIUS_SERVER_ERROR:
+      return "RADIUS_SERVER_ERROR";
+    default:
+      return "UNKNOWN_RESULT";
+  }
+}
+
 std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state) {
   switch (state) {
     case SubscriberQuotaUpdate_Type_VALID_QUOTA:

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -14,6 +14,7 @@
 
 #include "StoredState.h"
 #include "ServiceAction.h"
+#include <lte/protos/abort_session.pb.h>
 
 namespace magma {
 std::string reauth_state_to_str(ReAuthState state);
@@ -29,6 +30,8 @@ std::string session_fsm_state_to_str(SessionFsmState state);
 std::string credit_update_type_to_str(CreditUsage::UpdateType update);
 
 std::string raa_result_to_str(ReAuthResult res);
+
+std::string asr_result_to_str(AbortSessionResult_Code res);
 
 std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state);
 

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -152,17 +152,28 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   /**
-   * terminate_session handles externally triggered session termination.
-   * This assumes that the termination is coming from the access component, so
-   * it does not notify the termination back to the access component.
+   * handle_termination_from_access handles externally triggered session
+   * termination. This assumes that the termination is coming from the access
+   * component, so it does not notify the termination back to the access
+   * component.
    * @param session_map
    * @param imsi
    * @param apn
    * @param session_update
    */
-  void terminate_session(
+  bool handle_termination_from_access(
       SessionMap& session_map, const std::string& imsi, const std::string& apn,
-      SessionUpdate& session_update);
+      SessionUpdate& session_updates);
+
+  /**
+   * handle abort session - ungraceful termination
+   * 1. Remove all rules attached to the session + update PipelineD
+   * 2. Notify the access component
+   * 3. Remove the session from SessionMap
+   */
+  bool handle_abort_session(
+      SessionMap& session_map, const std::string& imsi,
+      const std::string& session_id, SessionUpdate& session_updates);
 
   /**
    * Initialize reauth for a subscriber service. If the subscriber cannot be
@@ -368,6 +379,16 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   /**
+   * find_and_terminate_session call start_session_termination on
+   * a session with IMSI + session id.
+   * @return true if start_session_termination was called, false if session was
+   * not found
+   */
+  bool find_and_terminate_session(
+      SessionMap& session_map, const std::string& imsi,
+      const std::string& session_id, SessionUpdate& session_updates);
+
+  /**
    * Completes the session termination and executes the callback function
    * registered in terminate_session.
    * complete_termination is called some time after terminate_session
@@ -438,16 +459,6 @@ class LocalEnforcer {
       const std::vector<std::string>& static_rules,
       const std::vector<PolicyRule>& dynamic_rules, Status status,
       ActivateFlowsResult resp);
-
-  /**
-   * find_and_terminate_session call start_session_termination on a session with
-   * IMSI + session id.
-   * @return true if start_session_termination was called, false if session was
-   * not found
-   */
-  bool find_and_terminate_session(
-      SessionMap& session_map, const std::string& imsi,
-      const std::string& session_id, SessionUpdate& session_update);
 
   /**
    * start_session_termination starts the termination process. This includes:

--- a/lte/gateway/c/session_manager/SessionManagerServer.cpp
+++ b/lte/gateway/c/session_manager/SessionManagerServer.cpp
@@ -74,12 +74,21 @@ void AmfPduSessionSmContextAsyncService::init_call_data() {
 
 SessionProxyResponderAsyncService::SessionProxyResponderAsyncService(
     std::unique_ptr<ServerCompletionQueue> cq,
-    std::unique_ptr<SessionProxyResponderHandler> handler)
-    : AsyncService(std::move(cq)), handler_(std::move(handler)) {}
+    std::shared_ptr<SessionProxyResponderHandler> handler)
+    : AsyncService(std::move(cq)), handler_(handler) {}
 
 void SessionProxyResponderAsyncService::init_call_data() {
   new ChargingReAuthCallData(cq_.get(), *this, *handler_);
   new PolicyReAuthCallData(cq_.get(), *this, *handler_);
+}
+
+AbortSessionResponderAsyncService::AbortSessionResponderAsyncService(
+    std::unique_ptr<ServerCompletionQueue> cq,
+    std::shared_ptr<SessionProxyResponderHandler> handler)
+    : AsyncService(std::move(cq)), handler_(handler) {}
+
+void AbortSessionResponderAsyncService::init_call_data() {
+  new AbortSessionCallData(cq_.get(), *this, *handler_);
 }
 
 template<class GRPCService, class RequestType, class ResponseType>
@@ -87,10 +96,14 @@ AsyncGRPCRequest<GRPCService, RequestType, ResponseType>::AsyncGRPCRequest(
     ServerCompletionQueue* cq, GRPCService& service)
     : cq_(cq), status_(PROCESS), responder_(&ctx_), service_(service) {}
 
+// Internal state management logic for AsyncGRPCRequest
+// Once a request has started processing, create a new AsyncGRPCRequest to
+// standby for new requests. After a request has finished processing, delete the
+// object.
 template<class GRPCService, class RequestType, class ResponseType>
 void AsyncGRPCRequest<GRPCService, RequestType, ResponseType>::proceed() {
   if (status_ == PROCESS) {
-    clone();
+    clone();  // Create another stand by CallData
     process();
     status_ = FINISH;
   } else {

--- a/lte/gateway/c/session_manager/SessionManagerServer.h
+++ b/lte/gateway/c/session_manager/SessionManagerServer.h
@@ -13,10 +13,14 @@
 #pragma once
 #include <grpc++/grpc++.h>
 #include <lte/protos/session_manager.grpc.pb.h>
+#include <lte/protos/abort_session.grpc.pb.h>
 
 #include "LocalSessionManagerHandler.h"
 #include "SessionProxyResponderHandler.h"
 #include "SetMessageManagerHandler.h"
+
+#include <lte/protos/abort_session.grpc.pb.h>
+
 using grpc::ServerCompletionQueue;
 using grpc::ServerContext;
 using grpc::Status;
@@ -70,12 +74,12 @@ class AsyncService {
  * through a completion queue where requests are processed and returned async
  */
 class LocalSessionManagerAsyncService final :
-  public AsyncService,
-  public LocalSessionManager::AsyncService {
+    public AsyncService,
+    public LocalSessionManager::AsyncService {
  public:
   LocalSessionManagerAsyncService(
-    std::unique_ptr<ServerCompletionQueue> cq,
-    std::unique_ptr<LocalSessionManagerHandler> handler);
+      std::unique_ptr<ServerCompletionQueue> cq,
+      std::unique_ptr<LocalSessionManagerHandler> handler);
 
  protected:
   void init_call_data();
@@ -105,18 +109,33 @@ class AmfPduSessionSmContextAsyncService final :
  * through a completion queue where requests are processed and returned async
  */
 class SessionProxyResponderAsyncService final :
-  public AsyncService,
-  public SessionProxyResponder::AsyncService {
+    public AsyncService,
+    public SessionProxyResponder::AsyncService {
  public:
   SessionProxyResponderAsyncService(
-    std::unique_ptr<ServerCompletionQueue> cq,
-    std::unique_ptr<SessionProxyResponderHandler> handler);
+      std::unique_ptr<ServerCompletionQueue> cq,
+      std::shared_ptr<SessionProxyResponderHandler> handler);
 
  protected:
   void init_call_data();
 
  private:
-  std::unique_ptr<SessionProxyResponderHandler> handler_;
+  std::shared_ptr<SessionProxyResponderHandler> handler_;
+};
+
+class AbortSessionResponderAsyncService final
+    : public AsyncService,
+      public AbortSessionResponder::AsyncService {
+ public:
+  AbortSessionResponderAsyncService(
+      std::unique_ptr<ServerCompletionQueue> cq,
+      std::shared_ptr<SessionProxyResponderHandler> handler);
+
+ protected:
+  void init_call_data();
+
+ private:
+  std::shared_ptr<SessionProxyResponderHandler> handler_;
 };
 
 /**
@@ -186,24 +205,24 @@ class AsyncGRPCRequest : public CallData {
  * Class to handle ReportRuleStats requests
  */
 class ReportRuleStatsCallData :
-  public AsyncGRPCRequest<
-    LocalSessionManager::AsyncService,
-    RuleRecordTable,
-    Void> {
+    public AsyncGRPCRequest<
+        LocalSessionManager::AsyncService,
+        RuleRecordTable,
+        Void> {
  public:
   ReportRuleStatsCallData(
-    ServerCompletionQueue *cq,
-    LocalSessionManager::AsyncService &service,
-    LocalSessionManagerHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
+      ServerCompletionQueue *cq,
+      LocalSessionManager::AsyncService &service,
+      LocalSessionManagerHandler &handler):
+      AsyncGRPCRequest(cq, service),
+      handler_(handler)
   {
     // By calling RequestReportRuleStats, any RPC to ReportRuleStats will get
     // added to the request queue cq_ with the tag being the memory address
     // of this instance. When the request is completed, it will be added to
     // cq_ again to be finished
     service_.RequestReportRuleStats(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
   }
 
  protected:
@@ -258,20 +277,20 @@ private:
  * Class to handle CreateSession requests
  */
 class CreateSessionCallData :
-  public AsyncGRPCRequest<
-    LocalSessionManager::AsyncService,
-    LocalCreateSessionRequest,
-    LocalCreateSessionResponse> {
+    public AsyncGRPCRequest<
+        LocalSessionManager::AsyncService,
+        LocalCreateSessionRequest,
+        LocalCreateSessionResponse> {
  public:
   CreateSessionCallData(
-    ServerCompletionQueue *cq,
-    LocalSessionManager::AsyncService &service,
-    LocalSessionManagerHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
+      ServerCompletionQueue *cq,
+      LocalSessionManager::AsyncService &service,
+      LocalSessionManagerHandler &handler):
+      AsyncGRPCRequest(cq, service),
+      handler_(handler)
   {
     service_.RequestCreateSession(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
   }
 
  protected:
@@ -290,20 +309,20 @@ class CreateSessionCallData :
  * Class to handle EndSession requests
  */
 class EndSessionCallData :
-  public AsyncGRPCRequest<
-    LocalSessionManager::AsyncService,
-    LocalEndSessionRequest,
-    LocalEndSessionResponse> {
+    public AsyncGRPCRequest<
+        LocalSessionManager::AsyncService,
+        LocalEndSessionRequest,
+        LocalEndSessionResponse> {
  public:
   EndSessionCallData(
-    ServerCompletionQueue *cq,
-    LocalSessionManager::AsyncService &service,
-    LocalSessionManagerHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
+      ServerCompletionQueue *cq,
+      LocalSessionManager::AsyncService &service,
+      LocalSessionManagerHandler &handler):
+      AsyncGRPCRequest(cq, service),
+      handler_(handler)
   {
     service_.RequestEndSession(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
   }
 
  protected:
@@ -322,20 +341,20 @@ class EndSessionCallData :
  * Class to handle BindPolicy2Bearer requests
  */
 class BindPolicy2BearerCallData :
-  public AsyncGRPCRequest<
-    LocalSessionManager::AsyncService,
-    PolicyBearerBindingRequest,
-    PolicyBearerBindingResponse> {
+    public AsyncGRPCRequest<
+        LocalSessionManager::AsyncService,
+        PolicyBearerBindingRequest,
+        PolicyBearerBindingResponse> {
  public:
   BindPolicy2BearerCallData(
-    ServerCompletionQueue *cq,
-    LocalSessionManager::AsyncService &service,
-    LocalSessionManagerHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
+      ServerCompletionQueue *cq,
+      LocalSessionManager::AsyncService &service,
+      LocalSessionManagerHandler &handler):
+      AsyncGRPCRequest(cq, service),
+      handler_(handler)
   {
     service_.RequestBindPolicy2Bearer(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
   }
 
  protected:
@@ -354,52 +373,72 @@ class BindPolicy2BearerCallData :
  * Class to handle SetSessionRules requests
  */
 class SetSessionRulesCallData :
-  public AsyncGRPCRequest<
-    LocalSessionManager::AsyncService,
-    SessionRules,
-    Void> {
+    public AsyncGRPCRequest<
+        LocalSessionManager::AsyncService,
+        SessionRules,
+        Void> {
  public:
   SetSessionRulesCallData(
-    ServerCompletionQueue *cq,
-    LocalSessionManager::AsyncService &service,
-    LocalSessionManagerHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
-  {
+      ServerCompletionQueue* cq, LocalSessionManager::AsyncService& service,
+      LocalSessionManagerHandler& handler)
+      : AsyncGRPCRequest(cq, service), handler_(handler) {
     service_.RequestSetSessionRules(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void*) this);
   }
 
  protected:
-  void clone() override { new SetSessionRulesCallData(cq_, service_, handler_); }
+  void clone() override {
+    new SetSessionRulesCallData(cq_, service_, handler_);
+  }
 
-  void process() override
-  {
+  void process() override {
     handler_.SetSessionRules(&ctx_, &request_, get_finish_callback());
   }
 
  private:
-  LocalSessionManagerHandler &handler_;
+  LocalSessionManagerHandler& handler_;
+};
+
+/**
+ * Class to handle AbortSessionRequest requests
+ */
+class AbortSessionCallData : public AsyncGRPCRequest<
+    AbortSessionResponder::AsyncService,
+    AbortSessionRequest, AbortSessionResult> {
+ public:
+  AbortSessionCallData(
+      ServerCompletionQueue* cq, AbortSessionResponder::AsyncService& service,
+      SessionProxyResponderHandler& handler)
+      : AsyncGRPCRequest(cq, service), handler_(handler) {
+    service_.RequestAbortSession(
+        &ctx_, &request_, &responder_, cq_, cq_, (void*) this);
+  }
+
+ protected:
+  void clone() override { new AbortSessionCallData(cq_, service_, handler_); }
+
+  void process() override {
+    handler_.AbortSession(&ctx_, &request_, get_finish_callback());
+  }
+
+ private:
+  SessionProxyResponderHandler& handler_;
 };
 
 /**
  * Class to handle ChargingReauth requests
  */
-class ChargingReAuthCallData :
-  public AsyncGRPCRequest<
-    SessionProxyResponder::AsyncService,
-    ChargingReAuthRequest,
-    ChargingReAuthAnswer> {
+class ChargingReAuthCallData
+    : public AsyncGRPCRequest<
+        SessionProxyResponder::AsyncService, ChargingReAuthRequest,
+        ChargingReAuthAnswer> {
  public:
   ChargingReAuthCallData(
-    ServerCompletionQueue *cq,
-    SessionProxyResponder::AsyncService &service,
-    SessionProxyResponderHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
-  {
+      ServerCompletionQueue* cq, SessionProxyResponder::AsyncService& service,
+      SessionProxyResponderHandler& handler)
+      : AsyncGRPCRequest(cq, service), handler_(handler) {
     service_.RequestChargingReAuth(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void*) this);
   }
 
  protected:
@@ -418,20 +457,20 @@ class ChargingReAuthCallData :
  * Class to handle PolicyReauth requests
  */
 class PolicyReAuthCallData :
-  public AsyncGRPCRequest<
-    SessionProxyResponder::AsyncService,
-    PolicyReAuthRequest,
-    PolicyReAuthAnswer> {
+    public AsyncGRPCRequest<
+        SessionProxyResponder::AsyncService,
+        PolicyReAuthRequest,
+        PolicyReAuthAnswer> {
  public:
   PolicyReAuthCallData(
-    ServerCompletionQueue *cq,
-    SessionProxyResponder::AsyncService &service,
-    SessionProxyResponderHandler &handler):
-    AsyncGRPCRequest(cq, service),
-    handler_(handler)
+      ServerCompletionQueue *cq,
+      SessionProxyResponder::AsyncService &service,
+      SessionProxyResponderHandler &handler):
+      AsyncGRPCRequest(cq, service),
+      handler_(handler)
   {
     service_.RequestPolicyReAuth(
-      &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
+        &ctx_, &request_, &responder_, cq_, cq_, (void *) this);
   }
 
  protected:

--- a/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
+++ b/lte/gateway/c/session_manager/SessionProxyResponderHandler.cpp
@@ -36,8 +36,8 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
                << request->session_id() << " and charging_key "
                << request->charging_key();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy,
-                                                    response_callback]() {
-    auto session_map = get_sessions_for_charging(request_cpy);
+                                                       response_callback]() {
+    auto session_map = session_store_.read_sessions({request_cpy.sid()});
     SessionUpdate update =
         SessionStore::get_default_session_update(session_map);
     auto result =
@@ -45,14 +45,13 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
     MLOG(MDEBUG) << "Result of Gy (Charging) ReAuthRequest "
                  << raa_result_to_str(result);
     ChargingReAuthAnswer ans;
+    Status status;
     ans.set_result(result);
 
     bool update_success = session_store_.update_sessions(update);
     if (update_success) {
-      MLOG(MDEBUG) << "Sending RAA response for Gy ReAuth "
-                   << request_cpy.session_id();
       PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
-      response_callback(Status::OK, ans);
+      status = Status::OK;
     } else {
       // Todo If update fails, we should rollback changes from the request
       MLOG(MERROR) << "Failed to update Gy (Charging) ReAuthRequest changes...";
@@ -61,9 +60,9 @@ void SessionProxyResponderHandlerImpl::ChargingReAuth(
           "ChargingReAuth no longer valid due to another update that "
           "updated the session first.");
       PrintGrpcMessage(static_cast<const google::protobuf::Message&>(ans));
-      response_callback(status, ans);
     }
-    MLOG(MDEBUG) << "Sent RAA response for Gy ReAuth "
+    response_callback(status, ans);
+    MLOG(MDEBUG) << "Sent RAA response " << result << " for Gy ReAuth "
                  << request_cpy.session_id();
   });
 }
@@ -76,9 +75,9 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
   MLOG(MDEBUG) << "Received a Gx (Policy) ReAuthRequest for session_id "
                << request->session_id();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy,
-                                                    response_callback]() {
+                                                       response_callback]() {
     PolicyReAuthAnswer ans;
-    auto session_map = get_sessions_for_policy(request_cpy);
+    auto session_map = session_store_.read_sessions({request_cpy.imsi()});
     SessionUpdate update =
         SessionStore::get_default_session_update(session_map);
     enforcer_->init_policy_reauth(session_map, request_cpy, ans, update);
@@ -105,15 +104,39 @@ void SessionProxyResponderHandlerImpl::PolicyReAuth(
   });
 }
 
-SessionMap SessionProxyResponderHandlerImpl::get_sessions_for_charging(
-    const ChargingReAuthRequest& request) {
-  SessionRead req = {request.sid()};
-  return session_store_.read_sessions(req);
-}
-
-SessionMap SessionProxyResponderHandlerImpl::get_sessions_for_policy(
-    const PolicyReAuthRequest& request) {
-  SessionRead req = {request.imsi()};
-  return session_store_.read_sessions(req);
+void SessionProxyResponderHandlerImpl::AbortSession(
+    ServerContext* context, const AbortSessionRequest* request,
+    std::function<void(Status, AbortSessionResult)> response_callback) {
+  PrintGrpcMessage(static_cast<const google::protobuf::Message&>(*request));
+  const auto imsi       = request->user_name();
+  const auto session_id = request->session_id();
+  MLOG(MINFO) << "Received an ASR for session_id " << session_id;
+  enforcer_->get_event_base().runInEventBaseThread([this, imsi, session_id,
+                                                       response_callback]() {
+    grpc::Status status = Status::OK;
+    AbortSessionResult answer;
+    auto session_map = session_store_.read_sessions({imsi});
+    SessionUpdate updates =
+        SessionStore::get_default_session_update(session_map);
+    auto found =
+        enforcer_->handle_abort_session(session_map, imsi, session_id, updates);
+    if (found) {
+      answer.set_code(AbortSessionResult_Code_SESSION_REMOVED);
+    } else {
+      answer.set_code(AbortSessionResult_Code_SESSION_NOT_FOUND);
+    }
+    bool update_success = session_store_.update_sessions(updates);
+    if (!update_success) {
+      MLOG(MERROR) << "SessionStore update failed when processing ASR for "
+                   << session_id;
+      status =
+          Status(grpc::ABORTED, "ASR failed due to internal datastore error");
+      answer.set_code(AbortSessionResult_Code_SESSION_NOT_FOUND);
+    }
+    PrintGrpcMessage(static_cast<const google::protobuf::Message&>(answer));
+    response_callback(status, answer);
+    MLOG(MINFO) << "Sent ASA for " << session_id << " with code "
+                << asr_result_to_str(answer.code());
+  });
 }
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -630,7 +630,7 @@ SubscriberQuotaUpdate_Type SessionState::get_subscriber_quota_state() const {
   return subscriber_quota_state_;
 }
 
-bool SessionState::complete_termination(SessionStateUpdateCriteria& uc) {
+bool SessionState::can_complete_termination(SessionStateUpdateCriteria& uc) {
   switch (curr_state_) {
     case SESSION_ACTIVE:
       MLOG(MERROR) << "Encountered unexpected state 'ACTIVE' when "

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -194,12 +194,12 @@ class SessionState {
   bool is_terminating();
 
   /**
-   * complete_termination checks the FSM state and transitions the state to
+   * can_complete_termination checks the FSM state and transitions the state to
    * TERMINATED, if it can. If the state is ACTIVE or TERMINATED, it will not do
    * anything.
    * This function will return true if the termination happened successfully.
    */
-  bool complete_termination(SessionStateUpdateCriteria& update_criteria);
+  bool can_complete_termination(SessionStateUpdateCriteria& update_criteria);
 
   bool reset_reporting_charging_credit(
       const CreditKey& key, SessionStateUpdateCriteria& update_criteria);
@@ -234,7 +234,7 @@ class SessionState {
    * get_total_credit_usage returns the tx and rx of the session,
    * accounting for all unique keys (charging and monitoring) used by all
    * rules (static and dynamic)
-   * Should be called after complete_termination.
+   * Should be called after can_complete_termination.
    */
   TotalCreditUsage get_total_credit_usage();
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -355,7 +355,8 @@ TEST_F(LocalEnforcerTest, test_aggregate_records_for_termination) {
   insert_static_rule(2, "", "rule3");
 
   auto update = SessionStore::get_default_session_update(session_map);
-  local_enforcer->terminate_session(session_map, IMSI1, "IMS", update);
+  local_enforcer->handle_termination_from_access(
+      session_map, IMSI1, "IMS", update);
 
   RuleRecordTable table;
   auto record_list = table.mutable_records();
@@ -554,7 +555,7 @@ TEST_F(LocalEnforcerTest, test_terminate_credit) {
       *reporter,
       report_terminate_session(CheckTerminateRequestCount(IMSI1, 0, 2), _))
       .Times(1);
-  local_enforcer->terminate_session(
+  local_enforcer->handle_termination_from_access(
       session_map, IMSI1, test_cfg_.common_context.apn(), update);
 
   RuleRecordTable empty_table;
@@ -605,7 +606,8 @@ TEST_F(LocalEnforcerTest, test_terminate_credit_during_reporting) {
 
   session_map = session_store->read_sessions(SessionRead{IMSI1});
   // Collecting terminations should key 1 anyways during reporting
-  local_enforcer->terminate_session(session_map, IMSI1, "IMS", update);
+  local_enforcer->handle_termination_from_access(
+      session_map, IMSI1, "IMS", update);
 
   EXPECT_CALL(
       *reporter,
@@ -991,7 +993,8 @@ TEST_F(LocalEnforcerTest, test_all) {
       1024);
 
   // Terminate IMSI1
-  local_enforcer->terminate_session(session_map, IMSI1, "IMS", update);
+  local_enforcer->handle_termination_from_access(
+      session_map, IMSI1, "IMS", update);
 
   EXPECT_CALL(
       *reporter,

--- a/lte/gateway/configs/service_registry.yml
+++ b/lte/gateway/configs/service_registry.yml
@@ -35,6 +35,9 @@ services:
   sessiond:
     ip_address: 127.0.0.1
     port: 50065
+  abort_session:
+    ip_address: 127.0.0.1
+    port: 50065
   test_service:
     ip_address: 127.0.0.1
     port: 50066

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -117,6 +117,7 @@ s1aptests/test_attach_ul_udp_data.py \
 s1aptests/test_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
+s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -38,6 +38,10 @@ from lte.protos.session_manager_pb2 import (
     PolicyReAuthRequest,
     QoSInformation,
 )
+from lte.protos.abort_session_pb2 import (
+    AbortSessionRequest,
+    AbortSessionResult,
+)
 from lte.protos.spgw_service_pb2 import (
     CreateBearerRequest,
     DeleteBearerRequest,
@@ -45,6 +49,7 @@ from lte.protos.spgw_service_pb2 import (
 from lte.protos.spgw_service_pb2_grpc import SpgwServiceStub
 from magma.subscriberdb.sid import SIDUtils
 from lte.protos.session_manager_pb2_grpc import SessionProxyResponderStub
+from lte.protos.abort_session_pb2_grpc import AbortSessionResponderStub
 from orc8r.protos.directoryd_pb2 import GetDirectoryFieldRequest
 from orc8r.protos.directoryd_pb2_grpc import GatewayDirectoryServiceStub
 
@@ -788,6 +793,9 @@ class SessionManagerUtil(object):
         self._session_stub = SessionProxyResponderStub(
             get_rpc_channel("sessiond")
         )
+        self._abort_session_stub = AbortSessionResponderStub(
+            get_rpc_channel("sessiond")
+        )
         self._directorydstub = GatewayDirectoryServiceStub(
             get_rpc_channel("directoryd")
         )
@@ -917,5 +925,26 @@ class SessionManagerUtil(object):
                 revalidation_time=None,
                 usage_monitoring_credits=[],
                 qos_info=qos,
+            )
+        )
+
+    def create_AbortSessionRequest(self, imsi: str) -> AbortSessionResult:
+        # Get SessionID
+        req = GetDirectoryFieldRequest(id=imsi, field_key="session_id")
+        try:
+            res = self._directorydstub.GetDirectoryField(
+                req, DEFAULT_GRPC_TIMEOUT
+            )
+        except grpc.RpcError as err:
+            logging.error(
+                "GetDirectoryFieldRequest error for id: %s! [%s] %s",
+                imsi,
+                err.code(),
+                err.details(),
+            )
+        return self._abort_session_stub.AbortSession(
+            AbortSessionRequest(
+                session_id=res.value,
+                user_name=imsi,
             )
         )

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -1,0 +1,85 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import s1ap_types
+import time
+
+from integ_tests.s1aptests import s1ap_wrapper
+from integ_tests.s1aptests.s1ap_utils import SpgwUtil
+from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+
+
+class TestAttachASR(unittest.TestCase):
+    SPGW_TABLE = 0
+    GTP_PORT = 32768
+    LOCAL_PORT = "LOCAL"
+
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self._sessionManager_util = SessionManagerUtil()
+        self._spgw_util = SpgwUtil()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_attach_asr_tcp_data(self):
+        """ attach + send ASR Req to session manager with a"""
+        """ single UE """
+        num_ues = 1
+        self._s1ap_wrapper.configUEDevice(num_ues)
+        datapath = get_datapath()
+
+        req = self._s1ap_wrapper.ue_req
+        print(
+            "********************** Running End to End attach for ",
+            "UE id ",
+            req.ue_id,
+        )
+        # Now actually complete the attach
+        self._s1ap_wrapper._s1_util.attach(
+            req.ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+
+        print(
+            "********************** Sending ASR for IMSI",
+            "".join([str(i) for i in req.imsi]),
+        )
+        self._sessionManager_util.create_AbortSessionRequest(
+            "IMSI" + "".join([str(i) for i in req.imsi]),
+        )
+
+        print("Sleeping for 5 seconds")
+        time.sleep(5)
+
+        print("Checking that uplink/downlink flows were deleted")
+        flows = get_flows(
+            datapath, {"table_id": self.SPGW_TABLE, "priority": 0}
+        )
+        self.assertEqual(
+            len(flows), 2, "There should only be 2 default table 0 flows"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/scripts/session_manager_cli.py
+++ b/lte/gateway/python/scripts/session_manager_cli.py
@@ -34,6 +34,12 @@ from lte.protos.session_manager_pb2_grpc import (
     LocalSessionManagerStub,
     SessionProxyResponderStub,
 )
+from lte.protos.abort_session_pb2 import (
+    AbortSessionRequest,
+)
+from lte.protos.abort_session_pb2_grpc import (
+    AbortSessionResponderStub,
+)
 from lte.protos.subscriberdb_pb2 import SubscriberID
 from magma.common.rpc_utils import grpc_wrapper
 from magma.common.service_registry import ServiceRegistry
@@ -208,6 +214,20 @@ def send_policy_rar(client, args):
     print(reauth_result)
 
 
+@grpc_wrapper
+def send_abort_session(client, args):
+    abort_session_chan = ServiceRegistry.get_rpc_channel("abort_session", ServiceRegistry.LOCAL)
+    abort_session_client = AbortSessionResponderStub(abort_session_chan)
+
+    asr = AbortSessionRequest(
+        session_id=args.session_id,
+        user_name=args.user_name,
+    )
+
+    asa = abort_session_client.AbortSession(asr)
+    print(asa)
+
+
 def create_parser():
     """
     Creates the argparse parser with all the arguments.
@@ -228,7 +248,7 @@ def create_parser():
     create_session_parser.add_argument("imsi", help="e.g., 001010000088888")
     create_session_parser.set_defaults(func=send_create_session)
 
-    # Create Session
+    # PolicyReAuth
     create_session_parser = subparsers.add_parser(
         "policy_rar", help="Send Policy Reauthorization Request to sessiond"
     )
@@ -246,16 +266,25 @@ def create_parser():
     create_session_parser.add_argument(
         "flow_rules",
         help="List of 6-tuples: "
-        "[direction,protocol,src_ip,src_port,dst_ip,dst_port] "
-        "separated by ';',e.g., "
-        "UL,6,192.168.50.1,0,192.168.40.2,12345;DL,1,8.8.8.8,0,192.168.50.1,0",
+             "[direction,protocol,src_ip,src_port,dst_ip,dst_port] "
+             "separated by ';',e.g., "
+             "UL,6,192.168.50.1,0,192.168.40.2,12345;DL,1,8.8.8.8,0,192.168.50.1,0",
     )
     create_session_parser.add_argument(
         "qos",
         help="QoS-tuple: [max_req_bw_ul,max_req_bw_dl,gbr_ul,gbr_dl,arp_prio,"
-        "pre_cap,pre_vul] e.g., 10000000,10000000,0,0,15,1,0",
+             "pre_cap,pre_vul] e.g., 10000000,10000000,0,0,15,1,0",
     )
     create_session_parser.set_defaults(func=send_policy_rar)
+
+    # ASR
+    abort_session_parser = subparsers.add_parser(
+        "abort_session",
+        help="Send an AbortSessionRequest to SessionD service",
+    )
+    abort_session_parser.add_argument("session_id", help="e.g., 001010000088888")
+    abort_session_parser.add_argument("user_name", help="e.g., IMSI010000088888")
+    abort_session_parser.set_defaults(func=send_abort_session)
 
     return parser
 

--- a/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
+++ b/orc8r/gateway/c/common/async_grpc/CMakeLists.txt
@@ -18,8 +18,8 @@ list(APPEND PROTO_SRCS "")
 list(APPEND PROTO_HDRS "")
 
 set(ASYNC_ORC8R_CPP_PROTOS common redis eventd)
-set(ASYNC_LTE_CPP_PROTOS session_manager policydb subscriberdb mobilityd)
-set(ASYNC_LTE_GRPC_PROTOS session_manager mobilityd)
+set(ASYNC_LTE_CPP_PROTOS session_manager abort_session policydb subscriberdb mobilityd)
+set(ASYNC_LTE_GRPC_PROTOS session_manager abort_session mobilityd)
 set(ASYNC_ORC8R_GRPC_PROTOS eventd)
 
 generate_all_protos("${ASYNC_LTE_CPP_PROTOS}" "${ASYNC_ORC8R_CPP_PROTOS}"


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
1. Host ASR server in SessionD for FWA deployments
2. Add simple s1ap test to assert an ASR removes all flows
3. Modify session_manager_cli.py to add an ASR command

Added a new optional GRPC service for AbortSession in SessionD. This service is attached to the main grpc server IF the deployment type is FWA. (In CWF, it is currently handled in AAA. That is left alone for now, since we support an option to run AAA on its own.)
AbortSession message is handled by the SessionProxyResponseHandler service, as it is coming from the policy component. (Same as ReAuth). 
The actual logic is essentially the same as an externally triggered session terminate.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF integ tests
S1AP tests
SessionD unit tests
New S1AP test to run ASR call flow
```
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.651707  7806 LocalSessionManagerHandler.cpp:595] Received a LocalCreateSessionRequest for IMSI001010000000001 with APN:magma.ipv4, default bearer ID:5, PLMN ID:00101, IMSI PLMN ID:00101
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.651779  7806 LocalSessionManagerHandler.cpp:243] Sending a CreateSessionRequest to fetch policies for IMSI001010000000001-106117
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.653730  7806 LocalSessionManagerHandler.cpp:253] Processing a CreateSessionResponse for IMSI001010000000001-106117
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.653805  7806 LocalEnforcer.cpp:746] Activating untracked rule allowlist_sid-IMSI001010000000001-magma.ipv4
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.653898  7806 PipelinedClient.cpp:57] Sending AMBR info for IMSI001010000000001, ip addr=192.168.128.230, dl=100000000, ul=200000000
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.654016  7806 PipelinedClient.cpp:57] Sending AMBR info for IMSI001010000000001, ip addr=192.168.128.230, dl=100000000, ul=200000000
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.654191  7806 LocalEnforcer.cpp:1915] Failed mac/name parsiong for apn magma.ipv4
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.654467  7806 LocalSessionManagerHandler.cpp:260] Successfully initialized new session IMSI001010000000001-106117 in SessionD for subscriber IMSI001010000000001
Sep 24 17:06:04 magma-dev eventd[8165]: DEBUG:root:Logging event: stream_name: "sessiond"
Sep 24 17:06:04 magma-dev sessiond[7806]: I0924 17:06:04.658771  7851 SessionEvents.cpp:82] Could not log session_created event {"pdp_start_time":1600967164,"session_id":"IMSI001010000000001-106117","imsi":"IMSI001010000000001","msisdn":"","spgw_ip":"192.168.60.142","apn":"magma.ipv4","mac_addr":"","imei":"","ip_addr":"192.168.128.230"}, Error Message: Could not connect to FluentBit locally, Details: [Errno 111] Connection refused
Sep 24 17:06:09 magma-dev sessiond[7806]: I0924 17:06:09.677762  7858 SessionProxyResponderHandler.cpp:113] Received an ASR for session_id IMSI001010000000001-106117
Sep 24 17:06:09 magma-dev sessiond[7806]: I0924 17:06:09.678580  7806 LocalEnforcer.cpp:367] Initiating session termination for IMSI001010000000001-106117
Sep 24 17:06:09 magma-dev sessiond[7806]: I0924 17:06:09.678858  7806 SpgwServiceClient.cpp:72] Deleting default bearer and corresponding PDN session for IMSI: IMSI001010000000001 APN IP addr 192.168.128.230 Bearer ID 5
Sep 24 17:06:09 magma-dev sessiond[7806]: I0924 17:06:09.679253  7806 LocalEnforcer.cpp:1439] IMSI001010000000001-106117 deleted from SessionMap
Sep 24 17:06:09 magma-dev sessiond[7806]: I0924 17:06:09.679553  7806 SessionProxyResponderHandler.cpp:138] Sent ASA for IMSI001010000000001-106117 with code SESSION_REMOVED
Sep 24 17:06:09 magma-dev eventd[8165]: DEBUG:root:Logging event: stream_name: "sessiond"
Sep 24 17:06:09 magma-dev control_proxy[7888]: 2020-09-24T17:06:09.675Z [192.168.60.141 -> sessiond.local,8443] "POST /magma.lte.AbortSessionResponder/AbortSession HTTP/2" 200 7bytes 0.002s
Sep 24 17:06:09 magma-dev sessiond[7806]: I0924 17:06:09.685093  7851 SessionEvents.cpp:208] Could not log session_terminated event {"mac_addr":"","monitoring_rx":0,"ip_addr":"192.168.128.230","pdp_start_time":1600967164,"charging_tx":0,"monitoring_tx":0,"imei":"","pdp_end_time":1600967169,"apn":"magma.ipv4","msisdn":"","total_rx":0,"imsi":"IMSI001010000000001","session_id":"IMSI001010000000001-106117","spgw_ip":"192.168.60.142","charging_rx":0,"total_tx":0}, Error Message: Could not connect to FluentBit locally, Details: [Errno 111] Connection refused
Sep 24 17:06:10 magma-dev sessiond[7806]: I0924 17:06:10.457720  7806 LocalEnforcer.cpp:260] Could not find session for IMSI001010000000001 and 192.168.128.230 during record aggregation
Sep 24 17:06:39 magma-dev sessiond[7806]: I0924 17:06:39.713505  7806 LocalSessionManagerHandler.cpp:456] Received a termination request from Access for IMSI001010000000001 apn magma.ipv4
Sep 24 17:06:39 magma-dev sessiond[7806]: I0924 17:06:39.713537  7806 LocalSessionManagerHandler.cpp:461] Failed to find session to terminate for subscriber IMSI001010000000001 apn magma.ipv4
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
