### PR TITLE
[docker][logs] Update logging driver to journald

### DIFF
--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -2,10 +2,9 @@ version: "3.7"
 
 # Standard logging for each service
 x-logging: &logging_anchor
-  driver: "json-file"
+  driver: "journald"
   options:
-    max-size: "10mb"
-    max-file: "10"
+    tag: "{{.Name}}/{{.ID}}"
 
 # Standard volumes mounted
 x-standard-volumes: &volumes_anchor

--- a/feg/gateway/docker/docker-compose.yml
+++ b/feg/gateway/docker/docker-compose.yml
@@ -2,10 +2,9 @@ version: "3.7"
 
 # Standard logging for each service
 x-logging: &logging_anchor
-  driver: "json-file"
+  driver: "journald"
   options:
-    max-size: "10mb"
-    max-file: "10"
+    tag: "{{.Name}}/{{.ID}}"
 
 # Standard volumes mounted
 x-volumes: &volumes_anchor


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR changes the gateway docker log driver to journald.
This change allows us to continue to use `docker logs` as normal 
(same format as well), but also persists the logs beyond container
and host restarts.

Long term we should use fluentd in production. The only issue 
here is that only docker enterprise supports dual-logging. 
This means we'll need different configurations for dev and prod.

## Test Plan

Ran locally to ensure normal logging
`journalctl -f`, `journalctl -b` to check after reboot
