### PR TITLE
[cwag_integ_test] fix TestGyCreditExhaustionRestrict

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -742,13 +742,10 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	assert.NoError(t, err)
 	tr.WaitForEnforcementStatsToSync()
 
-	// Check that UE mac flow was not removed and data was passed
-	verifyPolicyUsage(t, tr, ue.GetImsi(), "static-pass-all-ocs2", 0, 5*MegaBytes)
-
 	// Wait for service deactivation
 	time.Sleep(3 * time.Second)
 
-	// we need to generate more traffic to hit restrict rule
+	// we need to generate more traffic and validate it goes through restrict rule
 	req = &cwfprotos.GenTrafficRequest{
 		Imsi:    ue.GetImsi(),
 		Volume:  &wrappers.StringValue{Value: "2M"},


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

It looks like this test is checking for the existence of a flow that gets deleted after restriction is applied. 


## Test Plan

cwf integ_test

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
