### PR TITLE
Reduced timer values for service restart test cases

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -84,7 +84,7 @@ elif [[ $1 == "sctpd_post" ]]; then
   fi
   sudo service magma@magmad start
   # Sleep for a bit so OVS and Magma services come up before proceeding
-  sleep 60
+  sleep 15
   exit 0
 else
   echo "Invalid argument. Use one of the following"
@@ -105,7 +105,7 @@ check_stateless_agw; ret_check=$?
 if [[ $ret_check -eq 1 ]]; then
   sudo service magma@magmad start
   # Sleep for a bit so OVS and Magma services come up before proceeding
-  sleep 60
+  sleep 15
 fi
 
 exit $ret_check

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py
@@ -43,7 +43,7 @@ class TestAttachDetachMultipleIpBlocksMobilitydRestart(unittest.TestCase):
 
         print("************************* Restarting mobilityd")
         self._s1ap_wrapper.magmad_util.restart_services(["mobilityd"])
-        for j in range(60):
+        for j in range(30):
             print("Waiting for", j, "seconds")
             sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mme_restart.py
@@ -56,7 +56,7 @@ class TestAttachDetachWithMmeRestart(unittest.TestCase):
                   "gateway")
             self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
-            for j in range(60):
+            for j in range(30):
                 print("Waiting for", j, "seconds")
                 time.sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_mobilityd_restart.py
@@ -52,7 +52,7 @@ class TestAttachDetachMobilitydRestart(unittest.TestCase):
             print('************************* Restarting mobilityd')
             self._s1ap_wrapper.magmad_util.restart_services(['mobilityd'])
             # Timeout for mobilityd restart
-            for j in range(60):
+            for j in range(30):
                 print("Waiting for", j, "seconds")
                 sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py
@@ -56,7 +56,7 @@ class TestAttachUlUdpDataWithMultipleServiceRestart(unittest.TestCase):
         self._s1ap_wrapper.magmad_util.restart_services(["mobilityd", "mme",
                                                          "pipelined"])
 
-        for j in range(60):
+        for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_implicit_detach_timer_with_mme_restart.py
@@ -103,7 +103,7 @@ class TestImplicitDetachTimerWithMmeRestart(unittest.TestCase):
         print("************************* Restarting MME service on gateway")
         self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
-        for j in range(60):
+        for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_mobile_reachability_timer_with_mme_restart.py
@@ -90,7 +90,7 @@ class TestMobileReachabilityTimerWithMmeRestart(unittest.TestCase):
         print("************************* Restarting MME service on gateway")
         self._s1ap_wrapper.magmad_util.restart_services(["mme"])
 
-        for j in range(60):
+        for j in range(30):
             print("Waiting for", j, "seconds")
             time.sleep(1)
 


### PR DESCRIPTION
[lte] Reduced timer values for service restart test cases

## Summary
Reduced the timer values, on mme restart command, test case doesn't require 60 seconds to wait for all services to be active. So 30 seconds would be sufficient. 
Also reduced the timer value while switching from AGW-Statefull to AGW-Stateless and vice-versa.

## Test Plan
Executed s1ap sanity test suite
