### PR TITLE
[orc8r][indexers] Fix double-logging of reindexer error

### DIFF
--- a/orc8r/cloud/go/serde/registry.go
+++ b/orc8r/cloud/go/serde/registry.go
@@ -168,7 +168,7 @@ func Serialize(data interface{}, typ string, registry Registry) ([]byte, error) 
 
 // Deserialize a byte array by delegating to the passed serde registry.
 func Deserialize(data []byte, typ string, registry Registry) (interface{}, error) {
-	if data == nil || len(data) == 0 {
+	if len(data) == 0 {
 		return nil, nil
 	}
 	serde, err := registry.GetSerde(typ)

--- a/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/queue_sql.go
@@ -362,9 +362,9 @@ func (s *sqlJobQueue) getNewJobs(tx *sql.Tx) ([]*reindexJob, error) {
 }
 
 // Venn diagram of indexer IDs in old and new jobs
-//	- old_only:	indexer ID only present in old jobs -- existing job uncomplete, but no new job needed
+//	- old_only:	indexer ID only present in old jobs -- existing job incomplete, but no new job needed
 //	- new_only:	indexer ID only present in new jobs -- existing job not found, and new job needed
-//	- both:		indexer ID present in both old and new jobs -- existing job uncomplete, and new job also needed
+//	- both:		indexer ID present in both old and new jobs -- existing job incomplete, and new job also needed
 // {    old_only    [    both    }    new_only    ]
 func (s *sqlJobQueue) getComposedJobs(tx *sql.Tx, newJobs []*reindexJob) ([]*reindexJob, error) {
 	oldJobs, err := s.getExistingIncompleteJobs(tx)

--- a/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
+++ b/orc8r/cloud/go/services/state/indexer/reindex/reindexer.go
@@ -205,6 +205,7 @@ func (r *reindexerImpl) reportStatusMetrics() {
 		idx, err := indexer.GetIndexer(id)
 		if err != nil {
 			glog.Errorf("Report reindex metrics failed to get indexer %s from registry with error: %v", id, err)
+			continue
 		}
 		if idx == nil {
 			glog.Errorf("Report reindex metrics failed to get indexer %s from registry", id)


### PR DESCRIPTION
## Summary

Reindexer report metrics errors were getting logged twice:

```
state stderr | E1021 01:18:25.765535   11118 reindexer.go:207] Report reindex metrics failed to get indexer orc8r-subscriberdb from registry with error: get indexer for service orc8r-subscriberdb: service orc8r-subscriberdb not registered
state stderr | E1021 01:18:25.765593   11118 reindexer.go:210] Report reindex metrics failed to get indexer orc8r-subscriberdb from registry
```

This PR corrects the problem by only logging a single time.

Also one small style fix in serdes registry.

## Test Plan

- [x] make test

## Additional Information

- [ ] This change is backwards-breaking