### PR TITLE
[agw] [stateless mme] Fix memory leaks in stateless MME

### DIFF
--- a/lte/gateway/c/oai/common/itti_free_defined_msg.c
+++ b/lte/gateway/c/oai/common/itti_free_defined_msg.c
@@ -99,7 +99,8 @@ void itti_free_msg_content(MessageDef* const message_p) {
       break;
 
     case S11_CREATE_SESSION_REQUEST: {
-      // DO nothing
+      clear_protocol_configuration_options(
+          &message_p->ittiMsg.s11_create_session_request.pco);
     } break;
 
     case S11_CREATE_SESSION_RESPONSE: {

--- a/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.cpp
@@ -19,9 +19,10 @@
 #include <string>
 
 extern "C" {
-#include "s1ap_state.h"
-#include "log.h"
+#include "assertions.h"
 #include "hashtable.h"
+#include "log.h"
+#include "s1ap_state.h"
 }
 
 using grpc::ServerContext;
@@ -58,6 +59,7 @@ Status S1apServiceImpl::GetEnbConnected(
         response->add_enb_ids(enb_ref->enb_id);
       }
     }
+    FREE_HASHTABLE_KEY_ARRAY(ht_keys);
   }
 
   return Status::OK;

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_state_converter.cpp
@@ -117,6 +117,7 @@ void MmeNasStateConverter::guti_table_to_proto(
   hashtable_rc_t ht_rc =
       obj_hashtable_uint64_ts_get_keys(guti_htbl, key_array_p, &size);
   if ((!*key_array_p) || (ht_rc != HASH_TABLE_OK)) {
+    FREE_OBJ_HASHTABLE_KEY_ARRAY(key_array_p);
     return;
   }
   for (auto i = 0; i < size; i++) {
@@ -189,6 +190,7 @@ void MmeNasStateConverter::proto_to_guti_table(
           "Failed to insert mme_ue_s1ap_id %u in GUTI table, error: %s\n",
           mme_ue_id, hashtable_rc_code2string(ht_rc));
     }
+    free_wrapper((void**) &guti_p);
   }
 }
 

