### PR TITLE
[nms] Disable flaky e2e test for policy dashboard

### DIFF
--- a/nms/app/packages/magmalte/app/e2e/__tests__/Policy-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/Policy-test.js
@@ -59,115 +59,116 @@ describe('NMS', () => {
   }, 60000);
 });
 
-describe('NMS Policy Add', () => {
-  test('verifying policy dashboard', async () => {
-    const page = await browser.newPage();
-    try {
-      await page.goto('https://magma-test.localhost/nms/test/traffic/policy');
+// TODO (andreilee): Get these tests working again without flakiness
+// describe('NMS Policy Add', () => {
+//   test('verifying policy dashboard', async () => {
+//     const page = await browser.newPage();
+//     try {
+//       await page.goto('https://magma-test.localhost/nms/test/traffic/policy');
 
-      // check if the description is right
-      await page.waitForXPath(`//span[text()='Policies']`);
+//       // check if the description is right
+//       await page.waitForXPath(`//span[text()='Policies']`);
 
-      const buttonSelector = await page.$x(`//span[text()='Create New']`);
-      buttonSelector[0].click();
+//       const buttonSelector = await page.$x(`//span[text()='Create New']`);
+//       buttonSelector[0].click();
 
-      const policyButtonSelector = '[data-testid="newPolicyMenuItem"]';
-      await page.waitForSelector(policyButtonSelector);
-      page.click(policyButtonSelector);
+//       const policyButtonSelector = '[data-testid="newPolicyMenuItem"]';
+//       await page.waitForSelector(policyButtonSelector);
+//       page.click(policyButtonSelector);
 
-      await page.waitForXPath(`//span[text()='Add New Policy']`);
+//       await page.waitForXPath(`//span[text()='Add New Policy']`);
 
-      // verify if we have policy info tab active
-      await page.waitForXPath(`//span[text()='Basic policy rule fields']`);
-      const policySelector = '[data-testid="policyID"]';
-      const prioSelector = '[data-testid="policyPriority"]';
+//       // verify if we have policy info tab active
+//       await page.waitForXPath(`//span[text()='Basic policy rule fields']`);
+//       const policySelector = '[data-testid="policyID"]';
+//       const prioSelector = '[data-testid="policyPriority"]';
 
-      // add policy information attributes
-      await page.waitForSelector(policySelector);
-      await page.click(policySelector);
-      await page.type(policySelector, 'test_policy0');
-      await page.waitForSelector(prioSelector);
-      await page.click(prioSelector);
-      await page.type(prioSelector, '10');
+//       // add policy information attributes
+//       await page.waitForSelector(policySelector);
+//       await page.click(policySelector);
+//       await page.type(policySelector, 'test_policy0');
+//       await page.waitForSelector(prioSelector);
+//       await page.click(prioSelector);
+//       await page.type(prioSelector, '10');
 
-      let saveButtonSelector = await page.$x(
-        `//span[text()='Save And Continue']`,
-      );
-      saveButtonSelector[0].click();
-      await page.waitForXPath(`//span[text()='Policy saved successfully']`);
+//       let saveButtonSelector = await page.$x(
+//         `//span[text()='Save And Continue']`,
+//       );
+//       saveButtonSelector[0].click();
+//       await page.waitForXPath(`//span[text()='Policy saved successfully']`);
 
-      // wait for flow tab
-      await page.waitForXPath(
-        `//span[text()="A policy's flows determines how it routes traffic"]`,
-      );
+//       // wait for flow tab
+//       await page.waitForXPath(
+//         `//span[text()="A policy's flows determines how it routes traffic"]`,
+//       );
 
-      const addFlowSelector = '[data-testid="addFlowButton"]';
-      await page.waitForSelector(addFlowSelector);
-      await page.click(addFlowSelector);
-      const ipSrc = '[data-testid="ipSrc"]';
-      const ipDst = '[data-testid="ipDest"]';
+//       const addFlowSelector = '[data-testid="addFlowButton"]';
+//       await page.waitForSelector(addFlowSelector);
+//       await page.click(addFlowSelector);
+//       const ipSrc = '[data-testid="ipSrc"]';
+//       const ipDst = '[data-testid="ipDest"]';
 
-      // add policy information attributes
-      await page.waitForSelector(ipSrc);
-      await page.click(ipSrc);
-      await page.type(ipSrc, '1.1.1.1');
-      await page.waitForSelector(ipDst);
-      await page.click(ipDst);
-      await page.type(ipDst, '2.2.2.2');
+//       // add policy information attributes
+//       await page.waitForSelector(ipSrc);
+//       await page.click(ipSrc);
+//       await page.type(ipSrc, '1.1.1.1');
+//       await page.waitForSelector(ipDst);
+//       await page.click(ipDst);
+//       await page.type(ipDst, '2.2.2.2');
 
-      saveButtonSelector = await page.$x(`//span[text()='Save And Continue']`);
-      saveButtonSelector[0].click();
-      await page.waitForXPath(`//span[text()='Policy saved successfully']`);
-    } catch (err) {
-      await page.screenshot({path: ARTIFACTS_DIR + 'policy_add_failed.png'});
-      await page.close();
-      throw err;
-    }
+//       saveButtonSelector = await page.$x(`//span[text()='Save And Continue']`);
+//       saveButtonSelector[0].click();
+//       await page.waitForXPath(`//span[text()='Policy saved successfully']`);
+//     } catch (err) {
+//       await page.screenshot({path: ARTIFACTS_DIR + 'policy_add_failed.png'});
+//       await page.close();
+//       throw err;
+//     }
 
-    await page.screenshot({
-      path: ARTIFACTS_DIR + 'policy_add.png',
-    });
-  }, 60000);
-});
+//     await page.screenshot({
+//       path: ARTIFACTS_DIR + 'policy_add.png',
+//     });
+//   }, 60000);
+// });
 
