### PR TITLE
[agw][mme] Fix the logic for checking zero eNB IP addr

### DIFF
--- a/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
+++ b/lte/gateway/c/oai/tasks/gtpv1-u/gtp_tunnel_openflow.c
@@ -186,7 +186,7 @@ static uint32_t find_gtp_port_no(struct in_addr enb_addr) {
   if (!spgw_config.sgw_config.ovs_config.multi_tunnel) {
     return 0;
   }
-  if (!(uint32_t) enb_addr.s_addr == 0) {
+  if ((uint32_t) enb_addr.s_addr == 0) {
     OAILOG_WARNING(LOG_GTPV1U, "zero enb IP address not supported");
     return 0;
   }


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The check for zero eNB IP address in https://github.com/magma/magma/pull/3378/files is reversed, leading to failure on OVS tests in S1AP integration tests. This change fixes the bug.

## Test Plan

- make test_oai on magma VM
- make integ_test on magma_test VM
- Integration test with CUPS SPGW will be done in Jenkins CI

