### PR TITLE
[5G: MVC][Bug_Fix][SessionD] Condition added to fix spgw crash during cwf integ test

### DIFF
--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -217,8 +217,11 @@ int main(int argc, char* argv[]) {
   std::shared_ptr<magma::AsyncSpgwServiceClient> spgw_client;
   std::shared_ptr<aaa::AsyncAAAClient> aaa_client;
 
-  //AMF service client to handle response message
-  auto amf_srv_client = std::make_shared<magma::AsyncAmfServiceClient>();
+  std::shared_ptr<magma::AsyncAmfServiceClient> amf_srv_client;
+  if (converged_access) {
+    //AMF service client to handle response message
+    amf_srv_client = std::make_shared<magma::AsyncAmfServiceClient>();
+  }
   // Case on config, setup the appropriate client for the access component
   std::thread access_response_handling_thread;
   if (config["support_carrier_wifi"].as<bool>()) {


### PR DESCRIPTION
Signed-off-by: ronit-kumar-acl <ronit.k@altencalsoftlabs.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Fix for sessiond crash due to spgw_service during CWF integration test.
Added a condition in sessiond_main to bypass if converged condition is not passed.
 
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
