### PR TITLE
[xwf-m] Fix path to yq during cleanup

### DIFF
--- a/xwf/gateway/deploy/roles/cleanup/tasks/main.yml
+++ b/xwf/gateway/deploy/roles/cleanup/tasks/main.yml
@@ -16,11 +16,11 @@
         rm -f /var/opt/magma/certs/rest_admin.crt
 
 - name: clean rest key from xwfwhoami
-  shell: yq -i -Y 'del(.rest_admin_key)' /etc/xwfwhoami
+  shell: /usr/local/bin/yq -i -Y 'del(.rest_admin_key)' /etc/xwfwhoami
   args:
     warn: false
 
 - name: clean rest crt from xwfwhoami
-  shell: yq -i -Y 'del(.rest_admin_crt)' /etc/xwfwhoami
+  shell: /usr/local/bin/yq -i -Y 'del(.rest_admin_crt)' /etc/xwfwhoami
   args:
     warn: false


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

## Summary
Use absolute path for yq when running cleanup ansible role

## Test Plan
tested on xwfmqa1
