### PR TITLE
[lte][orc8r] Fix 3009 which prevented add of multi apn_resource

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -3002,6 +3002,17 @@ func TestAPNResource(t *testing.T) {
 		ExpectedStatus: 201,
 	}
 	tests.RunUnitTest(t, e, tc)
+	apn2 := newAPN("apn2")
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/:network_id/apns",
+		Payload:        apn2,
+		Handler:        postAPN,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
 
 	// Post, successful
 	gw.ApnResources = lteModels.ApnResources{"apn0": {ApnName: "apn0", ID: "res0", VlanID: 4}}
@@ -3102,7 +3113,11 @@ func TestAPNResource(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Put, create new APN resource
-	gw.ApnResources = lteModels.ApnResources{"apn1": {ApnName: "apn1", ID: "res1", VlanID: 4}}
+	// TODO: make sure that this works
+	gw.ApnResources = lteModels.ApnResources{
+		"apn1": {ApnName: "apn1", ID: "res1", VlanID: 4},
+		"apn2": {ApnName: "apn2", ID: "res2", VlanID: 4},
+	}
 	tc = tests.Test{
 		Method:         "PUT",
 		URL:            "/magma/v1/lte/n0/gateways/gw0",
@@ -3183,7 +3198,7 @@ func TestAPNResource(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Get, APN resource is gone due to cascading delete
-	gw.ApnResources = lteModels.ApnResources{}
+	gw.ApnResources = lteModels.ApnResources{"apn2": {ApnName: "apn2", ID: "res2", VlanID: 4}}
 	tc = tests.Test{
 		Method:         "GET",
 		URL:            "/magma/v1/lte/n0/gateways/gw0",

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -538,8 +538,9 @@ func LoadAPNResources(networkID string, ids []string) (ApnResources, error) {
 
 func (m *ApnResources) GetByID() map[string]*ApnResource {
 	byID := map[string]*ApnResource{}
-	for _, r := range *m {
-		byID[r.ID] = &r
+	for i, r := range *m {
+		var apnr = (*m)[i]
+		byID[r.ID] = &apnr
 	}
 	return byID
 }


### PR DESCRIPTION
## Summary

A pointer issue was preventing multiple APN Resources from being added to a gateway at the same time. This pointer issue would result in orc8r attempting to create the same APN Resource entity.

## Test Plan

- Added a new unit test
- Also tested manually on a dev setup of orc8r, added two APN Resources to a single gateway at the same time
```
"apn_resources": {
    "management": {
            "apn_name": "management",
            "gateway_ip": "192.168.9.1",
            "gateway_mac": "e0:63:da:22:47:21",
            "id": "management_apn_resource_10_05_2020",
            "vlan_id": 12
        },
        "internet": {
            "apn_name": "internet",
            "gateway_ip": "192.168.10.1",
            "gateway_mac": "e0:63:da:22:47:21",
            "id": "internet_apn_resource_10_05_2020",
            "vlan_id": 13
        }
  },
```

## Additional Information

- [ ] This change is backwards-breaking