### PR TITLE
[lte][agw] Using enb_id to identify s1_setup event as enb_name is optional param

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_events.cpp
@@ -103,5 +103,7 @@ int s1_setup_success_event(const char* enb_name, uint32_t enb_id) {
 
   event_value["enb_id"]      = enb_id;
 
-  return report_event(event_value, S1_SETUP_SUCCESS, MME_STREAM_NAME, enb_name);
+  return report_event(
+      event_value, S1_SETUP_SUCCESS, MME_STREAM_NAME,
+      folly::to<std::string>(enb_id));
 }


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Passing enb_id as event_stream value to identify s1_setup event as enb_name (optional param) can be empty, which was causing crash on MME if this wasn't specified

## Test Plan

- Manually set enb_name param to null to reproduce crash, after using enb_id event is logged correctly 
- make integ_test as sanity 

## Additional Information

- [ ] This change is backwards-breaking

