### PR TITLE
[cwag_integ_test] fixed TestGxAbortSessionRequest

### DIFF
--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -363,9 +363,11 @@ func TestGxAbortSessionRequest(t *testing.T) {
 	tr.WaitForPoliciesToSync()
 
 	tr.AuthenticateAndAssertSuccess(imsi)
+	tr.WaitForEnforcementStatsToSync()
+
 	recordsBySubID, err := tr.GetPolicyUsage()
 	assert.NoError(t, err)
-	assert.Empty(t, recordsBySubID[prependIMSIPrefix(imsi)][ruleKey])
+	assert.NotEmpty(t, recordsBySubID[prependIMSIPrefix(imsi)][ruleKey])
 
 	asa, err := sendPolicyAbortSession(
 		&fegProtos.AbortSessionRequest{


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This test was failing because we were checking too quick that the record was not existing. In fact, after authentication the record should exist in pipelined. But if we check too fast, the report will have not come yet and it will show as `empty` 

This test was failing because in some occasions, report from pipelined was quicker to be received than the test to execute the check

This PR adds a delay to make sure the stats are synch and changes the sign of the assertion to make sure the record DOES exist.


## Test Plan

cwag integ test
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
