### PR TITLE
[pipelined]Fix Routing For IPv6 Packets

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/dpi.py
+++ b/lte/gateway/python/magma/pipelined/app/dpi.py
@@ -19,12 +19,10 @@ from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.app.ipfix import IPFIXController
 from magma.pipelined.openflow.magma_match import MagmaMatch
-from magma.pipelined.openflow.registers import Direction, DPI_REG
+from magma.pipelined.openflow.registers import DPI_REG
 from magma.pipelined.policy_converters import FlowMatchError, \
     flow_match_to_magma_match, flip_flow_match
 from lte.protos.pipelined_pb2 import FlowRequest
-
-from ryu.lib.packet import ether_types
 
 # TODO might move to config file
 # Current classification will finalize if found in APP_PROTOS, if found in
@@ -160,11 +158,7 @@ class DPIController(MagmaController):
         parser = self._datapath.ofproto_parser
 
         # Setup flows to classify & mirror to sampling port
-        inbound_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
-                                   direction=Direction.IN)
-        outbound_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
-                                    direction=Direction.OUT)
-
+        match = MagmaMatch()
         actions = [
             parser.NXActionResubmitTable(table_id=self._classify_app_tbl_num)]
 
@@ -172,11 +166,7 @@ class DPIController(MagmaController):
             actions.append(parser.OFPActionOutput(self._mon_port_number))
 
         flows.add_resubmit_next_service_flow(datapath, self.tbl_num,
-                                             inbound_match, actions,
-                                             priority=flows.MINIMUM_PRIORITY,
-                                             resubmit_table=self.next_table)
-        flows.add_resubmit_next_service_flow(datapath, self.tbl_num,
-                                             outbound_match, actions,
+                                             match, actions,
                                              priority=flows.MINIMUM_PRIORITY,
                                              resubmit_table=self.next_table)
 

--- a/lte/gateway/python/magma/pipelined/app/ipfix.py
+++ b/lte/gateway/python/magma/pipelined/app/ipfix.py
@@ -18,10 +18,7 @@ from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.openflow import flows
 from ryu.controller.controller import Datapath
 from magma.pipelined.openflow.magma_match import MagmaMatch
-from magma.pipelined.openflow.registers import Direction
 from magma.pipelined.imsi import encode_imsi
-from ryu.lib.packet import ether_types
-
 
 class IPFIXController(MagmaController):
     """
@@ -169,16 +166,9 @@ class IPFIXController(MagmaController):
         Args:
             datapath: ryu datapath struct
         """
