### PR TITLE
[xwf][xwfm][fluentbit] we will log also locally on mount bind pointing to directory on the host which we will clean with cron

### DIFF
--- a/xwf/gateway/deploy/roles/containers/files/clean_fluentbit_logs
+++ b/xwf/gateway/deploy/roles/containers/files/clean_fluentbit_logs
@@ -1,0 +1,4 @@
+SHELL=/bin/bash
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+
+10 10 * * * root find /var/log/fluentbit-logs/ -type f -mtime +7 -exec rm {} \;

--- a/xwf/gateway/deploy/roles/containers/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/containers/tasks/main.yml
@@ -30,6 +30,19 @@
     dest: /var/opt/magma/docker/.env
     mode: 0400
 
+- name: create directories for magma configs and files
+  file:
+    path: "/var/log/fluentbit-logs/"
+    state: directory
+    mode: '0700'
+
+- name: place clean_fluentbit_logs cron file
+  copy:
+   src: clean_fluentbit_logs
+   dest: /etc/cron.d/clean_fluentbit_logs
+   mode: '0644'
+
+
 - name: Clone the git repo
   git:
    repo: "https://github.com/magma/magma.git"

--- a/xwf/gateway/docker/docker-compose.yml
+++ b/xwf/gateway/docker/docker-compose.yml
@@ -128,6 +128,8 @@ services:
       - SCRIBE_ACCESS_TOKEN=${SCUBA_ACCESS_TOKEN}
       - SCUBA_TABLE=perfpipe_xwf_xwfm_logs
       - PARTNER_SHORTNAME=${PARTNER_SHORTNAME}
+    volumes:
+      - /var/log/fluentbit-logs:/var/log/fluentbit-logs
 
   cadvisor:
     image: gcr.io/google-containers/cadvisor:latest


### PR DESCRIPTION
…g to directory on the host which we will clean with cron

Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

[xwf][xwfm][fluentbit] we will log also locally on mount bind pointing to directory on the host which we will clean with cron

## Summary

the ansible will create new directory which will be mounted for fluentbit logs and will also perform the cleanups of that directory via cron script

## Test Plan
tested on new provisioned xwfm box with:
```
git clone https://github.com/ayliD/magma.git -b local_fluentbit_logs_and_cleanup
cd magma/xwf/gateway/deploy/ && ansible-playbook -e "xwfm_deprovision=True" xwf.yml
```

## Additional Information

- [ ] This change is backwards-breaking
