### PR TITLE
[CWFIntegTest] Add Junit XML file to upload test results to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,8 @@ commands:
             cp *_version versions || true
       - store_artifacts:
           path: /tmp/logs
+      - store_test_results:
+          path: /tmp/test-results
       - run:
           name: Double-check that the node is freed
           command: |

--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -236,8 +236,17 @@ def _run_remote_cwf_integ_test(repo: str, magma_root: str):
                 '-f docker-compose.nginx.yml '
                 '-f docker-compose.integ-test.yml '
                 'build --parallel')
-        result = run('fab integ_test:destroy_vm=True,transfer_images=True',
+        test_xml = "tests.xml"
+        result = run('fab integ_test:'
+                     'destroy_vm=True,'
+                     'transfer_images=True,'
+                     'test_result_xml=' + test_xml,
                      timeout=110*60, warn_only=True)
+        # Move JUnit test result to /tmp/test-results directory
+        local('mkdir cwf-tests-xml')
+        get(test_xml, 'cwf-tests-xml')
+        local('sudo mkdir -p /tmp/test-results/')
+        local('sudo mv cwf-tests-xml/* /tmp/test-results/')
         # On failure, transfer logs of key services from docker containers and
         # copy to the log directory. This will get stored as an artifact in the
         # circleCI config.


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Capture an XML file of test results and upload it to CircleCI at the end of each integ test run
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Tested on upstream branch 'add-junit': 
https://app.circleci.com/pipelines/github/magma/magma/4766/workflows/2b52fd15-94af-43dc-a0d9-1e781d6f39fe/jobs/49788

For a sample of what a failure looks like: 
https://app.circleci.com/pipelines/github/magma/magma/4756/workflows/d3694978-076a-4ea1-84c3-b766a7278f45/jobs/49654/tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
