### PR TITLE
Add grpc keepalives for c++ and python clients.

### DIFF
--- a/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
+++ b/orc8r/gateway/c/common/service_registry/ServiceRegistrySingleton.cpp
@@ -159,6 +159,7 @@ const std::shared_ptr<Channel> ServiceRegistrySingleton::CreateGrpcChannel(
   grpc::ChannelArguments arg;
 
   arg.SetString("grpc.default_authority", authority);
+  arg.SetInt("grpc.keepalive_time_ms", 30*1000);
   std::ostringstream ss;
   ss << ip << ":" << port;
 

--- a/orc8r/gateway/python/magma/common/service_registry.py
+++ b/orc8r/gateway/python/magma/common/service_registry.py
@@ -19,7 +19,7 @@ import os
 from magma.configuration.exceptions import LoadConfigError
 from magma.configuration.service_configs import load_service_config
 
-
+GRPC_KEEPALIVE_MS = 30 * 1000
 class ServiceRegistry:
     """
     ServiceRegistry provides the framework to discover services.
@@ -143,6 +143,10 @@ class ServiceRegistry:
             if channel is not None:
                 return channel
 
+        if grpc_options is None:
+            grpc_options = [
+                ("grpc.keepalive_time_ms", GRPC_KEEPALIVE_MS),
+            ]
         # We need to figure out the ip and port to connnect, if we need to use
         # SSL and the authority to use.
         if destination == ServiceRegistry.LOCAL:


### PR DESCRIPTION
Added grpc keepalives for c++ and python clients.
Also added only keepalive_time_ms, keepalive_timeout_ms is set to 20 seconds by default
https://grpc.github.io/grpc/cpp/md_doc_keepalive.html

Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
