### PR TITLE
[ci] gracefully exit on ci when cwf_integ_test raises exception

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -43,6 +43,9 @@ CWF_IMAGES = [
 
 DEFAULT_DOCKER_REG = 'facebookconnectivity-magma-docker.jfrog.io'
 
+class FabricException(Exception):
+    pass
+
 
 class NodeLease:
     def __init__(self, node_id: str, lease_id: str, vpn_ip: str):
@@ -237,11 +240,17 @@ def _run_remote_cwf_integ_test(repo: str, magma_root: str):
                 '-f docker-compose.integ-test.yml '
                 'build --parallel')
         test_xml = "tests.xml"
-        result = run('fab integ_test:'
-                     'destroy_vm=True,'
-                     'transfer_images=True,'
-                     'test_result_xml=' + test_xml,
-                     timeout=110*60, warn_only=True)
+        with settings(abort_exception=FabricException):
+            try:
+                result = run('fab integ_test:'
+                             'destroy_vm=True,'
+                             'transfer_images=True,'
+                             'test_result_xml=' + test_xml,
+                             timeout=110*60, warn_only=True)
+            except Exception as e:
+                _transfer_all_artifacts()
+                print(f'Exception while running cwf integ_test\n {e}')
+                sys.exit(1)
         # Move JUnit test result to /tmp/test-results directory
         local('mkdir cwf-tests-xml')
         get(test_xml, 'cwf-tests-xml')
@@ -251,18 +260,21 @@ def _run_remote_cwf_integ_test(repo: str, magma_root: str):
         # copy to the log directory. This will get stored as an artifact in the
         # circleCI config.
         if result.return_code:
-            services = "sessiond session_proxy pcrf ocs pipelined ingress"
-            run(f'fab transfer_artifacts:services="{services}",'
-                'get_core_dump=True')
-
-            # Copy the log files out from the node
-            local('mkdir cwf-artifacts')
-            get('*.log', 'cwf-artifacts')
-            if exists("coredump.tar.gz"):
-                get('coredump.tar.gz', 'cwf-artifacts')
-            local('sudo mkdir -p /tmp/logs/')
-            local('sudo mv cwf-artifacts/* /tmp/logs/')
+            _transfer_all_artifacts()
         sys.exit(result.return_code)
+
+
+def _transfer_all_artifacts():
+    services = "sessiond session_proxy pcrf ocs pipelined ingress"
+    run(f'fab transfer_artifacts:services="{services}",'
+        'get_core_dump=True')
+    # Copy log files out from the node
+    local('mkdir cwf-artifacts')
+    get('*.log', 'cwf-artifacts')
+    if exists("coredump.tar.gz"):
+        get('coredump.tar.gz', 'cwf-artifacts')
+    local('sudo mkdir -p /tmp/logs/')
+    local('sudo mv cwf-artifacts/* /tmp/logs/')
 
 
 def _run_remote_lte_package(repo: str, magma_root: str,

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -179,10 +179,16 @@ def transfer_artifacts(gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml",
         execute(_tar_coredump, gateway_vm=gateway_vm, gateway_ansible_file=gateway_ansible_file)
 
     # get uesim logs
-    _switch_to_vm(None, "cwag_test", "cwag_test.yml", False)
-    uesim_log = 'uesim.log'
-    with cd(f'{CWAG_ROOT}'):
-        run('tmux capture-pane -pt "$target-pane" >>' + uesim_log)
+    # TODO: make sure exception is not triggered
+    with settings(abort_exception=FabricException):
+        result = None
+        try:
+            _switch_to_vm(None, "cwag_test", "cwag_test.yml", False)
+            uesim_log = 'uesim.log'
+            with cd(f'{CWAG_ROOT}'):
+                result = run('tmux capture-pane -pt "$target-pane" >>' + uesim_log)
+        except Exception:
+            print("Error copying uesim.log %s" % str(result if result else ""))
 
 def _tar_coredump(gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml"):
     _switch_to_vm_no_destroy(None, gateway_vm, gateway_ansible_file)

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -802,7 +802,12 @@ func TestGyWithErrorCode(t *testing.T) {
 	tr.AuthenticateAndAssertSuccess(ue.GetImsi())
 
 	// we need to generate over 80% but less than 100%  trigger a CCR update without triggering termination
-	req := &cwfprotos.GenTrafficRequest{Imsi: ue.GetImsi(), Volume: &wrappers.StringValue{Value: *swag.String("4.6M")}}
+	req := &cwfprotos.GenTrafficRequest{
+		Imsi: ue.GetImsi(),
+		Volume: &wrappers.StringValue{Value: *swag.String("4.6M")},
+		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Timeout: 60,
+	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
It looks like sometimes cwf integ_test raises an exception and crashes the whole stack of fabfiles. That prevent us to collect all the logs (if any)

With this PR we try to catch the exception, collect all the artifacts, print the content of the exception and exit with error code 1 

Example of this situation may be the one below. Per what I can see in the full log, the script crashes while running integ_test and it never have the opportunity to collect logs 
https://app.circleci.com/pipelines/github/magma/magma/5561/workflows/220c2c94-c32a-4c4b-a0b7-8122df7c243a/jobs/57177/steps

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
