### PR TITLE
AGW: pipelineD: use enodeB specific tunnel port

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/inout.py
+++ b/lte/gateway/python/magma/pipelined/app/inout.py
@@ -33,7 +33,7 @@ from magma.pipelined.openflow import flows
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.openflow.magma_match import MagmaMatch
 from magma.pipelined.openflow.registers import load_direction, Direction, \
-    PASSTHROUGH_REG_VAL
+    PASSTHROUGH_REG_VAL, TUN_PORT_REG
 
 from ryu.lib import hub
 from ryu.lib.packet import ether_types
@@ -174,8 +174,8 @@ class InOutController(MagmaController):
         if self._mtr_service_enabled:
             _install_vlan_egress_flows(dp,
                                        self._midle_tbl_num,
-                                       self.config.mtr_port,
                                        self.config.mtr_ip,
+                                       self.config.mtr_port,
                                        priority=flows.UE_FLOW_PRIORITY,
                                        direction=Direction.OUT)
 
@@ -193,7 +193,6 @@ class InOutController(MagmaController):
         if self.config.setup_type == 'LTE':
             _install_vlan_egress_flows(dp,
                                        self._egress_tbl_num,
-                                       self.config.gtp_port,
                                        "0.0.0.0/0")
         else:
             # Use regular match for Non LTE setup.
@@ -262,13 +261,6 @@ class InOutController(MagmaController):
         next_table = self._service_manager.get_next_table_num(INGRESS)
 
         # set traffic direction bits
-        # set a direction bit for outgoing (pn -> inet) traffic.
-        match = MagmaMatch(in_port=self.config.gtp_port)
-        actions = [load_direction(parser, Direction.OUT)]
-        flows.add_resubmit_next_service_flow(dp, self._ingress_tbl_num, match,
-                                             actions=actions,
-                                             priority=flows.DEFAULT_PRIORITY,
-                                             resubmit_table=next_table)
 
         # set a direction bit for incoming (internet -> UE) traffic.
         match = MagmaMatch(in_port=OFPP_LOCAL)
@@ -301,6 +293,14 @@ class InOutController(MagmaController):
             flows.add_resubmit_next_service_flow(dp, self._ingress_tbl_num,
                                                  match, actions=actions, priority=flows.DEFAULT_PRIORITY,
                                                  resubmit_table=next_table)
+
+        # set a direction bit for outgoing (pn -> inet) traffic for remaining traffic
+        match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP)
+        actions = [load_direction(parser, Direction.OUT)]
+        flows.add_resubmit_next_service_flow(dp, self._ingress_tbl_num, match,
+                                             actions=actions,
+                                             priority=flows.MINIMUM_PRIORITY,
+                                             resubmit_table=next_table)
 
     def _get_gw_mac_address(self, ip: IPAddress, vlan: str = "") -> str:
         try:
@@ -378,8 +378,8 @@ class InOutController(MagmaController):
         Setup egress flow to forward traffic to internet GW.
         Start a thread to figure out MAC address of uplink NAT gw.
 
