### PR TITLE
SPGW: OAI: GTP: introduce IPv6 support

### DIFF
--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.cpp
@@ -90,15 +90,45 @@ void ExternalEvent::set_of_connection(fluid_base::OFConnection* ofconn) {
 }
 
 UeNetworkInfo::UeNetworkInfo(const struct in_addr ue_ip)
-    : ue_ip_(ue_ip),
-      vlan_(0) {}
+    : ue_ip_(ue_ip), vlan_(0), ue_ipv6_(in6addr_any) {}
+
+UeNetworkInfo::UeNetworkInfo(
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6)
+    : ue_ip_(ue_ip), vlan_(0) {
+  if (ue_ipv6) {
+    ue_ipv6_ = *ue_ipv6;
+  } else {
+    ue_ipv6_ = in6addr_any;
+  }
+}
 
 UeNetworkInfo::UeNetworkInfo(const struct in_addr ue_ip, int vlan)
-    : ue_ip_(ue_ip),
-      vlan_(vlan) {}
+    : ue_ip_(ue_ip), vlan_(vlan), ue_ipv6_(in6addr_any) {}
+
+UeNetworkInfo::UeNetworkInfo(
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan)
+    : ue_ip_(ue_ip), vlan_(vlan) {
+  if (ue_ipv6) {
+    ue_ipv6_ = *ue_ipv6;
+  } else {
+    ue_ipv6_ = in6addr_any;
+  }
+}
+
+const bool UeNetworkInfo::is_ue_ipv6_addr_valid() const {
+  return !!memcmp(&ue_ipv6_, &in6addr_any, sizeof(ue_ipv6_));
+}
+
+const bool UeNetworkInfo::is_ue_ipv4_addr_valid() const {
+  return ue_ip_.s_addr != INADDR_ANY;
+}
 
 const struct in_addr& UeNetworkInfo::get_ip() const {
   return ue_ip_;
+}
+
+const struct in6_addr& UeNetworkInfo::get_ipv6() const {
+  return ue_ipv6_;
 }
 
 const int UeNetworkInfo::get_vlan() const {
@@ -106,10 +136,10 @@ const int UeNetworkInfo::get_vlan() const {
 }
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip, int vlan, const struct in_addr enb_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-    uint32_t gtp_port_no)
-    : ue_info_(ue_ip, vlan),
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+    const struct in_addr enb_ip, const uint32_t in_tei, const uint32_t out_tei,
+    const char* imsi, uint32_t gtp_port_no)
+    : ue_info_(ue_ip, ue_ipv6, vlan),
       enb_ip_(enb_ip),
       in_tei_(in_tei),
       out_tei_(out_tei),
@@ -121,10 +151,10 @@ AddGTPTunnelEvent::AddGTPTunnelEvent(
       gtp_portno_(gtp_port_no) {}
 
 AddGTPTunnelEvent::AddGTPTunnelEvent(
-    const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
-    const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-    const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence,
-    uint32_t gtp_port_no)
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+    const struct in_addr enb_ip, const uint32_t in_tei, const uint32_t out_tei,
+    const char* imsi, const struct ip_flow_dl* dl_flow,
+    const uint32_t dl_flow_precedence, uint32_t gtp_port_no)
     : ue_info_(ue_ip, vlan),
       enb_ip_(enb_ip),
       in_tei_(in_tei),
@@ -164,7 +194,7 @@ const bool AddGTPTunnelEvent::is_dl_flow_valid() const {
   return dl_flow_valid_;
 }
 
-const struct ipv4flow_dl& AddGTPTunnelEvent::get_dl_flow() const {
+const struct ip_flow_dl& AddGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 
@@ -177,9 +207,9 @@ const uint32_t AddGTPTunnelEvent::get_gtp_portno() const {
 }
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-    const struct in_addr ue_ip, const uint32_t in_tei,
-    const struct ipv4flow_dl* dl_flow, uint32_t gtp_port_no)
-    : ue_info_(ue_ip),
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
+    const struct ip_flow_dl* dl_flow, uint32_t gtp_port_no)
+    : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
       dl_flow_valid_(true),
       dl_flow_(*dl_flow),
@@ -187,13 +217,18 @@ DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
       gtp_portno_(gtp_port_no) {}
 
 DeleteGTPTunnelEvent::DeleteGTPTunnelEvent(
-    const struct in_addr ue_ip, const uint32_t in_tei, uint32_t gtp_port_no)
-    : ue_info_(ue_ip),
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
+    uint32_t gtp_port_no)
+    : ue_info_(ue_ip, ue_ipv6),
       in_tei_(in_tei),
       dl_flow_valid_(false),
       dl_flow_(),
       ExternalEvent(EVENT_DELETE_GTP_TUNNEL),
       gtp_portno_(gtp_port_no) {}
