### PR TITLE
[orc8r] [metricsd] Ensure metricsd provides strong guarantees for GatewayId when processing Collect() messages

### DIFF
--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -70,7 +70,6 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 	if checkID.HardwareId != nil && checkID.HardwareId != hardwareID {
 		glog.Errorf("Expected %s, but found %s as Hardware ID", checkID.HardwareId, hardwareID)
 		hardwareID = checkID.HardwareId
-
 	}
 	networkID, gatewayID, err := configurator.GetNetworkAndEntityIDForPhysicalID(hardwareID)
 	if err != nil {

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -63,6 +63,15 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 	}
 
 	hardwareID := in.GetGatewayId()
+	checkID, err := GetGatewayIdentity(ctx) 
+	If err != nil { 
+		return new(protos.Void), err
+	}
+	if checkID.HardwareId != nil && checkID.HardwareId != hardwareID {
+		glog.Errorf("Expected %s, but found %s as Hardware ID", checkID.HardwareId, hardwareID)
+		hardwareID = checkID.HardwareId
+
+	}
 	networkID, gatewayID, err := configurator.GetNetworkAndEntityIDForPhysicalID(hardwareID)
 	if err != nil {
 		return new(protos.Void), err

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -63,7 +63,7 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 	}
 
 	hardwareID := in.GetGatewayId()
-    checkID, err := protos.GetGatewayIdentity(ctx)
+        checkID, err := protos.GetGatewayIdentity(ctx)
 	if err != nil {
 		return new(protos.Void), err
 	}

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -63,7 +63,7 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 	}
 
 	hardwareID := in.GetGatewayId()
-        checkID, err := protos.GetGatewayIdentity(ctx)
+	checkID, err := protos.GetGatewayIdentity(ctx)
 	if err != nil {
 		return new(protos.Void), err
 	}

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -63,11 +63,11 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 	}
 
 	hardwareID := in.GetGatewayId()
-	checkID, err := GetGatewayIdentity(ctx) 
-	If err != nil { 
+    checkID, err := protos.GetGatewayIdentity(ctx)
+	if err != nil {
 		return new(protos.Void), err
 	}
-	if checkID.HardwareId != nil && checkID.HardwareId != hardwareID {
+	if len(checkID.HardwareId) > 0 && checkID.HardwareId != hardwareID {
 		glog.Errorf("Expected %s, but found %s as Hardware ID", checkID.HardwareId, hardwareID)
 		hardwareID = checkID.HardwareId
 	}

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
@@ -88,7 +88,7 @@ func TestCollect(t *testing.T) {
 
 	// Register a fake gateway
 	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
-    id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
+    	id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
 	ctx := id.NewContextWithIdentity(context.Background())
 	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
 
@@ -217,7 +217,7 @@ func TestCollectMismatchedGateway(t *testing.T) {
 
 	// Register a fake gateway
 	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
-    id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
+    	id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
 	ctx := id.NewContextWithIdentity(context.Background())
 	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
 

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
@@ -82,14 +82,14 @@ func TestCollect(t *testing.T) {
 	test_init.StartNewTestExporter(t, e)
 	srv := servicers.NewMetricsControllerServer()
 
-	ctx := context.Background()
-
 	// Create test network
 	networkID := "metricsd_servicer_test_network"
 	test_utils.RegisterNetwork(t, networkID, "Test Network Name")
 
 	// Register a fake gateway
 	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
+    id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
+	ctx := id.NewContextWithIdentity(context.Background())
 	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
 
 	name := strconv.Itoa(int(MetricName))
@@ -202,8 +202,6 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, prevInfoLines+1, glog.Stats.Info.Lines())
 }
 
-/*
-
 func TestCollectMismatchedGateway(t *testing.T) {
 	device_test_init.StartTestService(t)
 	configurator_test_init.StartTestService(t)
@@ -213,14 +211,14 @@ func TestCollectMismatchedGateway(t *testing.T) {
 	test_init.StartNewTestExporter(t, e)
 	srv := servicers.NewMetricsControllerServer()
 
-	ctx := context.Background()
-
 	// Create test network
 	networkID := "metricsd_servicer_test_network"
 	test_utils.RegisterNetwork(t, networkID, "Test Network Name")
 
 	// Register a fake gateway
 	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
+    id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
+	ctx := id.NewContextWithIdentity(context.Background())
 	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
 
     // Mismatched gateway ID
@@ -230,7 +228,6 @@ func TestCollectMismatchedGateway(t *testing.T) {
 	key := strconv.Itoa(int(LabelName))
 	value := LabelValue
 	float := 1.0
-	int_val := uint64(1)
 	counter_type := dto.MetricType_COUNTER
 	counters := protos.MetricsContainer{
 		GatewayId: mismatchgatewayID,
@@ -254,8 +251,6 @@ func TestCollectMismatchedGateway(t *testing.T) {
 	e.queue = e.queue[:0]
 
 }
-
-*/
 
 func TestConsume(t *testing.T) {
 	metricsChan := make(chan *dto.MetricFamily)

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
@@ -202,6 +202,61 @@ func TestCollect(t *testing.T) {
 	assert.Equal(t, prevInfoLines+1, glog.Stats.Info.Lines())
 }
 
+/*
+
+func TestCollectMismatchedGateway(t *testing.T) {
+	device_test_init.StartTestService(t)
+	configurator_test_init.StartTestService(t)
+	_ = serde.RegisterSerdes(serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &models.GatewayDevice{}))
+
+	e := &testMetricExporter{}
+	test_init.StartNewTestExporter(t, e)
+	srv := servicers.NewMetricsControllerServer()
+
+	ctx := context.Background()
+
+	// Create test network
+	networkID := "metricsd_servicer_test_network"
+	test_utils.RegisterNetwork(t, networkID, "Test Network Name")
+
+	// Register a fake gateway
+	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
+	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
+
+    // Mismatched gateway ID
+	mismatchgatewayID := "2876171d-bf38-4254-b4da-71a713954029"
+
+	name := strconv.Itoa(int(MetricName))
+	key := strconv.Itoa(int(LabelName))
+	value := LabelValue
+	float := 1.0
+	int_val := uint64(1)
+	counter_type := dto.MetricType_COUNTER
+	counters := protos.MetricsContainer{
+		GatewayId: mismatchgatewayID,
+		Family: []*dto.MetricFamily{{
+			Type: &counter_type,
+			Name: &name,
+			Metric: []*dto.Metric{
+				{
+					Label:   []*dto.LabelPair{{Name: &key, Value: &value}},
+					Counter: &dto.Counter{Value: &float}}}}}}
+
+	// Collect counters
+	_, err := srv.Collect(ctx, &counters)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(e.queue))
+	assert.Equal(t, strconv.FormatFloat(float, 'f', -1, 64), e.queue[0].Value())
+	// check that label protos are converted
+	assert.True(t, tests.HasLabelName(e.queue[0].Labels(), protos.GetEnumNameIfPossible(key, protos.MetricLabelName_name)))
+	assert.True(t, tests.HasLabel(e.queue[0].Labels(), metrics.NetworkLabelName, networkID))
+	// clear queue
+	e.queue = e.queue[:0]
+
+}
+
+*/
+
 func TestConsume(t *testing.T) {
 	metricsChan := make(chan *dto.MetricFamily)
 	e := &testMetricExporter{}

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
@@ -88,7 +88,7 @@ func TestCollect(t *testing.T) {
 
 	// Register a fake gateway
 	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
-    	id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
+	id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
 	ctx := id.NewContextWithIdentity(context.Background())
 	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
 
@@ -217,11 +217,11 @@ func TestCollectMismatchedGateway(t *testing.T) {
 
 	// Register a fake gateway
 	gatewayID := "2876171d-bf38-4254-b4da-71a713952904"
-    	id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
+	id := protos.NewGatewayIdentity(gatewayID, "testNwId", "testLogicalId")
 	ctx := id.NewContextWithIdentity(context.Background())
 	test_utils.RegisterGateway(t, networkID, gatewayID, &models.GatewayDevice{HardwareID: gatewayID})
 
-    // Mismatched gateway ID
+	// Mismatched gateway ID
 	mismatchgatewayID := "2876171d-bf38-4254-b4da-71a713954029"
 
 	name := strconv.Itoa(int(MetricName))
@@ -236,8 +236,12 @@ func TestCollectMismatchedGateway(t *testing.T) {
 			Name: &name,
 			Metric: []*dto.Metric{
 				{
-					Label:   []*dto.LabelPair{{Name: &key, Value: &value}},
-					Counter: &dto.Counter{Value: &float}}}}}}
+					Label: []*dto.LabelPair{{
+						Name:  &key,
+						Value: &value}},
+					Counter: &dto.Counter{
+						Value: &float},
+				}}}}}
 
 	// Collect counters
 	_, err := srv.Collect(ctx, &counters)
