### PR TITLE
[FeG][S6APROXY] Add V2 level logging to print diameter messages for S6A PROXY

### DIFF
--- a/feg/gateway/services/s6a_proxy/servicers/ai.go
+++ b/feg/gateway/services/s6a_proxy/servicers/ai.go
@@ -25,6 +25,7 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
+	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 
 	"magma/feg/cloud/go/protos"
@@ -64,6 +65,7 @@ func (s *s6aProxy) sendAIR(sid string, req *protos.AuthenticationInformationRequ
 			diameter.Vendor3GPP,
 			genAuthInfoAvp(req.NumRequestedUtranGeranVectors, irp, req.UtranGeranResyncInfo))
 	}
+	glog.V(2).Infof("Sending S6a AIR message\n%s\n", m)
 	err = c.SendRequest(m, retryCount)
 	if err != nil {
 		err = Error(codes.DataLoss, err)
@@ -94,6 +96,7 @@ func genAuthInfoAvp(requestedVectorNum, irp uint32, resyncInfo []byte) *diam.Gro
 // S6a AIA
 func handleAIA(s *s6aProxy) diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {
+		glog.V(2).Infof("Received S6a AIA message:\n%s\n", m)
 		var aia AIA
 		err := m.Unmarshal(&aia)
 		if err != nil {

--- a/feg/gateway/services/s6a_proxy/servicers/cl.go
+++ b/feg/gateway/services/s6a_proxy/servicers/cl.go
@@ -34,7 +34,7 @@ const (
 // S6a CLR
 func handleCLR(s *s6aProxy) diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {
-		glog.V(2).Infof("handling CLR\n")
+		glog.V(2).Infof("Received S6a CLR message:\n%s\n", m)
 		var code uint32 //result-code
 		var clr CLR
 		err := m.Unmarshal(&clr)
@@ -91,7 +91,7 @@ func (s *s6aProxy) sendCLA(c diam.Conn, m *diam.Message, code uint32, clr *CLR, 
 	ans.InsertAVP(diam.NewAVP(avp.SessionID, avp.Mbit, 0, datatype.UTF8String(clr.SessionID)))
 	ans.NewAVP(avp.AuthSessionState, avp.Mbit, 0, datatype.Enumerated(clr.AuthSessionState))
 	s.addDiamOriginAVPs(m)
-
+	glog.V(2).Infof("Sending S6a CLA message\n%s\n", m)
 	_, err := ans.WriteToWithRetry(c, retries)
 	return err
 

--- a/feg/gateway/services/s6a_proxy/servicers/ul.go
+++ b/feg/gateway/services/s6a_proxy/servicers/ul.go
@@ -24,6 +24,7 @@ import (
 	"github.com/fiorix/go-diameter/v4/diam/avp"
 	"github.com/fiorix/go-diameter/v4/diam/datatype"
 	"github.com/fiorix/go-diameter/v4/diam/dict"
+	"github.com/golang/glog"
 	"google.golang.org/grpc/codes"
 
 	"magma/feg/cloud/go/protos"
@@ -46,6 +47,7 @@ func (s *s6aProxy) sendULR(sid string, req *protos.UpdateLocationRequest, retryC
 	m.NewAVP(avp.ULRFlags, avp.Vbit|avp.Mbit, uint32(diameter.Vendor3GPP), datatype.Unsigned32(ULR_FLAGS))
 	m.NewAVP(avp.VisitedPLMNID, avp.Vbit|avp.Mbit, diameter.Vendor3GPP, datatype.OctetString(req.VisitedPlmn))
 
+	glog.V(2).Infof("Sending S6a ULR message\n%s\n", m)
 	err = c.SendRequest(m, retryCount)
 	if err != nil {
 		err = Error(codes.DataLoss, err)
@@ -56,6 +58,7 @@ func (s *s6aProxy) sendULR(sid string, req *protos.UpdateLocationRequest, retryC
 // S6a ULA
 func handleULA(s *s6aProxy) diam.HandlerFunc {
 	return func(c diam.Conn, m *diam.Message) {
+		glog.V(2).Infof("Received S6a ULA message:\n%s\n", m)
 		var ula ULA
 		err := m.Unmarshal(&ula)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
The v2 logging to log raw-ish messages on SessionProxy is pretty useful, so adding that for S6A Proxy as well.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
FeG precommit
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
