### PR TITLE
[magma][go][cwf][feg] GRPC Request Id tracer API & tracers 4 CWAG Auth & CreateSession

### DIFF
--- a/feg/gateway/services/aaa/pipelined/client_api.go
+++ b/feg/gateway/services/aaa/pipelined/client_api.go
@@ -24,6 +24,7 @@ import (
 	"magma/feg/gateway/registry"
 	"magma/feg/gateway/services/aaa/protos"
 	lte_protos "magma/lte/cloud/go/protos"
+	lib_protos "magma/orc8r/lib/go/protos"
 )
 
 type pipelinedClient struct {
@@ -50,7 +51,7 @@ func AddUeMacFlow(sid *lte_protos.SubscriberID, aaaCtx *protos.Context) error {
 		return err
 	}
 
-	response, err := cli.AddUEMacFlow(context.Background(), flowRequest)
+	response, err := cli.AddUEMacFlow(lib_protos.AddRequestId(context.Background(), aaaCtx.GetSessionId()), flowRequest)
 	if err != nil {
 		return err
 	}
@@ -68,7 +69,8 @@ func DeleteUeMacFlow(sid *lte_protos.SubscriberID, aaaCtx *protos.Context) error
 		return err
 	}
 
-	response, err := cli.DeleteUEMacFlow(context.Background(), flowRequest)
+	response, err :=
+		cli.DeleteUEMacFlow(lib_protos.AddRequestId(context.Background(), aaaCtx.GetSessionId()), flowRequest)
 	if err != nil {
 		return err
 	}

