### PR TITLE
[backport-v1.2] build: avoid git-cherry-pick ovs build script

### DIFF
--- a/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_prepare/tasks/main.yml
@@ -124,7 +124,7 @@
       - "{{ all_vars.patches }}"
 
 - name: Cherry pick vlan patch
-  command: git cherry-pick "{{ all_vars.vlan_fix_hash }}"
+  command: bash -c 'git show "{{ all_vars.vlan_fix_hash }}" | git apply -3 -'
   args:
     chdir: "{{ GIT_HOME.path }}/ovs"
 

--- a/lte/gateway/release/build-ovs.sh
+++ b/lte/gateway/release/build-ovs.sh
@@ -85,9 +85,9 @@ cd ovs
 git checkout ${OVS_VERSION}
 cp $PATCH_ROOT/*.patch $WORK_DIR/ovs
 cp -r "${FLOWBASED_PATH}" "${WORK_DIR}/ovs/flow-based-gtp-linux-v4.9"
-git am ${PATCHES}
+git apply ${PATCHES}
 # vlan fix
-git cherry-pick $VLAN_FIX
+git show $VLAN_FIX | git apply -3 -
 
 ./boot.sh
 # Building OVS user packages


### PR DESCRIPTION
## Summary

`git cherry-pick` needs git config on the build host. This patch
uses `git apply` to remove this requirement to fix AGW deployment.



Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
ran ovs build script build-ovs.sh


<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
