### PR TITLE
[nms][cwag] Add CWAG HA status to NMS CWAG page

### DIFF
--- a/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
+++ b/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
@@ -133,6 +133,11 @@ export type carrier_wifi_gateway_health_status = {
     description: string,
     status: "HEALTHY" | "UNHEALTHY",
 };
+export type carrier_wifi_ha_pair_state = {
+    gateway1_health ? : carrier_wifi_gateway_health_status,
+    gateway2_health ? : carrier_wifi_gateway_health_status,
+    ha_pair_status ? : carrier_wifi_ha_pair_status,
+};
 export type carrier_wifi_ha_pair_status = {
     active_gateway: string,
 };
@@ -169,6 +174,7 @@ export type cwf_ha_pair = {
     gateway_id_1: string,
     gateway_id_2: string,
     ha_pair_id: string,
+    state ? : carrier_wifi_ha_pair_state,
 };
 export type cwf_ha_pair_configs = {
     transport_virtual_ip: string,
@@ -746,6 +752,7 @@ export type mutable_cwf_ha_pair = {
     config: cwf_ha_pair_configs,
     gateway_id_1: string,
     gateway_id_2: string,
+    ha_pair_id: string,
 };
 export type mutable_enodebd_e2e_test = {
     config: enodebd_test_config,
@@ -2301,7 +2308,7 @@ export default class MagmaAPIBindings {
     static async postCwfByNetworkIdHaPairs(
         parameters: {
             'networkId': string,
-            'haPair': cwf_ha_pair,
+            'haPair': mutable_cwf_ha_pair,
         }
     ): Promise < "Success" > {
         let path = '/cwf/{network_id}/ha_pairs';

--- a/nms/app/packages/magmalte/app/components/cwf/CWFGateways.js
+++ b/nms/app/packages/magmalte/app/components/cwf/CWFGateways.js
@@ -16,6 +16,7 @@
 
 import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
 import type {cwf_gateway} from '@fbcnms/magma-api';
+import type {cwf_ha_pair} from '@fbcnms/magma-api';
 
 import AddGatewayDialog from '../AddGatewayDialog';
 import Button from '@fbcnms/ui/components/design-system/Button';
@@ -26,6 +27,7 @@ import DeviceStatusCircle from '@fbcnms/ui/components/icons/DeviceStatusCircle';
 import EditIcon from '@material-ui/icons/Edit';
 import ExpandMore from '@material-ui/icons/ExpandMore';
 import IconButton from '@material-ui/core/IconButton';
+import StarIcon from '@material-ui/icons/Star';
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 import NestedRouteLink from '@fbcnms/ui/components/NestedRouteLink';
 import Paper from '@material-ui/core/Paper';
@@ -86,6 +88,11 @@ const useStyles = makeStyles(theme => ({
     fontWeight: 'bolder',
     paddingRight: '10px',
   },
+  star: {
+    color: '#ffd700',
+    width: '18px',
+    verticalAlign: 'bottom',
+  },
 }));
 
 const FIVE_MINS = 5 * 60 * 1000;
@@ -106,24 +113,31 @@ function gatewayStatus(gateway: cwf_gateway): string {
   return status;
 }
 
-function CWFGateways(props: WithAlert & {}) {
+export function CWFGateways(props: WithAlert & {}) {
   const [gateways, setGateways] = useState<?(cwf_gateway[])>(null);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [haPairs, setHaPairs] = useState<?(cwf_ha_pair[])>(null);
   const {match, history, relativePath, relativeUrl} = useRouter();
   const [lastFetchTime, setLastFetchTime] = useState(Date.now());
   const networkId = nullthrows(match.params.networkId);
   const classes = useStyles();
 
-  const {isLoading} = useMagmaAPI(
+  useMagmaAPI(
     MagmaV1API.getCwfByNetworkIdGateways,
     {networkId},
     useCallback(response => setGateways(map(response, g => g)), []),
     lastFetchTime,
   );
 
+  useMagmaAPI(
+      MagmaV1API.getCwfByNetworkIdHaPairs,
+      {networkId},
+      useCallback(response => setHaPairs(map(response, h => h)), []),
+      lastFetchTime,
+  );
+
   useInterval(() => setLastFetchTime(Date.now()), REFRESH_INTERVAL);
 
-  if (!gateways || isLoading) {
+  if (!gateways || !haPairs) {
     return <LoadingFiller />;
   }
 
@@ -181,54 +195,11 @@ function CWFGateways(props: WithAlert & {}) {
   };
 
   const rows = gateways.map(gateway => (
-    <>
-      <TableRow key={gateway.id}>
-        <Tooltip title={gatewayStatus(gateway)} placement={'bottom-start'}>
-          <TableCell className={classes.gatewayCell}>
-            <IconButton
-              className={classes.expandIconButton}
-              onClick={() => {
-                const newExpanded = new Set(expanded);
-                expanded.has(gateway.id)
-                  ? newExpanded.delete(gateway.id)
-                  : newExpanded.add(gateway.id);
-                setExpanded(newExpanded);
-              }}>
-              {expanded.has(gateway.id) ? <ExpandMore /> : <ChevronRight />}
-            </IconButton>
-
-            <span className={classes.gatewayName}>{gateway.name}</span>
-            <DeviceStatusCircle
-              isGrey={!gateway.status?.checkin_time}
-              isActive={
-                Math.max(0, Date.now() - (gateway.status?.checkin_time || 0)) <
-                  FIVE_MINS && gateway.carrier_wifi.allowed_gre_peers.length > 0
-              }
-            />
-          </TableCell>
-        </Tooltip>
-
-        <TableCell>{gateway.device.hardware_id}</TableCell>
-        <TableCell>
-          <IconButton
-            color="primary"
-            onClick={() => history.push(relativeUrl(`/edit/${gateway.id}`))}>
-            <EditIcon />
-          </IconButton>
-          <IconButton color="primary" onClick={() => deleteGateway(gateway)}>
-            <DeleteIcon />
-          </IconButton>
-        </TableCell>
-      </TableRow>
-      {expanded.has(gateway.id) &&
-        gateway.carrier_wifi.allowed_gre_peers.map((gre, i) => (
-          <TableRow key={i} classeName={classes.tableRow}>
-            <TableCell className={classes.greCell}>{gre.ip}</TableCell>
-            <TableCell>{gre.key}</TableCell>
-            <TableCell />
-          </TableRow>
-        ))}
-    </>
+    <GatewayRow
+      key={gateway.id}
+      gateway={gateway}
+      haPairs={haPairs}
+    />
   ));
 
   return (
@@ -279,6 +250,87 @@ function CWFGateways(props: WithAlert & {}) {
         )}
       />
     </div>
+  );
+}
+
+function GatewayRow(props: {
+  gateway: cwf_gateway,
+  haPairs: cwf_ha_pair[],
+}) {
+  const {gateway, haPairs} = props;
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const classes = useStyles();
+  const {match, history, relativePath, relativeUrl} = useRouter();
+
+  const gatewayHaPair = haPairs.filter(haPair => {
+    return haPair.gateway_id_1 === gateway.id ||
+        haPair.gateway_id_2 === gateway.id
+  });
+
+  const isPrimary = gatewayHaPair?.[0]?.state?.ha_pair_status?.active_gateway
+      === gateway.id;
+  const isGateway1 = gatewayHaPair?.[0]?.gateway_id_1 === gateway.id;
+
+  const isNonHaGatewayHealthy = Math.max(0, Date.now() -
+      (gateway.status?.checkin_time || 0)) < FIVE_MINS &&
+      gateway.carrier_wifi.allowed_gre_peers.length > 0;
+  const gatewayHealth = isGateway1 ?
+      gatewayHaPair[0]?.state?.gateway1_health?.status
+      : gatewayHaPair?.[0] ? gatewayHaPair[0]?.state?.gateway2_health?.status
+      : isNonHaGatewayHealthy ? "HEALTHY"
+      : "UNHEALTHY";
+
+  return (
+    <>
+      <TableRow key={gateway.id}>
+        <Tooltip title={gatewayStatus(gateway)} placement={'bottom-start'}>
+          <TableCell className={classes.gatewayCell}>
+            <IconButton
+              className={classes.expandIconButton}
+              onClick={() => {
+                const newExpanded = new Set(expanded);
+                expanded.has(gateway.id)
+                  ? newExpanded.delete(gateway.id)
+                  : newExpanded.add(gateway.id);
+                setExpanded(newExpanded);
+              }}>
+              {expanded.has(gateway.id) ? <ExpandMore /> : <ChevronRight />}
+            </IconButton>
+
+            <span className={classes.gatewayName}>{gateway.name}</span>
+            <DeviceStatusCircle
+              isGrey={!gateway.status?.checkin_time}
+              isActive={gatewayHealth === 'HEALTHY'}
+            />
+            {isPrimary && (
+              <Tooltip title="Primary CWAG" placement="right">
+                <StarIcon className={classes.star} />
+              </Tooltip>
+            )}
+          </TableCell>
+        </Tooltip>
+
+        <TableCell>{gateway.device.hardware_id}</TableCell>
+        <TableCell>
+          <IconButton
+            color="primary"
+            onClick={() => history.push(relativeUrl(`/edit/${gateway.id}`))}>
+            <EditIcon />
+          </IconButton>
+          <IconButton color="primary" onClick={() => deleteGateway(gateway)}>
+            <DeleteIcon />
+          </IconButton>
+        </TableCell>
+      </TableRow>
+      {expanded.has(gateway.id) &&
+        gateway.carrier_wifi.allowed_gre_peers.map((gre, i) => (
+          <TableRow key={i} classeName={classes.tableRow}>
+            <TableCell className={classes.greCell}>{gre.ip}</TableCell>
+            <TableCell>{gre.key}</TableCell>
+            <TableCell />
+          </TableRow>
+      ))}
+    </>
   );
 }
 

--- a/nms/app/packages/magmalte/app/components/cwf/__tests__/CWFGateways-test.js
+++ b/nms/app/packages/magmalte/app/components/cwf/__tests__/CWFGateways-test.js
@@ -14,9 +14,9 @@
  * @format
  */
 
-import {CWFGateways} from '../CWFGateways';
 import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
 import React from 'react';
+import {CWFGateways} from '../CWFGateways';
 import {MemoryRouter, Route, Switch} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {SnackbarProvider} from 'notistack';
@@ -28,8 +28,7 @@ import MagmaAPIBindings from '@fbcnms/magma-api';
 import axiosMock from 'axios';
 import defaultTheme from '@fbcnms/ui/theme/default';
 
-import {cleanup, getByTitle, render, wait, queryByTitle}
-  from '@testing-library/react';
+import {cleanup, render, wait} from '@testing-library/react';
 
 const CWF_HA_GATEWAY_1: cwf_gateway = {
   magmad: {
@@ -61,33 +60,52 @@ const CWF_HA_GATEWAY_1: cwf_gateway = {
       mme_connected: '0',
     },
   },
+  carrier_wifi: {
+    allowed_gre_peers: [
+      {
+        ip: '192.168.128.0/32',
+        key: 1,
+      },
+    ],
+    gateway_health_configs: {
+      cpu_util_threshold_pct: 0.9,
+      gre_probe_interval_secs: 5,
+      icmp_probe_pkt_count: 3,
+      mem_util_threshold_pct: 0.9,
+    },
+    ipdr_export_dst: {
+      ip: '192.168.128.88',
+      port: 2040,
+    },
+  },
 };
 
-let CWF_HA_GATEWAY_2 = JSON.parse(JSON.stringify(CWF_HA_GATEWAY_1));
-CWF_HA_GATEWAY_2.id = "mock_cwf02";
-CWF_HA_GATEWAY_2.name = "mock_cwf2";
+const CWF_HA_GATEWAY_2 = JSON.parse(JSON.stringify(CWF_HA_GATEWAY_1));
+CWF_HA_GATEWAY_2.id = 'mock_cwf02';
+CWF_HA_GATEWAY_2.name = 'mock_cwf2';
 CWF_HA_GATEWAY_2.device.hardware_id = 'bb35dd3f-efaa-435a-bcb6-8168d0caf333';
+CWF_HA_GATEWAY_2.status.checkin_time = 1000;
 
 const CWF_HA_PAIR: cwf_ha_pair = {
   config: {
-    transport_virtual_ip: '10.10.10.12'
+    transport_virtual_ip: '10.10.10.12',
   },
   gateway_id_1: 'mock_cwf01',
   gateway_id_2: 'mock_cwf02',
   ha_pair_id: 'pair1',
   state: {
     ha_pair_status: {
-      active_gateway: 'mock_cwf01'
+      active_gateway: 'mock_cwf01',
     },
     gateway1_health: {
       status: 'HEALTHY',
-      description: 'OK'
+      description: 'OK',
     },
     gateway2_health: {
       status: 'UNHEALTHY',
-      description: 'Service restart'
+      description: 'Service restart',
     },
-  }
+  },
 };
 
 jest.mock('axios');
@@ -131,7 +149,7 @@ describe('<CWFGateways />', () => {
   });
 
   it('renders', async () => {
-    const {getAllByRole} = render(<Wrapper />);
+    const {getByTitle, getAllByTitle, getAllByRole} = render(<Wrapper />);
 
     await wait();
 
@@ -145,24 +163,20 @@ describe('<CWFGateways />', () => {
 
     expect(rowItems[1]).toHaveTextContent('mock_cwf');
     expect(rowItems[1]).toHaveTextContent(
-        'a935dd3f-efaa-435a-bcb6-8168d0caf333'
+      'a935dd3f-efaa-435a-bcb6-8168d0caf333',
     );
-    const gatewayStatusCell = getByTitle(
-        rowItems[1],
-        'Last refreshed 12/31/1969, 7:00:00 PM'
-    );
-    expect(getByTitle(gatewayStatusCell, "Primary CWAG"))
-        .toBeInTheDocument();
+    expect(
+      getByTitle('Last refreshed 12/31/1969, 7:00:00 PM'),
+    ).toBeInTheDocument();
+    const primaryCwag = getAllByTitle('Primary CWAG');
+    expect(primaryCwag).toHaveLength(1);
 
     expect(rowItems[2]).toHaveTextContent('mock_cwf2');
     expect(rowItems[2]).toHaveTextContent(
-        'bb35dd3f-efaa-435a-bcb6-8168d0caf333',
+      'bb35dd3f-efaa-435a-bcb6-8168d0caf333',
     );
-     const gatewayStatusCell2 = getByTitle(
-        rowItems[2],
-        'Last refreshed 12/31/1969, 7:00:00 PM'
-    );
-    expect(queryByTitle(gatewayStatusCell2, "Primary CWAG"))
-        .not.toBeInTheDocument();
+    expect(
+      getByTitle('Last refreshed 12/31/1969, 7:00:01 PM'),
+    ).toBeInTheDocument();
   });
 });

--- a/nms/app/packages/magmalte/app/components/cwf/__tests__/CWFGateways-test.js
+++ b/nms/app/packages/magmalte/app/components/cwf/__tests__/CWFGateways-test.js
@@ -165,9 +165,9 @@ describe('<CWFGateways />', () => {
     expect(rowItems[1]).toHaveTextContent(
       'a935dd3f-efaa-435a-bcb6-8168d0caf333',
     );
-    expect(
-      getByTitle('Last refreshed 12/31/1969, 7:00:00 PM'),
-    ).toBeInTheDocument();
+    const expectedGatewayDate =
+      'Last refreshed ' + new Date(0).toLocaleString();
+    expect(getByTitle(expectedGatewayDate)).toBeInTheDocument();
     const primaryCwag = getAllByTitle('Primary CWAG');
     expect(primaryCwag).toHaveLength(1);
 
@@ -175,8 +175,8 @@ describe('<CWFGateways />', () => {
     expect(rowItems[2]).toHaveTextContent(
       'bb35dd3f-efaa-435a-bcb6-8168d0caf333',
     );
-    expect(
-      getByTitle('Last refreshed 12/31/1969, 7:00:01 PM'),
-    ).toBeInTheDocument();
+    const expectedGatewayDate2 =
+      'Last refreshed ' + new Date(1).toLocaleString();
+    expect(getByTitle(expectedGatewayDate2)).toBeInTheDocument();
   });
 });

--- a/nms/app/packages/magmalte/app/components/cwf/__tests__/CWFGateways-test.js
+++ b/nms/app/packages/magmalte/app/components/cwf/__tests__/CWFGateways-test.js
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import {CWFGateways} from '../CWFGateways';
+import MuiStylesThemeProvider from '@material-ui/styles/ThemeProvider';
+import React from 'react';
+import {MemoryRouter, Route, Switch} from 'react-router-dom';
+import {MuiThemeProvider} from '@material-ui/core/styles';
+import {SnackbarProvider} from 'notistack';
+import type {cwf_gateway} from '@fbcnms/magma-api';
+import type {cwf_ha_pair} from '@fbcnms/magma-api';
+
+import 'jest-dom/extend-expect';
+import MagmaAPIBindings from '@fbcnms/magma-api';
+import axiosMock from 'axios';
+import defaultTheme from '@fbcnms/ui/theme/default';
+
+import {cleanup, getByTitle, render, wait, queryByTitle}
+  from '@testing-library/react';
+
+const CWF_HA_GATEWAY_1: cwf_gateway = {
+  magmad: {
+    autoupgrade_enabled: true,
+    autoupgrade_poll_interval: 300,
+    checkin_interval: 60,
+    checkin_timeout: 100,
+    tier: 'default',
+  },
+  id: 'mock_cwf01',
+  name: 'mock_cwf',
+  description: 'mock gateway',
+  tier: 'default',
+  device: {
+    hardware_id: 'a935dd3f-efaa-435a-bcb6-8168d0caf333',
+    key: {
+      key:
+        'MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESpHVXt266GW0WTKL0CvIvEFpECQL0rkHgs5Bc0efoSde01wuphb8tK1zL9t8rsVFlv2tyUHXeoJt7/AaEonGYOuEkbHocRy9LBAVue2sOFWrIhJvqieujrd15dLH1zBm',
+      key_type: 'SOFTWARE_ECDSA_SHA256',
+    },
+  },
+  status: {
+    checkin_time: 1,
+    meta: {
+      gps_latitude: '0',
+      gps_longitude: '0',
+      gps_connected: '0',
+      enodeb_connected: '0',
+      mme_connected: '0',
+    },
+  },
+};
+
+let CWF_HA_GATEWAY_2 = JSON.parse(JSON.stringify(CWF_HA_GATEWAY_1));
+CWF_HA_GATEWAY_2.id = "mock_cwf02";
+CWF_HA_GATEWAY_2.name = "mock_cwf2";
+CWF_HA_GATEWAY_2.device.hardware_id = 'bb35dd3f-efaa-435a-bcb6-8168d0caf333';
+
+const CWF_HA_PAIR: cwf_ha_pair = {
+  config: {
+    transport_virtual_ip: '10.10.10.12'
+  },
+  gateway_id_1: 'mock_cwf01',
+  gateway_id_2: 'mock_cwf02',
+  ha_pair_id: 'pair1',
+  state: {
+    ha_pair_status: {
+      active_gateway: 'mock_cwf01'
+    },
+    gateway1_health: {
+      status: 'HEALTHY',
+      description: 'OK'
+    },
+    gateway2_health: {
+      status: 'UNHEALTHY',
+      description: 'Service restart'
+    },
+  }
+};
+
+jest.mock('axios');
+jest.mock('@fbcnms/magma-api');
+
+const Wrapper = () => (
+  <MemoryRouter initialEntries={['/nms/mynetwork']} initialIndex={0}>
+    <MuiThemeProvider theme={defaultTheme}>
+      <MuiStylesThemeProvider theme={defaultTheme}>
+        <SnackbarProvider>
+          <Switch>
+            <Route path="/nms/:networkId" component={CWFGateways} />
+          </Switch>
+        </SnackbarProvider>
+      </MuiStylesThemeProvider>
+    </MuiThemeProvider>
+  </MemoryRouter>
+);
+
+afterEach(cleanup);
+
+describe('<CWFGateways />', () => {
+  beforeEach(() => {
+    axiosMock.get.mockResolvedValueOnce({
+      data: [CWF_HA_GATEWAY_1, CWF_HA_GATEWAY_2],
+    });
+    MagmaAPIBindings.getCwfByNetworkIdGateways.mockResolvedValue({
+      mock_cwf01: CWF_HA_GATEWAY_1,
+      mock_cwf02: CWF_HA_GATEWAY_2,
+    });
+    MagmaAPIBindings.getCwfByNetworkIdHaPairs.mockResolvedValue({
+      pair1: CWF_HA_PAIR,
+    });
+    MagmaAPIBindings.getNetworksByNetworkIdTiers.mockResolvedValueOnce([
+      'default',
+    ]);
+  });
+
+  afterEach(() => {
+    axiosMock.get.mockClear();
+  });
+
+  it('renders', async () => {
+    const {getAllByRole} = render(<Wrapper />);
+
+    await wait();
+
+    expect(MagmaAPIBindings.getCwfByNetworkIdGateways).toHaveBeenCalledTimes(1);
+    expect(MagmaAPIBindings.getCwfByNetworkIdHaPairs).toHaveBeenCalledTimes(1);
+
+    const rowItems = getAllByRole('row');
+    expect(rowItems).toHaveLength(3);
+    expect(rowItems[0]).toHaveTextContent('Name');
+    expect(rowItems[0]).toHaveTextContent('Hardware UUID / GRE Key');
+
+    expect(rowItems[1]).toHaveTextContent('mock_cwf');
+    expect(rowItems[1]).toHaveTextContent(
+        'a935dd3f-efaa-435a-bcb6-8168d0caf333'
+    );
+    const gatewayStatusCell = getByTitle(
+        rowItems[1],
+        'Last refreshed 12/31/1969, 7:00:00 PM'
+    );
+    expect(getByTitle(gatewayStatusCell, "Primary CWAG"))
+        .toBeInTheDocument();
+
+    expect(rowItems[2]).toHaveTextContent('mock_cwf2');
+    expect(rowItems[2]).toHaveTextContent(
+        'bb35dd3f-efaa-435a-bcb6-8168d0caf333',
+    );
+     const gatewayStatusCell2 = getByTitle(
+        rowItems[2],
+        'Last refreshed 12/31/1969, 7:00:00 PM'
+    );
+    expect(queryByTitle(gatewayStatusCell2, "Primary CWAG"))
+        .not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR adds CWAG HA status by fetching all HA pairs that
exist in a CWF network and setting status accordingly.

If the gateway does not reside in an HA pair, the behavior
will remain unchanged.

## Test Plan

Added unit test.

Video of CWAG HA pair

![cwf_hapair_status](https://user-images.githubusercontent.com/12876991/95524504-9047b280-099f-11eb-8837-b3eb65c4230c.gif)

Video of CWAG non-HA pair
![cwf_non_hapair_status](https://user-images.githubusercontent.com/12876991/95524592-c9802280-099f-11eb-8136-bff546cb44d0.gif)