### PR TITLE
[CI] [lte-integ-tests] Remove flaky stateless AGW tests from sanity test suite

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -119,15 +119,15 @@ s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
-s1aptests/test_attach_detach_with_mobilityd_restart.py \
+s1aptests/test_attach_detach_attach_ul_tcp_data.py \
+s1aptests/test_restore_mme_config_after_sanity.py
+#s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_restore_mme_config_after_sanity.py
 
 # These test cases pass without memory leaks, but needs DL-route in TRF server
 # sudo /sbin/route add -net 192.168.128.0 gw 192.168.60.142


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Recent CI runs have been failing non-deterministically on the `test_attach_detach_with_mobilityd_restart.py` test case. This change comments out all stateless tests while we fix this error.

## Test Plan

S1ap integration tests
