### PR TITLE
[bug_fix] [agw] Check for valid EMM context before handling T3489 timer

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/esm/esm_data_context.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_data_context.c
@@ -98,6 +98,7 @@ void nas_stop_T3489(esm_context_t* const esm_ctx) {
       if (nas_timer_callback_args) {
         esm_ebr_timer_data_t* data =
             (esm_ebr_timer_data_t*) nas_timer_callback_args;
+        data->ctx = NULL;
         bdestroy_wrapper(&data->msg);
         free_wrapper((void**) &data);
       }

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
@@ -179,7 +179,7 @@ static void _esm_information_t3489_handler(void* args, imsi64_t* imsi64) {
    */
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
-  if (esm_ebr_timer_data) {
+  if (esm_ebr_timer_data && esm_ebr_timer_data->ctx) {
     /*
      * Increment the retransmission counter
      */


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

A race condition occurs when the MME rejects a UE and clears the EMM/ESM context, while the T3489 timer expires and tries to access that deleted context. This change explicitly nulls the EMM context in the timer argument data when EMM/ESM context is cleared and checks whether the context is non-null before handling the timer expiry.

## Test Plan

- Sanity tests with S1AP integration tests after applying this change on master branch
- Also tested on v1.1 for backporting by destroying and re-creating all VMs, downgrading S1ap-tester and re-running sanity tests.


