### PR TITLE
[orc8r][helm] Update orc8r helm charts to support k8s service registry

### DIFF
--- a/cwf/cloud/helm/cwf-orc8r/Chart.lock
+++ b/cwf/cloud/helm/cwf-orc8r/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: orc8rlib
   repository: file://../../../../orc8r/cloud/helm/orc8rlib
-  version: 0.1.0
-digest: sha256:9a488a7a909183d038917e593faaec6312b78ee22a101fb2a69908eb425ebd84
-generated: "2020-08-18T01:27:29.156275-07:00"
+  version: 0.1.1
+digest: sha256:9d2148b03efda4b4bdf14d5428b5f80dc3212a7e95388e256de7f7cdafd4714f
+generated: "2020-09-25T21:21:55.392052-04:00"

--- a/cwf/cloud/helm/cwf-orc8r/Chart.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/Chart.yaml
@@ -25,5 +25,5 @@ keywords:
 # Library chart for common orchestrator module components
 dependencies:
 - name: orc8rlib
-  version: 0.1.0
+  version: 0.1.1
   repository: file://../../../../orc8r/cloud/helm/orc8rlib

--- a/fbinternal/cloud/helm/fbinternal-orc8r/Chart.lock
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: orc8rlib
   repository: file://../../../../orc8r/cloud/helm/orc8rlib
-  version: 0.1.0
-digest: sha256:9a488a7a909183d038917e593faaec6312b78ee22a101fb2a69908eb425ebd84
-generated: "2020-08-18T01:57:18.593446-07:00"
+  version: 0.1.1
+digest: sha256:9d2148b03efda4b4bdf14d5428b5f80dc3212a7e95388e256de7f7cdafd4714f
+generated: "2020-09-25T21:25:14.579889-04:00"

--- a/fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml
@@ -25,5 +25,5 @@ keywords:
 # Library chart for common orchestrator module components
 dependencies:
 - name: orc8rlib
-  version: 0.1.0
+  version: 0.1.1
   repository: file://../../../../orc8r/cloud/helm/orc8rlib

--- a/feg/cloud/helm/feg-orc8r/Chart.lock
+++ b/feg/cloud/helm/feg-orc8r/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: orc8rlib
   repository: file://../../../../orc8r/cloud/helm/orc8rlib
-  version: 0.1.0
-digest: sha256:9a488a7a909183d038917e593faaec6312b78ee22a101fb2a69908eb425ebd84
-generated: "2020-08-18T01:59:44.115019-07:00"
+  version: 0.1.1
+digest: sha256:9d2148b03efda4b4bdf14d5428b5f80dc3212a7e95388e256de7f7cdafd4714f
+generated: "2020-09-25T21:17:25.438899-04:00"

--- a/feg/cloud/helm/feg-orc8r/Chart.yaml
+++ b/feg/cloud/helm/feg-orc8r/Chart.yaml
@@ -25,5 +25,5 @@ keywords:
 # Library chart for common orchestrator module components
 dependencies:
 - name: orc8rlib
-  version: 0.1.0
+  version: 0.1.1
   repository: file://../../../../orc8r/cloud/helm/orc8rlib

--- a/lte/cloud/helm/lte-orc8r/Chart.lock
+++ b/lte/cloud/helm/lte-orc8r/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: orc8rlib
   repository: file://../../../../orc8r/cloud/helm/orc8rlib
-  version: 0.1.0
-digest: sha256:9a488a7a909183d038917e593faaec6312b78ee22a101fb2a69908eb425ebd84
-generated: "2020-08-18T02:01:50.525505-07:00"
+  version: 0.1.1
+digest: sha256:9d2148b03efda4b4bdf14d5428b5f80dc3212a7e95388e256de7f7cdafd4714f
+generated: "2020-09-25T21:22:57.867981-04:00"

--- a/lte/cloud/helm/lte-orc8r/Chart.yaml
+++ b/lte/cloud/helm/lte-orc8r/Chart.yaml
@@ -25,5 +25,5 @@ keywords:
 # Library chart for common orchestrator module components
 dependencies:
 - name: orc8rlib
-  version: 0.1.0
+  version: 0.1.1
   repository: file://../../../../orc8r/cloud/helm/orc8rlib

--- a/orc8r/cloud/helm/README.md
+++ b/orc8r/cloud/helm/README.md
@@ -11,6 +11,13 @@ to match.
 
 3. Bump the version of the main chart in Chart.yaml
 
