### PR TITLE
[feg][aaa][sim] Support for EAP-SIM over S6a vectors

### DIFF
--- a/feg/gateway/services/eap/providers/aka/servicers/handlers/s6a_auth_utils.go
+++ b/feg/gateway/services/eap/providers/aka/servicers/handlers/s6a_auth_utils.go
@@ -16,6 +16,7 @@ package handlers
 import (
 	"time"
 
+	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -49,6 +50,7 @@ checkAIError:
 		if se, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
 			errCode = se.GRPCStatus().Code()
 			if errCode == DIAMETER_ERROR_UNKNOWN_EPS_SUBSCRIPTION && air.NumRequestedUtranGeranVectors > 0 {
+				glog.Warningf("No UTRAN/GERAN profile for IMSI: %s, error: %v", imsi, err)
 				// No UTRAN/GERAN profile, try E-UTRAN
 				air.NumRequestedEutranVectors = 1
 				air.ResyncInfo = resyncInfo

--- a/feg/gateway/services/eap/providers/sim/definitions.go
+++ b/feg/gateway/services/eap/providers/sim/definitions.go
@@ -86,6 +86,7 @@ const (
 	StateIdentity               // Valid permanent identity received
 	StateChallenge              // Auth Challenge was returned to UE
 	StateAuthenticated          // UE is successfully authenticated
+	StateRedirected             // UE is redirected to another Auth method, cache this state to prevent redirection loop
 )
 
 const (

--- a/feg/gateway/services/eap/providers/sim/metrics/metrics.go
+++ b/feg/gateway/services/eap/providers/sim/metrics/metrics.go
@@ -87,6 +87,22 @@ var (
 		Name: "eap_sim_peer_failures_total",
 		Help: "Total number of SIM Errors/Failures originated from peers",
 	})
+	S6aRequests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "eap_sim_s6a_requests_total",
+		Help: "Total number of s6a Proxy RPC Requiests sent",
+	})
+	S6aFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "eap_sim_s6a_failures_total",
+		Help: "Total number of s6a Proxy RPC Failures",
+	})
+	S6aULRequests = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "eap_sim_s6a_ul_requests_total",
+		Help: "Total number of s6a Proxy RPC Requiests sent",
+	})
+	S6aULFailures = prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "eap_sim_s6a_ul_failures_total",
+		Help: "Total number of s6a Proxy RPC Failures",
+	})
 
 	// Latencies
 	SWxLatency = prometheus.NewSummary(prometheus.SummaryOpts{
@@ -97,6 +113,16 @@ var (
 	AuthLatency = prometheus.NewSummary(prometheus.SummaryOpts{
 		Name:       "eap_sim_auth_lat",
 		Help:       "Latency of EAP-SIM Authentication round (seconds). Only calculated for completed authentications.",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	S6aLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "eap_sim_s6a_ai_lat",
+		Help:       "Latency of s6a Proxy requests (seconds).",
+		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
+	})
+	S6aULLatency = prometheus.NewSummary(prometheus.SummaryOpts{
+		Name:       "eap_sim_s6a_ul_lat",
+		Help:       "Latency of s6a Proxy Update-Location requests (seconds).",
 		Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
 	})
 )

--- a/feg/gateway/services/eap/providers/sim/servicers/handlers/s6a_auth_utils.go
+++ b/feg/gateway/services/eap/providers/sim/servicers/handlers/s6a_auth_utils.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	s6a_protos "magma/feg/cloud/go/protos"
+	"magma/feg/gateway/services/eap/providers/sim"
+	"magma/feg/gateway/services/eap/providers/sim/metrics"
+	"magma/feg/gateway/services/eap/providers/sim/servicers"
+	"magma/feg/gateway/services/s6a_proxy"
+	"magma/feg/gateway/tgpp"
+)
+
+const DIAMETER_ERROR_UNKNOWN_EPS_SUBSCRIPTION codes.Code = 5420
+
+// EUTRANOnlyVectorsErr - this error indicates that the user only has EUTRAN (4G) profile
+// and may be able to authenticate with EAP-AKA/AKA'
+var EUTRANOnlyVectorsErr = status.Errorf(codes.Internal, "Only GERAN vectors available")
+
+func getS6aVectors(s *servicers.EapSimSrv, imsi string) (*tgppAuthResult, error) {
+	var (
+		err error
+		ans *s6a_protos.AuthenticationInformationAnswer
+		res tgppAuthResult
+	)
+	visitedPlmn := tgpp.GetPlmnID(imsi, s.MncLen())
+	for vlen := 0; vlen < sim.GsmTripletsNumber; {
+		metrics.S6aRequests.Inc()
+		s6aStartTime := time.Now()
+		air := &s6a_protos.AuthenticationInformationRequest{
+			UserName:                      imsi,
+			VisitedPlmn:                   visitedPlmn,
+			ImmediateResponsePreferred:    true,
+			NumRequestedUtranGeranVectors: sim.GsmTripletsNumber - uint32(vlen),
+		}
+		ans, err = s6a_proxy.AuthenticationInformation(air)
+		metrics.S6aLatency.Observe(time.Since(s6aStartTime).Seconds())
+		if err != nil {
+			metrics.S6aFailures.Inc()
+			errCode := codes.Internal
+			if se, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
+				errCode = se.GRPCStatus().Code()
+				if errCode == DIAMETER_ERROR_UNKNOWN_EPS_SUBSCRIPTION {
+					// No UTRAN/GERAN profile
+					return nil, EUTRANOnlyVectorsErr
+				}
+			}
+			return nil, status.Errorf(errCode, "AI Failure: %v; IMSI: %s", err, imsi)
+		}
+		if ans == nil {
+			return nil, status.Error(codes.Internal, "AI Error: Nil S6a Response")
+		}
+		// first check for GERAN vectors, they are direct mapping for EAP-SIM
+		if len(ans.GetGeranVectors()) > 0 {
+			for _, v := range ans.GetGeranVectors() {
+				res.rand[vlen], res.Kc[vlen], res.sres[vlen] = v.GetRand(), v.GetKc(), v.GetSres()
+				vlen++
+				if vlen >= sim.GsmTripletsNumber {
+					break
+				}
+			}
+		} else {
+			// no GERAN vectors/profile, try to use UTRAN vectors
+			if len(ans.GetUtranVectors()) == 0 {
+				return nil, status.Error(codes.Internal, "Invalid S6a Response, no GERAN/UTRAN vectors")
+			}
+			for _, v := range ans.GetUtranVectors() {
+				res.rand[vlen] = v.GetRand()
+				res.Kc[vlen], res.sres[vlen] =
+					sim.GsmFromUmts1(v.GetConfidentialityKey(), v.GetIntegrityKey(), v.GetXres())
+				vlen++
+				if vlen >= sim.GsmTripletsNumber {
+					break
+				}
+			}
+		}
+	}
+	metrics.S6aULRequests.Inc()
+	s6aStartTime := time.Now()
+	ula, err := s6a_proxy.UpdateLocation(
+		&s6a_protos.UpdateLocationRequest{
+			UserName:    imsi,
+			VisitedPlmn: visitedPlmn,
+		})
+	metrics.S6aULLatency.Observe(time.Since(s6aStartTime).Seconds())
+	if err != nil {
+		metrics.S6aULFailures.Inc()
+		errCode := codes.Internal
+		if se, ok := err.(interface{ GRPCStatus() *status.Status }); ok {
+			errCode = se.GRPCStatus().Code()
+		}
+		return nil, status.Errorf(errCode, "UL Failure: %v; IMSI: %s", err, imsi)
+	}
+	if ula == nil {
+		return nil, status.Error(codes.Internal, "UI Error: Nil S6a Response")
+	}
+	res.profile = &s6a_protos.AuthenticationAnswer_UserProfile{Msisdn: tgpp.DecodeMsisdn(ula.GetMsisdn())}
+	return &res, nil
+}

