### PR TITLE
[bug fix][lte][agw] Fix for sending MBR after receiving erab setup rsp and activate default bearer accept

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
@@ -43,6 +43,7 @@
 #include "mme_app_state.h"
 
 #define ERAB_SETUP_RSP_COUNTER_MAX 5
+// TODO - Make it configurable
 #define ERAB_SETUP_RSP_TMR 5  // In secs
 
 /****************************************************************************/

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
@@ -592,6 +592,22 @@ esm_cause_t esm_recv_information_response(
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, esm_cause);
 }
 
+/****************************************************************************
+ **                                                                        **
+ ** Name:    _erab_setup_rsp_tmr_exp_handler()                             **
+ **                                                                        **
+ ** Description: Handles Erab setup rsp timer expiry                       **
+ **                                                                        **
+ ** Inputs:                                                                **
+ **      imsi64:     IMSI                                                 **
+ **      args:       timer data                                            **
+ **                                                                        **
+ ** Outputs:     None                                                      **
+ **      Return:  None                                                     **
+ **      Others:  None                                                     **
+ **                                                                        **
+ ***************************************************************************/
+
 static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
@@ -643,6 +659,20 @@ static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
               "\n",
               esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
         }
+      } else {
+        OAILOG_WARNING(
+            LOG_NAS_ESM,
+            "ESM-PROC  - ERAB_SETUP_RSP_COUNTER_MAX reached for ERAB_SETUP_RSP "
+            "ue_id= " MME_UE_S1AP_ID_FMT
+            " ebi (%u)"
+            "\n",
+            esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
+        if (bearer_ctx->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
+          bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
+        }
+        if (esm_ebr_timer_data) {
+          free_wrapper((void**) &esm_ebr_timer_data);
+        }
       }
     } else {
       rc = send_modify_bearer_req(
@@ -653,7 +683,6 @@ static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
             "ESM-SAP - Sending Modify bearer req failed for (ebi=%u)"
             "\n",
             esm_ebr_timer_data->ebi);
-        OAILOG_FUNC_OUT(LOG_NAS_ESM);
       }
       if (bearer_ctx->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
         bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
@@ -42,6 +42,9 @@
 #include "mme_app_itti_messaging.h"
 #include "mme_app_state.h"
 
+#define ERAB_SETUP_RSP_COUNTER_MAX 5
+#define ERAB_SETUP_RSP_TMR 5  // In secs
+
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
 /****************************************************************************/
@@ -589,6 +592,80 @@ esm_cause_t esm_recv_information_response(
   OAILOG_FUNC_RETURN(LOG_NAS_ESM, esm_cause);
 }
 
+static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
+  OAILOG_FUNC_IN(LOG_NAS_ESM);
+  int rc;
+
+  /*
+   * Get retransmission timer parameters data
+   */
+  esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
+
+  if (esm_ebr_timer_data) {
+    /*
+     * Increment the retransmission counter
+     */
+    esm_ebr_timer_data->count += 1;
+    OAILOG_WARNING(
+        LOG_NAS_ESM,
+        "ESM-PROC  - erab_setup_rsp timer expired (ue_id=" MME_UE_S1AP_ID_FMT
+        ", ebi=%d), "
+        "retransmission counter = %d\n",
+        esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi,
+        esm_ebr_timer_data->count);
+
+    *imsi64 = esm_ebr_timer_data->ctx->_imsi64;
+    ue_mm_context_t* ue_mm_context =
+        mme_ue_context_exists_mme_ue_s1ap_id(esm_ebr_timer_data->ue_id);
+
+    bearer_context_t* bearer_ctx =
+        mme_app_get_bearer_context(ue_mm_context, esm_ebr_timer_data->ebi);
+    if (!bearer_ctx) {
+      OAILOG_ERROR(
+          LOG_NAS_ESM,
+          "Bearer context is NULL for (ebi=%u)"
+          "\n",
+          esm_ebr_timer_data->ebi);
+      OAILOG_FUNC_OUT(LOG_NAS_ESM);
+    }
+    if (!bearer_ctx->enb_fteid_s1u.teid) {
+      if (esm_ebr_timer_data->count < ERAB_SETUP_RSP_COUNTER_MAX) {
+        // Restart the timer
+        rc = esm_ebr_start_timer(
+            esm_ebr_timer_data->ctx, esm_ebr_timer_data->ebi, NULL,
+            ERAB_SETUP_RSP_TMR, _erab_setup_rsp_tmr_exp_handler);
+        if (rc != RETURNerror) {
+          OAILOG_INFO(
+              LOG_NAS_ESM,
+              "ESM-PROC  - Started ERAB_SETUP_RSP_TMR for "
+              "ue_id=" MME_UE_S1AP_ID_FMT
+              "ebi (%u)"
+              "\n",
+              esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
+        }
+      }
+    } else {
+      rc = send_modify_bearer_req(
+          esm_ebr_timer_data->ue_id, esm_ebr_timer_data->ebi);
+      if (rc != RETURNok) {
+        OAILOG_ERROR(
+            LOG_NAS_ESM,
+            "ESM-SAP - Sending Modify bearer req failed for (ebi=%u)"
+            "\n",
+            esm_ebr_timer_data->ebi);
+        OAILOG_FUNC_OUT(LOG_NAS_ESM);
+      }
+      if (bearer_ctx->esm_ebr_context.timer.id != NAS_TIMER_INACTIVE_ID) {
+        bearer_ctx->esm_ebr_context.timer.id = NAS_TIMER_INACTIVE_ID;
+      }
+      if (esm_ebr_timer_data) {
+        free_wrapper((void**) &esm_ebr_timer_data);
+      }
+    }
+  }
+  OAILOG_FUNC_OUT(LOG_NAS_ESM);
+}
+
 /****************************************************************************
  **                                                                        **
  ** Name:    esm_recv_activate_default_eps_bearer_context_accept()     **
@@ -668,14 +745,50 @@ esm_cause_t esm_recv_activate_default_eps_bearer_context_accept(
    */
   if (emm_context->esm_ctx.is_standalone == true) {
     emm_context->esm_ctx.is_standalone = false;
-    rc                                 = send_modify_bearer_req(ue_id, ebi);
-    if (rc != RETURNok) {
+    bearer_context_t* bearer_ctx       = mme_app_get_bearer_context(
+        PARENT_STRUCT(emm_context, struct ue_mm_context_s, emm_context), ebi);
+    if (!bearer_ctx) {
       OAILOG_ERROR(
           LOG_NAS_ESM,
-          "ESM-SAP - Sending Modify bearer req failed for (ebi=%u)"
+          "Bearer context is NULL for (ebi=%u)"
           "\n",
           ebi);
-      OAILOG_FUNC_RETURN(LOG_NAS_ESM, ESM_CAUSE_PROTOCOL_ERROR);
+      OAILOG_FUNC_RETURN(LOG_NAS_ESM, ESM_CAUSE_INVALID_EPS_BEARER_IDENTITY);
+    }
+    /* Send MBR only after receiving ERAB_SETUP_RSP.
+     * bearer_ctx->enb_fteid_s1u.teid gets updated after receiving
+     * ERAB_SETUP_RSP.*/
+    if (bearer_ctx->enb_fteid_s1u.teid) {
+      rc = send_modify_bearer_req(ue_id, ebi);
+      if (rc != RETURNok) {
+        OAILOG_ERROR(
+            LOG_NAS_ESM,
+            "ESM-SAP - Sending Modify bearer req failed for (ebi=%u)"
+            "\n",
+            ebi);
+        OAILOG_FUNC_RETURN(LOG_NAS_ESM, ESM_CAUSE_PROTOCOL_ERROR);
+      }
+      OAILOG_DEBUG(
+          LOG_NAS_ESM,
+          "ESM-PROC  - Sending Modify bearer req ue_id=" MME_UE_S1AP_ID_FMT
+          "ebi (%u), enb_fteid_s1u.teid %x"
+          "\n",
+          ue_id, ebi, bearer_ctx->enb_fteid_s1u.teid);
+
+    } else {
+      // Wait for ERAB SETUP RSP.Start a timer for 5 secs
+      rc = esm_ebr_start_timer(
+          emm_context, ebi, NULL, ERAB_SETUP_RSP_TMR,
+          _erab_setup_rsp_tmr_exp_handler);
+      if (rc != RETURNerror) {
+        OAILOG_DEBUG(
+            LOG_NAS_ESM,
+            "ESM-PROC  - Started ERAB_SETUP_RSP_TMR for "
+            "ue_id=" MME_UE_S1AP_ID_FMT
+            "ebi (%u)"
+            "\n",
+            ue_id, ebi);
+      }
     }
   }
   /*

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_recv.c
@@ -600,7 +600,7 @@ esm_cause_t esm_recv_information_response(
  ** Description: Handles Erab setup rsp timer expiry                       **
  **                                                                        **
  ** Inputs:                                                                **
- **      imsi64:     IMSI                                                 **
+ **      imsi64:     IMSI                                                  **
  **      args:       timer data                                            **
  **                                                                        **
  ** Outputs:     None                                                      **
@@ -613,15 +613,11 @@ static void _erab_setup_rsp_tmr_exp_handler(void* args, imsi64_t* imsi64) {
   OAILOG_FUNC_IN(LOG_NAS_ESM);
   int rc;
 
-  /*
-   * Get retransmission timer parameters data
-   */
+  // Get retransmission timer parameters data
   esm_ebr_timer_data_t* esm_ebr_timer_data = (esm_ebr_timer_data_t*) (args);
 
   if (esm_ebr_timer_data) {
-    /*
-     * Increment the retransmission counter
-     */
+    // Increment the retransmission counter
     esm_ebr_timer_data->count += 1;
     OAILOG_WARNING(
         LOG_NAS_ESM,


### PR DESCRIPTION
[bug fix][lte][agw] Fix for sending MBR after receiving erab setup rsp and activate default bearer accept

## Summary

MME used to send modify bearer req message to spgw after receiving activate default eps bearer context accept message without waiting for erab setup rsp message from enb. This PR sends modify bearer req message only after receiving both activate default eps bearer context accept and erab setup rsp messages.

## Test Plan
- Verified s1ap tester sanity
- Modified s1ap tester code to delay erab setup rsp message(yet to raise PR) and executed test_attach_detach_secondary_pdn.py TC