-describe('NMS Policy Edit', () => {
-  test('verifying policy dashboard', async () => {
-    const page = await browser.newPage();
-    try {
-      await page.goto('https://magma-test.localhost/nms/test/traffic/policy');
+// describe('NMS Policy Edit', () => {
+//   test('verifying policy dashboard', async () => {
+//     const page = await browser.newPage();
+//     try {
+//       await page.goto('https://magma-test.localhost/nms/test/traffic/policy');
 
-      // check if the description is right
-      await page.waitForXPath(`//span[text()='Policies']`);
+//       // check if the description is right
+//       await page.waitForXPath(`//span[text()='Policies']`);
 
-      const buttonSelector = await page.$x(`//button[text()='test1']`);
-      buttonSelector[0].click();
+//       const buttonSelector = await page.$x(`//button[text()='test1']`);
+//       buttonSelector[0].click();
 
-      await page.waitForXPath(`//span[text()='Edit Policy']`);
+//       await page.waitForXPath(`//span[text()='Edit Policy']`);
 
-      // verify if we have policy info tab active
-      await page.waitForXPath(`//span[text()='Basic policy rule fields']`);
-      const prioSelector = '[data-testid="policyPriority"]';
+//       // verify if we have policy info tab active
+//       await page.waitForXPath(`//span[text()='Basic policy rule fields']`);
+//       const prioSelector = '[data-testid="policyPriority"]';
 
-      // add policy information attributes
-      await page.waitForSelector(prioSelector);
-      await page.click(prioSelector);
-      await page.evaluate(prioSelector => {
-        document.querySelector(prioSelector).value = '';
-      }, prioSelector);
-      await page.type(prioSelector, '10');
+//       // add policy information attributes
+//       await page.waitForSelector(prioSelector);
+//       await page.click(prioSelector);
+//       await page.evaluate(prioSelector => {
+//         document.querySelector(prioSelector).value = '';
+//       }, prioSelector);
+//       await page.type(prioSelector, '10');
 
-      const saveButtonSelector = await page.$x(`//span[text()='Save']`);
-      saveButtonSelector[0].click();
+//       const saveButtonSelector = await page.$x(`//span[text()='Save']`);
+//       saveButtonSelector[0].click();
 
-      await page.waitForXPath(`//span[text()='Policy saved successfully']`);
-    } catch (err) {
-      await page.screenshot({path: ARTIFACTS_DIR + 'policy_edit_failed.png'});
-      await page.close();
-      throw err;
-    }
+//       await page.waitForXPath(`//span[text()='Policy saved successfully']`);
+//     } catch (err) {
+//       await page.screenshot({path: ARTIFACTS_DIR + 'policy_edit_failed.png'});
+//       await page.close();
+//       throw err;
+//     }
 
-    await page.screenshot({
-      path: ARTIFACTS_DIR + 'policy_edit.png',
-    });
-  }, 60000);
-});
+//     await page.screenshot({
+//       path: ARTIFACTS_DIR + 'policy_edit.png',
+//     });
+//   }, 60000);
+// });


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

We have flaky e2e tests for nms. This revision disables those tests to unblock CI, with the intention of fixing these tests later (within days if possible).

## Test Plan

- [ ]Wait for circleCI nms e2e tests to pass

## Additional Information

- [ ] This change is backwards-breaking
