### PR TITLE
[SubscriberDB] Add MSISDN from SubscriberDB to ULA sent to MME

### DIFF
--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -106,6 +106,7 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
         ula.total_ambr.max_bandwidth_ul = profile.max_ul_bit_rate
         ula.total_ambr.max_bandwidth_dl = profile.max_dl_bit_rate
         ula.all_apns_included = 0
+        ula.msisdn = self.encode_msisdn(sub_data.non_3gpp.msisdn)
 
         context_id = 0
         for apn in sub_data.non_3gpp.apn_config:
@@ -128,3 +129,18 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
                 s6a_proxy_pb2.UpdateLocationAnswer.APNConfiguration.IPV4
             )
         return ula
+
+    @staticmethod
+    def encode_msisdn(msisdn: str) -> bytes:
+        # Mimic how the MSISDN is encoded in ULA : 3GPP TS 29.329-f10
+        # For odd length MSISDN pad it with an extra 'F'/'1111'
+        if len(msisdn) % 2 != 0:
+            msisdn = msisdn + "F"
+        result = []
+        # Treat each 2 characters as a byte and flip the order
+        for i in range(len(msisdn)//2):
+            first = int(msisdn[2*i])
+            second = int(msisdn[2*i+1], 16)
+            flipped = first + (second << 4)
+            result.append(flipped)
+        return bytes(result)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A change was recently made to send down MSISDN as part of subscriber information from Orc8r ->GW SubscriberDB, but this value was never passed onto MME as part of UpdateLocationAnswer.
A little tricky thing is that the UpdateLocationAnswer should mimic the way the federated gw relays the value, so there's a tiny bit of arithmetic to get it into a hex array.
(Details on the encoding)
http://minnis.org/DiaDict/Dictionary/MSISDN.html
```
6.3.2	MSISDN AVP
The MSISDN AVP is of type OctetString. 
This AVP contains an MSISDN, in international number format as described in ITU-T Rec E.164 [8], 
encoded as a TBCD-string, i.e. digits from 0 through 9 are encoded 0000 to 1001; 
1111 is used as a filler when there is an odd number of digits; 
bits 8 to 5 of octet n encode digit 2n; 
bits 4 to 1 of octet n encode digit 2(n-1)+1.
```

## Test Plan
Running modified / not modified S1AP tests. (Will update tests to include MSISDN)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
