### PR TITLE
[nms] change XWFM dashboard to be CWF

### DIFF
--- a/nms/app/packages/magmalte/grafana/dashboards/XWFMDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/XWFMDashboards.js
@@ -19,8 +19,9 @@ import type {GrafanaDBData} from './Dashboards';
 
 export const XWFMDBData = (networks: Array<string>): GrafanaDBData => {
   return {
-    title: 'XWF-M Container/Node Stats',
-    description: '',
+    title: 'Container/Node Stats',
+    description:
+      'This dashboard shows stats from node_exporter and cAdvisor if those services are installed on your gateways.',
     templates: [getNetworkTemplate(networks), gatewayTemplate],
     rows: [
       {

--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -18,7 +18,7 @@ import {isEqual, sortBy} from 'lodash';
 
 import MagmaV1API from '@fbcnms/platform-server/magma/index';
 import {AnalyticsDBData} from './dashboards/AnalyticsDashboards';
-import {CWF, XWFM} from '@fbcnms/types/network';
+import {CWF} from '@fbcnms/types/network';
 import {
   CWFAccessPointDBData,
   CWFGatewayDBData,
@@ -504,11 +504,9 @@ export async function syncDashboards(
       dashboardData(createDashboard(AnalyticsDBData(networks)).generate()),
     );
   }
-  if (await hasNetworkOfType(XWFM, networks)) {
-    const xwfmNetworks = await networksOfType(XWFM, networks);
-    posts.push(
-      dashboardData(createDashboard(XWFMDBData(xwfmNetworks)).generate()),
-    );
+  // TODO: When XWFM networks are a real thing change this to XWFM
+  if (await hasNetworkOfType(CWF, networks)) {
+    posts.push(dashboardData(createDashboard(XWFMDBData(networks)).generate()));
   }
 
   for (const post of posts) {
@@ -614,26 +612,6 @@ function organizationsEqual(
     nmsOrg.name == orc8rTenant.name &&
     isEqual(sortBy(nmsOrg.networkIDs), sortBy(orc8rTenant.networks))
   );
-}
-
-async function networksOfType(
-  type: network_type,
-  networks: Array<string>,
-): Promise<Array<string>> {
-  const ret = [];
-  for (const networkId of networks) {
-    try {
-      const networkInfo = await MagmaV1API.getNetworksByNetworkId({networkId});
-      if (networkInfo.type === type) {
-        ret.push(networkId);
-      }
-    } catch (error) {
-      logger.error(
-        `Error retrieving network info for network while building dashboards: ${networkId}. Error: ${error}`,
-      );
-    }
-  }
-  return ret;
 }
 
 async function hasNetworkOfType(


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
XWFM networks are actually represented as CWF networks, so there is no way of distinguishing between those types. Change the dashboard to be created for orgs with CWF networks, remove XWFM naming, and add description explaining where these metrics are coming from.

## Test Plan
* Dashboard is created same as before on orgs with XWFM or CWF networks
