### PR TITLE
[lte][agw] Update RAR TCs to use enum values in FlowMatch instead of strings

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -339,7 +339,7 @@ class S1ApUtil(object):
             total_num_dl_flows_to_be_verified = 1
             for item in value:
                 for flow in item:
-                    if flow["direction"] == "DL":
+                    if flow["direction"] == FlowMatch.DOWNLINK:
                         total_num_dl_flows_to_be_verified += 1
             total_dl_ovs_flows_created = get_flows(
                 self.datapath,
@@ -360,14 +360,10 @@ class S1ApUtil(object):
             # Now verify the rules for every flow
             for item in value:
                 for flow in item:
-                    if flow["direction"] == "DL":
+                    if flow["direction"] == FlowMatch.DOWNLINK:
                         ipv4_src_addr = flow["ipv4_src"]
                         tcp_src_port = flow["tcp_src_port"]
-                        ip_proto = (
-                            FlowMatch.IPPROTO_TCP
-                            if (flow["ip_proto"] == "TCP")
-                            else FlowMatch.IPPROTO_UDP
-                        )
+                        ip_proto = flow["ip_proto"]
                         for i in range(self.MAX_NUM_RETRIES):
                             print("Get downlink flows: attempt ", i)
                             downlink_flows = get_flows(
@@ -978,14 +974,11 @@ class SessionManagerUtil(object):
         Populates flow match list
         """
         for flow in flow_list:
-            flow_direction = (
-                FlowMatch.UPLINK
-                if flow["direction"] == "UL"
-                else FlowMatch.DOWNLINK
-            )
+            flow_direction = flow["direction"]
+            print("flow_direction", flow_direction)
             ip_protocol = flow["ip_proto"]
-            if ip_protocol == "TCP":
-                ip_protocol = FlowMatch.IPPROTO_TCP
+            print("ip_proto", ip_protocol)
+            if ip_protocol == FlowMatch.IPPROTO_TCP:
                 udp_src_port = 0
                 udp_dst_port = 0
                 tcp_src_port = (
@@ -994,8 +987,7 @@ class SessionManagerUtil(object):
                 tcp_dst_port = (
                     int(flow["tcp_dst_port"]) if "tcp_dst_port" in flow else 0
                 )
-            elif ip_protocol == "UDP":
-                ip_protocol = FlowMatch.IPPROTO_UDP
+            elif ip_protocol == FlowMatch.IPPROTO_UDP:
                 tcp_src_port = 0
                 tcp_dst_port = 0
                 udp_src_port = (

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -975,9 +975,7 @@ class SessionManagerUtil(object):
         """
         for flow in flow_list:
             flow_direction = flow["direction"]
-            print("flow_direction", flow_direction)
             ip_protocol = flow["ip_proto"]
-            print("ip_proto", ip_protocol)
             if ip_protocol == FlowMatch.IPPROTO_TCP:
                 udp_src_port = 0
                 udp_dst_port = 0

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_rar_tcp_data.py
@@ -19,6 +19,7 @@ from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil, GTPBridgeUtils
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
@@ -73,64 +74,64 @@ class TestAttachDetachMultipleRarTcpData(unittest.TestCase):
             ulFlow1 = {
                 "ipv4_dst": "192.168.129.42",  # IPv4 destination address
                 "tcp_dst_port": 5002,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # UL Flow description #2
             ulFlow2 = {
                 "ipv4_dst": "192.168.129.42",  # IPv4 destination address
                 "tcp_dst_port": 5001,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # UL Flow description #3
             ulFlow3 = {
                 "ipv4_dst": "192.168.129.64",  # IPv4 destination address
                 "tcp_dst_port": 5003,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # UL Flow description #4
             ulFlow4 = {
                 "ipv4_dst": "192.168.129.42",  # IPv4 destination address
                 "tcp_dst_port": 5001,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # DL Flow description #1
             dlFlow1 = {
                 "ipv4_src": "192.168.129.42",  # IPv4 source address
                 "tcp_src_port": 5001,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # DL Flow description #2
             dlFlow2 = {
                 "ipv4_src": "192.168.129.64",  # IPv4 source address
                 "tcp_src_port": 5002,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # DL Flow description #3
             dlFlow3 = {
                 "ipv4_src": "192.168.129.64",  # IPv4 source address
                 "tcp_src_port": 5003,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # DL Flow description #4
             dlFlow4 = {
                 "ipv4_src": "192.168.129.42",  # IPv4 source address
                 "tcp_src_port": 5001,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # Flow lists to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_rar_tcp_data.py
@@ -19,6 +19,7 @@ from integ_tests.s1aptests import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SpgwUtil
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil, GTPBridgeUtils
 from integ_tests.s1aptests.ovs.rest_api import get_datapath, get_flows
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachDetachRarTcpData(unittest.TestCase):
@@ -70,64 +71,64 @@ class TestAttachDetachRarTcpData(unittest.TestCase):
             ulFlow1 = {
                 "ipv4_dst": "192.168.129.42",  # IPv4 destination address
                 "tcp_dst_port": 5002,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # UL Flow description #2
             ulFlow2 = {
                 "ipv4_dst": "192.168.129.42",  # IPv4 destination address
                 "tcp_dst_port": 5001,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # UL Flow description #3
             ulFlow3 = {
                 "ipv4_dst": "192.168.129.64",  # IPv4 destination address
                 "tcp_dst_port": 5003,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # UL Flow description #4
             ulFlow4 = {
                 "ipv4_dst": "192.168.129.42",  # IPv4 destination address
                 "tcp_dst_port": 5004,  # TCP dest port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "UL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.UPLINK,  # Direction
             }
 
             # DL Flow description #1
             dlFlow1 = {
                 "ipv4_src": "192.168.129.42",  # IPv4 source address
                 "tcp_src_port": 5001,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # DL Flow description #2
             dlFlow2 = {
                 "ipv4_src": "192.168.129.64",  # IPv4 source address
                 "tcp_src_port": 5002,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # DL Flow description #3
             dlFlow3 = {
                 "ipv4_src": "192.168.129.64",  # IPv4 source address
                 "tcp_src_port": 5003,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # DL Flow description #4
             dlFlow4 = {
                 "ipv4_src": "192.168.129.42",  # IPv4 source address
                 "tcp_src_port": 5004,  # TCP source port
-                "ip_proto": "TCP",  # Protocol Type
-                "direction": "DL",  # Direction
+                "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+                "direction": FlowMatch.DOWNLINK,  # Direction
             }
 
             # Flow list to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers.py
@@ -18,6 +18,7 @@ import gpp_types
 import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
@@ -62,63 +63,63 @@ class TestAttachServiceWithMultiPdnsAndBearers(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow lists to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_failure.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 import ipaddress
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
@@ -59,62 +60,62 @@ class TestAttachServiceMultiPdnsBearersFailure(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow lists to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_looped.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 import ipaddress
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
@@ -65,63 +66,63 @@ class TestAttachServiceWithMultiPdnsAndBearersLooped(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow lists to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_mt_data.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 import ipaddress
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
@@ -62,63 +63,63 @@ class TestAttachServiceWithMultiPdnsAndBearersMtData(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow lists to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_service_with_multi_pdns_and_bearers_multi_ue.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
@@ -43,63 +44,63 @@ class TestAttachServiceWithMultiPdnsAndBearersMultiUe(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow lists to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
 import ipaddress
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
@@ -39,63 +40,63 @@ class TestDedicatedBearerActivationIdleMode(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow list to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_multi_ue.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
@@ -43,63 +44,63 @@ class TestDedicatedBearerActivationIdleModeMultiUe(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow list to be configured

--- a/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_dedicated_bearer_activation_idle_mode_paging_timer_expiry.py
@@ -19,6 +19,7 @@ import s1ap_types
 import s1ap_wrapper
 import ipaddress
 from integ_tests.s1aptests.s1ap_utils import SessionManagerUtil
+from lte.protos.policydb_pb2 import FlowMatch
 
 
 class TestDedicatedBearerActivationIdleModePagingTmrExpiry(unittest.TestCase):
@@ -44,63 +45,63 @@ class TestDedicatedBearerActivationIdleModePagingTmrExpiry(unittest.TestCase):
         ulFlow1 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5002,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #2
         ulFlow2 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5001,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #3
         ulFlow3 = {
             "ipv4_dst": "192.168.129.64",  # IPv4 destination address
             "tcp_dst_port": 5003,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # UL Flow description #4
         ulFlow4 = {
             "ipv4_dst": "192.168.129.42",  # IPv4 destination address
             "tcp_dst_port": 5004,  # TCP dest port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "UL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.UPLINK,  # Direction
         }
 
         # DL Flow description #1
         dlFlow1 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5001,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #2
         dlFlow2 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5002,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
         # DL Flow description #3
         dlFlow3 = {
             "ipv4_src": "192.168.129.64",  # IPv4 source address
             "tcp_src_port": 5003,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # DL Flow description #4
         dlFlow4 = {
             "ipv4_src": "192.168.129.42",  # IPv4 source address
             "tcp_src_port": 5004,  # TCP source port
-            "ip_proto": "TCP",  # Protocol Type
-            "direction": "DL",  # Direction
+            "ip_proto": FlowMatch.IPPROTO_TCP,  # Protocol Type
+            "direction": FlowMatch.DOWNLINK,  # Direction
         }
 
         # Flow list to be configured


### PR DESCRIPTION
[lte][agw] Update RAR TCs to use enum values in FlowMatch instead of strings

## Summary
Protocol type and traffic flow directions required to send RAR were passed as strings from the test script, which were later converted into FlowMatch enum values defined in policydb.proto file. Fixed this by passing FlowMatch enum values directly from the test scripts

## Test Plan
Verified s1 sim sanity and test cases related to idle mode handling
