### PR TITLE
[pipelined]Remove CWF GY Redirect IP Requirement

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/gy.py
+++ b/lte/gateway/python/magma/pipelined/app/gy.py
@@ -221,12 +221,17 @@ class GYController(PolicyMixin, MagmaController):
         rule_version = self._session_rule_version_mapper.get_version(imsi,
                                                                      ip_addr,
                                                                      rule.id)
+        # CWF generates an internal IP for redirection so ip_addr is not needed
+        if self._setup_type == 'CWF':
+            ip_addr_str = None
+        elif ip_addr and ip_addr.address:
+            ip_addr_str = ip_addr.address.decode('utf-8')
         priority = rule.priority
         # TODO currently if redirection is enabled we ignore other flows
         # from rule.flow_list, confirm that this is the expected behaviour
         redirect_request = RedirectionManager.RedirectRequest(
             imsi=imsi,
-            ip_addr=ip_addr.address.decode('utf-8'),
+            ip_addr=ip_addr_str,
             rule=rule,
             rule_num=rule_num,
             rule_version=rule_version,


### PR DESCRIPTION
Signed-off-by: Nick Yurchenko <koolzz@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Per CWF _complicated redirect design_ we don't actually use the original UE IP src IP for redirect, instead we used the internal generated IP. Thus we can ignore the ue ip and not look it up on sessiond end.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
