### PR TITLE
[docker][mme] Adding missing clang-format to dockerfile

### DIFF
--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 14)
 
+project(MagmaCore)
+
 # generate sctpd protos
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)
 

--- a/lte/gateway/c/sctpd/CMakeLists.txt
+++ b/lte/gateway/c/sctpd/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.7)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_CXX_STANDARD 14)
 
-project(MagmaCore)
+project(MagmaSctpd)
 
 # generate sctpd protos
 include($ENV{MAGMA_ROOT}/orc8r/gateway/c/common/CMakeProtoMacros.txt)

--- a/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
+++ b/lte/gateway/docker/mme/Dockerfile.ubuntu18.04
@@ -6,6 +6,7 @@ FROM ubuntu:bionic as magma-mme-builder
 ARG GIT_PROXY
 ARG FEATURES=mme_oai
 ENV MAGMA_ROOT=/magma
+ENV BUILD_TYPE=Debug
 ENV C_BUILD=/build/c
 
 RUN mkdir -p $C_BUILD
@@ -16,7 +17,7 @@ RUN ["/bin/bash", "-c", "echo \"Install general purpouse packages\" && \
     apt-get install -y gnupg wget software-properties-common autoconf automake \
     libtool curl make g++ unzip git build-essential autoconf libtool pkg-config \
     gcc-6 g++-6 apt-transport-https ca-certificates apt-utils vim redis-server \
-    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev && \
+    libssl-dev ninja-build golang python2.7 automake perl libgmp3-dev clang-format-7 && \
     echo \"Configure C/C++ compiler v6.5 as primary\" && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 10 && \
     update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 10 && \
@@ -27,6 +28,7 @@ RUN ["/bin/bash", "-c", "echo \"Install general purpouse packages\" && \
     apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main' && \
     echo \"Add required package repository for Prometheus\" && \
     wget -qO- https://repos.influxdata.com/influxdb.key | apt-key add - && \
+    ln -s /usr/bin/clang-format-7 /usr/bin/clang-format && \
     source /etc/lsb-release && \
     echo \"deb https://repos.influxdata.com/${DISTRIB_ID,,} ${DISTRIB_CODENAME} stable\" | tee /etc/apt/sources.list.d/influxdb.list"]
 
@@ -382,4 +384,5 @@ RUN sed -i -e "s@echo_error@echo@" -e "s@echo_success@echo@" -e "s@echo_warning@
 WORKDIR /magma-mme
 RUN openssl rand -out /root/.rnd 128
 
-# CMD []
+# For the moment, let have a dummy command
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary

* Lately I've seen that `clang-format` was being using when building MME and SCTPD
* I also saw that when building SCTPD, there was a warning for missing project

## Test Plan

I built manually and it worked fine in my Ubuntu18 container. And it passed my dsTester validation.