### PR TITLE
[NMS] Double test timeout for NMS e2e tests

### DIFF
--- a/nms/app/packages/magmalte/app/e2e/__tests__/App-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/App-test.js
@@ -19,7 +19,7 @@ import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
 let browser;
 beforeEach(async () => {
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors'],
     headless: true,
@@ -44,5 +44,5 @@ describe('NMS dashboard', () => {
 
     await page.screenshot({path: ARTIFACTS_DIR + 'dashboard.png'});
     browser.close();
-  }, 30000);
+  }, 60000);
 });

--- a/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
@@ -24,7 +24,7 @@ const NAV_SELECTOR = `//body/div[1]/div/div/div[last()]`;
 
 let browser;
 beforeEach(async () => {
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors'],
     headless: true,
@@ -80,7 +80,7 @@ describe('Admin component', () => {
       path: ARTIFACTS_DIR + 'organization_network_list.png',
     });
     await page.close();
-  }, 30000);
+  }, 60000);
 });
 
 describe('NMS', () => {
@@ -130,5 +130,5 @@ describe('NMS', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'feg_lte_network_dashboard.png',
     });
-  }, 30000);
+  }, 60000);
 });

--- a/nms/app/packages/magmalte/app/e2e/__tests__/Policy-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/Policy-test.js
@@ -19,7 +19,7 @@ import {ARTIFACTS_DIR, SimulateNMSLogin} from '../LoginUtils';
 
 let browser;
 beforeEach(async () => {
-  jest.setTimeout(30000);
+  jest.setTimeout(60000);
   browser = await puppeteer.launch({
     args: ['--ignore-certificate-errors'],
     headless: true,
@@ -56,7 +56,7 @@ describe('NMS', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'policy_dashboard.png',
     });
-  }, 30000);
+  }, 60000);
 });
 
 describe('NMS Policy Add', () => {
@@ -71,8 +71,9 @@ describe('NMS Policy Add', () => {
       const buttonSelector = await page.$x(`//span[text()='Create New']`);
       buttonSelector[0].click();
 
-      const policybuttonSelector = await page.$x(`//span[text()='Policy']`);
-      policybuttonSelector[0].click();
+      const policyButtonSelector = '[data-testid="newPolicyMenuItem"]';
+      await page.waitForSelector(policyButtonSelector);
+      page.click(policyButtonSelector);
 
       await page.waitForXPath(`//span[text()='Add New Policy']`);
 
@@ -126,7 +127,7 @@ describe('NMS Policy Add', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'policy_add.png',
     });
-  }, 30000);
+  }, 60000);
 });
 
 describe('NMS Policy Edit', () => {
@@ -168,5 +169,5 @@ describe('NMS Policy Edit', () => {
     await page.screenshot({
       path: ARTIFACTS_DIR + 'policy_edit.png',
     });
-  }, 30000);
+  }, 60000);
 });

--- a/nms/app/packages/magmalte/e2e_test_setup.sh
+++ b/nms/app/packages/magmalte/e2e_test_setup.sh
@@ -36,6 +36,7 @@ docker-compose exec magmalte yarn createOrganization magma-test nms test,test_fe
 
 # run the end to end test
 cd ../../
+set +e
 yarn test:e2e
 exit_code=$?
 


### PR DESCRIPTION
## Summary

Tests are taking longer than expected. Doubling the timeout for now.

## Test Plan
e2e tests work

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
