### PR TITLE
[sessiond] added support for error codes (4010 and 4012)

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -25,6 +25,7 @@ import (
 	"magma/feg/cloud/go/protos"
 	fegProtos "magma/feg/cloud/go/protos"
 	fegprotos "magma/feg/cloud/go/protos"
+	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/services/session_proxy/credit_control/gy"
 	lteprotos "magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
@@ -752,4 +753,72 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 
 	// Wait for service deactivation
 	time.Sleep(3 * time.Second)
+}
+
+// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//   respond with a quota grant of 4M.
+//   Generate traffic and assert the CCR-I is received.
+// - Set an expectation for a CCR-U with >80% of data usage to be sent up to
+// 	 OCS, to which it will response with an ERROR CODE
+// - Generate traffic over 80% and under 100% to make sure sessiond triggers an update but that
+//   we don't go over 100% and cause a termination due to quota exhaustion instead of due to
+//   ERROR CODE
+// - Assert that UE flows are deleted.
+// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+func TestGyWithErrorCode(t *testing.T) {
+	fmt.Println("\nRunning TestGyWithErrorCode...")
+
+	tr, ruleManager, ue := ocsTestSetup(t)
+	defer func() {
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearOCSMockDriver())
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
+	// CCR-I
+	quotaGrant := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 5 * MegaBytes,
+		},
+		IsFinalCredit: false,
+		ResultCode:    diam.Success,
+	}
+	initRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_INITIAL)
+	initAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant)
+	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	// CCR-U  with ERROR CODE 4012 (DiameterCreditLimitReached)
+	updateRequest1 := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_UPDATE)
+	updateAnswer1 := protos.NewGyCCAnswer(diameter.DiameterCreditLimitReached)
+	updateExpectation1 := protos.NewGyCreditControlExpectation().Expect(updateRequest1).Return(updateAnswer1)
+
+	// CCR-T
+	terminateRequest := protos.NewGyCCRequest(ue.GetImsi(), protos.CCRequestType_TERMINATION)
+	terminateAnswer := protos.NewGyCCAnswer(diam.Success)
+	terminateExpectation := protos.NewGyCreditControlExpectation().Expect(terminateRequest).Return(terminateAnswer)
+
+	// Load expectations into OCS
+	expectations := []*protos.GyCreditControlExpectation{initExpectation, updateExpectation1, terminateExpectation}
+	assert.NoError(t, setOCSExpectations(expectations, nil)) // We only expect one single CCR-U to be sent
+	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
+
+	// we need to generate over 80% but less than 100%  trigger a CCR update without triggering termination
+	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("4.6M")}}
+	_, err := tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	tr.WaitForEnforcementStatsToSync()
+
+	// Wait for flow deletion due to quota exhaustion
+	tr.WaitForEnforcementStatsToSync()
+
+	// Check that UE mac flow is removed
+	recordsBySubID, err := tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	record := recordsBySubID["IMSI"+ue.GetImsi()]["static-pass-all-ocs2"]
+	assert.Nil(t, record, fmt.Sprintf("Policy usage record for imsi: %v was not removed", ue.GetImsi()))
+
+	// Assert that we saw a Terminate request
+	tr.AssertAllGyExpectationsMetNoError()
 }

