### PR TITLE
Add grpc logging to pipelined

### DIFF
--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -147,6 +147,9 @@ clean_restart: true
 
 redis_enabled: false
 
+# Logs grpc payload content
+print_grpc_payload: false
+
 # Information for cwf check quota servers
 quota_check_ip: '192.0.0.1'
 has_quota_port: 51115

--- a/cwf/gateway/configs/pipelined.yml
+++ b/cwf/gateway/configs/pipelined.yml
@@ -148,7 +148,7 @@ clean_restart: true
 redis_enabled: false
 
 # Logs grpc payload content
-print_grpc_payload: false
+magma_print_grpc_payload: false
 
 # Information for cwf check quota servers
 quota_check_ip: '192.0.0.1'

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -141,7 +141,7 @@ li_mirror_all: false
 redis_enabled: false
 
 # Logs grpc payload content
-print_grpc_payload: true
+magma_print_grpc_payload: true
 
 # Configuration for IPFIX sampling
 ipfix:

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -140,6 +140,9 @@ li_mirror_all: false
 
 redis_enabled: false
 
+# Logs grpc payload content
+print_grpc_payload: true
+
 # Configuration for IPFIX sampling
 ipfix:
   enabled: true

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -126,6 +126,9 @@ clean_restart: true
 
 redis_enabled: false
 
+# Logs grpc payload content
+print_grpc_payload: false
+
 # MTR iface IP
 mtr_ip: 10.0.2.10
 mtr_interface: mtr0

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -127,7 +127,7 @@ clean_restart: true
 redis_enabled: false
 
 # Logs grpc payload content
-print_grpc_payload: false
+magma_print_grpc_payload: false
 
 # MTR iface IP
 mtr_ip: 10.0.2.10

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -124,6 +124,9 @@ clean_restart: true
 
 redis_enabled: false
 
+# Logs grpc payload content
+print_grpc_payload: false
+
 ###############
 ## IMPORTANT ##
 ###############

--- a/lte/gateway/configs/pipelined.yml_prod
+++ b/lte/gateway/configs/pipelined.yml_prod
@@ -125,7 +125,7 @@ clean_restart: true
 redis_enabled: false
 
 # Logs grpc payload content
-print_grpc_payload: false
+magma_print_grpc_payload: false
 
 ###############
 ## IMPORTANT ##

--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -135,7 +135,7 @@ clean_restart: true
 redis_enabled: false
 
 # Logs grpc payload content
-print_grpc_payload: false
+magma_print_grpc_payload: false
 
 # Information for cwf check quota servers
 quota_check_ip: '192.0.0.1'

--- a/xwf/gateway/configs/pipelined.yml
+++ b/xwf/gateway/configs/pipelined.yml
@@ -134,6 +134,9 @@ clean_restart: true
 
 redis_enabled: false
 
+# Logs grpc payload content
+print_grpc_payload: false
+
 # Information for cwf check quota servers
 quota_check_ip: '192.0.0.1'
 has_quota_port: 51115


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

If flag enabled dumps grpc payload logs, f.e:
```
INFO:root:Received GRPC payload:
  UEMacFlowRequest {
    sid {
      id: "IMSI439414250916987"
    }
    mac_addr: "4e:3c:37:c3:2e:45"
    msisdn: "5100001234"
    ap_mac_addr: "98-DE-D0-84-B5-47"
    ap_name: "CWF-TP-LINK_B547_5G"
    pdp_start_time: 1603183125
  }
```

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
