### PR TITLE
Fix Gy stats by using an existing monitoring key

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -73,13 +73,13 @@ func ocsTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwfprotos.UEConfig)
 func provisionRestrictRules(t *testing.T, tr *TestRunner, ruleManager *RuleManager) {
 	// Set a block all rule to be installed by the final unit action
 	err := ruleManager.AddStaticRuleToDB(
-		getStaticDenyAll("restrict-deny-all", "restrict-key", 0, models.PolicyRuleConfigTrackingTypeONLYPCRF, 200),
+		getStaticDenyAll("restrict-deny-all", "mkey-ocs", 0, models.PolicyRuleConfigTrackingTypeONLYPCRF, 200),
 	)
 	assert.NoError(t, err)
 
 	// set a pass rule for traffic from TrafficCltIPP
 	err = ruleManager.AddStaticRuleToDB(
-		getStaticPassTraffic("restrict-pass-user", TrafficCltIP, MATCH_ALL, "restrict-key", 0, models.PolicyRuleConfigTrackingTypeONLYPCRF, 100, nil),
+		getStaticPassTraffic("restrict-pass-user", TrafficCltIP, MATCH_ALL, "mkey-ocs", 0, models.PolicyRuleConfigTrackingTypeONLYPCRF, 100, nil),
 	)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

This PR fixes Gy rules reporting and change integration test TestGyCreditExhaustionRestrict to use an existing monitoring key.
 
## Test Plan

SessionD logs

I0929 05:39:30.911908    23 LocalSessionManagerHandler.cpp:51] Aggregating 4 records
I0929 05:39:30.912510     8 SessionState.cpp:435] Updating used charging credit for Rule=static-pass-all-ocs2 Rating Group=1 Service Identifier=0
I0929 05:39:30.912531     8 SessionCredit.cpp:555] ===> Used     Tx: 5033393 Rx: 28290 Total: 5061683
I0929 05:39:30.912536     8 SessionCredit.cpp:558] ===> Reported Tx: 5033393 Rx: 28290 Total: 5061683
I0929 05:39:30.912539     8 SessionCredit.cpp:561] ===> Allowed  Tx: 5033393 Rx: 28290 Total: 9255987
I0929 05:39:30.912541     8 SessionCredit.cpp:564] ===> A_Floor  Tx: 5033393 Rx: 28290 Total: 5061683
I0929 05:39:30.912544     8 SessionCredit.cpp:567] ===> (%used)  Tx: _% Rx: _% Total: 0%
I0929 05:39:30.912549     8 SessionCredit.cpp:580] ===> Grant tracking type TOTAL_ONLY,  Reporting: 0
I0929 05:39:30.912551     8 SessionCredit.cpp:585] ===> Last Granted Units Received (tx/rx/total) 0/0/4194304
I0929 05:39:30.912577     8 SessionState.cpp:453] Updating used monitoring credit for Rule=restrict-deny-all Monitoring Key=mkey-ocs
I0929 05:39:30.912585     8 SessionCredit.cpp:555] ===> Used     Tx: 2087756 Rx: 78296 Total: 2166052
I0929 05:39:30.912587     8 SessionCredit.cpp:558] ===> Reported Tx: 2087425 Rx: 77951 Total: 2165376
I0929 05:39:30.912590     8 SessionCredit.cpp:561] ===> Allowed  Tx: 2087425 Rx: 77951 Total: 2175616
I0929 05:39:30.912592     8 SessionCredit.cpp:564] ===> A_Floor  Tx: 2087425 Rx: 77951 Total: 2165376
I0929 05:39:30.912595     8 SessionCredit.cpp:567] ===> (%used)  Tx: _% Rx: _% Total: 6%
I0929 05:39:30.912598     8 SessionCredit.cpp:580] ===> Grant tracking type TOTAL_ONLY,  Reporting: 0
I0929 05:39:30.912601     8 SessionCredit.cpp:585] ===> Last Granted Units Received (tx/rx/total) 0/0/10240
I0929 05:39:30.912606     8 SessionState.cpp:453] Updating used monitoring credit for Rule=static-pass-all-ocs1 Monitoring Key=mkey-ocs
I0929 05:39:30.912611     8 SessionCredit.cpp:555] ===> Used     Tx: 2087756 Rx: 78296 Total: 2166052
I0929 05:39:30.912612     8 SessionCredit.cpp:558] ===> Reported Tx: 2087425 Rx: 77951 Total: 2165376
I0929 05:39:30.912616     8 SessionCredit.cpp:561] ===> Allowed  Tx: 2087425 Rx: 77951 Total: 2175616
I0929 05:39:30.912618     8 SessionCredit.cpp:564] ===> A_Floor  Tx: 2087425 Rx: 77951 Total: 2165376
I0929 05:39:30.912621     8 SessionCredit.cpp:567] ===> (%used)  Tx: _% Rx: _% Total: 6%
I0929 05:39:30.912623     8 SessionCredit.cpp:580] ===> Grant tracking type TOTAL_ONLY,  Reporting: 0
I0929 05:39:30.912626     8 SessionCredit.cpp:585] ===> Last Granted Units Received (tx/rx/total) 0/0/10240
I0929 05:39:30.912640     8 SessionState.cpp:453] Updating used monitoring credit for Rule=**restrict-pass-user** Monitoring Key=mkey-ocs
I0929 05:39:30.912643     8 SessionCredit.cpp:555] ===> Used     Tx: 2087756 Rx: 78296 Total: 2166052
I0929 05:39:30.912647     8 SessionCredit.cpp:558] ===> Reported Tx: 2087425 Rx: 77951 Total: 2165376
I0929 05:39:30.912649     8 SessionCredit.cpp:561] ===> Allowed  Tx: 2087425 Rx: 77951 Total: 2175616
I0929 05:39:30.912652     8 SessionCredit.cpp:564] ===> A_Floor  Tx: 2087425 Rx: 77951 Total: 2165376
I0929 05:39:30.912654     8 SessionCredit.cpp:567] ===> (%used)  Tx: _% Rx: _% Total: 6%
I0929 05:39:30.912657     8 SessionCredit.cpp:580] ===> Grant tracking type TOTAL_ONLY,  Reporting: 0
I0929 05:39:30.912660     8 SessionCredit.cpp:585] ===> Last Granted Units Received (tx/rx/total) 0/0/10240



