### PR TITLE
[feg][lte][milenage][s6a][hss] Add UTRAN Vectors support to HSS Lite

### DIFF
--- a/feg/gateway/services/testcore/hss/servicers/ai.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai.go
@@ -17,16 +17,16 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/fiorix/go-diameter/v4/diam"
+	"github.com/fiorix/go-diameter/v4/diam/avp"
+	"github.com/fiorix/go-diameter/v4/diam/datatype"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/feg/gateway/diameter"
 	s6a "magma/feg/gateway/services/s6a_proxy/servicers"
 	"magma/feg/gateway/services/testcore/hss/storage"
 	"magma/lte/cloud/go/crypto"
 	lteprotos "magma/lte/cloud/go/protos"
-
-	"github.com/fiorix/go-diameter/v4/diam"
-	"github.com/fiorix/go-diameter/v4/diam/avp"
-	"github.com/fiorix/go-diameter/v4/diam/datatype"
 )
 
 // NewAIA outputs a authentication information answer (AIA) to reply to an
@@ -63,7 +63,9 @@ func NewAIA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 	const plmnOffsetBytes = 1
 	plmn := air.VisitedPLMNID.Serialize()[plmnOffsetBytes:]
 
-	vectors, lteAuthNextSeq, err := GenerateLteAuthVectors(uint32(air.RequestedEUTRANAuthInfo.NumVectors),
+	vectors, utranVectors, lteAuthNextSeq, err := GenerateLteAuthVectors(
+		uint32(air.RequestedEUTRANAuthInfo.NumVectors),
+		uint32(air.RequestedUtranGeranAuthInfo.NumVectors),
 		srv.Milenage, subscriber, plmn, srv.Config.LteAuthOp, srv.AuthSqnInd)
 	if err == nil {
 		err = srv.setLteAuthNextSeq(subscriber, lteAuthNextSeq)
@@ -72,7 +74,7 @@ func NewAIA(srv *HomeSubscriberServer, msg *diam.Message) (*diam.Message, error)
 		return ConvertAuthErrorToFailureMessage(err, msg, air.SessionID, srv.Config.Server), err
 	}
 
-	return srv.NewSuccessfulAIA(msg, air.SessionID, vectors), nil
+	return srv.NewSuccessfulAIA(msg, air.SessionID, vectors, utranVectors), nil
 }
 
 func (srv *HomeSubscriberServer) setLteAuthNextSeq(subscriber *lteprotos.SubscriberData, lteAuthNextSeq uint64) error {
@@ -87,7 +89,10 @@ func (srv *HomeSubscriberServer) setLteAuthNextSeq(subscriber *lteprotos.Subscri
 // authentication information request (AIR) message. It populates AIA with all of the mandatory fields
 // and adds the authentication vectors.
 func (srv *HomeSubscriberServer) NewSuccessfulAIA(
-	msg *diam.Message, sessionID datatype.UTF8String, vectors []*crypto.EutranVector) *diam.Message {
+	msg *diam.Message,
+	sessionID datatype.UTF8String,
+	vectors []*crypto.EutranVector,
+	utranVectors []*crypto.UtranVector) *diam.Message {
 
 	answer := ConstructSuccessAnswer(msg, sessionID, srv.Config.Server, diam.TGPP_S6A_APP_ID)
 	evs := []*diam.AVP{}
@@ -99,6 +104,26 @@ func (srv *HomeSubscriberServer) NewSuccessfulAIA(
 				diam.NewAVP(avp.XRES, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Xres[:])),
 				diam.NewAVP(avp.AUTN, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Autn[:])),
 				diam.NewAVP(avp.KASME, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Kasme[:])),
+			},
+		}))
+	}
+	for itemNumber, vector := range utranVectors {
+		evs = append(evs, diam.NewAVP(avp.UTRANVector, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, &diam.GroupedAVP{
+			AVP: []*diam.AVP{
+				diam.NewAVP(avp.ItemNumber, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(itemNumber)),
+				diam.NewAVP(avp.RAND, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Rand[:])),
+				diam.NewAVP(avp.XRES, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Xres[:])),
+				diam.NewAVP(avp.AUTN, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.OctetString(vector.Autn[:])),
+				diam.NewAVP(
+					avp.ConfidentialityKey,
+					avp.Mbit|avp.Vbit,
+					diameter.Vendor3GPP,
+					datatype.OctetString(vector.ConfidentialityKey[:])),
+				diam.NewAVP(
+					avp.IntegrityKey,
+					avp.Mbit|avp.Vbit,
+					diameter.Vendor3GPP,
+					datatype.OctetString(vector.IntegrityKey[:])),
 			},
 		}))
 	}