-4. `helm package orc8r` from this directory and deploy the .tgz file to the
+4. Run `helm dependency update` to pull in any `orc8rlib` changes
+
+5. `helm package orc8r` from this directory and deploy the .tgz file to the
 chart repository. You can do this with the JFrog web UI or using the JFrog
 CLI (if you've configured it): `jfrog rt upload orc8r-X.tgz orc8r-charts`
+
+If you're making changes to the chart under orc8rlib/, you need to run
+`helm dependency update` from the directory of the helm chart (e.g.
+`/magma/orc8r/cloud/helm/orc8r`) that uses this libary chart in order to
+pull in the changes.

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.36
+version: 1.4.37
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -88,7 +88,15 @@ $ helm install \
     --name postgresql \
     --namespace magma \
     --set postgresqlPassword=postgres,postgresqlDatabase=magma,fullnameOverride=postgresql \
-    stable/postgresql
+    bitnami/postgresql
+```
+
+Note: If the postgresql pod is crashing with error : `unable to write
+to directory /bitnami/...`, redeploy with `--values=<vals.yml>`:
+
+```bash
+volumePermissions:
+  enabled: true
 ```
 
 - Copy orchestrator secrets (this replaces the secret management steps for
@@ -113,13 +121,13 @@ kubectl exec -it -n magma \
     /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
 ```
 
-- Port forward traffic to orchestrator proxy:
+- Port forward traffic to orchestrator nginx proxy:
 ```bash
-kubectl port-forward -n magma svc/orc8r-proxy 9443:9443
+kubectl port-forward -n magma svc/orc8r-nginx-proxy 8443:8443
 
 # If using minikube, run:
-minikube service orc8r-proxy -n magma --https
+minikube service orc8r-nginx-proxy -n magma --https
 ```
 
-- Orchestrator proxy should be reachable via https://localhost:9443 and
+- Orchestrator proxy should be reachable via https://localhost:8443 and
 requires magma client certificate to be installed on browser.

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -7,9 +7,12 @@ dependencies:
   version: 1.4.15
 - name: nms
   repository: ""
-  version: 0.1.6
+  version: 0.1.7
 - name: logging
   repository: ""
   version: 0.1.10
-digest: sha256:25cdc16d971bef65681a576b37021b2be3967b60fe9ce7f348ad31db9bf16c0a
-generated: "2019-11-14T21:58:25.774323-08:00"
+- name: orc8rlib
+  repository: file://../orc8rlib
+  version: 0.1.1
+digest: sha256:b2ddacd02a5dff6f6430ed0b7c47fb7d3a7d5a2874dcb961dd1536dd0bcbefd2
+generated: "2020-09-25T21:57:25.417543-04:00"

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -26,3 +26,6 @@ dependencies:
     version: 0.1.10
     repository: ""
     condition: logging.enabled
+  - name: orc8rlib
+    version: 0.1.1
+    repository: file://../orc8rlib

--- a/orc8r/cloud/helm/orc8r/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8r/templates/_helpers.tpl
@@ -15,8 +15,17 @@ limitations under the License.
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: helm
-app.kubernetes.io/part-of: magma
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}
+
+{{/* Label for orc8r non-applications */}}
+{{- define "orc8r-labels" -}}
+app.kubernetes.io/part-of: orc8r
+{{- end -}}
+
+{{/* Label for orc8r applications */}}
+{{- define "orc8r-app-labels" -}}
+app.kubernetes.io/part-of: orc8r-app
 {{- end -}}
 
 {{/* Generate selector labels */}}

