### PR TITLE
Updating directoryd report location to be done until UE registered state

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -578,9 +578,6 @@ void mme_ue_context_update_coll_keys(
         ue_context_p, ue_context_p->enb_ue_s1ap_id,
         ue_context_p->mme_ue_s1ap_id, imsi, hashtable_rc_code2string(h_rc));
   }
-  _directoryd_report_location(
-      ue_context_p->emm_context._imsi64,
-      ue_context_p->emm_context._imsi.length);
 
   h_rc = hashtable_uint64_ts_remove(
       mme_ue_context_p->tun11_ue_context_htbl,
@@ -764,10 +761,6 @@ int mme_insert_ue_context(
             ue_context_p->emm_context._imsi64);
         OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
       }
-
-      _directoryd_report_location(
-          ue_context_p->emm_context._imsi64,
-          ue_context_p->emm_context._imsi.length);
     }
 
     // filled S11 tun id
@@ -2012,6 +2005,11 @@ void mme_ue_context_update_ue_emm_state(
   if ((ue_context_p->mm_state == UE_UNREGISTERED) &&
       (new_mm_state == UE_REGISTERED)) {
     ue_context_p->mm_state = new_mm_state;
+
+    // Report directoryd UE record
+    _directoryd_report_location(
+        ue_context_p->emm_context._imsi64,
+        ue_context_p->emm_context._imsi.length);
 
     // Update Stats
     update_mme_app_stats_attached_ue_add();


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- MME creates record for UE on directoryd on setting up the UE context state, there have been reported issues due to UEs not successfully attaching and creating a lot of garbage left-over records on directoryd and making directoryd unresponsive to gRPC requests, this updates MME task to only create the record after successful attach process. 

## Test Plan

- make test
- make integ_test
- setting up eNB with magma VM and UE to validate attach and record is created in directoryd


## Additional Information

- [ ] This change is backwards-breaking

