### PR TITLE
Update Vagrant LTE VM box with envoy/go

### DIFF
--- a/lte/gateway/Vagrantfile
+++ b/lte/gateway/Vagrantfile
@@ -27,7 +27,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # - updated vbguest-tool
     magma.vm.box = "fbcmagma/magma_dev"
     magma.vm.hostname = "magma-dev"
-    magma.vm.box_version = "1.0.1594511999"
+    magma.vm.box_version = "1.0.1604610159"
     magma.vbguest.auto_update = false
 
     # Create a private network, which allows host-only access to the machine

--- a/lte/gateway/deploy/magma_dev.yml
+++ b/lte/gateway/deploy/magma_dev.yml
@@ -46,4 +46,5 @@
         magma_repo: /home/{{ ansible_user }}/magma-packages
         magma_deps: /home/{{ ansible_user }}/magma-deps
     - role: fluent_bit
+    - role: envoy
     - role: pyvenv

--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -183,6 +183,9 @@
       - iperf3
       - libsystemd-dev
       - pkg-config
+      - libpcap-dev
+      - libtins-dev
+      - libmnl-dev
   retries: 5
   when: preburn
 

--- a/lte/gateway/deploy/roles/envoy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/envoy/tasks/main.yml
@@ -1,0 +1,44 @@
+---
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+- name: Ensure required dependencies packages are installed.
+  apt:
+    state: present
+    update_cache: yes
+    pkg:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg2
+      - software-properties-common
+  retries: 5
+  when: preburn
+
+- name: Add Getenvoy.io apt key
+  apt_key:
+    url: https://getenvoy.io/gpg
+    state: present
+  when: preburn
+
+- name: Add Getenvoy.io repo
+  apt_repository:
+    repo: "deb [arch=amd64] https://dl.bintray.com/tetrate/getenvoy-deb stretch stable"
+    state: present
+  register: envoy_getenvoy_debian_repo
+  when: preburn
+
+- name: Ensure Envoy package is installed
+  apt:
+    state: present
+    update_cache: yes
+    pkg:
+     - "getenvoy-envoy"
+  when: preburn

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -10,6 +10,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
+- name: Include vars of all.yaml
+  include_vars:
+    file: all.yaml
+    name: all_vars
+
 - name: Copy magma service files
   copy:
     src: "systemd/magma_{{ item }}.service"
@@ -224,6 +230,20 @@
   with_items:
     - gtest
     - gmock
+  when: preburn
+
+- name: Download golang tar
+  get_url:
+    url: "https://storage.googleapis.com/golang/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
+    dest: "{{ all_vars.WORK_DIR }}"
+    mode: 0440
+  when: preburn
+
+- name: Extract Go tarball
+  unarchive:
+    src: "{{all_vars.WORK_DIR}}/go{{ all_vars.GO_VERSION }}.linux-amd64.tar.gz"
+    dest: /usr/local
+    copy: no
   when: preburn
 
 - name: Install dnsmasq

--- a/lte/gateway/deploy/roles/magma/tasks/main.yml
+++ b/lte/gateway/deploy/roles/magma/tasks/main.yml
@@ -10,7 +10,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 - name: Include vars of all.yaml
   include_vars:
     file: all.yaml

--- a/lte/gateway/deploy/roles/magma/vars/all.yaml
+++ b/lte/gateway/deploy/roles/magma/vars/all.yaml
@@ -1,0 +1,2 @@
+WORK_DIR: "~/"
+GO_VERSION: "1.15.3"


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
```
==> virtualbox-iso (vagrant-cloud): Uploading box: builds/magma_dev_virtualbox.box
    virtualbox-iso (vagrant-cloud): Depending on your internet connection and the size of the box,
    virtualbox-iso (vagrant-cloud): this may take some time
    virtualbox-iso (vagrant-cloud): Uploading box
```
**this may take some time**
_well this is an understatement of a century_, only took 2 hours 🎉 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
