### PR TITLE
[agw][mme] [teravm] Start SGS and SMS Grpc listeners only when services are enabled

### DIFF
--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service.cpp
@@ -29,6 +29,7 @@
 
 extern "C" {
 #include "log.h"
+#include "mme_config.h"
 }
 
 using grpc::InsecureServerCredentials;
@@ -63,7 +64,12 @@ void start_grpc_service(bstring server_address) {
 #endif
   builder.RegisterService(&s6a_proxy);
   builder.RegisterService(&s6a_service);
-  builder.RegisterService(&sgs_service);
+  // Start the SGS service only if non_eps_service_control is not set to OFF
+  char* non_eps_service_control = bdata(mme_config.non_eps_service_control);
+  if (!strcmp(non_eps_service_control, "CSFB_SMS") ||
+      !strcmp(non_eps_service_control, "SMS")) {
+    builder.RegisterService(&sgs_service);
+  }
   builder.RegisterService(&sms_orc8r_service);
   builder.RegisterService(&s1ap_service);
   server = builder.BuildAndStart();

--- a/lte/gateway/c/oai/tasks/grpc_service/grpc_service.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/grpc_service.cpp
@@ -70,7 +70,10 @@ void start_grpc_service(bstring server_address) {
       !strcmp(non_eps_service_control, "SMS")) {
     builder.RegisterService(&sgs_service);
   }
-  builder.RegisterService(&sms_orc8r_service);
+  // Start the SMS service only if non_eps_service_control is set to SMS_ORC8R
+  if (!strcmp(non_eps_service_control, "SMS_ORC8R")) {
+    builder.RegisterService(&sms_orc8r_service);
+  }
   builder.RegisterService(&s1ap_service);
   server = builder.BuildAndStart();
 }


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

As reported in #3415 , the MME crashes whenever non EPS services are disabled on AGW and it receives a Reset message from VLR.

## Test Plan

- Regression testing with S1ap integration tests
- The crash disappears on TeraVM after applying the patch (Thanks @uri200 for testing!)

