### PR TITLE
[orc8r][nginx] Update orc8r helm charts to support conf for k8s registry mode

### DIFF
--- a/cwf/cloud/helm/cwf-orc8r/Chart.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's cwf module
 name: cwf-orc8r
-version: 0.1.1
+version: 0.1.2
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/cwf/cloud/helm/cwf-orc8r/templates/analytics.service.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/templates/analytics.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "analytics.service") -}}
 {{- define "analytics.service" -}}
 metadata:
-  name: {{ .Release.Name }}-analytics
+  name: orc8r-analytics
   labels:
     {{- with .Values.analytics.service.labels }}
 {{ toYaml . | indent 4}}

--- a/cwf/cloud/helm/cwf-orc8r/templates/cwf.service.yaml
+++ b/cwf/cloud/helm/cwf-orc8r/templates/cwf.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "cwf.service") -}}
 {{- define "cwf.service" -}}
 metadata:
-  name: {{ .Release.Name }}-cwf
+  name: orc8r-cwf
   labels:
     {{- with .Values.cwf.service.labels }}
 {{ toYaml . | indent 4}}

--- a/fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's fbinternal module
 name: fbinternal-orc8r
-version: 0.1.0
+version: 0.1.1
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/fbinternal/cloud/helm/fbinternal-orc8r/templates/download.service.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/templates/download.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "download.service") -}}
 {{- define "download.service" -}}
 metadata:
-  name: {{ .Release.Name }}-download
+  name: orc8r-download
   labels:
     {{- with .Values.download.service.labels }}
 {{ toYaml . | indent 4}}

--- a/fbinternal/cloud/helm/fbinternal-orc8r/templates/fbinternal.service.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/templates/fbinternal.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "fbinternal.service") -}}
 {{- define "fbinternal.service" -}}
 metadata:
-  name: {{ .Release.Name }}-fbinternal
+  name: orc8r-fbinternal
   labels:
     {{- with .Values.fbinternal.service.labels }}
 {{ toYaml . | indent 4}}

--- a/fbinternal/cloud/helm/fbinternal-orc8r/templates/testcontroller.service.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/templates/testcontroller.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "testcontroller.service") -}}
 {{- define "testcontroller.service" -}}
 metadata:
-  name: {{ .Release.Name }}-testcontroller
+  name: orc8r-testcontroller
   labels:
     {{- with .Values.testcontroller.service.labels }}
 {{ toYaml . | indent 4}}

--- a/fbinternal/cloud/helm/fbinternal-orc8r/templates/vpn.service.yaml
+++ b/fbinternal/cloud/helm/fbinternal-orc8r/templates/vpn.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "vpn.service") -}}
 {{- define "vpn.service" -}}
 metadata:
-  name: {{ .Release.Name }}-vpnservice
+  name: orc8r-vpnservice
   labels:
     {{- with .Values.vpnservice.service.labels }}
 {{ toYaml . | indent 4}}

--- a/feg/cloud/helm/feg-orc8r/Chart.yaml
+++ b/feg/cloud/helm/feg-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's feg module
 name: feg-orc8r
-version: 0.1.1
+version: 0.1.2
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/feg/cloud/helm/feg-orc8r/templates/feg.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/feg.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "feg.service") -}}
 {{- define "feg.service" -}}
 metadata:
-  name: {{ .Release.Name }}-feg
+  name: orc8r-feg
   labels:
     {{- with .Values.feg.service.labels }}
 {{ toYaml . | indent 4}}

--- a/feg/cloud/helm/feg-orc8r/templates/feg_relay.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/feg_relay.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "feg_relay.service") -}}
 {{- define "feg_relay.service" -}}
 metadata:
-  name: {{ .Release.Name }}-feg-relay
+  name: orc8r-feg-relay
   labels:
     {{- with .Values.feg_relay.service.labels }}
 {{ toYaml . | indent 4}}

--- a/feg/cloud/helm/feg-orc8r/templates/health.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/health.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "health.service") -}}
 {{- define "health.service" -}}
 metadata:
-  name: {{ .Release.Name }}-health
+  name: orc8r-health
   labels:
     {{- with .Values.health.service.labels }}
 {{ toYaml . | indent 4}}

--- a/lte/cloud/helm/lte-orc8r/Chart.yaml
+++ b/lte/cloud/helm/lte-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's lte module
 name: lte-orc8r
-version: 0.1.2
+version: 0.1.3
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/lte/cloud/helm/lte-orc8r/templates/lte.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/lte.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "lte.service") -}}
 {{- define "lte.service" -}}
 metadata:
-  name: {{ .Release.Name }}-lte
+  name: orc8r-lte
   labels:
     {{- with .Values.lte.service.labels }}
 {{ toYaml . | indent 4}}

