### PR TITLE
[xwf][xwfm] setup dhcp_always_broadcast if enabled

### DIFF
--- a/xwf/gateway/deploy/roles/dhcpd/templates/dhcpd.conf.j2
+++ b/xwf/gateway/deploy/roles/dhcpd/templates/dhcpd.conf.j2
@@ -3,7 +3,7 @@ option domain-name-servers ns1.xwfn.lan, ns2.xwfn.lan;
 default-lease-time 3600;
 max-lease-time 7200;
 authoritative;
-{% if dhcp_always_broadcast == true %}
+{% if dhcp_always_broadcast | default(false) == true %}
 always-broadcast on;
 {% endif %}
 

--- a/xwf/gateway/deploy/roles/dhcpd/templates/dhcpd.conf.j2
+++ b/xwf/gateway/deploy/roles/dhcpd/templates/dhcpd.conf.j2
@@ -3,6 +3,10 @@ option domain-name-servers ns1.xwfn.lan, ns2.xwfn.lan;
 default-lease-time 3600;
 max-lease-time 7200;
 authoritative;
+{% if dhcp_always_broadcast == true %}
+always-broadcast on;
+{% endif %}
+
 subnet {{ dhcp_subnet }} netmask {{ dhcp_netmask }} {
     option routers                  {{ dhcp_router }};
     option subnet-mask              {{ dhcp_netmask }};


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[xwf][xwfm] setup dhcp_always_broadcast if enabled
## Summary

some xwfm partners will need to setup 'always-broadcast on;' on their dhcpd.conf based on their xwfwhoami config

## Test Plan

### on newly created xwfm box

I updated xwfwhoami with the following:
```
dhcp_always_broadcast: true
```

# rerun sensible rules:
```
$ ansible-playbook xwf.yml
```

Looked at config:
```
# cat /etc/dhcp/dhcpd.conf
option domain-name "xwfn.lan";
option domain-name-servers ns1.xwfn.lan, ns2.xwfn.lan;
default-lease-time 3600;
max-lease-time 7200;
authoritative;
always-broadcast on;
subnet 10.100.0.0 netmask 255.255.0.0 {
    option routers                  10.100.0.1;
    option subnet-mask              255.255.0.0;
    option domain-search            "xwfo.lan";
    option domain-name-servers      8.8.8.8;
    range   10.100.1.1   10.100.255.250;
}
```
Made sire dhcpd restart works:
```
$ systemctl status dhcpd.service
dhcpd.service - DHCPv4 Server Daemon
   Loaded: loaded (/usr/lib/systemd/system/dhcpd.service; enabled; vendor preset: disabled)
   Active: active (running) since Sun 2020-10-18 11:21:07 UTC; 3min 12s ago
     Docs: man:dhcpd(8)
           man:dhcpd.conf(5)
 Main PID: 16528 (dhcpd)
   Status: "Dispatching packets..."
    Tasks: 1
   Memory: 25.0M
   CGroup: /system.slice/dhcpd.service
           └─16528 /usr/sbin/dhcpd -f -cf /etc/dhcp/dhcpd.conf -user dhcpd -group dhcpd --no-pid gw0

Oct 18 11:22:00 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPDISCOVER from aa:e4:71:01:32:bc via gw0
Oct 18 11:22:01 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPOFFER on 10.100.1.20 to aa:e4:71:01:32:bc via gw0
Oct 18 11:22:01 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPREQUEST for 10.100.1.20 (10.100.0.1) from aa:e4:71:01:32:bc via gw0
Oct 18 11:22:01 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPACK on 10.100.1.20 to aa:e4:71:01:32:bc via gw0
Oct 18 11:24:00 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPREQUEST for 10.100.1.20 from b6:8e:7d:5e:bd:e9 via gw0: lease 10.100.1.20 unavailable.
Oct 18 11:24:00 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPNAK on 10.100.1.20 to b6:8e:7d:5e:bd:e9 via gw0
Oct 18 11:24:00 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPDISCOVER from b6:8e:7d:5e:bd:e9 via gw0
Oct 18 11:24:01 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPOFFER on 10.100.1.21 to b6:8e:7d:5e:bd:e9 via gw0
Oct 18 11:24:01 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPREQUEST for 10.100.1.21 (10.100.0.1) from b6:8e:7d:5e:bd:e9 via gw0
Oct 18 11:24:01 xwfm.ofpqa1-gh.qa.1 dhcpd[16528]: DHCPACK on 10.100.1.21 to b6:8e:7d:5e:bd:e9 via gw0
```

Changed the dhcp_always_broadcast to false in xwfwhoami , validate config and that service is up and running

```
$ cat /etc/dhcp/dhcpd.conf
option domain-name "xwfn.lan";
option domain-name-servers ns1.xwfn.lan, ns2.xwfn.lan;
default-lease-time 3600;
max-lease-time 7200;
authoritative;
subnet 10.100.0.0 netmask 255.255.0.0 {
    option routers                  10.100.0.1;
    option subnet-mask              255.255.0.0;
    option domain-search            "xwfo.lan";
    option domain-name-servers      8.8.8.8;
    range   10.100.1.1   10.100.255.250;
}

```

## Additional Information

- [ ] This change is backwards-breaking

