### PR TITLE
[NMS] Add support for add/edit/view policy qos profiles

### DIFF
--- a/nms/app/packages/magmalte/app/views/traffic/PolicyOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/PolicyOverview.js
@@ -14,7 +14,7 @@
  * @format
  */
 import type {WithAlert} from '@fbcnms/ui/components/Alert/withAlert';
-import type {policy_rule} from '@fbcnms/magma-api';
+import type {policy_rule, qos_class_id} from '@fbcnms/magma-api';
 
 import ActionTable from '../../components/ActionTable';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -24,6 +24,7 @@ import Link from '@material-ui/core/Link';
 import LteNetworkContext from '../../components/context/LteNetworkContext';
 import PolicyContext from '../../components/context/PolicyContext';
 import PolicyRuleEditDialog from './PolicyEdit';
+import ProfileEditDialog from './ProfileEdit';
 import React from 'react';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
@@ -116,6 +117,13 @@ type PolicyRowType = {
   networkWide: string,
 };
 
+type ProfileRowType = {
+  classID: qos_class_id,
+  profileID: string,
+  uplinkBandwidth: number,
+  downlinkBandwidth: number,
+};
+
 const MagmaTabs = withStyles({
   indicator: {
     backgroundColor: colors.secondary.dodgerBlue,
@@ -154,7 +162,7 @@ export default function PolicyOverview() {
         })}
       </MagmaTabs>
       {currTabIndex === 0 && <PolicyTable />}
-      {currTabIndex === 1 && <Text>Policy Qos Profiles </Text>}
+      {currTabIndex === 1 && <ProfileTable />}
       {currTabIndex === 2 && <Text> Rating Groups </Text>}
     </div>
   );
@@ -287,6 +295,107 @@ export function PolicyTableRaw(props: WithAlert) {
   );
 }
 
