### PR TITLE
[SessionD] Allow credits with 0 GSU to be initialized / received

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -55,6 +55,10 @@ struct ChargingGrant {
       const magma::lte::ChargingCredit& credit,
       SessionCreditUpdateCriteria* uc = NULL);
 
+  // Returns true if the credit returned from the Policy component is valid and
+  // good to be installed.
+  static bool is_valid_credit_response(const CreditUpdateResponse& update);
+
   // Returns a SessionCreditUpdateCriteria that reflects the current state
   SessionCreditUpdateCriteria get_update_criteria();
 

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -206,15 +206,14 @@ class SessionState {
    * Receive the credit grant if the credit update was successful
    *
    * @param update
-   * @param uc
+   * @param session_uc
    * @return True if usage for the charging key is allowed after receiving
    *         the credit response. This requires that the credit update was
-   *         a success. Also it must either be an infinite credit rating group,
-   *         or have associated credit grant.
+   *         a success.
    */
   bool receive_charging_credit(
       const CreditUpdateResponse& update,
-      SessionStateUpdateCriteria& update_criteria);
+      SessionStateUpdateCriteria& session_uc);
 
   uint64_t get_charging_credit(const CreditKey& key, Bucket bucket) const;
 
@@ -585,14 +584,14 @@ class SessionState {
    * Receive the credit grant if the credit update was successful
    *
    * @param update
-   * @param uc
+   * @param session_uc
    * @return True if usage for the charging key is allowed after receiving
    *         the credit response. This requires that the credit update was
-   *         a success. Also it must either be an infinite credit rating group,
-   *         or have associated credit grant.
+   *         a success.
    */
   bool init_charging_credit(
-      const CreditUpdateResponse& update, SessionStateUpdateCriteria& uc);
+      const CreditUpdateResponse& update,
+      SessionStateUpdateCriteria& session_uc);
 
   /**
    * Return true if any credit unit is valid and has non-zero volume

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -55,7 +55,7 @@ void create_charging_credit(
     uint64_t volume, bool is_final, ChargingCredit* credit);
 
 void create_credit_update_response(
-    const std::string& imsi, const std::string sessiond_id,
+    const std::string& imsi, const std::string session_id,
     uint32_t charging_key, CreditLimitType limit_type,
     CreditUpdateResponse* response);
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We should not be rejecting any successful credit grant that has 0 GSU. This should be counted as a valid credit just with 0 credit. For example, if we receive a 0 credit with FUA-redirect, we want to immediately go into the redirect state, not reject the credit.

New criteria for Gy credits: (We look at the cases in the following order)
1. If command level result code for CCA or MSCC level result code is not 2001, we will reject the credit. 
    * This means the credit is not maintained in SessionD. No rules with the rating group will be installed.
2. If GSU is empty (no valid total/rx/tx AVPs) AND there is no FUA specified, we will also reject the credit as there is no action to take. 
    * This means the credit is not maintained in SessionD. No rules with the rating group will be installed. 
3. If GSU is empty (no valid total/rx/tx AVPs) AND there is a FUA specified, we will accept the credit.
    * This means the credit will be tracked and the rules associated with the RG will be installed. 
    * In this case, the FUA will kick off right after the next usage update from PipelineD. (~1-2 seconds depending on configuration).
4. In all other cases, we accept the credit. 

<!-- Enumerate changes you made and why you made them -->

## Test Plan
SessionD unit tests
CWF integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
