### PR TITLE
[orc8r][helm] Bump Helm chart version

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.4.41
+version: 1.4.42
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma


### PR DESCRIPTION
## Summary

Active SEV https://www.internalfb.com/intern/sevmanager/view/s/215517/ was caused by recent PR https://github.com/magma/magma/pull/3633/ changing the orc8r Helm chart but not including the bump to the chart version. This PR includes the version bump.

## Test Plan

n/a

## Additional Information

- [ ] This change is backwards-breaking