### PR TITLE
[sessiond] nested report_create_session inside a thread for testing

### DIFF
--- a/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
+++ b/lte/gateway/c/session_manager/test/test_cloud_reporter.cpp
@@ -101,12 +101,22 @@ TEST_F(SessionReporterTest, test_single_call) {
       .WillOnce(testing::DoAll(
           testing::SetArgPointee<2>(response),
           testing::Return(grpc::Status::OK)));
+
+  std::promise<void> promise1;
   CreateSessionRequest request;
   reporter->report_create_session(
-      request, [this](Status status, CreateSessionResponse response_out) {
+      request,
+      [this, &promise1]
+      (Status status, CreateSessionResponse response_out) {
         mock_callback.create_callback(status, response_out);
-        evb.terminateLoopSoon();
+        promise1.set_value();
       });
+
+  // wait for one response
+  std::thread([&]() {
+    promise1.get_future().wait();
+    evb.terminateLoopSoon();
+  }).detach();
 
   set_timeout(1000);
 
@@ -158,8 +168,7 @@ TEST_F(SessionReporterTest, test_multi_call) {
     promise2.get_future().wait();
     promise3.get_future().wait();
     evb.terminateLoopSoon();
-  })
-      .detach();
+  }).detach();
 
   set_timeout(1000);
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>



## Summary

Sessiond test `test_single_call` has some kind of random failures on CI. It looks like the issue is the main thread may be too slow in some occasions. 

In this PR we launch the request inside a thread and we will wait until the thread is done to continue.

Very similar as the code we had before. So if it doesn't work we will remove it.

## Test Plan

make test at agw

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
