### PR TITLE
[docs] Fix sgi_management_iface_vlan configuration example

### DIFF
--- a/docs/readmes/howtos/ue_ip_address_management.md
+++ b/docs/readmes/howtos/ue_ip_address_management.md
@@ -231,7 +231,7 @@ API: /lte/{network_id}/gateways/{gateway_id}/cellular
 {
   "epc": {
     ...
-    "sgi_management_iface_vlan": 100
+    "sgi_management_iface_vlan": "100"
     ...
   },
 ```


### PR DESCRIPTION
Signed-off-by: Oleksandr Berezovskyi <berezovskyi.oleksandr@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

In current documentation example, `sgi_management_iface_vlan` shown as an integer field.
It should be string instead.
