### PR TITLE
[sessiond] Delete Imsis with no sessions from redis

### DIFF
--- a/lte/gateway/c/session_manager/MemoryStoreClient.cpp
+++ b/lte/gateway/c/session_manager/MemoryStoreClient.cpp
@@ -58,6 +58,11 @@ bool MemoryStoreClient::write_sessions(SessionMap session_map) {
       auto stored_session = session->marshal();
       sessions.push_back(stored_session);
     }
+    if (sessions.empty()) {
+      // if session is empty that means subs should be deleted from the map
+      session_map_.erase(it.first);
+      continue;
+    }
     session_map_[it.first] = std::move(sessions);
   }
   return true;


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

When a subscriber is terminated and no more sessions are left, the key is left on the map. That may not be important on stateful case because when we restart the process the object is wiped. But in case of stateless, redis will persist any imsi it had ever access to the system.

With this PR we delete entries from redis in case in does not contain any session

## Test Plan

make precommit_sm

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
