### PR TITLE
[orc8r][state] Don't panic on non-validateable reported state

### DIFF
--- a/orc8r/cloud/go/services/state/types/types.go
+++ b/orc8r/cloud/go/services/state/types/types.go
@@ -254,7 +254,19 @@ func MakeState(p *protos.State, serdes serde.Registry) (State, *protos.IDAndErro
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}
-	if err := st.ReportedState.(serde.ValidateableBinaryConvertible).ValidateModel(); err != nil {
+
+	if st.ReportedState == nil {
+		err = errors.Errorf("state {type: %s, key: %s} should not have nil SerializedReportedState value", p.Type, p.DeviceID)
+		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
+		return State{}, sErr, nil
+	}
+	model, ok := st.ReportedState.(serde.ValidateableBinaryConvertible)
+	if !ok {
+		err = errors.Errorf("could not convert state {type: %s, key: %s} to validateable model", p.Type, p.DeviceID)
+		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
+		return State{}, sErr, nil
+	}
+	if err := model.ValidateModel(); err != nil {
 		sErr := &protos.IDAndError{Type: p.Type, DeviceID: p.DeviceID, Error: err.Error()}
 		return State{}, sErr, nil
 	}


### PR DESCRIPTION
## Summary

The state service is panicking in staging because it tries to validate an old piece of state.

### Error log

```
state stderr | panic: interface conversion: interface is nil, not serde.ValidateableBinaryConvertible
state stderr |
state stderr | goroutine 14 [running]:
state stderr | magma/orc8r/cloud/go/services/state/types.MakeState(0xc0007ea780, 0x1372500, 0xc000514ed0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
state stderr |  /src/magma/orc8r/cloud/go/services/state/types/types.go:257 +0x2f0
state stderr | magma/orc8r/cloud/go/services/state/types.MakeStatesByID(0xc0000d2ae8, 0x1, 0x1, 0x1372500, 0xc000514ed0,
state stderr | 0x0, 0x0, 0xc00095b8c0)
state stderr |  /src/magma/orc8r/cloud/go/services/state/types/types.go:218 +0xed
state stderr | magma/orc8r/cloud/go/services/state.GetStates(0xc0005e8610, 0xf, 0xc0007e1aa0, 0x1, 0x1, 0x1372500, 0xc000514ed0, 0xc000956630, 0x0, 0x0)
state stderr |  /src/magma/orc8r/cloud/go/services/state/client_api.go:77 +0x1da
state stderr | magma/orc8r/cloud/go/services/state.GetState(0xc0005e8610, 0xf, 0x122d551, 0x8, 0xc00020b350, 0x24, 0x1372500, 0xc000514ed0, 0x0, 0x0, ...)
state stderr |  /src/magma/orc8r/cloud/go/services/state/client_api.go:44 +0x101
state stderr | magma/orc8r/cloud/go/services/state/wrappers.GetGatewayStatus(0xc0005e8610, 0xf, 0xc00020b350, 0x24, 0x0, 0x0, 0x0)
state stderr |  /src/magma/orc8r/cloud/go/services/state/wrappers/wrappers.go:29 +0x94
state stderr | magma/orc8r/cloud/go/services/state/metrics.reportGatewayStatus(0xc0004ea8a0, 0xc0000f9fb0)
state stderr |  /src/magma/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go:58 +0x153
state stderr | magma/orc8r/cloud/go/services/state/metrics.PeriodicallyReportGatewayStatus(0xdf8475800)
state stderr |  /src/magma/orc8r/cloud/go/services/state/metrics/gateway_status_reporter.go:30 +0x82
state stderr | created by main.main
state stderr |  /src/magma/orc8r/cloud/go/services/state/state/main.go:60 +0x369
2020-10-21 01:18:26,864 INFO exited: state (exit status 2; expected)
2020-10-21 01:18:27,867 INFO spawned: 'state' with pid 11227
```

### Root cause

There's a single piece of state in the staging orc8r which has its reported state under the key `ReportedValue`, instead of the standard `SerializedReportedState`. This is likely long-dead state as this naming was changed to `SerializedReportedState` in July 2019 as part of 256913d3b. (This naming is fully managed by orc8r -- gateways can't control it.)

This piece of state, when deserialized, leads `SerializedReportedState` to have an untyped nil value. When we then try to cast that untyped nil to a `serde.ValidateableBinaryConvertible` and subsequently call `ValidateModel()`, we get a panic.

This points to the idea that outdated state can stick around, so we should handle this failure mode gracefully. In this case, we'll just log the issue as we do with other serialization-based state issues.

## Test Plan

- [x] make test

## Additional Information

- [ ] This change is backwards-breaking