### PR TITLE
[mme] use random number to generate tmsi

### DIFF
--- a/lte/gateway/c/oai/oai_mme/oai_mme.c
+++ b/lte/gateway/c/oai/oai_mme/oai_mme.c
@@ -81,6 +81,7 @@ static void main_exit(void) {
 }
 
 int main(int argc, char* argv[]) {
+  srand(time(NULL));
   char* pid_file_name;
 
   CHECK_INIT_RETURN(OAILOG_INIT(

--- a/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
+++ b/lte/gateway/c/oai/tasks/nas/api/mme/mme_api.c
@@ -71,6 +71,8 @@
 /* Total number of PDN connections (should not exceed MME_API_PDN_MAX) */
 static int _mme_api_pdn_id = 0;
 
+static tmsi_t generate_random_TMSI(void);
+
 /****************************************************************************/
 /******************  E X P O R T E D    F U N C T I O N S  ******************/
 /****************************************************************************/
@@ -437,7 +439,7 @@ int mme_api_new_guti(
     }
     is_plmn_equal = false;
     // TODO Find another way to generate m_tmsi
-    guti->m_tmsi = (tmsi_t)(uintptr_t) ue_context;
+    guti->m_tmsi = generate_random_TMSI();
     if (guti->m_tmsi == INVALID_M_TMSI) {
       OAILOG_FUNC_RETURN(LOG_NAS, RETURNerror);
     }
@@ -620,4 +622,9 @@ int mme_api_unsubscribe(bstring apn) {
    */
   _mme_api_pdn_id -= 1;
   OAILOG_FUNC_RETURN(LOG_NAS, rc);
+}
+
+static tmsi_t generate_random_TMSI() {
+  // note srand with seed is init at main
+  return (tmsi_t) rand();
 }


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>



## Summary

In teravm we have observed that in some cases, where a UE detaches and attaches again and they reuses the TMSI. Since the TMSI are given using memory addresses, that may mean that a memory address, which was identifying specific UE may, be available for a different UE.  

To avoid that we will use `rand()` that provides a pseudo-random sequence of `INT_MAX` elements. So collisions are almost impossible.

We will initialize `srand()` with a seed based on time on main to provide different pseudo-random sequence every time mme is restarted.

## Test Plan

build_oai
test in teravm
![image](https://user-images.githubusercontent.com/16157139/98301738-20155800-1f70-11eb-9e69-435890853146.png)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
