### PR TITLE
[orc8r] Adding TAC to unmanaged eNB configs

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/lte/obsidian/handlers/handlers_test.go
@@ -2434,6 +2434,7 @@ func TestCreateEnodeb(t *testing.T) {
 				UnmanagedConfig: &lteModels.UnmanagedEnodebConfiguration{
 					CellID:    swag.Uint32(1234),
 					IPAddress: &ip,
+					Tac:       swag.Uint32(1),
 				},
 			},
 			Name:        "foobar",
@@ -2623,6 +2624,7 @@ func TestUpdateEnodeb(t *testing.T) {
 				UnmanagedConfig: &lteModels.UnmanagedEnodebConfiguration{
 					CellID:    swag.Uint32(1234),
 					IPAddress: &ip,
+					Tac:       swag.Uint32(1),
 				},
 			},
 			Name:        "foobar",

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -2060,6 +2060,7 @@ definitions:
     required:
       - cell_id
       - ip_address
+      - tac
     properties:
       cell_id:
         type: integer
@@ -2070,6 +2071,12 @@ definitions:
         type: string
         format: ipv4
         example: '192.168.1.142'
+      tac:
+        type: integer
+        format: uint32
+        minimum: 1
+        maximum: 65535
+        example: 1
 
   enodeb_state:
     description: Single Enodeb State

--- a/lte/cloud/go/services/lte/obsidian/models/unmanaged_enodeb_configuration_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/unmanaged_enodeb_configuration_swaggergen.go
@@ -26,6 +26,12 @@ type UnmanagedEnodebConfiguration struct {
 	// Required: true
 	// Format: ipv4
 	IPAddress *strfmt.IPv4 `json:"ip_address"`
+
+	// tac
+	// Required: true
+	// Maximum: 65535
+	// Minimum: 1
+	Tac *uint32 `json:"tac"`
 }
 
 // Validate validates this unmanaged enodeb configuration
@@ -37,6 +43,10 @@ func (m *UnmanagedEnodebConfiguration) Validate(formats strfmt.Registry) error {
 	}
 
 	if err := m.validateIPAddress(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateTac(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -66,6 +76,23 @@ func (m *UnmanagedEnodebConfiguration) validateIPAddress(formats strfmt.Registry
 	}
 
 	if err := validate.FormatOf("ip_address", "body", "ipv4", m.IPAddress.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *UnmanagedEnodebConfiguration) validateTac(formats strfmt.Registry) error {
+
+	if err := validate.Required("tac", "body", m.Tac); err != nil {
+		return err
+	}
+
+	if err := validate.MinimumInt("tac", "body", int64(*m.Tac), 1, false); err != nil {
+		return err
+	}
+
+	if err := validate.MaximumInt("tac", "body", int64(*m.Tac), 65535, false); err != nil {
 		return err
 	}
 

--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -331,6 +331,11 @@ func getEnodebConfigsBySerial(nwConfig *lte_models.NetworkCellularConfigs, gwCon
 		} else if enodebConfig.ConfigType == "UNMANAGED" {
 			cellularEnbConfig := enodebConfig.UnmanagedConfig
 			enbMconfig.CellId = int32(swag.Uint32Value(cellularEnbConfig.CellID))
+			enbMconfig.Tac = int32(swag.Uint32Value(cellularEnbConfig.Tac))
+
+			if enbMconfig.Tac == 0 {
+				enbMconfig.Tac = int32(nwConfig.Epc.Tac)
+			}
 		}
 
 		ret[serial] = enbMconfig

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -740,6 +740,7 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 			EnbConfigsBySerial: map[string]*lte_mconfig.EnodebD_EnodebConfig{
 				"enb1": {
 					CellId: 138777000,
+					Tac:    1,
 				},
 			},
 		},
@@ -761,7 +762,7 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 			HssRelayEnabled:          false,
 			CloudSubscriberdbEnabled: false,
 			EnableDnsCaching:         false,
-			AttachedEnodebTacs:       []int32{0},
+			AttachedEnodebTacs:       []int32{1},
 			NatEnabled:               true,
 		},
 		"pipelined": &lte_mconfig.PipelineD{
@@ -903,6 +904,7 @@ func newDefaultUnmanagedEnodebConfig() *lte_models.EnodebConfig {
 		ConfigType: "UNMANAGED",
 		UnmanagedConfig: &lte_models.UnmanagedEnodebConfiguration{
 			CellID:    swag.Uint32(138777000),
+			Tac:       swag.Uint32(1),
 			IPAddress: &ip,
 		},
 	}


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Adding TAC value to eNB unmanaged configs 
- MME filters invalid TAC values (0x0, 0xFE) which cause MME service to stop if registered eNB doesn't contain this value

## Test Plan

- make precommit
- running locally with eNB configured manually and UE and registering unmanaged radio for MME to validate

## Additional Information

- [x] This change is backwards-breaking

This adds `tac` field as required for unmanaged configs, however we don't have any of these registered yet on any of the environments so we should be good