### PR TITLE
[lte][orc8r] Fix 3009 which prevented add of multi apn_resource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -860,10 +860,11 @@ workflows:
       - lte-test
       - lte-integ-test:
           <<: *only_master
+      - agw_hold:
+          type: approval
       - lte-agw-deploy:
-          <<: *only_master
           requires:
-            - lte-integ-test
+            - agw_hold
 
   feg:
     jobs:

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -3001,6 +3001,17 @@ func TestAPNResource(t *testing.T) {
 		ExpectedStatus: 201,
 	}
 	tests.RunUnitTest(t, e, tc)
+	apn2 := newAPN("apn2")
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/:network_id/apns",
+		Payload:        apn2,
+		Handler:        postAPN,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
 
 	// Post, successful
 	gw.ApnResources = lteModels.ApnResources{"apn0": {ApnName: "apn0", ID: "res0", VlanID: 4}}
@@ -3101,7 +3112,11 @@ func TestAPNResource(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Put, create new APN resource
-	gw.ApnResources = lteModels.ApnResources{"apn1": {ApnName: "apn1", ID: "res1", VlanID: 4}}
+	// TODO: make sure that this works
+	gw.ApnResources = lteModels.ApnResources{
+		"apn1": {ApnName: "apn1", ID: "res1", VlanID: 4},
+		"apn2": {ApnName: "apn2", ID: "res2", VlanID: 4},
+	}
 	tc = tests.Test{
 		Method:         "PUT",
 		URL:            "/magma/v1/lte/n0/gateways/gw0",
@@ -3182,7 +3197,7 @@ func TestAPNResource(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Get, APN resource is gone due to cascading delete
-	gw.ApnResources = lteModels.ApnResources{}
+	gw.ApnResources = lteModels.ApnResources{"apn2": {ApnName: "apn2", ID: "res2", VlanID: 4}}
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/lte/n0/gateways/gw0",

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -494,8 +494,9 @@ func LoadAPNResources(networkID string, ids []string) (ApnResources, error) {
 
 func (m *ApnResources) GetByID() map[string]*ApnResource {
 	byID := map[string]*ApnResource{}
-	for _, r := range *m {
-		byID[r.ID] = &r
+	for i, r := range *m {
+		var apnr = (*m)[i]
+		byID[r.ID] = &apnr
 	}
 	return byID
 }

--- a/lte/cloud/go/services/policydb/streamer/providers.go
+++ b/lte/cloud/go/services/policydb/streamer/providers.go
@@ -124,13 +124,13 @@ func loadQosProfiles(networkID string) (map[string]configurator.NetworkEntity, e
 		return nil, err
 	}
 
+	// Select all attached QoS profiles
 	byPolicyID := map[string]configurator.NetworkEntity{}
 	for _, prof := range profiles {
 		tk, err := prof.ParentAssociations.GetFirst(lte.PolicyRuleEntityType)
-		if err != nil {
-			return nil, err
+		if err == nil {
+			byPolicyID[tk.Key] = prof
 		}
-		byPolicyID[tk.Key] = prof
 	}
 
 	return byPolicyID, nil

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -121,12 +121,22 @@ func TestPolicyStreamers(t *testing.T) {
 
 	// create the rules first otherwise base names can't associate to them
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
+		// Attached qos profile
 		{
 			Type: lte.PolicyQoSProfileEntityType,
 			Key:  "p1",
 			Config: &models.PolicyQosProfile{
 				ClassID: 42,
 				ID:      "p1",
+			},
+		},
+		// Dangling qos profile
+		{
+			Type: lte.PolicyQoSProfileEntityType,
+			Key:  "p2",
+			Config: &models.PolicyQosProfile{
+				ClassID: 420,
+				ID:      "p2",
 			},
 		},
 		{

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -119,9 +119,8 @@ func TestPolicyStreamers(t *testing.T) {
 	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
 	assert.NoError(t, err)
 
-	// create the rules first otherwise base names can't associate to them
 	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		// Attached qos profile
+		// Attached qos profile (shared)
 		{
 			Type: lte.PolicyQoSProfileEntityType,
 			Key:  "p1",
@@ -170,6 +169,9 @@ func TestPolicyStreamers(t *testing.T) {
 					ServerAddress: swag.String("https://www.google.com"),
 					Support:       swag.String("ENABLED"),
 				},
+			},
+			Associations: []storage.TypeAndKey{
+				{Type: lte.PolicyQoSProfileEntityType, Key: "p1"},
 			},
 		},
 		{
@@ -227,6 +229,7 @@ func TestPolicyStreamers(t *testing.T) {
 				AddressType:   lte_protos.RedirectInformation_IPv4,
 				ServerAddress: "https://www.google.com",
 			},
+			Qos: &lte_protos.FlowQos{Qci: 42},
 		},
 		{Id: "r3", MonitoringKey: []byte("bar")},
 	}

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -41,8 +41,8 @@ std::chrono::milliseconds time_difference_from_now(
 }  // namespace
 
 namespace magma {
-
-uint32_t LocalEnforcer::REDIRECT_FLOW_PRIORITY = 2000;
+uint32_t LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 2000;
+uint32_t LocalEnforcer::REDIRECT_FLOW_PRIORITY                = 2000;
 
 using google::protobuf::RepeatedPtrField;
 using google::protobuf::util::TimeUtil;
@@ -896,12 +896,8 @@ bool LocalEnforcer::handle_session_init_rule_updates(
     SessionMap& session_map, const std::string& imsi,
     SessionState& session_state, const CreateSessionResponse& response,
     std::unordered_set<uint32_t>& charging_credits_received) {
-
   RulesToProcess rules_to_activate;
   RulesToProcess rules_to_deactivate;
-
-  // Can use a default UpdateCriteria since SessionStore's create and update
-  // methods are separate.
   std::vector<StaticRuleInstall> static_rule_installs =
       to_vec(response.static_rules());
   std::vector<DynamicRuleInstall> dynamic_rule_installs =
@@ -909,24 +905,94 @@ bool LocalEnforcer::handle_session_init_rule_updates(
   filter_rule_installs(
       static_rule_installs, dynamic_rule_installs, charging_credits_received);
 
-  auto uc = get_default_update_criteria();
+  auto uc = get_default_update_criteria();  // TODO remove unused UC
   process_rules_to_install(
       session_state, imsi, static_rule_installs, dynamic_rule_installs,
       rules_to_activate, rules_to_deactivate, uc);
 
-  const auto& config = session_state.get_config();
-  // activate_flows_for_rules() should be called even if there is no rule to
-  // activate, because pipelined activates a "drop all packet" rule
+  // activate_flows_for_rules() should be called even if there is no rule
+  // to activate, because pipelined activates a "drop all packet" rule
   // when no rule is provided as the parameter.
+  const auto& config = session_state.get_config();
   propagate_rule_updates_to_pipelined(
       imsi, config, rules_to_activate, rules_to_deactivate, true);
 
   if (config.common_context.rat_type() == TGPP_LTE) {
-    const auto update = session_state.get_dedicated_bearer_updates(
+    auto bearer_updates = session_state.get_dedicated_bearer_updates(
         rules_to_activate, rules_to_deactivate, uc);
-    propagate_bearer_updates_to_mme(update);
+    if (bearer_updates.needs_creation) {
+      // If a bearer creation is needed, we need to delay this by a few seconds
+      // so that the attach fully completes before.
+      schedule_session_init_bearer_creations(
+          imsi, session_state.get_session_id(), bearer_updates);
+    }
   }
   return true;
+}
+
+void LocalEnforcer::schedule_session_init_bearer_creations(
+    const std::string& imsi, const std::string& session_id,
+    BearerUpdate& bearer_updates) {
+  MLOG(MINFO) << "Scheduling a bearer creation request for newly created "
+              << session_id << " in "
+              << LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT << " ms";
+  evb_->runAfterDelay(
+      [this, imsi, session_id, bearer_updates]() mutable {
+        auto session_map = session_store_.read_sessions({imsi});
+        auto it          = session_map.find(imsi);
+        if (it == session_map.end()) {
+          MLOG(MWARNING) << "Ignoring dedicated bearer creations from session "
+                            "creation for "
+                         << session_id << " since it no longer exists";
+          return;
+        }
+        for (auto& session : it->second) {
+          if (session->get_session_id() != session_id) {
+            continue;
+          }
+          // Skip bearer update if it is no longer ACTIVE
+          if (session->get_state() != SESSION_ACTIVE) {
+            MLOG(MWARNING) << "Ignoring dedicated bearer create request from"
+                           << " session creation for " << session_id
+                           << " since the session is no longer active";
+            return;
+          }
+          // Check that the policies are still installed and needs a
+          // bearer
+          auto rules = bearer_updates.create_req.mutable_policy_rules();
+          auto it    = rules->begin();
+          while (it != rules->end()) {
+            auto policy_type = session->get_policy_type(it->id());
+            if (!policy_type) {
+              MLOG(MWARNING) << "Ignoring dedicated bearer create request from"
+                             << " session creation for " << session_id
+                             << " policy ID: " << it->id()
+                             << " since the policy is no longer active in the "
+                                "session";
+              it = rules->erase(it);
+              continue;
+            }
+            if (!session->policy_needs_bearer_creation(
+                    *policy_type, it->id(), session->get_config())) {
+              MLOG(MWARNING) << "Ignoring dedicated bearer create request from "
+                             << "session creation for " << session_id
+                             << " and policy ID: " << it->id()
+                             << " since the policy no longer needs a bearer";
+              it = rules->erase(it);
+              continue;
+            }
+            ++it;
+          }
+          if (rules->size() > 0) {
+            propagate_bearer_updates_to_mme(bearer_updates);
+          }
+          return;
+        }
+        // No need to update session store for bearer creations.
+        // SessionStore will be updated once the bearer binding
+        // completes/fails.
+      },
+      LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT);
 }
 
 bool LocalEnforcer::init_session_credit(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -125,6 +125,10 @@ class LocalEnforcer {
       SessionState& session_state, const CreateSessionResponse& response,
       std::unordered_set<uint32_t>& charging_credits_received);
 
+  void schedule_session_init_bearer_creations(
+      const std::string& imsi, const std::string& session_id,
+      BearerUpdate& update);
+
   /**
    * Initialize credit received from the cloud in the system. This adds all the
    * charging keys to the credit manager for tracking
@@ -230,6 +234,7 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   static uint32_t REDIRECT_FLOW_PRIORITY;
+  static uint32_t BEARER_CREATION_DELAY_ON_SESSION_INIT;
 
  private:
   struct RedirectInstallInfo {

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -246,6 +246,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
         PrintGrpcMessage(
             static_cast<const google::protobuf::Message&>(response));
         if (status.ok()) {
+          MLOG(MINFO) << "Received a CreateSessionResponse for " << sid;
           bool success = enforcer_->init_session_credit(
               *session_map_ptr, imsi, sid, cfg, response);
           if (!success) {
@@ -548,10 +549,11 @@ void LocalSessionManagerHandlerImpl::BindPolicy2Bearer(
         response_callback) {
   auto& request_cpy = *request;
   PrintGrpcMessage(static_cast<const google::protobuf::Message&>(request_cpy));
-  MLOG(INFO) << "imsi: " << request->sid().id()
-             << " default bearer: " << request->linked_bearer_id()
-             << " policy rule: " << request->policy_rule_id()
-             << " created bearer: " << request->bearer_id();
+  MLOG(INFO) << "Received a BindPolicy2Bearer request for "
+             << request->sid().id()
+             << " with default bearerID: " << request->linked_bearer_id()
+             << " policyID: " << request->policy_rule_id()
+             << " created dedicated bearerID: " << request->bearer_id();
   enforcer_->get_event_base().runInEventBaseThread([this, request_cpy]() {
     auto session_map = session_store_.read_sessions({request_cpy.sid().id()});
     SessionUpdate update =

--- a/lte/gateway/c/session_manager/PipelinedClient.cpp
+++ b/lte/gateway/c/session_manager/PipelinedClient.cpp
@@ -51,9 +51,9 @@ magma::ActivateFlowsRequest create_activate_req(
   req.mutable_request_origin()->set_type(origin_type);
   if (ambr) {
     // TODO remove log once feature is stable
-    MLOG(MINFO) << "Sending AMBR info for " << imsi << " ip addr " << ip_addr
-                 << "dl " << ambr->max_bandwidth_dl() << "ul "
-                 << ambr->max_bandwidth_ul();
+    MLOG(MINFO) << "Sending AMBR info for " << imsi << ", ip addr=" << ip_addr
+                << ", dl=" << ambr->max_bandwidth_dl()
+                << ", ul=" << ambr->max_bandwidth_ul();
     req.mutable_apn_ambr()->CopyFrom(*ambr);
   }
   auto ids = req.mutable_rule_ids();
@@ -232,8 +232,8 @@ bool AsyncPipelinedClient::activate_flows_for_rules(
     const std::vector<PolicyRule>& dynamic_rules,
     std::function<void(Status status, ActivateFlowsResult)> callback) {
   MLOG(MDEBUG) << "Activating " << static_rules.size() << " static rules and "
-               << dynamic_rules.size() << " dynamic rules for subscriber "
-               << imsi;
+               << dynamic_rules.size() << " dynamic rules for " << imsi
+               << " and ip " << ip_addr;
   // Activate static rules and dynamic rules separately until bug is fixed in
   // pipelined which crashes if activated at the same time
   auto static_req = create_activate_req(

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -402,7 +402,16 @@ class SessionState {
   BearerUpdate get_dedicated_bearer_updates(
       RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
       SessionStateUpdateCriteria& uc);
-
+  /**
+   * Determine whether a policy with type+ID needs a bearer to be created
+   * @param policy_type
+   * @param rule_id
+   * @param config
+   * @return an optional wrapped PolicyRule if creation is needed, {} otherwise
+   */
+  std::experimental::optional<PolicyRule> policy_needs_bearer_creation(
+      const PolicyType policy_type, const std::string& rule_id,
+      const SessionConfig& config);
   /**
    *
    * @param rule_set

--- a/lte/gateway/c/session_manager/sessiond_main.cpp
+++ b/lte/gateway/c/session_manager/sessiond_main.cpp
@@ -100,7 +100,7 @@ static uint32_t get_log_verbosity(
   }
 }
 
-void set_session_credit_consts(const YAML::Node& config) {
+void set_consts(const YAML::Node& config) {
   auto reporting_threshold = config["usage_reporting_threshold"].as<float>();
   if (reporting_threshold <= MIN_USAGE_REPORTING_THRESHOLD ||
       reporting_threshold >= MAX_USAGE_REPORTING_THRESHOLD) {
@@ -114,6 +114,11 @@ void set_session_credit_consts(const YAML::Node& config) {
 
   magma::SessionCredit::TERMINATE_SERVICE_WHEN_QUOTA_EXHAUSTED =
       config["terminate_service_when_quota_exhausted"].as<bool>();
+
+  if (config["bearer_creation_delay_on_session_init"].IsDefined()) {
+    magma::LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT =
+        config["bearer_creation_delay_on_session_init"].as<uint32_t>();
+  }
 }
 
 magma::SessionStore* create_session_store(
@@ -231,7 +236,7 @@ int main(int argc, char* argv[]) {
   magma::SessionStore* session_store = create_session_store(config, rule_store);
 
   // Some setup work for the SessionCredit class
-  set_session_credit_consts(config);
+  set_consts(config);
   // Initialize the main logical component of SessionD
   auto local_enforcer = std::make_shared<magma::LocalEnforcer>(
       reporter, rule_store, *session_store, pipelined_client, directoryd_client,

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1453,6 +1453,93 @@ TEST_F(LocalEnforcerTest, test_rar_create_dedicated_bearer) {
   EXPECT_EQ(raa.result(), ReAuthResult::UPDATE_INITIATED);
 }
 
+// This test covers some edge cases for the dedicated bearer creation scheduling
+// for a new session. For session creation, we delay the actual call to create
+// bearer by a few seconds. (BEARER_CREATION_DELAY_ON_SESSION_INIT)
+// But since we could have a case where the rule state is modified during the
+// scheduling and the actual call, we want to ensure that we do not create
+// bearers if:
+// 1. Policy is no longer installed.
+// 2. Policy no longer needs a bearer for some reason. One case of this could be
+// that it is already tied to a bearer.
+// The success case where the creation takes place is covered by another test
+// "test_dedicated_bearer_lifecycle"
+TEST_F(LocalEnforcerTest, test_dedicated_bearer_creation_on_session_init) {
+  CreateSessionResponse response1, response2;
+  const std::string IMSI1 = "IMSI1";
+  const std::string IMSI2 = "IMSI2";
+  const std::string SESSION_ID_1 = "SESSION_ID_1";
+  const std::string SESSION_ID_2 = "SESSION_ID_2";
+  const uint32_t default_bearer_id = 5;
+  const uint32_t bearer_1          = 6;
+  insert_static_rule_with_qos(0, "m1", "rule1", 1);             // QCI=1
+  LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 1000;  // 1 sec
+
+  // test_cfg_ is initialized with QoSInfo field w/ QCI 5
+  test_cfg_.common_context.mutable_sid()->set_id(IMSI1);
+  test_cfg_.common_context.set_apn("apn1");
+  auto lte_context = test_cfg_.rat_specific_context.mutable_lte_context();
+  lte_context->mutable_qos_info()->set_qos_class_id(5);
+  lte_context->set_bearer_id(default_bearer_id);  // linked_bearer_id
+
+  // CASE 1: policy has a bearer by the time the scheduled function is executed
+  response1.mutable_static_rules()->Add()->set_rule_id("rule1");
+  // Schedules default bearer install in 1 sec
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response1);
+  // Write + Read in/from SessionStore
+  bool write_success =
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
+  EXPECT_TRUE(write_success);
+
+  // Before we hit the 1 second, simulate a case where another call triggered
+  // the policy to be tied a bearer already
+  session_map = session_store->read_sessions({IMSI1});
+  auto update = SessionStore::get_default_session_update(session_map);
+  auto bearer_bind_req_success1 = create_policy_bearer_bind_req(
+      IMSI1, default_bearer_id, "rule1", bearer_1);
+  local_enforcer->bind_policy_to_bearer(
+      session_map, bearer_bind_req_success1, update);
+  // Write + Read in/from SessionStore
+  write_success = session_store->update_sessions(update);
+  EXPECT_TRUE(write_success);
+  // Since the policy is already tied to a bearer, we should not see an
+  // additional create bearer request when the scheduled creation happens
+  EXPECT_CALL(
+      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
+      .Times(0);
+  evb->loopOnce();
+
+  // CASE 2: policy has been removed
+  session_map = session_store->read_all_sessions();
+  response2.mutable_static_rules()->Add()->set_rule_id("rule1");
+  // Schedules default bearer install in 1 sec
+  local_enforcer->init_session_credit(
+      session_map, IMSI2, SESSION_ID_2, test_cfg_, response2);
+
+  // Write + Read in/from SessionStore
+  write_success =
+      session_store->create_sessions(IMSI2, std::move(session_map[IMSI2]));
+  EXPECT_TRUE(write_success);
+  // Before we hit the 1 second, remove the policy
+  session_map = session_store->read_sessions({IMSI2});
+  update      = SessionStore::get_default_session_update(session_map);
+  SessionRules session_rules;
+  auto rule_set_per_sub = session_rules.mutable_rules_per_subscriber()->Add();
+  rule_set_per_sub->set_imsi(IMSI2);
+  rule_set_per_sub->mutable_rule_set()->Add()->CopyFrom(
+      create_rule_set(false, "apn1", {}, {}));  // Remove all rules
+  local_enforcer->handle_set_session_rules(session_map, session_rules, update);
+  // Write + Read in/from SessionStore
+  write_success = session_store->update_sessions(update);
+  EXPECT_TRUE(write_success);
+  // Rule is removed, expect no bearer creation
+  EXPECT_CALL(
+      *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(IMSI1, 1)))
+      .Times(0);
+  evb->loopOnce();
+}
+
 // Create multiple rules with QoS and assert dedicated bearers are created
 // Simulate a policy->bearer mapping from MME, both success + failure.
 // Simulate additional rule updates to trigger dedicated bearer deletions
@@ -1488,7 +1575,8 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
       *spgw_client, create_dedicated_bearer(CheckCreateBearerReq(imsi, 3)))
       .Times(1)
       .WillOnce(testing::Return(true));
-
+  // For testing change the delay to 0 ms.
+  LocalEnforcer::BEARER_CREATION_DELAY_ON_SESSION_INIT = 0;
   local_enforcer->init_session_credit(
       session_map, imsi, session_id, test_cfg_, response);
   // Write + Read in/from SessionStore
@@ -1497,7 +1585,8 @@ TEST_F(LocalEnforcerTest, test_dedicated_bearer_lifecycle) {
   EXPECT_TRUE(write_success);
   session_map = session_store->read_sessions({imsi});
   auto update = SessionStore::get_default_session_update(session_map);
-
+  // Progress the loop to run the scheduled bearer creation request
+  evb->loopOnce();
   // Test successful creation of dedicated bearer for rule1 + rule2
   auto bearer_bind_req_success1 =
       create_policy_bearer_bind_req(imsi, default_bearer_id, "rule1", bearer_1);
@@ -1621,6 +1710,8 @@ TEST_F(LocalEnforcerTest, test_set_session_rules) {
       session_map, imsi, session_id1, config1, response);
   local_enforcer->init_session_credit(
       session_map, imsi, session_id2, config2, response);
+  evb->loopOnce();
+  evb->loopOnce();
   // Assert the rules exist
   EXPECT_TRUE(session_map[imsi][0]->is_static_rule_installed("static1"));
   EXPECT_TRUE(session_map[imsi][0]->is_static_rule_installed("static2"));

--- a/lte/gateway/configs/sessiond.yml
+++ b/lte/gateway/configs/sessiond.yml
@@ -38,6 +38,11 @@ support_carrier_wifi: false
 # quota.
 cwf_quota_exhaustion_termination_on_init_ms: 30000
 
+# On session creation, we want to delay the bearer creation requests to after
+# the attach has completed. This value indicates how many ms to wait before
+# sending the bearer create request.
+bearer_creation_delay_on_session_init: 2000
+
 # Set to true to store session state in Redis for persistence.
 support_stateless: false
 

--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -8,7 +8,7 @@ SUCCESS_MESSAGE="ok"
 NEED_REBOOT=0
 WHOAMI=$(whoami)
 KVERS=$(uname -r)
-MAGMA_VERSION="v1.1"
+MAGMA_VERSION="v1.2"
 
 echo "Checking if the script has been executed by root user"
 if [ "$WHOAMI" != "root" ]; then

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -81,7 +81,7 @@
     name: "{{ packages }}"
   vars:
     packages:
-      - magma
+      - 'magma=1.2.0-1599526409-b82d5c80'   # Change this hash if v1.2 branch gets more commits
 
 - name: Start service openvswitch-switch.
   become: yes

--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -81,7 +81,7 @@
     name: "{{ packages }}"
   vars:
     packages:
-      - 'magma=1.2.0-1599526409-b82d5c80'   # Change this hash if v1.2 branch gets more commits
+      - 'magma=1.2.0-1600052642-41609608'   # Change this hash if v1.2 branch gets more commits
 
 - name: Start service openvswitch-switch.
   become: yes

--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -10,6 +10,6 @@ packages:
   - "openvswitch-switch_2.8.9-1_amd64.deb"
   - "python-openvswitch_2.8.9-1_all.deb"
 
-private_package: "deb http://packages.magma.etagecom.io stretch-test main"
+private_package: "deb http://packages.magma.etagecom.io stretch-stable main"
 source_name: "packages_magma_etagecom_io"
 apt_key: "http://packages.magma.etagecom.io/pubkey.gpg"

--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -4,10 +4,11 @@ ovs_version: "v2.8.9"
 packages:
   - "oai-gtp_4.9-5_amd64.deb"
   - "libopenvswitch_2.8.9-1_amd64.deb"
-  - "openvswitch-datapath-dkms_2.8.9-1_all.deb"
+  - "openvswitch-datapath-module-4.9.0-9-amd64_2.8.9-1_amd64.deb"
   - "openvswitch-datapath-source_2.8.9-1_all.deb"
   - "openvswitch-common_2.8.9-1_amd64.deb"
   - "openvswitch-switch_2.8.9-1_amd64.deb"
+  - "python-openvswitch_2.8.9-1_all.deb"
 
 private_package: "deb http://packages.magma.etagecom.io stretch-test main"
 source_name: "packages_magma_etagecom_io"

--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -9,6 +9,6 @@ packages:
   - "openvswitch-common_2.8.9-1_amd64.deb"
   - "openvswitch-switch_2.8.9-1_amd64.deb"
 
-private_package: "deb http://packages.magma.etagecom.io stretch-stable main"
+private_package: "deb http://packages.magma.etagecom.io stretch-test main"
 source_name: "packages_magma_etagecom_io"
 apt_key: "http://packages.magma.etagecom.io/pubkey.gpg"

--- a/lte/gateway/python/magma/mobilityd/mac.py
+++ b/lte/gateway/python/magma/mobilityd/mac.py
@@ -36,7 +36,7 @@ class MacAddress:
         """
         key = str(self.mac_address).replace(':', '_').lower()
         if vlan:
-            return vlan + "." + key
+            return "v{}.{}".format(vlan, key)
         else:
             return key
 

--- a/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
+++ b/lte/gateway/python/magma/mobilityd/subscriberdb_client.py
@@ -116,11 +116,9 @@ class SubscriberDbClient:
             selected_apn_conf = None
             for apn_config in data.non_3gpp.apn_config:
                 logging.debug("APN config: %s", apn_config)
-                if apn_config.assigned_static_ip is None or \
-                        apn_config.assigned_static_ip == "":
-                    continue
                 try:
-                    ipaddress.ip_address(apn_config.assigned_static_ip)
+                    if apn_config.assigned_static_ip:
+                        ipaddress.ip_address(apn_config.assigned_static_ip)
                 except ValueError:
                     continue
                 if apn_config.service_selection == '*':
@@ -129,7 +127,6 @@ class SubscriberDbClient:
                     selected_apn_conf = apn_config
                     break
 
-            if selected_apn_conf and selected_apn_conf.assigned_static_ip:
-                return selected_apn_conf
+            return selected_apn_conf
 
         return None

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -370,8 +370,8 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
 
         # check if retrieved ip is the same as the one allocated
         self.assertEqual(ip0, ip0_returned)
-        self.assertEqual(ip0, ipaddress.ip_address(wild_assigned_ip))
-        self.check_type(sid, IPType.STATIC)
-        self.check_vlan(sid, vlan_wild)
+        self.assertNotEqual(ip0, ipaddress.ip_address(wild_assigned_ip))
+        self.check_type(sid, IPType.IP_POOL)
+        self.check_vlan(sid, 0)
         self.check_gw_info(vlan, None, None)
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_static_ip_alloc.py
@@ -257,8 +257,8 @@ class StaticIPAllocationTests(unittest.TestCase):
 
         # check if retrieved ip is the same as the one allocated
         self.assertEqual(ip0, ip0_returned)
-        self.assertEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
-        self.check_type(sid, IPType.STATIC)
+        self.assertNotEqual(ip0, ipaddress.ip_address(assigned_ip_wild))
+        self.check_type(sid, IPType.IP_POOL)
 
     def test_get_ip_for_subscriber_with_apn_with_gw(self):
         """ test get_ip_for_sid with static IP """

--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -107,8 +107,7 @@ class UplinkBridgeController(MagmaController):
 
         # 1.b. DHCP traffic
         match = "in_port=%s,ip,udp,tp_dst=68" % self.config.uplink_eth_port_name
-        actions = "output:%s,output:%s,output:LOCAL" % (self.config.dhcp_port,
-                                                        self.config.uplink_patch)
+        actions = "output:%s,output:LOCAL" % self.config.dhcp_port
         self._install_flow(flows.MAXIMUM_PRIORITY - 1, match, actions)
 
         # 2.a. all egress traffic

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -1,4 +1,4 @@
- priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,in_port=70 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest.testFlowSnapshotMatch.snapshot
@@ -1,4 +1,4 @@
- priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,in_port=70 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
@@ -1,8 +1,10 @@
- priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65535,in_port=3,dl_vlan=100 actions=strip_vlan,LOCAL
+ priority=65535,in_port=LOCAL actions=mod_vlan_vid:100,output:3
+ priority=100,in_port=70 actions=drop
+ priority=1,in_port=71 actions=drop
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
  priority=100,ip,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
- priority=100,in_port=70 actions=drop
- priority=1,in_port=71 actions=drop
  priority=0 actions=NORMAL

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTestVlan.testFlowSnapshotMatch.snapshot
@@ -2,7 +2,7 @@
  priority=65535,in_port=LOCAL actions=mod_vlan_vid:100,output:3
  priority=100,in_port=70 actions=drop
  priority=1,in_port=71 actions=drop
- priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -2,7 +2,7 @@
  priority=65535,in_port=LOCAL actions=mod_vlan_vid:500,output:3
  priority=100,in_port=70 actions=drop
  priority=1,in_port=71 actions=drop
- priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_uplink_bridge.UplinkBridgeWithNonNATTest_IP_VLAN.testFlowSnapshotMatch.snapshot
@@ -1,8 +1,10 @@
- priority=65535,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
+ priority=65535,in_port=3,dl_vlan=500 actions=strip_vlan,LOCAL
+ priority=65535,in_port=LOCAL actions=mod_vlan_vid:500,output:3
+ priority=100,in_port=70 actions=drop
+ priority=1,in_port=71 actions=drop
+ priority=65534,udp,in_port=3,tp_dst=68 actions=output:1,output:2,LOCAL
  priority=100,ip,in_port=2 actions=mod_dl_src:02:bb:5e:36:06:4b,output:3
  priority=100,ip,in_port=3,vlan_tci=0x0000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=output:2
  priority=100,ip,in_port=3,vlan_tci=0x1000/0x1000,dl_dst=02:bb:5e:36:06:4b actions=strip_vlan,output:70
  priority=100,ip,in_port=71,dl_dst=02:bb:5e:36:06:4b actions=output:2
- priority=100,in_port=70 actions=drop
- priority=1,in_port=71 actions=drop
  priority=0 actions=NORMAL

--- a/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_uplink_bridge.py
@@ -171,9 +171,6 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
 
         # dummy uplink interface
         vlan = "10"
-        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
-                          "tag=" + vlan]).wait()
-        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
 
         BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
                                           cls.UPLINK_DHCP, None)
@@ -197,7 +194,6 @@ class UplinkBridgeWithNonNATTest(unittest.TestCase):
         cls = self.__class__
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
                                      include_stats=False)
-        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), '[]')
 
 
 class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
@@ -276,9 +272,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
         # validate vlan id set
         vlan = "10"
         BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
-        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
-                          "tag=" + vlan]).wait()
-        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
 
         BridgeTools.create_internal_iface(cls.UPLINK_BRIDGE,
                                           cls.UPLINK_DHCP, None)
@@ -303,7 +296,6 @@ class UplinkBridgeWithNonNATTestVlan(unittest.TestCase):
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
                                      include_stats=False)
 
-        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), cls.VLAN_TAG)
 
 class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     BRIDGE = 'testing_br'
@@ -314,7 +306,7 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
     UPLINK_DHCP = 'test_dhcp0'
     UPLINK_PATCH = 'test_patch_p2'
     UPLINK_ETH_PORT = 'test_eth3'
-    VLAN_TAG='100'
+    VLAN_TAG='500'
     SGi_IP="1.6.5.7"
 
     @classmethod
@@ -370,9 +362,6 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         # validate vlan id set
         vlan = "10"
         BridgeTools.create_bridge(cls.UPLINK_BRIDGE, cls.UPLINK_BRIDGE)
-        subprocess.Popen(["ovs-vsctl", "set", "port", cls.UPLINK_BRIDGE,
-                          "tag=" + vlan]).wait()
-        assert get_ovsdb_port_tag(cls.UPLINK_BRIDGE) == vlan
 
         set_ip_cmd = ["ip",
                       "addr", "replace",
@@ -403,7 +392,6 @@ class UplinkBridgeWithNonNATTest_IP_VLAN(unittest.TestCase):
         cls = self.__class__
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager,
                                      include_stats=False)
-        self.assertEqual(get_ovsdb_port_tag(cls.UPLINK_BRIDGE), cls.VLAN_TAG)
 
         self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.UPLINK_BRIDGE), "ip not found")
 
@@ -591,6 +579,7 @@ class UplinkBridgeTestNatIPAddr(unittest.TestCase):
 
         assert_bridge_snapshot_match(self, self.UPLINK_BRIDGE, self.service_manager)
         self.assertIn(cls.SGi_IP, get_iface_ipv4(cls.BRIDGE_ETH_PORT), "ip not found")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/lte/gateway/python/setup.py
+++ b/lte/gateway/python/setup.py
@@ -86,7 +86,7 @@ setup(
         'lxml==4.2.1',
         'ryu>=4.30',
         'spyne==2.12.16',
-        'scapy==2.4.3',
+        'scapy==2.4.4',
         'flask>=1.0.2',
         'aioeventlet>=0.4',
         'aiodns>=1.1.1',

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -112,6 +112,7 @@ MAGMA_DEPS=(
     "libboost-chrono-dev" # required for folly
     "td-agent-bit >= 1.3.2" # fluent-bit
     "ntpdate" # required for eventd time synchronization
+    "python3-scapy >= 2.4.3-4"
     )
 
 # OAI runtime dependencies

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -132,11 +132,11 @@ OAI_DEPS=(
 # OVS runtime dependencies
 OVS_DEPS=(
     "magma-libfluid >= 0.1.0.4"
-    "openvswitch-common >= 2.8.9"
     "libopenvswitch >= 2.8.9"
     "openvswitch-switch >= 2.8.9"
-    "openvswitch-datapath-source-4.9.0-9 >= 2.8.9"
-    "openvswitch-datapath-dkms >= 2.8.9"
+    "openvswitch-common >= 2.8.9"
+    "python-openvswitch >= 2.8.9"
+    "openvswitch-datapath-module-4.9.0-9-amd64 >= 2.8.9"
     )
 
 # generate string for FPM

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -126,11 +126,17 @@ OAI_DEPS=(
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
+    "oai-gtp >= 4.9.5"
     )
 
 # OVS runtime dependencies
 OVS_DEPS=(
     "magma-libfluid >= 0.1.0.4"
+    "openvswitch-common >= 2.8.9"
+    "libopenvswitch >= 2.8.9"
+    "openvswitch-switch >= 2.8.9"
+    "openvswitch-datapath-source-4.9.0-9 >= 2.8.9"
+    "openvswitch-datapath-dkms >= 2.8.9"
     )
 
 # generate string for FPM

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -126,7 +126,7 @@ OAI_DEPS=(
     "liblfds710"
     "magma-sctpd >= ${SCTPD_MIN_VERSION}"
     "libczmq-dev >= 4.0.2-7"
-    "oai-gtp >= 4.9.5"
+    "oai-gtp >= 4.9-5"
     )
 
 # OVS runtime dependencies

--- a/nms/app/packages/magmalte/app/state/EquipmentState.js
+++ b/nms/app/packages/magmalte/app/state/EquipmentState.js
@@ -341,7 +341,7 @@ export async function RunGatewayCommands(props: GatewayCommandProps) {
 
     default:
       if (props.params != null) {
-        return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandReboot(
+        return await MagmaV1API.postNetworksByNetworkIdGatewaysByGatewayIdCommandGeneric(
           {networkId, gatewayId, parameters: props.params},
         );
       }

--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailMain.js
@@ -13,6 +13,9 @@
  * @flow strict-local
  * @format
  */
+import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
+
+import Button from '@material-ui/core/Button';
 import CardTitleRow from '../../components/layout/CardTitleRow';
 import DashboardIcon from '@material-ui/icons/Dashboard';
 import DateTimeMetricChart from '../../components/DateTimeMetricChart';
@@ -26,17 +29,34 @@ import SettingsIcon from '@material-ui/icons/Settings';
 import SettingsInputAntennaIcon from '@material-ui/icons/SettingsInputAntenna';
 import TopBar from '../../components/TopBar';
 import nullthrows from '@fbcnms/util/nullthrows';
+import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {EnodebJsonConfig} from './EnodebDetailConfig';
 import {EnodebStatus, EnodebSummary} from './EnodebDetailSummaryStatus';
 import {Redirect, Route, Switch} from 'react-router-dom';
+import {RunGatewayCommands} from '../../state/EquipmentState';
+import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useContext} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
 const useStyles = makeStyles(theme => ({
   dashboardRoot: {
     margin: theme.spacing(5),
+  },
+  appBarBtn: {
+    color: colors.primary.white,
+    background: colors.primary.comet,
+    fontFamily: typography.button.fontFamily,
+    fontWeight: typography.button.fontWeight,
+    fontSize: typography.button.fontSize,
+    lineHeight: typography.button.lineHeight,
+    letterSpacing: typography.button.letterSpacing,
+
+    '&:hover': {
+      background: colors.primary.mirage,
+    },
   },
 }));
 const CHART_TITLE = 'Bandwidth Usage';
@@ -56,11 +76,13 @@ export function EnodebDetail() {
             label: 'Overview',
             to: '/overview',
             icon: DashboardIcon,
+            filters: <EnodebRebootButton />,
           },
           {
             label: 'Config',
             to: '/config',
             icon: SettingsIcon,
+            filters: <EnodebRebootButton />,
           },
         ]}
       />
@@ -78,6 +100,64 @@ export function EnodebDetail() {
     </>
   );
 }
+
+function EnodebRebootButtonInternal(props: WithAlert) {
+  const classes = useStyles();
+  const ctx = useContext(EnodebContext);
+  const {match} = useRouter();
+  const networkId: string = nullthrows(match.params.networkId);
+  const enodebSerial: string = nullthrows(match.params.enodebSerial);
+  const enbInfo = ctx.state.enbInfo[enodebSerial];
+  const gatewayId = enbInfo?.enb_state?.reporting_gateway_id;
+  const enqueueSnackbar = useEnqueueSnackbar();
+
+  const handleClick = () => {
+    if (gatewayId == null) {
+      enqueueSnackbar('Unable to trigger reboot, reporting gateway not found', {
+        variant: 'error',
+      });
+      return;
+    }
+
+    props
+      .confirm(`Are you sure you want to reboot ${enodebSerial}?`)
+      .then(async confirmed => {
+        if (!confirmed) {
+          return;
+        }
+        const params = {
+          command: 'reboot_enodeb',
+          params: {shell_params: {[enodebSerial]: {}}},
+        };
+
+        try {
+          await RunGatewayCommands({
+            networkId,
+            gatewayId,
+            command: 'generic',
+            params,
+          });
+          enqueueSnackbar('eNodeB reboot triggered successfully', {
+            variant: 'success',
+          });
+        } catch (e) {
+          enqueueSnackbar(e.response?.data?.message ?? e.message, {
+            variant: 'error',
+          });
+        }
+      });
+  };
+
+  return (
+    <Button
+      variant="contained"
+      className={classes.appBarBtn}
+      onClick={handleClick}>
+      Reboot
+    </Button>
+  );
+}
+const EnodebRebootButton = withAlert(EnodebRebootButtonInternal);
 
 function Overview() {
   const ctx = useContext(EnodebContext);

--- a/orc8r/cloud/deploy/scripts/self_sign_certs.sh
+++ b/orc8r/cloud/deploy/scripts/self_sign_certs.sh
@@ -54,9 +54,3 @@ echo "###########################"
 echo "Deleting intermediate files"
 echo "###########################"
 rm -f controller.csr rootCA.srl
-
-echo ""
-echo "####################"
-echo "Deleting root CA key"
-echo "####################"
-rm -f rootCA.key

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -34,6 +34,7 @@ resource "null_resource" orc8r_seed_secrets {
 
 locals {
   orc8r_cert_names = [
+    "rootCA.key",
     "rootCA.pem",
     "controller.key",
     "controller.crt",


### PR DESCRIPTION
## Summary

A pointer issue was preventing multiple APN Resources from being added to a gateway at the same time. This pointer issue would result in orc8r attempting to create the same APN Resource entity.

## Test Plan

- Added a new unit test
- Also tested manually on a dev setup of orc8r, added two APN Resources to a single gateway at the same time
```
"apn_resources": {
    "management": {
            "apn_name": "management",
            "gateway_ip": "192.168.9.1",
            "gateway_mac": "e0:63:da:22:47:21",
            "id": "management_apn_resource_10_05_2020",
            "vlan_id": 12
        },
        "internet": {
            "apn_name": "internet",
            "gateway_ip": "192.168.10.1",
            "gateway_mac": "e0:63:da:22:47:21",
            "id": "internet_apn_resource_10_05_2020",
            "vlan_id": 13
        }
  },
```

## Additional Information

- [ ] This change is backwards-breaking