### PR TITLE
[orc8r][helm] Thanos Helm Deployment

### DIFF
--- a/cwf/gateway/go.mod
+++ b/cwf/gateway/go.mod
@@ -49,8 +49,7 @@ require (
 	github.com/sparrc/go-ping v0.0.0-20190613174326-4e5b6552494c
 	github.com/stretchr/testify v1.5.1
 	github.com/vishvananda/netlink v1.1.0
-	golang.org/x/net v0.0.0-20200625001655-4c5254603344
-	golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6 // indirect
+	golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/grpc v1.31.0
 	magma/cwf/cloud/go v0.0.0-00010101000000-000000000000

--- a/cwf/gateway/go.sum
+++ b/cwf/gateway/go.sum
@@ -658,6 +658,7 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200722175500-76b94024e4b6/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180805044716-cb6730876b98/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/orc8r/cloud/helm/orc8r/README.md
+++ b/orc8r/cloud/helm/orc8r/README.md
@@ -122,6 +122,7 @@ kubectl exec -it -n magma \
 ```
 
 - Port forward traffic to orchestrator nginx proxy:
+
 ```bash
 kubectl port-forward -n magma svc/orc8r-nginx-proxy 8443:8443
 

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma metrics
 name: metrics
-version: 1.4.18
+version: 1.4.19
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/charts/metrics/README.md
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/README.md
@@ -1,0 +1,112 @@
+# Thanos Helm Deployment
+
+Thanos provides scaling and data retention improvements to the prometheus metrics deployment.
+It can be deployed by following the instructions below.
+
+## Set up AWS infrastructure
+
+Thanos is configured to use an S3 bucket to store long-term data, while only keeping a small amount of data in the Prometheus server. To support this, you must have an accessible S3 bucket
+created.
+
+### Create S3 Bucket and IAM User
+
+- Create a bucket here: https://s3.console.aws.amazon.com/s3/home
+
+  - Make sure it is in the same region as your orchestrator deployment, and disable public access.
+
+- Create an IAM user that has full s3 access permissions
+  - Save the access code and secret key
+
+> NOTE: You can also reuse and existing IAM user as long as they have s3 access.
+
+## Setup Helm
+
+You will need to set some values and regenerate secret configs to enable thanos.
+
+### Download Thanos Chart
+
+```
+$ cd MAGMA_ROOT/orc8r/cloud/helm/orc8r/charts/metrics
+$ helm dep update
+```
+
+### Set values file
+
+Add the following section to your values file:
+
+```
+metrics:
+  thanos:
+    enabled: true
+    objstore:
+      config:
+        bucket: <S3-Bucket-Name>
+        endpoint: s3.<region-code>.amazonaws.com
+        region: <region-code>
+        access_key: <ACCESS_KEY>
+        secret_key: <SECRET_KEY>
+```
+
+### Generate and configure secrets
+
+Similar to the instructions at TODO Get the right URL HERE!!! https://magma.github.io/magma/docs/orc8r/deploy_intro, configure the necessary secrets but this time add a value to enable Thanos configurations:
+
+```
+helm template orc8r-secrets charts/secrets \
+    --namespace magma \
+    --set-string secret.certs.enabled=true \
+    --set-file secret.certs.files."rootCA\.pem"=charts/secrets/.secrets/certs/rootCA.pem \
+    --set-file secret.certs.files."controller\.crt"=charts/secrets/.secrets/certs/controller.crt \
+    --set-file secret.certs.files."controller\.key"=charts/secrets/.secrets/certs/controller.key \
+    --set-file secret.certs.files."admin_operator\.pem"=charts/secrets/.secrets/certs/admin_operator.pem \
+    --set-file secret.certs.files."admin_operator\.key\.pem"=charts/secrets/.secrets/certs/admin_operator.key.pem \
+    --set-file secret.certs.files."certifier\.pem"=charts/secrets/.secrets/certs/certifier.pem \
+    --set-file secret.certs.files."certifier\.key"=charts/secrets/.secrets/certs/certifier.key \
+    --set-file secret.certs.files."nms_nginx\.pem"=charts/secrets/.secrets/certs/nms_nginx.pem \
+    --set-file secret.certs.files."nms_nginx\.key\.pem"=charts/secrets/.secrets/certs/nms_nginx.key \
+    --set-thanos_enabled=true \
+    --set=docker.registry=$DOCKER_REGISTRY \
+    --set=docker.username=$DOCKER_USERNAME \
+    --set=docker.password=$DOCKER_PASSWORD |
+    kubectl apply -f -
+```
+
+### Redeploy with the thanos-enabled values file
+
+Follow instructions at <INSERT URL> and make sure to use the correct values file. If this succeeds your deployment should look like
+
+```
+NAME                                             READY   STATUS    RESTARTS   AGE
+mysql-57955549d5-jvs4t                           1/1     Running   0          6m33s
+nms-magmalte-6cdb5dc7f-qtlt8                     1/1     Running   0          8m45s
+nms-nginx-proxy-5b86f479f7-8v59t                 1/1     Running   0          8m45s
+orc8r-alertmanager-57d5d6ccc4-nkp8q              1/1     Running   0          8m45s
+orc8r-alertmanager-configurer-76cf8f8f57-mgr7h   1/1     Running   0          8m45s
+orc8r-controller-76948bc84-s67nd                 1/1     Running   0          8m44s
+orc8r-nginx-7d6c78647-98zb7                      1/1     Running   0          8m45s
+orc8r-prometheus-649ffd7ccb-hhjj2                2/2     Running   0          8m45s
+orc8r-prometheus-cache-6d647df4d9-wqnnk          1/1     Running   0          8m45s
+orc8r-prometheus-configurer-d474d69cc-rwrvz      2/2     Running   0          8m44s
+orc8r-thanos-compact-cd995b9fd-wjcb9             1/1     Running   0          8m45s
+orc8r-thanos-query-5c85d57886-dfpxb              1/1     Running   0          8m44s
+orc8r-thanos-store-0-7479bf59f6-54mg5            1/1     Running   0          8m45s
+orc8r-user-grafana-6498bb6959-lhmpj              1/1     Running   0          8m45s
+postgresql-0                                     1/1     Running   0          22m
+```
+
+No additional work is required and monitoring and alerting will work as usual, but now Thanos
+controls querying and long-term data storage in S3. Since the prometheus server retention time is now set to 6h, you can
+be certain that thanos querying is working once you see data that is older than 6 hours from when you deployed. Additionally,
+you can check the contents of your s3 bucket to see if prometheus data is making it there (will happen approximately every 2 hours). The bucket will look like this eventually:
+
+```
+aws s3 ls s3://<bucket-name> | head -n 8
+                           PRE 01EN12K3EAXRDN1E3JDYXGF8FN/
+                           PRE 01EN12N4W5GM8GPHJ3QCCJ3BKD/
+                           PRE 01EN75YA9D51XHMKG5CM27PBFQ/
+                           PRE 01EN9Z8JZZGW8GSK8SCB2NSHAA/
+                           PRE 01ENAHV7V9M3AVD2XBY6SQ8RT3/
+                           PRE 01ENAKTEP36W3QZSM7YX3MW3NS/
+                           PRE 01ENARPZ7VHD106BCGDE994HAN/
+                           PRE 01ENAZJPMZJAXXKH14B14TS0AX/
+```

--- a/orc8r/cloud/helm/orc8r/charts/metrics/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/requirements.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: thanos
+  repository: https://kubernetes-charts.banzaicloud.com
+  version: 0.3.28
+digest: sha256:ea189d2877a31a3d24d96ecad29be793fc222d85164afe07ab012bad725f0b8a
+generated: "2020-10-08T10:32:51.359786-07:00"

--- a/orc8r/cloud/helm/orc8r/charts/metrics/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/requirements.yaml
@@ -1,4 +1,3 @@
----
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -10,10 +9,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-prometheusQueryAddress: "http://prometheus:9090"
-# If using Thanos: comment out the above value and use the follwing:
-# prometheusQueryAddress: "http://thanosQuery:19192"
-
-alertmanagerApiURL: "http://alertmanager:9093/api/v2"
-prometheusConfigServiceURL: "http://prometheus-configurer:9100/v1"
-alertmanagerConfigServiceURL: "http://alertmanager-configurer:9101/v1"
+dependencies:
+  - name: thanos
+    version: 0.3.28
+    repository: "@banzaicloud-stable"
+    condition: thanos.enabled

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus-configurer.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus-configurer.deployment.yaml
@@ -49,6 +49,21 @@ spec:
       {{- end }}
 
       volumes:
+  {{ if .Values.thanos.enabled }}
+  {{ if .Values.thanos.thanosRule.enabled }}
+        - name: thanos-data
+          emptyDir: {}
+        - name: thanos-objstore-config
+          configMap:
+            name: thanos-objstore-config
+        {{ if .Values.thanos.rule.certSecretName }}
+        - name: {{ .Values.thanos.rule.certSecretName }}
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.thanos.rule.certSecretName }}
+        {{- end }}
+  {{- end }}
+  {{- end }}
         - name: "prometheus-config"
 {{ toYaml .Values.metrics.volumes.prometheusConfig.volumeSpec | indent 10 }}
 
