### PR TITLE
[sessiond] fix is_reporting field

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -130,6 +130,7 @@ CreditUsage ChargingGrant::get_credit_usage(
 bool ChargingGrant::get_update_type(
     CreditUsage::UpdateType* update_type) const {
   if (credit.is_reporting()) {
+    MLOG(MDEBUG) << "is_reporting is True , not sending update";
     return false;  // No update
   }
   if (reauth_state == REAUTH_REQUIRED) {
@@ -250,4 +251,7 @@ void ChargingGrant::log_final_action_info() const {
   MLOG(MINFO) << "This is a final credit, with " << final_action;
 }
 
+void ChargingGrant::set_reporting(bool reporting) {
+  credit.set_reporting(reporting);
+}
 }  // namespace magma

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -101,6 +101,10 @@ struct ChargingGrant {
   void set_service_state(
       const ServiceState new_service_state, SessionCreditUpdateCriteria& uc);
 
+  // Set the flag reporting. Used to signal this credit is waiting to receive
+  // a response from the core
+  void set_reporting(bool reporting);
+
   // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
   // and assign it to expiry_time
   void set_expiry_time_as_timestamp(uint32_t rel_time_sec);

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -705,6 +705,7 @@ UpdateSessionRequest LocalEnforcer::collect_updates(
 
 void LocalEnforcer::reset_updates(
     SessionMap& session_map, const UpdateSessionRequest& failed_request) {
+  MLOG(MDEBUG) << "Reseting_updates";
   for (const auto& update : failed_request.updates()) {
     auto it = session_map.find(update.sid());
     if (it == session_map.end()) {
@@ -1280,15 +1281,16 @@ void LocalEnforcer::update_charging_credits(
   for (const auto& credit_update_resp : response.responses()) {
     const std::string& imsi       = credit_update_resp.sid();
     const std::string& session_id = credit_update_resp.session_id();
+    const auto ckey               = credit_update_resp.charging_key();
     SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
       MLOG(MERROR) << "Could not find session " << session_id
-                   << " during charging update for RG "
-                   << credit_update_resp.charging_key();
+                   << " during charging update for RG " << ckey;
       continue;
     }
     auto& session = **session_it;
+    auto& uc      = session_update[imsi][session_id];
 
     if (!credit_update_resp.success()) {
       handle_command_level_result_code(
@@ -1297,7 +1299,6 @@ void LocalEnforcer::update_charging_credits(
       continue;
     }
 
-    auto& uc = session_update[imsi][session_id];
     const auto& credit_key(credit_update_resp);
     // We need to retrieve restrict_rules and is_final_action_state
     // prior to receiving charging credit as they will be updated.
@@ -1329,15 +1330,17 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
   for (const auto& usage_monitor_resp : response.usage_monitor_responses()) {
     const std::string& imsi       = usage_monitor_resp.sid();
     const std::string& session_id = usage_monitor_resp.session_id();
+    const std::string& mkey = usage_monitor_resp.credit().monitoring_key();
+
     SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
       MLOG(MERROR) << "Could not find session for " << session_id
-                   << " during monitoring update for mkey "
-                   << usage_monitor_resp.credit().monitoring_key();
+                   << " during monitoring update for mkey " << mkey;
       continue;
     }
     auto& session = **session_it;
+    auto& uc      = session_update[imsi][session_id];
 
     if (!usage_monitor_resp.success()) {
       handle_command_level_result_code(
@@ -1346,7 +1349,6 @@ void LocalEnforcer::update_monitoring_credits_and_rules(
       continue;
     }
 
-    auto& uc           = session_update[imsi][session_id];
     const auto& config = session->get_config();
     session->receive_monitor(usage_monitor_resp, uc);
     session->set_tgpp_context(usage_monitor_resp.tgpp_ctx(), uc);

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -68,13 +68,12 @@ void LocalSessionManagerHandlerImpl::ReportRuleStats(
 }
 
 void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
-    SessionMap session_map, SessionUpdate& session_update) {
+    SessionMap session_map, SessionUpdate& session_uc) {
   std::vector<std::unique_ptr<ServiceAction>> actions;
-  auto request =
-      enforcer_->collect_updates(session_map, actions, session_update);
-  enforcer_->execute_actions(session_map, actions, session_update);
+  auto request = enforcer_->collect_updates(session_map, actions, session_uc);
+  enforcer_->execute_actions(session_map, actions, session_uc);
   if (request.updates_size() == 0 && request.usage_monitors_size() == 0) {
-    auto update_success = session_store_.update_sessions(session_update);
+    auto update_success = session_store_.update_sessions(session_uc);
     if (update_success) {
       MLOG(MDEBUG) << "Succeeded in updating session after no reporting";
     } else {
@@ -82,13 +81,18 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
     }
     return;  // nothing to report
   }
+
   MLOG(MINFO) << "Sending " << request.updates_size()
               << " charging updates and " << request.usage_monitors_size()
               << " monitor updates to OCS and PCRF";
 
+  // set reporting flag for those sessions reporting
+  session_store_.set_and_save_reporting_flag(true, request, session_uc);
+
   // Before reporting and returning control to the event loop, increment the
   // request numbers stored for the sessions in SessionStore
-  session_store_.sync_request_numbers(session_update);
+  session_store_.sync_request_numbers(session_uc);
+
   // report to cloud
   // NOTE: It is not possible to construct a std::function from a move-only type
   //       So because of this, we can't directly move session_map into the
@@ -98,21 +102,25 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
   //       https://stackoverflow.com/questions/25421346/how-to-create-an-stdfunction-from-a-move-capturing-lambda-expression
   reporter_->report_updates(
       request,
-      [this, request, session_update,
+      [this, request, session_uc,
        session_map_ptr = std::make_shared<SessionMap>(std::move(session_map))](
           Status status, UpdateSessionResponse response) mutable {
         PrintGrpcMessage(
             static_cast<const google::protobuf::Message&>(response));
+
+        // clear all the reporting flags
+        session_store_.set_and_save_reporting_flag(false, request, session_uc);
+
         if (!status.ok()) {
           MLOG(MERROR) << "Update of size " << request.updates_size()
                        << " to OCS failed entirely: " << status.error_message();
           report_session_update_event_failure(
-              *session_map_ptr, session_update, status.error_message());
+              *session_map_ptr, session_uc, status.error_message());
         } else {
           enforcer_->update_session_credits_and_rules(
-              *session_map_ptr, response, session_update);
-          session_store_.update_sessions(session_update);
-          report_session_update_event(*session_map_ptr, session_update);
+              *session_map_ptr, response, session_uc);
+          session_store_.update_sessions(session_uc);
+          report_session_update_event(*session_map_ptr, session_uc);
         }
       });
 }

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -140,7 +140,7 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
 
  private:
   void check_usage_for_reporting(
-      SessionMap session_map, SessionUpdate& session_update);
+      SessionMap session_map, SessionUpdate& session_uc);
   bool is_pipelined_restarted();
   bool restart_pipelined(const std::uint64_t& epoch);
 

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -112,6 +112,8 @@ class SessionCredit {
   void set_report_last_credit(
       bool report_last_credit, SessionCreditUpdateCriteria& uc);
 
+  void set_reporting(bool reporting);
+
   bool is_report_last_credit();
 
   /**
@@ -124,6 +126,12 @@ class SessionCredit {
   void add_credit(
       uint64_t credit, Bucket bucket,
       SessionCreditUpdateCriteria& update_criteria);
+
+  /**
+   * Merges SessionCredit UpdateCriteria with credit
+   * */
+  void merge(SessionCreditUpdateCriteria& uc);
+
   /**
    * is_quota_exhausted checks if any of the remaining quota (Allowed - Used)
    * on tx, rx, or tx+rx amounts are under a specific threshold, and depending

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -213,6 +213,10 @@ class SessionState {
 
   uint64_t get_charging_credit(const CreditKey& key, Bucket bucket) const;
 
+  bool set_credit_reporting(
+      const CreditKey& key, bool reporting,
+      SessionStateUpdateCriteria* update_criteria);
+
   ReAuthResult reauth_key(
       const CreditKey& charging_key,
       SessionStateUpdateCriteria& update_criteria);
@@ -429,6 +433,10 @@ class SessionState {
       SessionStateUpdateCriteria& session_uc);
 
   uint64_t get_monitor(const std::string& key, Bucket bucket) const;
+
+  bool set_monitor_reporting(
+      const std::string& key, bool reporting,
+      SessionStateUpdateCriteria* update_criteria);
 
   bool add_to_monitor(
       const std::string& key, uint64_t used_tx, uint64_t used_rx,

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -39,6 +39,65 @@ SessionMap SessionStore::read_all_sessions() {
   return store_client_->read_all_sessions();
 }
 
+void SessionStore::set_and_save_reporting_flag(
+    bool value, const UpdateSessionRequest& update_session_request,
+    SessionUpdate& session_uc) {
+  MLOG(MDEBUG) << "saving flag is_reporting = " << value << " on session store";
+  auto session_map = store_client_->read_all_sessions();
+
+  for (const CreditUsageUpdate& credit_update :
+       update_session_request.updates()) {
+    const std::string imsi       = credit_update.sid();
+    const std::string session_id = credit_update.session_id();
+    const CreditKey& ckey        = credit_update.usage().charging_key();
+    const std::string mkey       = credit_update.usage().monitoring_key();
+
+    SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+    auto session_it = find_session(session_map, criteria);
+    if (!session_it) {
+      MLOG(MERROR) << session_id
+                   << " not found when setting set_and_save_reporting_flag";
+      continue;
+    }
+
+    auto& session   = **session_it;
+    auto& credit_uc = session_uc[imsi][session_id];
+
+    if (!session->set_credit_reporting(ckey, value, &credit_uc)) {
+      MLOG(MDEBUG)
+          << session_id
+          << " set_and_save_reporting_flag couldn't set reporting for ckey "
+          << ckey;
+    }
+  }
+
+  for (const UsageMonitoringUpdateRequest& monitor_update :
+       update_session_request.usage_monitors()) {
+    const std::string imsi       = monitor_update.sid();
+    const std::string session_id = monitor_update.session_id();
+    const auto mkey              = monitor_update.update().monitoring_key();
+
+    SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+    auto session_it = find_session(session_map, criteria);
+    if (!session_it) {
+      MLOG(MERROR) << session_id
+                   << " not found when setting set_and_save_reporting_flag";
+      continue;
+    }
+    auto& session   = **session_it;
+    auto& credit_uc = session_uc[imsi][session_id];
+
+    if (!session->set_monitor_reporting(mkey, value, &credit_uc)) {
+      MLOG(MDEBUG)
+          << session_id
+          << " set_and_save_reporting_flag couldn't set monitors for mkey:"
+          << mkey;
+    }
+  }
+
+  store_client_->write_sessions(std::move(session_map));
+}
+
 void SessionStore::sync_request_numbers(const SessionUpdate& update_criteria) {
   // Read the current stored state
   auto subscriber_ids = std::set<std::string>{};

--- a/lte/gateway/c/session_manager/SessionStore.h
+++ b/lte/gateway/c/session_manager/SessionStore.h
@@ -104,6 +104,19 @@ class SessionStore {
   void sync_request_numbers(const SessionUpdate& update_criteria);
 
   /**
+   * Goes over all the RG keys and monitoring keys on the UpdateSessionRequest
+   * object, and updates is_reporting flab with the value. This function it is
+   * used to mark a specific key is currently waiting to get an answer back
+   * from the core
+   * @param value
+   * @param update_session_request
+   * @param session_uc
+   */
+  void set_and_save_reporting_flag(
+      bool value, const UpdateSessionRequest& update_session_request,
+      SessionUpdate& session_uc);
+
+  /**
    * Read the last written values for the requested sessions through the
    * storage interface. This also modifies the request_numbers stored before
    * returning the SessionMap to the caller, incremented by one for each

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -176,6 +176,28 @@ void create_credit_update_response(
   response->set_charging_key(charging_key);
 }
 
+void create_update_session_request(
+    std::string imsi, std::string session_id, uint32_t ckey, std::string mkey,
+    CreditUsage::UpdateType type, uint64_t bytes_rx, uint64_t bytes_tx,
+    UpdateSessionRequest* usr) {
+  CreditUsageUpdate* credit_update = usr->add_updates();
+  create_usage_update(imsi, ckey, bytes_rx, bytes_tx, type, credit_update);
+
+  UsageMonitoringUpdateRequest* monitor_credit_update =
+      usr->add_usage_monitors();
+  create_usage_monitoring_update_request(
+      imsi, mkey, bytes_rx, bytes_tx, monitor_credit_update);
+}
+
+void create_usage_monitoring_update_request(
+    const std::string& imsi, std::string monitoring_key, uint64_t bytes_rx,
+    uint64_t bytes_tx, UsageMonitoringUpdateRequest* update) {
+  auto usage = update->mutable_update();
+  usage->set_monitoring_key(monitoring_key);
+  usage->set_bytes_rx(bytes_rx);
+  usage->set_bytes_tx(bytes_tx);
+}
+
 void create_usage_update(
     const std::string& imsi, uint32_t charging_key, uint64_t bytes_rx,
     uint64_t bytes_tx, CreditUsage::UpdateType type,

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -121,6 +121,15 @@ void create_usage_update(
     const std::string& imsi, uint32_t charging_key, uint64_t bytes_rx,
     uint64_t bytes_tx, CreditUsage::UpdateType type, CreditUsageUpdate* update);
 
+void create_update_session_request(
+    std::string imsi, std::string session_id, uint32_t ckey, std::string mkey,
+    CreditUsage::UpdateType type, uint64_t bytes_rx, uint64_t bytes_tx,
+    UpdateSessionRequest* usr);
+
+void create_usage_monitoring_update_request(
+    const std::string& imsi, std::string monitoring_key, uint64_t bytes_rx,
+    uint64_t bytes_tx, UsageMonitoringUpdateRequest* update);
+
 void create_policy_reauth_request(
     const std::string& session_id, const std::string& imsi,
     const std::vector<std::string>& rules_to_remove,

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -43,7 +43,8 @@ class SessionProxyResponderHandlerTest : public ::testing::Test {
     std::thread([&]() {
       std::cout << "Started event loop thread\n";
       folly::EventBaseManager::get()->setEventBase(evb, 0);
-    }).detach();
+    })
+        .detach();
 
     monitoring_key = "mk1";
     rule_id        = "test_rule_1";


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

When we send a update to the core, sessiond holds the session and doesn't store it on memory. If a new policy report comes from pipelined for that same key, a new update will be triggered again. In case there is a network breakdown for few seconds, that would trigger several repeated updates.

This PR adds a function that is triggered right before we launch the call to the core. This function goes over the all RG keys and monitor keys on the CCR-U being set, sets the flag `is_reporting` to true on session map, and stores the map into the store.

Then the same function is run (now with value = false).

Update criteria was never updated since we store the field directly. 

Need to add some kind of meaningful unitest on sessiond.

## Test Plan

make test
Teravm


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
