### PR TITLE
[agw][stateless MME] Turn-off 5G GTP app for pipelined

### DIFF
--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -160,4 +160,4 @@ ovs_gtp_stats_polling_interval: 60
 
 # For 5G Functionality Support flag
 5G_feature_set:
- enable: True
+ enable: False

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -121,13 +121,13 @@ s1aptests/test_attach_asr.py \
 s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
-s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_restore_mme_config_after_sanity.py
-#s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
+s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
+s1aptests/test_attach_detach_attach_ul_tcp_data.py \
+s1aptests/test_restore_mme_config_after_sanity.py
 
 # These test cases pass without memory leaks, but needs DL-route in TRF server
 # sudo /sbin/route add -net 192.168.128.0 gw 192.168.60.142


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The data traffic test cases for stateless AGW were failing in S1AP test suite as the 5G GTP app in Pipelined was cleaning up flows on restart. Disabling the GTP app for now until we make it stateless.

## Test Plan

S1AP integration tests with all tests enabled.