### PR TITLE
[lte][agw] Replace unsigned arithmetic in condition statements

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachAccept.c
@@ -65,7 +65,7 @@ int decode_attach_accept(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachReject.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachReject.c
@@ -44,7 +44,7 @@ int decode_attach_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AttachRequest.c
@@ -76,7 +76,7 @@ int decode_attach_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationFailure.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/AuthenticationFailure.c
@@ -46,7 +46,7 @@ int decode_authentication_failure(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/CsServiceNotification.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/CsServiceNotification.c
@@ -46,7 +46,7 @@ int decode_cs_service_notification(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/EmmInformation.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/EmmInformation.c
@@ -38,7 +38,7 @@ int decode_emm_information(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/GutiReallocationCommand.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/GutiReallocationCommand.c
@@ -46,7 +46,7 @@ int decode_guti_reallocation_command(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeCommand.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeCommand.c
@@ -66,7 +66,7 @@ int decode_security_mode_command(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeComplete.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/SecurityModeComplete.c
@@ -40,7 +40,7 @@ int decode_security_mode_complete(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateAccept.c
@@ -47,7 +47,7 @@ int decode_tracking_area_update_accept(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/TrackingAreaUpdateRequest.c
@@ -60,7 +60,7 @@ int decode_tracking_area_update_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextAccept.c
@@ -41,7 +41,7 @@ int decode_activate_dedicated_eps_bearer_context_accept(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextReject.c
@@ -48,7 +48,7 @@ int decode_activate_dedicated_eps_bearer_context_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDedicatedEpsBearerContextRequest.c
@@ -64,7 +64,7 @@ int decode_activate_dedicated_eps_bearer_context_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextAccept.c
@@ -41,7 +41,7 @@ int decode_activate_default_eps_bearer_context_accept(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextReject.c
@@ -48,7 +48,7 @@ int decode_activate_default_eps_bearer_context_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ActivateDefaultEpsBearerContextRequest.c
@@ -63,7 +63,7 @@ int decode_activate_default_eps_bearer_context_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceAllocationReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceAllocationReject.c
@@ -47,7 +47,7 @@ int decode_bearer_resource_allocation_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceAllocationRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceAllocationRequest.c
@@ -61,7 +61,7 @@ int decode_bearer_resource_allocation_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceModificationReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceModificationReject.c
@@ -48,7 +48,7 @@ int decode_bearer_resource_modification_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceModificationRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/BearerResourceModificationRequest.c
@@ -56,7 +56,7 @@ int decode_bearer_resource_modification_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextAccept.c
@@ -41,7 +41,7 @@ int decode_deactivate_eps_bearer_context_accept(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/DeactivateEpsBearerContextRequest.c
@@ -48,7 +48,7 @@ int decode_deactivate_eps_bearer_context_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/EsmInformationResponse.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/EsmInformationResponse.c
@@ -42,7 +42,7 @@ int decode_esm_information_response(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ModifyEpsBearerContextAccept.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ModifyEpsBearerContextAccept.c
@@ -40,7 +40,7 @@ int decode_modify_eps_bearer_context_accept(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ModifyEpsBearerContextReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ModifyEpsBearerContextReject.c
@@ -48,7 +48,7 @@ int decode_modify_eps_bearer_context_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/ModifyEpsBearerContextRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/ModifyEpsBearerContextRequest.c
@@ -43,7 +43,7 @@ int decode_modify_eps_bearer_context_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityReject.c
@@ -48,7 +48,7 @@ int decode_pdn_connectivity_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/PdnConnectivityRequest.c
@@ -53,7 +53,7 @@ int decode_pdn_connectivity_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/PdnDisconnectReject.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/PdnDisconnectReject.c
@@ -48,7 +48,7 @@ int decode_pdn_disconnect_reject(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*

--- a/lte/gateway/c/oai/tasks/nas/esm/msg/PdnDisconnectRequest.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/msg/PdnDisconnectRequest.c
@@ -48,7 +48,7 @@ int decode_pdn_disconnect_request(
   /*
    * Decoding optional fields
    */
-  while (len - decoded > 0) {
+  while (len > decoded) {
     uint8_t ieiDecoded = *(buffer + decoded);
 
     /*


### PR DESCRIPTION
## Summary

While loops in IE decoding helper functions utilize  a pattern of (a - b > 0) statements where a and b are unsigned integer and their subtraction also leads to unsigned integer which would not catch the cases where b > a. This leads to going out of memory bounds.

## Test Plan

S1AP sanity tests.
