### PR TITLE
[lte][agw] Using separate IP state map descriptor for IPV6 addresses

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
+++ b/lte/gateway/python/magma/mobilityd/ipv6_allocator_pool.py
@@ -77,7 +77,7 @@ class IPv6AllocatorPool(IPAllocator):
             return []
 
         if not force:
-            allocated_ip_block_set = self._store.ip_state_map.get_allocated_ip_block_set()
+            allocated_ip_block_set = self._store.ipv6_state_map.get_allocated_ip_block_set()
             if allocated_ip_block_set:
                 return []
 
@@ -89,11 +89,11 @@ class IPv6AllocatorPool(IPAllocator):
         for sid in list(self._store.sid_ips_map):
             ip_desc = self._store.sid_ips_map[sid]
             if ip_desc.ip.version == 6:
-                self._store.ip_state_map.remove_ip_from_state(ip_desc.ip,
-                                                              IPState.FREE)
+                self._store.ipv6_state_map.remove_ip_from_state(ip_desc.ip,
+                                                                IPState.FREE)
                 if force:
-                    self._store.ip_state_map.remove_ip_from_state(ip_desc.ip,
-                                                                  IPState.ALLOCATED)
+                    self._store.ipv6_state_map.remove_ip_from_state(
+                        ip_desc.ip, IPState.ALLOCATED)
                 self._store.sid_ips_map.pop(sid)
 
         removed_blocks.append(self._assigned_ip_block)

--- a/lte/gateway/python/magma/mobilityd/mobility_store.py
+++ b/lte/gateway/python/magma/mobilityd/mobility_store.py
@@ -43,6 +43,7 @@ class MobilityStore(object):
                    redis_port: int):
         if not persist_to_redis:
             self.ip_state_map = IpDescriptorMap(defaultdict(dict))
+            self.ipv6_state_map = IpDescriptorMap(defaultdict(dict))
             self.assigned_ip_blocks = set()  # {ip_block}
             self.sid_ips_map = defaultdict(IPDesc)  # {SID=>IPDesc}
             self.dhcp_gw_info = UplinkGatewayInfo(defaultdict(GWInfo))
@@ -54,6 +55,8 @@ class MobilityStore(object):
                 raise ValueError(
                     'Must specify a redis_port in mobilityd config.')
             self.ip_state_map = IpDescriptorMap(
+                defaultdict_key(lambda key: ip_states(client, key)))
+            self.ipv6_state_map = IpDescriptorMap(
                 defaultdict_key(lambda key: ip_states(client, key)))
             self.assigned_ip_blocks = AssignedIpBlocksSet(client)
             self.sid_ips_map = IPDescDict(client)

--- a/lte/gateway/python/magma/mobilityd/rpc_servicer.py
+++ b/lte/gateway/python/magma/mobilityd/rpc_servicer.py
@@ -15,12 +15,15 @@ import ipaddress
 import logging
 
 import grpc
-from lte.protos.mobilityd_pb2 import AllocateIPRequest, IPAddress, IPBlock, \
-    ListAddedIPBlocksResponse, ListAllocatedIPsResponse, RemoveIPBlockResponse, \
-    SubscriberIPTable, GWInfo, ListGWInfoResponse, AllocateIPAddressResponse
+from google.protobuf.json_format import MessageToJson
+from lte.protos.mobilityd_pb2 import AllocateIPAddressResponse, \
+    AllocateIPRequest, IPAddress, IPBlock, ListAddedIPBlocksResponse, \
+    ListAllocatedIPsResponse, ListGWInfoResponse, RemoveIPBlockResponse, \
+    SubscriberIPTable
 from lte.protos.mobilityd_pb2_grpc import MobilityServiceServicer, \
     add_MobilityServiceServicer_to_server
 from lte.protos.subscriberdb_pb2 import SubscriberID
+
 from magma.common.rpc_utils import return_void
 from magma.subscriberdb.sid import SIDUtils
 from .ip_address_man import IPAddressManager, IPNotInUseError, \
@@ -28,12 +31,9 @@ from .ip_address_man import IPAddressManager, IPNotInUseError, \
 from .ip_allocator_base import DuplicateIPAssignmentError, \
     DuplicatedIPAllocationError, IPBlockNotFoundError, NoAvailableIPError, \
     OverlappedIPBlocksError
-
-from .subscriberdb_client import SubscriberDBConnectionError,\
-    SubscriberDBStaticIPValueError, SubscriberDBMultiAPNValueError
-
 from .ipv6_allocator_pool import MaxCalculationError
-from google.protobuf.json_format import MessageToJson
+from .subscriberdb_client import SubscriberDBConnectionError, \
+    SubscriberDBMultiAPNValueError, SubscriberDBStaticIPValueError
 
 
 class MobilityServiceRpcServicer(MobilityServiceServicer):
