### PR TITLE
[orc8r][mesh][serdes] Convert cfg entity serdes to non-registry pattern

### DIFF
--- a/cwf/cloud/go/plugin/plugin.go
+++ b/cwf/cloud/go/plugin/plugin.go
@@ -16,10 +16,8 @@ package plugin
 import (
 	"magma/cwf/cloud/go/cwf"
 	cwf_service "magma/cwf/cloud/go/services/cwf"
-	"magma/cwf/cloud/go/services/cwf/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -44,11 +42,7 @@ func (*CwfOrchestratorPlugin) GetServices() []registry.ServiceLocation {
 }
 
 func (*CwfOrchestratorPlugin) GetSerdes() []serde.Serde {
-	return []serde.Serde{
-		configurator.NewNetworkConfigSerde(cwf.CwfNetworkType, &models.NetworkCarrierWifiConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(cwf.CwfGatewayType, &models.GatewayCwfConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(cwf.CwfHAPairType, &models.CwfHaPairConfigs{}),
-	}
+	return []serde.Serde{}
 }
 
 func (*CwfOrchestratorPlugin) GetMconfigBuilders() []mconfig.Builder {

--- a/cwf/cloud/go/serdes/serdes.go
+++ b/cwf/cloud/go/serdes/serdes.go
@@ -16,19 +16,27 @@ package serdes
 import (
 	"magma/cwf/cloud/go/cwf"
 	"magma/cwf/cloud/go/services/cwf/obsidian/models"
+	feg_models "magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/state"
 )
 
 var (
-	// CWFStateSerdes contains the CWF-specific state serdes
-	CWFStateSerdes = serde.NewRegistry(
+	// Network contains the full set of configurator network config serdes
+	// used in the CWF module
+	Network = serdes.Network.
+		MustMerge(models.NetworkSerdes).
+		MustMerge(feg_models.NetworkSerdes)
+	// Entity contains the full set of configurator network entity serdes used
+	// in the CWF module
+	Entity = serdes.Entity.
+		MustMerge(models.EntitySerdes).
+		MustMerge(feg_models.EntitySerdes)
+	// State contains the full set of state serdes used in the CWF module
+	State = serdes.State.MustMerge(serde.NewRegistry(
 		state.NewStateSerde(cwf.CwfSubscriberDirectoryType, &models.CwfSubscriberDirectoryRecord{}),
 		state.NewStateSerde(cwf.CwfHAPairStatusType, &models.CarrierWifiHaPairStatus{}),
 		state.NewStateSerde(cwf.CwfGatewayHealthType, &models.CarrierWifiGatewayHealthStatus{}),
-	)
-
-	// StateSerdes contains the full set of state serdes used in the LTE module
-	StateSerdes = CWFStateSerdes.MustMerge(serdes.StateSerdes)
+	))
 )

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers.go
@@ -78,7 +78,7 @@ const (
 
 func GetHandlers() []obsidian.Handler {
 	ret := []obsidian.Handler{
-		handlers.GetListGatewaysHandler(ListGatewaysPath, &cwfModels.MutableCwfGateway{}, makeCwfGateways),
+		handlers.GetListGatewaysHandler(ListGatewaysPath, &cwfModels.MutableCwfGateway{}, makeCwfGateways, serdes.Entity),
 		{Path: ListGatewaysPath, Methods: obsidian.POST, HandlerFunc: createGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
@@ -101,31 +101,31 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageNetworkRuleNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberRuleName},
 	}
 
-	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListNetworksPath, ManageNetworkPath, cwf.CwfNetworkType, &cwfModels.CwfNetwork{})...)
+	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListNetworksPath, ManageNetworkPath, cwf.CwfNetworkType, &cwfModels.CwfNetwork{}, serdes.Network)...)
 
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8rModels.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSPath, &orc8rModels.NetworkDNSConfig{}, orc8r.DnsdNetworkType)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCarrierWifiPath, &cwfModels.NetworkCarrierWifiConfigs{}, cwf.CwfNetworkType)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFederationPath, &fegModels.FederatedNetworkConfigs{}, cwf.CwfNetworkType)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkSubscriberPath, &policyModels.NetworkSubscriberConfig{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkRuleNamesPath, new(policyModels.RuleNames), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkBaseNamesPath, new(policyModels.BaseNames), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkLiUesPath, new(cwfModels.LiUes), "")...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8rModels.NetworkFeatures{}, orc8r.NetworkFeaturesConfig, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSPath, &orc8rModels.NetworkDNSConfig{}, orc8r.DnsdNetworkType, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCarrierWifiPath, &cwfModels.NetworkCarrierWifiConfigs{}, cwf.CwfNetworkType, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFederationPath, &fegModels.FederatedNetworkConfigs{}, cwf.CwfNetworkType, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkSubscriberPath, &policyModels.NetworkSubscriberConfig{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkRuleNamesPath, new(policyModels.RuleNames), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkBaseNamesPath, new(policyModels.BaseNames), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkLiUesPath, new(cwfModels.LiUes), "", serdes.Network)...)
 
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8rModels.MagmadGatewayConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8rModels.TierID))...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8rModels.MagmadGatewayConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8rModels.TierID), serdes.Entity)...)
 	ret = append(ret, handlers.GetGatewayDeviceHandlers(ManageGatewayDevicePath)...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCarrierWifiPath, &cwfModels.GatewayCwfConfigs{})...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCarrierWifiPath, &cwfModels.GatewayCwfConfigs{}, serdes.Entity)...)
 
 	return ret
 }
 
 func createGateway(c echo.Context) error {
-	if nerr := handlers.CreateGateway(c, &cwfModels.MutableCwfGateway{}); nerr != nil {
+	if nerr := handlers.CreateGateway(c, &cwfModels.MutableCwfGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusCreated)
@@ -145,6 +145,7 @@ func getGateway(c echo.Context) error {
 	ent, err := configurator.LoadEntity(
 		nid, cwf.CwfGatewayType, gid,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: false},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load cwf gateway"), http.StatusInternalServerError)
@@ -171,7 +172,7 @@ func updateGateway(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	if nerr = handlers.UpdateGateway(c, nid, gid, &cwfModels.MutableCwfGateway{}); nerr != nil {
+	if nerr = handlers.UpdateGateway(c, nid, gid, &cwfModels.MutableCwfGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -231,7 +232,7 @@ func getSubscriberDirectoryHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	configuratorNetwork, err := configurator.LoadNetwork(networkID, false, false)
+	configuratorNetwork, err := configurator.LoadNetwork(networkID, false, false, serdes.Network)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusNotFound)
 	}
@@ -242,7 +243,7 @@ func getSubscriberDirectoryHandler(c echo.Context) error {
 	if subscriberID == "" {
 		return obsidian.HttpError(fmt.Errorf("SubscriberID cannot be empty"), http.StatusBadRequest)
 	}
-	directoryState, err := state.GetState(networkID, orc8r.DirectoryRecordType, subscriberID, serdes.StateSerdes)
+	directoryState, err := state.GetState(networkID, orc8r.DirectoryRecordType, subscriberID, serdes.State)
 	if err == merrors.ErrNotFound {
 		return obsidian.HttpError(err, http.StatusNotFound)
 	} else if err != nil {
@@ -278,7 +279,7 @@ func getHAPairStatusHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	network, err := configurator.LoadNetwork(nid, true, true)
+	network, err := configurator.LoadNetwork(nid, true, true, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return c.NoContent(http.StatusNotFound)
 	}
@@ -319,7 +320,7 @@ func listHAPairsHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	haPairEnts, err := configurator.LoadAllEntitiesInNetwork(nid, cwf.CwfHAPairType, configurator.FullEntityLoadCriteria())
+	haPairEnts, err := configurator.LoadAllEntitiesOfType(nid, cwf.CwfHAPairType, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -348,7 +349,7 @@ func createHAPairHandler(c echo.Context) error {
 	if err := haPair.ValidateModel(); err != nil {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
-	_, err := configurator.CreateEntity(networkID, haPair.ToEntity())
+	_, err := configurator.CreateEntity(networkID, haPair.ToEntity(), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -361,10 +362,9 @@ func getHAPairHandler(c echo.Context) error {
 		return nerr
 	}
 	ent, err := configurator.LoadEntity(
-		networkID,
-		cwf.CwfHAPairType,
-		haPairID,
+		networkID, cwf.CwfHAPairType, haPairID,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
 		return obsidian.HttpError(err, http.StatusNotFound)
@@ -405,7 +405,7 @@ func updateHAPairHandler(c echo.Context) error {
 	if !exists {
 		return echo.ErrNotFound
 	}
-	_, err = configurator.UpdateEntity(networkID, mutableHaPair.ToEntityUpdateCriteria(haPairID))
+	_, err = configurator.UpdateEntity(networkID, mutableHaPair.ToEntityUpdateCriteria(haPairID), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -442,7 +442,7 @@ func getHaPairState(networkID string, haPair *cwfModels.CwfHaPair) *cwfModels.Ca
 }
 
 func getCwfGatewayHealth(networkID string, gatewayID string) (*cwfModels.CarrierWifiGatewayHealthStatus, error) {
-	reportedGatewayState, err := state.GetState(networkID, cwf.CwfGatewayHealthType, gatewayID, serdes.StateSerdes)
+	reportedGatewayState, err := state.GetState(networkID, cwf.CwfGatewayHealthType, gatewayID, serdes.State)
 	if err == merrors.ErrNotFound {
 		return nil, obsidian.HttpError(err, http.StatusNotFound)
 	} else if err != nil {
@@ -459,7 +459,7 @@ func getCwfGatewayHealth(networkID string, gatewayID string) (*cwfModels.Carrier
 }
 
 func getCwfHaPairStatus(networkID string, haPairID string) (*cwfModels.CarrierWifiHaPairStatus, error) {
-	reportedHaPairStatus, err := state.GetState(networkID, cwf.CwfHAPairStatusType, haPairID, serdes.StateSerdes)
+	reportedHaPairStatus, err := state.GetState(networkID, cwf.CwfHAPairStatusType, haPairID, serdes.State)
 	if err == merrors.ErrNotFound {
 		return nil, obsidian.HttpError(err, http.StatusNotFound)
 	} else if err != nil {

--- a/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
+++ b/cwf/cloud/go/services/cwf/obsidian/handlers/handlers_test.go
@@ -190,7 +190,7 @@ func TestCwfNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -856,6 +856,7 @@ func seedCwfNetworks(t *testing.T) {
 				},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 	_, err = configurator.CreateNetworks(
@@ -889,6 +890,7 @@ func seedCwfNetworks(t *testing.T) {
 				Configs:     map[string]interface{}{},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 }
@@ -897,7 +899,7 @@ func reportSubscriberDirectoryRecord(t *testing.T, ctx context.Context, id strin
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedRecord, err := serde.Serialize(req, orc8r.DirectoryRecordType, serdes.StateSerdes)
+	serializedRecord, err := serde.Serialize(req, orc8r.DirectoryRecordType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{
@@ -918,7 +920,7 @@ func reportHaPairStatus(t *testing.T, ctx context.Context, pairID string, req *m
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedRecord, err := serde.Serialize(req, cwf.CwfHAPairStatusType, serdes.StateSerdes)
+	serializedRecord, err := serde.Serialize(req, cwf.CwfHAPairStatusType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{
@@ -939,7 +941,7 @@ func reportGatewayHealthStatus(t *testing.T, ctx context.Context, gatewayID stri
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedRecord, err := serde.Serialize(req, cwf.CwfGatewayHealthType, serdes.StateSerdes)
+	serializedRecord, err := serde.Serialize(req, cwf.CwfGatewayHealthType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{
@@ -1007,6 +1009,7 @@ func seedCwfTier(t *testing.T, networkID string) {
 		[]configurator.NetworkEntity{
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 }

--- a/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/conversion.go
@@ -185,7 +185,7 @@ func (m *MutableCwfGateway) GetAdditionalWritesOnUpdate(
 }
 
 func (m *GatewayCwfConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	carrierWifi, err := configurator.LoadEntityConfig(networkID, cwf.CwfGatewayType, gatewayID)
+	carrierWifi, err := configurator.LoadEntityConfig(networkID, cwf.CwfGatewayType, gatewayID, EntitySerdes)
 	if err != nil {
 		return err
 	}

--- a/cwf/cloud/go/services/cwf/obsidian/models/serdes.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/serdes.go
@@ -1,0 +1,32 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/cwf/cloud/go/cwf"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(cwf.CwfNetworkType, &NetworkCarrierWifiConfigs{}),
+	)
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(cwf.CwfGatewayType, &GatewayCwfConfigs{}),
+		configurator.NewNetworkEntityConfigSerde(cwf.CwfHAPairType, &CwfHaPairConfigs{}),
+	)
+)

--- a/cwf/cloud/go/services/cwf/servicers/builder_servicer.go
+++ b/cwf/cloud/go/services/cwf/servicers/builder_servicer.go
@@ -20,6 +20,7 @@ import (
 
 	"magma/cwf/cloud/go/cwf"
 	cwf_mconfig "magma/cwf/cloud/go/protos/mconfig"
+	"magma/cwf/cloud/go/serdes"
 	"magma/cwf/cloud/go/services/cwf/obsidian/models"
 	feg_mconfig "magma/feg/cloud/go/protos/mconfig"
 	lte_mconfig "magma/lte/cloud/go/protos/mconfig"
@@ -54,11 +55,11 @@ func NewBuilderServicer() builder_protos.MconfigBuilderServer {
 func (s *builderServicer) Build(ctx context.Context, request *builder_protos.BuildRequest) (*builder_protos.BuildResponse, error) {
 	ret := &builder_protos.BuildResponse{ConfigsByKey: map[string][]byte{}}
 
-	network, err := (configurator.Network{}).FromStorageProto(request.Network)
+	network, err := (configurator.Network{}).FromProto(request.Network, serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graph, err := (configurator.EntityGraph{}).FromStorageProto(request.Graph)
+	graph, err := (configurator.EntityGraph{}).FromProto(request.Graph, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/cwf/cloud/go/services/cwf/servicers/builder_servicer_test.go
+++ b/cwf/cloud/go/services/cwf/servicers/builder_servicer_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/cwf/cloud/go/cwf"
 	cwf_plugin "magma/cwf/cloud/go/plugin"
 	cwf_mconfig "magma/cwf/cloud/go/protos/mconfig"
+	"magma/cwf/cloud/go/serdes"
 	cwf_service "magma/cwf/cloud/go/services/cwf"
 	"magma/cwf/cloud/go/services/cwf/obsidian/models"
 	cwf_test_init "magma/cwf/cloud/go/services/cwf/test_init"
@@ -169,11 +170,11 @@ func TestBuilder_Build(t *testing.T) {
 }
 
 func build(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
-	networkProto, err := network.ToStorageProto()
+	networkProto, err := network.ToProto(serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graphProto, err := graph.ToStorageProto()
+	graphProto, err := graph.ToProto(serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/fbinternal/cloud/go/plugin/plugin.go
+++ b/fbinternal/cloud/go/plugin/plugin.go
@@ -1,3 +1,16 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
 package plugin
 
 import (
@@ -7,7 +20,6 @@ import (
 	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/metricsd/collection"
@@ -34,7 +46,6 @@ func (*FbinternalOrchestratorPlugin) GetServices() []registry.ServiceLocation {
 
 func (*FbinternalOrchestratorPlugin) GetSerdes() []serde.Serde {
 	return []serde.Serde{
-		configurator.NewNetworkConfigSerde(fbinternal.TestControllerNetworkType, &models.TestConfig{}),
 		serde.NewBinarySerde(testcontroller.SerdeDomain, testcontroller.EnodedTestCaseType, &models.EnodebdTestConfig{}),
 		serde.NewBinarySerde(testcontroller.SerdeDomain, testcontroller.EnodedTestExcludeTraffic, &models.EnodebdTestConfig{}),
 	}

--- a/fbinternal/cloud/go/serdes/serdes.go
+++ b/fbinternal/cloud/go/serdes/serdes.go
@@ -1,0 +1,25 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package serdes
+
+import (
+	"magma/fbinternal/cloud/go/services/testcontroller/obsidian/models"
+	"magma/orc8r/cloud/go/serdes"
+)
+
+var (
+	// Network contains the full set of configurator network config serdes
+	// used in the fbinternal module
+	Network = serdes.Network.MustMerge(models.NetworkSerdes)
+)

--- a/fbinternal/cloud/go/services/testcontroller/obsidian/models/serdes.go
+++ b/fbinternal/cloud/go/services/testcontroller/obsidian/models/serdes.go
@@ -1,0 +1,27 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/fbinternal/cloud/go/fbinternal"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(fbinternal.TestControllerNetworkType, &TestConfig{}),
+	)
+)

--- a/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
+++ b/fbinternal/cloud/go/services/testcontroller/statemachines/enodebd_test.go
@@ -95,7 +95,7 @@ func Test_EnodebdE2ETestStateMachine_HappyPath(t *testing.T) {
 	// ---
 	// Check for upgrade find version ahead of what tier is configured to
 	// ---
-	err = configurator.CreateOrUpdateEntityConfig("n1", orc8r.UpgradeTierEntityType, "t1", &models2.Tier{Version: "0.0.0-0-abcdefg"})
+	err = configurator.CreateOrUpdateEntityConfig("n1", orc8r.UpgradeTierEntityType, "t1", &models2.Tier{Version: "0.0.0-0-abcdefg"}, serdes.Entity)
 	assert.NoError(t, err)
 	mockResp = &http.Response{Status: "200", Body: ioutil.NopCloser(bytes.NewBuffer(testdata))}
 	cli.On("Get", mock.AnythingOfType("string")).Return(mockResp, nil).Times(1)
@@ -106,7 +106,7 @@ func Test_EnodebdE2ETestStateMachine_HappyPath(t *testing.T) {
 	assert.Equal(t, 10*time.Minute, actualDuration)
 
 	// Tier should get updated
-	actualTierCfg, err := configurator.LoadEntityConfig("n1", orc8r.UpgradeTierEntityType, "t1")
+	actualTierCfg, err := configurator.LoadEntityConfig("n1", orc8r.UpgradeTierEntityType, "t1", serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, &models2.Tier{Version: "0.3.74-1560824953-b50f1bab"}, actualTierCfg)
 
@@ -810,11 +810,12 @@ func SetupTests(t *testing.T, dbName string) {
 
 func RegisterAGW(t *testing.T) {
 	// Register an AGW
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntity(
 		"n1",
 		configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t1", Config: &models2.Tier{Name: "t1", Version: "0.3.74-1560824953-b50f1bab"}},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
@@ -859,6 +860,7 @@ func RegisterAGW(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 }
@@ -927,7 +929,7 @@ func reportEnodebState(t *testing.T, ctx context.Context, enodebSerial string, r
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedEnodebState, err := serde.Serialize(req, lte.EnodebStateType, serdes.StateSerdes)
+	serializedEnodebState, err := serde.Serialize(req, lte.EnodebStateType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{

--- a/feg/cloud/go/plugin/plugin.go
+++ b/feg/cloud/go/plugin/plugin.go
@@ -19,10 +19,8 @@ package plugin
 import (
 	"magma/feg/cloud/go/feg"
 	feg_service "magma/feg/cloud/go/services/feg"
-	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -48,12 +46,7 @@ func (*FegOrchestratorPlugin) GetServices() []registry.ServiceLocation {
 }
 
 func (*FegOrchestratorPlugin) GetSerdes() []serde.Serde {
-	return []serde.Serde{
-		// configurator serdes
-		configurator.NewNetworkConfigSerde(feg.FegNetworkType, &models.NetworkFederationConfigs{}),
-		configurator.NewNetworkConfigSerde(feg.FederatedNetworkType, &models.FederatedNetworkConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(feg.FegGatewayType, &models.GatewayFederationConfigs{}),
-	}
+	return []serde.Serde{}
 }
 
 func (*FegOrchestratorPlugin) GetMconfigBuilders() []mconfig.Builder {

--- a/feg/cloud/go/serdes/serdes.go
+++ b/feg/cloud/go/serdes/serdes.go
@@ -1,0 +1,33 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package serdes
+
+import (
+	"magma/feg/cloud/go/services/feg/obsidian/models"
+	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
+	"magma/orc8r/cloud/go/serdes"
+)
+
+var (
+	// Network contains the full set of configurator network config serdes
+	// used in the FeG module
+	Network = serdes.Network.
+		MustMerge(models.NetworkSerdes).
+		MustMerge(lte_models.NetworkSerdes)
+	// Entity contains the full set of configurator network entity serdes used
+	// in the FeG module
+	Entity = serdes.Entity.
+		MustMerge(models.EntitySerdes).
+		MustMerge(lte_models.EntitySerdes)
+)

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 
 	"magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/serdes"
 	fegModels "magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/feg/cloud/go/services/health"
 	lteHandlers "magma/lte/cloud/go/services/lte/obsidian/handlers"
@@ -66,7 +67,7 @@ const (
 
 func GetHandlers() []obsidian.Handler {
 	ret := []obsidian.Handler{
-		handlers.GetListGatewaysHandler(ListGatewaysPath, &fegModels.MutableFederationGateway{}, makeFederationGateways),
+		handlers.GetListGatewaysHandler(ListGatewaysPath, &fegModels.MutableFederationGateway{}, makeFederationGateways, serdes.Entity),
 		{Path: ListGatewaysPath, Methods: obsidian.POST, HandlerFunc: createGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
@@ -86,24 +87,24 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageFegLteNetworkRuleNamePath, Methods: obsidian.DELETE, HandlerFunc: lteHandlers.RemoveNetworkWideSubscriberRuleName},
 	}
 
-	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegNetworksPath, ManageFegNetworkPath, feg.FederationNetworkType, &fegModels.FegNetwork{})...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkFederationPath, &fegModels.NetworkFederationConfigs{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkSubscriberPath, &policyModels.NetworkSubscriberConfig{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkRuleNamesPath, new(policyModels.RuleNames), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkBaseNamesPath, new(policyModels.BaseNames), "")...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayFederationPath, &fegModels.GatewayFederationConfigs{})...)
+	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegNetworksPath, ManageFegNetworkPath, feg.FederationNetworkType, &fegModels.FegNetwork{}, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkFederationPath, &fegModels.NetworkFederationConfigs{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkSubscriberPath, &policyModels.NetworkSubscriberConfig{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkRuleNamesPath, new(policyModels.RuleNames), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegNetworkBaseNamesPath, new(policyModels.BaseNames), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayFederationPath, &fegModels.GatewayFederationConfigs{}, serdes.Entity)...)
 
-	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegLteNetworksPath, ManageFegLteNetworkPath, feg.FederatedLteNetworkType, &fegModels.FegLteNetwork{})...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkFederationPath, &fegModels.FederatedNetworkConfigs{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkSubscriberPath, &policyModels.NetworkSubscriberConfig{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkRuleNamesPath, new(policyModels.RuleNames), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkBaseNamesPath, new(policyModels.BaseNames), "")...)
+	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListFegLteNetworksPath, ManageFegLteNetworkPath, feg.FederatedLteNetworkType, &fegModels.FegLteNetwork{}, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkFederationPath, &fegModels.FederatedNetworkConfigs{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkSubscriberPath, &policyModels.NetworkSubscriberConfig{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkRuleNamesPath, new(policyModels.RuleNames), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageFegLteNetworkBaseNamesPath, new(policyModels.BaseNames), "", serdes.Network)...)
 
 	return ret
 }
 
 func createGateway(c echo.Context) error {
-	if nerr := handlers.CreateGateway(c, &fegModels.MutableFederationGateway{}); nerr != nil {
+	if nerr := handlers.CreateGateway(c, &fegModels.MutableFederationGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusCreated)
@@ -123,6 +124,7 @@ func getGateway(c echo.Context) error {
 	ent, err := configurator.LoadEntity(
 		nid, feg.FegGatewayType, gid,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load federation gateway"), http.StatusInternalServerError)
@@ -146,7 +148,7 @@ func updateGateway(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	if nerr = handlers.UpdateGateway(c, nid, gid, &fegModels.MutableFederationGateway{}); nerr != nil {
+	if nerr = handlers.UpdateGateway(c, nid, gid, &fegModels.MutableFederationGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -207,7 +209,7 @@ func getClusterStatusHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	network, err := configurator.LoadNetwork(nid, true, true)
+	network, err := configurator.LoadNetwork(nid, true, true, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return c.NoContent(http.StatusNotFound)
 	}

--- a/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
+++ b/feg/cloud/go/services/feg/obsidian/handlers/handlers_test.go
@@ -20,6 +20,7 @@ import (
 
 	"magma/feg/cloud/go/feg"
 	plugin2 "magma/feg/cloud/go/plugin"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/handlers"
 	models2 "magma/feg/cloud/go/services/feg/obsidian/models"
 	healthTestInit "magma/feg/cloud/go/services/health/test_init"
@@ -173,7 +174,7 @@ func TestFederationNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -209,6 +210,7 @@ func TestFederationNetworks(t *testing.T) {
 		[]configurator.NetworkEntity{
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -287,6 +289,7 @@ func TestFederationGateways(t *testing.T) {
 		[]configurator.NetworkEntity{
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -600,7 +603,7 @@ func TestFederatedLteNetworks(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -684,6 +687,7 @@ func seedFederationNetworks(t *testing.T) {
 				Configs:     map[string]interface{}{},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 }
@@ -719,6 +723,7 @@ func seedFederatedLteNetworks(t *testing.T) {
 				Configs:     map[string]interface{}{},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 }

--- a/feg/cloud/go/services/feg/obsidian/models/conversion.go
+++ b/feg/cloud/go/services/feg/obsidian/models/conversion.go
@@ -253,7 +253,7 @@ func (m *FederatedNetworkConfigs) ToUpdateCriteria(network configurator.Network)
 }
 
 func (m *GatewayFederationConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	federationConfig, err := configurator.LoadEntityConfig(networkID, feg.FegGatewayType, gatewayID)
+	federationConfig, err := configurator.LoadEntityConfig(networkID, feg.FegGatewayType, gatewayID, EntitySerdes)
 	if err != nil {
 		return err
 	}

--- a/feg/cloud/go/services/feg/obsidian/models/serdes.go
+++ b/feg/cloud/go/services/feg/obsidian/models/serdes.go
@@ -1,0 +1,32 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/feg/cloud/go/feg"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(feg.FegNetworkType, &NetworkFederationConfigs{}),
+		configurator.NewNetworkConfigSerde(feg.FederatedNetworkType, &FederatedNetworkConfigs{}),
+	)
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(feg.FegGatewayType, &GatewayFederationConfigs{}),
+	)
+)

--- a/feg/cloud/go/services/feg/servicers/builder_servicer.go
+++ b/feg/cloud/go/services/feg/servicers/builder_servicer.go
@@ -19,6 +19,7 @@ import (
 
 	"magma/feg/cloud/go/feg"
 	feg_mconfig "magma/feg/cloud/go/protos/mconfig"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
@@ -40,11 +41,11 @@ func NewBuilderServicer() builder_protos.MconfigBuilderServer {
 func (s *builderServicer) Build(ctx context.Context, request *builder_protos.BuildRequest) (*builder_protos.BuildResponse, error) {
 	ret := &builder_protos.BuildResponse{ConfigsByKey: map[string][]byte{}}
 
-	network, err := (configurator.Network{}).FromStorageProto(request.Network)
+	network, err := (configurator.Network{}).FromProto(request.Network, serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graph, err := (configurator.EntityGraph{}).FromStorageProto(request.Graph)
+	graph, err := (configurator.EntityGraph{}).FromProto(request.Graph, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/feg/cloud/go/services/feg/servicers/builder_servicer_test.go
+++ b/feg/cloud/go/services/feg/servicers/builder_servicer_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/feg/cloud/go/feg"
 	feg_plugin "magma/feg/cloud/go/plugin"
 	feg_mconfig "magma/feg/cloud/go/protos/mconfig"
+	"magma/feg/cloud/go/serdes"
 	feg_service "magma/feg/cloud/go/services/feg"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	feg_test_init "magma/feg/cloud/go/services/feg/test_init"
@@ -272,11 +273,11 @@ func TestBuilder_Build(t *testing.T) {
 }
 
 func build(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
-	networkProto, err := network.ToStorageProto()
+	networkProto, err := network.ToProto(serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graphProto, err := graph.ToStorageProto()
+	graphProto, err := graph.ToProto(serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/feg/cloud/go/services/health"
 	"magma/orc8r/cloud/go/http2"
@@ -154,7 +155,7 @@ func createNewRequest(req *http.Request, addr, hwId string) (*http.Request, *htt
 }
 
 func getFeGHwIdForNetwork(agNwID string) (string, error) {
-	cfg, err := configurator.LoadNetworkConfig(agNwID, feg.FederatedNetworkType)
+	cfg, err := configurator.LoadNetworkConfig(agNwID, feg.FederatedNetworkType, serdes.Network)
 	if err != nil {
 		return "", fmt.Errorf("could not load federated network configs for access network %s: %s", agNwID, err)
 	}
@@ -165,7 +166,7 @@ func getFeGHwIdForNetwork(agNwID string) (string, error) {
 	if federatedConfig.FegNetworkID == nil || *federatedConfig.FegNetworkID == "" {
 		return "", fmt.Errorf("FegNetworkID is empty in network config of network: %s", agNwID)
 	}
-	fegCfg, err := configurator.LoadNetworkConfig(*federatedConfig.FegNetworkID, feg.FegNetworkType)
+	fegCfg, err := configurator.LoadNetworkConfig(*federatedConfig.FegNetworkID, feg.FegNetworkType, serdes.Network)
 	if err != nil || fegCfg == nil {
 		return "", fmt.Errorf("unable to retrieve config for federation network: %s", *federatedConfig.FegNetworkID)
 	}

--- a/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
+++ b/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/feg/cloud/go/services/feg_relay/utils"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -131,7 +132,7 @@ func getFegServedIds(networkId string) ([]string, error) {
 	if len(networkId) == 0 {
 		return []string{}, fmt.Errorf("Empty networkID provided.")
 	}
-	fegCfg, err := configurator.LoadNetworkConfig(networkId, feg.FegNetworkType)
+	fegCfg, err := configurator.LoadNetworkConfig(networkId, feg.FegNetworkType, serdes.Network)
 	if err != nil || fegCfg == nil {
 		return []string{}, fmt.Errorf("unable to retrieve config for federation network: %s", networkId)
 	}

--- a/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
+++ b/feg/cloud/go/services/feg_relay/utils/get_all_gateways.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -56,7 +57,11 @@ func GetAllGatewayIDs(ctx context.Context) ([]string, error) {
 	// Find as many gateways as possible, don't exit on error, just return last error to the caller along with
 	// the list of GWs found
 	for _, networkID := range cfg.ServedNetworkIds {
-		gateways, _, err := configurator.LoadEntities(networkID, swag.String(orc8r.MagmadGatewayType), nil, nil, nil, configurator.EntityLoadCriteria{})
+		gateways, _, err := configurator.LoadEntities(
+			networkID, swag.String(orc8r.MagmadGatewayType), nil, nil, nil,
+			configurator.EntityLoadCriteria{},
+			serdes.Entity,
+		)
 		if err != nil {
 			glog.Errorf("List Network '%s' Gateways error: %v", networkID, err)
 			continue
@@ -79,7 +84,11 @@ func GetAllGatewayIDs(ctx context.Context) ([]string, error) {
 }
 
 func getFegCfg(networkID, gatewayID string) (*models.GatewayFederationConfigs, error) {
-	fegGateway, err := configurator.LoadEntity(networkID, feg.FegGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadConfig: true})
+	fegGateway, err := configurator.LoadEntity(
+		networkID, feg.FegGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
 	if err != nil && err != merrors.ErrNotFound {
 		return nil, errors.WithStack(err)
 	}
@@ -87,7 +96,7 @@ func getFegCfg(networkID, gatewayID string) (*models.GatewayFederationConfigs, e
 		return fegGateway.Config.(*models.GatewayFederationConfigs), nil
 	}
 
-	iNetworkConfig, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType)
+	iNetworkConfig, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType, serdes.Network)
 	if err != nil {
 		return nil, merrors.ErrNotFound
 	}

--- a/feg/cloud/go/services/health/reporter/network_health_reporter.go
+++ b/feg/cloud/go/services/health/reporter/network_health_reporter.go
@@ -18,6 +18,7 @@ import (
 
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/protos"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/health"
 	"magma/feg/cloud/go/services/health/metrics"
 	"magma/feg/cloud/go/services/health/servicers"
@@ -46,12 +47,16 @@ func (reporter *NetworkHealthStatusReporter) reportHealthStatus() error {
 		return err
 	}
 	for _, networkID := range networks {
-		config, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType)
+		config, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType, serdes.Network)
 		// Consider a FeG network to be only those that have FeG Network configs defined
 		if err != nil || config == nil {
 			continue
 		}
-		gateways, _, err := configurator.LoadEntities(networkID, swag.String(orc8r.MagmadGatewayType), nil, nil, nil, configurator.EntityLoadCriteria{})
+		gateways, _, err := configurator.LoadEntities(
+			networkID, swag.String(orc8r.MagmadGatewayType), nil, nil, nil,
+			configurator.EntityLoadCriteria{},
+			serdes.Entity,
+		)
 		if err != nil {
 			glog.Errorf("error getting gateways for network %v: %v\n", networkID, err)
 			continue

--- a/feg/cloud/go/services/health/servicers/config.go
+++ b/feg/cloud/go/services/health/servicers/config.go
@@ -15,6 +15,7 @@ package servicers
 
 import (
 	"magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/feg/obsidian/models"
 	"magma/orc8r/cloud/go/services/configurator"
 
@@ -36,7 +37,7 @@ func GetHealthConfigForNetwork(networkID string) *healthConfig {
 		memAvailableThreshold: defaultMemAvailableThreshold,
 		staleUpdateThreshold:  defaultStaleUpdateThreshold,
 	}
-	config, err := configurator.GetNetworkConfigsByType(networkID, feg.FegNetworkType)
+	config, err := configurator.LoadNetworkConfig(networkID, feg.FegNetworkType, serdes.Network)
 	if err != nil {
 		glog.V(2).Infof("Using default health configuration for network %s; %s", networkID, err)
 		return defaultConfig

--- a/feg/cloud/go/services/health/servicers/health.go
+++ b/feg/cloud/go/services/health/servicers/health.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	fegprotos "magma/feg/cloud/go/protos"
+	"magma/feg/cloud/go/serdes"
 	"magma/feg/cloud/go/services/health/metrics"
 	"magma/feg/cloud/go/services/health/storage"
 	"magma/orc8r/cloud/go/blobstore"
@@ -118,7 +119,11 @@ func (srv *HealthServer) UpdateHealth(ctx context.Context, req *fegprotos.Health
 	// Get FeGs registered in configurator, then make a health decision based off of the
 	// the number of gateways, which gateway is active, and gateway health
 	magmadGatewayTypeVal := orc8r.MagmadGatewayType
-	gateways, _, err := configurator.LoadEntities(networkID, &magmadGatewayTypeVal, nil, nil, nil, configurator.EntityLoadCriteria{})
+	gateways, _, err := configurator.LoadEntities(
+		networkID, &magmadGatewayTypeVal, nil, nil, nil,
+		configurator.EntityLoadCriteria{},
+		serdes.Entity,
+	)
 	if err != nil {
 		errMsg := fmt.Errorf(
 			"Update Health Error: Could not retrieve gateways registered in network: %s",

--- a/feg/cloud/go/services/health/test_utils/test_utils.go
+++ b/feg/cloud/go/services/health/test_utils/test_utils.go
@@ -21,6 +21,7 @@ import (
 
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/protos"
+	"magma/feg/cloud/go/serdes"
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/test_utils"
@@ -99,10 +100,13 @@ func GetUnhealthyRequest() *protos.HealthRequest {
 }
 
 func RegisterNetwork(t *testing.T, networkID string) {
-	err := configurator.CreateNetwork(configurator.Network{
-		ID:   TestFegNetwork,
-		Type: feg.FegNetworkType,
-	})
+	err := configurator.CreateNetwork(
+		configurator.Network{
+			ID:   TestFegNetwork,
+			Type: feg.FegNetworkType,
+		},
+		serdes.Network,
+	)
 	assert.NoError(t, err)
 }
 

--- a/lte/cloud/go/plugin/plugin.go
+++ b/lte/cloud/go/plugin/plugin.go
@@ -16,12 +16,8 @@ package plugin
 import (
 	"magma/lte/cloud/go/lte"
 	lte_service "magma/lte/cloud/go/services/lte"
-	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
-	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
-	subscriberdb_models "magma/lte/cloud/go/services/subscriberdb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -46,22 +42,7 @@ func (*LteOrchestratorPlugin) GetServices() []registry.ServiceLocation {
 }
 
 func (*LteOrchestratorPlugin) GetSerdes() []serde.Serde {
-	return []serde.Serde{
-		configurator.NewNetworkConfigSerde(lte.CellularNetworkConfigType, &lte_models.NetworkCellularConfigs{}),
-		configurator.NewNetworkConfigSerde(lte.NetworkSubscriberConfigType, &policydb_models.NetworkSubscriberConfig{}),
-
-		configurator.NewNetworkEntityConfigSerde(lte.CellularGatewayEntityType, &lte_models.GatewayCellularConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(lte.CellularEnodebEntityType, &lte_models.EnodebConfig{}),
-
-		configurator.NewNetworkEntityConfigSerde(lte.SubscriberEntityType, &subscriberdb_models.SubscriberConfig{}),
-		configurator.NewNetworkEntityConfigSerde(lte.PolicyRuleEntityType, &policydb_models.PolicyRuleConfig{}),
-		configurator.NewNetworkEntityConfigSerde(lte.BaseNameEntityType, &policydb_models.BaseNameRecord{}),
-		configurator.NewNetworkEntityConfigSerde(lte.RatingGroupEntityType, &policydb_models.RatingGroup{}),
-		configurator.NewNetworkEntityConfigSerde(lte.APNEntityType, &lte_models.ApnConfiguration{}),
-		configurator.NewNetworkEntityConfigSerde(lte.APNResourceEntityType, &lte_models.ApnResource{}),
-
-		configurator.NewNetworkEntityConfigSerde(lte.PolicyQoSProfileEntityType, &policydb_models.PolicyQosProfile{}),
-	}
+	return []serde.Serde{}
 }
 
 func (*LteOrchestratorPlugin) GetMconfigBuilders() []mconfig.Builder {

--- a/lte/cloud/go/serdes/serdes.go
+++ b/lte/cloud/go/serdes/serdes.go
@@ -16,6 +16,7 @@ package serdes
 import (
 	"magma/lte/cloud/go/lte"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
+	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
 	subscriberdb_models "magma/lte/cloud/go/services/subscriberdb/obsidian/models"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/serdes"
@@ -23,8 +24,19 @@ import (
 )
 
 var (
-	// LTEStateSerdes contains the LTE-specific state serdes
-	LTEStateSerdes = serde.NewRegistry(
+	// Network contains the full set of configurator network config serdes
+	// used in the LTE module
+	Network = serdes.Network.
+		MustMerge(lte_models.NetworkSerdes).
+		MustMerge(policydb_models.NetworkSerdes)
+	// Entity contains the full set of configurator network entity serdes used
+	// in the LTE module
+	Entity = serdes.Entity.
+		MustMerge(lte_models.EntitySerdes).
+		MustMerge(subscriberdb_models.EntitySerdes).
+		MustMerge(policydb_models.EntitySerdes)
+	// State contains the full set of state serdes used in the LTE module
+	State = serdes.State.MustMerge(serde.NewRegistry(
 		state.NewStateSerde(lte.EnodebStateType, &lte_models.EnodebState{}),
 		state.NewStateSerde(lte.ICMPStateType, &subscriberdb_models.IcmpStatus{}),
 
@@ -34,8 +46,5 @@ var (
 		state.NewStateSerde(lte.SPGWStateType, &state.ArbitraryJSON{}),
 		state.NewStateSerde(lte.S1APStateType, &state.ArbitraryJSON{}),
 		state.NewStateSerde(lte.MobilitydStateType, &state.ArbitraryJSON{}),
-	)
-
-	// StateSerdes contains the full set of state serdes used in the LTE module
-	StateSerdes = LTEStateSerdes.MustMerge(serdes.StateSerdes)
+	))
 )

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers.go
@@ -90,7 +90,7 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageNetworkDNSRecordByDomainPath, Methods: obsidian.PUT, HandlerFunc: handlers.UpdateDNSRecord},
 		{Path: ManageNetworkDNSRecordByDomainPath, Methods: obsidian.DELETE, HandlerFunc: handlers.DeleteDNSRecord},
 
-		handlers.GetListGatewaysHandler(ListGatewaysPath, &lte_models.MutableLteGateway{}, makeLTEGateways),
+		handlers.GetListGatewaysHandler(ListGatewaysPath, &lte_models.MutableLteGateway{}, makeLTEGateways, serdes.Entity),
 		{Path: ListGatewaysPath, Methods: obsidian.POST, HandlerFunc: createGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
@@ -118,33 +118,33 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageNetworkSubscriberBaseNamePath, Methods: obsidian.DELETE, HandlerFunc: RemoveNetworkWideSubscriberBaseName},
 		{Path: ManageNetworkSubscriberRuleNamePath, Methods: obsidian.DELETE, HandlerFunc: RemoveNetworkWideSubscriberRuleName},
 	}
-	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListNetworksPath, ManageNetworkPath, lte.NetworkType, &lte_models.LteNetwork{})...)
+	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(ListNetworksPath, ManageNetworkPath, lte.NetworkType, &lte_models.LteNetwork{}, serdes.Network)...)
 
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8r_models.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSPath, &orc8r_models.NetworkDNSConfig{}, orc8r.DnsdNetworkType)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSRecordsPath, new(orc8r_models.NetworkDNSRecords), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularPath, &lte_models.NetworkCellularConfigs{}, lte.CellularNetworkConfigType)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularEpcPath, &lte_models.NetworkEpcConfigs{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularRanPath, &lte_models.NetworkRanConfigs{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularFegNetworkID, new(lte_models.FegNetworkID), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkSubscriberPath, &policydb_models.NetworkSubscriberConfig{}, "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkRuleNamesPath, new(policydb_models.RuleNames), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkBaseNamesPath, new(policydb_models.BaseNames), "")...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8r_models.NetworkFeatures{}, orc8r.NetworkFeaturesConfig, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSPath, &orc8r_models.NetworkDNSConfig{}, orc8r.DnsdNetworkType, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDNSRecordsPath, new(orc8r_models.NetworkDNSRecords), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularPath, &lte_models.NetworkCellularConfigs{}, lte.CellularNetworkConfigType, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularEpcPath, &lte_models.NetworkEpcConfigs{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularRanPath, &lte_models.NetworkRanConfigs{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkCellularFegNetworkID, new(lte_models.FegNetworkID), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkSubscriberPath, &policydb_models.NetworkSubscriberConfig{}, "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkRuleNamesPath, new(policydb_models.RuleNames), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkBaseNamesPath, new(policydb_models.BaseNames), "", serdes.Network)...)
 
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8r_models.MagmadGatewayConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8r_models.TierID))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularPath, &lte_models.GatewayCellularConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularEpcPath, &lte_models.GatewayEpcConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularRanPath, &lte_models.GatewayRanConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularNonEpsPath, &lte_models.GatewayNonEpsConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularDNSPath, &lte_models.GatewayDNSConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDNSRecordsPath, &lte_models.GatewayDNSRecords{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConnectedEnodebsPath, &lte_models.EnodebSerials{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayVPNConfigPath, &orc8r_models.GatewayVpnConfigs{})...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8r_models.MagmadGatewayConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8r_models.TierID), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularPath, &lte_models.GatewayCellularConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularEpcPath, &lte_models.GatewayEpcConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularRanPath, &lte_models.GatewayRanConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularNonEpsPath, &lte_models.GatewayNonEpsConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayCellularDNSPath, &lte_models.GatewayDNSConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDNSRecordsPath, &lte_models.GatewayDNSRecords{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConnectedEnodebsPath, &lte_models.EnodebSerials{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayVPNConfigPath, &orc8r_models.GatewayVpnConfigs{}, serdes.Entity)...)
 
 	ret = append(ret, handlers.GetGatewayDeviceHandlers(ManageGatewayDevicePath)...)
 
@@ -152,7 +152,7 @@ func GetHandlers() []obsidian.Handler {
 }
 
 func createGateway(c echo.Context) error {
-	if nerr := handlers.CreateGateway(c, &lte_models.MutableLteGateway{}); nerr != nil {
+	if nerr := handlers.CreateGateway(c, &lte_models.MutableLteGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusCreated)
@@ -172,6 +172,7 @@ func getGateway(c echo.Context) error {
 	ent, err := configurator.LoadEntity(
 		nid, lte.CellularGatewayEntityType, gid,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load cellular gateway"), http.StatusInternalServerError)
@@ -197,7 +198,7 @@ func getGateway(c echo.Context) error {
 		case lte.CellularEnodebEntityType:
 			ret.ConnectedEnodebSerials = append(ret.ConnectedEnodebSerials, tk.Key)
 		case lte.APNResourceEntityType:
-			e, err := configurator.LoadEntity(nid, tk.Type, tk.Key, configurator.EntityLoadCriteria{LoadConfig: true})
+			e, err := configurator.LoadEntity(nid, tk.Type, tk.Key, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 			if err != nil {
 				return errors.Wrap(err, "error loading apn resource entity")
 			}
@@ -214,7 +215,7 @@ func updateGateway(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	if nerr = handlers.UpdateGateway(c, nid, gid, &lte_models.MutableLteGateway{}); nerr != nil {
+	if nerr = handlers.UpdateGateway(c, nid, gid, &lte_models.MutableLteGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -232,6 +233,7 @@ func deleteGateway(c echo.Context) error {
 	gw, err := configurator.LoadEntity(
 		nid, lte.CellularGatewayEntityType, gid,
 		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "error loading existing cellular gateway"), http.StatusInternalServerError)
@@ -287,9 +289,10 @@ func listEnodebs(c echo.Context) error {
 		return nerr
 	}
 
-	ents, err := configurator.LoadAllEntitiesInNetwork(
+	ents, err := configurator.LoadAllEntitiesOfType(
 		nid, lte.CellularEnodebEntityType,
 		configurator.EntityLoadCriteria{LoadMetadata: true, LoadConfig: true, LoadAssocsToThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
@@ -319,14 +322,18 @@ func createEnodeb(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "attached_gateway_id is a read-only property")
 	}
 
-	_, err := configurator.CreateEntity(nid, configurator.NetworkEntity{
-		Type:        lte.CellularEnodebEntityType,
-		Key:         payload.Serial,
-		Name:        payload.Name,
-		Description: payload.Description,
-		PhysicalID:  payload.Serial,
-		Config:      payload.EnodebConfig,
-	})
+	_, err := configurator.CreateEntity(
+		nid,
+		configurator.NetworkEntity{
+			Type:        lte.CellularEnodebEntityType,
+			Key:         payload.Serial,
+			Name:        payload.Name,
+			Description: payload.Description,
+			PhysicalID:  payload.Serial,
+			Config:      payload.EnodebConfig,
+		},
+		serdes.Entity,
+	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -343,6 +350,7 @@ func getEnodeb(c echo.Context) error {
 	ent, err := configurator.LoadEntity(
 		nid, lte.CellularEnodebEntityType, eid,
 		configurator.EntityLoadCriteria{LoadMetadata: true, LoadConfig: true, LoadAssocsToThis: true},
+		serdes.Entity,
 	)
 	switch {
 	case err == merrors.ErrNotFound:
@@ -375,7 +383,7 @@ func updateEnodeb(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "serial in body must match serial in path")
 	}
 
-	_, err := configurator.UpdateEntity(nid, payload.ToEntityUpdateCriteria())
+	_, err := configurator.UpdateEntity(nid, payload.ToEntityUpdateCriteria(), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -400,7 +408,7 @@ func getEnodebState(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	st, err := state.GetState(nid, lte.EnodebStateType, eid, serdes.StateSerdes)
+	st, err := state.GetState(nid, lte.EnodebStateType, eid, serdes.State)
 	if err == merrors.ErrNotFound {
 		return obsidian.HttpError(err, http.StatusNotFound)
 	} else if err != nil {
@@ -408,7 +416,7 @@ func getEnodebState(c echo.Context) error {
 	}
 	enodebState := st.ReportedState.(*lte_models.EnodebState)
 	enodebState.TimeReported = st.TimeMs
-	ent, err := configurator.LoadEntityForPhysicalID(st.ReporterID, configurator.EntityLoadCriteria{})
+	ent, err := configurator.LoadEntityForPhysicalID(st.ReporterID, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err == nil {
 		enodebState.ReportingGatewayID = ent.Key
 	}
@@ -434,7 +442,11 @@ func deleteConnectedEnodeb(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	_, err := configurator.UpdateEntity(networkID, (&lte_models.EnodebSerials{}).ToDeleteUpdateCriteria(networkID, gatewayID, enodebSerial))
+	_, err := configurator.UpdateEntity(
+		networkID,
+		(&lte_models.EnodebSerials{}).ToDeleteUpdateCriteria(networkID, gatewayID, enodebSerial),
+		serdes.Entity,
+	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -452,7 +464,11 @@ func addConnectedEnodeb(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	_, err := configurator.UpdateEntity(networkID, (&lte_models.EnodebSerials{}).ToCreateUpdateCriteria(networkID, gatewayID, enodebSerial))
+	_, err := configurator.UpdateEntity(
+		networkID,
+		(&lte_models.EnodebSerials{}).ToCreateUpdateCriteria(networkID, gatewayID, enodebSerial),
+		serdes.Entity,
+	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -465,7 +481,11 @@ func listApns(c echo.Context) error {
 		return nerr
 	}
 
-	ents, err := configurator.LoadAllEntitiesInNetwork(networkID, lte.APNEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
+	ents, err := configurator.LoadAllEntitiesOfType(
+		networkID, lte.APNEntityType,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -491,11 +511,15 @@ func createApn(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	_, err := configurator.CreateEntity(networkID, configurator.NetworkEntity{
-		Type:   lte.APNEntityType,
-		Key:    string(payload.ApnName),
-		Config: payload.ApnConfiguration,
-	})
+	_, err := configurator.CreateEntity(
+		networkID,
+		configurator.NetworkEntity{
+			Type:   lte.APNEntityType,
+			Key:    string(payload.ApnName),
+			Config: payload.ApnConfiguration,
+		},
+		serdes.Entity,
+	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -509,7 +533,7 @@ func getApnConfiguration(c echo.Context) error {
 		return nerr
 	}
 
-	ent, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{LoadConfig: true})
+	ent, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
@@ -535,7 +559,7 @@ func updateApnConfiguration(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	_, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{})
+	_, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{}, serdes.Entity)
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
@@ -543,7 +567,7 @@ func updateApnConfiguration(c echo.Context) error {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load existing APN"), http.StatusInternalServerError)
 	}
 
-	err = configurator.CreateOrUpdateEntityConfig(networkID, lte.APNEntityType, apnName, payload.ApnConfiguration)
+	err = configurator.CreateOrUpdateEntityConfig(networkID, lte.APNEntityType, apnName, payload.ApnConfiguration, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -556,7 +580,11 @@ func deleteApnConfiguration(c echo.Context) error {
 		return nerr
 	}
 
-	ent, err := configurator.LoadEntity(networkID, lte.APNEntityType, apnName, configurator.EntityLoadCriteria{LoadAssocsToThis: true})
+	ent, err := configurator.LoadEntity(
+		networkID, lte.APNEntityType, apnName,
+		configurator.EntityLoadCriteria{LoadAssocsToThis: true},
+		serdes.Entity,
+	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -639,7 +667,7 @@ func RemoveNetworkWideSubscriberBaseName(c echo.Context) error {
 }
 
 func addToNetworkSubscriberConfig(networkID, ruleName, baseName string) error {
-	network, err := configurator.LoadNetwork(networkID, false, true)
+	network, err := configurator.LoadNetwork(networkID, false, true, serdes.Network)
 	if err != nil {
 		return err
 	}
@@ -675,11 +703,11 @@ func addToNetworkSubscriberConfig(networkID, ruleName, baseName string) error {
 			subscriberConfig.NetworkWideBaseNames = append(subscriberConfig.NetworkWideBaseNames, policydb_models.BaseName(baseName))
 		}
 	}
-	return configurator.UpdateNetworkConfig(networkID, lte.NetworkSubscriberConfigType, subscriberConfig)
+	return configurator.UpdateNetworkConfig(networkID, lte.NetworkSubscriberConfigType, subscriberConfig, serdes.Network)
 }
 
 func removeFromNetworkSubscriberConfig(networkID, ruleName, baseName string) error {
-	network, err := configurator.LoadNetwork(networkID, false, true)
+	network, err := configurator.LoadNetwork(networkID, false, true, serdes.Network)
 	if err != nil {
 		return err
 	}
@@ -699,7 +727,7 @@ func removeFromNetworkSubscriberConfig(networkID, ruleName, baseName string) err
 		subscriberConfig.NetworkWideBaseNames = funk.Filter(subscriberConfig.NetworkWideBaseNames,
 			func(b policydb_models.BaseName) bool { return string(b) != baseName }).([]policydb_models.BaseName)
 	}
-	return configurator.UpdateNetworkConfig(networkID, lte.NetworkSubscriberConfigType, subscriberConfig)
+	return configurator.UpdateNetworkConfig(networkID, lte.NetworkSubscriberConfigType, subscriberConfig, serdes.Network)
 }
 
 func getNetworkAndApnName(c echo.Context) (string, string, *echo.HTTPError) {

--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -139,7 +139,7 @@ func TestCreateNetwork(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadNetwork("n1", true, true)
+	actual, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -319,7 +319,7 @@ func TestUpdateNetwork(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -500,7 +500,9 @@ func TestCellularPartialGet(t *testing.T) {
 				lte.CellularNetworkConfigType: cellularConfig,
 			},
 		},
-	})
+	},
+		serdes.Network,
+	)
 	assert.NoError(t, err)
 
 	// happy case FegNetworkID from cellular config
@@ -548,7 +550,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN2, err := configurator.LoadNetwork("n2", true, true)
+	actualN2, err := configurator.LoadNetwork("n2", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n2",
@@ -608,7 +610,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualN2, err = configurator.LoadNetwork("n2", true, true)
+	actualN2, err = configurator.LoadNetwork("n2", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected.Configs[lte.CellularNetworkConfigType].(*lteModels.NetworkCellularConfigs).Epc = epcConfig
 	expected.Version = 2
@@ -654,7 +656,7 @@ func TestCellularPartialUpdate(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actualN2, err = configurator.LoadNetwork("n2", true, true)
+	actualN2, err = configurator.LoadNetwork("n2", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected.Configs[lte.CellularNetworkConfigType].(*lteModels.NetworkCellularConfigs).Ran = ranConfig
 	expected.Version = 3
@@ -710,7 +712,7 @@ func TestCellularDelete(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err := configurator.LoadNetworkConfig("n1", lte.CellularNetworkConfigType)
+	_, err := configurator.LoadNetworkConfig("n1", lte.CellularNetworkConfigType, serdes.Network)
 	assert.EqualError(t, err, "Not found")
 }
 
@@ -745,7 +747,7 @@ func Test_GetNetworkSubscriberConfigHandlers(t *testing.T) {
 		NetworkWideBaseNames: []policyModels.BaseName{"base1"},
 		NetworkWideRuleNames: []string{"rule1"},
 	}
-	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, subscriberConfig))
+	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, subscriberConfig, serdes.Network))
 
 	// happy case
 	tc = tests.Test{
@@ -857,7 +859,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	iSubscriberConfig, err := configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	iSubscriberConfig, err := configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, subscriberConfig, iSubscriberConfig.(*policyModels.NetworkSubscriberConfig))
 
@@ -889,7 +891,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig := iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 
@@ -913,7 +915,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 
@@ -971,7 +973,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 		NetworkWideBaseNames: []policyModels.BaseName{"base3", "base4"},
 		NetworkWideRuleNames: []string{"rule3", "rule4"},
 	}
-	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
@@ -1004,7 +1006,7 @@ func Test_ModifyNetworkSubscriberConfigHandlers(t *testing.T) {
 		NetworkWideBaseNames: []policyModels.BaseName{"base3"},
 		NetworkWideRuleNames: []string{"rule3"},
 	}
-	iSubscriberConfig, err = configurator.GetNetworkConfigsByType("n1", lte.NetworkSubscriberConfigType)
+	iSubscriberConfig, err = configurator.LoadNetworkConfig("n1", lte.NetworkSubscriberConfigType, serdes.Network)
 	assert.NoError(t, err)
 	actualSubscriberConfig = iSubscriberConfig.(*policyModels.NetworkSubscriberConfig)
 	assert.Equal(t, newSubscriberConfig, actualSubscriberConfig)
@@ -1018,7 +1020,7 @@ func TestCreateGateway(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 
 	// setup fixtures in backend
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 	_, err = configurator.CreateEntities(
 		"n1",
@@ -1026,6 +1028,7 @@ func TestCreateGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice(
@@ -1078,6 +1081,7 @@ func TestCreateGateway(t *testing.T) {
 			{Type: lte.CellularGatewayEntityType, Key: "g1"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	actualDevice, err := device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hw1")
@@ -1145,6 +1149,7 @@ func TestCreateGateway(t *testing.T) {
 			{Type: lte.CellularGatewayEntityType, Key: "g3"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	// the device should get created regardless
@@ -1210,7 +1215,7 @@ func TestListAndGetGateways(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1277,6 +1282,7 @@ func TestListAndGetGateways(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -1411,7 +1417,7 @@ func TestUpdateGateway(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1455,6 +1461,7 @@ func TestUpdateGateway(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -1510,6 +1517,7 @@ func TestUpdateGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	actualDevice, err := device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hw1")
@@ -1556,7 +1564,7 @@ func TestDeleteGateway(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1599,6 +1607,7 @@ func TestDeleteGateway(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -1622,6 +1631,7 @@ func TestDeleteGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	actualDevice, err := device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hw1")
@@ -1640,7 +1650,7 @@ func TestGetCellularGatewayConfig(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1672,6 +1682,7 @@ func TestGetCellularGatewayConfig(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -1750,7 +1761,7 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -1775,6 +1786,7 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: "g1"}},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -1806,7 +1818,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 		},
 	}
 
-	entities, _, err := configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err := configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
@@ -1839,7 +1855,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			Version: 2,
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
@@ -1871,7 +1891,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			Version: 3,
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
@@ -1919,7 +1943,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			Version: 4,
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
@@ -1955,11 +1983,15 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			},
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularEnodebEntityType, Key: "enb3"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularEnodebEntityType, Key: "enb3"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	// happy case
@@ -1995,7 +2027,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			},
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
@@ -2031,7 +2067,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			},
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 
@@ -2063,7 +2103,11 @@ func TestUpdateCellularGatewayConfig(t *testing.T) {
 			Version: 8,
 		},
 	}
-	entities, _, err = configurator.LoadEntities("n1", nil, swag.String("g1"), nil, nil, configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	entities, _, err = configurator.LoadEntities(
+		"n1", nil, swag.String("g1"), nil, nil,
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, entities.MakeByTK())
 }
@@ -2074,7 +2118,7 @@ func TestListAndGetEnodebs(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2084,54 +2128,58 @@ func TestListAndGetEnodebs(t *testing.T) {
 	listEnodebs := tests.GetHandlerByPathAndMethod(t, handlers, testURLRoot, obsidian.GET).HandlerFunc
 	getEnodeb := tests.GetHandlerByPathAndMethod(t, handlers, fmt.Sprintf("%s/:enodeb_serial", testURLRoot), obsidian.GET).HandlerFunc
 
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		{
-			Type:        lte.CellularEnodebEntityType,
-			Key:         "abcdefg",
-			Name:        "abc enodeb",
-			Description: "abc enodeb description",
-			PhysicalID:  "abcdefg",
-			Config: &lteModels.EnodebConfig{
-				ConfigType: "MANAGED",
-				ManagedConfig: &lteModels.EnodebConfiguration{
-					BandwidthMhz:           20,
-					CellID:                 swag.Uint32(1234),
-					DeviceClass:            "Baicells Nova-233 G2 OD FDD",
-					Earfcndl:               39450,
-					Pci:                    260,
-					SpecialSubframePattern: 7,
-					SubframeAssignment:     2,
-					Tac:                    1,
-					TransmitEnabled:        swag.Bool(true),
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type:        lte.CellularEnodebEntityType,
+				Key:         "abcdefg",
+				Name:        "abc enodeb",
+				Description: "abc enodeb description",
+				PhysicalID:  "abcdefg",
+				Config: &lteModels.EnodebConfig{
+					ConfigType: "MANAGED",
+					ManagedConfig: &lteModels.EnodebConfiguration{
+						BandwidthMhz:           20,
+						CellID:                 swag.Uint32(1234),
+						DeviceClass:            "Baicells Nova-233 G2 OD FDD",
+						Earfcndl:               39450,
+						Pci:                    260,
+						SpecialSubframePattern: 7,
+						SubframeAssignment:     2,
+						Tac:                    1,
+						TransmitEnabled:        swag.Bool(true),
+					},
 				},
 			},
-		},
-		{
-			Type:        lte.CellularEnodebEntityType,
-			Key:         "vwxyz",
-			Name:        "xyz enodeb",
-			Description: "xyz enodeb description",
-			PhysicalID:  "vwxyz",
-			Config: &lteModels.EnodebConfig{
-				ConfigType: "MANAGED",
-				ManagedConfig: &lteModels.EnodebConfiguration{
-					BandwidthMhz:           20,
-					CellID:                 swag.Uint32(1234),
-					DeviceClass:            "Baicells Nova-233 G2 OD FDD",
-					Earfcndl:               39450,
-					Pci:                    260,
-					SpecialSubframePattern: 7,
-					SubframeAssignment:     2,
-					Tac:                    1,
-					TransmitEnabled:        swag.Bool(true),
+			{
+				Type:        lte.CellularEnodebEntityType,
+				Key:         "vwxyz",
+				Name:        "xyz enodeb",
+				Description: "xyz enodeb description",
+				PhysicalID:  "vwxyz",
+				Config: &lteModels.EnodebConfig{
+					ConfigType: "MANAGED",
+					ManagedConfig: &lteModels.EnodebConfiguration{
+						BandwidthMhz:           20,
+						CellID:                 swag.Uint32(1234),
+						DeviceClass:            "Baicells Nova-233 G2 OD FDD",
+						Earfcndl:               39450,
+						Pci:                    260,
+						SpecialSubframePattern: 7,
+						SubframeAssignment:     2,
+						Tac:                    1,
+						TransmitEnabled:        swag.Bool(true),
+					},
 				},
 			},
+			{
+				Type: lte.CellularGatewayEntityType, Key: "gw1",
+				Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: "abcdefg"}},
+			},
 		},
-		{
-			Type: lte.CellularGatewayEntityType, Key: "gw1",
-			Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: "abcdefg"}},
-		},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	expected := map[string]*lteModels.Enodeb{
@@ -2248,7 +2296,7 @@ func TestCreateEnodeb(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2297,7 +2345,7 @@ func TestCreateEnodeb(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdef", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdef", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -2397,7 +2445,7 @@ func TestCreateEnodeb(t *testing.T) {
 		ExpectedStatus: 201,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "unmanaged", configurator.FullEntityLoadCriteria())
+	actual, err = configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "unmanaged", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 }
 
@@ -2407,7 +2455,7 @@ func TestUpdateEnodeb(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2416,29 +2464,33 @@ func TestUpdateEnodeb(t *testing.T) {
 	handlers := handlers.GetHandlers()
 	updateEnodeb := tests.GetHandlerByPathAndMethod(t, handlers, testURLRoot, obsidian.PUT).HandlerFunc
 
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		{
-			Type:        lte.CellularEnodebEntityType,
-			Key:         "abcdefg",
-			Name:        "abc enodeb",
-			Description: "abc enodeb description",
-			PhysicalID:  "abcdefg",
-			Config: &lteModels.EnodebConfig{
-				ConfigType: "MANAGED",
-				ManagedConfig: &lteModels.EnodebConfiguration{
-					BandwidthMhz:           20,
-					CellID:                 swag.Uint32(1234),
-					DeviceClass:            "Baicells Nova-233 G2 OD FDD",
-					Earfcndl:               39450,
-					Pci:                    260,
-					SpecialSubframePattern: 7,
-					SubframeAssignment:     2,
-					Tac:                    1,
-					TransmitEnabled:        swag.Bool(true),
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type:        lte.CellularEnodebEntityType,
+				Key:         "abcdefg",
+				Name:        "abc enodeb",
+				Description: "abc enodeb description",
+				PhysicalID:  "abcdefg",
+				Config: &lteModels.EnodebConfig{
+					ConfigType: "MANAGED",
+					ManagedConfig: &lteModels.EnodebConfiguration{
+						BandwidthMhz:           20,
+						CellID:                 swag.Uint32(1234),
+						DeviceClass:            "Baicells Nova-233 G2 OD FDD",
+						Earfcndl:               39450,
+						Pci:                    260,
+						SpecialSubframePattern: 7,
+						SubframeAssignment:     2,
+						Tac:                    1,
+						TransmitEnabled:        swag.Bool(true),
+					},
 				},
 			},
 		},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	tc := tests.Test{
@@ -2481,7 +2533,7 @@ func TestUpdateEnodeb(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdefg", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdefg", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -2590,7 +2642,7 @@ func TestDeleteEnodeb(t *testing.T) {
 
 	configuratorTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2599,28 +2651,32 @@ func TestDeleteEnodeb(t *testing.T) {
 	handlers := handlers.GetHandlers()
 	deleteEnodeb := tests.GetHandlerByPathAndMethod(t, handlers, testURLRoot, obsidian.DELETE).HandlerFunc
 
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		{
-			Type:       lte.CellularEnodebEntityType,
-			Key:        "abcdefg",
-			Name:       "abc enodeb",
-			PhysicalID: "abcdefg",
-			Config: &lteModels.EnodebConfig{
-				ConfigType: "MANAGED",
-				ManagedConfig: &lteModels.EnodebConfiguration{
-					BandwidthMhz:           20,
-					CellID:                 swag.Uint32(1234),
-					DeviceClass:            "Baicells Nova-233 G2 OD FDD",
-					Earfcndl:               39450,
-					Pci:                    260,
-					SpecialSubframePattern: 7,
-					SubframeAssignment:     2,
-					Tac:                    1,
-					TransmitEnabled:        swag.Bool(true),
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type:       lte.CellularEnodebEntityType,
+				Key:        "abcdefg",
+				Name:       "abc enodeb",
+				PhysicalID: "abcdefg",
+				Config: &lteModels.EnodebConfig{
+					ConfigType: "MANAGED",
+					ManagedConfig: &lteModels.EnodebConfiguration{
+						BandwidthMhz:           20,
+						CellID:                 swag.Uint32(1234),
+						DeviceClass:            "Baicells Nova-233 G2 OD FDD",
+						Earfcndl:               39450,
+						Pci:                    260,
+						SpecialSubframePattern: 7,
+						SubframeAssignment:     2,
+						Tac:                    1,
+						TransmitEnabled:        swag.Bool(true),
+					},
 				},
 			},
 		},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	tc := tests.Test{
@@ -2633,7 +2689,7 @@ func TestDeleteEnodeb(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdefg", configurator.FullEntityLoadCriteria())
+	_, err = configurator.LoadEntity("n1", lte.CellularEnodebEntityType, "abcdefg", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.EqualError(t, err, "Not found")
 }
 
@@ -2644,7 +2700,7 @@ func TestGetEnodebState(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2653,7 +2709,8 @@ func TestGetEnodebState(t *testing.T) {
 	handlers := handlers.GetHandlers()
 	getEnodebState := tests.GetHandlerByPathAndMethod(t, handlers, testURLRoot, obsidian.GET).HandlerFunc
 
-	_, err = configurator.CreateEntities("n1",
+	_, err = configurator.CreateEntities(
+		"n1",
 		[]configurator.NetworkEntity{
 			{
 				Type: lte.CellularEnodebEntityType, Key: "serial1",
@@ -2664,7 +2721,9 @@ func TestGetEnodebState(t *testing.T) {
 				PhysicalID:   "hwid1",
 				Associations: []storage.TypeAndKey{{Type: lte.CellularEnodebEntityType, Key: "serial1"}},
 			},
-		})
+		},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	// 404
@@ -2707,7 +2766,7 @@ func TestCreateApn(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{})
 
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2728,7 +2787,7 @@ func TestCreateApn(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.APNEntityType, "foo", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.APNEntityType, "foo", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -2745,7 +2804,7 @@ func TestListApns(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{})
 
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2798,6 +2857,7 @@ func TestListApns(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -2849,7 +2909,7 @@ func TestGetApn(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{})
 
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2885,6 +2945,7 @@ func TestGetApn(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -2919,7 +2980,7 @@ func TestUpdateApn(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{})
 
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -2974,6 +3035,7 @@ func TestUpdateApn(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -2988,7 +3050,7 @@ func TestUpdateApn(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadEntity("n1", lte.APNEntityType, "oai.ipv4", configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity("n1", lte.APNEntityType, "oai.ipv4", configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntity{
 		NetworkID: "n1",
@@ -3006,7 +3068,7 @@ func TestDeleteApn(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &ltePlugin.LteOrchestratorPlugin{})
 
 	configuratorTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -3048,6 +3110,7 @@ func TestDeleteApn(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -3061,7 +3124,7 @@ func TestDeleteApn(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actual, err := configurator.LoadAllEntitiesInNetwork("n1", lte.APNEntityType, configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadAllEntitiesOfType("n1", lte.APNEntityType, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(actual))
 	expected := configurator.NetworkEntity{
@@ -3093,9 +3156,9 @@ func TestAPNResource(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"})
+	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -3349,7 +3412,7 @@ func TestAPNResource(t *testing.T) {
 	assert.False(t, exists)
 
 	// Configurator confirms all APN resources are now deleted
-	ents, err := configurator.LoadAllEntitiesInNetwork("n0", lte.APNResourceEntityType, configurator.EntityLoadCriteria{})
+	ents, err := configurator.LoadAllEntitiesOfType("n0", lte.APNResourceEntityType, configurator.EntityLoadCriteria{}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Empty(t, ents)
 
@@ -3366,7 +3429,7 @@ func TestAPNResource(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator confirms gw's APN resources exist again
-	ents, err = configurator.LoadAllEntitiesInNetwork("n0", lte.APNResourceEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
+	ents, err = configurator.LoadAllEntitiesOfType("n0", lte.APNResourceEntityType, configurator.EntityLoadCriteria{LoadConfig: true}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Len(t, ents, 2)
 	assert.ElementsMatch(t, []string{"res1", "res2"}, []string{ents[0].Key, ents[1].Key})
@@ -3384,13 +3447,17 @@ func TestAPNResource(t *testing.T) {
 	tests.RunUnitTest(t, e, tc)
 
 	// Configurator confirms gateway now has only 1 apn_resource assoc
-	gwEnt, err := configurator.LoadEntity("n0", lte.CellularGatewayEntityType, "gw0", configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true})
+	gwEnt, err := configurator.LoadEntity(
+		"n0", lte.CellularGatewayEntityType, "gw0",
+		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Len(t, gwEnt.Associations.Filter(lte.APNResourceEntityType), 1)
 	assert.Equal(t, "res2", gwEnt.Associations.Filter(lte.APNResourceEntityType).Keys()[0])
 
 	// Configurator confirms APN resource was deleted due to cascading delete
-	ents, err = configurator.LoadAllEntitiesInNetwork("n0", lte.APNResourceEntityType, configurator.EntityLoadCriteria{})
+	ents, err = configurator.LoadAllEntitiesOfType("n0", lte.APNResourceEntityType, configurator.EntityLoadCriteria{}, serdes.Entity)
 	assert.NoError(t, err)
 	assert.Len(t, ents, 1)
 	assert.Equal(t, "res2", ents[0].Key)
@@ -3417,9 +3484,9 @@ func TestAPNResource_Regression_3088(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"})
+	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -3543,9 +3610,9 @@ func TestAPNResource_Regression_3149(t *testing.T) {
 	configuratorTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n0"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n0"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"})
+	_, err = configurator.CreateEntity("n0", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t0"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -3561,7 +3628,7 @@ func TestAPNResource_Regression_3149(t *testing.T) {
 	postAPN := tests.GetHandlerByPathAndMethod(t, lteHandlers, "/magma/v1/lte/:network_id/apns", obsidian.POST).HandlerFunc
 
 	// Create enb0
-	_, err = configurator.CreateEntities("n0", []configurator.NetworkEntity{{Type: lte.CellularEnodebEntityType, Key: "enb0"}})
+	_, err = configurator.CreateEntities("n0", []configurator.NetworkEntity{{Type: lte.CellularEnodebEntityType, Key: "enb0"}}, serdes.Entity)
 	assert.NoError(t, err)
 
 	gw0 := newMutableGateway("gw0")
@@ -3761,7 +3828,7 @@ func reportEnodebState(t *testing.T, ctx context.Context, enodebSerial string, r
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedEnodebState, err := serde.Serialize(req, lte.EnodebStateType, serdes.StateSerdes)
+	serializedEnodebState, err := serde.Serialize(req, lte.EnodebStateType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{
@@ -3807,6 +3874,7 @@ func seedNetworks(t *testing.T) {
 				Configs:     map[string]interface{}{},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 }

--- a/lte/cloud/go/services/lte/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/lte/obsidian/models/conversion.go
@@ -304,7 +304,7 @@ func (m *MutableLteGateway) getAPNResourceChanges(
 }
 
 func (m *GatewayCellularConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	cellularConfig, err := configurator.LoadEntityConfig(networkID, lte.CellularGatewayEntityType, gatewayID)
+	cellularConfig, err := configurator.LoadEntityConfig(networkID, lte.CellularGatewayEntityType, gatewayID, EntitySerdes)
 	if err != nil {
 		return err
 	}
@@ -426,7 +426,11 @@ func (m *GatewayDNSRecords) ToUpdateCriteria(networkID string, gatewayID string)
 }
 
 func (m *EnodebSerials) FromBackendModels(networkID string, gatewayID string) error {
-	cellularGatewayEntity, err := configurator.LoadEntity(networkID, lte.CellularGatewayEntityType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
+	cellularGatewayEntity, err := configurator.LoadEntity(
+		networkID, lte.CellularGatewayEntityType, gatewayID,
+		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+		EntitySerdes,
+	)
 	if err != nil {
 		return err
 	}
@@ -524,6 +528,7 @@ func LoadAPNResources(networkID string, ids []string) (ApnResources, error) {
 		nil, nil, nil,
 		storage.MakeTKs(lte.APNResourceEntityType, ids),
 		configurator.EntityLoadCriteria{LoadConfig: true},
+		EntitySerdes,
 	)
 	if err != nil {
 		return ret, err

--- a/lte/cloud/go/services/lte/obsidian/models/serdes.go
+++ b/lte/cloud/go/services/lte/obsidian/models/serdes.go
@@ -1,0 +1,34 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/lte/cloud/go/lte"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(lte.CellularNetworkConfigType, &NetworkCellularConfigs{}),
+	)
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(lte.APNEntityType, &ApnConfiguration{}),
+		configurator.NewNetworkEntityConfigSerde(lte.APNResourceEntityType, &ApnResource{}),
+		configurator.NewNetworkEntityConfigSerde(lte.CellularEnodebEntityType, &EnodebConfig{}),
+		configurator.NewNetworkEntityConfigSerde(lte.CellularGatewayEntityType, &GatewayCellularConfigs{}),
+	)
+)

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -20,6 +20,7 @@ import (
 
 	"magma/lte/cloud/go/lte"
 	lte_mconfig "magma/lte/cloud/go/protos/mconfig"
+	"magma/lte/cloud/go/serdes"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
@@ -45,11 +46,11 @@ func NewBuilderServicer() builder_protos.MconfigBuilderServer {
 func (s *builderServicer) Build(ctx context.Context, request *builder_protos.BuildRequest) (*builder_protos.BuildResponse, error) {
 	ret := &builder_protos.BuildResponse{ConfigsByKey: map[string][]byte{}}
 
-	network, err := (configurator.Network{}).FromStorageProto(request.Network)
+	network, err := (configurator.Network{}).FromProto(request.Network, serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graph, err := (configurator.EntityGraph{}).FromStorageProto(request.Graph)
+	graph, err := (configurator.EntityGraph{}).FromProto(request.Graph, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/lte/cloud/go/lte"
 	lte_plugin "magma/lte/cloud/go/plugin"
 	lte_mconfig "magma/lte/cloud/go/protos/mconfig"
+	"magma/lte/cloud/go/serdes"
 	lte_service "magma/lte/cloud/go/services/lte"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	lte_test_init "magma/lte/cloud/go/services/lte/test_init"
@@ -802,11 +803,11 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 }
 
 func build(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
-	networkProto, err := network.ToStorageProto()
+	networkProto, err := network.ToProto(serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graphProto, err := graph.ToStorageProto()
+	graphProto, err := graph.ToProto(serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/provider_servicer_test.go
@@ -19,6 +19,7 @@ import (
 
 	"magma/lte/cloud/go/lte"
 	lte_plugin "magma/lte/cloud/go/plugin"
+	"magma/lte/cloud/go/serdes"
 	lte_service "magma/lte/cloud/go/services/lte"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	lte_test_init "magma/lte/cloud/go/services/lte/test_init"
@@ -71,58 +72,62 @@ func TestLTEStreamProviderServicer_GetUpdates(t *testing.T) {
 }
 
 func initSubscriber(t *testing.T, hwID string) {
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: hwID})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: hwID}, serdes.Entity)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: lte.CellularGatewayEntityType, Key: "g1"}, serdes.Entity)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		{
-			Type: lte.APNEntityType, Key: "apn1",
-			Config: &lte_models.ApnConfiguration{
-				Ambr: &lte_models.AggregatedMaximumBitrate{
-					MaxBandwidthDl: swag.Uint32(42),
-					MaxBandwidthUl: swag.Uint32(100),
-				},
-				QosProfile: &lte_models.QosProfile{
-					ClassID:                 swag.Int32(1),
-					PreemptionCapability:    swag.Bool(true),
-					PreemptionVulnerability: swag.Bool(true),
-					PriorityLevel:           swag.Uint32(1),
-				},
-			},
-		},
-		{
-			Type: lte.APNEntityType, Key: "apn2",
-			Config: &lte_models.ApnConfiguration{
-				Ambr: &lte_models.AggregatedMaximumBitrate{
-					MaxBandwidthDl: swag.Uint32(42),
-					MaxBandwidthUl: swag.Uint32(100),
-				},
-				QosProfile: &lte_models.QosProfile{
-					ClassID:                 swag.Int32(2),
-					PreemptionCapability:    swag.Bool(false),
-					PreemptionVulnerability: swag.Bool(false),
-					PriorityLevel:           swag.Uint32(2),
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: lte.APNEntityType, Key: "apn1",
+				Config: &lte_models.ApnConfiguration{
+					Ambr: &lte_models.AggregatedMaximumBitrate{
+						MaxBandwidthDl: swag.Uint32(42),
+						MaxBandwidthUl: swag.Uint32(100),
+					},
+					QosProfile: &lte_models.QosProfile{
+						ClassID:                 swag.Int32(1),
+						PreemptionCapability:    swag.Bool(true),
+						PreemptionVulnerability: swag.Bool(true),
+						PriorityLevel:           swag.Uint32(1),
+					},
 				},
 			},
-		},
-		{
-			Type: lte.SubscriberEntityType, Key: "IMSI12345",
-			Config: &models.SubscriberConfig{
-				Lte: &models.LteSubscription{
-					State:   "ACTIVE",
-					AuthKey: []byte("\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22"),
-					AuthOpc: []byte("\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22"),
+			{
+				Type: lte.APNEntityType, Key: "apn2",
+				Config: &lte_models.ApnConfiguration{
+					Ambr: &lte_models.AggregatedMaximumBitrate{
+						MaxBandwidthDl: swag.Uint32(42),
+						MaxBandwidthUl: swag.Uint32(100),
+					},
+					QosProfile: &lte_models.QosProfile{
+						ClassID:                 swag.Int32(2),
+						PreemptionCapability:    swag.Bool(false),
+						PreemptionVulnerability: swag.Bool(false),
+						PriorityLevel:           swag.Uint32(2),
+					},
 				},
-				StaticIps: map[string]strfmt.IPv4{"apn1": "192.168.100.1"},
 			},
-			Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: "apn1"}, {Type: lte.APNEntityType, Key: "apn2"}},
+			{
+				Type: lte.SubscriberEntityType, Key: "IMSI12345",
+				Config: &models.SubscriberConfig{
+					Lte: &models.LteSubscription{
+						State:   "ACTIVE",
+						AuthKey: []byte("\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22"),
+						AuthOpc: []byte("\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22\x22"),
+					},
+					StaticIps: map[string]strfmt.IPv4{"apn1": "192.168.100.1"},
+				},
+				Associations: []storage.TypeAndKey{{Type: lte.APNEntityType, Key: "apn1"}, {Type: lte.APNEntityType, Key: "apn2"}},
+			},
+			{Type: lte.SubscriberEntityType, Key: "IMSI67890", Config: &models.SubscriberConfig{Lte: &models.LteSubscription{State: "INACTIVE", SubProfile: "foo"}}},
 		},
-		{Type: lte.SubscriberEntityType, Key: "IMSI67890", Config: &models.SubscriberConfig{Lte: &models.LteSubscription{State: "INACTIVE", SubProfile: "foo"}}},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/handlers.go
@@ -14,6 +14,7 @@
 package handlers
 
 import (
+	"magma/lte/cloud/go/serdes"
 	lte_handlers "magma/lte/cloud/go/services/lte/obsidian/handlers"
 	policydb_models "magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
@@ -59,7 +60,7 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ratingGroupsManagePath, Methods: obsidian.DELETE, HandlerFunc: DeleteRatingGroup},
 	}
 
-	ret = append(ret, handlers.GetPartialEntityHandlers(qosProfileManagePath, "profile_id", &policydb_models.PolicyQosProfile{})...)
+	ret = append(ret, handlers.GetPartialEntityHandlers(qosProfileManagePath, "profile_id", &policydb_models.PolicyQosProfile{}, serdes.Entity)...)
 
 	return ret
 }

--- a/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/policy_handlers_test.go
@@ -19,6 +19,7 @@ import (
 
 	"magma/lte/cloud/go/lte"
 	lteplugin "magma/lte/cloud/go/plugin"
+	"magma/lte/cloud/go/serdes"
 	"magma/lte/cloud/go/services/policydb/obsidian/handlers"
 	policyModels "magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
@@ -42,7 +43,7 @@ func TestPolicyDBHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	listPolicies := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/policies/rules", obsidian.GET).HandlerFunc
@@ -630,7 +631,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	createPolicy := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/policies/rules", obsidian.POST).HandlerFunc
@@ -650,6 +651,7 @@ func TestPolicyHandlersAssociations(t *testing.T) {
 			{Type: lte.SubscriberEntityType, Key: imsi2},
 			{Type: lte.SubscriberEntityType, Key: imsi3},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -854,7 +856,7 @@ func TestQoSProfile(t *testing.T) {
 	e := echo.New()
 
 	policydbHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	getAllProfiles := tests.GetHandlerByPathAndMethod(t, policydbHandlers, "/magma/v1/lte/:network_id/policy_qos_profiles", obsidian.GET).HandlerFunc
@@ -1076,7 +1078,7 @@ func TestPolicyWithQoSProfile(t *testing.T) {
 	e := echo.New()
 
 	policydbHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	postProfile := tests.GetHandlerByPathAndMethod(t, policydbHandlers, "/magma/v1/lte/:network_id/policy_qos_profiles", obsidian.POST).HandlerFunc
@@ -1206,7 +1208,11 @@ func TestPolicyWithQoSProfile(t *testing.T) {
 func validatePolicy(t *testing.T, e *echo.Echo, getRule echo.HandlerFunc, expectedModel *policyModels.PolicyRule, expectedEnt configurator.NetworkEntity) {
 	expectedEnt.Config = getExpectedRuleConfig(expectedModel)
 
-	actual, err := configurator.LoadEntity("n1", lte.PolicyRuleEntityType, string(expectedModel.ID), configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity(
+		"n1", lte.PolicyRuleEntityType, string(expectedModel.ID),
+		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnt, actual)
 	tc := tests.Test{
@@ -1233,7 +1239,11 @@ func getExpectedRuleConfig(m *policyModels.PolicyRule) *policyModels.PolicyRuleC
 }
 
 func validateBaseName(t *testing.T, e *echo.Echo, getName echo.HandlerFunc, expectedModel *policyModels.BaseNameRecord, expectedEnt configurator.NetworkEntity) {
-	actual, err := configurator.LoadEntity("n1", lte.BaseNameEntityType, string(expectedModel.Name), configurator.FullEntityLoadCriteria())
+	actual, err := configurator.LoadEntity(
+		"n1", lte.BaseNameEntityType, string(expectedModel.Name),
+		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnt, actual)
 	tc := tests.Test{

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 
 	"magma/lte/cloud/go/lte"
+	"magma/lte/cloud/go/serdes"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -37,9 +38,10 @@ func ListRatingGroups(c echo.Context) error {
 		return nerr
 	}
 
-	ents, err := configurator.LoadAllEntitiesInNetwork(
+	ents, err := configurator.LoadAllEntitiesOfType(
 		networkID, lte.RatingGroupEntityType,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
@@ -67,7 +69,7 @@ func CreateRatingGroup(c echo.Context) error {
 		return obsidian.HttpError(err, http.StatusBadRequest)
 	}
 
-	_, err := configurator.CreateEntity(networkID, group.ToEntity())
+	_, err := configurator.CreateEntity(networkID, group.ToEntity(), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -81,10 +83,9 @@ func GetRatingGroup(c echo.Context) error {
 	}
 
 	ent, err := configurator.LoadEntity(
-		networkID,
-		lte.RatingGroupEntityType,
-		ratingGroupID,
+		networkID, lte.RatingGroupEntityType, ratingGroupID,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	switch {
 	case err == merrors.ErrNotFound:
@@ -123,7 +124,7 @@ func UpdateRatingGroup(c echo.Context) error {
 		return echo.ErrNotFound
 	}
 
-	_, err = configurator.UpdateEntity(networkID, ratingGroup.ToEntityUpdateCriteria(groupID))
+	_, err = configurator.UpdateEntity(networkID, ratingGroup.ToEntityUpdateCriteria(groupID), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}

--- a/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers_test.go
+++ b/lte/cloud/go/services/policydb/obsidian/handlers/rating_groups_handlers_test.go
@@ -18,6 +18,7 @@ import (
 
 	"magma/lte/cloud/go/lte"
 	lteplugin "magma/lte/cloud/go/plugin"
+	"magma/lte/cloud/go/serdes"
 	"magma/lte/cloud/go/services/policydb/obsidian/handlers"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/obsidian"
@@ -40,7 +41,7 @@ func TestRatingGroupHandlersBasic(t *testing.T) {
 	e := echo.New()
 
 	obsidianHandlers := handlers.GetHandlers()
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1", Type: lte.NetworkType}, serdes.Network)
 	assert.NoError(t, err)
 
 	listRatingGroups := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/rating_groups", obsidian.GET).HandlerFunc

--- a/lte/cloud/go/services/policydb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/conversion.go
@@ -392,7 +392,7 @@ func (m *NetworkSubscriberConfig) ToUpdateCriteria(network configurator.Network)
 }
 
 func (m *PolicyQosProfile) FromBackendModels(networkID string, key string) error {
-	config, err := configurator.LoadEntityConfig(networkID, lte.PolicyQoSProfileEntityType, key)
+	config, err := configurator.LoadEntityConfig(networkID, lte.PolicyQoSProfileEntityType, key, EntitySerdes)
 	if err != nil {
 		return err
 	}

--- a/lte/cloud/go/services/policydb/obsidian/models/serdes.go
+++ b/lte/cloud/go/services/policydb/obsidian/models/serdes.go
@@ -1,0 +1,34 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/lte/cloud/go/lte"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(lte.NetworkSubscriberConfigType, &NetworkSubscriberConfig{}),
+	)
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(lte.BaseNameEntityType, &BaseNameRecord{}),
+		configurator.NewNetworkEntityConfigSerde(lte.PolicyQoSProfileEntityType, &PolicyQosProfile{}),
+		configurator.NewNetworkEntityConfigSerde(lte.PolicyRuleEntityType, &PolicyRuleConfig{}),
+		configurator.NewNetworkEntityConfigSerde(lte.RatingGroupEntityType, &RatingGroup{}),
+	)
+)

--- a/lte/cloud/go/services/policydb/servicers/assignments.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments.go
@@ -20,6 +20,7 @@ package servicers
 import (
 	"magma/lte/cloud/go/lte"
 	"magma/lte/cloud/go/protos"
+	"magma/lte/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/storage"
 	orcprotos "magma/orc8r/lib/go/protos"
@@ -47,7 +48,7 @@ func (srv *PolicyAssignmentServer) EnableStaticRules(ctx context.Context, req *p
 	for _, baseName := range req.BaseNames {
 		updates = append(updates, getBaseNameUpdateForEnable(baseName, req.Imsi))
 	}
-	_, err = configurator.UpdateEntities(networkID, updates)
+	_, err = configurator.UpdateEntities(networkID, updates, serdes.Entity)
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, "Failed to enable")
 	}
@@ -66,7 +67,7 @@ func (srv *PolicyAssignmentServer) DisableStaticRules(ctx context.Context, req *
 	for _, baseName := range req.BaseNames {
 		updates = append(updates, getBaseNameUpdateForDisable(baseName, req.Imsi))
 	}
-	_, err = configurator.UpdateEntities(networkID, updates)
+	_, err = configurator.UpdateEntities(networkID, updates, serdes.Entity)
 	if err != nil {
 		return nil, status.Errorf(codes.Aborted, "Failed to disable")
 	}

--- a/lte/cloud/go/services/policydb/servicers/assignments_test.go
+++ b/lte/cloud/go/services/policydb/servicers/assignments_test.go
@@ -14,17 +14,18 @@ limitations under the License.
 package servicers_test
 
 import (
-	plugin2 "magma/lte/cloud/go/plugin"
-	lteModels "magma/lte/cloud/go/services/lte/obsidian/models"
-	"magma/lte/cloud/go/services/policydb/obsidian/models"
-	"magma/orc8r/cloud/go/plugin"
-	"magma/orc8r/cloud/go/pluginimpl"
 	"testing"
 
 	"magma/lte/cloud/go/lte"
+	plugin2 "magma/lte/cloud/go/plugin"
 	"magma/lte/cloud/go/protos"
+	"magma/lte/cloud/go/serdes"
+	lteModels "magma/lte/cloud/go/services/lte/obsidian/models"
+	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/lte/cloud/go/services/policydb/servicers"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/test_init"
 	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
@@ -51,7 +52,7 @@ func TestAssignmentsServicer(t *testing.T) {
 	testBaseName := "b1"
 
 	// Initialize network
-	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkId})
+	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkId}, serdes.Network)
 	assert.NoError(t, err)
 
 	// Initialize gateway -> subscriber, and create a policy rule
@@ -95,6 +96,7 @@ func TestAssignmentsServicer(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: testGwLogicalId}},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -128,10 +130,9 @@ func TestAssignmentsServicer(t *testing.T) {
 
 	// Verify that the rule is associated to the subscriber
 	ent, err := configurator.LoadEntity(
-		testNetworkId,
-		lte.PolicyRuleEntityType,
-		testPolicyId,
+		testNetworkId, lte.PolicyRuleEntityType, testPolicyId,
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	testPolicy := (&models.PolicyRule{}).FromEntity(ent)
 	assert.NoError(t, err)
@@ -139,10 +140,9 @@ func TestAssignmentsServicer(t *testing.T) {
 
 	// Verify that the base name is associated to the subscriber
 	ent, err = configurator.LoadEntity(
-		testNetworkId,
-		lte.BaseNameEntityType,
-		testBaseName,
+		testNetworkId, lte.BaseNameEntityType, testBaseName,
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	baseName := (&models.BaseNameRecord{}).FromEntity(ent)
 	assert.NoError(t, err)
@@ -155,10 +155,9 @@ func TestAssignmentsServicer(t *testing.T) {
 
 	// Verify that the rule is disassociated from the subscriber
 	ent, err = configurator.LoadEntity(
-		testNetworkId,
-		lte.PolicyRuleEntityType,
-		testPolicyId,
+		testNetworkId, lte.PolicyRuleEntityType, testPolicyId,
 		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
 	)
 	testPolicy = (&models.PolicyRule{}).FromEntity(ent)
 	assert.NoError(t, err)
@@ -166,10 +165,9 @@ func TestAssignmentsServicer(t *testing.T) {
 
 	// Verify that the base name is disassociated from the subscriber
 	ent, err = configurator.LoadEntity(
-		testNetworkId,
-		lte.BaseNameEntityType,
-		testBaseName,
+		testNetworkId, lte.BaseNameEntityType, testBaseName,
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	baseName = (&models.BaseNameRecord{}).FromEntity(ent)
 	assert.NoError(t, err)

--- a/lte/cloud/go/services/policydb/streamer/providers.go
+++ b/lte/cloud/go/services/policydb/streamer/providers.go
@@ -19,6 +19,7 @@ import (
 
 	"magma/lte/cloud/go/lte"
 	lte_protos "magma/lte/cloud/go/protos"
+	"magma/lte/cloud/go/serdes"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/storage"
@@ -39,12 +40,16 @@ func (p *RatingGroupsProvider) GetStreamName() string {
 }
 
 func (p *RatingGroupsProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
-	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{})
+	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}
 
-	ratingGroupEnts, err := configurator.LoadAllEntitiesInNetwork(gwEnt.NetworkID, lte.RatingGroupEntityType, configurator.EntityLoadCriteria{LoadConfig: true})
+	ratingGroupEnts, err := configurator.LoadAllEntitiesOfType(
+		gwEnt.NetworkID, lte.RatingGroupEntityType,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -89,14 +94,15 @@ func (p *PoliciesProvider) GetStreamName() string {
 }
 
 func (p *PoliciesProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
-	gw, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{})
+	gw, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}
 
-	rules, err := configurator.LoadAllEntitiesInNetwork(
+	rules, err := configurator.LoadAllEntitiesOfType(
 		gw.NetworkID, lte.PolicyRuleEntityType,
 		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return nil, err
@@ -116,9 +122,10 @@ func (p *PoliciesProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*
 // loadQosProfiles returns all policy_qos_profile ents, keyed by the key of
 // their parent policy rule ent, once for each parent.
 func loadQosProfiles(networkID string) (map[string]configurator.NetworkEntity, error) {
-	profiles, err := configurator.LoadAllEntitiesInNetwork(
+	profiles, err := configurator.LoadAllEntitiesOfType(
 		networkID, lte.PolicyQoSProfileEntityType,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsToThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return nil, err
@@ -168,14 +175,15 @@ func (p *BaseNamesProvider) GetStreamName() string {
 }
 
 func (p *BaseNamesProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
-	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{})
+	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}
 
-	bnEnts, err := configurator.LoadAllEntitiesInNetwork(
+	bnEnts, err := configurator.LoadAllEntitiesOfType(
 		gwEnt.NetworkID, lte.BaseNameEntityType,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true, LoadAssocsToThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return nil, err
@@ -215,13 +223,13 @@ func (p *ApnRuleMappingsProvider) GetStreamName() string {
 
 // GetUpdates implements GetUpdates for the rule mappings stream provider
 func (p *ApnRuleMappingsProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
-	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{})
+	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}
 
 	loadCrit := configurator.EntityLoadCriteria{LoadAssocsFromThis: true}
-	subEnts, err := configurator.LoadAllEntitiesInNetwork(gwEnt.NetworkID, lte.SubscriberEntityType, loadCrit)
+	subEnts, err := configurator.LoadAllEntitiesOfType(gwEnt.NetworkID, lte.SubscriberEntityType, loadCrit, serdes.Entity)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load subscribers")
 	}
@@ -290,7 +298,7 @@ func loadApnPolicyProfileEnts(networkID string, tks []storage.TypeAndKey) (confi
 	}
 	loadCrit := configurator.EntityLoadCriteria{LoadAssocsFromThis: true}
 	typeFilter := lte.APNPolicyProfileEntityType
-	apnPolicyProfileEnts, _, err := configurator.LoadEntities(networkID, &typeFilter, nil, nil, tks, loadCrit)
+	apnPolicyProfileEnts, _, err := configurator.LoadEntities(networkID, &typeFilter, nil, nil, tks, loadCrit, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}
@@ -330,11 +338,11 @@ func (p *NetworkWideRulesProvider) GetStreamName() string {
 }
 
 func (p *NetworkWideRulesProvider) GetUpdates(gatewayId string, extraArgs *any.Any) ([]*protos.DataUpdate, error) {
-	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{})
+	gwEnt, err := configurator.LoadEntityForPhysicalID(gatewayId, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}
-	iNetworkSubscriberConfig, err := configurator.LoadNetworkConfig(gwEnt.NetworkID, lte.NetworkSubscriberConfigType)
+	iNetworkSubscriberConfig, err := configurator.LoadNetworkConfig(gwEnt.NetworkID, lte.NetworkSubscriberConfigType, serdes.Network)
 	if err == merrors.ErrNotFound {
 		return []*protos.DataUpdate{}, nil
 	}

--- a/lte/cloud/go/services/policydb/streamer/providers_test.go
+++ b/lte/cloud/go/services/policydb/streamer/providers_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/lte/cloud/go/lte"
 	lte_plugin "magma/lte/cloud/go/plugin"
 	lte_protos "magma/lte/cloud/go/protos"
+	"magma/lte/cloud/go/serdes"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	lte_test_init "magma/lte/cloud/go/services/lte/test_init"
 	"magma/lte/cloud/go/services/policydb/obsidian/models"
@@ -45,38 +46,46 @@ func TestRatingGroupStreamers(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.RatingGroupStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
+	_, err = configurator.CreateEntity(
+		"n1",
+		configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	// create the rating groups
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		{
-			Type: lte.RatingGroupEntityType,
-			Key:  "111",
-			Config: &models.RatingGroup{
-				ID:        111,
-				LimitType: swag.String("FINITE"),
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type: lte.RatingGroupEntityType,
+				Key:  "111",
+				Config: &models.RatingGroup{
+					ID:        111,
+					LimitType: swag.String("FINITE"),
+				},
+			},
+			{
+				Type: lte.RatingGroupEntityType,
+				Key:  "222",
+				Config: &models.RatingGroup{
+					ID:        222,
+					LimitType: swag.String("INFINITE_METERED"),
+				},
+			},
+			{
+				Type: lte.RatingGroupEntityType,
+				Key:  "333",
+				Config: &models.RatingGroup{
+					ID:        333,
+					LimitType: swag.String("INFINITE_UNMETERED"),
+				},
 			},
 		},
-		{
-			Type: lte.RatingGroupEntityType,
-			Key:  "222",
-			Config: &models.RatingGroup{
-				ID:        222,
-				LimitType: swag.String("INFINITE_METERED"),
-			},
-		},
-		{
-			Type: lte.RatingGroupEntityType,
-			Key:  "333",
-			Config: &models.RatingGroup{
-				ID:        333,
-				LimitType: swag.String("INFINITE_UNMETERED"),
-			},
-		},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	expectedProtos := []*lte_protos.RatingGroup{
@@ -114,111 +123,123 @@ func TestPolicyStreamers(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.PolicyStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
+	_, err = configurator.CreateEntity(
+		"n1",
+		configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		// Attached qos profile (shared)
-		{
-			Type: lte.PolicyQoSProfileEntityType,
-			Key:  "p1",
-			Config: &models.PolicyQosProfile{
-				ClassID: 42,
-				ID:      "p1",
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			// Attached qos profile (shared)
+			{
+				Type: lte.PolicyQoSProfileEntityType,
+				Key:  "p1",
+				Config: &models.PolicyQosProfile{
+					ClassID: 42,
+					ID:      "p1",
+				},
 			},
-		},
-		// Dangling qos profile
-		{
-			Type: lte.PolicyQoSProfileEntityType,
-			Key:  "p2",
-			Config: &models.PolicyQosProfile{
-				ClassID: 420,
-				ID:      "p2",
+			// Dangling qos profile
+			{
+				Type: lte.PolicyQoSProfileEntityType,
+				Key:  "p2",
+				Config: &models.PolicyQosProfile{
+					ClassID: 420,
+					ID:      "p2",
+				},
 			},
-		},
-		{
-			Type: lte.PolicyRuleEntityType,
-			Key:  "r1",
-			Config: &models.PolicyRuleConfig{
-				FlowList: []*models.FlowDescription{
-					{
-						Action: swag.String("PERMIT"),
-						Match: &models.FlowMatch{
-							Direction: swag.String("UPLINK"),
-							IPProto:   swag.String("IPPROTO_IP "),
-							IPDst: &models.IPAddress{
-								Version: models.IPAddressVersionIPV4,
-								Address: "192.168.160.0/24",
+			{
+				Type: lte.PolicyRuleEntityType,
+				Key:  "r1",
+				Config: &models.PolicyRuleConfig{
+					FlowList: []*models.FlowDescription{
+						{
+							Action: swag.String("PERMIT"),
+							Match: &models.FlowMatch{
+								Direction: swag.String("UPLINK"),
+								IPProto:   swag.String("IPPROTO_IP "),
+								IPDst: &models.IPAddress{
+									Version: models.IPAddressVersionIPV4,
+									Address: "192.168.160.0/24",
+								},
+								IPSrc: &models.IPAddress{
+									Version: models.IPAddressVersionIPV4,
+									Address: "192.168.128.0/24",
+								},
 							},
-							IPSrc: &models.IPAddress{
-								Version: models.IPAddressVersionIPV4,
-								Address: "192.168.128.0/24",
+						},
+						{
+							Action: swag.String("DENY"),
+							Match: &models.FlowMatch{
+								Direction: swag.String("UPLINK"),
+								IPProto:   swag.String("IPPROTO_IP "),
+								IPSrc: &models.IPAddress{
+									Version: models.IPAddressVersionIPV4,
+									Address: "192.168.128.0/24",
+								},
 							},
 						},
 					},
-					{
-						Action: swag.String("DENY"),
-						Match: &models.FlowMatch{
-							Direction: swag.String("UPLINK"),
-							IPProto:   swag.String("IPPROTO_IP "),
-							IPSrc: &models.IPAddress{
-								Version: models.IPAddressVersionIPV4,
-								Address: "192.168.128.0/24",
-							},
-						},
+					MonitoringKey: "foo",
+				},
+				Associations: []storage.TypeAndKey{
+					{Type: lte.PolicyQoSProfileEntityType, Key: "p1"},
+				},
+			},
+			{
+				Type: lte.PolicyRuleEntityType,
+				Key:  "r2",
+				Config: &models.PolicyRuleConfig{
+					Priority: swag.Uint32(42),
+					Redirect: &models.RedirectInformation{
+						AddressType:   swag.String("IPv4"),
+						ServerAddress: swag.String("https://www.google.com"),
+						Support:       swag.String("ENABLED"),
 					},
 				},
-				MonitoringKey: "foo",
-			},
-			Associations: []storage.TypeAndKey{
-				{Type: lte.PolicyQoSProfileEntityType, Key: "p1"},
-			},
-		},
-		{
-			Type: lte.PolicyRuleEntityType,
-			Key:  "r2",
-			Config: &models.PolicyRuleConfig{
-				Priority: swag.Uint32(42),
-				Redirect: &models.RedirectInformation{
-					AddressType:   swag.String("IPv4"),
-					ServerAddress: swag.String("https://www.google.com"),
-					Support:       swag.String("ENABLED"),
+				Associations: []storage.TypeAndKey{
+					{Type: lte.PolicyQoSProfileEntityType, Key: "p1"},
 				},
 			},
-			Associations: []storage.TypeAndKey{
-				{Type: lte.PolicyQoSProfileEntityType, Key: "p1"},
+			{
+				Type: lte.PolicyRuleEntityType,
+				Key:  "r3",
+				Config: &models.PolicyRuleConfig{
+					MonitoringKey: "bar",
+				},
 			},
 		},
-		{
-			Type: lte.PolicyRuleEntityType,
-			Key:  "r3",
-			Config: &models.PolicyRuleConfig{
-				MonitoringKey: "bar",
-			},
-		},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntities("n1", []configurator.NetworkEntity{
-		{
-			Type:   lte.BaseNameEntityType,
-			Key:    "b1",
-			Config: &models.BaseNameRecord{Name: "b1"},
-			Associations: []storage.TypeAndKey{
-				{Type: lte.PolicyRuleEntityType, Key: "r1"},
-				{Type: lte.PolicyRuleEntityType, Key: "r2"},
+	_, err = configurator.CreateEntities(
+		"n1",
+		[]configurator.NetworkEntity{
+			{
+				Type:   lte.BaseNameEntityType,
+				Key:    "b1",
+				Config: &models.BaseNameRecord{Name: "b1"},
+				Associations: []storage.TypeAndKey{
+					{Type: lte.PolicyRuleEntityType, Key: "r1"},
+					{Type: lte.PolicyRuleEntityType, Key: "r2"},
+				},
+			},
+			{
+				Type:   lte.BaseNameEntityType,
+				Key:    "b2",
+				Config: &models.BaseNameRecord{Name: "b2"},
+				Associations: []storage.TypeAndKey{
+					{Type: lte.PolicyRuleEntityType, Key: "r3"},
+				},
 			},
 		},
-		{
-			Type:   lte.BaseNameEntityType,
-			Key:    "b2",
-			Config: &models.BaseNameRecord{Name: "b2"},
-			Associations: []storage.TypeAndKey{
-				{Type: lte.PolicyRuleEntityType, Key: "r3"},
-			},
-		},
-	})
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	expectedProtos := []*lte_protos.PolicyRule{
@@ -309,9 +330,13 @@ func TestApnRuleMappingsProvider(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.ApnRuleMappingsStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
+	_, err = configurator.CreateEntity(
+		"n1",
+		configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -355,6 +380,7 @@ func TestApnRuleMappingsProvider(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -375,6 +401,7 @@ func TestApnRuleMappingsProvider(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -398,6 +425,7 @@ func TestApnRuleMappingsProvider(t *testing.T) {
 			},
 			{Type: lte.SubscriberEntityType, Key: "s3"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -450,9 +478,13 @@ func TestNetworkWideRulesProvider(t *testing.T) {
 	provider, err := providers.GetStreamProvider(lte.NetworkWideRulesStreamName)
 	assert.NoError(t, err)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"})
+	_, err = configurator.CreateEntity(
+		"n1",
+		configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "g1", PhysicalID: "hw1"},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -466,13 +498,14 @@ func TestNetworkWideRulesProvider(t *testing.T) {
 			{Type: lte.BaseNameEntityType, Key: "b2"},
 			{Type: lte.BaseNameEntityType, Key: "b3"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	config := &models.NetworkSubscriberConfig{
 		NetworkWideBaseNames: []models.BaseName{"b1", "b2"},
 		NetworkWideRuleNames: []string{"r1", "r2"},
 	}
-	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, config))
+	assert.NoError(t, configurator.UpdateNetworkConfig("n1", lte.NetworkSubscriberConfigType, config, serdes.Network))
 
 	expectedProtos := []*lte_protos.AssignedPolicies{
 		{

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -130,7 +130,7 @@ func (m *MutableSubscriber) ToTK() storage.TypeAndKey {
 	return storage.TypeAndKey{Type: lte.SubscriberEntityType, Key: string(m.ID)}
 }
 
-func (m *MutableSubscriber) FromEnt(ent configurator.NetworkEntity) (*MutableSubscriber, error) {
+func (m *MutableSubscriber) FromEnt(ent configurator.NetworkEntity, policyProfileEnts configurator.NetworkEntities) (*MutableSubscriber, error) {
 	model := &MutableSubscriber{
 		ActivePoliciesByApn: policymodels.PolicyIdsByApn{},
 		ID:                  policymodels.SubscriberID(ent.Key),
@@ -152,23 +152,6 @@ func (m *MutableSubscriber) FromEnt(ent configurator.NetworkEntity) (*MutableSub
 		model.ActiveApns = append(model.ActiveApns, tk.Key)
 	}
 
-	policyProfileAssocs := ent.Associations.Filter(lte.APNPolicyProfileEntityType)
-	if len(policyProfileAssocs) == 0 {
-		return model, nil
-	}
-
-	// Need to load the policy profile ents to determine their edges.
-	// Configurator doesn't currently support loading a specified subgraph,
-	// so we have to load the subscriber and its policy profiles in
-	// separate calls.
-	policyProfileEnts, _, err := configurator.LoadEntities(
-		ent.NetworkID, nil, nil, nil,
-		policyProfileAssocs,
-		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
-	)
-	if err != nil {
-		return nil, err
-	}
 	// Each policy profile has 1 apn and n policy_rule
 	// Convert these assocs to a map of apn->policy_rules
 	for _, p := range policyProfileEnts {

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/serdes.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/serdes.go
@@ -1,0 +1,27 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/lte/cloud/go/lte"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(lte.SubscriberEntityType, &SubscriberConfig{}),
+	)
+)

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer.go
@@ -72,7 +72,7 @@ func (i *indexerServicer) GetIndexerInfo(ctx context.Context, req *protos.GetInd
 }
 
 func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (*protos.IndexResponse, error) {
-	states, err := state_types.MakeStatesByID(req.States, serdes.StateSerdes)
+	states, err := state_types.MakeStatesByID(req.States, serdes.State)
 	if err != nil {
 		return nil, err
 	}

--- a/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/subscriberdb/servicers/indexer_servicer_test.go
@@ -91,7 +91,7 @@ func TestIndexerIP(t *testing.T) {
 }
 
 func serialize(t *testing.T, mobilitydState *state.ArbitraryJSON) []byte {
-	bytes, err := serde.Serialize(mobilitydState, lte.MobilitydStateType, serdes.StateSerdes)
+	bytes, err := serde.Serialize(mobilitydState, lte.MobilitydStateType, serdes.State)
 	assert.NoError(t, err)
 	return bytes
 }

--- a/lte/cloud/go/tools/migrations/m010_default_apns/types/types.go
+++ b/lte/cloud/go/tools/migrations/m010_default_apns/types/types.go
@@ -63,6 +63,22 @@ type ApnConfiguration struct {
 	QosProfile *QosProfile `json:"qos_profile"`
 }
 
+func (m *ApnConfiguration) MarshalBinary() ([]byte, error) {
+	if m == nil {
+		return nil, nil
+	}
+	return swag.WriteJSON(m)
+}
+
+func (m *ApnConfiguration) UnmarshalBinary(b []byte) error {
+	var res ApnConfiguration
+	if err := swag.ReadJSON(b, &res); err != nil {
+		return err
+	}
+	*m = res
+	return nil
+}
+
 func (m *ApnConfiguration) MustMarshalBinary() []byte {
 	if m == nil {
 		return nil

--- a/orc8r/cloud/go/models/conversion.go
+++ b/orc8r/cloud/go/models/conversion.go
@@ -168,7 +168,10 @@ func (m *GatewayName) ToUpdateCriteria(networkID string, gatewayID string) ([]co
 }
 
 func (m *GatewayName) FromBackendModels(networkID string, gatewayID string) error {
-	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadMetadata: true})
+	entity, err := configurator.LoadSerializedEntity(
+		networkID, orc8r.MagmadGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+	)
 	if err != nil {
 		return err
 	}
@@ -187,7 +190,10 @@ func (m *GatewayDescription) ToUpdateCriteria(networkID string, gatewayID string
 }
 
 func (m *GatewayDescription) FromBackendModels(networkID string, gatewayID string) error {
-	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadMetadata: true})
+	entity, err := configurator.LoadSerializedEntity(
+		networkID, orc8r.MagmadGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+	)
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/pluginimpl/plugin.go
+++ b/orc8r/cloud/go/pluginimpl/plugin.go
@@ -17,7 +17,6 @@ import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/device"
 	"magma/orc8r/cloud/go/services/directoryd"
@@ -52,14 +51,6 @@ func (*BaseOrchestratorPlugin) GetSerdes() []serde.Serde {
 	return []serde.Serde{
 		// Device service serdes
 		serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &models.GatewayDevice{}),
-
-		// Config manager serdes
-		configurator.NewNetworkConfigSerde(orc8r.DnsdNetworkType, &models.NetworkDNSConfig{}),
-		configurator.NewNetworkConfigSerde(orc8r.NetworkFeaturesConfig, &models.NetworkFeatures{}),
-
-		configurator.NewNetworkEntityConfigSerde(orc8r.MagmadGatewayType, &models.MagmadGatewayConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(orc8r.UpgradeReleaseChannelEntityType, &models.ReleaseChannel{}),
-		configurator.NewNetworkEntityConfigSerde(orc8r.UpgradeTierEntityType, &models.Tier{}),
 	}
 }
 

--- a/orc8r/cloud/go/serdes/serdes.go
+++ b/orc8r/cloud/go/serdes/serdes.go
@@ -22,7 +22,12 @@ import (
 )
 
 var (
-	StateSerdes = serde.NewRegistry(
+	// Network contains the base orc8r serdes for configurator network configs
+	Network = models.NetworkSerdes
+	// Entity contains the base orc8r serdes for configurator network entities
+	Entity = models.EntitySerdes
+	// State contains the base orc8r serdes for the state service
+	State = serde.NewRegistry(
 		state.NewStateSerde(orc8r.GatewayStateType, &models.GatewayStatus{}),
 		state.NewStateSerde(orc8r.StringMapSerdeType, &state.StringToStringMap{}),
 		state.NewStateSerde(orc8r.DirectoryRecordType, &directoryd_types.DirectoryRecord{}),

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
@@ -21,6 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/clock"
 	"magma/orc8r/cloud/go/identity"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/certifier"
 	certprotos "magma/orc8r/cloud/go/services/certifier/protos"
 	"magma/orc8r/cloud/go/services/configurator"
@@ -209,7 +210,7 @@ func findGatewayIdentity(serialNumber string, md metadata.MD) (*protos.Identity,
 	// At this point we should have a valid GW Identity with HardwareId, so
 	// the Gateway is authenticated. Now we'll try to find GW Network & Logical
 	// ID & add them to the GW Identity
-	entity, err := configurator.LoadEntityForPhysicalID(gwIdentity.HardwareId, configurator.EntityLoadCriteria{})
+	entity, err := configurator.LoadEntityForPhysicalID(gwIdentity.HardwareId, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		log.Printf(
 			"Unregistered Gateway Id: %s for Cert SN: %s; err: %s; metadata: %+v",

--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator_test.go
@@ -111,7 +111,7 @@ func TestIdentityInjector(t *testing.T) {
 			"foo": "bar",
 		},
 	}
-	serializedGWStatus, err := serde.Serialize(gwState, orc8r.GatewayStateType, serdes.StateSerdes)
+	serializedGWStatus, err := serde.Serialize(gwState, orc8r.GatewayStateType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{

--- a/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/certifier"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
@@ -261,7 +262,7 @@ func verifySoftwareECDSASHA256(resp *protos.Response, key []byte) error {
 
 func getChallengeKey(hwID string) (protos.ChallengeKey_KeyType, []byte, error) {
 	var empty protos.ChallengeKey_KeyType
-	entity, err := configurator.LoadEntityForPhysicalID(hwID, configurator.EntityLoadCriteria{})
+	entity, err := configurator.LoadEntityForPhysicalID(hwID, configurator.EntityLoadCriteria{}, serdes.Entity)
 	if err != nil {
 		return empty, nil, errorLogger(status.Errorf(codes.NotFound, "Gateway with hwid %s is not registered: %s", hwID, err))
 	}

--- a/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper_test.go
+++ b/orc8r/cloud/go/services/bootstrapper/servicers/bootstrapper_test.go
@@ -31,6 +31,7 @@ import (
 	bootstrap_client "magma/gateway/services/bootstrapper/service"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/bootstrapper"
 	"magma/orc8r/cloud/go/services/bootstrapper/servicers"
 	certifier_test_init "magma/orc8r/cloud/go/services/certifier/test_init"
@@ -390,10 +391,7 @@ func TestBootstrapperServer(t *testing.T) {
 	_ = serde.RegisterSerdesLegacy(serde.NewBinarySerde(device.SerdeDomain, orc8r.AccessGatewayRecordType, &models.GatewayDevice{}))
 
 	testNetworkID := "bootstrapper_test_network"
-	err := configurator.CreateNetwork(configurator.Network{
-		ID:   testNetworkID,
-		Name: "Test Network Name",
-	})
+	err := configurator.CreateNetwork(configurator.Network{ID: testNetworkID, Name: "Test Network Name"}, serdes.Network)
 	assert.NoError(t, err)
 	exists, err := configurator.DoesNetworkExist(testNetworkID)
 	assert.True(t, exists)

--- a/orc8r/cloud/go/services/configurator/client_api_test.go
+++ b/orc8r/cloud/go/services/configurator/client_api_test.go
@@ -32,14 +32,15 @@ const (
 
 func TestConfiguratorService(t *testing.T) {
 	test_init.StartTestService(t)
-	err := serde.RegisterSerdesLegacy(&mockSerde{domain: configurator.NetworkConfigSerdeDomain, serdeType: "foo"})
-	assert.NoError(t, err)
-	err = serde.RegisterSerdesLegacy(&mockSerde{domain: configurator.NetworkEntitySerdeDomain, serdeType: "foo"})
-	assert.NoError(t, err)
-	err = serde.RegisterSerdesLegacy(&mockSerde{domain: configurator.NetworkConfigSerdeDomain, serdeType: "bar"})
-	assert.NoError(t, err)
-	err = serde.RegisterSerdesLegacy(&mockSerde{domain: configurator.NetworkEntitySerdeDomain, serdeType: "bar"})
-	assert.NoError(t, err)
+
+	networkSerdes := serde.NewRegistry(
+		&mockSerde{domain: configurator.NetworkConfigSerdeDomain, serdeType: "foo"},
+		&mockSerde{domain: configurator.NetworkConfigSerdeDomain, serdeType: "bar"},
+	)
+	entitySerdes := serde.NewRegistry(
+		&mockSerde{domain: configurator.NetworkEntitySerdeDomain, serdeType: "foo"},
+		&mockSerde{domain: configurator.NetworkEntitySerdeDomain, serdeType: "bar"},
+	)
 
 	// Test Basic Network Interface
 	config := map[string]interface{}{
@@ -52,10 +53,10 @@ func TestConfiguratorService(t *testing.T) {
 		Description: "description",
 		Configs:     config,
 	}
-	_, err = configurator.CreateNetworks([]configurator.Network{network1})
+	_, err := configurator.CreateNetworks([]configurator.Network{network1}, networkSerdes)
 	assert.NoError(t, err)
 
-	networks, notFound, err := configurator.LoadNetworks([]string{networkID1}, true, true)
+	networks, notFound, err := configurator.LoadNetworks([]string{networkID1}, true, true, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(notFound))
 	assert.Equal(t, 1, len(networks))
@@ -72,9 +73,9 @@ func TestConfiguratorService(t *testing.T) {
 		ConfigsToDelete:      toDelete,
 	}
 
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria1})
+	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{updateCriteria1}, networkSerdes)
 	assert.NoError(t, err)
-	networks, notFound, err = configurator.LoadNetworks([]string{networkID1}, true, true)
+	networks, notFound, err = configurator.LoadNetworks([]string{networkID1}, true, true, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(notFound))
 	assert.Equal(t, 1, len(networks))
@@ -89,7 +90,7 @@ func TestConfiguratorService(t *testing.T) {
 		Name:        "test_network2",
 		Description: "description2",
 	}
-	_, err = configurator.CreateNetworks([]configurator.Network{network2})
+	_, err = configurator.CreateNetworks([]configurator.Network{network2}, networkSerdes)
 	assert.NoError(t, err)
 
 	networkIDs, err := configurator.ListNetworkIDs()
@@ -101,30 +102,33 @@ func TestConfiguratorService(t *testing.T) {
 	err = configurator.DeleteNetworks([]string{network2.ID})
 	assert.NoError(t, err)
 
-	networks, notFound, err = configurator.LoadNetworks([]string{networkID2}, true, true)
+	networks, notFound, err = configurator.LoadNetworks([]string{networkID2}, true, true, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, len(networks))
 	assert.Equal(t, 1, len(notFound))
 
 	// Create Networks With Type
-	createdTypedLteNetworks, err := configurator.CreateNetworks([]configurator.Network{
-		{
-			Name: "lte network 1",
-			Type: "lte",
-			ID:   "test_network3",
+	createdTypedLteNetworks, err := configurator.CreateNetworks(
+		[]configurator.Network{
+			{
+				Name: "lte network 1",
+				Type: "lte",
+				ID:   "test_network3",
+			},
+			{
+				Name: "lte network 2",
+				Type: "lte",
+				ID:   "test_network4",
+			},
 		},
-		{
-			Name: "lte network 2",
-			Type: "lte",
-			ID:   "test_network4",
-		},
-	})
+		networkSerdes,
+	)
 	assert.NoError(t, err)
 
 	createdTypedLteNetworks[0].Name = ""
 	createdTypedLteNetworks[1].Name = ""
 
-	networks, err = configurator.LoadNetworksByType("lte", false, false)
+	networks, err = configurator.LoadNetworksOfType("lte", false, false, networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, createdTypedLteNetworks, networks)
 
@@ -155,7 +159,7 @@ func TestConfiguratorService(t *testing.T) {
 	}
 
 	// Create, Load
-	_, err = configurator.CreateEntities(networkID1, []configurator.NetworkEntity{entity1, entity2})
+	_, err = configurator.CreateEntities(networkID1, []configurator.NetworkEntity{entity1, entity2}, entitySerdes)
 	assert.NoError(t, err)
 
 	entities, entitiesNotFound, err := configurator.LoadEntities(
@@ -163,6 +167,7 @@ func TestConfiguratorService(t *testing.T) {
 		nil, nil, nil,
 		[]storage.TypeAndKey{entityID1, entityID2},
 		fullEntityLoad,
+		entitySerdes,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(entities))
@@ -171,7 +176,7 @@ func TestConfiguratorService(t *testing.T) {
 	assert.Equal(t, "fooboo", entities[1].Name)
 
 	// LoadAllPerType
-	entities, err = configurator.LoadAllEntitiesInNetwork(networkID1, "foo", fullEntityLoad)
+	entities, err = configurator.LoadAllEntitiesOfType(networkID1, "foo", fullEntityLoad, entitySerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(entities))
 	assert.Equal(t, "foobar", entities[0].Name)
@@ -186,13 +191,14 @@ func TestConfiguratorService(t *testing.T) {
 		AssociationsToAdd: []storage.TypeAndKey{entityID2},
 	}
 
-	_, err = configurator.UpdateEntities(networkID1, []configurator.EntityUpdateCriteria{entityUpdateCriteria})
+	_, err = configurator.UpdateEntities(networkID1, []configurator.EntityUpdateCriteria{entityUpdateCriteria}, entitySerdes)
 	assert.NoError(t, err)
 	entities, entitiesNotFound, err = configurator.LoadEntities(
 		networkID1,
 		strPointer("foo"),
 		nil, nil, nil,
 		fullEntityLoad,
+		entitySerdes,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(entities))
@@ -209,12 +215,15 @@ func TestConfiguratorService(t *testing.T) {
 	// client call
 	err = configurator.WriteEntities(
 		networkID1,
-		configurator.EntityUpdateCriteria{Type: entityID1.Type, Key: entityID1.Key, NewDescription: swag.String("newnewnew")},
-		configurator.NetworkEntity{Type: "foo", Key: "baz"},
-		configurator.EntityUpdateCriteria{
-			Type: entityID2.Type, Key: entityID2.Key,
-			AssociationsToAdd: []storage.TypeAndKey{{Type: "foo", Key: "baz"}},
+		[]configurator.EntityWriteOperation{
+			configurator.EntityUpdateCriteria{Type: entityID1.Type, Key: entityID1.Key, NewDescription: swag.String("newnewnew")},
+			configurator.NetworkEntity{Type: "foo", Key: "baz"},
+			configurator.EntityUpdateCriteria{
+				Type: entityID2.Type, Key: entityID2.Key,
+				AssociationsToAdd: []storage.TypeAndKey{{Type: "foo", Key: "baz"}},
+			},
 		},
+		entitySerdes,
 	)
 	assert.NoError(t, err)
 
@@ -223,6 +232,7 @@ func TestConfiguratorService(t *testing.T) {
 		swag.String("foo"), nil,
 		nil, nil,
 		fullEntityLoad,
+		entitySerdes,
 	)
 	assert.NoError(t, err)
 	expected := configurator.NetworkEntities{
@@ -261,6 +271,7 @@ func TestConfiguratorService(t *testing.T) {
 		strPointer("foo"),
 		nil, nil, nil,
 		fullEntityLoad,
+		entitySerdes,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, len(entities))

--- a/orc8r/cloud/go/services/configurator/servicers/northbound.go
+++ b/orc8r/cloud/go/services/configurator/servicers/northbound.go
@@ -17,8 +17,6 @@ import (
 	"context"
 	"fmt"
 
-	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/protos"
 	"magma/orc8r/cloud/go/services/configurator/storage"
 	orc8rStorage "magma/orc8r/cloud/go/storage"
@@ -83,10 +81,6 @@ func (srv *nbConfiguratorServicer) CreateNetworks(context context.Context, req *
 
 	createdNetworks := make([]*storage.Network, 0, len(req.Networks))
 	for _, network := range req.Networks {
-		err = networkConfigsAreValid(network.Configs)
-		if err != nil {
-			return emptyRes, err
-		}
 		createdNetwork, err := store.CreateNetwork(*network)
 		if err != nil {
 			storage.RollbackLogOnError(store)
@@ -106,10 +100,6 @@ func (srv *nbConfiguratorServicer) UpdateNetworks(context context.Context, req *
 
 	updates := []storage.NetworkUpdateCriteria{}
 	for _, update := range req.Updates {
-		err = networkConfigsAreValid(update.ConfigsToAddOrUpdate)
-		if err != nil {
-			return void, err
-		}
 		updates = append(updates, *update)
 	}
 	err = store.UpdateNetworks(updates)
@@ -167,19 +157,19 @@ func (srv *nbConfiguratorServicer) WriteEntities(context context.Context, req *p
 	for _, write := range req.Writes {
 		switch op := write.Request.(type) {
 		case *protos.WriteEntityRequest_Create:
-			createdEnt, err := createEntity(store, req.NetworkID, op.Create)
+			createdEnt, err := store.CreateEntity(req.NetworkID, *op.Create)
 			if err != nil {
 				storage.RollbackLogOnError(store)
 				return emptyRes, status.Error(codes.Internal, err.Error())
 			}
-			ret.CreatedEntities = append(ret.CreatedEntities, createdEnt)
+			ret.CreatedEntities = append(ret.CreatedEntities, &createdEnt)
 		case *protos.WriteEntityRequest_Update:
-			updatedEnt, err := updateEntity(store, req.NetworkID, op.Update)
+			updatedEnt, err := store.UpdateEntity(req.NetworkID, *op.Update)
 			if err != nil {
 				storage.RollbackLogOnError(store)
 				return emptyRes, status.Error(codes.Internal, err.Error())
 			}
-			ret.UpdatedEntities[updatedEnt.Key] = updatedEnt
+			ret.UpdatedEntities[updatedEnt.Key] = &updatedEnt
 		default:
 			storage.RollbackLogOnError(store)
 			return emptyRes, status.Error(codes.InvalidArgument, fmt.Sprintf("write request %T not recognized", write))
@@ -197,12 +187,12 @@ func (srv *nbConfiguratorServicer) CreateEntities(context context.Context, req *
 
 	createdEntities := []*storage.NetworkEntity{}
 	for _, entity := range req.Entities {
-		createdEntity, err := createEntity(store, req.NetworkID, entity)
+		createdEntity, err := store.CreateEntity(req.NetworkID, *entity)
 		if err != nil {
 			storage.RollbackLogOnError(store)
 			return emptyRes, err
 		}
-		createdEntities = append(createdEntities, createdEntity)
+		createdEntities = append(createdEntities, &createdEntity)
 	}
 	return &protos.CreateEntitiesResponse{CreatedEntities: createdEntities}, store.Commit()
 }
@@ -216,12 +206,12 @@ func (srv *nbConfiguratorServicer) UpdateEntities(context context.Context, req *
 
 	updatedEntities := map[string]*storage.NetworkEntity{}
 	for _, update := range req.Updates {
-		updatedEntity, err := updateEntity(store, req.NetworkID, update)
+		updatedEntity, err := store.UpdateEntity(req.NetworkID, *update)
 		if err != nil {
 			storage.RollbackLogOnError(store)
 			return emptyRes, err
 		}
-		updatedEntities[update.Key] = updatedEntity
+		updatedEntities[update.Key] = &updatedEntity
 	}
 	return &protos.UpdateEntitiesResponse{UpdatedEntities: updatedEntities}, store.Commit()
 }
@@ -246,44 +236,4 @@ func (srv *nbConfiguratorServicer) DeleteEntities(context context.Context, req *
 		}
 	}
 	return void, store.Commit()
-}
-
-func networkConfigsAreValid(configs map[string][]byte) error {
-	for typeVal, config := range configs {
-		_, err := serde.DeserializeLegacy(configurator.NetworkConfigSerdeDomain, typeVal, config)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func entityConfigIsValid(typeVal string, config []byte) error {
-	_, err := serde.DeserializeLegacy(configurator.NetworkEntitySerdeDomain, typeVal, config)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func createEntity(store storage.ConfiguratorStorage, networkID string, entity *storage.NetworkEntity) (*storage.NetworkEntity, error) {
-	if err := entityConfigIsValid(entity.Type, entity.Config); err != nil {
-		return nil, err
-	}
-	ent, err := store.CreateEntity(networkID, *entity)
-	return &ent, err
-}
-
-func updateEntity(store storage.ConfiguratorStorage, networkID string, update *storage.EntityUpdateCriteria) (*storage.NetworkEntity, error) {
-	if update.NewConfig != nil {
-		if err := entityConfigIsValid(update.Type, update.NewConfig.Value); err != nil {
-			return nil, err
-		}
-	}
-
-	updatedEntity, err := store.UpdateEntity(networkID, *update)
-	if err != nil {
-		return nil, err
-	}
-	return &updatedEntity, nil
 }

--- a/orc8r/cloud/go/services/configurator/test_utils/utils.go
+++ b/orc8r/cloud/go/services/configurator/test_utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/device"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
@@ -25,11 +26,7 @@ import (
 )
 
 func RegisterNetwork(t *testing.T, networkID string, networkName string) {
-	err := configurator.CreateNetwork(
-		configurator.Network{
-			ID:   networkID,
-			Name: networkName,
-		})
+	err := configurator.CreateNetwork(configurator.Network{ID: networkID, Name: networkName}, nil)
 	assert.NoError(t, err)
 }
 
@@ -60,7 +57,7 @@ func RegisterGatewayWithName(t *testing.T, networkID string, gatewayID string, n
 			Name: name,
 		}
 	}
-	_, err := configurator.CreateEntity(networkID, gwEntity)
+	_, err := configurator.CreateEntity(networkID, gwEntity, serdes.Entity)
 	assert.NoError(t, err)
 
 }

--- a/orc8r/cloud/go/services/configurator/types.go
+++ b/orc8r/cloud/go/services/configurator/types.go
@@ -44,15 +44,15 @@ type Network struct {
 	Version uint64
 }
 
-// ToStorageProto converts a Network struct to its proto representation.
-func (n Network) ToStorageProto() (*storage.Network, error) {
+// ToProto converts a Network struct to its proto representation.
+func (n Network) ToProto(serdes serde.Registry) (*storage.Network, error) {
 	ret := &storage.Network{
 		ID:          n.ID,
 		Type:        n.Type,
 		Name:        n.Name,
 		Description: n.Description,
 	}
-	bConfigs, err := marshalConfigs(n.Configs, NetworkConfigSerdeDomain)
+	bConfigs, err := marshalConfigs(n.Configs, serdes)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error serializing network %s", n.ID)
 	}
@@ -60,9 +60,9 @@ func (n Network) ToStorageProto() (*storage.Network, error) {
 	return ret, nil
 }
 
-// FromStorageProto converts a Network proto to it's internal go struct format.
-func (n Network) FromStorageProto(protoNet *storage.Network) (Network, error) {
-	iConfigs, err := unmarshalConfigs(protoNet.Configs, NetworkConfigSerdeDomain)
+// FromProto converts a Network proto to it's internal go struct format.
+func (n Network) FromProto(protoNet *storage.Network, serdes serde.Registry) (Network, error) {
+	iConfigs, err := unmarshalConfigs(protoNet.Configs, serdes)
 	if err != nil {
 		return n, errors.Wrapf(err, "error deserializing network %s", protoNet.ID)
 	}
@@ -98,8 +98,8 @@ type NetworkUpdateCriteria struct {
 	ConfigsToDelete []string
 }
 
-func (nuc NetworkUpdateCriteria) toStorageProto() (*storage.NetworkUpdateCriteria, error) {
-	bConfigs, err := marshalConfigs(nuc.ConfigsToAddOrUpdate, NetworkConfigSerdeDomain)
+func (nuc NetworkUpdateCriteria) toProto(serdes serde.Registry) (*storage.NetworkUpdateCriteria, error) {
+	bConfigs, err := marshalConfigs(nuc.ConfigsToAddOrUpdate, serdes)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to marshal update")
 	}
@@ -119,11 +119,12 @@ func (nuc NetworkUpdateCriteria) toStorageProto() (*storage.NetworkUpdateCriteri
 	return ret, nil
 }
 
-// NetworkEntity is the storage representation of a logical component of a
-// network. Networks are partitioned into DAGs of entities.
+// NetworkEntity is a logical component of a network.
+// Networks are partitioned into DAGs of entities. Read-only fields will be
+// ignored if provided to write APIs.
 type NetworkEntity struct {
-	// Network that the entity belongs to. This is a READ-ONLY field and will
-	// be ignored if provided to write APIs.
+	// Network the entity belongs to.
+	// Read-only.
 	NetworkID string
 
 	// (Type, Key) forms a unique identifier for the network entity within its
@@ -131,35 +132,37 @@ type NetworkEntity struct {
 	Type string
 	Key  string
 
+	// Config value for the entity, deserialized.
+	Config interface{}
+	// isSerialized is true iff Config was set by this pkg and the contents
+	// were not deserialized from byte array.
+	isSerialized bool
+
+	// Name and Description are metadata annotations for human consumption.
 	Name        string
 	Description string
 
-	// PhysicalID will be non-empty if the entity corresponds to a physical
-	// asset.
+	// PhysicalID is non-empty when the entity corresponds to a physical asset.
 	PhysicalID string
 
-	Config interface{}
-
 	// GraphID is a mostly-internal field to designate the DAG that this
-	// network entity belongs to. This field is system-generated and will be
-	// ignored if set during entity creation.
+	// network entity belongs to.
+	// Read-only.
 	GraphID string
 
 	// Associations are the directed edges originating from this entity.
 	Associations storage2.TKs
 
 	// ParentAssociations are the directed edges ending at this entity.
-	// This is a read-only field and will be ignored if set during entity
-	// creation.
+	// Read-only.
 	ParentAssociations storage2.TKs
 
-	// Note that we are not exposing permissions in the client API at this
-	// time
-
+	// Version of the entity.
+	// Read-only.
 	Version uint64
 }
 
-func (ent NetworkEntity) toStorageProto() (*storage.NetworkEntity, error) {
+func (ent NetworkEntity) toProto(serdes serde.Registry) (*storage.NetworkEntity, error) {
 	ret := &storage.NetworkEntity{
 		// NetworkID is a read-only field so we won't fill it in
 		Type:        ent.Type,
@@ -175,7 +178,7 @@ func (ent NetworkEntity) toStorageProto() (*storage.NetworkEntity, error) {
 	}
 
 	if ent.Config != nil {
-		bConfigs, err := serde.SerializeLegacy(NetworkEntitySerdeDomain, ent.Type, ent.Config)
+		bConfigs, err := serde.Serialize(ent.Config, ent.Type, serdes)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to serialize entity %s", ent.GetTypeAndKey())
 		}
@@ -185,27 +188,62 @@ func (ent NetworkEntity) toStorageProto() (*storage.NetworkEntity, error) {
 	return ret, nil
 }
 
-func (ent NetworkEntity) fromStorageProto(protoEnt *storage.NetworkEntity) (NetworkEntity, error) {
-	ent.NetworkID = protoEnt.NetworkID
-	ent.Type = protoEnt.Type
-	ent.Key = protoEnt.Key
-	ent.Name = protoEnt.Name
-	ent.Description = protoEnt.Description
-	ent.PhysicalID = protoEnt.PhysicalID
-	ent.GraphID = protoEnt.GraphID
-	ent.Associations = entIDsToTKs(protoEnt.Associations)
-	ent.ParentAssociations = entIDsToTKs(protoEnt.ParentAssociations)
-	ent.Version = protoEnt.Version
+func (ent NetworkEntity) fromProto(p *storage.NetworkEntity, serdes serde.Registry) (NetworkEntity, error) {
+	e := ent.fromProtoSerialized(p)
 
-	if !funk.IsEmpty(protoEnt.Config) {
-		iConfig, err := serde.DeserializeLegacy(NetworkEntitySerdeDomain, ent.Type, protoEnt.Config)
+	if len(p.Config) != 0 {
+		iConfig, err := serde.Deserialize(p.Config, e.Type, serdes)
 		if err != nil {
 			return ent, errors.Wrapf(err, "failed to deserialize entity %s", ent.GetTypeAndKey())
 		}
-		ent.Config = iConfig
+		e.Config = iConfig
+		e.isSerialized = false
 	}
 
-	return ent, nil
+	return e, nil
+}
+
+// fromProtoSerialized is the same as fromProto, except it leaves the entity's
+// config as serialized bytes.
+func (ent NetworkEntity) fromProtoSerialized(p *storage.NetworkEntity) NetworkEntity {
+	e := NetworkEntity{
+		NetworkID:          p.NetworkID,
+		Type:               p.Type,
+		Key:                p.Key,
+		Name:               p.Name,
+		Description:        p.Description,
+		PhysicalID:         p.PhysicalID,
+		GraphID:            p.GraphID,
+		Associations:       entIDsToTKs(p.Associations),
+		ParentAssociations: entIDsToTKs(p.ParentAssociations),
+		Version:            p.Version,
+	}
+	if len(p.Config) != 0 {
+		e.Config = p.Config
+		e.isSerialized = true
+	}
+	return e
+}
+
+// fromProtoWithDefault tries to return fromProto, defaulting to
+// fromProtoSerialized when it encounters an error.
+func (ent NetworkEntity) fromProtoWithDefault(p *storage.NetworkEntity, serdes serde.Registry) (NetworkEntity, error) {
+	// Default to returning serialized when no serde found
+	if _, err := serdes.GetSerde(p.Type); err != nil {
+		return ent.fromProtoSerialized(p), nil
+	}
+
+	e, err := ent.fromProto(p, serdes)
+	if err != nil {
+		return NetworkEntity{}, err
+	}
+	return e, nil
+}
+
+// IsSerialized returns true iff this package created the ent and its state
+// was not deserialized.
+func (ent NetworkEntity) IsSerialized() bool {
+	return ent.isSerialized
 }
 
 func (ent NetworkEntity) GetTypeAndKey() storage2.TypeAndKey {
@@ -224,6 +262,18 @@ func (ne NetworkEntities) MakeByTK() NetworkEntitiesByTK {
 	return ret
 }
 
+// MakeByParentTK returns the network entities, keyed by the TK of their parent
+// associations, once per parent association.
+func (ne NetworkEntities) MakeByParentTK() map[storage2.TypeAndKey]NetworkEntities {
+	ret := map[storage2.TypeAndKey]NetworkEntities{}
+	for _, ent := range ne {
+		for _, parentTK := range ent.ParentAssociations {
+			ret[parentTK] = append(ret[parentTK], ent)
+		}
+	}
+	return ret
+}
+
 func (ne NetworkEntities) GetFirst(typ string) (NetworkEntity, error) {
 	for _, e := range ne {
 		if e.Type == typ {
@@ -231,6 +281,26 @@ func (ne NetworkEntities) GetFirst(typ string) (NetworkEntity, error) {
 		}
 	}
 	return NetworkEntity{}, fmt.Errorf("no network entity of type %s found in %v", typ, ne)
+}
+
+func (ne NetworkEntities) fromProtos(protos []*storage.NetworkEntity, serdes serde.Registry) (NetworkEntities, error) {
+	var ents NetworkEntities
+	for _, p := range protos {
+		ent, err := (&NetworkEntity{}).fromProto(p, serdes)
+		if err != nil {
+			return nil, err
+		}
+		ents = append(ents, ent)
+	}
+	return ents, nil
+}
+
+func (ne NetworkEntities) fromProtosSerialized(protos []*storage.NetworkEntity) NetworkEntities {
+	var ents NetworkEntities
+	for _, p := range protos {
+		ents = append(ents, (&NetworkEntity{}).fromProtoSerialized(p))
+	}
+	return ents
 }
 
 type NetworkEntitiesByTK map[storage2.TypeAndKey]NetworkEntity
@@ -282,11 +352,11 @@ type EntityGraph struct {
 	reverseEdgesByTK map[storage2.TypeAndKey][]storage2.TypeAndKey
 }
 
-// FromStorageProto converts a proto EntityGraph to it's go struct format.
-func (eg EntityGraph) FromStorageProto(protoGraph *storage.EntityGraph) (EntityGraph, error) {
+// FromProto converts a proto EntityGraph to its native counterpart.
+func (eg EntityGraph) FromProto(protoGraph *storage.EntityGraph, serdes serde.Registry) (EntityGraph, error) {
 	eg.Entities = make([]NetworkEntity, 0, len(protoGraph.Entities))
 	for _, protoEnt := range protoGraph.Entities {
-		ent, err := (NetworkEntity{}).fromStorageProto(protoEnt)
+		ent, err := (NetworkEntity{}).fromProtoWithDefault(protoEnt, serdes)
 		if err != nil {
 			return eg, errors.Wrapf(err, "failed to deserialize entity %s", protoEnt.GetTypeAndKey())
 		}
@@ -297,16 +367,16 @@ func (eg EntityGraph) FromStorageProto(protoGraph *storage.EntityGraph) (EntityG
 
 	eg.Edges = make([]GraphEdge, 0, len(protoGraph.Edges))
 	for _, protoEdge := range protoGraph.Edges {
-		eg.Edges = append(eg.Edges, (GraphEdge{}).fromStorageProto(protoEdge))
+		eg.Edges = append(eg.Edges, (GraphEdge{}).fromProto(protoEdge))
 	}
 	return eg, nil
 }
 
-// ToStorageProto converts an EntityGraph struct to it's proto representation.
-func (eg EntityGraph) ToStorageProto() (*storage.EntityGraph, error) {
+// ToProto converts an EntityGraph struct to it's proto representation.
+func (eg EntityGraph) ToProto(serdes serde.Registry) (*storage.EntityGraph, error) {
 	protoGraph := &storage.EntityGraph{}
 	for _, ent := range eg.Entities {
-		protoEnt, err := ent.toStorageProto()
+		protoEnt, err := ent.toProto(serdes)
 		if err != nil {
 			return protoGraph, errors.Wrapf(err, "failed to convert entity %s to storage proto", ent.GetTypeAndKey())
 		}
@@ -315,7 +385,7 @@ func (eg EntityGraph) ToStorageProto() (*storage.EntityGraph, error) {
 	protoGraph.RootEntities = tksToEntIDs(eg.RootEntities)
 
 	for _, edge := range eg.Edges {
-		protoGraph.Edges = append(protoGraph.Edges, edge.toStorageProto())
+		protoGraph.Edges = append(protoGraph.Edges, edge.toProto())
 	}
 	return protoGraph, nil
 }
@@ -325,13 +395,13 @@ type GraphEdge struct {
 	To   storage2.TypeAndKey
 }
 
-func (ge GraphEdge) fromStorageProto(protoEdge *storage.GraphEdge) GraphEdge {
+func (ge GraphEdge) fromProto(protoEdge *storage.GraphEdge) GraphEdge {
 	ge.From = protoEdge.From.ToTypeAndKey()
 	ge.To = protoEdge.To.ToTypeAndKey()
 	return ge
 }
 
-func (ge GraphEdge) toStorageProto() *storage.GraphEdge {
+func (ge GraphEdge) toProto() *storage.GraphEdge {
 	protoTo := (&storage.EntityID{}).FromTypeAndKey(ge.To)
 	protoFrom := (&storage.EntityID{}).FromTypeAndKey(ge.From)
 	return &storage.GraphEdge{
@@ -371,7 +441,7 @@ type EntityLoadCriteria struct {
 	LoadAssocsFromThis bool
 }
 
-func (elc EntityLoadCriteria) toStorageProto() *storage.EntityLoadCriteria {
+func (elc EntityLoadCriteria) toProto() *storage.EntityLoadCriteria {
 	return &storage.EntityLoadCriteria{
 		LoadMetadata:       elc.LoadMetadata,
 		LoadConfig:         elc.LoadConfig,
@@ -434,7 +504,7 @@ type EntityUpdateCriteria struct {
 	AssociationsToDelete []storage2.TypeAndKey
 }
 
-func (euc EntityUpdateCriteria) toStorageProto() (*storage.EntityUpdateCriteria, error) {
+func (euc EntityUpdateCriteria) toProto(serdes serde.Registry) (*storage.EntityUpdateCriteria, error) {
 	ret := &storage.EntityUpdateCriteria{
 		Type:                 euc.Type,
 		Key:                  euc.Key,
@@ -458,7 +528,7 @@ func (euc EntityUpdateCriteria) toStorageProto() (*storage.EntityUpdateCriteria,
 	}
 
 	if euc.NewConfig != nil {
-		bConfig, err := serde.SerializeLegacy(NetworkEntitySerdeDomain, euc.Type, euc.NewConfig)
+		bConfig, err := serde.Serialize(euc.NewConfig, euc.Type, serdes)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to serialize update %s", euc.GetTypeAndKey())
 		}
@@ -477,14 +547,14 @@ func (euc EntityUpdateCriteria) GetTypeAndKey() storage2.TypeAndKey {
 
 func (euc EntityUpdateCriteria) isEntityWriteOperation() {}
 
-func marshalConfigs(configs map[string]interface{}, domain string) (map[string][]byte, error) {
+func marshalConfigs(configs map[string]interface{}, serdes serde.Registry) (map[string][]byte, error) {
 	ret := map[string][]byte{}
 	for configType, iConfig := range configs {
 		if iConfig == nil {
 			continue
 		}
 
-		sConfig, err := serde.SerializeLegacy(domain, configType, iConfig)
+		sConfig, err := serde.Serialize(iConfig, configType, serdes)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to serialize config %s", configType)
 		}
@@ -493,10 +563,10 @@ func marshalConfigs(configs map[string]interface{}, domain string) (map[string][
 	return ret, nil
 }
 
-func unmarshalConfigs(configs map[string][]byte, domain string) (map[string]interface{}, error) {
+func unmarshalConfigs(configs map[string][]byte, serdes serde.Registry) (map[string]interface{}, error) {
 	ret := map[string]interface{}{}
 	for configType, sConfig := range configs {
-		iConfig, err := serde.DeserializeLegacy(domain, configType, sConfig)
+		iConfig, err := serde.Deserialize(sConfig, configType, serdes)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to deserialize config %s", configType)
 		}

--- a/orc8r/cloud/go/services/directoryd/client_api.go
+++ b/orc8r/cloud/go/services/directoryd/client_api.go
@@ -132,7 +132,7 @@ func MapSessionIDsToIMSIs(networkID string, sessionIDToIMSI map[string]string) e
 // GetHWIDForIMSI returns the HWID mapped to by the IMSI.
 // Primary state, stored in state service.
 func GetHWIDForIMSI(networkID, imsi string) (string, error) {
-	st, err := state.GetState(networkID, orc8r.DirectoryRecordType, imsi, serdes.StateSerdes)
+	st, err := state.GetState(networkID, orc8r.DirectoryRecordType, imsi, serdes.State)
 	if err != nil {
 		return "", err
 	}
@@ -146,7 +146,7 @@ func GetHWIDForIMSI(networkID, imsi string) (string, error) {
 // GetSessionIDForIMSI returns the session ID mapped to by the IMSI.
 // Primary state, stored in state service.
 func GetSessionIDForIMSI(networkID, imsi string) (string, error) {
-	st, err := state.GetState(networkID, orc8r.DirectoryRecordType, imsi, serdes.StateSerdes)
+	st, err := state.GetState(networkID, orc8r.DirectoryRecordType, imsi, serdes.State)
 	if err != nil {
 		return "", err
 	}

--- a/orc8r/cloud/go/services/metricsd/servicers/servicer.go
+++ b/orc8r/cloud/go/services/metricsd/servicers/servicer.go
@@ -16,6 +16,7 @@ package servicers
 import (
 	"time"
 
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/metricsd/exporters"
@@ -23,6 +24,7 @@ import (
 	"magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	prom_proto "github.com/prometheus/client_model/go"
 	"golang.org/x/net/context"
 )
@@ -71,7 +73,7 @@ func (srv *MetricsControllerServer) Collect(ctx context.Context, in *protos.Metr
 		glog.Errorf("Expected %s, but found %s as Hardware ID", checkID.HardwareId, hardwareID)
 		hardwareID = checkID.HardwareId
 	}
-	networkID, gatewayID, err := configurator.GetNetworkAndEntityIDForPhysicalID(hardwareID)
+	networkID, gatewayID, err := getNetworkAndEntityIDForPhysicalID(hardwareID)
 	if err != nil {
 		return new(protos.Void), err
 	}
@@ -210,4 +212,15 @@ func addLabel(metric *prom_proto.Metric, labelName, labelValue string) {
 
 func strPtr(s string) *string {
 	return &s
+}
+
+func getNetworkAndEntityIDForPhysicalID(physicalID string) (string, string, error) {
+	if len(physicalID) == 0 {
+		return "", "", errors.New("Empty Hardware ID")
+	}
+	entity, err := configurator.LoadEntityForPhysicalID(physicalID, configurator.EntityLoadCriteria{}, serdes.Entity)
+	if err != nil {
+		return "", "", err
+	}
+	return entity.NetworkID, entity.Key, nil
 }

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/entity_handler_factory.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/entity_handler_factory.go
@@ -42,10 +42,10 @@ type PartialEntityModel interface {
 // - paramName: the parameter name in the url at which the entity key is stored
 // - model: 	the input and output of the handler and it also provides FromBackendModels
 //   and ToUpdateCriteria to go between the configurator model.
-func GetPartialEntityHandlers(path string, paramName string, model PartialEntityModel) []obsidian.Handler {
+func GetPartialEntityHandlers(path string, paramName string, model PartialEntityModel, serdes serde.Registry) []obsidian.Handler {
 	return []obsidian.Handler{
-		GetPartialUpdateEntityHandler(path, paramName, model),
-		GetPartialReadEntityHandler(path, paramName, model),
+		GetPartialUpdateEntityHandler(path, paramName, model, serdes),
+		GetPartialReadEntityHandler(path, paramName, model, serdes),
 	}
 }
 
@@ -62,7 +62,7 @@ func GetPartialEntityHandlers(path string, paramName string, model PartialEntity
 //		}
 // 		getTierNameHandler := handlers.GetPartialReadEntityHandler(URL, "tier_id", new(models.TierName))
 //      would return a GET handler that can read the tier name of a tier with the specified ID.
-func GetPartialReadEntityHandler(path string, paramName string, model PartialEntityModel) obsidian.Handler {
+func GetPartialReadEntityHandler(path string, paramName string, model PartialEntityModel, serdes serde.Registry) obsidian.Handler {
 	return obsidian.Handler{
 		Path:    path,
 		Methods: obsidian.GET,
@@ -97,7 +97,7 @@ func GetPartialReadEntityHandler(path string, paramName string, model PartialEnt
 // 		}
 // 		updateTierNameHandler := handlers.GetPartialUpdateEntityHandler(URL, "tier_id", new(models.TierName))
 //      would return a PUT handler that updates the tier name of a tier with the specified ID.
-func GetPartialUpdateEntityHandler(path string, paramName string, model PartialEntityModel) obsidian.Handler {
+func GetPartialUpdateEntityHandler(path string, paramName string, model PartialEntityModel, serdes serde.Registry) obsidian.Handler {
 	return obsidian.Handler{
 		Path:    path,
 		Methods: obsidian.PUT,
@@ -116,7 +116,7 @@ func GetPartialUpdateEntityHandler(path string, paramName string, model PartialE
 			if err != nil {
 				return obsidian.HttpError(err, http.StatusBadRequest)
 			}
-			_, err = configurator.UpdateEntities(networkID, updates)
+			_, err = configurator.UpdateEntities(networkID, updates, serdes)
 			if err != nil {
 				return obsidian.HttpError(err, http.StatusInternalServerError)
 			}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handler_factory_test.go
@@ -21,6 +21,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/configurator/test_utils"
@@ -50,7 +51,7 @@ func Test_GetPartialReadGatewayHandler(t *testing.T) {
 	gatewayRoot := fmt.Sprintf("%s/:network_id/gateways/:gateway_id", testURLRoot)
 
 	// Test 404
-	getGatewayName := handlers.GetPartialReadGatewayHandler(fmt.Sprintf("%s/Name", gatewayRoot), &testName{})
+	getGatewayName := handlers.GetPartialReadGatewayHandler(fmt.Sprintf("%s/Name", gatewayRoot), &testName{}, nil)
 	tc := tests.Test{
 		Method:         "GET",
 		URL:            gatewayRoot,
@@ -63,13 +64,13 @@ func Test_GetPartialReadGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	assert.NoError(t, configurator.CreateNetwork(network))
+	assert.NoError(t, configurator.CreateNetwork(network, serdes.Network))
 	gateway := configurator.NetworkEntity{
 		Key:  "gw1",
 		Type: orc8r.MagmadGatewayType,
 		Name: "gateway 1",
 	}
-	_, err := configurator.CreateEntity(networkID, gateway)
+	_, err := configurator.CreateEntity(networkID, gateway, serdes.Entity)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -102,7 +103,7 @@ func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
 	gatewayRoot := fmt.Sprintf("%s/:network_id/gateways/:gateway_id", testURLRoot)
 
 	// Test 404
-	updateGatewayName := handlers.GetPartialUpdateGatewayHandler(fmt.Sprintf("%s/Name", gatewayRoot), &testName{})
+	updateGatewayName := handlers.GetPartialUpdateGatewayHandler(fmt.Sprintf("%s/Name", gatewayRoot), &testName{}, nil)
 	tc := tests.Test{
 		Method:         "PUT",
 		URL:            gatewayRoot,
@@ -115,13 +116,13 @@ func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	assert.NoError(t, configurator.CreateNetwork(network))
+	assert.NoError(t, configurator.CreateNetwork(network, serdes.Network))
 	Gateway := configurator.NetworkEntity{
 		Key:  "test_gateway_1",
 		Type: orc8r.MagmadGatewayType,
 		Name: "Gateway 1",
 	}
-	_, err := configurator.CreateEntity(networkID, Gateway)
+	_, err := configurator.CreateEntity(networkID, Gateway, serdes.Entity)
 	assert.NoError(t, err)
 
 	// validation failure
@@ -148,7 +149,11 @@ func Test_GetPartialUpdateGatewayHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	Gateway, err = configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, "test_gateway_1", configurator.EntityLoadCriteria{LoadMetadata: true})
+	Gateway, err = configurator.LoadEntity(
+		networkID, orc8r.MagmadGatewayType, "test_gateway_1",
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, "updated Name!", Gateway.Name)
 }
@@ -208,7 +213,11 @@ func (m *testName) ValidateModel() error {
 }
 
 func (m *testName) FromBackendModels(networkID string, gatewayID string) error {
-	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadMetadata: true})
+	entity, err := configurator.LoadEntity(
+		networkID, orc8r.MagmadGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+		serdes.Entity,
+	)
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/gateway_handlers_test.go
@@ -24,6 +24,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/device"
@@ -46,7 +47,7 @@ func TestListGateways(t *testing.T) {
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -74,6 +75,7 @@ func TestListGateways(t *testing.T) {
 			{Type: orc8r.MagmadGatewayType, Key: "g1", Config: &models.MagmadGatewayConfigs{}, PhysicalID: "hw1"},
 			{Type: orc8r.MagmadGatewayType, Key: "g2", Config: &models.MagmadGatewayConfigs{CheckinInterval: 15}},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	expectedResult := map[string]models.MagmadGateway{
@@ -108,13 +110,13 @@ func TestCreateGateway(t *testing.T) {
 	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	// create 2 tiers
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t1"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t1"}, serdes.Entity)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t2"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.UpgradeTierEntityType, Key: "t2"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	e := echo.New()
@@ -162,6 +164,7 @@ func TestCreateGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	actualDevice, err := device.GetDevice("n1", orc8r.AccessGatewayRecordType, "foo-bar-baz-123-42")
@@ -231,6 +234,7 @@ func TestCreateGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t2"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	actualDevice, err = device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hello-world-42")
@@ -324,7 +328,7 @@ func TestGetGateway(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -360,6 +364,7 @@ func TestGetGateway(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -445,7 +450,7 @@ func TestUpdateGateway(t *testing.T) {
 	stateTestInit.StartTestService(t)
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -468,6 +473,7 @@ func TestUpdateGateway(t *testing.T) {
 			},
 			{Type: orc8r.UpgradeTierEntityType, Key: "t2"},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -524,6 +530,7 @@ func TestUpdateGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t2"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	actualDevice, err := device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hw1")
@@ -583,7 +590,7 @@ func TestDeleteGateway(t *testing.T) {
 
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -605,6 +612,7 @@ func TestDeleteGateway(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: "g1"}},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -634,6 +642,7 @@ func TestDeleteGateway(t *testing.T) {
 			{Type: orc8r.UpgradeTierEntityType, Key: "t1"},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	_, err = device.GetDevice("n1", orc8r.AccessGatewayRecordType, "hw1")
@@ -655,7 +664,7 @@ func TestGetPartialReadHandlers(t *testing.T) {
 	deviceTestInit.StartTestService(t)
 	stateTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	gwConfig := &models.MagmadGatewayConfigs{
@@ -679,6 +688,7 @@ func TestGetPartialReadHandlers(t *testing.T) {
 				PhysicalID: "hw2",
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -809,7 +819,7 @@ func TestGetGatewayTierHandler(t *testing.T) {
 	obsidianHandlers := handlers.GetObsidianHandlers()
 	getGatewayTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/tier", obsidian.GET).HandlerFunc
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -821,6 +831,7 @@ func TestGetGatewayTierHandler(t *testing.T) {
 				PhysicalID: "hw1",
 			},
 		},
+		serdes.Entity,
 	)
 	// 404 tier
 	tc := tests.Test{
@@ -847,6 +858,7 @@ func TestGetGatewayTierHandler(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -875,7 +887,7 @@ func TestUpdateGatewayTierHandler(t *testing.T) {
 	obsidianHandlers := handlers.GetObsidianHandlers()
 	updateGatewayTier := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/gateways/:gateway_id/tier", obsidian.PUT).HandlerFunc
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	_, err = configurator.CreateEntities(
@@ -887,6 +899,7 @@ func TestUpdateGatewayTierHandler(t *testing.T) {
 				PhysicalID: "hw1",
 			},
 		},
+		serdes.Entity,
 	)
 	// 404 tier
 	tc := tests.Test{
@@ -914,6 +927,7 @@ func TestUpdateGatewayTierHandler(t *testing.T) {
 				Key:  "t2",
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -936,6 +950,7 @@ func TestUpdateGatewayTierHandler(t *testing.T) {
 		nil,
 		nil,
 		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	expectedTiers := configurator.NetworkEntities{
@@ -980,6 +995,7 @@ func TestUpdateGatewayTierHandler(t *testing.T) {
 		nil,
 		nil,
 		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	expectedTiers = configurator.NetworkEntities{
 		{
@@ -1012,7 +1028,7 @@ func TestGetPartialUpdateHandlers(t *testing.T) {
 	test_init.StartTestService(t)
 	deviceTestInit.StartTestService(t)
 
-	err := configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
 
 	gwConfig := &models.MagmadGatewayConfigs{
@@ -1036,6 +1052,7 @@ func TestGetPartialUpdateHandlers(t *testing.T) {
 				PhysicalID: "hw2",
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	err = device.RegisterDevice("n1", orc8r.AccessGatewayRecordType, "hw1", &models.GatewayDevice{HardwareID: "hw1", Key: &models.ChallengeKey{KeyType: "ECHO"}})
@@ -1075,7 +1092,11 @@ func TestGetPartialUpdateHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	entity, err := configurator.LoadEntity("n1", orc8r.MagmadGatewayType, "g1", configurator.EntityLoadCriteria{LoadMetadata: true})
+	entity, err := configurator.LoadEntity(
+		"n1", orc8r.MagmadGatewayType, "g1",
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, "newname", entity.Name)
 
@@ -1091,7 +1112,11 @@ func TestGetPartialUpdateHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	entity, err = configurator.LoadEntity("n1", orc8r.MagmadGatewayType, "g1", configurator.EntityLoadCriteria{LoadMetadata: true})
+	entity, err = configurator.LoadEntity(
+		"n1", orc8r.MagmadGatewayType, "g1",
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, "newdesc", entity.Description)
 
@@ -1124,7 +1149,11 @@ func TestGetPartialUpdateHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	entity, err = configurator.LoadEntity("n1", orc8r.MagmadGatewayType, "g1", configurator.EntityLoadCriteria{LoadConfig: true})
+	entity, err = configurator.LoadEntity(
+		"n1", orc8r.MagmadGatewayType, "g1",
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, gwConfig, entity.Config)
 

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/handlers.go
@@ -20,6 +20,7 @@ import (
 	"magma/orc8r/cloud/go/models"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	eventdh "magma/orc8r/cloud/go/services/eventd/obsidian/handlers"
 	models2 "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/lib/go/service/config"
@@ -114,23 +115,23 @@ func GetObsidianHandlers() []obsidian.Handler {
 		{Path: GatewayGenericCommandV1, Methods: obsidian.POST, HandlerFunc: gatewayGenericCommand},
 		{Path: TailGatewayLogsV1, Methods: obsidian.POST, HandlerFunc: tailGatewayLogs},
 	}
-	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "")...)
-	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkTypePath, new(models.NetworkType), "")...)
-	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "")...)
-	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &models2.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
-	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDNSPath, &models2.NetworkDNSConfig{}, orc8r.DnsdNetworkType)...)
-	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDNSRecordsPath, new(models2.NetworkDNSRecords), "")...)
+	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "", serdes.Network)...)
+	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkTypePath, new(models.NetworkType), "", serdes.Network)...)
+	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "", serdes.Network)...)
+	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &models2.NetworkFeatures{}, orc8r.NetworkFeaturesConfig, serdes.Network)...)
+	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDNSPath, &models2.NetworkDNSConfig{}, orc8r.DnsdNetworkType, serdes.Network)...)
+	ret = append(ret, GetPartialNetworkHandlers(ManageNetworkDNSRecordsPath, new(models2.NetworkDNSRecords), "", serdes.Network)...)
 
-	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
-	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
-	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayConfigPath, &models2.MagmadGatewayConfigs{})...)
-	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayTierPath, new(models2.TierID))...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName), serdes.Entity)...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription), serdes.Entity)...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayConfigPath, &models2.MagmadGatewayConfigs{}, serdes.Entity)...)
+	ret = append(ret, GetPartialGatewayHandlers(ManageGatewayTierPath, new(models2.TierID), serdes.Entity)...)
 	ret = append(ret, GetGatewayDeviceHandlers(ManageGatewayDevicePath)...)
 
-	ret = append(ret, GetPartialEntityHandlers(ManageTierNamePath, "tier_id", new(models2.TierName))...)
-	ret = append(ret, GetPartialEntityHandlers(ManageTierVersionPath, "tier_id", new(models2.TierVersion))...)
-	ret = append(ret, GetPartialEntityHandlers(ManageTierImagesPath, "tier_id", new(models2.TierImages))...)
-	ret = append(ret, GetPartialEntityHandlers(ManageTierGatewaysPath, "tier_id", new(models2.TierGateways))...)
+	ret = append(ret, GetPartialEntityHandlers(ManageTierNamePath, "tier_id", new(models2.TierName), serdes.Entity)...)
+	ret = append(ret, GetPartialEntityHandlers(ManageTierVersionPath, "tier_id", new(models2.TierVersion), serdes.Entity)...)
+	ret = append(ret, GetPartialEntityHandlers(ManageTierImagesPath, "tier_id", new(models2.TierImages), serdes.Entity)...)
+	ret = append(ret, GetPartialEntityHandlers(ManageTierGatewaysPath, "tier_id", new(models2.TierGateways), serdes.Entity)...)
 
 	// Elastic
 	elasticConfig, err := config.GetServiceConfig(orc8r.ModuleName, "elastic")

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handler_factory_test.go
@@ -45,7 +45,7 @@ type (
 func Test_GetPartialReadNetworkHandler(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
 	configuratorTestInit.StartTestService(t)
-	serde.RegisterSerdesLegacy(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
+	networkSerdes := serde.NewRegistry(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks"
 
@@ -56,12 +56,12 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 		Name:        "Test Network 1",
 		Description: "Test Network 1",
 	}
-	assert.NoError(t, configurator.CreateNetwork(network))
+	assert.NoError(t, configurator.CreateNetwork(network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
 	// Test 404
-	getFullConfig := handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{})
+	getFullConfig := handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{}, networkSerdes)
 	getFeatures := tests.Test{
 		Method:         "GET",
 		URL:            networkURL,
@@ -74,7 +74,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, getFeatures)
 
-	getPartialConfig := handlers.GetPartialReadNetworkHandler(networkURL, &ID{})
+	getPartialConfig := handlers.GetPartialReadNetworkHandler(networkURL, &ID{}, networkSerdes)
 	getName := tests.Test{
 		Method:         "GET",
 		URL:            networkURL,
@@ -94,10 +94,10 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 			"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"},
 		},
 	}
-	assert.NoError(t, configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update}))
+	assert.NoError(t, configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update}, networkSerdes))
 
 	// happy full case
-	getFullConfig = handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{})
+	getFullConfig = handlers.GetPartialReadNetworkHandler(networkURL, &TestFeature1{}, networkSerdes)
 	getFeatures = tests.Test{
 		Method:         "GET",
 		URL:            networkURL,
@@ -111,7 +111,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 	tests.RunUnitTest(t, e, getFeatures)
 
 	// happy partial case
-	getPartialConfig = handlers.GetPartialReadNetworkHandler(networkURL, &ID{})
+	getPartialConfig = handlers.GetPartialReadNetworkHandler(networkURL, &ID{}, networkSerdes)
 	getName = tests.Test{
 		Method:         "GET",
 		URL:            networkURL,
@@ -127,7 +127,7 @@ func Test_GetPartialReadNetworkHandler(t *testing.T) {
 
 func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	serde.RegisterSerdesLegacy(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
+	networkSerdes := serde.NewRegistry(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
 	configuratorTestInit.StartTestService(t)
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks"
@@ -141,12 +141,12 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 		Description: "Test Network 1",
 		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
 	}
-	assert.NoError(t, configurator.CreateNetwork(network))
+	assert.NoError(t, configurator.CreateNetwork(network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
-	updateConfigsFull := handlers.GetPartialUpdateNetworkHandler(networkURL, &TestFeature1{})
-	updateConfigsPartial := handlers.GetPartialUpdateNetworkHandler(networkURL, &ID{})
+	updateConfigsFull := handlers.GetPartialUpdateNetworkHandler(networkURL, &TestFeature1{}, networkSerdes)
+	updateConfigsPartial := handlers.GetPartialUpdateNetworkHandler(networkURL, &ID{}, networkSerdes)
 
 	// name is empty
 	badConfig := &TestFeature1{ID: &ID{Name: ""}, Desc: "goodbye!"}
@@ -188,7 +188,7 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, updateFullConfig)
 
-	config, err := configurator.LoadNetworkConfig(networkID, "test")
+	config, err := configurator.LoadNetworkConfig(networkID, "test", networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, config)
 
@@ -205,14 +205,14 @@ func TestGetUpdateNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, updateFullConfig)
 
-	config, err = configurator.LoadNetworkConfig(networkID, "test")
+	config, err = configurator.LoadNetworkConfig(networkID, "test", networkSerdes)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedConfig, config)
 }
 
 func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 	plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
-	serde.RegisterSerdesLegacy(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
+	networkSerdes := serde.NewRegistry(configurator.NewNetworkConfigSerde("test", &TestFeature1{}))
 	configuratorTestInit.StartTestService(t)
 	e := echo.New()
 	testURLRoot := "/magma/v1/networks"
@@ -226,11 +226,11 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 		Description: "Test Network 1",
 		Configs:     map[string]interface{}{"test": &TestFeature1{ID: &ID{Name: "hello!"}, Desc: "goodbye!"}},
 	}
-	assert.NoError(t, configurator.CreateNetwork(network))
+	assert.NoError(t, configurator.CreateNetwork(network, networkSerdes))
 
 	networkURL := fmt.Sprintf("%s/%s", testURLRoot, networkID)
 
-	deleteHandler := handlers.GetPartialDeleteNetworkHandler(networkURL, "test")
+	deleteHandler := handlers.GetPartialDeleteNetworkHandler(networkURL, "test", networkSerdes)
 	deleteTestConfig := tests.Test{
 		Method:         "DELETE",
 		URL:            networkURL,
@@ -241,8 +241,8 @@ func TestGetDeleteNetworkConfigHandler(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, deleteTestConfig)
 
-	_, err := configurator.LoadNetworkConfig(networkID, "test")
-	assert.EqualError(t, errors.ErrNotFound, err.Error())
+	_, err := configurator.LoadNetworkConfig(networkID, "test", networkSerdes)
+	assert.EqualError(t, err, errors.ErrNotFound.Error())
 }
 
 func (m *ID) Validate(_ strfmt.Registry) error {

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/network_handlers_test.go
@@ -23,6 +23,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/handlers"
@@ -75,7 +76,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:   "n1",
 		Name: networkName1,
 	}
-	err := configurator.CreateNetwork(network1)
+	err := configurator.CreateNetwork(network1, serdes.Network)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -113,7 +114,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:                   "n1",
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.NetworkFeaturesConfig: networkFeatures1},
 	}
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1})
+	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -143,7 +144,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		NewDescription:       &description1,
 		ConfigsToAddOrUpdate: map[string]interface{}{orc8r.DnsdNetworkType: dnsdConfig},
 	}
-	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1})
+	err = configurator.UpdateNetworks([]configurator.NetworkUpdateCriteria{update1}, serdes.Network)
 	assert.NoError(t, err)
 
 	expectedNetwork1 = models.Network{
@@ -174,7 +175,7 @@ func Test_GetNetworkHandlers(t *testing.T) {
 		ID:   networkID2,
 		Name: networkName2,
 	}
-	err = configurator.CreateNetwork(network2)
+	err = configurator.CreateNetwork(network2, serdes.Network)
 	assert.NoError(t, err)
 
 	tc = tests.Test{
@@ -300,7 +301,7 @@ func Test_PostNetworkHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualNetwork1, err := configurator.LoadNetwork("n1", true, true)
+	actualNetwork1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1 := configurator.Network{
 		ID:          string(network1.ID),
@@ -619,7 +620,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	actualNetwork, err := configurator.LoadNetwork("n1", true, false)
+	actualNetwork, err := configurator.LoadNetwork("n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Version = 1
 	expectedNetwork1.Name = "new_name"
@@ -636,7 +637,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actualNetwork, err = configurator.LoadNetwork("n1", true, false)
+	actualNetwork, err = configurator.LoadNetwork("n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Type = "new_type"
 	expectedNetwork1.Version = 2
@@ -654,7 +655,7 @@ func Test_PutNetworkMetadataHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, putNetworkDesc)
 
-	actualNetwork, err = configurator.LoadNetwork("n1", true, false)
+	actualNetwork, err = configurator.LoadNetwork("n1", true, false, serdes.Network)
 	assert.NoError(t, err)
 	expectedNetwork1.Description = "new_name"
 	expectedNetwork1.Version = 3
@@ -715,7 +716,7 @@ func Test_PutNetworkFeaturesHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err := configurator.LoadNetworkConfig("n1", orc8r.NetworkFeaturesConfig)
+	config, err := configurator.LoadNetworkConfig("n1", orc8r.NetworkFeaturesConfig, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, newFeatures, config)
 }
@@ -847,7 +848,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	config, err := configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType)
+	config, err := configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, newDNS, config)
 
@@ -870,7 +871,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType)
+	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, models.NetworkDNSRecords(records), config.(*models.NetworkDNSConfig).Records)
 
@@ -910,7 +911,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType)
+	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, record, config.(*models.NetworkDNSConfig).Records[0])
 
@@ -926,7 +927,7 @@ func Test_PutNetworkDNSHandlers(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType)
+	config, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	assert.Empty(t, config.(*models.NetworkDNSConfig).Records)
 }
@@ -1018,7 +1019,7 @@ func Test_DeleteNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	config, err := configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType)
+	config, err := configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.NoError(t, err)
 	dnsConfig := config.(*models.NetworkDNSConfig)
 	assert.Empty(t, dnsConfig.Records)
@@ -1033,7 +1034,7 @@ func Test_DeleteNetworkDNSHandlers(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	_, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType)
+	_, err = configurator.LoadNetworkConfig("n1", orc8r.DnsdNetworkType, serdes.Network)
 	assert.EqualError(t, err, "Not found")
 
 }
@@ -1059,6 +1060,7 @@ func seedNetworks(t *testing.T) {
 				Configs:     map[string]interface{}{},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 }

--- a/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/handlers/upgrade_handlers.go
@@ -21,6 +21,7 @@ import (
 
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	merrors "magma/orc8r/lib/go/errors"
@@ -51,7 +52,7 @@ func createChannelHandler(c echo.Context) error {
 		Name:   string(channel.Name),
 		Config: channel,
 	}
-	_, err := configurator.CreateInternalEntity(entity)
+	_, err := configurator.CreateInternalEntity(entity, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -63,7 +64,11 @@ func readChannelHandler(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	entity, err := configurator.LoadInternalEntity(orc8r.UpgradeReleaseChannelEntityType, channelID, configurator.EntityLoadCriteria{LoadConfig: true})
+	entity, err := configurator.LoadInternalEntity(
+		orc8r.UpgradeReleaseChannelEntityType, channelID,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
 	if err == merrors.ErrNotFound {
 		return obsidian.HttpError(err, http.StatusNotFound)
 	}
@@ -91,7 +96,7 @@ func updateChannelHandler(c echo.Context) error {
 		NewName:   swag.String(string(channel.Name)),
 		NewConfig: channel,
 	}
-	_, err := configurator.UpdateInternalEntity(update)
+	_, err := configurator.UpdateInternalEntity(update, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -134,7 +139,7 @@ func createTierHandler(c echo.Context) error {
 	}
 	tier := payload.(*models.Tier)
 	entity := tier.ToNetworkEntity()
-	_, err := configurator.CreateEntity(networkID, entity)
+	_, err := configurator.CreateEntity(networkID, entity, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -156,7 +161,7 @@ func updateTierHandler(c echo.Context) error {
 		return obsidian.HttpError(fmt.Errorf("TierID in URL and payload do not match."), http.StatusBadRequest)
 	}
 	update := tier.ToUpdateCriteria()
-	_, err := configurator.UpdateEntity(networkID, update)
+	_, err := configurator.UpdateEntity(networkID, update, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -171,6 +176,7 @@ func readTierHandler(c echo.Context) error {
 	entity, err := configurator.LoadEntity(
 		networkID, orc8r.UpgradeTierEntityType, tierID,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true, LoadMetadata: true},
+		serdes.Entity,
 	)
 	if err == merrors.ErrNotFound {
 		return obsidian.HttpError(err, http.StatusNotFound)
@@ -211,7 +217,7 @@ func createTierImage(c echo.Context) error {
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
-	_, err = configurator.UpdateEntities(networkID, updates)
+	_, err = configurator.UpdateEntities(networkID, updates, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -234,7 +240,7 @@ func deleteImage(c echo.Context) error {
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
-	_, err = configurator.UpdateEntity(networkID, update)
+	_, err = configurator.UpdateEntity(networkID, update, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -252,7 +258,7 @@ func createTierGateway(c echo.Context) error {
 	}
 
 	update := (&models.TierGateways{}).ToAddGatewayUpdateCriteria(tierID, gatewayID)
-	_, err := configurator.UpdateEntity(networkID, update)
+	_, err := configurator.UpdateEntity(networkID, update, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -269,7 +275,7 @@ func deleteTierGateway(c echo.Context) error {
 		return nerr
 	}
 	update := (&models.TierGateways{}).ToDeleteGatewayUpdateCriteria(tierID, gatewayID)
-	_, err := configurator.UpdateEntity(networkID, update)
+	_, err := configurator.UpdateEntity(networkID, update, serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/conversion.go
@@ -267,7 +267,7 @@ func (m *MagmadGatewayConfigs) ToUpdateCriteria(networkID string, gatewayID stri
 }
 
 func (m *MagmadGatewayConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	config, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID)
+	config, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID, EntitySerdes)
 	if err != nil {
 		return err
 	}
@@ -276,7 +276,11 @@ func (m *MagmadGatewayConfigs) FromBackendModels(networkID string, gatewayID str
 }
 
 func (m *TierID) FromBackendModels(networkID string, gatewayID string) error {
-	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsToThis: true})
+	entity, err := configurator.LoadEntity(
+		networkID, orc8r.MagmadGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{LoadAssocsToThis: true},
+		EntitySerdes,
+	)
 	if err != nil {
 		return err
 	}
@@ -302,7 +306,11 @@ func (m *TierID) ToUpdateCriteria(networkID string, gatewayID string) ([]configu
 	}
 
 	// Remove association from old tier
-	entity, err := configurator.LoadEntity(networkID, orc8r.MagmadGatewayType, gatewayID, configurator.EntityLoadCriteria{LoadAssocsToThis: true})
+	entity, err := configurator.LoadEntity(
+		networkID, orc8r.MagmadGatewayType, gatewayID,
+		configurator.EntityLoadCriteria{LoadAssocsToThis: true},
+		EntitySerdes,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -385,7 +393,11 @@ func (m *TierName) ToUpdateCriteria(networkID string, key string) ([]configurato
 }
 
 func (m *TierName) FromBackendModels(networkID string, key string) error {
-	entity, err := configurator.LoadEntity(networkID, orc8r.UpgradeTierEntityType, key, configurator.EntityLoadCriteria{LoadMetadata: true})
+	entity, err := configurator.LoadEntity(
+		networkID, orc8r.UpgradeTierEntityType, key,
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+		EntitySerdes,
+	)
 	if err != nil {
 		return err
 	}
@@ -394,7 +406,7 @@ func (m *TierName) FromBackendModels(networkID string, key string) error {
 }
 
 func (m *TierVersion) FromBackendModels(networkID string, key string) error {
-	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key)
+	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key, EntitySerdes)
 	if err != nil {
 		return err
 	}
@@ -403,7 +415,7 @@ func (m *TierVersion) FromBackendModels(networkID string, key string) error {
 }
 
 func (m *TierVersion) ToUpdateCriteria(networkID, key string) ([]configurator.EntityUpdateCriteria, error) {
-	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key)
+	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key, EntitySerdes)
 	if err != nil {
 		return []configurator.EntityUpdateCriteria{}, err
 	}
@@ -419,7 +431,7 @@ func (m *TierVersion) ToString() string {
 }
 
 func (m *TierImages) FromBackendModels(networkID string, key string) error {
-	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key)
+	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key, EntitySerdes)
 	if err != nil {
 		return err
 	}
@@ -428,7 +440,7 @@ func (m *TierImages) FromBackendModels(networkID string, key string) error {
 }
 
 func (m *TierImages) ToUpdateCriteria(networkID, key string) ([]configurator.EntityUpdateCriteria, error) {
-	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key)
+	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key, EntitySerdes)
 	if err != nil {
 		return []configurator.EntityUpdateCriteria{}, err
 	}
@@ -442,7 +454,11 @@ func (m *TierImages) ToUpdateCriteria(networkID, key string) ([]configurator.Ent
 }
 
 func (m *TierGateways) FromBackendModels(networkID string, key string) error {
-	tierEnt, err := configurator.LoadEntity(networkID, orc8r.UpgradeTierEntityType, key, configurator.EntityLoadCriteria{LoadAssocsFromThis: true})
+	tierEnt, err := configurator.LoadEntity(
+		networkID, orc8r.UpgradeTierEntityType, key,
+		configurator.EntityLoadCriteria{LoadAssocsFromThis: true},
+		EntitySerdes,
+	)
 	if err != nil {
 		return err
 	}
@@ -474,7 +490,7 @@ func (m *TierGateways) ToDeleteGatewayUpdateCriteria(tierID, gatewayID string) c
 }
 
 func (m *TierImage) ToUpdateCriteria(networkID string, key string) ([]configurator.EntityUpdateCriteria, error) {
-	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key)
+	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, key, EntitySerdes)
 	if err != nil {
 		return []configurator.EntityUpdateCriteria{}, err
 	}
@@ -486,7 +502,7 @@ func (m *TierImage) ToUpdateCriteria(networkID string, key string) ([]configurat
 }
 
 func (m *TierImage) ToDeleteImageUpdateCriteria(networkID, tierID, imageName string) (configurator.EntityUpdateCriteria, error) {
-	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, tierID)
+	iConfig, err := configurator.LoadEntityConfig(networkID, orc8r.UpgradeTierEntityType, tierID, EntitySerdes)
 	if err != nil {
 		return configurator.EntityUpdateCriteria{}, err
 	}
@@ -515,7 +531,7 @@ func (m *GatewayVpnConfigs) ToUpdateCriteria(networkID string, gatewayID string)
 }
 
 func (m *GatewayVpnConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	config, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID)
+	config, err := configurator.LoadEntityConfig(networkID, orc8r.MagmadGatewayType, gatewayID, EntitySerdes)
 	if err != nil {
 		return err
 	}

--- a/orc8r/cloud/go/services/orchestrator/obsidian/models/serdes.go
+++ b/orc8r/cloud/go/services/orchestrator/obsidian/models/serdes.go
@@ -1,0 +1,34 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(orc8r.DnsdNetworkType, &NetworkDNSConfig{}),
+		configurator.NewNetworkConfigSerde(orc8r.NetworkFeaturesConfig, &NetworkFeatures{}),
+	)
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(orc8r.MagmadGatewayType, &MagmadGatewayConfigs{}),
+		configurator.NewNetworkEntityConfigSerde(orc8r.UpgradeReleaseChannelEntityType, &ReleaseChannel{}),
+		configurator.NewNetworkEntityConfigSerde(orc8r.UpgradeTierEntityType, &Tier{}),
+	)
+)

--- a/orc8r/cloud/go/services/orchestrator/servicers/builder_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/builder_servicer.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
@@ -66,7 +67,7 @@ type baseOrchestratorBuilder struct{}
 
 func (b *baseOrchestratorBuilder) Build(network *storage.Network, graph *storage.EntityGraph, gatewayID string) (mconfig.ConfigsByKey, error) {
 	networkID := network.ID
-	nativeGraph, err := (configurator.EntityGraph{}).FromStorageProto(graph)
+	nativeGraph, err := (configurator.EntityGraph{}).FromProto(graph, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/services/orchestrator/servicers/builder_servicer_test.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/builder_servicer_test.go
@@ -19,6 +19,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/orchestrator"
@@ -322,11 +323,11 @@ func TestBaseOrchestratorMconfigBuilder_Build(t *testing.T) {
 }
 
 func buildBaseOrchestrator(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
-	networkProto, err := network.ToStorageProto()
+	networkProto, err := network.ToProto(serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graphProto, err := graph.ToStorageProto()
+	graphProto, err := graph.ToProto(serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer.go
@@ -68,7 +68,7 @@ func (i *indexerServicer) GetIndexerInfo(ctx context.Context, req *protos.GetInd
 }
 
 func (i *indexerServicer) Index(ctx context.Context, req *protos.IndexRequest) (*protos.IndexResponse, error) {
-	states, err := state_types.MakeStatesByID(req.States, serdes.StateSerdes)
+	states, err := state_types.MakeStatesByID(req.States, serdes.State)
 	if err != nil {
 		return nil, err
 	}

--- a/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer_test.go
+++ b/orc8r/cloud/go/services/orchestrator/servicers/indexer_servicer_test.go
@@ -128,7 +128,7 @@ func serialize(t *testing.T, st state_types.State, typ string) state_types.Seria
 		TimeMs:             st.TimeMs,
 		CertExpirationTime: st.CertExpirationTime,
 	}
-	rep, err := serde.Serialize(st.ReportedState, typ, serdes.StateSerdes)
+	rep, err := serde.Serialize(st.ReportedState, typ, serdes.State)
 	assert.NoError(t, err)
 	s.SerializedReportedState = rep
 	return s

--- a/orc8r/cloud/go/services/state/indexer/index/index_test.go
+++ b/orc8r/cloud/go/services/state/indexer/index/index_test.go
@@ -117,7 +117,7 @@ func serialize(t *testing.T, states state_types.StatesByID) state_types.Serializ
 			TimeMs:             st.TimeMs,
 			CertExpirationTime: st.CertExpirationTime,
 		}
-		rep, err := serde.Serialize(st.ReportedState, id.Type, serdes.StateSerdes)
+		rep, err := serde.Serialize(st.ReportedState, id.Type, serdes.State)
 		assert.NoError(t, err)
 		s.SerializedReportedState = rep
 		serialized[id] = s

--- a/orc8r/cloud/go/services/state/indexer/integ_test.go
+++ b/orc8r/cloud/go/services/state/indexer/integ_test.go
@@ -143,7 +143,7 @@ func reportGatewayStatusForID(t *testing.T, id state_types.ID) {
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serialized, err := serde.Serialize(status, orc8r.GatewayStateType, serdes.StateSerdes)
+	serialized, err := serde.Serialize(status, orc8r.GatewayStateType, serdes.State)
 	assert.NoError(t, err)
 	pState := &protos.State{
 		Type:     orc8r.GatewayStateType,
@@ -189,7 +189,7 @@ func assertEqualStatus(t *testing.T, recv interface{}, sid state_types.ID) {
 	recvStates := recv.(state_types.SerializedStatesByID)
 	assert.Len(t, recvStates, 1)
 	assert.Equal(t, hwid, recvStates[sid].ReporterID)
-	actualReported, err := serde.Deserialize(recvStates[sid].SerializedReportedState, orc8r.GatewayStateType, serdes.StateSerdes)
+	actualReported, err := serde.Deserialize(recvStates[sid].SerializedReportedState, orc8r.GatewayStateType, serdes.State)
 	assert.NoError(t, err)
 	assert.Equal(t, reported, actualReported)
 }

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer_test.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer_test.go
@@ -285,7 +285,7 @@ func reportDirectoryRecord(t *testing.T, ctx context.Context, deviceIDs []string
 
 	var states []*protos.State
 	for i, st := range records {
-		serialized, err := serde.Serialize(st, orc8r.DirectoryRecordType, serdes.StateSerdes)
+		serialized, err := serde.Serialize(st, orc8r.DirectoryRecordType, serdes.State)
 		assert.NoError(t, err)
 		pState := &protos.State{Type: orc8r.DirectoryRecordType, DeviceID: deviceIDs[i], Value: serialized}
 		states = append(states, pState)
@@ -298,7 +298,7 @@ func reportGatewayStatus(t *testing.T, ctx context.Context, gwStatus *models.Gat
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serialized, err := serde.Serialize(gwStatus, orc8r.GatewayStateType, serdes.StateSerdes)
+	serialized, err := serde.Serialize(gwStatus, orc8r.GatewayStateType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{

--- a/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go
+++ b/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/state/wrappers"
 	"magma/orc8r/lib/go/errors"
@@ -47,6 +48,7 @@ func reportGatewayStatus() error {
 			nil,
 			nil,
 			configurator.EntityLoadCriteria{},
+			serdes.Entity,
 		)
 		if err != nil {
 			glog.Errorf("error getting gateways for network %v: %v\n", networkID, err)

--- a/orc8r/cloud/go/services/state/test_utils/utils.go
+++ b/orc8r/cloud/go/services/state/test_utils/utils.go
@@ -34,7 +34,7 @@ func ReportGatewayStatus(t *testing.T, ctx context.Context, req *models.GatewayS
 	client, err := state.GetStateClient()
 	assert.NoError(t, err)
 
-	serializedGWStatus, err := serde.Serialize(req, orc8r.GatewayStateType, serdes.StateSerdes)
+	serializedGWStatus, err := serde.Serialize(req, orc8r.GatewayStateType, serdes.State)
 	assert.NoError(t, err)
 	states := []*protos.State{
 		{

--- a/orc8r/cloud/go/services/state/wrappers/wrappers.go
+++ b/orc8r/cloud/go/services/state/wrappers/wrappers.go
@@ -26,7 +26,7 @@ import (
 
 // GetGatewayStatus returns the status for an indicated gateway.
 func GetGatewayStatus(networkID string, deviceID string) (*models.GatewayStatus, error) {
-	st, err := state.GetState(networkID, orc8r.GatewayStateType, deviceID, serdes.StateSerdes)
+	st, err := state.GetState(networkID, orc8r.GatewayStateType, deviceID, serdes.State)
 	if err != nil {
 		return nil, err
 	}
@@ -40,7 +40,7 @@ func GetGatewayStatus(networkID string, deviceID string) (*models.GatewayStatus,
 // device ID.
 func GetGatewayStatuses(networkID string, deviceIDs []string) (map[string]*models.GatewayStatus, error) {
 	stateIDs := types.MakeIDs(orc8r.GatewayStateType, deviceIDs...)
-	res, err := state.GetStates(networkID, stateIDs, serdes.StateSerdes)
+	res, err := state.GetStates(networkID, stateIDs, serdes.State)
 	if err != nil {
 		return map[string]*models.GatewayStatus{}, err
 	}

--- a/orc8r/cloud/go/services/streamer/providers/providers_test.go
+++ b/orc8r/cloud/go/services/streamer/providers/providers_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/configurator/mconfig/mocks"
@@ -52,9 +53,9 @@ func TestMconfigStreamer_Configurator(t *testing.T) {
 	mockBuilder.On("Build", mock.Anything, mock.Anything, "gw1").Return(marshaledConfigs, nil)
 	configurator_test_init.StartNewTestBuilder(t, mockBuilder)
 
-	err = configurator.CreateNetwork(configurator.Network{ID: "n1"})
+	err = configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
 	assert.NoError(t, err)
-	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "gw1", PhysicalID: "hw1"})
+	_, err = configurator.CreateEntity("n1", configurator.NetworkEntity{Type: orc8r.MagmadGatewayType, Key: "gw1", PhysicalID: "hw1"}, serdes.Entity)
 	assert.NoError(t, err)
 
 	conn, err := registry.GetConnection(streamer.ServiceName)

--- a/wifi/cloud/go/plugin/plugin.go
+++ b/wifi/cloud/go/plugin/plugin.go
@@ -16,7 +16,6 @@ package plugin
 import (
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/metricsd"
 	"magma/orc8r/cloud/go/services/state/indexer"
@@ -24,7 +23,6 @@ import (
 	"magma/orc8r/lib/go/registry"
 	"magma/orc8r/lib/go/service/config"
 	wifi_service "magma/wifi/cloud/go/services/wifi"
-	"magma/wifi/cloud/go/services/wifi/obsidian/models"
 	"magma/wifi/cloud/go/wifi"
 )
 
@@ -43,11 +41,7 @@ func (*WifiOrchestratorPlugin) GetServices() []registry.ServiceLocation {
 }
 
 func (*WifiOrchestratorPlugin) GetSerdes() []serde.Serde {
-	return []serde.Serde{
-		configurator.NewNetworkConfigSerde(wifi.WifiNetworkType, &models.NetworkWifiConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(wifi.WifiGatewayType, &models.GatewayWifiConfigs{}),
-		configurator.NewNetworkEntityConfigSerde(wifi.MeshEntityType, &models.MeshWifiConfigs{}),
-	}
+	return []serde.Serde{}
 }
 
 func (*WifiOrchestratorPlugin) GetMconfigBuilders() []mconfig.Builder {

--- a/wifi/cloud/go/serdes/serdes.go
+++ b/wifi/cloud/go/serdes/serdes.go
@@ -1,0 +1,28 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package serdes
+
+import (
+	"magma/orc8r/cloud/go/serdes"
+	"magma/wifi/cloud/go/services/wifi/obsidian/models"
+)
+
+var (
+	// Network contains the full set of configurator network config serdes
+	// used in the wifi module
+	Network = serdes.Network.MustMerge(models.NetworkSerdes)
+	// Entity contains the full set of configurator network entity serdes used
+	// in the wifi module
+	Entity = serdes.Entity.MustMerge(models.EntitySerdes)
+)

--- a/wifi/cloud/go/services/wifi/obsidian/handlers/handlers.go
+++ b/wifi/cloud/go/services/wifi/obsidian/handlers/handlers.go
@@ -27,6 +27,7 @@ import (
 	orc8rmodels "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/storage"
 	merrors "magma/orc8r/lib/go/errors"
+	"magma/wifi/cloud/go/serdes"
 	wifimodels "magma/wifi/cloud/go/services/wifi/obsidian/models"
 	"magma/wifi/cloud/go/wifi"
 
@@ -63,7 +64,7 @@ const (
 // GetHandlers returns all obsidian handlers for Wifi
 func GetHandlers() []obsidian.Handler {
 	ret := []obsidian.Handler{
-		handlers.GetListGatewaysHandler(BaseGatewaysPath, &wifimodels.MutableWifiGateway{}, makeWifiGateways),
+		handlers.GetListGatewaysHandler(BaseGatewaysPath, &wifimodels.MutableWifiGateway{}, makeWifiGateways, serdes.Entity),
 		{Path: BaseGatewaysPath, Methods: obsidian.POST, HandlerFunc: createGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.GET, HandlerFunc: getGateway},
 		{Path: ManageGatewayPath, Methods: obsidian.PUT, HandlerFunc: updateGateway},
@@ -76,21 +77,21 @@ func GetHandlers() []obsidian.Handler {
 		{Path: ManageMeshPath, Methods: obsidian.PUT, HandlerFunc: updateMesh},
 		{Path: ManageMeshPath, Methods: obsidian.DELETE, HandlerFunc: deleteMesh},
 	}
-	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(BaseNetworksPath, ManageNetworkPath, wifi.WifiNetworkType, &wifimodels.WifiNetwork{})...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "")...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8rmodels.NetworkFeatures{}, orc8r.NetworkFeaturesConfig)...)
-	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkWifiPath, &wifimodels.NetworkWifiConfigs{}, wifi.WifiNetworkType)...)
+	ret = append(ret, handlers.GetTypedNetworkCRUDHandlers(BaseNetworksPath, ManageNetworkPath, wifi.WifiNetworkType, &wifimodels.WifiNetwork{}, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkNamePath, new(models.NetworkName), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkDescriptionPath, new(models.NetworkDescription), "", serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkFeaturesPath, &orc8rmodels.NetworkFeatures{}, orc8r.NetworkFeaturesConfig, serdes.Network)...)
+	ret = append(ret, handlers.GetPartialNetworkHandlers(ManageNetworkWifiPath, &wifimodels.NetworkWifiConfigs{}, wifi.WifiNetworkType, serdes.Network)...)
 
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription))...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8rmodels.MagmadGatewayConfigs{})...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8rmodels.TierID))...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayNamePath, new(models.GatewayName), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayDescriptionPath, new(models.GatewayDescription), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayConfigPath, &orc8rmodels.MagmadGatewayConfigs{}, serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayTierPath, new(orc8rmodels.TierID), serdes.Entity)...)
 	ret = append(ret, handlers.GetGatewayDeviceHandlers(ManageGatewayDevicePath)...)
-	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayWifiPath, &wifimodels.GatewayWifiConfigs{})...)
+	ret = append(ret, handlers.GetPartialGatewayHandlers(ManageGatewayWifiPath, &wifimodels.GatewayWifiConfigs{}, serdes.Entity)...)
 
-	ret = append(ret, handlers.GetPartialEntityHandlers(ManageMeshNamePath, MeshID, new(wifimodels.MeshName))...)
-	ret = append(ret, handlers.GetPartialEntityHandlers(ManageMeshConfigPath, MeshID, &wifimodels.MeshWifiConfigs{})...)
+	ret = append(ret, handlers.GetPartialEntityHandlers(ManageMeshNamePath, MeshID, new(wifimodels.MeshName), serdes.Entity)...)
+	ret = append(ret, handlers.GetPartialEntityHandlers(ManageMeshConfigPath, MeshID, &wifimodels.MeshWifiConfigs{}, serdes.Entity)...)
 
 	return ret
 }
@@ -132,7 +133,7 @@ func makeWifiGateways(
 }
 
 func createGateway(c echo.Context) error {
-	if nerr := handlers.CreateGateway(c, &wifimodels.MutableWifiGateway{}); nerr != nil {
+	if nerr := handlers.CreateGateway(c, &wifimodels.MutableWifiGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusCreated)
@@ -152,6 +153,7 @@ func getGateway(c echo.Context) error {
 	ent, err := configurator.LoadEntity(
 		nid, wifi.WifiGatewayType, gid,
 		configurator.EntityLoadCriteria{LoadConfig: true, LoadAssocsFromThis: true},
+		serdes.Entity,
 	)
 	if err != nil {
 		return obsidian.HttpError(errors.Wrap(err, "failed to load wifi gateway"), http.StatusInternalServerError)
@@ -178,7 +180,7 @@ func updateGateway(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	if nerr = handlers.UpdateGateway(c, nid, gid, &wifimodels.MutableWifiGateway{}); nerr != nil {
+	if nerr = handlers.UpdateGateway(c, nid, gid, &wifimodels.MutableWifiGateway{}, serdes.Entity); nerr != nil {
 		return nerr
 	}
 	return c.NoContent(http.StatusNoContent)
@@ -189,9 +191,7 @@ func deleteGateway(c echo.Context) error {
 	if nerr != nil {
 		return nerr
 	}
-	gwEnt, err := configurator.LoadEntity(
-		nid, orc8r.MagmadGatewayType, gid, configurator.EntityLoadCriteria{},
-	)
+	gwEnt, err := configurator.LoadEntity(nid, orc8r.MagmadGatewayType, gid, configurator.EntityLoadCriteria{}, serdes.Entity)
 
 	err = configurator.DeleteEntities(
 		nid,
@@ -250,13 +250,17 @@ func createMesh(c echo.Context) error {
 		gwIDs = append(gwIDs, storage.TypeAndKey{Key: string(gwID), Type: orc8r.MagmadGatewayType})
 	}
 
-	_, err := configurator.CreateEntity(nid, configurator.NetworkEntity{
-		Type:         wifi.MeshEntityType,
-		Key:          string(payload.ID),
-		Name:         string(payload.Name),
-		Config:       payload.Config,
-		Associations: gwIDs,
-	})
+	_, err := configurator.CreateEntity(
+		nid,
+		configurator.NetworkEntity{
+			Type:         wifi.MeshEntityType,
+			Key:          string(payload.ID),
+			Name:         string(payload.Name),
+			Config:       payload.Config,
+			Associations: gwIDs,
+		},
+		serdes.Entity,
+	)
 
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
@@ -271,7 +275,7 @@ func getMesh(c echo.Context) error {
 		return nerr
 	}
 
-	ent, err := configurator.LoadEntity(nid, wifi.MeshEntityType, mid, configurator.FullEntityLoadCriteria())
+	ent, err := configurator.LoadEntity(nid, wifi.MeshEntityType, mid, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
@@ -300,7 +304,7 @@ func updateMesh(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "mesh ID in body must match mesh_id in path")
 	}
 
-	ent, err := configurator.LoadEntity(nid, wifi.MeshEntityType, mid, configurator.FullEntityLoadCriteria())
+	ent, err := configurator.LoadEntity(nid, wifi.MeshEntityType, mid, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound
@@ -320,7 +324,7 @@ func updateMesh(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "can't update gateways here! please update the individual gateways instead.")
 	}
 
-	_, err = configurator.UpdateEntities(nid, payload.ToUpdateCriteria())
+	_, err = configurator.UpdateEntities(nid, payload.ToUpdateCriteria(), serdes.Entity)
 	if err != nil {
 		return obsidian.HttpError(err, http.StatusInternalServerError)
 	}
@@ -333,7 +337,7 @@ func deleteMesh(c echo.Context) error {
 		return nerr
 	}
 
-	ent, err := configurator.LoadEntity(nid, wifi.MeshEntityType, mid, configurator.FullEntityLoadCriteria())
+	ent, err := configurator.LoadEntity(nid, wifi.MeshEntityType, mid, configurator.FullEntityLoadCriteria(), serdes.Entity)
 	switch {
 	case err == merrors.ErrNotFound:
 		return echo.ErrNotFound

--- a/wifi/cloud/go/services/wifi/obsidian/handlers/handlers_test.go
+++ b/wifi/cloud/go/services/wifi/obsidian/handlers/handlers_test.go
@@ -30,6 +30,7 @@ import (
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	stateTestInit "magma/orc8r/cloud/go/services/state/test_init"
 	"magma/orc8r/cloud/go/storage"
+	"magma/wifi/cloud/go/serdes"
 	"magma/wifi/cloud/go/services/wifi/obsidian/handlers"
 
 	"github.com/labstack/echo"
@@ -123,7 +124,7 @@ func TestCreateNetwork(t *testing.T) {
 			wifi.WifiNetworkType:        models2.NewDefaultWifiNetworkConfig(),
 		},
 	}
-	actual, err := configurator.LoadNetwork("n1", true, true)
+	actual, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, expected, actual)
 }
@@ -243,7 +244,7 @@ func TestUpdateNetwork(t *testing.T) {
 	tc.ExpectedStatus = 204
 	tests.RunUnitTest(t, e, tc)
 
-	actualN1, err := configurator.LoadNetwork("n1", true, true)
+	actualN1, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	expected := configurator.Network{
 		ID:          "n1",
@@ -401,7 +402,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err := configurator.LoadNetwork("n1", true, true)
+	actual, err := configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedName, actual.Name)
 	tc = tests.Test{
@@ -427,7 +428,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadNetwork("n1", true, true)
+	actual, err = configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedDescription, actual.Description)
 	tc = tests.Test{
@@ -453,7 +454,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadNetwork("n1", true, true)
+	actual, err = configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedFeatures, actual.Configs[orc8r.NetworkFeaturesConfig].(*models.NetworkFeatures))
 	tc = tests.Test{
@@ -479,7 +480,7 @@ func TestPartialUpdateAndGetNetwork(t *testing.T) {
 		ExpectedStatus: 204,
 	}
 	tests.RunUnitTest(t, e, tc)
-	actual, err = configurator.LoadNetwork("n1", true, true)
+	actual, err = configurator.LoadNetwork("n1", true, true, serdes.Network)
 	assert.NoError(t, err)
 	assert.Equal(t, updatedWifi, actual.Configs[wifi.WifiNetworkType].(*models2.NetworkWifiConfigs))
 	tc = tests.Test{
@@ -537,14 +538,14 @@ func TestListGateways(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	expectedEnts := configurator.NetworkEntities{}
 	actualEnts, _, err := configurator.LoadEntities(
 		"n1", nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedEnts, actualEnts)
+	assert.Empty(t, actualEnts)
 
 	// Test network with one gateway
 	expectedResult := models2.WifiGateway{
@@ -578,7 +579,7 @@ func TestListGateways(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	expectedEnts = configurator.NetworkEntities{
+	expectedEnts := configurator.NetworkEntities{
 		{
 			NetworkID:   nID,
 			Type:        orc8r.MagmadGatewayType,
@@ -617,6 +618,7 @@ func TestListGateways(t *testing.T) {
 			{Type: wifi.WifiGatewayType, Key: gID},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnts, actualEnts)
@@ -639,14 +641,14 @@ func TestCreateGateway(t *testing.T) {
 
 	// Initially empty
 	seedNetworks(t)
-	expectedEnts := configurator.NetworkEntities{}
 	actualEnts, _, err := configurator.LoadEntities(
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedEnts, actualEnts)
+	assert.Empty(t, actualEnts)
 
 	// Test missing payload
 	tc := tests.Test{
@@ -675,7 +677,7 @@ func TestCreateGateway(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	expectedEnts = configurator.NetworkEntities{
+	expectedEnts := configurator.NetworkEntities{
 		{
 			NetworkID:   nID,
 			Type:        orc8r.MagmadGatewayType,
@@ -725,6 +727,7 @@ func TestCreateGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnts, actualEnts)
@@ -923,7 +926,8 @@ func TestUpdateGateway(t *testing.T) {
 
 	// Correctly update gateway
 	_, err := configurator.CreateEntities(
-		nID, []configurator.NetworkEntity{
+		nID,
+		[]configurator.NetworkEntity{
 			{
 				Type: wifi.MeshEntityType, Key: nmID,
 				Name:         "not_mesh_1",
@@ -931,6 +935,7 @@ func TestUpdateGateway(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: gID}},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	tc = tests.Test{
@@ -1004,6 +1009,7 @@ func TestUpdateGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnts, actualEnts)
@@ -1059,6 +1065,7 @@ func TestDeleteGateway(t *testing.T) {
 			{Type: wifi.MeshEntityType, Key: mID},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -1116,13 +1123,15 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 	seedNetworks(t)
 	seedGatewaysAndMeshes(t)
 	_, err := configurator.CreateEntities(
-		nID, []configurator.NetworkEntity{
+		nID,
+		[]configurator.NetworkEntity{
 			{
 				Type: wifi.MeshEntityType, Key: nmID,
 				Name:   "not_mesh_1",
 				Config: models2.NewDefaultMeshWifiConfigs(),
 			},
 		},
+		serdes.Entity,
 	)
 
 	expectedEnts := map[string]*configurator.NetworkEntity{
@@ -1217,6 +1226,7 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -1260,6 +1270,7 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -1306,6 +1317,7 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -1352,6 +1364,7 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -1392,6 +1405,7 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -1488,6 +1502,7 @@ func TestPartialUpdateAndGetGateway(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -1547,14 +1562,14 @@ func TestListMeshes(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	expectedEnts := configurator.NetworkEntities{}
 	actualEnts, _, err := configurator.LoadEntities(
 		"n1", nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedEnts, actualEnts)
+	assert.Empty(t, actualEnts)
 
 	// List the meshes correctly
 	seedGatewaysAndMeshes(t)
@@ -1570,7 +1585,7 @@ func TestListMeshes(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	expectedEnts = configurator.NetworkEntities{
+	expectedEnts := configurator.NetworkEntities{
 		{
 			NetworkID: nID,
 			Type:      wifi.MeshEntityType, Key: mID,
@@ -1580,7 +1595,12 @@ func TestListMeshes(t *testing.T) {
 			Associations: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: gID}},
 		},
 	}
-	actualEnts, _, err = configurator.LoadEntities("n1", swag.String(wifi.MeshEntityType), nil, nil, nil, configurator.FullEntityLoadCriteria())
+	actualEnts, _, err = configurator.LoadEntities(
+		"n1", swag.String(wifi.MeshEntityType), nil, nil,
+		nil,
+		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
+	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnts, actualEnts)
 }
@@ -1602,14 +1622,14 @@ func TestCreateMesh(t *testing.T) {
 
 	// Initially empty
 	seedNetworks(t)
-	expectedEnts := configurator.NetworkEntities{}
 	actualEnts, _, err := configurator.LoadEntities(
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
-	assert.Equal(t, expectedEnts, actualEnts)
+	assert.Empty(t, actualEnts)
 
 	// Test missing payload
 	tc := tests.Test{
@@ -1638,7 +1658,7 @@ func TestCreateMesh(t *testing.T) {
 	}
 	tests.RunUnitTest(t, e, tc)
 
-	expectedEnts = configurator.NetworkEntities{
+	expectedEnts := configurator.NetworkEntities{
 		{
 			NetworkID:   nID,
 			Type:        orc8r.MagmadGatewayType,
@@ -1687,6 +1707,7 @@ func TestCreateMesh(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnts, actualEnts)
@@ -1893,6 +1914,7 @@ func TestUpdateMesh(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEnts, actualEnts)
@@ -1946,13 +1968,15 @@ func TestDeleteMesh(t *testing.T) {
 
 	// Disassociate gateway then delete mesh
 	_, err := configurator.CreateEntities(
-		nID, []configurator.NetworkEntity{
+		nID,
+		[]configurator.NetworkEntity{
 			{
 				Type: wifi.MeshEntityType, Key: nmID,
 				Name:   "not_mesh_1",
 				Config: models2.NewDefaultMeshWifiConfigs(),
 			},
 		},
+		serdes.Entity,
 	)
 	payload := models2.GatewayWifiConfigs{
 		AdditionalProps: map[string]string{
@@ -2013,6 +2037,7 @@ func TestDeleteMesh(t *testing.T) {
 			{Type: wifi.MeshEntityType, Key: mID},
 		},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 
@@ -2164,6 +2189,7 @@ func TestPartialUpdateAndGetMesh(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -2217,6 +2243,7 @@ func TestPartialUpdateAndGetMesh(t *testing.T) {
 		nID, nil, nil, nil,
 		[]storage.TypeAndKey{},
 		configurator.FullEntityLoadCriteria(),
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedEntsVals, actualEnts)
@@ -2251,6 +2278,7 @@ func seedNetworks(t *testing.T) {
 				Configs:     map[string]interface{}{},
 			},
 		},
+		serdes.Network,
 	)
 	assert.NoError(t, err)
 }
@@ -2269,6 +2297,7 @@ func seedPreGateway(t *testing.T) {
 				Config: models2.NewDefaultMeshWifiConfigs(),
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 }
@@ -2311,6 +2340,7 @@ func seedPreMesh(t *testing.T) {
 				},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 }
@@ -2362,6 +2392,7 @@ func seedGatewaysAndMeshes(t *testing.T) {
 				Associations: []storage.TypeAndKey{{Type: orc8r.MagmadGatewayType, Key: gID}},
 			},
 		},
+		serdes.Entity,
 	)
 	assert.NoError(t, err)
 }

--- a/wifi/cloud/go/services/wifi/obsidian/models/conversion.go
+++ b/wifi/cloud/go/services/wifi/obsidian/models/conversion.go
@@ -169,7 +169,7 @@ func (m *MutableWifiGateway) GetAdditionalWritesOnUpdate(
 }
 
 func (m *GatewayWifiConfigs) FromBackendModels(networkID string, gatewayID string) error {
-	wifiConfig, err := configurator.LoadEntityConfig(networkID, wifi.WifiGatewayType, gatewayID)
+	wifiConfig, err := configurator.LoadEntityConfig(networkID, wifi.WifiGatewayType, gatewayID, EntitySerdes)
 	if err != nil {
 		return err
 	}
@@ -185,9 +185,7 @@ func (m *GatewayWifiConfigs) ToUpdateCriteria(networkID string, gatewayID string
 		NewConfig: m,
 	})
 
-	existingWifiConfigEnt, err := configurator.LoadEntityConfig(
-		networkID, wifi.WifiGatewayType, gatewayID,
-	)
+	existingWifiConfigEnt, err := configurator.LoadEntityConfig(networkID, wifi.WifiGatewayType, gatewayID, EntitySerdes)
 	if err != nil {
 		return nil, err
 	}
@@ -241,7 +239,7 @@ func (m *WifiMesh) ToUpdateCriteria() []configurator.EntityUpdateCriteria {
 }
 
 func (m *MeshWifiConfigs) FromBackendModels(networkID string, meshID string) error {
-	meshConfig, err := configurator.LoadEntityConfig(networkID, wifi.MeshEntityType, meshID)
+	meshConfig, err := configurator.LoadEntityConfig(networkID, wifi.MeshEntityType, meshID, EntitySerdes)
 	if err != nil {
 		return err
 	}
@@ -261,7 +259,11 @@ func (m *MeshWifiConfigs) ToUpdateCriteria(networkID string, meshID string) ([]c
 }
 
 func (m *MeshName) FromBackendModels(networkID string, meshID string) error {
-	meshEnt, err := configurator.LoadEntity(networkID, wifi.MeshEntityType, meshID, configurator.EntityLoadCriteria{LoadMetadata: true})
+	meshEnt, err := configurator.LoadEntity(
+		networkID, wifi.MeshEntityType, meshID,
+		configurator.EntityLoadCriteria{LoadMetadata: true},
+		EntitySerdes,
+	)
 	if err != nil {
 		return err
 	}

--- a/wifi/cloud/go/services/wifi/obsidian/models/serdes.go
+++ b/wifi/cloud/go/services/wifi/obsidian/models/serdes.go
@@ -1,0 +1,32 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/wifi/cloud/go/wifi"
+)
+
+var (
+	// NetworkSerdes contains the package's configurator network config serdes
+	NetworkSerdes = serde.NewRegistry(
+		configurator.NewNetworkConfigSerde(wifi.WifiNetworkType, &NetworkWifiConfigs{}),
+	)
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(wifi.WifiGatewayType, &GatewayWifiConfigs{}),
+		configurator.NewNetworkEntityConfigSerde(wifi.MeshEntityType, &MeshWifiConfigs{}),
+	)
+)

--- a/wifi/cloud/go/services/wifi/servicers/builder_servicer.go
+++ b/wifi/cloud/go/services/wifi/servicers/builder_servicer.go
@@ -21,6 +21,7 @@ import (
 	builder_protos "magma/orc8r/cloud/go/services/configurator/mconfig/protos"
 	merrors "magma/orc8r/lib/go/errors"
 	wifi_mconfig "magma/wifi/cloud/go/protos/mconfig"
+	"magma/wifi/cloud/go/serdes"
 	"magma/wifi/cloud/go/services/wifi/obsidian/models"
 	"magma/wifi/cloud/go/wifi"
 
@@ -36,11 +37,11 @@ func NewBuilderServicer() builder_protos.MconfigBuilderServer {
 func (s *builderServicer) Build(ctx context.Context, request *builder_protos.BuildRequest) (*builder_protos.BuildResponse, error) {
 	ret := &builder_protos.BuildResponse{ConfigsByKey: map[string][]byte{}}
 
-	network, err := (configurator.Network{}).FromStorageProto(request.Network)
+	network, err := (configurator.Network{}).FromProto(request.Network, serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graph, err := (configurator.EntityGraph{}).FromStorageProto(request.Graph)
+	graph, err := (configurator.EntityGraph{}).FromProto(request.Graph, serdes.Entity)
 	if err != nil {
 		return nil, err
 	}

--- a/wifi/cloud/go/services/wifi/servicers/builder_servicer_test.go
+++ b/wifi/cloud/go/services/wifi/servicers/builder_servicer_test.go
@@ -23,6 +23,7 @@ import (
 	"magma/orc8r/cloud/go/storage"
 	wifi_plugin "magma/wifi/cloud/go/plugin"
 	wifi_mconfig "magma/wifi/cloud/go/protos/mconfig"
+	"magma/wifi/cloud/go/serdes"
 	wifi_service "magma/wifi/cloud/go/services/wifi"
 	"magma/wifi/cloud/go/services/wifi/obsidian/models"
 	wifi_test_init "magma/wifi/cloud/go/services/wifi/test_init"
@@ -505,11 +506,11 @@ func TestBuilder_Build_OverrideXwf(t *testing.T) {
 }
 
 func build(network *configurator.Network, graph *configurator.EntityGraph, gatewayID string) (map[string]proto.Message, error) {
-	networkProto, err := network.ToStorageProto()
+	networkProto, err := network.ToProto(serdes.Network)
 	if err != nil {
 		return nil, err
 	}
-	graphProto, err := graph.ToStorageProto()
+	graphProto, err := graph.ToProto(serdes.Entity)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

This is the second in a set of stacked PRs to move serdes away from the plugin+global registry pattern and into the explicit registry pattern.

### Context: serdes

We currently manage 5 serde domains:
- device
- testcontroller
- state
- configurator: network configs
- configurator: ent configs

This PR handles the two configurator domains, across all orc8r modules.

### Serde changes

As part of the service mesh changes, core orc8r services must function without compile-time build information from non-core orc8r services. This means, e.g., the state service needs to pass around state which it will no longer be able to deserialize.

Rather than keeping an implicit, global, multi-domain registry of serdes populated during plugin registration (plugin pattern), we instead prefer an explicit, per-process, flat "registry" of serdes populated as a const-like variable. Each module (or service) tracks their own set of serdes. This simplifies the codebase and lowers the surface area for introducing bugs. 

### Configurator serde changes

The main impediment to straightforward conversion of configurator serdes is configurator supports bulk, type-agnostic graph operations such as loading an entire graph. We currently need to preserve this functionality for building mconfigs. However, each builder is only interested in a subset of types within a graph, so we introduce the `isSerialized` field to `NetworkEntity`, along with the `IsSerialized()` method, to determine explicitly whether an entity is deserialized to native type. Converting to native NetworkEntity types then can leave entities serialized if no relevant serde was provided -- and each mconfig builder can then implicitly assume the entities it cares about are deserialized (since it tracks them in its local the serdes registry).

The other issue was deciding where to locate serdes -- service-level, package-level, or module-level (lte vs. cwf vs. ...). Ultimately, we decided on a hybrid of pkg-level and module-level (to sidestep some import cycles). Each models pkg defines and uses its own pkg-local serdes, and all other pkgs within a module use the module-level serdes (which is just the aggregation of all pkg-level serdes in the module).

Finally, configurator is used extensively across the codebase, so this diff is a bit sizeable. Thankfully, it's also pretty repetitive.

## Test Plan

- [x] make test

## Additional Information

- [ ] This change is backwards-breaking