### PR TITLE
Fix wrong service name on lte service_registry

### DIFF
--- a/lte/gateway/configs/service_registry.yml
+++ b/lte/gateway/configs/service_registry.yml
@@ -35,7 +35,7 @@ services:
   sessiond:
     ip_address: 127.0.0.1
     port: 50065
-  abort_session:
+  abort_session_service:
     ip_address: 127.0.0.1
     port: 50065
   test_service:

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -967,7 +967,7 @@ class SessionManagerUtil(object):
             get_rpc_channel("sessiond")
         )
         self._abort_session_stub = AbortSessionResponderStub(
-            get_rpc_channel("sessiond")
+            get_rpc_channel("abort_session_service")
         )
         self._directorydstub = GatewayDirectoryServiceStub(
             get_rpc_channel("directoryd")

--- a/lte/gateway/python/scripts/session_manager_cli.py
+++ b/lte/gateway/python/scripts/session_manager_cli.py
@@ -216,7 +216,7 @@ def send_policy_rar(client, args):
 
 @grpc_wrapper
 def send_abort_session(client, args):
-    abort_session_chan = ServiceRegistry.get_rpc_channel("abort_session", ServiceRegistry.LOCAL)
+    abort_session_chan = ServiceRegistry.get_rpc_channel("abort_session_service", ServiceRegistry.LOCAL)
     abort_session_client = AbortSessionResponderStub(abort_session_chan)
 
     asr = AbortSessionRequest(
@@ -279,7 +279,7 @@ def create_parser():
 
     # ASR
     abort_session_parser = subparsers.add_parser(
-        "abort_session",
+        "abort_session_service",
         help="Send an AbortSessionRequest to SessionD service",
     )
     abort_session_parser.add_argument("session_id", help="e.g., 001010000088888")


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The name of service was incorrect in the service_registry, so the ASR was not getting through for LTE case. Simple change of rename here.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
LTE integ tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