--- a/feg/gateway/services/aaa/session_manager/client_api.go
+++ b/feg/gateway/services/aaa/session_manager/client_api.go
@@ -23,6 +23,7 @@ import (
 
 	"magma/feg/gateway/registry"
 	"magma/lte/cloud/go/protos"
+	lib_protos "magma/orc8r/lib/go/protos"
 )
 
 type sessionManagerClient struct {
@@ -61,7 +62,9 @@ func CreateSession(in *protos.LocalCreateSessionRequest) (*protos.LocalCreateSes
 	if err != nil {
 		return nil, err
 	}
-	return cli.CreateSession(context.Background(), in)
+	return cli.CreateSession(
+		lib_protos.AddRequestId(context.Background(), in.GetRatSpecificContext().GetWlanContext().GetRadiusSessionId()),
+		in)
 }
 
 func EndSession(in *protos.LocalEndSessionRequest) (*protos.LocalEndSessionResponse, error) {

--- a/feg/gateway/services/session_proxy/servicers/session_controller.go
+++ b/feg/gateway/services/session_proxy/servicers/session_controller.go
@@ -18,6 +18,10 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
+	"github.com/thoas/go-funk"
+	"golang.org/x/net/context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
 	"magma/feg/gateway/policydb"
@@ -28,10 +32,6 @@ import (
 	"magma/lte/cloud/go/protos"
 	"magma/orc8r/lib/go/errors"
 	orcprotos "magma/orc8r/lib/go/protos"
-
-	"github.com/golang/glog"
-	"github.com/thoas/go-funk"
-	"golang.org/x/net/context"
 )
 
 // CentralSessionController acts as the gRPC server for accepting calls from
@@ -81,10 +81,13 @@ func NewCentralSessionController(
 // CreateSession begins a UE session by requesting rules from PCEF
 // and credit from OCS (if RatingGroup is present) and returning them.
 func (srv *CentralSessionController) CreateSession(
-	_ context.Context,
+	ctx context.Context,
 	request *protos.CreateSessionRequest,
 ) (*protos.CreateSessionResponse, error) {
 	glog.V(2).Info("Trying to create session")
+
+	defer orcprotos.ForwardRequestId(ctx)
+
 	if err := checkCreateSessionRequest(request); err != nil {
 		return nil, err
 	}

--- a/feg/gateway/services/swx_proxy/client_api.go
+++ b/feg/gateway/services/swx_proxy/client_api.go
@@ -27,6 +27,7 @@ import (
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
+	lib_protos "magma/orc8r/lib/go/protos"
 	"magma/orc8r/lib/go/util"
 )
 
@@ -60,7 +61,7 @@ func getSwxProxyClient() (*swxProxyClient, error) {
 
 // Authenticate sends MAR (code 303) over diameter connection,
 // waits (blocks) for MAA & returns its RPC representation
-func Authenticate(req *protos.AuthenticationRequest) (*protos.AuthenticationAnswer, error) {
+func Authenticate(req *protos.AuthenticationRequest, reqId ...string) (*protos.AuthenticationAnswer, error) {
 	err := verifyAuthenticationRequest(req)
 	if err != nil {
 		errMsg := fmt.Errorf("Invalid AuthenticationRequest provided: %s", err)
@@ -70,7 +71,11 @@ func Authenticate(req *protos.AuthenticationRequest) (*protos.AuthenticationAnsw
 	if err != nil {
 		return nil, err
 	}
-	return cli.Authenticate(context.Background(), req)
+	ctx := context.Background()
+	if len(reqId) > 0 && len(reqId[0]) > 0 {
+		ctx = lib_protos.AddRequestId(ctx, reqId[0])
+	}
+	return cli.Authenticate(ctx, req)
 }
 
 // Register sends SAR (Code 301) over diameter connection with ServerAssignmentType

--- a/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
+++ b/feg/gateway/services/swx_proxy/servicers/swx_proxy.go
@@ -172,6 +172,7 @@ func (s *swxProxy) Authenticate(
 	if err == nil {
 		metrics.AuthLatency.Observe(time.Since(authStartTime).Seconds())
 	}
+	orcprotos.ForwardRequestId(ctx)
 	return res, err
 }
 

--- a/orc8r/lib/go/protos/magma_id.go
+++ b/orc8r/lib/go/protos/magma_id.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protos
+
+import (
+	"context"
+	"strings"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// X_MAGMA_ID is a request/response tracing header which must be carried between RPC calls
+const X_MAGMA_ID = "x-magma-id"
+
+// AddRequestId creates and returns new outgoing GRPC CTX with specified Id's header
+// Intended for GRPC client use
+func AddRequestId(ctx context.Context, id string) context.Context {
+	md := metadata.New(map[string]string{X_MAGMA_ID: id})
+	return metadata.NewOutgoingContext(ctx, md)
+}
+
+// ForwardRequestId fetches the ID from incoming GRPC CTX and appends it to the server's response
+// Should be called immediately before return from RPC handler
+func ForwardRequestId(ctx context.Context) error {
+	if ctx == nil {
+		return status.Errorf(codes.InvalidArgument, "nil '%s' ctx", X_MAGMA_ID)
+	}
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok || md == nil {
+		return status.Errorf(codes.DataLoss, "missing metadata for %s", X_MAGMA_ID)
+	}
+	hdrs := md[X_MAGMA_ID]
+	if len(hdrs) == 0 {
+		return status.Errorf(codes.InvalidArgument, "missing '%s' header", X_MAGMA_ID)
+	}
+	id := strings.TrimSpace(hdrs[0])
+	if len(id) == 0 {
+		return status.Errorf(codes.InvalidArgument, "empty '%s' header", X_MAGMA_ID)
+	}
+	return SendRequestId(ctx, id)
+}
+
+// SendRequestId sends given ID with GRPC CTX to the client
+// Should be called immediately before return from RPC handler
+func SendRequestId(ctx context.Context, id string) error {
+	if ctx == nil {
+		return status.Errorf(codes.InvalidArgument, "nil '%s' ctx", X_MAGMA_ID)
+	}
+	header := metadata.New(map[string]string{X_MAGMA_ID: id})
+	err := grpc.SendHeader(ctx, header)
+	if err != nil {
+		err = status.Errorf(codes.Internal, "error sending '%s' header: %v", X_MAGMA_ID, err)
+	}
+	return err
+}


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

GRPC Request Id tracer API & tracers 4 CWAG Auth & CreateSession

New API for Go GRPC clients/servers to add request ID tracing headers.
AAA Auth, create session tracers using the API

## Test Plan

make precommit

## Additional Information

- [ ] This change is backwards-breaking
