### PR TITLE
[ci][xwfm_test] Try to pull latest images and ignore caches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -919,6 +919,7 @@ jobs:
             env
             docker login -u ${XWF_ARTIFACTORY_USER} -p ${XWF_ARTIFACTORY_API_KEY} ${XWF_ARTIFACTORY_LINK}
             cd ${MAGMA_ROOT}/xwf/docker/
+            docker-compose pull || true
             docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py --type=analytic
 
   xwfm-deploy:


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[ci][xwfm_test] Try to pull latest images and ignore caches

## Summary

sometimes we have noticed that docker compose works on non latest images, we want to try to re-pull images but not fail test on network issues.

## Test Plan

ssh-ed to failing circleci hourly job and executed:
```
circleci@default-ef0e0a9e-99de-4fa0-b8ac-9f95329e76c3:~$ cd project/xwf/docker
circleci@default-ef0e0a9e-99de-4fa0-b8ac-9f95329e76c3:~/project/xwf/docker$ docker-compose pull || true
WARNING: The ENV variable is not set. Defaulting to a blank string.
WARNING: The MAGMA_BASE variable is not set. Defaulting to a blank string.
Pulling logrouter       ... done
Pulling ofredirector    ... done
Pulling ofproxy         ... done
Pulling tls-termination ... done
Pulling radiusserver    ... done
Pulling dynamo_db       ... done
Pulling ofproxy-mt      ... done
Pulling ofpradius       ... done
Pulling nlb             ... done
Pulling xwf_client      ... done
Pulling xwfm            ... done
Pulling pipelined       ... done
Pulling tests           ... done
Pulling httpserver      ... done
```
## Additional Information

- [ ] This change is backwards-breaking
