### PR TITLE
[5G: MVC][AMF] AMF Set Interface Server

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -10,11 +10,9 @@ limitations under the License.
 */
 
 #include <string>
-
 #include "lte/protos/session_manager.pb.h"
 
 extern "C" {
-#include "spgw_service_handler.h"
 #include "log.h"
 }
 #include "AmfServiceImpl.h"

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Magma Authors.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <string>
+
+#include "lte/protos/session_manager.pb.h"
+#include "lte/protos/spgw_service.pb.h"
+#include <folly/IPAddress.h>
+
+extern "C" {
+#include "spgw_service_handler.h"
+#include "log.h"
+}
+#include "AmfServiceImpl.h"
+
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
+
+using grpc::ServerContext;
+using grpc::Status;
+using magma::lte::SetSMSessionContextAccess;
+using magma::lte::SmContextVoid;
+using magma::lte::SmfPduSessionSmContext;
+
+namespace magma {
+using namespace lte;
+
+AmfServiceImpl::AmfServiceImpl() {}
+//Set message from SessionD received
+Status AmfServiceImpl::SetSmfSessionContext(
+    ServerContext* context, const SetSMSessionContextAccess* request,
+    SmContextVoid* response) {
+  OAILOG_INFO(LOG_UTIL, "Received  GRPC SetSMSessionContextAccess request\n"); 
+    
+//ToDo processing ITTI,ZMQ
+
+   return Status::OK;
+ }
+
+}  // namespace magma

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -12,8 +12,6 @@ limitations under the License.
 #include <string>
 
 #include "lte/protos/session_manager.pb.h"
-#include "lte/protos/spgw_service.pb.h"
-#include <folly/IPAddress.h>
 
 extern "C" {
 #include "spgw_service_handler.h"
@@ -39,7 +37,7 @@ AmfServiceImpl::AmfServiceImpl() {}
 Status AmfServiceImpl::SetSmfSessionContext(
     ServerContext* context, const SetSMSessionContextAccess* request,
     SmContextVoid* response) {
-  OAILOG_INFO(LOG_UTIL, "Received  GRPC SetSMSessionContextAccess request\n"); 
+  OAILOG_INFO(LOG_UTIL, "Received GRPC SetSMSessionContextAccess request\n"); 
     
 //ToDo processing ITTI,ZMQ
 

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.cpp
@@ -41,5 +41,4 @@ Status AmfServiceImpl::SetSmfSessionContext(
 
    return Status::OK;
  }
-
 }  // namespace magma

--- a/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/AmfServiceImpl.h
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Magma Authors.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#pragma once
+
+#include <grpc++/grpc++.h>
+#include <grpcpp/impl/codegen/status.h>
+
+#include "lte/protos/session_manager.grpc.pb.h"
+#include "lte/protos/spgw_service.grpc.pb.h"
+#include "lte/protos/policydb.pb.h"
+
+extern "C" {
+#include "spgw_service_handler.h"
+#include "log.h"
+}
+
+namespace grpc {
+class ServerContext;
+}  // namespace grpc
+namespace magma {
+namespace lte {
+class SetSMSessionContextAccess;
+class SmContextVoid;
+ }  // namespace lte
+}  // namespace magma
+
+using grpc::ServerContext;
+using magma::lte::SetSMSessionContextAccess;
+using magma::lte::SmContextVoid;
+using magma::lte::SmfPduSessionSmContext;
+
+namespace magma {
+using namespace lte;
+
+//SessionD to AMF server
+class AmfServiceImpl final : public SmfPduSessionSmContext::Service {
+ public:
+  AmfServiceImpl();
+  
+  grpc::Status SetSmfSessionContext (
+      ServerContext* context, const SetSMSessionContextAccess* request,
+      SmContextVoid* response) override;
+ };
+
+} // namespace magma


### PR DESCRIPTION
Signed-off-by: ronit-kumar-acl <ronit.k@altencalsoftlabs.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Added AMF server implementation inside oai/tasks.
Receives Set interface grpc requests when client services use "amf_service"  as the name of the channel in the client code. 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

Unit Test logs: [amf_server_unit_test.log](https://github.com/magma/magma/files/5383827/amf_server_unit_test.log)
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
