### PR TITLE
Fix the code to ensure that correct key, apn gets displayed

### DIFF
--- a/nms/app/packages/magmalte/app/state/lte/ApnState.js
+++ b/nms/app/packages/magmalte/app/state/lte/ApnState.js
@@ -47,8 +47,8 @@ export async function SetApnState(props: Props) {
       apnName: key,
     });
     if (apn) {
-      const newPolicies = {...apns, [key]: apn};
-      setApns(newPolicies);
+      const newApns = {...apns, [key]: apn};
+      setApns(newApns);
     }
   } else {
     await MagmaV1API.deleteLteByNetworkIdApnsByApnName({

--- a/nms/app/packages/magmalte/app/views/traffic/ApnOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/ApnOverview.js
@@ -228,7 +228,7 @@ export function ApnJsonConfig() {
           if (apn.apn_name === '') {
             throw Error('Invalid Name');
           }
-          ctx.setState(apnName, apn);
+          ctx.setState(apn.apn_name, apn);
           enqueueSnackbar('APN saved successfully', {
             variant: 'success',
           });


### PR DESCRIPTION
## Summary

Upon adding a new APN, the apnName was incorrectly being displayed as undefined. The key being sent in setState was incorrect. This patch fixes this issue.
![apn_bug](https://user-images.githubusercontent.com/8224854/95391903-b6d8f100-08ac-11eb-9f46-362e56d99655.png)

## Test Plan

Fixed it by verifying adding APN in staging. 
![Screen Shot 2020-10-07 at 2 53 38 PM](https://user-images.githubusercontent.com/8224854/95392038-edaf0700-08ac-11eb-9613-b452449bb9c6.png)
![Screen Shot 2020-10-07 at 2 53 43 PM](https://user-images.githubusercontent.com/8224854/95392042-f0116100-08ac-11eb-8d4c-00231457a989.png)
[skipJenkins]

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