-        :param datapath: datapath to install flows.
-        :return: None
+        Args:
+            datapath: datapath to install flows.
         """
         if self._gw_mac_monitor is not None:
             # No need to multiple probes here.
@@ -401,8 +401,23 @@ class InOutController(MagmaController):
         threading.Event().wait(1)
 
 
-def _install_vlan_egress_flows(dp, table_no, out_port, ip,
+def _install_vlan_egress_flows(dp, table_no, ip, out_port=None,
                                priority=0, direction=Direction.IN):
+    """
+    Install egress flows
+    Args:
+        dp datapath
+        table_no table to install flow
+        out_port specify egress port, if None reg value is used
+        priority flow priority
+        direction packet direction.
+    """
+
+    if out_port:
+        output_reg = None
+    else:
+        output_reg = TUN_PORT_REG
+
     # Pass non vlan packet as it is.
     match = MagmaMatch(direction=direction,
                        eth_type=ether_types.ETH_TYPE_IP,
@@ -411,6 +426,7 @@ def _install_vlan_egress_flows(dp, table_no, out_port, ip,
     flows.add_output_flow(dp,
                           table_no, match,
                           [], priority=priority,
+                          output_reg=output_reg,
                           output_port=out_port)
 
     # remove vlan header for out_port.
@@ -423,4 +439,5 @@ def _install_vlan_egress_flows(dp, table_no, out_port, ip,
                           table_no, match,
                           actions_vlan_pop,
                           priority=priority,
+                          output_reg=output_reg,
                           output_port=out_port)

--- a/lte/gateway/python/magma/pipelined/openflow/registers.py
+++ b/lte/gateway/python/magma/pipelined/openflow/registers.py
@@ -21,6 +21,7 @@ DPI_REG = 'reg10'
 TEST_PACKET_REG = 'reg5'
 PASSTHROUGH_REG = 'reg6'
 VLAN_TAG_REG = 'reg7'
+TUN_PORT_REG = 'reg8'
 
 # Local scratch registers (These registers are reset when submitting to
 # another app):

--- a/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
+++ b/lte/gateway/python/magma/pipelined/tests/pipelined_test_util.py
@@ -425,7 +425,7 @@ def expected_snapshot(test_case: TestCase,
             for line in file:
                 prev_snapshot.append(line.rstrip('\n'))
     except OSError as e:
-        fail(test_case, str(e), bridge_name, snapshot_name, current_snapshot)
+        fail(test_case, str(e), bridge_name, combined_name, current_snapshot)
 
     return snapshot_file, prev_snapshot
 
@@ -461,7 +461,7 @@ def assert_bridge_snapshot_match(test_case: TestCase, bridge_name: str,
                                          fromfile='previous snapshot',
                                          tofile='current snapshot'))),
              bridge_name,
-             snapshot_name,
+             snapshot_file,
              current_snapshot)
 
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTest.testFlowSnapshotMatch.snapshot
@@ -1,5 +1,5 @@
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,ip actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTestLTE.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout.InOutTestLTE.testFlowSnapshotMatch.snapshot
@@ -1,0 +1,10 @@
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=211 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,ip actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=12,ip,reg1=0x1,vlan_tci=0x0000/0x1000,nw_dst=1.2.3.4 actions=output:211
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=12,ip,reg1=0x1,vlan_tci=0x1000/0x1000,nw_dst=1.2.3.4 actions=strip_vlan,output:211
+ cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x0000/0x1000 actions=output:NXM_NX_REG8[]
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10,vlan_tci=0x1000/0x1000 actions=strip_vlan,output:NXM_NX_REG8[]
+ cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x1 actions=LOCAL

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutNonNatTest.testFlowSnapshotMatch.snapshot
@@ -1,6 +1,6 @@
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=2 actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,ip actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=10,reg1=0x1 actions=set_field:b2:a0:cc:85:80:7a->eth_dst,output:2

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_inout_non_nat.InOutTestNonNATBasicFlows.testFlowSnapshotMatch.snapshot
@@ -1,5 +1,5 @@
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,ip actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=egress(main_table), n_packets=0, n_bytes=0, priority=0,reg1=0x10 actions=output:32768

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_li_mirror.LIMirrorTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_li_mirror.LIMirrorTest.testFlowSnapshotMatch.snapshot
@@ -1,6 +1,6 @@
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=1 actions=set_field:0x10->reg1,resubmit(,li_mirror(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,ip actions=set_field:0x1->reg1,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=15,reg6=0x1 actions=resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=middle(main_table), n_packets=0, n_bytes=0, priority=10 actions=resubmit(,li_mirror(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=li_mirror(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=output:2,resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_ue_passthrough.UEMacAddressTest.test_passthrough_rules.snapshot
@@ -1,8 +1,8 @@
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=12,dl_src=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ue_mac(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ue_mac(main_table), n_packets=4, n_bytes=384, priority=12,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ue_mac(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ue_mac(main_table), n_packets=0, n_bytes=0, priority=10,arp actions=resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=10,in_port=32768 actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=ingress(main_table), n_packets=4, n_bytes=384, priority=10,in_port=LOCAL actions=set_field:0x10->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=ingress(main_table), n_packets=0, n_bytes=0, priority=0,ip actions=set_field:0x1->reg1,resubmit(,arpd(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.2.3.4,arp_op=2 actions=set_field:0x1->reg6,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.2.3.4,arp_op=1 actions=move:NXM_OF_ETH_SRC[]->NXM_OF_ETH_DST[],mod_dl_src:00:aa:bb:cc:dd:ee,load:0x2->NXM_OF_ARP_OP[],move:NXM_NX_ARP_SHA[]->NXM_NX_ARP_THA[],load:0xaabbccddee->NXM_NX_ARP_SHA[],move:NXM_OF_ARP_TPA[]->NXM_NX_REG0[],move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[],move:NXM_NX_REG0[]->NXM_OF_ARP_SPA[],IN_PORT
  cookie=0x0, table=arpd(main_table), n_packets=0, n_bytes=0, priority=12,arp,reg1=0x10,arp_tpa=1.1.1.1,arp_op=2 actions=set_field:0x1->reg6,resubmit(,middle(main_table)),set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/test_inout.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout.py
@@ -90,5 +90,70 @@ class InOutTest(unittest.TestCase):
         assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
 
 
+class InOutTestLTE(unittest.TestCase):
+    BRIDGE = 'testing_br'
+    IFACE = 'testing_br'
+    MAC_DEST = "5e:cc:cc:b1:49:4b"
+    BRIDGE_IP = '192.168.128.1'
+
+    @classmethod
+    def setUpClass(cls):
+        """
+        Starts the thread which launches ryu apps
+
+        Create a testing bridge, add a port, setup the port interfaces. Then
+        launch the ryu apps for testing pipelined. Gets the references
+        to apps launched by using futures.
+        """
+        super(InOutTestLTE, cls).setUpClass()
+        warnings.simplefilter('ignore')
+        cls.service_manager = create_service_manager([])
+
+        inout_controller_reference = Future()
+        testing_controller_reference = Future()
+        test_setup = TestSetup(
+            apps=[PipelinedController.InOut,
+                  PipelinedController.Testing,
+                  PipelinedController.StartupFlows],
+            references={
+                PipelinedController.InOut:
+                    inout_controller_reference,
+                PipelinedController.Testing:
+                    testing_controller_reference,
+                PipelinedController.StartupFlows:
+                    Future(),
+            },
+            config={
+                'setup_type': 'LTE',
+                'bridge_name': cls.BRIDGE,
+                'bridge_ip_address': cls.BRIDGE_IP,
+                'ovs_gtp_port_number': 32768,
+                'clean_restart': True,
+                'enable_nat': True,
+                'uplink_gw_mac': '11:22:33:44:55:66',
+                'mtr_ip': '1.2.3.4',
+                'ovs_mtr_port_number': 211
+            },
+            mconfig=None,
+            loop=None,
+            service_manager=cls.service_manager,
+            integ_test=False,
+        )
+
+        BridgeTools.create_bridge(cls.BRIDGE, cls.IFACE)
+
+        cls.thread = start_ryu_app_thread(test_setup)
+        cls.inout_controller = inout_controller_reference.result()
+        cls.testing_controller = testing_controller_reference.result()
+
+    @classmethod
+    def tearDownClass(cls):
+        stop_ryu_app_thread(cls.thread)
+        BridgeTools.destroy_bridge(cls.BRIDGE)
+
+    def testFlowSnapshotMatch(self):
+        assert_bridge_snapshot_match(self, self.BRIDGE, self.service_manager)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_inout_non_nat.py
@@ -393,11 +393,11 @@ class InOutTestNonNATBasicFlows(unittest.TestCase):
         BridgeTools.destroy_bridge(cls.BRIDGE)
 
     def testFlowSnapshotMatch(self):
-        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+        snapshot_verifier = SnapshotVerifier(self,
+                                             self.BRIDGE,
                                              self.service_manager,
                                              max_sleep_time=20,
-                                             datapath=InOutTestNonNATBasicFlows.inout_controller._datapath,
-                                             try_snapshot=True)
+                                             datapath=InOutTestNonNATBasicFlows.inout_controller._datapath)
 
         with snapshot_verifier:
             pass


### PR DESCRIPTION
## Summary

MME can create enodeB specific port. Start using it traffic
towards UE. One of use of separate tunnel is enodeB stats collections.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x] make test
- [x] integ tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
