### PR TITLE
AGW: SGW: Create separate tunnel for each eNodeB

### DIFF
--- a/lte/gateway/c/oai/include/sgw_config.h
+++ b/lte/gateway/c/oai/include/sgw_config.h
@@ -56,6 +56,7 @@
 #define SGW_CONFIG_STRING_OVS_INTERNAL_SAMPLING_FWD_TBL_NUM "INTERNAL_SAMPLING_FWD_TBL_NUM"
 #define SGW_CONFIG_STRING_OVS_UPLINK_PORT_NUM "UPLINK_PORT_NUM"
 #define SGW_CONFIG_STRING_OVS_UPLINK_MAC "UPLINK_MAC"
+#define SGW_CONFIG_STRING_OVS_MULTI_TUNNEL "MULTI_TUNNEL"
 
 #define SPGW_ABORT_ON_ERROR true
 #define SPGW_WARN_ON_ERROR false
@@ -68,6 +69,7 @@ typedef struct ovs_config_s {
   int internal_sampling_fwd_tbl_num;
   int uplink_port_num;
   bstring uplink_mac;
+  bool multi_tunnel;
 } ovs_config_t;
 
 typedef struct sgw_config_s {

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -107,7 +107,8 @@ const int UeNetworkInfo::get_vlan() const {
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, int vlan, const struct in_addr enb_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const char* imsi)
+    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+    uint32_t gtp_port_no)
     : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       in_tei_(in_tei),
@@ -116,12 +117,14 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       dl_flow_valid_(false),
       dl_flow_(),
       dl_flow_precedence_(DEFAULT_PRECEDENCE),
-      ExternalEvent(EVENT_ADD_GTP_TUNNEL) {}
+      ExternalEvent(EVENT_ADD_GTP_TUNNEL),
+      gtp_portno_(gtp_port_no) {}
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
     const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
     const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-    const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence)
+    const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence,
+    uint32_t gtp_port_no)
     : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       in_tei_(in_tei),
@@ -130,7 +133,8 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
       dl_flow_precedence_(dl_flow_precedence),
-      ExternalEvent(EVENT_ADD_GTP_TUNNEL) {}
+      ExternalEvent(EVENT_ADD_GTP_TUNNEL),
+      gtp_portno_(gtp_port_no) {}
 
 const struct in_addr& AddGTPTunnelEvent::get_ue_ip() const {
   return ue_info_.get_ip();
@@ -168,22 +172,28 @@ const uint32_t AddGTPTunnelEvent::get_dl_flow_precedence() const {
   return dl_flow_precedence_;
 }
 
+const uint32_t AddGTPTunnelEvent::get_gtp_portno() const {
+  return gtp_portno_;
+}
+
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
     const struct in_addr ue_ip, const uint32_t in_tei,
-    const struct ipv4flow_dl* dl_flow)
+    const struct ipv4flow_dl* dl_flow, uint32_t gtp_port_no)
     : ue_info_(ue_ip),
       in_tei_(in_tei),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
