### PR TITLE
[SessionD] Remove GY rules if any exist on termination

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -332,16 +332,6 @@ class LocalEnforcer {
       RulesToProcess& rules_to_deactivate, SessionStateUpdateCriteria& uc);
 
   /**
-   * Populate existing rules from a specific session;
-   * used to delete flow rules for a PDN session,
-   * distinct APNs are assumed to have mutually exclusive
-   * rules.
-   */
-  void populate_rules_from_session_to_remove(
-      const std::string& imsi, const std::unique_ptr<SessionState>& session,
-      RulesToProcess& rules_to_deactivate);
-
-  /**
    * Process protobuf StaticRuleInstalls and DynamicRuleInstalls to fill in
    * rules_to_activate and rules_to_deactivate. Modifies session state.
    * TODO separate out logic that modifies state vs logic that does not.

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1102,6 +1102,18 @@ static FinalActionInfo get_final_action_info(
   return final_action_info;
 }
 
+RulesToProcess SessionState::get_all_final_unit_rules() {
+  RulesToProcess rules;
+  for (auto& credit_pair : credit_map_) {
+    auto& grant = credit_pair.second;
+    if (grant->service_state == SERVICE_RESTRICTED) {
+      rules.static_rules = grant->final_action_info.restrict_rules;
+    }
+  }
+  get_gy_dynamic_rules().get_rules(rules.dynamic_rules);
+  return rules;
+}
+
 bool SessionState::reset_reporting_charging_credit(
     const CreditKey& key, SessionStateUpdateCriteria& update_criteria) {
   auto it = credit_map_.find(key);

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -223,6 +223,8 @@ class SessionState {
       const CreditKey& key, ChargingGrant charging_grant,
       SessionStateUpdateCriteria& uc);
 
+  RulesToProcess get_all_final_unit_rules();
+
   /**
    * get_total_credit_usage returns the tx and rx of the session,
    * accounting for all unique keys (charging and monitoring) used by all


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
If a session is terminated while it is in FUA-Redirect, we do not remove the redirect rule before terminating. Fixing that here. 
When we terminate and remove all rules, check for any gy rules and remove all.
Additional unit test is added for this case.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
