### PR TITLE
[CWF][Helm] Update cwf gateway helm charts to fully support HA deployments

### DIFF
--- a/cwf/gateway/docker/.env
+++ b/cwf/gateway/docker/.env
@@ -26,6 +26,9 @@ CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
 CONFIGS_DEFAULT_VOLUME=../configs
 SECRETS_VOLUME=/var/opt/magma/secrets
 
+RADIUS_STORAGE_TYPE=memory
+RADIUS_REDIS_ADDR=
+
 ## cwf Interface override
 INGRESS_PORT=
 UPLINK_PORTS=

--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -26,6 +26,9 @@ CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
 CONFIGS_DEFAULT_VOLUME=/etc/magma
 SECRETS_VOLUME=/var/opt/magma/secrets
 
+RADIUS_STORAGE_TYPE=memory
+RADIUS_REDIS_ADDR=
+
 ## cwf Interface override
 INGRESS_PORT=
 UPLINK_PORTS=

--- a/cwf/gateway/docker/docker-compose.yml
+++ b/cwf/gateway/docker/docker-compose.yml
@@ -188,8 +188,8 @@ services:
       - AAA_ENDPOINT=127.0.0.1:9109
       - ANALYTICS_GRAPHQL_TOKEN=${ANALYTICS_GRAPHQL_TOKEN}
       - ANALYTICS_GRAPHQL_ENDPOINT=${ANALYTICS_GRAPHQL_ENDPOINT}
-      - STORAGE_TYPE=memory
-      - REDIS_ADDR=
+      - STORAGE_TYPE=${RADIUS_STORAGE_TYPE}
+      - REDIS_ADDR=${RADIUS_REDIS_ADDR}
     healthcheck:
       test: ["CMD", "nc", "-zv", "localhost","9108"]
       timeout: "4s"

--- a/cwf/gateway/helm/cwf-kubevirt/Chart.yaml
+++ b/cwf/gateway/helm/cwf-kubevirt/Chart.yaml
@@ -12,7 +12,7 @@
 apiVersion: "1.0"
 description: Magma Carrier Gateway
 name: cwf
-version: 0.2.0
+version: 0.2.1
 home: https://github.com/magma/magma
 sources:
   - https://github.com/magma/magma

--- a/cwf/gateway/helm/cwf-kubevirt/templates/bin/_env.tpl
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/bin/_env.tpl
@@ -25,6 +25,14 @@ CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
 CONFIGS_DEFAULT_VOLUME=/etc/magma
 SECRETS_VOLUME=/var/opt/magma/secrets
 
+{{ if .Values.cwf.gateway_ha.enabled }}
+RADIUS_STORAGE_TYPE=redis
+RADIUS_REDIS_ADDR={{ .Values.cwf.redis.bind }}:{{.Values.cwf.redis.port }}
+{{ else }}
+RADIUS_STORAGE_TYPE=memory
+RADIUS_REDIS_ADDR=
+{{- end }}
+
 {{ if .Values.cwf.dpi }}
 DPI_LICENSE_NAME={{ .Values.cwf.dpi.dpi_license_name }}
 {{- end }}

--- a/cwf/gateway/helm/cwf-kubevirt/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/bin/_install_gateway.sh.tpl
@@ -150,6 +150,9 @@ cp -TR "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/configs /etc/magma
 # Copy config templates
 cp -R "$INSTALL_DIR"/magma/orc8r/gateway/configs/templates /etc/magma
 
+# Copy template sessiond config
+cp sessiond.yml /etc/magma/
+
 # Copy certs
 cp rootCA.pem /var/opt/magma/certs/
 

--- a/cwf/gateway/helm/cwf-kubevirt/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/bin/_install_gateway.sh.tpl
@@ -150,9 +150,6 @@ cp -TR "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/configs /etc/magma
 # Copy config templates
 cp -R "$INSTALL_DIR"/magma/orc8r/gateway/configs/templates /etc/magma
 
-# Copy template sessiond config
-cp sessiond.yml /etc/magma/
-
 # Copy certs
 cp rootCA.pem /var/opt/magma/certs/
 
