### PR TITLE
[orc8r][subscriberdb] Add IP-indexed subscriber lookup

### DIFF
--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -38,7 +38,10 @@ services:
     proxy_type: "clientcert"
     labels:
       orc8r.io/obsidian_handlers: "true"
+      orc8r.io/state_indexer: "true"
     annotations:
+      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record"
+      orc8r.io/state_indexer_version: "1"
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/lte/:network_id/msisdns,
         /magma/v1/lte/:network_id/subscribers,

--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers.go
@@ -49,6 +49,7 @@ const (
 	manageMSISDNsPath = listMSISDNsPath + obsidian.UrlSep + ":msisdn"
 
 	ParamMSISDN = "msisdn"
+	ParamIP     = "ip"
 )
 
 func GetHandlers() []obsidian.Handler {
@@ -92,6 +93,23 @@ var subscriberStateTypes = []string{
 	orc8r.DirectoryRecordType,
 }
 
+type subscriberFilter func(sub *subscribermodels.Subscriber) bool
+
+func acceptAll(sub *subscribermodels.Subscriber) bool { return true }
+
+// listSubscribersHandler handles the base subscriber endpoint.
+// The returned subscribers can be filtered using the following query
+// parameters
+//	- msisdn
+//	- ip
+//
+// The MSISDN parameter is config-based, and is enforced to be a unique
+// identifier.
+//
+// The IP parameter is state-based, and not guaranteed to be unique. The
+// IP->IMSI mapping is cached as the output of a mobilityd state indexer, then
+// each reported subscriber is checked to ensure it actually is assigned the
+// requested IP.
 func listSubscribersHandler(c echo.Context) error {
 	networkID, nerr := obsidian.GetNetworkId(c)
 	if nerr != nil {
@@ -100,15 +118,27 @@ func listSubscribersHandler(c echo.Context) error {
 
 	// First check for query params to filter by
 	if msisdn := c.QueryParam(ParamMSISDN); msisdn != "" {
-		imsi, err := subscriberdb.GetIMSIForMSISDN(networkID, msisdn)
+		queryIMSI, err := subscriberdb.GetIMSIForMSISDN(networkID, msisdn)
 		if err != nil {
 			return makeErr(err)
 		}
-		sub, err := loadSubscribers(networkID, imsi)
+		subs, err := loadSubscribers(networkID, acceptAll, queryIMSI)
 		if err != nil {
 			return makeErr(err)
 		}
-		return c.JSON(http.StatusOK, sub)
+		return c.JSON(http.StatusOK, subs)
+	}
+	if ip := c.QueryParam(ParamIP); ip != "" {
+		queryIMSIs, err := subscriberdb.GetIMSIsForIP(networkID, ip)
+		if err != nil {
+			return makeErr(err)
+		}
+		filter := func(sub *subscribermodels.Subscriber) bool { return sub.IsAssignedIP(ip) }
+		subs, err := loadSubscribers(networkID, filter, queryIMSIs...)
+		if err != nil {
+			return makeErr(err)
+		}
+		return c.JSON(http.StatusOK, subs)
 	}
 
 	// Default to listing all subscribers
@@ -381,14 +411,16 @@ func loadSubscriber(networkID, key string) (*subscribermodels.Subscriber, error)
 	return sub, nil
 }
 
-func loadSubscribers(networkID string, keys ...string) (map[string]*subscribermodels.Subscriber, error) {
+func loadSubscribers(networkID string, includeSub subscriberFilter, keys ...string) (map[string]*subscribermodels.Subscriber, error) {
 	subs := map[string]*subscribermodels.Subscriber{}
 	for _, key := range keys {
 		sub, err := loadSubscriber(networkID, key)
 		if err != nil {
 			return nil, errors.Wrapf(err, "error loading subscriber %s", key)
 		}
-		subs[string(sub.ID)] = sub
+		if includeSub(sub) {
+			subs[string(sub.ID)] = sub
+		}
 	}
 	return subs, nil
 }

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -14,15 +14,14 @@
 package models
 
 import (
-	"encoding/base64"
 	"fmt"
-	"net"
 	"sort"
 	"strings"
 	"time"
 
 	"magma/lte/cloud/go/lte"
 	policymodels "magma/lte/cloud/go/services/policydb/obsidian/models"
+	subscriberdb_state "magma/lte/cloud/go/services/subscriberdb/state"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/directoryd"
@@ -32,7 +31,6 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/golang/glog"
-	"github.com/pkg/errors"
 	"github.com/thoas/go-funk"
 )
 
@@ -93,7 +91,7 @@ func (m *Subscriber) FillAugmentedFields(states state_types.StatesByID) error {
 			}
 			// We swallow and log errors because we don't want to block an API
 			// request if some AGW is sending buggy/malformed mobilityd state
-			reportedIP, err := getAssignedIPAddress(*reportedState)
+			reportedIP, err := subscriberdb_state.GetAssignedIPAddress(*reportedState)
 			if err != nil {
 				glog.Errorf("failed to retrieve allocated IP for state key %s: %s", stateID.DeviceID, err)
 			}
@@ -112,6 +110,20 @@ func (m *Subscriber) FillAugmentedFields(states state_types.StatesByID) error {
 	}
 
 	return nil
+}
+
+// IsAssignedIP returns true if the subscriber has mobility state assigning it
+// the passed IP address, else false.
+func (m *Subscriber) IsAssignedIP(ip string) bool {
+	if m.State == nil {
+		return false
+	}
+	for _, st := range m.State.Mobility {
+		if string(st.IP) == ip {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *MutableSubscriber) ToTK() storage.TypeAndKey {
@@ -178,46 +190,6 @@ func (m *MutableSubscriber) GetAssocs() []storage.TypeAndKey {
 	assocs = append(assocs, m.ActivePoliciesByApn.ToTKs(string(m.ID))...)
 	assocs = append(assocs, m.ActiveApns.ToTKs()...)
 	return assocs
-}
-
-// We expect something along the lines of:
-// {
-//   "state": "ALLOCATED",
-//   "sid": {"id": "IMSI001010000000001.magma.ipv4"},
-//   "ipBlock": {"netAddress": "wKiAAA==", "prefixLen": 24},
-//   "ip": {"address": "wKiArg=="}
-//  }
-// The IP addresses are base64 encoded versions of the packed bytes
-func getAssignedIPAddress(mobilitydState state.ArbitraryJSON) (string, error) {
-	ipField, ipExists := mobilitydState["ip"]
-	if !ipExists {
-		return "", errors.New("no ip field found in mobilityd state")
-	}
-	ipFieldAsMap, castOK := ipField.(map[string]interface{})
-	if !castOK {
-		return "", errors.New("could not cast ip field of mobilityd state to arbitrary JSON map type")
-	}
-	ipAddress, addrExists := ipFieldAsMap["address"]
-	if !addrExists {
-		return "", errors.New("no IP address found in mobilityd state")
-	}
-	ipAddressAsString, castOK := ipAddress.(string)
-	if !castOK {
-		return "", errors.New("encoded IP address is not a string as expected")
-	}
-
-	return base64DecodeIPAddress(ipAddressAsString)
-}
-
-func base64DecodeIPAddress(encodedIP string) (string, error) {
-	ipBytes, err := base64.StdEncoding.DecodeString(encodedIP)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to decode mobilityd IP address")
-	}
-	if len(ipBytes) != 4 {
-		return "", errors.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))
-	}
-	return net.IPv4(ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3]).String(), nil
 }
 
 func (m *SubProfile) ValidateModel() error {

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
@@ -47,7 +47,12 @@ paths:
         - in: query
           name: msisdn
           type: string
-          description: Get a single subscriber via MSISDN
+          description: Filter to subscribers with the passed MSISDN
+          required: false
+        - in: query
+          name: ip
+          type: string
+          description: Filter to subscribers assigned the passed IP address
           required: false
       responses:
         '200':

--- a/lte/cloud/go/services/subscriberdb/protos/subscriberdb.pb.go
+++ b/lte/cloud/go/services/subscriberdb/protos/subscriberdb.pb.go
@@ -283,6 +283,234 @@ func (m *DeleteMSISDNResponse) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_DeleteMSISDNResponse proto.InternalMessageInfo
 
+type GetIPsRequest struct {
+	// network_id of the subscriber
+	NetworkId string `protobuf:"bytes,1,opt,name=network_id,json=networkId,proto3" json:"network_id,omitempty"`
+	// ips whose IMSIs should be retrieved
+	// An empty list returns all tracked IPs
+	Ips                  []string `protobuf:"bytes,2,rep,name=ips,proto3" json:"ips,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *GetIPsRequest) Reset()         { *m = GetIPsRequest{} }
+func (m *GetIPsRequest) String() string { return proto.CompactTextString(m) }
+func (*GetIPsRequest) ProtoMessage()    {}
+func (*GetIPsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_7926c2bb91580e5a, []int{6}
+}
+
+func (m *GetIPsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetIPsRequest.Unmarshal(m, b)
+}
+func (m *GetIPsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetIPsRequest.Marshal(b, m, deterministic)
+}
+func (m *GetIPsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetIPsRequest.Merge(m, src)
+}
+func (m *GetIPsRequest) XXX_Size() int {
+	return xxx_messageInfo_GetIPsRequest.Size(m)
+}
+func (m *GetIPsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetIPsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetIPsRequest proto.InternalMessageInfo
+
+func (m *GetIPsRequest) GetNetworkId() string {
+	if m != nil {
+		return m.NetworkId
+	}
+	return ""
+}
+
+func (m *GetIPsRequest) GetIps() []string {
+	if m != nil {
+		return m.Ips
+	}
+	return nil
+}
+
+type GetIPsResponse struct {
+	// ip_mappings found
+	IpMappings           []*IPMapping `protobuf:"bytes,1,rep,name=ip_mappings,json=ipMappings,proto3" json:"ip_mappings,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
+	XXX_unrecognized     []byte       `json:"-"`
+	XXX_sizecache        int32        `json:"-"`
+}
+
+func (m *GetIPsResponse) Reset()         { *m = GetIPsResponse{} }
+func (m *GetIPsResponse) String() string { return proto.CompactTextString(m) }
+func (*GetIPsResponse) ProtoMessage()    {}
+func (*GetIPsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_7926c2bb91580e5a, []int{7}
+}
+
+func (m *GetIPsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_GetIPsResponse.Unmarshal(m, b)
+}
+func (m *GetIPsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_GetIPsResponse.Marshal(b, m, deterministic)
+}
+func (m *GetIPsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_GetIPsResponse.Merge(m, src)
+}
+func (m *GetIPsResponse) XXX_Size() int {
+	return xxx_messageInfo_GetIPsResponse.Size(m)
+}
+func (m *GetIPsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_GetIPsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_GetIPsResponse proto.InternalMessageInfo
+
+func (m *GetIPsResponse) GetIpMappings() []*IPMapping {
+	if m != nil {
+		return m.IpMappings
+	}
+	return nil
+}
+
+type SetIPsRequest struct {
+	// network_id of the subscriber
+	NetworkId string `protobuf:"bytes,1,opt,name=network_id,json=networkId,proto3" json:"network_id,omitempty"`
+	// ip_mappings to set
+	IpMappings           []*IPMapping `protobuf:"bytes,2,rep,name=ip_mappings,json=ipMappings,proto3" json:"ip_mappings,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
+	XXX_unrecognized     []byte       `json:"-"`
+	XXX_sizecache        int32        `json:"-"`
+}
+
+func (m *SetIPsRequest) Reset()         { *m = SetIPsRequest{} }
+func (m *SetIPsRequest) String() string { return proto.CompactTextString(m) }
+func (*SetIPsRequest) ProtoMessage()    {}
+func (*SetIPsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_7926c2bb91580e5a, []int{8}
+}
+
+func (m *SetIPsRequest) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SetIPsRequest.Unmarshal(m, b)
+}
+func (m *SetIPsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SetIPsRequest.Marshal(b, m, deterministic)
+}
+func (m *SetIPsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetIPsRequest.Merge(m, src)
+}
+func (m *SetIPsRequest) XXX_Size() int {
+	return xxx_messageInfo_SetIPsRequest.Size(m)
+}
+func (m *SetIPsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetIPsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetIPsRequest proto.InternalMessageInfo
+
+func (m *SetIPsRequest) GetNetworkId() string {
+	if m != nil {
+		return m.NetworkId
+	}
+	return ""
+}
+
+func (m *SetIPsRequest) GetIpMappings() []*IPMapping {
+	if m != nil {
+		return m.IpMappings
+	}
+	return nil
+}
+
+type SetIPsResponse struct {
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *SetIPsResponse) Reset()         { *m = SetIPsResponse{} }
+func (m *SetIPsResponse) String() string { return proto.CompactTextString(m) }
+func (*SetIPsResponse) ProtoMessage()    {}
+func (*SetIPsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_7926c2bb91580e5a, []int{9}
+}
+
+func (m *SetIPsResponse) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_SetIPsResponse.Unmarshal(m, b)
+}
+func (m *SetIPsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_SetIPsResponse.Marshal(b, m, deterministic)
+}
+func (m *SetIPsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_SetIPsResponse.Merge(m, src)
+}
+func (m *SetIPsResponse) XXX_Size() int {
+	return xxx_messageInfo_SetIPsResponse.Size(m)
+}
+func (m *SetIPsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_SetIPsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_SetIPsResponse proto.InternalMessageInfo
+
+type IPMapping struct {
+	// ip to set
+	Ip string `protobuf:"bytes,1,opt,name=ip,proto3" json:"ip,omitempty"`
+	// imsi whose IP should be set
+	Imsi string `protobuf:"bytes,2,opt,name=imsi,proto3" json:"imsi,omitempty"`
+	// apn under which this IMSI is assigned the IP
+	Apn                  string   `protobuf:"bytes,3,opt,name=apn,proto3" json:"apn,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *IPMapping) Reset()         { *m = IPMapping{} }
+func (m *IPMapping) String() string { return proto.CompactTextString(m) }
+func (*IPMapping) ProtoMessage()    {}
+func (*IPMapping) Descriptor() ([]byte, []int) {
+	return fileDescriptor_7926c2bb91580e5a, []int{10}
+}
+
+func (m *IPMapping) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_IPMapping.Unmarshal(m, b)
+}
+func (m *IPMapping) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_IPMapping.Marshal(b, m, deterministic)
+}
+func (m *IPMapping) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_IPMapping.Merge(m, src)
+}
+func (m *IPMapping) XXX_Size() int {
+	return xxx_messageInfo_IPMapping.Size(m)
+}
+func (m *IPMapping) XXX_DiscardUnknown() {
+	xxx_messageInfo_IPMapping.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_IPMapping proto.InternalMessageInfo
+
+func (m *IPMapping) GetIp() string {
+	if m != nil {
+		return m.Ip
+	}
+	return ""
+}
+
+func (m *IPMapping) GetImsi() string {
+	if m != nil {
+		return m.Imsi
+	}
+	return ""
+}
+
+func (m *IPMapping) GetApn() string {
+	if m != nil {
+		return m.Apn
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*GetMSISDNsRequest)(nil), "magma.lte.subscriberdb.GetMSISDNsRequest")
 	proto.RegisterType((*GetMSISDNsResponse)(nil), "magma.lte.subscriberdb.GetMSISDNsResponse")
@@ -291,35 +519,48 @@ func init() {
 	proto.RegisterType((*SetMSISDNResponse)(nil), "magma.lte.subscriberdb.SetMSISDNResponse")
 	proto.RegisterType((*DeleteMSISDNRequest)(nil), "magma.lte.subscriberdb.DeleteMSISDNRequest")
 	proto.RegisterType((*DeleteMSISDNResponse)(nil), "magma.lte.subscriberdb.DeleteMSISDNResponse")
+	proto.RegisterType((*GetIPsRequest)(nil), "magma.lte.subscriberdb.GetIPsRequest")
+	proto.RegisterType((*GetIPsResponse)(nil), "magma.lte.subscriberdb.GetIPsResponse")
+	proto.RegisterType((*SetIPsRequest)(nil), "magma.lte.subscriberdb.SetIPsRequest")
+	proto.RegisterType((*SetIPsResponse)(nil), "magma.lte.subscriberdb.SetIPsResponse")
+	proto.RegisterType((*IPMapping)(nil), "magma.lte.subscriberdb.IPMapping")
 }
 
 func init() { proto.RegisterFile("subscriberdb.proto", fileDescriptor_7926c2bb91580e5a) }
 
 var fileDescriptor_7926c2bb91580e5a = []byte{
-	// 356 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x53, 0x4f, 0x4b, 0xfb, 0x40,
-	0x10, 0xfd, 0x25, 0xf9, 0x59, 0xcd, 0xa8, 0xd8, 0x4e, 0x4b, 0x09, 0x01, 0xa1, 0xec, 0x29, 0x55,
-	0xc9, 0xa1, 0x5e, 0x44, 0x10, 0xa4, 0x54, 0xa4, 0xd0, 0x7a, 0x48, 0x6e, 0x82, 0x94, 0xc6, 0x0c,
-	0x12, 0xd2, 0x26, 0x35, 0xbb, 0x51, 0xf2, 0xe1, 0xfc, 0x02, 0x7e, 0x2a, 0xc9, 0x9f, 0xc6, 0x68,
-	0x5b, 0xc8, 0xc1, 0x53, 0x76, 0x26, 0x6f, 0xde, 0x9b, 0xf7, 0x96, 0x05, 0xe4, 0xb1, 0xc3, 0x9f,
-	0x23, 0xcf, 0xa1, 0xc8, 0x75, 0xcc, 0x55, 0x14, 0x8a, 0x10, 0xbb, 0xcb, 0xf9, 0xcb, 0x72, 0x6e,
-	0x2e, 0x04, 0x99, 0xd5, 0xbf, 0x6c, 0x02, 0xad, 0x7b, 0x12, 0x53, 0x7b, 0x6c, 0x8f, 0x1e, 0xb8,
-	0x45, 0xaf, 0x31, 0x71, 0x81, 0xa7, 0x00, 0x01, 0x89, 0xf7, 0x30, 0xf2, 0x67, 0x9e, 0xab, 0x49,
-	0x3d, 0xc9, 0x50, 0x2d, 0xb5, 0xe8, 0x8c, 0x5d, 0xd4, 0x60, 0x7f, 0xc9, 0x3d, 0xee, 0x06, 0x5c,
-	0x93, 0x7b, 0x8a, 0xa1, 0x5a, 0xeb, 0x92, 0x7d, 0x48, 0x80, 0x55, 0x3a, 0xbe, 0x0a, 0x03, 0x4e,
-	0x48, 0x70, 0xe2, 0xa5, 0x90, 0x99, 0x93, 0xcc, 0x72, 0xa8, 0x26, 0xf5, 0x14, 0xe3, 0x70, 0x70,
-	0x63, 0x6e, 0x5f, 0xcb, 0xdc, 0x24, 0x31, 0xc7, 0xe9, 0xe4, 0x30, 0x99, 0x66, 0xf3, 0x77, 0x81,
-	0x88, 0x12, 0xeb, 0xd8, 0xab, 0xf6, 0xf4, 0x5b, 0xc0, 0x4d, 0x10, 0x36, 0x41, 0xf1, 0x29, 0x29,
-	0x5c, 0xa4, 0x47, 0xec, 0xc0, 0xde, 0xdb, 0x7c, 0x11, 0x93, 0x26, 0x67, 0xbd, 0xbc, 0xb8, 0x96,
-	0xaf, 0x24, 0xf6, 0x04, 0x4d, 0x7b, 0xad, 0x5c, 0x33, 0x8c, 0x2e, 0x34, 0x0a, 0x4b, 0x39, 0x5b,
-	0x51, 0x21, 0xc2, 0xff, 0x74, 0x3b, 0x4d, 0xc9, 0xba, 0xd9, 0x99, 0xb5, 0xa1, 0x55, 0xa1, 0xcf,
-	0x7d, 0xb1, 0x09, 0xb4, 0x47, 0xb4, 0x20, 0x41, 0x7f, 0x21, 0xcb, 0xba, 0xd0, 0xf9, 0xc9, 0x96,
-	0xab, 0x0c, 0x3e, 0x65, 0x68, 0xda, 0x65, 0xc2, 0x93, 0x30, 0xf4, 0xe3, 0x15, 0x12, 0xc0, 0x77,
-	0xd0, 0xd8, 0xaf, 0x73, 0x19, 0xd9, 0x72, 0xfa, 0x59, 0xfd, 0x7b, 0x63, 0xff, 0xd0, 0x01, 0xb5,
-	0xb4, 0x8d, 0xc6, 0xae, 0xd1, 0xdf, 0xc1, 0xeb, 0xfd, 0x1a, 0xc8, 0x52, 0xc3, 0x87, 0xa3, 0xaa,
-	0x6f, 0x3c, 0xdf, 0x35, 0xbc, 0x25, 0x6b, 0xfd, 0xa2, 0x1e, 0x78, 0x2d, 0x36, 0x3c, 0x78, 0x6c,
-	0x64, 0xaf, 0x8a, 0x3b, 0xf9, 0xf7, 0xf2, 0x2b, 0x00, 0x00, 0xff, 0xff, 0x14, 0xea, 0x4f, 0xbe,
-	0x73, 0x03, 0x00, 0x00,
+	// 483 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xac, 0x54, 0xd1, 0x8a, 0xd3, 0x40,
+	0x14, 0xdd, 0x24, 0x6b, 0x35, 0x77, 0x6d, 0xcd, 0xde, 0x5d, 0x4a, 0x08, 0x08, 0x75, 0x40, 0xe9,
+	0xaa, 0xe4, 0x61, 0x7d, 0x11, 0x41, 0x58, 0xcb, 0xca, 0x12, 0x68, 0x65, 0xc9, 0xf8, 0xa2, 0x20,
+	0x25, 0xb1, 0xc3, 0x32, 0xb4, 0x4d, 0xc6, 0xcc, 0x54, 0xe9, 0x9b, 0x3f, 0xe6, 0xbf, 0x49, 0x92,
+	0x49, 0x9a, 0xed, 0x6e, 0xdd, 0x28, 0x3e, 0xf5, 0xce, 0xf4, 0xdc, 0x73, 0xe6, 0xde, 0x73, 0x5a,
+	0x40, 0xb9, 0x8a, 0xe5, 0xd7, 0x8c, 0xc7, 0x2c, 0x9b, 0xc5, 0xbe, 0xc8, 0x52, 0x95, 0x62, 0x7f,
+	0x19, 0x5d, 0x2d, 0x23, 0x7f, 0xa1, 0x98, 0xdf, 0xfc, 0x96, 0x8c, 0xe1, 0xf0, 0x82, 0xa9, 0x09,
+	0x0d, 0xe8, 0xf9, 0x07, 0x19, 0xb2, 0x6f, 0x2b, 0x26, 0x15, 0x3e, 0x06, 0x48, 0x98, 0xfa, 0x91,
+	0x66, 0xf3, 0x29, 0x9f, 0xb9, 0xc6, 0xc0, 0x18, 0xda, 0xa1, 0xad, 0x6f, 0x82, 0x19, 0xba, 0x70,
+	0x7f, 0x29, 0xb9, 0x9c, 0x25, 0xd2, 0x35, 0x07, 0xd6, 0xd0, 0x0e, 0xab, 0x23, 0xf9, 0x65, 0x00,
+	0x36, 0xe9, 0xa4, 0x48, 0x13, 0xc9, 0x90, 0xc1, 0x23, 0x9e, 0x43, 0xa6, 0xf1, 0x7a, 0x5a, 0x42,
+	0x5d, 0x63, 0x60, 0x0d, 0x0f, 0x4e, 0xdf, 0xfa, 0xb7, 0x3f, 0xcb, 0xbf, 0x49, 0xe2, 0x07, 0x79,
+	0xe7, 0x68, 0x3d, 0x29, 0xfa, 0xdf, 0x27, 0x2a, 0x5b, 0x87, 0x5d, 0xde, 0xbc, 0xf3, 0xce, 0x00,
+	0x6f, 0x82, 0xd0, 0x01, 0x6b, 0xce, 0xd6, 0x7a, 0x8a, 0xbc, 0xc4, 0x63, 0xb8, 0xf7, 0x3d, 0x5a,
+	0xac, 0x98, 0x6b, 0x16, 0x77, 0xe5, 0xe1, 0x8d, 0xf9, 0xda, 0x20, 0x5f, 0xc0, 0xa1, 0x95, 0x72,
+	0xcb, 0x65, 0xf4, 0xa1, 0xa3, 0x47, 0x2a, 0xd9, 0xf4, 0x09, 0x11, 0xf6, 0xf3, 0xd7, 0xb9, 0x56,
+	0x71, 0x5b, 0xd4, 0xe4, 0x08, 0x0e, 0x1b, 0xf4, 0xe5, 0x5c, 0x64, 0x0c, 0x47, 0xe7, 0x6c, 0xc1,
+	0x14, 0xfb, 0x1f, 0xb2, 0xa4, 0x0f, 0xc7, 0xd7, 0xd9, 0xb4, 0xca, 0x19, 0x74, 0x2f, 0x98, 0x0a,
+	0x2e, 0xdb, 0x7a, 0xec, 0x80, 0xc5, 0x45, 0xe5, 0x6f, 0x5e, 0x92, 0x8f, 0xd0, 0xab, 0x18, 0xb4,
+	0xad, 0x23, 0x38, 0xe0, 0x62, 0xba, 0x8c, 0x84, 0xe0, 0xc9, 0x95, 0xd4, 0x96, 0x3e, 0xd9, 0x65,
+	0x69, 0x70, 0x39, 0x29, 0x91, 0x21, 0x70, 0xa1, 0x4b, 0x49, 0x32, 0xe8, 0xd2, 0xbf, 0x79, 0xd7,
+	0x96, 0xa6, 0xf9, 0x2f, 0x9a, 0x0e, 0xf4, 0xe8, 0xb5, 0x49, 0xc8, 0x3b, 0xb0, 0x6b, 0x28, 0xf6,
+	0xc0, 0xe4, 0x42, 0x2b, 0x9b, 0x5c, 0xd4, 0x4e, 0x9a, 0x1b, 0x27, 0xf3, 0xf5, 0x44, 0x22, 0xd1,
+	0xe6, 0xe6, 0xe5, 0xe9, 0xcf, 0x7d, 0x70, 0x68, 0xad, 0x3d, 0x4e, 0xd3, 0xf9, 0x4a, 0x20, 0x03,
+	0xd8, 0x24, 0x19, 0x4f, 0xda, 0xa4, 0xbd, 0xd8, 0x82, 0xf7, 0xbc, 0xfd, 0x0f, 0x83, 0xec, 0x61,
+	0x0c, 0x76, 0x9d, 0x2b, 0x1c, 0xee, 0x6a, 0xdd, 0x4e, 0xb6, 0x77, 0xd2, 0x02, 0x59, 0x6b, 0xcc,
+	0xe1, 0x61, 0x33, 0x58, 0xf8, 0x62, 0x57, 0xf3, 0x2d, 0x61, 0xf6, 0x5e, 0xb6, 0x03, 0xd7, 0x62,
+	0x9f, 0xa0, 0x53, 0x66, 0x0d, 0x9f, 0xfe, 0x61, 0x11, 0x9b, 0xd4, 0x78, 0xcf, 0xee, 0x82, 0x35,
+	0xa9, 0xe9, 0x1d, 0xd4, 0xb4, 0x1d, 0xf5, 0x56, 0x86, 0xf6, 0x46, 0x0f, 0x3e, 0x77, 0x8a, 0x3f,
+	0x5b, 0x19, 0x97, 0x9f, 0xaf, 0x7e, 0x07, 0x00, 0x00, 0xff, 0xff, 0x86, 0x0c, 0x92, 0x79, 0x8a,
+	0x05, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -340,8 +581,12 @@ type SubscriberLookupClient interface {
 	// Error if MSISDN has already been assigned.
 	SetMSISDN(ctx context.Context, in *SetMSISDNRequest, opts ...grpc.CallOption) (*SetMSISDNResponse, error)
 	// DeleteMSISDN removes the MSISDN -> IMSI mapping.
-	// Error if MSISDN has already been assigned.
 	DeleteMSISDN(ctx context.Context, in *DeleteMSISDNRequest, opts ...grpc.CallOption) (*DeleteMSISDNResponse, error)
+	// GetIPs returns IP -> IMSI mappings.
+	GetIPs(ctx context.Context, in *GetIPsRequest, opts ...grpc.CallOption) (*GetIPsResponse, error)
+	// SetIPs creates an IP -> IMSI mapping.
+	// Error if IP has already been assigned.
+	SetIPs(ctx context.Context, in *SetIPsRequest, opts ...grpc.CallOption) (*SetIPsResponse, error)
 }
 
 type subscriberLookupClient struct {
@@ -379,6 +624,24 @@ func (c *subscriberLookupClient) DeleteMSISDN(ctx context.Context, in *DeleteMSI
 	return out, nil
 }
 
+func (c *subscriberLookupClient) GetIPs(ctx context.Context, in *GetIPsRequest, opts ...grpc.CallOption) (*GetIPsResponse, error) {
+	out := new(GetIPsResponse)
+	err := c.cc.Invoke(ctx, "/magma.lte.subscriberdb.SubscriberLookup/GetIPs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *subscriberLookupClient) SetIPs(ctx context.Context, in *SetIPsRequest, opts ...grpc.CallOption) (*SetIPsResponse, error) {
+	out := new(SetIPsResponse)
+	err := c.cc.Invoke(ctx, "/magma.lte.subscriberdb.SubscriberLookup/SetIPs", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SubscriberLookupServer is the server API for SubscriberLookup service.
 type SubscriberLookupServer interface {
 	// GetMSISDNs returns MSISDN -> IMSI mappings.
@@ -387,8 +650,12 @@ type SubscriberLookupServer interface {
 	// Error if MSISDN has already been assigned.
 	SetMSISDN(context.Context, *SetMSISDNRequest) (*SetMSISDNResponse, error)
 	// DeleteMSISDN removes the MSISDN -> IMSI mapping.
-	// Error if MSISDN has already been assigned.
 	DeleteMSISDN(context.Context, *DeleteMSISDNRequest) (*DeleteMSISDNResponse, error)
+	// GetIPs returns IP -> IMSI mappings.
+	GetIPs(context.Context, *GetIPsRequest) (*GetIPsResponse, error)
+	// SetIPs creates an IP -> IMSI mapping.
+	// Error if IP has already been assigned.
+	SetIPs(context.Context, *SetIPsRequest) (*SetIPsResponse, error)
 }
 
 // UnimplementedSubscriberLookupServer can be embedded to have forward compatible implementations.
@@ -403,6 +670,12 @@ func (*UnimplementedSubscriberLookupServer) SetMSISDN(ctx context.Context, req *
 }
 func (*UnimplementedSubscriberLookupServer) DeleteMSISDN(ctx context.Context, req *DeleteMSISDNRequest) (*DeleteMSISDNResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteMSISDN not implemented")
+}
+func (*UnimplementedSubscriberLookupServer) GetIPs(ctx context.Context, req *GetIPsRequest) (*GetIPsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetIPs not implemented")
+}
+func (*UnimplementedSubscriberLookupServer) SetIPs(ctx context.Context, req *SetIPsRequest) (*SetIPsResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method SetIPs not implemented")
 }
 
 func RegisterSubscriberLookupServer(s *grpc.Server, srv SubscriberLookupServer) {
@@ -463,6 +736,42 @@ func _SubscriberLookup_DeleteMSISDN_Handler(srv interface{}, ctx context.Context
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SubscriberLookup_GetIPs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetIPsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SubscriberLookupServer).GetIPs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/magma.lte.subscriberdb.SubscriberLookup/GetIPs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SubscriberLookupServer).GetIPs(ctx, req.(*GetIPsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SubscriberLookup_SetIPs_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(SetIPsRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SubscriberLookupServer).SetIPs(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/magma.lte.subscriberdb.SubscriberLookup/SetIPs",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SubscriberLookupServer).SetIPs(ctx, req.(*SetIPsRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 var _SubscriberLookup_serviceDesc = grpc.ServiceDesc{
 	ServiceName: "magma.lte.subscriberdb.SubscriberLookup",
 	HandlerType: (*SubscriberLookupServer)(nil),
@@ -478,6 +787,14 @@ var _SubscriberLookup_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteMSISDN",
 			Handler:    _SubscriberLookup_DeleteMSISDN_Handler,
+		},
+		{
+			MethodName: "GetIPs",
+			Handler:    _SubscriberLookup_GetIPs_Handler,
+		},
+		{
+			MethodName: "SetIPs",
+			Handler:    _SubscriberLookup_SetIPs_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lte/cloud/go/services/subscriberdb/protos/subscriberdb.proto
+++ b/lte/cloud/go/services/subscriberdb/protos/subscriberdb.proto
@@ -20,6 +20,14 @@ option go_package = "protos";
 // alternative identifiers.
 // Stores the following mappings
 //  - MSISDN -> IMSI
+//  - IP -> IMSI
+//
+// Notes:
+//  - MSISDN
+//    - Each MSISDN is enforced to map to at most 1 IMSI
+//  - IP
+//    - Each IP is expected to map to at most 1 IMSI, but this is not enforced,
+//      deferring to caller-enforcement as-required
 service SubscriberLookup {
   // GetMSISDNs returns MSISDN -> IMSI mappings.
   rpc GetMSISDNs (GetMSISDNsRequest) returns (GetMSISDNsResponse) {}
@@ -29,8 +37,14 @@ service SubscriberLookup {
   rpc SetMSISDN (SetMSISDNRequest) returns (SetMSISDNResponse) {}
 
   // DeleteMSISDN removes the MSISDN -> IMSI mapping.
-  // Error if MSISDN has already been assigned.
   rpc DeleteMSISDN (DeleteMSISDNRequest) returns (DeleteMSISDNResponse) {}
+
+  // GetIPs returns IP -> IMSI mappings.
+  rpc GetIPs (GetIPsRequest) returns (GetIPsResponse) {}
+
+  // SetIPs creates an IP -> IMSI mapping.
+  // Error if IP has already been assigned.
+  rpc SetIPs (SetIPsRequest) returns (SetIPsResponse) {}
 }
 
 message GetMSISDNsRequest {
@@ -65,3 +79,34 @@ message DeleteMSISDNRequest {
 }
 
 message DeleteMSISDNResponse {}
+
+message GetIPsRequest {
+  // network_id of the subscriber
+  string network_id = 1;
+  // ips whose IMSIs should be retrieved
+  // An empty list returns all tracked IPs
+  repeated string ips = 2;
+}
+
+message GetIPsResponse {
+  // ip_mappings found
+  repeated IPMapping ip_mappings = 1;
+}
+
+message SetIPsRequest {
+  // network_id of the subscriber
+  string network_id = 1;
+  // ip_mappings to set
+  repeated IPMapping ip_mappings = 2;
+}
+
+message SetIPsResponse {}
+
+message IPMapping {
+  // ip to set
+  string ip = 1;
+  // imsi whose IP should be set
+  string imsi = 2;
+  // apn under which this IMSI is assigned the IP
+  string apn = 3;
+}

--- a/lte/cloud/go/services/subscriberdb/protos/validate.go
+++ b/lte/cloud/go/services/subscriberdb/protos/validate.go
@@ -14,7 +14,7 @@
 package protos
 
 import (
-	"errors"
+	"github.com/pkg/errors"
 )
 
 func (m *GetMSISDNsRequest) Validate() error {
@@ -43,6 +43,31 @@ func (m *DeleteMSISDNRequest) Validate() error {
 	}
 	if m.Msisdn == "" {
 		return errors.New("msisdn cannot be empty")
+	}
+	return nil
+}
+
+func (m *GetIPsRequest) Validate() error {
+	if m.NetworkId == "" {
+		return errors.New("network ID cannot be empty")
+	}
+	return nil
+}
+
+func (m *SetIPsRequest) Validate() error {
+	if m.NetworkId == "" {
+		return errors.New("network ID cannot be empty")
+	}
+	for _, mapping := range m.IpMappings {
+		if mapping.Ip == "" {
+			return errors.Errorf("ip cannot be empty in mapping %v", mapping)
+		}
+		if mapping.Imsi == "" {
+			return errors.Errorf("imsi cannot be empty in mapping %v", mapping)
+		}
+		if mapping.Apn == "" {
+			return errors.Errorf("apn cannot be empty in mapping %v", mapping)
+		}
 	}
 	return nil
 }

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+
+	"magma/lte/cloud/go/lte"
+	"magma/lte/cloud/go/services/subscriberdb"
+	subscriberdb_protos "magma/lte/cloud/go/services/subscriberdb/protos"
+	subscriberdb_state "magma/lte/cloud/go/services/subscriberdb/state"
+	"magma/orc8r/cloud/go/services/state"
+	"magma/orc8r/cloud/go/services/state/indexer"
+	"magma/orc8r/cloud/go/services/state/protos"
+	state_types "magma/orc8r/cloud/go/services/state/types"
+
+	"github.com/golang/glog"
+	"github.com/pkg/errors"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	indexerVersion indexer.Version = 1
+)
+
+var (
+	indexerTypes = []string{lte.MobilitydStateType}
+)
+
+type indexerServicer struct{}
+
+// NewIndexerServicer returns the state indexer for subscriberdb.
+//
+// The directoryd indexer performs the following indexing functions:
+//	- ipToIMSI: map IP address to IMSI
+//
+// ipToIMSI
+//
+// Mobilityd state is reported as IMSI.APN -> arbitrary JSON. The arbitrary
+// JSON contains the assigned IP address for the IMSI under the associated APN,
+// which we extract to form the reverse map.
+// NOTE: the indexer provides a best-effort generation of the IP -> IMSI map,
+// meaning
+//	- an {IP -> IMSI} mapping only makes sense under non-NAT deployments and/or
+//	  for non-private IP addresses
+//	- an {IP -> IMSI} mapping may be missing even though the IMSI is assigned
+//	  that IP
+//	- an {IP -> IMSI} mapping may be stale (caller should check for staleness)
+func NewIndexerServicer() protos.IndexerServer {
+	return &indexerServicer{}
+}
+
+func (i *indexerServicer) GetIndexerInfo(ctx context.Context, req *protos.GetIndexerInfoRequest) (*protos.GetIndexerInfoResponse, error) {
+	res := &protos.GetIndexerInfoResponse{
+		Version:    uint32(indexerVersion),
+		StateTypes: indexerTypes,
+	}
+	return res, nil
+}
+
+func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (*protos.IndexResponse, error) {
+	states, err := state_types.MakeStatesByID(req.States)
+	if err != nil {
+		return nil, err
+	}
+	stErrs, err := indexImpl(req.NetworkId, states)
+	res := &protos.IndexResponse{StateErrors: state_types.MakeProtoStateErrors(stErrs)}
+	return res, nil
+}
+
+func (i *indexerServicer) PrepareReindex(ctx context.Context, req *protos.PrepareReindexRequest) (*protos.PrepareReindexResponse, error) {
+	return &protos.PrepareReindexResponse{}, nil
+}
+
+func (i *indexerServicer) CompleteReindex(ctx context.Context, req *protos.CompleteReindexRequest) (*protos.CompleteReindexResponse, error) {
+	if req.FromVersion == 0 && req.ToVersion == 1 {
+		return &protos.CompleteReindexResponse{}, nil
+	}
+	return nil, status.Errorf(codes.InvalidArgument, "unsupported from/to for CompleteReindex: %v to %v", req.FromVersion, req.ToVersion)
+}
+
+func indexImpl(networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+	return setIPMappings(networkID, states)
+}
+
+// setIPMappings maps {IP -> IMSI}.
+func setIPMappings(networkID string, states state_types.StatesByID) (state_types.StateErrors, error) {
+	var ipMappings []*subscriberdb_protos.IPMapping
+	stateErrors := state_types.StateErrors{}
+	for id, st := range states {
+		reportedState := st.ReportedState.(*state.ArbitraryJSON)
+		ip, err := subscriberdb_state.GetAssignedIPAddress(*reportedState)
+		if err != nil {
+			stateErrors[id] = err
+			continue
+		}
+		if ip == "" {
+			glog.V(2).Infof("IP missing from mobilityd state for state key %s", id.DeviceID)
+			continue
+		}
+		imsi, apn, err := subscriberdb_state.GetIMSIAndAPNFromMobilitydStateKey(id.DeviceID)
+		if err != nil {
+			stateErrors[id] = err
+			continue
+		}
+		ipMappings = append(ipMappings, &subscriberdb_protos.IPMapping{Ip: ip, Imsi: imsi, Apn: apn})
+	}
+
+	if len(ipMappings) == 0 {
+		return stateErrors, nil
+	}
+
+	err := subscriberdb.SetIMSIsForIPs(networkID, ipMappings)
+	if err != nil {
+		return stateErrors, errors.Wrapf(err, "update directoryd mapping of session IDs to IMSIs %+v", ipMappings)
+	}
+
+	return stateErrors, nil
+}

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers_test
+
+import (
+	"encoding/base64"
+	"net"
+	"testing"
+
+	"magma/lte/cloud/go/lte"
+	lte_plugin "magma/lte/cloud/go/plugin"
+	"magma/lte/cloud/go/services/subscriberdb"
+	subscriberdb_test_init "magma/lte/cloud/go/services/subscriberdb/test_init"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/services/state"
+	"magma/orc8r/cloud/go/services/state/indexer"
+	state_types "magma/orc8r/cloud/go/services/state/types"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+func TestIndexerIP(t *testing.T) {
+	const (
+		version indexer.Version = 1 // copied from indexer_servicer.go
+	)
+	var (
+		types = []string{lte.MobilitydStateType} // copied from indexer_servicer.go
+	)
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{}))
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &lte_plugin.LteOrchestratorPlugin{}))
+
+	subscriberdb_test_init.StartTestService(t)
+	idx := indexer.NewRemoteIndexer(subscriberdb.ServiceName, version, types...)
+
+	id00 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI0.apn0"}
+	id01 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI0.apn1"}
+	id10 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI1.apn0"}
+	id11 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI1.apn1"}
+	id2 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "IMSI2.apn2"}
+
+	// Reported state takes the form
+	// {
+	//   "state": "ALLOCATED",
+	//   "sid": {"id": "IMSI001010000000001.magma.ipv4"},
+	//   "ipBlock": {"netAddress": "wKiAAA==", "prefixLen": 24},
+	//   "ip": {"address": "wKiArg=="}
+	//  }
+	states := state_types.StatesByID{
+		id00: {Type: lte.MobilitydStateType, ReportedState: &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}},
+		id01: {Type: lte.MobilitydStateType, ReportedState: &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}},
+		id10: {Type: lte.MobilitydStateType, ReportedState: &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.1")}}},
+		id11: {Type: lte.MobilitydStateType, ReportedState: &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.2")}}},
+	}
+
+	// Index the imsi0->sid0 state, result is sid0->imsi0 reverse mapping
+	errs, err := idx.Index("nid0", states)
+	assert.NoError(t, err)
+	assert.Empty(t, errs)
+	gotA, err := subscriberdb.GetIMSIsForIP("nid0", "127.0.0.1")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"IMSI0", "IMSI1"}, gotA)
+	gotB, err := subscriberdb.GetIMSIsForIP("nid0", "127.0.0.2")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"IMSI1"}, gotB)
+
+	// Correctly handle per-state errs
+	states = state_types.StatesByID{
+		id00: {Type: lte.MobilitydStateType, ReportedState: &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": encodeIP("127.0.0.3")}}},
+		id2:  {Type: lte.MobilitydStateType, ReportedState: &state.ArbitraryJSON{"ip": state.ArbitraryJSON{"address": "deadbeef"}}},
+	}
+	errs, err = idx.Index("nid0", states)
+	assert.NoError(t, err)
+	assert.Error(t, errs[id2])
+	gotC, err := subscriberdb.GetIMSIsForIP("nid0", "127.0.0.3")
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"IMSI0"}, gotC)
+}
+
+func encodeIP(ip string) string {
+	ipBytes := net.ParseIP(ip)[12:16] // get just the IPv4 bytes
+	return base64.StdEncoding.EncodeToString(ipBytes)
+}

--- a/lte/cloud/go/services/subscriberdb/servicers/lookup_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/lookup_test.go
@@ -20,6 +20,7 @@ import (
 	"magma/lte/cloud/go/services/subscriberdb"
 	"magma/lte/cloud/go/services/subscriberdb/protos"
 	"magma/lte/cloud/go/services/subscriberdb/servicers"
+	"magma/lte/cloud/go/services/subscriberdb/storage"
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/sqorc"
 
@@ -33,7 +34,7 @@ func TestLookupServicer_MSISDNs(t *testing.T) {
 	fact := blobstore.NewSQLBlobStorageFactory(subscriberdb.LookupTableBlobstore, db, sqorc.GetSqlBuilder())
 	err = fact.InitializeFactory()
 	assert.NoError(t, err)
-	l := servicers.NewLookupServicer(fact)
+	l := servicers.NewLookupServicer(fact, nil)
 
 	t.Run("initially empty", func(t *testing.T) {
 		got, err := l.GetMSISDNs(ctx, &protos.GetMSISDNsRequest{
@@ -192,5 +193,93 @@ func TestLookupServicer_MSISDNs(t *testing.T) {
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, map[string]string{"msisdn2": "imsi2"}, gotAll1.ImsisByMsisdn)
+	})
+}
+
+func TestLookupServicer_IPs(t *testing.T) {
+	ctx := context.Background()
+	db, err := sqorc.Open("sqlite3", ":memory:")
+	assert.NoError(t, err)
+	store := storage.NewIPLookup(db, sqorc.GetSqlBuilder())
+	assert.NoError(t, err)
+	err = store.Initialize()
+	assert.NoError(t, err)
+	l := servicers.NewLookupServicer(nil, store)
+
+	t.Run("basic", func(t *testing.T) {
+		got, err := l.GetIPs(ctx, &protos.GetIPsRequest{
+			NetworkId: "nid0",
+			Ips:       nil,
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, got.IpMappings)
+
+		want := []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipB", Imsi: "IMSI0", Apn: "apn1"},
+			{Ip: "ipC", Imsi: "IMSI1", Apn: "apn0"},
+		}
+		_, err = l.SetIPs(ctx, &protos.SetIPsRequest{
+			NetworkId:  "nid0",
+			IpMappings: want,
+		})
+		assert.NoError(t, err)
+
+		got, err = l.GetIPs(ctx, &protos.GetIPsRequest{
+			NetworkId: "nid0",
+			Ips:       []string{"ipA", "ipB", "ipC"},
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, want, got.IpMappings)
+	})
+
+	t.Run("validate requests", func(t *testing.T) {
+		// Empty network ID
+		_, err = l.SetIPs(ctx, &protos.SetIPsRequest{
+			NetworkId:  "",
+			IpMappings: []*protos.IPMapping{{Ip: "ipA", Imsi: "imsi0", Apn: "apn0"}},
+		})
+		assert.Error(t, err)
+
+		// Empty IP
+		_, err = l.SetIPs(ctx, &protos.SetIPsRequest{
+			NetworkId:  "nid0",
+			IpMappings: []*protos.IPMapping{{Ip: "", Imsi: "imsi0", Apn: "apn0"}},
+		})
+		assert.Error(t, err)
+
+		// Empty IMSI
+		_, err = l.SetIPs(ctx, &protos.SetIPsRequest{
+			NetworkId:  "nid0",
+			IpMappings: []*protos.IPMapping{{Ip: "ipA", Imsi: "", Apn: "apn0"}},
+		})
+		assert.Error(t, err)
+
+		// Empty APN
+		_, err = l.SetIPs(ctx, &protos.SetIPsRequest{
+			NetworkId:  "nid0",
+			IpMappings: []*protos.IPMapping{{Ip: "ipA", Imsi: "imsi0", Apn: ""}},
+		})
+		assert.Error(t, err)
+
+		// Empty network ID
+		_, err = l.GetIPs(ctx, &protos.GetIPsRequest{
+			NetworkId: "",
+			Ips:       nil,
+		})
+		assert.Error(t, err)
+
+		// All mutations should have failed
+		got, err := l.GetIPs(ctx, &protos.GetIPsRequest{
+			NetworkId: "nid0",
+			Ips:       []string{"ipA", "ipB", "ipC"},
+		})
+		assert.NoError(t, err)
+		want := []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipB", Imsi: "IMSI0", Apn: "apn1"},
+			{Ip: "ipC", Imsi: "IMSI1", Apn: "apn0"},
+		}
+		assert.Equal(t, want, got.IpMappings)
 	})
 }

--- a/lte/cloud/go/services/subscriberdb/state/extract.go
+++ b/lte/cloud/go/services/subscriberdb/state/extract.go
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package state
+
+import (
+	"encoding/base64"
+	"net"
+	"regexp"
+
+	"magma/orc8r/cloud/go/services/state"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	imsiAPNExpectedMatchCount = 3
+)
+
+var (
+	// imsiAPNRegex matches the expected IMSI column value of IMSI.APN
+	imsiAPNRegex = regexp.MustCompile(`^(IMSI\d+)\.(.+)$`)
+)
+
+// GetAssignedIPAddress extracts the IP address from a mobilityd state element.
+// We expect something along the lines of:
+// {
+//   "state": "ALLOCATED",
+//   "sid": {"id": "IMSI001010000000001.magma.ipv4"},
+//   "ipBlock": {"netAddress": "wKiAAA==", "prefixLen": 24},
+//   "ip": {"address": "wKiArg=="}
+//  }
+// The IP addresses are base64 encoded versions of the packed bytes
+func GetAssignedIPAddress(mobilitydState state.ArbitraryJSON) (string, error) {
+	ipField, ipExists := mobilitydState["ip"]
+	if !ipExists {
+		return "", errors.New("no ip field found in mobilityd state")
+	}
+	ipFieldAsMap, castOK := ipField.(map[string]interface{})
+	if !castOK {
+		return "", errors.New("could not cast ip field of mobilityd state to arbitrary JSON map type")
+	}
+	ipAddress, addrExists := ipFieldAsMap["address"]
+	if !addrExists {
+		return "", errors.New("no IP address found in mobilityd state")
+	}
+	ipAddressAsString, castOK := ipAddress.(string)
+	if !castOK {
+		return "", errors.New("encoded IP address is not a string as expected")
+	}
+
+	return base64DecodeIPAddress(ipAddressAsString)
+}
+
+// GetIMSIAndAPNFromMobilitydStateKey returns the IMSI and APN from the
+// mobilityd state key of IMSI.APN.
+func GetIMSIAndAPNFromMobilitydStateKey(key string) (string, string, error) {
+	matches := imsiAPNRegex.FindStringSubmatch(key)
+	if len(matches) != imsiAPNExpectedMatchCount {
+		return "", "", errors.Errorf("mobilityd state key %s did not match regex", key)
+	}
+	imsi, apn := matches[1], matches[2]
+	return imsi, apn, nil
+}
+
+func base64DecodeIPAddress(encodedIP string) (string, error) {
+	ipBytes, err := base64.StdEncoding.DecodeString(encodedIP)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to decode mobilityd IP address")
+	}
+	if len(ipBytes) != 4 {
+		return "", errors.Errorf("expected IP address to decode to 4 bytes, got %d", len(ipBytes))
+	}
+	return net.IPv4(ipBytes[0], ipBytes[1], ipBytes[2], ipBytes[3]).String(), nil
+}

--- a/lte/cloud/go/services/subscriberdb/storage/ip_lookup.go
+++ b/lte/cloud/go/services/subscriberdb/storage/ip_lookup.go
@@ -1,0 +1,143 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"sort"
+
+	"magma/lte/cloud/go/services/subscriberdb/protos"
+	"magma/lte/cloud/go/services/subscriberdb/state"
+	"magma/orc8r/cloud/go/sqorc"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/pkg/errors"
+)
+
+type IPLookup interface {
+	// Initialize the backing store.
+	Initialize() error
+
+	// GetIPs returns the set of IMSIs each IP is marked as assigned to, keyed
+	// by IP address.
+	GetIPs(networkID string, ips []string) ([]*protos.IPMapping, error)
+
+	// SetIPs assigns an IP to an IMSI under a particular APN, one per mapping.
+	SetIPs(networkID string, mappings []*protos.IPMapping) error
+}
+
+const (
+	tableName = "subscriberdb_ip_to_imsi"
+
+	nidCol  = "network_id"
+	ipCol   = "ip"
+	imsiCol = "imsi_and_apn"
+)
+
+type ipLookup struct {
+	db      *sql.DB
+	builder sqorc.StatementBuilder
+}
+
+func NewIPLookup(db *sql.DB, builder sqorc.StatementBuilder) IPLookup {
+	return &ipLookup{db: db, builder: builder}
+}
+
+func (l *ipLookup) Initialize() error {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		_, err := l.builder.CreateTable(tableName).
+			IfNotExists().
+			Column(nidCol).Type(sqorc.ColumnTypeText).NotNull().EndColumn().
+			Column(ipCol).Type(sqorc.ColumnTypeText).NotNull().EndColumn().
+			Column(imsiCol).Type(sqorc.ColumnTypeText).NotNull().EndColumn().
+			PrimaryKey(nidCol, ipCol, imsiCol).
+			Unique(nidCol, imsiCol).
+			RunWith(tx).
+			Exec()
+		return nil, errors.Wrap(err, "initialize IP lookup table")
+	}
+	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
+	return err
+}
+
+func (l *ipLookup) GetIPs(networkID string, ips []string) ([]*protos.IPMapping, error) {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		rows, err := l.builder.
+			Select(ipCol, imsiCol).
+			From(tableName).
+			Where(squirrel.Eq{nidCol: networkID, ipCol: ips}).
+			RunWith(tx).
+			Query()
+		if err != nil {
+			return nil, errors.Wrapf(err, "select IMSIs for IPs %v", ips)
+		}
+		defer sqorc.CloseRowsLogOnError(rows, "GetIPs")
+
+		var mappings []*protos.IPMapping
+		for rows.Next() {
+			m := &protos.IPMapping{}
+			imsiVal := ""
+			err = rows.Scan(&m.Ip, &imsiVal)
+			if err != nil {
+				return nil, errors.Wrap(err, "select IMSIs for IPs, SQL row scan error")
+			}
+			m.Imsi, m.Apn, err = state.GetIMSIAndAPNFromMobilitydStateKey(imsiVal)
+			if err != nil {
+				return nil, err
+			}
+			mappings = append(mappings, m)
+		}
+		err = rows.Err()
+		if err != nil {
+			return nil, errors.Wrap(err, "select IMSIs for IPs, SQL rows error")
+		}
+
+		sort.Slice(mappings, func(i, j int) bool { return mappings[i].String() < mappings[j].String() })
+		return mappings, nil
+	}
+	txRet, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
+	if err != nil {
+		return nil, err
+	}
+	ret := txRet.([]*protos.IPMapping)
+	return ret, nil
+}
+
+func (l *ipLookup) SetIPs(networkID string, mappings []*protos.IPMapping) error {
+	txFn := func(tx *sql.Tx) (interface{}, error) {
+		sc := squirrel.NewStmtCache(tx)
+		defer sqorc.ClearStatementCacheLogOnError(sc, "SetIPs")
+
+		for _, m := range mappings {
+			_, err := l.builder.
+				Insert(tableName).
+				Columns(nidCol, ipCol, imsiCol).
+				Values(networkID, m.Ip, fmt.Sprintf("%s.%s", m.Imsi, m.Apn)).
+				OnConflict(
+					[]sqorc.UpsertValue{{Column: ipCol, Value: m.Ip}},
+					nidCol, imsiCol,
+				).
+				RunWith(sc).
+				Exec()
+			if err != nil {
+				return nil, errors.Wrapf(err, "insert IP mapping %+v", m)
+			}
+		}
+
+		return nil, nil
+	}
+	_, err := sqorc.ExecInTx(l.db, nil, nil, txFn)
+	return err
+}

--- a/lte/cloud/go/services/subscriberdb/storage/ip_lookup_test.go
+++ b/lte/cloud/go/services/subscriberdb/storage/ip_lookup_test.go
@@ -1,0 +1,125 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package storage_test
+
+import (
+	"testing"
+
+	"magma/lte/cloud/go/services/subscriberdb/protos"
+	"magma/lte/cloud/go/services/subscriberdb/storage"
+	"magma/orc8r/cloud/go/sqorc"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIPLookup(t *testing.T) {
+	db, err := sqorc.Open("sqlite3", ":memory:")
+	assert.NoError(t, err)
+	s := storage.NewIPLookup(db, sqorc.GetSqlBuilder())
+	assert.NoError(t, s.Initialize())
+
+	t.Run("empty initially", func(t *testing.T) {
+		got, err := s.GetIPs("n0", []string{})
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+
+		got, err = s.GetIPs("n0", []string{"ip0"})
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("basic insert", func(t *testing.T) {
+		err := s.SetIPs("n0", []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
+			{Ip: "ipB", Imsi: "IMSI1", Apn: "apn1"},
+			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn2"},
+		})
+		assert.NoError(t, err)
+
+		got, err := s.GetIPs("n0", []string{"ipA"})
+		assert.NoError(t, err)
+		want := []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
+		}
+		assert.Equal(t, want, got)
+
+		got, err = s.GetIPs("n0", []string{"ipA", "ipB"})
+		assert.NoError(t, err)
+		want = []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
+			{Ip: "ipB", Imsi: "IMSI1", Apn: "apn1"},
+			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn2"},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("upsert", func(t *testing.T) {
+		err := s.SetIPs("n0", []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"}, // same pk
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn1"}, // different pk, non-unique imsi.apn (change APN)
+			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn1"}, // different pk, non-unique imsi.apn (change IMSI)
+			{Ip: "ipC", Imsi: "IMSI2", Apn: "apn2"}, // different pk, overwrite IP
+		})
+		assert.NoError(t, err)
+
+		got, err := s.GetIPs("n0", []string{"ipA"})
+		assert.NoError(t, err)
+		want := []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn1"},
+		}
+		assert.Equal(t, want, got)
+
+		got, err = s.GetIPs("n0", []string{"ipA", "ipB", "ipC"})
+		assert.NoError(t, err)
+		want = []*protos.IPMapping{
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn1"},
+			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn1"},
+			{Ip: "ipC", Imsi: "IMSI2", Apn: "apn2"},
+		}
+		assert.Equal(t, want, got)
+	})
+
+	t.Run("additional network", func(t *testing.T) {
+		err := s.SetIPs("n1", []*protos.IPMapping{
+			{Ip: "ipZ", Imsi: "IMSI0", Apn: "apn0"},
+		})
+		assert.NoError(t, err)
+
+		got, err := s.GetIPs("n0", []string{"ipA", "ipB", "ipC", "ipZ"})
+		assert.NoError(t, err)
+		want := []*protos.IPMapping{
+			// Same as in previous sub-test
+			{Ip: "ipA", Imsi: "IMSI0", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn0"},
+			{Ip: "ipA", Imsi: "IMSI1", Apn: "apn1"},
+			{Ip: "ipB", Imsi: "IMSI2", Apn: "apn1"},
+			{Ip: "ipC", Imsi: "IMSI2", Apn: "apn2"},
+		}
+		assert.Equal(t, want, got)
+
+		got, err = s.GetIPs("n1", []string{"ipA", "ipB", "ipC", "ipZ"})
+		assert.NoError(t, err)
+		want = []*protos.IPMapping{
+			{Ip: "ipZ", Imsi: "IMSI0", Apn: "apn0"},
+		}
+		assert.Equal(t, want, got)
+	})
+}

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -31,8 +31,13 @@ subscriberdb:
   service:
     labels:
       orc8r.io/obsidian_handlers: "true"
+      orc8r.io/state_indexer: "true"
     annotations:
-      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte/:network_id/subscribers"
+      orc8r.io/state_indexer_types: "mobilityd_ipdesc_record"
+      orc8r.io/state_indexer_version: "1"
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/lte/:network_id/msisdns,
+        /magma/v1/lte/:network_id/subscribers,
 
 smsd:
   service:

--- a/lte/gateway/python/scripts/mobility_cli.py
+++ b/lte/gateway/python/scripts/mobility_cli.py
@@ -62,10 +62,12 @@ def allocate_ip_handler(client, args):
         return
 
     request = AllocateIPRequest()
-    request.version = AllocateIPRequest.IPV4
     request.sid.CopyFrom(sid_msg)
+    request.version = AllocateIPRequest.IPV4
+    request.apn = args.apn
 
-    ip_msg = client.AllocateIPAddress(request)
+    response = client.AllocateIPAddress(request)
+    ip_msg = response.ip_addr
     if ip_msg.version == IPAddress.IPV4:
         ip = ipaddress.IPv4Address(ip_msg.address)
         print("IPv4 address allocated: %s" % ip)
@@ -218,6 +220,7 @@ def main():
     subparser = subparsers.add_parser(
         'allocate_ip', help='Allocate an IP address')
     subparser.add_argument('sid', help='Subscriber ID, e.g. "IMSI12345"')
+    subparser.add_argument('apn', help='Access Point Name, e.g. "internet"')
     subparser.set_defaults(func=allocate_ip_handler)
 
     # release_ip


### PR DESCRIPTION
## Summary

Together with #2906, this PR provides subscriber lookups via the REST API using IP addresses rather than IMSIs.

Unlike #2906, which used a config-based value as the lookup key, IP-lookup uses a state-based value as the lookup key. This requires a state indexer implementation, which we attach to the subscriberdb service to insert mobilityd state into a subscriberdb-managed SQL table. The SQL table's impl provides efficient reverse lookup, as well as functionally-acceptable garbage collection of the derived state.

## Test Plan

- [x] make test with new tests
- [x] e2e test described below

E2e test
- Enable mobilityd's persist_to_redis
- Allocate an IP to an existing subscriber, under an existing APN, using mobility_cli.py
- Look up that subscriber via rest api using the cli-reported IP addr
- Rest endpoint should report the specified sub

## Additional Information

- [x] This change is backwards-breaking

This change is forward breaking for non-Postgres deployments. *We don't need to do anything for our staging/prod deployments, since they are Postgres-backed.*

Non-Postgres deployments will need to manually kick off the reindex job for the subscriberdb state indexer. From a controller container, run `envdir /var/opt/magma/envdir /var/opt/magma/bin/indexers reindex` and ensure success