### PR TITLE
[Backport v1.2] mobilityD: relax checks for apn resources (#2762)

### DIFF
--- a/lte/gateway/python/magma/mobilityd/mac.py
+++ b/lte/gateway/python/magma/mobilityd/mac.py
@@ -36,7 +36,7 @@ class MacAddress:
         """
         key = str(self.mac_address).replace(':', '_').lower()
         if vlan:
-            return vlan + "." + key
+            return "v{}.{}".format(vlan, key)
         else:
             return key
 

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -116,11 +116,9 @@ class SubscriberDbClient:
             selected_apn_conf = None
             for apn_config in data.non_3gpp.apn_config:
                 logging.debug("APN config: %s", apn_config)
-                if apn_config.assigned_static_ip is None or \
-                        apn_config.assigned_static_ip == "":
-                    continue
                 try:
-                    ipaddress.ip_address(apn_config.assigned_static_ip)
+                    if apn_config.assigned_static_ip:
+                        ipaddress.ip_address(apn_config.assigned_static_ip)
                 except ValueError:
                     continue
                 if apn_config.service_selection == '*':
@@ -129,7 +127,6 @@ class SubscriberDbClient:
                     selected_apn_conf = apn_config
                     break
 
-            if selected_apn_conf and selected_apn_conf.assigned_static_ip:
-                return selected_apn_conf
+            return selected_apn_conf
 
         return None

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -370,8 +370,8 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
         # check if retrieved ip is the same as the one allocated
         self.assertEqual(ip0, ip0_returned)
-        self.assertEqual(ip0, ipaddress.ip_address(wild_assigned_ip))
-        self.check_type(sid, IPType.STATIC)
-        self.check_vlan(sid, vlan_wild)
+        self.assertNotEqual(ip0, ipaddress.ip_address(wild_assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+        self.check_vlan(sid, 0)
         self.check_gw_info(vlan, None, None)
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -257,8 +257,8 @@ class StaticIPAllocationTests(unittest.TestCase):
 
         # check if retrieved ip is the same as the one allocated
         self.assertEqual(ip0, ip0_returned)
-        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
-        self.check_type(sid, IPType.STATIC)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
+        self.check_type(sid, IPType.IP_POOL)
 
     def test_get_ip_for_subscriber_with_apn_with_gw(self):
         """ test get_ip_for_sid with static IP """


### PR DESCRIPTION
following patch allow static ip and APN resource
setting independently.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