@@ -145,7 +145,6 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         """ Allocate an IP address from the free IP pool """
         logging.debug("Received AllocateIPAddress")
         self._print_grpc(request)
-        ip_addr = IPAddress()
         composite_sid = SIDUtils.to_str(request.sid)
         if request.apn:
             composite_sid = composite_sid + "." + request.apn
@@ -153,18 +152,18 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         if request.version == AllocateIPRequest.IPV4:
             resp = self._get_allocate_ip_response(composite_sid + ",ipv4",
                                                   IPAddress.IPV4, context,
-                                                  ip_addr, request)
+                                                  request)
         elif request.version == AllocateIPRequest.IPV6:
             resp = self._get_allocate_ip_response(composite_sid + ",ipv6",
                                                   IPAddress.IPV6, context,
-                                                  ip_addr, request)
+                                                  request)
         elif request.version == AllocateIPRequest.IPV4V6:
             ipv4_response = self._get_allocate_ip_response(
                 composite_sid + ",ipv4", IPAddress.IPV4,
-                context, ip_addr, request)
+                context, request)
             ipv6_response = self._get_allocate_ip_response(
                 composite_sid + ",ipv6", IPAddress.IPV6,
-                context, ip_addr, request)
+                context, request)
             ipv4_addr = ipv4_response.ip_list[0]
             ipv6_addr = ipv6_response.ip_list[0]
             # Get vlan from IPv4 Allocate response
@@ -312,15 +311,13 @@ class MobilityServiceRpcServicer(MobilityServiceServicer):
         self._ip_address_man.set_gateway_info(info)
 
     def _get_allocate_ip_response(self, composite_sid, version, context,
-                                  ip_addr,
                                   request):
         try:
             ip, vlan = self._ip_address_man.alloc_ip_address(composite_sid,
                                                              version)
             logging.info("Allocated IP %s for sid %s for apn %s"
                          % (ip, SIDUtils.to_str(request.sid), request.apn))
-            ip_addr.version = version
-            ip_addr.address = ip.packed
+            ip_addr = IPAddress(address=ip.packed, version=version)
             return AllocateIPAddressResponse(ip_list=[ip_addr],
                                              vlan=str(vlan))
         except NoAvailableIPError:


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- This updates ip allocators to use separate IP state maps for IPV4 and IPV6 addresses to track current state of the IP addresses, as previously there can be a case when IPv4 allocator can retrieve IPv6 addresses allocated on the same map.

## Test Plan

- make test
- make integ_test

```
Oct 28 23:57:44 magma-dev mobilityd[17068]: INFO:root:Adding ipv4 block
Oct 28 23:57:44 magma-dev mobilityd[17068]: INFO:root:Added block 192.168.128.0/24 to the IPv4 address pool
Oct 28 23:57:49 magma-dev mobilityd[17068]: WARNING:root:Invalid data for sid IMSI001010000000001.magma.ipv4,ipv4:
Oct 28 23:57:49 magma-dev mobilityd[17068]: INFO:root:Allocated IP 192.168.128.182 for sid IMSI001010000000001 for apn magma.ipv4
Oct 28 23:57:54 magma-dev mobilityd[17068]: INFO:root:Allocated IP fdee:5:6c:5c77:2896:8ec5:547c:57ff for sid IMSI001010000000001 for apn ims
Oct 28 23:58:04 magma-dev mobilityd[17068]: WARNING:root:Invalid data for sid IMSI001010000000001.internet,ipv4:
Oct 28 23:58:04 magma-dev mobilityd[17068]: INFO:root:Allocated IP 192.168.128.164 for sid IMSI001010000000001 for apn internet
Oct 28 23:58:04 magma-dev mobilityd[17068]: INFO:root:Allocated IP fdee:5:6c:d764:82f0:1781:5ba5:c351 for sid IMSI001010000000001 for apn internet
Oct 28 23:58:14 magma-dev mobilityd[17068]: INFO:root:Released IP fdee:5:6c:5c77:2896:8ec5:547c:57ff for sid IMSI001010000000001
Oct 28 23:58:14 magma-dev mobilityd[17068]: INFO:root:Released IP 192.168.128.182 for sid IMSI001010000000001
Oct 28 23:58:14 magma-dev mobilityd[17068]: INFO:root:Released IP fdee:5:6c:d764:82f0:1781:5ba5:c351 for sid IMSI001010000000001
Oct 28 23:58:14 magma-dev mobilityd[17068]: INFO:root:Released IP 192.168.128.164 for sid IMSI001010000000001
```

## Additional Information

- [ ] This change is backwards-breaking

