### PR TITLE
SPGW: GTP_APP: detect zero enb IP address.

### DIFF
--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -186,7 +186,10 @@ static uint32_t find_gtp_port_no(struct in_addr enb_addr) {
   if (!spgw_config.sgw_config.ovs_config.multi_tunnel) {
     return 0;
   }
-
+  if (!(uint32_t) enb_addr.s_addr == 0) {
+    OAILOG_WARNING(LOG_GTPV1U, "zero enb IP address not supported");
+    return 0;
+  }
   char port_name[MAX_GTP_PORT_NAME_LENGTH];
   ip_addr_to_gtp_port_name(enb_addr, port_name);
 
@@ -300,8 +303,8 @@ int openflow_send_end_marker(struct in_addr enb, uint32_t tei) {
     return -ENODEV;
   }
 
-  if (tei == 0) {
-    // No need to send end marker for tunnel with tei zero.
+  if (tei == 0 || (uint32_t) enb.s_addr == 0) {
+    // No need to send end marker for tunnel with zero tunnel metadata.
     return 0;
   }
   // use a ethernet packet just to make packet out happy.


### PR DESCRIPTION
## Summary

MME is configuring GTP tunnel with zero IP address,
This would not work, so catch it and use default tunnel dev.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
`make test_oai`
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
