### PR TITLE
[NMS] Fix the error displayed when network information is edited. 

### DIFF
--- a/nms/app/packages/magmalte/app/components/admin/CWFNetworkDialog.js
+++ b/nms/app/packages/magmalte/app/components/admin/CWFNetworkDialog.js
@@ -73,11 +73,14 @@ export default function CWFNetworkDialog(props: Props) {
       },
     })
       .then(props.onSave)
-      .catch(error =>
-        enqueueSnackbar(error.response?.data?.error || error, {
-          variant: 'error',
-        }),
-      );
+      .catch(error => {
+        enqueueSnackbar(
+          error.response?.data?.message || "error: couldn't edit network",
+          {
+            variant: 'error',
+          },
+        );
+      });
   };
 
   return (

--- a/nms/app/packages/magmalte/app/components/admin/EditNetworkDialog.js
+++ b/nms/app/packages/magmalte/app/components/admin/EditNetworkDialog.js
@@ -66,9 +66,12 @@ export default function NetworkDialog(props: Props) {
     })
       .then(props.onSave)
       .catch(error =>
-        enqueueSnackbar(error.response?.data?.error || error, {
-          variant: 'error',
-        }),
+        enqueueSnackbar(
+          error?.response?.data?.message || "error: couldn't edit network",
+          {
+            variant: 'error',
+          },
+        ),
       );
   };
 

--- a/nms/app/packages/magmalte/app/components/admin/FEGNetworkDialog.js
+++ b/nms/app/packages/magmalte/app/components/admin/FEGNetworkDialog.js
@@ -77,9 +77,12 @@ export default function FEGNetworkDialog(props: Props) {
     })
       .then(props.onSave)
       .catch(error =>
-        enqueueSnackbar(error.response?.data?.error || error, {
-          variant: 'error',
-        }),
+        enqueueSnackbar(
+          error.response?.data?.message || "error: couldn't edit network",
+          {
+            variant: 'error',
+          },
+        ),
       );
   };
 


### PR DESCRIPTION
## Summary
eap_sim was recently added as a mandatory param in network config.  This causes the api to raise validation failure since NMS hasn't been upgraded to include this parameter yet. However the NMS fails poorly instead of displaying valid error message. This commit addresses this issue. 
[skipJenkins]

## Test Plan
Tested it manually.
Now we display a proper snackbar message as show below
![Screen Shot 2020-10-01 at 7 54 20 PM](https://user-images.githubusercontent.com/8224854/94884135-73e8ca80-0421-11eb-91a0-fde1e31c49e8.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
