### PR TITLE
[xwfm][ci] Update xwfm tests to report status to slack channels

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,10 @@ commands:
 
   magma_slack_notify:
     description: Notify Slack on magma job failure
+    parameters:
+      channel:
+        type: string
+        default: "#magma_ci"
     steps:
       - run:
           command: |
@@ -304,6 +308,7 @@ commands:
             email=$(git show -s --format='%ae')
             rel_time=$(git show -s --format='%cr')
             abs_time=$(git show -s --format='%cd')
+            slack_channel=<< parameters.channel >>
             gh_text="<https://github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/commit/${CIRCLE_SHA1}|${CIRCLE_SHA1:0:8}> by ${author} <${email}> ${rel_time} (${abs_time})"
 
             pretext="Job \`${CIRCLE_JOB}\` #${CIRCLE_BUILD_NUM} on branch \`${CIRCLE_BRANCH}\` of ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} failed. Check the <${CIRCLE_BUILD_URL}|build logs> for details."
@@ -311,6 +316,7 @@ commands:
 
             slack_data=$(cat \<<EOF
             {
+              "channel": "${slack_channel}",
               "text": "*CircleCI Job Failure*",
               "attachments": [
                 {
@@ -881,6 +887,15 @@ jobs:
   ### XWF
 
   xwfm-test:
+    parameters:
+      notify_magma_ci:
+        description: "should run magma_slack_notify for #magma_ci channel"
+        type: boolean
+        default: true
+      notify_xwfm_ci:
+        description: "should run magma_slack_notify for #xwfm_ci channel"
+        type: boolean
+        default: true
     machine:
       image: ubuntu-1604:201903-01
       docker_layer_caching: true
@@ -902,6 +917,14 @@ jobs:
             docker login -u ${XWF_ARTIFACTORY_USER} -p ${XWF_ARTIFACTORY_API_KEY} ${XWF_ARTIFACTORY_LINK}
             cd ${MAGMA_ROOT}/xwf/docker/
             docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py --type=analytic
+      - when:
+          condition: <<parameters.notify_magma_ci>>
+          steps: magma_slack_notify
+      - when:
+          condition: <<parameters.notify_xwfm_ci>>
+          steps:
+            - magma_slack_notify:
+                channel: "#xwfm_ci"
 
   xwfm-deploy:
     parameters:
@@ -1005,7 +1028,8 @@ workflows:
           cron: "0 * * * *"
           <<: *only_master
     jobs:
-      - xwfm-test
+      - xwfm-test:
+          notify_magma_ci: false
       - xwfm-deploy:
           requires:
             - xwfm-test


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR updates the circleCI config to report xwfm-test failures to specified slack channels.
This also ensures that we don't report the hourly test results to the magma_ci channel as this 
can be noisy when the test is broken.

## Test Plan

`circleci config validate`

Deploy to upstream branch and ensure that test failure are properly reported:

https://app.circleci.com/pipelines/github/magma/magma/4394/workflows/2c27a59b-fb9d-4254-9abb-64fe3b62e603/jobs/45510