-      ExternalEvent(EVENT_DELETE_GTP_TUNNEL) {}
+      ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
+      gtp_portno_(gtp_port_no) {}
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-    const struct in_addr ue_ip, const uint32_t in_tei)
+    const struct in_addr ue_ip, const uint32_t in_tei, uint32_t gtp_port_no)
     : ue_info_(ue_ip),
       in_tei_(in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
-      ExternalEvent(EVENT_DELETE_GTP_TUNNEL) {}
+      ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
+      gtp_portno_(gtp_port_no) {}
 
 const struct in_addr& DeleteGTPTunnelEvent::get_ue_ip() const {
   return ue_info_.get_ip();
@@ -199,6 +209,10 @@ const bool DeleteGTPTunnelEvent::is_dl_flow_valid() const {
 
 const struct ipv4flow_dl& DeleteGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
+}
+
+const uint32_t DeleteGTPTunnelEvent::get_gtp_portno() const {
+  return gtp_portno_;
 }
 
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -164,11 +164,13 @@ class AddGTPTunnelEvent : public ExternalEvent {
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
       const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-      const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence);
+      const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence,
+      uint32_t gtp_port_no);
 
   AddGTPTunnelEvent(
       const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
-      const uint32_t in_tei, const uint32_t out_tei, const char* imsi);
+      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
+      uint32_t gtp_port_no);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
@@ -179,6 +181,7 @@ class AddGTPTunnelEvent : public ExternalEvent {
   const bool is_dl_flow_valid() const;
   const struct ipv4flow_dl& get_dl_flow() const;
   const uint32_t get_dl_flow_precedence() const;
+  const uint32_t get_gtp_portno() const;
 
  private:
   const UeNetworkInfo ue_info_;
@@ -189,6 +192,7 @@ class AddGTPTunnelEvent : public ExternalEvent {
   const struct ipv4flow_dl dl_flow_;
   const bool dl_flow_valid_;
   const uint32_t dl_flow_precedence_;
+  const uint32_t gtp_portno_;
 };
 
 /*
@@ -198,20 +202,24 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
  public:
   DeleteGTPTunnelEvent(
       const struct in_addr ue_ip, const uint32_t in_tei,
-      const struct ipv4flow_dl* dl_flow);
-  DeleteGTPTunnelEvent(const struct in_addr ue_ip, const uint32_t in_tei);
+      const struct ipv4flow_dl* dl_flow,
+      uint32_t gtp_port_no);
+  DeleteGTPTunnelEvent(const struct in_addr ue_ip, const uint32_t in_tei,
+      uint32_t gtp_port_no);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
   const bool is_dl_flow_valid() const;
   const struct ipv4flow_dl& get_dl_flow() const;
+  const uint32_t get_gtp_portno() const;
 
  private:
   const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
   const struct ipv4flow_dl dl_flow_;
   const bool dl_flow_valid_;
+  const uint32_t gtp_portno_;
 };
 
 /*

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -88,28 +88,31 @@ static void* external_event_callback(std::shared_ptr<void> data) {
 int openflow_controller_add_gtp_tunnel(
     struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
     const char* imsi, struct ipv4flow_dl* flow_dl,
-    uint32_t flow_precedence_dl) {
+    uint32_t flow_precedence_dl, uint32_t gtp_portno) {
   if (flow_dl) {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
+        ue, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl,
+        gtp_portno);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   } else {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, vlan, enb, i_tei, o_tei, imsi);
+        ue, vlan, enb, i_tei, o_tei, imsi, gtp_portno);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   }
   return 0;
 }
 
 int openflow_controller_del_gtp_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl) {
+    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
+    uint32_t gtp_portno) {
   if (flow_dl) {
     auto del_tunnel =
-        std::make_shared<openflow::DeleteGTPTunnelEvent>(ue, i_tei, flow_dl);
+        std::make_shared<openflow::DeleteGTPTunnelEvent>(ue, i_tei, flow_dl,
+                                                         gtp_portno);
     ctrl.inject_external_event(del_tunnel, external_event_callback);
   } else {
     auto del_tunnel =
-        std::make_shared<openflow::DeleteGTPTunnelEvent>(ue, i_tei);
+        std::make_shared<openflow::DeleteGTPTunnelEvent>(ue, i_tei, gtp_portno);
     ctrl.inject_external_event(del_tunnel, external_event_callback);
   }
   return 0;

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
@@ -31,10 +31,12 @@ int stop_of_controller(void);
 
 int openflow_controller_add_gtp_tunnel(
     struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    const char* imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
+    const char* imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl,
+    uint32_t gtp_portno);
 
 int openflow_controller_del_gtp_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl);
+    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
+    uint32_t gtp_portno);
 
 int openflow_controller_discard_data_on_tunnel(
     struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl);

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -20,6 +20,7 @@
 #include <gmp.h>  // gross but necessary to link spgw_config.h
 
 #include "OpenflowController.h"
+#include "gtpv1u.h"
 
 namespace openflow {
 
@@ -130,6 +131,15 @@ class GTPApplication : public Application {
       const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
       uint32_t port_number);
 
+  /**
+   * Add uplink port match to UL flows
+   * @param uplink_fm OF flow mod msg
+   * @param gtp_port GTP port from event
+   * @param i_tei tunnel id.
+   */
+  void add_uplink_match(
+    of13::FlowMod& uplink_fm, uint32_t gtp_port, uint32_t i_tei);
+
  private:
   static const uint32_t DEFAULT_PRIORITY = 10;
   static const std::string GTP_PORT_MAC;
@@ -137,7 +147,7 @@ class GTPApplication : public Application {
   static const uint32_t LOW_PRIORITY = 0;
 
   const std::string uplink_mac_;
-  const uint32_t gtp_port_num_;
+  const uint32_t gtp0_port_num_;
   // Internal port number for monitoring service
   const uint32_t mtr_port_num_;
   // Internal port for sampling internal ipfix packets

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
@@ -172,7 +172,7 @@ int libgtpnl_add_tunnel(
   return ret;
 }
 
-int libgtpnl_del_tunnel(
+int libgtpnl_del_tunnel(__attribute__((unused)) struct in_addr enb,
     __attribute__((unused)) struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
     struct ipv4flow_dl* flow_dl) {
   struct gtp_tunnel* t;

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -15,6 +15,7 @@
  *      contact@openairinterface.org
  */
 
+#include <assert.h>
 #include <errno.h>
 #include <stdint.h>
 #include <netinet/in.h>
@@ -30,6 +31,195 @@
 
 extern struct gtp_tunnel_ops gtp_tunnel_ops;
 
+// Tunnel port related functionality
+static const char* ovs_gtp_type;
+
+#define MAX_GTP_PORT_NAME_LENGTH 15
+
+#define INIT_GTP_TABLE_SIZE 64
+#define MAX_GTP_TABLE_SIZE 1024
+
+struct gtp_portno {
+  // GTP port name is limited at 14 char
+  char name[MAX_GTP_PORT_NAME_LENGTH];
+  // zero port number is unknown port
+  uint32_t portno;
+};
+
+struct gtp_portno_record {
+  struct gtp_portno* arr;
+  int allocated;
+  int size;
+};
+
+static struct gtp_portno_record gtp_portno_rec;
+
+/**
+ * Generate GTP port name from eNodeB IP address
+ */
+static void ip_addr_to_gtp_port_name(struct in_addr enb_addr, char name[]) {
+  int rc;
+  rc = snprintf(
+      name, MAX_GTP_PORT_NAME_LENGTH, "g_%x", (uint32_t) enb_addr.s_addr);
+  assert(rc > 0);
+}
+
+static uint32_t search_portno_records(char* name) {
+  int i;
+  for (i = 0; i < gtp_portno_rec.allocated; i++) {
+    if (!strncmp(name, gtp_portno_rec.arr[i].name, MAX_GTP_PORT_NAME_LENGTH)) {
+      return gtp_portno_rec.arr[i].portno;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Implements basic port number map with linear seach.
+ */
+static void add_portno_rec(char* port_name, uint32_t portno) {
+  if (gtp_portno_rec.allocated == gtp_portno_rec.size) {
+    int new_size = gtp_portno_rec.size * 2;
+    if (new_size > MAX_GTP_TABLE_SIZE) {
+      // in case of unpected increase in table size, flush
+      // all records.
+      new_size = INIT_GTP_TABLE_SIZE;
+    }
+    struct gtp_portno* new_arr = calloc(new_size, sizeof(struct gtp_portno));
+    if (!new_arr) {
+      return;
+    }
+    if (new_size > gtp_portno_rec.size) {
+      // In case of table size increase copy existing records.
+      memcpy(
+          new_arr, gtp_portno_rec.arr,
+          sizeof(gtp_portno_rec.arr[0]) * gtp_portno_rec.size);
+    } else {
+      // Flush all records if size resets to init-size.
+      gtp_portno_rec.allocated = 0;
+    }
+    free(gtp_portno_rec.arr);
+    gtp_portno_rec.arr  = new_arr;
+    gtp_portno_rec.size = gtp_portno_rec.size * 2;
+  }
+  // Now we shld have space to add new port.
+  int i;
+
+  for (i = 0; i < gtp_portno_rec.size; i++) {
+    struct gtp_portno* rec = &gtp_portno_rec.arr[i];
+
+    if (!rec->portno) {
+      strncpy(rec->name, port_name, MAX_GTP_PORT_NAME_LENGTH);
+      rec->portno = portno;
+      gtp_portno_rec.allocated++;
+      return;
+    }
+  }
+  // port number caching is best effort.
+}
+
+/**
+ * Read GTP tunnel port number from OVSDB.
+ */
+static uint32_t get_gtp_port_no(char port_name[]) {
+  FILE* fp;
+  uint32_t port_no = 0;
+  char ovsdb_dump[256];
+
+  /* Open the command for reading. */
+  fp = popen("sudo ovsdb-client dump Interface name ofport", "r");
+  if (fp == NULL) {
+    OAILOG_ERROR(LOG_GTPV1U, "could not read ovsdb");
+    return 0;
+  }
+
+  /* Read the output a line at a time - output it. */
+  while (fgets(ovsdb_dump, sizeof(ovsdb_dump), fp) != NULL) {
+    OAILOG_DEBUG(LOG_GTPV1U, "ovsdb: %s\n", ovsdb_dump);
+    char* p = strstr(ovsdb_dump, port_name);
+    if (p) {
+      int len = strlen(port_name);
+      // ovsdb dump has port number after portname separated by whitespaces.
+      port_no = atoi(&p[len + 1]);
+      break;
+    }
+  }
+
+  pclose(fp);
+  return port_no;
+}
+
+/**
+ * Create GTP tunnel using OVS tool
+ */
+static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
+  char gtp_port_create[512];
+  int rc;
+  rc = snprintf(
+      gtp_port_create, sizeof(gtp_port_create),
+      "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s type=%s "
+      "options:remote_ip=%s options:key=flow",
+      port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr));
+  if (rc < 0) {
+    OAILOG_ERROR(LOG_GTPV1U, "gtp-port create: format error %d", rc);
+    return rc;
+  }
+  rc = system(gtp_port_create);
+  if (rc != 0) {
+    // ignore failures. we can always fallback to gtp0 for GTP tunnel traffic.
+    OAILOG_ERROR(
+        LOG_GTPV1U, "gtp port create: [%s] failed: %d", gtp_port_create, rc);
+  } else {
+    OAILOG_DEBUG(LOG_GTPV1U, "gtp port create done: for ENB: %s ", inet_ntoa(enb_addr));
+  }
+
+  return get_gtp_port_no(port_name);
+}
+
+/**
+ * seach port in cached table. otherwise create tunnel and
+ * retrieve port number from OVSDB.
+ */
+static uint32_t find_gtp_port_no(struct in_addr enb_addr) {
+  if (!spgw_config.sgw_config.ovs_config.multi_tunnel) {
+    return 0;
+  }
+
+  char port_name[MAX_GTP_PORT_NAME_LENGTH];
+  ip_addr_to_gtp_port_name(enb_addr, port_name);
+
+  uint32_t portno = search_portno_records(port_name);
+  if (portno) {
+    return portno;
+  }
+
+  portno = create_gtp_port(enb_addr, port_name);
+  add_portno_rec(port_name, portno);
+  return portno;
+}
+
+/**
+ * Initialize GTP port table for caching GTP tunnel port numbers.
+ */
+static void openflow_multi_tunnel_init(void) {
+  char* probe_gtp_type = "sudo ovs-vsctl list Open_vSwitch | grep gtpu";
+
+  // OVS GTP tunnel type has changed upstream, for better compatibility
+  // detect it on initilization.
+  int rc = system(probe_gtp_type);
+  if (rc != 0) {
+    ovs_gtp_type = strdup("gtp");
+  } else {
+    ovs_gtp_type = strdup("gtpu");
+  }
+  OAILOG_INFO(LOG_GTPV1U, "Using GTP type: %s", ovs_gtp_type);
+
+  gtp_portno_rec.arr = calloc(INIT_GTP_TABLE_SIZE, sizeof(struct gtp_portno));
+  assert(gtp_portno_rec.arr != NULL);
+  gtp_portno_rec.size = INIT_GTP_TABLE_SIZE;
+}
+
+// tunnel flows
 int openflow_uninit(void) {
   int ret;
   if ((ret = stop_of_controller()) < 0) {
@@ -53,17 +243,22 @@ int openflow_reset(void) {
 }
 
 int openflow_add_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl) {
+    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei,
+    uint32_t o_tei, Imsi_t imsi, struct ipv4flow_dl* flow_dl,
+    uint32_t flow_precedence_dl) {
+  uint32_t gtp_portno = find_gtp_port_no(enb);
+
   return openflow_controller_add_gtp_tunnel(
       ue, vlan, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
-      flow_precedence_dl);
+      flow_precedence_dl, gtp_portno);
 }
 
 int openflow_del_tunnel(
-    struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
+    struct in_addr enb, struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
     struct ipv4flow_dl* flow_dl) {
-  return openflow_controller_del_gtp_tunnel(ue, i_tei, flow_dl);
+  uint32_t gtp_portno = find_gtp_port_no(enb);
+
+  return openflow_controller_del_gtp_tunnel(ue, i_tei, flow_dl, gtp_portno);
 }
 
 int openflow_discard_data_on_tunnel(
@@ -126,8 +321,9 @@ int openflow_send_end_marker(struct in_addr enb, uint32_t tei) {
         LOG_GTPV1U, "end marker cmd: [%s] failed: %d", end_marker_cmd, rc);
     end_marker_supported = false;
   } else {
-    OAILOG_DEBUG(LOG_GTPV1U, "End marker sent: tei %" PRIu32
-        " tun_dst %s", tei, inet_ntoa(enb));
+    OAILOG_DEBUG(
+        LOG_GTPV1U, "End marker sent: tei %" PRIu32 " tun_dst %s", tei,
+        inet_ntoa(enb));
   }
   return rc;
 }
@@ -151,5 +347,9 @@ static const struct gtp_tunnel_ops openflow_ops = {
 };
 
 const struct gtp_tunnel_ops* gtp_tunnel_ops_init_openflow(void) {
+  if (spgw_config.sgw_config.ovs_config.multi_tunnel) {
+    openflow_multi_tunnel_init();
+  }
+
   return &openflow_ops;
 }

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -129,7 +129,7 @@ struct gtp_tunnel_ops {
   int (*add_tunnel)(
       struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
       Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
-  int (*del_tunnel)(
+  int (*del_tunnel)(struct in_addr enb,
       struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
       struct ipv4flow_dl* flow_dl);
   int (*discard_data_on_tunnel)(

--- a/lte/gateway/c/oai/tasks/sgw/sgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_config.c
@@ -310,6 +310,7 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
     libconfig_int internal_sampling_port_num    = 0;
     libconfig_int internal_sampling_fwd_tbl_num = 0;
     libconfig_int uplink_port_num               = 0;
+    char* multi_tunnel                          = NULL;
     char* uplink_mac                            = NULL;
     if (config_setting_lookup_string(
             ovs_settings, SGW_CONFIG_STRING_OVS_BRIDGE_NAME,
@@ -329,7 +330,10 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
             &internal_sampling_port_num) &&
         config_setting_lookup_int(
             ovs_settings, SGW_CONFIG_STRING_OVS_INTERNAL_SAMPLING_FWD_TBL_NUM,
-            &internal_sampling_fwd_tbl_num)) {
+            &internal_sampling_fwd_tbl_num) &&
+        config_setting_lookup_string(
+            ovs_settings, SGW_CONFIG_STRING_OVS_MULTI_TUNNEL,
+            (const char **) &multi_tunnel)) {
       config_pP->ovs_config.bridge_name  = bfromcstr(ovs_bridge_name);
       config_pP->ovs_config.gtp_port_num = gtp_port_num;
       config_pP->ovs_config.mtr_port_num = mtr_port_num;
@@ -339,6 +343,14 @@ int sgw_config_parse_file(sgw_config_t* config_pP)
           internal_sampling_fwd_tbl_num;
       config_pP->ovs_config.uplink_port_num = uplink_port_num;
       config_pP->ovs_config.uplink_mac      = bfromcstr(uplink_mac);
+      if (strcasecmp(multi_tunnel, "false") == 0) {
+        config_pP->ovs_config.multi_tunnel = false;
+      } else {
+        config_pP->ovs_config.multi_tunnel = true;
+      }
+      OAILOG_INFO(
+          LOG_SPGW_APP, "Multi tunnel enable: %s\n",
+          multi_tunnel);
     } else {
       AssertFatal(false, "Couldn't find all ovs settings in spgw config\n");
     }

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -702,7 +702,11 @@ int sgw_handle_sgi_endpoint_deleted(
         }
       }
       // delete GTPv1-U tunnel
-      rv = gtp_tunnel_ops->del_tunnel(
+      struct in_addr enb = {.s_addr = 0};
+      enb.s_addr =
+          eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
+
+      rv = gtp_tunnel_ops->del_tunnel(enb,
           ue, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u, NULL);
       if (rv < 0) {
@@ -915,7 +919,7 @@ int sgw_handle_modify_bearer_request(
           // This is best effort, ignore return code.
           gtp_tunnel_ops->send_end_marker(enb, modify_bearer_pP->teid);
           // delete GTPv1-U tunnel
-          rv = gtp_tunnel_ops->del_tunnel(
+          rv = gtp_tunnel_ops->del_tunnel(enb,
               ue, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
         }
@@ -1024,7 +1028,11 @@ int sgw_handle_delete_session_request(
 
         if (eps_bearer_ctxt_p) {
           if (ebi != delete_session_req_pP->lbi) {
-            rv = gtp_tunnel_ops->del_tunnel(
+            struct in_addr enb = {.s_addr = 0};
+            enb.s_addr = eps_bearer_ctxt_p->enb_ip_address_S1u.address
+                           .ipv4_address.s_addr;
+
+            rv = gtp_tunnel_ops->del_tunnel(enb,
                 eps_bearer_ctxt_p->paa.ipv4_address,
                 eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
                 eps_bearer_ctxt_p->enb_teid_S1u, NULL);
@@ -1185,7 +1193,11 @@ int sgw_handle_release_access_bearers_request(
           ctx_p->sgw_eps_bearer_context_information.pdn_connection
               .sgw_eps_bearers_array[ebx];
       if (eps_bearer_ctxt) {
-        rv = gtp_tunnel_ops->del_tunnel(
+        struct in_addr enb = {.s_addr = 0};
+        enb.s_addr = eps_bearer_ctxt->enb_ip_address_S1u.address
+                           .ipv4_address.s_addr;
+
+        rv = gtp_tunnel_ops->del_tunnel(enb,
             eps_bearer_ctxt->paa.ipv4_address,
             eps_bearer_ctxt->s_gw_teid_S1u_S12_S4_up,
             eps_bearer_ctxt->enb_teid_S1u, NULL);
@@ -1676,8 +1688,13 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
           &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection, ebi);
 
       if (eps_bearer_ctxt_p) {
+
         if (ebi != *s11_pcrf_ded_bearer_deactv_rsp->lbi) {
-          rc = gtp_tunnel_ops->del_tunnel(
+          struct in_addr enb = {.s_addr = 0};
+          enb.s_addr = eps_bearer_ctxt_p->enb_ip_address_S1u.address
+                           .ipv4_address.s_addr;
+
+          rc = gtp_tunnel_ops->del_tunnel(enb,
               eps_bearer_ctxt_p->paa.ipv4_address,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
@@ -1747,7 +1764,11 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
               &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                     .packetfiltercontents),
               eps_bearer_ctxt_p->paa.ipv4_address.s_addr, &dlflow);
-          rc = gtp_tunnel_ops->del_tunnel(
+          struct in_addr enb = {.s_addr = 0};
+          enb.s_addr = eps_bearer_ctxt_p->enb_ip_address_S1u.address
+                           .ipv4_address.s_addr;
+
+          rc = gtp_tunnel_ops->del_tunnel(enb,
               eps_bearer_ctxt_p->paa.ipv4_address,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, &dlflow);

--- a/lte/gateway/configs/spgw.yml
+++ b/lte/gateway/configs/spgw.yml
@@ -37,3 +37,4 @@ ovs_internal_sampling_fwd_tbl_number: 201
 
 # Non-NAT specific config
 ovs_uplink_port_number: 2
+ovs_multi_tunnel: false

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -45,6 +45,7 @@ S-GW :
       INTERNAL_SAMPLING_FWD_TBL_NUM        = {{ ovs_internal_sampling_fwd_tbl_number }};
       UPLINK_PORT_NUM                      = {{ ovs_uplink_port_number }};
       UPLINK_MAC                           = "{{ ovs_uplink_mac }}";
+      MULTI_TUNNEL                         = "{{ ovs_multi_tunnel }}";
     };
 };
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_asr.py
@@ -23,7 +23,6 @@ from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 
 class TestAttachASR(unittest.TestCase):
     SPGW_TABLE = 0
-    GTP_PORT = 32768
     LOCAL_PORT = "LOCAL"
 
     def setUp(self):

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach.py
@@ -12,7 +12,6 @@ limitations under the License.
 """
 
 import unittest
-
 import s1ap_types
 
 from integ_tests.s1aptests import s1ap_wrapper

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -16,14 +16,13 @@ import s1ap_types
 import time
 
 from integ_tests.s1aptests import s1ap_wrapper
-from integ_tests.s1aptests.s1ap_utils import SpgwUtil
+from integ_tests.s1aptests.s1ap_utils import SpgwUtil, GTPBridgeUtils
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 
 
 class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
     SPGW_TABLE = 0
-    GTP_PORT = 32768
     LOCAL_PORT = "LOCAL"
 
     def setUp(self):
@@ -49,6 +48,8 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         datapath = get_datapath()
         MAX_NUM_RETRIES = 5
+        gtp_br_util = GTPBridgeUtils()
+        GTP_PORT = gtp_br_util.get_gtp_port_no()
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
@@ -240,7 +241,7 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
                     datapath,
                     {
                         "table_id": self.SPGW_TABLE,
-                        "match": {"in_port": self.GTP_PORT},
+                        "match": {"in_port": GTP_PORT},
                     },
                 )
                 if len(uplink_flows) > 2:

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -17,13 +17,12 @@ import time
 
 from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
-from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 
 
 class TestAttachDetachRarTcpData(unittest.TestCase):
     SPGW_TABLE = 0
-    GTP_PORT = 32768
     LOCAL_PORT = "LOCAL"
 
     def setUp(self):
@@ -46,6 +45,8 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(num_ues)
         datapath = get_datapath()
         MAX_NUM_RETRIES = 5
+        gtp_br_util = GTPBridgeUtils()
+        GTP_PORT = gtp_br_util.get_gtp_port_no()
 
         for i in range(num_ues):
             req = self._s1ap_wrapper.ue_req
@@ -196,7 +197,7 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
                     datapath,
                     {
                         "table_id": self.SPGW_TABLE,
-                        "match": {"in_port": self.GTP_PORT},
+                        "match": {"in_port": GTP_PORT},
                     },
                 )
                 if len(uplink_flows) > 1:

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ovs.py
@@ -16,6 +16,7 @@ import unittest
 
 import s1ap_types
 import s1ap_wrapper
+from s1ap_utils import GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
 from magma.pipelined.imsi import decode_imsi
 
@@ -23,7 +24,6 @@ from magma.pipelined.imsi import decode_imsi
 class TestAttachDetachWithOVS(unittest.TestCase):
 
     SPGW_TABLE = 0
-    GTP_PORT = 32768
     LOCAL_PORT = "LOCAL"
 
     def setUp(self):
@@ -70,14 +70,16 @@ class TestAttachDetachWithOVS(unittest.TestCase):
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
         # UPLINK
-        print("Checking for uplink flow")
+        gtp_br_util = GTPBridgeUtils()
+        gtp_port_no = gtp_br_util.get_gtp_port_no()
+        print("Checking for uplink flow in-port %d", gtp_port_no)
         # try at least 5 times before failing as gateway
         # might take some time to install the flows in ovs
         for i in range(MAX_NUM_RETRIES):
             print("Get uplink flows: attempt ", i)
             uplink_flows = get_flows(datapath,
                                      {"table_id": self.SPGW_TABLE,
-                                      "match": {"in_port": self.GTP_PORT}})
+                                      "match": {"in_port": gtp_port_no}})
             if len(uplink_flows) > 0:
                 break
             time.sleep(5)  # sleep for 5 seconds before retrying

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
@@ -23,7 +23,6 @@ import ipaddress
 
 class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
     SPGW_TABLE = 0
-    GTP_PORT = 32768
     LOCAL_PORT = "LOCAL"
 
     def setUp(self):


### PR DESCRIPTION
## Summary

This patch create separate tunnel to each eNodeB on UE attach.
These tunnel are useful to track stats for each eNodeB.

This is feature is flag protected.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
- [x]  make test
- [x] integ tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
