### PR TITLE
[SessionD] Schedule termination by session

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -54,6 +54,7 @@ require (
 	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.27.1
+	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000
 	magma/feg/cloud/go/protos v0.0.0
 	magma/feg/gateway v0.0.0-00010101000000-000000000000

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -639,6 +639,7 @@ golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 h1:X9xIZ1YU8bLZA3l6gqDUHSFiD0GFI9S548h6C8nDtOY=
 golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -305,7 +305,7 @@ class LocalEnforcer {
    */
   void update_charging_credits(
       SessionMap& session_map, const UpdateSessionResponse& response,
-      std::unordered_set<std::string>& subscribers_to_terminate,
+      std::unordered_set<ImsiAndSessionID>& subscribers_to_terminate,
       SessionUpdate& session_update);
 
   /**
@@ -317,7 +317,7 @@ class LocalEnforcer {
    */
   void update_monitoring_credits_and_rules(
       SessionMap& session_map, const UpdateSessionResponse& response,
-      std::unordered_set<std::string>& subscribers_to_terminate,
+      std::unordered_set<ImsiAndSessionID>& subscribers_to_terminate,
       SessionUpdate& session_update);
 
   /**
@@ -528,11 +528,11 @@ class LocalEnforcer {
       SubscriberQuotaUpdate_Type new_state);
 
   /**
-   * Deactivate rules for multiple IMSIs.
-   * Notify AAA service if the session is a CWF session.
+   * Start the termination process for multiple sessions
    */
-  void terminate_multiple_services(
-      SessionMap& session_map, const std::unordered_set<std::string>& imsis,
+  void terminate_multiple_sessions(
+      SessionMap& session_map,
+      const std::unordered_set<ImsiAndSessionID>& sessions,
       SessionUpdate& session_update);
 
   void handle_activate_service_action(
@@ -554,7 +554,7 @@ class LocalEnforcer {
   /**
    * Remove final action flows through pipelined
    */
-  void cancelling_final_unit_action(
+  void cancel_final_unit_action(
       const std::unique_ptr<SessionState>& session,
       const std::vector<std::string>& restrict_rules,
       SessionStateUpdateCriteria& uc);
@@ -595,7 +595,7 @@ class LocalEnforcer {
 
   bool terminate_on_wallet_exhaust();
 
-  void schedule_termination(std::unordered_set<std::string>& imsis);
+  void schedule_termination(std::unordered_set<ImsiAndSessionID>& sessions);
 
   void propagate_bearer_updates_to_mme(const BearerUpdate& updates);
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The principle behind this change is that all session lifecycle management operations should be per-session, not per-IMSI. 
The main functions affected are the `terminate_multiple_sessions` function. Previously, we passed in a set of IMSIs, but now we pass in a pair of IMSI + SessionID. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
S1AP test
make precommit_sm
CWF Integration Test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