@@ -69,4 +84,85 @@ spec:
             - "-restrict-queries"
           resources:
 {{ toYaml .Values.prometheusConfigurer.resources | indent 12 }}
+        {{ if .Values.thanos.enabled }}
+        {{ if .Values.thanos.thanosRule.enabled }}
+        - name: thanos-rule
+          image: "{{ .Values.thanos.image.repository }}:{{ .Values.thanos.image.tag }}"
+          imagePullPolicy: {{ .Values.thanos.image.pullPolicy }}
+          resources: {{ toYaml .Values.thanos.rule.resources | nindent 12 }}
+          {{- with .Values.thanos.rule.extraEnv }}
+          env: {{ toYaml . | nindent 10 }}
+          {{- end }}
+          args:
+            - "rule"
+            - "--data-dir=/var/thanos/store"
+            - "--log.level={{ .Values.thanos.rule.logLevel }}"
+            - "--log.format={{ .Values.thanos.rule.logFormat }}"
+            - "--http-address=0.0.0.0:{{ .Values.thanos.rule.http.port }}"
+            - "--grpc-address=0.0.0.0:{{ .Values.thanos.rule.grpc.port }}"
+            - "--objstore.config-file=/etc/thanos/objstore.yaml"
+            - "--rule-file={{ .Values.thanos.rule.ruleFile }}"
+            {{- range $key, $val := .Values.thanos.rule.ruleLabels }}
+            - '--label={{ $key }}={{ $val | quote }}'
+            {{- end }}
+            {{- if .Values.thanos.rule.resendDelay }}
+            - "--resend-delay={{ .Values.thanos.rule.resendDelay }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.evalInterval }}
+            - "--eval-interval={{ .Values.thanos.rule.evalInterval }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.tsdbBlockDuration }}
+            - "--tsdb.block-duration={{ .Values.thanos.rule.tsdbBlockDuration }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.tsdbRetention }}
+            - "--tsdb.retention={{ .Values.thanos.rule.tsdbRetention }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.webRoutePrefix }}
+            - "--web.route-prefix={{ .Values.thanos.rule.webRoutePrefix }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.webExternalPrefix }}
+            - "--web.external-prefix={{ .Values.thanos.rule.webExternalPrefix }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.webPrefixHeader }}
+            - "--web.prefix-header={{ .Values.thanos.rule.webPrefixHeader }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.queryDNSDiscovery }}
+            - "--query=dnssrv+_http._tcp.orc8r-thanos-query-http.{{ .Release.Namespace }}.svc.cluster.local"
+            {{- end  }}
+            {{- range .Values.thanos.rule.alertmanagers }}
+            - "--alertmanagers.url={{ . }}"
+            {{- end  }}
+            {{- if .Values.thanos.rule.alertmanagersSendTimeout }}
+            - "--alertmanagers.send-timeout={{ .Values.thanos.rule.alertmanagersSendTimeout }}"
+            {{- end }}
+            {{- if .Values.thanos.rule.alertQueryUrl }}
+            - "--alert.query-url={{ .Values.thanos.rule.alertQueryUrl }}"
+            {{- end }}
+            {{- range .Values.thanos.rule.alertLabelDrop }}
+            - "--alert.label-drop={{ . }}"
+            {{- end  }}
+            {{- if .Values.thanos.rule.extraArgs }}
+            {{- toYaml .Values.thanos.rule.extraArgs | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.thanos.rule.http.port }}
+            - name: grpc
+              containerPort: {{ .Values.thanos.rule.grpc.port }}
+          volumeMounts:
+            - name: prometheus-config
+              mountPath: /etc/rules
+              readOnly: true
+            - name: thanos-objstore-config
+              mountPath: /etc/thanos
+              readOnly: true
+            - name: thanos-data
+              mountPath: /var/thanos/store
+            {{- if .Values.thanos.rule.certSecretName }}
+            - mountPath: /etc/certs
+              name: {{ .Values.thanos.rule.certSecretName }}
+              readOnly: true
+            {{- end }}
+        {{- end }}
+        {{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/prometheus.deployment.yaml
@@ -29,6 +29,7 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/component: prometheus
+        app: prometheus
 {{ include "selector-labels" . | indent 8 }}
     spec:
       {{- with .Values.prometheus.nodeSelector }}
@@ -61,6 +62,12 @@ spec:
           configMap:
             name: orc8r-alert-rules
         {{- end}}
+        {{ if .Values.thanos.enabled }}
+        - name: "thanos-objstore-config"
+          configMap:
+            name: thanos-objstore-config
+        {{- end}}
+
 
   {{ if .Values.prometheus.useMinikube }}
       initContainers:
@@ -93,9 +100,16 @@ spec:
           ports:
             - containerPort: 9090
           args: ['--config.file=/prometheus/prometheus.yml',
-                 '--storage.tsdb.retention.time={{ .Values.prometheus.retention.time }}',
                  '--storage.tsdb.path=/data',
-                 '--web.enable-lifecycle']
+                 '--web.enable-lifecycle',
+                 {{ if .Values.thanos.enabled }}
+                 '--storage.tsdb.min-block-duration=2h',
+                 '--storage.tsdb.max-block-duration=2h',
+                 '--storage.tsdb.retention.time={{ .Values.thanos.prometheusRetentionTime }}',
+                 {{- else }}
+                 '--storage.tsdb.retention.time={{ .Values.prometheus.retention.time }}',
+                 {{- end}}
+                ]
           livenessProbe:
             httpGet:
               path: /graph
@@ -104,6 +118,24 @@ spec:
             periodSeconds: 30
           resources:
 {{ toYaml .Values.prometheus.resources | indent 12 }}
+        {{ if .Values.thanos.enabled }}
+        - name: "thanos-sidecar"
+          image: {{ required "thanos.image.repository must be provided" .Values.thanos.image.repository }}:{{ .Values.thanos.image.tag }}
+          imagePullPolicy: {{ .Values.thanos.image.pullPolicy }}
+          ports:
+            - name: grpc
+              containerPort: 10901
+          volumeMounts:
+            - name: "thanos-objstore-config"
+              mountPath: /etc/thanos
+              readOnly: true
+            - name: "prometheus-data"
+              mountPath: /data
+          args: ['sidecar',
+                 '--tsdb.path=/data',
+                 '--prometheus.url=http://localhost:9090', # Localhost since they run on same pod
+                 '--objstore.config-file=/etc/thanos/objstore.yaml']
+        {{- end}}
 
 ---
 apiVersion: v1

--- a/orc8r/cloud/helm/orc8r/charts/metrics/templates/thanos-objstore-config.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/templates/thanos-objstore-config.yaml
@@ -1,4 +1,4 @@
----
+{{/*
 # Copyright 2020 The Magma Authors.
 
 # This source code is licensed under the BSD-style license found in the
@@ -9,11 +9,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+*/}}
 
-prometheusQueryAddress: "http://prometheus:9090"
-# If using Thanos: comment out the above value and use the follwing:
-# prometheusQueryAddress: "http://thanosQuery:19192"
-
-alertmanagerApiURL: "http://alertmanager:9093/api/v2"
-prometheusConfigServiceURL: "http://prometheus-configurer:9100/v1"
-alertmanagerConfigServiceURL: "http://alertmanager-configurer:9101/v1"
+{{- if .Values.thanos.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: thanos-objstore-config
+data:
+  objstore.yaml: |
+{{ toYaml .Values.thanos.objstore | indent 4 }}
+{{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/values.yaml
@@ -6,15 +6,78 @@ metrics:
   # alertmanager, and configmanager pods
   volumes:
     prometheusData:
-      volumeSpec: {}
+      volumeSpec:
+        {}
         # hostPath:
         #   path: /prometheusData
         #   type: DirectoryOrCreate
     prometheusConfig:
-      volumeSpec: {}
+      volumeSpec:
+        {}
         # hostPath:
         #   path: /configs/prometheus
         #   type: DirectoryOrCreate
+
+thanos:
+  enabled: false
+
+  image:
+    repository: docker.io/thanosio/thanos
+    tag: v0.15.0
+    pullPolicy: IfNotPresent
+
+  prometheusRetentionTime: 6h
+
+  query:
+    storeDNSDiscovery: true
+    sidecarDNSDiscovery: true
+    logLevel: debug
+
+  # Use thanosRule.enabled for rule configurations since we are using a custom deployment
+  # instead of the third-party helm chart. Use thanos.rule for all other configs
+  # since those have the helm chart defaults. Thanos rule component must be deployed
+  # as part of prometheus-configurer deployment since configurer manages the shared
+  # config files
+  thanosRule:
+    enabled: true
+
+  rule:
+    enabled: false
+    alertmanagers:
+      - orc8r-alertmanager:9093
+    queryDNSDiscovery: true
+    ruleFile: "/etc/rules/alert_rules/*"
+
+  compact:
+    retentionResolutionRaw: 30d
+    retentionResolution5m: 120d
+    retentionResolution1h: 1y
+
+  bucket:
+    enabled: false
+
+  sidecar:
+    selector:
+      app.kubernetes.io/component: prometheus
+
+  objstore:
+    type: S3
+    config:
+      bucket: ""
+      endpoint: ""
+      region: ""
+      access_key: ""
+      secret_key: ""
+      insecure: false
+      signature_version2: false
+      put_user_metadata: {}
+      http_config:
+        idle_conn_timeout: 0s
+        response_header_timeout: 0s
+        insecure_skip_verify: false
+      trace:
+        enable: false
+      part_size: 0
 
 prometheus:
   # Enable/Disable chart

--- a/orc8r/cloud/helm/orc8r/charts/secrets/README.md
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/README.md
@@ -26,6 +26,8 @@ helm template charts/secrets \
 kubectl apply -f -
 ```
 
+Note: If deploying metrics with Thanos add `--set=thanos_enabled=true` when templating
+
 ## Overview
 
 This chart installs a set to secrets required by magma orchestrator.

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
@@ -21,7 +21,21 @@ metadata:
 {{ include "labels" . | indent 4 }}
 data:
 {{- if .Values.secret.configs.enabled }}
+{{ $thanos_enabled := .Values.thanos_enabled}}
 {{- range $key, $value := .Values.secret.configs.orc8r }}
+  # Set metricsd.yml explicitly if thanos is enabled
+  {{- if eq $key "metricsd.yml" }}
+    {{- if $thanos_enabled }}
+  {{ $value = `
+       profile: "prometheus"
+
+       prometheusQueryAddress: "http://{{ .Release.name }}-thanos-query-http:10902"
+
+       alertmanagerApiURL: "http://{{ .Release.name }}-alertmanager:9093/api/v2"
+       prometheusConfigServiceURL: "http://{{ .Release.name }}-prometheus-configurer:9100/v1"
+       alertmanagerConfigServiceURL: "http://{{ .Release.name }}-alertmanager-configurer:9101/v1"` }}
+    {{- end }}
+  {{- end }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/requirements.lock
+++ b/orc8r/cloud/helm/orc8r/requirements.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.1.7
 - name: metrics
   repository: ""
-  version: 1.4.18
+  version: 1.4.19
 - name: nms
   repository: ""
   version: 0.1.7
@@ -14,5 +14,5 @@ dependencies:
 - name: orc8rlib
   repository: file://../orc8rlib
   version: 0.1.1
-digest: sha256:02779c7381a791eaa6e962658e7703a06e641376c9769ac11b4b2cb98daabbed
-generated: "2020-10-15T14:36:59.18567-07:00"
+digest: sha256:2b29530032b5da56f56e70b64a36594e01fd61f0074cc8e48a520bc5e7a79d58
+generated: "2020-10-28T16:07:03.37778-07:00"

--- a/orc8r/cloud/helm/orc8r/requirements.yaml
+++ b/orc8r/cloud/helm/orc8r/requirements.yaml
@@ -15,7 +15,7 @@ dependencies:
     repository: ""
     condition: secrets.create
   - name: metrics
-    version: 1.4.18
+    version: 1.4.19
     repository: ""
     condition: metrics.enabled
   - name: nms

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -38,6 +38,8 @@ metrics:
     create: false
   prometheusConfigurer:
     create: false
+  thanos:
+    enabled: false
 
 # secrets sub-chart configuration.
 secrets:


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Deploys Thanos in kubernetes in the metrics helm chart. Installation steps described in README. Note: Will add tf support/automation for this in another diff, but as of now it requires a little bit of manual intervention to get set up.

* S3 bucket is used for object storage for all data older than 6 hours (thanos recommendation)
* Most of the functionality comes from the Bitnami thanos helm chart, but a few modifications had to be made on our deployment to get things working:
  * Prometheus/Alertmanager Configurer deployments had to be modified slightly to enable these to continue working as thanos complicates the configuration managment.
  * Prometheus deployment is modified to deploy the Thanos Sidecar along with it (when enabled)
  * Thanos Rule component is used for global rule evaluation. Since we're only deploying a single prometheus server still (so far) this isn't strictly necessary, but doing this will mean there's no work required on that end to scale up the number of servers we're running.
* Secrets management is updated to configure orc8r to point to Thanos Query component for querying instead of prometheus directly

## Test Plan
* Follow instructions in metrics README, see thanos is deployed
  * Also deploy with thanos disabled and see no changes

* S3 bucket after several days of running: 
![image](https://user-images.githubusercontent.com/13274915/97228031-91485480-1793-11eb-8e64-bf9a123ce506.png)

* Thanos Query operating showing it can query both the sidecar (immediate data) and the store (long-term data):
* Grafana works from the NMS
* Alerting rules can be created and alerts show up when triggered

Note: See terraform updates in https://github.com/magma/magma/pull/3509