### PR TITLE
[agw] [subscriberdb] Start subscriberdb rpc servicer if there are subscribers in the db

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -56,8 +56,8 @@ def main():
     # Wait until the datastore is populated by addition or resync before
     # listening for clients.
     def serve():
-        # Waiting for subscribers to be added to store
         if not store.list_subscribers():
+            # Waiting for subscribers to be added to store
             yield from store.on_ready()
 
         if service.config['s6a_over_grpc']:

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -57,7 +57,8 @@ def main():
     # listening for clients.
     def serve():
         # Waiting for subscribers to be added to store
-        yield from store.on_ready()
+        if not store.list_subscribers():
+            yield from store.on_ready()
 
         if service.config['s6a_over_grpc']:
             s6a_proxy_servicer = S6aProxyRpcServicer(processor)


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Subscriberdb starts the rpc servicer only when an add_subscriber or resync event occurs (`store.on_ready()`). So if subscriberdb is restarted and orc8r checkin is failing, it just gets stuck, even though subscriber information is present in the local data store. This change adds a check at start time to run the rpc servicer if there is at least one subscriber present in the data store.

## Test Plan

On bare metal AGW:
Add UEs to subscriberdb using `subscriber_cli.py`

Before the change, on restarting subscriberdb, `sudo journalctl -fu magma@subscriberdb` gets stuck at:
```
Sep 22 17:41:36 shruti systemd[1]: Started Magma subscriberdb service.
Sep 22 17:41:37 shruti subscriberdb[1992]: INFO:root:enable_streaming set to False. Streamer disabled!
Sep 22 17:41:37 shruti subscriberdb[1992]: INFO:root:Starting subscriberdb...
Sep 22 17:41:37 shruti subscriberdb[1992]: INFO:root:Listening on address 127.0.0.1:50051
```
And UE fails to attach as subscriberdb rpc servicer is not running.

After the change, on restarting subscriberdb, `sudo journalctl -fu magma@subscriberdb` shows:
```
Sep 29 18:32:14 shruti systemd[1]: Started Magma subscriberdb service.
Sep 29 18:32:18 shruti subscriberdb[18535]: INFO:root:enable_streaming set to False. Streamer disabled!
Sep 29 18:32:18 shruti subscriberdb[18535]: INFO:root:Starting subscriberdb...
Sep 29 18:32:18 shruti subscriberdb[18535]: INFO:root:Listening on address 127.0.0.1:50051
Sep 29 18:32:29 shruti subscriberdb[18535]: INFO:root:starting s6a_proxy servicer
```
