### PR TITLE
[NMS] Add e2e test to verify add/edit of feg_lte network

### DIFF
--- a/nms/app/package.json
+++ b/nms/app/package.json
@@ -42,7 +42,7 @@
     "eslint-plugin-react-hooks": "^4.1.2",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
     "faker": "^5.1.0",
-    "flow-bin": "0.131.0",
+    "flow-bin": "0.132.0",
     "jest": "^26.4.2",
     "jest-cli": "^26.4.2",
     "jest-dom": "^3.1.3",
@@ -58,7 +58,7 @@
     "eslint": "./node_modules/.bin/eslint --ignore-path .eslintignore",
     "jest": "echo 'Dont run jest directly, use \"yarn run test\"' && exit 1",
     "test": "NODE_ENV=test jest --testPathIgnorePatterns=e2e",
-    "test:e2e": "NODE_ENV=test jest e2e",
+    "test:e2e": "NODE_ENV=test jest --runInBand e2e",
     "test:ci": "NODE_ENV=test jest -w 1 --testPathIgnorePatterns=e2e",
     "flow": "flow",
     "flow-typed-install": "flow-typed --flowVersion $(flow version --json | jq -r .semver) install --"

--- a/nms/app/packages/magmalte/Dockerfile
+++ b/nms/app/packages/magmalte/Dockerfile
@@ -10,6 +10,7 @@ COPY packages/magmalte/package.json packages/magmalte/
 COPY packages/fbcnms-magma-api/package.json packages/fbcnms-magma-api/
 
 # Install node dependencies
+ENV PUPPETEER_SKIP_DOWNLOAD "true"
 RUN yarn install --mutex network --frozen-lockfile && yarn cache clean
 
 # Build our static files

--- a/nms/app/packages/magmalte/app/e2e/LoginUtils.js
+++ b/nms/app/packages/magmalte/app/e2e/LoginUtils.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+import puppeteer from 'puppeteer';
+
+const DASHBOARD_SELECTOR = `//span[text()='Dashboard']`;
+const LOGINFORM_SELECTOR = `//span[text()='Magma']`;
+export const ARTIFACTS_DIR = `/tmp/nms_artifacts/`;
+
+const user = {
+  email: 'admin@magma.test',
+  passwd: 'password1234',
+};
+export async function SimulateNMSLogin(page: typeof puppeteer.Page) {
+  await page.goto('https://magma-test.localhost/');
+  await page.waitForXPath(LOGINFORM_SELECTOR);
+  await page.click('input[name=email]');
+  await page.type('input[name=email]', user.email);
+
+  await page.click('input[name=password]');
+  await page.type('input[name=password]', user.passwd);
+
+  await page.click('button');
+  await page.waitForXPath(DASHBOARD_SELECTOR, {
+    timeout: 15000,
+  });
+}

