### PR TITLE
[feg][swx] Modify SWx Proxy caching to honor given # of requested vectors

### DIFF
--- a/feg/gateway/services/swx_proxy/cache/swx_cache.go
+++ b/feg/gateway/services/swx_proxy/cache/swx_cache.go
@@ -1,9 +1,7 @@
 /*
 Copyright 2020 The Magma Authors.
-
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -87,19 +85,19 @@ func NewExt(interval, ttl time.Duration) (*Impl, chan struct{}) {
 }
 
 // Get retrieves one auth vector from cache if available, adjusts cache and returns the vector, returns nil otherwise
-func (swxCache *Impl) Get(imsi string) *protos.AuthenticationAnswer {
+func (swxCache *Impl) Get(imsi string, neededNumber int) *protos.AuthenticationAnswer {
 	swxCache.mu.Lock()
 	defer swxCache.mu.Unlock()
 	ent, found := swxCache.data.vectors[imsi]
 	if found {
-		if len(ent.ans.SipAuthVectors) <= 1 {
+		if len(ent.ans.SipAuthVectors) <= neededNumber {
 			delete(swxCache.data.vectors, imsi)
 			heap.Remove(&swxCache.data, ent.idx)
 			return ent.ans
 		}
 		res := *ent.ans // copy answer
-		res.SipAuthVectors = res.SipAuthVectors[:1]
-		ent.ans.SipAuthVectors = ent.ans.SipAuthVectors[1:]
+		res.SipAuthVectors = res.SipAuthVectors[:neededNumber]
+		ent.ans.SipAuthVectors = ent.ans.SipAuthVectors[neededNumber:]
 		ent.lastUsed = time.Now()
 		heap.Fix(&swxCache.data, ent.idx)
 		return &res
@@ -120,30 +118,34 @@ func (swxCache *Impl) Remove(imsi string) *protos.AuthenticationAnswer {
 	return nil
 }
 
-// Put adds ans vectors into the cache after extracting the first vector from the list, which it returns back to
-// the caller in the returned AuthenticationAnswer
-func (swxCache *Impl) Put(ans *protos.AuthenticationAnswer) *protos.AuthenticationAnswer {
+// Put adds ans vectors into the cache after extracting the first neededNumber vectors from the list,
+// which it returns back to the caller in the returned AuthenticationAnswer
+func (swxCache *Impl) Put(ans *protos.AuthenticationAnswer, neededNumber int) *protos.AuthenticationAnswer {
 	if ans == nil || len(ans.UserName) == 0 {
 		return ans
 	}
+	if neededNumber <= 0 {
+		neededNumber = 1
+	}
 	swxCache.mu.Lock()
 	defer swxCache.mu.Unlock()
-	// delete old cache if present
+	// merge with the old cache if present
 	ent, found := swxCache.data.vectors[ans.UserName]
+	// Under normal, non-concurrent UE usage, the UE vectors cache should already be empty
+	// but, if not - clean it
 	if found {
 		heap.Remove(&swxCache.data, ent.idx)
 	}
-	if len(ans.SipAuthVectors) <= 1 {
+	if len(ans.SipAuthVectors) <= neededNumber {
 		if found {
 			delete(swxCache.data.vectors, ans.UserName)
 		}
-		return ans // only one vector, nothing to cache, just return it
+		return ans // only needed # of vectors, nothing to cache, just return it
 	}
-
 	// cash & return the first vector in a cloned answer
 	res := *ans // copy answer
-	res.SipAuthVectors = res.SipAuthVectors[:1]
-	ans.SipAuthVectors = ans.SipAuthVectors[1:]
+	res.SipAuthVectors = res.SipAuthVectors[:neededNumber]
+	ans.SipAuthVectors = ans.SipAuthVectors[neededNumber:]
 
 	ent = &authEnt{lastUsed: time.Now(), ans: ans}
 	swxCache.data.vectors[ans.UserName] = ent

--- a/feg/gateway/services/swx_proxy/cache/swx_cache.go
+++ b/feg/gateway/services/swx_proxy/cache/swx_cache.go
@@ -84,7 +84,8 @@ func NewExt(interval, ttl time.Duration) (*Impl, chan struct{}) {
 	return cache, cache.Gc(interval, ttl) // start garbage collector with given interval & ttl
 }
 
-// Get retrieves one auth vector from cache if available, adjusts cache and returns the vector, returns nil otherwise
+// Get retrieves up to neededNumber of auth vectors from cache if available, adjusts cache and returns the vectors,
+// returns nil if there no vectors left to return
 func (swxCache *Impl) Get(imsi string, neededNumber int) *protos.AuthenticationAnswer {
 	swxCache.mu.Lock()
 	defer swxCache.mu.Unlock()

--- a/feg/gateway/services/swx_proxy/cache/swx_cache_test.go
+++ b/feg/gateway/services/swx_proxy/cache/swx_cache_test.go
@@ -1,9 +1,7 @@
 /*
 Copyright 2020 The Magma Authors.
-
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree.
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -32,7 +30,7 @@ func TestSwxCacheGC(t *testing.T) {
 	err := test_init.InitTestMconfig(t, "127.0.0.1:0", true)
 	assert.NoError(t, err)
 	interval := time.Millisecond * 10
-	ttl := time.Millisecond * 100
+	ttl := time.Millisecond * 200
 	cache, done := cache.NewExt(interval, ttl)
 	srv, err := test_init.StartTestServiceWithCache(t, cache)
 	if err != nil {
@@ -41,7 +39,7 @@ func TestSwxCacheGC(t *testing.T) {
 
 	authReq := &protos.AuthenticationRequest{
 		UserName:             test.BASE_IMSI,
-		SipNumAuthVectors:    uint32(3),
+		SipNumAuthVectors:    1,
 		AuthenticationScheme: protos.AuthenticationScheme_EAP_AKA,
 	}
 
@@ -58,7 +56,7 @@ func TestSwxCacheGC(t *testing.T) {
 	assert.Equal(t, []byte(test.DefaultCK), v.GetConfidentialityKey())
 	assert.Equal(t, []byte(test.DefaultIK), v.GetIntegrityKey())
 
-	authRes = cache.Get(test.BASE_IMSI)
+	authRes = cache.Get(test.BASE_IMSI, 1)
 	assert.Equal(t, 1, len(authRes.GetSipAuthVectors()))
 	v = authRes.SipAuthVectors[0]
 	assert.Equal(t, protos.AuthenticationScheme_EAP_AKA, v.GetAuthenticationScheme())
@@ -67,10 +65,40 @@ func TestSwxCacheGC(t *testing.T) {
 	assert.Equal(t, []byte(test.DefaultCK), v.GetConfidentialityKey())
 	assert.Equal(t, []byte(test.DefaultIK), v.GetIntegrityKey())
 
+	// 5 vectors requested, 2 consumed, 3 left
+	authRes = cache.Get(test.BASE_IMSI, 2)
+	assert.Equal(t, 2, len(authRes.GetSipAuthVectors()))
+
 	time.Sleep(ttl + interval*2)
 
-	authRes = cache.Get(test.BASE_IMSI)
+	authRes = cache.Get(test.BASE_IMSI, 1)
 	assert.Equal(t, (*protos.AuthenticationAnswer)(nil), authRes)
+
+	authReq = &protos.AuthenticationRequest{
+		UserName:             test.BASE_IMSI,
+		SipNumAuthVectors:    3,
+		AuthenticationScheme: protos.AuthenticationScheme_EAP_AKA,
+	}
+	authRes, err = swx_proxy.Authenticate(authReq)
+	if err != nil {
+		t.Fatalf("GRPC MAR Error: %v", err)
+		return
+	}
+	assert.Equal(t, 3, len(authRes.GetSipAuthVectors()))
+	authReq = &protos.AuthenticationRequest{
+		UserName:             test.BASE_IMSI,
+		SipNumAuthVectors:    3,
+		AuthenticationScheme: protos.AuthenticationScheme_EAP_AKA,
+	}
+	authRes, err = swx_proxy.Authenticate(authReq)
+	if err != nil {
+		t.Fatalf("GRPC MAR Error: %v", err)
+		return
+	}
+	assert.Equal(t, 3, len(authRes.GetSipAuthVectors()))
+	// 10 vectors requested, 6 consumed, 4 left
+	authRes = cache.Get(test.BASE_IMSI, 4)
+	assert.Equal(t, 4, len(authRes.GetSipAuthVectors()))
 
 	done <- struct{}{}
 

--- a/feg/gateway/services/swx_proxy/client_api_test.go
+++ b/feg/gateway/services/swx_proxy/client_api_test.go
@@ -54,7 +54,7 @@ func TestSwxProxyClient_VerifyAuthorizationOff(t *testing.T) {
 
 func standardSwxProxyTest(t *testing.T) {
 	expectedUsername := test.BASE_IMSI
-	numVectors := 5
+	numVectors := 1
 	expectedAuthScheme := protos.AuthenticationScheme_EAP_AKA
 	authReq := &protos.AuthenticationRequest{
 		UserName:             expectedUsername,

--- a/feg/gateway/services/swx_proxy/servicers/test/test_swx_server.go
+++ b/feg/gateway/services/swx_proxy/servicers/test/test_swx_server.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	BASE_IMSI   = "0010100000000"
+	BASE_IMSI   = "0010100000"
 	VENDOR_3GPP = diameter.Vendor3GPP
 
 	DefaultSIPAuthenticate  = "\x94\xbf/T\xc3v\xf3\x0e\x87\x83\x06k'\x18Z"


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

Modify SWx Proxy caching to honor given # of requested vectors. Current implementation returns one vector unconditionally.
EAP-SIM requires 3 UMTS vectors for a single auth & currently needs multiple requests.

## Test Plan

Add corresponding unit tests; FeG make precommit

## Additional Information

- [ ] This change is backwards-breaking
