### PR TITLE
[feg]Add IPv6 Policy Rule Parsing Support

### DIFF
--- a/feg/gateway/policydb/flow_parser.go
+++ b/feg/gateway/policydb/flow_parser.go
@@ -28,8 +28,9 @@ const (
 )
 
 type address struct {
-	ip   string
-	port uint32
+	ip      string
+	version protos.IPAddress_IPVersion
+	port    uint32
 }
 
 // GetFlowDescriptionFromFlowString returns a proto.FlowDescription from a IPFilterRule string
@@ -84,17 +85,20 @@ func getFlowDescriptionFromSplit(matches []string) (*protos.FlowDescription, err
 		Match: &protos.FlowMatch{
 			Direction: direction,
 			IpProto:   proto,
-			IpSrc: &protos.IPAddress{
-				Version: protos.IPAddress_IPV4,
-				Address: []byte(src.ip),
-			},
-			IpDst: &protos.IPAddress{
-				Version: protos.IPAddress_IPV4,
-				Address: []byte(dst.ip),
-			},
 		},
 	}
-
+	if src.ip != "" {
+		rule.Match.IpSrc = &protos.IPAddress{
+			Version: src.version,
+			Address: []byte(src.ip),
+		}
+	}
+	if dst.ip != "" {
+		rule.Match.IpDst = &protos.IPAddress{
+			Version: dst.version,
+			Address: []byte(dst.ip),
+		}
+	}
 	if proto == protos.FlowMatch_IPPROTO_TCP {
 		rule.Match.TcpSrc = src.port
 		rule.Match.TcpDst = dst.port
@@ -150,12 +154,18 @@ func parseAddress(addr string) (*address, error) {
 		return nil, fmt.Errorf("Invalid format for address %s", addr)
 	}
 	ipAddr := matches[0]
+	version := protos.IPAddress_IPV4
 	if ipAddr == "any" {
-		return &address{ip: "", port: 0}, nil
+		return &address{ip: "", version: version, port: 0}, nil
+	}
+
+	// Easy check if its an ipv6 addr
+	if strings.Count(ipAddr, ":") >= 2 {
+		version = protos.IPAddress_IPV6
 	}
 
 	if len(matches) < 2 {
-		return &address{ip: ipAddr, port: 0}, nil
+		return &address{ip: ipAddr, version: version, port: 0}, nil
 	}
 
 	// Don't support port ranges for now
@@ -163,5 +173,5 @@ func parseAddress(addr string) (*address, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &address{ip: ipAddr, port: uint32(portInt)}, nil
+	return &address{ip: ipAddr, version: version, port: uint32(portInt)}, nil
 }

--- a/feg/gateway/policydb/flow_parser_test.go
+++ b/feg/gateway/policydb/flow_parser_test.go
@@ -60,7 +60,7 @@ func TestFlowAddresses(t *testing.T) {
 	assert.NoError(t, err)
 	flow1 := flow1Desc.Match
 	assert.Equal(t, flow1.IpSrc.Address, []byte("1.1.1.0/28"))
-	assert.Equal(t, flow1.IpDst.Address, []byte(""))
+	assert.Equal(t, flow1.IpDst, (*protos.IPAddress)(nil))
 
 	flow2Desc, err := policydb.GetFlowDescriptionFromFlowString("permit in 17 from 1.1.1.0/28 to 1.1.2.0/32 8000")
 	assert.NoError(t, err)
@@ -75,10 +75,33 @@ func TestFlowAddresses(t *testing.T) {
 	assert.NoError(t, err)
 	flow3 := flow3Desc.Match
 	assert.Equal(t, flow3.IpSrc.Address, []byte("1.1.1.0/28"))
+	assert.Equal(t, flow3.IpSrc.Version, protos.IPAddress_IPV4)
 	assert.Equal(t, flow3.TcpSrc, uint32(8000))
 	assert.Equal(t, flow3.UdpSrc, uint32(0))
 	assert.Equal(t, flow3.IpDst.Address, []byte("1.1.2.0/32"))
+	assert.Equal(t, flow3.IpDst.Version, protos.IPAddress_IPV4)
 	assert.Equal(t, flow3.TcpDst, uint32(0))
+
+	flow4Desc, err := policydb.GetFlowDescriptionFromFlowString("permit in 6 from 2001:db8::/32 8000 to 8522:44e5:595a::c523")
+	assert.NoError(t, err)
+	flow4 := flow4Desc.Match
+	assert.Equal(t, flow4.IpSrc.Address, []byte("2001:db8::/32"))
+	assert.Equal(t, flow4.IpSrc.Version, protos.IPAddress_IPV6)
+	assert.Equal(t, flow4.TcpSrc, uint32(8000))
+	assert.Equal(t, flow4.UdpSrc, uint32(0))
+	assert.Equal(t, flow4.IpDst.Address, []byte("8522:44e5:595a::c523"))
+	assert.Equal(t, flow4.IpDst.Version, protos.IPAddress_IPV6)
+	assert.Equal(t, flow4.TcpDst, uint32(0))
+
+	flow5Desc, err := policydb.GetFlowDescriptionFromFlowString("permit in 6 from b522::10 92 to any")
+	assert.NoError(t, err)
+	flow5 := flow5Desc.Match
+	assert.Equal(t, flow5.IpSrc.Address, []byte("b522::10"))
+	assert.Equal(t, flow5.IpSrc.Version, protos.IPAddress_IPV6)
+	assert.Equal(t, flow5.TcpSrc, uint32(92))
+	assert.Equal(t, flow5.UdpSrc, uint32(0))
+	assert.Equal(t, flow5.IpDst, (*protos.IPAddress)(nil))
+	assert.Equal(t, flow5.TcpDst, uint32(0))
 }
 
 func TestAll(t *testing.T) {
@@ -88,7 +111,7 @@ func TestAll(t *testing.T) {
 	assert.Equal(t, flow1Desc.Action, protos.FlowDescription_DENY)
 	assert.Equal(t, flow1.Direction, protos.FlowMatch_DOWNLINK)
 	assert.Equal(t, flow1.IpProto, protos.FlowMatch_IPPROTO_UDP)
-	assert.Equal(t, flow1.IpSrc.Address, []byte(""))
+	assert.Equal(t, flow1.IpSrc, (*protos.IPAddress)(nil))
 	assert.Equal(t, flow1.TcpSrc, uint32(0))
 	assert.Equal(t, flow1.UdpSrc, uint32(0))
 	assert.Equal(t, flow1.IpDst.Address, []byte("1.1.2.0/32"))


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

 - Add support for parsing ipv6 addresses
 - If address is any default to default value for protobuf
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
