### PR TITLE
AGW: Use envoy client to setup HTTP header rules

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/envoy.yaml
+++ b/lte/gateway/deploy/roles/magma/files/envoy.yaml
@@ -33,7 +33,7 @@ static_resources:
   - connect_timeout: 1s
     hosts:
     - socket_address:
-        address: 127.0.0.1
+        address: 10.5.0.2
         port_value: 18000
     http2_protocol_options: {}
     name: xds_cluster

--- a/lte/gateway/deploy/roles/magma/files/systemd/magma_envoy.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/magma_envoy.service
@@ -17,7 +17,7 @@ Before=magma@envoy_controller.service
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment
-ExecStart=/sbin/ip netns exec envoy_ns1 /usr/bin/envoy -c /var/opt/magma/envoy.yaml -l debug
+ExecStart=/sbin/ip netns exec envoy_ns1 /usr/bin/envoy -c /var/opt/magma/envoy.yaml --log-path /var/log/envoy.log -l debug
 MemoryAccounting=yes
 StandardOutput=syslog
 StandardError=syslog

--- a/lte/gateway/python/magma/pipelined/app/policy_mixin.py
+++ b/lte/gateway/python/magma/pipelined/app/policy_mixin.py
@@ -239,7 +239,7 @@ class PolicyMixin(metaclass=ABCMeta):
 
     def _remove_he_flows(self, ip_addr: IPAddress, rule_id:int = -1):
         if self.proxy_controller:
-            self.proxy_controller.remove_subscriber_flow(ip_addr, rule_id)
+            self.proxy_controller.remove_subscriber_he_flows(ip_addr, rule_id)
 
     def _install_flow_for_static_rule(self, imsi, msisdn: bytes, uplink_tunnel: int, ip_addr, apn_ambr, rule_id):
         """
@@ -359,9 +359,10 @@ class PolicyMixin(metaclass=ABCMeta):
             ue_ip = ipv4_address_to_str(ip_addr)
             ip_dst = get_flow_ip_dst(flow.match)
 
-            proxy_msgs = self.proxy_controller.get_subscriber_flows(ue_ip, uplink_tunnel, ip_dst,
-                                                                    rule_num,
-                                                                    urls, imsi, msisdn)
+            proxy_msgs = self.proxy_controller.get_subscriber_he_flows(ue_ip, uplink_tunnel,
+                                                                       ip_dst,
+                                                                       rule_num,
+                                                                       urls, imsi, msisdn)
             msgs.extend(proxy_msgs)
         return msgs
 

--- a/lte/gateway/python/magma/pipelined/envoy_client.py
+++ b/lte/gateway/python/magma/pipelined/envoy_client.py
@@ -17,18 +17,50 @@ import logging
 
 from magma.common.service_registry import ServiceRegistry
 from feg.protos.envoy_controller_pb2_grpc import EnvoyControllerStub
-from feg.protos.envoy_controller_pb2 import AddUEHeaderEnrichmentRequest
+from feg.protos.envoy_controller_pb2 import AddUEHeaderEnrichmentRequest, \
+    DeactivateUEHeaderEnrichmentRequest, Header
+from lte.protos.mobilityd_pb2 import IPAddress
 
-SERVICE_NAME = "envoyd"
+SERVICE_NAME = "envoy_controller"
 IMSI_HDR = 'imsi'
 MSISDN_HDR = 'msisdn'
+TIMEOUT_SEC = 30
 
 
-def set_he_urls_for_ue(ip: str, urls: List[str], imsi: str, msisdn: str):
+def activate_he_urls_for_ue(ip: IPAddress, urls: List[str], imsi: str, msisdn: str) -> bool:
     """
-    Make RPC call to 'SetGatewayInfo' method of local mobilityD service
+    Make RPC call to 'Envoy Controller' to add target URLs to envoy datapath.
     """
+    try:
+        chan = ServiceRegistry.get_rpc_channel(SERVICE_NAME,
+                                               ServiceRegistry.LOCAL)
+    except grpc.RpcError:
+        logging.error('Cant get RPC channel to %s', SERVICE_NAME)
+        return False
 
+    client = EnvoyControllerStub(chan)
+    try:
+        headers = [Header(name=IMSI_HDR, value=imsi)]
+        if msisdn:
+            headers.append(Header(name=MSISDN_HDR, value=msisdn))
+        he_info = AddUEHeaderEnrichmentRequest(ue_ip=ip,
+                                               websites=urls,
+                                               headers=headers)
+        client.AddUEHeaderEnrichment(he_info, timeout=TIMEOUT_SEC)
+        return True
+    except grpc.RpcError as err:
+        logging.error(
+            "Activate HE proxy error[%s] %s",
+            err.code(),
+            err.details())
+
+    return False
+
+
+def deactivate_he_urls_for_ue(ip: IPAddress):
+    """
+    Make RPC call to 'Envoy Controller' to remove the proxy rule for the UE.
+    """
     try:
         chan = ServiceRegistry.get_rpc_channel(SERVICE_NAME,
                                                ServiceRegistry.LOCAL)
@@ -37,16 +69,14 @@ def set_he_urls_for_ue(ip: str, urls: List[str], imsi: str, msisdn: str):
         return
 
     client = EnvoyControllerStub(chan)
-    try:
-        h1 = {IMSI_HDR: imsi}
-        h2 = {MSISDN_HDR: msisdn}
 
-        he_info = AddUEHeaderEnrichmentRequest(ue_ip=ip,
-                                               websites=urls,
-                                               headers=[h1, h2])
-        client.AddUEHeaderEnrichment(he_info)
+    try:
+        he_info = DeactivateUEHeaderEnrichmentRequest(ue_ip=ip)
+        client.DeactivateUEHeaderEnrichment(he_info, timeout=TIMEOUT_SEC)
+
     except grpc.RpcError as err:
         logging.error(
-            "SetGatewayInfo error[%s] %s",
+            "Deactivate HE proxy error[%s] %s",
             err.code(),
             err.details())
+


### PR DESCRIPTION
This patch make use of envoy controller service to setup proxy
rules in envoy datapath.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
