### PR TITLE
[S1APTest] Modify s1ap tests to include a default MSISDN value

### DIFF
--- a/lte/gateway/python/integ_tests/common/subscriber_db_client.py
+++ b/lte/gateway/python/integ_tests/common/subscriber_db_client.py
@@ -15,9 +15,9 @@ import logging
 import time
 
 import abc
-import base64
 import grpc
 import subprocess
+from typing import List
 
 from orc8r.protos.common_pb2 import Void
 from lte.protos.subscriberdb_pb2 import (
@@ -138,7 +138,7 @@ class SubscriberDbGrpc(SubscriberDbClient):
         return SubscriberData(sid=sub_db_sid, lte=lte, state=state)
 
     @staticmethod
-    def _get_apn_data(sid, apn_list):
+    def _get_apn_data(sid, apn_list) -> SubscriberUpdate:
         """
         Get APN data in protobuf format.
 
@@ -195,9 +195,10 @@ class SubscriberDbGrpc(SubscriberDbClient):
         sids = ['IMSI' + sid.id for sid in sids_pb]
         return sids
 
-    def config_apn_details(self, imsi, apn_list):
+    def config_apn_details(self, imsi: str, msisdn: str, apn_list: List[object]):
         sid = SIDUtils.to_pb(imsi)
         update_sub = self._get_apn_data(sid, apn_list)
+        update_sub.data.non_3gpp.msisdn = msisdn
         fields = update_sub.mask.paths
         fields.append('non_3gpp')
         SubscriberDbGrpc._try_to_call(

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -20,7 +20,10 @@ import threading
 import time
 from enum import Enum
 from queue import Queue
-from typing import Optional
+from typing import (
+    Optional,
+    List,
+)
 
 import grpc
 import subprocess
@@ -534,9 +537,9 @@ class SubscriberUtil(object):
         self._subscriber_client.wait_for_changes()
         return subscribers
 
-    def config_apn_data(self, imsi, apn_list):
+    def config_apn_data(self, imsi: str, msisdn: str, apn_list: List[object]):
         """ Add APN details """
-        self._subscriber_client.config_apn_details(imsi, apn_list)
+        self._subscriber_client.config_apn_details(imsi, msisdn, apn_list)
 
     def cleanup(self):
         """ Cleanup added subscriber from subscriberdb """

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -14,6 +14,7 @@ limitations under the License.
 import os
 import time
 import ctypes
+from typing import List
 
 import s1ap_types
 from integ_tests.common.magmad_client import MagmadServiceGrpc
@@ -310,7 +311,11 @@ class TestWrapper(object):
             )
             self._configuredUes.append(reqs[i])
 
-    def configAPN(self, imsi, apn_list, default=True):
+    def configAPN(
+            self,
+            imsi: str,
+            apn_list: List[object],
+            default=True):
         """ Configure the APN """
         # add a default APN to be used in attach requests
         if default:
@@ -328,7 +333,8 @@ class TestWrapper(object):
                 apn_list.insert(0, magma_default_apn)
             else:
                 apn_list = [magma_default_apn]
-        self._sub_util.config_apn_data(imsi, apn_list)
+        default_msisdn = "8801833182167"
+        self._sub_util.config_apn_data(imsi, default_msisdn, apn_list)
 
     def check_gw_health_after_ue_load(self):
         """ Wait for the MME only after adding entries to HSS """


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Include a default MSISDN value in the subscriber config used.
This ensures that there's some default value for MSISDN passed in for testing.

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run S1AP tests
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
