### PR TITLE
[lte][agw] Add build of OVS with patches to default gateway build

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -16,6 +16,7 @@
 
 set -e
 shopt -s extglob
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
@@ -352,3 +353,12 @@ $(glob_files "${PY_TMP_BUILD}/usr/bin/*" /usr/local/bin/) \
 $(glob_files "${ANSIBLE_FILES}/config_stateless_*.sh" /usr/local/bin/)"
 
 eval "$BUILDCMD"
+
+cd "${MAGMA_ROOT}"
+OVS_DIFF_LINES=$(git diff master -- third_party/gtp_ovs/ lte/gateway/release/build-ovs.sh | wc -l | tr -dc 0-9)
+
+# if env var FORCE_OVS_BUILD is non-empty or there is are changes to openvswitch-related files build openvswitch
+if [[ x"${FORCE_OVS_BUILD}" != "x" || x"${OVS_DIFF_LINES}" != x0 ]]; then
+    cd "${PWD}"
+    "${SCRIPT_DIR}"/build-ovs.sh "${OUTPUT_DIR}"
+fi

--- a/lte/gateway/release/build-ovs.sh
+++ b/lte/gateway/release/build-ovs.sh
@@ -39,10 +39,10 @@
 # /!\ Note this file is going to move elsewhere It's just temp.
 
 set -e
-WORK_DIR=~/build-ovs
-OVS_VERSION="v2.8.9"
+WORK_DIR=/tmp/build-ovs
 OVS_VERSION_SHORT="2.8.9"
-MAGMA_ROOT="../../../"
+OVS_VERSION="v${OVS_VERSION_SHORT}"
+MAGMA_ROOT="$(realpath "$(dirname $0)"/../../../)"
 GTP_PATCH_PATH="${MAGMA_ROOT}/third_party/gtp_ovs/kernel-4.9"
 # Build time dependencies
 BUILD_DEPS="graphviz debhelper dh-autoreconf python-all python-twisted-conch module-assistant git ruby-dev openssl pkg-config libssl-dev build-essential"
@@ -50,6 +50,8 @@ PATCHES="$(ls ${GTP_PATCH_PATH}/${OVS_VERSION_SHORT})"
 FLOWBASED_PATH=$(readlink -f ${MAGMA_ROOT}/third_party/gtp_ovs/kernel-4.9/gtp-v4.9-backport/)
 PATCH_ROOT=$(readlink -f "$GTP_PATCH_PATH/$OVS_VERSION_SHORT/")
 VLAN_FIX="3cf2b424bb"
+# be sure to increment this to enable upgrade from package repo when rebuilding identical upstream versions
+LOCAL_REV=1
 
 # The resulting package is placed in $OUTPUT_DIR
 # or in the cwd.
@@ -80,7 +82,7 @@ sudo gem install fpm
 
 # pull code and apply patches
 cd ${WORK_DIR}
-git clone https://github.com/openvswitch/ovs.git
+(wget "${OVS_ARCHIVE_URL}" && tar xzf "${OVS_ARCHIVE}") || git clone https://github.com/openvswitch/ovs.git
 cd ovs
 git checkout ${OVS_VERSION}
 cp $PATCH_ROOT/*.patch $WORK_DIR/ovs
@@ -88,6 +90,23 @@ cp -r "${FLOWBASED_PATH}" "${WORK_DIR}/ovs/flow-based-gtp-linux-v4.9"
 git apply ${PATCHES}
 # vlan fix
 git show $VLAN_FIX | git apply -3 -
+
+# fakeroot finds version in debian/changelog
+# -- build changelog entry with the correct version string and patch
+cat <<EOF | git apply -
+diff --git a/debian/changelog b/debian/changelog
+index 824ed7d5f..b606d4331 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,3 +1,9 @@
++openvswitch (${OVS_VERSION_SHORT}-${LOCAL_REV}) unstable; urgency=low
++   [ local team ]
++   * New local version
++
++ -- local team <noreply@example.com>  $(date '+%a, %d %b %Y %H:%M:%S %z')
++
+$(head -3 debian/changelog | sed 's/^/ /g')
+EOF
 
 ./boot.sh
 # Building OVS user packages
@@ -102,4 +121,4 @@ kvers=$(uname -r)
 ksrc="/lib/modules/$kvers/build"
 sudo make -f debian/rules.modules KSRC="$ksrc" KVERS="$kvers" binary-modules
 
-cp /usr/src/*.deb ${WORK_DIR}
+cp /usr/src/*.deb ${WORK_DIR}/*.deb ${OUTPUT_DIR}

--- a/third_party/gtp_ovs/kernel-4.9/gtp-v4.9-backport/Makefile
+++ b/third_party/gtp_ovs/kernel-4.9/gtp-v4.9-backport/Makefile
@@ -16,7 +16,7 @@ obj-m += gtp.o
 
 build:
 	make -C /lib/modules/`uname -r`/build M=$(PWD) modules
-	
+
 modules_install: build
 	make -C /lib/modules/`uname -r`/build M=$(PWD) modules_install
 	mkdir -p ${DEPMOD_CONFIG_DIR}


### PR DESCRIPTION
verify openvswitch patches build as part of normal CI and create binary openvswitch packages in normal build process

Signed-off-by: Ken Kahrs <kahrs@fb.com>

## Summary
add call to `build-ovs.sh` inside `build-magma.sh`
if an environment variable `OVS_ARCHIVE_URL` is set to a .tar.gz archive of the openvswitch git repo, download and unpack it instead of `git clone ...`

## Test Plan
* verify all expected packages build and end up in `~/magma-packages` when running `fab dev package:vcs=git`
* verify magma can install from local pkgrepo including openvswitch packages

## Additional Information

- [ ] This change is backwards-breaking

