### PR TITLE
[lte][agw] Fixing service_restarts_map update on state recovery job

### DIFF
--- a/lte/gateway/python/magma/health/state_recovery.py
+++ b/lte/gateway/python/magma/health/state_recovery.py
@@ -117,9 +117,9 @@ class StateRecoveryJob(Job):
                 # Restart sctpd
                 await self.restart_service_async('sctpd')
 
-                # Update latest number of restarts for service
-                self._services_restarts_map[
-                    service] = result.num_fail_exits
+            # Update latest number of restarts for services
+            self._services_restarts_map[
+                service] = result.num_fail_exits
             logging.debug('Unexpected restarts for service %s: %s',
                           service, current_restarts)
 


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- On state recovery job on health service, service_restarts_map should be updated whether the services are restarting or not, this change fixes this to update every polling interval.

## Test Plan

- make integ_test
- make test
- Checking state recovery job still detects services failure:

```
Nov 04 21:07:15 magma-dev systemd[1]: Started Magma health service.
Nov 04 21:07:16 magma-dev health[24555]: WARNING:root:Service (health) missing in mconfig
Nov 04 21:07:16 magma-dev health[24555]: INFO:root:Starting health...
Nov 04 21:07:16 magma-dev health[24555]: INFO:root:Listening on address 127.0.0.1:50080
Nov 04 21:09:16 magma-dev health[24555]: INFO:root:Service mme has failed 6 times over last 60 seconds, restarting sctpd to clean state...
Nov 04 21:09:16 magma-dev sudo[26703]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/sbin/service sctpd restart
```

## Additional Information

- [ ] This change is backwards-breaking

