### PR TITLE
[5G: MVC][SessionD][Pipelined] Re-Definition of Pipelined and Session manager protos

### DIFF
--- a/lte/protos/pipelined.proto
+++ b/lte/protos/pipelined.proto
@@ -201,36 +201,19 @@ message PacketDropTableId {
 // source file: https://www.etsi.org/deliver/etsi_ts/129200_129299/129244/15.08.00_60/ts_129244v150800p.pdf
 //
 
-message NodeID {
-  enum NodeIDType {
-    IPv4 = 0;
-    IPv6 = 1;
-    FQDN = 2;
-    }
-  NodeIDType node_id_type = 1;
-  string node_id = 2;
-}
 
 //ToDo latest state change will reflect in upcoming proto
 message Fsm_state {
   enum FsmState {
-        SESSION_ACTIVE                        = 0;
-        SESSION_TERMINATED                    = 4;
-        SESSION_RELEASED                      = 6;
-        CREATING                              = 7;
-        CREATED                               = 8;
-        ACTIVE                                = 9;
-        INACTIVE                              = 10;
-        RELEASE                               = 11;
+    UNUSED       = 0;
+    //Adhering to current refactored converged sessiond states
+    CREATING     = 7;
+    CREATED      = 8;
+    ACTIVE       = 9;
+    INACTIVE     = 10;
+    RELEASE      = 11;
   }
-  FsmState  state = 1;
-}
-
-
-//CPFseid message
-message CpFSeid {
-  uint64 f_seid = 1;
-  NodeID node_id = 2;
+  FsmState state = 1;
 }
 
 message OuterHeadRemoval {
@@ -247,57 +230,31 @@ message SdfFilters {                               //8.2.5
 
 message FlowDescriptor {
 FlowMatchNew match = 1;
-  enum Action {
-    PERMIT = 0;
-    DENY = 1;
-  }
-  Action action = 2;
+Action action = 2;
 }
 
 message FlowMatchNew {
   string ipv4_src = 1;
   string ipv4_dst = 2;
-  uint32 tcp_src = 3;
-  uint32 tcp_dst = 4;
-  uint32 udp_src = 5;
-  uint32 udp_dst = 6;
+  string protocol_type = 3;   //can be UDP TCP
+  uint32 dst_port = 4;
+  uint32 src_port = 5;
 }
 
-message MacAddress {            //8.2.93
-  bytes mac_src_value = 1;
-  bytes mac_dst_value = 2;
-  bytes upper_mac_src_value = 3;
-  bytes upper_mac_dst_value = 4;
-}
-
-//Table 7.5.2.2-3: Ethernet Packet Filter IE within PFCP Session Establishment $
-message EthPackFilter {
-  uint32 eth_filt_id = 1;
-  uint32 eth_filt_prop = 2;
-  MacAddress mac_addr = 3;
-  uint32 c_tag = 4;                              
-  uint32 s_tag = 5;
-  SdfFilters sdf_filters = 6;
-  uint32 ethertype = 7;
-}
-
-//ToDo ApplyAction will be simplified and will reflect in upcoming proto
-message ApplyAction {               //8.2.26
-  enum Action{
-    DROP = 0;
-    FORW = 1;
-//Below fields may be required In future.
-    BUFF = 2;
-    NOCP = 3;
-    DUPL = 4;
-  }
-  repeated Action apply_action = 1;
+//8.2.26
+enum Action {
+  DROP = 0;
+  FORW = 1;
+  //Below will be required in future use case
+  BUFF = 2;
+  NOCP = 3;
+  DUPL = 4;
 }
 
 message RedirectInfo {                //8.2.20
   enum RedirectAddrType {
-    IPV4 = 0;
-    IPV6 = 1;
+    IPV4_0 = 0;
+    IPV6_0 = 1;
     URL = 2;
     SIPURI = 3;
     IPV4V6 = 4;
@@ -315,7 +272,7 @@ message OuterHeaderCreation {
 //Table 7.5.2.3-2: Forwarding Parameters IE in FAR
 message FwdParam {
   uint32 dest_iface = 1;     
-  string net_instace = 2;
+  string net_instance = 2;
   RedirectInfo redirect_info = 3;
   OuterHeaderCreation outr_head_cr = 4;
 }
@@ -323,6 +280,12 @@ message FwdParam {
 //Table 7.5.2.3-3: Duplicating Parameters IE in FAR
 message DupParam {
   uint32 dest_iface = 1;
+}
+
+//pdr_state variable for SessionSet message per PDR.
+enum PdrState {
+  ADD =   0;
+  RELEASE = 1;
 }
 
 //PDI Message Table 7.5.2.2-2: PDI IE within PFCP Session Establishment Request
@@ -336,49 +299,84 @@ message PDI {
   string app_id = 7;
 }
 
-//Group Type messages - Currently Includes -> 1. PDR 2. FAR
+//Group Type messages - Currently Includes -> 1. PDR 2. FAR 3.For QER ActivateFlowRequest
 
 //PDR message Table 7.5.2.2-1: Create PDR IE within PFCP Session Establishment
 message SetGroupPDR {
   uint32 pdr_id = 1;
-  int32 sess_ver_no = 2;
+  int32 pdr_version = 2;
   uint32 precedence = 3;
-  PDI pdi = 4;
-  OuterHeadRemoval o_h_remo_desc = 5;   
-  uint32 far_id = 6;
-  uint32 urr_id = 7;
-  uint32 qer_id = 8;
-  uint32 bar_id = 9;
-  string active_pred_rule = 10;    //8.2.72
+  PdrState pdr_state = 4;
+  PDI pdi = 5;
+  uint32 o_h_remo_desc = 6; 
+  string active_pred_rule = 7;
+  ActivateFlowsRequest activate_flow_req = 8;
+  SetGroupFAR set_gr_far = 9;  
 }
 
 //FAR message Table 7.5.2.3-1: Create FAR IE within PFCP Session Establishment
 message SetGroupFAR {
   uint32 far_id = 1;
-  int32 sess_ver_no = 2;
-  ApplyAction apply_action = 3;
-  FwdParam fwd_parm = 4;
-  DupParam du_param = 5;
-  uint32 bar_id = 6;
+  repeated Action far_action_to_apply = 2;
+  FwdParam fwd_parm = 3;
+  DupParam du_param = 4;
 }
 
 // ToDO  SetGroupQER
 // ToDo  SetGroupBAR
 
 //SET message - SMF to Upf Session Requests
-//ToDo Flattening of SessionSet is in progress so will be updated along with addressing the comments
 message SessionSet {
   string seid = 1;
-  int32 sess_ver_no = 2;    //ToDo renaming of the field example sess_ver_no will be done on the latest proto
+  int32 session_version = 2; 
   NodeID node_id = 3;
-  Fsm_state  state = 16;
-  CpFSeid f_seid = 4;
+  Fsm_state state = 16;
   repeated SetGroupPDR set_gr_pdr = 5;
-  repeated SetGroupFAR set_gr_far = 6;
 }
 
-//ToDo Response will reflect in upcoming proto
-message UpfRes {}
+//UPF Response
+message  UPFSessionContextState {
+    CauseIE cause_info = 1;
+    UPFSessionState session_snaphot = 2;
+    FailureRuleInformation failure_rule_id = 3; // The session and version which failed in UPF
+}
+
+message CauseIE {
+   //15.8, Table 8.2.1-1
+   enum CauseValues {
+       RESERVED = 0;
+       REQUEST_ACCEPTED = 1;
+       REQUEST_REJECTED_NO_REASON = 2;
+       SESSION_CONTEXT_NOT_FOUND = 3;
+       MANDATORY_IE_MISSING = 4;
+       CONDITIONAL_IE_MISSING = 5;
+       INVALID_LENGTH = 6;
+       MANDATORY_IE_INCORRECT = 7;
+       INVALID_FORWARDING_POLICY = 8;
+       INVALID_F_TEID_ALLOCATION_OPTION = 9;
+       NO_ESTABLISHED_PFCP_ASSOCIATION = 10;
+       RULE_CREATION_OR_MODIFICATION_FAILURE = 11;
+       PFCP_ENTRY_IN_CONGESTION = 12;
+       NO_RESOURCES_AVAILABLE = 13;
+       SERVICE_NOT_SUPPORTED = 14;
+       SYSTEM_FAILURE = 15;
+   }
+
+   CauseValues cause_ie=1;
+}
+
+message FailureRuleInformation {
+   OffendingIE pdr = 1;
+   OffendingIE far = 2;
+   OffendingIE qer = 3;
+   OffendingIE urr = 4;
+   OffendingIE bar = 5;
+}
+
+message OffendingIE {
+    uint32 identifier = 1;
+    uint32 version = 2;
+}
 
 
 // --------------------------------------------------------------------------
@@ -390,7 +388,7 @@ service Pipelined {
   // Smf to Upf rpc
   // ------------
 
-  rpc SetSMFSessions(SessionSet) returns (UpfRes) {}
+  rpc SetSMFSessions(SessionSet) returns (UPFSessionContextState) {}
 
   // ----------------
   // Enforcement App:

--- a/lte/protos/pipelined.proto
+++ b/lte/protos/pipelined.proto
@@ -253,8 +253,8 @@ enum Action {
 
 message RedirectInfo {                //8.2.20
   enum RedirectAddrType {
-    IPV4_0 = 0;
-    IPV6_0 = 1;
+    IPV4 = 0;
+    IPV6 = 1;
     URL = 2;
     SIPURI = 3;
     IPV4V6 = 4;
@@ -284,8 +284,8 @@ message DupParam {
 
 //pdr_state variable for SessionSet message per PDR.
 enum PdrState {
-  ADD =   0;
-  RELEASE = 1;
+  ADD = 0;
+  REMOVE = 1;
 }
 
 //PDI Message Table 7.5.2.2-2: PDI IE within PFCP Session Establishment Request
@@ -327,7 +327,7 @@ message SetGroupFAR {
 
 //SET message - SMF to Upf Session Requests
 message SessionSet {
-  string seid = 1;
+  string imsi = 1;          //IMSI along with teid will be sent
   int32 session_version = 2; 
   NodeID node_id = 3;
   Fsm_state state = 16;

--- a/lte/protos/session_manager.proto
+++ b/lte/protos/session_manager.proto
@@ -798,7 +798,7 @@ message SetSMSessionContextAccess {
 
 
 message UPFSessionState {
-  string seid = 1;            // Session ID
+  string imsi = 1;            
   int32 sess_ver_no = 2;      // Successful Version number snapshot from UPF. If its not the expected parse Failure report.
 }
 

--- a/lte/protos/session_manager.proto
+++ b/lte/protos/session_manager.proto
@@ -570,6 +570,17 @@ service CentralSessionController {
 }
 
 ////////////5GSMCONTEXT/////////////
+
+message NodeID {
+  enum NodeIDType {
+    IPv4 = 0;
+    IPv6 = 1;
+    FQDN = 2;
+    }
+  NodeIDType node_id_type = 1;
+  string node_id = 2;
+}
+
 //PduSessionType
 enum PduSessionType {
    IPV4 = 0;
@@ -784,6 +795,23 @@ message SetSMSessionContextAccess {
   CommonSessionContext common_context = 1;  //Common message for 4g, 5g and WiFi.
   RatSpecificContextAccess   rat_specific_context = 2;
 }
+
+
+message UPFSessionState {
+  string seid = 1;            // Session ID
+  int32 sess_ver_no = 2;      // Successful Version number snapshot from UPF. If its not the expected parse Failure report.
+}
+
+// Perodic Session snapshot information from UPF to SMF
+message UPFSessionConfigState {
+     repeated UPFSessionState upf_session_state = 1;
+}
+
+//Set Interface from Pipelined
+service SetInterfaceForUserPlane {
+    rpc SetUPFSessionsConfig(UPFSessionConfigState) returns (magma.orc8r.Void) {}
+}
+
 
 // RPC service and method
 service SmfPduSessionSmContext {


### PR DESCRIPTION
Signed-off-by: ronit-kumar-acl <ronit.k@altencalsoftlabs.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Contains latest protos which have been concluded recently - 
Major Changes: 
1. NodeId moved to session_manager
2. QER support in pipelined using existing ActivateFlowsRequest
3. Flattened SessionSet message
4. Pdr State added
5. Renaming of few fields like session_version.
## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