All integration tests passed,

[vagrant@127.0.0.1:2201] out: Running TestGyCreditExhaustionRestrict...
[vagrant@127.0.0.1:2201] out: ************************* TestRunner setup
[vagrant@127.0.0.1:2201] out: Adding Mock HSS service at 192.168.70.101:9204
[vagrant@127.0.0.1:2201] out: Adding Mock PCRF service at 192.168.70.101:9202
[vagrant@127.0.0.1:2201] out: Adding Mock OCS service at 192.168.70.101:9201
[vagrant@127.0.0.1:2201] out: Adding Pipelined service at 192.168.70.101:8443
[vagrant@127.0.0.1:2201] out: Adding Redis service at 192.168.70.101:6380
[vagrant@127.0.0.1:2201] out: Adding Directoryd service at 192.168.70.101:8443
[vagrant@127.0.0.1:2201] out: ************************* Configuring 1 UE(s), PCRF instance: PCRF_REMOTE
[vagrant@127.0.0.1:2201] out: Added UE to Simulator, HSS_REMOTE, PCRF_REMOTE, and OCS_REMOTE:
[vagrant@127.0.0.1:2201] out: 	IMSI: 965138295073757	Key: c3034deaec593c5ae81ec747c3e61cfb	Opc: 82e8104bbc60df7508966e5900af6ced	Seq: 1141694542322
[vagrant@127.0.0.1:2201] out: Successfully configured UE(s)
[vagrant@127.0.0.1:2201] out: ************************* Adding PCRF Usage Monitor for UE with IMSI: 965138295073757
[vagrant@127.0.0.1:2201] out: ************************* Adding a Pass-All static rule: static-pass-all-ocs1
[vagrant@127.0.0.1:2201] out: ************************* Adding a Pass-All static rule: static-pass-all-ocs2
[vagrant@127.0.0.1:2201] out: ************************* Adding PCRF Rule for UE with IMSI: 965138295073757 with ruleNames=[static-pass-all-ocs1 static-pass-all-ocs2], baseNames=[]
[vagrant@127.0.0.1:2201] out: ************************* Adding a static rule: restrict-deny-all
[vagrant@127.0.0.1:2201] out: ************************* Adding a static rule: restrict-pass-user
[vagrant@127.0.0.1:2201] out: ************************* Authenticating UE with IMSI: 965138295073757
[vagrant@127.0.0.1:2201] out: Finished Authenticating UE
[vagrant@127.0.0.1:2201] out: ************************* Generating Traffic for UE with Req: imsi:"965138295073757" volume:<value:"5M" > 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"static-pass-all-ocs2" bytes_tx:5033393 bytes_rx:28290 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"restrict-deny-all" 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"static-pass-all-ocs1" 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"restrict-pass-user" 
[vagrant@127.0.0.1:2201] out: ************************* Generating Traffic for UE with Req: imsi:"965138295073757" volume:<value:"2M" > 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"static-pass-all-ocs2" bytes_tx:5033393 bytes_rx:28290 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"restrict-deny-all" 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"static-pass-all-ocs1" 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"restrict-pass-user" bytes_tx:2087756 bytes_rx:78296 
[vagrant@127.0.0.1:2201] out: Asserting all Gy expectations were met...
[vagrant@127.0.0.1:2201] out: Passed!
[vagrant@127.0.0.1:2201] out: ************************* Generating Traffic for UE with Req: imsi:"965138295073757" volume:<value:"2M" > 
[vagrant@127.0.0.1:2201] out: Record sid:"IMSI965138295073757" rule_id:"static-pass-all-ocs2" bytes_tx:2021410 bytes_rx:25953 
[vagrant@127.0.0.1:2201] out: --- PASS: TestGyCreditExhaustionRestrict (34.63s)
[vagrant@127.0.0.1:2201] out: PASS
[vagrant@127.0.0.1:2201] out: ok  	magma/cwf/gateway/integ_tests	34.701s
[vagrant@127.0.0.1:2201] out: 
[vagrant@127.0.0.1:2201] out: DONE 1 tests in 40.702s




