### PR TITLE
[orc8r][lte][bugfix] Fix buggy apn_resource bulk update

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -569,10 +569,11 @@ func (m *ApnResource) ToTK() storage.TypeAndKey {
 }
 
 func (m *ApnResource) ToEntity() configurator.NetworkEntity {
+	cfg := *m // make explicit copy
 	return configurator.NetworkEntity{
 		Type:         lte.APNResourceEntityType,
 		Key:          m.ID,
-		Config:       m,
+		Config:       &cfg,
 		Associations: m.getAssocs(),
 	}
 }

--- a/orc8r/cloud/go/obsidian/tests/unit_test_utils.go
+++ b/orc8r/cloud/go/obsidian/tests/unit_test_utils.go
@@ -82,7 +82,7 @@ func RunUnitTest(t *testing.T, e *echo.Echo, test Test) {
 		}
 	} else if test.ExpectedErrorSubstring != "" {
 		if handlerErr == nil {
-			assert.Fail(t, "error was nil but was expecting %s", test.ExpectedErrorSubstring)
+			assert.Fail(t, "unexpected nil error", "error was nil but was expecting %s", test.ExpectedErrorSubstring)
 		} else {
 			assert.Contains(t, handlerErr.Error(), test.ExpectedErrorSubstring)
 		}


### PR DESCRIPTION
## Summary

Pointer sadness in apn_resource logic caused bulk update of apn_resource for a single gateway to have unexpected outcomes

## Test Plan

- [x] make test with new regression case

## Additional Information

- [ ] This change is backwards-breaking