--- a/nms/app/packages/magmalte/app/e2e/NetworkUtils.js
+++ b/nms/app/packages/magmalte/app/e2e/NetworkUtils.js
@@ -1,0 +1,98 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+import puppeteer from 'puppeteer';
+
+const ADD_NETWORK_SELECTOR = `//span[text()='Add Network']`;
+const ADD_NETWORK_DIALOG = `//h2[text()='Add Network']`;
+const ADD_NETWORK_SAVE = `//span[text()='Save']`;
+
+type AddParams = {
+  name: string,
+  desc: string,
+  federation?: string,
+};
+
+export async function addFegNetwork(
+  page: typeof puppeteer.Page,
+  params: AddParams,
+) {
+  // assuming that we are in administrative tools page
+  await page.waitForXPath(ADD_NETWORK_SELECTOR);
+  const buttonSelector = await page.$x(ADD_NETWORK_SELECTOR);
+  buttonSelector[0].click();
+
+  await page.waitForXPath(ADD_NETWORK_DIALOG);
+  await page.waitForSelector('input[name=name]');
+  await page.click('input[name=name]');
+  await page.type('input[name=name]', params.name);
+
+  await page.click('input[name=description]');
+  await page.type('input[name=description]', params.desc);
+
+  // select network type
+  await page.click('#types');
+  const [fegSelector] = await page.$x(`//span[text()='feg']`);
+  fegSelector.click();
+  await page.waitForFunction(
+    'document.getElementById("types").value === "feg"',
+  );
+
+  //  TODO  need to figure out why we need to add this delay
+  await page.waitFor(500);
+  const [saveButton] = await page.$x(ADD_NETWORK_SAVE);
+  await saveButton.click();
+  await page.waitForXPath(`//td[text()='${params.name}']`);
+}
+
+export async function addFegLteNetwork(
+  page: typeof puppeteer.Page,
+  params: AddParams,
+) {
+  // assuming that we are in administrative tools page
+  await page.waitForXPath(ADD_NETWORK_SELECTOR);
+  const buttonSelector = await page.$x(ADD_NETWORK_SELECTOR);
+  buttonSelector[0].click();
+
+  await page.waitForXPath(ADD_NETWORK_DIALOG);
+
+  await page.waitForSelector('input[name=name]');
+  await page.click('input[name=name]');
+  await page.type('input[name=name]', params.name);
+
+  await page.click('input[name=description]');
+  await page.type('input[name=description]', params.desc);
+
+  // select network type
+  await page.click('#types');
+  const [fegSelector] = await page.$x(`//span[text()='feg_lte']`);
+  fegSelector.click();
+  await page.waitForFunction(
+    'document.getElementById("types").value === "feg_lte"',
+  );
+
+  if (params.federation) {
+    await page.waitForSelector('input[name=fegNetworkID]');
+    await page.click('input[name=fegNetworkID]', {delay: 500});
+    await page.type('input[name=fegNetworkID]', params.federation);
+  }
+
+  // need to figure out why we need to add this delay
+  await page.waitFor(500);
+  const [saveButton] = await page.$x(ADD_NETWORK_SAVE);
+  await saveButton.click();
+
+  await page.waitForXPath(`//td[text()='${params.name}']`);
+}

--- a/nms/app/packages/magmalte/app/e2e/__tests__/App-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/App-test.js
@@ -14,38 +14,19 @@
  * @format
  */
 