@@ -161,6 +158,9 @@ cp control_proxy.yml /var/opt/magma/configs/
 
 # Copy redis override
 cp redis.yml /var/opt/magma/configs/
+
+# Copy sessiond override
+cp sessiond.yml /var/opt/magma/configs/
 
 # Copy docker files
 cp docker-compose.yml /var/opt/magma/docker/

--- a/cwf/gateway/helm/cwf-kubevirt/templates/bin/_sessiond.yml.tpl
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/bin/_sessiond.yml.tpl
@@ -1,0 +1,53 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log_level: INFO
+rule_update_inteval_sec: 1
+
+# Session manager will report the usage when the usage is greater than
+# usage_reporting_threshold * available quota since last update
+# In this way, session manager will report the usage before the subscriber
+# completely uses up the quota.
+usage_reporting_threshold: 0.8
+
+# Set to true to terminate service when the quota of a session is exhausted.
+# An user can still use up to the extra margin.
+# Set to false to allow users to use without any constraint.
+terminate_service_when_quota_exhausted: true
+
+# Maximum time to wait for the flow to be deleted by pipelined before forcefully
+# terminating the session. This should be at least twice the poll interval of
+# pipelined
+session_force_termination_timeout_ms: 5000
+
+# Set to true to enable sessiond support of carrier wifi
+support_carrier_wifi: true
+
+# CWF only
+# Number of ms before sessiond terminates a session when it is started without
+# quota.
+cwf_quota_exhaustion_termination_on_init_ms: 30000
+
+# If this flag is set, we will send the GW's timezone information to the policy
+# component as part of CreateSessionRequest.
+send_access_timezone: false
+
+# Set to true to store session state in Redis for persistence.
+support_stateless: {{ .Values.cwf.gateway_ha.enabled }}
+
+# Redis table name for session state.
+sessions_table: sessiond:sessions
+
+# Sets the amount of octets that will be requested on the CCR-I for credit if
+# credit is given. If unset, defaults to 200000
+default_requested_units: 200000

--- a/cwf/gateway/helm/cwf-kubevirt/templates/configmap-env.yaml
+++ b/cwf/gateway/helm/cwf-kubevirt/templates/configmap-env.yaml
@@ -25,6 +25,8 @@ data:
 {{ tuple "bin/_control_proxy.yml.tpl" . | include "template" | indent 4 }}
   redis.yml: |
 {{ tuple "bin/_redis.yml.tpl" . | include "template" | indent 4 }}
+  sessiond.yml: |
+{{ tuple "bin/_sessiond.yml.tpl" . | include "template" | indent 4 }}
   bootstrap.sh: |
 {{ tuple "bin/_bootstrap.sh.tpl" . | include "template" | indent 4 }}
   install_gateway.sh: |

--- a/cwf/gateway/helm/cwf-kubevirt/values.yaml
+++ b/cwf/gateway/helm/cwf-kubevirt/values.yaml
@@ -52,6 +52,8 @@ secret:
 ## Key Values for docker inside VM ( CWF services )
 cwf:
   type: cwag
+  gateway_ha:
+    enabled: false
   image:
     docker_registry: docker.io/cwf_
     tag: "latest"

--- a/cwf/gateway/helm/cwf-virtlet/Chart.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/Chart.yaml
@@ -12,7 +12,7 @@
 apiVersion: "1.0"
 description: Magma Carrier Gateway
 name: cwf
-version: 0.1.9
+version: 0.1.10
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/cwf/gateway/helm/cwf-virtlet/templates/bin/_env.tpl
+++ b/cwf/gateway/helm/cwf-virtlet/templates/bin/_env.tpl
@@ -36,6 +36,14 @@ CONFIGS_OVERRIDE_VOLUME=/var/opt/magma/configs
 CONFIGS_DEFAULT_VOLUME=/etc/magma
 SECRETS_VOLUME=/var/opt/magma/secrets
 