@@ -247,8 +251,7 @@ func TestCollectMismatchedGateway(t *testing.T) {
 	// check that label protos are converted
 	assert.True(t, tests.HasLabelName(e.queue[0].Labels(), protos.GetEnumNameIfPossible(key, protos.MetricLabelName_name)))
 	assert.True(t, tests.HasLabel(e.queue[0].Labels(), metrics.NetworkLabelName, networkID))
-	// clear queue
-	e.queue = e.queue[:0]
+	assert.True(t, tests.HasLabel(e.queue[0].Labels(), metrics.GatewayLabelName, gatewayID))
 
 }
 

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer_test.go
@@ -231,17 +231,19 @@ func TestCollectMismatchedGateway(t *testing.T) {
 	counter_type := dto.MetricType_COUNTER
 	counters := protos.MetricsContainer{
 		GatewayId: mismatchgatewayID,
-		Family: []*dto.MetricFamily{{
-			Type: &counter_type,
-			Name: &name,
-			Metric: []*dto.Metric{
-				{
-					Label: []*dto.LabelPair{{
-						Name:  &key,
-						Value: &value}},
-					Counter: &dto.Counter{
-						Value: &float},
-				}}}}}
+		Family: []*dto.MetricFamily{
+			{
+				Type: &counter_type,
+				Name: &name,
+				Metric: []*dto.Metric{
+					{
+						Label:   []*dto.LabelPair{{Name: &key, Value: &value}},
+						Counter: &dto.Counter{Value: &float},
+					},
+				},
+			},
+		},
+	}
 
 	// Collect counters
 	_, err := srv.Collect(ctx, &counters)


### PR DESCRIPTION
## Summary

Servicer now verifies GatewayId in MetricsContainer message with HardwareId from Context. 

GatewayId retrieved from Collect() message is compared against the HarwareId of the caller retrieved from Context. The HardwareId is used as the Client Nonce (CN) when authenticating with the Ingress Proxy. In case of a mismatch, Services logs it and proceeds to use the value retrieved from Context.

## Test Plan

- Enhanced TestCollect() to include Client context
- Create new TestCollectMistmatchedId() to cover new code added to validate and address mismatch

Unit tests passed successfully.

$> servicers % go test ./...
ok      magma/orc8r/cloud/go/services/metricsd/servicers        1.738s
$> servicers % 

## Additional Information

- [ ] This change is backwards-breaking
