### PR TITLE
[orc8r][secrets] Modify default prometheusPushAddresses value as an array

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.38
+version: 1.4.39
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart to create magma orchestrator secrets
 name: secrets
-version: 0.1.5
+version: 0.1.6
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -64,7 +64,8 @@ secret:
         elasticPort: 9200
 
       orchestrator.yml: |-
-        prometheusPushAddresses: "http://orc8r-prometheus-cache:9091/metrics"
+        prometheusPushAddresses:
+          - "http://orc8r-prometheus-cache:9091/metrics"
 
   # cwf:
   #   key: value

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -11,7 +11,7 @@
 
 dependencies:
   - name: secrets
-    version: 0.1.5
+    version: 0.1.6
     repository: ""
     condition: secrets.create
   - name: metrics


### PR DESCRIPTION


Signed-off-by: Sudhi Kandi <sudhikan@fb.com>

[orc8r][secrets]
## Summary

Modify the default values for orchestrator.yml > prometheusPushAddresses to be an array. Else orc8r controller pod crashes. 

## Test Plan

Tested on on-prem deployment running `28f7f2e8`

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
