### PR TITLE
Cwf operator changes

### DIFF
--- a/cwf/k8s/cwf_operator/README.md
+++ b/cwf/k8s/cwf_operator/README.md
@@ -160,6 +160,7 @@ $ kubectl -n magma create -f deploy/crds/magma.cwf.k8s_haclusters_crd.yaml
 $ kubectl -n magma create -f deploy/service_account.yaml
 $ kubectl -n magma create -f deploy/role.yaml
 $ kubectl -n magma create -f deploy/role_binding.yaml
+$ kubectl -n magma create -f deploy/crds/charts.helm.k8s.io_cwfs_crd.yaml
 ```
 
 Before creating the operator pod, the `operator.yaml` file will need to be
@@ -192,7 +193,7 @@ define:
  * `gatewayID` - the gateway ID created in the NMS
  * `helmReleaseName` - the release name of the gateway helm deployment
 
-If you are unsure what the helm release name should be, run `helm ls -n magma`
+If you are unsure what the helm release name should be, run `helm ls --namespace magma`
 to check the list of releases.
 
 After making this change, the yaml file should something like:

--- a/cwf/k8s/cwf_operator/deploy/crds/magma.cwf.k8s_v1alpha1_hacluster_cr.yaml
+++ b/cwf/k8s/cwf_operator/deploy/crds/magma.cwf.k8s_v1alpha1_hacluster_cr.yaml
@@ -36,3 +36,4 @@ spec:
     - gatewayID: "mpk_cwf02"
       helmReleaseName: "cwf02"
   haPairID: "pair1"
+  maxConsecutiveActiveErrors: 3

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -64,7 +64,8 @@ secret:
         elasticPort: 9200
 
       orchestrator.yml: |-
-        prometheusPushAddresses: "http://orc8r-prometheus-cache:9091/metrics"
+        prometheusPushAddresses:
+          - "http://orc8r-prometheus-cache:9091/metrics"
 
   # cwf:
   #   key: value


### PR DESCRIPTION
[cwf][ha][operator]

## Summary

This PR makes the following changes:
* Minor syntax change to helm ls
* kubectl command to create a cwf custom resource
* Add maxConsecutiveActiveErrors to crds/magma.cwf.k8s_v1alpha1_hacluster_cr.yaml

## Test Plan

Tested on an on-prem deployment running 28f7f2e8.

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
