### PR TITLE
[sessiond] add dropped bytes to add_rule_usage

### DIFF
--- a/lte/gateway/c/session_manager/PipelinedClient.h
+++ b/lte/gateway/c/session_manager/PipelinedClient.h
@@ -69,6 +69,19 @@ class PipelinedClient {
   virtual bool deactivate_all_flows(const std::string& imsi) = 0;
 
   /**
+   * Deactivate all flows for the specified rules plus any drop default rule
+   * added by pipelined
+   * @param imsi - UE to delete flows for
+   * @param rule_ids - rules to deactivate
+   * @return true if the operation was successful
+   */
+  virtual bool deactivate_flows_for_rules_for_termination(
+      const std::string& imsi, const std::string& ip_addr,
+      const std::string& ipv6_addr, const std::vector<std::string>& rule_ids,
+      const std::vector<PolicyRule>& dynamic_rules,
+      const RequestOriginType_OriginType origin_type) = 0;
+
+  /**
    * Deactivate all flows for the specified rules
    * @param imsi - UE to delete flows for
    * @param rule_ids - rules to deactivate
@@ -183,6 +196,19 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
   bool deactivate_all_flows(const std::string& imsi);
 
   /**
+   * Deactivate all flows related to a specific charging key plus any default
+   * rule installed by pipelined. Used for session termination.
+   * @param imsi - UE to delete flows for
+   * @param charging_key - key to deactivate
+   * @return true if the operation was successful
+   */
+  bool deactivate_flows_for_rules_for_termination(
+      const std::string& imsi, const std::string& ip_addr,
+      const std::string& ipv6_addr, const std::vector<std::string>& rule_ids,
+      const std::vector<PolicyRule>& dynamic_rules,
+      const RequestOriginType_OriginType origin_type);
+
+  /**
    * Deactivate all flows related to a specific charging key
    * @param imsi - UE to delete flows for
    * @param charging_key - key to deactivate
@@ -193,6 +219,13 @@ class AsyncPipelinedClient : public GRPCReceiver, public PipelinedClient {
       const std::string& ipv6_addr, const std::vector<std::string>& rule_ids,
       const std::vector<PolicyRule>& dynamic_rules,
       const RequestOriginType_OriginType origin_type);
+
+  /**
+   * Deactivate all flows included on the request
+   * @param request
+   * @return true if the operation was successful
+   */
+  bool deactivate_flows(DeactivateFlowsRequest& request);
 
   /**
    * Activate all rules for the specified rules, using a normal vector

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -428,6 +428,7 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
 
 void SessionState::add_rule_usage(
     const std::string& rule_id, uint64_t used_tx, uint64_t used_rx,
+    uint64_t dropped_tx, uint64_t dropped_rx,
     SessionStateUpdateCriteria& update_criteria) {
   CreditKey charging_key;
   if (dynamic_rules_.get_charging_key_for_rule_id(rule_id, &charging_key) ||
@@ -459,8 +460,9 @@ void SessionState::add_rule_usage(
     add_to_monitor(session_level_key_, used_tx, used_rx, update_criteria);
   }
   if (is_dynamic_rule_installed(rule_id) || is_static_rule_installed(rule_id)) {
-    update_data_usage_metrics(used_tx, used_rx);
+    update_used_data_metrics(used_tx, used_rx);
   }
+  update_dropped_data_metrics(dropped_tx, dropped_rx);
 }
 
 void SessionState::apply_session_rule_set(
@@ -1959,7 +1961,7 @@ optional<RuleSetToApply> RuleSetBySubscriber::get_combined_rule_set_for_apn(
   return {};
 }
 
-void SessionState::update_data_usage_metrics(
+void SessionState::update_used_data_metrics(
     uint64_t bytes_tx, uint64_t bytes_rx) {
   const auto sid    = get_config().common_context.sid().id();
   const auto msisdn = get_config().common_context.msisdn();
@@ -1970,6 +1972,21 @@ void SessionState::update_data_usage_metrics(
       DIRECTION_UP);
   increment_counter(
       "ue_reported_usage", bytes_rx, size_t(4), LABEL_IMSI, sid.c_str(),
+      LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
+      DIRECTION_DOWN);
+}
+
+void SessionState::update_dropped_data_metrics(
+    uint64_t dropped_tx, uint64_t dropped_rx) {
+  const auto sid    = get_config().common_context.sid().id();
+  const auto msisdn = get_config().common_context.msisdn();
+  const auto apn    = get_config().common_context.apn();
+  increment_counter(
+      "ue_dropped_usage", dropped_tx, size_t(4), LABEL_IMSI, sid.c_str(),
+      LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
+      DIRECTION_UP);
+  increment_counter(
+      "ue_dropped_usage", dropped_rx, size_t(4), LABEL_IMSI, sid.c_str(),
       LABEL_APN, apn.c_str(), LABEL_MSISDN, msisdn.c_str(), LABEL_DIRECTION,
       DIRECTION_DOWN);
 }

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -173,6 +173,7 @@ class SessionState {
    */
   void add_rule_usage(
       const std::string& rule_id, uint64_t used_tx, uint64_t used_rx,
+      uint64_t dropped_tx, uint64_t dropped_rx,
       SessionStateUpdateCriteria& update_criteria);
 
   /**
@@ -713,7 +714,14 @@ class SessionState {
    * @param bytes_tx
    * @param bytes_rx
    */
-  void update_data_usage_metrics(uint64_t bytes_tx, uint64_t bytes_rx);
+  void update_used_data_metrics(uint64_t bytes_tx, uint64_t bytes_rx);
+
+  /**
+   * Increments data usage values for session
+   * @param dropped_tx
+   * @param dropped_rx
+   */
+  void update_dropped_data_metrics(uint64_t dropped_tx, uint64_t dropped_rx);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -88,6 +88,21 @@ void create_rule_record(
   rule_record->set_rule_id(rule_id);
   rule_record->set_bytes_rx(bytes_rx);
   rule_record->set_bytes_tx(bytes_tx);
+  rule_record->set_dropped_rx(0);
+  rule_record->set_dropped_tx(0);
+  rule_record->set_ue_ipv4(ip);
+}
+
+void create_rule_record(
+    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    uint64_t bytes_rx, uint64_t bytes_tx, uint64_t dropped_rx,
+    uint64_t dropped_tx, RuleRecord* rule_record) {
+  rule_record->set_sid(imsi);
+  rule_record->set_rule_id(rule_id);
+  rule_record->set_bytes_rx(bytes_rx);
+  rule_record->set_bytes_tx(bytes_tx);
+  rule_record->set_dropped_rx(dropped_rx);
+  rule_record->set_dropped_tx(dropped_tx);
   rule_record->set_ue_ipv4(ip);
 }
 

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -46,6 +46,11 @@ void create_rule_record(
     const std::string& imsi, const std::string& ip, const std::string& rule_id,
     uint64_t bytes_rx, uint64_t bytes_tx, RuleRecord* rule_record);
 
+void create_rule_record(
+    const std::string& imsi, const std::string& ip, const std::string& rule_id,
+    uint64_t bytes_rx, uint64_t bytes_tx, uint64_t dropped_rx,
+    uint64_t dropped_tx, RuleRecord* rule_record);
+
 void create_charging_credit(
     uint64_t volume, bool is_final, ChargingCredit* credit);
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -67,6 +67,8 @@ class MockPipelinedClient : public PipelinedClient {
     ON_CALL(*this, deactivate_all_flows(_)).WillByDefault(Return(true));
     ON_CALL(*this, deactivate_flows_for_rules(_, _, _, _, _, _))
         .WillByDefault(Return(true));
+    ON_CALL(*this, deactivate_flows_for_rules_for_termination(_, _, _, _, _, _))
+        .WillByDefault(Return(true));
     ON_CALL(*this, activate_flows_for_rules(_, _, _, _, _, _, _))
         .WillByDefault(Return(true));
     ON_CALL(*this, add_ue_mac_flow(_, _, _, _, _, _))
@@ -102,6 +104,14 @@ class MockPipelinedClient : public PipelinedClient {
   MOCK_METHOD1(deactivate_all_flows, bool(const std::string& imsi));
   MOCK_METHOD6(
       deactivate_flows_for_rules,
+      bool(
+          const std::string& imsi, const std::string& ip_addr,
+          const std::string& ipv6_addr,
+          const std::vector<std::string>& rule_ids,
+          const std::vector<PolicyRule>& dynamic_rules,
+          const RequestOriginType_OriginType origin_type));
+  MOCK_METHOD6(
+      deactivate_flows_for_rules_for_termination,
       bool(
           const std::string& imsi, const std::string& ip_addr,
           const std::string& ipv6_addr,

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -262,7 +262,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
   grpc::ServerContext create_context;
   EXPECT_CALL(
       *pipelined_client,
-      deactivate_flows_for_rules(
+      deactivate_flows_for_rules_for_termination(
           IMSI1, _, _, CheckCount(1), CheckCount(0), RequestOriginType::GX))
       .Times(1)
       .WillOnce(testing::Return(true));

--- a/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_manager_handler.cpp
@@ -206,7 +206,7 @@ TEST_F(SessionManagerHandlerTest, test_session_recycling_lte) {
   // Termination process for the previous session is started
   EXPECT_CALL(
       *pipelined_client,
-      deactivate_flows_for_rules(
+      deactivate_flows_for_rules_for_termination(
           IMSI1, IP1, IPv6_1, testing::_, testing::_, testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));

--- a/lte/gateway/c/session_manager/test/test_session_state.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_state.cpp
@@ -259,7 +259,7 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
           .credit.buckets[ALLOWED_TOTAL],
       3000);
 
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
@@ -270,7 +270,7 @@ TEST_F(SessionStateTest, test_add_rule_usage) {
   EXPECT_EQ(
       update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 1000);
 
-  session_state->add_rule_usage("dyn_rule1", 4000, 2000, update_criteria);
+  session_state->add_rule_usage("dyn_rule1", 4000, 2000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_RX), 2000);
   EXPECT_EQ(session_state->get_monitor("m2", USED_TX), 4000);
@@ -326,7 +326,7 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
           .credit.buckets[ALLOWED_TOTAL],
       3000);
 
-  session_state->add_rule_usage("dyn_rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("dyn_rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
 
@@ -335,13 +335,13 @@ TEST_F(SessionStateTest, test_mixed_tracking_rules) {
   EXPECT_EQ(
       update_criteria.monitor_credit_map["m1"].bucket_deltas[USED_RX], 1000);
 
-  session_state->add_rule_usage("dyn_rule2", 4000, 2000, update_criteria);
+  session_state->add_rule_usage("dyn_rule2", 4000, 2000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_RX), 2000);
   EXPECT_EQ(
       update_criteria.charging_credit_map[CreditKey(2)].bucket_deltas[USED_TX],
       4000);
-  session_state->add_rule_usage("dyn_rule3", 5000, 3000, update_criteria);
+  session_state->add_rule_usage("dyn_rule3", 5000, 3000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(3, USED_TX), 5000);
   EXPECT_EQ(session_state->get_charging_credit(3, USED_RX), 3000);
   EXPECT_EQ(
@@ -371,7 +371,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   EXPECT_EQ(update_criteria.updated_session_level_key, "m1");
 
   // add usage to go over quota
-  session_state->add_rule_usage("rule1", 5000, 2000, update_criteria);
+  session_state->add_rule_usage("rule1", 5000, 2000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 5000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2000);
   EXPECT_EQ(
@@ -395,7 +395,7 @@ TEST_F(SessionStateTest, test_session_level_key) {
   receive_credit_from_pcrf("m1", 0, MonitoringLevel::SESSION_LEVEL);
 
   // add usage to go over quota
-  session_state->add_rule_usage("rule1", 1001, 1, update_criteria);
+  session_state->add_rule_usage("rule1", 1001, 1, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 6001);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2001);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -432,7 +432,7 @@ TEST_F(SessionStateTest, test_reauth_key) {
 
   receive_credit_from_ocs(1, 1500);
 
-  session_state->add_rule_usage("rule1", 1000, 500, update_criteria);
+  session_state->add_rule_usage("rule1", 1000, 500, 0, 0, update_criteria);
 
   UpdateSessionRequest update;
   std::vector<std::unique_ptr<ServiceAction>> actions;
@@ -459,7 +459,7 @@ TEST_F(SessionStateTest, test_reauth_key) {
   reauth_res = session_state->reauth_key(1, uc);
   EXPECT_EQ(reauth_res, ReAuthResult::UPDATE_INITIATED);
 
-  session_state->add_rule_usage("rule1", 2, 1, update_criteria);
+  session_state->add_rule_usage("rule1", 2, 1, 0, 0, update_criteria);
   UpdateSessionRequest reauth_update;
   session_state->get_updates(reauth_update, &actions, update_criteria);
   EXPECT_EQ(reauth_update.updates_size(), 1);
@@ -519,8 +519,8 @@ TEST_F(SessionStateTest, test_reauth_all) {
   receive_credit_from_ocs(1, 1024);
   receive_credit_from_ocs(2, 1024);
 
-  session_state->add_rule_usage("rule1", 10, 20, update_criteria);
-  session_state->add_rule_usage("dyn_rule1", 30, 40, update_criteria);
+  session_state->add_rule_usage("rule1", 10, 20, 0, 0, update_criteria);
+  session_state->add_rule_usage("dyn_rule1", 30, 40, 0, 0, update_criteria);
   // If any charging key isn't reporting, an update is needed
   auto uc         = get_default_update_criteria();
   auto reauth_res = session_state->reauth_all(uc);
@@ -559,7 +559,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
   receive_credit_from_pcrf("m1", 1024, MonitoringLevel::PCC_RULE_LEVEL);
   receive_credit_from_ocs(1, 1024);
   insert_rule(1, "m1", "rule1", STATIC, 0, 0);
-  session_state->add_rule_usage("rule1", 1024, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1024, 0, 0, 0, update_criteria);
   EXPECT_EQ(true, session_state->active_monitored_rules_exist());
 
   EXPECT_EQ(session_state->get_monitor("m1", ALLOWED_TOTAL), 1024);
@@ -589,7 +589,7 @@ TEST_F(SessionStateTest, test_tgpp_context_is_set_on_update) {
 
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
   insert_rule(0, "", "rule1", STATIC, 0, 0);
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   SessionState::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
@@ -601,7 +601,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_no_key) {
 TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_single_key) {
   insert_rule(1, "", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   SessionState::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 0);
@@ -614,7 +614,7 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_single_rule_multiple_key) {
   insert_rule(1, "m1", "rule1", STATIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   SessionState::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 2000);
@@ -630,8 +630,8 @@ TEST_F(SessionStateTest, test_get_total_credit_usage_multiple_rule_shared_key) {
   insert_rule(0, "m1", "rule2", DYNAMIC, 0, 0);
   receive_credit_from_ocs(1, 3000);
   receive_credit_from_pcrf("m1", 3000, MonitoringLevel::PCC_RULE_LEVEL);
-  session_state->add_rule_usage("rule1", 1000, 10, update_criteria);
-  session_state->add_rule_usage("rule2", 500, 5, update_criteria);
+  session_state->add_rule_usage("rule1", 1000, 10, 0, 0, update_criteria);
+  session_state->add_rule_usage("rule2", 500, 5, 0, 0, update_criteria);
   SessionState::TotalCreditUsage actual =
       session_state->get_total_credit_usage();
   EXPECT_EQ(actual.monitoring_tx, 1500);
@@ -767,7 +767,7 @@ TEST_F(SessionStateTest, test_empty_credit_grant) {
   EXPECT_EQ(u_credit.credit.buckets[ALLOWED_RX], 0);
 
   // Report some rule usage, and ensure the final action gets triggered
-  session_state->add_rule_usage("rule1", 100, 100, update_criteria);
+  session_state->add_rule_usage("rule1", 100, 100, 0, 0, update_criteria);
   auto credit_uc = update_criteria.charging_credit_map[1];
   EXPECT_EQ(credit_uc.service_state, SERVICE_NEEDS_DEACTIVATION);
 }
@@ -813,11 +813,11 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
       2000);
 
   // add usage for 2 times to go over quota
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
 
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
 
@@ -873,7 +873,7 @@ TEST_F(SessionStateTest, test_multiple_final_action_empty_grant) {
       0);
 
   // force to check for the state (no traffic sent)
-  session_state->add_rule_usage("rule1", 0, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 0, 0, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 2000);
   EXPECT_TRUE(update_criteria.charging_credit_map[CreditKey(1)].is_final);
@@ -990,7 +990,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   // reset update_criteria (before any add_rule_usage)
   // update_criteria = get_default_update_criteria();
   // add usage for 2 times to go over quota
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 2000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 1000);
   EXPECT_FALSE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -1001,7 +1001,7 @@ TEST_F(SessionStateTest, test_monitor_cycle) {
   receive_credit_from_pcrf("m1", 0, 100, 200, MonitoringLevel::PCC_RULE_LEVEL);
   // reset update_criteria (before any add_rule_usage)
   // update_criteria = get_default_update_criteria();
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 4000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 2000);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);
@@ -1042,11 +1042,11 @@ TEST_F(SessionStateTest, test_get_charging_credit_summaries) {
           .credit.buckets[ALLOWED_TOTAL],
       3000);
 
-  session_state->add_rule_usage("rule1", 2000, 1000, update_criteria);
+  session_state->add_rule_usage("rule1", 2000, 1000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_TX), 2000);
   EXPECT_EQ(session_state->get_charging_credit(1, USED_RX), 1000);
 
-  session_state->add_rule_usage("dyn_rule1", 4000, 2000, update_criteria);
+  session_state->add_rule_usage("dyn_rule1", 4000, 2000, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_TX), 4000);
   EXPECT_EQ(session_state->get_charging_credit(2, USED_RX), 2000);
 

--- a/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
+++ b/lte/gateway/c/session_manager/test/test_usage_monitor.cpp
@@ -56,7 +56,7 @@ TEST_F(SessionStateTest, test_remove_monitor) {
           .credit.buckets[ALLOWED_TOTAL],
       1000);
 
-  session_state->add_rule_usage("rule1", 1000, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1000, 0, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1000);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
 
@@ -66,7 +66,7 @@ TEST_F(SessionStateTest, test_remove_monitor) {
   update_criteria = get_default_update_criteria();
 
   // add usage to trigger the quota exhaustion
-  session_state->add_rule_usage("rule1", 1, 0, update_criteria);
+  session_state->add_rule_usage("rule1", 1, 0, 0, 0, update_criteria);
   EXPECT_EQ(session_state->get_monitor("m1", USED_TX), 1001);
   EXPECT_EQ(session_state->get_monitor("m1", USED_RX), 0);
   EXPECT_TRUE(update_criteria.monitor_credit_map["m1"].report_last_credit);

--- a/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
+++ b/lte/gateway/python/magma/pipelined/app/enforcement_stats.py
@@ -423,8 +423,6 @@ class EnforcementStatsController(PolicyMixin, MagmaController):
             else:
                 # This must be the default drop flow
                 rule_id = self._default_drop_flow_name
-                # TODO wait for sessiond changes and remove this return
-                return current_usage
         # If this is a pass through app name flow ignore stats
         if _get_policy_type(flow_stat.match) == IGNORE_STATS:
             return current_usage


### PR DESCRIPTION


Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Before, pipelined was reporting rules with allowed traffic. Now, in order to report as a metric the number of packets dropped, pipelined will report
- Dropped bytes: grpc message was previously modified to include `dropped_tx` and `dropped_rx`.
- Internal drop rule: `internal_default_drop_flow_rule` which will be used to report any packet dropped by traffic not matching anyo the installed rules.

That change causes some conflict on how we handle termination: so far we were terminating users that were on terminate state AND pipelined did not send any report for them. Now, since we will always have reports from dropped `internal_default_drop_flow_rule` we have to better define this condition

Also this PR includes the new metrics to be sent for `dropped bytes`

## Test Plan

make precommit_sm
test in teravm

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
