### PR TITLE
[docs] Add note for tcpdump requirement for DHCP_BROADCAST IP allocation

### DIFF
--- a/docs/readmes/howtos/ue_ip_address_management.md
+++ b/docs/readmes/howtos/ue_ip_address_management.md
@@ -95,6 +95,8 @@ first-come-first-served basis.
 
 ### DHCP
 
+NOTE: This feature requires installed `libpcap`.
+
 To enable this feature, set `ip_allocation_mode` to `DHCP_BROADCAST`.
 
 ```


### PR DESCRIPTION
Signed-off-by: Oleksandr Berezovskyi <berezovskyi.oleksandr@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Current documentation doesn't mention, that it is required to have `tcpdump` installed to use DHCP_BROADCAST IP allocation.

This pull request adds a note for that.
<!-- Enumerate changes you made and why you made them -->