-        inbound_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
-                                   direction=Direction.IN)
-        outbound_match = MagmaMatch(eth_type=ether_types.ETH_TYPE_IP,
-                                    direction=Direction.OUT)
+        match = MagmaMatch()
         flows.add_resubmit_next_service_flow(
-            datapath, self.tbl_num, inbound_match, [],
-            priority=flows.MINIMUM_PRIORITY,
-            resubmit_table=self.next_main_table)
-        flows.add_resubmit_next_service_flow(
-            datapath, self.tbl_num, outbound_match, [],
+            datapath, self.tbl_num, match, [],
             priority=flows.MINIMUM_PRIORITY,
             resubmit_table=self.next_main_table)
 

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_add_app_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_add_app_rules.snapshot
@@ -1,5 +1,4 @@
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,dpi(scratch_table_0)),resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x1 actions=resubmit(,dpi(scratch_table_0)),resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,dpi(scratch_table_0)),resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=dpi(scratch_table_0), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,udp,nw_dst=1.1.1.1 actions=set_field:0->reg10,set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=dpi(scratch_table_0), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,udp,nw_src=1.1.1.1 actions=set_field:0->reg10,set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=dpi(scratch_table_0), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,tcp,nw_src=1.2.3.4,nw_dst=45.10.0.8,tp_src=51115,tp_dst=80 actions=set_field:0xa->reg10,set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_remove_app_rules.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_dpi.DPITest.test_remove_app_rules.snapshot
@@ -1,5 +1,4 @@
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x10 actions=resubmit(,dpi(scratch_table_0)),resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
- cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0,ip,reg1=0x1 actions=resubmit(,dpi(scratch_table_0)),resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
+ cookie=0x0, table=dpi(main_table), n_packets=0, n_bytes=0, priority=0 actions=resubmit(,dpi(scratch_table_0)),resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=dpi(scratch_table_0), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,udp,nw_dst=1.1.1.1 actions=set_field:0->reg10,set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=dpi(scratch_table_0), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,udp,nw_src=1.1.1.1 actions=set_field:0->reg10,set_field:0->reg0,set_field:0->reg3
  cookie=0x0, table=dpi(scratch_table_0), n_packets=0, n_bytes=0, idle_timeout=42, priority=10,tcp,nw_src=45.10.0.8,nw_dst=1.2.3.4,tp_src=80,tp_dst=51115 actions=set_field:0xa->reg10,set_field:0->reg0,set_field:0->reg3

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_gy.GYTableTest.test_subscriber_redirect_policy.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_gy.GYTableTest.test_subscriber_redirect_policy.snapshot
@@ -17,6 +17,5 @@
  cookie=0x1, table=gy(main_table), priority=3,udp,reg1=0x10,metadata=0x48c2739fd9c3,tp_src=53 actions=note:b'redir_test',set_field:0x1->reg2,set_field:0->reg4,resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x1, table=gy(main_table), priority=3,tcp,reg1=0x10,metadata=0x48c2739fd9c3,tp_src=53 actions=note:b'redir_test',set_field:0x1->reg2,set_field:0->reg4,resubmit(,egress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x1, table=gy(main_table), priority=1,metadata=0x48c2739fd9c3 actions=drop
- table=gy(main_table), priority=0,ip,reg1=0x10 actions=resubmit(,enforcement(main_table)),set_field:0->reg0,set_field:0->reg3
- table=gy(main_table), priority=0,ip,reg1=0x1 actions=resubmit(,enforcement(main_table)),set_field:0->reg0,set_field:0->reg3
+ table=gy(main_table), priority=0 actions=resubmit(,enforcement(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x1, table=204, priority=12,tcp,nw_src=192.168.128.1,nw_dst=192.168.0.1,tp_src=8080,tp_dst=42132 actions=load:0x1201020aabb->NXM_OF_ETH_DST[],load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0xc0a8804a->NXM_OF_IP_DST[],load:0x972a297a->NXM_OF_IP_SRC[],load:0x50->NXM_OF_TCP_SRC[]

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_gy.GYTableTest.test_subscriber_restrict_policy.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_gy.GYTableTest.test_subscriber_restrict_policy.snapshot
@@ -2,6 +2,5 @@
  priority=65535,ip,nw_dst=192.168.128.74 actions=load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0x10->NXM_NX_REG1[],resubmit(,gy(main_table))
  priority=10,in_port=LOCAL actions=resubmit(,204),resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x2, table=gy(main_table), priority=65533,ip,reg1=0x1,metadata=0x48c2739fd9c3,nw_src=192.168.128.74,nw_dst=8.8.8.0/24 actions=note:b'restrict_match',set_field:0x2->reg2,set_field:0->reg4,resubmit(,enforcement_stats(main_table)),resubmit(,egress(main_table))
- table=gy(main_table), priority=0,ip,reg1=0x10 actions=resubmit(,enforcement(main_table)),set_field:0->reg0,set_field:0->reg3
- table=gy(main_table), priority=0,ip,reg1=0x1 actions=resubmit(,enforcement(main_table)),set_field:0->reg0,set_field:0->reg3
+ table=gy(main_table), priority=0 actions=resubmit(,enforcement(main_table)),set_field:0->reg0,set_field:0->reg3
  cookie=0x1, table=204, priority=12,tcp,nw_src=192.168.128.1,nw_dst=192.168.0.1,tp_src=8080,tp_dst=42132 actions=load:0x1201020aabb->NXM_OF_ETH_DST[],load:0x48c2739fd9c3->OXM_OF_METADATA[],load:0xc0a8804a->NXM_OF_IP_DST[],load:0x972a297a->NXM_OF_IP_SRC[],load:0x50->NXM_OF_TCP_SRC[]

--- a/lte/gateway/python/magma/pipelined/tests/snapshots/test_internal_pkt_ipfix_export.InternalPktIpfixExportTest.test_subscriber_policy.snapshot
+++ b/lte/gateway/python/magma/pipelined/tests/snapshots/test_internal_pkt_ipfix_export.InternalPktIpfixExportTest.test_subscriber_policy.snapshot
@@ -2,8 +2,10 @@
  priority=12,dl_src=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ue_mac(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
  priority=12,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,ue_mac(scratch_table_0)),set_field:0->reg0,set_field:0->reg3
  priority=10,arp actions=resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
- table=dpi(main_table), priority=0,ip,reg1=0x10 actions=resubmit(,dpi(scratch_table_0)),resubmit(,ipfix(main_table)),set_field:0->reg0,set_field:0->reg3
- table=dpi(main_table), priority=0,ip,reg1=0x1 actions=resubmit(,dpi(scratch_table_0)),resubmit(,ipfix(main_table)),set_field:0->reg0,set_field:0->reg3
+ table=dpi(main_table), priority=0 actions=resubmit(,dpi(scratch_table_0)),resubmit(,ipfix(main_table)),set_field:0->reg0,set_field:0->reg3
+ table=dpi(scratch_table_0), idle_timeout=42, priority=10,tcp,nw_src=1.2.3.0,nw_dst=45.10.0.1,tp_src=51115,tp_dst=80 actions=set_field:0xa->reg10,set_field:0->reg0,set_field:0->reg3
+ table=dpi(scratch_table_0), idle_timeout=42, priority=10,tcp,nw_src=45.10.0.1,nw_dst=1.2.3.0,tp_src=80,tp_dst=51115 actions=set_field:0xa->reg10,set_field:0->reg0,set_field:0->reg3
+ table=dpi(scratch_table_0), priority=0 actions=set_field:0xffffffff->reg10,set_field:0->reg0,set_field:0->reg3
  table=ue_mac(scratch_table_0), priority=15,udp,tp_src=68,tp_dst=67 actions=set_field:0x1->reg6,resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
  table=ue_mac(scratch_table_0), priority=15,udp,tp_src=67,tp_dst=68 actions=set_field:0x1->reg6,resubmit(,ue_mac(scratch_table_1)),set_field:0->reg0,set_field:0->reg3
  table=ue_mac(scratch_table_0), priority=15,udp,tp_dst=53 actions=set_field:0x1->reg6,resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
@@ -14,9 +16,6 @@
  table=ue_mac(scratch_table_0), priority=15,tcp,tp_src=853 actions=set_field:0x1->reg6,resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
  table=ue_mac(scratch_table_0), priority=0 actions=resubmit(,ingress(main_table)),set_field:0->reg0,set_field:0->reg3
  table=ue_mac(scratch_table_1), priority=15 actions=CONTROLLER:65535,resubmit(,ingress(main_table))
- table=dpi(scratch_table_0), idle_timeout=42, priority=10,tcp,nw_src=1.2.3.0,nw_dst=45.10.0.1,tp_src=51115,tp_dst=80 actions=set_field:0xa->reg10,set_field:0->reg0,set_field:0->reg3
- table=dpi(scratch_table_0), idle_timeout=42, priority=10,tcp,nw_src=45.10.0.1,nw_dst=1.2.3.0,tp_src=80,tp_dst=51115 actions=set_field:0xa->reg10,set_field:0->reg0,set_field:0->reg3
- table=dpi(scratch_table_0), priority=0 actions=set_field:0xffffffff->reg10,set_field:0->reg0,set_field:0->reg3
  table=201, priority=0 actions=resubmit(,dpi(scratch_table_0)),resubmit(,202),set_field:0->reg0,set_field:0->reg3
  table=202, priority=12,dl_src=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,203),set_field:0->reg0,set_field:0->reg3
  table=202, priority=12,dl_dst=5e:cc:cc:b1:49:4b actions=set_field:0x48c2739fd9c3->metadata,resubmit(,203),set_field:0->reg0,set_field:0->reg3


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Previously we matched on ether type in default rule as well as direction which is unnecessary and breaks ipv6 routing. Removed the extra match args.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
