### PR TITLE
[feg][radiusd] Fix radiusd metric labeling

### DIFF
--- a/feg/gateway/services/radiusd/collection/registry_wrapper.go
+++ b/feg/gateway/services/radiusd/collection/registry_wrapper.go
@@ -15,6 +15,7 @@ package collection
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/golang/glog"
 	"github.com/prometheus/client_golang/prometheus"
@@ -41,10 +42,12 @@ func NewMetricAggregateRegistry() MetricAggregateRegistry {
 func (r *MetricAggregateRegistry) Update(metricFamilies map[string]*dto.MetricFamily) {
 	for metricName, metricFamily := range metricFamilies {
 		// We want to mark the metric as coming from the radius server
-		// Some basic metrics would otherwise be duplicated
-		modifiedMetricName := fmt.Sprintf("%s%s", RadiusMetricPrefix, metricName)
-		r.register(modifiedMetricName, metricFamily)
-		r.update(modifiedMetricName, metricFamily)
+		// Some metrics already have this prefix, but others need it added
+		if !strings.HasPrefix(metricName, RadiusMetricPrefix) {
+			metricName = fmt.Sprintf("%s%s", RadiusMetricPrefix, metricName)
+		}
+		r.register(metricName, metricFamily)
+		r.update(metricName, metricFamily)
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR updates the metrics labeled by radiusd to be consistently labeled`radius_<metric_name>`. 

## Test Plan

Ran locally:
`docker-compose exec magmad bash`
`/usr/local/bin/service303_cli.py metrics radiusd`
Ensure properly labeled metrics.
