### PR TITLE
[cwf_integ_test] added bandwith limit to gx_reauth test

### DIFF
--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -84,6 +84,8 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
 		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
+		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -158,6 +160,8 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
 		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
+		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -230,6 +234,8 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
 		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
+		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -324,6 +330,8 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
 		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
+		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -423,6 +431,8 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:   imsi,
 		Volume: &wrappers.StringValue{Value: *swag.String("500K")},
+		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

It looks like reauth test may have issues when the test send traffic instantly. This PR limits the bitrate of the traffic generator to make sure sessiond and pcrf have enough time to observe and report the traffic (which is closer to reality)

## Test Plan

cwag_integ_test 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
