### PR TITLE
[lte][agw] Filling fields param with default hashmap on UpdateRecord gRPC call

### DIFF
--- a/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.cpp
+++ b/lte/gateway/c/oai/lib/directoryd/GatewayDirectorydClient.cpp
@@ -14,14 +14,16 @@
  * For more information about the OpenAirInterface (OAI) Software Alliance:
  *      contact@openairinterface.org
  */
+#include "GatewayDirectorydClient.h"
 
-#include <grpcpp/impl/codegen/async_unary_call.h>
 #include <memory>
 #include <thread>
 #include <utility>
 
+#include <grpcpp/impl/codegen/async_unary_call.h>
+#include <google/protobuf/map.h>
+
 #include "orc8r/protos/common.pb.h"
-#include "GatewayDirectorydClient.h"
 #include "ServiceRegistrySingleton.h"
 
 namespace grpc {
@@ -33,6 +35,7 @@ class Status;
 using grpc::Channel;
 using grpc::ClientContext;
 using grpc::Status;
+using google::protobuf::Map;
 using magma::GatewayDirectoryService;
 using magma::GatewayDirectoryServiceClient;
 using magma::UpdateRecordRequest;
@@ -61,6 +64,13 @@ bool GatewayDirectoryServiceClient::UpdateRecord(
 
   request.set_id(id);
   request.set_location(location);
+
+  // No values for fields param in UpdateRecord
+  auto fields = request.fields();
+  std::unordered_map<std::string, std::string> fields_map;
+
+  Map<std::string, std::string> proto_fields(fields_map.begin(), fields_map.end());
+  fields = proto_fields;
 
   // Create a raw response pointer that stores a callback to be called when the
   // gRPC call is answered


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- There was an apparent crash on v1.1 (5dbd6822) version of AGW - MME when UpdateRecord gRPC request is sent to directoryd:

```
#0  0x000055af565406dc in std::_Hashtable<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, google::protobuf::MapPair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >*>, google::protobuf::Map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::MapAllocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, google::protobuf::MapPair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >*> >, std::__detail::_Select1st, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, google::protobuf::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<true, false, true> >::size (this=0x604000313230)
    at /usr/include/c++/6/bits/hashtable.h:508
#1  0x000055af5653ee32 in std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, google::protobuf::MapPair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >*, google::protobuf::hash<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, google::protobuf::Map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::MapAllocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, google::protobuf::MapPair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >*> > >::size (this=0x604000313230) at /usr/include/c++/6/bits/unordered_map.h:302
#2  0x000055af5653d5f4 in google::protobuf::Map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >::size (this=0x6020002724e0) at /usr/include/google/protobuf/map.h:1499
#3  0x000055af5653cf84 in google::protobuf::internal::MapField<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, (google::protobuf::internal::WireFormatLite::FieldType)9, (google::protobuf::internal::WireFormatLite::FieldType)9, 0>::size (this=0x7facc509c4d8)
    at /usr/include/google/protobuf/map_field_inl.h:217
#4  0x000055af5653cbf8 in magma::orc8r::UpdateRecordRequest::fields_size (this=0x7facc509c4b0) at lib/directoryd/orc8r/protos/directoryd.pb.h:1660
#5  0x000055af565364d3 in magma::orc8r::UpdateRecordRequest::ByteSize (this=0x7facc509c4b0) at /home/vagrant/build/c/oai/lib/directoryd/orc8r/protos/directoryd.pb.cc:2891
```

As it looks an internal serialization issue on gRPC, what it would help would be to explicitly set the value of `fields` param on the request to avoid serialization crashes.

## Test Plan

- Tested on v1.1 branch / commit, re-creating VM and running s1ap tests and local AGW testing to ensure backwards compatibility 
- Tested on master version of AGW with same method of testing 

## Additional Information

- [ ] This change is backwards-breaking
