### PR TITLE
[SessionD] Add operation state callback to SessionD

### DIFF
--- a/lte/gateway/c/session_manager/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/CMakeLists.txt
@@ -161,8 +161,12 @@ add_library(SESSION_MANAGER
     SessionStateEnforcer.cpp
     AmfServiceClient.h
     AmfServiceClient.cpp
+    Utilities.cpp
+    Utilities.h
+    OperationalStatesHandler.cpp
+    OperationalStatesHandler.h
     ${PROTO_SRCS}
-    ${PROTO_HDRS} Utilities.cpp Utilities.h)
+    ${PROTO_HDRS})
 
 
 

--- a/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.cpp
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <folly/dynamic.h>
+#include <folly/json.h>
+#include <google/protobuf/util/json_util.h>
+
+#include "EnumToString.h"
+#include "magma_logging.h"
+#include "OperationalStatesHandler.h"
+#include "Utilities.h"
+
+namespace magma {
+
+OpState get_operational_states(magma::SessionStore* session_store) {
+  std::list<std::map<std::string, std::string>> states;
+  auto session_map = session_store->read_all_sessions();
+  for (auto& it : session_map) {
+    std::map<std::string, std::string> state;
+    state[TYPE]                    = SUBSCRIBER_STATE_TYPE;
+    state[DEVICE_ID]               = it.first;
+    folly::dynamic sessions_by_apn = folly::dynamic::object;
+
+    for (auto& session : it.second) {
+      const auto apn = session->get_config().common_context.apn();
+      if (sessions_by_apn[apn].empty()) {
+        sessions_by_apn[apn] = folly::dynamic::array;
+      }
+      sessions_by_apn[apn].push_back(get_dynamic_session_state(session));
+    }
+    state[VALUE] = folly::toJson(sessions_by_apn);
+    states.push_back(state);
+  }
+  return states;
+}
+
+folly::dynamic get_dynamic_session_state(
+    const std::unique_ptr<SessionState>& session) {
+  folly::dynamic state      = folly::dynamic::object;
+  const auto config         = session->get_config().common_context;
+  state[SESSION_ID]         = session->get_session_id();
+  state[MSISDN]             = config.msisdn();
+  state[magma::IPV4]        = config.ue_ipv4();
+  state[APN]                = config.apn();
+  state[SESSION_START_TIME] = session->get_pdp_start_time();
+  state[LIFECYCLE_STATE]    = session_fsm_state_to_str(session->get_state());
+  state[ACTIVE_DURATION_SECOND] = session->get_active_duration_in_seconds();
+  state[ACTIVE_POLICY_RULES]    = get_dynamic_active_policies(session);
+  return state;
+}
+
+folly::dynamic get_dynamic_active_policies(
+    const std::unique_ptr<SessionState>& session) {
+  google::protobuf::util::JsonPrintOptions options;
+  options.add_whitespace = false;
+
+  folly::dynamic policies = folly::dynamic::array;
+  auto active_policies    = session->get_all_active_policies();
+  for (auto& policy : active_policies) {
+    std::string json_policy;
+    auto status = google::protobuf::util::MessageToJsonString(
+        policy, &json_policy, options);
+    if (!status.ok()) {
+      MLOG(MERROR) << "Error serializing PolicyRule " << policy.id()
+                   << " to JSON: " << status.error_message();
+      continue;
+    }
+    policies.push_back(json_policy);
+  }
+  return policies;
+}
+
+}  // namespace magma

--- a/lte/gateway/c/session_manager/OperationalStatesHandler.h
+++ b/lte/gateway/c/session_manager/OperationalStatesHandler.h
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/dynamic.h>
+
+#include "SessionStore.h"
+
+namespace magma {
+const std::string TYPE                   = "type";
+const std::string SUBSCRIBER_STATE_TYPE  = "subscriber_state";
+const std::string DEVICE_ID              = "device_id";
+const std::string VALUE                  = "value";
+const std::string SESSION_ID             = "session_id";
+const std::string IMSI                   = "imsi";
+const std::string MSISDN                 = "msisdn";
+const std::string APN                    = "apn";
+const std::string IPV4                   = "ipv4";
+const std::string ACTIVE_POLICY_RULES    = "active_policy_rules";
+const std::string SESSION_START_TIME     = "session_start_time";
+const std::string ACTIVE_DURATION_SECOND = "active_duration_sec";
+const std::string LIFECYCLE_STATE        = "lifecycle_state";
+
+typedef std::list<std::map<std::string, std::string>> OpState;
+
+OpState get_operational_states(magma::SessionStore* session_store);
+
+folly::dynamic get_dynamic_session_state(
+    const std::unique_ptr<SessionState>& session);
+
+folly::dynamic get_dynamic_active_policies(
+    const std::unique_ptr<SessionState>& session);
+
+}  // namespace magma

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -274,6 +274,8 @@ class SessionState {
 
   uint64_t get_pdp_end_time();
 
+  uint64_t get_active_duration_in_seconds();
+
   void increment_request_number(uint32_t incr);
 
   SessionTerminateRequest make_termination_request(
@@ -355,6 +357,8 @@ class SessionState {
   DynamicRuleStore& get_dynamic_rules();
 
   DynamicRuleStore& get_scheduled_dynamic_rules();
+
+  std::vector<PolicyRule> get_all_active_policies();
 
   /**
    * Schedule a dynamic rule for activation in the future.


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Implementing the `GetOperationalStates` callback handler that dumps a service's state onto the Orc8r. 
This state will be displayed on the NMS to provide some run-time information on active subscribers and its active policies.

## Test Plan
make precommit_sm 
Also test locally with a local Orc8r to see the states show up in Postgres

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
