### PR TITLE
[agw] [mme + sessiond] Populate User Location Information (ULI) in create session request

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -1534,8 +1534,8 @@ const char* const get_short_file_name(const char* const source_file_nameP) {
 char* bytes_to_hex(char* byte_array, int length, char* hex_array) {
   int i;
   for(i = 0; i < length; i++){
-    sprintf(hex_array+i*2, "%02x", (unsigned char)byte_array[i]);
+    sprintf(hex_array+i*3, " %02x", (unsigned char)byte_array[i]);
   }
-  hex_array[2*length+1] = '\0';
+  hex_array[3*length+1] = '\0';
   return hex_array;
 }

--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -1528,3 +1528,14 @@ const char* const get_short_file_name(const char* const source_file_nameP) {
 
   return root_startP + strlen(LOG_MAGMA_REPO_ROOT);
 }
+
+// Return the hex representation of a char array
+
+char* bytes_to_hex(char* byte_array, int length, char* hex_array) {
+  int i;
+  for(i = 0; i < length; i++){
+    sprintf(hex_array+i*2, "%02x", (unsigned char)byte_array[i]);
+  }
+  hex_array[2*length+1] = '\0';
+  return hex_array;
+}

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -364,6 +364,7 @@ int append_log_ctx_info_prefix_id(
 
 const char* const get_short_file_name(const char* const source_file_nameP);
 
+// Return the hex representation of a char array
 char* bytes_to_hex(char* byte_array, int length, char* hex_array);
 
 #define OAILOG_LOG_CONFIGURE log_configure

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -364,6 +364,8 @@ int append_log_ctx_info_prefix_id(
 
 const char* const get_short_file_name(const char* const source_file_nameP);
 
+char* bytes_to_hex(char* byte_array, int length, char* hex_array);
+
 #define OAILOG_LOG_CONFIGURE log_configure
 #define OAILOG_LEVEL_STR2INT log_level_str2int
 #define OAILOG_LEVEL_INT2STR log_level_int2str

--- a/lte/gateway/c/oai/include/TrackingAreaIdentity.h
+++ b/lte/gateway/c/oai/include/TrackingAreaIdentity.h
@@ -114,6 +114,18 @@ typedef struct paging_tai_list_s {
 #define MOBILE_NETWORK_CODE_ATTR_XML_STR "mnc"
 #endif
 
+// Copy TAIs
+#define COPY_TAI(tai_dst, tai_src)                                             \
+  do {                                                                         \
+    tai_dst.mcc_digit2 = tai_src.mcc_digit2;                                   \
+    tai_dst.mcc_digit1 = tai_src.mcc_digit1;                                   \
+    tai_dst.mnc_digit3 = tai_src.mnc_digit3;                                   \
+    tai_dst.mcc_digit3 = tai_src.mcc_digit3;                                   \
+    tai_dst.mnc_digit2 = tai_src.mnc_digit2;                                   \
+    tai_dst.mnc_digit1 = tai_src.mnc_digit1;                                   \
+    tai_dst.tac        = tai_src.tac;                                          \
+  } while (0)
+
 int encode_tracking_area_identity(
     tai_t* tai, uint8_t iei, uint8_t* buffer, uint32_t len);
 int decode_tracking_area_identity(

--- a/lte/gateway/c/oai/include/sgw_ie_defs.h
+++ b/lte/gateway/c/oai/include/sgw_ie_defs.h
@@ -29,6 +29,7 @@
 #include "3gpp_24.007.h"
 #include "3gpp_24.008.h"
 #include "3gpp_29.274.h"
+#include "TrackingAreaIdentity.h"
 
 typedef uint8_t DelayValue_t;
 typedef uint32_t SequenceNumber_t;
@@ -176,8 +177,8 @@ typedef struct {
     Cgi_t cgi;
     Sai_t sai;
     Rai_t rai;
-    Tai_t tai;
-    Ecgi_t ecgi;
+    tai_t tai;
+    ecgi_t ecgi;
     Lai_t lai;
   } s;
 } Uli_t;

--- a/lte/gateway/c/oai/include/sgw_ie_defs.h
+++ b/lte/gateway/c/oai/include/sgw_ie_defs.h
@@ -147,20 +147,6 @@ typedef struct {
 typedef struct {
   uint8_t mcc[3];
   uint8_t mnc[3];
-  uint16_t tac;
-} Tai_t;
-
-typedef struct {
-  plmn_t plmn;
-  uint8_t mcc[3];
-  uint8_t mnc[3];
-  eci_t
-      cell_identity; /*!< \brief  The ECI shall be of fixed length of 28 bits */
-} Ecgi_t;
-
-typedef struct {
-  uint8_t mcc[3];
-  uint8_t mnc[3];
   uint16_t lac;
 } Lai_t;
 

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -210,7 +210,7 @@ static int get_uli_from_session_req(
     return 0;
   }
 
-  uli[0] = 130;  // TAI and ECGI - defined in 29.061
+  uli[0] = saved_req->uli.present;
 
   // TAI as defined in 29.274 8.21.4
   uli[1] = ((saved_req->uli.s.tai.mcc_digit2 & 0xf) << 4) |
@@ -235,6 +235,10 @@ static int get_uli_from_session_req(
   uli[12] = saved_req->uli.s.ecgi.cell_identity.cell_id & 0xff;
   uli[13] = '\0';
 
+  char hex_uli[2*ULI_DATA_SIZE+1];
+  OAILOG_DEBUG(
+      LOG_SPGW_APP, "Session request ULI %s",
+      bytes_to_hex(uli, ULI_DATA_SIZE, hex_uli));
   return 1;
 }
 

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -235,7 +235,7 @@ static int get_uli_from_session_req(
   uli[12] = saved_req->uli.s.ecgi.cell_identity.cell_id & 0xff;
   uli[13] = '\0';
 
-  char hex_uli[2*ULI_DATA_SIZE+1];
+  char hex_uli[3*ULI_DATA_SIZE+1];
   OAILOG_DEBUG(
       LOG_SPGW_APP, "Session request ULI %s",
       bytes_to_hex(uli, ULI_DATA_SIZE, hex_uli));

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -210,7 +210,7 @@ static int get_uli_from_session_req(
     return 0;
   }
 
-  uli[0] = saved_req->uli.present;
+  uli[0] = 130;  // TAI and ECGI - defined in 29.061
 
   // TAI as defined in 29.274 8.21.4
   uli[1] = ((saved_req->uli.s.tai.mcc_digit2 & 0xf) << 4) |

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -82,6 +82,7 @@ static void pcef_fill_create_session_req(
     lte_context->set_imei(session_data->imeisv, IMEISV_DIGITS_MAX);
   }
   if (session_data->uli_exists) {
+    OAILOG_DEBUG(LOG_SPGW_APP, "Sending ULI to PCEF");
     lte_context->set_user_location(session_data->uli, ULI_DATA_SIZE);
   }
   // QoS Info
@@ -212,22 +213,22 @@ static int get_uli_from_session_req(
   uli[0] = 130;  // TAI and ECGI - defined in 29.061
 
   // TAI as defined in 29.274 8.21.4
-  uli[1] = ((saved_req->uli.s.tai.mcc[1] & 0xf) << 4) |
-           ((saved_req->uli.s.tai.mcc[0] & 0xf));
-  uli[2] = ((saved_req->uli.s.tai.mnc[2] & 0xf) << 4) |
-           ((saved_req->uli.s.tai.mcc[2] & 0xf));
-  uli[3] = ((saved_req->uli.s.tai.mnc[1] & 0xf) << 4) |
-           ((saved_req->uli.s.tai.mnc[0] & 0xf));
+  uli[1] = ((saved_req->uli.s.tai.mcc_digit2 & 0xf) << 4) |
+           ((saved_req->uli.s.tai.mcc_digit1 & 0xf));
+  uli[2] = ((saved_req->uli.s.tai.mnc_digit3 & 0xf) << 4) |
+           ((saved_req->uli.s.tai.mcc_digit3 & 0xf));
+  uli[3] = ((saved_req->uli.s.tai.mnc_digit2 & 0xf) << 4) |
+           ((saved_req->uli.s.tai.mnc_digit1 & 0xf));
   uli[4] = (saved_req->uli.s.tai.tac >> 8) & 0xff;
   uli[5] = saved_req->uli.s.tai.tac & 0xff;
 
   // ECGI as defined in 29.274 8.21.5
-  uli[6] = ((saved_req->uli.s.ecgi.mcc[1] & 0xf) << 4) |
-           ((saved_req->uli.s.ecgi.mcc[0] & 0xf));
-  uli[7] = ((saved_req->uli.s.ecgi.mnc[2] & 0xf) << 4) |
-           ((saved_req->uli.s.ecgi.mcc[2] & 0xf));
-  uli[8] = ((saved_req->uli.s.ecgi.mnc[1] & 0xf) << 4) |
-           ((saved_req->uli.s.ecgi.mnc[0] & 0xf));
+  uli[6] = ((saved_req->uli.s.ecgi.plmn.mcc_digit2 & 0xf) << 4) |
+           ((saved_req->uli.s.ecgi.plmn.mcc_digit1 & 0xf));
+  uli[7] = ((saved_req->uli.s.ecgi.plmn.mnc_digit3 & 0xf) << 4) |
+           ((saved_req->uli.s.ecgi.plmn.mcc_digit3 & 0xf));
+  uli[8] = ((saved_req->uli.s.ecgi.plmn.mnc_digit2 & 0xf) << 4) |
+           ((saved_req->uli.s.ecgi.plmn.mnc_digit1 & 0xf));
   uli[9] = (saved_req->uli.s.ecgi.cell_identity.enb_id >> 16) & 0xf;
   uli[10] = (saved_req->uli.s.ecgi.cell_identity.enb_id >> 8) & 0xff;
   uli[11] = saved_req->uli.s.ecgi.cell_identity.enb_id & 0xff;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_defs.h
@@ -311,6 +311,10 @@ ue_mm_context_t* mme_app_get_ue_context_for_timer(
 void mme_app_handle_modify_bearer_rsp(
     itti_s11_modify_bearer_response_t* const s11_modify_bearer_response,
     ue_mm_context_t* ue_context_p);
+
+void mme_app_get_user_location_information(
+    Uli_t* uli_t_p, const ue_mm_context_t* ue_context_p);
+
 #define ATTACH_REQ (1 << 0)
 #define TAU_REQUEST (1 << 1)
 #define INTIAL_CONTEXT_SETUP_PROCEDURE_FAILED 0x00

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -235,6 +235,11 @@ int mme_app_send_s11_create_session_req(
   } else {
     session_request_p->msisdn.length = 0;
   }
+
+  // Fill User Location Information
+  session_request_p->uli.present = 0;   // initialize the presencemask
+  mme_app_get_user_location_information(&session_request_p->uli, ue_mm_context);
+
   session_request_p->rat_type = RAT_EUTRAN;
 
   // default bearer already created by NAS

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_location.c
@@ -479,3 +479,15 @@ int mme_app_send_s6a_cancel_location_ans(
   rc = send_msg_to_task(&mme_app_task_zmq_ctx, TASK_S6A, message_p);
   OAILOG_FUNC_RETURN(LOG_MME_APP, rc);
 }
+
+void mme_app_get_user_location_information(
+    Uli_t* uli_t_p, const ue_mm_context_t* ue_context_p) {
+  uli_t_p->present = uli_t_p->present | ULI_TAI;
+  COPY_TAI(uli_t_p->s.tai, ue_context_p->emm_context.originating_tai);
+  uli_t_p->present = uli_t_p->present | ULI_ECGI;
+  COPY_PLMN(uli_t_p->s.ecgi.plmn, ue_context_p->e_utran_cgi.plmn);
+  uli_t_p->s.ecgi.cell_identity.enb_id =
+      ue_context_p->e_utran_cgi.cell_identity.enb_id;
+  uli_t_p->s.ecgi.cell_identity.cell_id =
+      ue_context_p->e_utran_cgi.cell_identity.cell_id;
+}

--- a/lte/gateway/c/oai/tasks/s11/s11_ie_formatter.c
+++ b/lte/gateway/c/oai/tasks/s11/s11_ie_formatter.c
@@ -1632,9 +1632,9 @@ int gtpv2c_uli_ie_set(nw_gtpv2c_msg_handle_t* msg, const Uli_t* uli) {
     length += 7;
   }
   if (ULI_TAI & uli->present) {
-    current[0] = (uli->s.tai.mcc[1] << 4) | (uli->s.tai.mcc[0]);
-    current[1] = (uli->s.tai.mnc[2] << 4) | (uli->s.tai.mcc[2]);
-    current[2] = (uli->s.tai.mnc[1] << 4) | (uli->s.tai.mnc[0]);
+    current[0] = (uli->s.tai.mcc_digit2 << 4) | (uli->s.tai.mcc_digit1);
+    current[1] = (uli->s.tai.mnc_digit3 << 4) | (uli->s.tai.mcc_digit3);
+    current[2] = (uli->s.tai.mnc_digit2 << 4) | (uli->s.tai.mnc_digit1);
     current[3] = (uint8_t)((uli->s.tai.tac & 0xFF00) >> 8);
     current[4] = (uint8_t)(uli->s.tai.tac & 0x00FF);
     current    = &current[5];

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -288,9 +288,9 @@ void SpgwStateConverter::sgw_create_session_message_to_proto(
   }
 
   if (session_request->uli.present) {
-    char uli[sizeof(Uli_t)];
-    memcpy(&uli, &session_request->uli, sizeof(Uli_t));
-    proto->set_uli(uli);
+    char uli[sizeof(Uli_t)] = "";
+    memcpy(uli, &session_request->uli, sizeof(Uli_t));
+    proto->set_uli(uli, sizeof(Uli_t));
   }
 
   proto->mutable_serving_network()->set_mcc(
@@ -383,7 +383,6 @@ void SpgwStateConverter::proto_to_sgw_create_session_message(
   }
 
   if (proto.uli().length() > 0) {
-    session_request->uli.present = true;
     memcpy(&session_request->uli, proto.uli().c_str(), sizeof(Uli_t));
   }
   memcpy(

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -584,6 +584,20 @@ void LocalSessionManagerHandlerImpl::SetSessionRules(
   response_callback(Status::OK, Void());
 }
 
+std::string LocalSessionManagerHandlerImpl::bytes_to_hex(const std::string& s)
+{
+   std::ostringstream ret;
+
+    unsigned int c;
+    for (std::string::size_type i = 0; i < s.length(); ++i)
+    {
+        c = (unsigned int)(unsigned char)s[i];
+        ret << std::hex << std::setfill('0') <<
+            std::setw(2) << (std::nouppercase) << c;
+    }
+    return ret.str();
+}
+
 void LocalSessionManagerHandlerImpl::log_create_session(SessionConfig& cfg) {
   const auto& imsi = cfg.common_context.sid().id();
   const auto& apn  = cfg.common_context.apn();
@@ -593,7 +607,8 @@ void LocalSessionManagerHandlerImpl::log_create_session(SessionConfig& cfg) {
     const auto& lte = cfg.rat_specific_context.lte_context();
     create_message += ", default bearer ID:" + std::to_string(lte.bearer_id()) +
                       ", PLMN ID:" + lte.plmn_id() +
-                      ", IMSI PLMN ID:" + lte.imsi_plmn_id();
+                      ", IMSI PLMN ID:" + lte.imsi_plmn_id() +
+                      ", User location:" + bytes_to_hex(lte.user_location());
   } else if (cfg.rat_specific_context.has_wlan_context()) {
     create_message +=
         ", MAC addr:" + cfg.rat_specific_context.wlan_context().mac_addr();

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -592,7 +592,7 @@ std::string LocalSessionManagerHandlerImpl::bytes_to_hex(const std::string& s)
     for (std::string::size_type i = 0; i < s.length(); ++i)
     {
         c = (unsigned int)(unsigned char)s[i];
-        ret << std::hex << std::setfill('0') <<
+        ret << " " << std::hex << std::setfill('0') <<
             std::setw(2) << (std::nouppercase) << c;
     }
     return ret.str();

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -224,6 +224,8 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
           response_callback);
 
   void log_create_session(SessionConfig& cfg);
+
+  std::string bytes_to_hex(const std::string& s);
 };
 
 }  // namespace magma


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary
This change adds the optional IE User Location Information(ULI) in Create Session Request from MME. Specifically, 
- add function `mme_app_get_user_location_information` to populate the ULI IE from UE context
- remove Tai_t and Ecgi_t structures as they are not used anywhere else
- add macro to copy TAI values
- added functions to convert byte array to hex array in Sessiond and MME for debugging

## Test Plan

Feature agw_of: S1ap integration tests
Feature mme: Compiled with `make FEATURES="mme" build_oai` on dev VM, integration test will be done in CI

After running `test_attach_detach.py`, sessiond syslog shows:
`Oct 01 22:07:00 magma-dev sessiond[1398]: I1001 22:07:00.284286  1398 LocalSessionManagerHandler.cpp:616] Received a LocalCreateSessionRequest for IMSI001010000000002 with APN:magma.ipv4, default bearer ID:5, PLMN ID:00101, IMSI PLMN ID:00101, User location: 82 00 f1 10 00 01 00 f1 10 00 00 00 0a
```
002322 Thu Oct  1 22:07:00 2020 7F4121FE5700 DEBUG SPGW-A lib/pcef/pcef_handlers.cpp      :0241    Session request ULI  82 00 f1 10 00 01 00 f1 10 00 00 00 0a
002323 Thu Oct  1 22:07:00 2020 7F4121FE5700 DEBUG SPGW-A lib/pcef/pcef_handlers.cpp      :0085    Sending ULI to PCEF
```