+{{ if .Values.cwf.gateway_ha.enabled }}
+RADIUS_STORAGE_TYPE=redis
+RADIUS_REDIS_ADDR={{ .Values.cwf.redis.bind }}:{{.Values.cwf.redis.port }}
+{{ else }}
+RADIUS_STORAGE_TYPE=memory
+RADIUS_REDIS_ADDR=
+{{- end }}
+
 {{ if .Values.cwf.dpi }}
 DPI_LICENSE_NAME={{ .Values.cwf.dpi.dpi_license_name }}
 {{- end }}

--- a/cwf/gateway/helm/cwf-virtlet/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf-virtlet/templates/bin/_install_gateway.sh.tpl
@@ -150,6 +150,9 @@ cp -TR "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/configs /etc/magma
 # Copy config templates
 cp -R "$INSTALL_DIR"/magma/orc8r/gateway/configs/templates /etc/magma
 
+# Copy template sessiond config
+cp sessiond.yml /etc/magma/
+
 # Copy certs
 cp rootCA.pem /var/opt/magma/certs/
 

--- a/cwf/gateway/helm/cwf-virtlet/templates/bin/_install_gateway.sh.tpl
+++ b/cwf/gateway/helm/cwf-virtlet/templates/bin/_install_gateway.sh.tpl
@@ -150,9 +150,6 @@ cp -TR "$INSTALL_DIR"/magma/"$MODULE_DIR"/gateway/configs /etc/magma
 # Copy config templates
 cp -R "$INSTALL_DIR"/magma/orc8r/gateway/configs/templates /etc/magma
 
-# Copy template sessiond config
-cp sessiond.yml /etc/magma/
-
 # Copy certs
 cp rootCA.pem /var/opt/magma/certs/
 
@@ -161,6 +158,9 @@ cp control_proxy.yml /var/opt/magma/configs/
 
 # Copy redis override
 cp redis.yml /var/opt/magma/configs/
+
+# Copy sessiond override
+cp sessiond.yml /var/opt/magma/configs/
 
 # Copy docker files
 cp docker-compose.yml /var/opt/magma/docker/

--- a/cwf/gateway/helm/cwf-virtlet/templates/bin/_sessiond.yml.tpl
+++ b/cwf/gateway/helm/cwf-virtlet/templates/bin/_sessiond.yml.tpl
@@ -1,0 +1,53 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+log_level: INFO
+rule_update_inteval_sec: 1
+
+# Session manager will report the usage when the usage is greater than
+# usage_reporting_threshold * available quota since last update
+# In this way, session manager will report the usage before the subscriber
+# completely uses up the quota.
+usage_reporting_threshold: 0.8
+
+# Set to true to terminate service when the quota of a session is exhausted.
+# An user can still use up to the extra margin.
+# Set to false to allow users to use without any constraint.
+terminate_service_when_quota_exhausted: true
+
+# Maximum time to wait for the flow to be deleted by pipelined before forcefully
+# terminating the session. This should be at least twice the poll interval of
+# pipelined
+session_force_termination_timeout_ms: 5000
+
+# Set to true to enable sessiond support of carrier wifi
+support_carrier_wifi: true
+
+# CWF only
+# Number of ms before sessiond terminates a session when it is started without
+# quota.
+cwf_quota_exhaustion_termination_on_init_ms: 30000
+
+# If this flag is set, we will send the GW's timezone information to the policy
+# component as part of CreateSessionRequest.
+send_access_timezone: false
+
+# Set to true to store session state in Redis for persistence.
+support_stateless: {{ .Values.cwf.gateway_ha.enabled }}
+
+# Redis table name for session state.
+sessions_table: sessiond:sessions
+
+# Sets the amount of octets that will be requested on the CCR-I for credit if
+# credit is given. If unset, defaults to 200000
+default_requested_units: 200000

--- a/cwf/gateway/helm/cwf-virtlet/templates/configmap-env.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/templates/configmap-env.yaml
@@ -25,6 +25,8 @@ data:
 {{ tuple "bin/_control_proxy.yml.tpl" . | include "template" | indent 4 }}
   redis.yml: |
 {{ tuple "bin/_redis.yml.tpl" . | include "template" | indent 4 }}
