### PR TITLE
[cwf_integ_test] add retries due to iperf connectivity error

### DIFF
--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -25,7 +25,6 @@ import (
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 
 	"github.com/fiorix/go-diameter/v4/diam"
-	"github.com/go-openapi/swag"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/stretchr/testify/assert"
 )
@@ -82,9 +81,9 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
-		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "450K"},
+		Bitrate: &wrappers.StringValue{Value: "20M"},
 		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
@@ -159,9 +158,9 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
-		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "450K"},
+		Bitrate: &wrappers.StringValue{Value: "20M"},
 		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
@@ -231,9 +230,9 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
-		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "450K"},
+		Bitrate: &wrappers.StringValue{Value: "20M"},
 		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
@@ -325,9 +324,9 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: *swag.String("450K")},
-		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "450K"},
+		Bitrate: &wrappers.StringValue{Value: "20M"},
 		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
@@ -424,9 +423,9 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi:   imsi,
-		Volume: &wrappers.StringValue{Value: *swag.String("500K")},
-		Bitrate: &wrappers.StringValue{Value: *swag.String("20M")},
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "500K"},
+		Bitrate: &wrappers.StringValue{Value: "20M"},
 		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds new feature on UEsim to catch IPERF error at command level. 

When we receive `error - unable to receive control message: Connection reset by peer"` we will retry for few more times. This error may be caused due to iperf3 grpc client not responding properly to the request of generating traffic

This PR also adds some bandwidth limits to some tests to make sure they don't generate traffic instantly (which make cause issues on Gx/Gy counting algorithm) 

## Test Plan

cwag integ test


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
