### PR TITLE
AGW: pipelined: QoS: TC: Fix APN AMBR

### DIFF
--- a/lte/gateway/python/magma/pipelined/qos/common.py
+++ b/lte/gateway/python/magma/pipelined/qos/common.py
@@ -25,11 +25,13 @@ from magma.configuration.service_configs import load_service_config
 LOG = logging.getLogger("pipelined.qos.common")
 #LOG.setLevel(logging.DEBUG)
 
+
 def normalize_imsi(imsi: str) -> str:
     imsi = imsi.lower()
     if imsi.startswith("imsi"):
         imsi = imsi[4:]
     return imsi
+
 
 class QosImplType(Enum):
     LINUX_TC = "linux_tc"
@@ -39,23 +41,35 @@ class QosImplType(Enum):
     def list():
         return list(map(lambda t: t.value, QosImplType))
 
+
 class SubscriberSession(object):
     def __init__(self, ip_addr: str):
         self.ip_addr = ip_addr
         self.ambr_ul = 0
+        self.ambr_ul_leaf = 0
         self.ambr_dl = 0
+        self.ambr_dl_leaf = 0
+
         self.rules = set()
 
-    def set_ambr(self, d: FlowMatch.Direction, qos_handle: int) -> None:
+    def set_ambr(self, d: FlowMatch.Direction, root: int, leaf: int) -> None:
         if d == FlowMatch.UPLINK:
-            self.ambr_ul = qos_handle
+            self.ambr_ul = root
+            self.ambr_ul_leaf = leaf
         else:
-            self.ambr_dl = qos_handle
+            self.ambr_dl = root
+            self.ambr_dl_leaf = leaf
 
     def get_ambr(self, d: FlowMatch.Direction) -> int:
         if d == FlowMatch.UPLINK:
             return self.ambr_ul
         return self.ambr_dl
+
+    def get_ambr_leaf(self, d: FlowMatch.Direction) -> int:
+        if d == FlowMatch.UPLINK:
+            return self.ambr_ul_leaf
+        return self.ambr_dl_leaf
+
 
 class SubscriberState(object):
     def __init__(self, imsi: str, qos_store : Dict):
@@ -65,7 +79,7 @@ class SubscriberState(object):
         self._qos_store = qos_store
 
     def check_empty(self,) -> bool:
-        return (not self.rules and not self.sessions)
+        return not self.rules and not self.sessions
 
     def get_or_create_session(self, ip_addr: str):
         session = self.sessions.get(ip_addr)
@@ -125,6 +139,7 @@ class SubscriberState(object):
                     return qos_handle
         return 0
 
+
 class QosManager(object):
     @staticmethod
     def get_impl(datapath, loop, config):
@@ -140,13 +155,14 @@ class QosManager(object):
             return TCManager(datapath, loop, config)
 
     @classmethod
-    def debug(cls, _):
+    def debug(cls, _, __, ___):
         config = load_service_config('pipelined')
         qos_impl_type = QosImplType(config["qos"]["impl"])
         qos_store = QosStore(cls.__name__)
         for k, v in qos_store.items():
-            _, imsi, rule_num, d = get_key(k)
+            _, imsi, ip_addr, rule_num, d = get_key(k)
             print('imsi :', imsi)
+            print('ip_addr :', ip_addr)
             print('rule_num :', rule_num)
             print('direction :', d)
             print('qos_handle:', v)
@@ -187,7 +203,6 @@ class QosManager(object):
                      self._redis_conn_retry_secs)
             self._loop.call_later(self._redis_conn_retry_secs, self.setup)
 
-
     def _setupInternal(self):
         if self._clean_restart:
             LOG.info("Qos Setup: clean start")
@@ -216,9 +231,15 @@ class QosManager(object):
                         subscriber.update_rule(ip_addr, rule_num, d, v)
 
                         qid_state = qos_state[v]
-                        if qid_state['ambr'] != 0:
+                        if qid_state['ambr_qid'] != 0:
                             session = subscriber.get_or_create_session(ip_addr)
