### PR TITLE
[SessionD] Add fields to terminate event

### DIFF
--- a/lte/gateway/c/session_manager/SessionEvents.cpp
+++ b/lte/gateway/c/session_manager/SessionEvents.cpp
@@ -28,6 +28,7 @@ const std::string SESSION_TERMINATED_EV     = "session_terminated";
 const std::string SESSION_ID     = "session_id";
 const std::string IMSI           = "imsi";
 const std::string IMEI           = "imei";
+const std::string USER_LOCATION  = "user_location";
 const std::string IP_ADDR        = "ip_addr";
 const std::string IPV6_ADDR      = "ipv6_addr";
 const std::string MAC_ADDR       = "mac_addr";
@@ -37,6 +38,14 @@ const std::string APN            = "apn";
 const std::string PDP_START_TIME = "pdp_start_time";
 const std::string PDP_END_TIME   = "pdp_end_time";
 const std::string FAILURE_REASON = "failure_reason";
+
+const std::string SERVICE_DATA        = "list_of_service_data";
+const std::string RATING_GROUP        = "rating_group";
+const std::string SERVICE_IDENTIFIER  = "service_identifier";
+const std::string DATA_UPLINK         = "data_volume_downlink";
+const std::string DATA_DOWNLINK       = "data_volume_uplink";
+const std::string TIME_OF_FIRST_USAGE = "time_of_first_usage";
+const std::string TIME_OF_LAST_USAGE  = "time_of_last_usage";
 
 const std::string TOTAL_TX      = "total_tx";
 const std::string TOTAL_RX      = "total_rx";
@@ -198,10 +207,29 @@ void EventsReporterImpl::session_terminated(
   event_value[PDP_START_TIME] = session->get_pdp_start_time();
   event_value[PDP_END_TIME]   = session->get_pdp_end_time();
   // LTE specific
-  event_value[IMEI]    = get_imei(session_cfg);
-  event_value[SPGW_IP] = get_spgw_ipv4(session_cfg);
+  event_value[IMEI]          = get_imei(session_cfg);
+  event_value[SPGW_IP]       = get_spgw_ipv4(session_cfg);
+  event_value[USER_LOCATION] = get_user_location(session_cfg);
   // CWF specific
   event_value[MAC_ADDR] = get_mac_addr(session_cfg);
+
+  // Add Gy tracked credits
+  auto credit_summaries            = session->get_charging_credit_summaries();
+  folly::dynamic service_data_list = folly::dynamic::array;
+  for (auto summary_pair : credit_summaries) {
+    folly::dynamic service_data = folly::dynamic::object;
+    auto summary                = summary_pair.second;
+    service_data[RATING_GROUP]  = summary_pair.first.rating_group;
+    if (summary_pair.first.service_identifier) {
+      service_data[SERVICE_IDENTIFIER] = summary_pair.first.service_identifier;
+    }
+    service_data[DATA_UPLINK]         = summary.usage.bytes_tx;
+    service_data[DATA_DOWNLINK]       = summary.usage.bytes_rx;
+    service_data[TIME_OF_FIRST_USAGE] = summary.time_of_first_usage;
+    service_data[TIME_OF_LAST_USAGE]  = summary.time_of_last_usage;
+    service_data_list.push_back(service_data);
+  }
+  event_value[SERVICE_DATA] = service_data_list;
 
   std::string event_value_string = folly::toJson(event_value);
   event.set_value(event_value_string);
@@ -243,6 +271,16 @@ std::string EventsReporterImpl::get_spgw_ipv4(const SessionConfig& config) {
     spgw_ipv4 = rat_specific.lte_context().spgw_ipv4();
   }
   return spgw_ipv4;
+}
+
+std::string EventsReporterImpl::get_user_location(const SessionConfig& config) {
+  // UserLocation is only relevant for LTE
+  const auto& rat_specific  = config.rat_specific_context;
+  std::string user_location = "";
+  if (rat_specific.has_lte_context()) {
+    user_location = rat_specific.lte_context().user_location();
+  }
+  return user_location;
 }
 
 }  // namespace lte

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -82,6 +82,7 @@ class EventsReporterImpl : public EventsReporter {
   std::string get_mac_addr(const SessionConfig& config);
   std::string get_imei(const SessionConfig& config);
   std::string get_spgw_ipv4(const SessionConfig& config);
+  std::string get_user_location(const SessionConfig& config);
 
  private:
   AsyncEventdClient& eventd_client_;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -695,6 +695,16 @@ SessionTerminateRequest SessionState::make_termination_request(
   return req;
 }
 
+ChargingCreditSummaries SessionState::get_charging_credit_summaries() {
+  ChargingCreditSummaries charging_credit_summaries(
+      credit_map_.size(), &ccHash, &ccEqual);
+  for (auto& credit_pair : credit_map_) {
+    auto summary = credit_pair.second->credit.get_credit_summary();
+    charging_credit_summaries[credit_pair.first] = summary;
+  }
+  return charging_credit_summaries;
+}
+
 SessionState::TotalCreditUsage SessionState::get_total_credit_usage() {
   // Collate unique charging/monitoring keys used by rules
   std::unordered_set<CreditKey, decltype(&ccHash), decltype(&ccEqual)>

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -33,6 +33,9 @@ typedef std::unordered_map<
     CreditKey, std::unique_ptr<ChargingGrant>, decltype(&ccHash),
     decltype(&ccEqual)>
     CreditMap;
+typedef std::unordered_map<
+    CreditKey, SessionCredit::Summary, decltype(&ccHash), decltype(&ccEqual)>
+    ChargingCreditSummaries;
 typedef std::unordered_map<std::string, std::unique_ptr<Monitor>> MonitorMap;
 static SessionStateUpdateCriteria UNUSED_UPDATE_CRITERIA;
 
@@ -236,6 +239,8 @@ class SessionState {
    * Should be called after can_complete_termination.
    */
   TotalCreditUsage get_total_credit_usage();
+
+  ChargingCreditSummaries get_charging_credit_summaries();
 
   std::string get_session_id() const;
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Add the following fields to the session terminated event.
- USER_LOCATION
- RATING_GROUP (per-RG / RG+ServiceId)
- SERVICE_IDENTIFIER (per-RG / RG+ServiceId)
- DATA_UPLINK (per-RG / RG+ServiceId)
- DATA_DOWNLINK (per-RG / RG+ServiceId)
- TIME_OF_FIRST_USAGE (per-RG / RG+ServiceId)
- TIME_OF_LAST_USAGE (per-RG / RG+ServiceId)


Event Log from running CWF Integration Test
```
{
   "list_of_service_data":[
      {
         "time_of_last_usage":1603731220,
         "time_of_first_usage":1603731218,
         "data_volume_uplink":31024,
         "rating_group":1,
         "data_volume_downlink":489111
      }
   ],
   "mac_addr":"ee:a1:c5:74:8a:44",
   "user_location":"",
   "apn":"98-DE-D0-84-B5-47:CWF-TP-LINK_B547_5G",
   "spgw_ip":"",
   "imsi":"IMSI609740980709938",
   "ipv6_addr":"",
   "ip_addr":"",
   "total_tx":489111,
   "total_rx":31024,
   "session_id":"IMSI609740980709938-615028",
   "pdp_start_time":1603731217,
   "imei":"",
   "msisdn":"5100001234",
   "charging_rx":31024,
   "monitoring_tx":0,
   "monitoring_rx":0,
   "charging_tx":489111,
   "pdp_end_time":1603731228
}
```
<!-- Enumerate changes you made and why you made them -->

## Test Plan
CWF IntegTest
S1AP Tests
SessionD unit tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
