### PR TITLE
[pipelined]Remove default enf stats rule on sub deactivation

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -374,6 +374,13 @@ class EnforcementStatsController(PolicyMixin, MagmaController):
 
         self._delete_old_flows(stats_msgs)
 
+    def deactivate_default_flow(self, imsi, ip_addr):
+        match_in = _generate_rule_match(imsi, ip_addr, 0, 0, Direction.IN)
+        match_out = _generate_rule_match(imsi, ip_addr, 0, 0, Direction.OUT)
+
+        flows.delete_flow(self._datapath, self.tbl_num, match_in)
+        flows.delete_flow(self._datapath, self.tbl_num, match_out)
+
     def _report_usage(self, delta_usage):
         """
         Report usage to sessiond using rpc

--- a/lte/gateway/python/magma/pipelined/rpc_servicer.py
+++ b/lte/gateway/python/magma/pipelined/rpc_servicer.py
@@ -327,6 +327,8 @@ class PipelinedRpcServicer(pipelined_pb2_grpc.PipelinedServicer):
             # If no rule ids are given, all flows are deactivated
             self._service_manager.session_rule_version_mapper.update_version(
                 request.sid.id, ip_address)
+            self._enforcement_stats.deactivate_default_flow(request.sid.id,
+                                                            ip_address)
         self._enforcer_app.deactivate_rules(request.sid.id, ip_address,
                                             request.rule_ids)
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement_stats.EnforcementStatsTest.test_rule_deactivation.nuke_ue.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_enforcement_stats.EnforcementStatsTest.test_rule_deactivation.nuke_ue.snapshot
@@ -1,0 +1,2 @@
+ cookie=0xfffffffffffffffe, table=enforcement(main_table), n_packets=3968, n_bytes=134912, priority=0 actions=resubmit(,enforcement_stats(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0xfffffffffffffffe, table=enforcement_stats(main_table), n_packets=0, n_bytes=0, priority=0 actions=drop

--- a/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/tests/test_enforcement_stats.py
@@ -524,6 +524,14 @@ class EnforcementStatsTest(unittest.TestCase):
 
         self.assertEqual(len(stats), 1)
 
+        self.enforcement_stats_controller.deactivate_default_flow(
+            imsi, convert_ipv4_str_to_ip_proto(sub_ip))
+        snapshot_verifier = SnapshotVerifier(self, self.BRIDGE,
+                                             self.service_manager,
+                                             'nuke_ue')
+        with snapshot_verifier:
+            pass
+
     def test_rule_reactivation(self):
         """
         Adds a policy to a subscriber, deletes it by incrementing the


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Previously we were not removing the default stats flow, this pr fixes that

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