--- a/feg/gateway/services/eap/providers/sim/servicers/handlers/sim_start.go
+++ b/feg/gateway/services/eap/providers/sim/servicers/handlers/sim_start.go
@@ -148,10 +148,15 @@ func startResponse(s *servicers.EapSimSrv, ctx *protos.Context, req eap.Packet) 
 		glog.Errorf(
 			"EAP SIM StartResponse: Unexpected user state: %d,%s for IMSI: %s, CTX Identity: %s",
 			state, t, imsi, uc.Identity)
+		if state == sim.StateRedirected {
+			sim.EapErrorResPacket(
+				identifier, sim.NOTIFICATION_FAILURE, codes.FailedPrecondition,
+				"IMSI: %s is redirected to another method", imsi)
+		}
 	}
 	uc.Identity = identity
 	uc.SetState(sim.StateIdentity)
-	p, err := createChallengeRequest(uc, identifier, nonce, []byte{0, sim.Version}, version)
+	p, err := createChallengeRequest(s, uc, identifier, nonce, []byte{0, sim.Version}, version)
 	if err == nil {
 		// Update state
 		uc.SetState(sim.StateChallenge)


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

Support for EAP-SIM over S6a vectors.

## Test Plan

make precommit;
test with OpenWRT based AAA setup:

Tue Oct 27 15:23:43 2020 daemon.info hostapd: wlan0: STA 64:bc:0c:4c:fd:70 IEEE 802.11: authenticated
Tue Oct 27 15:23:43 2020 daemon.info hostapd: wlan0: STA 64:bc:0c:4c:fd:70 IEEE 802.11: associated (aid 1)
Tue Oct 27 15:23:43 2020 daemon.notice hostapd: wlan0: CTRL-EVENT-EAP-STARTED 64:bc:0c:4c:fd:70
Tue Oct 27 15:23:43 2020 daemon.notice hostapd: wlan0: CTRL-EVENT-EAP-PROPOSED-METHOD vendor=0 method=1
Tue Oct 27 15:23:43 2020 daemon.info aaa_server[11583]: I1027 22:23:43.509588   11583 client_api.go:83] Handling EAP-SIM (0)
Tue Oct 27 15:23:43 2020 daemon.err aaa_server[11583]: E1027 22:23:43.511156   11583 linked_client_api.go:52] Error getting EAP SIM service configs: No configs found for service: 'eap_sim' in /var/opt/magma/configs/gateway.mconfig
Tue Oct 27 15:23:43 2020 daemon.info aaa_server[11583]: I1027 22:23:43.512362   11583 service.go:148] EAP-SIM: Using S6a Auth Vectors
Tue Oct 27 15:23:43 2020 daemon.info aaa_server[11583]: I1027 22:23:43.522126   11583 service_config.go:169] Successfully loaded '::control_proxy' service configs from '/etc/magma/configs/control_proxy.yml'
Tue Oct 27 15:23:43 2020 daemon.info aaa_server[11583]: I1027 22:23:43.913141   11583 cloud_connection.go:116] connecting to: controller-staging.magma.etagecom.io:443, authority: s6a_proxy-controller-staging.magma.etagecom.io
Tue Oct 27 15:23:45 2020 daemon.info magmad[1552]: I1027 22:23:45.850726    1552 sync_rpc_client.go:200] [SyncRpc] heartbeat success
Tue Oct 27 15:23:46 2020 daemon.info aaa_server[11583]: I1027 22:23:46.135578   11583 in_memory.go:159] setting timeout of 300.000000 seconds for session: C7D9327E442CC590
Tue Oct 27 15:23:46 2020 daemon.info aaa_server[11583]: I1027 22:23:46.136111   11583 auth.go:174] successfully authenticated user: 1001010000000141@wlan.mnc001.mcc001.3gppnetwork.org
Tue Oct 27 15:23:46 2020 daemon.notice hostapd: wlan0: CTRL-EVENT-EAP-SUCCESS2 64:bc:0c:4c:fd:70
Tue Oct 27 15:23:46 2020 daemon.info hostapd: wlan0: STA 64:bc:0c:4c:fd:70 WPA: pairwise key handshake completed (RSN)
Tue Oct 27 15:23:46 2020 daemon.notice hostapd: wlan0: AP-STA-CONNECTED 64:bc:0c:4c:fd:70
Tue Oct 27 15:23:46 2020 daemon.info hostapd: wlan0: STA 64:bc:0c:4c:fd:70 RADIUS: starting accounting session C7D9327E442CC590
Tue Oct 27 15:23:46 2020 daemon.info hostapd: wlan0: STA 64:bc:0c:4c:fd:70 IEEE 802.1X: authenticated - EAP type: 18 (unknown)
Tue Oct 27 15:23:46 2020 daemon.info aaa_server[11583]: I1027 22:23:46.158481   11583 acct.go:148] successfully handled Start Accounting Request for session_id:"C7D9327E442CC590" apn:"C6-41-1E-21-EF-55:OpenWrt_MDO" mac_addr:"64-BC-0C-4C-FD-70"

## Additional Information

- [ ] This change is backwards-breaking

