### PR TITLE
[5G: MVC][component: agw][type: enhancement] 5G NAS termination - Basic UE Registration/Deregistration Support #2038 PDU Messages

### DIFF
--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionEstablishmentAccept.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionEstablishmentAccept.h
@@ -1,0 +1,48 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+#include "IntegrityProtMaxDataRate.h"
+#include "PDUSessionType.h"
+#include "SSCMode.h"
+#include "QOSRules.h"
+#include "SessionAMBR.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionEstablishmentAccept Message Class
+class PDUSessionEstablishmentAcceptMsg {
+ public:
+#define PDU_SESSION_ESTABLISH_ACPT_MIN_LEN 18
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+  PDUSessionTypeMsg pdusessiontype;
+  SSCModeMsg sscmode;
+  QOSRulesMsg qosrules;
+  SessionAMBRMsg sessionambr;
+
+  PDUSessionEstablishmentAcceptMsg();
+  ~PDUSessionEstablishmentAcceptMsg();
+  int DecodePDUSessionEstablishmentAcceptMsg(
+      PDUSessionEstablishmentAcceptMsg* pdusessionestablishmentaccept,
+      uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionEstablishmentAcceptMsg(
+      PDUSessionEstablishmentAcceptMsg* pdusessionestablishmentaccept,
+      uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionEstablishmentReject.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionEstablishmentReject.h
@@ -1,0 +1,41 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+#include "5GSMCause.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionEstablishmentReject Message Class
+class PDUSessionEstablishmentRejectMsg {
+ public:
+#define PDU_SESSION_ESTABLISHMENT_REJ_MIN_LEN 5
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+  M5GSMCauseMsg m5gsmcause;
+
+  PDUSessionEstablishmentRejectMsg();
+  ~PDUSessionEstablishmentRejectMsg();
+  int DecodePDUSessionEstablishmentRejectMsg(
+      PDUSessionEstablishmentRejectMsg* pdusessionestablishmentreject,
+      uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionEstablishmentRejectMsg(
+      PDUSessionEstablishmentRejectMsg* pdusessionestablishmentreject,
+      uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionEstablishmentRequest.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionEstablishmentRequest.h
@@ -1,0 +1,45 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+#include "IntegrityProtMaxDataRate.h"
+#include "PDUSessionType.h"
+#include "SSCMode.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionEstablishmentRequest Message Class
+class PDUSessionEstablishmentRequestMsg {
+ public:
+#define PDU_SESSION_ESTABLISH_REQ_MIN_LEN 4
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+  IntegrityProtMaxDataRateMsg integrityprotmaxdatarate;
+  PDUSessionTypeMsg pdusessiontype;
+  SSCModeMsg sscmode;
+
+  PDUSessionEstablishmentRequestMsg();
+  ~PDUSessionEstablishmentRequestMsg();
+  int DecodePDUSessionEstablishmentRequestMsg(
+      PDUSessionEstablishmentRequestMsg* pdusessionestablishmentrequest,
+      uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionEstablishmentRequestMsg(
+      PDUSessionEstablishmentRequestMsg* pdusessionestablishmentrequest,
+      uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionModificationReject.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionModificationReject.h
@@ -1,0 +1,41 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+#include "5GSMCause.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionModificationReject Message Class
+class PDUSessionModificationRejectMsg {
+ public:
+#define PDU_SESSION_MODIFICATION_REJECT_MIN_LEN 5
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+  M5GSMCauseMsg m5gsmcause;
+
+  PDUSessionModificationRejectMsg();
+  ~PDUSessionModificationRejectMsg();
+  int DecodePDUSessionModificationRejectMsg(
+      PDUSessionModificationRejectMsg* pdusessionmodificationreject,
+      uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionModificationRejectMsg(
+      PDUSessionModificationRejectMsg* pdusessionmodificationreject,
+      uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionModificationRequest.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionModificationRequest.h
@@ -1,0 +1,39 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionModificationRequest Message Class
+class PDUSessionModificationRequestMsg {
+ public:
+#define PDU_SESSION_MODIFICATION_REQ_MIN_LEN 4
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+
+  PDUSessionModificationRequestMsg();
+  ~PDUSessionModificationRequestMsg();
+  int DecodePDUSessionModificationRequestMsg(
+      PDUSessionModificationRequestMsg* pdusessionmodificationrequest,
+      uint8_t* buffer, uint32_t len);
+  int EncodePDUSessionModificationRequestMsg(
+      PDUSessionModificationRequestMsg* pdusessionmodificationrequest,
+      uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionReleaseReject.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionReleaseReject.h
@@ -1,0 +1,41 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+#include "5GSMCause.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionReleaseReject Message Class
+class PDUSessionReleaseRejectMsg {
+ public:
+#define PDU_SESSION_RELEASE_REJECT_MIN_LEN 5
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+  M5GSMCauseMsg m5gsmcause;
+
+  PDUSessionReleaseRejectMsg();
+  ~PDUSessionReleaseRejectMsg();
+  int DecodePDUSessionReleaseRejectMsg(
+      PDUSessionReleaseRejectMsg* pdusessionreleasereject, uint8_t* buffer,
+      uint32_t len);
+  int EncodePDUSessionReleaseRejectMsg(
+      PDUSessionReleaseRejectMsg* pdusessionreleasereject, uint8_t* buffer,
+      uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionReleaseRequest.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/PDUSessionReleaseRequest.h
@@ -1,0 +1,39 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include "ExtendedProtocolDiscriminator.h"
+#include "PDUSessionIdentity.h"
+#include "PTI.h"
+#include "MessageType.h"
+
+using namespace std;
+namespace magma5g {
+// PDUSessionReleaseRequest Message Class
+class PDUSessionReleaseRequestMsg {
+ public:
+#define PDU_SESSION_RELEASE_REQ_MIN_LEN 4
+  ExtendedProtocolDiscriminatorMsg extendedprotocoldiscriminator;
+  PDUSessionIdentityMsg pdusessionidentity;
+  PTIMsg pti;
+  MessageTypeMsg messagetype;
+
+  PDUSessionReleaseRequestMsg();
+  ~PDUSessionReleaseRequestMsg();
+  int DecodePDUSessionReleaseRequestMsg(
+      PDUSessionReleaseRequestMsg* pdusessionreleaserequest, uint8_t* buffer,
+      uint32_t len);
+  int EncodePDUSessionReleaseRequestMsg(
+      PDUSessionReleaseRequestMsg* pdusessionreleaserequest, uint8_t* buffer,
+      uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/5GSMCause.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/5GSMCause.h
@@ -1,0 +1,31 @@
+/*
+  Copyright 2020 The Magma Authors.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// M5GSMCause IE Class
+class M5GSMCauseMsg {
+ public:
+  uint8_t iei;
+  uint8_t causevalue;
+
+  M5GSMCauseMsg();
+  ~M5GSMCauseMsg();
+  int EncodeM5GSMCauseMsg(
+      M5GSMCauseMsg* m5gsmcause, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeM5GSMCauseMsg(
+      M5GSMCauseMsg* m5gsmcause, uint8_t iei, uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/IntegrityProtMaxDataRate.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/IntegrityProtMaxDataRate.h
@@ -1,0 +1,33 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// IntegrityProtMaxDataRate IE Class
+class IntegrityProtMaxDataRateMsg {
+ public:
+  uint8_t maxuplink;
+  uint8_t maxdownlink;
+
+  IntegrityProtMaxDataRateMsg();
+  ~IntegrityProtMaxDataRateMsg();
+  int EncodeIntegrityProtMaxDataRateMsg(
+      IntegrityProtMaxDataRateMsg* integrityprotmaxdatarate, uint8_t iei,
+      uint8_t* buffer, uint32_t len);
+  int DecodeIntegrityProtMaxDataRateMsg(
+      IntegrityProtMaxDataRateMsg* integrityprotmaxdatarate, uint8_t iei,
+      uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/PDUAddress.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/PDUAddress.h
@@ -1,0 +1,32 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// PDUAddress IE Class
+class PDUAddressMsg {
+ public:
+  uint8_t iei;
+  uint8_t typeval : 3;
+  uint8_t addressinfo[12];
+
+  PDUAddressMsg();
+  ~PDUAddressMsg();
+  int EncodePDUAddressMsg(
+      PDUAddressMsg* pduaddress, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePDUAddressMsg(
+      PDUAddressMsg* pduaddress, uint8_t iei, uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/PDUSessionIdentity.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/PDUSessionIdentity.h
@@ -1,0 +1,32 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// PDUSessionIdentity IE Class
+class PDUSessionIdentityMsg {
+ public:
+  uint8_t pdusessionid;
+
+  PDUSessionIdentityMsg();
+  ~PDUSessionIdentityMsg();
+  int EncodePDUSessionIdentityMsg(
+      PDUSessionIdentityMsg* pdusessionid, uint8_t iei, uint8_t* buffer,
+      uint32_t len);
+  int DecodePDUSessionIdentityMsg(
+      PDUSessionIdentityMsg* pdusessionid, uint8_t iei, uint8_t* buffer,
+      uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/PDUSessionType.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/PDUSessionType.h
@@ -1,0 +1,33 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// PDUSessionType Class
+class PDUSessionTypeMsg {
+ public:
+  uint8_t iei : 4;
+  uint32_t typeval : 3;
+
+  PDUSessionTypeMsg();
+  ~PDUSessionTypeMsg();
+  int EncodePDUSessionTypeMsg(
+      PDUSessionTypeMsg* pdusessiontype, uint8_t iei, uint8_t* buffer,
+      uint32_t len);
+  int DecodePDUSessionTypeMsg(
+      PDUSessionTypeMsg* pdusessiontype, uint8_t iei, uint8_t* buffer,
+      uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/PTI.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/PTI.h
@@ -1,0 +1,27 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+using namespace std;
+namespace magma5g {
+// PTI IE Class
+class PTIMsg {
+ public:
+  uint8_t pti;
+
+  PTIMsg();
+  ~PTIMsg();
+  int EncodePTIMsg(PTIMsg* pti, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodePTIMsg(PTIMsg* pti, uint8_t iei, uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/QOSRules.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/QOSRules.h
@@ -1,0 +1,65 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#define ONE_K 1024
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// New QOSRule Class
+class NewQOSRulePktFilter {
+ public:
+  uint8_t spare : 2;
+  uint8_t pktfilterdir : 2;
+  uint8_t pktfilterid : 4;
+  uint8_t len;
+  uint8_t contents[4 * ONE_K];  // need to revisit if the QOS rules occupy more
+                                // space than 4k.
+  NewQOSRulePktFilter();
+  ~NewQOSRulePktFilter();
+};
+
+// QOSRule Class
+class QOSRule {
+ public:
+  uint8_t qosruleid;
+  uint16_t len;
+  uint8_t ruleopercode : 3;
+  uint8_t dqrbit : 1;
+  uint8_t noofpktfilters : 4;
+  NewQOSRulePktFilter newqosrulepktfilter[16];
+  uint8_t qosruleprecedence;
+  uint8_t spare : 1;
+  uint8_t segregation : 1;
+  uint8_t qfi : 6;
+
+  QOSRule();
+  ~QOSRule();
+};
+
+// QOSRules IE Class
+class QOSRulesMsg {
+ public:
+#define QOSRULE_MIN_LEN 3
+  uint8_t iei;
+  uint8_t length;
+  QOSRule qosrule[32];  // need to revisit based on max num of QOS rules
+                        // exchanged btw UE and core.
+  QOSRulesMsg();
+  ~QOSRulesMsg();
+  int EncodeQOSRulesMsg(
+      QOSRulesMsg* qosrules, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeQOSRulesMsg(
+      QOSRulesMsg* qosrules, uint8_t iei, uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/SSCMode.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/SSCMode.h
@@ -1,0 +1,31 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// SSCMode IE Class
+class SSCModeMsg {
+ public:
+  uint8_t iei : 4;
+  uint32_t modeval : 3;
+
+  SSCModeMsg();
+  ~SSCModeMsg();
+  int EncodeSSCModeMsg(
+      SSCModeMsg* sscmode, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeSSCModeMsg(
+      SSCModeMsg* sscmode, uint8_t iei, uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/include/ies/SessionAMBR.h
+++ b/lte/gateway/c/oai/tasks/nas5g/include/ies/SessionAMBR.h
@@ -1,0 +1,36 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#pragma once
+#include <sstream>
+#include <cstdint>
+
+using namespace std;
+namespace magma5g {
+// SessionAMBR Class
+class SessionAMBRMsg {
+ public:
+#define AMBR_MIN_LEN 2
+  uint8_t iei;
+  uint8_t length;
+  uint8_t dlunit;
+  uint16_t dlsessionambr;
+  uint8_t ulunit;
+  uint16_t ulsessionambr;
+
+  SessionAMBRMsg();
+  ~SessionAMBRMsg();
+  int EncodeSessionAMBRMsg(
+      SessionAMBRMsg* sessionambr, uint8_t iei, uint8_t* buffer, uint32_t len);
+  int DecodeSessionAMBRMsg(
+      SessionAMBRMsg* sessionambr, uint8_t iei, uint8_t* buffer, uint32_t len);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionEstablishmentAccept.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionEstablishmentAccept.cpp
@@ -1,0 +1,98 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionEstablishmentAccept.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionEstablishmentAcceptMsg::PDUSessionEstablishmentAcceptMsg(){};
+PDUSessionEstablishmentAcceptMsg::~PDUSessionEstablishmentAcceptMsg(){};
+
+// Decode PDUSessionEstablishmentAccept Message and its IEs
+int PDUSessionEstablishmentAcceptMsg::DecodePDUSessionEstablishmentAcceptMsg(
+    PDUSessionEstablishmentAcceptMsg* pdusessionestablishmentaccept,
+    uint8_t* buffer, uint32_t len) {
+  // Not yet implemented, will be supported POST MVC
+  return 0;
+}
+
+// Encode PDUSessionEstablishmentAccept Message and its IEs
+int PDUSessionEstablishmentAcceptMsg::EncodePDUSessionEstablishmentAcceptMsg(
+    PDUSessionEstablishmentAcceptMsg* pdusessionestablishmentaccept,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t encoded  = 0;
+  int encodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_ESTABLISH_ACPT_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "EncodePDUSessionEstablishmentAcceptMsg : \n";
+  if ((encodedresult =
+           pdusessionestablishmentaccept->extendedprotocoldiscriminator
+               .EncodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionestablishmentaccept
+                        ->extendedprotocoldiscriminator,
+                   0, buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentaccept->pdusessionidentity
+               .EncodePDUSessionIdentityMsg(
+                   &pdusessionestablishmentaccept->pdusessionidentity, 0,
+                   buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionestablishmentaccept->pti.EncodePTIMsg(
+           &pdusessionestablishmentaccept->pti, 0, buffer + encoded,
+           len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentaccept->messagetype.EncodeMessageTypeMsg(
+               &pdusessionestablishmentaccept->messagetype, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionestablishmentaccept->sscmode.EncodeSSCModeMsg(
+           &pdusessionestablishmentaccept->sscmode, 0, buffer + encoded,
+           len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionestablishmentaccept->pdusessiontype
+                           .EncodePDUSessionTypeMsg(
+                               &pdusessionestablishmentaccept->pdusessiontype,
+                               0, buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentaccept->qosrules.EncodeQOSRulesMsg(
+               &pdusessionestablishmentaccept->qosrules, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentaccept->sessionambr.EncodeSessionAMBRMsg(
+               &pdusessionestablishmentaccept->sessionambr, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+
+  return encoded;
+}
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionEstablishmentReject.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionEstablishmentReject.cpp
@@ -1,0 +1,77 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionEstablishmentReject.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionEstablishmentRejectMsg::PDUSessionEstablishmentRejectMsg(){};
+PDUSessionEstablishmentRejectMsg::~PDUSessionEstablishmentRejectMsg(){};
+
+// Decode PDUSessionEstablishmentReject Message and its IEs
+int PDUSessionEstablishmentRejectMsg::DecodePDUSessionEstablishmentRejectMsg(
+    PDUSessionEstablishmentRejectMsg* pdusessionestablishmentreject,
+    uint8_t* buffer, uint32_t len) {
+  // Not yet Implemented, will be supported POST MVC
+  return 0;
+}
+
+// Encode PDUSessionEstablishmentReject Message and its IEs
+int PDUSessionEstablishmentRejectMsg::EncodePDUSessionEstablishmentRejectMsg(
+    PDUSessionEstablishmentRejectMsg* pdusessionestablishmentreject,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t encoded  = 0;
+  int encodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_ESTABLISHMENT_REJ_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "EncodePDUSessionEstablishmentRejectMsg : \n";
+  if ((encodedresult =
+           pdusessionestablishmentreject->extendedprotocoldiscriminator
+               .EncodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionestablishmentreject
+                        ->extendedprotocoldiscriminator,
+                   0, buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentreject->pdusessionidentity
+               .EncodePDUSessionIdentityMsg(
+                   &pdusessionestablishmentreject->pdusessionidentity, 0,
+                   buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionestablishmentreject->pti.EncodePTIMsg(
+           &pdusessionestablishmentreject->pti, 0, buffer + encoded,
+           len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentreject->messagetype.EncodeMessageTypeMsg(
+               &pdusessionestablishmentreject->messagetype, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionestablishmentreject->m5gsmcause.EncodeM5GSMCauseMsg(
+               &pdusessionestablishmentreject->m5gsmcause, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  return encoded;
+}
+}  // Namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionEstablishmentRequest.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionEstablishmentRequest.cpp
@@ -1,0 +1,92 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionEstablishmentRequest.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionEstablishmentRequestMsg::PDUSessionEstablishmentRequestMsg(){};
+PDUSessionEstablishmentRequestMsg::~PDUSessionEstablishmentRequestMsg(){};
+
+// Decode PDUSessionEstablishmentRequest Message and its IEs
+int PDUSessionEstablishmentRequestMsg::DecodePDUSessionEstablishmentRequestMsg(
+    PDUSessionEstablishmentRequestMsg* pdusessionestablishmentrequest,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t decoded  = 0;
+  int decodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_ESTABLISH_REQ_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "DecodePDUSessionEstablishmentRequestMsg : ";
+  if ((decodedresult =
+           pdusessionestablishmentrequest->extendedprotocoldiscriminator
+               .DecodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionestablishmentrequest
+                        ->extendedprotocoldiscriminator,
+                   0, buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionestablishmentrequest->pdusessionidentity
+               .DecodePDUSessionIdentityMsg(
+                   &pdusessionestablishmentrequest->pdusessionidentity, 0,
+                   buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult = pdusessionestablishmentrequest->pti.DecodePTIMsg(
+           &pdusessionestablishmentrequest->pti, 0, buffer + decoded,
+           len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionestablishmentrequest->messagetype.DecodeMessageTypeMsg(
+               &pdusessionestablishmentrequest->messagetype, 0,
+               buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionestablishmentrequest->integrityprotmaxdatarate
+               .DecodeIntegrityProtMaxDataRateMsg(
+                   &pdusessionestablishmentrequest->integrityprotmaxdatarate, 0,
+                   buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionestablishmentrequest->pdusessiontype
+               .DecodePDUSessionTypeMsg(
+                   &pdusessionestablishmentrequest->pdusessiontype,
+                   PDUSESSIONTYPE, buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult = pdusessionestablishmentrequest->sscmode.DecodeSSCModeMsg(
+           &pdusessionestablishmentrequest->sscmode, SSCMODE, buffer + decoded,
+           len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  return decoded;
+}
+
+// Encode PDUSessionEstablishmentRequest Message and its IEs
+int PDUSessionEstablishmentRequestMsg::EncodePDUSessionEstablishmentRequestMsg(
+    PDUSessionEstablishmentRequestMsg* pdusessionestablishmentrequest,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t Encode  = 0;
+// Not yet implemented, will be supported POST MVC
+}
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionModificationReject.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionModificationReject.cpp
@@ -1,0 +1,77 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionModificationReject.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionModificationRejectMsg::PDUSessionModificationRejectMsg(){};
+PDUSessionModificationRejectMsg::~PDUSessionModificationRejectMsg(){};
+
+// Decode PDUSessionModificationReject Message and its IEs
+int PDUSessionModificationRejectMsg::DecodePDUSessionModificationRejectMsg(
+    PDUSessionModificationRejectMsg* pdusessionmodificationreject,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t decoded  = 0;
+  //Not yet Implemented, will be supported POST MVC.
+  return decoded;
+}
+
+// Encode PDUSessionModificationReject Message and its IEs
+int PDUSessionModificationRejectMsg::EncodePDUSessionModificationRejectMsg(
+    PDUSessionModificationRejectMsg* pdusessionmodificationreject,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t encoded  = 0;
+  int encodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_MODIFICATION_REJECT_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "EncodePDUSessionModificationRejectMsg : \n";
+  if ((encodedresult =
+           pdusessionmodificationreject->extendedprotocoldiscriminator
+               .EncodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionmodificationreject->extendedprotocoldiscriminator,
+                   0, buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionmodificationreject->pdusessionidentity
+               .EncodePDUSessionIdentityMsg(
+                   &pdusessionmodificationreject->pdusessionidentity, 0,
+                   buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionmodificationreject->pti.EncodePTIMsg(
+           &pdusessionmodificationreject->pti, 0, buffer + encoded,
+           len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionmodificationreject->messagetype.EncodeMessageTypeMsg(
+               &pdusessionmodificationreject->messagetype, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionmodificationreject->m5gsmcause.EncodeM5GSMCauseMsg(
+               &pdusessionmodificationreject->m5gsmcause, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  return encoded;
+}
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionModificationRequest.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionModificationRequest.cpp
@@ -1,0 +1,73 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionModificationRequest.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionModificationRequestMsg::PDUSessionModificationRequestMsg(){};
+PDUSessionModificationRequestMsg::~PDUSessionModificationRequestMsg(){};
+
+// Decode PDUSessionModificationRequest Message and its IEs
+int PDUSessionModificationRequestMsg::DecodePDUSessionModificationRequestMsg(
+    PDUSessionModificationRequestMsg* pdusessionmodificationrequest,
+    uint8_t* buffer, uint32_t len) {
+  uint32_t decoded  = 0;
+  int decodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_MODIFICATION_REQ_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "DecodePDUSessionModificationRequestMsg\n";
+  if ((decodedresult =
+           pdusessionmodificationrequest->extendedprotocoldiscriminator
+               .DecodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionmodificationrequest
+                        ->extendedprotocoldiscriminator,
+                   0, buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionmodificationrequest->pdusessionidentity
+               .DecodePDUSessionIdentityMsg(
+                   &pdusessionmodificationrequest->pdusessionidentity, 0,
+                   buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult = pdusessionmodificationrequest->pti.DecodePTIMsg(
+           &pdusessionmodificationrequest->pti, 0, buffer + decoded,
+           len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionmodificationrequest->messagetype.DecodeMessageTypeMsg(
+               &pdusessionmodificationrequest->messagetype, 0, buffer + decoded,
+               len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+
+  return 0;
+}
+
+// Encode PDUSessionModificationRequest Message and its IEs
+int PDUSessionModificationRequestMsg::EncodePDUSessionModificationRequestMsg(
+    PDUSessionModificationRequestMsg* pdusessionmodificationrequest,
+    uint8_t* buffer, uint32_t len) {
+  MLOG(MDEBUG) << "EncodePDUSessionModificationRequestMsg\n";
+  // Not yet implemented, Will be supported POST MVC.
+  return 0;
+}
+
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionReleaseReject.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionReleaseReject.cpp
@@ -1,0 +1,75 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionReleaseReject.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionReleaseRejectMsg::PDUSessionReleaseRejectMsg(){};
+PDUSessionReleaseRejectMsg::~PDUSessionReleaseRejectMsg(){};
+
+// Decode PDUSessionReleaseReject Message and its IEs
+int PDUSessionReleaseRejectMsg::DecodePDUSessionReleaseRejectMsg(
+    PDUSessionReleaseRejectMsg* pdusessionreleasereject, uint8_t* buffer,
+    uint32_t len) {
+  uint32_t decoded  = 0;
+  //Not yet implemented, Will be supported POST MVC.
+  return 0;
+}
+
+// Encode PDUSessionReleaseReject Message and its IEs
+int PDUSessionReleaseRejectMsg::EncodePDUSessionReleaseRejectMsg(
+    PDUSessionReleaseRejectMsg* pdusessionreleasereject, uint8_t* buffer,
+    uint32_t len) {
+  uint32_t encoded  = 0;
+  int encodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_RELEASE_REJECT_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "EncodePDUSessionReleaseRejectMsg : \n";
+  if ((encodedresult =
+           pdusessionreleasereject->extendedprotocoldiscriminator
+               .EncodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionreleasereject->extendedprotocoldiscriminator, 0,
+                   buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionreleasereject->pdusessionidentity
+                           .EncodePDUSessionIdentityMsg(
+                               &pdusessionreleasereject->pdusessionidentity, 0,
+                               buffer + encoded, len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionreleasereject->pti.EncodePTIMsg(
+           &pdusessionreleasereject->pti, 0, buffer + encoded, len - encoded)) <
+      0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult =
+           pdusessionreleasereject->messagetype.EncodeMessageTypeMsg(
+               &pdusessionreleasereject->messagetype, 0, buffer + encoded,
+               len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  if ((encodedresult = pdusessionreleasereject->m5gsmcause.EncodeM5GSMCauseMsg(
+           &pdusessionreleasereject->m5gsmcause, 0, buffer + encoded,
+           len - encoded)) < 0)
+    return encodedresult;
+  else
+    encoded += encodedresult;
+  return encoded;
+}
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionReleaseRequest.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/PDUSessionReleaseRequest.cpp
@@ -1,0 +1,70 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include "PDUSessionReleaseRequest.h"
+#include "CommonDefs.h"
+
+namespace magma5g {
+PDUSessionReleaseRequestMsg::PDUSessionReleaseRequestMsg(){};
+PDUSessionReleaseRequestMsg::~PDUSessionReleaseRequestMsg(){};
+
+// Decode PDUSessionReleaseRequest Message and its IEs
+int PDUSessionReleaseRequestMsg::DecodePDUSessionReleaseRequestMsg(
+    PDUSessionReleaseRequestMsg* pdusessionreleaserequest, uint8_t* buffer,
+    uint32_t len) {
+  uint32_t decoded  = 0;
+  int decodedresult = 0;
+  CHECK_PDU_POINTER_AND_LENGTH_DECODER(
+      buffer, PDU_SESSION_RELEASE_REQ_MIN_LEN, len);
+
+  MLOG(MDEBUG) << "DecodePDUSessionReleaseRequestMsg\n";
+  if ((decodedresult =
+           pdusessionreleaserequest->extendedprotocoldiscriminator
+               .DecodeExtendedProtocolDiscriminatorMsg(
+                   &pdusessionreleaserequest->extendedprotocoldiscriminator, 0,
+                   buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult = pdusessionreleaserequest->pdusessionidentity
+                           .DecodePDUSessionIdentityMsg(
+                               &pdusessionreleaserequest->pdusessionidentity, 0,
+                               buffer + decoded, len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult = pdusessionreleaserequest->pti.DecodePTIMsg(
+           &pdusessionreleaserequest->pti, 0, buffer + decoded,
+           len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+  if ((decodedresult =
+           pdusessionreleaserequest->messagetype.DecodeMessageTypeMsg(
+               &pdusessionreleaserequest->messagetype, 0, buffer + decoded,
+               len - decoded)) < 0)
+    return decodedresult;
+  else
+    decoded += decodedresult;
+
+  return decoded;
+}
+
+// Encode PDUSessionReleaseRequest Message and its IEs
+int PDUSessionReleaseRequestMsg::EncodePDUSessionReleaseRequestMsg(
+    PDUSessionReleaseRequestMsg* pdusessionreleaserequest, uint8_t* buffer,
+    uint32_t len) {
+  MLOG(MDEBUG) << "EncodePDUSessionReleaseRequestMsg\n";
+  //Not yet implemented, Will be supported POST MVC.
+  return 0;
+}
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/5GSMCause.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/5GSMCause.cpp
@@ -1,0 +1,60 @@
+/*
+Copyright 2020 The Magma Authors.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+#include <iostream>
+#include <sstream>
+#include <cstdint>
+#include <cstring>
+#include "5GSMCause.h"
+#include "CommonDefs.h"
+using namespace std;
+namespace magma5g {
+M5GSMCauseMsg::M5GSMCauseMsg(){};
+M5GSMCauseMsg::~M5GSMCauseMsg(){};
+
+// Decode M5GSMCause IE
+int M5GSMCauseMsg::DecodeM5GSMCauseMsg(
+    M5GSMCauseMsg* m5gsmcause, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int decoded    = 0;
+  uint32_t ielen = 0;
+
+  if (iei > 0) {
+    m5gsmcause->iei = *buffer;
+    CHECK_IEI_DECODER(iei, (unsigned char) m5gsmcause->iei);
+  }
+
+  m5gsmcause->causevalue = *buffer;
+  decoded++;
+  MLOG(MDEBUG) << "DecodeM5GSMCauseMsg__: iei = " << hex << int(m5gsmcause->iei)
+               << endl;
+  MLOG(MDEBUG) << "DecodeM5GSMCauseMsg__: causevalue = " << hex
+               << int(m5gsmcause->causevalue) << endl;
+
+  return (decoded);
+};
+
+// Encode M5GSMCause IE
+int M5GSMCauseMsg::EncodeM5GSMCauseMsg(
+    M5GSMCauseMsg* m5gsmcause, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int encoded = 0;
+
+  if (iei > 0) {
+    m5gsmcause->iei = *buffer;
+    CHECK_IEI_DECODER(iei, (unsigned char) m5gsmcause->iei);
+  }
+
+  *(buffer + encoded) = m5gsmcause->causevalue;
+  MLOG(MDEBUG) << "EncodeM5GSMCauseMsg__: causevalue = " << hex
+               << int(m5gsmcause->causevalue) << endl;
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/IntegrityProtMaxDataRate.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/IntegrityProtMaxDataRate.cpp
@@ -1,0 +1,57 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include <cstdint>
+#include "IntegrityProtMaxDataRate.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+IntegrityProtMaxDataRateMsg::IntegrityProtMaxDataRateMsg(){};
+IntegrityProtMaxDataRateMsg::~IntegrityProtMaxDataRateMsg(){};
+
+// Decode IntegrityProtMaxDataRate IE
+int IntegrityProtMaxDataRateMsg::DecodeIntegrityProtMaxDataRateMsg(
+    IntegrityProtMaxDataRateMsg* integrityprotmaxdatarate, uint8_t iei,
+    uint8_t* buffer, uint32_t len) {
+  uint8_t decoded = 0;
+
+  MLOG(MDEBUG) << "   DecodeIntegrityProtMaxDataRateMsg : ";
+  integrityprotmaxdatarate->maxuplink = *(buffer + decoded);
+  decoded++;
+  integrityprotmaxdatarate->maxdownlink = *(buffer + decoded);
+  decoded++;
+  MLOG(MDEBUG) << " maxuplink = " << dec
+               << int(integrityprotmaxdatarate->maxuplink);
+  MLOG(MDEBUG) << " maxdownlink = " << dec
+               << int(integrityprotmaxdatarate->maxdownlink);
+  return (decoded);
+};
+
+// Encode IntegrityProtMaxDataRate IE
+int IntegrityProtMaxDataRateMsg::EncodeIntegrityProtMaxDataRateMsg(
+    IntegrityProtMaxDataRateMsg* integrityprotmaxdatarate, uint8_t iei,
+    uint8_t* buffer, uint32_t len) {
+  int encoded = 0;
+
+  MLOG(MDEBUG) << " EncodeIntegrityProtMaxDataRateMsg : ";
+  *(buffer + encoded) = integrityprotmaxdatarate->maxuplink;
+  MLOG(MDEBUG) << " maxuplink =0x" << hex
+               << int(integrityprotmaxdatarate->maxuplink);
+  encoded++;
+  *(buffer + encoded) = integrityprotmaxdatarate->maxdownlink;
+  MLOG(MDEBUG) << " maxdownlink =0x" << hex
+               << int(integrityprotmaxdatarate->maxdownlink);
+  encoded++;
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/PDUAddress.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/PDUAddress.cpp
@@ -1,0 +1,54 @@
+/*
+  Copyright 2020 The Magma Authors.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <iostream>
+#include <sstream>
+#include <cstdint>
+#include <cstring>
+#include "PDUAddress.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+PDUAddressMsg::PDUAddressMsg(){};
+PDUAddressMsg::~PDUAddressMsg(){};
+
+// Decode PDUAddress IE
+int PDUAddressMsg::DecodePDUAddressMsg(
+    PDUAddressMsg* pduaddress, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  // Not yet Implemented, will be supported POST MVC
+  return 0;
+};
+
+// Encode PDUAddress IE
+int PDUAddressMsg::EncodePDUAddressMsg(
+    PDUAddressMsg* pduaddress, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int encoded = 0;
+  uint8_t* lenPtr;
+
+  if (iei > 0) {
+    pduaddress->iei = (*buffer & 0xf0) >> 4;
+    CHECK_IEI_DECODER(iei, (unsigned char) pduaddress->iei);
+    encoded++;
+  }
+
+  lenPtr = (buffer + encoded);
+  encoded++;
+  *(buffer + encoded) = 0x00 | (pduaddress->typeval & 0x07);
+  MLOG(MDEBUG) << "EncodePDUAddressMsg__: typeval = " << hex
+               << int(pduaddress->typeval) << endl;
+  encoded++;
+  memcpy(buffer + encoded, pduaddress->addressinfo, 12);
+  encoded = encoded + 12;
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/PDUSessionIdentity.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/PDUSessionIdentity.cpp
@@ -1,0 +1,50 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include <cstdint>
+#include "PDUSessionIdentity.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+PDUSessionIdentityMsg::PDUSessionIdentityMsg(){};
+PDUSessionIdentityMsg::~PDUSessionIdentityMsg(){};
+
+// Decode PDUSessionIdentity IE
+int PDUSessionIdentityMsg::DecodePDUSessionIdentityMsg(
+    PDUSessionIdentityMsg* pdusessionidentity, uint8_t iei, uint8_t* buffer,
+    uint32_t len) {
+  uint8_t decoded = 0;
+
+  MLOG(MDEBUG) << "   DecodePDUSessionIdentityMsg : ";
+  pdusessionidentity->pdusessionid = *(buffer + decoded);
+  decoded++;
+  MLOG(MDEBUG) << " PDUSessionIdentity = " << hex
+               << int(pdusessionidentity->pdusessionid);
+
+  return (decoded);
+};
+
+// Encode PDUSessionIdentity IE
+int PDUSessionIdentityMsg::EncodePDUSessionIdentityMsg(
+    PDUSessionIdentityMsg* pdusessionidentity, uint8_t iei, uint8_t* buffer,
+    uint32_t len) {
+  int encoded = 0;
+
+  MLOG(MDEBUG) << " EncodePDUSessionIdentityMsg : ";
+  *(buffer + encoded) = pdusessionidentity->pdusessionid;
+  MLOG(MDEBUG) << "PDUSessionIdentity = 0x" << hex << int(*(buffer + encoded));
+  encoded++;
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/PDUSessionType.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/PDUSessionType.cpp
@@ -1,0 +1,65 @@
+/*
+  Copyright 2020 The Magma Authors.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <iostream>
+#include <sstream>
+#include <cstdint>
+#include <cstring>
+#include "PDUSessionType.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+PDUSessionTypeMsg::PDUSessionTypeMsg(){};
+PDUSessionTypeMsg::~PDUSessionTypeMsg(){};
+
+// Decode PDUSessionType IE
+int PDUSessionTypeMsg::DecodePDUSessionTypeMsg(
+    PDUSessionTypeMsg* pdusessiontype, uint8_t iei, uint8_t* buffer,
+    uint32_t len) {
+  int decoded = 0;
+
+  if (iei > 0) {
+    pdusessiontype->iei = (*buffer & 0xf0) >> 4;
+    CHECK_IEI_DECODER((unsigned char) iei, pdusessiontype->iei);
+    MLOG(MDEBUG) << "In DecodePDUSessionTypeMsg: iei" << hex
+                 << int(pdusessiontype->iei) << endl;
+    decoded++;
+  }
+
+  pdusessiontype->typeval = (*buffer & 0x07);
+  MLOG(MDEBUG) << "DecodePDUSessionTypeMsg: typeval = " << hex
+               << int(pdusessiontype->typeval) << endl;
+
+  return (decoded);
+};
+
+// Encode PDUSessionType IE
+int PDUSessionTypeMsg::EncodePDUSessionTypeMsg(
+    PDUSessionTypeMsg* pdusessiontype, uint8_t iei, uint8_t* buffer,
+    uint32_t len) {
+  int encoded = 0;
+
+  if (iei > 0) {
+    *buffer = (pdusessiontype->iei & 0x0f) << 4;
+    CHECK_IEI_ENCODER((unsigned char) iei, pdusessiontype->iei);
+    MLOG(MDEBUG) << "In EncodePDUSessionTypeMsg: iei" << hex << int(*buffer)
+                 << endl;
+  }
+
+  *buffer = 0x00 | (*buffer & 0xf0) | (pdusessiontype->typeval & 0x07);
+  MLOG(MDEBUG) << "EncodePDUSessionTypeMsg: typeval = " << hex << int(*(buffer))
+               << endl;
+  encoded++;
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/PTI.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/PTI.cpp
@@ -1,0 +1,47 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+#include <sstream>
+#include <cstdint>
+#include "PTI.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+PTIMsg::PTIMsg(){};
+PTIMsg::~PTIMsg(){};
+
+// Decode PTI IE
+int PTIMsg::DecodePTIMsg(
+    PTIMsg* pti, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  uint8_t decoded = 0;
+
+  MLOG(MDEBUG) << " DecodePTIMsg : ";
+  pti->pti = *(buffer + decoded);
+  decoded++;
+  MLOG(MDEBUG) << " PTI = 0x" << hex << int(pti->pti);
+
+  return (decoded);
+};
+
+// Encode PTI IE
+int PTIMsg::EncodePTIMsg(
+    PTIMsg* pti, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int encoded = 0;
+
+  MLOG(MDEBUG) << " EncodePTIMsg : ";
+  *(buffer + encoded) = pti->pti;
+  MLOG(MDEBUG) << "PTI = 0x" << hex << int(*(buffer + encoded));
+  encoded++;
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/QOSRules.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/QOSRules.cpp
@@ -1,0 +1,103 @@
+/*
+  Copyright 2020 The Magma Authors.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <sstream>
+#include <cstdint>
+#include <cstring>
+#include "QOSRules.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+NewQOSRulePktFilter::NewQOSRulePktFilter(){};
+NewQOSRulePktFilter::~NewQOSRulePktFilter(){};
+QOSRule::QOSRule(){};
+QOSRulesMsg::QOSRulesMsg(){};
+QOSRule::~QOSRule(){};
+QOSRulesMsg::~QOSRulesMsg(){};
+
+// Decode QOSRules IE
+int QOSRulesMsg::DecodeQOSRulesMsg(
+    QOSRulesMsg* qosrulesmsg, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  // Not yet Implemented, will be suppported POST MVC
+  return (0);
+};
+
+// Encode QOSRules IE
+int QOSRulesMsg::EncodeQOSRulesMsg(
+    QOSRulesMsg* qosrulesmsg, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  uint16_t encoded = 0;
+  uint8_t i        = 0;
+  uint8_t j        = 0;
+
+  // Checking IEI and pointer
+  CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, QOSRULE_MIN_LEN, len);
+
+  if (iei > 0) {
+    CHECK_IEI_ENCODER((unsigned char) iei, qosrulesmsg->iei);
+    *buffer = iei;
+    MLOG(MDEBUG) << "In EncodeQOSRulesMsg: iei" << hex << int(*buffer) << endl;
+    encoded++;
+  }
+
+  IES_ENCODE_U16(buffer, encoded, qosrulesmsg->length);
+  MLOG(MDEBUG) << "Length : " << hex << int(qosrulesmsg->length) << endl;
+  while (encoded < (qosrulesmsg->length) && i <= 255) {
+    *(buffer + encoded) = qosrulesmsg->qosrule[i].qosruleid;
+    MLOG(MDEBUG) << "qosruleid: " << hex << int(*(buffer + encoded)) << endl;
+    encoded++;
+    IES_ENCODE_U16(buffer, encoded, qosrulesmsg->qosrule[i].len);
+    *(buffer + encoded) = 0x00 |
+                          ((qosrulesmsg->qosrule[i].ruleopercode & 0x07) << 5) |
+                          ((qosrulesmsg->qosrule[i].dqrbit & 0x01) << 4) |
+                          (qosrulesmsg->qosrule[i].noofpktfilters & 0x0f);
+    MLOG(MDEBUG) << "ruleopercode, dqrbit, noofpktfilters: " << hex
+                 << int(*(buffer + encoded)) << endl;
+    encoded++;
+    for (j = 0; j < qosrulesmsg->qosrule[i].noofpktfilters; j++) {
+      *(buffer + encoded) =
+          0x00 |
+          ((qosrulesmsg->qosrule[i].newqosrulepktfilter[j].spare & 0x03) << 6) |
+          ((qosrulesmsg->qosrule[i].newqosrulepktfilter[j].pktfilterdir & 0x03)
+           << 4) |
+          (qosrulesmsg->qosrule[i].newqosrulepktfilter[j].pktfilterid & 0x0f);
+      MLOG(MDEBUG) << "pktfilterdir, pktfilterid: " << hex
+                   << int(*(buffer + encoded)) << endl;
+      encoded++;
+      *(buffer + encoded) = qosrulesmsg->qosrule[i].newqosrulepktfilter[j].len;
+      MLOG(MDEBUG) << "len: " << hex << int(*(buffer + encoded)) << endl;
+      encoded++;
+      memcpy(
+          buffer + encoded,
+          qosrulesmsg->qosrule[i].newqosrulepktfilter[j].contents,
+          qosrulesmsg->qosrule[i].newqosrulepktfilter[j].len);
+      BUFFER_PRINT_LOG(
+          buffer + encoded, qosrulesmsg->qosrule[i].newqosrulepktfilter[j].len);
+      encoded = encoded + qosrulesmsg->qosrule[i].newqosrulepktfilter[j].len;
+      encoded++;
+    }
+
+    *(buffer + encoded) = qosrulesmsg->qosrule[i].qosruleprecedence;
+    MLOG(MDEBUG) << "qosruleprecedence: " << hex << int(*(buffer + encoded))
+                 << endl;
+    encoded++;
+    *(buffer + encoded) = 0x00 | ((qosrulesmsg->qosrule[i].spare & 0x01) << 7) |
+                          ((qosrulesmsg->qosrule[i].segregation & 0x01) << 6) |
+                          (qosrulesmsg->qosrule[i].qfi & 0x3f);
+    MLOG(MDEBUG) << "segregation, qfi: " << hex << int(*(buffer + encoded))
+                 << endl;
+    encoded++;
+    i++;
+  }
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/SSCMode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/SSCMode.cpp
@@ -1,0 +1,62 @@
+/*
+  Copyright 2020 The Magma Authors.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <iostream>
+#include <sstream>
+#include <cstdint>
+#include <cstring>
+#include "SSCMode.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+SSCModeMsg::SSCModeMsg(){};
+SSCModeMsg::~SSCModeMsg(){};
+
+// Decode SSCMode IE
+int SSCModeMsg::DecodeSSCModeMsg(
+    SSCModeMsg* sscmode, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int decoded = 0;
+
+  if (iei > 0) {
+    sscmode->iei = (*buffer & 0xf0) >> 4;
+    CHECK_IEI_ENCODER((unsigned char) iei, sscmode->iei);
+    MLOG(MDEBUG) << "In DecodeSSCModeMsg: iei = " << hex << int(sscmode->iei)
+                 << endl;
+    decoded++;
+  }
+
+  sscmode->modeval = (*buffer & 0x07);
+  MLOG(MDEBUG) << "DecodeSSCModeMsg__: modeval = " << hex
+               << int(sscmode->modeval) << endl;
+
+  return (decoded);
+};
+
+// Encode SSCMode IE
+int SSCModeMsg::EncodeSSCModeMsg(
+    SSCModeMsg* sscmode, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int encoded = 0;
+
+  if (iei > 0) {
+    CHECK_IEI_ENCODER((unsigned char) iei, sscmode->iei);
+    *buffer = 0x00 | (sscmode->iei & 0x0f) << 4;
+    MLOG(MDEBUG) << "In EncodeSSCModeMsg: iei" << hex << int(*buffer) << endl;
+    encoded++;
+  }
+
+  *buffer = (sscmode->modeval << 4) & 0xf0;
+  MLOG(MDEBUG) << "EncodeSSCModeMsg__: modeval = " << hex << int(*buffer)
+               << endl;
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/src/ies/SessionAMBR.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/src/ies/SessionAMBR.cpp
@@ -1,0 +1,60 @@
+/*
+  Copyright 2020 The Magma Authors.
+  This source code is licensed under the BSD-style license found in the
+  LICENSE file in the root directory of this source tree.
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+
+#include <sstream>
+#include <cstdint>
+#include "SessionAMBR.h"
+#include "CommonDefs.h"
+
+using namespace std;
+namespace magma5g {
+SessionAMBRMsg::SessionAMBRMsg(){};
+SessionAMBRMsg::~SessionAMBRMsg(){};
+
+// Decode SessionAMBR IE
+int SessionAMBRMsg::DecodeSessionAMBRMsg(
+    SessionAMBRMsg* sessionambr, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  int decoded = 0;
+  // Not yet Implemented, will be supported POST MVC
+  return (decoded);
+};
+
+// Encode SessionAMBR IE
+int SessionAMBRMsg::EncodeSessionAMBRMsg(
+    SessionAMBRMsg* sessionambr, uint8_t iei, uint8_t* buffer, uint32_t len) {
+  uint16_t* lenPtr;
+  uint32_t encoded = 0;
+
+  // Checking IEI and pointer
+  CHECK_PDU_POINTER_AND_LENGTH_ENCODER(buffer, AMBR_MIN_LEN, len);
+
+  if (iei > 0) {
+    CHECK_IEI_ENCODER((unsigned char) iei, sessionambr->iei);
+    *buffer = iei;
+    MLOG(MDEBUG) << "In EncodeSessionAMBRMsg: iei" << hex << int(*buffer)
+                 << endl;
+    encoded++;
+  }
+
+  lenPtr              = (uint16_t*) (buffer + encoded);
+  *(buffer + encoded) = sessionambr->length;
+  encoded++;
+  *(buffer + encoded) = sessionambr->dlunit;
+  encoded++;
+  IES_ENCODE_U16(buffer, encoded, sessionambr->dlsessionambr);
+  *(buffer + encoded) = sessionambr->ulunit;
+  encoded++;
+  IES_ENCODE_U16(buffer, encoded, sessionambr->ulsessionambr);
+  *lenPtr = encoded - 1 - ((iei > 0) ? 1 : 0);
+
+  return (encoded);
+};
+}  // namespace magma5g

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionEstAcptEncode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionEstAcptEncode.cpp
@@ -1,0 +1,89 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Encoding functionality of
+ * PDU Session Est Accept Message */
+
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+#include "PDUSessionEstablishmentAccept.h"
+#include "CommonDefs.h"
+
+using namespace std;
+using namespace magma5g;
+namespace magma5g {
+int encode(void) {
+  int ret = 0;
+  uint8_t buffer[31];
+  int len = 31;
+  PDUSessionEstablishmentAcceptMsg msg;
+
+  // Message to be Encoded
+  msg.extendedprotocoldiscriminator.extendedprotodiscriminator = 46;
+  msg.pdusessionidentity.pdusessionid                          = 1;
+  msg.pti.pti                                                  = 1;
+  msg.messagetype.msgtype                                      = 0xC2;
+  msg.pdusessiontype.typeval                                   = 1;
+  msg.sscmode.modeval                                          = 1;
+  msg.qosrules.length                                          = 18;
+  msg.qosrules.qosrule[0].qosruleid                            = 1;
+  msg.qosrules.qosrule[0].len                                  = 3;
+  msg.qosrules.qosrule[0].ruleopercode                         = 1;
+  msg.qosrules.qosrule[0].dqrbit                               = 1;
+  msg.qosrules.qosrule[0].noofpktfilters                       = 0;
+  msg.qosrules.qosrule[0].qosruleprecedence                    = 0;
+  msg.qosrules.qosrule[0].spare                                = 0;
+  msg.qosrules.qosrule[0].segregation                          = 0;
+  msg.qosrules.qosrule[0].qfi                                  = 1;
+  msg.qosrules.qosrule[1].qosruleid                            = 1;
+  msg.qosrules.qosrule[1].len                                  = 3;
+  msg.qosrules.qosrule[1].ruleopercode                         = 1;
+  msg.qosrules.qosrule[1].dqrbit                               = 0;
+  msg.qosrules.qosrule[1].noofpktfilters                       = 0;
+  msg.qosrules.qosrule[1].qosruleprecedence                    = 0;
+  msg.qosrules.qosrule[1].spare                                = 0;
+  msg.qosrules.qosrule[1].segregation                          = 0;
+  msg.qosrules.qosrule[1].qfi                                  = 1;
+  msg.qosrules.qosrule[2].qosruleid                            = 2;
+  msg.qosrules.qosrule[2].len                                  = 3;
+  msg.qosrules.qosrule[2].ruleopercode                         = 1;
+  msg.qosrules.qosrule[2].dqrbit                               = 0;
+  msg.qosrules.qosrule[2].noofpktfilters                       = 0;
+  msg.qosrules.qosrule[2].qosruleprecedence                    = 0;
+  msg.qosrules.qosrule[2].spare                                = 0;
+  msg.qosrules.qosrule[2].segregation                          = 0;
+  msg.qosrules.qosrule[2].qfi                                  = 2;
+  msg.sessionambr.length                                       = 6;
+  msg.sessionambr.dlunit                                       = 0;
+  msg.sessionambr.dlsessionambr                                = 0;
+  msg.sessionambr.ulunit                                       = 0;
+  msg.sessionambr.ulsessionambr                                = 0;
+
+  MLOG(MDEBUG) << "\n\n---Encoding Message---\n\n";
+  ret = msg.EncodePDUSessionEstablishmentAcceptMsg(&msg, buffer, len);
+
+  MLOG(MDEBUG) << "---Encoded Message---";
+  for (size_t i = 0; i < sizeof(buffer); i++) {
+    MLOG(MDEBUG) << setfill('0') << hex << setw(2) << int(buffer[i]);
+  }
+
+  return 0;
+}
+}  // namespace magma5g
+
+// Main Function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::encode();
+
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionEstRejEncode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionEstRejEncode.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Encoding functionality of
+ * PDU Session Est Reject Message */
+
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+#include "PDUSessionEstablishmentReject.h"
+#include "CommonDefs.h"
+
+using namespace std;
+using namespace magma5g;
+namespace magma5g {
+int encode(void) {
+  int ret = 0;
+  uint8_t buffer[5];
+  int len = 5;
+  PDUSessionEstablishmentRejectMsg msg;
+
+  // Message to be Encoded
+  msg.extendedprotocoldiscriminator.extendedprotodiscriminator = 46;
+  msg.pdusessionidentity.pdusessionid                          = 1;
+  msg.pti.pti                                                  = 1;
+  msg.messagetype.msgtype                                      = 0xC3;
+  msg.m5gsmcause.causevalue                                    = 7;
+
+  MLOG(MDEBUG) << "\n\n---Encoding Message---\n\n";
+  ret = msg.EncodePDUSessionEstablishmentRejectMsg(&msg, buffer, len);
+
+  MLOG(MDEBUG) << "---Encoded Message---";
+  for (size_t i = 0; i <= sizeof(buffer); i++) {
+    MLOG(MDEBUG) << setfill('0') << hex << setw(2) << int(buffer[i]);
+  }
+
+  return 0;
+}
+}  // namespace magma5g
+
+// Main Function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::encode();
+
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionEstReqDecode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionEstReqDecode.cpp
@@ -1,0 +1,45 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Decoding functionality of
+ * PDU Session Est Request Message */
+
+#include <iostream>
+#include <PDUSessionEstablishmentRequest.h>
+
+using namespace std;
+using namespace magma5g;
+
+namespace magma5g {
+// Testing Decoding functionality
+int decode(void) {
+  int ret = 0;
+
+  // Message to be decoded
+  uint8_t buffer[] = {0x2e, 0x01, 0x01, 0xC1, 0xFF, 0xFF, 0x91, 0xA1,
+                      0x12, 0x01, 0x81, 0x22, 0x04, 0x09, 0x00, 0x00,
+                      0x05, 0X25, 0X0C, 0x07, 0x63, 0x61, 0x72, 0x72,
+                      0x69, 0x65, 0x72, 0x03, 0x63, 0x6F, 0x6D};
+  int len          = 31;
+  PDUSessionEstablishmentRequestMsg Req;
+
+  // Decoding Message
+  ret = Req.DecodePDUSessionEstablishmentRequestMsg(&Req, buffer, len);
+  return 0;
+}
+}  // namespace magma5g
+
+// Main function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::decode();
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionModRejectEncode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionModRejectEncode.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Encoding functionality of
+ * PDU Session Modification Reject Message */
+
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+#include "PDUSessionModificationReject.h"
+#include "CommonDefs.h"
+
+using namespace std;
+using namespace magma5g;
+namespace magma5g {
+int encode(void) {
+  int ret = 0;
+  uint8_t buffer[5];
+  int len = 5;
+  PDUSessionModificationRejectMsg msg;
+
+  // Message to be Encoded
+  msg.extendedprotocoldiscriminator.extendedprotodiscriminator = 46;
+  msg.pdusessionidentity.pdusessionid                          = 1;
+  msg.pti.pti                                                  = 1;
+  msg.messagetype.msgtype                                      = 0xCA;
+  msg.m5gsmcause.causevalue                                    = 7;
+
+  MLOG(MDEBUG) << "\n\n---Encoding Message---\n\n";
+  ret = msg.EncodePDUSessionModificationRejectMsg(&msg, buffer, len);
+
+  MLOG(MDEBUG) << "---Encoded Message---";
+  for (size_t i = 0; i < sizeof(buffer); i++) {
+    MLOG(MDEBUG) << setfill('0') << hex << setw(2) << int(buffer[i]);
+  }
+
+  return 0;
+}
+}  // namespace magma5g
+
+// Main Function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::encode();
+
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionModReqDecode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionModReqDecode.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Decoding functionality of
+ * PDU Session Modification Request Message */
+
+#include <iostream>
+#include <PDUSessionModificationRequest.h>
+
+using namespace std;
+using namespace magma5g;
+
+namespace magma5g {
+// Testing Decoding functionality
+int decode(void) {
+  int ret = 0;
+
+  // Message to be decoded
+  uint8_t buffer[] = {0x2e, 0x01, 0x02, 0xC9};
+  int len          = 4;
+  PDUSessionModificationRequestMsg Req;
+
+  // Decoding Message
+  ret = Req.DecodePDUSessionModificationRequestMsg(&Req, buffer, len);
+  return 0;
+}
+}  // namespace magma5g
+
+// Main function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::decode();
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionReleaseRejEncode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionReleaseRejEncode.cpp
@@ -1,0 +1,55 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Encoding functionality of
+ * PDU Session Release Reject Message */
+
+#include <iostream>
+#include <iomanip>
+#include <cstring>
+#include "PDUSessionReleaseReject.h"
+#include "CommonDefs.h"
+
+using namespace std;
+using namespace magma5g;
+namespace magma5g {
+int encode(void) {
+  int ret = 0;
+  uint8_t buffer[5];
+  int len = 5;
+  PDUSessionReleaseRejectMsg msg;
+
+  // Message to be Encoded
+  msg.extendedprotocoldiscriminator.extendedprotodiscriminator = 46;
+  msg.pdusessionidentity.pdusessionid                          = 1;
+  msg.pti.pti                                                  = 1;
+  msg.messagetype.msgtype                                      = 0xD2;
+  msg.m5gsmcause.causevalue                                    = 7;
+
+  MLOG(MDEBUG) << "\n\n---Encoding Message---\n\n";
+  ret = msg.EncodePDUSessionReleaseRejectMsg(&msg, buffer, len);
+
+  MLOG(MDEBUG) << "---Encoded Message---";
+  for (size_t i = 0; i < sizeof(buffer); i++) {
+    MLOG(MDEBUG) << setfill('0') << hex << setw(2) << int(buffer[i]);
+  }
+
+  return 0;
+}
+}  // namespace magma5g
+
+// Main Function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::encode();
+
+  return 0;
+}

--- a/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionReleaseReqDecode.cpp
+++ b/lte/gateway/c/oai/tasks/nas5g/test/PDUSessionReleaseReqDecode.cpp
@@ -1,0 +1,42 @@
+/*
+   Copyright 2020 The Magma Authors.
+   This source code is licensed under the BSD-style license found in the
+   LICENSE file in the root directory of this source tree.
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+
+/* using this stub code we are going to test Decoding functionality of
+ * PDU Session Release Request Message */
+
+#include <iostream>
+#include <PDUSessionReleaseRequest.h>
+
+using namespace std;
+using namespace magma5g;
+
+namespace magma5g {
+// Testing Decoding functionality
+int decode(void) {
+  int ret = 0;
+
+  // Message to be decoded
+  uint8_t buffer[] = {0x2e, 0x01, 0x02, 0xD1};
+  int len          = 4;
+  PDUSessionReleaseRequestMsg Req;
+
+  // Decoding Message
+  ret = Req.DecodePDUSessionReleaseRequestMsg(&Req, buffer, len);
+  return 0;
+}
+}  // namespace magma5g
+
+// Main function to call test decode function
+int main(void) {
+  int ret;
+  ret = magma5g::decode();
+  return 0;
+}


### PR DESCRIPTION
… and Reject, PDU Sesssion Modification Request and Reject, PDU Session Release Request and Reject.

Signed-off-by: chandra-77 <dangudubiyyam.c@altencalsoftlabs.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Code Added for PDU Session Establishment Request, Accept and Reject, PDU Session Modification Request and Reject, PDU Session Release Request and Reject.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
UT completed using the stub code provided in test directory. Attached the log files of UT.
[PDUSessionEstReqDecode.log](https://github.com/magma/magma/files/5371883/PDUSessionEstReqDecode.log)
[PDUSessionEstAcptEncode.log](https://github.com/magma/magma/files/5371886/PDUSessionEstAcptEncode.log)
[PDUSessionEstRejEncode.log](https://github.com/magma/magma/files/5371888/PDUSessionEstRejEncode.log)
[PDUSessionModReqDecode.log](https://github.com/magma/magma/files/5371889/PDUSessionModReqDecode.log)
[PDUSessionModRejectEncode.log](https://github.com/magma/magma/files/5371890/PDUSessionModRejectEncode.log)
[PDUSessionReleaseReqDecode.log](https://github.com/magma/magma/files/5371891/PDUSessionReleaseReqDecode.log)
[PDUSessionReleaseRejEncode.log](https://github.com/magma/magma/files/5371892/PDUSessionReleaseRejEncode.log)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
