### PR TITLE
[FeG] Fix timezone AVP algorithm

### DIFF
--- a/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
+++ b/feg/gateway/services/session_proxy/credit_control/gx/gx_client_test.go
@@ -421,9 +421,18 @@ func TestDefaultFramedIpv4Addr(t *testing.T) {
 
 func TestTimezoneConversion(t *testing.T) {
 	// Test behind UTC (negative offset)
-	pTimezone := &protos.Timezone{OffsetMinutes: -8 * HOUR_IN_MIN}
+	pTimezone := &protos.Timezone{OffsetMinutes: -6 * HOUR_IN_MIN}
 	convertedTimezone := gx.GetTimezoneByte(pTimezone)
+	assert.Equal(t, byte(0x4a), convertedTimezone)
+
+	pTimezone = &protos.Timezone{OffsetMinutes: -8 * HOUR_IN_MIN}
+	convertedTimezone = gx.GetTimezoneByte(pTimezone)
 	assert.Equal(t, byte(0x2b), convertedTimezone)
+
+	pTimezone = &protos.Timezone{OffsetMinutes: -7 * HOUR_IN_MIN}
+	convertedTimezone = gx.GetTimezoneByte(pTimezone)
+	assert.Equal(t, byte(0x8a), convertedTimezone)
+
 	// Test ahead UTC (positive offset)
 	pTimezone = &protos.Timezone{OffsetMinutes: 1 * HOUR_IN_MIN}
 	convertedTimezone = gx.GetTimezoneByte(pTimezone)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The algorithm was wrong since I was cutting off the ones value by doing `&0x7` when the value could range from 0-9.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Confirmed on TerraVM / modified unit test to add more test cases
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