+  sessiond.yml: |
+{{ tuple "bin/_sessiond.yml.tpl" . | include "template" | indent 4 }}
   bootstrap.sh: |
 {{ tuple "bin/_bootstrap.sh.tpl" . | include "template" | indent 4 }}
   install_gateway.sh: |

--- a/cwf/gateway/helm/cwf-virtlet/values.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/values.yaml
@@ -34,6 +34,8 @@ secret:
 ## Key Values for docker inside VM
 cwf:
   type: cwag
+  gateway_ha:
+    enabled: false
   image:
     docker_registry: ""
     tag: "latest"

--- a/cwf/k8s/cwf_operator/README.md
+++ b/cwf/k8s/cwf_operator/README.md
@@ -6,18 +6,12 @@ chart (located at `magma/cwf/gateway/helm`) in a highly available
 configuration. The only configuration currently supported is 2 CWAGs
 running in active/standby mode.
 
-**Note**: This feature only works AP/WLCs that support redundant
-RADIUS servers and GRE tunnels. Magma is in the process of removing this
-requirement.
+Note: The `cwf-virtlet` helm chart is deprecated. If deploying a new
+gateway, use the chart located at `magma/cwf/gateway/helm/cwf-kubevirt`.
 
 ## Prerequisites
 
-Before installing the CWF Operator, the following prereqs must be done to
-ensure that HA will work properly:
-* Redis-ha helm chart deployed
-* CWAGs configured to use deployed redis server
-* Stateless sessiond enabled
-* RADIUS server configured to use redis
+Before installing the CWF Operator, the `redis-ha` helm chart must be deployed:
 
 ### Deploying HA Redis
 
@@ -49,46 +43,116 @@ Given these values, the helm chart can be deployed with:
 helm upgrade --install redis-ha stable/redis-ha --namespace magma --values=vals-redis-ha.yml
 ```
 
-### CWAG Configuration
+### CWAG Helm Configuration
 
-For each CWF helm release, there is a section of values that need to be updated
-to use the redis server deployed above. In the `vals.yml` for each cwf release,
-`port` should be changed to the port `vals-redis-ha.yml` and `bind` should be
-changed to the `haproxy` svc name that was created.
+For each CWF helm release, there is a section of values that need to be
+updated. In the `vals.yml` override for each cwf release, set `gateway_ha`
+to `enabled`.
+
+Then set the redis section to the port and bind address to match the redis-ha
+deployment. `port` should be changed to the port in `vals-redis-ha.yml` an
+d
+`bind` should be changed to the `haproxy` svc name that was created.
 
 ```console
 cwf:
   ...
+  gateway_ha:
+    enabled: false
   ...
   redis:
     port: 6380
     bind: redis-ha-haproxy
 ```
 
-To enable stateless sessiond, on each gateway, modify the file at
-`/etc/magma/sessiond.yml`. The field `support_stateless: false` should
-be set to `true`.
+Once these values are set, deploy the CWF helm chart with these
+values
+ overrides specified.
 
-To enable stateless RADIUS server, on each gateway, the file at
-`/var/opt/magma/docker/docker-compose.yml` should be updated to properly
-set the redis server:
+## Gateway Configuration and Registration
+
+Once the gateway pods have fully spun up, check to ensure that the installation
+succeeded for both gateways. To do this:
 
 ```console
