### PR TITLE
[lte][agw] Fix eNB clear_stats metrics

### DIFF
--- a/lte/cloud/go/services/lte/servicers/builder_servicer.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer.go
@@ -333,6 +333,7 @@ func getEnodebConfigsBySerial(nwConfig *lte_models.NetworkCellularConfigs, gwCon
 			cellularEnbConfig := enodebConfig.UnmanagedConfig
 			enbMconfig.CellId = int32(swag.Uint32Value(cellularEnbConfig.CellID))
 			enbMconfig.Tac = int32(swag.Uint32Value(cellularEnbConfig.Tac))
+			enbMconfig.IpAddress = string(*cellularEnbConfig.IPAddress)
 
 			if enbMconfig.Tac == 0 {
 				enbMconfig.Tac = int32(nwConfig.Epc.Tac)

--- a/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/builder_servicer_test.go
@@ -741,8 +741,9 @@ func TestBuilder_BuildUnmanagedEnbConfig(t *testing.T) {
 			Arfcn_2G:            nil,
 			EnbConfigsBySerial: map[string]*lte_mconfig.EnodebD_EnodebConfig{
 				"enb1": {
-					CellId: 138777000,
-					Tac:    1,
+					CellId:    138777000,
+					Tac:       1,
+					IpAddress: "192.168.0.124",
 				},
 			},
 		},

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -358,8 +358,8 @@ def get_enb_s1_connected_states(configured_serial_ids, mconfig) -> List[State]:
     states = []
     enb_s1_connected = get_all_enb_connected()
     for enb_id in enb_s1_connected:
-        enb_config = find_enb_by_cell_id(mconfig, enb_id)
-        if enb_config and enb_config.serial_num not in configured_serial_ids:
+        enb = find_enb_by_cell_id(mconfig, enb_id)
+        if enb and enb.serial_num not in configured_serial_ids:
             status = EnodebStatus(enodeb_configured=False,
                                   gps_latitude='N/A',
                                   gps_longitude='N/A',
@@ -372,11 +372,11 @@ def get_enb_s1_connected_states(configured_serial_ids, mconfig) -> List[State]:
                                   mme_connected=True,
                                   fsm_state='N/A')
             status_dict = status._asdict()
-            status_dict['ip_address'] = enb_config.ip_address
+            status_dict['ip_address'] = enb.config.ip_address
             serialized = json.dumps(status_dict)
             state = State(
                 type="single_enodeb",
-                deviceID=enb_config.serial_num,
+                deviceID=enb.serial_num,
                 value=serialized.encode('utf-8')
             )
             states.append(state)

--- a/lte/gateway/python/magma/enodebd/stats_manager.py
+++ b/lte/gateway/python/magma/enodebd/stats_manager.py
@@ -362,5 +362,7 @@ class StatsManager:
         """
         logger.info('Clearing performance counter statistics')
         # Set all metrics to 0 if eNodeB not connected
-        for metric in self.PM_FILE_TO_METRIC_MAP.values():
-            metric.set(0)
+        for pm_name, metric in self.PM_FILE_TO_METRIC_MAP:
+            # eNB data usage metrics will not be cleared
+            if pm_name not in ('PDCP.UpOctUl', 'PDCP.UpOctDl'):
+                metric.set(0)


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- For enodebd datapath metrics, a label `enodeb` which represents the name of the enodeb was added, when these are cleared, the labels aren't passed so prometheus_client metric object complains with: `AttributeError: '_LabelWrapper' object has no attribute 'set'`, these metrics shouldn't be cleared anyways so this adds a check to not clear them. 
- This also fixes the ipAddress streaming updates config to the gateway from Orc8r.

## Test Plan

- make integ_test
- Tested on dogfooding setup
- Testing with managed/unmanaged eNBs on agw setup, to check metrics are cleared successfully. 

## Additional Information

- [ ] This change is backwards-breaking

