### PR TITLE
[NMS] Handle newly migrated enodeb configurations

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailConfigEdit.js
@@ -519,6 +519,16 @@ export function ConfigEdit(props: Props) {
           return;
         }
       }
+
+      if (enb.config == null) {
+        enb.config = DEFAULT_ENB_CONFIG.config;
+      }
+      if (enb.enodeb_config == null || enb.enodeb_config.config_type == '') {
+        enb.enodeb_config = {
+          config_type: 'MANAGED',
+          managed_config: DEFAULT_ENB_CONFIG.config,
+        };
+      }
       await ctx.setState(enb.serial, {
         enb_state: enbInfo?.enb_state ?? {},
         enb: enb,

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebConfigTest.js
@@ -315,6 +315,14 @@ describe('<AddEditEnodeButton />', () => {
           device_class: 'Baicells Nova-233 G2 OD FDD',
           transmit_enabled: false,
         },
+        enodeb_config: {
+          config_type: 'MANAGED',
+          managed_config: {
+            cell_id: 0,
+            device_class: 'Baicells Nova-233 G2 OD FDD',
+            transmit_enabled: false,
+          },
+        },
         description: 'Enode1 Description',
         name: 'Test Enodeb 1',
         serial: 'TestEnodebSerial1',
@@ -369,6 +377,14 @@ describe('<AddEditEnodeButton />', () => {
         description: 'Enode1 New Description',
         name: 'Test Enodeb 1',
         serial: 'TestEnodebSerial1',
+        enodeb_config: {
+          config_type: 'MANAGED',
+          managed_config: {
+            cell_id: 0,
+            device_class: 'Baicells Nova-233 G2 OD FDD',
+            transmit_enabled: false,
+          },
+        },
       },
       enodebSerial: 'TestEnodebSerial1',
       networkId: 'test',


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

In migrated enodeb configurations, the "config" attribute shows up as null and "enodeb_config" shows up as a default entity with { config_type : "" }. This migrated configuration isn't valid when we attempt to submit it. Fixing it in NMS where we replace the invalid configs with valid defaults.

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
