### PR TITLE
[orc8r][test] Default to logging statements in postgres_test

### DIFF
--- a/orc8r/cloud/docker/docker-compose.override.yml
+++ b/orc8r/cloud/docker/docker-compose.override.yml
@@ -31,4 +31,5 @@ services:
       POSTGRES_USER: magma_test
       POSTGRES_PASSWORD: magma_test
       POSTGRES_DB: magma_test
+    command: ["postgres", "-c", "log_statement=all"]
     restart: always


### PR DESCRIPTION
## Summary

This was useful for debugging some issues related to resource exhaustion. Also serves as the template for how to turn on statement logging for the `postgres` container when needed.

Example logs:

```
postgres_test_1  | 2020-10-21 07:58:36.839 UTC [2321] LOG:  statement: BEGIN READ WRITE
postgres_test_1  | 2020-10-21 07:58:36.845 UTC [2321] LOG:  execute <unnamed>: SELECT type, "key", value, version FROM states WHERE ((network_id = $1 AND ...
postgres_test_1  | 2020-10-21 07:58:36.845 UTC [2321] DETAIL:  parameters: $1 = 'some_networkid_2', $2 = 'directory_record', $3 = 'imsi100', $4 = ...
postgres_test_1  | 2020-10-21 07:58:36.847 UTC [2321] LOG:  statement: COMMIT
postgres_test_1  | 2020-10-21 07:58:36.851 UTC [2320] LOG:  statement: BEGIN READ WRITE
postgres_test_1  | 2020-10-21 07:58:36.854 UTC [2320] LOG:  execute <unnamed>: SELECT type, "key", value, version FROM states WHERE ((network_id = $1 AND type = $2 AND "key" = $3))
postgres_test_1  | 2020-10-21 07:58:36.854 UTC [2320] DETAIL:  parameters: $1 = 'some_networkid_2', $2 = 'gw_state', $3 = 'some_hwid_0'
postgres_test_1  | 2020-10-21 07:58:36.855 UTC [2320] LOG:  statement: COMMIT
postgres_test_1  | 2020-10-21 07:58:36.857 UTC [2321] LOG:  statement: BEGIN ISOLATION LEVEL SERIALIZABLE READ WRITE
postgres_test_1  | 2020-10-21 07:58:36.860 UTC [2321] LOG:  execute <unnamed>: UPDATE indexer_versions SET version_actual = $1 WHERE indexer_id = $2
postgres_test_1  | 2020-10-21 07:58:36.860 UTC [2321] DETAIL:  parameters: $1 = '10', $2 = 'some_indexerid_0'
postgres_test_1  | 2020-10-21 07:58:36.864 UTC [2321] LOG:  execute <unnamed>: UPDATE reindex_job_queue SET status = $1, error = $2, last_status_change = $3 WHERE indexer_id = $4
postgres_test_1  | 2020-10-21 07:58:36.864 UTC [2321] DETAIL:  parameters: $1 = 'complete', $2 = '', $3 = '1603267116', $4 = 'some_indexerid_0'
postgres_test_1  | 2020-10-21 07:58:36.865 UTC [2321] LOG:  statement: COMMIT
```

![Screen Shot 2020-10-21 at 1 06 03 AM](https://user-images.githubusercontent.com/8029544/96691311-62248400-134a-11eb-804c-89daeac87338.png)

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking