### PR TITLE
Update Orc8r menu titles

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.1.0/lte/upgrade.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/lte/upgrade.md
@@ -1,11 +1,11 @@
 ---
 id: version-1.1.0-agw_110_upgrade
-title: Upgrading from 1.0
+title: Upgrade to 1.1
 sidebar_label: Upgrading from 1.0
 hide_title: true
 original_id: agw_110_upgrade
 ---
-# Upgrading from 1.0
+# Upgrade to 1.1
 
 You can upgrade your access gateways remotely from the NMS or SSH directly
 into them and run an `apt-get install`.

--- a/docs/docusaurus/versioned_docs/version-1.2.0/lte/upgrade_120.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/lte/upgrade_120.md
@@ -1,10 +1,10 @@
 ---
 id: version-1.2.0-agw_120_upgrade
-title: Upgrading from 1.1
+title: Upgrade to 1.2 
 hide_title: true
 original_id: agw_120_upgrade
 ---
-# Upgrading from 1.1
+# Upgrade to 1.2
 
 You can upgrade your access gateways remotely from the NMS or SSH directly
 into them and run an `apt-get install`.

--- a/docs/docusaurus/versioned_docs/version-1.3.0/lte/upgrade_130.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/lte/upgrade_130.md
@@ -1,10 +1,10 @@
 ---
 id: version-1.3.0-agw_130_upgrade
-title: Upgrading from 1.2
+title: Upgrade to 1.3
 hide_title: true
 original_id: agw_130_upgrade
 ---
-# Upgrading from 1.2
+# Upgrade to 1.3
 
 You can upgrade your access gateways remotely from the NMS or SSH directly
 into them and run an `apt-get install`.


### PR DESCRIPTION
Update AGW upgrade menu titles

## Summary

The AGW upgrade menu titles did not match the Orc8r titles "Upgrade to 1.3" versus "Upgrade from 1.2" which could cause confusion for partners. I updated them so they match. 

## Test Plan

![Screen Shot 2020-11-11 at 4 52 28 PM](https://user-images.githubusercontent.com/61836831/98881228-5f471b80-243e-11eb-9aba-1ca6171b3769.png)

Ran script to test locally

