### PR TITLE
[tf] Thanos AWS infrastructure

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-aws/variables.tf
@@ -342,3 +342,4 @@ variable "elasticsearch_domain_tags" {
   description = "Extra tags for the ES domain."
   default     = {}
 }
+

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/main.tf
@@ -80,6 +80,12 @@ resource "helm_release" "orc8r" {
     alertmanager_hostname     = format("%s-alertmanager", var.helm_deployment_name)
     alertmanager_url          = format("%s-alertmanager:9093", var.helm_deployment_name)
     prometheus_url            = format("%s-prometheus:9090", var.helm_deployment_name)
+
+    thanos_enabled         = var.thanos_enabled
+    thanos_bucket          = var.thanos_enabled ? aws_s3_bucket.thanos_object_store_bucket[0].bucket : ""
+    thanos_aws_access_key  = var.thanos_enabled ? aws_iam_access_key.thanos_s3_access_key[0].id : ""
+    thanos_aws_secret_key  = var.thanos_enabled ? aws_iam_access_key.thanos_s3_access_key[0].secret : ""
+    region                 = var.region
   })]
 
   set_sensitive {

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -103,7 +103,7 @@ metrics:
     create: true
     image:
       repository: docker.io/facebookincubator/prometheus-edge-hub
-      tag: 1.0.0
+      tag: 1.1.0
     limit: 500000
   grafana:
     create: false
@@ -126,6 +126,27 @@ metrics:
       grafanaData:
         persistentVolumeClaim:
           claimName: ${grafana_pvc_grafanaData}
+
+  thanos:
+    enabled: ${thanos_enabled}
+    objstore:
+      type: S3
+      config:
+        bucket: ${thanos_bucket}
+        endpoint: s3.${region}.amazonaws.com
+        region: ${region}
+        access_key: ${thanos_aws_access_key}
+        secret_key: ${thanos_aws_secret_key}
+        insecure: false
+        signature_version2: false
+        put_user_metadata: {}
+        http_config:
+          idle_conn_timeout: 0s
+          response_header_timeout: 0s
+          insecure_skip_verify: false
+        trace:
+          enable: false
+        part_size: 0
 
 nms:
   enabled: ${deploy_nms}

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/thanos.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/thanos.tf
@@ -1,0 +1,60 @@
+################################################################################
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+resource "aws_s3_bucket" "thanos_object_store_bucket" {
+  count = var.thanos_enabled ? 1 : 0
+
+  bucket = var.thanos_object_store_bucket_name
+  acl = "private"
+  tags = {
+    Name = "Thanos Object Store"
+  }
+}
+
+resource "aws_iam_user" "thanos_s3_user" {
+  count = var.thanos_enabled ? 1 : 0
+
+  name = "thanos_s3_user"
+}
+
+resource "aws_iam_access_key" "thanos_s3_access_key" {
+  count = var.thanos_enabled ? 1 : 0
+
+  user = aws_iam_user.thanos_s3_user[0].name
+}
+
+resource "aws_iam_user_policy" "thanos_s3_policy" {
+  count = var.thanos_enabled ? 1 : 0
+
+  name = "thanos_s3_policy"
+  user = aws_iam_user.thanos_s3_user[0].name
+
+  policy = data.aws_iam_policy_document.thanos_s3_policy_doc[0].json
+}
+
+data "aws_iam_policy_document" "thanos_s3_policy_doc" {
+  count = var.thanos_enabled ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "s3:*",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.thanos_object_store_bucket[0].bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.thanos_object_store_bucket[0].bucket}/*",
+    ]
+  }
+}

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/variables.tf
@@ -265,3 +265,19 @@ variable "deploy_openvpn" {
   type        = bool
   default     = false
 }
+
+##############################################################################
+# Thanos Object Storage
+##############################################################################
+
+variable "thanos_enabled" {
+  description = "Deploy thanos components and object storage"
+  type        = bool
+  default     = false
+}
+
+variable "thanos_object_store_bucket_name" {
+  description = "Bucket name for s3 object storage. Must be globally unique"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
Adds infra + configuration required to run Thanos to the terraform modules

Note: Dependent on PR: https://github.com/magma/magma/pull/3445

## Test Plan

* Deploy following "installing orchestrator" guide
* Set the values in `main.tf`:
  * ```
     thanos_enabled: true
     thanos_object_store_bucket_name = "smithscott-example-thanos-object-store"
     ```
* Orc8r is deployed with everything running and no errors
* Data shows up in configured s3 bucket

