### PR TITLE
[v1.3] Update orc8r terraform modules for 1.3 release

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -82,7 +82,7 @@ variable "eks_worker_groups" {
   default = [
     {
       name                 = "wg-1"
-      instance_type        = "t3.large"
+      instance_type        = "t3.xlarge"
       asg_desired_capacity = 3
       asg_min_size         = 1
       asg_max_size         = 3

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/basic/main.tf
@@ -12,6 +12,7 @@
 ################################################################################
 
 module orc8r {
+  # Change this to pull from github with a specified ref
   source = "../../../orc8r-aws"
 
   region = "us-west-2"
@@ -26,7 +27,7 @@ module orc8r {
 
   deploy_elasticsearch          = true
   elasticsearch_domain_name     = "orc8r-es"
-  elasticsearch_version         = "7.1"
+  elasticsearch_version         = "7.7"
   elasticsearch_instance_type   = "t2.medium.elasticsearch"
   elasticsearch_instance_count  = 2
   elasticsearch_az_count        = 2
@@ -36,6 +37,7 @@ module orc8r {
 }
 
 module orc8r-app {
+  # Change this to pull from github with a specified ref
   source = "../.."
 
   region = "us-west-2"
@@ -78,8 +80,8 @@ module orc8r-app {
 
   elasticsearch_endpoint = module.orc8r.es_endpoint
 
-  orc8r_chart_version = "1.4.7"
-  orc8r_tag           = "1.0.1"
+  orc8r_chart_version = "1.4.36"
+  orc8r_tag           = "1.3.0"
 }
 
 output "nameservers" {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/remote/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/remote/main.tf
@@ -64,6 +64,7 @@ data "aws_secretsmanager_secret_version" "root_secrets" {
 }
 
 module orc8r {
+  # Change this to pull from github with a specified ref
   source = "../../../orc8r-aws"
 
   region = local.region
@@ -78,7 +79,7 @@ module orc8r {
 
   deploy_elasticsearch          = true
   elasticsearch_domain_name     = "orc8r-es"
-  elasticsearch_version         = "7.1"
+  elasticsearch_version         = "7.7"
   elasticsearch_instance_type   = "t2.medium.elasticsearch"
   elasticsearch_instance_count  = 2
   elasticsearch_az_count        = 2
@@ -88,6 +89,7 @@ module orc8r {
 }
 
 module orc8r-app {
+  # Change this to pull from github with a specified ref
   source = "../.."
 
   region = local.region
@@ -135,8 +137,8 @@ module orc8r-app {
 
   elasticsearch_endpoint = module.orc8r.es_endpoint
 
-  orc8r_chart_version = "1.4.21"
-  orc8r_tag           = "1.1.0"
+  orc8r_chart_version = "1.4.36"
+  orc8r_tag           = "1.3.0"
   deploy_nms          = true
 }
 

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -34,6 +34,7 @@ resource "null_resource" orc8r_seed_secrets {
 
 locals {
   orc8r_cert_names = [
+    "rootCA.key",
     "rootCA.pem",
     "controller.key",
     "controller.crt",

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -94,7 +94,7 @@ variable "orc8r_proxy_replicas" {
 variable "use_nginx_proxy" {
   description = "Feature flag for Nginx proxy."
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "orc8r_db_name" {


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- Bump version numbers in example root modules
- Deploy nginx as proxy by default
- Use t3.xlarge node instances by default
- Upload rootCA.key to k8s as a secret

<!-- Enumerate changes you made and why you made them -->

## Test Plan

- Deployed on AWS

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