--- a/orc8r/cloud/helm/orc8r/templates/accessd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "accessd.service") -}}
+{{- define "accessd.service" -}}
+metadata:
+  name: {{ .Release.Name }}-accessd
+  labels:
+    {{- with .Values.accessd.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.accessd.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9091
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/bootstrapper.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrapper.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "bootstrapper.service") -}}
+{{- define "bootstrapper.service" -}}
+metadata:
+  name: {{ .Release.Name }}-bootstrapper
+  labels:
+    {{- with .Values.bootstrapper.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.bootstrapper.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9088
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/certifier.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/certifier.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "certifier.service") -}}
+{{- define "certifier.service" -}}
+metadata:
+  name: {{ .Release.Name }}-certifier
+  labels:
+    {{- with .Values.certifier.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.certifier.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9086
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/configurator.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "configurator.service") -}}
+{{- define "configurator.service" -}}
+metadata:
+  name: {{ .Release.Name }}-configurator
+  labels:
+    {{- with .Values.configurator.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.configurator.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9108
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/controller.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.deployment.yaml
@@ -18,22 +18,22 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-app-labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.controller.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-{{ include "selector-labels" . | indent 6 }}
   template:
     metadata:
       labels:
         app.kubernetes.io/component: controller
-{{ include "selector-labels" . | indent 8 }}
       annotations:
         {{- with .Values.controller.podAnnotations }}
 {{ toYaml . | indent 8 }}
         {{- end }}
     spec:
+      serviceAccountName: {{ .Release.Name }}-service-reader
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -95,6 +95,8 @@ spec:
             - containerPort: {{ $port }}
             {{- end }}
             {{- end }}
+            - name: grpc
+              containerPort: 9180
           env:
             - name: DATABASE_SOURCE
               valueFrom:
@@ -115,15 +117,21 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP
+            - name: SERVICE_REGISTRY_MODE
+              value: {{ .Values.controller.spec.service_registry.mode }}
+            - name: HELM_RELEASE_NAME
+              value: {{ .Release.Name }}
           livenessProbe:
             tcpSocket:
               port: 9081
             initialDelaySeconds: 10
             periodSeconds: 30
-          readinessProbe:
-            tcpSocket:
-              port: 9081
-            initialDelaySeconds: 5
-            periodSeconds: 10
+          # Readiness probe prevents service registry mode 'k8s' from working
+          # properly
+          #readinessProbe:
+          #  tcpSocket:
+          #    port: 9081
+          #  initialDelaySeconds: 5
+          #  periodSeconds: 10
           resources:
 {{ toYaml .Values.controller.resources | indent 12 }}

--- a/orc8r/cloud/helm/orc8r/templates/controller.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.pdb.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-app-labels" . | indent 4 }}
 spec:
   {{- with .Values.controller.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}
@@ -28,5 +29,4 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: controller
-{{ include "selector-labels" . | indent 6 }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/controller.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.secret.yaml
@@ -17,6 +17,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
 type: Opaque
 data:
   {{- with .Values.controller.spec.database }}

--- a/orc8r/cloud/helm/orc8r/templates/controller.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.service.yaml
@@ -16,6 +16,7 @@ metadata:
   labels:
     app.kubernetes.io/component: controller
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.controller.service.labels }}
 {{ toYaml . | indent 4}}
     {{- end}}
@@ -26,7 +27,6 @@ metadata:
 spec:
   selector:
     app.kubernetes.io/component: controller
-{{ include "selector-labels" . | indent 4 }}
   type: {{ .Values.controller.service.type }}
   ports:
     {{- with .Values.controller.service }}

--- a/orc8r/cloud/helm/orc8r/templates/device.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "device.service") -}}
+{{- define "device.service" -}}
+metadata:
+  name: {{ .Release.Name }}-device
+  labels:
+    {{- with .Values.device.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.device.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9106
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "directoryd.service") -}}
+{{- define "directoryd.service" -}}
+metadata:
+  name: {{ .Release.Name }}-directoryd
+  labels:
+    {{- with .Values.directoryd.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.directoryd.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9100
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "dispatcher.service") -}}
+{{- define "dispatcher.service" -}}
+metadata:
+  name: {{ .Release.Name }}-dispatcher
+  labels:
+    {{- with .Values.dispatcher.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.dispatcher.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9096
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/ingress.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/ingress.service.yaml
@@ -21,6 +21,7 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.nginx.service.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
@@ -66,6 +67,7 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.nginx.service.labels }}
 {{ toYaml . | indent 4 }}
     {{- end }}
@@ -114,6 +116,7 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
     {{- with .Values.nginx.service.labels }}
 {{ toYaml . | indent 4 }}
   {{- end }}

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "metricsd.service") -}}
+{{- define "metricsd.service" -}}
+metadata:
+  name: {{ .Release.Name }}-metricsd
+  labels:
+    {{- with .Values.metricsd.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.metricsd.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9084
+    - name: http
+      port: 8080
+      targetPort: 10984
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
@@ -19,6 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.nginx.replicas }}
   selector:

--- a/orc8r/cloud/helm/orc8r/templates/nginx.pdb.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/nginx.pdb.yaml
@@ -18,6 +18,7 @@ metadata:
   labels:
     app.kubernetes.io/component: nginx-proxy
 {{ include "labels" . | indent 4 }}
