### PR TITLE
[SessionD] Fix UserLocationInfo and add some more fields to terminate event

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -162,7 +162,7 @@ add_library(SESSION_MANAGER
     AmfServiceClient.h
     AmfServiceClient.cpp
     ${PROTO_SRCS}
-    ${PROTO_HDRS})
+    ${PROTO_HDRS} Utilities.cpp Utilities.h)
 
 
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -148,8 +148,6 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
       SessionMap& session_map, const SubscriberID& sid, const std::string& apn,
       std::function<void(Status, LocalEndSessionResponse)> response_callback);
 
-  std::string convert_mac_addr_to_str(const std::string& mac_addr);
-
   void add_session_to_directory_record(
       const std::string& imsi, const std::string& session_id,
       const std::string& msisdn);
@@ -224,8 +222,6 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
           response_callback);
 
   void log_create_session(SessionConfig& cfg);
-
-  std::string bytes_to_hex(const std::string& s);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/SessionCredit.cpp
+++ b/lte/gateway/c/session_manager/SessionCredit.cpp
@@ -17,15 +17,7 @@
 #include "EnumToString.h"
 #include "SessionCredit.h"
 #include "magma_logging.h"
-
-namespace {
-uint64_t get_time_in_sec_since_epoch() {
-  auto now = std::chrono::system_clock::now();
-  return std::chrono::duration_cast<std::chrono::seconds>(
-             now.time_since_epoch())
-      .count();
-}
-}  // namespace
+#include "Utilities.h"
 
 namespace magma {
 
@@ -115,7 +107,7 @@ void SessionCredit::add_used_credit(
 
 void SessionCredit::update_usage_timestamps(
     SessionCreditUpdateCriteria& credit_uc) {
-  auto now = get_time_in_sec_since_epoch();
+  auto now = magma::get_time_in_sec_since_epoch();
   if (time_of_first_usage_ == 0) {
     time_of_first_usage_          = now;
     credit_uc.time_of_first_usage = now;

--- a/lte/gateway/c/session_manager/Utilities.cpp
+++ b/lte/gateway/c/session_manager/Utilities.cpp
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <chrono>
+#include <sstream>
+#include <iomanip>
+#include <google/protobuf/util/time_util.h>
+
+#include "Utilities.h"
+
+namespace magma {
+
+std::string bytes_to_hex(const std::string& s) {
+  std::ostringstream ret;
+  unsigned int c;
+  for (std::string::size_type i = 0; i < s.length(); ++i) {
+    c = (unsigned int) (unsigned char) s[i];
+    ret << " " << std::hex << std::setfill('0') << std::setw(2)
+        << (std::nouppercase) << c;
+  }
+  return ret.str();
+}
+
+uint64_t get_time_in_sec_since_epoch() {
+  auto now = std::chrono::system_clock::now();
+  return std::chrono::duration_cast<std::chrono::seconds>(
+             now.time_since_epoch())
+      .count();
+}
+
+std::chrono::milliseconds time_difference_from_now(
+    const google::protobuf::Timestamp& timestamp) {
+  const auto rule_time_sec =
+      google::protobuf::util::TimeUtil::TimestampToSeconds(timestamp);
+  const auto now   = time(NULL);
+  const auto delta = std::max(rule_time_sec - now, 0L);
+  std::chrono::seconds sec(delta);
+  return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
+}
+
+}  // namespace magma

--- a/lte/gateway/c/session_manager/Utilities.h
+++ b/lte/gateway/c/session_manager/Utilities.h
@@ -1,0 +1,23 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <google/protobuf/timestamp.pb.h>
+#include <google/protobuf/util/time_util.h>
+
+namespace magma {
+std::string bytes_to_hex(const std::string& s);
+uint64_t get_time_in_sec_since_epoch();
+std::chrono::milliseconds time_difference_from_now(
+    const google::protobuf::Timestamp& timestamp);
+}  // namespace magma


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Created `Utilities.cpp`/`Utilities.h` to include non class specific functions.
Converting the UserLocationInformation field to be a string of hex values to make sure it is utf-8 friendly
Adding some additional fields that are specific to the CDR needs.
- `DURATION`
- `CAUSE_FOR_RECORD_CLOSING`
- `RECORD_SEQUENCE_NUMBER`
I have added the fields here for now, but I am working on moving these fields out to an upper-layer logic.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
Running S1AP tests to make sure there are no issues with event serialization
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
