### PR TITLE
[cwf] Fix reauth tests to wait and check for a conditional

### DIFF
--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -415,10 +415,8 @@ func TestGxQosDowngradeWithReAuth(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	tr.WaitForReAuthToProcess()
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	_, err = tr.GenULTraffic(req)

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -109,13 +109,14 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 		&fegprotos.PolicyReAuthTarget{Imsi: imsi, RulesToRemove: rulesRemoval},
 	)
 	assert.NoError(t, err)
-	tr.WaitForReAuthToProcess()
 
-	// Check ReAuth success
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
+
 	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Check that UE flows were deleted for rule 2 and 3
+	tr.WaitForEnforcementStatsToSync()
+
 	recordsBySubID, err = tr.GetPolicyUsage()
 	assert.NoError(t, err)
 
@@ -181,14 +182,12 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 		&fegprotos.PolicyReAuthTarget{Imsi: imsi, RulesToRemove: rulesRemoval},
 	)
 	assert.NoError(t, err)
-	tr.WaitForReAuthToProcess()
-
-	// Check ReAuth success
-	assert.NotNil(t, raa)
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Check that all UE mac flows are deleted
+	tr.WaitForEnforcementStatsToSync()
+
 	recordsBySubID, err = tr.GetPolicyUsage()
 	assert.NoError(t, err)
 
@@ -270,10 +269,8 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	tr.WaitForReAuthToProcess()
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Generate more traffic
@@ -371,10 +368,8 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	tr.WaitForReAuthToProcess()
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Generate more traffic
@@ -445,10 +440,8 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 		},
 	)
 	assert.NoError(t, err)
-	tr.WaitForReAuthToProcess()
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
-	// Check ReAuth success
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, diam.Success, int(raa.ResultCode))
 
 	// Generate more traffic

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -441,11 +441,10 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 
 	// Send ReAuth Request to update quota
 	raa, err := sendChargingReAuthRequest(ue.GetImsi(), 1)
-	tr.WaitForReAuthToProcess()
+	assert.NoError(t, err)
+	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, ue.GetImsi()), time.Minute, 2*time.Second)
 
 	// Check ReAuth success
-	assert.NoError(t, err)
-	assert.Contains(t, raa.SessionId, "IMSI"+ue.GetImsi())
 	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
 	// Assert that a CCR-I and CCR-U were sent to the OCS
@@ -526,11 +525,10 @@ func TestGyCreditUpdateCommandLevelFail(t *testing.T) {
 	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
 	// Trigger a ReAuth to force an update request
 	raa, err := sendChargingReAuthRequest(ue.GetImsi(), 1)
-	tr.WaitForReAuthToProcess()
+	assert.NoError(t, err)
+	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, ue.GetImsi()), time.Minute, 2*time.Second)
 
 	// Check ReAuth success
-	assert.NoError(t, err)
-	assert.Contains(t, raa.SessionId, "IMSI"+ue.GetImsi())
 	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
 	// Wait for a termination to propagate
@@ -729,11 +727,10 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 
 	// Send ReAuth Request to update quota
 	raa, err := sendChargingReAuthRequest(ue.GetImsi(), 1)
-	tr.WaitForReAuthToProcess()
+	assert.NoError(t, err)
+	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, ue.GetImsi()), time.Minute, 2*time.Second)
 
 	// Check ReAuth success
-	assert.NoError(t, err)
-	assert.Contains(t, raa.SessionId, "IMSI"+ue.GetImsi())
 	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
 	// Assert that a CCR-I and CCR-U were sent to the OCS

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -111,11 +111,10 @@ func TestGyReAuth(t *testing.T) {
 
 	// Send ReAuth Request to update quota
 	raa, err := sendChargingReAuthRequest(imsi, ratingGroup)
-	tr.WaitForReAuthToProcess()
+	assert.NoError(t, err)
+	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
 	// Check ReAuth success
-	assert.NoError(t, err)
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
 
 	// Generate over 1M of data to check that initial quota was updated

--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -137,11 +137,9 @@ func TestOmnipresentRules(t *testing.T) {
 	}
 	fmt.Printf("Sending a ReAuthRequest with target %v\n", target)
 	raa, err := sendPolicyReAuthRequest(target)
-	tr.WaitForReAuthToProcess()
+	assert.Eventually(t, tr.WaitForPolicyReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
 
 	// Check ReAuth success
-	assert.NoError(t, err)
-	assert.Contains(t, raa.SessionId, "IMSI"+imsi)
 	fmt.Printf("RAA result code=%v, should be=%v\n", int(raa.ResultCode), diam.Success)
 	//assert.Equal(t, diam.Success, int(raa.ResultCode))
 

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -25,6 +25,7 @@ import (
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/cwf/gateway/registry"
 	"magma/cwf/gateway/services/uesim"
+	fegprotos "magma/feg/cloud/go/protos"
 	"magma/lte/cloud/go/crypto"
 	lteprotos "magma/lte/cloud/go/protos"
 
@@ -298,9 +299,28 @@ func (tr *TestRunner) WaitForPoliciesToSync() {
 	time.Sleep(4 * ruleUpdatePeriod)
 }
 
-func (tr *TestRunner) WaitForReAuthToProcess() {
+//WaitForPolicyReAuthToProcess returns a method which checks for reauth answer and
+// if it has sessionID which contains the IMSI
+func (tr *TestRunner) WaitForPolicyReAuthToProcess(raa *fegprotos.PolicyReAuthAnswer, imsi string) func() bool {
 	// Todo figure out the best way to figure out when RAR is processed
-	time.Sleep(4 * time.Second)
+	return func() bool {
+		if raa != nil && strings.Contains(raa.SessionId, "IMSI"+imsi) {
+			return true
+		}
+		return false
+	}
+}
+
+//WaitForChargingReAuthToProcess returns a method which checks for reauth answer and
+// if it has sessionID which contains the IMSI
+func (tr *TestRunner) WaitForChargingReAuthToProcess(raa *fegprotos.ChargingReAuthAnswer, imsi string) func() bool {
+	// Todo figure out the best way to figure out when RAR is processed
+	return func() bool {
+		if raa != nil && strings.Contains(raa.SessionId, "IMSI"+imsi) {
+			return true
+		}
+		return false
+	}
 }
 
 func (tr *TestRunner) PrintElapsedTime() {


### PR DESCRIPTION
## Summary

There is a lot of flakiness in the reauth test due to the way we sleep for 4-5 seconds and test for raa. Modifying this to instead poll for a condition to be true atleast for a minute. 
[skipJenkins]