### PR TITLE
[pipelined] Fix pipelined crash due to missing 5g config

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -151,6 +151,10 @@ quota_check_ip: '192.0.0.1'
 has_quota_port: 51115
 no_quota_port: 51125
 
+# For 5G Functionality Support flag
+5G_feature_set:
+ enable: false
+
 ###############
 ## IMPORTANT ##
 ###############

--- a/lte/gateway/python/magma/pipelined/service_manager.py
+++ b/lte/gateway/python/magma/pipelined/service_manager.py
@@ -410,11 +410,11 @@ class ServiceManager:
 
     def __init__(self, magma_service: MagmaService):
         self._magma_service = magma_service
-        ng_flag = magma_service.config.get('5G_feature_set')
-        if ng_flag['enable'] == True:
-            self._5G_flag_enable = True
-        else:
+        if '5G_feature_set' not in magma_service.config:
             self._5G_flag_enable = False
+        else:
+          ng_flag = magma_service.config.get('5G_feature_set')
+          self._5G_flag_enable = ng_flag['enable']
         # inout is a mandatory app and it occupies:
         #   table 1(for ingress)
         #   table 10(for middle)

--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -138,6 +138,10 @@ quota_check_ip: '192.0.0.1'
 has_quota_port: 51115
 no_quota_port: 51125
 
+# For 5G Functionality Support flag
+5G_feature_set:
+ enable: false
+
 ###############
 ## IMPORTANT ##
 ###############


### PR DESCRIPTION
Signed-off-by: mgermano <mgermano@fb.com>

## Summary

This PR fixes failing integ tests due to a pipelined config issue.
A 5G section was added to lte configs but not cwf and xwf configs.
This adds the appropriate section and also improves the logic so that
we don't fail if this isn't configured. 

## Test Plan

Ensure pipelined doesn't crash on cwag.
