### PR TITLE
[circleci] increased vm resources for feg precomit and feg build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -514,6 +514,7 @@ jobs:
   feg-precommit:
     docker:
       - image: circleci/golang:1.13-stretch-node-browsers-legacy
+    resource_class: medium+
     environment:
       - GO111MODULE=on
     steps:
@@ -536,6 +537,7 @@ jobs:
     machine:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
+    resource_class: large
     environment:
       - MAGMA_ROOT=/home/circleci/project
     steps:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Feg precommit fails in ci due to lack of resources. 
This PR increases resources on Circle CI VMs n


## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
