### PR TITLE
[SessionD] Add pdp_end_time to update criteria to ensure it is persisted

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -364,7 +364,7 @@ void LocalEnforcer::handle_activate_service_action(
 // Terminates sessions that correspond to the given IMSI and session.
 void LocalEnforcer::start_session_termination(
     const std::string& imsi, const std::unique_ptr<SessionState>& session,
-    bool notify_access, SessionStateUpdateCriteria& uc) {
+    bool notify_access, SessionStateUpdateCriteria& session_uc) {
   auto session_id = session->get_session_id();
   if (session->is_terminating()) {
     // If the session is terminating already, do nothing.
@@ -373,10 +373,10 @@ void LocalEnforcer::start_session_termination(
     return;
   }
   MLOG(MINFO) << "Initiating session termination for " << session_id;
-  session->set_pdp_end_time(get_time_in_sec_since_epoch());
+  session->set_pdp_end_time(get_time_in_sec_since_epoch(), session_uc);
 
-  remove_all_rules_for_termination(imsi, session, uc);
-  session->set_fsm_state(SESSION_RELEASED, uc);
+  remove_all_rules_for_termination(imsi, session, session_uc);
+  session->set_fsm_state(SESSION_RELEASED, session_uc);
   const auto& config         = session->get_config();
   const auto& common_context = config.common_context;
   if (notify_access) {
@@ -390,7 +390,7 @@ void LocalEnforcer::start_session_termination(
   }
   if (terminate_on_wallet_exhaust()) {
     handle_subscriber_quota_state_change(
-        imsi, *session, SubscriberQuotaUpdate_Type_TERMINATE, uc);
+        imsi, *session, SubscriberQuotaUpdate_Type_TERMINATE, session_uc);
   }
   // The termination should be completed when aggregated usage record no
   // longer

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -795,8 +795,10 @@ uint64_t SessionState::get_pdp_end_time() {
   return pdp_end_time_;
 }
 
-void SessionState::set_pdp_end_time(uint64_t epoch) {
+void SessionState::set_pdp_end_time(
+    uint64_t epoch, SessionStateUpdateCriteria& session_uc) {
   pdp_end_time_ = epoch;
+  session_uc.updated_pdp_end_time = epoch;
 }
 
 void SessionState::increment_request_number(uint32_t incr) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -263,7 +263,7 @@ class SessionState {
 
   uint64_t get_pdp_start_time();
 
-  void set_pdp_end_time(uint64_t epoch);
+  void set_pdp_end_time(uint64_t epoch, SessionStateUpdateCriteria& session_uc);
 
   uint64_t get_pdp_end_time();
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The pdp_end_time was set, but never set in the update criteria. This meant that the field was always empty when it was read for `session_terminated` event. With this change, the field shows a correct value.

Before....
```
Oct 22 17:48:31 magma-dev eventd[6488]: value: "{\"mac_addr\":\"\",\"monitoring_rx\":0,\"monitoring_tx\":0,\"session_id\":\"IMSI001010000000002-801484\",
\"spgw_ip\":\"192.168.60.142\",\"charging_rx\":0,\"ip_addr\":\"192.168.128.195\",\"pdp_start_time\":1603388908,\"charging_tx\":0,
\"msisdn\":\"\",\"total_rx\":0,\"ipv6_addr\":\"\",\"imsi\":\"IMSI001010000000002\",\"imei\":\"\",
\"pdp_end_time\":0,\"apn\":\"magma.ipv4\",\"total_tx\":0}"
```
After...
```
Oct 22 17:57:52 magma-dev eventd[13511]: value: "
{\"mac_addr\":\"\",\"monitoring_rx\":0,\"monitoring_tx\":0,\"session_id\":\"IMSI001010000000001-306158\",
\"spgw_ip\":\"192.168.60.142\",\"charging_rx\":0,\"ip_addr\":\"192.168.128.47\",\"pdp_start_time\":1603389469,\"charging_tx\":0,
\"msisdn\":\"\",\"total_rx\":0,\"ipv6_addr\":\"\",\"imsi\":\"IMSI001010000000001\",\"imei\":\"\",
\"pdp_end_time\":1603389469,\"apn\":\"magma.ipv4\",\"total_tx\":0}"
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
