### PR TITLE
[agw][stateless MME] Stateless test cases for Idle mode

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -128,6 +128,7 @@ s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
+s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
 s1aptests/test_restore_mme_config_after_sanity.py
 

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -122,6 +122,7 @@ s1aptests/test_attach_detach_with_mme_restart.py \
 s1aptests/test_attach_detach_with_mobilityd_restart.py \
 s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
 s1aptests/test_attach_detach_with_sctpd_restart.py \
+s1aptests/test_idle_mode_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \

--- a/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_idle_mode_with_mme_restart.py
@@ -1,0 +1,115 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import time
+
+import gpp_types
+import s1ap_types
+import s1ap_wrapper
+from s1ap_utils import MagmadUtil
+
+
+class TestIdleModeWithMmeRestart(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+        )
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_idle_mode_with_mme_restart(self):
+        """
+        The test case checks that state of UE in idle mode is resumed when
+        stateles MME restarts
+        Step1 : UE attaches to network
+        Step2 : UE moves to Idle state
+        Step3 : Restart MME
+        Step4 : Send Service Request, which should be accepted by the network
+        Step5 : Detach UE
+        """
+        self._s1ap_wrapper.configUEDevice(1)
+        time.sleep(20)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
+        # Now actually complete the attach
+        self._s1ap_wrapper._s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # Delay to ensure S1APTester sends attach complete before sending UE
+        # context release
+        time.sleep(0.5)
+
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ",
+            ue_id,
+        )
+        # Send UE context release request to move UE to idle mode
+        req = s1ap_types.ueCntxtRelReq_t()
+        req.ue_Id = ue_id
+        req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
+        self._s1ap_wrapper.s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
+
+        print("************************* Restarting MME service on gateway")
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+
+        for j in range(30):
+            print("Waiting for", j, "seconds")
+            time.sleep(1)
+
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
+        # Send service request to reconnect UE
+        req = s1ap_types.ueserviceReq_t()
+        req.ue_Id = ue_id
+        req.ueMtmsi = s1ap_types.ueMtmsi_t()
+        req.ueMtmsi.pres = False
+        req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
+        self._s1ap_wrapper.s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+        )
+
+        print("************************* Running UE detach for UE id ", ue_id)
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_service_req_ul_udp_data_with_mme_restart.py
@@ -1,0 +1,128 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+import time
+
+import gpp_types
+import s1ap_types
+import s1ap_wrapper
+from s1ap_utils import MagmadUtil
+
+
+class TestServiceReqUlUdpDataWithMmeRestart(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper(
+            stateless_mode=MagmadUtil.stateless_cmds.ENABLE
+        )
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_service_req_ul_udp_data_with_mme_restart(self):
+        """
+        The test case checks that state of UE in idle mode is resumed when
+        stateles MME restarts
+        Step1 : UE attaches to network
+        Step2 : UE moves to Idle state
+        Step3 : Restart MME
+        Step4 : Send Service Request, which should be accepted by the network
+        Step5 : Send UL UDP data
+        Step6 : Detach UE
+        """
+        self._s1ap_wrapper.configUEDevice(1)
+        time.sleep(20)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+        print(
+            "************************* Running End to End attach for UE id ",
+            ue_id,
+        )
+        # Now actually complete the attach
+        self._s1ap_wrapper._s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # Delay to ensure S1APTester sends attach complete before sending UE
+        # context release
+        time.sleep(0.5)
+
+        ul_test = self._s1ap_wrapper.configUplinkTest(
+            req, duration=1, is_udp=True
+        )
+
+        print(
+            "************************* Sending UE context release request ",
+            "for UE id ",
+            ue_id,
+        )
+        # Send UE context release request to move UE to idle mode
+        req = s1ap_types.ueCntxtRelReq_t()
+        req.ue_Id = ue_id
+        req.cause.causeVal = gpp_types.CauseRadioNetwork.USER_INACTIVITY.value
+        self._s1ap_wrapper.s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_CNTXT_REL_REQUEST, req
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
+
+        print("************************* Restarting MME service on gateway")
+        self._s1ap_wrapper.magmad_util.restart_services(["mme"])
+
+        for j in range(30):
+            print("Waiting for", j, "seconds")
+            time.sleep(1)
+
+        print(
+            "************************* Sending Service request for UE id ",
+            ue_id,
+        )
+        # Send service request to reconnect UE
+        req = s1ap_types.ueserviceReq_t()
+        req.ue_Id = ue_id
+        req.ueMtmsi = s1ap_types.ueMtmsi_t()
+        req.ueMtmsi.pres = False
+        req.rrcCause = s1ap_types.Rrc_Cause.TFW_MO_DATA.value
+        self._s1ap_wrapper.s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SERVICE_REQUEST, req
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+        )
+
+        print(
+            "************************* Running UE uplink (UDP) for UE id ",
+            req.ue_Id,
+        )
+
+        with ul_test:
+            ul_test.verify()
+
+        print("************************* Running UE detach for UE id ", ue_id)
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Adding two new test case to check if the state of UE in idle mode is:
- able to request service after MME restarts, with test_idle_mode_with_mme_restart.py
- able to send data after MME restarts, with test_service_req_ul_udp_data_with_mme_restart.py

## Test Plan

`make integ_test TESTS=s1aptests/test_idle_mode_with_mme_restart.py`
`make integ_test TESTS=s1aptests/test_service_req_ul_udp_data_with_mme_restart.py`
`make integ_test` with new tests added