### PR TITLE
AGW: handle missing "router_ip" option in DHCP response.

### DIFF
--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -98,6 +98,32 @@ class DefGwTest(unittest.TestCase):
         self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip2))
         self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), '')
 
+    def test_vlan_gw_info_none(self):
+        ip1 = "1.2.3.4"
+        vlan1 = "1"
+        mac1 = "11:22:33:44:55:66"
+
+        self.dhcp_gw_info.update_mac(ip1, mac1, vlan1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip1))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), mac1)
+
+        # check None IP or mac updates
+        self.dhcp_gw_info.update_ip(None, vlan1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip1))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), mac1)
+
+        self.dhcp_gw_info.update_mac(ip1, None, vlan1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip1))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), mac1)
+
+        self.dhcp_gw_info.update_mac(None, mac1, vlan1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip1))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), mac1)
+
+        self.dhcp_gw_info.update_mac(ip1, '', vlan1)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip1))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), mac1)
+
     def test_vlan_gw_info_list(self):
         ip1 = "1.2.3.4"
         vlan1 = "1"


### PR DESCRIPTION
## Summary

In some cases DHCP does not set upstream router IP.
This patch handles it gracefully.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
