### PR TITLE
[Backport v1.2] pipelined: update dhcp ingress flow. (#2805)

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -107,8 +107,7 @@ class UplinkBridgeController(MagmaController):
 
         # 1.b. DHCP traffic
         match = "in_port=%s,ip,udp,tp_dst=68" % self.config.uplink_eth_port_name
-        actions = "output:%s,output:%s,output:LOCAL" % (self.config.dhcp_port,
-                                                        self.config.uplink_patch)
+        actions = "output:%s,output:LOCAL" % self.config.dhcp_port
         self._install_flow(flows.MAXIMUM_PRIORITY - 1, match, actions)
 
         # 2.a. all egress traffic

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -1,4 +1,4 @@
- priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,in_port=70 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
@@ -2,7 +2,7 @@
  priority=65535,in_port=LOCAL actions=mod_vlan_vid:100,output:3
  priority=100,in_port=70 actions=drop
  priority=1,in_port=71 actions=drop
- priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -2,7 +2,7 @@
  priority=65535,in_port=LOCAL actions=mod_vlan_vid:500,output:3
  priority=100,in_port=70 actions=drop
  priority=1,in_port=71 actions=drop
- priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70


### PR DESCRIPTION
There is no need to send dhcp traffic to gtp-br since it
is handled by uplink-br.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