+
+const struct UeNetworkInfo& DeleteGTPTunnelEvent::get_ue_info() const {
+  return ue_info_;
+}
 
 const struct in_addr& DeleteGTPTunnelEvent::get_ue_ip() const {
   return ue_info_.get_ip();
@@ -207,7 +242,7 @@ const bool DeleteGTPTunnelEvent::is_dl_flow_valid() const {
   return dl_flow_valid_;
 }
 
-const struct ipv4flow_dl& DeleteGTPTunnelEvent::get_dl_flow() const {
+const struct ip_flow_dl& DeleteGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 
@@ -216,8 +251,8 @@ const uint32_t DeleteGTPTunnelEvent::get_gtp_portno() const {
 }
 
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
-    const struct in_addr ue_ip, const uint32_t in_tei,
-    const ControllerEventType event_type, const struct ipv4flow_dl* dl_flow,
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
+    const ControllerEventType event_type, const struct ip_flow_dl* dl_flow,
     const uint32_t dl_flow_precedence)
     : ue_info_(ue_ip),
       in_tei_(in_tei),
@@ -226,9 +261,8 @@ HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
       dl_flow_precedence_(dl_flow_precedence),
       ExternalEvent(event_type) {}
 
-
 HandleDataOnGTPTunnelEvent::HandleDataOnGTPTunnelEvent(
-    const struct in_addr ue_ip, const uint32_t in_tei,
+    const struct in_addr ue_ip, struct in6_addr* ue_ipv6, const uint32_t in_tei,
     const ControllerEventType event_type)
     : ue_info_(ue_ip),
       in_tei_(in_tei),
@@ -249,7 +283,7 @@ const bool HandleDataOnGTPTunnelEvent::is_dl_flow_valid() const {
   return dl_flow_valid_;
 }
 
-const struct ipv4flow_dl& HandleDataOnGTPTunnelEvent::get_dl_flow() const {
+const struct ip_flow_dl& HandleDataOnGTPTunnelEvent::get_dl_flow() const {
   return dl_flow_;
 }
 

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerEvents.h
@@ -146,13 +146,20 @@ class ExternalEvent : public ControllerEvent {
 class UeNetworkInfo {
  public:
   UeNetworkInfo(const struct in_addr ue_ip);
+  UeNetworkInfo(const struct in_addr ue_ip, struct in6_addr* ue_ipv6);
+
   UeNetworkInfo(const struct in_addr ue_ip, int vlan);
+  UeNetworkInfo(const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan);
 
   const struct in_addr& get_ip() const;
+  const struct in6_addr& get_ipv6() const;
   const int get_vlan() const;
+  const bool is_ue_ipv6_addr_valid() const;
+  const bool is_ue_ipv4_addr_valid() const;
 
  private:
   const struct in_addr ue_ip_;
+  struct in6_addr ue_ipv6_;
   const int vlan_;
 };
 
@@ -162,24 +169,27 @@ class UeNetworkInfo {
 class AddGTPTunnelEvent : public ExternalEvent {
  public:
   AddGTPTunnelEvent(
-      const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
-      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-      const struct ipv4flow_dl* dl_flow, const uint32_t dl_flow_precedence,
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+      const struct in_addr enb_ip, const uint32_t in_tei,
+      const uint32_t out_tei, const char* imsi,
+      const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence,
       uint32_t gtp_port_no);
 
   AddGTPTunnelEvent(
-      const struct in_addr ue_ip, int vlan,  const struct in_addr enb_ip,
-      const uint32_t in_tei, const uint32_t out_tei, const char* imsi,
-      uint32_t gtp_port_no);
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6, int vlan,
+      const struct in_addr enb_ip, const uint32_t in_tei,
+      const uint32_t out_tei, const char* imsi, uint32_t gtp_port_no);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
+  const struct in_addr& get_ue_ipv6() const;
+
   const struct in_addr& get_enb_ip() const;
   const uint32_t get_in_tei() const;
   const uint32_t get_out_tei() const;
   const std::string& get_imsi() const;
   const bool is_dl_flow_valid() const;
-  const struct ipv4flow_dl& get_dl_flow() const;
+  const struct ip_flow_dl& get_dl_flow() const;
   const uint32_t get_dl_flow_precedence() const;
   const uint32_t get_gtp_portno() const;
 
@@ -189,7 +199,7 @@ class AddGTPTunnelEvent : public ExternalEvent {
   const uint32_t in_tei_;
   const uint32_t out_tei_;
   const std::string imsi_;
-  const struct ipv4flow_dl dl_flow_;
+  const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;
   const uint32_t dl_flow_precedence_;
   const uint32_t gtp_portno_;
@@ -201,23 +211,24 @@ class AddGTPTunnelEvent : public ExternalEvent {
 class DeleteGTPTunnelEvent : public ExternalEvent {
  public:
   DeleteGTPTunnelEvent(
-      const struct in_addr ue_ip, const uint32_t in_tei,
-      const struct ipv4flow_dl* dl_flow,
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei, const struct ip_flow_dl* dl_flow,
       uint32_t gtp_port_no);
-  DeleteGTPTunnelEvent(const struct in_addr ue_ip, const uint32_t in_tei,
-      uint32_t gtp_port_no);
+  DeleteGTPTunnelEvent(
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei, uint32_t gtp_port_no);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
   const bool is_dl_flow_valid() const;
-  const struct ipv4flow_dl& get_dl_flow() const;
+  const struct ip_flow_dl& get_dl_flow() const;
   const uint32_t get_gtp_portno() const;
 
  private:
   const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
-  const struct ipv4flow_dl dl_flow_;
+  const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;
   const uint32_t gtp_portno_;
 };
@@ -232,24 +243,24 @@ class DeleteGTPTunnelEvent : public ExternalEvent {
 class HandleDataOnGTPTunnelEvent : public ExternalEvent {
  public:
   HandleDataOnGTPTunnelEvent(
-      const struct in_addr ue_ip, const uint32_t in_tei,
-      const ControllerEventType event_type, const struct ipv4flow_dl* dl_flow,
-      const uint32_t dl_flow_precedence);
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei, const ControllerEventType event_type,
+      const struct ip_flow_dl* dl_flow, const uint32_t dl_flow_precedence);
   HandleDataOnGTPTunnelEvent(
-      const struct in_addr ue_ip, const uint32_t in_tei,
-      const ControllerEventType event_type);
+      const struct in_addr ue_ip, struct in6_addr* ue_ipv6,
+      const uint32_t in_tei, const ControllerEventType event_type);
 
   const struct UeNetworkInfo& get_ue_info() const;
   const struct in_addr& get_ue_ip() const;
   const uint32_t get_in_tei() const;
   const bool is_dl_flow_valid() const;
-  const struct ipv4flow_dl& get_dl_flow() const;
+  const struct ip_flow_dl& get_dl_flow() const;
   const uint32_t get_dl_flow_precedence() const;
 
  private:
   const UeNetworkInfo ue_info_;
   const uint32_t in_tei_;
-  const struct ipv4flow_dl dl_flow_;
+  const struct ip_flow_dl dl_flow_;
   const bool dl_flow_valid_;
   const uint32_t dl_flow_precedence_;
 };
@@ -257,6 +268,8 @@ class HandleDataOnGTPTunnelEvent : public ExternalEvent {
 /*
  * Event triggered by SPGW to support UE paging when
  * S1 is released (i.e., UE is in IDLE mode)
+ *
+ * TODO: Ipv6 support.
  */
 class AddPagingRuleEvent : public ExternalEvent {
  public:

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.cpp
@@ -86,63 +86,65 @@ static void* external_event_callback(std::shared_ptr<void> data) {
 }
 
 int openflow_controller_add_gtp_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    const char* imsi, struct ipv4flow_dl* flow_dl,
-    uint32_t flow_precedence_dl, uint32_t gtp_portno) {
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    uint32_t i_tei, uint32_t o_tei, const char* imsi,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
+    uint32_t gtp_portno) {
   if (flow_dl) {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl,
+        ue, ue_ipv6, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl,
         gtp_portno);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   } else {
     auto add_tunnel = std::make_shared<openflow::AddGTPTunnelEvent>(
-        ue, vlan, enb, i_tei, o_tei, imsi, gtp_portno);
+        ue, ue_ipv6, vlan, enb, i_tei, o_tei, imsi, gtp_portno);
     ctrl.inject_external_event(add_tunnel, external_event_callback);
   }
   return 0;
 }
 
 int openflow_controller_del_gtp_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
-    uint32_t gtp_portno) {
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t gtp_portno) {
   if (flow_dl) {
-    auto del_tunnel =
-        std::make_shared<openflow::DeleteGTPTunnelEvent>(ue, i_tei, flow_dl,
-                                                         gtp_portno);
+    auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
+        ue, ue_ipv6, i_tei, flow_dl, gtp_portno);
     ctrl.inject_external_event(del_tunnel, external_event_callback);
   } else {
-    auto del_tunnel =
-        std::make_shared<openflow::DeleteGTPTunnelEvent>(ue, i_tei, gtp_portno);
+    auto del_tunnel = std::make_shared<openflow::DeleteGTPTunnelEvent>(
+        ue, ue_ipv6, i_tei, gtp_portno);
     ctrl.inject_external_event(del_tunnel, external_event_callback);
   }
   return 0;
 }
 
 int openflow_controller_discard_data_on_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl) {
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl) {
   if (flow_dl) {
     auto gtp_tunnel = std::make_shared<openflow::HandleDataOnGTPTunnelEvent>(
-        ue, i_tei, openflow::EVENT_DISCARD_DATA_ON_GTP_TUNNEL, flow_dl, false);
+        ue, ue_ipv6, i_tei, openflow::EVENT_DISCARD_DATA_ON_GTP_TUNNEL, flow_dl,
+        false);
     ctrl.inject_external_event(gtp_tunnel, external_event_callback);
   } else {
     auto gtp_tunnel = std::make_shared<openflow::HandleDataOnGTPTunnelEvent>(
-        ue, i_tei, openflow::EVENT_DISCARD_DATA_ON_GTP_TUNNEL);
+        ue, ue_ipv6, i_tei, openflow::EVENT_DISCARD_DATA_ON_GTP_TUNNEL);
     ctrl.inject_external_event(gtp_tunnel, external_event_callback);
   }
   return 0;
 }
 
 int openflow_controller_forward_data_on_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
