### PR TITLE
[helm][nms] mysql nms deployment

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.39
+version: 1.4.40
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -12,7 +12,7 @@
 apiVersion: v1
 description: Magma NMS
 name: nms
-version: 0.1.7
+version: 0.1.8
 home: https://github.com/facebookincubator/magma
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/magmalte-deployment.yaml
@@ -80,6 +80,8 @@ spec:
               value: {{ .Values.magmalte.env.mysql_db | quote }}
             - name: MYSQL_HOST
               value: {{ .Values.magmalte.env.mysql_host | quote }}
+            - name: MYSQL_PORT
+              value: {{ .Values.magmalte.env.mysql_port | quote }}
             - name: MYSQL_DIALECT
               value: {{ .Values.magmalte.env.mysql_dialect | quote }}
             - name: MYSQL_PASS

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/mysql-deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/mysql-deployment.yaml
@@ -1,0 +1,83 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if .Values.mysql.create }}
+{{- $envAll := . }}
+
+{{- $saNamespace := $envAll.Release.Namespace }}
+{{- $serviceAccountName := printf "%s" .Release.Name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nms-mysql
+  labels:
+{{ tuple $envAll "nms" "mysql" | include "nms.labels" | indent 4 }}
+spec:
+  replicas: {{ .Values.mysql.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+{{ tuple $envAll "nms" "mysql" | include "nms.selector-labels" | indent 6 }}
+  template:
+    metadata:
+      labels:
+{{ tuple $envAll "nms" "mysql" | include "nms.selector-labels" | indent 8 }}
+    spec:
+      {{- if .Values.rbac }}
+      serviceAccountName: {{ $serviceAccountName }}
+      {{- end }}
+      {{- with .Values.mysql.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.mysql.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.mysql.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: 60
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml . | trimSuffix "\n" | indent 8 }}
+      {{- end }}
+      restartPolicy: Always
+      containers:
+        - name: nms-mysql
+          image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
+          imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.mysql.resources | indent 12 }}
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: "mysql-data"
+              mountPath: /var/lib/mysql
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              value: {{ .Values.mysql.env.MYSQL_ROOT_PASSWORD | quote }}
+            - name: MYSQL_DATABASE
+              value: {{ .Values.mysql.env.MYSQL_DATABASE | quote }}
+            - name: MYSQL_USER
+              value: {{ .Values.mysql.env.MYSQL_USER | quote }}
+            - name: MYSQL_PASSWORD
+              value: {{ .Values.mysql.env.MYSQL_PASSWORD | quote }}
+      volumes:
+        - name: "mysql-data"
+{{ toYaml .Values.mysql.volumes.mysqlData.volumeSpec | indent 10 }}
+
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/nms/templates/mysql-service.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/templates/mysql-service.yaml
@@ -1,0 +1,53 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- if .Values.mysql.create }}
+{{- $envAll := . }}
+{{ $serviceType := .Values.mysql.service.type }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql
+  labels:
+{{ tuple $envAll "nms" "mysql" | include "nms.labels" | indent 4 }}
+  {{- if .Values.mysql.service.annotations }}
+  annotations:
+{{ with .Values.mysql.service.annotations }}{{ toYaml . | indent 4 }}{{ end }}
+  {{- end }}
+spec:
+  selector:
+{{ tuple $envAll "nms" "mysql" | include "nms.selector-labels" | indent 4 }}
+  type: "{{ .Values.mysql.service.type }}"
+  ports:
+  - name: mysql
+    port: {{ .Values.mysql.service.http.port }}
+    targetPort: {{ .Values.mysql.service.http.targetPort }}
+    protocol: TCP
+    {{- if eq $serviceType "NodePort" }}
+    {{- if .Values.mysql.service.http.nodePort }}
+    nodePort: {{ .Values.mysql.service.http.nodePort }}
+    {{- end -}}
+    {{- end -}}
+{{- if eq $serviceType "LoadBalancer" }}
+  {{- if .Values.mysql.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.mysql.service.loadBalancerIP }}
+  {{- end -}}
+  {{- if .Values.mysql.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range .Values.mysql.service.loadBalancerSourceRanges }}
+  - {{ . }}
+  {{- end }}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/values.yaml
@@ -29,10 +29,11 @@ magmalte:
     host: 0.0.0.0
     port: 8081
     mapbox_access_token: ""
-    mysql_host: mariadb.magma.svc.cluster.local
+    mysql_host: mysql
     mysql_db: magma
     mysql_user: magma
     mysql_pass: password
+    mysql_port: 3306
     mysql_dialect: mysql
     grafana_address: orc8r-user-grafana:3000
 
@@ -101,6 +102,56 @@ nginx:
     spec:
       ssl_cert_name: nms_nginx.pem
       ssl_cert_key_name: nms_nginx.key.pem
+
+  replicas: 1
+
+  # Resource limits & requests
+  resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+  # Define which Nodes the Pods are scheduled on.
+  # ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+
+  # Tolerations for use with node taints
+  # ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+  tolerations: []
+
+  # Assign proxy to run on specific nodes
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  affinity: {}
+
+mysql:
+  create: false
+
+  volumes:
+    mysqlData:
+      volumeSpec: {}
+
+  env:
+    MYSQL_ROOT_PASSWORD: password
+    MYSQL_DATABASE: magma
+    MYSQL_USER: magma
+    MYSQL_PASSWORD: password
+
+  labels: {}
+
+  image:
+    repository: docker.io/mysql
+    tag: 5.7
+    pullPolicy: IfNotPresent
+
+  service:
+    type: ClusterIP
+    http:
+      port: 3306
+      targetport: 3306
+      nodePort: ""
 
   replicas: 1
 

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -7,12 +7,12 @@ dependencies:
   version: 1.4.18
 - name: nms
   repository: ""
-  version: 0.1.7
+  version: 0.1.8
 - name: logging
   repository: ""
   version: 0.1.10
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.1
-digest: sha256:02779c7381a791eaa6e962658e7703a06e641376c9769ac11b4b2cb98daabbed
-generated: "2020-10-15T14:36:59.18567-07:00"
+digest: sha256:025ecd5b98e6563284a9883a5153435fdc963c1866bae758ffad0e3088617267
+generated: "2020-10-19T14:11:13.889413-07:00"

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -19,7 +19,7 @@ dependencies:
     repository: ""
     condition: metrics.enabled
   - name: nms
-    version: 0.1.7
+    version: 0.1.8
     repository: ""
     condition: nms.enabled
   - name: logging


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Adds mysql pod to the NMS deployment so the NMS can work out of the box with helm. Previously defaulted to using orc8r's postgres db, but the NMS is not configured to work with that syntax.

## Test Plan
Spin up orc8r, create user in magmalte, port-forward and access nms. Creating a network succeeded.
![image](https://user-images.githubusercontent.com/13274915/96512742-cbef4180-1215-11eb-9b84-f6599824fa70.png)
