### PR TITLE
[lte][agw] Update s1ap state proto namespace for v1.1

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -197,7 +197,7 @@ void S1apStateManager::write_s1ap_imsi_map_to_db() {
   if(!persist_state_enabled) {
     return;
   }
-  oai::S1apImsiMap imsi_proto = oai::S1apImsiMap();
+  gateway::s1ap::S1apImsiMap imsi_proto = gateway::s1ap::S1apImsiMap();
   S1apStateConverter::s1ap_imsi_map_to_proto(s1ap_imsi_map_, &imsi_proto);
   redis_client->write_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);
 }

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -166,7 +166,7 @@ void S1apStateManager::create_s1ap_imsi_map()
     hashtable_uint64_ts_create(max_ues_, nullptr, nullptr);
 
   if(persist_state_enabled) {
-    oai::S1apImsiMap imsi_proto = oai::S1apImsiMap();
+    gateway::s1ap::S1apImsiMap imsi_proto = gateway::s1ap::S1apImsiMap();
     redis_client->read_proto(S1AP_IMSI_MAP_TABLE_NAME, imsi_proto);
 
     S1apStateConverter::proto_to_s1ap_imsi_map(imsi_proto, s1ap_imsi_map_);


### PR DESCRIPTION
## Summary

- Updating namespace of s1ap_imsi_map proto as v1.1 version still points to `gateway::s1ap::` instead of `oai::` namespace

## Test Plan

- make build_oai succeeds
- make integ_test (test_attach_detach and test_attach_dl_tcp_data) succeeds

## Additional Information

- [ ] This change is backwards-breaking
