### PR TITLE
AGW: build: use scapy package from stable release.

### DIFF
--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -87,7 +87,7 @@ setup(
         'lxml==4.2.1',
         'ryu>=4.30',
         'spyne==2.12.16',
-        'scapy==2.4.3',
+        'scapy==2.4.4',
         'flask>=1.0.2',
         'aioeventlet>=0.4',
         'aiodns>=1.1.1',

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -112,6 +112,7 @@ MAGMA_DEPS=(
     "libboost-chrono-dev" # required for folly
     "td-agent-bit >= 1.3.2" # fluent-bit
     "ntpdate" # required for eventd time synchronization
+    "python3-scapy >= 2.4.3-4"
     )
 
 # OAI runtime dependencies

--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -24,6 +24,12 @@
       "sysdep": "python3-aiodns",
       "version": "1.1.1"
     },
+    "aioeventlet": {
+      "root": true,
+      "source": "apt",
+      "sysdep": "python3-aioeventlet",
+      "version": "0.5.1"
+    },
     "argparse": {
       "root": false,
       "source": "pypi",
@@ -54,17 +60,17 @@
       "sysdep": "python3-cython",
       "version": "0.29.1"
     },
+    "dnspython": {
+      "root": false,
+      "source": "apt",
+      "sysdep": "python3-dnspython",
+      "version": "1.15.0"
+    },
     "docker": {
       "root": true,
       "source": "pypi",
       "sysdep": "python3-docker",
       "version": "4.0.2"
-    },
-    "enum-compat": {
-      "root": false,
-      "source": "pypi",
-      "sysdep": "python3-enum-compat",
-      "version": "0.0.3"
     },
     "envoy": {
       "root": true,
@@ -73,10 +79,10 @@
       "version": "0.0.3"
     },
     "eventlet": {
-      "root": false,
+      "root": true,
       "source": "pypi",
       "sysdep": "python3-eventlet",
-      "version": "0.23.0"
+      "version": "0.24"
     },
     "fire": {
       "root": true,
@@ -90,6 +96,12 @@
       "sysdep": "python3-flask",
       "version": "1.0.2"
     },
+    "freezegun": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-freezegun",
+      "version": "0.3.15"
+    },
     "glob2": {
       "root": true,
       "source": "pypi",
@@ -101,6 +113,24 @@
       "source": "apt",
       "sysdep": "python3-greenlet",
       "version": "0.3"
+    },
+    "h2": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-h2",
+      "version": "3.2.0"
+    },
+    "hpack": {
+      "root": true,
+      "source": "pypi",
+      "sysdep": "python3-hpack",
+      "version": "3.0"
+    },
+    "hyperframe": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-hyperframe",
+      "version": "5.2.0"
     },
     "idna": {
       "root": true,
@@ -120,11 +150,17 @@
       "sysdep": "python3-lxml",
       "version": "4.2.1"
     },
+    "monotonic": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-monotonic",
+      "version": "1.4"
+    },
     "msgpack": {
       "root": false,
       "source": "pypi",
       "sysdep": "python3-msgpack",
-      "version": "0.6.2"
+      "version": "1.0.0"
     },
     "netaddr": {
       "root": false,
@@ -178,13 +214,13 @@
       "root": true,
       "source": "pypi",
       "sysdep": "python3-python-dateutil",
-      "version": "2.8"
+      "version": "2.8.1"
     },
     "pytz": {
       "root": false,
       "source": "pypi",
       "sysdep": "python3-pytz",
-      "version": "2019.3"
+      "version": "2020.1"
     },
     "repoze.lru": {
       "root": false,
@@ -214,7 +250,7 @@
       "root": true,
       "source": "pypi",
       "sysdep": "python3-scapy",
-      "version": "2.4.3rc3"
+      "version": "2.4.4"
     },
     "six": {
       "root": true,
@@ -246,6 +282,12 @@
       "sysdep": "python3-tinyrpc",
       "version": "1.0.4"
     },
+    "trollius": {
+      "root": false,
+      "source": "pypi",
+      "sysdep": "python3-trollius",
+      "version": "0.3"
+    },
     "urllib3": {
       "root": true,
       "source": "pypi",
@@ -275,6 +317,9 @@
     "aiodns": {
       "version": "1.1.1"
     },
+    "aioeventlet": {
+      "version": "0.4"
+    },
     "certifi": {
       "version": "2019.6.16"
     },
@@ -290,14 +335,26 @@
     "envoy": {
       "version": "0.0.3"
     },
+    "eventlet": {
+      "version": "0.24"
+    },
     "fire": {
       "version": "0.2.0"
     },
     "flask": {
       "version": "1.0.2"
     },
+    "freezegun": {
+      "version": "0.3.15"
+    },
     "glob2": {
       "version": "0.7"
+    },
+    "h2": {
+      "version": "3.2.0"
+    },
+    "hpack": {
+      "version": "3.0"
     },
     "idna": {
       "version": "2.8"
@@ -315,7 +372,7 @@
       "version": "0.5.0"
     },
     "python-dateutil": {
-      "version": "2.8"
+      "version": "2.8.1"
     },
     "requests": {
       "version": "2.22.0"
@@ -324,7 +381,7 @@
       "version": "4.30"
     },
     "scapy": {
-      "version": "2.4.3rc3"
+      "version": "2.4.4"
     },
     "six": {
       "version": "1.12.0"


### PR DESCRIPTION
## Summary

Replaces scapy release candidate "2.4.3rc3" with released package.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
manually built packages and deployed it on lab AGW.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
