### PR TITLE
[orc8r][lte] Fix bug updating gw with both enb and apn_resource

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -3361,6 +3361,228 @@ func TestAPNResource_Regression_3088(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 }
 
+// Regression test for issue #3149
+func TestAPNResource_Regression_3149(t *testing.T) {
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{}))
+	assert.NoError(t, plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{}))
+
+	configuratorTestInit.StartTestService(t)
+	stateTestInit.StartTestService(t)
+	deviceTestInit.StartTestService(t)
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"})
+	assert.NoError(t, err)
+	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"})
+	assert.NoError(t, err)
+
+	e := echo.New()
+	urlBase := "/magma/v1/lte/:network_id/gateways"
+	urlManage := urlBase + "/:gateway_id"
+	lteHandlers := handlers.GetHandlers()
+	getAllGateways := tests.GetHandlerByPathAndMethod(t, lteHandlers, urlBase, obsidian.GET).HandlerFunc
+	postGateway := tests.GetHandlerByPathAndMethod(t, lteHandlers, urlBase, obsidian.POST).HandlerFunc
+	putGateway := tests.GetHandlerByPathAndMethod(t, lteHandlers, urlManage, obsidian.PUT).HandlerFunc
+	getGateway := tests.GetHandlerByPathAndMethod(t, lteHandlers, urlManage, obsidian.GET).HandlerFunc
+	deleteGateway := tests.GetHandlerByPathAndMethod(t, lteHandlers, urlManage, obsidian.DELETE).HandlerFunc
+
+	postAPN := tests.GetHandlerByPathAndMethod(t, lteHandlers, "/magma/v1/lte/:network_id/apns", obsidian.POST).HandlerFunc
+
+	// Create enb0
+	_, err = configurator.CreateEntities("n0", []configurator.NetworkEntity{{Type: lte.CellularEnodebEntityType, Key: "enb0"}})
+	assert.NoError(t, err)
+
+	gw0 := newMutableGateway("gw0")
+
+	// Get all, initially empty
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways",
+		Handler:        getAllGateways,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]lteModels.MutableLteGateway{}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Post 2 APNs
+	apnInternet := newAPN("internet")
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/:network_id/apns",
+		Payload:        apnInternet,
+		Handler:        postAPN,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+	apnManagement := newAPN("management")
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/:network_id/apns",
+		Payload:        apnManagement,
+		Handler:        postAPN,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Post gw0 with 2 apn_resources, successful
+	gw0.ApnResources = lteModels.ApnResources{
+		"internet": {
+			ApnName:    "internet",
+			GatewayIP:  "192.168.10.1",
+			GatewayMac: "e0:63:da:22:47:21",
+			ID:         "internet_apn_resource",
+			VlanID:     13,
+		},
+		"management": {
+			ApnName:    "management",
+			GatewayIP:  "192.168.9.1",
+			GatewayMac: "e0:63:da:22:47:21",
+			ID:         "management_apn_resource",
+			VlanID:     12,
+		},
+	}
+	gw0.ConnectedEnodebSerials = []string{"enb0"}
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/n0/gateways",
+		Payload:        gw0,
+		Handler:        postGateway,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get all, posted gateway found
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways",
+		Handler:        getAllGateways,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*lteModels.MutableLteGateway{"gw0": gw0}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get posted gateway, found
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways/gw0",
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n0", "gw0"},
+		Handler:        getGateway,
+		ExpectedStatus: 200,
+		ExpectedResult: gw0,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Delete
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/lte/n0/gateways/gw0",
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n0", "gw0"},
+		Handler:        deleteGateway,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get, not found
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways/gw0",
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n0", "gw0"},
+		Handler:        getGateway,
+		ExpectedStatus: 404,
+		ExpectedError:  "Not Found",
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Post gw0 with 0 apn_resources, successful
+	gw0.ApnResources = lteModels.ApnResources{}
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/lte/n0/gateways",
+		Payload:        gw0,
+		Handler:        postGateway,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get posted gateway, found
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways/gw0",
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n0", "gw0"},
+		Handler:        getGateway,
+		ExpectedStatus: 200,
+		ExpectedResult: gw0,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Put, add 2 apn_resources to gw0
+	gw0.ApnResources = lteModels.ApnResources{
+		"internet": {
+			ApnName:    "internet",
+			GatewayIP:  "192.168.10.1",
+			GatewayMac: "e0:63:da:22:47:21",
+			ID:         "internet_apn_resource",
+			VlanID:     13,
+		},
+		"management": {
+			ApnName:    "management",
+			GatewayIP:  "192.168.9.1",
+			GatewayMac: "e0:63:da:22:47:21",
+			ID:         "management_apn_resource",
+			VlanID:     12,
+		},
+	}
+	gw0.ConnectedEnodebSerials = []string{"enb0"}
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/lte/n0/gateways/gw0",
+		Payload:        gw0,
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n0", "gw0"},
+		Handler:        putGateway,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get, changes are reflected
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways/gw0",
+		ParamNames:     []string{"network_id", "gateway_id"},
+		ParamValues:    []string{"n0", "gw0"},
+		Handler:        getGateway,
+		ExpectedStatus: 200,
+		ExpectedResult: gw0,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Get all, changes are reflected
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/lte/n0/gateways",
+		Handler:        getAllGateways,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n0"},
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*lteModels.MutableLteGateway{"gw0": gw0}),
+	}
+	tests.RunUnitTest(t, e, tc)
+}
+
 func reportEnodebState(t *testing.T, ctx context.Context, enodebSerial string, req *lteModels.EnodebState) {
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
@@ -3477,8 +3699,4 @@ func newMutableGateway(id string) *lteModels.MutableLteGateway {
 		ApnResources:           lteModels.ApnResources{},
 	}
 	return gw
-}
-
-func getTKs(ent configurator.NetworkEntity) []storage.TypeAndKey {
-	return []storage.TypeAndKey{ent.GetTypeAndKey()}
 }

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -252,7 +252,7 @@ func (m *MutableLteGateway) GetAdditionalWritesOnUpdate(
 		Type:              lte.CellularGatewayEntityType,
 		Key:               string(m.ID),
 		NewConfig:         m.Cellular,
-		AssociationsToAdd: newAPNResourceTKs,
+		AssociationsToSet: newAPNResourceTKs,
 	}
 	if string(m.Name) != existingGateway.Name {
 		gatewayUpdate.NewName = swag.String(string(m.Name))

--- a/orc8r/cloud/go/services/configurator/types.go
+++ b/orc8r/cloud/go/services/configurator/types.go
@@ -447,6 +447,11 @@ func (euc EntityUpdateCriteria) toStorageProto() (*storage.EntityUpdateCriteria,
 	}
 
 	if euc.AssociationsToSet != nil {
+		// AssociationsToSet overrides AssociationsToAdd, so this check
+		// prevents accidentally mixing the two fields
+		if len(euc.AssociationsToAdd) != 0 {
+			return nil, errors.New("cannot both add and set associations in the same EntityUpdateCriteria")
+		}
 		ret.AssociationsToSet = &storage.EntityAssociationsToSet{
 			AssociationsToSet: tksToEntIDs(euc.AssociationsToSet),
 		}


### PR DESCRIPTION
## Summary

This PR resolves #3149.

The apn_resources gw update used `AssociationsToAdd` when it should have used `AssociationsToSet`. enodebserials used `AssociationsToSet`, so when updating both apn_resources and enodebserials, the enodebserials "overwrote" the apn_resources.

This PR resolves the issue by having both update paths use `AssociationsToSet`.

## Test Plan

- [x] make test with added regression

## Additional Information

- [ ] This change is backwards-breaking