### PR TITLE
[magma][feg][cwag] Change EAP-SIM swagger config to optional

### DIFF
--- a/cwf/cloud/go/services/cwf/obsidian/models/network_carrier_wifi_configs_swaggergen.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/network_carrier_wifi_configs_swaggergen.go
@@ -34,8 +34,7 @@ type NetworkCarrierWifiConfigs struct {
 	EapAka *models2.EapAka `json:"eap_aka"`
 
 	// eap sim
-	// Required: true
-	EapSim *models2.EapSim `json:"eap_sim"`
+	EapSim *models2.EapSim `json:"eap_sim,omitempty"`
 
 	// li ues
 	LiUes *LiUes `json:"li_ues,omitempty"`
@@ -126,8 +125,8 @@ func (m *NetworkCarrierWifiConfigs) validateEapAka(formats strfmt.Registry) erro
 
 func (m *NetworkCarrierWifiConfigs) validateEapSim(formats strfmt.Registry) error {
 
-	if err := validate.Required("eap_sim", "body", m.EapSim); err != nil {
-		return err
+	if swag.IsZero(m.EapSim) { // not required
+		return nil
 	}
 
 	if m.EapSim != nil {

--- a/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
+++ b/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
@@ -956,7 +956,6 @@ definitions:
       - default_rule_id
       - network_services
       - eap_aka
-      - eap_sim
       - aaa_server
     properties:
       default_rule_id:

--- a/feg/cloud/go/services/feg/obsidian/models/gateway_federation_configs_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/gateway_federation_configs_swaggergen.go
@@ -29,8 +29,7 @@ type GatewayFederationConfigs struct {
 	EapAka *EapAka `json:"eap_aka"`
 
 	// eap sim
-	// Required: true
-	EapSim *EapSim `json:"eap_sim"`
+	EapSim *EapSim `json:"eap_sim,omitempty"`
 
 	// gx
 	// Required: true
@@ -171,8 +170,8 @@ func (m *GatewayFederationConfigs) validateEapAka(formats strfmt.Registry) error
 
 func (m *GatewayFederationConfigs) validateEapSim(formats strfmt.Registry) error {
 
-	if err := validate.Required("eap_sim", "body", m.EapSim); err != nil {
-		return err
+	if swag.IsZero(m.EapSim) { // not required
+		return nil
 	}
 
 	if m.EapSim != nil {

--- a/feg/cloud/go/services/feg/obsidian/models/network_federation_configs_swaggergen.go
+++ b/feg/cloud/go/services/feg/obsidian/models/network_federation_configs_swaggergen.go
@@ -29,8 +29,7 @@ type NetworkFederationConfigs struct {
 	EapAka *EapAka `json:"eap_aka"`
 
 	// eap sim
-	// Required: true
-	EapSim *EapSim `json:"eap_sim"`
+	EapSim *EapSim `json:"eap_sim,omitempty"`
 
 	// gx
 	// Required: true
@@ -171,8 +170,8 @@ func (m *NetworkFederationConfigs) validateEapAka(formats strfmt.Registry) error
 
 func (m *NetworkFederationConfigs) validateEapSim(formats strfmt.Registry) error {
 
-	if err := validate.Required("eap_sim", "body", m.EapSim); err != nil {
-		return err
+	if swag.IsZero(m.EapSim) { // not required
+		return nil
 	}
 
 	if m.EapSim != nil {

--- a/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
+++ b/feg/cloud/go/services/feg/obsidian/models/swagger.v1.yml
@@ -1122,7 +1122,6 @@ definitions:
       - gy
       - swx
       - eap_aka
-      - eap_sim
       - aaa_server
       - served_network_ids
       - health
@@ -1431,7 +1430,6 @@ definitions:
       - gy
       - swx
       - eap_aka
-      - eap_sim
       - aaa_server
       - served_network_ids
       - health


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

Change EAP-SIM swagger config to optional to avoid additional NMS changes
## Test Plan

unit tests

## Additional Information

- [ ] This change is backwards-breaking