--- a/lte/cloud/helm/lte-orc8r/templates/policydb.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/policydb.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "policydb.service") -}}
 {{- define "policydb.service" -}}
 metadata:
-  name: {{ .Release.Name }}-policydb
+  name: orc8r-policydb
   labels:
     {{- with .Values.policydb.service.labels }}
 {{ toYaml . | indent 4}}

--- a/lte/cloud/helm/lte-orc8r/templates/smsd.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/smsd.service.yaml
@@ -14,7 +14,7 @@
   {{- include "orc8rlib.service" (list . "smsd.service") -}}
   {{- define "smsd.service" -}}
 metadata:
-  name: {{ .Release.Name }}-smsd
+  name: orc8r-smsd
   labels:
   {{- with .Values.smsd.service.labels }}
   {{ toYaml . | indent 4}}

--- a/lte/cloud/helm/lte-orc8r/templates/subscriberdb.service.yaml
+++ b/lte/cloud/helm/lte-orc8r/templates/subscriberdb.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "subscriberdb.service") -}}
 {{- define "subscriberdb.service" -}}
 metadata:
-  name: {{ .Release.Name }}-subscriberdb
+  name: orc8r-subscriberdb
   labels:
     {{- with .Values.subscriberdb.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/docker/docker-compose.yml
+++ b/orc8r/cloud/docker/docker-compose.yml
@@ -259,6 +259,7 @@ services:
       PROXY_BACKENDS: controller
       TEST_MODE: "1"
       RESOLVER: 127.0.0.11
+      SERVICE_REGISTRY_MODE: yaml
     restart: always
 #    logging:
 #      driver: fluentd

--- a/orc8r/cloud/docker/nginx/generate_nginx_configs.py
+++ b/orc8r/cloud/docker/nginx/generate_nginx_configs.py
@@ -53,6 +53,7 @@ def main():
         'controller_hostname': os.environ['CONTROLLER_HOSTNAME'],
         'backend': os.environ['PROXY_BACKENDS'],
         'resolver': os.environ['RESOLVER'],
+        'service_registry_mode': os.environ.get('SERVICE_REGISTRY_MODE', 'yaml'),
     }
     _generate_config(context)
 

--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -85,11 +85,24 @@ http {
       {%- if resolver %}
       resolver {{ resolver }};
       {%- endif %}
+
+      {%- if service_registry_mode == 'k8s' %}
+      # Helm services don't allow for underscores. Magma convention is
+      # to use underscores in service names, so convert any hyphens in the
+      # k8s service name.
+      if ($srv ~* "(\w+)[_](\w+)") {
+        set $srv "$1-$2";
+      }
+      grpc_pass grpc://orc8r-$srv:9180;
+      grpc_set_header Host $srv:9180;
+
+      {%- else %}
       grpc_pass grpc://{{ backend }}:$srvport;
+      grpc_set_header Host $srv-{{ backend }}:$srvport;
+      {%- endif %}
 
       grpc_set_header x-magma-client-cert-cn $ssl_client_s_dn_cn;
       grpc_set_header x-magma-client-cert-serial $ssl_client_serial;
-      grpc_set_header Host $srv-{{ backend }}:$srvport;
     }
 
     # Setting max allowed size for client requests body to 50MB
@@ -113,7 +126,15 @@ http {
       resolver {{ resolver }};
       {%- endif %}
 
-      grpc_pass grpc://{{ backend }}:$open_srvport;
+      {%- if service_registry_mode == 'k8s' %}
+      # Convert underscore to hypen in service name
+      if ($srv ~* "(\w+)[_](\w+)") {
+        set $srv "$1-$2";
+      }
+      grpc_pass grpc://orc8r-$srv:9180;
+      {%- else %}
+      grpc_pass grpc://$srv:$open_srvport;
+      {%- endif %}
     }
   }
 
@@ -134,7 +155,12 @@ http {
       {%- if resolver %}
       resolver {{ resolver }};
       {%- endif %}
+
+      {%- if service_registry_mode == 'k8s' %}
+      proxy_pass http://orc8r-obsidian:8080;
+      {%- else %}
       proxy_pass http://{{ backend }}:9081;
+      {%- endif %}
 
       proxy_set_header x-magma-client-cert-cn $ssl_client_s_dn_cn;
       proxy_set_header x-magma-client-cert-serial $ssl_client_serial;

--- a/orc8r/cloud/go/services/service_registry/servicers/kubernetes_servicer_test.go
+++ b/orc8r/cloud/go/services/service_registry/servicers/kubernetes_servicer_test.go
@@ -34,9 +34,9 @@ func TestK8sListAllServices(t *testing.T) {
 	req := &protos.Void{}
 	response, err := servicer.ListAllServices(context.Background(), req)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"service1", "service-2"}, response.GetServices())
