### PR TITLE
[orc8r] Increase the buckets in nginx

### DIFF
--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -27,6 +27,9 @@ http {
       '"nginx.client_cn": "$ssl_client_s_dn_cn"'
     '}';
 
+  ## Fix - [emerg]: could not build the map_hash, you should increase
+  map_hash_bucket_size 64;
+
   # See https://kubernetes.github.io/ingress-nginx/examples/grpc/#notes-on-using-responserequest-streams
   grpc_send_timeout 1200s;
   grpc_read_timeout 1200s;


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Fix for the following issue observed in cwf setups

2020/09/28 17:30:13 [emerg] 1#1: could not build map_hash, you should increase map_hash_bucket_size: 32
nginx: [emerg] could not build map_hash, you should increase map_hash_bucket_size: 32
root@ctl01:/home/sudhikan# 2020/09/28 17:30:13 [emerg] 1#1: could not build map_hash, you should increase map_hash_bucket_size: 32



<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
