### PR TITLE
[lte][agw] Bug fix for bstring function

### DIFF
--- a/lte/gateway/c/oai/lib/bstr/bstrlib.c
+++ b/lte/gateway/c/oai/lib/bstr/bstrlib.c
@@ -247,7 +247,7 @@ bstring bfromcstr_with_str_len(const char* str, int len) {
     bstr__free(b);
     return NULL;
   }
-  bstr__memcpy(b->data, str, j - 1);
+  bstr__memcpy(b->data, str, j);
   b->data[j] = '\0';
   return b;
 }

--- a/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
+++ b/lte/gateway/c/oai/tasks/sms_orc8r/sms_orc8r_service_handler.c
@@ -37,12 +37,15 @@ int handle_sms_orc8r_downlink_unitdata(
   AssertFatal(message_p, "itti_alloc_new_message Failed");
   sgs_dl_unit_data_p = &message_p->ittiMsg.sgsap_downlink_unitdata;
   memset((void*) sgs_dl_unit_data_p, 0, sizeof(itti_sgsap_downlink_unitdata_t));
-  OAILOG_DEBUG(LOG_SMS_ORC8R, "Received SMO Downlink UnitData message from Orc8r\n");
+
   memcpy(
       sgs_dl_unit_data_p, sgs_dl_unitdata_p,
       sizeof(itti_sgsap_downlink_unitdata_t));
   // send it to NAS module for further processing
+  OAILOG_DEBUG(
+      LOG_SMS_ORC8R,
+      "Received SMO Downlink UnitData message %s from Orc8r\n",
+      sgs_dl_unit_data_p->nas_msg_container->data);
   rc = send_msg_to_task(&sms_orc8r_task_zmq_ctx, TASK_MME_APP, message_p);
   OAILOG_FUNC_RETURN(LOG_NAS_EMM, rc);
 }
-


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary
`bstring bfromcstr_with_str_len(const char* str, int len)` function is supposed to generate a bstring from str with data portion of `len` characters followed by `\0`. Instead it copies only `len - 1` characters from str and so last character is a random character that is initialized during malloc. We noticed this behavior during SMS tests, where the last character of the SMS message was replaced by an arbitrary value.

## Test Plan

Used sms_cli.py and new log message to see that proper values are shown.

Used CLI:
```
(python) vagrant@magma-dev:~$ sms_cli.py DU 001010000090122 414243
Sending Downlink Unitdata with following fields:
 imsi: "001010000090122"
nas_message_container: "ABC"
```
Before the change:
`000285 Sat Oct 10 04:42:16 2020 7F5FE956B700 DEBUG        tasks/sms_orc8r/sms_orc8r_servic:0058    Received SMO Downlink UnitData message AB? from Orc8r`

After the change:
`000282 Sat Oct 10 05:37:10 2020 7F74C0AB4700 DEBUG        tasks/sms_orc8r/sms_orc8r_servic:0048    Received SMO Downlink UnitData message ABC from Orc8r`
