### PR TITLE
[cwf_integ_test] improved detection of docker restarting container

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -12,9 +12,9 @@ limitations under the License.
 """
 from enum import Enum
 
-import sys
+import sys, time, os
 from fabric.api import (cd, env, execute, lcd, local, put, run, settings,
-                        sudo, shell_env, get)
+                        sudo, shell_env, get, hide)
 from fabric.contrib import files
 sys.path.append('../../orc8r')
 
@@ -346,14 +346,25 @@ def _stop_docker_services(services):
 
 
 def _check_docker_services(ignoreList):
-    with cd(CWAG_ROOT + "/docker"):
+    with cd(CWAG_ROOT + "/docker"), settings(warn_only=True), hide("warnings"):
+
         grepIgnore = "| grep --invert-match '" + \
                      '\|'.join(ignoreList) + "'" if ignoreList else ""
-        run(
-            " DCPS=$(docker ps --format \"{{.Names}}\t{{.Status}}\" | grep Restarting" + grepIgnore + ");"
-            " [[ -z \"$DCPS\" ]] ||"
-            " ( echo \"Container restarting detected.\" ; echo \"$DCPS\"; exit 1 )"
-        )
+        count = 0
+        while (count < 5):
+            # force wait to make sure docker logs are up
+            time.sleep(1)
+            result = run(" docker ps --format \"{{.Names}}\t{{.Status}}\" | "
+                         "grep Restarting" + grepIgnore )
+
+            if result.return_code == 1:
+                # grep returns code 1 when empty string
+                return
+            print("Container restarting detected. Tryin one more time")
+            count+=1
+    # if we got here, that means all attempts failed
+    print("ERROR: Test NOT started due to docker container restarting")
+    sys.exit(1)
 
 
 def _start_ue_simulator():
@@ -417,3 +428,6 @@ def _clean_up():
     with lcd(LTE_AGW_ROOT):
         vagrant_setup("magma_trfserver", False)
         run('pkill iperf3 > /dev/null &', pty=False, warn_only=True)
+
+class FabricException(Exception):
+    pass


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

In some occasions tests fails because fab script check too fast if docker container are restarting. This PR improves this detection by:
- Using fabric output to check the result of the command
- Retry (with a wait) for 5 times before failing integ test


## Test Plan

ran cwag integ test forcing restarts to check they were detected	

```
vagrant@127.0.0.1:2200] Executing task '_check_docker_services'
[vagrant@127.0.0.1:2200] run:  docker ps --format "{{.Names}}	{{.Status}}" | grep Restarting| grep --invert-match 'pcrf2'
[vagrant@127.0.0.1:2200] out: ocs2	Restarting (1) 3 seconds ago
[vagrant@127.0.0.1:2200] out:

Container restarting detected. Tryin one more time
[vagrant@127.0.0.1:2200] run:  docker ps --format "{{.Names}}	{{.Status}}" | grep Restarting| grep --invert-match 'pcrf2'
[vagrant@127.0.0.1:2200] out: ocs2	Restarting (1) 4 seconds ago
[vagrant@127.0.0.1:2200] out:

Container restarting detected. Tryin one more time
[vagrant@127.0.0.1:2200] run:  docker ps --format "{{.Names}}	{{.Status}}" | grep Restarting| grep --invert-match 'pcrf2'
[vagrant@127.0.0.1:2200] out: ocs2	Restarting (1) 5 seconds ago
[vagrant@127.0.0.1:2200] out:

Container restarting detected. Tryin one more time
[vagrant@127.0.0.1:2200] run:  docker ps --format "{{.Names}}	{{.Status}}" | grep Restarting| grep --invert-match 'pcrf2'
[vagrant@127.0.0.1:2200] out: ocs2	Restarting (1) Less than a second ago
[vagrant@127.0.0.1:2200] out:

Container restarting detected. Tryin one more time
[vagrant@127.0.0.1:2200] run:  docker ps --format "{{.Names}}	{{.Status}}" | grep Restarting| grep --invert-match 'pcrf2'
[vagrant@127.0.0.1:2200] out: ocs2	Restarting (1) 1 second ago
[vagrant@127.0.0.1:2200] out:

Container restarting detected. Tryin one more time
Disconnecting from vagrant@127.0.0.1:2200... done.
Disconnecting from vagrant@127.0.0.1:2222... done.
Disconnecting from vagrant@127.0.0.1:2202... done.
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
