### PR TITLE
Add debug server to enodebd, pipelined, subscriberd and mobilityd to perform introspection

### DIFF
--- a/lte/gateway/python/magma/enodebd/main.py
+++ b/lte/gateway/python/magma/enodebd/main.py
@@ -13,8 +13,10 @@ limitations under the License.
 
 from threading import Thread
 from unittest import mock
+
 from magma.enodebd.enodeb_status import get_service_status_old, \
     get_operational_states
+from magma.common.debug_server import run_debug_server
 from magma.enodebd.state_machines.enb_acs_manager import StateMachineManager
 from magma.enodebd.logger import EnodebdLogger as logger
 from .rpc_servicer import EnodebdRpcServicer
@@ -54,6 +56,9 @@ def main():
                            daemon=True)
     server_thread.start()
 
+    # start debug server
+    start_debug_server(run_debug_server, locals())
+
     # Add all servicers to the server
     enodebd_servicer = EnodebdRpcServicer(state_machine_manager)
     enodebd_servicer.add_to_server(service.rpc_server)
@@ -77,6 +82,12 @@ def main():
     # Cleanup the service
     service.close()
 
+def start_debug_server(target, namespace):
+    """ Starts service server threads """
+    debug_sockpath = '/tmp/enodebd.sock'
+    thread = Thread(target=target, args=(debug_sockpath, namespace))
+    thread.daemon = True
+    thread.start()
 
 def call_repeatedly(loop, interval, function, *args, **kwargs):
     """

--- a/lte/gateway/python/magma/pipelined/main.py
+++ b/lte/gateway/python/magma/pipelined/main.py
@@ -26,6 +26,7 @@ from scapy.arch import get_if_hwaddr
 
 from magma.common.misc_utils import call_process
 from magma.common.service import MagmaService
+from magma.common.debug_server import run_debug_server
 from magma.configuration import environment
 from magma.pipelined.app import of_rest_server
 from magma.pipelined.check_quota_server import run_flask
@@ -35,7 +36,6 @@ from magma.pipelined.rpc_servicer import PipelinedRpcServicer
 from magma.pipelined.gtp_stats_collector import GTPStatsCollector, \
     MIN_OVSDB_DUMP_POLLING_INTERVAL
 from lte.protos.mconfig import mconfigs_pb2
-
 
 def main():
     """
@@ -131,6 +131,10 @@ def main():
         start_check_quota_server(run_flask, bridge_ip, no_quota_port, False,
                                  on_exit_server_thread)
 
+
+    # start debug server
+    start_debug_server(run_debug_server, manager)
+
     if service.config['setup_type'] == 'LTE':
         polling_interval = service.config.get('ovs_gtp_stats_polling_interval',
                                               MIN_OVSDB_DUMP_POLLING_INTERVAL)
@@ -154,6 +158,13 @@ def start_check_quota_server(target, ip, port, response, exit_callback):
     thread.daemon = True
     thread.start()
 
+
+def start_debug_server(target, namespace):
+    """ Starts service server threads """
+    debug_sockpath = '/tmp/pipelined.sock'
+    thread = threading.Thread(target=target, args=(debug_sockpath, namespace,))
+    thread.daemon = True
+    thread.start()
 
 if __name__ == "__main__":
     main()

--- a/lte/gateway/python/magma/subscriberdb/main.py
+++ b/lte/gateway/python/magma/subscriberdb/main.py
@@ -12,9 +12,11 @@ limitations under the License.
 """
 import asyncio
 import logging
+import threading
 
 from magma.common.service import MagmaService
 from magma.common.streamer import StreamerClient
+from magma.common.debug_server import run_debug_server
 from .processor import Processor
 from .protocols.diameter.application import base, s6a
 from .protocols.diameter.server import S6aServer
@@ -83,6 +85,9 @@ def main():
             asyncio.ensure_future(s6a_server, loop=service.loop)
     asyncio.ensure_future(serve(), loop=service.loop)
 
+    # start debug server
+    start_debug_server(run_debug_server, locals())
+
     # Run the service loop
     service.run()
 
@@ -99,6 +104,12 @@ def _get_s6a_manager(service, processor):
         service.loop
     )
 
+def start_debug_server(target, namespace):
+    """ Starts service server threads """
+    debug_sockpath = '/tmp/subscriberdb.sock'
+    thread = threading.Thread(target=target, args=(debug_sockpath, namespace))
+    thread.daemon = True
+    thread.start()
 
 if __name__ == "__main__":
     main()

--- a/orc8r/gateway/python/magma/common/debug_server.py
+++ b/orc8r/gateway/python/magma/common/debug_server.py
@@ -1,0 +1,43 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import wsgiserver
+from flask import Flask, request
+
+def debug(**kwargs):
+    # pylint: disable=broad-except,eval-used
+    try:
+        expr = request.form.get('q')
+        if kwargs['namespace']:
+            namespace = {
+                'manager' : kwargs['namespace']
+            }
+            response = str(eval(expr, namespace))
+        else:
+            response = str(eval(expr))
+        return response
+    except Exception as e:
+        return "Exception %s " % str(e)
+
+def run_debug_server(debug_sockpath, namespace=None):
+    app = Flask(__name__)
+    app.add_url_rule(
+        '/debug', 'index', debug,
+        defaults={'namespace': namespace},
+        methods=['POST',])
+    server = wsgiserver.WSGIServer(app)
+    server.bind_addr = debug_sockpath
+    try:
+        server.start()
+    finally:
+        # When the flask server finishes running, do any other cleanup
+        pass


### PR DESCRIPTION
## Summary

Add debug server to enodebd, pipelined, subscriberd and mobilityd to perform introspection

## Test Plan
Able to run simple python expressions within pipelined
```
sudo curl --unix-socket /tmp/pipelined.sock -X POST http://localhost/debug -d "q=manager.applications['EnforcementController']._qos_mgr.__dict__"
{'_initialized': True, '_redis_conn_retry_secs': 1, '_loop': <EventLoop running=True closed=False debug=False>, '_clean_restart': True, 'impl': <magma.pipelined.qos.qos_tc_impl.TCManager object at 0x7f59ebbda748>, '_qos_enabled': True, '_subscriber_state': {}, '_qos_store': <redis_collections.QosStore at QosManager {}>}
```


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