--- a/lte/gateway/c/oai/tasks/nas/emm/Attach.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/Attach.c
@@ -2304,6 +2304,9 @@ void free_emm_attach_request_ies(emm_attach_request_ies_t** const ies) {
   if ((*ies)->drx_parameter) {
     free_wrapper((void**) &(*ies)->drx_parameter);
   }
+  if ((*ies)->mob_st_clsMark2) {
+    free_wrapper((void**) &(*ies)->mob_st_clsMark2);
+  }
   if ((*ies)->voicedomainpreferenceandueusagesetting) {
     free_wrapper((void**) &(*ies)->voicedomainpreferenceandueusagesetting);
   }

--- a/lte/gateway/c/oai/tasks/nas/esm/esm_data_context.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_data_context.c
@@ -120,6 +120,9 @@ void free_esm_context_content(esm_context_t* esm_ctx) {
   if (esm_ctx->esm_proc_data) {
     OAILOG_DEBUG(LOG_NAS_ESM, "Free up esm_proc_data");
     bdestroy_wrapper(&esm_ctx->esm_proc_data->apn);
+    if (esm_ctx->esm_proc_data->pco.num_protocol_or_container_id) {
+      clear_protocol_configuration_options(&esm_ctx->esm_proc_data->pco);
+    }
     free_wrapper((void**) &esm_ctx->esm_proc_data);
   }
 }

--- a/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/sap/esm_sap.c
@@ -605,6 +605,9 @@ static int _esm_sap_recv(
             emm_context, pti, ebi, &esm_msg.pdn_connectivity_request, &ebi,
             is_standalone);
 
+        clear_protocol_configuration_options(
+            &esm_msg.pdn_connectivity_request.protocolconfigurationoptions);
+
         if (esm_cause != ESM_CAUSE_SUCCESS) {
           /*
            * Return reject message

--- a/lte/gateway/c/oai/tasks/sgw/pgw_procedures.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_procedures.c
@@ -113,7 +113,15 @@ void pgw_delete_procedure_create_bearer(
 }
 //------------------------------------------------------------------------------
 void pgw_free_procedure_create_bearer(pgw_ni_cbr_proc_t** ni_cbr_proc) {
-  // DO here specific releases (memory,etc)
-  // nothing to do actually
+  if (*ni_cbr_proc && (*ni_cbr_proc)->pending_eps_bearers) {
+    sgw_eps_bearer_entry_wrapper_t* eps_bearer_entry_wrapper = NULL;
+    LIST_FOREACH(
+        eps_bearer_entry_wrapper, (*ni_cbr_proc)->pending_eps_bearers,
+        entries) {
+      LIST_REMOVE(eps_bearer_entry_wrapper, entries);
+      free_wrapper((void**) &eps_bearer_entry_wrapper->sgw_eps_bearer_entry);
+      free_wrapper((void**) &eps_bearer_entry_wrapper);
+    }
+  }
   free_wrapper((void**) ni_cbr_proc);
 }

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state.cpp
@@ -24,6 +24,7 @@ extern "C" {
 #include "assertions.h"
 #include "bstrlib.h"
 #include "dynamic_memory_check.h"
+#include "pgw_procedures.h"
 #include "sgw_context_manager.h"
 }
 
@@ -81,6 +82,7 @@ void sgw_free_s11_bearer_context_information(
     sgw_free_pdn_connection(
         &(*context_p)->sgw_eps_bearer_context_information.pdn_connection);
 
+    pgw_delete_procedures(*context_p);
     if ((*context_p)->pgw_eps_bearer_context_information.apns) {
       obj_hashtable_ts_destroy(
           (*context_p)->pgw_eps_bearer_context_information.apns);

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -188,7 +188,7 @@ void SpgwStateConverter::proto_to_spgw_bearer_context(
       &sgw_eps_bearer_context_state->saved_message);
   proto_to_sgw_pending_procedures(
       sgw_eps_bearer_context_proto,
-      sgw_eps_bearer_context_state->pending_procedures);
+      &sgw_eps_bearer_context_state->pending_procedures);
 
   auto* pgw_eps_bearer_context_state =
       &spgw_bearer_state->pgw_eps_bearer_context_information;
@@ -887,15 +887,15 @@ void SpgwStateConverter::sgw_pending_procedures_to_proto(
 
 void SpgwStateConverter::proto_to_sgw_pending_procedures(
     const oai::SgwEpsBearerContextInfo& proto,
-    sgw_eps_bearer_context_information_t::pending_procedures_s* procedures) {
-  procedures =
+    sgw_eps_bearer_context_information_t::pending_procedures_s** procedures_p) {
+  *procedures_p =
       (sgw_eps_bearer_context_information_t::pending_procedures_s*) calloc(
-          1, sizeof(*procedures));
-  LIST_INIT(procedures);
+          1, sizeof(*procedures_p));
+  LIST_INIT(*procedures_p);
   for (auto& procedure_proto : proto.pending_procedures()) {
     if (procedure_proto.type() ==
         PGW_BASE_PROC_TYPE_NETWORK_INITATED_CREATE_BEARER_REQUEST) {
-      insert_proc_into_sgw_pending_procedures(procedure_proto, procedures);
+      insert_proc_into_sgw_pending_procedures(procedure_proto, *procedures_p);
     }
   }
 }

--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.h
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.h
@@ -164,7 +164,7 @@ class SpgwStateConverter : StateConverter {
    */
   static void proto_to_sgw_pending_procedures(
       const oai::SgwEpsBearerContextInfo& proto,
-      sgw_eps_bearer_context_information_t::pending_procedures_s* procedures);
+      sgw_eps_bearer_context_information_t::pending_procedures_s** procedures);
 
   /**
    * Inserts new procedure struct to eps bearer pending procedures list


### PR DESCRIPTION
## Summary

This change fixes several memory leaks observed while running stateless MME S1AP tests and while testing stateless AGW in testbed in:
- Guti hash table
- Attach request IEs
- Protocol configuration options
- GetEnbConnected
- SPGW bearer context

This does not fix the leaks from:
- zlist_new in libczmq
- fluid_base::BaseOFConnection::OFReadBuffer::read_notify in libfluid (seen only on first run of MME)

These need to be suppressed using Lsan suppresion as they are leaks in third-party library. Future PR will handle them.

## Test Plan

- S1ap integration tests
- Build Magma package and test on FWA testbed

In both cases syslog shows only memory leaks from libzmq and/or libfluid

