### PR TITLE
[NMS] Fix puppeteer chrome download issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,6 +144,21 @@ commands:
             sudo apt-get update -y
             sudo apt-get install -y yarn
 
+  apt-install-chrome:
+    steps:
+      - run:
+          <<: *appdir
+          command: |
+            # Install latest chrome dev package
+            # Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+            # installs, work.
+            curl -sS https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+            echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | sudo tee /etc/apt/sources.list.d/google.list
+            sudo apt-get update -y
+            sudo apt-get install -y google-chrome-stable libxss1 --no-install-recommends
+            sudo rm -rf /var/lib/apt/lists/*
+
+
   tag-push-docker:
     description: Tag docker image and push it
     parameters:
@@ -792,12 +807,15 @@ jobs:
       image: ubuntu-1604:201903-01
     environment:
       - NMS_ROOT=${MAGMA_ROOT}/nms/app/packages/magmalte
+      - PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+      - PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
     steps:
       - checkout
       - build/determinator:
           <<: *nms_build_verify
       - docker/install-dc
       - apt-install-yarn
+      - apt-install-chrome
       - yarn-install
       - run: echo 'export MAGMA_ROOT=$(pwd)' >> $BASH_ENV
       - run:

--- a/nms/app/packages/magmalte/docker-compose-e2e.yml
+++ b/nms/app/packages/magmalte/docker-compose-e2e.yml
@@ -68,6 +68,8 @@ services:
       MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
       MYSQL_DIALECT: mariadb
       E2E_TEST: 1
+      # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
     healthcheck:
       test: curl -If localhost:8081/healthz
     restart: on-failure

--- a/nms/app/packages/magmalte/docker-compose.yml
+++ b/nms/app/packages/magmalte/docker-compose.yml
@@ -55,6 +55,8 @@ services:
       MYSQL_PASS: password
       MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
       MYSQL_DIALECT: mariadb
+      # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
     healthcheck:
       test: curl -If localhost:8081/healthz
     restart: on-failure


### PR DESCRIPTION
## Summary

This fix downloads stable chrome binary in an earlier step and skips the puppeteer download step which is kind of flaky.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
