### PR TITLE
[nms] automatic alerts for XWFM

### DIFF
--- a/nms/app/packages/magmalte/alerts/routes.js
+++ b/nms/app/packages/magmalte/alerts/routes.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import express from 'express';
+import syncAlerts from './sync';
+import type {ExpressResponse} from 'express';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+
+const router: express.Router<FBCNMSRequest, ExpressResponse> = express.Router();
+
+router.post('/:networkID', syncAlerts);
+
+export default router;

--- a/nms/app/packages/magmalte/alerts/sync.js
+++ b/nms/app/packages/magmalte/alerts/sync.js
@@ -1,0 +1,103 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import MagmaV1API from '@fbcnms/platform-server/magma/index';
+
+import {CWF} from '@fbcnms/types/network';
+import {xwfmAlerts} from './xwfmAlerts';
+import type {ExpressResponse} from 'express';
+import type {FBCNMSRequest} from '@fbcnms/auth/access';
+import type {network_type, prom_alert_config} from '@fbcnms/magma-api';
+
+async function syncAlertsForNetwork(
+  networkID: string,
+  autoAlerts: {[string]: prom_alert_config},
+) {
+  // Get currently configured alerts
+  const alerts = await MagmaV1API.getNetworksByNetworkIdPrometheusAlertConfig({
+    networkId: networkID,
+  });
+
+  const existingAlerts = alerts.reduce(
+    (map, obj) => ((map[obj.alert] = obj), map),
+    {},
+  );
+
+  const putAlerts: prom_alert_config[] = [];
+  const postAlerts: prom_alert_config[] = [];
+  for (const alertName in autoAlerts) {
+    if (existingAlerts[alertName] !== undefined) {
+      putAlerts.push(autoAlerts[alertName]);
+    } else {
+      postAlerts.push(autoAlerts[alertName]);
+    }
+  }
+
+  const requests = [];
+  for (const alert of postAlerts) {
+    requests.push(
+      MagmaV1API.postNetworksByNetworkIdPrometheusAlertConfig({
+        networkId: networkID,
+        alertConfig: alert,
+      }),
+    );
+  }
+  for (const alert of putAlerts) {
+    requests.push(
+      MagmaV1API.putNetworksByNetworkIdPrometheusAlertConfigByAlertName({
+        networkId: networkID,
+        alertName: alert.alert,
+        alertConfig: alert,
+      }),
+    );
+  }
+
+  await Promise.all(requests).catch(error => {
+    throw error.message;
+  });
+}
+
+async function syncAlerts(req: FBCNMSRequest, res: ExpressResponse) {
+  try {
+    const networkID = req.params.networkID;
+    const type = await getNetworkType(networkID);
+    if (type == null) {
+      res.status(500).send(`Invalid network type`).end();
+      return;
+    }
+    switch (type) {
+      // TODO: When XWFM networks are actually a thing in the NMS, change this
+      case CWF:
+        await syncAlertsForNetwork(networkID, xwfmAlerts);
+        break;
+      default:
+        res
+          .status(400)
+          .send(`Network type ${type} has no predefined alerts`)
+          .end();
+    }
+    res.status(200).end();
+  } catch (e) {
+    res.status(500).send(e).end();
+  }
+}
+
+async function getNetworkType(networkId: string): Promise<?network_type> {
+  const networkInfo = await MagmaV1API.getNetworksByNetworkId({networkId});
+  return networkInfo.type;
+}
+
+export default syncAlerts;

--- a/nms/app/packages/magmalte/alerts/xwfmAlerts.js
+++ b/nms/app/packages/magmalte/alerts/xwfmAlerts.js
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {prom_alert_config} from '@fbcnms/magma-api';
+
+export const xwfmAlerts: {[string]: prom_alert_config} = {
+  'Test Auto Alert': {
+    alert: 'Test Auto Alert',
+    expr: 'test_metric > 0',
+    labels: {severity: 'minor'},
+    annotations: {description: 'A test of the automatic alert system'},
+  },
+};

