### PR TITLE
[lte][agw] remove duplicate lockfile entries

### DIFF
--- a/lte/gateway/release/magma.lockfile
+++ b/lte/gateway/release/magma.lockfile
@@ -114,24 +114,6 @@
       "sysdep": "python3-hyperframe",
       "version": "5.2.0"
     },
-    "h2": {
-      "root": true,
-      "source": "pypi",
-      "sysdep": "python3-h2",
-      "version": "3.2.0"
-    },
-    "hpack": {
-      "root": true,
-      "source": "pypi",
-      "sysdep": "python3-hpack",
-      "version": "3.0"
-    },
-    "hyperframe": {
-      "root": false,
-      "source": "pypi",
-      "sysdep": "python3-hyperframe",
-      "version": "5.2.0"
-    },
     "idna": {
       "root": true,
       "source": "pypi",


### PR DESCRIPTION
 accidentally left in during merge conflict resolution

Signed-off-by: Ken Kahrs <kahrs@fb.com>

## Summary

duplicate entries for h2, hpack, hyperframe not needed

## Test Plan

verify `fab dev package:vcs=git` runs successfully and generates all needed python packages