@@ -119,7 +144,10 @@ func ValidateAIR(msg *diam.Message) error {
 	}
 	_, err = msg.FindAVP(avp.RequestedEUTRANAuthenticationInfo, diameter.Vendor3GPP)
 	if err != nil {
-		return errors.New("Missing requested E-UTRAN authentication info in message")
+		_, err = msg.FindAVP(avp.RequestedUTRANGERANAuthenticationInfo, diameter.Vendor3GPP)
+		if err != nil {
+			return errors.New("Missing requested E-UTRAN and UTRAN/GERAN authentication info in message")
+		}
 	}
 	_, err = msg.FindAVP(avp.SessionID, 0)
 	if err != nil {

--- a/feg/gateway/services/testcore/hss/servicers/ai_test.go
+++ b/feg/gateway/services/testcore/hss/servicers/ai_test.go
@@ -96,7 +96,7 @@ func TestNewAIA_SuccessfulResponse(t *testing.T) {
 
 func TestNewAIA_MultipleVectors(t *testing.T) {
 	server := test_utils.NewTestHomeSubscriberServer(t)
-	air := createAIRExtended("sub1", 3)
+	air := createAIRExtended("sub1", 3, 0)
 	response, err := hss.NewAIA(server, air)
 	assert.NoError(t, err)
 
@@ -182,7 +182,7 @@ func TestValidateAIR_MissingEUTRANInfo(t *testing.T) {
 	m.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String("magma"))
 	m.NewAVP(avp.VisitedPLMNID, avp.Mbit|avp.Vbit, diameter.Vendor3GPP, datatype.Unsigned32(0))
 
-	assert.EqualError(t, hss.ValidateAIR(m), "Missing requested E-UTRAN authentication info in message")
+	assert.EqualError(t, hss.ValidateAIR(m), "Missing requested E-UTRAN and UTRAN/GERAN authentication info in message")
 }
 
 func TestValidateAIR_MissingSessionId(t *testing.T) {
@@ -208,6 +208,10 @@ func TestValidateAIR_MissingSessionId(t *testing.T) {
 func TestValidateAIR_Success(t *testing.T) {
 	air := createAIR("sub1")
 	assert.NoError(t, hss.ValidateAIR(air))
+	air = createAIRExtended("sub2", 0, 1)
+	assert.NoError(t, hss.ValidateAIR(air))
+	air = createAIRExtended("sub2", 1, 1)
+	assert.NoError(t, hss.ValidateAIR(air))
 }
 
 // createBaseAIR outputs a mock authentication information request with only a
@@ -222,12 +226,12 @@ func createBaseAIR() *diam.Message {
 
 // createAIR outputs a mock authentication information request.
 func createAIR(userName string) *diam.Message {
-	return createAIRExtended(userName, 1)
+	return createAIRExtended(userName, 1, 0)
 }
 
 // createAIRExtended outputs a mock authentication information request.
 // It allows specifying more options than createAIR.
-func createAIRExtended(userName string, numRequestedVectors uint32) *diam.Message {
+func createAIRExtended(userName string, numRequestedVectors, numRequestedUtranVectors uint32) *diam.Message {
 	m := createBaseAIR()
 	m.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String("magma;123_1234"))
 	m.NewAVP(avp.UserName, avp.Mbit, 0, datatype.UTF8String(userName))
@@ -244,6 +248,20 @@ func createAIRExtended(userName string, numRequestedVectors uint32) *diam.Messag
 		},
 	}
 	m.NewAVP(avp.RequestedEUTRANAuthenticationInfo, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, authInfo)
+	if numRequestedUtranVectors > 0 {
+		authInfo := &diam.GroupedAVP{
+			AVP: []*diam.AVP{
+				diam.NewAVP(
+					avp.NumberOfRequestedVectors,
+					avp.Vbit|avp.Mbit,
+					diameter.Vendor3GPP,
+					datatype.Unsigned32(numRequestedUtranVectors)),
+				diam.NewAVP(
+					avp.ImmediateResponsePreferred, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, datatype.Unsigned32(0)),
+			},
+		}
+		m.NewAVP(avp.RequestedUTRANGERANAuthenticationInfo, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, authInfo)
+	}
 	return m
 }
 
@@ -251,7 +269,7 @@ func TestNewSuccessfulAIA(t *testing.T) {
 	server := test_utils.NewTestHomeSubscriberServer(t)
 	serverCfg := server.Config.Server
 
-	msg := createAIR("user1")
+	msg := createAIRExtended("user1", 1, 1)
 	var air definitions.AIR
 	err := msg.Unmarshal(&air)
 	assert.NoError(t, err)
@@ -260,9 +278,18 @@ func TestNewSuccessfulAIA(t *testing.T) {
 	copy(vector.Rand[:], []byte("\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n\x0b\x0c\r\x0e\x0f"))
 	copy(vector.Xres[:], []byte("\x2d\xaf\x87\x3d\x73\xf3\x10\xc6"))
 	copy(vector.Autn[:], []byte("o\xbf\xa3\x80\x1fW\x80\x00{\xdeY\x88n\x96\xe4\xfe"))
-	copy(vector.Kasme[:], []byte("\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2"))
+	copy(vector.Kasme[:],
+		[]byte("\x87H\xc1\xc0\xa2\x82o\xa4\x05\xb1\xe2~\xa1\x04CJ\xe5V\xc7e\xe8\xf0a\xeb\xdb\x8a\xe2\x86\xc4F\x16\xc2"))
 
-	response := server.NewSuccessfulAIA(msg, air.SessionID, []*crypto.EutranVector{vector})
+	utranVector := &crypto.UtranVector{}
+	copy(utranVector.Rand[:], []byte("\xb0\x02\x7e\x16\x95\x59\xc4\x8a\x2d\xc8\x3d\xb6\xb7\x6b\x77\xb5"))
+	copy(utranVector.Xres[:], []byte("\xc8\x8e\x71\xfa\x5a\x1b\x41\x50"))
+	copy(utranVector.Autn[:], []byte("\x56\x63\xa4\x78\x7f\x61\x80\x00\x8d\x45\x64\x77\x96\x06\x39\x22"))
+	copy(utranVector.ConfidentialityKey[:], []byte("\x5e\x8d\xc7\x0e\x0d\xfa\xa5\xde\x81\x90\xe9\xc5\x98\x6a\xc2\x23"))
+	copy(utranVector.IntegrityKey[:], []byte("\xf2\xc1\x9c\x15\xf5\x5a\xf1\xe8\xbb\xdb\x76\x19\x30\xeb\xef\x7c"))
+
+	response := server.NewSuccessfulAIA(
+		msg, air.SessionID, []*crypto.EutranVector{vector}, []*crypto.UtranVector{utranVector})
 	var aia definitions.AIA
 	err = response.Unmarshal(&aia)
 	assert.NoError(t, err)
@@ -280,4 +307,11 @@ func TestNewSuccessfulAIA(t *testing.T) {
 	assert.Equal(t, datatype.OctetString(vector.Xres[:]), vec.XRES)
 	assert.Equal(t, datatype.OctetString(vector.Autn[:]), vec.AUTN)
 	assert.Equal(t, datatype.OctetString(vector.Kasme[:]), vec.KASME)
+
+	uvec := ai.UtranVectors[0]
+	assert.Equal(t, datatype.OctetString(utranVector.Rand[:]), uvec.RAND)
+	assert.Equal(t, datatype.OctetString(utranVector.Xres[:]), uvec.XRES)
+	assert.Equal(t, datatype.OctetString(utranVector.Autn[:]), uvec.AUTN)
+	assert.Equal(t, datatype.OctetString(utranVector.ConfidentialityKey[:]), uvec.CK)
+	assert.Equal(t, datatype.OctetString(utranVector.IntegrityKey[:]), uvec.IK)
 }


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

Add UTRAN Vectors support to HSS Lite

## Test Plan

add UTRAN unit tests, make precommit;

## Additional Information

- [ ] This change is backwards-breaking

