### PR TITLE
[lte][agw][mme] Add sms_orc8r uplink path

### DIFF
--- a/lte/gateway/c/oai/lib/sms_orc8r_client/SMSOrc8rClient.cpp
+++ b/lte/gateway/c/oai/lib/sms_orc8r_client/SMSOrc8rClient.cpp
@@ -39,7 +39,7 @@ SMSOrc8rClient& SMSOrc8rClient::get_instance() {
 SMSOrc8rClient::SMSOrc8rClient() {
   // Create channel
   auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-      "sms_orc8r", ServiceRegistrySingleton::CLOUD);
+      "sms_orc8r_service", ServiceRegistrySingleton::LOCAL);
   // Create stub for LocalSessionManager gRPC service
   stub_ = SMSOrc8rService::NewStub(channel);
   std::thread resp_loop_thread([&]() { rpc_response_loop(); });

--- a/lte/gateway/c/oai/lib/sms_orc8r_client/sms_orc8r_client_api.cpp
+++ b/lte/gateway/c/oai/lib/sms_orc8r_client/sms_orc8r_client_api.cpp
@@ -23,13 +23,18 @@
 #include "SMSOrc8rClient.h"
 #include "orc8r/protos/common.pb.h"
 
-void empty_callback(grpc::Status status, magma::orc8r::Void void_response) {
+extern "C" {
+#include "log.h"
+}
+
+void void_callback(grpc::Status status, magma::orc8r::Void void_response) {
   return;
 }
 
-void send_uplink_unitdata(const itti_sgsap_uplink_unitdata_t* msg) {
-  std::cout << "[DEBUG] Sending UPLINK_UNITDATA with IMSI: "
-            << std::string(msg->imsi) << std::endl;
-  magma::SMSOrc8rClient::send_uplink_unitdata(msg, empty_callback);
+void send_smo_uplink_unitdata(const itti_sgsap_uplink_unitdata_t* msg) {
+  OAILOG_DEBUG(
+    LOG_SMS_ORC8R,
+    "Sending UPLINK_UNITDATA\n");
+  magma::SMSOrc8rClient::send_uplink_unitdata(msg, void_callback);
   return;
 }

--- a/lte/gateway/c/oai/lib/sms_orc8r_client/sms_orc8r_client_api.h
+++ b/lte/gateway/c/oai/lib/sms_orc8r_client/sms_orc8r_client_api.h
@@ -27,7 +27,7 @@ extern "C" {
 #include "intertask_interface.h"
 #include "sgs_messages_types.h"
 
-void send_uplink_unitdata(const itti_sgsap_uplink_unitdata_t* msg);
+void send_smo_uplink_unitdata(const itti_sgsap_uplink_unitdata_t* msg);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.c
@@ -379,7 +379,8 @@ int mme_app_send_s11_create_session_req(
  **                                                                        **
  ** name:    nas_itti_sgsap_uplink_unitdata                                **
  **                                                                        **
- ** description: Send itti mesage to SGS task to send NAS message          **
+ ** description: Send itti mesage to SGS or SMS_ORC8R task to send NAS     **
+ **              message.                                                  **
  **                                                                        **
  ** inputs:  imsi : IMSI of UE                                             **
  **          imsi_len : Length of IMSI                                     **
@@ -393,7 +394,7 @@ int mme_app_send_s11_create_session_req(
 void nas_itti_sgsap_uplink_unitdata(
     const char* const imsi, uint8_t imsi_len, bstring nas_msg,
     imeisv_t* imeisv_pP, MobileStationClassmark2* mobilestationclassmark2_pP,
-    tai_t* tai_pP, ecgi_t* ecgi_pP) {
+    tai_t* tai_pP, ecgi_t* ecgi_pP, bool sms_orc8r_enabled) {
   OAILOG_FUNC_IN(LOG_MME_APP);
   MessageDef* message_p = NULL;
   int uetimezone        = 0;
@@ -465,14 +466,28 @@ void nas_itti_sgsap_uplink_unitdata(
 
   IMSI_STRING_TO_IMSI64(imsi, &message_p->ittiMsgHeader.imsi);
   imsi64_t imsi64 = message_p->ittiMsgHeader.imsi;
-  if (send_msg_to_task(&mme_app_task_zmq_ctx, TASK_SGS, message_p) !=
-      RETURNok) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, imsi64,
-        "Failed to send SGSAP Uplink Unitdata to SGS task\n");
+
+  // Check if we're in SMS_ORC8R and send to the appropriate task if so
+  if (sms_orc8r_enabled) {
+    if (send_msg_to_task(&mme_app_task_zmq_ctx, TASK_SMS_ORC8R, message_p) !=
+        RETURNok) {
+      OAILOG_ERROR_UE(
+          LOG_MME_APP, imsi64,
+          "Failed to send SGSAP Uplink Unitdata to SMS_ORC8R task\n");
+    } else {
+      OAILOG_DEBUG_UE(
+          LOG_MME_APP, imsi64, "Sent SGSAP Uplink Unitdata to SMS_ORC8R task\n");
+    }
   } else {
-    OAILOG_DEBUG_UE(
-        LOG_MME_APP, imsi64, "Sent SGSAP Uplink Unitdata to SGS task\n");
+    if (send_msg_to_task(&mme_app_task_zmq_ctx, TASK_SGS, message_p) !=
+        RETURNok) {
+      OAILOG_ERROR_UE(
+          LOG_MME_APP, imsi64,
+          "Failed to send SGSAP Uplink Unitdata to SGS task\n");
+    } else {
+      OAILOG_DEBUG_UE(
+          LOG_MME_APP, imsi64, "Sent SGSAP Uplink Unitdata to SGS task\n");
+    }
   }
 
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.h
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_itti_messaging.h
@@ -121,7 +121,8 @@ static inline void mme_app_itti_ue_context_mod_for_csfb(
 
 void nas_itti_sgsap_uplink_unitdata(
     const char* const imsi, uint8_t imsi_len, bstring nas_msg, imeisv_t* imeisv,
-    MobileStationClassmark2* mobilestationclassmark2, tai_t* tai, ecgi_t* ecgi);
+    MobileStationClassmark2* mobilestationclassmark2, tai_t* tai, ecgi_t* ecgi,
+    bool sms_orc8r_enabled);
 
 void mme_app_itti_sgsap_tmsi_reallocation_comp(
     const char* imsi, const unsigned int imsi_len);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c
@@ -437,9 +437,9 @@ static void* mme_app_thread(__attribute__((unused)) void* args) {
   itti_mark_task_ready(TASK_MME_APP);
   init_task_context(
       TASK_MME_APP,
-      (task_id_t[]){TASK_SPGW_APP, TASK_SGS, TASK_S11, TASK_S6A, TASK_S1AP,
+      (task_id_t[]){TASK_SPGW_APP, TASK_SGS, TASK_SMS_ORC8R, TASK_S11, TASK_S6A, TASK_S1AP,
                     TASK_SERVICE303},
-      6, handle_message, &mme_app_task_zmq_ctx);
+      7, handle_message, &mme_app_task_zmq_ctx);
 
   // Service started, but not healthy yet
   send_app_health_to_service303(&mme_app_task_zmq_ctx, TASK_MME_APP, false);

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
@@ -316,6 +316,11 @@ int mme_api_get_esm_config(mme_api_esm_config_t* config) {
           (const char*) mme_config.non_eps_service_control->data, "CSFB_SMS") ==
       0) {
     config->features = config->features | MME_API_CSFB_SMS_SUPPORTED;
+  } else if (
+      strcmp(
+          (const char*) mme_config.non_eps_service_control->data, "SMS_ORC8R") ==
+      0) {
+    config->features = config->features | MME_API_SMS_ORC8R_SUPPORTED;
   }
 
   OAILOG_FUNC_RETURN(LOG_NAS, RETURNok);

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.h
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.h
@@ -64,7 +64,8 @@ typedef enum mme_api_feature_s {
   MME_API_SINGLE_ADDR_BEARERS  = (1 << 3),
   MME_API_SMS_SUPPORTED        = (1 << 4),
   MME_API_CSFB_SMS_SUPPORTED   = (1 << 5),
-  MME_API_VOLTE_SUPPORTED      = (1 << 6)
+  MME_API_VOLTE_SUPPORTED      = (1 << 6),
+  MME_API_SMS_ORC8R_SUPPORTED  = (1 << 7)
 } mme_api_feature_t;
 
 /* Network IP version capability */

--- a/lte/gateway/c/oai/tasks/nas/emm/NasTransportHdl.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/NasTransportHdl.c
@@ -113,12 +113,16 @@ int emm_proc_uplink_nas_transport(mme_ue_s1ap_id_t ue_id, bstring nas_msg_pP) {
   if (emm_ctxt_p != NULL) {
     ue_mm_context_t* ue_mm_context_p =
         PARENT_STRUCT(emm_ctxt_p, struct ue_mm_context_s, emm_context);
-    /* check if the non EPS service control is enable and combined attach*/
-    if (((_esm_data.conf.features & MME_API_SMS_SUPPORTED) ||
-         (_esm_data.conf.features & MME_API_CSFB_SMS_SUPPORTED)) &&
-        (emm_ctxt_p->attach_type == EMM_ATTACH_TYPE_COMBINED_EPS_IMSI)) {
-      // check if vlr reliable flag is true for sgs association
-      if (mme_ue_context_get_ue_sgs_vlr_reliable(ue_id) == true) {
+    /* check if the non EPS service control is enable and combined attach. If
+     * in SMS_ORC8R, we still want to send the uplink message, but we should
+     * disable vlr checks since SGs is not present.*/
+    if ( ((_esm_data.conf.features & MME_API_SMS_SUPPORTED) ||
+          (_esm_data.conf.features & MME_API_CSFB_SMS_SUPPORTED) ||
+	  (_esm_data.conf.features & MME_API_SMS_ORC8R_SUPPORTED)) &&
+         (emm_ctxt_p->attach_type == EMM_ATTACH_TYPE_COMBINED_EPS_IMSI) ) {
+      // check if vlr reliable flag is true for sgs association.
+      if ( mme_ue_context_get_ue_sgs_vlr_reliable(ue_id) ||
+	   (_esm_data.conf.features & MME_API_SMS_ORC8R_SUPPORTED) ) {
         if (IS_EMM_CTXT_PRESENT_IMEISV(emm_ctxt_p)) {
           p_imeisv = &emm_ctxt_p->_imeisv;
         }
@@ -132,7 +136,8 @@ int emm_proc_uplink_nas_transport(mme_ue_s1ap_id_t ue_id, bstring nas_msg_pP) {
 
         nas_itti_sgsap_uplink_unitdata(
             imsi_str, strlen(imsi_str), nas_msg_pP, p_imeisv, p_mob_st_clsMark2,
-            &emm_ctxt_p->originating_tai, &ue_mm_context_p->e_utran_cgi);
+            &emm_ctxt_p->originating_tai, &ue_mm_context_p->e_utran_cgi,
+	    _esm_data.conf.features & MME_API_SMS_ORC8R_SUPPORTED);
       } else {
         if (emm_ctxt_p->is_imsi_only_detach == true) {
           OAILOG_DEBUG(

--- a/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_task.c
+++ b/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_task.c
@@ -52,7 +52,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
        * * * *      Mobile terminating SMS - Uplink Nas Transport message
        */
       OAILOG_DEBUG(LOG_SMS_ORC8R, "Received SGSAP_UPLINK_UNITDATA message \n");
-      send_uplink_unitdata(&received_message_p->ittiMsg.sgsap_uplink_unitdata);
+      send_smo_uplink_unitdata(&received_message_p->ittiMsg.sgsap_uplink_unitdata);
     } break;
 
     case TERMINATE_MESSAGE: {

--- a/lte/gateway/configs/service_registry.yml
+++ b/lte/gateway/configs/service_registry.yml
@@ -56,7 +56,7 @@ services:
   sgs_service:
     ip_address: 127.0.0.1
     port: 50073
-  sms_orc8r_service:
+  sms_orc8r_gw_mme_service:
     ip_address: 127.0.0.1
     port: 50073
   s6a_service:

--- a/lte/gateway/python/scripts/sms_cli.py
+++ b/lte/gateway/python/scripts/sms_cli.py
@@ -64,7 +64,7 @@ def main():
         exit(1)
 
     # Execute the subcommand function
-    args.func(args, SMSOrc8rGatewayServiceStub, 'sms_orc8r_service')
+    args.func(args, SMSOrc8rGatewayServiceStub, 'sms_orc8r_gw_mme_service')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This adds support for UplinkUnitdata messages (used for UE->network SMS traffic, including delivery reports) to the MME for SMS_ORC8R mode, including support for for routing uplink unitdata through a local relay service rather than directly to the cloud to match the current feature design. We also ensure we do not check for VLR registration status for uplink SMS traffic while in SMS_ORC8R mode. Finally, this change incidentally fixes an issue observed during earlier testing where UEs would sometimes detach and re-attach after receipt of an SMS-DELIVER. 

## Test Plan

Manual testing with a UE, `make integ_test`
