### PR TITLE
AGW: mobilityD: DHCP: support to configure router IP via API

### DIFF
--- a/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
+++ b/lte/gateway/python/magma/mobilityd/ip_allocator_static.py
@@ -112,16 +112,16 @@ class IPAllocatorStaticWrapper(IPAllocator):
                 raise DuplicateIPAssignmentError(error_msg)
 
         # update gw info if available.
-        if ip_addr_info.gw_ip:
-            self._store.dhcp_gw_info.update_ip(ip_addr_info.gw_ip,
-                                               str(ip_addr_info.vlan))
+        if ip_addr_info.net_info.gw_ip:
+            self._store.dhcp_gw_info.update_ip(ip_addr_info.net_info.gw_ip,
+                                               ip_addr_info.net_info.vlan)
             # update mac if IP is present.
-            if ip_addr_info.gw_mac != "":
-                self._store.dhcp_gw_info.update_mac(ip_addr_info.gw_ip,
-                                               ip_addr_info.gw_mac,
-                                               str(ip_addr_info.vlan))
+            if ip_addr_info.net_info.gw_mac != "":
+                self._store.dhcp_gw_info.update_mac(ip_addr_info.net_info.gw_ip,
+                                                    ip_addr_info.net_info.gw_mac,
+                                                    ip_addr_info.net_info.vlan)
         ip_block = ip_network(ip_addr_info.ip)
         self._store.assigned_ip_blocks.add(ip_block)
         return IPDesc(ip=ip_addr_info.ip, state=IPState.ALLOCATED,
                       sid=sid, ip_block=ip_block, ip_type=IPType.STATIC,
-                      vlan_id=ip_addr_info.vlan)
+                      vlan_id=ip_addr_info.net_info.vlan)

--- a/lte/gateway/python/magma/mobilityd/main.py
+++ b/lte/gateway/python/magma/mobilityd/main.py
@@ -48,9 +48,9 @@ def _get_ipv4_allocator(store: MobilityStore, allocator_type: int,
             ip_allocator=ip_allocator)
 
     if multi_apn:
-        ip_allocator = IPAllocatorMultiAPNWrapper(
-            subscriberdb_rpc_stub=subscriberdb_rpc_stub,
-            ip_allocator=ip_allocator)
+        ip_allocator = IPAllocatorMultiAPNWrapper(store=store,
+                                                  subscriberdb_rpc_stub=subscriberdb_rpc_stub,
+                                                  ip_allocator=ip_allocator)
 
     logging.info("Using allocator: %s static ip: %s multi_apn %s",
                  allocator_type,

--- a/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_multi_apn_ip_alloc.py
@@ -114,9 +114,9 @@ class MultiAPNIPAllocationTests(unittest.TestCase):
         ip_allocator = IpAllocatorPool(store)
         ip_allocator_static = IPAllocatorStaticWrapper(
             store, MockedSubscriberDBStub(), ip_allocator)
-        ipv4_allocator = IPAllocatorMultiAPNWrapper(
-            subscriberdb_rpc_stub=MockedSubscriberDBStub(),
-            ip_allocator=ip_allocator_static)
+        ipv4_allocator = IPAllocatorMultiAPNWrapper(store,
+                                                    subscriberdb_rpc_stub=MockedSubscriberDBStub(),
+                                                    ip_allocator=ip_allocator_static)
         ipv6_allocator = IPv6AllocatorPool(store,
                                            session_prefix_alloc_mode='RANDOM')
         self._allocator = IPAddressManager(ipv4_allocator,

--- a/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_uplink_gw.py
@@ -16,14 +16,14 @@ import unittest
 from collections import defaultdict
 import subprocess
 
-from magma.mobilityd.uplink_gw import UplinkGatewayInfo
+from magma.mobilityd.uplink_gw import UplinkGatewayInfo, NO_VLAN
 from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 
 LOG = logging.getLogger('mobilityd.def_gw.test')
 LOG.isEnabledFor(logging.DEBUG)
 
 
-def _get_gw_info(ip, mac="", vlan=""):
+def _get_gw_info(ip, mac="", vlan=NO_VLAN):
     ip_addr = ipaddress.ip_address(ip)
     gw_ip = IPAddress(version=IPAddress.IPV4,
                       address=ip_addr.packed)
@@ -123,6 +123,13 @@ class DefGwTest(unittest.TestCase):
         self.dhcp_gw_info.update_mac(ip1, '', vlan1)
         self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan1), str(ip1))
         self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan1), mac1)
+
+        vlan2 = None
+        mac2 = "22:22:33:44:55:66"
+
+        self.dhcp_gw_info.update_mac(ip1, mac2, vlan2)
+        self.assertEqual(self.dhcp_gw_info.get_gw_ip(vlan2), str(ip1))
+        self.assertEqual(self.dhcp_gw_info.get_gw_mac(vlan2), mac2)
 
     def test_vlan_gw_info_list(self):
         ip1 = "1.2.3.4"

