### PR TITLE
[xwf-m] fix radiusd host resolution and shutdown workaround

### DIFF
--- a/xwf/gateway/configs/magmad.yml
+++ b/xwf/gateway/configs/magmad.yml
@@ -39,7 +39,7 @@ bootstrap_config:
   challenge_key: /var/opt/magma/certs/gw_challenge.key
 
 # Flags indicating the magmad features to be enabled
-enable_config_streamer: False
+enable_config_streamer: True
 enable_upgrade_manager: True
 enable_network_monitor: True
 enable_sync_rpc: True

--- a/xwf/gateway/deploy/roles/containers/files/xwfm_update.sh
+++ b/xwf/gateway/deploy/roles/containers/files/xwfm_update.sh
@@ -22,6 +22,15 @@ fi
 
 # Otherwise recreate containers with the new image
 cd /var/opt/magma/docker || exit
-/usr/local/bin/docker-compose down && /usr/local/bin/docker-compose up -d
+
+# Stop all containers
+# NOTE: add docker restart to work around GoRadius failures to stop
+/usr/local/bin/docker-compose down ||
+  systemctl restart docker.socket docker.service &&
+  docker stop $(docker ps -a -q)
+
+# Bring containers up
+/usr/local/bin/docker-compose up -d
+
 # Remove all stopped containers and dangling images
 docker system prune -af

--- a/xwf/gateway/deploy/roles/containers/templates/env.j2
+++ b/xwf/gateway/deploy/roles/containers/templates/env.j2
@@ -30,3 +30,4 @@ AAA_ACCESS_TOKEN={{ AAA_ACCESS_TOKEN | replace('\n', '') | trim | urlencode }}
 RADIUS_SECRET={{ RADIUS_SECRET }} 
 PARTNER_SHORTNAME={{ partner }}
 
+HOST_DOCKER_INTERNAL={{ ansible_default_ipv4.address }}

--- a/xwf/gateway/deploy/roles/provision/files/xwfm_provision.py
+++ b/xwf/gateway/deploy/roles/provision/files/xwfm_provision.py
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import argparse
-
+import socket
 import requests
 import urllib3
 import jsonpickle
@@ -177,7 +177,7 @@ def register_gateway(url: str, network_id: str, hardware_id: str, tier_id: str):
     gid = get_next_gateway_id(url, network_id)
     grePeer = AllowedGREPeers(ip="192.168.128.2", key=100)
     data = Gateway(
-        name=f"XWFM Gateway {gid}",
+        name=socket.gethostname().strip(),
         description=f"XWFM Gateway {gid}",
         tier="default",
         id=f"fbc_gw_{gid}",

--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -109,6 +109,8 @@ services:
     <<: *service
     image: ${DOCKER_REGISTRY}gateway_go:${IMAGE_VERSION}
     container_name: radiusd
+    extra_hosts:
+      - radius:${HOST_DOCKER_INTERNAL}
     command: envdir /var/opt/magma/envdir /var/opt/magma/bin/radiusd -logtostderr=true -v=0
 
   logrouter:


### PR DESCRIPTION

## Summary

- Add radius host resolution to work around radiusd configuration override by orc8r
- Add a workaround to force radiusd shutdown during an upgrade. (known bug)
- Enable orc8r config back
- Use hostname when provisioning the gateway in the nms.

## Test Plan

tested on xwfmqa1