-                            session.set_ambr(d, qid_state['ambr'])
+                            ambr_qid = qid_state['ambr_qid']
+                            leaf = 0
+                            # its AMBR QoS handle if its config matches with parent
+                            # pylint: disable=too-many-function-args
+                            if self.impl.same_qos_config(d, ambr_qid, v):
+                                leaf = v
+                            session.set_ambr(d, qid_state['ambr_qid'], leaf)
 
                     # purge entries from qos_store
                     for k in purge_store_set:
@@ -249,7 +270,6 @@ class QosManager(object):
             self._subscriber_state[imsi] = subscriber_state
         return subscriber_state
 
-
     def add_subscriber_qos(
         self,
         imsi: str,
@@ -261,10 +281,10 @@ class QosManager(object):
     ):
         if not self._qos_enabled or not self._initialized:
             LOG.error("add_subscriber_qos: not enabled or initialized")
-            return (None, None)
+            return None, None
 
-        LOG.debug("adding qos for imsi %s rule_num %d direction %d",
-                   imsi, rule_num, direction)
+        LOG.debug("adding qos for imsi %s rule_num %d direction %d apn_ambr %d, qos_info %s",
+                   imsi, rule_num, direction, apn_ambr, qos_info)
 
         imsi = normalize_imsi(imsi)
 
@@ -277,38 +297,57 @@ class QosManager(object):
         subscriber_state = self.get_or_create_subscriber(imsi)
 
         qos_handle = subscriber_state.get_qos_handle(rule_num, direction)
+        LOG.debug("existing rec: qos_handle %d", qos_handle)
         if qos_handle:
             LOG.debug("qos exists for imsi %s rule_num %d direction %d",
-                imsi, rule_num, direction)
+                      imsi, rule_num, direction)
             return self.impl.get_action_instruction(qos_handle)
 
+        ambr_qos_handle_root = None
         if apn_ambr > 0:
             session = subscriber_state.get_or_create_session(ip_addr)
-            ambr_qos_handle = session.get_ambr(direction)
-            if not ambr_qos_handle:
-                ambr_qos_handle = self.impl.add_qos(direction, QosInfo(gbr=0, mbr=apn_ambr))
-                if ambr_qos_handle:
-                    session.set_ambr(direction, ambr_qos_handle)
-                    LOG.debug('Adding ambr qos mbr %u direction %d qos_handle %d ',
-                          apn_ambr, direction, ambr_qos_handle)
-                else:
-                    LOG.error('Failed adding ambr qos mbr %u direction %d', apn_ambr,
-                        direction)
-                    return
+            ambr_qos_handle_root = session.get_ambr(direction)
+            LOG.debug("existing root rec: ambr_qos_handle_root %d", ambr_qos_handle_root)
 
-            if qos_info:
-                qos_handle = self.impl.add_qos(direction, qos_info, parent=ambr_qos_handle)
-                if qos_handle:
-                    LOG.debug('Adding qos %s direction %d qos_handle %d ',
-                              qos_info, direction, qos_handle)
+            if not ambr_qos_handle_root:
+                ambr_qos_handle_root = self.impl.add_qos(direction, QosInfo(gbr=None, mbr=apn_ambr))
+                if not ambr_qos_handle_root:
+                    LOG.error('Failed adding root ambr qos mbr %u direction %d',
+                              apn_ambr, direction)
+                    return None, None
                 else:
-                    LOG.error('Failed adding qos %s direction %d', qos_info, direction)
-                    return
+                    LOG.debug('Added root ambr qos mbr %u direction %d qos_handle %d ',
+                              apn_ambr, direction, ambr_qos_handle_root)
+
+            ambr_qos_handle_leaf = session.get_ambr_leaf(direction)
+            LOG.debug("existing leaf rec: ambr_qos_handle_leaf %d", ambr_qos_handle_leaf)
+
+            if not ambr_qos_handle_leaf:
+                ambr_qos_handle_leaf = self.impl.add_qos(direction,
+                                                         QosInfo(gbr=None, mbr=apn_ambr),
+                                                         parent=ambr_qos_handle_root)
+                if ambr_qos_handle_leaf:
+                    session.set_ambr(direction, ambr_qos_handle_root, ambr_qos_handle_leaf)
+                    LOG.debug('Added ambr qos mbr %u direction %d qos_handle %d/%d ',
+                              apn_ambr, direction, ambr_qos_handle_root, ambr_qos_handle_leaf)
+                else:
+                    LOG.error('Failed adding leaf ambr qos mbr %u direction %d',
+                              apn_ambr, direction)
+                    self.impl.remove_qos(ambr_qos_handle_root, direction)
+                    return None, None
+            qos_handle = ambr_qos_handle_leaf
+
+        if qos_info:
+            qos_handle = self.impl.add_qos(direction, qos_info, parent=ambr_qos_handle_root)
+            LOG.debug("Added ded brr handle: %d", qos_handle)
+            if qos_handle:
+                LOG.debug('Adding qos %s direction %d qos_handle %d ',
+                          qos_info, direction, qos_handle)
             else:
