### PR TITLE
[UESIM] - Return error to uesim cli in case of error reading parameters from uesim.yml file

### DIFF
--- a/cwf/gateway/tools/uesim_cli/main.go
+++ b/cwf/gateway/tools/uesim_cli/main.go
@@ -280,7 +280,7 @@ func getConfiguredSubscribers(params ...string) ([]*protos.UEConfig, error) {
 			ue, err := createUeConfig(imsi, 0, configMap)
 			if err != nil {
 				glog.Error(err)
-				continue
+				return nil, err
 			}
 			ues = append(ues, ue)
 		}


### PR DESCRIPTION


Signed-off-by: Sourabh Shekhar Nanoti <sourabhn@fb.com>

While configuring a single IMSI from uesim_cli in case there is an error in getting the ue parameters from uesim.yml file, then error has to be returned to the CLI so that the uesim.yml errors can be fixed. 

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

MisConfigured a UE in uesim.yml and ensured that error was returned. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
