### PR TITLE
[xwf-m] support dash in network ids for xwf-m deployment

### DIFF
--- a/xwf/gateway/deploy/roles/deprovision/files/xwfm_deprovision.py
+++ b/xwf/gateway/deploy/roles/deprovision/files/xwfm_deprovision.py
@@ -59,7 +59,7 @@ def create_parser():
     Creates the argparse parser with all the arguments.
     """
     parser = argparse.ArgumentParser(
-        description="Provision XwF-M Gateway",
+        description="Deprovision XwF-M Gateway",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument(
@@ -78,7 +78,7 @@ def main():
         parser.print_usage()
         exit(1)
 
-    partner = args.partner.replace("-", "_").strip()
+    partner = args.partner.strip()
     deregister_all_gateways(args.url, partner)
 
 if __name__ == "__main__":

--- a/xwf/gateway/deploy/roles/provision/files/xwfm_provision.py
+++ b/xwf/gateway/deploy/roles/provision/files/xwfm_provision.py
@@ -230,7 +230,7 @@ def main():
         exit(1)
 
     # Create XwF-M Network
-    partner = args.partner.replace("-", "_").strip()
+    partner = args.partner.strip()
     create_network_if_not_exists(args.url, partner)
     register_gateway(args.url, partner, args.hwid, "default")
 

--- a/xwf/gateway/deploy/roles/xwfm/files/xwfm_hostname.py
+++ b/xwf/gateway/deploy/roles/xwfm/files/xwfm_hostname.py
@@ -80,7 +80,7 @@ def main():
         exit(1)
 
     # Create XwF-M Network
-    partner = args.partner.replace("-", "_").strip()
+    partner = args.partner.strip()
     server_id = get_gateway_id(args.url, partner, args.hwid)
     hostname = 'xwfm.' + args.partner + '.' + args.env + '.' + server_id
     with open('/etc/hostname', 'w') as config:


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary

Use the same convention for network id and partner name.

## Test Plan

tested on xwfmqa1
