### PR TITLE
[cwf][obsidian] Update cwf handlers to support cwf ha pair status

### DIFF
--- a/cwf/cloud/go/cwf/const.go
+++ b/cwf/cloud/go/cwf/const.go
@@ -20,7 +20,7 @@ const (
 	CwfNetworkType             = "carrier_wifi_network"
 	CwfGatewayType             = "carrier_wifi_gateway"
 	CwfSubscriberDirectoryType = "cwf_subscriber_directory_record"
-	CwfClusterHealthType       = "cwf_cluster_status"
+	CwfHAPairStatusType        = "cwf_ha_pair_status"
 	CwfGatewayHealthType       = "cwf_gateway_health"
 	CwfHAPairType              = "cwf_ha_pair"
 )

--- a/cwf/cloud/go/plugin/plugin.go
+++ b/cwf/cloud/go/plugin/plugin.go
@@ -50,7 +50,7 @@ func (*CwfOrchestratorPlugin) GetSerdes() []serde.Serde {
 		configurator.NewNetworkEntityConfigSerde(cwf.CwfGatewayType, &models.GatewayCwfConfigs{}),
 		configurator.NewNetworkEntityConfigSerde(cwf.CwfHAPairType, &models.CwfHaPairConfigs{}),
 		state.NewStateSerde(cwf.CwfSubscriberDirectoryType, &models.CwfSubscriberDirectoryRecord{}),
-		state.NewStateSerde(cwf.CwfClusterHealthType, &models.CarrierWifiNetworkClusterStatus{}),
+		state.NewStateSerde(cwf.CwfHAPairStatusType, &models.CarrierWifiHaPairStatus{}),
 		state.NewStateSerde(cwf.CwfGatewayHealthType, &models.CarrierWifiGatewayHealthStatus{}),
 	}
 }

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
@@ -69,7 +69,6 @@ func TestCwfNetworks(t *testing.T) {
 	getNetworkFederationConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/federation", obsidian.GET).HandlerFunc
 	getCarrierWifiConfig := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/carrier_wifi", obsidian.GET).HandlerFunc
 	getSubscriberDirectory := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/subscribers/:subscriber_id/directory_record", obsidian.GET).HandlerFunc
-	getClusterStatus := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/cluster_status", obsidian.GET).HandlerFunc
 	getCarrierWifiLiUes := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/:li_ues", obsidian.GET).HandlerFunc
 	updateCarrierWifiLiUes := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/:li_ues", obsidian.PUT).HandlerFunc
 
@@ -267,28 +266,6 @@ func TestCwfNetworks(t *testing.T) {
 		Handler:        getSubscriberDirectory,
 		ExpectedStatus: 200,
 		ExpectedResult: tests.JSONMarshaler(expectedRecord),
-	}
-	tests.RunUnitTest(t, e, tc)
-
-	ctx = test_utils.GetContextWithCertificate(t, "hw1")
-	clusterReq := &models2.CarrierWifiNetworkClusterStatus{
-		ActiveGateway: "g1",
-	}
-	reportClusterStatus(t, ctx, clusterReq)
-	expectedRes := &models2.CarrierWifiNetworkClusterStatus{
-		ActiveGateway: "g1",
-	}
-
-	// Test Get Network HA status
-	tc = tests.Test{
-		Method:         "GET",
-		URL:            "/magma/v1/cwf/n1/cluster_status",
-		Payload:        nil,
-		ParamNames:     []string{"network_id"},
-		ParamValues:    []string{"n1"},
-		Handler:        getClusterStatus,
-		ExpectedStatus: 200,
-		ExpectedResult: expectedRes,
 	}
 	tests.RunUnitTest(t, e, tc)
 
@@ -711,6 +688,7 @@ func TestCwfHaPairs(t *testing.T) {
 	getHaPair := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/ha_pairs/:ha_pair_id", obsidian.GET).HandlerFunc
 	updateHaPair := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/ha_pairs/:ha_pair_id", obsidian.PUT).HandlerFunc
 	deleteHaPair := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/ha_pairs/:ha_pair_id", obsidian.DELETE).HandlerFunc
+	getHaPairStatus := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/cwf/:network_id/ha_pairs/:ha_pair_id/status", obsidian.GET).HandlerFunc
 
 	seedCwfNetworks(t)
 	seedCwfTier(t, "n1")
@@ -787,6 +765,28 @@ func TestCwfHaPairs(t *testing.T) {
 		Handler:        listHaPairs,
 		ExpectedStatus: 200,
 		ExpectedResult: tests.JSONMarshaler(expectedMap),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	ctx := test_utils.GetContextWithCertificate(t, "hw1")
+	haPairReq := &models2.CarrierWifiHaPairStatus{
+		ActiveGateway: "g1",
+	}
+	reportHaPairStatus(t, ctx, "pair1", haPairReq)
+	expectedRes := &models2.CarrierWifiHaPairStatus{
+		ActiveGateway: "g1",
+	}
+
+	// Test Get HA pair status
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/cwf/n1/hair_pairs/pair1/status",
+		Payload:        nil,
+		ParamNames:     []string{"network_id", "ha_pair_id"},
+		ParamValues:    []string{"n1", "pair1"},
+		Handler:        getHaPairStatus,
+		ExpectedStatus: 200,
+		ExpectedResult: expectedRes,
 	}
 	tests.RunUnitTest(t, e, tc)
 
@@ -890,16 +890,16 @@ func reportSubscriberDirectoryRecord(t *testing.T, ctx context.Context, id strin
 	assert.NoError(t, err)
 }
 
-func reportClusterStatus(t *testing.T, ctx context.Context, req *models2.CarrierWifiNetworkClusterStatus) {
+func reportHaPairStatus(t *testing.T, ctx context.Context, pairID string, req *models2.CarrierWifiHaPairStatus) {
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedRecord, err := serde.Serialize(state.SerdeDomain, cwf.CwfClusterHealthType, req)
+	serializedRecord, err := serde.Serialize(state.SerdeDomain, cwf.CwfHAPairStatusType, req)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{
-			Type:     cwf.CwfClusterHealthType,
-			DeviceID: "cluster",
+			Type:     cwf.CwfHAPairStatusType,
+			DeviceID: pairID,
 			Value:    serializedRecord,
 			Version:  1,
 		},

--- a/cwf/cloud/go/services/cwf/obsidian/models/carrier_wifi_ha_pair_status_swaggergen.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/carrier_wifi_ha_pair_status_swaggergen.go
@@ -13,17 +13,17 @@ import (
 	"github.com/go-openapi/validate"
 )
 
-// CarrierWifiNetworkClusterStatus Status of a Carrier Wifi HA cluster
-// swagger:model carrier_wifi_network_cluster_status
-type CarrierWifiNetworkClusterStatus struct {
+// CarrierWifiHaPairStatus Status of a Carrier Wifi HA pair status
+// swagger:model carrier_wifi_ha_pair_status
+type CarrierWifiHaPairStatus struct {
 
 	// active gateway
 	// Required: true
 	ActiveGateway string `json:"active_gateway"`
 }
 
-// Validate validates this carrier wifi network cluster status
-func (m *CarrierWifiNetworkClusterStatus) Validate(formats strfmt.Registry) error {
+// Validate validates this carrier wifi ha pair status
+func (m *CarrierWifiHaPairStatus) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateActiveGateway(formats); err != nil {
@@ -36,7 +36,7 @@ func (m *CarrierWifiNetworkClusterStatus) Validate(formats strfmt.Registry) erro
 	return nil
 }
 
-func (m *CarrierWifiNetworkClusterStatus) validateActiveGateway(formats strfmt.Registry) error {
+func (m *CarrierWifiHaPairStatus) validateActiveGateway(formats strfmt.Registry) error {
 
 	if err := validate.RequiredString("active_gateway", "body", string(m.ActiveGateway)); err != nil {
 		return err
@@ -46,7 +46,7 @@ func (m *CarrierWifiNetworkClusterStatus) validateActiveGateway(formats strfmt.R
 }
 
 // MarshalBinary interface implementation
-func (m *CarrierWifiNetworkClusterStatus) MarshalBinary() ([]byte, error) {
+func (m *CarrierWifiHaPairStatus) MarshalBinary() ([]byte, error) {
 	if m == nil {
 		return nil, nil
 	}
@@ -54,8 +54,8 @@ func (m *CarrierWifiNetworkClusterStatus) MarshalBinary() ([]byte, error) {
 }
 
 // UnmarshalBinary interface implementation
-func (m *CarrierWifiNetworkClusterStatus) UnmarshalBinary(b []byte) error {
-	var res CarrierWifiNetworkClusterStatus
+func (m *CarrierWifiHaPairStatus) UnmarshalBinary(b []byte) error {
+	var res CarrierWifiHaPairStatus
 	if err := swag.ReadJSON(b, &res); err != nil {
 		return err
 	}

--- a/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
+++ b/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
@@ -36,8 +36,8 @@ magma-gen-meta:
       filename: cwf_subscriber_directory_record_swaggergen.go
     - go-struct-name: GatewayHealthConfigs
       filename: gateway_health_configs_swaggergen.go
-    - go-struct-name: CarrierWifiClusterStatus
-      filename: carrier_wifi_network_cluster_status_swaggergen.go
+    - go-struct-name: CarrierWifiHAPairStatus
+      filename: carrier_wifi_ha_pair_status_swaggergen.go
     - go-struct-name: CarrierWifiGatewayHealthStatus
       filename: carrier_wifi_gateway_health_status_swaggergen.go
     - go-struct-name: CwfHaPair
@@ -324,6 +324,22 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /cwf/{network_id}/ha_pairs/{ha_pair_id}/status:
+    get:
+      summary: Retrieve status of a Carrier Wifi HA pair
+      tags:
+        - Carrier Wifi Networks
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/ha_pair_id'
+      responses:
+        '200':
+          description: Status of a HA pair
+          schema:
+            $ref: '#/definitions/carrier_wifi_ha_pair_status'
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
   /cwf/{network_id}/li_ues:
     get:
       summary: Get monitored LI UEs for Carrier Wifi network
@@ -516,21 +532,6 @@ paths:
           description: The directory record of a subscriber
           schema:
             $ref: '#/definitions/cwf_subscriber_directory_record'
-        default:
-          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
-
-  /cwf/{network_id}/cluster_status:
-    get:
-      summary: Retrieve HA cluster status of a Carrier Wifi Network
-      tags:
-        - Carrier Wifi Networks
-      parameters:
-        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
-      responses:
-        '200':
-          description: Cluster status of Carrier Wifi Network
-          schema:
-            $ref: '#/definitions/carrier_wifi_network_cluster_status'
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
@@ -1095,8 +1096,8 @@ definitions:
         format: uint32
         example: 3
 
-  carrier_wifi_network_cluster_status:
-    description: Status of a Carrier Wifi HA cluster
+  carrier_wifi_ha_pair_status:
+    description: Status of a Carrier Wifi HA pair status
     type: object
     required:
       - active_gateway

--- a/cwf/cloud/go/services/cwf/obsidian/models/validate.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/validate.go
@@ -59,7 +59,7 @@ func (m *CwfSubscriberDirectoryRecord) ValidateModel() error {
 	return nil
 }
 
-func (m *CarrierWifiNetworkClusterStatus) ValidateModel() error {
+func (m *CarrierWifiHaPairStatus) ValidateModel() error {
 	if err := m.Validate(strfmt.Default); err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

Previously we only allowed for one HA cluster of CWAGs per network. Now with the concept of HA pairs,
we can support multiple. This PR updates the implementation to associate an HA pair with a status
model.

## Test Plan

Update unit tests
Ensure local API properly reports status