### PR TITLE
[lte][agw] Adding default polling_interval for gtp_stats param to pipelined

### DIFF
--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -139,3 +139,5 @@ ovs_uplink_port_name: patch-up
 uplink_bridge: uplink_br0
 uplink_eth_port_name: eth0
 uplink_gw_mac: 'ff:ff:ff:ff:ff:ff'
+
+ovs_gtp_stats_polling_interval: 60

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -19,7 +19,6 @@ import asyncio
 import logging
 import threading
 
-
 import aioeventlet
 from ryu import cfg
 from ryu.base.app_manager import AppManager
@@ -33,7 +32,8 @@ from magma.pipelined.check_quota_server import run_flask
 from magma.pipelined.service_manager import ServiceManager
 from magma.pipelined.ifaces import monitor_ifaces
 from magma.pipelined.rpc_servicer import PipelinedRpcServicer
-from magma.pipelined.gtp_stats_collector import GTPStatsCollector
+from magma.pipelined.gtp_stats_collector import GTPStatsCollector, \
+    MIN_OVSDB_DUMP_POLLING_INTERVAL
 from lte.protos.mconfig import mconfigs_pb2
 
 
@@ -126,8 +126,10 @@ def main():
                                  on_exit_server_thread)
 
     if service.config['setup_type'] == 'LTE':
+        polling_interval = service.config.get('ovs_gtp_stats_polling_interval',
+                                              MIN_OVSDB_DUMP_POLLING_INTERVAL)
         collector = GTPStatsCollector(
-            service.config['ovs_gtp_stats_polling_interval'],
+            polling_interval,
             service.loop)
         collector.start()
 


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Due to the changes on https://github.com/magma/magma/pull/3020, when AGW is updated pipelined fails with 

```
Oct 07 11:52:18 magma-ag pipelined[47099]: Traceback (most recent call last):
Oct 07 11:52:18 magma-ag pipelined[47099]:   File "/usr/lib/python3.5/runpy.py", line 193, in _run_module_as_main
Oct 07 11:52:18 magma-ag pipelined[47099]:     "__main__", mod_spec)
Oct 07 11:52:18 magma-ag pipelined[47099]:   File "/usr/lib/python3.5/runpy.py", line 85, in _run_code
Oct 07 11:52:18 magma-ag pipelined[47099]:     exec(code, run_globals)
Oct 07 11:52:18 magma-ag pipelined[47099]:   File "/usr/local/lib/python3.5/dist-packages/magma/pipelined/main.py", line 151, in <module>
Oct 07 11:52:18 magma-ag pipelined[47099]:     main()
Oct 07 11:52:18 magma-ag pipelined[47099]:   File "/usr/local/lib/python3.5/dist-packages/magma/pipelined/main.py", line 130, in main
Oct 07 11:52:18 magma-ag pipelined[47099]:     service.config['ovs_gtp_stats_polling_interval'],
Oct 07 11:52:18 magma-ag pipelined[47099]: KeyError: 'ovs_gtp_stats_polling_interval'
```

This updates yml_prod file to include given polling_interval parameter 

## Test Plan

- tested on agw on teravm after adding parameter to ensure pipelined doesn't crash

## Additional Information

- [ ] This change is backwards-breaking
