### PR TITLE
[orc8r][dev] Fix dev_setup error log when no operators

### DIFF
--- a/orc8r/cloud/go/services/accessd/client_api.go
+++ b/orc8r/cloud/go/services/accessd/client_api.go
@@ -113,6 +113,9 @@ func GetOperatorACL(
 
 // GetOperatorsACLs returns the operators' Identities permission lists
 func GetOperatorsACLs(operators []*protos.Identity) ([]*accessprotos.AccessControl_List, error) {
+	if len(operators) == 0 {
+		return nil, nil
+	}
 	client, err := getAccessdClient()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

Previously, the first run of a new local orc8r deployment would give misleading errors relating to certs.

Not the end of the world, but annoying and misleading. This PR fixes, by allowing accessd's client_api `GetOperatorsACLs` to take an empty list of identities and short-circuit the return to an empty list of ACLs, solving the error log.

Also fixes a misleading info log about whether new certs were generated or the existing cert was used.

```
# Previous error log

controller_1     | accessd stderr | E1104 22:12:14.248480      92 handler.go:116] [ERROR /magma.orc8r.accessd.AccessControlManager/GetOperatorsACLs]: rpc error: code = InvalidArgument desc = nil Identity list
controller_1     | dev_setup stderr | E1104 22:12:14.248762     283 client_api.go:123] Get Permissions for Operators [] error: rpc error: code = InvalidArgument desc = nil Identity list
controller_1     | dev_setup stderr | 2020/11/04 22:12:14 Get Operators Error: Get Permissions for Operators [] error: rpc error: code = InvalidArgument desc = nil Identity list
controller_1     | 2020-11-04 22:12:14,575 INFO exited: dev_setup (exit status 0; expected)
controller_1     | dev_setup stdout | [success] test certs generated and added

# New log

controller_1     | dev_setup stdout | [success] test certs added
```

## Test Plan

- [x] make test
- [x] manually ensure the log disappears on a fresh deployment (pruned docker volumes)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->