-radius:
-    ...
-    ...
-    environment:
-      - STORAGE_TYPE=redis
-      - REDIS_ADDR=redis-ha-haproxy:6380
+[~/] kubectl -n magma get VirtualMachineInstances
+[~/] sudo virtctl -n magma console <cwfKubeVirtInstance>
+[user@cwf01:~/] cd /var/opt/magma/docker
+[user@cwf01:/var/opt/magma/docker] sudo docker ps
 ```
 
-**Note**: The sessiond and radius configuration changes will be incorporated
-into the cwf helm chart in the future.
+You should see all of the containers running:
+```console
+2bff32bb9787        docker.io/gateway_sessiond:tag    "/usr/local/bin/sess…"   1 hour ago        Up 1 hour (healthy)                       sessiond
+912626ef88fa        docker.io/gateway_python:tag      "python3.5 -m magma.…"   1 hour ago        Up 1 hour                                 state
+fc577508d4c4        docker.io/gateway_pipelined:tag   "python3.5 -m magma.…"   1 hour ago        Up 1 hour (healthy)                       policydb
+441b92fec477        docker.io/gateway_python:tag      "python3.5 -m magma.…"   1 hour ago        Up 1 hour (healthy)                       directoryd
+1c017b67b50f        docker.io/gateway_python:tag      "python3.5 -m magma.…"   1 hour ago        Up 1 hour                                 magmad
+9d118131385e        docker.io/gateway_go:tag          "envdir /var/opt/mag…"   1 hour ago        Up 1 hour (healthy)                       eap_aka
+0926c3c6613a        docker.io/gateway_python:tag      "/bin/bash -c '/usr/…"   1 hour ago        Up 1 hour                                 td-agent-bit
+6f2c3c82b723        docker.io/gateway_go:tag          "envdir /var/opt/mag…"   1 hour ago        Up 1 hour (healthy)                       aaa_server
+cd704bed6e75        docker.io/cwag_go:tag             "envdir /var/opt/mag…"   1 hour ago        Up 1 hour                                 health
+f12eb89a7cbd        docker.io/gateway_python:tag      "sh -c '/usr/local/b…"   1 hour ago        Up 1 hour                                 control_proxy
+3e806aa645ec        docker.io/gateway_python:tag      "python3.5 -m magma.…"   1 hour ago        Up 1 hour                                 eventd
+f786fd8f9d6c        docker.io/gateway_go:tag          "envdir /var/opt/mag…"   1 hour ago        Up 1 hour                                 radiusd
+beed2e197c13        docker.io/gateway_pipelined:tag   "sh -c 'set bridge c…"   1 hour ago        Up 1 hour (healthy)                       pipelined
+e6f78db3d8ad        docker.io/gateway_go:tag          "/bin/bash -c 'envsu…"   1 hour ago        Up 1 hour (healthy)                       radius
+9a097700e3a8        docker.io/gateway_python:tag      "/bin/bash -c '/usr/…"   1 hour ago        Up 1 hour                                 redis
+```
+
+Then register each gateway:
+```console
+[user@cwf01:~/] cd /var/opt/magma/docker
+[user@cwf01:/var/opt/magma/docker] sudo docker-compose exec magmad /usr/local/bin/show_gateway_info.py
+```
+
+You should see output similar to:
+
+```console
+Hardware ID:
+------------
+d8ae2bd1-a517-4f48-a01d-648fdfcd28da
+
+Challenge Key:
+-----------
+MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzQeuSAA1Rmb0UyCE87DuX1HiFJY3McKm2XqplyJIsiPkqg8HNQ7v1MZwnvVI28AF/JAmRiQXjJqWqIqL1n3IsvOa9XyqOvIruCSVPo8wUaVkbs5bx9nFkzUMthuBjVjY
+```
+
+Register the gateway by adding this information to the intended CWF network
+in your NMS.
+
+### Creating the HA Pair
+
+Lastly, we need to configure an `HAPair` network entity to associate these
+two gateways into an HA cluster. NMS support for this is not yet completed,
+so this will have to be done through the Orchestrator API.
+
+Navigate to the API, and find endpoint `/cwf/{network_id}/ha_pairs`. Use the
+`POST` method to create the pair. An important part of this configuration is
+the `transport_virtual_ip` field. This is the IP address that will be used by
+WLC/APs to connect to the CWAG cluster. The IP should be an unused IP in the
+SAME subnet as eth1 of the gateways.
+
+As an example, below is the pair we would create if our two gateways had
+gateway ID's `gw1` and `gw2`:
+
+```console
+{
+  "config": {
+    "transport_virtual_ip": "10.10.10.12/24"
+  },
+  "gateway_id_1": "gw1",
+  "gateway_id_2": "gw2",
+  "ha_pair_id": "cwf_pair1"
+}
+```
 
 ## Deploying CWF Operator
 
-To deploy the operator, copy the deploy directory at
-`magma/cwf/k8s/cwf_operator/deploy` to a controller node.
+Lastly, we need to deploy the operator to manage this cluster. To do so,
+copy the deploy directory at `magma/cwf/k8s/cwf_operator/deploy` to a
+controller node.
+
 Then run the following on the node:
 
 ```console
