### PR TITLE
[lte][agw] Remove interface leftover logging on gtp_stats_collector

### DIFF
--- a/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
+++ b/lte/gateway/python/magma/pipelined/gtp_stats_collector.py
@@ -40,7 +40,7 @@ interface_group = r"(?P<Interface>\w+)"
 remote_ip_group = r"(?P<remote_ip>.*)"
 rx_bytes_group = r"(?P<rx_bytes>\d+)"
 tx_bytes_group = r"(?P<tx_bytes>\d+)"
-stats_re_str = r'"{}"(.*)(remote_ip="{}"(.*))?rx_bytes={}.+tx_bytes={}'
+stats_re_str = r'"{}"(.*)(remote_ip="{}")(.*)?rx_bytes={}.+tx_bytes={}'
 
 interface_tx_rx_stats_re = re.compile(
     stats_re_str.format(interface_group, remote_ip_group, rx_bytes_group,
@@ -80,7 +80,6 @@ class GTPStatsCollector(Job):
         for r in list(dump_stats_results)[0].out:
             if GTP_IP_INTERFACE_PREFIX in r.Interface or \
                     r.Interface == GTP_INTERFACE_PREFIX:
-                logging.info(r.Interface)
                 GTP_PORT_USER_PLANE_DL_BYTES.labels(r.remote_ip).inc(
                     float(r.rx_bytes))
                 GTP_PORT_USER_PLANE_UL_BYTES.labels(r.remote_ip).inc(


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Removed logging.info for interface match on gtp_stats_collector
- Updated remote_ip regex match

## Test Plan

- make test
- make integ_test

```
name: "gtp_port_user_plane_dl_bytes"
type: COUNTER
metric {
  label {
    name: "ip_addr"
    value: "192.168.60.141"
  }
  counter {
    value: 0.0
  }
  timestamp_ms: 1603822145408
}
```

## Additional Information

- [ ] This change is backwards-breaking
