### PR TITLE
[SessionD] Disable lsan on release builds

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -28,10 +28,11 @@ if (NOT BUILD_TESTS)
       "${CMAKE_LINKER_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address")
   # Add LeakSanitizer (lsan) support to the release build of SessionD so that
   # we can find memory leaks in production.
-  set(CMAKE_C_FLAGS_RELWITHDEBINFO
-     "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
-  set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
-     "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
+  # Disabling LSAN on Prod until we figure out how to get gcore to work
+  #set(CMAKE_C_FLAGS_RELWITHDEBINFO
+  #   "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
+  #set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO
+  #   "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
 endif ()
 
 set(OUTPUT_DIR "${CMAKE_CURRENT_BINARY_DIR}")


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We have an issue where builds with lsan cannot produce a gcore. We'll add it back in when we figure out how to generate cores from running processes with the lsan flag on.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Built sessiond got coredump from running process :) 
```
vagrant@cwag-dev:~/magma/cwf/gateway/docker$ docker exec -it sessiond bash
 9 root      20   0 1688020  35492  17768 S   0.0  0.9   0:00.99 sessiond
```
```
root@cwag-dev:/# gdb --pid 9
GNU gdb (Ubuntu 8.1-0ubuntu3.2) 8.1.0.20180409-git
Copyright (C) 2018 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
[New LWP 25]
[New LWP 26]
[New LWP 27]
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
0x00007f2e1d415d67 in epoll_wait (epfd=3, events=0x55c8ab4a11f0, maxevents=32,
    timeout=-1) at ../sysdeps/unix/sysv/linux/epoll_wait.c:30
30	../sysdeps/unix/sysv/linux/epoll_wait.c: No such file or directory.
(gdb) gcore
Saved corefile core.9
(gdb)
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
