### PR TITLE
[orc8r] [configs] Fix misleading error when config is set to false

### DIFF
--- a/orc8r/gateway/python/magma/configuration/service_configs.py
+++ b/orc8r/gateway/python/magma/configuration/service_configs.py
@@ -116,7 +116,7 @@ def get_service_config_value(service: str, param: str, default: Any) -> Any:
     cached_service_configs[service] = service_configs
 
     config_value = service_configs.get(param)
-    if config_value:
+    if config_value is not None:
         return config_value
     else:
         logging.error(


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Misleading errors are reported by config parser when the config value is set to false, e.g. use_stateless config for MME service. This change fixes the check to check if the config is defined or not.

## Test Plan

Before the change, syslog for MME reports:
```
Sep 24 06:31:29 magma-dev mme[3546]: ERROR:root:Error retrieving config for mme, key not found: use_stateless
Sep 24 06:31:29 magma-dev mme[3546]: ERROR:root:Error retrieving config for mme, key not found: enable_nat
Sep 24 06:31:29 magma-dev mme[3546]: ERROR:root:Error retrieving config for spgw, key not found: ovs_internal_sampling_fwd_tbl
```

After the change, syslog for MME reports:
```
Sep 24 06:31:55 magma-dev mme[4055]: ERROR:root:Error retrieving config for mme, key not found: enable_nat
Sep 24 06:31:55 magma-dev mme[4055]: ERROR:root:Error retrieving config for spgw, key not found: ovs_internal_sampling_fwd_tbl
```