### PR TITLE
[cwf][openwrt][aaa] Add S6a CancelLocation & Reset responder service into GW service registry

### DIFF
--- a/cwf/gateway/configs/service_registry.yml
+++ b/cwf/gateway/configs/service_registry.yml
@@ -65,6 +65,9 @@ services:
   abort_session_service:
     ip_address: 127.0.0.1
     port: 9109
+  s6a_service:
+    ip_address: 127.0.0.1
+    port: 9109
   # If modifying the port, ensure the healthcheck at
   # magma/cwf/gateway/docker/docker-compose.yml is updated
   eap_sim:

--- a/openwrt/gateway/configs/etc/magma/configs/service_registry.yml
+++ b/openwrt/gateway/configs/etc/magma/configs/service_registry.yml
@@ -21,3 +21,9 @@ services:
   aaa_server:
     ip_address: 127.0.0.1
     port: 9109
+  abort_session_service:
+    ip_address: 127.0.0.1
+    port: 9109
+  s6a_service:
+    ip_address: 127.0.0.1
+    port: 9109


### PR DESCRIPTION

Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

Add S6a CancelLocation & Reset responder service into GW service registry

## Test Plan

unit tests

## Additional Information

- [ ] This change is backwards-breaking

