### PR TITLE
[xwfm] fix borken CI by adding backend var

### DIFF
--- a/xwf/docker/docker-compose.yml
+++ b/xwf/docker/docker-compose.yml
@@ -225,6 +225,7 @@ services:
       - PARTNERNAME=${XWF_PARTNER_SHORT_NAME}
       - CPURL=${XWF_CPURL}
       - VPCEndPointID=${XWF_VPCEndPointID}
+      - BACKEND=${BACKEND:-WWW}
     logging: *logging_anchor
     depends_on:
       - xwf_client


### PR DESCRIPTION
Signed-off-by: Aharon Novogrodski <novo@gmail.com>

[xwfm][ci]

## Summary

add missing environment var to the tests docker in docker-compose

## Test Plan

make sure CI is working now

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
