### PR TITLE
[lte][orc8r][agw] SMS bug fix for sms report decoding

### DIFF
--- a/lte/cloud/go/sms_ll/sms_cp.go
+++ b/lte/cloud/go/sms_ll/sms_cp.go
@@ -33,7 +33,7 @@ type cpMessage struct {
 	// Only present for CP-ERROR
 	cause byte
 
-	// Only present for CP-DATA
+	// Can be present for CP-DATA, CP-ACK and CP-ERROR
 	length byte
 
 	// Only present for CP-DATA
@@ -84,29 +84,41 @@ func (cpm cpMessage) marshalBinary() []byte {
 }
 
 func (cpm *cpMessage) unmarshalBinary(input []byte) error {
-	// must be at least two octets long
-	if len(input) < 2 {
+	msgLen := len(input)
+	// Message length must be at least two octets long
+	if msgLen < 2 {
 		return smsCpError("Message too short")
 	}
 
 	cpm.firstOctet = input[0]
 	cpm.messageType = input[1]
 
-	switch cpm.messageType {
-	case CpData:
-		cpm.length = input[2]
-		cpm.rpdu = make([]byte, len(input[3:]))
-		copy(cpm.rpdu, input[3:])
-	case CpError:
-		if _, ok := CpCauseStr[input[2]]; ok {
-			cpm.cause = input[2]
+	if cpm.messageType != CpData && cpm.messageType != CpError && cpm.messageType != CpAck {
+		return smsCpError(fmt.Sprintf("Invalid Message type: %x", cpm.messageType))
+	}
+	// Decode IEs
+	decoded := 2
+
+	for decoded < msgLen {
+		if input[decoded] == CpIeiUserData {
+			decoded++
+			cpm.length = input[decoded]
+			decoded++
+			end := decoded + int(cpm.length)
+			cpm.rpdu = make([]byte, cpm.length)
+			copy(cpm.rpdu, input[decoded:end])
+			decoded = end
+		} else if input[decoded] == CpIeiCause {
+			decoded++
+			if _, ok := CpCauseStr[input[decoded]]; ok {
+				cpm.cause = input[decoded]
+				decoded++
+			} else {
+				return smsCpError(fmt.Sprintf("Invalid cause: %x", cpm.cause))
+			}
 		} else {
-			return smsCpError(fmt.Sprintf("Invalid cause: %x", cpm.cause))
+			return smsCpError(fmt.Sprintf("Invalid IE type: %x", input[decoded]))
 		}
-	case CpAck:
-		// Do nothing -- no more data
-	default:
-		return smsCpError(fmt.Sprintf("Invalid IE type: %x", cpm.messageType))
 	}
 
 	return nil
@@ -133,8 +145,8 @@ const (
 	CpError = 0x10
 
 	// IE Types
-	CpIeiUser  = 0x1
-	CpIeiCause = 0x2
+	CpIeiUserData = 0x1
+	CpIeiCause    = 0x2
 )
 
 const (
@@ -155,7 +167,7 @@ var CpCauseStr = map[byte]string{
 	CpCauseCongestion:                   "Congestion",
 	CpCauseInvalidTi:                    "Invalid Transaction Identifier value",
 	CpCauseSemanticallyIncorrect:        "Semantically incorrect message",
-	CpCauseInvalidMandantoryInformation: "Invalid mandantory information",
+	CpCauseInvalidMandantoryInformation: "Invalid mandatory information",
 	CpCauseMessageTypeNonexistant:       "Message type non-existent or not implemented",
 	CpCauseMessageNotCompatible:         "Message not compatible with the short message protocol state",
 	CpCauseInfoElementNonexistant:       "Information element non-existent or not implemented",

--- a/lte/cloud/go/sms_ll/sms_ll.go
+++ b/lte/cloud/go/sms_ll/sms_ll.go
@@ -127,11 +127,6 @@ func Decode(input []byte) (SMSDeliveryReport, error) {
 		return ret, err
 	}
 
-	// Valid CPM, check type
-	if cpm.messageType != CpData {
-		return ret, fmt.Errorf("not a CP-DATA message: %x", cpm.messageType)
-	}
-
 	rpm := new(rpMessage)
 	err = rpm.unmarshalBinary(cpm.rpdu)
 	if err != nil {

--- a/lte/cloud/go/sms_ll/sms_rp.go
+++ b/lte/cloud/go/sms_ll/sms_rp.go
@@ -169,13 +169,13 @@ type rpMessage struct {
 	mti       byte
 	reference byte
 
-	// Mandantory. If UE->Network, must be length 0
+	// Mandatory. If UE->Network, must be length 0
 	originatorAddress rpAddressElement
 
-	// Mandantory. If Network->UE, must be length 0
+	// Mandatory. If Network->UE, must be length 0
 	destinationAddress rpAddressElement
 
-	// Mandantory for RP-DATA, includes tpdu. If RP-ACK or RP-ERROR, must
+	// Mandatory for RP-DATA, includes tpdu. If RP-ACK or RP-ERROR, must
 	// include IEI.
 	userData rpUserElement
 
@@ -351,7 +351,7 @@ var RpCauseStr = map[byte]string{
 	RpCauseRequestedFacNotImpl:    "Requested facility not implemented",
 	RpCauseInvalidSmTransRef:      "Invalid short message transfer reference value",
 	RpCauseSemIncorrectMessage:    "Semantically incorrect message",
-	RpCauseInvalidMandantoryInfo:  "Invalid mandantory information",
+	RpCauseInvalidMandantoryInfo:  "Invalid mandatory information",
 	RpCauseMsgTypeNotImpl:         "Message type not non-existent or not implemented",
 	RpCauseMsgTypeNotCompatible:   "Message not compatible with short message protocol state",
 	RpCauseInfoElementNonexistant: "Information element non-existent or not implemented",

--- a/lte/gateway/python/magma/smsd/relay.py
+++ b/lte/gateway/python/magma/smsd/relay.py
@@ -102,6 +102,6 @@ class SmsRelay(Job):
                 ),
             )
         except grpc.RpcError as err:
-            context.set_details('SMS delivery report to smsd failed: %s', err)
+            context.set_details('SMS delivery report to smsd failed: %s' % err)
             context.set_code(grpc.StatusCode.INTERNAL)
             return


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

Fixed two bugs for SMS handling:
- GRPC exception handling was passing too many parameters.
- Delivery report handling at Orc8r was missing IEI field as the octet preceding each IE.

## Test Plan
Modified and run SMS unit tests.

