### PR TITLE
[NMS] Adding network from network selector is broken

### DIFF
--- a/nms/app/packages/magmalte/app/components/lte/LteContext.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteContext.js
@@ -23,6 +23,7 @@ import type {
   mutable_subscriber,
   network_id,
   network_ran_configs,
+  network_type,
   policy_qos_profile,
   policy_rule,
   rating_group,
@@ -43,7 +44,7 @@ import NetworkContext from '../../components/context/NetworkContext';
 import PolicyContext from '../context/PolicyContext';
 import SubscriberContext from '../context/SubscriberContext';
 
-import {FEG_LTE} from '@fbcnms/types/network';
+import {FEG_LTE, LTE} from '@fbcnms/types/network';
 import {
   InitEnodeState,
   InitTierState,
@@ -70,6 +71,7 @@ import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 
 type Props = {
   networkId: network_id,
+  networkType: network_type,
   children: React.Node,
 };
 
@@ -601,15 +603,28 @@ export function LteNetworkContextProvider(props: Props) {
 }
 
 export function LteContextProvider(props: Props) {
-  const {networkId} = props;
+  const {networkId, networkType} = props;
+  const lteNetwork = networkType === LTE || networkType === FEG_LTE;
+  if (!lteNetwork) {
+    return props.children;
+  }
+
   return (
-    <LteNetworkContextProvider networkId={networkId}>
-      <PolicyProvider networkId={networkId}>
-        <ApnProvider networkId={networkId}>
-          <SubscriberContextProvider networkId={networkId}>
-            <GatewayTierContextProvider networkId={networkId}>
-              <EnodebContextProvider networkId={networkId}>
-                <GatewayContextProvider networkId={networkId}>
+    <LteNetworkContextProvider networkId={networkId} networkType={networkType}>
+      <PolicyProvider networkId={networkId} networkType={networkType}>
+        <ApnProvider networkId={networkId} networkType={networkType}>
+          <SubscriberContextProvider
+            networkId={networkId}
+            networkType={networkType}>
+            <GatewayTierContextProvider
+              networkId={networkId}
+              networkType={networkType}>
+              <EnodebContextProvider
+                networkId={networkId}
+                networkType={networkType}>
+                <GatewayContextProvider
+                  networkId={networkId}
+                  networkType={networkType}>
                   {props.children}
                 </GatewayContextProvider>
               </EnodebContextProvider>

--- a/nms/app/packages/magmalte/app/components/main/Index.js
+++ b/nms/app/packages/magmalte/app/components/main/Index.js
@@ -16,8 +16,8 @@
 
 import MagmaV1API from '@fbcnms/magma-api/client/WebClient';
 
-import {FEG_LTE, LTE, coalesceNetworkType} from '@fbcnms/types/network';
 import {LteContextProvider} from '../lte/LteContext';
+import {coalesceNetworkType} from '@fbcnms/types/network';
 import type {NetworkType} from '@fbcnms/types/network';
 import type {Theme} from '@material-ui/core';
 
@@ -80,30 +80,25 @@ export default function Index() {
     return <LoadingFiller />;
   }
 
-  const lteNetwork = networkType === LTE || networkType === FEG_LTE;
   return (
     <NetworkContext.Provider value={{networkId, networkType}}>
-      <div className={classes.root}>
-        <AppSideBar
-          mainItems={[<SectionLinks key={1} />, <VersionTooltip key={2} />]}
-          secondaryItems={[<NetworkSelector key={1} />]}
-          projects={getProjectLinks(tabs, user)}
-          showSettings={shouldShowSettings({
-            isSuperUser: user.isSuperUser,
-            ssoEnabled,
-          })}
-          user={user}
-        />
-        <AppContent>
-          {lteNetwork ? (
-            <LteContextProvider networkId={networkId}>
-              <SectionRoutes />
-            </LteContextProvider>
-          ) : (
+      <LteContextProvider networkId={networkId} networkType={networkType}>
+        <div className={classes.root}>
+          <AppSideBar
+            mainItems={[<SectionLinks key={1} />, <VersionTooltip key={2} />]}
+            secondaryItems={[<NetworkSelector key={1} />]}
+            projects={getProjectLinks(tabs, user)}
+            showSettings={shouldShowSettings({
+              isSuperUser: user.isSuperUser,
+              ssoEnabled,
+            })}
+            user={user}
+          />
+          <AppContent>
             <SectionRoutes />
-          )}
-        </AppContent>
-      </div>
+          </AppContent>
+        </div>
+      </LteContextProvider>
     </NetworkContext.Provider>
   );
 }

--- a/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/FegLte-test.js
@@ -84,6 +84,91 @@ describe('Admin component', () => {
 });
 
 describe('NMS', () => {
+  test('verifying LTE network addition from network selector', async () => {
+    const page = await browser.newPage();
+    try {
+      // test_feg_lte_network is mocked out
+      await page.goto('https://magma-test.localhost/');
+      await page.waitForXPath(`//span[text()='Dashboard']`, {
+        timeout: 15000,
+      });
+
+      const networkSelector = 'div[title="test"]';
+      page.waitForSelector(networkSelector);
+      await page.click(networkSelector);
+
+      await page.waitForXPath(`//span[text()='Create Network']`);
+      const buttonSelector = await page.$x(`//span[text()='Create Network']`);
+      buttonSelector[0].click();
+
+      const networkIDSelector = '[data-testid="networkID"]';
+      const networkNameSelector = '[data-testid="networkName"]';
+      const networkDescriptionSelector = '[data-testid="networkDescription"]';
+
+      // add network information attributes
+      await page.waitForSelector(networkIDSelector);
+      await page.click(networkIDSelector);
+      await page.type(networkIDSelector, 'test_network');
+
+      await page.waitForSelector(networkNameSelector);
+      await page.click(networkNameSelector);
+      await page.type(networkNameSelector, 'test_network');
+
+      await page.waitForSelector(networkDescriptionSelector);
+      await page.click(networkDescriptionSelector);
+      await page.type(networkDescriptionSelector, 'test_network');
+
+      // TODO need to figure out why we need to add this delay
+      await page.waitFor(500);
+
+      const saveButtonSelector = '[data-testid="saveButton"]';
+      await page.waitForSelector(saveButtonSelector);
+      await page.click(saveButtonSelector);
+
+      await page.waitForXPath(
+        `//span[text()='Network test_network successfully created']`,
+      );
+
+      // use epc defaults
+      const tacSelector = '[data-testid="tac"]';
+      await page.waitForSelector(tacSelector);
+      await page.click(tacSelector);
+      await page.evaluate(tacSelector => {
+        document.querySelector(tacSelector).value = '';
+      }, tacSelector);
+      await page.type(tacSelector, '2');
+
+      const epcSaveButtonSelector = '[data-testid="epcSaveButton"]';
+      await page.waitForSelector(epcSaveButtonSelector);
+      await (await page.$(epcSaveButtonSelector)).press('Enter');
+      await page.waitForXPath(
+        `//span[text()='EPC configs saved successfully']`,
+      );
+
+      const earfcndlSelector = '[data-testid="earfcndl"]';
+      await page.waitForSelector(earfcndlSelector);
+      await page.click(earfcndlSelector);
+      await page.evaluate(earfcndlSelector => {
+        document.querySelector(earfcndlSelector).value = '';
+      }, earfcndlSelector);
+
+      await page.type(earfcndlSelector, '44592');
+      const ranSaveButtonSelector = '[data-testid="ranSaveButton"]';
+      await page.waitForSelector(ranSaveButtonSelector);
+      await (await page.$(ranSaveButtonSelector)).press('Enter');
+
+      await page.waitForXPath(
+        `//span[text()='RAN configs saved successfully']`,
+      );
+    } catch (err) {
+      await page.screenshot({
+        path: ARTIFACTS_DIR + 'failed_networkselector_add.png',
+      });
+      await page.close();
+      throw err;
+    }
+  }, 60000);
+
   test('verifying feg_lte dashboard', async () => {
     const page = await browser.newPage();
     try {
@@ -115,7 +200,7 @@ describe('NMS', () => {
 
       await page.type(fegPlaceholder, 'test_feg_network2');
 
-      // TODO need to figure out why we need to add this delay
+      // @karthiksubraveti - TODO need to figure out why we need to add this delay
       await page.waitFor(500);
       const [saveButton] = await page.$x(`//span[text()='Save']`);
       await saveButton.click();

--- a/nms/app/packages/magmalte/app/views/network/NetworkEpc.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkEpc.js
@@ -260,10 +260,17 @@ export function NetworkEpcEdit(props: EditProps) {
         </List>
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.onClose} skin="regular">
+        <Button
+          data-testid="epcCancelButton"
+          onClick={props.onClose}
+          skin="regular">
           Cancel
         </Button>
-        <Button onClick={onSave} variant="contained" color="primary">
+        <Button
+          data-testid="epcSaveButton"
+          onClick={onSave}
+          variant="contained"
+          color="primary">
           {props.saveButtonTitle}
         </Button>
       </DialogActions>

--- a/nms/app/packages/magmalte/app/views/network/NetworkInfo.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkInfo.js
@@ -191,10 +191,17 @@ export function NetworkInfoEdit(props: EditProps) {
         </List>
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.onClose} skin="regular">
+        <Button
+          data-testid="cancelButton"
+          onClick={props.onClose}
+          skin="regular">
           Cancel
         </Button>
-        <Button onClick={onSave} variant="contained" color="primary">
+        <Button
+          data-testid="saveButton"
+          onClick={onSave}
+          variant="contained"
+          color="primary">
           {props.saveButtonTitle}
         </Button>
       </DialogActions>

--- a/nms/app/packages/magmalte/app/views/network/NetworkRanConfig.js
+++ b/nms/app/packages/magmalte/app/views/network/NetworkRanConfig.js
@@ -243,10 +243,17 @@ export function NetworkRanEdit(props: EditProps) {
         </List>
       </DialogContent>
       <DialogActions>
-        <Button onClick={props.onClose} skin="regular">
+        <Button
+          data-testid="ranCancelButton"
+          onClick={props.onClose}
+          skin="regular">
           Cancel
         </Button>
-        <Button onClick={onSave} variant="contained" color="primary">
+        <Button
+          data-testid="ranSaveButton"
+          onClick={onSave}
+          variant="contained"
+          color="primary">
           {props.saveButtonTitle}
         </Button>
       </DialogActions>

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/ApnAddTest.js
@@ -20,6 +20,7 @@ import NetworkContext from '../../../components/context/NetworkContext';
 import React from 'react';
 import TrafficDashboard from '../TrafficOverview';
 import defaultTheme from '@fbcnms/ui/theme/default';
+import {LTE} from '@fbcnms/types/network';
 
 import {
   ApnProvider,
@@ -99,8 +100,8 @@ describe('<TrafficDashboard />', () => {
             value={{
               networkId: 'test',
             }}>
-            <LteNetworkContextProvider networkId={'test'}>
-              <ApnProvider networkId={'test'}>
+            <LteNetworkContextProvider networkId={'test'} networkType={LTE}>
+              <ApnProvider networkId={'test'} networkType={LTE}>
                 <Route
                   path="/nms/:networkId/traffic"
                   component={TrafficDashboard}

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/PolicyAddEditTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/PolicyAddEditTest.js
@@ -193,8 +193,10 @@ describe('<TrafficDashboard />', () => {
               networkId: 'test',
               networkType: networkType,
             }}>
-            <LteNetworkContextProvider networkId={'test'}>
-              <PolicyProvider networkId={'test'}>
+            <LteNetworkContextProvider
+              networkId={'test'}
+              networkType={networkType}>
+              <PolicyProvider networkId={'test'} networkType={networkType}>
                 <Route
                   path="/nms/:networkId/traffic/policy"
                   component={TrafficDashboard}

--- a/nms/app/packages/magmalte/scripts/mockServer.js
+++ b/nms/app/packages/magmalte/scripts/mockServer.js
@@ -71,6 +71,18 @@ server.get('/magma/v1/lte/test', (req, res) => {
   }
 });
 
+server.put('/magma/v1/lte/test_network/cellular/epc', (req, res) => {
+  if (req.method === 'PUT') {
+    res.status(200).jsonp('Success');
+  }
+});
+
+server.put('/magma/v1/lte/test_network/cellular/ran', (req, res) => {
+  if (req.method === 'PUT') {
+    res.status(200).jsonp('Success');
+  }
+});
+
 const networks = ['test', 'test_feg_lte_network'];
 networks.forEach(network => {
   server.get(`/magma/v1/networks/${network}/gateways`, (req, res) => {


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Adding network from network selector button is broken currently. LTE context is not passed down to 
the network selector here. This patch fixes this issue. It moves the LTEContextProvider to the enclose
the network selector as well. 

## Test Plan
Added e2e test to verify the fix

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
