### PR TITLE
[cwag_integ_test] fix uesim logs

### DIFF
--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -178,17 +178,6 @@ def transfer_artifacts(gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml",
     if get_core_dump == "True":
         execute(_tar_coredump, gateway_vm=gateway_vm, gateway_ansible_file=gateway_ansible_file)
 
-    # get uesim logs
-    # TODO: make sure exception is not triggered
-    with settings(abort_exception=FabricException):
-        result = None
-        try:
-            _switch_to_vm(None, "cwag_test", "cwag_test.yml", False)
-            uesim_log = 'uesim.log'
-            with cd(f'{CWAG_ROOT}'):
-                result = run('tmux capture-pane -pt "$target-pane" >>' + uesim_log)
-        except Exception:
-            print("Error copying uesim.log %s" % str(result if result else ""))
 
 def _tar_coredump(gateway_vm="cwag", gateway_ansible_file="cwag_dev.yml"):
     _switch_to_vm_no_destroy(None, gateway_vm, gateway_ansible_file)
@@ -374,9 +363,9 @@ def _check_docker_services(ignoreList):
 
 
 def _start_ue_simulator():
-    """ Starts the UE Sim Service """
+    """ Starts the UE Sim Service and logs into uesim.log"""
     with cd(CWAG_ROOT + '/services/uesim/uesim'):
-        run('tmux new -d \'go run main.go -logtostderr=true -v=2\'')
+        run('tmux new -d \'go run main.go -logtostderr=true -v=9 &> %s/uesim.log\'' % CWAG_ROOT)
 
 
 def _start_trfserver():
@@ -408,11 +397,11 @@ def _run_integ_tests(test_host, trf_host, tests_to_run: SubTests,
     if test_re:
         shell_env_vars["TESTS"] = test_re
 
-    # QOS take a while to run. Increasing the timeout to 20m
+    # QOS take a while to run. Increasing the timeout to 50m
     go_test_cmd = "gotestsum --format=standard-verbose "
     if test_result_xml: # generate test result XML in cwf/gateway directory
         go_test_cmd += "--junitfile ../" + test_result_xml + " "
-    go_test_cmd += " -- -test.short -timeout 20m" # go test args
+    go_test_cmd += " -- -test.short -timeout 50m" # go test args
     go_test_cmd += " -tags=" + tests_to_run.value
     if test_re:
         go_test_cmd += " -run=" + test_re

--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -188,8 +188,8 @@ func TestGyCreditExhaustionWithCRRU(t *testing.T) {
 
 	// We need to generate over 100% of the quota to trigger a session termination
 	req = &cwfprotos.GenTrafficRequest{
-		Imsi:    ue.GetImsi(),
-		Volume:  &wrappers.StringValue{Value: "10M"},
+		Imsi:   ue.GetImsi(),
+		Volume: &wrappers.StringValue{Value: "10M"},
 	}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -252,7 +252,7 @@ func TestGyCreditValidityTime(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:    ue.GetImsi(),
 		Volume:  &wrappers.StringValue{Value: "500K"},
-		Bitrate: &wrappers.StringValue{Value:"10M"},
+		Bitrate: &wrappers.StringValue{Value: "10M"},
 		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
@@ -318,6 +318,7 @@ func TestGyCreditExhaustionWithoutCRRU(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:    ue.GetImsi(),
 		Volume:  &wrappers.StringValue{Value: "5M"},
+		Timeout: 60,
 	}
 	_, err := tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -734,7 +735,8 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	req := &cwfprotos.GenTrafficRequest{
 		Imsi:    ue.GetImsi(),
 		Volume:  &wrappers.StringValue{Value: "5M"},
-
+		Bitrate: &wrappers.StringValue{Value: "60M"},
+		Timeout: 60,
 	}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
@@ -750,7 +752,7 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	req = &cwfprotos.GenTrafficRequest{
 		Imsi:    ue.GetImsi(),
 		Volume:  &wrappers.StringValue{Value: "2M"},
-		Bitrate: &wrappers.StringValue{Value: "30M"},
+		Bitrate: &wrappers.StringValue{Value: "60M"},
 		Timeout: 60,
 	}
 	_, err = tr.GenULTraffic(req)
@@ -778,7 +780,7 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	req = &cwfprotos.GenTrafficRequest{
 		Imsi:    ue.GetImsi(),
 		Volume:  &wrappers.StringValue{Value: "2M"},
-		Bitrate: &wrappers.StringValue{Value: "30M"},
+		Bitrate: &wrappers.StringValue{Value: "60M"},
 		Timeout: 60,
 	}
 	_, err = tr.GenULTraffic(req)
@@ -843,7 +845,7 @@ func TestGyWithErrorCode(t *testing.T) {
 
 	// we need to generate over 80% but less than 100%  trigger a CCR update without triggering termination
 	req := &cwfprotos.GenTrafficRequest{
-		Imsi: ue.GetImsi(),
+		Imsi:   ue.GetImsi(),
 		Volume: &wrappers.StringValue{Value: "4.6M"},
 	}
 	_, err := tr.GenULTraffic(req)


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

In case of crash, uesim log was not collected because tmux was killed before capturing the pane
This PR simplifies the uesim collection (it will always dump it to uesim.log file)

This PR also increases the timeout for tests. It looks like 20 minutes is not enough anymore

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