+{{ include "orc8r-labels" . | indent 4 }}
 spec:
   {{- with .Values.nginx.podDisruptionBudget.minAvailable }}
   minAvailable: {{ . }}

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "obsidian.service") -}}
+{{- define "obsidian.service" -}}
+metadata:
+  name: {{ .Release.Name }}-obsidian
+  labels:
+    {{- with .Values.obsidian.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.obsidian.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9093
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
@@ -28,4 +28,7 @@ spec:
     - name: grpc
       port: 9180
       targetPort: 9093
+    - name: http
+      port: 8080
+      targetPort: 9081
 {{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "orchestrator.service") -}}
+{{- define "orchestrator.service" -}}
+metadata:
+  name: {{ .Release.Name }}-orchestrator
+  labels:
+    {{- with .Values.orchestrator.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.orchestrator.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9112
+    - name: http
+      port: 8080
+      targetPort: 10112
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/service_reader.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/service_reader.yaml
@@ -1,0 +1,44 @@
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Create service account, role and role binding for access to services via
+# K8s API
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-service-reader
+  namespace: {{ .Release.Namespace }}
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-service-reader-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get", "list"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-servicer-reader-role-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-service-reader
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-service-reader-role
+  apiGroup: rbac.authorization.k8s.io

--- a/orc8r/cloud/helm/orc8r/templates/service_registry.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/service_registry.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "service_registry.service") -}}
+{{- define "service_registry.service" -}}
+metadata:
+  name: {{ .Release.Name }}-service-registry
+  labels:
+    {{- with .Values.service_registry.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.service_registry.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9180
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/state.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "state.service") -}}
+{{- define "state.service" -}}
+metadata:
+  name: {{ .Release.Name }}-state
+  labels:
+    {{- with .Values.state.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.state.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9105
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/streamer.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.service.yaml
@@ -1,3 +1,4 @@
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -8,22 +9,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-apiVersion: v2
-appVersion: "1.0"
-description: A Helm chart for magma orchestrator's wifi module
-name: wifi-orc8r
-version: 0.1.0
-engine: gotpl
-sources:
-  - https://github.com/magma/magma
-keywords:
-  - magma
-  - or8cr
-  - wifi-orc8r
-
-# Library chart for common orchestrator module components
-dependencies:
-- name: orc8rlib
-  version: 0.1.1
-  repository: file://../../../../orc8r/cloud/helm/orc8rlib
+{{- include "orc8rlib.service" (list . "streamer.service") -}}
+{{- define "streamer.service" -}}
+metadata:
+  name: {{ .Release.Name }}-streamer
+  labels:
+    {{- with .Values.streamer.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.streamer.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9082
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/templates/tenants.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "tenants.service") -}}
+{{- define "tenants.service" -}}
+metadata:
+  name: {{ .Release.Name }}-tenants
+  labels:
+    {{- with .Values.tenants.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.tenants.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9110
+    - name: http
+      port: 8080
+      targetPort: 10110
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -147,7 +147,9 @@ controller:
     targetPort: 8080
     # port range exposed by controller
     portStart: 9079
-    portEnd: 9108
+    portEnd: 9117
+    httpPortStart: 10079
+    httpPortEnd: 10117
 
   # controller image
   image:
@@ -166,6 +168,8 @@ controller:
       port: 5432
       user: postgres
       pass: postgres
+    service_registry:
+      mode: "yaml"
 
   migration:
     new_handlers: 0
@@ -197,6 +201,101 @@ controller:
   # Assign proxy to run on specific nodes
   # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
   affinity: {}
+
+accessd:
+  service:
+    labels: {}
+    annotations: {}
+
+bootstrapper:
+  service:
+    labels: {}
+    annotations: {}
+
+certifier:
+  service:
+    labels: {}
+    annotations: {}
+
+configurator:
+  service:
+    labels: {}
+    annotations: {}
+
+device:
+  service:
+    labels: {}
+    annotations: {}
+
+directoryd:
+  service:
+    labels: {}
+    annotations: {}
+
+dispatcher:
+  service:
+    labels: {}
+    annotations: {}
+
+metricsd:
+  service:
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/networks/:network_id/alerts,
+        /magma/v1/networks/:network_id/metrics,
+        /magma/v1/networks/:network_id/prometheus,
+        /magma/v1/tenants/:tenant_id/metrics,
+        /magma/v1/tenants/targets_metadata,
+
+obsidian:
+  service:
+    labels: {}
+    annotations: {}
+
+orchestrator:
+  service:
+    labels:
+      orc8r.io/mconfig_builder: "true"
+      orc8r.io/metrics_exporter: "true"
+      orc8r.io/obsidian_handlers: "true"
+      orc8r.io/state_indexer: "true"
+      orc8r.io/stream_provider: "true"
+    annotations:
+      orc8r.io/state_indexer_types: "directory_record"
+      orc8r.io/state_indexer_version: "1"
+      orc8r.io/stream_provider_streams: "configs"
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /,
+        /magma/v1/channels,
+        /magma/v1/events,
+        /magma/v1/networks,
+        /magma/v1/networks/:network_id,
+
+service_registry:
+  service:
+    labels: {}
+    annotations: {}
+
+state:
+  service:
+    labels: {}
+    annotations: {}
+
+streamer:
+  service:
+    labels: {}
+    annotations: {}
+
+tenants:
+  service:
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/tenants,
+        /magma/v1/tenants/:tenants_id,
 
 # Set True to create a CloudWatch agent to monitor metrics
 cloudwatch:

--- a/orc8r/cloud/helm/orc8rlib/Chart.yaml
+++ b/orc8r/cloud/helm/orc8rlib/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: 1.0.0
 description: A Helm library chart for orchestrator modules
 name: orc8rlib
-version: 0.1.0
+version: 0.1.1
 type: library
 engine: gotpl
 sources:

--- a/orc8r/cloud/helm/orc8rlib/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8rlib/templates/_helpers.tpl
@@ -11,18 +11,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{/* Generate basic labels */}}
-{{- define "labels" -}}
+{{- define "default-labels" -}}
 app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/component: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: helm
-app.kubernetes.io/part-of: orc8r
+app.kubernetes.io/part-of: orc8r-app
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end -}}
 
 {{/* Generate selector labels */}}
