### PR TITLE
[orc8r][tf] Set portEnd for controller service to 9121 in Helm values

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -59,6 +59,8 @@ controller:
       host: ${orc8r_db_host}
       port: ${orc8r_db_port}
       user: ${orc8r_db_user}
+  service:
+    portEnd: 9121
 
 metrics:
   imagePullSecrets:


### PR DESCRIPTION
Signed-off-by: Jacky Tian <xjtian@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- `smsd` runs on port 9120 for GRPC

<!-- Enumerate changes you made and why you made them -->

## Test Plan

- Deployed to staging

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
