### PR TITLE
[agw] [stateless MME] Fix for failing stateless AGW integration tests

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme.c
@@ -260,7 +260,7 @@ static int handle_message(zloop_t* loop, zsock_t* reader, void* arg) {
           mme_ue_s1ap_id_t mme_ue_s1ap_id = timer_arg.instance_id;
           if ((ue_ref_p = s1ap_state_get_ue_mmeid(mme_ue_s1ap_id)) == NULL) {
             OAILOG_WARNING_UE(
-                imsi64, LOG_S1AP,
+                LOG_S1AP, imsi64,
                 "Timer expired but no assoicated UE context for UE id %d\n",
                 mme_ue_s1ap_id);
             timer_handle_expired(

--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_state_manager.cpp
@@ -165,12 +165,6 @@ void S1apStateManager::clear_s1ap_imsi_map() {
   hashtable_uint64_ts_destroy(s1ap_imsi_map_->mme_ue_id_imsi_htbl);
 
   free_wrapper((void**) &s1ap_imsi_map_);
-
-  if (persist_state_enabled) {
-    std::vector<std::string> keys_to_del;
-    keys_to_del.emplace_back(S1AP_IMSI_MAP_TABLE_NAME);
-    redis_client->clear_keys(keys_to_del);
-  }
 }
 
 s1ap_imsi_map_t* S1apStateManager::get_s1ap_imsi_map() {

--- a/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_agw.sh
@@ -83,8 +83,6 @@ elif [[ $1 == "sctpd_post" ]]; then
     exit 0
   fi
   sudo service magma@magmad start
-  # Sleep for a bit so OVS and Magma services come up before proceeding
-  sleep 15
   exit 0
 else
   echo "Invalid argument. Use one of the following"
@@ -102,10 +100,12 @@ echo "Config complete"
 
 check_stateless_agw; ret_check=$?
 
-if [[ $ret_check -eq 1 ]]; then
+if [[ $ret_check -eq $RETURN_STATEFUL ]]; then
+  # For stateless AGW, Magmad is started as part of sctpd_post
   sudo service magma@magmad start
-  # Sleep for a bit so OVS and Magma services come up before proceeding
-  sleep 15
 fi
+
+# Sleep for a bit so OVS and Magma services come up before proceeding
+sleep 60
 
 exit $ret_check

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -119,15 +119,15 @@ s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
-s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_restore_mme_config_after_sanity.py
-#s1aptests/test_attach_detach_with_mobilityd_restart.py \
+s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
+s1aptests/test_attach_detach_attach_ul_tcp_data.py \
+s1aptests/test_restore_mme_config_after_sanity.py
 
 # These test cases pass without memory leaks, but needs DL-route in TRF server
 # sudo /sbin/route add -net 192.168.128.0 gw 192.168.60.142

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -121,13 +121,13 @@ s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
-s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
+s1aptests/test_attach_detach_attach_ul_tcp_data.py \
+s1aptests/test_restore_mme_config_after_sanity.py
+#s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_restore_mme_config_after_sanity.py
 
 # These test cases pass without memory leaks, but needs DL-route in TRF server
 # sudo /sbin/route add -net 192.168.128.0 gw 192.168.60.142


### PR DESCRIPTION
## Summary

Running the test `test_attach_detach_with_<service>_restart.py` for mme or mobilityd multiple times in a row was showing a failure while trying to detach an attached UE. This was happening as the `s1ap_imsi_map` table was getting cleared from Redis every time the MME process exited, leading to the error: 

`Received S1AP UPLINK_NAS_TRANSPORT No UE is attached to this mme_ue_s1ap_id`

This error only showed up for the second run of the test case even though each test case attaches/detaches two UEs. This is because the first UE detaches with detach-type "Normal detach", which triggered procedures to re-insert the entry in `s1ap_imsi_map`. Only for the second UE, which detached with detach-type "Switch-off" the map stays empty forever.

This change fixes this issue by
- Removing the logic that clears the S1ap imsi map whenever service exits
- Increasing the delay on the stateless config switch script to 30 seconds to work around https://github.com/magma/magma/issues/3077
- Minor edit on a logging statement
- Re-add control plane stateless tests to sanity test suite, data tests still need to be fixed

## Test Plan

- S1AP integration tests with all stateless test cases included
- Run `test_attach_detach_with_mme_restart.py` multiple times and make sure the above error does not occur
- Integration test with CUPS SPGW will be done in Jenkins CI