+	assert.Equal(t, []string{"service1", "service_2"}, response.GetServices())
 
-	err = mockClient.Services(servicer.namespace).Delete("foo-service-2", &metav1.DeleteOptions{})
+	err = mockClient.Services(servicer.namespace).Delete("orc8r-service-2", &metav1.DeleteOptions{})
 	assert.NoError(t, err)
 	response, err = servicer.ListAllServices(context.Background(), req)
 	assert.NoError(t, err)
@@ -55,12 +55,12 @@ func TestK8sFindServices(t *testing.T) {
 	req.Label = "label2"
 	response, err = servicer.FindServices(context.Background(), req)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"service1", "service-2"}, response.GetServices())
+	assert.Equal(t, []string{"service1", "service_2"}, response.GetServices())
 
 	err = mockClient.Services(servicer.namespace).Delete("orc8r-service1", &metav1.DeleteOptions{})
 	response, err = servicer.FindServices(context.Background(), req)
 	assert.NoError(t, err)
-	assert.Equal(t, []string{"service-2"}, response.GetServices())
+	assert.Equal(t, []string{"service_2"}, response.GetServices())
 }
 
 func TestK8sGetServiceAddress(t *testing.T) {
@@ -139,7 +139,7 @@ func createK8sServices(t *testing.T, mockClient corev1Interface.CoreV1Interface,
 	svc2 := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
-			Name:      "foo-service-2",
+			Name:      "orc8r-service-2",
 			Labels: map[string]string{
 				partOfLabel: partOfOrc8rApp,
 				"label2":    "true",

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.42
+version: 1.4.43
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/templates/accessd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/accessd.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "accessd.service") -}}
 {{- define "accessd.service" -}}
 metadata:
-  name: {{ .Release.Name }}-accessd
+  name: orc8r-accessd
   labels:
     {{- with .Values.accessd.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/bootstrapper.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/bootstrapper.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "bootstrapper.service") -}}
 {{- define "bootstrapper.service" -}}
 metadata:
-  name: {{ .Release.Name }}-bootstrapper
+  name: orc8r-bootstrapper
   labels:
     {{- with .Values.bootstrapper.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/certifier.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/certifier.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "certifier.service") -}}
 {{- define "certifier.service" -}}
 metadata:
-  name: {{ .Release.Name }}-certifier
+  name: orc8r-certifier
   labels:
     {{- with .Values.certifier.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/configurator.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/configurator.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "configurator.service") -}}
 {{- define "configurator.service" -}}
 metadata:
-  name: {{ .Release.Name }}-configurator
+  name: orc8r-configurator
   labels:
     {{- with .Values.configurator.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/device.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/device.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "device.service") -}}
 {{- define "device.service" -}}
 metadata:
-  name: {{ .Release.Name }}-device
+  name: orc8r-device
   labels:
     {{- with .Values.device.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/directoryd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/directoryd.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "directoryd.service") -}}
 {{- define "directoryd.service" -}}
 metadata:
-  name: {{ .Release.Name }}-directoryd
+  name: orc8r-directoryd
   labels:
     {{- with .Values.directoryd.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "dispatcher.service") -}}
 {{- define "dispatcher.service" -}}
 metadata:
-  name: {{ .Release.Name }}-dispatcher
+  name: orc8r-dispatcher
   labels:
     {{- with .Values.dispatcher.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/metricsd.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/metricsd.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "metricsd.service") -}}
 {{- define "metricsd.service" -}}
 metadata:
-  name: {{ .Release.Name }}-metricsd
+  name: orc8r-metricsd
   labels:
     {{- with .Values.metricsd.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
@@ -80,6 +80,8 @@ spec:
               value: {{ required "nginx.spec.hostname must be provided" .Values.nginx.spec.hostname | quote }}
             - name: RESOLVER
               value: {{ .Values.nginx.spec.resolver | quote }}
+            - name: SERVICE_REGISTRY_MODE
+              value: {{ .Values.controller.spec.service_registry.mode }}
           livenessProbe:
             tcpSocket:
               port: health

--- a/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/obsidian.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "obsidian.service") -}}
 {{- define "obsidian.service" -}}
 metadata:
-  name: {{ .Release.Name }}-obsidian
+  name: orc8r-obsidian
   labels:
     {{- with .Values.obsidian.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/orchestrator.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/orchestrator.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "orchestrator.service") -}}
 {{- define "orchestrator.service" -}}
 metadata:
-  name: {{ .Release.Name }}-orchestrator
+  name: orc8r-orchestrator
   labels:
     {{- with .Values.orchestrator.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/service_registry.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/service_registry.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "service_registry.service") -}}
 {{- define "service_registry.service" -}}
 metadata:
