### PR TITLE
[NMS] Fix the ApnEditTest

### DIFF
--- a/nms/app/packages/magmalte/app/views/traffic/ApnEdit.js
+++ b/nms/app/packages/magmalte/app/views/traffic/ApnEdit.js
@@ -31,7 +31,6 @@ import InputAdornment from '@material-ui/core/InputAdornment';
 import List from '@material-ui/core/List';
 import ListItem from '@material-ui/core/ListItem';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
-import Paper from '@material-ui/core/Paper';
 import React from 'react';
 import Switch from '@material-ui/core/Switch';
 import Text from '../../theme/design-system/Text';
@@ -149,7 +148,7 @@ export function ApnEdit(props: Props) {
   return (
     <>
       <DialogContent data-testid="apnEditDialog">
-        <List component={Paper}>
+        <List>
           {error !== '' && (
             <AltFormField label={''}>
               <FormLabel data-testid="configEditError" error>

--- a/nms/app/packages/magmalte/app/views/traffic/ApnOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/ApnOverview.js
@@ -18,13 +18,11 @@ import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
 import ActionTable from '../../components/ActionTable';
 import ApnContext from '../../components/context/ApnContext';
 import ApnEditDialog from './ApnEdit';
-import Button from '@material-ui/core/Button';
-import Grid from '@material-ui/core/Grid';
+import CardTitleRow from '../../components/layout/CardTitleRow';
 import JsonEditor from '../../components/JsonEditor';
 import Link from '@material-ui/core/Link';
 import React from 'react';
 import RssFeedIcon from '@material-ui/icons/RssFeed';
-import Text from '../../theme/design-system/Text';
 import withAlert from '@fbcnms/ui/components/Alert/withAlert';
 
 import {colors, typography} from '../../theme/default';
@@ -33,7 +31,6 @@ import {useContext, useState} from 'react';
 import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
 import {useRouter} from '@fbcnms/ui/hooks';
 
-const APN_TITLE = 'APNs';
 const DEFAULT_APN_CONFIG = {
   apn_configuration: {
     ambr: {
@@ -116,6 +113,7 @@ type ApnRowType = {
   added: Date,
 };
 
+const APN_TITLE = 'APNs';
 function ApnOverview(props: WithAlert) {
   const classes = useStyles();
   const enqueueSnackbar = useEnqueueSnackbar();
@@ -137,108 +135,76 @@ function ApnOverview(props: WithAlert) {
   return (
     <div className={classes.dashboardRoot}>
       <>
-        <Grid container spacing={3}>
-          <Grid container>
-            <Grid item xs={6}>
-              <Text key="title" data-testid={`title_${APN_TITLE}`}>
-                <RssFeedIcon /> {APN_TITLE}
-              </Text>
-            </Grid>
-            <Grid
-              container
-              item
-              xs={6}
-              justify="flex-end"
-              alignItems="center"
-              spacing={2}>
-              <Grid item>
-                <Button className={classes.appBarBtnSecondary}>
-                  Upload CSV
-                </Button>
-              </Grid>
-            </Grid>
-          </Grid>
-          <Grid item xs={12}>
-            <ApnEditDialog
-              open={open}
-              onClose={() => setOpen(false)}
-              apn={
-                Object.keys(currRow).length ? apns[currRow.apnID] : undefined
-              }
-            />
-          </Grid>
-          <Grid item xs={12}>
-            <ActionTable
-              data={apnRows}
-              columns={[
-                {
-                  title: 'Apn ID',
-                  field: 'apnID',
-                  render: currRow => (
-                    <Link
-                      variant="body2"
-                      component="button"
-                      onClick={() => {
-                        setCurrRow(currRow);
-                        setOpen(true);
-                      }}>
-                      {currRow.apnID}
-                    </Link>
-                  ),
-                },
-                {title: 'Description', field: 'description'},
-                {title: 'Qos Profile', field: 'qosProfile', type: 'numeric'},
-                {title: 'Added', field: 'added', type: 'datetime'},
-              ]}
-              handleCurrRow={(row: ApnRowType) => setCurrRow(row)}
-              menuItems={[
-                {
-                  name: 'Edit',
-                  handleFunc: () => {
+        <CardTitleRow key="title" icon={RssFeedIcon} label={APN_TITLE} />
+        <ApnEditDialog
+          open={open}
+          onClose={() => setOpen(false)}
+          apn={Object.keys(currRow).length ? apns[currRow.apnID] : undefined}
+        />
+        <ActionTable
+          data={apnRows}
+          columns={[
+            {
+              title: 'Apn ID',
+              field: 'apnID',
+              render: currRow => (
+                <Link
+                  variant="body2"
+                  component="button"
+                  onClick={() => {
+                    setCurrRow(currRow);
                     setOpen(true);
-                  },
-                },
-                {
-                  name: 'Edit JSON',
-                  handleFunc: () => {
-                    history.push(relativeUrl('/' + currRow.apnID + '/json'));
-                  },
-                },
-                {name: 'Deactivate'},
-                {
-                  name: 'Remove',
-                  handleFunc: () => {
-                    props
-                      .confirm(
-                        `Are you sure you want to delete ${currRow.apnID}?`,
-                      )
-                      .then(async confirmed => {
-                        if (!confirmed) {
-                          return;
-                        }
+                  }}>
+                  {currRow.apnID}
+                </Link>
+              ),
+            },
+            {title: 'Description', field: 'description'},
+            {title: 'Qos Profile', field: 'qosProfile', type: 'numeric'},
+            {title: 'Added', field: 'added', type: 'datetime'},
+          ]}
+          handleCurrRow={(row: ApnRowType) => setCurrRow(row)}
+          menuItems={[
+            {
+              name: 'Edit',
+              handleFunc: () => {
+                setOpen(true);
+              },
+            },
+            {
+              name: 'Edit JSON',
+              handleFunc: () => {
+                history.push(relativeUrl('/' + currRow.apnID + '/json'));
+              },
+            },
+            {name: 'Deactivate'},
+            {
+              name: 'Remove',
+              handleFunc: () => {
+                props
+                  .confirm(`Are you sure you want to delete ${currRow.apnID}?`)
+                  .then(async confirmed => {
+                    if (!confirmed) {
+                      return;
+                    }
 
-                        try {
-                          // trigger deletion
-                          ctx.setState(currRow.apnID);
-                        } catch (e) {
-                          enqueueSnackbar(
-                            'failed deleting APN ' + currRow.apnID,
-                            {
-                              variant: 'error',
-                            },
-                          );
-                        }
+                    try {
+                      // trigger deletion
+                      ctx.setState(currRow.apnID);
+                    } catch (e) {
+                      enqueueSnackbar('failed deleting APN ' + currRow.apnID, {
+                        variant: 'error',
                       });
-                  },
-                },
-              ]}
-              options={{
-                actionsColumnIndex: -1,
-                pageSizeOptions: [5, 10],
-              }}
-            />
-          </Grid>
-        </Grid>
+                    }
+                  });
+              },
+            },
+          ]}
+          options={{
+            actionsColumnIndex: -1,
+            pageSizeOptions: [5, 10],
+          }}
+        />
       </>
     </div>
   );

--- a/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
@@ -120,7 +120,10 @@ function ApnMenu() {
   return (
     <div>
       <ApnEditDialog open={open} onClose={() => setOpen(false)} />
-      <Button onClick={() => setOpen(true)} className={classes.appBarBtn}>
+      <Button
+        data-testid="newApnButton"
+        onClick={() => setOpen(true)}
+        className={classes.appBarBtn}>
         Create New APN
       </Button>
     </div>

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/ApnAddTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/ApnAddTest.js
@@ -79,6 +79,18 @@ describe('<TrafficDashboard />', () => {
     MagmaAPIBindings.getLteByNetworkIdApns.mockResolvedValue(apns);
   });
 
+  const {location} = window;
+  beforeAll((): void => {
+    delete window.location;
+    window.location = {
+      pathname: '/nms/test/traffic/apn',
+    };
+  });
+
+  afterAll((): void => {
+    window.location = location;
+  });
+
   const ApnWrapper = () => (
     <MemoryRouter initialEntries={['/nms/test/traffic/apn']} initialIndex={0}>
       <MuiThemeProvider theme={defaultTheme}>
@@ -90,7 +102,7 @@ describe('<TrafficDashboard />', () => {
             <LteNetworkContextProvider networkId={'test'}>
               <ApnProvider networkId={'test'}>
                 <Route
-                  path="/nms/:networkId/traffic/apn"
+                  path="/nms/:networkId/traffic"
                   component={TrafficDashboard}
                 />
               </ApnProvider>
@@ -104,94 +116,98 @@ describe('<TrafficDashboard />', () => {
   // verify apn add
   // verify apn edit
 
-  // it('verify apn add', async () => {
-  //   const networkId = 'test';
-  //   const {queryByTestId, getByTestId, getByText} = render(<ApnWrapper />);
-  //   await wait();
+  it('verify apn add', async () => {
+    const networkId = 'test';
+    const {queryByTestId, getByTestId, getByText} = render(<ApnWrapper />);
+    await wait();
 
-  //   expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledWith({
-  //     networkId,
-  //   });
-  //   expect(MagmaAPIBindings.getLteByNetworkIdApns).toHaveBeenCalledWith({
-  //     networkId,
-  //   });
+    expect(MagmaAPIBindings.getLteByNetworkId).toHaveBeenCalledWith({
+      networkId,
+    });
+    expect(MagmaAPIBindings.getLteByNetworkIdApns).toHaveBeenCalledWith({
+      networkId,
+    });
 
-  //   expect(queryByTestId('editDialog')).toBeNull();
-  //   await wait();
-  //   fireEvent.click(getByText('APNs'));
-  //   await wait();
-  //   fireEvent.click(getByText('Create New APN'));
-  //   await wait();
-  //   expect(queryByTestId('editDialog')).not.toBeNull();
+    expect(queryByTestId('editDialog')).toBeNull();
+    await wait();
 
-  //   expect(queryByTestId('apnEditDialog')).not.toBeNull();
+    const newAPNButton = queryByTestId('newApnButton');
+    expect(newAPNButton).not.toBeNull();
 
-  //   const apnID = getByTestId('apnID').firstChild;
-  //   const classID = getByTestId('classID').firstChild;
-  //   const apnPriority = getByTestId('apnPriority').firstChild;
-  //   const apnBandwidthUL = getByTestId('apnBandwidthUL').firstChild;
-  //   const apnBandwidthDL = getByTestId('apnBandwidthDL').firstChild;
-  //   const preemptionCapability = getByTestId('preemptionCapability').firstChild;
-  //   const preemptionVulnerability = getByTestId('preemptionVulnerability')
-  //     .firstChild;
+    if (newAPNButton) {
+      fireEvent.click(newAPNButton);
+      await wait();
+    }
+    expect(queryByTestId('editDialog')).not.toBeNull();
 
-  //   // test adding an existing apn
-  //   if (apnID instanceof HTMLInputElement) {
-  //     fireEvent.change(apnID, {target: {value: 'apn_0'}});
-  //   } else {
-  //     throw 'invalid type';
-  //   }
+    expect(queryByTestId('apnEditDialog')).not.toBeNull();
 
-  //   fireEvent.click(getByText('Save'));
-  //   await wait();
+    const apnID = getByTestId('apnID').firstChild;
+    const classID = getByTestId('classID').firstChild;
+    const apnPriority = getByTestId('apnPriority').firstChild;
+    const apnBandwidthUL = getByTestId('apnBandwidthUL').firstChild;
+    const apnBandwidthDL = getByTestId('apnBandwidthDL').firstChild;
+    const preemptionCapability = getByTestId('preemptionCapability').firstChild;
+    const preemptionVulnerability = getByTestId('preemptionVulnerability')
+      .firstChild;
 
-  //   expect(getByTestId('configEditError')).toHaveTextContent(
-  //     'APN apn_0 already exists',
-  //   );
+    // test adding an existing apn
+    if (apnID instanceof HTMLInputElement) {
+      fireEvent.change(apnID, {target: {value: 'apn_0'}});
+    } else {
+      throw 'invalid type';
+    }
 
-  //   if (
-  //     apnID instanceof HTMLInputElement &&
-  //     classID instanceof HTMLInputElement &&
-  //     apnPriority instanceof HTMLInputElement &&
-  //     apnBandwidthUL instanceof HTMLInputElement &&
-  //     apnBandwidthDL instanceof HTMLInputElement
-  //   ) {
-  //     fireEvent.change(apnID, {target: {value: 'apn_2'}});
-  //     fireEvent.change(classID, {target: {value: 9}});
-  //     fireEvent.change(apnPriority, {target: {value: 15}});
-  //     fireEvent.change(apnBandwidthUL, {target: {value: 1000000}});
-  //     fireEvent.change(apnBandwidthDL, {target: {value: 1000000}});
-  //     if (preemptionCapability?.firstChild instanceof HTMLElement) {
-  //       fireEvent.click(preemptionCapability.firstChild);
-  //     }
-  //     if (preemptionVulnerability?.firstChild instanceof HTMLElement) {
-  //       fireEvent.click(preemptionVulnerability.firstChild);
-  //     }
-  //   } else {
-  //     throw 'invalid type';
-  //   }
+    fireEvent.click(getByText('Save'));
+    await wait();
 
-  //   fireEvent.click(getByText('Save'));
-  //   await wait();
+    expect(getByTestId('configEditError')).toHaveTextContent(
+      'APN apn_0 already exists',
+    );
 
-  //   const newApn = {
-  //     apn_configuration: {
-  //       ambr: {max_bandwidth_dl: 1000000, max_bandwidth_ul: 1000000},
-  //       qos_profile: {
-  //         class_id: 9,
-  //         preemption_capability: true,
-  //         preemption_vulnerability: true,
-  //         priority_level: 15,
-  //       },
-  //     },
-  //     apn_name: 'apn_2',
-  //   };
+    if (
+      apnID instanceof HTMLInputElement &&
+      classID instanceof HTMLInputElement &&
+      apnPriority instanceof HTMLInputElement &&
+      apnBandwidthUL instanceof HTMLInputElement &&
+      apnBandwidthDL instanceof HTMLInputElement
+    ) {
+      fireEvent.change(apnID, {target: {value: 'apn_2'}});
+      fireEvent.change(classID, {target: {value: 9}});
+      fireEvent.change(apnPriority, {target: {value: 15}});
+      fireEvent.change(apnBandwidthUL, {target: {value: 1000000}});
+      fireEvent.change(apnBandwidthDL, {target: {value: 1000000}});
+      if (preemptionCapability?.firstChild instanceof HTMLElement) {
+        fireEvent.click(preemptionCapability.firstChild);
+      }
+      if (preemptionVulnerability?.firstChild instanceof HTMLElement) {
+        fireEvent.click(preemptionVulnerability.firstChild);
+      }
+    } else {
+      throw 'invalid type';
+    }
 
-  //   expect(MagmaAPIBindings.postLteByNetworkIdApns).toHaveBeenCalledWith({
-  //     networkId,
-  //     apn: newApn,
-  //   });
-  // });
+    fireEvent.click(getByText('Save'));
+    await wait();
+
+    const newApn = {
+      apn_configuration: {
+        ambr: {max_bandwidth_dl: 1000000, max_bandwidth_ul: 1000000},
+        qos_profile: {
+          class_id: 9,
+          preemption_capability: true,
+          preemption_vulnerability: true,
+          priority_level: 15,
+        },
+      },
+      apn_name: 'apn_2',
+    };
+
+    expect(MagmaAPIBindings.postLteByNetworkIdApns).toHaveBeenCalledWith({
+      networkId,
+      apn: newApn,
+    });
+  });
 
   it('verify apn edit', async () => {
     const networkId = 'test';
@@ -209,8 +225,6 @@ describe('<TrafficDashboard />', () => {
     expect(queryByTestId('editDialog')).toBeNull();
 
     // click on apns tab
-    fireEvent.click(getByText('APNs'));
-    await wait();
     fireEvent.click(getByText('apn_0'));
     await wait();
     expect(queryByTestId('editDialog')).not.toBeNull();

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -103,7 +103,7 @@ const policies = {
   },
 };
 
-describe('<TrafficDashboard />', () => {
+describe('<TrafficDashboard Policy/>', () => {
   const networkId = 'test';
   const policyCtx = {
     state: policies,
@@ -140,7 +140,7 @@ describe('<TrafficDashboard />', () => {
           <PolicyContext.Provider value={policyCtx}>
             <ApnContext.Provider value={apnCtx}>
               <Route
-                path="/nms/:networkId/traffic/policy"
+                path="/nms/:networkId/traffic"
                 component={TrafficDashboard}
               />
             </ApnContext.Provider>
@@ -150,9 +150,7 @@ describe('<TrafficDashboard />', () => {
     </MemoryRouter>
   );
   it('renders', async () => {
-    const {getByTestId, getAllByRole, getAllByTitle, getByText} = render(
-      <Wrapper />,
-    );
+    const {getByTestId, getAllByRole, getAllByTitle} = render(<Wrapper />);
     await wait();
     // Policy tables rows
     const rowItemsPolicy = await getAllByRole('row');
@@ -188,30 +186,8 @@ describe('<TrafficDashboard />', () => {
     fireEvent.click(policyActionList[0]);
     await wait();
     expect(getByTestId('actions-menu')).toBeVisible();
-    // Apns tab
-    fireEvent.click(getByText('APNs'));
-    await wait();
-    expect(getByTestId('title_APNs')).toHaveTextContent('APNs');
-    // Apn tables rows
-    const rowItemsApns = await getAllByRole('row');
-    // first row is the header
-    expect(rowItemsApns[0]).toHaveTextContent('Apn ID');
-    expect(rowItemsApns[0]).toHaveTextContent('Description');
-    expect(rowItemsApns[0]).toHaveTextContent('Qos Profile');
-    expect(rowItemsApns[0]).toHaveTextContent('Added');
-    expect(rowItemsApns[1]).toHaveTextContent('apn_0');
-    expect(rowItemsApns[1]).toHaveTextContent('Test APN description');
-    expect(rowItemsApns[1]).toHaveTextContent('1');
-    expect(rowItemsApns[2]).toHaveTextContent('apn_1');
-    expect(rowItemsApns[2]).toHaveTextContent('Test APN description');
-    expect(rowItemsApns[2]).toHaveTextContent('1');
-    // click the actions button for apn 0
-    const apnActionList = getAllByTitle('Actions');
-    expect(getByTestId('actions-menu')).not.toBeVisible();
-    fireEvent.click(apnActionList[0]);
-    await wait();
-    expect(getByTestId('actions-menu')).toBeVisible();
   });
+
   it('shows prompt when remove policy is clicked', async () => {
     MagmaAPIBindings.deleteNetworksByNetworkIdPoliciesRulesByRuleId.mockResolvedValueOnce(
       {},
@@ -239,15 +215,106 @@ describe('<TrafficDashboard />', () => {
     });
     axiosMock.delete.mockClear();
   });
+});
+
+describe('<TrafficDashboard APNs/>', () => {
+  const {location} = window;
+  beforeAll((): void => {
+    delete window.location;
+    window.location = {
+      pathname: '/nms/test/traffic/apn',
+    };
+  });
+
+  afterAll((): void => {
+    window.location = location;
+  });
+
+  const networkId = 'test';
+  const policyCtx = {
+    state: policies,
+    qosProfiles: {},
+    setQosProfiles: async () => {},
+    setState: (key, value?) => {
+      return SetPolicyState({
+        policies,
+        setPolicies: () => {},
+        networkId,
+        key,
+        value,
+      });
+    },
+  };
+  const apnCtx = {
+    state: apns,
+    setState: (key, value?) => {
+      return SetApnState({
+        apns,
+        setApns: () => {},
+        networkId,
+        key,
+        value,
+      });
+    },
+  };
+  const Wrapper = () => (
+    <MemoryRouter initialEntries={['/nms/test/traffic/apn']} initialIndex={0}>
+      <MuiThemeProvider theme={defaultTheme}>
+        <MuiStylesThemeProvider theme={defaultTheme}>
+          <PolicyContext.Provider value={policyCtx}>
+            <ApnContext.Provider value={apnCtx}>
+              <Route
+                path="/nms/:networkId/traffic"
+                component={TrafficDashboard}
+              />
+            </ApnContext.Provider>
+          </PolicyContext.Provider>
+        </MuiStylesThemeProvider>
+      </MuiThemeProvider>
+    </MemoryRouter>
+  );
+  it('renders', async () => {
+    const {
+      debug,
+      getAllByText,
+      getByTestId,
+      getAllByRole,
+      getAllByTitle,
+    } = render(<Wrapper />);
+    await wait();
+    debug();
+
+    const apnTitles = getAllByText('APNs');
+    expect(apnTitles.length).toBe(2);
+
+    // Apn tables rows
+    const rowItemsApns = await getAllByRole('row');
+    // first row is the header
+    expect(rowItemsApns[0]).toHaveTextContent('Apn ID');
+    expect(rowItemsApns[0]).toHaveTextContent('Description');
+    expect(rowItemsApns[0]).toHaveTextContent('Qos Profile');
+    expect(rowItemsApns[0]).toHaveTextContent('Added');
+    expect(rowItemsApns[1]).toHaveTextContent('apn_0');
+    expect(rowItemsApns[1]).toHaveTextContent('Test APN description');
+    expect(rowItemsApns[1]).toHaveTextContent('1');
+    expect(rowItemsApns[2]).toHaveTextContent('apn_1');
+    expect(rowItemsApns[2]).toHaveTextContent('Test APN description');
+    expect(rowItemsApns[2]).toHaveTextContent('1');
+    // click the actions button for apn 0
+    const apnActionList = getAllByTitle('Actions');
+    expect(getByTestId('actions-menu')).not.toBeVisible();
+    fireEvent.click(apnActionList[0]);
+    await wait();
+    expect(getByTestId('actions-menu')).toBeVisible();
+  });
+
   it('shows prompt when remove apn is clicked', async () => {
     MagmaAPIBindings.deleteLteByNetworkIdApnsByApnName.mockResolvedValueOnce(
       {},
     );
     const {getByText, getByTestId, getAllByTitle} = render(<Wrapper />);
     await wait();
-    fireEvent.click(getByText('APNs'));
-    await wait();
-    // click remove action for policy 0
+
     const apnActionList = getAllByTitle('Actions');
     expect(getByTestId('actions-menu')).not.toBeVisible();
     fireEvent.click(apnActionList[0]);


### PR DESCRIPTION
## Summary

- ApnEditTest tabs didn't change because of the location.pathname. The tabs remained stuck to policies and hence the create new apn button wasn't visible. Hacking the pathname fixed this issue
- made minor changes remove paper component in list and made it consistent with other dialogs.
- remove upload csv secondary button in ApnOverview. When we implement it, we can add it to the tab filter

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