-    uint32_t flow_precedence_dl) {
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
   if (flow_dl) {
     auto gtp_tunnel = std::make_shared<openflow::HandleDataOnGTPTunnelEvent>(
-        ue, i_tei, openflow::EVENT_FORWARD_DATA_ON_GTP_TUNNEL, flow_dl,
+        ue, ue_ipv6, i_tei, openflow::EVENT_FORWARD_DATA_ON_GTP_TUNNEL, flow_dl,
         flow_precedence_dl);
     ctrl.inject_external_event(gtp_tunnel, external_event_callback);
   } else {
     auto gtp_tunnel = std::make_shared<openflow::HandleDataOnGTPTunnelEvent>(
-        ue, i_tei, openflow::EVENT_FORWARD_DATA_ON_GTP_TUNNEL);
+        ue, ue_ipv6, i_tei, openflow::EVENT_FORWARD_DATA_ON_GTP_TUNNEL);
     ctrl.inject_external_event(gtp_tunnel, external_event_callback);
   }
   return 0;

--- a/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/ControllerMain.h
@@ -30,20 +30,22 @@ int start_of_controller(bool persist_state);
 int stop_of_controller(void);
 
 int openflow_controller_add_gtp_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    const char* imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl,
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    uint32_t i_tei, uint32_t o_tei, const char* imsi,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl,
     uint32_t gtp_portno);
 
 int openflow_controller_del_gtp_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
-    uint32_t gtp_portno);
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t gtp_portno);
 
 int openflow_controller_discard_data_on_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl);
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl);
 
 int openflow_controller_forward_data_on_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
