### PR TITLE
[orc8r][mesh] Remove reliance on env vars in controller image

### DIFF
--- a/fbinternal/cloud/go/plugin/plugin.go
+++ b/fbinternal/cloud/go/plugin/plugin.go
@@ -15,13 +15,10 @@ package plugin
 
 import (
 	"magma/fbinternal/cloud/go/fbinternal"
-	fbinternal_service "magma/fbinternal/cloud/go/services/fbinternal"
 	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/serde"
 	"magma/orc8r/cloud/go/services/configurator/mconfig"
 	"magma/orc8r/cloud/go/services/metricsd"
-	"magma/orc8r/cloud/go/services/metricsd/collection"
-	"magma/orc8r/cloud/go/services/metricsd/exporters"
 	"magma/orc8r/cloud/go/services/state/indexer"
 	"magma/orc8r/cloud/go/services/streamer/providers"
 	"magma/orc8r/lib/go/registry"
@@ -51,7 +48,7 @@ func (*FbinternalOrchestratorPlugin) GetMconfigBuilders() []mconfig.Builder {
 }
 
 func (*FbinternalOrchestratorPlugin) GetMetricsProfiles(metricsConfig *config.ConfigMap) []metricsd.MetricsProfile {
-	return getMetricsProfiles()
+	return []metricsd.MetricsProfile{}
 }
 
 func (*FbinternalOrchestratorPlugin) GetObsidianHandlers(metricsConfig *config.ConfigMap) []obsidian.Handler {
@@ -64,64 +61,4 @@ func (*FbinternalOrchestratorPlugin) GetStreamerProviders() []providers.StreamPr
 
 func (*FbinternalOrchestratorPlugin) GetStateIndexers() []indexer.Indexer {
 	return []indexer.Indexer{}
-}
-
-const (
-	ProfileNameFacebook   = "facebook"
-	ProfileNameSys        = "sys"
-	ProfileNamePrometheus = "fbprometheus"
-	ProfileNameExportAll  = "fbexportall"
-)
-
-func getMetricsProfiles() []metricsd.MetricsProfile {
-	// Sys profile - collectors for disk usage and metricsd
-	sysProfile := metricsd.MetricsProfile{
-		Name: ProfileNameSys,
-		Collectors: []collection.MetricCollector{
-			&collection.DiskUsageMetricCollector{},
-			collection.NewCloudServiceMetricCollector(metricsd.ServiceName),
-		},
-		Exporters: []exporters.Exporter{exporters.NewRemoteExporter(fbinternal_service.ServiceName)},
-	}
-
-	// Facebook profile - 1 collector for each service
-	allServices := registry.ListControllerServices()
-	controllerCollectors := make([]collection.MetricCollector, 0, len(allServices)+1)
-	for _, srv := range allServices {
-		controllerCollectors = append(controllerCollectors, collection.NewCloudServiceMetricCollector(srv))
-	}
-
-	controllerCollectors = append(controllerCollectors, &collection.DiskUsageMetricCollector{})
-	facebookProfile := metricsd.MetricsProfile{
-		Name:       ProfileNameFacebook,
-		Collectors: controllerCollectors,
-		Exporters: []exporters.Exporter{
-			exporters.NewRemoteExporter(fbinternal_service.ServiceName),
-		},
-	}
-
-	prometheusProfile := metricsd.MetricsProfile{
-		Name:       ProfileNamePrometheus,
-		Collectors: controllerCollectors,
-		Exporters: []exporters.Exporter{
-			exporters.NewRemoteExporter(fbinternal_service.ServiceName),
-			exporters.NewRemoteExporter(metricsd.ServiceName),
-		},
-	}
-
-	allExporterProfile := metricsd.MetricsProfile{
-		Name:       ProfileNameExportAll,
-		Collectors: controllerCollectors,
-		Exporters: []exporters.Exporter{
-			exporters.NewRemoteExporter(fbinternal_service.ServiceName),
-			exporters.NewRemoteExporter(metricsd.ServiceName),
-		},
-	}
-
-	return []metricsd.MetricsProfile{
-		sysProfile,
-		facebookProfile,
-		prometheusProfile,
-		allExporterProfile,
-	}
 }

--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -119,10 +119,6 @@ resource "kubernetes_secret" "orc8r_envdir" {
     name      = "orc8r-envdir"
     namespace = kubernetes_namespace.orc8r.metadata[0].name
   }
-
-  data = {
-    "CONTROLLER_SERVICES" = "CONFIGURATOR,STATE,STREAMER,POLICYDB,METRICSD,CERTIFIER,BOOTSTRAPPER,ACCESSD,OBSIDIAN,DISPATCHER,DIRECTORYD"
-  }
 }
 
 resource "kubernetes_secret" "fluentd_certs" {

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       - $PWD/../../../.cache/test_certs:/var/opt/magma/certs
     environment:
       TEST_MODE: "1"  # Used to run dev scripts on startup
+      SERVICE_HOSTNAME: localhost  # All services are reachable through localhost
       SQL_DRIVER: postgres
       DATABASE_SOURCE: "dbname=magma_dev user=magma_dev password=magma_dev host=postgres sslmode=disable"
       SQL_DIALECT: psql

--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -23,10 +23,16 @@ const (
 	DirectoryRecordType     = "directory_record"
 	StringMapSerdeType      = "string_map"
 
+	DnsdNetworkType = "dnsd_network"
+
 	UpgradeTierEntityType           = "upgrade_tier"
 	UpgradeReleaseChannelEntityType = "upgrade_release_channel"
 
-	DnsdNetworkType = "dnsd_network"
+	// ServiceHostnameEnvVar is the name of an environment variable which is
+	// required to hold the public IP of the service.
+	// In dev, this will generally be localhost.
+	// In prod, this will be the relevant pod's IP.
+	ServiceHostnameEnvVar = "SERVICE_HOSTNAME"
 
 	MconfigBuilderLabel   = "orc8r.io/mconfig_builder"
 	MetricsExporterLabel  = "orc8r.io/metrics_exporter"

--- a/orc8r/cloud/go/service/hostname.go
+++ b/orc8r/cloud/go/service/hostname.go
@@ -1,0 +1,33 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package service
+
+import (
+	"os"
+
+	"magma/orc8r/cloud/go/orc8r"
+
+	"github.com/golang/glog"
+)
+
+// MustGetHostname gets the hostname of the calling service.
+// The hostname is determined by checking an environment variable that's
+// required to be set, so fatal on error.
+func MustGetHostname() string {
+	hostname, exist := os.LookupEnv(orc8r.ServiceHostnameEnvVar)
+	if !exist {
+		glog.Fatalf("Environment variable %s must be set (in dev: set to localhost) (in prod: set to the public IP of this pod)", orc8r.ServiceHostnameEnvVar)
+	}
+	return hostname
+}

--- a/orc8r/cloud/go/services/dispatcher/dispatcher/main.go
+++ b/orc8r/cloud/go/services/dispatcher/dispatcher/main.go
@@ -15,9 +15,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
-	"net/http"
-	"os"
 
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
@@ -32,7 +29,9 @@ import (
 	"google.golang.org/grpc"
 )
 
-const HttpServerPort = 9080
+const (
+	HttpServerPort = 9080
+)
 
 func main() {
 	// Set MaxConnectionAge to infinity so Sync RPC stream doesn't restart
@@ -47,20 +46,20 @@ func main() {
 		grpc.KeepaliveParams(keepaliveParams),
 	)
 	if err != nil {
-		glog.Fatalf("Error creating service: %s", err)
+		glog.Fatalf("Error creating service: %+v", err)
 	}
 
 	// create a broker
 	broker := syncRpcBroker.NewGatewayReqRespBroker()
 
 	// get ec2 public host name
-	hostName := getHostName()
-	glog.V(2).Infof("hostName is: %v\n", hostName)
+	hostName := service.MustGetHostname()
+	glog.Infof("SyncRPC hostname is %s", hostName)
 
 	// create servicer
 	syncRpcServicer, err := servicers.NewSyncRPCService(hostName, broker)
 	if err != nil {
-		glog.Fatalf("SyncRPCService Initialization Error: %s", err)
+		glog.Fatalf("Error initializing syncRPC service: %+v", err)
 	}
 	protos.RegisterSyncRPCServiceServer(srv.GrpcServer, syncRpcServicer)
 
@@ -70,29 +69,6 @@ func main() {
 
 	err = srv.Run()
 	if err != nil {
-		glog.Fatalf("Error running service: %s", err)
+		glog.Fatalf("Error running service: %+v", err)
 	}
-}
-
-// getHostName of the current SyncRPCService instance
-func getHostName() string {
-	// If there is env variable override, use the env variable
-	// This can be used in dev cloud
-	hostName, exist := os.LookupEnv("SERVICE_HOST_NAME")
-	if exist {
-		return hostName
-	}
-	//see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html
-	resp, err := http.Get("http://169.254.169.254/latest/meta-data/public-hostname")
-	if err != nil {
-		glog.Fatalf("Cannot get public-hostname of the current service instance")
-	}
-	if resp.StatusCode != 200 {
-		errMsg, _ := ioutil.ReadAll(resp.Body)
-		resp.Body.Close()
-		glog.Fatalf("Failed to getHostName: status code %d: %s", resp.StatusCode, errMsg)
-	}
-	body, err := ioutil.ReadAll(resp.Body)
-	resp.Body.Close()
-	return string(body)
 }

--- a/orc8r/cloud/go/services/metricsd/collection/gatherer.go
+++ b/orc8r/cloud/go/services/metricsd/collection/gatherer.go
@@ -17,57 +17,76 @@ import (
 	"fmt"
 	"time"
 
+	"magma/orc8r/lib/go/registry"
+
 	"github.com/golang/glog"
+	"github.com/pkg/errors"
 	prometheus_proto "github.com/prometheus/client_model/go"
 )
 
 // MetricsGatherer wraps a set of MetricCollectors, polling each collector
 // at the configured interval and putting the results onto an output channel.
 type MetricsGatherer struct {
-	Collectors      []MetricCollector
-	CollectInterval time.Duration
-	OutputChan      chan *prometheus_proto.MetricFamily
+	StaticCollectors []MetricCollector
+	CollectInterval  time.Duration
+	OutputChan       chan *prometheus_proto.MetricFamily
 }
 
 // NewMetricsGatherer validates params and returns a new metrics gatherer.
+// The gatherer accepts a static set of collectors, to which it will
+// dynamically append a collector per orc8r service.
 func NewMetricsGatherer(
-	collectors []MetricCollector,
+	staticCollectors []MetricCollector,
 	collectInterval time.Duration,
 	outputChan chan *prometheus_proto.MetricFamily,
 ) (*MetricsGatherer, error) {
-	if collectors == nil || len(collectors) == 0 {
-		return nil, fmt.Errorf("MetricsGatherer must be initialized with at least one MetricCollector")
-	}
 	if collectInterval < 0 {
-		return nil, fmt.Errorf("collectInterval should be positive")
+		return nil, fmt.Errorf("collectInterval must be positive")
 	}
-
 	return &MetricsGatherer{
-		Collectors:      collectors,
-		CollectInterval: collectInterval,
-		OutputChan:      outputChan,
+		StaticCollectors: staticCollectors,
+		CollectInterval:  collectInterval,
+		OutputChan:       outputChan,
 	}, nil
 }
 
-func (gatherer *MetricsGatherer) Run() {
+func (g *MetricsGatherer) Run() {
 	glog.V(2).Info("Running metrics gatherer")
-
 	// Gather metrics from each collector periodically in separate goroutines
 	// so a hanging collector doesn't block other collectors
-	for _, collector := range gatherer.Collectors {
-		go gatherer.gatherEvery(collector)
+	for _, collector := range g.getCollectors() {
+		go g.gatherEvery(collector)
 	}
 }
 
-func (gatherer *MetricsGatherer) gatherEvery(collector MetricCollector) {
-	for range time.Tick(gatherer.CollectInterval) {
+func (g *MetricsGatherer) gatherEvery(collector MetricCollector) {
+	for range time.Tick(g.CollectInterval) {
 		fams, err := collector.GetMetrics()
 		if err != nil {
 			glog.Errorf("Metric collector error: %s", err)
 		}
-
 		for _, fam := range fams {
-			gatherer.OutputChan <- fam
+			g.OutputChan <- fam
 		}
 	}
+}
+
+// getCollectors returns the set of metrics collectors.
+// Returned collectors include disk usage, process statistics, and
+// per-service custom metrics.
+func (g *MetricsGatherer) getCollectors() []MetricCollector {
+	collectors := g.StaticCollectors
+
+	services, err := registry.ListAllServices()
+	if err != nil {
+		err = errors.Wrap(err, "error getting metrics collectors: list all services")
+		glog.Warning(err)
+		return collectors
+	}
+
+	for _, s := range services {
+		collectors = append(collectors, NewCloudServiceMetricCollector(s))
+	}
+
+	return collectors
 }

--- a/orc8r/cloud/go/services/metricsd/collection/gatherer_test.go
+++ b/orc8r/cloud/go/services/metricsd/collection/gatherer_test.go
@@ -43,7 +43,7 @@ func TestMetricsGatherer_Gather(t *testing.T) {
 			&TestMetricCollector{ret: []*prometheus_proto.MetricFamily{expected1}},
 			&TestMetricCollector{ret: []*prometheus_proto.MetricFamily{expected2, expected3}},
 		},
-		time.Second*5,
+		time.Second,
 		output,
 	)
 	assert.NoError(t, err)
@@ -51,7 +51,7 @@ func TestMetricsGatherer_Gather(t *testing.T) {
 	go gatherer.Run()
 	timeout := make(chan struct{}, 1)
 	go func() {
-		time.Sleep(15 * time.Second)
+		time.Sleep(5 * time.Second)
 		timeout <- struct{}{}
 	}()
 

--- a/orc8r/cloud/helm/orc8r/templates/controller.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/controller.deployment.yaml
@@ -107,13 +107,7 @@ spec:
               value: {{ .Values.controller.spec.database.driver }}
             - name: SQL_DIALECT
               value: {{ .Values.controller.spec.database.sql_dialect }}
-            # Hostname override for dispatcher
-            - name: SERVICE_HOST_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
-            # Hostname override for metricsd
-            - name: HOST_NAME
+            - name: SERVICE_HOSTNAME
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP

--- a/orc8r/lib/go/registry/global_registry.go
+++ b/orc8r/lib/go/registry/global_registry.go
@@ -15,9 +15,6 @@ limitations under the License.
 package registry
 
 import (
-	"os"
-	"strings"
-
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -140,16 +137,4 @@ func GetConnection(service string) (*grpc.ClientConn, error) {
 
 func GetConnectionImpl(ctx context.Context, service string, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	return globalRegistry.GetConnectionImpl(ctx, service, opts...)
-}
-
-// ListControllerServices list all services that should run on a controller instances
-// This is a comma separated list in an env var named CONTROLLER_SERVICES. This
-// will be used for metricsd on controller to determine
-// what services to pull metrics from.
-func ListControllerServices() []string {
-	controllerServices, ok := os.LookupEnv("CONTROLLER_SERVICES")
-	if !ok {
-		return make([]string, 0)
-	}
-	return strings.Split(controllerServices, ",")
 }


### PR DESCRIPTION
## Summary

As part of the service mesh changes, we're reworking the controller image to support orc8r services running as top-level pods (or Docker services in dev). This is a good opportunity to rework some of the existing functionality.

Currently, a few places in the codebase rely on env vars baked into the controller image, where in some cases
- they're expected to be overridden
- they are incorrect for service mesh deployments (non-yaml service registry type)
- multiple env vars performing redundant functionality
- etc

Ultimately, we don't need these, so this PR refactors the application code to support removing the following env vars:

```
# TODO: automatically read the services from the plugins
ENV CONTROLLER_SERVICES STREAMER,SUBSCRIBERDB,POLICYDB,METRICSD,CERTIFIER,BOOTSTRAPPER,ACCESSD,OBSIDIAN,DISPATCHER,DIRECTORYD,FEG_RELAY,HEALTH,VPNSERVICE,STATE,DEVICE,ANALYTICS,TENANTS
# TODO: fix dispatcher to work on containers
ENV SERVICE_HOST_NAME localhost
# TODO: fix metricsd for fetching host level metrics
ENV HOST_NAME dev
```

A subsequent PR will actually rework the controller image such that it doesn't include these env vars.

## Test Plan

- [x] make test
- [ ] run locally and ensure nothing's borked

## Additional Information

- [ ] This change is backwards-breaking