-const puppeteer = require('puppeteer');
-
-const user = {
-  email: 'admin@magma.test',
-  passwd: 'password1234',
-};
-
-const DASHBOARD_SELECTOR = `//span[text()='Dashboard']`;
-const LOGINFORM_SELECTOR = `//span[text()='Magma']`;
-const ARTIFACTS_DIR = `/tmp/nms_artifacts/`;
+import puppeteer from 'puppeteer';
+import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
 describe('NMS dashboard', () => {
   test('NMS loads correctly', async () => {
     const browser = await puppeteer.launch({
       args: ['--ignore-certificate-errors'],
-      headless: false,
+      headless: true,
       defaultViewport: null,
     });
     const page = await browser.newPage();
     try {
-      await page.goto('https://magma-test.localhost/');
-      await page.waitForXPath(LOGINFORM_SELECTOR);
-      await page.click('input[name=email]');
-      await page.type('input[name=email]', user.email);
-
-      await page.click('input[name=password]');
-      await page.type('input[name=password]', user.passwd);
-
-      await page.click('button');
-      await page.waitForXPath(DASHBOARD_SELECTOR, {
-        timeout: 15000,
-      });
+      await SimulateNMSLogin(page);
     } catch (err) {
       await page.screenshot({path: ARTIFACTS_DIR + 'failed.png'});
       browser.close();

--- a/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
@@ -1,0 +1,134 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow
+ * @format
+ */
+
+import puppeteer from 'puppeteer';
+import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
+import {addFegLteNetwork, addFegNetwork} from '../NetworkUtils';
+
+const ADMIN_SELECTOR = `//span[text()='Administrative Tools']`;
+const ADMIN_NW_SELECTOR = `//a[starts-with(@href, '/admin/networks')]`;
+const NAV_SELECTOR = `//body/div[1]/div/div/div[last()]`;
+
+let browser;
+beforeEach(async () => {
+  jest.setTimeout(30000);
+  browser = await puppeteer.launch({
+    args: ['--ignore-certificate-errors'],
+    headless: true,
+    defaultViewport: null,
+  });
+  const page = await browser.newPage();
+  await SimulateNMSLogin(page);
+});
+
+afterEach(() => {
+  browser.close();
+});
+
+describe('Admin component', () => {
+  test('verifying addition of feg_lte networks', async () => {
+    const page = await browser.newPage();
+    try {
+      await page.goto('https://magma-test.localhost/');
+      await page.waitForXPath(`//span[text()='Dashboard']`, {
+        timeout: 15000,
+      });
+      await page.waitForXPath(NAV_SELECTOR);
+      const navSelector = await page.$x(NAV_SELECTOR);
+      await navSelector[0].click();
+
+      const adminSelector = await page.$x(ADMIN_SELECTOR);
+      await adminSelector[0].click();
+
+      // wait for 'admin network page'
+      await page.waitForNavigation();
+      await page.waitForXPath(ADMIN_NW_SELECTOR);
+      const adminNwSelector = await page.$x(ADMIN_NW_SELECTOR);
+      await adminNwSelector[0].click();
+
+      const fegNetwork = {
+        name: 'test_feg_network2',
+        desc: 'Test Feg Network Description',
+      };
+      await addFegNetwork(page, fegNetwork);
+
+      const fegLteNetwork = {
+        name: 'test_feg_lte_network2',
+        desc: 'Test Feg LTE Network Description',
+        federation: fegNetwork.name,
+      };
+
+      await addFegLteNetwork(page, fegLteNetwork);
+    } catch (err) {
+      await page.screenshot({path: ARTIFACTS_DIR + 'failed.png'});
+      throw err;
+    }
+    await page.screenshot({
+      path: ARTIFACTS_DIR + 'organization_network_list.png',
+    });
+    await page.close();
+  }, 30000);
+});
+
+describe('NMS', () => {
+  test('verifying feg_lte dashboard', async () => {
+    const page = await browser.newPage();
+    try {
+      // test_feg_lte_network is mocked out
+      await page.goto(
+        'https://magma-test.localhost/nms/test_feg_lte_network/network/network',
+      );
+
+      // check if the description is right
+      await page.waitForXPath(`//span[text()='Network']`);
+      await page.waitForXPath(`//span[text()='test_feg_lte_network']`);
+      await page.waitForXPath(
+        `//span[text()='Test Feg LTE Network Description']`,
+      );
+      await page.waitForXPath(`//span[text()='test_feg_network']`);
+
+      // edit description
+      const editSelector = '[data-testid="infoEditButton"]';
+      await page.waitForSelector(editSelector);
+      await page.click(editSelector);
+
+      const fegPlaceholder = '[placeholder="Enter Federation Network ID"]';
+      await page.waitForSelector(fegPlaceholder);
+      await page.click(fegPlaceholder);
+
+      await page.evaluate(selector => {
+        document.querySelector(selector).value = '';
+      }, fegPlaceholder);
+
+      await page.type(fegPlaceholder, 'test_feg_network2');
+
+      // TODO need to figure out why we need to add this delay
+      await page.waitFor(500);
+      const [saveButton] = await page.$x(`//span[text()='Save']`);
+      await saveButton.click();
+
+      await page.waitForXPath(`//span[text()='Network']`);
+    } catch (err) {
+      await page.screenshot({path: ARTIFACTS_DIR + 'failed.png'});
+      await page.close();
+      throw err;
+    }
+
+    await page.screenshot({
+      path: ARTIFACTS_DIR + 'feg_lte_network_dashboard.png',
+    });
+  }, 30000);
+});

--- a/nms/app/packages/magmalte/config/webpack.config.js
+++ b/nms/app/packages/magmalte/config/webpack.config.js
@@ -153,9 +153,7 @@ module.exports = {
       },
     },
   },
-  devServer: {
-    watchOptions: {
-      ignored: /node_modules/,
-    },
+  watchOptions: {
+    ignored: /node_modules/,
   },
 };

--- a/nms/app/packages/magmalte/docker-compose-e2e.yml
+++ b/nms/app/packages/magmalte/docker-compose-e2e.yml
@@ -35,6 +35,7 @@ services:
     environment:
       API_CERT_FILENAME: /run/secrets/api_cert
       API_PRIVATE_KEY_FILENAME: /run/secrets/api_key
+      PUPPETEER_SKIP_DOWNLOAD: "true"
     secrets:
       - api_cert
       - api_key
@@ -43,7 +44,7 @@ services:
     build:
       context: ../..
       dockerfile: packages/magmalte/Dockerfile
-    command: "/usr/local/bin/wait-for-it.sh -s -t 30 mariadb:3306 -- yarn run start:prod"
+    command: "/usr/local/bin/wait-for-it.sh -s -t 30 mariadb:3306 -- yarn run start:dev"
     volumes:
       - ../../packages/fbcnms-magma-api:/usr/src/packages/fbcnms-magma-api
       - ../../packages/magmalte/app:/usr/src/packages/magmalte/app
@@ -67,9 +68,8 @@ services:
       MYSQL_PASS: password
       MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
       MYSQL_DIALECT: mariadb
-      E2E_TEST: 1
       # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      PUPPETEER_SKIP_DOWNLOAD: "true"
     healthcheck:
       test: curl -If localhost:8081/healthz
     restart: on-failure

--- a/nms/app/packages/magmalte/docker-compose.yml
+++ b/nms/app/packages/magmalte/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       MAPBOX_ACCESS_TOKEN: ${MAPBOX_ACCESS_TOKEN:-}
       MYSQL_DIALECT: mariadb
       # Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
-      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      PUPPETEER_SKIP_DOWNLOAD: "true"
     healthcheck:
       test: curl -If localhost:8081/healthz
     restart: on-failure

--- a/nms/app/packages/magmalte/e2e_test_setup.sh
+++ b/nms/app/packages/magmalte/e2e_test_setup.sh
@@ -32,7 +32,7 @@ do
 done
 
 docker-compose exec magmalte yarn setAdminPassword magma-test admin@magma.test password1234
-docker-compose exec magmalte yarn createOrganization magma-test nms test
+docker-compose exec magmalte yarn createOrganization magma-test nms test,test_feg_lte_network
 
 # run the end to end test
 cd ../../

--- a/nms/app/packages/magmalte/mock/db.json
+++ b/nms/app/packages/magmalte/mock/db.json
@@ -1,5 +1,5 @@
 {
-  "networks": [ "test"],
+  "networks": [ "test", "test_feg_network", "test_feg_lte_network"],
   "lte":{
     "test": {
       "gateways":{
@@ -1636,7 +1636,101 @@
           "tier": "default"
         }
       }
-    }
+    },
+    "test_feg_lte_network": {
+      "type": "feg_lte",
+        "cellular": {
+          "epc": {
+            "default_rule_id": "default_rule_1",
+            "gx_gy_relay_enabled": true,
+            "hss_relay_enabled": true,
+            "lte_auth_amf": "gAA=",
+            "lte_auth_op": "EREREREREREREREREREREQ==",
+            "mcc": "001",
+            "mnc": "01",
+            "mobility": {
+              "ip_allocation_mode": "NAT",
+              "nat": {
+                "ip_blocks": [
+                  "192.168.0.0/16"
+                ]
+              },
+              "reserved_addresses": [
+                "192.168.0.1"
+              ],
+              "static": {
+                "ip_blocks_by_tac": {
+                  "1": [
+                    "192.168.0.0/16"
+                  ],
+                  "2": [
+                    "172.10.0.0/16",
+                    "172.20.0.0/16"
+                  ]
+                }
+              }
+            },
+            "network_services": [
+              "dpi",
+              "policy_enforcement"
+            ],
+            "sub_profiles": {
+              "additionalProp1": {
+                "max_dl_bit_rate": 20000000,
+                "max_ul_bit_rate": 100000000
+              },
+              "additionalProp2": {
+                "max_dl_bit_rate": 20000000,
+                "max_ul_bit_rate": 100000000
+              },
+              "additionalProp3": {
+                "max_dl_bit_rate": 20000000,
+                "max_ul_bit_rate": 100000000
+              }
+            },
+            "tac": 1
+          },
+          "feg_network_id": "test_feg_network",
+          "ran": {
+            "bandwidth_mhz": 20,
+            "tdd_config": {
+              "earfcndl": 44590,
+              "special_subframe_pattern": 7,
+              "subframe_assignment": 2
+            }
+          }
+        },
+        "description": "Foobar network",
+        "dns": {
+          "enable_caching": false,
+          "local_ttl": 0,
+          "records": [
+            {
+              "a_record": [
+                "192.88.99.142"
+              ],
+              "aaaa_record": [
+                "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+              ],
+              "cname_record": [
+                "cname.example.com"
+              ],
+              "domain": "example.com"
+            }
+          ]
+        },
+        "features": {
+          "features": {
+            "featureName1": "featureProp1",
+            "featureName2": "featureProp2"
+          }
+        },
+        "federation": {
+          "feg_network_id": "test_feg_network"
+        },
+        "id": "test_feg_lte_network",
+        "name": "Test Feg LTE Network Description"
+      }
   },
   "subscribers": {
     "IMSI001010002220018": {

--- a/nms/app/packages/magmalte/package.json
+++ b/nms/app/packages/magmalte/package.json
@@ -60,7 +60,7 @@
     "babel-loader": "^8.0.5",
     "css-loader": "^1.0.1",
     "file-loader": "^6.0.0",
-    "flow-bin": "0.131.0",
+    "flow-bin": "0.132.0",
     "identity-obj-proxy": "^3.0.0",
     "json-server": "^0.16.1",
     "nodemon": "^2.0.4",

--- a/nms/app/packages/magmalte/scripts/mockServer.js
+++ b/nms/app/packages/magmalte/scripts/mockServer.js
@@ -30,91 +30,134 @@ server.use(middlewares);
 const buffer = fs.readFileSync('./mock/db.json', 'utf-8');
 const db = JSON.parse(buffer);
 
-// add custom route handlers
+// Add feg and feg_lte handlers
+server.post('/magma/v1/feg', (req, res) => {
+  if (req.method === 'POST') {
+    res.status(200).jsonp('Success');
+  }
+});
+
+server.post('/magma/v1/feg_lte', (req, res) => {
+  if (req.method === 'POST') {
+    res.status(200).jsonp('Success');
+  }
+});
+server.post('/magma/v1/networks/test_feg_network2/tiers', (req, res) => {
+  if (req.method === 'POST') {
+    res.status(200).jsonp('Success');
+  }
+});
+server.post('/magma/v1/networks/test_feg_lte_network2/tiers', (req, res) => {
+  if (req.method === 'POST') {
+    res.status(200).jsonp('Success');
+  }
+});
+
+server.put('/magma/v1/feg_lte/test_feg_lte_network', (req, res) => {
+  if (req.method === 'PUT') {
+    res.status(200).jsonp('Success');
+  }
+});
+
+server.get('/magma/v1/feg_lte/test_feg_lte_network', (req, res) => {
+  if (req.method === 'GET') {
+    res.status(200).jsonp(db['networksFull']['test_feg_lte_network']);
+  }
+});
+
 server.get('/magma/v1/lte/test', (req, res) => {
   if (req.method === 'GET') {
     res.status(200).jsonp(db['networksFull']['test']);
   }
 });
-
-server.get('/magma/v1/networks/test/gateways', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(db['networksFull']['test']['gateways']);
-  }
-});
-
-server.get('/magma/v1/networks/test/type', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(db['networksFull']['test']['type']);
-  }
-});
-
-server.get('/magma/v1/lte/test/gateways', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(db['lte']['gateways']);
-  }
-});
-
-server.get('/magma/v1/networks/test/prometheus/query_range', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp({
-      status: 'success',
-      data: {
-        resultType: 'vector',
-        result: [],
-      },
-    });
-  }
-});
-
-server.get('/magma/v1/networks/test/prometheus/query', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp({
-      status: 'success',
-      data: {
-        resultType: 'vector',
-        result: [],
-      },
-    });
-  }
-});
-
-server.get('/magma/v1/events/test/about/count', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(0);
-  }
-});
-
-server.get('/magma/v1/events/test', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp([]);
-  }
-});
-
-server.get('/magma/v1/lte/test/enodebs', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(db['lte']['enodebs']);
-  }
-});
-server.get(
-  '/magma/v1/lte/test/enodebs/12020000051696P0013/state',
-  (req, res) => {
+const networks = ['test', 'test_feg_lte_network'];
+networks.forEach(network => {
+  server.get(`/magma/v1/networks/${network}/gateways`, (req, res) => {
     if (req.method === 'GET') {
-      res.status(200).jsonp(db['lte']['enodebState']['12020000051696P0013']);
+      res.status(200).jsonp(db['networksFull'][network]['gateways']);
     }
-  },
-);
-server.get('/magma/v1/networks/test/policies/rules', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(db['policies']);
-  }
+  });
+
+  server.get(`/magma/v1/networks/${network}/type`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(db['networksFull'][network]['type']);
+    }
+  });
+
+  server.get(`/magma/v1/lte/${network}/gateways`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(db['lte']['gateways']);
+    }
+  });
+
+  server.get(`/magma/v1/feg_lte/${network}/gateways`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(db['feg_lte']['gateways']);
+    }
+  });
+
+  server.get(
+    `/magma/v1/networks/${network}/prometheus/query_range`,
+    (req, res) => {
+      if (req.method === 'GET') {
+        res.status(200).jsonp({
+          status: 'success',
+          data: {
+            resultType: 'vector',
+            result: [],
+          },
+        });
+      }
+    },
+  );
+
+  server.get(`/magma/v1/networks/${network}/prometheus/query`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp({
+        status: 'success',
+        data: {
+          resultType: 'vector',
+          result: [],
+        },
+      });
+    }
+  });
+  server.get(`/magma/v1/networks/${network}/policies/rules`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(db['policies']);
+    }
+  });
+
+  server.get(`/magma/v1/networks/${network}/apns`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(db['apns']);
+    }
+  });
+  server.get(`/magma/v1/events/${network}/about/count`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(0);
+    }
+  });
+  server.get(`/magma/v1/events/${network}`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp([]);
+    }
+  });
+  server.get(`/magma/v1/lte/${network}/enodebs`, (req, res) => {
+    if (req.method === 'GET') {
+      res.status(200).jsonp(db['lte']['enodebs']);
+    }
+  });
+  server.get(
+    `/magma/v1/lte/{network}/enodebs/12020000051696P0013/state`,
+    (req, res) => {
+      if (req.method === 'GET') {
+        res.status(200).jsonp(db['lte']['enodebState']['12020000051696P0013']);
+      }
+    },
+  );
 });
 
