### PR TITLE
[SessionD] Enable creation/termination  event logging for CWF sessions as well

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1129,9 +1129,7 @@ void LocalEnforcer::init_session_credit(
                  << session_id;
     session_map[imsi] = SessionVector();
   }
-  if (session_state->is_radius_cwf_session() == false) {
-    events_reporter_->session_created(imsi, session_id, cfg, session_state);
-  }
+  events_reporter_->session_created(imsi, session_id, cfg, session_state);
   session_map[imsi].push_back(std::move(session_state));
 }
 
@@ -1233,9 +1231,7 @@ void LocalEnforcer::complete_termination(
   auto termination_req = session->make_termination_request(session_uc);
   auto logging_cb = SessionReporter::get_terminate_logging_cb(termination_req);
   reporter_->report_terminate_session(termination_req, logging_cb);
-  if (session->is_radius_cwf_session() == false) {
-    events_reporter_->session_terminated(imsi, session);
-  }
+  events_reporter_->session_terminated(imsi, session);
 
   // Delete the session from SessionMap
   session_uc.is_session_ended = true;
@@ -1457,9 +1453,8 @@ bool LocalEnforcer::handle_abort_session(
   start_session_termination(imsi, session, true, session_uc);
   // ASRs do not require a CCR-T, this means we can immediately terminate
   // without waiting for final usage reports.
-  if (session->is_radius_cwf_session() == false) {
-    events_reporter_->session_terminated(imsi, session);
-  }
+  events_reporter_->session_terminated(imsi, session);
+
   // Delete the session from SessionMap
   session_uc.is_session_ended = true;
   session_map[imsi].erase(*session_it);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
These are probably left over logic from when event logging was not enabled for CWF. Enabling them now so that we have less CWF specific logic.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