+export function ProfileTableRaw(props: WithAlert) {
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const [open, setOpen] = React.useState(false);
+  const [currRow, setCurrRow] = useState<ProfileRowType>({});
+  const ctx = useContext(PolicyContext);
+  const profiles = ctx.qosProfiles;
+  const profileRows: Array<ProfileRowType> = profiles
+    ? Object.keys(profiles).map((profileID: string) => {
+        const profile = profiles[profileID];
+        return {
+          profileID: profile.id,
+          classID: profile.class_id,
+          uplinkBandwidth: profile.max_req_bw_ul,
+          downlinkBandwidth: profile.max_req_bw_dl,
+        };
+      })
+    : [];
+
+  return (
+    <>
+      <ProfileEditDialog
+        open={open}
+        onClose={() => setOpen(false)}
+        profile={
+          Object.keys(currRow).length ? profiles[currRow.profileID] : undefined
+        }
+      />
+      <ActionTable
+        data={profileRows}
+        columns={[
+          {
+            title: 'Profile ID',
+            field: 'profileID',
+            render: currRow => (
+              <Link
+                variant="body2"
+                component="button"
+                onClick={() => {
+                  setCurrRow(currRow);
+                  setOpen(true);
+                }}>
+                {currRow.profileID}
+              </Link>
+            ),
+          },
+          {title: 'Class ID', field: 'classID', type: 'numeric'},
+          {
+            title: 'Uplink Bandwidth',
+            field: 'uplinkBandwidth',
+            type: 'numeric',
+          },
+          {
+            title: 'Downlink Bandwidth',
+            field: 'downlinkBandwidth',
+            type: 'numeric',
+          },
+        ]}
+        handleCurrRow={(row: ProfileRowType) => setCurrRow(row)}
+        menuItems={[
+          {
+            name: 'Edit',
+            handleFunc: () => {
+              setOpen(true);
+            },
+          },
+          {
+            name: 'Remove',
+            handleFunc: () => {
+              props
+                .confirm(
+                  `Are you sure you want to delete ${currRow.profileID}?`,
+                )
+                .then(async confirmed => {
+                  if (!confirmed) {
+                    return;
+                  }
+
+                  try {
+                    // trigger deletion
+                    ctx.setQosProfiles(currRow.profileID);
+                  } catch (e) {
+                    enqueueSnackbar(
+                      'failed deleting profile ' + currRow.profileID,
+                      {
+                        variant: 'error',
+                      },
+                    );
+                  }
+                });
+            },
+          },
+        ]}
+        options={{
+          actionsColumnIndex: -1,
+          pageSizeOptions: [5, 10],
+        }}
+      />
+    </>
+  );
+}
+
 const DEFAULT_POLICY_CONFIG = {
   flow_list: [],
   id: '',
@@ -354,3 +463,4 @@ export function PolicyJsonConfig() {
 }
 
 const PolicyTable = withAlert(PolicyTableRaw);
+const ProfileTable = withAlert(ProfileTableRaw);

--- a/nms/app/packages/magmalte/app/views/traffic/ProfileEdit.js
+++ b/nms/app/packages/magmalte/app/views/traffic/ProfileEdit.js
@@ -1,0 +1,204 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {policy_qos_profile} from '@fbcnms/magma-api';
+
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '../../theme/design-system/DialogTitle';
+import FormLabel from '@material-ui/core/FormLabel';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import OutlinedInput from '@material-ui/core/OutlinedInput';
+import PolicyContext from '../../components/context/PolicyContext';
+import React from 'react';
+
+import {AltFormField} from '../../components/FormField';
+import {colors} from '../../theme/default';
+import {makeStyles} from '@material-ui/styles';
+import {useContext, useEffect, useState} from 'react';
+import {useEnqueueSnackbar} from '@fbcnms/ui/hooks/useSnackbar';
+
+const useStyles = makeStyles(() => ({
+  tabBar: {
+    backgroundColor: colors.primary.brightGray,
+    color: colors.primary.white,
+  },
+  input: {
+    display: 'inline-flex',
+    margin: '5px 0',
+    width: '50%',
+    fullWidth: true,
+  },
+}));
+
+type Props = {
+  open: boolean,
+  onClose: () => void,
+  profile?: policy_qos_profile,
+};
+
+export default function ProfileEditDialog(props: Props) {
+  const classes = useStyles();
+  const ctx = useContext(PolicyContext);
+  const qosProfiles = ctx.qosProfiles;
+  const enqueueSnackbar = useEnqueueSnackbar();
+  const [error, setError] = useState('');
+
+  const [profile, setProfile] = useState<policy_qos_profile>(
+    props.profile || {
+      id: '',
+      class_id: 0,
+      max_req_bw_dl: 9,
+      max_req_bw_ul: 9,
+    },
+  );
+
+  useEffect(() => {
+    setProfile(
+      props.profile || {
+        id: '',
+        class_id: 0,
+        max_req_bw_dl: 9,
+        max_req_bw_ul: 9,
+      },
+    );
+    setError('');
+  }, [props.open, props.profile]);
+
+  const isAdd = props.profile ? false : true;
+  const handleProfileChange = (key: string, val) => {
+    setProfile({...profile, [key]: val});
+  };
+  const onSave = async () => {
+    try {
+      if (isAdd) {
+        if (profile.id === '') {
+          setError('empty profile id');
+          return;
+        }
+        if (profile.id in qosProfiles) {
+          setError(`Profile ${profile.id} already exists`);
+          return;
+        }
+      }
+      await ctx.setQosProfiles(profile.id, profile);
+      enqueueSnackbar('Profile saved successfully', {
+        variant: 'success',
+      });
+
+      props.onClose();
+    } catch (e) {
+      setError(e.response?.data?.message ?? e.message);
+    }
+  };
+
+  const onClose = () => {
+    props.onClose();
+  };
+
+  return (
+    <Dialog
+      data-testid="editDialog"
+      open={props.open}
+      scroll="body"
+      fullWidth={true}
+      maxWidth={'md'}>
+      <DialogTitle
+        onClose={onClose}
+        label={props.profile ? 'Edit Profile' : 'Add New Profile'}
+      />
+      <DialogContent>
+        <List>
+          {error !== '' && (
+            <AltFormField disableGutters label={''}>
+              <FormLabel data-testid="configEditError" error>
+                {error}
+              </FormLabel>
+            </AltFormField>
+          )}
+          <ListItem dense disableGutters />
+          <AltFormField label={'Profile ID'} disableGutters>
+            <OutlinedInput
+              className={classes.input}
+              fullWidth={true}
+              data-testid="profileID"
+              placeholder="Eg. profile_id"
+              value={profile.id}
+              onChange={({target}) => handleProfileChange('id', target.value)}
+            />
+          </AltFormField>
+          <AltFormField label={'Class ID'} disableGutters>
+            <OutlinedInput
+              className={classes.input}
+              type="number"
+              fullWidth={true}
+              data-testid="profileClassID"
+              placeholder="9"
+              value={profile.class_id}
+              onChange={({target}) =>
+                handleProfileChange('class_id', parseInt(target.value) || '')
+              }
+            />
+          </AltFormField>
+          <AltFormField label={'Max Bandwidth Downlink'} disableGutters>
+            <OutlinedInput
+              className={classes.input}
+              type="number"
+              fullWidth={true}
+              min={0}
+              data-testid="maxReqBwDl"
+              placeholder="9"
+              value={profile.max_req_bw_dl}
+              onChange={({target}) =>
+                handleProfileChange(
+                  'max_req_bw_dl',
+                  parseInt(target.value) || '',
+                )
+              }
+            />
+          </AltFormField>
+          <AltFormField label={'Max Bandwidth Uplink'} disableGutters>
+            <OutlinedInput
+              className={classes.input}
+              type="number"
+              fullWidth={true}
+              data-testid="maxReqBwUl"
+              placeholder="9"
+              value={profile.max_req_bw_ul}
+              onChange={({target}) =>
+                handleProfileChange(
+                  'max_req_bw_ul',
+                  parseInt(target.value) || '',
+                )
+              }
+            />
+          </AltFormField>
+        </List>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={props.onClose} skin="regular">
+          {'Close'}
+        </Button>
+        <Button variant="contained" color="primary" onClick={onSave}>
+          Save
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/TrafficOverview.js
@@ -22,6 +22,7 @@ import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
 import PolicyOverview from './PolicyOverview';
 import PolicyRuleEditDialog from './PolicyEdit';
+import ProfileEditDialog from './ProfileEdit';
 import React from 'react';
 import RssFeedIcon from '@material-ui/icons/RssFeed';
 import Text from '../../theme/design-system/Text';
@@ -76,7 +77,7 @@ function PolicyMenu() {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = React.useState(null);
   const [open, setOpen] = React.useState(false);
-
+  const [profileDialog, setProfileDialog] = React.useState(false);
   const handleClick = event => {
     setAnchorEl(event.currentTarget);
   };
@@ -88,6 +89,10 @@ function PolicyMenu() {
   return (
     <div>
       <PolicyRuleEditDialog open={open} onClose={() => setOpen(false)} />
+      <ProfileEditDialog
+        open={profileDialog}
+        onClose={() => setProfileDialog(false)}
+      />
       <Button
         onClick={handleClick}
         className={classes.appBarBtn}
@@ -102,11 +107,11 @@ function PolicyMenu() {
         <MenuItem data-testid="newPolicyMenuItem" onClick={() => setOpen(true)}>
           <Text variant="subtitle2">Policy</Text>
         </MenuItem>
-        <MenuItem>
-          <Text variant="subtitle2">Profiles</Text>
+        <MenuItem onClick={() => setProfileDialog(true)}>
+          <Text variant="subtitle2">Profile</Text>
         </MenuItem>
         <MenuItem>
-          <Text variant="subtitle2">Rating Groups</Text>
+          <Text variant="subtitle2">Rating Group</Text>
         </MenuItem>
       </StyledMenu>
     </div>


### PR DESCRIPTION
Signed-off-by: HannaFar <hannafarag159@gmail.com>


## Summary

Add support for add/edit/view policy qos profiles.
Add policy qos profiles unit test.

<img width="1792" alt="Capture d’écran 2020-11-03 à 14 59 15" src="https://user-images.githubusercontent.com/26038920/97994761-f03a4900-1de5-11eb-913d-8541a15fb774.png">
<img width="1792" alt="Capture d’écran 2020-11-02 à 22 00 39" src="https://user-images.githubusercontent.com/26038920/97918809-0220db00-1d57-11eb-9e64-1c0422bc7e73.png">
<img width="1792" alt="Capture d’écran 2020-11-02 à 22 00 49" src="https://user-images.githubusercontent.com/26038920/97918808-01884480-1d57-11eb-864e-09955b8de48d.png">