--- a/nms/app/packages/magmalte/app/components/admin/AddNetworkDialog.js
+++ b/nms/app/packages/magmalte/app/components/admin/AddNetworkDialog.js
@@ -31,9 +31,11 @@ import TextField from '@material-ui/core/TextField';
 import axios from 'axios';
 
 import nullthrows from '@fbcnms/util/nullthrows';
-import {AllNetworkTypes} from '@fbcnms/types/network';
+import {AllNetworkTypes, XWFM} from '@fbcnms/types/network';
 import {CWF, FEG, FEG_LTE} from '@fbcnms/types/network';
 import {makeStyles} from '@material-ui/styles';
+import {triggerAlertSync} from './Alerts';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useState} from 'react';
 
 const useStyles = makeStyles(() => ({
@@ -51,6 +53,7 @@ type Props = {
 
 export default function NetworkDialog(props: Props) {
   const classes = useStyles();
+  const enqueueSnackbar = useEnqueueSnackbar();
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [networkID, setNetworkId] = useState('');
@@ -75,6 +78,9 @@ export default function NetworkDialog(props: Props) {
       .then(response => {
         if (response.data.success) {
           props.onSave(nullthrows(networkID));
+          if (payload.data.networkType === XWFM) {
+            triggerAlertSync(networkID, enqueueSnackbar);
+          }
         } else {
           setError(response.data.message);
         }

--- a/nms/app/packages/magmalte/app/components/admin/Admin.js
+++ b/nms/app/packages/magmalte/app/components/admin/Admin.js
@@ -17,6 +17,8 @@
 import * as React from 'react';
 import AdminContextProvider from './AdminContextProvider';
 import AdminMain from './AdminMain';
+import AlarmIcon from '@material-ui/icons/Alarm';
+import Alerts from './Alerts';
 import AppContext from '@fbcnms/ui/context/AppContext';
 import ApplicationMain from '@fbcnms/ui/components/ApplicationMain';
 import AssignmentIcon from '@material-ui/icons/Assignment';
@@ -64,6 +66,11 @@ function NavItems() {
         path={relativeUrl('/networks')}
         icon={<SignalCellularAlt />}
       />
+      <NavListItem
+        label="Alerts"
+        path={relativeUrl('/alerts')}
+        icon={<AlarmIcon />}
+      />
     </>
   );
 }
@@ -76,6 +83,7 @@ function NavRoutes() {
       <Route path={relativeUrl('/users')} component={UsersSettings} />
       <Route path={relativeUrl('/audit_log')} component={AuditLog} />
       <Route path={relativeUrl('/networks')} component={Networks} />
+      <Route path={relativeUrl('/alerts')} component={Alerts} />
       <Route
         path={relativeUrl('/settings')}
         render={() => (

--- a/nms/app/packages/magmalte/app/components/admin/Alerts.js
+++ b/nms/app/packages/magmalte/app/components/admin/Alerts.js
@@ -1,0 +1,112 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import Button from '@fbcnms/ui/components/design-system/Button';
+import FormControl from '@material-ui/core/FormControl';
+import FormHelperText from '@material-ui/core/FormHelperText';
+import Grid from '@material-ui/core/Grid';
+import LoadingFiller from '@fbcnms/ui/components/LoadingFiller';
+import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
+import MenuItem from '@material-ui/core/MenuItem';
+import React, {useCallback} from 'react';
+import Select from '@material-ui/core/Select';
+import axios from 'axios';
+import useMagmaAPI from '@fbcnms/ui/magma/useMagmaAPI';
+import {makeStyles} from '@material-ui/styles';
+import {sortBy} from 'lodash';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+import {useState} from 'react';
+
+const useStyles = makeStyles(() => ({
+  header: {
+    margin: '10px',
+    display: 'flex',
+    justifyContent: 'space-between',
+  },
+  paper: {
+    margin: '10px',
+  },
+  noNetworks: {
+    height: '70vh',
+  },
+}));
+
+function Alerts() {
+  const classes = useStyles();
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  const [network, setNetwork] = useState<string>('');
+  const [networkIDs, setNetworkIDs] = useState(null);
+
+  const {error, isLoading} = useMagmaAPI(
+    MagmaV1API.getNetworks,
+    {},
+    useCallback(res => setNetworkIDs(sortBy(res, [n => n.toLowerCase()])), []),
+  );
+
+  if (error || isLoading || !networkIDs) {
+    return <LoadingFiller />;
+  }
+
+  return (
+    <div className={classes.paper}>
+      <div className={classes.header}>
+        <h1>Predefined Alerts</h1>
+      </div>
+      <p>
+        Use this to create and/or sync predefined alerts for the selected XWFM
+        network.
+      </p>
+      <Grid container>
+        <Grid item xs={1}>
+          <FormControl>
+            <Select value={network} onChange={e => setNetwork(e.target.value)}>
+              {networkIDs.map(networkID => (
+                <MenuItem key={networkID} value={networkID}>
+                  {networkID}
+                </MenuItem>
+              ))}
+            </Select>
+            <FormHelperText>Network to Sync</FormHelperText>
+          </FormControl>
+        </Grid>
+        <Grid item xs={3}>
+          <Button onClick={() => triggerAlertSync(network, enqueueSnackbar)}>
+            Sync Alerts
+          </Button>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+export async function triggerAlertSync(
+  networkID: string,
+  enqueueSnackbar: any,
+) {
+  try {
+    await axios.post(`/sync_alerts/${networkID}`);
+    enqueueSnackbar(`Successfully synced alerts for ${networkID}`, {
+      variant: 'success',
+    });
+  } catch (e) {
+    enqueueSnackbar(`Error syncing alerts: ${e?.response?.data}`, {
+      variant: 'error',
+    });
+  }
+}
+
+export default Alerts;

--- a/nms/app/packages/magmalte/docker-compose.yml
+++ b/nms/app/packages/magmalte/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - ../../packages/magmalte/scripts:/usr/src/packages/magmalte/scripts
       - ../../packages/magmalte/server:/usr/src/packages/magmalte/server
       - ../../packages/magmalte/grafana:/usr/src/packages/magmalte/grafana
+      - ../../packages/magmalte/alerts:/usr/src/packages/magmalte/alerts
     depends_on:
       - mariadb
     networks:

--- a/nms/app/packages/magmalte/nodemon.json
+++ b/nms/app/packages/magmalte/nodemon.json
@@ -5,7 +5,8 @@
     "config/",
     "scripts/",
     "server/",
-    "grafana/"
+    "grafana/",
+    "alerts/"
   ],
   "exec": "node -r '@fbcnms/babel-register'"
 }

--- a/nms/app/packages/magmalte/server/app.js
+++ b/nms/app/packages/magmalte/server/app.js
@@ -106,6 +106,9 @@ app.use(configureAccess({loginUrl: '/user/login'}));
 // to superusers
 app.use('/grafana', access(SUPERUSER), require('../grafana/routes.js').default);
 
+// Trigger syncing of automatically generated alerts
+app.use('/sync_alerts', access(USER), require('../alerts/routes.js').default);
+
 app.use('/', csrfMiddleware(), access(USER), require('./main/routes').default);
 
 export default app;


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Automatically create predefined alert rules for XWFM networks. 
* Creates alerts when an XWFM network is created
* new tab on admin page lets an admin sync these alerts at any time, allowing modification of the alerts in the meantime.

No real alerts have been defined yet, going to add those soon after feedback from xfn.

## Test Plan
![auto_alerts](https://user-images.githubusercontent.com/13274915/94075876-ce927e80-fdb0-11ea-9a2b-11875fd2f87d.gif)
