### PR TITLE
[SessionD] Add first_usage and last_usage in SessionCredit

### DIFF
--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -18,6 +18,15 @@
 #include "SessionCredit.h"
 #include "magma_logging.h"
 
+namespace {
+uint64_t get_time_in_sec_since_epoch() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             now.time_since_epoch())
+      .count();
+}
+}  // namespace
+
 namespace magma {
 
 float SessionCredit::USAGE_REPORTING_THRESHOLD             = 0.8;
@@ -36,7 +45,9 @@ SessionCredit::SessionCredit(
       reporting_(false),
       credit_limit_type_(credit_limit_type),
       grant_tracking_type_(TRACKING_UNSET),
-      report_last_credit_(false) {}
+      report_last_credit_(false),
+      time_of_first_usage_(0),
+      time_of_last_usage_(0) {}
 
 SessionCredit::SessionCredit(const StoredSessionCredit& marshaled) {
   reporting_              = marshaled.reporting;
@@ -44,6 +55,8 @@ SessionCredit::SessionCredit(const StoredSessionCredit& marshaled) {
   grant_tracking_type_    = marshaled.grant_tracking_type;
   received_granted_units_ = marshaled.received_granted_units;
   report_last_credit_     = marshaled.report_last_credit;
+  time_of_first_usage_    = marshaled.time_of_first_usage;
+  time_of_last_usage_     = marshaled.time_of_last_usage;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
@@ -60,6 +73,8 @@ StoredSessionCredit SessionCredit::marshal() {
   marshaled.grant_tracking_type    = grant_tracking_type_;
   marshaled.received_granted_units = received_granted_units_;
   marshaled.report_last_credit     = report_last_credit_;
+  marshaled.time_of_first_usage    = time_of_first_usage_;
+  marshaled.time_of_last_usage     = time_of_last_usage_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket             = static_cast<Bucket>(bucket_int);
@@ -74,6 +89,8 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
   uc.grant_tracking_type    = grant_tracking_type_;
   uc.received_granted_units = received_granted_units_;
   uc.report_last_credit     = report_last_credit_;
+  uc.time_of_first_usage    = time_of_first_usage_;
+  uc.time_of_last_usage     = time_of_last_usage_;
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket            = static_cast<Bucket>(bucket_int);
@@ -83,13 +100,28 @@ SessionCreditUpdateCriteria SessionCredit::get_update_criteria() {
 }
 
 void SessionCredit::add_used_credit(
-    uint64_t used_tx, uint64_t used_rx, SessionCreditUpdateCriteria& uc) {
-  buckets_[USED_TX] += used_tx;
-  buckets_[USED_RX] += used_rx;
-  uc.bucket_deltas[USED_TX] += used_tx;
-  uc.bucket_deltas[USED_RX] += used_rx;
+    uint64_t used_tx, uint64_t used_rx,
+    SessionCreditUpdateCriteria& credit_uc) {
+  if (used_tx > 0 || used_rx > 0) {
+    buckets_[USED_TX] += used_tx;
+    buckets_[USED_RX] += used_rx;
+    credit_uc.bucket_deltas[USED_TX] += used_tx;
+    credit_uc.bucket_deltas[USED_RX] += used_rx;
+    update_usage_timestamps(credit_uc);
+  }
 
   log_quota_and_usage();
+}
+
+void SessionCredit::update_usage_timestamps(
+    SessionCreditUpdateCriteria& credit_uc) {
+  auto now = get_time_in_sec_since_epoch();
+  if (time_of_first_usage_ == 0) {
+    time_of_first_usage_          = now;
+    credit_uc.time_of_first_usage = now;
+  }
+  time_of_last_usage_          = now;
+  credit_uc.time_of_last_usage = now;
 }
 
 void SessionCredit::reset_reporting_credit(SessionCreditUpdateCriteria* uc) {
@@ -104,7 +136,8 @@ void SessionCredit::reset_reporting_credit(SessionCreditUpdateCriteria* uc) {
 void SessionCredit::mark_failure(
     uint32_t code, SessionCreditUpdateCriteria* uc) {
   if (DiameterCodeHandler::is_transient_failure(code)) {
-    MLOG(MDEBUG) << "mark_faliure triggered. Reseting reporting";
+    MLOG(MDEBUG) << "Found transient failure code in mark_failure. Resetting "
+                    "'REPORTING' values";
     buckets_[REPORTED_RX] += buckets_[REPORTING_RX];
     buckets_[REPORTED_TX] += buckets_[REPORTING_TX];
     if (uc != NULL) {
@@ -116,7 +149,7 @@ void SessionCredit::mark_failure(
 }
 
 // receive_credit will add received grant to current credits. Note that if
-// there is overuseage, the extra amount will be added to the counters by
+// there is over-usage, the extra amount will be added to the counters by
 // calculate_delta_allowed_floor and calculate_delta_allowed
 void SessionCredit::receive_credit(
     const GrantedUnits& gsu, SessionCreditUpdateCriteria* uc) {
@@ -295,6 +328,18 @@ SessionCredit::Usage SessionCredit::get_all_unreported_usage_for_reporting(
   update_criteria.reporting = true;
   log_usage_report(usage);
   return usage;
+}
+
+SessionCredit::Summary SessionCredit::get_credit_summary() {
+  return SessionCredit::Summary{
+      .usage =
+          SessionCredit::Usage{
+              .bytes_tx = buckets_[USED_TX],
+              .bytes_rx = buckets_[USED_RX],
+          },
+      .time_of_first_usage = time_of_first_usage_,
+      .time_of_last_usage  = time_of_last_usage_,
+  };
 }
 
 SessionCredit::Usage SessionCredit::get_usage_for_reporting(
@@ -491,16 +536,18 @@ bool SessionCredit::is_report_last_credit() {
   return report_last_credit_;
 }
 
-void SessionCredit::merge(SessionCreditUpdateCriteria& uc) {
-  grant_tracking_type_    = uc.grant_tracking_type;
-  received_granted_units_ = uc.received_granted_units;
-  report_last_credit_     = uc.report_last_credit;
-  // DO NOT UPDATE reporting_. (done bv LocalSessionManagerHandler)
+void SessionCredit::merge(SessionCreditUpdateCriteria& credit_uc) {
+  grant_tracking_type_    = credit_uc.grant_tracking_type;
+  received_granted_units_ = credit_uc.received_granted_units;
+  report_last_credit_     = credit_uc.report_last_credit;
+  time_of_first_usage_    = credit_uc.time_of_first_usage;
+  time_of_last_usage_     = credit_uc.time_of_last_usage;
+  // DO NOT UPDATE reporting_. (done by LocalSessionManagerHandler)
 
   // add credit
   for (int i = USED_TX; i != MAX_VALUES; i++) {
     Bucket bucket = static_cast<Bucket>(i);
-    auto credit   = uc.bucket_deltas.find(bucket)->second;
+    auto credit   = credit_uc.bucket_deltas.find(bucket)->second;
     buckets_[bucket] += credit;
   }
 }

--- a/lte/gateway/c/session_manager/SessionCredit.h
+++ b/lte/gateway/c/session_manager/SessionCredit.h
@@ -29,6 +29,12 @@ class SessionCredit {
     uint64_t bytes_rx;
   };
 
+  struct Summary {
+    SessionCredit::Usage usage;
+    uint64_t time_of_first_usage;
+    uint64_t time_of_last_usage;
+  };
+
   SessionCredit();
 
   SessionCredit(ServiceState start_state);
@@ -51,7 +57,7 @@ class SessionCredit {
    */
   void add_used_credit(
       uint64_t used_tx, uint64_t used_rx,
-      SessionCreditUpdateCriteria& update_criteria);
+      SessionCreditUpdateCriteria& credit_uc);
 
   /**
    * reset_reporting_credit resets the REPORTING_* to 0
@@ -92,6 +98,11 @@ class SessionCredit {
 
   SessionCredit::Usage get_all_unreported_usage_for_reporting(
       SessionCreditUpdateCriteria& update_criteria);
+
+  /**
+   * Returns the credit's cumulative rx/tx usage and first/last usage timestamps
+   */
+  SessionCredit::Summary get_credit_summary();
 
   /**
    * Returns true if either of REPORTING_* buckets are more than 0
@@ -184,6 +195,12 @@ class SessionCredit {
   // stores the granted credits we received the last
   GrantedUnits received_granted_units_;
   bool report_last_credit_;
+  // Timestamp for the first IP packet to be transmitted and mapped to this
+  // service data container (TS 132 298 - V8.4.0 : 5.1.2.2.22A)
+  uint64_t time_of_first_usage_;
+  // Timestamp for the most recent IP packet to be transmitted and mapped to
+  // this service data container (TS 132 298 - V8.4.0 : 5.1.2.2.22A)
+  uint64_t time_of_last_usage_;
 
  private:
   void log_quota_and_usage() const;
@@ -216,6 +233,8 @@ class SessionCredit {
 
   uint64_t calculate_delta_allowed(
       uint64_t gsu_volume, Bucket allowed, uint64_t volume_used);
+
+  void update_usage_timestamps(SessionCreditUpdateCriteria& credit_uc);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -797,7 +797,7 @@ uint64_t SessionState::get_pdp_end_time() {
 
 void SessionState::set_pdp_end_time(
     uint64_t epoch, SessionStateUpdateCriteria& session_uc) {
-  pdp_end_time_ = epoch;
+  pdp_end_time_                   = epoch;
   session_uc.updated_pdp_end_time = epoch;
 }
 

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -171,7 +171,10 @@ std::string serialize_stored_session_credit(StoredSessionCredit& stored) {
       static_cast<int>(stored.grant_tracking_type);
   marshaled["received_granted_units"] =
       stored.received_granted_units.SerializeAsString();
-  marshaled["report_last_credit"] = stored.report_last_credit;
+  marshaled["report_last_credit"]  = stored.report_last_credit;
+  marshaled["time_of_first_usage"] = std::to_string(stored.time_of_first_usage);
+  marshaled["time_of_last_usage"]  = std::to_string(stored.time_of_last_usage);
+
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket = static_cast<Bucket>(bucket_int);
     marshaled["buckets"][std::to_string(bucket_int)] =
@@ -199,6 +202,10 @@ StoredSessionCredit deserialize_stored_session_credit(
       marshaled["received_granted_units"].getString());
   stored.received_granted_units = received_granted_units;
   stored.report_last_credit     = marshaled["report_last_credit"].getBool();
+  stored.time_of_first_usage    = static_cast<uint64_t>(
+      std::stoul(marshaled["time_of_first_usage"].getString()));
+  stored.time_of_last_usage = static_cast<uint64_t>(
+      std::stoul(marshaled["time_of_last_usage"].getString()));
 
   for (int bucket_int = USED_TX; bucket_int != MAX_VALUES; bucket_int++) {
     Bucket bucket          = static_cast<Bucket>(bucket_int);

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -138,6 +138,8 @@ struct StoredSessionCredit {
   GrantTrackingType grant_tracking_type;
   GrantedUnits received_granted_units;
   bool report_last_credit;
+  uint64_t time_of_first_usage;
+  uint64_t time_of_last_usage;
 };
 
 struct StoredMonitor {
@@ -239,6 +241,9 @@ struct SessionCreditUpdateCriteria {
 
   bool deleted;
   bool report_last_credit;
+
+  uint64_t time_of_first_usage;
+  uint64_t time_of_last_usage;
 };
 
 struct SessionStateUpdateCriteria {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Adding two timestamps into SessionCredit to keep track of 
1. The first time we added usage into this credit
2. The most recent time we added usage into this credit

These fields will be mainly used for the session terminated event log to summarize each credit.
Also added a `get_summary` function which is only used for testing in this PR, but it will be used to export the summary in later PRs.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
New unit test added for the `get_summary` function
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
