### PR TITLE
[orc8r][indexers] Fix broken indexer manager CLI

### DIFF
--- a/orc8r/cloud/go/tools/indexers/cmd/root.go
+++ b/orc8r/cloud/go/tools/indexers/cmd/root.go
@@ -59,6 +59,7 @@ func globalPre(cmd *cobra.Command, args []string) {
 		defer log.SetOutput(os.Stderr)
 	}
 	plugin.LoadAllPluginsFatalOnError(&plugin.DefaultOrchestratorPluginLoader{})
+	registry.MustPopulateServices()
 }
 
 func getClient() indexer_protos.IndexerManagerClient {


### PR DESCRIPTION
## Summary

Indexer manager CLI broke during the service registry changes. This PR fixes the breakage in preparation for the 1.3 release, which includes a new state indexer.

## Test Plan

- [x] `envdir /var/opt/magma/envdir /var/opt/magma/bin/indexers reindex -f` from within controller to force-reindex an existing indexer

## Additional Information

- [ ] This change is backwards-breaking