### PR TITLE
[orc8r] allow dash in network/gateway id

### DIFF
--- a/orc8r/cloud/go/models/gateway_id_swaggergen.go
+++ b/orc8r/cloud/go/models/gateway_id_swaggergen.go
@@ -24,7 +24,7 @@ func (m GatewayID) Validate(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("", "body", string(m), `^[a-z][\da-z_]+$`); err != nil {
+	if err := validate.Pattern("", "body", string(m), `^[a-z][\da-z_-]+$`); err != nil {
 		return err
 	}
 

--- a/orc8r/cloud/go/models/network_id_swaggergen.go
+++ b/orc8r/cloud/go/models/network_id_swaggergen.go
@@ -24,7 +24,7 @@ func (m NetworkID) Validate(formats strfmt.Registry) error {
 		return err
 	}
 
-	if err := validate.Pattern("", "body", string(m), `^[a-z][\da-z_]+$`); err != nil {
+	if err := validate.Pattern("", "body", string(m), `^[a-z][\da-z_-]+$`); err != nil {
 		return err
 	}
 

--- a/orc8r/cloud/go/models/swagger-common.yml
+++ b/orc8r/cloud/go/models/swagger-common.yml
@@ -99,7 +99,7 @@ definitions:
     minLength: 1
     x-nullable: false
     example: network_1
-    pattern: '^[a-z][\da-z_]+$'
+    pattern: '^[a-z][\da-z_-]+$'
   network_name:
     type: string
     minLength: 1
@@ -119,7 +119,7 @@ definitions:
     type: string
     minLength: 1
     x-nullable: false
-    pattern: '^[a-z][\da-z_]+$'
+    pattern: '^[a-z][\da-z_-]+$'
     example: gw1
   gateway_name:
     type: string

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
@@ -223,7 +223,7 @@ func Test_PostNetworkHandlers(t *testing.T) {
 		Handler:        createNetwork,
 		ExpectedStatus: 400,
 		ExpectedError: "validation failure list:\n" +
-			"id in body should match '^[a-z][\\da-z_]+$'",
+			"id in body should match '^[a-z][\\da-z_-]+$'",
 	}
 	tests.RunUnitTest(t, e, tc)
 


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

This just a tentative proposition to change the network/gateway names convention in orc8r to allow "-"
all xwf partners names concatenates the country code to the name (ex. name-us)
It would allow us to have all the exported metrics on same dashboard per partner.

## Test Plan

Tested locally 

