### PR TITLE
Vm reboot fix

### DIFF
--- a/xwf/gateway/deploy/roles/dhcpd/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/dhcpd/tasks/main.yml
@@ -55,6 +55,14 @@
   become: true
   when: gateway_mode == 'gateway'
 
+- name: make sure rc local service starts at boot
+  systemd:
+    name: 'rc-local'
+    state: started
+    enabled: yes
+  tags:
+    - no_ci
+
 - name: execute the rc.local file
   shell: /etc/rc.local
   when: gateway_mode == 'gateway'

--- a/xwf/gateway/deploy/roles/dhcpd/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/dhcpd/tasks/main.yml
@@ -40,6 +40,7 @@
     name: dhcpd
     state: restarted
     daemon_reload: yes
+    enabled: yes
   tags:
     - no_ci
   become: true
@@ -47,7 +48,7 @@
 - name: make rc local file so firewall rules persist reboots
   template:
      src: rc.local.j2
-     dest: /etc/rc.local
+     dest: /etc/rc.d/rc.local
      mode: 0775
   tags:
     - no_ci

--- a/xwf/gateway/deploy/roles/dhcpd/templates/rc.local.j2
+++ b/xwf/gateway/deploy/roles/dhcpd/templates/rc.local.j2
@@ -15,3 +15,4 @@ iptables --table nat --append POSTROUTING --out-interface {{ nat_interface }} -j
 iptables -t mangle -A FORWARD -o gw0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ mss }}
 iptables -t mangle -A FORWARD -i gw0 -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --set-mss {{ mss }}
 service dhcpd restart
+service docker restart

--- a/xwf/gateway/deploy/roles/docker/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/docker/tasks/main.yml
@@ -49,5 +49,6 @@
     name: docker
 
 - name: start docker service
-  service: name=docker state=started
+  systemd: name=docker state=started enabled=yes
+
 


### PR DESCRIPTION

 
    [xwfm] Make sure service start at boot.

## Summary

When the system reboot the services were not autostarted, this should fix it and all services should be started at boot

## Test Plan

tested in devserver