-server.get('/magma/v1/networks/test/apns', (req, res) => {
-  if (req.method === 'GET') {
-    res.status(200).jsonp(db['apns']);
-  }
-});
 server.use('/magma/v1', router);
 
 https

--- a/nms/app/packages/magmalte/server/app.js
+++ b/nms/app/packages/magmalte/server/app.js
@@ -55,10 +55,6 @@ const {
 import type {ExpressResponse} from 'express';
 import type {FBCNMSRequest} from '@fbcnms/auth/access';
 
-// disable secure cookies when e2e test is running
-const devMode =
-  process.env.NODE_ENV !== 'production' || process.env.E2E_TEST === '1';
-
 // Create Sequelize Store
 const SessionStore = connectSession(session.Store);
 const sequelizeSessionStore = new SessionStore({db: sequelize});
@@ -70,7 +66,7 @@ app.use(organizationMiddleware());
 app.use(appMiddleware());
 app.use(
   sessionMiddleware({
-    devMode,
+    devMode: DEV_MODE,
     sessionStore: sequelizeSessionStore,
     sessionToken:
       process.env.SESSION_TOKEN || 'fhcfvugnlkkgntihvlekctunhbbdbjiu',
@@ -93,6 +89,7 @@ app.set('views', path.join(__dirname, '..', 'views'));
 app.set('view engine', 'pug');
 
 // Routes
+// TO DO - fix this in webpack-dev-middleware code in fbc-js-core
 app.use(
   webpackSmartMiddleware({
     devMode: DEV_MODE,

--- a/nms/app/yarn.lock
+++ b/nms/app/yarn.lock
@@ -6409,10 +6409,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-flow-bin@0.131.0:
-  version "0.131.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.131.0.tgz#d4228b6070afdf3b2a76acdee77a7f3f8e8f5133"
-  integrity sha512-fZmoIBcDrtLhy/NNMxwJysSYzMr1ksRcAOMi3AHSoYXfcuQqTvhGJx+wqjlIOqIwz8RRYm8J4V4JrSJbIKP+Xg==
+flow-bin@0.132.0:
+  version "0.132.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.132.0.tgz#8bf80a79630db24bd1422dc2cc4b5e97f97ccb98"
+  integrity sha512-S1g/vnAyNaLUdajmuUHCMl30qqye12gS6mr4LVyswf1k+JDF4efs6SfKmptuvnpitF3LGCVf0TIffChP8ljwnw==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
- Added e2e test to verify add and edit of feg_lte networks.
- Added other utilities including NMS login and network add.
- Fixed few earlier hacks(including E2E_TEST mode) added to docker file to prevent chokidar watch errors. 
- Fixed PUPPETEER_DOWNLOAD environment variable issue.

[skipJenkins]

## Test Plan
Following artifacts are produced after running the e2e tests.
![organization_network_list](https://user-images.githubusercontent.com/8224854/94877522-97a31500-040f-11eb-8743-3882993d26bf.png)
![feg_lte_network_dashboard](https://user-images.githubusercontent.com/8224854/94877539-9eca2300-040f-11eb-8763-3a37cbe100da.png)

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
