### PR TITLE
[docker][metrics] Thanos deployment for docker

### DIFF
--- a/orc8r/cloud/docker/docker-compose.thanos.yml
+++ b/orc8r/cloud/docker/docker-compose.thanos.yml
@@ -1,0 +1,83 @@
+# This compose file installs the required thanos components for orchestrator, as well as overriding
+# some configurations to make thanos work properly. It is NOT recommended to use this in any
+# production setting, but rather just as a way of development testing and experimentation.
+
+version: "3.7"
+
+services:
+  prometheus:
+    command:
+      - "--config.file=/etc/prometheus/prometheus-thanos.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.min-block-duration=2h"
+      - "--storage.tsdb.max-block-duration=2h"
+      - "--storage.tsdb.retention.time=6h"
+      - "--web.enable-lifecycle"
+
+  thanosSidecar:
+    image: thanosio/thanos:master-2020-09-30-e4941a5c
+    volumes:
+      - /Users/smithscott/prometheus_docker_data:/prometheus
+      - /Users/smithscott/prometheus_objstore_data:/objstorage:ro
+      - $PWD/../../../orc8r/cloud/docker/metrics-configs/thanos:/etc/thanos:ro
+    command:
+      - "sidecar"
+      - "--tsdb.path=/prometheus"
+      - "--prometheus.url=http://prometheus:9090"
+      - "--grpc-address=0.0.0.0:19090" # Store API endpoint for querier
+      - "--objstore.config-file=/etc/thanos/objstore.yml"
+
+  thanosQuery:
+    image: thanosio/thanos:master-2020-09-30-e4941a5c
+    ports:
+      - 19192:19192/tcp # query UI
+    command:
+      - "query"
+      - "--http-address=0.0.0.0:19192"
+      - "--store=thanosSidecar:19090"
+      - "--store=thanosStore:10901"
+
+  thanosRuler:
+    image: thanosio/thanos:master-2020-09-30-e4941a5c
+    volumes:
+      - $PWD/../../../orc8r/cloud/docker/metrics-configs/thanos:/etc/thanos
+      - $PWD/../../../orc8r/cloud/docker/metrics-configs/alert_rules:/etc/configs/alert_rules
+    ports:
+      - 10903:10902/tcp
+    command:
+      - "rule"
+      - "--eval-interval=30s"
+      - "--rule-file=/etc/configs/alert_rules/*"
+      - "--alertmanagers.url=http://alertmanager:9093"
+      - "--query=http://thanosQuery:19192"
+      - "--objstore.config-file=/etc/thanos/objstore.yml"
+
+  thanosCompactor:
+    image: thanosio/thanos:master-2020-09-30-e4941a5c
+    volumes:
+      - $PWD/../../../orc8r/cloud/docker/metrics-configs/thanos:/etc/thanos
+    command:
+      - "compact"
+      - "--objstore.config-file=/etc/thanos/objstore.yml"
+      - "--retention.resolution-raw=365d"
+      - "--retention.resolution-5m=365d"
+      - "--retention.resolution-1h=365d"
+      - "--wait"
+
+  thanosStore:
+    image: thanosio/thanos:master-2020-09-30-e4941a5c
+    ports:
+      - 10901:10901/tcp
+    volumes:
+      - $PWD/../../../orc8r/cloud/docker/metrics-configs/thanos:/etc/thanos
+    command:
+      - "store"
+      - "--objstore.config-file=/etc/thanos/objstore.yml"
+
+  prometheus-configurer:
+    command:
+      - "-port=9100"
+      - "-rules-dir=/etc/configs/alert_rules/"
+      - "-prometheusURL=thanosRuler:10902"
+      - "-multitenant-label=networkID"
+      - "-restrict-queries"

--- a/orc8r/cloud/docker/metrics-configs/prometheus-thanos.yml
+++ b/orc8r/cloud/docker/metrics-configs/prometheus-thanos.yml
@@ -1,0 +1,45 @@
+global:
+  scrape_interval:     15s # By default, scrape targets every 15 seconds.
+  evaluation_interval: 15s # By default, scrape targets every 15 seconds.
+  external_labels:
+    monitor: 'master'
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: "magma_pushgateway"
+    honor_labels: true
+    metric_relabel_configs:
+      - regex: 'job'
+        action: labeldrop
+      - regex: 'instance'
+        action: labeldrop
+    static_configs:
+      - targets: ['prometheus-cache:9091']
+
+  - job_name: "thanos_sidecar"
+    static_configs:
+      - targets: ['thanosSidecar:10902']
+
+  - job_name: "thanos_ruler"
+    static_configs:
+      - targets: ['thanosRuler:10902']
+
+  - job_name: "thanos_compactor"
+    static_configs:
+      - targets: ['thanosCompactor:10902']
+
+  - job_name: "thanos_query"
+    static_configs:
+      - targets: ['thanosQuery:19192']
+
+rule_files:
+  - '/etc/prometheus/alert_rules/*_rules.yml'
+
+alerting:
+  alertmanagers:
+    - scheme: http
+      static_configs:
+        - targets: ['alertmanager:9093']

--- a/orc8r/cloud/docker/metrics-configs/thanos/objstore.yml
+++ b/orc8r/cloud/docker/metrics-configs/thanos/objstore.yml
@@ -1,0 +1,3 @@
+type: FILESYSTEM
+config:
+  directory: "/objstore"

--- a/orc8r/cloud/docker/run.sh
+++ b/orc8r/cloud/docker/run.sh
@@ -2,6 +2,8 @@
 
 if [ "$1" == "-all" ]; then
     docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.metrics.yml up -d
+elif [ "$1" == "-thanos" ]; then
+    docker-compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.metrics.yml -f docker-compose.thanos.yml up -d
 else
     docker-compose up -d
 fi


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Adds thanos components to the docker deployment. To be used for development/experimentation only.
* thanosSidecar: Takes data from prometheus tsdb and periodically backs it up to the thanosStore
* thanosStore: acts as an API gateway to query data in the configured object storage
* thanosCompactor: periodically compacts data in object storage
* thanosQuery: Replaces prometheus as the query API
* thanosRule: Replaces the built-in prometheus alerting rule evaluator

Unchanged:
* Configmanagers
* Alertmanager
* Prometheus (except for some configuration changes)
* Nothing about operation is changed unless you add the `-thanos` argument to `run.sh`

## Test Plan

`./run.sh -thanos`
Querying metrics works, adding/editing rules are reflected in alertmanager, data is accessible past the prometheus retention time
