### PR TITLE
[Sanity_Testing] Corrected mobile reachability timer with service restart test cases for sanity

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -21,10 +21,10 @@ from s1ap_utils import MagmadUtil
 
 
 class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
-
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
-            stateless_mode=MagmadUtil.stateless_cmds.ENABLE)
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -51,13 +51,17 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         self._s1ap_wrapper.configUEDevice(1)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
-# Now actually complete the attach
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
+        # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
-            ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -66,17 +70,22 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         # context release
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ",
+            ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
 
         # Delay by 6 minutes to ensure Mobile reachability timer expires.
         # Mobile Reachability Timer value = 1 minute (conf file) + delta value
@@ -91,8 +100,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
             timeSlept += 10
             print("*********** Slept for", timeSlept, "seconds")
 
-        print("************************* Restarting MME service on",
-              "gateway")
+        print("************************* Restarting MME service on gateway")
         self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
         for j in range(30):
@@ -103,16 +111,20 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         # UE contexts locally, S1ap tester shall send Service Request expecting
         # Service Reject as UE contexts are already deleted
         # Implicit detach timer = Mobile reachability timer
-        print("************************* Waiting for Implicit Detach Timer"
-              " to expire 6 minutes")
+        print(
+            "************************* Waiting for Implicit Detach Timer"
+            " to expire. Sleeping for 6 minutes.."
+        )
         timeSlept = 0
         while timeSlept < 360:
             time.sleep(10)
             timeSlept += 10
             print("*********** Slept for", timeSlept, "seconds")
 
-        print("************************* Sending Service request for UE id ",
-              ue_id)
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
         # Send service request to reconnect UE
         req = s1ap_types.ueserviceReq_t()
         req.ue_Id = ue_id
@@ -120,18 +132,24 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+        )
 
-        print("************************* Received Service Reject for UE id ",
-              ue_id)
+        print(
+            "************************* Received Service Reject for UE id ",
+            ue_id,
+        )
 
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
@@ -17,12 +17,14 @@ import time
 import gpp_types
 import s1ap_types
 import s1ap_wrapper
+from s1ap_utils import MagmadUtil
 
 
 class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
-
     def setUp(self):
-        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+        )
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
@@ -31,6 +33,9 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         """
         The test case validates Mobile Reachability Timer resumes the
         configured timer value on MME restart
+        NOTE: Before execution of this test case, run the test case,
+              test_modify_mme_config_for_sanity.py to modify the default
+              3412 timer value from 54 minutes to 1 minute
         Step1 : UE attaches to network
         Step2 : UE moves to Idle state
         Step3 : Once MME restarts, MME shall resume
@@ -43,15 +48,20 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
 
         """
         self._s1ap_wrapper.configUEDevice(1)
+        time.sleep(20)
         req = self._s1ap_wrapper.ue_req
         ue_id = req.ue_id
-        print("************************* Running End to End attach for UE id ",
-              ue_id)
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
         # Now actually complete the attach
         self._s1ap_wrapper._s1_util.attach(
-            ue_id, s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
-            s1ap_types.ueAttachAccept_t)
+            s1ap_types.ueAttachAccept_t,
+        )
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
@@ -60,34 +70,53 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         # context release
         time.sleep(0.5)
 
-        print("************************* Sending UE context release request ",
-              "for UE id ", ue_id)
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ",
+            ue_id,
+        )
         # Send UE context release request to move UE to idle mode
         req = s1ap_types.ueCntxtRelReq_t()
         req.ue_Id = ue_id
         req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req)
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
 
-        print("************************* Restarting MME service on",
-              "gateway")
+        print("************************* Restarting MME service on gateway")
         self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
         for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 
-        print("Waiting for Mobile Reachability Timer (58 Minutes) and"
-              " Implicit Detach Timer (58 minutes) to expire"
-              " together timer value is set to 7020 seconds")
-        # 58 Minutes + 58 minutes = 116 minutes (6960 seconds)
-        # 6960 seconds + 60 seconds, delta(Randomly chosen)
-        time.sleep(7020)
-        print("************************* Sending Service request for UE id ",
-              ue_id)
+        # Delay by 11 minutes to ensure Mobile reachability timer and Implicit
+        # detach timer expires
+        # Mobile Reachability Timer value = 1 minute (conf file) + delta value
+        # at mme (4 minute)
+        # Implicit Detach Timer value = 1 minute (conf file) + delta value
+        # at mme (4 minute)
+        print(
+            "************************* Waiting for Mobile Reachability Timer"
+            " (5 Minutes) and Implicit Detach Timer (5 minutes) to expire."
+            " Together timer value is set to 660 seconds"
+        )
+        # 5 Minutes + 5 minutes = 10 minutes (600 seconds)
+        # 600 seconds + 60 seconds, delta(Randomly chosen)
+        timeSlept = 0
+        while timeSlept < 660:
+            time.sleep(10)
+            timeSlept += 10
+            print("*********** Slept for", timeSlept, "seconds")
+
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
         # Send service request to reconnect UE
         req = s1ap_types.ueserviceReq_t()
         req.ue_Id = ue_id
@@ -95,18 +124,23 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         req.ueMtmsi.pres = False
         req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
         self._s1ap_wrapper.s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req)
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+        )
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_SERVICE_REJECT_IND.value
+        )
 
-        print("************************* Received Service Reject for UE id ",
-              ue_id)
+        print(
+            "************************* Received Service Reject for UE id ",
+            ue_id,
+        )
 
         # Wait for UE Context Release command
         response = self._s1ap_wrapper.s1_util.get_response()
         self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value)
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Title
[Sanity_Testing] Corrected mobile reachability timer with service restart test cases for sanity

## Summary
The mobile reachability timer value is very large for sanity testing. So reduced the wait timer to be quickly tested in Sanity.

## Test Plan
Verified individually and with Sanity

Signed-off-by: VinashakAnkitAman <ankit.aman@radisys.com>