--- a/lte/gateway/python/magma/mobilityd/uplink_gw.py
+++ b/lte/gateway/python/magma/mobilityd/uplink_gw.py
@@ -20,13 +20,21 @@ from lte.protos.mobilityd_pb2 import GWInfo, IPAddress
 NO_VLAN = "NO_VLAN"
 
 
-def _get_vlan_key(vlan: Optional[str]) -> str:
-    if vlan is None or vlan == '' or vlan == NO_VLAN or vlan == "0":
-        return NO_VLAN
-    if int(vlan) < 0 or int(vlan) > 4095:
-        raise InvalidVlanId("invalid vlan: " + vlan)
+def _get_vlan_key(vlan) -> str:
+    # Validate vlan id is valid VLAN
+    vlan_id_parsed = 0
+    try:
+        if vlan:
+            vlan_id_parsed = int(vlan)
+    except ValueError:
+        logging.debug("invalid vlan id: %s", vlan)
 
-    return vlan
+    if vlan_id_parsed == 0:
+        return NO_VLAN
+    if vlan_id_parsed < 0 or vlan_id_parsed > 4095:
+        raise InvalidVlanId("invalid vlan: " + str(vlan))
+
+    return str(vlan)
 
 
 # TODO: move helper class to separate directory.
@@ -34,14 +42,19 @@ class UplinkGatewayInfo:
     def __init__(self, gw_info_map: MutableMapping[str, GWInfo]):
         """
             This maintains uptodate information about upstream GW.
+            The GW table is keyed bt vlan-id.
 
         Args:
             gw_info_map: map to store GW info.
         """
         self._backing_map = gw_info_map
 
-    # TODO: change vlan_id type to int
     def get_gw_ip(self, vlan_id: Optional[str] = "") -> Optional[str]:
+        """
+        Retrieve gw IP address
+        Args:
+            vlan_id: vlan if of the GW.
+        """
         vlan_key = _get_vlan_key(vlan_id)
         if vlan_key in self._backing_map:
             gw_info = self._backing_map.get(vlan_key)
@@ -57,8 +70,13 @@ class UplinkGatewayInfo:
                     default_gw[netifaces.AF_INET] is not None:
                 self.update_ip(default_gw[netifaces.AF_INET][0])
 
-    def update_ip(self, ip: Optional[str], vlan_id: Optional[str] = ""):
-
+    def update_ip(self, ip: Optional[str], vlan_id=None):
+        """
+        Update IP address of the GW in mobilityD GW table.
+        Args:
+            ip: gw ip address
+            vlan_id: vlan of the GW, None in case of no vlan used.
+        """
         try:
             ip_addr = ipaddress.ip_address(ip)
         except ValueError:
@@ -75,19 +93,30 @@ class UplinkGatewayInfo:
                 logging.debug("GW update: no change %s", ip)
                 return
 
-        updated_info = GWInfo(ip=gw_ip, mac="", vlan=vlan_id)
+        updated_info = GWInfo(ip=gw_ip, mac="", vlan=vlan_key)
         self._backing_map[vlan_key] = updated_info
         logging.info("GW update: GW IP[%s]: %s" % (vlan_key, ip))
 
-    def get_gw_mac(self, vlan_id: Optional[str] = "") -> Optional[str]:
+    def get_gw_mac(self, vlan_id: Optional[str] = None) -> Optional[str]:
+        """
+        Retrieve Mac address of default gw.
+        Args:
+            vlan_id: vlan of the gw, None if GW is not in a vlan.
+        """
         vlan_key = _get_vlan_key(vlan_id)
-
         if vlan_key in self._backing_map:
             return self._backing_map.get(vlan_key).mac
         else:
             return None
 
-    def update_mac(self, ip: Optional[str], mac: Optional[str], vlan_id: Optional[str] = ""):
+    def update_mac(self, ip: Optional[str], mac: Optional[str], vlan_id=None):
+        """
+        Update mac address of GW in mobilityD GW table
+        Args:
+            ip: gw ip address.
+            vlan_id: Vlan of the gw.
+            mac: mac address of the GW.
+        """
         try:
             ip_addr = ipaddress.ip_address(ip)
         except ValueError:
@@ -102,7 +131,7 @@ class UplinkGatewayInfo:
             return
         gw_ip = IPAddress(version=IPAddress.IPV4,
                           address=ip_addr.packed)
-        updated_info = GWInfo(ip=gw_ip, mac=mac, vlan=vlan_id)
+        updated_info = GWInfo(ip=gw_ip, mac=mac, vlan=vlan_key)
         self._backing_map[vlan_key] = updated_info
         logging.info("GW update: GW IP[%s]: %s : mac %s" % (vlan_key, ip, mac))
 


### PR DESCRIPTION
## Summary

There is a API to set router IP for static IP allocation. This
patch extends same API for UE IP allocated via DHCP.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
