### PR TITLE
[nms][grafana] availability metric

### DIFF
--- a/nms/app/packages/magmalte/grafana/dashboards/XWFMDashboards.js
+++ b/nms/app/packages/magmalte/grafana/dashboards/XWFMDashboards.js
@@ -62,6 +62,16 @@ export const XWFMDBData = (networks: Array<string>): GrafanaDBData => {
             unit: 'decbytes',
             description: 'Memory Usage (bytes) per container',
           },
+          {
+            title: '7-Day Rolling Availability',
+            targets: [
+              {
+                expr:
+                  'sum_over_time(min by(networkID,gatewayID)(time() - container_last_seen{gatewayID=~"$gatewayID",networkID=~"$networkID",name=~".+",name!="cadvisor"} <= bool 30)[7d:1m]) / 10080',
+                legendFormat: '{{networkID}}-{{gatewayID}}',
+              },
+            ],
+          },
         ],
       },
       {


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

Adds 7-day rolling availability panel to Container/Node Stats dashboard. The query is kinda complicated, but trust me.

## Test Plan
![image](https://user-images.githubusercontent.com/13274915/97509013-4e76b000-193e-11eb-859b-cf2b0b416e00.png)
