### PR TITLE
[orc8r][serdes] Fix broken mconfig for shared network types

### DIFF
--- a/orc8r/cloud/go/serde/registry.go
+++ b/orc8r/cloud/go/serde/registry.go
@@ -36,6 +36,14 @@ type Registry interface {
 	MustMerge(rr Registry) Registry
 }
 
+func HasSerde(r Registry, typ string) bool {
+	_, err := r.GetSerde(typ)
+	if err == nil {
+		return true
+	}
+	return false
+}
+
 type registry map[string]Serde
 
 func NewRegistry(serdes ...Serde) Registry {


### PR DESCRIPTION
## Summary

Mconfig requests were failing for certain network types because the configurator network had configs from multiple network types. When e.g. a cwf network tried to deserialize its network configs, it also found feg-like network configs and, upon failing to deserialize, errored the entire mconfig request.

Now, we just ignore this expected err.

## Test Plan

- [x] make test

## Additional Information

- [ ] This change is backwards-breaking