### PR TITLE
Fix all useEffect exhaustive dep lint errors in NMS

### DIFF
--- a/nms/app/.eslintrc.js
+++ b/nms/app/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports.overrides = [
   {
     files: ['*'],
     rules: {
+      'react-hooks/exhaustive-deps': 'error',
       'prettier/prettier': [
         2,
         {

--- a/nms/app/packages/magmalte/app/components/EventAlertChart.js
+++ b/nms/app/packages/magmalte/app/components/EventAlertChart.js
@@ -195,7 +195,7 @@ export default function EventAlertChart(props: Props) {
     };
 
     fetchAllData();
-  }, [start, end, enqueueSnackbar, networkId]);
+  }, [start, end, delta, unit, enqueueSnackbar, networkId]);
 
   if (isLoading) {
     return <LoadingFiller />;

--- a/nms/app/packages/magmalte/app/components/cwf/CWFSections.js
+++ b/nms/app/packages/magmalte/app/components/cwf/CWFSections.js
@@ -25,7 +25,7 @@ import React from 'react';
 import SettingsCellIcon from '@material-ui/icons/SettingsCell';
 import ShowChartIcon from '@material-ui/icons/ShowChart';
 
-export function getCWFSections(): SectionsConfigs {
+export function getCWFSections(dashboardV2Enabled: boolean): SectionsConfigs {
   const sections = [
     {
       path: 'gateways',
@@ -52,6 +52,10 @@ export function getCWFSections(): SectionsConfigs {
       component: Alarms,
     },
   ];
+
+  if (dashboardV2Enabled) {
+    // TODO add equipment, policy and subscriber section
+  }
 
   return [
     'gateways', // landing path

--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -15,13 +15,15 @@
  */
 import type {SectionsConfigs} from '@fbcnms/magmalte/app/components/layout/Section';
 
+import AlarmIcon from '@material-ui/icons/Alarm';
+import Alarms from '@fbcnms/ui/insights/Alarms/Alarms';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import FEGConfigure from './FEGConfigure';
 import FEGGateways from './FEGGateways';
 import React from 'react';
 import SettingsCellIcon from '@material-ui/icons/SettingsCell';
 
-export function getFEGSections(): SectionsConfigs {
+export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
   const sections = [
     {
       path: 'gateways',
@@ -35,7 +37,17 @@ export function getFEGSections(): SectionsConfigs {
       icon: <SettingsCellIcon />,
       component: FEGConfigure,
     },
+    {
+      path: 'alerts',
+      label: 'Alerts',
+      icon: <AlarmIcon />,
+      component: Alarms,
+    },
   ];
+
+  if (dashboardV2Enabled) {
+    // TODO add equipment, policy and subscriber section
+  }
 
   return [
     'gateways', // landing path

--- a/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
+++ b/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
@@ -86,7 +86,7 @@ const testCases: {[string]: TestCase} = {
   },
   feg: {
     default: 'gateways',
-    sections: ['gateways', 'configure'],
+    sections: ['gateways', 'configure', 'alerts'],
   },
   carrier_wifi_network: {
     default: 'gateways',

--- a/nms/app/packages/magmalte/app/components/layout/useSections.js
+++ b/nms/app/packages/magmalte/app/components/layout/useSections.js
@@ -33,12 +33,19 @@ import {useContext, useEffect, useState} from 'react';
 
 export default function useSections(): SectionsConfigs {
   const {networkId} = useContext<NetworkContextType>(NetworkContext);
-  const {isFeatureEnabled} = useContext(AppContext);
+  const {user, isFeatureEnabled} = useContext(AppContext);
   const [networkType, setNetworkType] = useState<?NetworkType>(null);
   const alertsEnabled = isFeatureEnabled('alerts');
   const logsEnabled = isFeatureEnabled('logs');
   const dashboardV2Enabled = isFeatureEnabled('dashboard_v2');
+  let dashboardV2EnabledFegCwf = false;
 
+  // enable dashboard v2 for cwf and feg in test mode
+  if (user && user.tenant !== '') {
+    if (user.tenant.endsWith('-test') && dashboardV2Enabled) {
+      dashboardV2EnabledFegCwf = true;
+    }
+  }
   useEffect(() => {
     const fetchNetworkType = async () => {
       if (networkId) {
@@ -60,9 +67,9 @@ export default function useSections(): SectionsConfigs {
     case WIFI:
       return getMeshSections(alertsEnabled);
     case CWF:
-      return getCWFSections();
+      return getCWFSections(dashboardV2EnabledFegCwf);
     case FEG:
-      return getFEGSections();
+      return getFEGSections(dashboardV2EnabledFegCwf);
     case LTE:
     default: {
       if (dashboardV2Enabled) {

--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -297,7 +297,7 @@ export function PolicyProvider(props: Props) {
       setIsLoading(false);
     };
     fetchState();
-  }, [networkId, enqueueSnackbar]);
+  }, [networkId, networkType, lteNetworkCtx, enqueueSnackbar]);
 
   if (isLoading) {
     return <LoadingFiller />;
@@ -533,7 +533,7 @@ export function LteNetworkContextProvider(props: Props) {
       setIsLoading(false);
     };
     fetchState();
-  }, [networkId, enqueueSnackbar]);
+  }, [networkId, networkCtx, enqueueSnackbar]);
 
   if (isLoading) {
     return <LoadingFiller />;

--- a/nms/app/packages/magmalte/app/components/lte/LteSections.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteSections.js
@@ -27,7 +27,7 @@ import Insights from '@fbcnms/ui/insights/Insights';
 import ListIcon from '@material-ui/icons/List';
 import Logs from '@fbcnms/ui/insights/Logs/Logs';
 import LteConfigure from '../LteConfigure';
-import LteDashboard from './LteDashboard';
+import LteDashboard from '../../views/dashboard/lte/LteDashboard';
 import LteMetrics from './LteMetrics';
 import NetworkCheckIcon from '@material-ui/icons/NetworkCheck';
 import NetworkDashboard from '../../views/network/NetworkDashboard';

--- a/nms/app/packages/magmalte/app/views/dashboard/lte/LteDashboard.js
+++ b/nms/app/packages/magmalte/app/views/dashboard/lte/LteDashboard.js
@@ -13,20 +13,20 @@
  * @flow strict-local
  * @format
  */
-import DashboardAlertTable from '../DashboardAlertTable';
-import DashboardKPIs from '../DashboardKPIs';
-import EventAlertChart from '../EventAlertChart';
-import EventsTable from '../../views/events/EventsTable';
+import DashboardAlertTable from '../../../components/DashboardAlertTable';
+import DashboardKPIs from '../../../components/DashboardKPIs';
+import EventAlertChart from '../../../components/EventAlertChart';
+import EventsTable from '../../events/EventsTable';
 import Grid from '@material-ui/core/Grid';
 import React, {useState} from 'react';
-import Text from '../../theme/design-system/Text';
-import TopBar from '../TopBar';
+import Text from '../../../theme/design-system/Text';
+import TopBar from '../../../components/TopBar';
 import moment from 'moment';
 
 import {DateTimePicker} from '@material-ui/pickers';
 import {NetworkCheck} from '@material-ui/icons';
 import {Redirect, Route, Switch} from 'react-router-dom';
-import {colors} from '../../theme/default';
+import {colors} from '../../../theme/default';
 import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '@fbcnms/ui/hooks';
 

--- a/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkEdit.js
@@ -119,21 +119,18 @@ export function NetworkEditDialog(props: DialogProps) {
   const classes = useStyles();
   const ctx = useContext(LteNetworkContext);
 
-  const [lteNetwork, setLteNetwork] = useState<lte_network>(
-    editProps ? ctx.state : {},
-  );
-  const [epcConfigs, setEpcConfigs] = useState<network_epc_configs>(
-    editProps ? ctx.state.cellular?.epc ?? {} : {},
-  );
+  const [lteNetwork, setLteNetwork] = useState<lte_network>({});
+  const [epcConfigs, setEpcConfigs] = useState<network_epc_configs>({});
   const lteRanConfigs = editProps ? ctx.state.cellular?.ran : undefined;
 
   const [tabPos, setTabPos] = React.useState(
     editProps ? EditTableType[editProps.editTable] : 0,
   );
+
   useEffect(() => {
     setLteNetwork(editProps ? ctx.state : {});
     setEpcConfigs(editProps ? ctx.state.cellular?.epc ?? {} : {});
-  }, [open]);
+  }, [open, editProps, ctx.state]);
 
   const onClose = () => {
     setTabPos(0);

--- a/nms/app/packages/magmalte/app/views/traffic/PolicyOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/PolicyOverview.js
@@ -276,7 +276,7 @@ export function PolicyJsonConfig() {
         ),
       );
     }
-  }, [policyID]);
+  }, [policyID, lteNetwork]);
   return (
     <JsonEditor
       content={policy}


### PR DESCRIPTION
## Summary

Missing dependencies in react useEffect can lead to subtle errors. Fixing this and adding this as a linter rule to err. 

## Test Plan

yarn eslint and flow succeeds. 
Manually clicked around and verified NMS
[skipJenkins]

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
