### PR TITLE
[SessionD] Do not report credit that is in final state

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -136,7 +136,7 @@ bool ChargingGrant::get_update_type(
     *update_type = CreditUsage::REAUTH_REQUIRED;
     return true;
   }
-  if (is_final_grant && credit.is_quota_exhausted(1)) {
+  if (is_final_grant) {
     // Don't request updates if this is the final grant
     return false;
   }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A bit of an edge case previously not covered by any tests.
When we have a credit that is final, we do NOT want to report any usage because there is no credit to be given. We will only send an update request if it is prompted by a Gy ReAuth. 

Also added a unit test to cover this case. The test fails without the change.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF integ test + manually verifying on the setup with large delays between traffic chunks to make sure there are no updates
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
