### PR TITLE
[LTE][AGW][Installation] Adding a new check for linux Headers

### DIFF
--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -53,8 +53,9 @@ else
   done
 fi
 
-echo "Checking if the righ kernel version is installed (4.9.0-9-amd64)"
-if [ "$KVERS" != "4.9.0-9-amd64" ]; then
+LINUX_HEADERS_INSTALLED=$(dpkg -l | grep linux-headers-4.9.0-9-amd64 >  /dev/null 2>&1 echo "$SUCCESS_MESSAGE")
+echo "Checking if the righ kernel version and linux headers are installed (4.9.0-9-amd64)"
+if [ "$KVERS" != "4.9.0-9-amd64" ] || [ "$LINUX_HEADERS_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   # Adding the snapshot to retrieve 4.9.0-9-amd64
   if ! grep -q "deb http://snapshot.debian.org/archive/debian/20190801T025637Z" /etc/apt/sources.list; then
     echo "deb http://snapshot.debian.org/archive/debian/20190801T025637Z stretch main non-free contrib" >> /etc/apt/sources.list


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[LTE][AGW][Installation] Adding a new check for linux Headers

## Summary

Some partners are doing manual steps (installing the right kernel version by themselves) but they forget to install the linux-headers which leads to missing headers and the check in the ansible script make the installation fail. 
Adding a new check in order to make sure we'll install them any way. 

## Test Plan

cd ~/lte/gateway/deploy && sh agw_installation.sh

## Additional Information

- [ ] This change is backwards-breaking
