### PR TITLE
[NMS] Adding placeholders for policy qos profiles and rating

### DIFF
--- a/nms/app/packages/magmalte/app/e2e/__tests__/Policy-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/Policy-test.js
@@ -68,10 +68,11 @@ describe('NMS Policy Add', () => {
       // check if the description is right
       await page.waitForXPath(`//span[text()='Policies']`);
 
-      const buttonSelector = await page.$x(
-        `//span[text()='Create New Policy']`,
-      );
+      const buttonSelector = await page.$x(`//span[text()='Create New']`);
       buttonSelector[0].click();
+
+      const policybuttonSelector = await page.$x(`//span[text()='Policy']`);
+      policybuttonSelector[0].click();
 
       await page.waitForXPath(`//span[text()='Add New Policy']`);
 

--- a/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
@@ -14,16 +14,103 @@
  * @format
  */
 import ApnOverview from './ApnOverview';
+import ArrowDropDownIcon from '@material-ui/icons/ArrowDropDown';
+import Button from '@material-ui/core/Button';
 import LibraryBooksIcon from '@material-ui/icons/LibraryBooks';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
 import PolicyOverview from './PolicyOverview';
+import PolicyRuleEditDialog from './PolicyEdit';
 import React from 'react';
 import RssFeedIcon from '@material-ui/icons/RssFeed';
+import Text from '../../theme/design-system/Text';
 import TopBar from '../../components/TopBar';
 
 import {ApnJsonConfig} from './ApnOverview';
 import {PolicyJsonConfig} from './PolicyOverview';
 import {Redirect, Route, Switch} from 'react-router-dom';
+import {colors, typography} from '../../theme/default';
+import {makeStyles} from '@material-ui/styles';
 import {useRouter} from '@fbcnms/ui/hooks';
+import {withStyles} from '@material-ui/core/styles';
+
+const useStyles = makeStyles(_ => ({
+  appBarBtn: {
+    color: colors.primary.white,
+    background: colors.primary.comet,
+    fontFamily: typography.button.fontFamily,
+    fontWeight: typography.button.fontWeight,
+    fontSize: typography.button.fontSize,
+    lineHeight: typography.button.lineHeight,
+    letterSpacing: typography.button.letterSpacing,
+
+    '&:hover': {
+      background: colors.primary.mirage,
+    },
+  },
+}));
+
+const StyledMenu = withStyles({
+  paper: {
+    border: '1px solid #d3d4d5',
+  },
+})(props => (
+  <Menu
+    data-testid="policy_menu"
+    elevation={0}
+    getContentAnchorEl={null}
+    anchorOrigin={{
+      vertical: 'bottom',
+      horizontal: 'center',
+    }}
+    transformOrigin={{
+      vertical: 'top',
+      horizontal: 'center',
+    }}
+    {...props}
+  />
+));
+
+function PolicyMenu() {
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [open, setOpen] = React.useState(false);
+
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <div>
+      <PolicyRuleEditDialog open={open} onClose={() => setOpen(false)} />
+      <Button
+        onClick={handleClick}
+        className={classes.appBarBtn}
+        endIcon={<ArrowDropDownIcon />}>
+        Create New{' '}
+      </Button>
+      <StyledMenu
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}>
+        <MenuItem data-testid="newPolicyMenuItem" onClick={() => setOpen(true)}>
+          <Text variant="subtitle2">Policy</Text>
+        </MenuItem>
+        <MenuItem>
+          <Text variant="subtitle2">Profiles</Text>
+        </MenuItem>
+        <MenuItem>
+          <Text variant="subtitle2">Rating Groups</Text>
+        </MenuItem>
+      </StyledMenu>
+    </div>
+  );
+}
 
 export default function TrafficDashboard() {
   const {relativePath, relativeUrl} = useRouter();
@@ -37,6 +124,7 @@ export default function TrafficDashboard() {
             label: 'Policies',
             to: '/policy',
             icon: LibraryBooksIcon,
+            filters: <PolicyMenu />,
           },
           {
             label: 'APNs',

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/PolicyAddEditTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/PolicyAddEditTest.js
@@ -26,6 +26,7 @@ import {
   LteNetworkContextProvider,
   PolicyProvider,
 } from '../../../components/lte/LteContext';
+
 import {MemoryRouter, Route} from 'react-router-dom';
 import {MuiThemeProvider} from '@material-ui/core/styles';
 import {cleanup, fireEvent, render, wait} from '@testing-library/react';
@@ -238,8 +239,14 @@ describe('<TrafficDashboard />', () => {
     ).toHaveBeenCalledWith({networkId: fegNetworkId});
 
     expect(queryByTestId('editDialog')).toBeNull();
-    fireEvent.click(getByText('Create New Policy'));
+
+    fireEvent.click(getByText('Create New'));
     await wait();
+
+    const newPolicyMenu = getByTestId('newPolicyMenuItem');
+    fireEvent.click(newPolicyMenu);
+    await wait();
+
     expect(queryByTestId('editDialog')).not.toBeNull();
 
     expect(queryByTestId('infoEdit')).not.toBeNull();
@@ -358,8 +365,13 @@ describe('<TrafficDashboard />', () => {
     ).toHaveBeenCalledWith({networkId});
 
     expect(queryByTestId('editDialog')).toBeNull();
-    fireEvent.click(getByText('Create New Policy'));
+
+    fireEvent.click(getByText('Create New'));
     await wait();
+
+    fireEvent.click(getByTestId('newPolicyMenuItem'));
+    await wait();
+
     expect(queryByTestId('editDialog')).not.toBeNull();
 
     expect(queryByTestId('infoEdit')).not.toBeNull();
@@ -452,7 +464,11 @@ describe('<TrafficDashboard />', () => {
     ).toHaveBeenCalledWith({networkId});
 
     expect(queryByTestId('editDialog')).toBeNull();
-    fireEvent.click(getByText('Create New Policy'));
+
+    fireEvent.click(getByText('Create New'));
+    await wait();
+
+    fireEvent.click(getByTestId('newPolicyMenuItem'));
     await wait();
     expect(queryByTestId('editDialog')).not.toBeNull();
 

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -154,8 +154,6 @@ describe('<TrafficDashboard />', () => {
       <Wrapper />,
     );
     await wait();
-    // Policy tab
-    expect(getByTestId('title_Policies')).toHaveTextContent('Policies');
     // Policy tables rows
     const rowItemsPolicy = await getAllByRole('row');
     // first row is the header


### PR DESCRIPTION
## Summary

Currently we don't have a way of configuring Qos profiles and rating groups. Following PR adds placeholders for configuring them. Also Brave Ux designs don't cover this. Added this based on existing theme


## Test Plan
yarn test and yarn test:e2e works

Moved the create new (policy/profile/rating groups) to the top
![profile](https://user-images.githubusercontent.com/8224854/96386120-5cae1a80-114d-11eb-8e52-9d1ae6635f37.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