-    uint32_t flow_precedence_dl);
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl);
 
 int openflow_controller_add_paging_rule(struct in_addr ue_ip);
 

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -33,7 +33,7 @@ using namespace fluid_msg;
 namespace openflow {
 
 const std::string GTPApplication::GTP_PORT_MAC = "02:00:00:00:00:01";
-const std:: uint16_t OFPVID_PRESENT = 0x1000;
+const std::uint16_t OFPVID_PRESENT             = 0x1000;
 
 GTPApplication::GTPApplication(
     const std::string& uplink_mac, uint32_t gtp_port_num, uint32_t mtr_port_num,
@@ -200,9 +200,7 @@ static void add_downlink_arp_match(
 }
 
 static void add_downlink_match(
-    of13::FlowMod& downlink_fm, const struct in_addr& ue_ip, uint32_t port)
-
-{
+    of13::FlowMod& downlink_fm, const struct in_addr& ue_ip, uint32_t port) {
   // Set match on uplink port and IP eth type
   of13::InPort uplink_port_match(port);
   downlink_fm.add_oxm_field(uplink_port_match);
@@ -214,24 +212,57 @@ static void add_downlink_match(
   downlink_fm.add_oxm_field(ip_match);
 }
 
-static void add_ded_brr_dl_match(
-    of13::FlowMod& downlink_fm, const struct ipv4flow_dl& flow, uint32_t port) {
+static void add_downlink_match_ipv6(
+    of13::FlowMod& downlink_fm, const struct in6_addr& ue_ip6, uint32_t port) {
   // Set match on uplink port and IP eth type
   of13::InPort uplink_port_match(port);
   downlink_fm.add_oxm_field(uplink_port_match);
-  of13::EthType ip_type(0x0800);
-  downlink_fm.add_oxm_field(ip_type);
+  of13::EthType ip6_type(0x08DD);
+  downlink_fm.add_oxm_field(ip6_type);
 
   // Match UE IP destination
-  if (flow.set_params & DST_IPV4) {
-    of13::IPv4Dst ipv4_dst(flow.dst_ip.s_addr);
-    downlink_fm.add_oxm_field(ipv4_dst);
-  }
+  of13::IPv6Dst ipv6_dst(IPAddress((struct in6_addr) ue_ip6));
+  downlink_fm.add_oxm_field(ipv6_dst);
+}
 
-  // Match IP source
-  if (flow.set_params & SRC_IPV4) {
-    of13::IPv4Src ipv4_src(flow.src_ip.s_addr);
-    downlink_fm.add_oxm_field(ipv4_src);
+/**
+ * Helper function to add dedicated brr flow match
+ */
+static void add_ded_brr_dl_match(
+    of13::FlowMod& downlink_fm, const struct ip_flow_dl& flow, uint32_t port) {
+  // Set match on uplink port and IP eth type
+  of13::InPort uplink_port_match(port);
+  downlink_fm.add_oxm_field(uplink_port_match);
+
+  // Match UE IP destination
+  if ((flow.set_params & DST_IPV4) || (flow.set_params & SRC_IPV4)) {
+    of13::EthType ip_type(0x0800);
+    downlink_fm.add_oxm_field(ip_type);
+
+    if (flow.set_params & DST_IPV4) {
+      of13::IPv4Dst ipv4_dst(flow.dst_ip.s_addr);
+      downlink_fm.add_oxm_field(ipv4_dst);
+    }
+
+    // Match IP source
+    if (flow.set_params & SRC_IPV4) {
+      of13::IPv4Src ipv4_src(flow.src_ip.s_addr);
+      downlink_fm.add_oxm_field(ipv4_src);
+    }
+  } else {
+    of13::EthType ip_type(0x08DD);
+    downlink_fm.add_oxm_field(ip_type);
+
+    if (flow.set_params & DST_IPV6) {
+      of13::IPv6Dst ipv6_dst(IPAddress(flow.dst_ip6));
+      downlink_fm.add_oxm_field(ipv6_dst);
+    }
+
+    // Match IP source
+    if (flow.set_params & SRC_IPV6) {
+      of13::IPv6Src ipv6_src(IPAddress(flow.src_ip6));
+      downlink_fm.add_oxm_field(ipv6_src);
+    }
   }
 
   if (flow.set_params & IP_PROTO) {
@@ -260,21 +291,13 @@ static void add_ded_brr_dl_match(
   }
 }
 
-void GTPApplication::add_downlink_tunnel_flow(
+/**
+ * Helper function to add downlink flow action.
+ */
+void GTPApplication::add_downlink_tunnel_flow_action(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
-    uint32_t port_number) {
+    of13::FlowMod downlink_fm) {
   auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
-  uint32_t flow_priority =
-      convert_precedence_to_priority(ev.get_dl_flow_precedence());
-  of13::FlowMod downlink_fm =
-      messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
-
-  if (ev.is_dl_flow_valid()) {
-    add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
-  } else {
-    add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
-  }
-
   of13::ApplyActions apply_dl_inst;
 
   // Set outgoing tunnel id and tunnel destination ip
@@ -306,17 +329,67 @@ void GTPApplication::add_downlink_tunnel_flow(
   OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "Downlink flow added\n");
 }
 
-void GTPApplication::add_downlink_arp_flow(
+void GTPApplication::add_downlink_tunnel_flow_ipv4(
     const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
     uint32_t port_number) {
-  auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
   uint32_t flow_priority =
       convert_precedence_to_priority(ev.get_dl_flow_precedence());
   of13::FlowMod downlink_fm =
       messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
 
-  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), port_number);
+  add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
+  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm);
+}
 
+void GTPApplication::add_downlink_tunnel_flow_ipv6(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  uint32_t flow_priority =
+      convert_precedence_to_priority(ev.get_dl_flow_precedence());
+  of13::FlowMod downlink_fm =
+      messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
+
+  add_downlink_match_ipv6(
+      downlink_fm, ev.get_ue_info().get_ipv6(), port_number);
+  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm);
+}
+
+void GTPApplication::add_downlink_tunnel_flow_ded_brr(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  uint32_t flow_priority =
+      convert_precedence_to_priority(ev.get_dl_flow_precedence());
+  of13::FlowMod downlink_fm =
+      messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
+
+  add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
+  add_downlink_tunnel_flow_action(ev, messenger, downlink_fm);
+}
+
+void GTPApplication::add_downlink_tunnel_flow(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  if (ev.is_dl_flow_valid()) {
+    add_downlink_tunnel_flow_ded_brr(ev, messenger, port_number);
+    return;
+  }
+  UeNetworkInfo ue_info = ev.get_ue_info();
+
+  if (ue_info.is_ue_ipv4_addr_valid()) {
+    add_downlink_tunnel_flow_ipv4(ev, messenger, port_number);
+  }
+  if (ue_info.is_ue_ipv6_addr_valid()) {
+    add_downlink_tunnel_flow_ipv6(ev, messenger, port_number);
+  }
+}
+
+/**
+ * Helper function to add ARP actions
+ */
+void GTPApplication::add_downlink_arp_flow_action(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    of13::FlowMod downlink_fm) {
+  auto imsi = IMSIEncoder::compact_imsi(ev.get_imsi());
   of13::ApplyActions apply_dl_inst;
 
   // add imsi to packet metadata to pass to other tables
@@ -333,7 +406,20 @@ void GTPApplication::add_downlink_arp_flow(
   OAILOG_DEBUG_UE(LOG_GTPV1U, imsi, "ARP flow added\n");
 }
 
-void GTPApplication::delete_downlink_tunnel_flow(
+void GTPApplication::add_downlink_arp_flow(
+    const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  uint32_t flow_priority =
+      convert_precedence_to_priority(ev.get_dl_flow_precedence());
+  of13::FlowMod downlink_fm =
+      messenger.create_default_flow_mod(0, of13::OFPFC_ADD, flow_priority);
+
+  add_downlink_arp_match(downlink_fm, ev.get_ue_ip(), port_number);
+
+  add_downlink_arp_flow_action(ev, messenger, downlink_fm);
+}
+
+void GTPApplication::delete_downlink_tunnel_flow_ipv4(
     const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
     uint32_t port_number) {
   of13::FlowMod downlink_fm =
@@ -342,13 +428,52 @@ void GTPApplication::delete_downlink_tunnel_flow(
   downlink_fm.out_port(of13::OFPP_ANY);
   downlink_fm.out_group(of13::OFPG_ANY);
 
-  if (ev.is_dl_flow_valid()) {
-    add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
-  } else {
-    add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
-  }
-
+  add_downlink_match(downlink_fm, ev.get_ue_ip(), port_number);
   messenger.send_of_msg(downlink_fm, ev.get_connection());
+}
+
+void GTPApplication::delete_downlink_tunnel_flow_ded_brr(
+    const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  of13::FlowMod downlink_fm =
+      messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
+  // match all ports and groups
+  downlink_fm.out_port(of13::OFPP_ANY);
+  downlink_fm.out_group(of13::OFPG_ANY);
+
+  add_ded_brr_dl_match(downlink_fm, ev.get_dl_flow(), port_number);
+  messenger.send_of_msg(downlink_fm, ev.get_connection());
+}
+
+void GTPApplication::delete_downlink_tunnel_flow_ipv6(
+    const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  of13::FlowMod downlink_fm =
+      messenger.create_default_flow_mod(0, of13::OFPFC_DELETE, 0);
+  // match all ports and groups
+  downlink_fm.out_port(of13::OFPP_ANY);
+  downlink_fm.out_group(of13::OFPG_ANY);
+
+  add_downlink_match_ipv6(
+      downlink_fm, ev.get_ue_info().get_ipv6(), port_number);
+  messenger.send_of_msg(downlink_fm, ev.get_connection());
+}
+
+void GTPApplication::delete_downlink_tunnel_flow(
+    const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+    uint32_t port_number) {
+  if (ev.is_dl_flow_valid()) {
+    delete_downlink_tunnel_flow_ded_brr(ev, messenger, port_number);
+    return;
+  }
+  UeNetworkInfo ue_info = ev.get_ue_info();
+
+  if (ue_info.is_ue_ipv4_addr_valid()) {
+    delete_downlink_tunnel_flow_ipv4(ev, messenger, port_number);
+  }
+  if (ue_info.is_ue_ipv6_addr_valid()) {
+    delete_downlink_tunnel_flow_ipv6(ev, messenger, port_number);
+  }
 }
 
 void GTPApplication::delete_downlink_arp_flow(

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.h
@@ -138,7 +138,7 @@ class GTPApplication : public Application {
    * @param i_tei tunnel id.
    */
   void add_uplink_match(
-    of13::FlowMod& uplink_fm, uint32_t gtp_port, uint32_t i_tei);
+      of13::FlowMod& uplink_fm, uint32_t gtp_port, uint32_t i_tei);
 
  private:
   static const uint32_t DEFAULT_PRIORITY = 10;
@@ -159,6 +159,34 @@ class GTPApplication : public Application {
   const uint64_t cookie = 1;
 
   const uint32_t uplink_port_num_;
+
+  void add_downlink_arp_flow_action(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      of13::FlowMod downlink_fm);
+
+  void add_downlink_tunnel_flow_action(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      of13::FlowMod downlink_fm);
+
+  void add_downlink_tunnel_flow_ipv4(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      uint32_t port_number);
+  void add_downlink_tunnel_flow_ipv6(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      uint32_t port_number);
+  void add_downlink_tunnel_flow_ded_brr(
+      const AddGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      uint32_t port_number);
+
+  void delete_downlink_tunnel_flow_ipv4(
+      const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      uint32_t port_number);
+  void delete_downlink_tunnel_flow_ipv6(
+      const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      uint32_t port_number);
+  void delete_downlink_tunnel_flow_ded_brr(
+      const DeleteGTPTunnelEvent& ev, const OpenflowMessenger& messenger,
+      uint32_t port_number);
 };
 
 }  // namespace openflow

--- a/lte/gateway/c/oai/lib/openflow/controller/OpenflowController.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/OpenflowController.cpp
@@ -94,7 +94,8 @@ void OpenflowController::dispatch_event(const ControllerEvent& ev) {
 void OpenflowController::inject_external_event(
     std::shared_ptr<ExternalEvent> ev, void* (*cb)(std::shared_ptr<void>) ) {
   if (latest_ofconn_ == NULL) {
-    OAILOG_ERROR(LOG_GTPV1U, "Null connection on event type %d", ev->get_type());
+    OAILOG_ERROR(
+        LOG_GTPV1U, "Null connection on event type %d", ev->get_type());
     throw std::runtime_error("Controller not connected to switch:\n");
   }
   ev->set_of_connection(latest_ofconn_);

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_libgtpnl.c
@@ -149,8 +149,9 @@ int libgtpnl_reset(void) {
 }
 
 int libgtpnl_add_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    Imsi_t imsi, struct ipv4flow_dl* flow_dl) {
+    struct in_addr ue, __attribute__((unused)) struct in6_addr* ue_ipv6,
+    __attribute__((unused)) int vlan, struct in_addr enb, uint32_t i_tei,
+    uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl) {
   struct gtp_tunnel* t;
   int ret;
 
@@ -172,9 +173,11 @@ int libgtpnl_add_tunnel(
   return ret;
 }
 
-int libgtpnl_del_tunnel(__attribute__((unused)) struct in_addr enb,
-    __attribute__((unused)) struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
-    struct ipv4flow_dl* flow_dl) {
+int libgtpnl_del_tunnel(
+    __attribute__((unused)) struct in_addr enb,
+    __attribute__((unused)) struct in_addr ue,
+    __attribute__((unused)) struct in6_addr* ue_ipv6, uint32_t i_tei,
+    uint32_t o_tei, struct ip_flow_dl* flow_dl) {
   struct gtp_tunnel* t;
   int ret;
 

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -157,7 +157,8 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
   int rc;
   rc = snprintf(
       gtp_port_create, sizeof(gtp_port_create),
-      "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s type=%s "
+      "sudo ovs-vsctl --may-exist add-port gtp_br0 %s -- set Interface %s "
+      "type=%s "
       "options:remote_ip=%s options:key=flow",
       port_name, port_name, ovs_gtp_type, inet_ntoa(enb_addr));
   if (rc < 0) {
@@ -170,7 +171,8 @@ static uint32_t create_gtp_port(struct in_addr enb_addr, char port_name[]) {
     OAILOG_ERROR(
         LOG_GTPV1U, "gtp port create: [%s] failed: %d", gtp_port_create, rc);
   } else {
-    OAILOG_DEBUG(LOG_GTPV1U, "gtp port create done: for ENB: %s ", inet_ntoa(enb_addr));
+    OAILOG_DEBUG(
+        LOG_GTPV1U, "gtp port create done: for ENB: %s ", inet_ntoa(enb_addr));
   }
 
   return get_gtp_port_no(port_name);
@@ -243,34 +245,37 @@ int openflow_reset(void) {
 }
 
 int openflow_add_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei,
-    uint32_t o_tei, Imsi_t imsi, struct ipv4flow_dl* flow_dl,
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
     uint32_t flow_precedence_dl) {
   uint32_t gtp_portno = find_gtp_port_no(enb);
 
   return openflow_controller_add_gtp_tunnel(
-      ue, vlan, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
+      ue, ue_ipv6, vlan, enb, i_tei, o_tei, (const char*) imsi.digit, flow_dl,
       flow_precedence_dl, gtp_portno);
 }
 
 int openflow_del_tunnel(
-    struct in_addr enb, struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
-    struct ipv4flow_dl* flow_dl) {
+    struct in_addr enb, struct in_addr ue, struct in6_addr* ue_ipv6,
+    uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl) {
   uint32_t gtp_portno = find_gtp_port_no(enb);
 
-  return openflow_controller_del_gtp_tunnel(ue, i_tei, flow_dl, gtp_portno);
+  return openflow_controller_del_gtp_tunnel(
+      ue, ue_ipv6, i_tei, flow_dl, gtp_portno);
 }
 
 int openflow_discard_data_on_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl) {
-  return openflow_controller_discard_data_on_tunnel(ue, i_tei, flow_dl);
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl) {
+  return openflow_controller_discard_data_on_tunnel(
+      ue, ue_ipv6, i_tei, flow_dl);
 }
 
 int openflow_forward_data_on_tunnel(
-    struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
-    uint32_t flow_precedence_dl) {
+    struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+    struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl) {
   return openflow_controller_forward_data_on_tunnel(
-      ue, i_tei, flow_dl, flow_precedence_dl);
+      ue, ue_ipv6, i_tei, flow_dl, flow_precedence_dl);
 }
 
 int openflow_add_paging_rule(struct in_addr ue) {

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u.h
@@ -41,6 +41,8 @@
 #define UDP_SRC_PORT 0x10
 #define UDP_DST_PORT 0x20
 #define IP_PROTO 0x40
+#define SRC_IPV6 0x80
+#define DST_IPV6 0x100
 
 // This is the default precedence value for flow rules.
 // A flow rule with precedence value 0 takes precedence over
@@ -54,15 +56,23 @@
 // precedence over latter rules.
 #define MAX_PRIORITY 65535
 
-struct ipv4flow_dl {
-  struct in_addr dst_ip;
-  struct in_addr src_ip;
+struct ip_flow_dl {
   uint32_t set_params;
   uint16_t tcp_dst_port;
   uint16_t tcp_src_port;
   uint16_t udp_dst_port;
   uint16_t udp_src_port;
   uint8_t ip_proto;
+  union {
+    struct {
+      struct in_addr dst_ip;
+      struct in_addr src_ip;
+    };
+    struct {
+      struct in6_addr dst_ip6;
+      struct in6_addr src_ip6;
+    };
+  };
 };
 
 /*
@@ -127,16 +137,18 @@ struct gtp_tunnel_ops {
   int (*uninit)(void);
   int (*reset)(void);
   int (*add_tunnel)(
-      struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-      Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
-  int (*del_tunnel)(struct in_addr enb,
-      struct in_addr ue, uint32_t i_tei, uint32_t o_tei,
-      struct ipv4flow_dl* flow_dl);
-  int (*discard_data_on_tunnel)(
-      struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl);
-  int (*forward_data_on_tunnel)(
-      struct in_addr ue, uint32_t i_tei, struct ipv4flow_dl* flow_dl,
+      struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+      uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
       uint32_t flow_precedence_dl);
+  int (*del_tunnel)(
+      struct in_addr enb, struct in_addr ue, struct in6_addr* ue_ipv6,
+      uint32_t i_tei, uint32_t o_tei, struct ip_flow_dl* flow_dl);
+  int (*discard_data_on_tunnel)(
+      struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+      struct ip_flow_dl* flow_dl);
+  int (*forward_data_on_tunnel)(
+      struct in_addr ue, struct in6_addr* ue_ipv6, uint32_t i_tei,
+      struct ip_flow_dl* flow_dl, uint32_t flow_precedence_dl);
   int (*add_paging_rule)(struct in_addr ue);
   int (*delete_paging_rule)(struct in_addr ue);
   int (*send_end_marker)(struct in_addr enbode, uint32_t i_tei);
@@ -150,6 +162,7 @@ const struct gtp_tunnel_ops* gtp_tunnel_ops_init_libgtpnl(void);
 #endif
 
 int gtpv1u_add_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl);
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl);
 #endif /* FILE_GTPV1_U_SEEN */

--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtpv1u_task.c
@@ -166,8 +166,9 @@ int gtpv1u_init(
 }
 
 int gtpv1u_add_tunnel(
-    struct in_addr ue, int vlan, struct in_addr enb, uint32_t i_tei, uint32_t o_tei,
-    Imsi_t imsi, struct ipv4flow_dl* flow_dl, uint32_t flow_precedence_dl) {
+    struct in_addr ue, struct in6_addr* ue_ipv6, int vlan, struct in_addr enb,
+    uint32_t i_tei, uint32_t o_tei, Imsi_t imsi, struct ip_flow_dl* flow_dl,
+    uint32_t flow_precedence_dl) {
   OAILOG_DEBUG(LOG_GTPV1U, "Add tunnel ue %s", inet_ntoa(ue));
 
   if (spgw_config.pgw_config.enable_nat) {
@@ -196,7 +197,7 @@ int gtpv1u_add_tunnel(
   }
 
   return gtp_tunnel_ops->add_tunnel(
-      ue, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
+      ue, ue_ipv6, vlan, enb, i_tei, o_tei, imsi, flow_dl, flow_precedence_dl);
 }
 
 //------------------------------------------------------------------------------

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -75,7 +75,7 @@ static void _handle_failed_create_bearer_response(
     teid_t teid);
 static void _generate_dl_flow(
     packet_filter_contents_t* packet_filter, in_addr_t s_addr,
-    struct ipv4flow_dl* dlflow);
+    struct ip_flow_dl* dlflow);
 
 #if EMBEDDED_SGW
 #define TASK_MME TASK_MME_APP
@@ -504,7 +504,7 @@ static void sgw_add_gtp_tunnel(
   if (new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.pdn_connection
           .ue_suspended_for_ps_handover) {
     rv = gtp_tunnel_ops->forward_data_on_tunnel(
-        ue, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
+        ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
         DEFAULT_PRECEDENCE);
     if (rv < 0) {
       OAILOG_ERROR_UE(
@@ -520,7 +520,7 @@ static void sgw_add_gtp_tunnel(
             .pdn_connection.default_bearer) {
       // Set default precedence and tft for default bearer
       rv = gtpv1u_add_tunnel(
-          ue, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+          ue, NULL, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u, imsi, NULL, DEFAULT_PRECEDENCE);
       if (rv < 0) {
         OAILOG_ERROR_UE(
@@ -530,14 +530,14 @@ static void sgw_add_gtp_tunnel(
       for (int itrn = 0; itrn < eps_bearer_ctxt_p->tft.numberofpacketfilters;
            ++itrn) {
         // Prepare DL flow rule
-        struct ipv4flow_dl dlflow;
+        struct ip_flow_dl dlflow;
         _generate_dl_flow(
             &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                   .packetfiltercontents),
             ue.s_addr, &dlflow);
 
         rv = gtpv1u_add_tunnel(
-            ue, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+            ue, NULL, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
             eps_bearer_ctxt_p->enb_teid_S1u, imsi, &dlflow,
             eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                 .eval_precedence);
@@ -693,7 +693,7 @@ int sgw_handle_sgi_endpoint_deleted(
       if (new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
               .pdn_connection.ue_suspended_for_ps_handover) {
         rv = gtp_tunnel_ops->forward_data_on_tunnel(
-            ue, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
+            ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
             DEFAULT_PRECEDENCE);
         if (rv < 0) {
           OAILOG_ERROR_UE(
@@ -706,8 +706,8 @@ int sgw_handle_sgi_endpoint_deleted(
       enb.s_addr =
           eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
-      rv = gtp_tunnel_ops->del_tunnel(enb,
-          ue, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+      rv = gtp_tunnel_ops->del_tunnel(
+          enb, ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u, NULL);
       if (rv < 0) {
         OAILOG_ERROR_UE(LOG_SPGW_APP, imsi64, "ERROR in deleting TUNNEL\n");
@@ -919,8 +919,8 @@ int sgw_handle_modify_bearer_request(
           // This is best effort, ignore return code.
           gtp_tunnel_ops->send_end_marker(enb, modify_bearer_pP->teid);
           // delete GTPv1-U tunnel
-          rv = gtp_tunnel_ops->del_tunnel(enb,
-              ue, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+          rv = gtp_tunnel_ops->del_tunnel(
+              enb, ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
         }
         populate_sgi_end_point_update(
@@ -1029,11 +1029,11 @@ int sgw_handle_delete_session_request(
         if (eps_bearer_ctxt_p) {
           if (ebi != delete_session_req_pP->lbi) {
             struct in_addr enb = {.s_addr = 0};
-            enb.s_addr = eps_bearer_ctxt_p->enb_ip_address_S1u.address
-                           .ipv4_address.s_addr;
+            enb.s_addr         = eps_bearer_ctxt_p->enb_ip_address_S1u.address
+                             .ipv4_address.s_addr;
 
-            rv = gtp_tunnel_ops->del_tunnel(enb,
-                eps_bearer_ctxt_p->paa.ipv4_address,
+            rv = gtp_tunnel_ops->del_tunnel(
+                enb, eps_bearer_ctxt_p->paa.ipv4_address, NULL,
                 eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
                 eps_bearer_ctxt_p->enb_teid_S1u, NULL);
             if (rv < 0) {
@@ -1194,11 +1194,11 @@ int sgw_handle_release_access_bearers_request(
               .sgw_eps_bearers_array[ebx];
       if (eps_bearer_ctxt) {
         struct in_addr enb = {.s_addr = 0};
-        enb.s_addr = eps_bearer_ctxt->enb_ip_address_S1u.address
-                           .ipv4_address.s_addr;
+        enb.s_addr =
+            eps_bearer_ctxt->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
-        rv = gtp_tunnel_ops->del_tunnel(enb,
-            eps_bearer_ctxt->paa.ipv4_address,
+        rv = gtp_tunnel_ops->del_tunnel(
+            enb, eps_bearer_ctxt->paa.ipv4_address, NULL,
             eps_bearer_ctxt->s_gw_teid_S1u_S12_S4_up,
             eps_bearer_ctxt->enb_teid_S1u, NULL);
         if (rv < 0) {
@@ -1430,7 +1430,7 @@ int sgw_handle_suspend_notification(
       // delete GTPv1-U tunnel
       struct in_addr ue = eps_bearer_entry_p->paa.ipv4_address;
       rv                = gtp_tunnel_ops->discard_data_on_tunnel(
-          ue, eps_bearer_entry_p->s_gw_teid_S1u_S12_S4_up, NULL);
+          ue, NULL, eps_bearer_entry_p->s_gw_teid_S1u_S12_S4_up, NULL);
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64, "ERROR in Disabling DL data on TUNNEL\n");
@@ -1587,14 +1587,15 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
           for (int i = 0;
                i < eps_bearer_ctxt_entry_p->tft.numberofpacketfilters; ++i) {
             // Prepare DL flow rule
-            struct ipv4flow_dl dlflow;
+            struct ip_flow_dl dlflow;
             _generate_dl_flow(
                 &(eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
                       .packetfiltercontents),
                 ue.s_addr, &dlflow);
 
             rc = gtpv1u_add_tunnel(
-                ue, vlan, enb, eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,
+                ue, NULL, vlan, enb,
+                eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,
                 eps_bearer_ctxt_entry_p->enb_teid_S1u, imsi, &dlflow,
                 eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
                     .eval_precedence);
@@ -1688,14 +1689,13 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
           &spgw_ctxt->sgw_eps_bearer_context_information.pdn_connection, ebi);
 
       if (eps_bearer_ctxt_p) {
-
         if (ebi != *s11_pcrf_ded_bearer_deactv_rsp->lbi) {
           struct in_addr enb = {.s_addr = 0};
-          enb.s_addr = eps_bearer_ctxt_p->enb_ip_address_S1u.address
-                           .ipv4_address.s_addr;
+          enb.s_addr =
+              eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
-          rc = gtp_tunnel_ops->del_tunnel(enb,
-              eps_bearer_ctxt_p->paa.ipv4_address,
+          rc = gtp_tunnel_ops->del_tunnel(
+              enb, eps_bearer_ctxt_p->paa.ipv4_address, NULL,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
           if (rc < 0) {
@@ -1759,17 +1759,17 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
         for (int itrn = 0; itrn < eps_bearer_ctxt_p->tft.numberofpacketfilters;
              ++itrn) {
           // Prepare DL flow rule from stored packet filters
-          struct ipv4flow_dl dlflow;
+          struct ip_flow_dl dlflow;
           _generate_dl_flow(
               &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                     .packetfiltercontents),
               eps_bearer_ctxt_p->paa.ipv4_address.s_addr, &dlflow);
           struct in_addr enb = {.s_addr = 0};
-          enb.s_addr = eps_bearer_ctxt_p->enb_ip_address_S1u.address
-                           .ipv4_address.s_addr;
+          enb.s_addr =
+              eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
-          rc = gtp_tunnel_ops->del_tunnel(enb,
-              eps_bearer_ctxt_p->paa.ipv4_address,
+          rc = gtp_tunnel_ops->del_tunnel(
+              enb, eps_bearer_ctxt_p->paa.ipv4_address, NULL,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, &dlflow);
           if (rc < 0) {
@@ -1879,7 +1879,7 @@ static void _handle_failed_create_bearer_response(
 // Fills up downlink (DL) flow match rule from packet filters of eps bearer
 static void _generate_dl_flow(
     packet_filter_contents_t* packet_filter, in_addr_t s_addr,
-    struct ipv4flow_dl* dlflow) {
+    struct ip_flow_dl* dlflow) {
   // Prepare DL flow rule
   // The TFTs are DL TFTs: UE is the destination/local,
   // PDN end point is the source/remote.

--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -94,6 +94,13 @@ MATCHER_P(CheckIPv4Dst, ip, "") {
   return ipv4_field->value().getIPv4() == ip.s_addr;
 }
 
+MATCHER_P(CheckIPv6Dst, ipv6, "") {
+  auto msg        = static_cast<of13::FlowMod*>(&arg);
+  auto ipv6_field = static_cast<of13::IPv6Dst*>(
+      msg->get_oxm_field(of13::OFPXMT_OFB_IPV6_DST));
+  return !!memcpy(ipv6_field->value().getIPv6(), &ipv6, sizeof(ipv6));
+}
+
 MATCHER_P(CheckArpTpa, ip, "") {
   auto msg = static_cast<of13::FlowMod*>(&arg);
   auto ipv4_field =
@@ -118,6 +125,13 @@ MATCHER_P(CheckIPv4Src, ip, "") {
   auto ipv4_field = static_cast<of13::IPv4Src*>(
       msg->get_oxm_field(of13::OFPXMT_OFB_IPV4_SRC));
   return ipv4_field->value().getIPv4() == ip.s_addr;
+}
+
+MATCHER_P(CheckIPv6Src, ipv6, "") {
+  auto msg        = static_cast<of13::FlowMod*>(&arg);
+  auto ipv6_field = static_cast<of13::IPv6Src*>(
+      msg->get_oxm_field(of13::OFPXMT_OFB_IPV6_SRC));
+  return !!memcpy(ipv6_field->value().getIPv6(), &ipv6, sizeof(ipv6));
 }
 
 MATCHER_P(CheckIPv4Proto, ip_proto, "") {
@@ -154,8 +168,9 @@ TEST_F(GTPApplicationTest, TestAddTunnel) {
   uint32_t in_tei  = 1;
   uint32_t out_tei = 2;
   char imsi[]      = "001010000000013";
-  int vlan = 0;
-  AddGTPTunnelEvent add_tunnel(ue_ip, vlan, enb_ip, in_tei, out_tei, imsi, 0);
+  int vlan         = 0;
+  AddGTPTunnelEvent add_tunnel(
+      ue_ip, NULL, vlan, enb_ip, in_tei, out_tei, imsi, 0);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -210,7 +225,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnel) {
   struct in_addr ue_ip;
   ue_ip.s_addr    = inet_addr("0.0.0.1");
   uint32_t in_tei = 1;
-  DeleteGTPTunnelEvent del_tunnel(ue_ip, in_tei, 0);
+  DeleteGTPTunnelEvent del_tunnel(ue_ip, NULL, in_tei, 0);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -271,9 +286,9 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlow) {
   uint32_t in_tei  = 1;
   uint32_t out_tei = 2;
   char imsi[]      = "001010000000013";
-  struct ipv4flow_dl dl_flow;
+  struct ip_flow_dl dl_flow;
   uint32_t dl_flow_precedence = 0;
-  int vlan = 0;
+  int vlan                    = 0;
 
   dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
   dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
@@ -284,7 +299,8 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlow) {
       SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
 
   AddGTPTunnelEvent add_tunnel(
-      ue_ip, vlan, enb_ip, in_tei, out_tei, imsi, &dl_flow, dl_flow_precedence, 0);
+      ue_ip, NULL, vlan, enb_ip, in_tei, out_tei, imsi, &dl_flow,
+      dl_flow_precedence, 0);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -348,7 +364,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlow) {
   struct in_addr ue_ip;
   ue_ip.s_addr    = inet_addr("0.0.0.1");
   uint32_t in_tei = 1;
-  struct ipv4flow_dl dl_flow;
+  struct ip_flow_dl dl_flow;
 
   dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
   dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
@@ -358,7 +374,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlow) {
   dl_flow.set_params =
       SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
 
-  DeleteGTPTunnelEvent del_tunnel(ue_ip, in_tei, &dl_flow, 0);
+  DeleteGTPTunnelEvent del_tunnel(ue_ip, NULL, in_tei, &dl_flow, 0);
   // Uplink
   EXPECT_CALL(
       *messenger,
@@ -423,9 +439,9 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlowGtpPort) {
   uint32_t in_tei  = 1;
   uint32_t out_tei = 2;
   char imsi[]      = "001010000000013";
-  struct ipv4flow_dl dl_flow;
+  struct ip_flow_dl dl_flow;
   uint32_t dl_flow_precedence = 0;
-  int vlan = 0;
+  int vlan                    = 0;
 
   dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
   dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
@@ -436,14 +452,15 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlowGtpPort) {
       SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
 
   AddGTPTunnelEvent add_tunnel(
-      ue_ip, vlan, enb_ip, in_tei, out_tei, imsi, &dl_flow, dl_flow_precedence, 10);
+      ue_ip, NULL, vlan, enb_ip, in_tei, out_tei, imsi, &dl_flow,
+      dl_flow_precedence, 10);
   // Uplink
   EXPECT_CALL(
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(10),
-              CheckTunnelId(in_tei), CheckCommandType(of13::OFPFC_ADD)),
+              CheckTableId(0), CheckInPort(10), CheckTunnelId(in_tei),
+              CheckCommandType(of13::OFPFC_ADD)),
           _))
       .Times(1);
   // downlink
@@ -496,7 +513,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowGtpPort) {
   struct in_addr ue_ip;
   ue_ip.s_addr    = inet_addr("0.0.0.1");
   uint32_t in_tei = 1;
-  struct ipv4flow_dl dl_flow;
+  struct ip_flow_dl dl_flow;
 
   dl_flow.dst_ip.s_addr = inet_addr("0.0.0.3");
   dl_flow.src_ip.s_addr = inet_addr("0.0.0.4");
@@ -506,14 +523,14 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowGtpPort) {
   dl_flow.set_params =
       SRC_IPV4 | DST_IPV4 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
 
-  DeleteGTPTunnelEvent del_tunnel(ue_ip, in_tei, &dl_flow, 30);
+  DeleteGTPTunnelEvent del_tunnel(ue_ip, NULL, in_tei, &dl_flow, 30);
   // Uplink
   EXPECT_CALL(
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(30),
-              CheckTunnelId(in_tei), CheckCommandType(of13::OFPFC_DELETE)),
+              CheckTableId(0), CheckInPort(30), CheckTunnelId(in_tei),
+              CheckCommandType(of13::OFPFC_DELETE)),
           _))
       .Times(1);
   // downlink
@@ -535,6 +552,309 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowGtpPort) {
           AllOf(
               CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
               CheckIPv4Dst(dl_flow.dst_ip), CheckIPv4Src(dl_flow.src_ip),
+              CheckIPv4Proto(dl_flow.ip_proto),
+              CheckTcpDstPort(dl_flow.tcp_dst_port),
+              CheckTcpSrcPort(dl_flow.tcp_src_port),
+              CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x0806), CheckArpTpa(ue_ip),
+                          CheckCommandType(of13::OFPFC_DELETE)),
+                      _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0806),
+              CheckArpTpa(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+
+  controller->dispatch_event(del_tunnel);
+}
+
+TEST_F(GTPApplicationTest, TestAddTunnelIpv6) {
+  struct in_addr ue_ip;
+  ue_ip.s_addr = inet_addr("0.0.0.1");
+  struct in_addr enb_ip;
+  enb_ip.s_addr    = inet_addr("0.0.0.2");
+  uint32_t in_tei  = 1;
+  uint32_t out_tei = 2;
+  char imsi[]      = "001010000000013";
+  int vlan         = 0;
+  struct in6_addr ue_ipv6;
+  inet_pton(AF_INET6, "::7", &ue_ipv6);
+
+  AddGTPTunnelEvent add_tunnel(
+      ue_ip, &ue_ipv6, vlan, enb_ip, in_tei, out_tei, imsi, 0);
+  // Uplink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_GTP_PORT),
+              CheckTunnelId(in_tei), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+  // downlink
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x0800), CheckIPv4Dst(ue_ip),
+                          CheckCommandType(of13::OFPFC_ADD)),
+                      _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  // downlink ipv6
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x08DD), CheckIPv6Dst(ue_ipv6),
+                          CheckCommandType(of13::OFPFC_ADD)),
+                      _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckIPv6Dst(ue_ipv6), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x0806), CheckArpTpa(ue_ip),
+                          CheckCommandType(of13::OFPFC_ADD)),
+                      _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0806),
+              CheckArpTpa(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  controller->dispatch_event(add_tunnel);
+}
+
+TEST_F(GTPApplicationTest, TestDeleteTunnelIpv6) {
+  struct in_addr ue_ip;
+  ue_ip.s_addr    = inet_addr("0.0.0.1");
+  uint32_t in_tei = 1;
+  struct in6_addr ue_ipv6;
+  inet_pton(AF_INET6, "::9", &ue_ipv6);
+
+  DeleteGTPTunnelEvent del_tunnel(ue_ip, &ue_ipv6, in_tei, 0);
+  // Uplink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_GTP_PORT),
+              CheckTunnelId(in_tei), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+  // downlink
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x0800), CheckIPv4Dst(ue_ip),
+                          CheckCommandType(of13::OFPFC_DELETE)),
+                      _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0800),
+              CheckIPv4Dst(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+
+  // downlink ipv6
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x08DD), CheckIPv6Dst(ue_ipv6),
+                          CheckCommandType(of13::OFPFC_DELETE)),
+                      _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckIPv6Dst(ue_ipv6), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x0806), CheckArpTpa(ue_ip),
+                          CheckCommandType(of13::OFPFC_DELETE)),
+                      _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0806),
+              CheckArpTpa(ue_ip), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+
+  controller->dispatch_event(del_tunnel);
+}
+
+TEST_F(GTPApplicationTest, TestAddTunnelDlFlowIpv6) {
+  struct in_addr ue_ip;
+  ue_ip.s_addr = inet_addr("0.0.0.1");
+  struct in_addr enb_ip;
+  enb_ip.s_addr    = inet_addr("0.0.0.2");
+  uint32_t in_tei  = 1;
+  uint32_t out_tei = 2;
+  char imsi[]      = "001010000000013";
+  struct ip_flow_dl dl_flow;
+  uint32_t dl_flow_precedence = 0;
+  int vlan                    = 0;
+
+  inet_pton(AF_INET6, "::9", &dl_flow.dst_ip6);
+  inet_pton(AF_INET6, "::7", &dl_flow.src_ip6);
+
+  dl_flow.tcp_dst_port = 33;
+  dl_flow.tcp_src_port = 44;
+  dl_flow.ip_proto     = 6;  // TCP
+  dl_flow.set_params =
+      SRC_IPV6 | DST_IPV6 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
+
+  AddGTPTunnelEvent add_tunnel(
+      ue_ip, NULL, vlan, enb_ip, in_tei, out_tei, imsi, &dl_flow,
+      dl_flow_precedence, 0);
+  // Uplink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_GTP_PORT),
+              CheckTunnelId(in_tei), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+  // downlink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+              CheckEthType(0x08DD), CheckIPv6Dst(dl_flow.dst_ip6),
+              CheckIPv6Src(dl_flow.src_ip6), CheckIPv4Proto(dl_flow.ip_proto),
+              CheckTcpDstPort(dl_flow.tcp_dst_port),
+              CheckTcpSrcPort(dl_flow.tcp_src_port),
+              CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckIPv6Dst(dl_flow.dst_ip6), CheckIPv6Src(dl_flow.src_ip6),
+              CheckIPv4Proto(dl_flow.ip_proto),
+              CheckTcpDstPort(dl_flow.tcp_dst_port),
+              CheckTcpSrcPort(dl_flow.tcp_src_port),
+              CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  EXPECT_CALL(
+      *messenger, send_of_msg(
+                      AllOf(
+                          CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+                          CheckEthType(0x0806), CheckArpTpa(ue_ip),
+                          CheckCommandType(of13::OFPFC_ADD)),
+                      _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x0806),
+              CheckArpTpa(ue_ip), CheckCommandType(of13::OFPFC_ADD)),
+          _))
+      .Times(1);
+
+  controller->dispatch_event(add_tunnel);
+}
+
+TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowIpv6) {
+  struct in_addr ue_ip;
+  ue_ip.s_addr    = inet_addr("0.0.0.1");
+  uint32_t in_tei = 1;
+  struct ip_flow_dl dl_flow;
+
+  inet_pton(AF_INET6, "::99", &dl_flow.dst_ip6);
+  inet_pton(AF_INET6, "::79", &dl_flow.src_ip6);
+  dl_flow.tcp_dst_port = 33;
+  dl_flow.tcp_src_port = 44;
+  dl_flow.ip_proto     = 6;  // TCP
+  dl_flow.set_params =
+      SRC_IPV6 | DST_IPV6 | TCP_SRC_PORT | TCP_DST_PORT | IP_PROTO;
+
+  DeleteGTPTunnelEvent del_tunnel(ue_ip, NULL, in_tei, &dl_flow, 0);
+  // Uplink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_GTP_PORT),
+              CheckTunnelId(in_tei), CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+  // downlink
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
+              CheckEthType(0x08DD), CheckIPv6Dst(dl_flow.dst_ip6),
+              CheckIPv6Src(dl_flow.src_ip6), CheckIPv4Proto(dl_flow.ip_proto),
+              CheckTcpDstPort(dl_flow.tcp_dst_port),
+              CheckTcpSrcPort(dl_flow.tcp_src_port),
+              CheckCommandType(of13::OFPFC_DELETE)),
+          _))
+      .Times(1);
+  EXPECT_CALL(
+      *messenger,
+      send_of_msg(
+          AllOf(
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckIPv6Dst(dl_flow.dst_ip6), CheckIPv6Src(dl_flow.src_ip6),
               CheckIPv4Proto(dl_flow.ip_proto),
               CheckTcpDstPort(dl_flow.tcp_dst_port),
               CheckTcpSrcPort(dl_flow.tcp_src_port),


### PR DESCRIPTION
## Summary

This patch adds support for UE ipv6 flow generation. It uses
existing OpenFlow controller events to propagate IPv6 info from
SPGW to GTP APP.
IPV6 support for default brr and dedicated brr is added.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test_oai`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