-                qos_handle = ambr_qos_handle
-        else:
-            qos_handle = self.impl.add_qos(direction, qos_info)
+                LOG.error('Failed adding qos %s direction %d', qos_info, direction)
+                return None, None
 
+        LOG.debug("qos_handle %d", qos_handle)
         subscriber_state.update_rule(ip_addr, rule_num, direction, qos_handle)
         return self.impl.get_action_instruction(qos_handle)
 
@@ -323,7 +362,6 @@ class QosManager(object):
             return
 
         imsi = normalize_imsi(imsi)
-
         subscriber_state = self._subscriber_state.get(imsi)
         if not subscriber_state:
             LOG.debug('imsi %s not found, nothing to remove ', imsi)
@@ -353,7 +391,6 @@ class QosManager(object):
             LOG.debug("removing rule %s %s ", imsi, rule_num)
             to_be_deleted_rules.append(rule_num)
 
-
         for rule_num in to_be_deleted_rules:
             subscriber_state.remove_rule(rule_num)
 
@@ -362,7 +399,7 @@ class QosManager(object):
             for d in (FlowMatch.UPLINK, FlowMatch.DOWNLINK):
                 ambr_qos_handle = session.get_ambr(d)
                 if ambr_qos_handle:
-                    LOG.debug("removing ambr qos handle %d direction %d", ambr_qos_handle, d)
+                    LOG.debug("removing root ambr qos handle %d direction %d", ambr_qos_handle, d)
                     self.impl.remove_qos(ambr_qos_handle, d)
             LOG.debug("purging session %s %s ", imsi, session.ip_addr)
             subscriber_state.remove_session(session.ip_addr)

--- a/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
+++ b/lte/gateway/python/magma/pipelined/qos/qos_meter_impl.py
@@ -57,11 +57,11 @@ class MeterManager(object):
         ofproto = self._datapath.ofproto
         return None, parser.OFPInstructionMeter(meter_id, ofproto.OFPIT_METER)
 
-    def add_qos(self, _, qos_info: QosInfo, parent_qid=None) -> int:
+    def add_qos(self, _, qos_info: QosInfo, parent=None) -> int:
         if self._qos_impl_broken:
             raise RuntimeError(BROKEN_KERN_ERROR_MSG)
 
-        if parent_qid:
+        if parent:
             #TODO add ovs meter logic to handle APN AMBR
             pass
 
@@ -96,7 +96,7 @@ class MeterManager(object):
         for stat in ev_body:
             meter_id_map[stat.meter_id] = {
                 'direction': 0,
-                'ambr': 0,
+                'ambr_qid': 0,
             }
         self._id_manager.restore_state(meter_id_map)
         self._fut.set_result(meter_id_map)
@@ -117,3 +117,9 @@ class MeterManager(object):
             print(output.decode())
         except subprocess.CalledProcessError:
             print("Exception dumping meter state for %s", meter_id)
+
+    # pylint: disable=unused-argument
+    def same_qos_config(self, d,
+                        qid1: int, qid2: int) -> bool:
+        # Once APN AMBR support is added, implement this methode
+        return False


### PR DESCRIPTION
## Summary

current implementation is using middle node for APN rate
limiting, HTB does not support it. This patch fixes it by creating
separate TC class (leaf node) for APN under APN HTB class same as
ded brr class and use that for APN rate limiting.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
