### PR TITLE
[lte][agw] Fix IMSI prefix handling and cli service

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/proto_msg_to_itti_msg.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/proto_msg_to_itti_msg.cpp
@@ -39,8 +39,15 @@ using namespace lte;
 // SMS Orc8r Downlink
 void convert_proto_msg_to_itti_sgsap_downlink_unitdata(
     const SMODownlinkUnitdata* msg, itti_sgsap_downlink_unitdata_t* itti_msg) {
-  auto imsi             = msg->imsi();
-  itti_msg->imsi_length = imsi.length();
+
+  std::string imsi = msg->imsi();
+  // If north bound is Orc8r itself, IMSI prefix is used;
+  // in AGW local tests, IMSI prefix is not used
+  // Strip off any IMSI prefix
+  if (imsi.compare(0, 4, "IMSI") == 0) {
+    imsi = imsi.substr(4, std::string::npos);
+  }
+  itti_msg->imsi_length = imsi.size();
   strcpy(itti_msg->imsi, imsi.c_str());
 
   auto nas_msg = msg->nas_message_container();

--- a/lte/gateway/python/scripts/sms_cli.py
+++ b/lte/gateway/python/scripts/sms_cli.py
@@ -64,7 +64,7 @@ def main():
         exit(1)
 
     # Execute the subcommand function
-    args.func(args, SMSOrc8rGatewayServiceStub, 'sms_orc8r_gw_mme_service')
+    args.func(args, SMSOrc8rGatewayServiceStub, 'sms_mme_service')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

- When GRPC client passes imsi field with prefix "IMSI", MME side was not stripping off the prefix. The change checks if such prefix exists and removes it.
- CLI was broken as the service end point name was not correct.

## Test Plan

Used the local CLI facility with/without IMSI prefix and verified that it was stripped off properly.

