### PR TITLE
[NMS] Add support to configure AGW management network GW IP

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -63,7 +63,7 @@ import nullthrows from '@fbcnms/util/nullthrows';
 import {AltFormField} from '../../components/FormField';
 import {colors, typography} from '../../theme/default';
 import {makeStyles} from '@material-ui/styles';
-import {useContext, useState} from 'react';
+import {useContext, useEffect, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
@@ -80,6 +80,9 @@ const DEFAULT_GATEWAY_CONFIG = {
       nat_enabled: true,
       dns_primary: '',
       dns_secondary: '',
+      sgi_management_iface_gw: '',
+      sgi_management_iface_static_ip: '',
+      sgi_management_iface_vlan: '',
     },
     ran: {
       pci: 260,
@@ -636,6 +639,13 @@ export function EPCEdit(props: Props) {
     props.gateway?.cellular.epc || DEFAULT_GATEWAY_CONFIG.cellular.epc,
   );
 
+  useEffect(() => {
+    setEPCConfig(
+      props.gateway?.cellular.epc || DEFAULT_GATEWAY_CONFIG.cellular.epc,
+    );
+    setError('');
+  }, [props.gateway?.cellular.epc]);
+
   const onSave = async () => {
     try {
       const gateway = {
@@ -655,7 +665,6 @@ export function EPCEdit(props: Props) {
       setError(e.response?.data?.message ?? e.message);
     }
   };
-
   return (
     <>
       <DialogContent data-testid="epcEdit">
@@ -676,7 +685,7 @@ export function EPCEdit(props: Props) {
           <AltFormField label={'IP Block'}>
             <OutlinedInput
               data-testid="ipBlock"
-              placeholder="Enter IP Block"
+              placeholder="192.168.128.0/24"
               type="string"
               fullWidth={true}
               value={EPCConfig.ip_block}
@@ -686,10 +695,10 @@ export function EPCEdit(props: Props) {
           <AltFormField label={'DNS Primary'}>
             <OutlinedInput
               data-testid="dnsPrimary"
-              placeholder="Enter Primary DNS"
+              placeholder="8.8.8.8"
               type="string"
               fullWidth={true}
-              value={EPCConfig.dns_primary}
+              value={EPCConfig.dns_primary ?? ''}
               onChange={({target}) =>
                 handleEPCChange('dns_primary', target.value)
               }
@@ -698,15 +707,56 @@ export function EPCEdit(props: Props) {
           <AltFormField label={'DNS Secondary'}>
             <OutlinedInput
               data-testid="dnsSecondary"
-              placeholder="Enter Secondary DNS"
+              placeholder="8.8.4.4"
               type="string"
               fullWidth={true}
-              value={EPCConfig.dns_secondary}
+              value={EPCConfig.dns_secondary ?? ''}
               onChange={({target}) =>
                 handleEPCChange('dns_secondary', target.value)
               }
             />
           </AltFormField>
+          <AltFormField label={'SGi network Gateway IP address'}>
+            <OutlinedInput
+              data-testid="gwSgiIP"
+              placeholder="1.1.1.1"
+              required={
+                EPCConfig.sgi_management_iface_static_ip ?? false ? true : false
+              }
+              type="string"
+              fullWidth={true}
+              value={EPCConfig.sgi_management_iface_gw ?? ''}
+              onChange={({target}) =>
+                handleEPCChange('sgi_management_iface_gw', target.value)
+              }
+            />
+          </AltFormField>
+          <AltFormField label={'SGi management interface IP address'}>
+            <OutlinedInput
+              data-testid="sgiStaticIP"
+              placeholder="1.1.1.1/24"
+              type="string"
+              fullWidth={true}
+              value={EPCConfig.sgi_management_iface_static_ip ?? ''}
+              onChange={({target}) =>
+                handleEPCChange('sgi_management_iface_static_ip', target.value)
+              }
+            />
+          </AltFormField>
+          {!EPCConfig.nat_enabled && (
+            <AltFormField label={'SGi management network VLAN id'}>
+              <OutlinedInput
+                data-testid="sgiVlanID"
+                placeholder="100"
+                type="string"
+                fullWidth={true}
+                value={EPCConfig.sgi_management_iface_vlan ?? ''}
+                onChange={({target}) =>
+                  handleEPCChange('sgi_management_iface_vlan', target.value)
+                }
+              />
+            </AltFormField>
+          )}
         </List>
       </DialogContent>
       <DialogActions>

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/EquipmentGatewayTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/EquipmentGatewayTest.js
@@ -64,7 +64,9 @@ const mockGw0: lte_gateway = {
   cellular: {
     epc: {
       ip_block: '192.168.0.1/24',
-      nat_enabled: true,
+      nat_enabled: false,
+      sgi_management_iface_static_ip: '1.1.1.1/24',
+      sgi_management_iface_vlan: '100',
     },
     ran: {
       pci: 620,

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -64,7 +64,9 @@ const mockGw0: lte_gateway = {
   cellular: {
     epc: {
       ip_block: '192.168.0.1/24',
-      nat_enabled: true,
+      nat_enabled: false,
+      sgi_management_iface_static_ip: '1.1.1.1/24',
+      sgi_management_iface_vlan: '100',
     },
     ran: {
       pci: 620,
@@ -223,6 +225,9 @@ describe('<AddEditGatewayButton />', () => {
             dns_secondary: '',
             ip_block: '192.168.128.0/24',
             nat_enabled: true,
+            sgi_management_iface_gw: '',
+            sgi_management_iface_static_ip: '',
+            sgi_management_iface_vlan: '',
           },
           ran: {
             pci: 260,


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>



## Summary

Add support to configure AGW management network GW IP

<img width="1063" alt="Capture d’écran 2020-10-16 à 18 51 03" src="https://user-images.githubusercontent.com/26038920/96286390-96adde00-0fe0-11eb-87d2-25e3da5ec3e9.png">


<img width="1046" alt="Capture d’écran 2020-10-16 à 18 51 49" src="https://user-images.githubusercontent.com/26038920/96286472-b513d980-0fe0-11eb-8ea0-97a0cab69ffc.png">





## Additional Information

- [ ] This change is backwards-breaking