--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -260,10 +260,13 @@ func getSingleCreditResponseFromCCA(
 ) *protos.CreditUpdateResponse {
 	success := answer.ResultCode == diameter.SuccessCode
 	imsi := credit_control.AddIMSIPrefix(request.IMSI)
+
 	if len(answer.Credits) == 0 {
 		return &protos.CreditUpdateResponse{
-			Success: false,
-			Sid:     imsi,
+			Success:    false,
+			Sid:        imsi,
+			SessionId:  request.SessionID,
+			ResultCode: answer.ResultCode,
 		}
 	}
 	receivedCredit := answer.Credits[0]

--- a/lte/gateway/c/session_manager/DiameterCodes.cpp
+++ b/lte/gateway/c/session_manager/DiameterCodes.cpp
@@ -13,13 +13,28 @@
 
 #include "DiameterCodes.h"
 
+uint32_t terminator_codes[] = {
+    magma::DIAMETER_END_USER_SERVICE_DENIED,
+    magma::DIAMETER_CREDIT_LIMIT_REACHED,
+};
+
 namespace magma {
+
+bool DiameterCodeHandler::is_permanent_failure(const uint32_t code) {
+  return 5000 <= code && code < 6000;
+}
+
+bool DiameterCodeHandler::is_terminator_failure(const uint32_t code) {
+  for (const uint32_t c : terminator_codes) {
+    if (c == code) {
+      return true;
+    }
+  }
+  return false;
+}
+
 bool DiameterCodeHandler::is_transient_failure(const uint32_t code) {
   return 4000 <= code && code < 5000;
 }
 
-// Diameter code of form 5xxx marks a permanent failure
-bool DiameterCodeHandler::is_permanent_failure(const uint32_t code) {
-  return 5000 <= code && code < 6000;
-}
 }  // namespace magma

--- a/lte/gateway/c/session_manager/DiameterCodes.h
+++ b/lte/gateway/c/session_manager/DiameterCodes.h
@@ -161,8 +161,24 @@ enum DiameterResultCode {
 
 class DiameterCodeHandler {
  public:
-  static bool is_transient_failure(const uint32_t code);
-
+  /** Diameter code of form 5xxx marks a permanent failure
+   * @param code
+   * @return
+   */
   static bool is_permanent_failure(const uint32_t code);
+
+  /** Individual messages included in terminator_codes list will trigger a
+   * session termination. This function is run before is_permanent_failure
+   * @param code
+   * @return
+   */
+  static bool is_terminator_failure(const uint32_t code);
+
+  /** Diameter code of form 4xxx marks a transient failure. Normally used after
+   * running is_terminator_failure
+   * @param code
+   * @return
+   */
+  static bool is_transient_failure(const uint32_t code);
 };
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -584,18 +584,16 @@ void LocalSessionManagerHandlerImpl::SetSessionRules(
   response_callback(Status::OK, Void());
 }
 
-std::string LocalSessionManagerHandlerImpl::bytes_to_hex(const std::string& s)
-{
-   std::ostringstream ret;
+std::string LocalSessionManagerHandlerImpl::bytes_to_hex(const std::string& s) {
+  std::ostringstream ret;
 
-    unsigned int c;
-    for (std::string::size_type i = 0; i < s.length(); ++i)
-    {
-        c = (unsigned int)(unsigned char)s[i];
-        ret << " " << std::hex << std::setfill('0') <<
-            std::setw(2) << (std::nouppercase) << c;
-    }
-    return ret.str();
+  unsigned int c;
+  for (std::string::size_type i = 0; i < s.length(); ++i) {
+    c = (unsigned int) (unsigned char) s[i];
+    ret << " " << std::hex << std::setfill('0') << std::setw(2)
+        << (std::nouppercase) << c;
+  }
+  return ret.str();
 }
 
 void LocalSessionManagerHandlerImpl::log_create_session(SessionConfig& cfg) {

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -110,7 +110,8 @@ bool RestartHandler::populate_sessions_to_terminate_with_retries() {
   while (rpc_try < max_cleanup_retries_) {
     std::future<bool> directoryd_future = directoryd_res.get_future();
     directoryd_client_->get_all_directoryd_records(
-        [this, &directoryd_res](Status status, AllDirectoryRecords response) {
+        [this, &directoryd_res](
+            Status status, const AllDirectoryRecords& response) {
           if (!status.ok()) {
             directoryd_res.set_value(false);
             return;
@@ -148,8 +149,9 @@ void RestartHandler::terminate_previous_session(
   std::future<bool> termination_future = termination_res.get_future();
   (*reporter_)
       .report_terminate_session(
-          term_req, [this, &termination_res, sid, session_id](
-                        Status status, SessionTerminateResponse response) {
+          term_req,
+          [this, &termination_res, sid, session_id](
+              Status status, const SessionTerminateResponse& response) {
             if (!status.ok()) {
               MLOG(MERROR) << "CCR-T cleanup for subscriber " << sid
                            << ", session id: " << session_id << " failed";
@@ -160,7 +162,7 @@ void RestartHandler::terminate_previous_session(
             del_request.set_id(response.sid());
             directoryd_client_->delete_directoryd_record(
                 del_request, [this, &del_request, &termination_res, sid](
-                                 Status status, Void) {
+                                 Status status, const Void&) {
                   if (!status.ok()) {
                     MLOG(MERROR) << "DirectoryD DeleteRecord failed to remove "
                                  << "subscriber " << sid << " from DirectoryD";


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

## Summary

Error code support was not working properly. This PR 
- Adds support for `DIAMETER_CREDIT_LIMIT_REACHED` abd `DIAMETER_END_USER_SERVICE_DENIED`. Those messages will cause a session termination. 
- fixes some bugs on feg that prevented the errors messages to be sent to sessiond
- adds other features like do not send update if session is on released mode
- adds new cwag integ test to check  error codes are properly handled 

## Test Plan

make precommit feg
make and make test at agw
cwag integ test 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
