### PR TITLE
[agw][lte] Remove directoryd record before clearing UE context

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -849,6 +849,11 @@ void mme_remove_ue_context(
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
 
+  // First, notify directoryd of removal
+  _directoryd_remove_location(
+      ue_context_p->emm_context._imsi64,
+      ue_context_p->emm_context._imsi.length);
+
   // Release emm and esm context
   delete_mme_ue_state(ue_context_p->emm_context._imsi64);
   _clear_emm_ctxt(&ue_context_p->emm_context);
@@ -933,9 +938,6 @@ void mme_remove_ue_context(
           ue_context_p->enb_ue_s1ap_id, ue_context_p->mme_ue_s1ap_id);
   }
 
-  _directoryd_remove_location(
-      ue_context_p->emm_context._imsi64,
-      ue_context_p->emm_context._imsi.length);
   free_wrapper((void**) &ue_context_p);
   OAILOG_FUNC_OUT(LOG_MME_APP);
 }


### PR DESCRIPTION
##  Summary

Currently, we clear the UE context before notifying directoryd, which means directoryd receives a blank IMSI; as a result, detached users are never removed from directoryd. This reverses the order so directoryd is notified before the context is cleared, removing the directory record on detach as intended. 

## Test Plan

`make integ_test`, manual testing with a UE and checking directoryd status. 