### PR TITLE
[Bug_Fix] [Data_Testing] Fixed data flow after service request test case

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_data_flow_after_service_request.py
@@ -16,10 +16,10 @@ import unittest
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
+import time
 
 
 class TestDataFlowAfterServiceRequest(unittest.TestCase):
-
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
 
@@ -35,20 +35,29 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
         reqs = tuple(self._s1ap_wrapper.ue_req for _ in range(num_ues))
 
         for req in reqs:
-            print("************************* Running End to End attach for ",
-                  "UE id ", req.ue_id)
+            print(
+                "************************* Running End to End attach for ",
+                "UE id",
+                req.ue_id,
+            )
             # Now actually complete the attach
             self._s1ap_wrapper._s1_util.attach(
-                req.ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                req.ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-                s1ap_types.ueAttachAccept_t)
+                s1ap_types.ueAttachAccept_t,
+            )
             # Wait on EMM Information from MME
             self._s1ap_wrapper._s1_util.receive_emm_info()
 
         dl_reqs = reqs[::2]
         ul_reqs = reqs[1::2]
-        print("************************* Running UE downlink (TCP) for UE "
-              "ids ", dl_reqs, " and uplink (TCP) for UE ids", ul_reqs)
+        print(
+            "************************* Running UE downlink (TCP) for UE Ids",
+            [req.ue_id for req in dl_reqs],
+            "and uplink (TCP) for UE Ids",
+            [req.ue_id for req in ul_reqs],
+        )
         dl_tests = self._s1ap_wrapper.configDownlinkTest(*dl_reqs, duration=1)
         ul_tests = self._s1ap_wrapper.configUplinkTest(*ul_reqs, duration=1)
         test = dl_tests.combine(dl_tests, ul_tests)
@@ -56,29 +65,36 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
         with test:
             test.verify()
 
+        # Added sleep to avoid chances of incoming paging indication
+        time.sleep(0.5)
+
         for req in reqs:
             ue_id = req.ue_id
-            print("************************* Sending UE context release "
-                  "request for UE id ", ue_id)
+            print(
+                "************************* Sending UE context release "
+                "request for UE id",
+                ue_id,
+            )
             # Send UE context release request to move UE to idle mode
             req = s1ap_types.ueCntxtRelReq_t()
             req.ue_Id = ue_id
-            req.cause.causeVal = (gpp_types.
-                                  CauseRadioNetwork.
-                                  USER_INACTIVITY.value)
+            req.cause.causeVal = (
+                gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
+            )
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+                s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+            )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
-
-        with test:
-            test.verify()
+                response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+            )
 
         for req in reqs:
             ue_id = req.ue_id
-            print("************************* Sending Service request for UE "
-                  "id ", ue_id)
+            print(
+                "************************* Sending Service request for UE Id",
+                ue_id,
+            )
             # Send service request to reconnect UE
             req = s1ap_types.ueserviceReq_t()
             req.ue_Id = ue_id
@@ -86,21 +102,27 @@ class TestDataFlowAfterServiceRequest(unittest.TestCase):
             req.ueMtmsi.pres = False
             req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
             self._s1ap_wrapper.s1_util.issue_cmd(
-                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+                s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+            )
             response = self._s1ap_wrapper.s1_util.get_response()
             self.assertEqual(
-                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value)
+                response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+            )
 
         with test:
-            test.wait()
+            test.verify()
 
         for req in reqs:
-            print("************************* Running UE detach for UE id ",
-                  req.ue_id)
+            print(
+                "************************* Running UE detach for UE id",
+                req.ue_id,
+            )
             # Now detach the UE
             self._s1ap_wrapper.s1_util.detach(
-                req.ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
-                False)
+                req.ue_id,
+                s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value,
+                False,
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Title
Fixed data flow after service request test case

## Summary
The test case "test_data_flow_after_service_request.py" was failing because of data trigger after UE context release in non-paging scenario. This PR fixes the issue by placing the data triggers have been after the service request as per the test case name and a sleep of 0.5 seconds have been added to avoid rare chances of paging indication (because the test case is not expecting to handle paging messages).

## Test Plan
Verified individually as well as with Sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>