### PR TITLE
Changing the secret value to be from an env variable

### DIFF
--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -98,7 +98,7 @@ services:
       - SCUBA_ACCESS_TOKEN=${SCUBA_ACCESS_TOKEN}
       - AAA_ENDPOINT=https://graph.expresswifi.com/radius/authorization
       - AAA_ACCESS_TOKEN=${AAA_ACCESS_TOKEN}
-      - RADIUS_SECRET=123456
+      - RADIUS_SECRET=${RADIUS_SECRET:-123456}
       - TEMPLATE_ENV=radius.ofpanalytics.config.json.template
       - PARTNER_SHORTNAME=${PARTNER_SHORTNAME}
     command: >


### PR DESCRIPTION
Signed-off-by: rongalay <rongalay@gmail.com>

[xwfm][radius] Changing how we initialize radius

## Summary

The radius secret isn't configurable, changing it to be so

## Test Plan

Tested on our qa partner the change. Changed the docker-compose and restarted radius. Checked that indeed the secret is taken correctly