-{{- define "selector-labels" -}}
-app.kubernetes.io/name: {{ .Chart.Name }}
-app.kubernetes.io/component: {{ .Chart.Name }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+{{/* TODO: Add back instance, name labels after the controller is split */}}
+{{- define "default-selector-labels" -}}
+app.kubernetes.io/component: controller
 {{- end -}}

--- a/orc8r/cloud/helm/orc8rlib/templates/_service.yaml
+++ b/orc8r/cloud/helm/orc8rlib/templates/_service.yaml
@@ -16,10 +16,11 @@ kind: Service
 metadata:
   name: {{ .Release.Name }}-svc
   labels:
-{{ include "labels" . | indent 4 }}
+    app.kubernetes.io/component: controller
+{{ include "default-labels" . | indent 4 }}
 spec:
   selector:
-{{ include "selector-labels" . | indent 4 }}
+{{ include "default-selector-labels" . | indent 4 }}
   type: ClusterIP
   # Standardize on service ports for gRPC and HTTP servers
   ports:

--- a/wifi/cloud/helm/wifi-orc8r/Chart.lock
+++ b/wifi/cloud/helm/wifi-orc8r/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: orc8rlib
   repository: file://../../../../orc8r/cloud/helm/orc8rlib
-  version: 0.1.0
-digest: sha256:9a488a7a909183d038917e593faaec6312b78ee22a101fb2a69908eb425ebd84
-generated: "2020-08-18T02:06:01.644182-07:00"
+  version: 0.1.1
+digest: sha256:9d2148b03efda4b4bdf14d5428b5f80dc3212a7e95388e256de7f7cdafd4714f
+generated: "2020-09-25T21:26:43.492441-04:00"


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR updates the orc8r helm chart and orc8r module helm charts to properly
support a k8s backed service registry. This includes:

- defining service template files for the orc8r
- setting labels to part-of=orc8r-app for application components
- modify controller deployment selector labels so that the orc8r module services
  backend to the controller pod properly.

## Test Plan

Deployed to minikube using application code from https://github.com/magma/magma/pull/2936
Ensure orc8r functions with mode "yaml" and mode "k8s". 

## Additional Information

- [x] This change is backwards-breaking

This change modifies the selector labels used for the orc8r deployment.
Since these fields are immutable in k8s, this will require a helm delete and redeploy.
To avoid having to re-create the orc8r deployment, it advisable to skip this helm chart and use:

```
    service_registry:
      mode: "yaml"
```

in the orc8r vals.yml file.