-  name: {{ .Release.Name }}-service-registry
+  name: orc8r-service-registry
   labels:
     {{- with .Values.service_registry.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/state.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/state.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "state.service") -}}
 {{- define "state.service" -}}
 metadata:
-  name: {{ .Release.Name }}-state
+  name: orc8r-state
   labels:
     {{- with .Values.state.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/streamer.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/streamer.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "streamer.service") -}}
 {{- define "streamer.service" -}}
 metadata:
-  name: {{ .Release.Name }}-streamer
+  name: orc8r-streamer
   labels:
     {{- with .Values.streamer.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/cloud/helm/orc8r/templates/tenants.service.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/tenants.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "tenants.service") -}}
 {{- define "tenants.service" -}}
 metadata:
-  name: {{ .Release.Name }}-tenants
+  name: orc8r-tenants
   labels:
     {{- with .Values.tenants.service.labels }}
 {{ toYaml . | indent 4}}

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -33,8 +33,6 @@ import (
 
 const (
 	ServiceRegistryServiceName = "service_registry"
-
-	HelmReleaseNameEnvVar     = "HELM_RELEASE_NAME"
 	ServiceRegistryModeEnvVar = "SERVICE_REGISTRY_MODE"
 	DockerRegistryMode        = "docker"
 	K8sRegistryMode           = "k8s"
@@ -55,7 +53,6 @@ type ServiceRegistry struct {
 	cloudConnections map[string]cloudConnection
 
 	serviceRegistryMode string
-	releaseName         string
 }
 
 type cloudConnection struct {
@@ -72,13 +69,11 @@ var localKeepaliveParams = keepalive.ClientParameters{
 // New creates and returns a new registry
 func New() *ServiceRegistry {
 	registryMode := os.Getenv(ServiceRegistryModeEnvVar)
-	releaseName := os.Getenv(HelmReleaseNameEnvVar)
 	return &ServiceRegistry{
 		ServiceConnections:  map[string]*grpc.ClientConn{},
 		ServiceLocations:    map[string]ServiceLocation{},
 		cloudConnections:    map[string]cloudConnection{},
 		serviceRegistryMode: registryMode,
-		releaseName:         releaseName,
 	}
 }
 
@@ -88,7 +83,6 @@ func NewWithMode(mode string) *ServiceRegistry {
 		ServiceLocations:    map[string]ServiceLocation{},
 		cloudConnections:    map[string]cloudConnection{},
 		serviceRegistryMode: mode,
-		releaseName:         os.Getenv(HelmReleaseNameEnvVar),
 	}
 }
 
@@ -445,12 +439,7 @@ func (r *ServiceRegistry) getGRPCDialOptions() []grpc.DialOption {
 func (r *ServiceRegistry) getServiceRegistryServiceAddress() string {
 	// Use hardcoded address for service_registry service as we can't
 	// dynamically discover the service registry service itself
-	if r.serviceRegistryMode == DockerRegistryMode {
-		return fmt.Sprintf("service_registry:%d", GrpcServicePort)
-	} else if r.serviceRegistryMode == K8sRegistryMode {
-		return fmt.Sprintf("%s-service-registry:%d", r.releaseName, GrpcServicePort)
-	}
-	return ""
+	return fmt.Sprintf("orc8r-service-registry:%d", GrpcServicePort)
 }
 
 func (r *ServiceRegistry) addUnsafe(location ServiceLocation) {

--- a/wifi/cloud/helm/wifi-orc8r/Chart.yaml
+++ b/wifi/cloud/helm/wifi-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's wifi module
 name: wifi-orc8r
-version: 0.1.1
+version: 0.1.2
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/wifi/cloud/helm/wifi-orc8r/templates/wifi.service.yaml
+++ b/wifi/cloud/helm/wifi-orc8r/templates/wifi.service.yaml
@@ -14,7 +14,7 @@
 {{- include "orc8rlib.service" (list . "wifi.service") -}}
 {{- define "wifi.service" -}}
 metadata:
-  name: {{ .Release.Name }}-wifi
+  name: orc8r-wifi
   labels:
     {{- with .Values.wifi.service.labels }}
 {{ toYaml . | indent 4}}


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR updates orc8r helm charts and nginx conf to support k8s service registry mode.
Specifically the changes made are:

- Remove release name prefix from orc8r k8s services. Since the orc8r module services are a part of different helm charts, the release name prefix for the services differs, making the logic complicated to properly reverse proxy to all of these. Without this, we can just capture the service name and proxy to this service at standardized port 9180.
- Update service registry to no longer expect helm release prefix as a part of the service names.
- Update nginx conf to proxy to the services directly rather than orc8r-controller when service reg mode == 'k8s'.

## Test Plan

Deployed locally to minikube and ensured API and gateway calls through nginx work properly with both yaml registry
mode and k8s.
