### PR TITLE
Fixing version in source for orc8r installation

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/upgrade_1_3.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/upgrade_1_3.md
@@ -35,12 +35,12 @@ container versions:
 
 ```hcl-terraform
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.2"
+  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.3"
   # ...
 }
 
 module orc8r-app {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.2"
+  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.3"
   # ...
   orc8r_chart_version = "1.4.36"
   orc8r_tag           = "MAGMA_TAG"  # from build step, e.g. v1.3.0

--- a/docs/readmes/orc8r/upgrade_1_3.md
+++ b/docs/readmes/orc8r/upgrade_1_3.md
@@ -34,12 +34,12 @@ container versions:
 
 ```hcl-terraform
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.2"
+  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.3"
   # ...
 }
 
 module orc8r-app {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.2"
+  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.3"
   # ...
   orc8r_chart_version = "1.4.36"
   orc8r_tag           = "MAGMA_TAG"  # from build step, e.g. v1.3.0


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>

[orc8r] Correct version number in source main.tf file


## Summary

In the upgrade procedure to 1.3, the source variable is pointing to 1.2 for orc8r and orc8r-app

source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.2"
source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.2"	

Changing to 1.3

source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.3"
source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.3"


## Test Plan
![image](https://user-images.githubusercontent.com/37117037/98878267-8b6b9800-2450-11eb-94cf-2dc7bba32e78.png)

Tested locally with create_docusaurus_website.sh

## Additional Information