@@ -99,9 +163,12 @@ $ kubectl -n magma create -f deploy/role_binding.yaml
 ```
 
 Before creating the operator pod, the `operator.yaml` file will need to be
-modified with the appropriate `imagePullSecrets` and `image` fields. These
-fields should correspond to the Docker registry that contains the
-`cwf_operator` image (e.g. `image: docker.io/cwf_operator:latest`).
+modified. The following fields should be updated:
+ * `imagePullSecrets` - update to the correct secrets to pull the operator
+ image
+ * `image` - update to the correct image (e.g. `docker.io/operator:latest`)
+ * `REDIS_ADDR` - update to the deployed redis addr for the redis-ha helm chart
+ (e.g. `redis-ha-haproxy:6380`)
 
 Now, create the operator pod:
 ```console
@@ -119,21 +186,28 @@ cwf02-747b5bf75b-4njp9                        1/1     Running            0      
 
 Lastly, we need to modify
 `deploy/crds/magma.cwf.k8s_v1alpha1_hacluster_cr.yaml` to track our intended
-CWAGs. To do this, modify `gatewayResourceNames` to the name of the 2 CWAGs
-that will be configured in the active/standby cluster. The names should be
-the **helm release name** of the deployed cwf helm charts. If you are unsure
-what these should be, run `helm ls` to check the list of releases.
+CWAGs. To do this, modify `gatewayResources` to the name of 2 CWAG resources
+that will be configured in the active/standby cluster. For each resource,
+define:
+ * `gatewayID` - the gateway ID created in the NMS
+ * `helmReleaseName` - the release name of the gateway helm deployment
+
+If you are unsure what the helm release name should be, run `helm ls -n magma`
+to check the list of releases.
 
 After making this change, the yaml file should something like:
 ```console
 apiVersion: magma.cwf.k8s/v1alpha1
 kind: HACluster
 metadata:
-  name: cwf-hacluster
+  name: example-hacluster
 spec:
-  gatewayResourceNames:
-   - "cwf01"
-   - "cwf02"
+  gatewayResources:
+    - gatewayID: "gw1"
+      helmReleaseName: "cwf01"
+    - gatewayID: "gw2"
+      helmReleaseName: "cwf02"
+  haPairID: "cwf_pair1"
 ```
 
 Create this custom resource by running:
@@ -168,3 +242,8 @@ I0708 08:46:05.699199       1 hacluster_controller.go:112] controller_hacluster 
 I0708 08:46:05.902238       1 hacluster_controller.go:146] controller_hacluster "level"=0 "msg"="Fetched active health status" "Request.Name"="cwf-hacluster" "Request.Namespace"="magma" "health"="HEALTHY" "message"="gateway status appears healthy"
 I0708 08:46:05.904689       1 hacluster_controller.go:152] controller_hacluster "level"=0 "msg"="Fetched standby health status" "Request.Name"="cwf-hacluster" "Request.Namespace"="magma" "health"="HEALTHY" "message"="gateway status appears healthy"
 ```
+
+**Note**: If creating more than 1 HA cluster, the operator need only be
+deployed once. Just define a new HACluster resource
+(a new `magma.cwf.k8s_v1alpha1_hacluster_cr.yaml` file) set to the
+appropriate gateways and run `kubectl -n magma create -f <new_cluster_cr.yaml>`.


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR updates the cwf helm chart deployment to allow
for all customization needed to enable HA. This ensures 
that if a gateway pod is evicted and restarts, it'll return with 
all necessary configuration to continue operating in the cluster.

This also includes an update to the CWF Operator README to
be up-to-date.

## Test Plan

Deployed to the lab