### PR TITLE
[xwfm] remove sed line from CI docker entrypoint

### DIFF
--- a/xwf/gateway/integ_tests/gw/entrypoint.sh
+++ b/xwf/gateway/integ_tests/gw/entrypoint.sh
@@ -28,7 +28,6 @@ cp orc8r/gateway/configs/templates/* /etc/magma/
 
 echo "get xwfwhoami"
 curl -X POST -k https://graph.expresswifi.com/openflow/configxwfm?access_token=$ACCESSTOKEN | jq -r .configxwfm > /etc/xwfwhoami
-sed -i '/^uplink_if/d'  /etc/xwfwhoami # TODO: remove this
 
 echo "run XWF ansible"
 ANSIBLE_CONFIG=xwf/gateway/ansible.cfg ansible-playbook -e xwf_ctrl_ip="${CtrlIP} connection_mode=$CONNECTION_MODE" \


### PR DESCRIPTION
Signed-off-by: Aharon Novogrodski <novo@gmail.com>

[xwfm]

## Summary

Remove sed line that removes inlink from xwfwhoami in CI docker. We don't need this, and more then this it creates issues now that we do need this partmer
## Test Plan

checked CI on local machine

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
