### PR TITLE
[agw][lte][new feature] ipv6 support for control plane

### DIFF
--- a/lte/gateway/c/oai/common/common_types.c
+++ b/lte/gateway/c/oai/common/common_types.c
@@ -164,8 +164,6 @@ bstring paa_to_bstring(const paa_t* paa) {
     case IPv4_AND_v6:
       if (paa->ipv6_prefix_length == IPV6_PREFIX_LEN) {
         bstr = blk2bstr(&paa->ipv6_address, paa->ipv6_prefix_length / 8);
-        bstr =
-            blk2bstr(&paa->ipv6_address.s6_addr, paa->ipv6_prefix_length / 8);
         bcatblk(bstr, &paa->ipv4_address, 4);
       } else {
         OAILOG_ERROR(

--- a/lte/gateway/c/oai/common/common_types.c
+++ b/lte/gateway/c/oai/common/common_types.c
@@ -43,6 +43,7 @@
 #include "3gpp_23.003.h"
 #include "common_types.h"
 #include "3gpp_29.274.h"
+#include "log.h"
 
 /* Clear GUTI without free it */
 void clear_guti(guti_t* const guti) {
@@ -152,15 +153,25 @@ bstring paa_to_bstring(const paa_t* paa) {
       bstr = blk2bstr(&paa->ipv4_address.s_addr, 4);
       break;
     case IPv6:
-      DevAssert(
-          paa->ipv6_prefix_length == 64);  // NAS seems to only support 64 bits
-      bstr = blk2bstr(&paa->ipv6_address, paa->ipv6_prefix_length / 8);
+      if (paa->ipv6_prefix_length == IPV6_PREFIX_LEN) {
+        bstr = blk2bstr(&paa->ipv6_address, paa->ipv6_prefix_length / 8);
+      } else {
+        OAILOG_ERROR(
+            LOG_COMMON, "Invalid ipv6_prefix_length : %u\n",
+            paa->ipv6_prefix_length);
+      }
       break;
     case IPv4_AND_v6:
-      DevAssert(
-          paa->ipv6_prefix_length == 64);  // NAS seems to only support 64 bits
-      bstr = blk2bstr(&paa->ipv4_address.s_addr, 4);
-      bcatblk(bstr, &paa->ipv6_address, paa->ipv6_prefix_length / 8);
+      if (paa->ipv6_prefix_length == IPV6_PREFIX_LEN) {
+        bstr = blk2bstr(&paa->ipv6_address, paa->ipv6_prefix_length / 8);
+        bstr =
+            blk2bstr(&paa->ipv6_address.s6_addr, paa->ipv6_prefix_length / 8);
+        bcatblk(bstr, &paa->ipv4_address, 4);
+      } else {
+        OAILOG_ERROR(
+            LOG_COMMON, "Invalid ipv6_prefix_length : %u\n",
+            paa->ipv6_prefix_length);
+      }
       break;
     case IPv4_OR_v6:
       // do it like that now, TODO

--- a/lte/gateway/c/oai/common/common_types.h
+++ b/lte/gateway/c/oai/common/common_types.h
@@ -125,6 +125,11 @@ typedef uint64_t imsi64_t;
 #define MAX_APN_PER_UE (10)
 
 //------------------------------------------------------------------------------
+// IPv6 Interface Identifier length in bytes
+#define IPV6_INTERFACE_ID_LEN 8
+// IPv6 Prefix length in bites
+#define IPV6_PREFIX_LEN 64
+//------------------------------------------------------------------------------
 typedef uint8_t ksi_t;
 #define KSI_NO_KEY_AVAILABLE 0x07
 

--- a/lte/gateway/c/oai/common/common_types.h
+++ b/lte/gateway/c/oai/common/common_types.h
@@ -127,7 +127,7 @@ typedef uint64_t imsi64_t;
 //------------------------------------------------------------------------------
 // IPv6 Interface Identifier length in bytes
 #define IPV6_INTERFACE_ID_LEN 8
-// IPv6 Prefix length in bites
+// IPv6 Prefix length in bits
 #define IPV6_PREFIX_LEN 64
 //------------------------------------------------------------------------------
 typedef uint8_t ksi_t;

--- a/lte/gateway/c/oai/common/log.h
+++ b/lte/gateway/c/oai/common/log.h
@@ -166,6 +166,7 @@ typedef enum {
   LOG_SMS_ORC8R,
   LOG_ASYNC_SYSTEM,
   LOG_ASSERT,
+  LOG_COMMON,
   MAX_LOG_PROTOS,
 } log_proto_t;
 

--- a/lte/gateway/c/oai/include/pgw_config.h
+++ b/lte/gateway/c/oai/include/pgw_config.h
@@ -77,6 +77,7 @@
 #define PGW_WARN_ON_ERROR true
 #define PGW_CONFIG_P_CSCF_IPV4_ADDRESS "P_CSCF_IPV4_ADDRESS"
 #define PGW_CONFIG_P_CSCF_IPV6_ADDRESS "P_CSCF_IPV6_ADDRESS"
+#define PGW_CONFIG_DNS_SERVER_IPV6_ADDRESS "DNS_SERVER_IPV6_ADDRESS"
 
 #define PGW_CONFIG_STRING_NAT_ENABLED "ENABLE_NAT"
 
@@ -131,6 +132,10 @@ typedef struct pgw_config_s {
     struct in_addr ipv4_addr;
     struct in6_addr ipv6_addr;
   } pcscf;
+
+  struct {
+    struct in6_addr dns_ipv6_addr;
+  } ipv6;
 
   STAILQ_HEAD(ipv4_pool_head_s, conf_ipv4_list_elm_s) ipv4_pool_list;
 } pgw_config_t;

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -258,11 +258,10 @@ static itti_sgi_create_end_point_response_t handle_allocate_ipv6_address_status(
           "ue_pdn_connection", 1, 2, "pdn_type", "ipv6", "result",
           "ip_address_already_allocated");
       /*
-       * This implies that UE session was not release properly.
+       * This implies that UE session was not released properly.
        * Release the IP address so that subsequent attempt is successfull
        */
       release_ipv6_address(imsi, apn, &addr);
-      // TODO - Release the GTP-tunnel corresponding to this IP address
       sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
     } else {
       increment_counter(
@@ -376,11 +375,10 @@ handle_allocate_ipv4v6_address_status(
           "ue_pdn_connection", 1, 2, "pdn_type", "ipv4v6", "result",
           "ip_address_already_allocated");
       /*
-       * This implies that UE session was not release properly.
+       * This implies that UE session was not released properly.
        * Release the IP address so that subsequent attempt is successfull
        */
       release_ipv4v6_address(imsi, apn, &ip4_addr, &ip6_addr);
-      // TODO - Release the GTP-tunnel corresponding to this IP address
       sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
     } else {
       increment_counter(

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -28,6 +28,7 @@
 #include "service303.h"
 #include "spgw_types.h"
 #include "intertask_interface.h"
+#include "common_types.h"
 
 #include "MobilityServiceClient.h"
 
@@ -47,6 +48,18 @@ static itti_sgi_create_end_point_response_t handle_allocate_ipv4_address_status(
     const char* imsi, const char* apn, const char* pdn_type,
     itti_sgi_create_end_point_response_t sgi_create_endpoint_resp);
 
+static itti_sgi_create_end_point_response_t handle_allocate_ipv6_address_status(
+    const grpc::Status& status, struct in6_addr addr, int vlan,
+    const char* imsi, const char* apn, const char* pdn_type,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp);
+
+static itti_sgi_create_end_point_response_t
+handle_allocate_ipv4v6_address_status(
+    const grpc::Status& status, struct in_addr ip4_addr,
+    struct in6_addr ip6_addr, int vlan, const char* imsi, const char* apn,
+    const char* pdn_type,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp);
+
 int get_assigned_ipv4_block(
     int index, struct in_addr* netaddr, uint32_t* netmask) {
   int status = MobilityServiceClient::getInstance().GetAssignedIPv4Block(
@@ -57,8 +70,7 @@ int get_assigned_ipv4_block(
 int pgw_handle_allocate_ipv4_address(
     const char* subscriber_id, const char* apn, struct in_addr* addr,
     itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
-    const char* pdn_type, teid_t context_teid, ebi_t eps_bearer_id,
-    spgw_state_t* spgw_state,
+    const char* pdn_type, spgw_state_t* spgw_state,
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     s5_create_session_response_t s5_response) {
   MobilityServiceClient::getInstance().AllocateIPv4AddressAsync(
@@ -78,8 +90,8 @@ int pgw_handle_allocate_ipv4_address(
         if (sgi_resp.status == SGI_STATUS_OK) {
           // create session in PCEF and return
           s5_create_session_request_t session_req = {0};
-          session_req.context_teid                = context_teid;
-          session_req.eps_bearer_id               = eps_bearer_id;
+          session_req.context_teid  = sgi_create_endpoint_resp.context_teid;
+          session_req.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
           char ip_str[INET_ADDRSTRLEN];
           inet_ntop(AF_INET, &(addr->s_addr), ip_str, INET_ADDRSTRLEN);
           struct pcef_create_session_data session_data;
@@ -89,13 +101,13 @@ int pgw_handle_allocate_ipv4_address(
                    .saved_message,
               &session_data);
           pcef_create_session(
-              spgw_state, subscriber_id, ip_str, &session_data, sgi_resp,
+              spgw_state, subscriber_id, ip_str, NULL, &session_data, sgi_resp,
               session_req, new_bearer_ctxt_info_p);
           OAILOG_FUNC_OUT(LOG_PGW_APP);
         }
 
-        s5_response.eps_bearer_id = eps_bearer_id;
-        s5_response.context_teid  = context_teid;
+        s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+        s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
         handle_s5_create_session_response(
             spgw_state, new_bearer_ctxt_info_p, s5_response);
         OAILOG_FUNC_OUT(LOG_PGW_APP);
@@ -166,5 +178,236 @@ int get_subscriber_id_from_ipv4(
   if (!subscriber_id_str.empty()) {
     *subscriber_id = strdup(subscriber_id_str.c_str());
   }
+  return status;
+}
+
+int pgw_handle_allocate_ipv6_address(
+    const char* subscriber_id, const char* apn, struct in6_addr* ip6_addr,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
+    const char* pdn_type, spgw_state_t* spgw_state,
+    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
+    s5_create_session_response_t s5_response) {
+  // Make an RPC call to Mobilityd
+  MobilityServiceClient::getInstance().AllocateIPv6AddressAsync(
+      subscriber_id, apn,
+      [=, &s5_response](
+          const Status& status, AllocateIPAddressResponse ip_msg) {
+        std::string ipv6_addr_str = "";
+        if (ip_msg.ip_list_size() > 0) {
+          ipv6_addr_str = ip_msg.ip_list(0).address();
+        }
+        memcpy(ip6_addr->s6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
+        int vlan = atoi(ip_msg.vlan().c_str());
+
+        auto sgi_resp = handle_allocate_ipv6_address_status(
+            status, *ip6_addr, vlan, subscriber_id, apn, pdn_type,
+            sgi_create_endpoint_resp);
+
+        // create session in PCEF and return
+        if (sgi_resp.status == SGI_STATUS_OK) {
+          char ip6_str[INET6_ADDRSTRLEN];
+          inet_ntop(AF_INET6, ip6_addr, ip6_str, INET6_ADDRSTRLEN);
+
+          OAILOG_INFO(
+              LOG_UTIL,
+              "Allocated IPv6 Address <%s>, PDN Type <%s>,"
+              " for IMSI <%s> and APN <%s>\n",
+              ip6_str, pdn_type, subscriber_id, apn);
+
+          s5_create_session_request_t session_req = {0};
+          session_req.context_teid  = sgi_create_endpoint_resp.context_teid;
+          session_req.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+          struct pcef_create_session_data session_data;
+          get_session_req_data(
+              spgw_state,
+              &new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+                   .saved_message,
+              &session_data);
+          pcef_create_session(
+              spgw_state, subscriber_id, NULL, ip6_str, &session_data, sgi_resp,
+              session_req, new_bearer_ctxt_info_p);
+          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+        }
+        s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+        s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
+        handle_s5_create_session_response(
+            spgw_state, new_bearer_ctxt_info_p, s5_response);
+        OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+      });
+  return 0;
+}
+
+static itti_sgi_create_end_point_response_t handle_allocate_ipv6_address_status(
+    const Status& status, struct in6_addr addr, int vlan, const char* imsi,
+    const char* apn, const char* pdn_type,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp) {
+  if (status.ok()) {
+    increment_counter(
+        "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "success");
+    sgi_create_endpoint_resp.paa.ipv6_address       = addr;
+    sgi_create_endpoint_resp.paa.ipv6_prefix_length = IPV6_PREFIX_LEN;
+    sgi_create_endpoint_resp.paa.pdn_type           = IPv6;
+    sgi_create_endpoint_resp.paa.vlan               = vlan;
+    sgi_create_endpoint_resp.status                 = SGI_STATUS_OK;
+    OAILOG_DEBUG(
+        LOG_UTIL, "Allocated IPv6 address for imsi <%s>, apn <%s> vlan %d\n",
+        imsi, apn, vlan);
+  } else {
+    if (status.error_code() == RPC_STATUS_ALREADY_EXISTS) {
+      increment_counter(
+          "ue_pdn_connection", 1, 2, "pdn_type", "ipv6", "result",
+          "ip_address_already_allocated");
+      /*
+       * This implies that UE session was not release properly.
+       * Release the IP address so that subsequent attempt is successfull
+       */
+      release_ipv6_address(imsi, apn, &addr);
+      // TODO - Release the GTP-tunnel corresponding to this IP address
+      sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
+    } else {
+      increment_counter(
+          "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "failure");
+      OAILOG_ERROR(
+          LOG_UTIL,
+          "Failed to allocate IPv6 PAA for PDN type IPv6 for "
+          "imsi <%s> and apn <%s>\n",
+          imsi, apn);
+      sgi_create_endpoint_resp.status =
+          SGI_STATUS_ERROR_ALL_DYNAMIC_ADDRESSES_OCCUPIED;
+    }
+  }
+  return sgi_create_endpoint_resp;
+}
+
+int pgw_handle_allocate_ipv4v6_address(
+    const char* subscriber_id, const char* apn, struct in_addr* ip4_addr,
+    struct in6_addr* ip6_addr,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
+    const char* pdn_type, spgw_state_t* spgw_state,
+    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
+    s5_create_session_response_t s5_response) {
+  // Get IPv4v6 address
+  MobilityServiceClient::getInstance().AllocateIPv4v6AddressAsync(
+      subscriber_id, apn,
+      [=, &s5_response](
+          const Status& status, AllocateIPAddressResponse ip_msg) {
+        std::string ipv4_addr_str = "";
+        std::string ipv6_addr_str = "";
+        if (ip_msg.ip_list_size() == 2) {
+          ipv4_addr_str = ip_msg.ip_list(0).address();
+          ipv6_addr_str = ip_msg.ip_list(1).address();
+          OAILOG_INFO(
+              LOG_UTIL,
+              "Allocated IPv4 Address <%s>, IPv6 Address <%s>, PDN Type <%s>,"
+              " for IMSI <%s> and APN <%s>\n",
+              ipv4_addr_str, ipv6_addr_str, pdn_type, subscriber_id, apn);
+        } else {
+          OAILOG_ERROR(
+              LOG_UTIL,
+              " Error in allocating ipv4v6 address for IMSI <%s> apn <%s>\n",
+              subscriber_id, apn);
+          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
+        }
+        memcpy(ip4_addr, ipv4_addr_str.c_str(), sizeof(in_addr));
+        memcpy(ip6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
+        int vlan      = atoi(ip_msg.vlan().c_str());
+        auto sgi_resp = handle_allocate_ipv4v6_address_status(
+            status, *ip4_addr, *ip6_addr, vlan, subscriber_id, apn, pdn_type,
+            sgi_create_endpoint_resp);
+
+        // create session in PCEF and return
+        if (sgi_resp.status == SGI_STATUS_OK) {
+          s5_create_session_request_t session_req = {0};
+          session_req.context_teid  = sgi_create_endpoint_resp.context_teid;
+          session_req.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+          char ip4_str[INET_ADDRSTRLEN];
+          inet_ntop(AF_INET, &(ip4_addr->s_addr), ip4_str, INET_ADDRSTRLEN);
+          char ip6_str[INET6_ADDRSTRLEN];
+          inet_ntop(AF_INET6, ip6_addr, ip6_str, INET6_ADDRSTRLEN);
+          OAILOG_INFO(
+              LOG_UTIL,
+              "Allocated IPv4 Address <%s>, IPv6 Address <%s>, PDN Type <%s>,"
+              " for IMSI <%s> and APN <%s>\n",
+              ip4_str, ip6_str, pdn_type, subscriber_id, apn);
+
+          struct pcef_create_session_data session_data;
+          get_session_req_data(
+              spgw_state,
+              &new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+                   .saved_message,
+              &session_data);
+          pcef_create_session(
+              spgw_state, subscriber_id, ip4_str, ip6_str, &session_data,
+              sgi_resp, session_req, new_bearer_ctxt_info_p);
+          s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+          s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
+          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+        }
+        // If status != SGI_STATUS_OK
+        s5_response.eps_bearer_id = sgi_create_endpoint_resp.eps_bearer_id;
+        s5_response.context_teid  = sgi_create_endpoint_resp.context_teid;
+        handle_s5_create_session_response(
+            spgw_state, new_bearer_ctxt_info_p, s5_response);
+        OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+      });
+  OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNok);
+}
+
+static itti_sgi_create_end_point_response_t
+handle_allocate_ipv4v6_address_status(
+    const Status& status, struct in_addr ip4_addr, struct in6_addr ip6_addr,
+    int vlan, const char* imsi, const char* apn, const char* pdn_type,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp) {
+  if (status.ok()) {
+    increment_counter(
+        "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "success");
+    sgi_create_endpoint_resp.paa.ipv4_address       = ip4_addr;
+    sgi_create_endpoint_resp.paa.ipv6_address       = ip6_addr;
+    sgi_create_endpoint_resp.paa.ipv6_prefix_length = IPV6_PREFIX_LEN;
+    sgi_create_endpoint_resp.paa.pdn_type           = IPv4_AND_v6;
+    sgi_create_endpoint_resp.paa.vlan               = vlan;
+    sgi_create_endpoint_resp.status                 = SGI_STATUS_OK;
+    OAILOG_DEBUG(
+        LOG_UTIL, "Allocated IPv6 address for imsi <%s>, apn <%s> vlan %d\n",
+        imsi, apn, vlan);
+  } else {
+    if (status.error_code() == RPC_STATUS_ALREADY_EXISTS) {
+      increment_counter(
+          "ue_pdn_connection", 1, 2, "pdn_type", "ipv4v6", "result",
+          "ip_address_already_allocated");
+      /*
+       * This implies that UE session was not release properly.
+       * Release the IP address so that subsequent attempt is successfull
+       */
+      release_ipv4v6_address(imsi, apn, &ip4_addr, &ip6_addr);
+      // TODO - Release the GTP-tunnel corresponding to this IP address
+      sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SYSTEM_FAILURE;
+    } else {
+      increment_counter(
+          "ue_pdn_connection", 1, 2, "pdn_type", pdn_type, "result", "failure");
+      OAILOG_ERROR(
+          LOG_UTIL,
+          "Failed to allocate IPv4v6 PAA for PDN type IPv4v6 for "
+          "imsi <%s> and apn <%s>\n",
+          imsi, apn);
+      sgi_create_endpoint_resp.status =
+          SGI_STATUS_ERROR_ALL_DYNAMIC_ADDRESSES_OCCUPIED;
+    }
+  }
+  return sgi_create_endpoint_resp;
+}
+
+int release_ipv6_address(
+    const char* subscriber_id, const char* apn, const struct in6_addr* addr) {
+  int status = MobilityServiceClient::getInstance().ReleaseIPv6Address(
+      subscriber_id, apn, *addr);
+  return status;
+}
+
+int release_ipv4v6_address(
+    const char* subscriber_id, const char* apn, const struct in_addr* ipv4_addr,
+    const struct in6_addr* ipv6_addr) {
+  int status = MobilityServiceClient::getInstance().ReleaseIPv4v6Address(
+      subscriber_id, apn, *ipv4_addr, *ipv6_addr);
   return status;
 }

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.cpp
@@ -195,7 +195,14 @@ int pgw_handle_allocate_ipv6_address(
         std::string ipv6_addr_str = "";
         if (ip_msg.ip_list_size() > 0) {
           ipv6_addr_str = ip_msg.ip_list(0).address();
+        } else {
+          OAILOG_ERROR(
+              LOG_UTIL,
+              " Error in allocating ipv6 address for IMSI <%s> apn <%s>\n",
+              subscriber_id, apn);
+          OAILOG_FUNC_RETURN(LOG_SPGW_APP, RETURNerror);
         }
+
         memcpy(ip6_addr->s6_addr, ipv6_addr_str.c_str(), sizeof(in6_addr));
         int vlan = atoi(ip_msg.vlan().c_str());
 

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
@@ -26,6 +26,7 @@ extern "C" {
 #include "log.h"
 #include "ip_forward_messages_types.h"
 #include "intertask_interface.h"
+#include "dynamic_memory_check.h"
 #include "spgw_state.h"
 
 // Status codes from gRPC
@@ -69,8 +70,6 @@ int get_assigned_ipv4_block(
  * "host byte order"
  * @param sgi_create_endpoint_resp itti message for sgi_create_endpoint_resp
  * @param pdn_type str for PDN type (ipv4, ipv6...)
- * @param context_teid tunnel id
- * @param eps_bearer_id bearer id
  * @param spgw_state spgw_state_t struct
  * @param new_bearer_ctxt_info_p SPGW ue context struct
  * @param s5_response itti message for s5_create_session response
@@ -79,8 +78,29 @@ int get_assigned_ipv4_block(
 int pgw_handle_allocate_ipv4_address(
     const char* subscriber_id, const char* apn, struct in_addr* addr,
     itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
-    const char* pdn_type, teid_t context_teid, ebi_t eps_bearer_id,
-    spgw_state_t* spgw_state,
+    const char* pdn_type, spgw_state_t* spgw_state,
+    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
+    s5_create_session_response_t s5_response);
+
+/**
+ * Allocate IP address from MobilityServiceClient over gRPC (non-blocking),
+ * and handle response for PGW handler.
+ * @param subscriber_id: subscriber id string, i.e. IMSI
+ * @param apn: access point name string, e.g., "ims", "internet", etc.
+ * @param ipv6_addr: contains the IP address allocated upon returning in
+ * "host byte order"
+ * @param sgi_create_endpoint_resp itti message for sgi_create_endpoint_resp
+ * @param pdn_type str for PDN type (ipv6...)
+ * @param spgw_state spgw_state_t struct
+ * @param new_bearer_ctxt_info_p SPGW ue context struct
+ * @param s5_response itti message for s5_create_session response
+ * @return status of gRPC call
+ */
+
+int pgw_handle_allocate_ipv6_address(
+    const char* subscriber_id, const char* apn, struct in6_addr* ip6_addr,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
+    const char* pdn_type, spgw_state_t* spgw_state,
     s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
     s5_create_session_response_t s5_response);
 
@@ -97,6 +117,38 @@ int pgw_handle_allocate_ipv4_address(
  */
 int release_ipv4_address(
     const char* subscriber_id, const char* apn, const struct in_addr* addr);
+
+/*
+ * Release an allocated IP address.
+ *
+ * The released IP address is put into a tombstone state, and recycled
+ * periodically.
+ *
+ * @param subscriber_id: subscriber id string, i.e. IMSI
+ * @param apn: access point name string, e.g., "ims", "internet", etc.
+ * @param addr: IPv6 address to release in "host byte order
+ * @return 0 on success
+ * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
+ */
+int release_ipv6_address(
+    const char* subscriber_id, const char* apn, const struct in6_addr* addr);
+
+/*
+ * Release an allocated IP address.
+ *
+ * The released IP address is put into a tombstone state, and recycled
+ * periodically.
+ *
+ * @param subscriber_id: subscriber id string, i.e. IMSI
+ * @param apn: access point name string, e.g., "ims", "internet", etc.
+ * @param ipv4_addr: IPv4 address to release in "host byte order
+ * @param ipv6_addr: IPv6 address to release in "host byte order
+ * @return 0 on success
+ * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
+ */
+int release_ipv4v6_address(
+    const char* subscriber_id, const char* apn, const struct in_addr* ipv4_addr,
+    const struct in6_addr* ipv6_addr);
 
 /*
  * Get the allocated IPv4 address for a subscriber
@@ -119,6 +171,31 @@ int get_ipv4_address_for_subscriber(
  */
 int get_subscriber_id_from_ipv4(
     const struct in_addr* addr, char** subscriber_id);
+
+/**
+ * Allocate IP address from MobilityServiceClient over gRPC (non-blocking),
+ * and handle response for PGW handler.
+ * @param subscriber_id: subscriber id string, i.e. IMSI
+ * @param apn: access point name string, e.g., "ims", "internet", etc.
+ * @param ip4_addr: contains the IP address allocated upon returning in
+ * "host byte order"
+ * @param ipv6_addr: contains the IP address allocated upon returning in
+ * "host byte order"
+ * @param sgi_create_endpoint_resp itti message for sgi_create_endpoint_resp
+ * @param pdn_type str for PDN type (ipv4v6...)
+ * @param spgw_state spgw_state_t struct
+ * @param new_bearer_ctxt_info_p SPGW ue context struct
+ * @param s5_response itti message for s5_create_session response
+ * @return status of gRPC call
+ */
+
+int pgw_handle_allocate_ipv4v6_address(
+    const char* subscriber_id, const char* apn, struct in_addr* ip4_addr,
+    struct in6_addr* ip6_addr,
+    itti_sgi_create_end_point_response_t sgi_create_endpoint_resp,
+    const char* pdn_type, spgw_state_t* spgw_state,
+    s_plus_p_gw_eps_bearer_context_information_t* new_bearer_ctxt_info_p,
+    s5_create_session_response_t s5_response);
 
 #ifdef __cplusplus
 }

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityClientAPI.h
@@ -87,10 +87,9 @@ int pgw_handle_allocate_ipv4_address(
  * and handle response for PGW handler.
  * @param subscriber_id: subscriber id string, i.e. IMSI
  * @param apn: access point name string, e.g., "ims", "internet", etc.
- * @param ipv6_addr: contains the IP address allocated upon returning in
- * "host byte order"
+ * @param ipv6_addr: contains the IP address allocated upon returning
  * @param sgi_create_endpoint_resp itti message for sgi_create_endpoint_resp
- * @param pdn_type str for PDN type (ipv6...)
+ * @param pdn_type str for PDN type (ipv6)
  * @param spgw_state spgw_state_t struct
  * @param new_bearer_ctxt_info_p SPGW ue context struct
  * @param s5_response itti message for s5_create_session response
@@ -111,7 +110,7 @@ int pgw_handle_allocate_ipv6_address(
  * periodically.
  *
  * @param subscriber_id: subscriber id string, i.e. IMSI
- * @param addr: IP address to release in "host byte order"
+ * @param addr: IP address to release
  * @return 0 on success
  * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
  */
@@ -179,10 +178,9 @@ int get_subscriber_id_from_ipv4(
  * @param apn: access point name string, e.g., "ims", "internet", etc.
  * @param ip4_addr: contains the IP address allocated upon returning in
  * "host byte order"
- * @param ipv6_addr: contains the IP address allocated upon returning in
- * "host byte order"
+ * @param ipv6_addr: contains the IP address allocated upon returning
  * @param sgi_create_endpoint_resp itti message for sgi_create_endpoint_resp
- * @param pdn_type str for PDN type (ipv4v6...)
+ * @param pdn_type str for PDN type (ipv4v6)
  * @param spgw_state spgw_state_t struct
  * @param new_bearer_ctxt_info_p SPGW ue context struct
  * @param s5_response itti message for s5_create_session response

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.h
@@ -73,8 +73,7 @@ class MobilityServiceClient : public GRPCReceiver {
    * Allocate an IPv6 address from the free IP pool (non-blocking)
    * @param imsi: IMSI string
    * @param apn:  APN string
-   * @param addr (out): contains the IP address allocated upon returning in
-   * "network byte order"
+   * @param addr (out): contains the IP address allocated upon returning
    * @return status of gRPC call
    */
   int AllocateIPv6AddressAsync(
@@ -86,8 +85,7 @@ class MobilityServiceClient : public GRPCReceiver {
    * Allocate an IPv4v6 address from the free IP pool (non-blocking)
    * @param imsi: IMSI string
    * @param apn:  APN string
-   * @param addr (out): contains the IP address allocated upon returning in
-   * "network byte order"
+   * @param addr (out): contains the IP address allocated upon returning
    * @return status of gRPC call
    */
   int AllocateIPv4v6AddressAsync(
@@ -119,7 +117,7 @@ class MobilityServiceClient : public GRPCReceiver {
    *
    * @param imsi: IMSI string
    * @param apn:  APN string
-   * @param addr: IPv6 address to release in "network byte order"
+   * @param addr: IPv6 address to release
    * @return 0 on success
    * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
    */
@@ -136,7 +134,7 @@ class MobilityServiceClient : public GRPCReceiver {
    * @param imsi: IMSI string
    * @param apn:  APN string
    * @param ipv4_addr: IPv4 address to release in "network byte order"
-   * @param ipv6_addr: IPv6 address to release in "network byte order"
+   * @param ipv6_addr: IPv6 address to release
    * @return 0 on success
    * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
    */

--- a/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.h
+++ b/lte/gateway/c/oai/lib/mobility_client/MobilityServiceClient.h
@@ -70,6 +70,32 @@ class MobilityServiceClient : public GRPCReceiver {
           callback);
 
   /**
+   * Allocate an IPv6 address from the free IP pool (non-blocking)
+   * @param imsi: IMSI string
+   * @param apn:  APN string
+   * @param addr (out): contains the IP address allocated upon returning in
+   * "network byte order"
+   * @return status of gRPC call
+   */
+  int AllocateIPv6AddressAsync(
+      const std::string& imsi, const std::string& apn,
+      const std::function<void(grpc::Status, AllocateIPAddressResponse)>&
+          callback);
+
+  /**
+   * Allocate an IPv4v6 address from the free IP pool (non-blocking)
+   * @param imsi: IMSI string
+   * @param apn:  APN string
+   * @param addr (out): contains the IP address allocated upon returning in
+   * "network byte order"
+   * @return status of gRPC call
+   */
+  int AllocateIPv4v6AddressAsync(
+      const std::string& imsi, const std::string& apn,
+      const std::function<void(grpc::Status, AllocateIPAddressResponse)>&
+          callback);
+
+  /**
    * Release an allocated IPv4 address. (non-blocking)
    *
    * The released IP address is put into a tombstone state, and recycled
@@ -84,6 +110,39 @@ class MobilityServiceClient : public GRPCReceiver {
   int ReleaseIPv4Address(
       const std::string& imsi, const std::string& apn,
       const struct in_addr& addr);
+
+  /**
+   * Release an allocated IPv6 address. (non-blocking)
+   *
+   * The released IP address is put into a tombstone state, and recycled
+   * periodically.
+   *
+   * @param imsi: IMSI string
+   * @param apn:  APN string
+   * @param addr: IPv6 address to release in "network byte order"
+   * @return 0 on success
+   * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
+   */
+  int ReleaseIPv6Address(
+      const std::string& imsi, const std::string& apn,
+      const struct in6_addr& addr);
+
+  /**
+   * Release an allocated IPv4v6 address. (non-blocking)
+   *
+   * The released IP address is put into a tombstone state, and recycled
+   * periodically.
+   *
+   * @param imsi: IMSI string
+   * @param apn:  APN string
+   * @param ipv4_addr: IPv4 address to release in "network byte order"
+   * @param ipv6_addr: IPv6 address to release in "network byte order"
+   * @return 0 on success
+   * @return -RPC_STATUS_NOT_FOUND if the requested (SID, IP) pair is not found
+   */
+  int ReleaseIPv4v6Address(
+      const std::string& imsi, const std::string& apn,
+      const struct in_addr& ipv4_addr, const struct in6_addr& ipv6_addr);
 
   /*
    * Get the allocated IPv4 address for a subscriber
@@ -122,7 +181,7 @@ class MobilityServiceClient : public GRPCReceiver {
    * @param request AllocateIP gRPC Request proto
    * @param callback std::function that returns Status and actual gRPC response
    */
-  void AllocateIPv4AddressRPC(
+  void AllocateIPAddressRPC(
       const AllocateIPRequest& request,
       const std::function<void(grpc::Status, AllocateIPAddressResponse)>&
           callback);
@@ -132,7 +191,7 @@ class MobilityServiceClient : public GRPCReceiver {
    * @param request ReleaseIP gRPC Request proto
    * @param callback std::function that returns Status and actual gRPC response
    */
-  void ReleaseIPv4AddressRPC(
+  void ReleaseIPAddressRPC(
       const ReleaseIPRequest& request,
       const std::function<void(grpc::Status, magma::orc8r::Void)>& callback);
 };

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -250,7 +250,7 @@ static void add_ded_brr_dl_match(
       downlink_fm.add_oxm_field(ipv4_src);
     }
   } else {
-    of13::EthType ip_type(0x08DD);
+    of13::EthType ip_type(0x086DD);
     downlink_fm.add_oxm_field(ip_type);
 
     if (flow.set_params & DST_IPV6) {

--- a/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
+++ b/lte/gateway/c/oai/lib/openflow/controller/GTPApplication.cpp
@@ -217,7 +217,10 @@ static void add_downlink_match_ipv6(
   // Set match on uplink port and IP eth type
   of13::InPort uplink_port_match(port);
   downlink_fm.add_oxm_field(uplink_port_match);
-  of13::EthType ip6_type(0x08DD);
+  /* TODO-Made this local fix as it was not yet available in master
+   * without this fix ovs rules are not getting created
+   */
+  of13::EthType ip6_type(0x086DD);
   downlink_fm.add_oxm_field(ip6_type);
 
   // Match UE IP destination

--- a/lte/gateway/c/oai/lib/pcef/PCEFClient.cpp
+++ b/lte/gateway/c/oai/lib/pcef/PCEFClient.cpp
@@ -100,4 +100,15 @@ void PCEFClient::bind_policy2bearer(
   local_response->set_response_reader(std::move(response_reader));
 }
 
+void PCEFClient::update_teids(
+    const UpdateTunnelIdsRequest& request,
+    std::function<void(Status, UpdateTunnelIdsResponse)> callback) {
+  PCEFClient& client  = get_instance();
+  auto local_response = new AsyncLocalResponse<UpdateTunnelIdsResponse>(
+      std::move(callback), RESPONSE_TIMEOUT);
+  auto response_reader = client.stub_->AsyncUpdateTunnelIds(
+      local_response->get_context(), request, &client.queue_);
+  local_response->set_response_reader(std::move(response_reader));
+}
+
 }  // namespace magma

--- a/lte/gateway/c/oai/lib/pcef/PCEFClient.h
+++ b/lte/gateway/c/oai/lib/pcef/PCEFClient.h
@@ -71,6 +71,13 @@ class PCEFClient : public GRPCReceiver {
       const PolicyBearerBindingRequest& request,
       std::function<void(Status, PolicyBearerBindingResponse)> callback);
 
+  /**
+   * Proxy a  gRPC call to sessiond
+   */
+  static void update_teids(
+      const UpdateTunnelIdsRequest& request,
+      std::function<void(Status, UpdateTunnelIdsResponse)> callback);
+
  public:
   PCEFClient(PCEFClient const&) = delete;
   void operator=(PCEFClient const&) = delete;

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -48,9 +48,15 @@ static void create_session_response(
   s5_response.failure_cause                = S5_OK;
 
   if (!status.ok()) {
-    // BUFFER_TO_IN_ADDR (sgi_response.paa.ipv4_address, addr);
-    release_ipv4_address(
-        imsi.c_str(), apn.c_str(), &sgi_response.paa.ipv4_address);
+    if ((sgi_response.paa.pdn_type == IPv4) ||
+        (sgi_response.paa.pdn_type == IPv4_AND_v6)) {
+      release_ipv4_address(
+          imsi.c_str(), apn.c_str(), &sgi_response.paa.ipv4_address);
+    }
+    if (sgi_response.paa.pdn_type == IPv6) {
+      release_ipv6_address(
+          imsi.c_str(), apn.c_str(), &sgi_response.paa.ipv6_address);
+    }
     s5_response.failure_cause = PCEF_FAILURE;
   }
   handle_s5_create_session_response(state, ctx_p, s5_response);
@@ -59,13 +65,18 @@ static void create_session_response(
 // TODO Clean up pcef_create_session_data structure to include
 // imsi/ip/bearer_id etc.
 static void pcef_fill_create_session_req(
-    std::string& imsi, std::string& ip, ebi_t eps_bearer_id,
+    std::string& imsi, std::string& ip4, std::string& ip6, ebi_t eps_bearer_id,
     const struct pcef_create_session_data* session_data,
     magma::LocalCreateSessionRequest* sreq) {
   // Common Context
   auto common_context = sreq->mutable_common_context();
   common_context->mutable_sid()->set_id("IMSI" + imsi);
-  common_context->set_ue_ipv4(ip);
+  if (!ip4.empty()) {
+    common_context->set_ue_ipv4(ip4);
+  }
+  if (!ip6.empty()) {
+    common_context->set_ue_ipv6(ip6);
+  }
   common_context->set_apn(session_data->apn);
   common_context->set_msisdn(session_data->msisdn, session_data->msisdn_len);
   common_context->set_rat_type(magma::RATType::TGPP_LTE);
@@ -103,17 +114,25 @@ static void pcef_fill_create_session_req(
 }
 
 void pcef_create_session(
-    spgw_state_t* state, const char* imsi, const char* ip,
+    spgw_state_t* state, const char* imsi, const char* ip4, const char* ip6,
     const pcef_create_session_data* session_data,
     itti_sgi_create_end_point_response_t sgi_response,
     s5_create_session_request_t session_request,
     s_plus_p_gw_eps_bearer_context_information_t* ctx_p) {
   auto imsi_str = std::string(imsi);
-  auto ip_str   = std::string(ip);
+  std::string ip4_str, ip6_str;
+
+  if (ip4) {
+    ip4_str = ip4;
+  }
+  if (ip6) {
+    ip6_str = ip6;
+  }
   // Change ip to spgw_ip. Get it from sgw_app_t sgw_app;
   magma::LocalCreateSessionRequest sreq;
   pcef_fill_create_session_req(
-      imsi_str, ip_str, session_request.eps_bearer_id, session_data, &sreq);
+      imsi_str, ip4_str, ip6_str, session_request.eps_bearer_id, session_data,
+      &sreq);
 
   auto apn = std::string(session_data->apn);
   // call the `CreateSession` gRPC method and execute the inline function
@@ -151,6 +170,20 @@ void pcef_send_policy2bearer_binding(
       [&](grpc::Status status, magma::PolicyBearerBindingResponse response) {
         return;  // For now, do nothing. TODO: handle errors asynchronously
       });
+}
+
+void pcef_update_teids(
+    const char* imsi, uint8_t default_bearer_id, uint32_t enb_teid,
+    uint32_t agw_teid) {
+  magma::UpdateTunnelIdsRequest request;
+  request.mutable_sid()->set_id("IMSI" + std::string(imsi));
+  request.set_bearer_id(default_bearer_id);
+  request.set_enb_teid(enb_teid);
+  request.set_agw_teid(agw_teid);
+
+  magma::PCEFClient::update_teids(
+      request, [&](grpc::Status status,
+                   magma::UpdateTunnelIdsResponse response) { return; });
 }
 
 /*
@@ -310,6 +343,7 @@ void get_session_req_data(
       sizeof(charging_characteristics_t));
 
   memcpy(data->apn, saved_req->apn, APN_MAX_LENGTH + 1);
+  data->pdn_type = saved_req->pdn_type;
 
   inet_ntop(
       AF_INET, &spgw_state->sgw_ip_address_S1u_S12_S4_up, data->sgw_ip,

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.cpp
@@ -53,7 +53,8 @@ static void create_session_response(
       release_ipv4_address(
           imsi.c_str(), apn.c_str(), &sgi_response.paa.ipv4_address);
     }
-    if (sgi_response.paa.pdn_type == IPv6) {
+    if ((sgi_response.paa.pdn_type == IPv6) ||
+        (sgi_response.paa.pdn_type == IPv4_AND_v6)) {
       release_ipv6_address(
           imsi.c_str(), apn.c_str(), &sgi_response.paa.ipv6_address);
     }

--- a/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
+++ b/lte/gateway/c/oai/lib/pcef/pcef_handlers.h
@@ -49,6 +49,7 @@ struct pcef_create_session_data {
   uint32_t pci;
   uint32_t pvi;
   uint32_t qci;
+  uint8_t pdn_type;
 };
 
 /**
@@ -57,7 +58,7 @@ struct pcef_create_session_data {
  * This is a long process, so it needs to by asynchronous
  */
 void pcef_create_session(
-    spgw_state_t* state, const char* imsi, const char* ip,
+    spgw_state_t* state, const char* imsi, const char* ip4, const char* ip6,
     const struct pcef_create_session_data* session_data,
     itti_sgi_create_end_point_response_t sgi_response,
     s5_create_session_request_t bearer_request,
@@ -84,6 +85,15 @@ void get_session_req_data(
     const itti_s11_create_session_request_t* saved_req,
     struct pcef_create_session_data* data);
 
+/**
+ * pcef_update_teids is an asynchronous call that updates
+ * enb teid and sgw/agw teid for a particular session that is
+ * uniquely identified by imsi and default bearer id.
+ */
+
+void pcef_update_teids(
+    const char* imsi, uint8_t default_bearer_id, uint32_t enb_teid,
+    uint32_t agw_teid);
 #ifdef __cplusplus
 }
 #endif

--- a/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -262,10 +262,10 @@ bool SpgwServiceImpl::fillUpPacketFilterContents(
           return false;
         }
       }
-      if (flow_match_rule->ip_dst().version() ==
-          flow_match_rule->ip_dst().IPV6) {
+      if (flow_match_rule->ip_src().version() ==
+          flow_match_rule->ip_src().IPV6) {
         flags |= TRAFFIC_FLOW_TEMPLATE_IPV6_REMOTE_ADDR_FLAG;
-        if (!fillIpv6(pf_content, flow_match_rule->ip_dst().address())) {
+        if (!fillIpv6(pf_content, flow_match_rule->ip_src().address())) {
           return false;
         }
       }

--- a/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.cpp
@@ -224,9 +224,19 @@ bool SpgwServiceImpl::fillUpPacketFilterContents(
   // GRPC interface does not support a third option (e.g., bidirectional)
   if (flow_match_rule->direction() == FlowMatch::UPLINK) {
     if (!flow_match_rule->ip_dst().address().empty()) {
-      flags |= TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG;
-      if (!fillIpv4(pf_content, flow_match_rule->ip_dst().address())) {
-        return false;
+      if (flow_match_rule->ip_dst().version() ==
+          flow_match_rule->ip_dst().IPV4) {
+        flags |= TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG;
+        if (!fillIpv4(pf_content, flow_match_rule->ip_dst().address())) {
+          return false;
+        }
+      }
+      if (flow_match_rule->ip_dst().version() ==
+          flow_match_rule->ip_dst().IPV6) {
+        flags |= TRAFFIC_FLOW_TEMPLATE_IPV6_REMOTE_ADDR_FLAG;
+        if (!fillIpv6(pf_content, flow_match_rule->ip_dst().address())) {
+          return false;
+        }
       }
     }
     if (flow_match_rule->tcp_src() != 0) {
@@ -245,9 +255,19 @@ bool SpgwServiceImpl::fillUpPacketFilterContents(
     }
   } else if (flow_match_rule->direction() == FlowMatch::DOWNLINK) {
     if (!flow_match_rule->ip_src().address().empty()) {
-      flags |= TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG;
-      if (!fillIpv4(pf_content, flow_match_rule->ip_src().address())) {
-        return false;
+      if (flow_match_rule->ip_src().version() ==
+          flow_match_rule->ip_src().IPV4) {
+        flags |= TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG;
+        if (!fillIpv4(pf_content, flow_match_rule->ip_src().address())) {
+          return false;
+        }
+      }
+      if (flow_match_rule->ip_dst().version() ==
+          flow_match_rule->ip_dst().IPV6) {
+        flags |= TRAFFIC_FLOW_TEMPLATE_IPV6_REMOTE_ADDR_FLAG;
+        if (!fillIpv6(pf_content, flow_match_rule->ip_dst().address())) {
+          return false;
+        }
       }
     }
     if (flow_match_rule->tcp_dst() != 0) {
@@ -307,6 +327,31 @@ bool SpgwServiceImpl::fillIpv4(
       pf_content->ipv4remoteaddr[2].addr, pf_content->ipv4remoteaddr[3].addr,
       pf_content->ipv4remoteaddr[0].mask, pf_content->ipv4remoteaddr[1].mask,
       pf_content->ipv4remoteaddr[2].mask, pf_content->ipv4remoteaddr[3].mask);
+  return true;
+}
+
+bool SpgwServiceImpl::fillIpv6(
+    packet_filter_contents_t* pf_content, const std::string ipv6addr) {
+  struct in6_addr in6addr;
+  if (inet_pton(AF_INET6, ipv6addr.c_str(), &in6addr) != 1) {
+    OAILOG_ERROR(LOG_UTIL, "Invalid address string %s \n", ipv6addr.c_str());
+    return false;
+  }
+  for (int i = 0; i < TRAFFIC_FLOW_TEMPLATE_IPV6_ADDR_SIZE; i++) {
+    pf_content->ipv6remoteaddr[i].addr = in6addr.s6_addr[i];
+  }
+
+  OAILOG_DEBUG(
+      LOG_UTIL,
+      "Network Address: %x:%x:%x:%x:%x:%x:%x:%x:%x:%x:%x:%x:%x:%x:%x:%x\n",
+      pf_content->ipv6remoteaddr[0].addr, pf_content->ipv6remoteaddr[1].addr,
+      pf_content->ipv6remoteaddr[2].addr, pf_content->ipv6remoteaddr[3].addr,
+      pf_content->ipv6remoteaddr[4].addr, pf_content->ipv6remoteaddr[5].addr,
+      pf_content->ipv6remoteaddr[6].addr, pf_content->ipv6remoteaddr[7].addr,
+      pf_content->ipv6remoteaddr[8].addr, pf_content->ipv6remoteaddr[9].addr,
+      pf_content->ipv6remoteaddr[10].addr, pf_content->ipv6remoteaddr[11].addr,
+      pf_content->ipv6remoteaddr[12].addr, pf_content->ipv6remoteaddr[13].addr,
+      pf_content->ipv6remoteaddr[14].addr, pf_content->ipv6remoteaddr[15].addr);
   return true;
 }
 

--- a/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/SpgwServiceImpl.h
@@ -97,6 +97,15 @@ class SpgwServiceImpl final : public SpgwService::Service {
    */
   bool fillIpv4(
       packet_filter_contents_t* pf_content, const std::string ipv4addr);
+
+  /*
+   * Fill up the ipv6 remote address field in packet filter
+   * @param pf_content: packet filter object to be filled
+   * @param ipv6addr: IPv6 address in string form (e.g, "x:x:x:x::x")
+   * @return bool: Return true if successful, false if not
+   */
+  bool fillIpv6(
+      packet_filter_contents_t* pf_content, const std::string ipv6addr);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -1173,11 +1173,35 @@ int mme_app_handle_create_sess_resp(
   emm_cn_cs_response_success_t nas_pdn_cs_respose_success = {0};
   nas_pdn_cs_respose_success.pdn_cid                      = pdn_cx_id;
   nas_pdn_cs_respose_success.pti = transaction_identifier;  // NAS internal ref
-  nas_pdn_cs_respose_success.pdn_addr =
-      paa_to_bstring(&create_sess_resp_pP->paa);
+
+  /* In Create session response IPv6 prefix + interface idntifier is sent.
+   * Copy only the interface identifier to be sent in NAS ESM message
+   */
+  if (create_sess_resp_pP->paa.pdn_type == IPv4) {
+    nas_pdn_cs_respose_success.pdn_addr =
+        paa_to_bstring(&create_sess_resp_pP->paa);
+  } else {
+    paa_t paa_temp;
+    paa_temp.pdn_type           = create_sess_resp_pP->paa.pdn_type;
+    paa_temp.ipv6_prefix_length = create_sess_resp_pP->paa.ipv6_prefix_length;
+    memcpy(
+        &paa_temp.ipv6_address,
+        &create_sess_resp_pP->paa.ipv6_address.s6_addr[IPV6_INTERFACE_ID_LEN],
+        IPV6_INTERFACE_ID_LEN);
+    if (create_sess_resp_pP->paa.pdn_type == IPv4_AND_v6) {
+      paa_temp.ipv4_address = create_sess_resp_pP->paa.ipv4_address;
+    }
+    nas_pdn_cs_respose_success.pdn_addr = paa_to_bstring(&paa_temp);
+  }
+  if (!nas_pdn_cs_respose_success.pdn_addr) {
+    OAILOG_ERROR_UE(
+        LOG_MME_APP, ue_context_p->emm_context._imsi64,
+        "Error in converting PAA to bstring\n");
+    OAILOG_FUNC_RETURN(LOG_MME_APP, RETURNerror);
+  }
   nas_pdn_cs_respose_success.pdn_type = create_sess_resp_pP->paa.pdn_type;
 
-  // ASSUME NO HO now, so assume 1 bearer only and is default bearer
+  // ASSUME NO HO now
 
   nas_pdn_cs_respose_success.ue_id      = ue_context_p->mme_ue_s1ap_id;
   nas_pdn_cs_respose_success.ebi        = bearer_id;

--- a/lte/gateway/c/oai/tasks/nas/esm/PdnConnectivity.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/PdnConnectivity.c
@@ -398,6 +398,7 @@ static int _pdn_connectivity_create(
                          &pdn_context->paa.ipv6_address),
                 "BAD IPv6 ADDRESS FORMAT FOR PAA!\n");
             break;
+          // TODO Handle static IPv4v6 addr allocation
           case IPv4_AND_v6:
             AssertFatal(0, "TODO\n");
             break;

--- a/lte/gateway/c/oai/tasks/sgw/mobilityd_ue_ip_address_alloc.c
+++ b/lte/gateway/c/oai/tasks/sgw/mobilityd_ue_ip_address_alloc.c
@@ -32,6 +32,15 @@ int release_ue_ipv4_address(
   return release_ipv4_address(imsi, apn, addr);
 }
 
+int release_ue_ipv6_address(
+    const char* imsi, const char* apn, struct in6_addr* addr) {
+  increment_counter(
+      "ue_pdn_connection", 1, 2, "pdn_type", "ipv6", "result",
+      "ip_address_released");
+  // Release IP address back to PGW IP Address allocator
+  return release_ipv6_address(imsi, apn, addr);
+}
+
 int get_ip_block(struct in_addr* netaddr, uint32_t* netmask) {
   int rv;
 

--- a/lte/gateway/c/oai/tasks/sgw/pgw_config.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_config.c
@@ -218,12 +218,13 @@ int pgw_config_parse_file(pgw_config_t* config_pP) {
   int i                         = 0;
   unsigned char buf_in_addr[sizeof(struct in_addr)];
   struct in_addr addr_start;
-  bstring system_cmd = NULL;
-  libconfig_int mtu  = 0;
-  int prefix_mask    = 0;
-  char* pcscf_ipv4   = NULL;
-  char* pcscf_ipv6   = NULL;
-  char* nat_enabled  = NULL;
+  bstring system_cmd  = NULL;
+  libconfig_int mtu   = 0;
+  int prefix_mask     = 0;
+  char* pcscf_ipv4    = NULL;
+  char* pcscf_ipv6    = NULL;
+  char* dns_ipv6_addr = NULL;
+  char* nat_enabled   = NULL;
 
   config_init(&cfg);
 
@@ -418,6 +419,20 @@ int pgw_config_parse_file(pgw_config_t* config_pP) {
           pcscf_ipv6);
     } else {
       OAILOG_WARNING(LOG_SPGW_APP, "NO P-CSCF IPv6 CONFIGURATION FOUND\n");
+    }
+
+    if (config_setting_lookup_string(
+            setting_pgw, PGW_CONFIG_DNS_SERVER_IPV6_ADDRESS,
+            (const char**) &dns_ipv6_addr)) {
+      IPV6_STR_ADDR_TO_INADDR(
+          dns_ipv6_addr, config_pP->ipv6.dns_ipv6_addr,
+          "BAD IPv6 ADDRESS FORMAT FOR DNS SERVER IPv6 address !\n");
+      OAILOG_DEBUG(
+          LOG_SPGW_APP,
+          "Parsing configuration file DNS SERVER IPv6 address: %s\n",
+          pcscf_ipv6);
+    } else {
+      OAILOG_WARNING(LOG_SPGW_APP, "NO DNS SERVER IPv6 CONFIGURATION FOUND\n");
     }
 
     if (config_setting_lookup_string(

--- a/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_handlers.c
@@ -100,6 +100,7 @@ void handle_s5_create_session_request(
   itti_sgi_create_end_point_response_t sgi_create_endpoint_resp = {0};
   s5_create_session_response_t s5_response                      = {0};
   struct in_addr inaddr;
+  struct in6_addr in6addr;
   char* imsi = NULL;
   char* apn  = NULL;
 
@@ -183,25 +184,21 @@ void handle_s5_create_session_request(
       // implement different logic between the PDN types.
       if (!pco_ids.ci_ipv4_address_allocation_via_dhcpv4) {
         pgw_handle_allocate_ipv4_address(
-            imsi, apn, &inaddr, sgi_create_endpoint_resp, "ipv4", context_teid,
-            eps_bearer_id, spgw_state, new_bearer_ctxt_info_p, s5_response);
+            imsi, apn, &inaddr, sgi_create_endpoint_resp, "ipv4", spgw_state,
+            new_bearer_ctxt_info_p, s5_response);
       }
       break;
 
     case IPv6:
-      increment_counter(
-          "ue_pdn_connection", 1, 2, "pdn_type", "ipv6", "result", "failure");
-      OAILOG_ERROR_UE(
-          LOG_SPGW_APP,
-          new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi64,
-          "IPV6 PDN type NOT Supported\n");
-      sgi_create_endpoint_resp.status = SGI_STATUS_ERROR_SERVICE_NOT_SUPPORTED;
+      pgw_handle_allocate_ipv6_address(
+          imsi, apn, &in6addr, sgi_create_endpoint_resp, "ipv6", spgw_state,
+          new_bearer_ctxt_info_p, s5_response);
       break;
 
     case IPv4_AND_v6:
-      pgw_handle_allocate_ipv4_address(
-          imsi, apn, &inaddr, sgi_create_endpoint_resp, "ipv4v6", context_teid,
-          eps_bearer_id, spgw_state, new_bearer_ctxt_info_p, s5_response);
+      pgw_handle_allocate_ipv4v6_address(
+          imsi, apn, &inaddr, &in6addr, sgi_create_endpoint_resp, "ipv4v6",
+          spgw_state, new_bearer_ctxt_info_p, s5_response);
       break;
 
     default:

--- a/lte/gateway/c/oai/tasks/sgw/pgw_pco.c
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_pco.c
@@ -360,6 +360,23 @@ int pgw_process_pco_pcscf_ipv6_address_req(
 }
 
 //------------------------------------------------------------------------------
+int pgw_process_pco_dns_server_ipv6_address_req(
+    protocol_configuration_options_t* const pco_resp) {
+  struct in6_addr dns_ipv6_addr = spgw_config.pgw_config.ipv6.dns_ipv6_addr;
+  pco_protocol_or_container_id_t poc_id_resp = {0};
+
+  OAILOG_DEBUG(
+      LOG_SPGW_APP,
+      "PCO: Protocol identifier PCO_CI_DNS_SERVER_IPV6_ADDRESS\n");
+  poc_id_resp.id     = PCO_CI_DNS_SERVER_IPV6_ADDRESS;
+  poc_id_resp.length = 16;
+  poc_id_resp.contents =
+      blk2bstr(dns_ipv6_addr.s6_addr, sizeof(struct in6_addr));
+
+  return pgw_pco_push_protocol_or_container_id(pco_resp, &poc_id_resp);
+}
+
+//------------------------------------------------------------------------------
 
 int pgw_process_pco_request(
     const protocol_configuration_options_t* const pco_req,
@@ -416,6 +433,10 @@ int pgw_process_pco_request(
 
       case PCO_CI_P_CSCF_IPV6_ADDRESS_REQUEST:
         rc = pgw_process_pco_pcscf_ipv6_address_req(pco_resp);
+        break;
+
+      case PCO_CI_DNS_SERVER_IPV6_ADDRESS_REQUEST:
+        rc = pgw_process_pco_dns_server_ipv6_address_req(pco_resp);
         break;
 
       default:

--- a/lte/gateway/c/oai/tasks/sgw/pgw_ue_ip_address_alloc.h
+++ b/lte/gateway/c/oai/tasks/sgw/pgw_ue_ip_address_alloc.h
@@ -36,4 +36,7 @@ int release_ue_ipv4_address(
 
 int get_ip_block(struct in_addr* netaddr, uint32_t* netmask);
 
+int release_ue_ipv6_address(
+    const char* imsi, const char* apn, struct in6_addr* addr);
+
 #endif /*PGW_UE_IP_ADDRESS_ALLOC_SEEN */

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1983,14 +1983,11 @@ static void _generate_dl_flow(
   // The TFTs are DL TFTs: UE is the destination/local,
   // PDN end point is the source/remote.
 
-  if (pdn_type == IPv4) {
-    // Adding UE to the rule is safe
-    dlflow->dst_ip.s_addr = ipv4_s_addr;
+  // Adding UE to the rule is safe
+  dlflow->dst_ip.s_addr = ipv4_s_addr;
 
-    // At least we can match UE IPv4 addr;
-    // when IPv6 is supported, we need to revisit this.
-    dlflow->set_params = DST_IPV4;
-  }
+  // At least we can match UE IPv4 addr;
+  dlflow->set_params = DST_IPV4;
   if ((pdn_type == IPv6) || (pdn_type == IPv4_AND_v6)) {
     if (!ue_ipv6) {
       OAILOG_ERROR(LOG_SPGW_APP, "ue_ipv6 address is NULL\n");
@@ -2001,7 +1998,6 @@ static void _generate_dl_flow(
     dlflow->set_params = DST_IPV6;
   }
 
-  // Adding UE to the rule is safe
   // Process remote address if present
   if ((TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG & packet_filter->flags) ==
       TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG) {

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -74,7 +74,8 @@ static void _handle_failed_create_bearer_response(
     gtpv2c_cause_value_t cause, imsi64_t imsi64, uint8_t eps_bearer_id,
     teid_t teid);
 static void _generate_dl_flow(
-    packet_filter_contents_t* packet_filter, in_addr_t s_addr,
+    packet_filter_contents_t* packet_filter, in_addr_t ipv4_s_addr,
+    struct in6_addr* ue_ipv6, pdn_type_value_t pdn_type,
     struct ip_flow_dl* dlflow);
 
 static bool does_bearer_context_hold_valid_enb_ip(
@@ -495,11 +496,21 @@ static void sgw_add_gtp_tunnel(
   enb.s_addr =
       eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
-  struct in_addr ue = {.s_addr = 0};
-  ue.s_addr         = eps_bearer_ctxt_p->paa.ipv4_address.s_addr;
-  int vlan          = eps_bearer_ctxt_p->paa.vlan;
-  Imsi_t imsi = new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi;
+  struct in_addr ue_ipv4   = {.s_addr = 0};
+  struct in6_addr* ue_ipv6 = NULL;
+  ue_ipv4.s_addr           = eps_bearer_ctxt_p->paa.ipv4_address.s_addr;
+  if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+      (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+    ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+  }
 
+  int vlan    = eps_bearer_ctxt_p->paa.vlan;
+  Imsi_t imsi = new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.imsi;
+  char ip6_str[INET6_ADDRSTRLEN];
+
+  if (ue_ipv6) {
+    inet_ntop(AF_INET6, ue_ipv6, ip6_str, INET6_ADDRSTRLEN);
+  }
   /* UE is switching back to EPS services after the CS Fallback
    * If Modify bearer Request is received in UE suspended mode, Resume PS
    * data
@@ -507,7 +518,7 @@ static void sgw_add_gtp_tunnel(
   if (new_bearer_ctxt_info_p->sgw_eps_bearer_context_information.pdn_connection
           .ue_suspended_for_ps_handover) {
     rv = gtp_tunnel_ops->forward_data_on_tunnel(
-        ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
+        ue_ipv4, ue_ipv6, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
         DEFAULT_PRECEDENCE);
     if (rv < 0) {
       OAILOG_ERROR_UE(
@@ -517,17 +528,32 @@ static void sgw_add_gtp_tunnel(
   } else {
     OAILOG_DEBUG_UE(
         LOG_SPGW_APP, imsi64, "Adding tunnel for bearer %u ue addr %x\n",
-        eps_bearer_ctxt_p->eps_bearer_id, ue.s_addr);
+        eps_bearer_ctxt_p->eps_bearer_id, ue_ipv4.s_addr);
     if (eps_bearer_ctxt_p->eps_bearer_id ==
         new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
             .pdn_connection.default_bearer) {
       // Set default precedence and tft for default bearer
+      if (ue_ipv6) {
+        OAILOG_INFO_UE(
+            LOG_SPGW_APP, imsi64,
+            "Adding tunnel for ipv6 ue addr %s, enb %x, "
+            "s_gw_teid_S1u_S12_S4_up %x, enb_teid_S1u %x\n",
+            ip6_str, enb.s_addr, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+            eps_bearer_ctxt_p->enb_teid_S1u);
+      }
+
       rv = gtpv1u_add_tunnel(
-          ue, NULL, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+          ue_ipv4, ue_ipv6, vlan, enb,
+          eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u, imsi, NULL, DEFAULT_PRECEDENCE);
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64, "ERROR in setting up TUNNEL err=%d\n", rv);
+      } else {
+        pcef_update_teids(
+            (char*) imsi.digit, eps_bearer_ctxt_p->eps_bearer_id,
+            eps_bearer_ctxt_p->enb_teid_S1u,
+            eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up);
       }
     } else {
       for (int itrn = 0; itrn < eps_bearer_ctxt_p->tft.numberofpacketfilters;
@@ -537,10 +563,17 @@ static void sgw_add_gtp_tunnel(
         _generate_dl_flow(
             &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                   .packetfiltercontents),
-            ue.s_addr, &dlflow);
+            ue_ipv4.s_addr, ue_ipv6, eps_bearer_ctxt_p->paa.pdn_type, &dlflow);
+        OAILOG_INFO_UE(
+            LOG_SPGW_APP, imsi64,
+            "Adding tunnel for ded bearer ipv6 ue addr %s, enb %x, "
+            "s_gw_teid_S1u_S12_S4_up %x, enb_teid_S1u %x\n",
+            ip6_str, enb.s_addr, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+            eps_bearer_ctxt_p->enb_teid_S1u);
 
         rv = gtpv1u_add_tunnel(
-            ue, NULL, vlan, enb, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+            ue_ipv4, ue_ipv6, vlan, enb,
+            eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
             eps_bearer_ctxt_p->enb_teid_S1u, imsi, &dlflow,
             eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                 .eval_precedence);
@@ -661,6 +694,7 @@ int sgw_handle_sgi_endpoint_deleted(
   char* imsi                               = NULL;
   char* apn                                = NULL;
   struct in_addr inaddr;
+  struct in6_addr in6addr;
 
   OAILOG_FUNC_IN(LOG_SPGW_APP);
 
@@ -688,7 +722,12 @@ int sgw_handle_sgi_endpoint_deleted(
           LOG_SPGW_APP, imsi64,
           "Rx SGI_DELETE_ENDPOINT_REQUEST: REQUEST_ACCEPTED\n");
 
-      struct in_addr ue = eps_bearer_ctxt_p->paa.ipv4_address;
+      struct in_addr ue_ipv4   = eps_bearer_ctxt_p->paa.ipv4_address;
+      struct in6_addr* ue_ipv6 = NULL;
+      if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+          (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+        ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+      }
       // If the forwarding was suspended, first resume it.
       // Note that forward_data_on_tunnel does not install a new forwarding
       // rule, but simply deletes previously installed drop rule by
@@ -696,7 +735,7 @@ int sgw_handle_sgi_endpoint_deleted(
       if (new_bearer_ctxt_info_p->sgw_eps_bearer_context_information
               .pdn_connection.ue_suspended_for_ps_handover) {
         rv = gtp_tunnel_ops->forward_data_on_tunnel(
-            ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
+            ue_ipv4, ue_ipv6, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up, NULL,
             DEFAULT_PRECEDENCE);
         if (rv < 0) {
           OAILOG_ERROR_UE(
@@ -710,14 +749,14 @@ int sgw_handle_sgi_endpoint_deleted(
           eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
       rv = gtp_tunnel_ops->del_tunnel(
-          enb, ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+          enb, ue_ipv4, ue_ipv6, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
           eps_bearer_ctxt_p->enb_teid_S1u, NULL);
       if (rv < 0) {
         OAILOG_ERROR_UE(LOG_SPGW_APP, imsi64, "ERROR in deleting TUNNEL\n");
       }
       // delete paging rule
-      char* ip_str = inet_ntoa(ue);
-      rv           = gtp_tunnel_ops->delete_paging_rule(ue);
+      char* ip_str = inet_ntoa(ue_ipv4);
+      rv           = gtp_tunnel_ops->delete_paging_rule(ue_ipv4);
       if (rv < 0) {
         OAILOG_ERROR(
             LOG_SPGW_APP, "ERROR in deleting paging rule for IP Addr: %s\n",
@@ -744,9 +783,15 @@ int sgw_handle_sgi_endpoint_deleted(
           break;
 
         case IPv6:
-          OAILOG_ERROR_UE(
-              LOG_SPGW_APP, imsi64,
-              "Failed to release IPv6 PAA for PDN type IPv6\n");
+          in6addr = resp_pP->paa.ipv6_address;
+          if (!release_ue_ipv6_address(imsi, apn, &in6addr)) {
+            OAILOG_DEBUG_UE(
+                LOG_SPGW_APP, imsi64, "Released IPv6 PAA for PDN type IPv6\n");
+          } else {
+            OAILOG_ERROR_UE(
+                LOG_SPGW_APP, imsi64,
+                "Failed to release IPv6 PAA for PDN type IPv6\n");
+          }
           break;
 
         case IPv4_AND_v6:
@@ -759,6 +804,16 @@ int sgw_handle_sgi_endpoint_deleted(
             OAILOG_ERROR_UE(
                 LOG_SPGW_APP, imsi64,
                 "Failed to release IPv4 PAA for PDN type IPv4_AND_v6\n");
+          }
+          in6addr = resp_pP->paa.ipv6_address;
+          if (!release_ue_ipv6_address(imsi, apn, &in6addr)) {
+            OAILOG_DEBUG_UE(
+                LOG_SPGW_APP, imsi64,
+                "Released IPv6 PAA for PDN type IPv4v6\n");
+          } else {
+            OAILOG_ERROR_UE(
+                LOG_SPGW_APP, imsi64,
+                "Failed to release IPv6 PAA for PDN type IPv4v6\n");
           }
           break;
 
@@ -913,7 +968,12 @@ int sgw_handle_modify_bearer_request(
                      .bearer_contexts[idx]
                      .s1_eNB_fteid,
                 &eps_bearer_ctxt_p->enb_ip_address_S1u) == false) {
-          struct in_addr ue = eps_bearer_ctxt_p->paa.ipv4_address;
+          struct in_addr ue_ipv4   = eps_bearer_ctxt_p->paa.ipv4_address;
+          struct in6_addr* ue_ipv6 = NULL;
+          if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+              (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+            ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+          }
 
           OAILOG_DEBUG_UE(
               LOG_SPGW_APP, imsi64,
@@ -925,7 +985,7 @@ int sgw_handle_modify_bearer_request(
           gtp_tunnel_ops->send_end_marker(enb, modify_bearer_pP->teid);
           // delete GTPv1-U tunnel
           rv = gtp_tunnel_ops->del_tunnel(
-              enb, ue, NULL, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
+              enb, ue_ipv4, ue_ipv6, eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
         }
         populate_sgi_end_point_update(
@@ -1036,9 +1096,14 @@ int sgw_handle_delete_session_request(
             struct in_addr enb = {.s_addr = 0};
             enb.s_addr         = eps_bearer_ctxt_p->enb_ip_address_S1u.address
                              .ipv4_address.s_addr;
+            struct in6_addr* ue_ipv6 = NULL;
+            if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+                (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+              ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+            }
 
             rv = gtp_tunnel_ops->del_tunnel(
-                enb, eps_bearer_ctxt_p->paa.ipv4_address, NULL,
+                enb, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
                 eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
                 eps_bearer_ctxt_p->enb_teid_S1u, NULL);
             if (rv < 0) {
@@ -1202,8 +1267,14 @@ int sgw_handle_release_access_bearers_request(
         enb.s_addr =
             eps_bearer_ctxt->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
+        struct in6_addr* ue_ipv6 = NULL;
+        if ((eps_bearer_ctxt->paa.pdn_type == IPv6) ||
+            (eps_bearer_ctxt->paa.pdn_type == IPv4_AND_v6)) {
+          ue_ipv6 = &eps_bearer_ctxt->paa.ipv6_address;
+        }
+
         rv = gtp_tunnel_ops->del_tunnel(
-            enb, eps_bearer_ctxt->paa.ipv4_address, NULL,
+            enb, eps_bearer_ctxt->paa.ipv4_address, ue_ipv6,
             eps_bearer_ctxt->s_gw_teid_S1u_S12_S4_up,
             eps_bearer_ctxt->enb_teid_S1u, NULL);
         if (rv < 0) {
@@ -1433,9 +1504,15 @@ int sgw_handle_suspend_notification(
           "Tunnel mapping in"
           "GTP-U Kernel module \n");
       // delete GTPv1-U tunnel
-      struct in_addr ue = eps_bearer_entry_p->paa.ipv4_address;
-      rv                = gtp_tunnel_ops->discard_data_on_tunnel(
-          ue, NULL, eps_bearer_entry_p->s_gw_teid_S1u_S12_S4_up, NULL);
+      struct in_addr ue_ipv4   = eps_bearer_entry_p->paa.ipv4_address;
+      struct in6_addr* ue_ipv6 = NULL;
+      if ((eps_bearer_entry_p->paa.pdn_type == IPv6) ||
+          (eps_bearer_entry_p->paa.pdn_type == IPv4_AND_v6)) {
+        ue_ipv6 = &eps_bearer_entry_p->paa.ipv6_address;
+      }
+
+      rv = gtp_tunnel_ops->discard_data_on_tunnel(
+          ue_ipv4, ue_ipv6, eps_bearer_entry_p->s_gw_teid_S1u_S12_S4_up, NULL);
       if (rv < 0) {
         OAILOG_ERROR_UE(
             LOG_SPGW_APP, imsi64, "ERROR in Disabling DL data on TUNNEL\n");
@@ -1580,9 +1657,14 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
           struct in_addr enb = {.s_addr = 0};
           enb.s_addr = eps_bearer_ctxt_entry_p->enb_ip_address_S1u.address
                            .ipv4_address.s_addr;
-          struct in_addr ue = {.s_addr = 0};
-          int vlan          = eps_bearer_ctxt_entry_p->paa.vlan;
-          ue.s_addr         = eps_bearer_ctxt_entry_p->paa.ipv4_address.s_addr;
+          struct in_addr ue_ipv4   = {.s_addr = 0};
+          ue_ipv4.s_addr           = eps_bearer_ctxt_p->paa.ipv4_address.s_addr;
+          struct in6_addr* ue_ipv6 = NULL;
+          if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+              (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+            ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+          }
+          int vlan    = eps_bearer_ctxt_entry_p->paa.vlan;
           Imsi_t imsi = spgw_context->sgw_eps_bearer_context_information.imsi;
           strcpy(policy_rule_name, eps_bearer_ctxt_entry_p->policy_rule_name);
           // Iterate of packet filter rules
@@ -1596,10 +1678,11 @@ int sgw_handle_nw_initiated_actv_bearer_rsp(
             _generate_dl_flow(
                 &(eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
                       .packetfiltercontents),
-                ue.s_addr, &dlflow);
+                ue_ipv4.s_addr, ue_ipv6, eps_bearer_ctxt_p->paa.pdn_type,
+                &dlflow);
 
             rc = gtpv1u_add_tunnel(
-                ue, NULL, vlan, enb,
+                ue_ipv4, ue_ipv6, vlan, enb,
                 eps_bearer_ctxt_entry_p->s_gw_teid_S1u_S12_S4_up,
                 eps_bearer_ctxt_entry_p->enb_teid_S1u, imsi, &dlflow,
                 eps_bearer_ctxt_entry_p->tft.packetfilterlist.createnewtft[i]
@@ -1698,9 +1781,14 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
           struct in_addr enb = {.s_addr = 0};
           enb.s_addr =
               eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
+          struct in6_addr* ue_ipv6 = NULL;
+          if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+              (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+            ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+          }
 
           rc = gtp_tunnel_ops->del_tunnel(
-              enb, eps_bearer_ctxt_p->paa.ipv4_address, NULL,
+              enb, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, NULL);
           if (rc < 0) {
@@ -1765,16 +1853,22 @@ int sgw_handle_nw_initiated_deactv_bearer_rsp(
              ++itrn) {
           // Prepare DL flow rule from stored packet filters
           struct ip_flow_dl dlflow;
+          struct in6_addr* ue_ipv6 = NULL;
+          if ((eps_bearer_ctxt_p->paa.pdn_type == IPv6) ||
+              (eps_bearer_ctxt_p->paa.pdn_type == IPv4_AND_v6)) {
+            ue_ipv6 = &eps_bearer_ctxt_p->paa.ipv6_address;
+          }
           _generate_dl_flow(
               &(eps_bearer_ctxt_p->tft.packetfilterlist.createnewtft[itrn]
                     .packetfiltercontents),
-              eps_bearer_ctxt_p->paa.ipv4_address.s_addr, &dlflow);
+              eps_bearer_ctxt_p->paa.ipv4_address.s_addr, ue_ipv6,
+              eps_bearer_ctxt_p->paa.pdn_type, &dlflow);
           struct in_addr enb = {.s_addr = 0};
           enb.s_addr =
               eps_bearer_ctxt_p->enb_ip_address_S1u.address.ipv4_address.s_addr;
 
           rc = gtp_tunnel_ops->del_tunnel(
-              enb, eps_bearer_ctxt_p->paa.ipv4_address, NULL,
+              enb, eps_bearer_ctxt_p->paa.ipv4_address, ue_ipv6,
               eps_bearer_ctxt_p->s_gw_teid_S1u_S12_S4_up,
               eps_bearer_ctxt_p->enb_teid_S1u, &dlflow);
           if (rc < 0) {
@@ -1882,19 +1976,32 @@ static void _handle_failed_create_bearer_response(
 
 // Fills up downlink (DL) flow match rule from packet filters of eps bearer
 static void _generate_dl_flow(
-    packet_filter_contents_t* packet_filter, in_addr_t s_addr,
+    packet_filter_contents_t* packet_filter, in_addr_t ipv4_s_addr,
+    struct in6_addr* ue_ipv6, pdn_type_value_t pdn_type,
     struct ip_flow_dl* dlflow) {
   // Prepare DL flow rule
   // The TFTs are DL TFTs: UE is the destination/local,
   // PDN end point is the source/remote.
 
+  if (pdn_type == IPv4) {
+    // Adding UE to the rule is safe
+    dlflow->dst_ip.s_addr = ipv4_s_addr;
+
+    // At least we can match UE IPv4 addr;
+    // when IPv6 is supported, we need to revisit this.
+    dlflow->set_params = DST_IPV4;
+  }
+  if ((pdn_type == IPv6) || (pdn_type == IPv4_AND_v6)) {
+    if (!ue_ipv6) {
+      OAILOG_ERROR(LOG_SPGW_APP, "ue_ipv6 address is NULL\n");
+      OAILOG_FUNC_OUT(LOG_SPGW_APP);
+    }
+    // memcpy(&dlflow->dst_ip6, ue_ipv6, sizeof(dlflow->dst_ip6));
+    dlflow->dst_ip6    = *ue_ipv6;
+    dlflow->set_params = DST_IPV6;
+  }
+
   // Adding UE to the rule is safe
-  dlflow->dst_ip.s_addr = s_addr;
-
-  // At least we can match UE IPv4 addr;
-  // when IPv6 is supported, we need to revisit this.
-  dlflow->set_params = DST_IPV4;
-
   // Process remote address if present
   if ((TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG & packet_filter->flags) ==
       TRAFFIC_FLOW_TEMPLATE_IPV4_REMOTE_ADDR_FLAG) {
@@ -1905,6 +2012,13 @@ static void _generate_dl_flow(
                         packet_filter->ipv4remoteaddr[3].addr;
     dlflow->src_ip.s_addr = ntohl(remoteaddr.s_addr);
     dlflow->set_params |= SRC_IPV4;
+  }
+  if ((TRAFFIC_FLOW_TEMPLATE_IPV6_REMOTE_ADDR_FLAG & packet_filter->flags) ==
+      TRAFFIC_FLOW_TEMPLATE_IPV6_REMOTE_ADDR_FLAG) {
+    struct in6_addr remoteaddr = {.s6_addr = 0};
+    memcpy(remoteaddr.s6_addr, packet_filter->ipv6remoteaddr, INET6_ADDRSTRLEN);
+    memcpy(dlflow->src_ip6.s6_addr, remoteaddr.s6_addr, INET6_ADDRSTRLEN);
+    dlflow->set_params |= SRC_IPV6;
   }
 
   // Specify the next header

--- a/lte/gateway/configs/templates/spgw.conf.template
+++ b/lte/gateway/configs/templates/spgw.conf.template
@@ -76,6 +76,8 @@ P-GW =
     # DNS address communicated to UEs
     DEFAULT_DNS_IPV4_ADDRESS     = "{{ ipv4_dns }}";
     DEFAULT_DNS_SEC_IPV4_ADDRESS = "{{ ipv4_sec_dns }}";
+    # Google Public DNS
+    DNS_SERVER_IPV6_ADDRESS     = "2001:4860:4860:0:0:0:0:8888";
     P_CSCF_IPV4_ADDRESS = "172.27.23.150";
     P_CSCF_IPV6_ADDRESS = "2a12:577:9941:f99c:0002:0001:c731:f114";
 

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -392,7 +392,11 @@ class S1ApUtil(object):
             for item in value:
                 for flow in item:
                     if flow["direction"] == FlowMatch.DOWNLINK:
-                        ip_src_addr = flow["ipv4_src"] if key.version == 4 else flow["ipv6_src"]
+                        ip_src_addr = (
+                            flow["ipv4_src"]
+                            if key.version == 4
+                            else flow["ipv6_src"]
+                        )
                         ip_src = "ipv4_src" if key.version == 4 else "ipv6_src"
                         ip_dst = "ipv4_dst" if key.version == 4 else "ipv6_dst"
                         tcp_src_port = flow["tcp_src_port"]
@@ -421,9 +425,7 @@ class S1ApUtil(object):
                         assert (
                             len(downlink_flows) >= num_dl_flows
                         ), "Downlink flow missing for UE"
-                        assert (
-                            downlink_flows[0]["match"][ip_dst] == ue_ip_str
-                        )
+                        assert downlink_flows[0]["match"][ip_dst] == ue_ip_str
                         actions = downlink_flows[0]["instructions"][0][
                             "actions"
                         ]
@@ -448,8 +450,10 @@ class S1ApUtil(object):
             uplink_flows = get_flows(
                 self.datapath,
                 {
-                    "table_id": self.SPGW_TABLE,
-                    "match": {"in_port": GTP_PORT},
+                   "table_id": self.SPGW_TABLE,
+                   "match": {
+                       "in_port": GTP_PORT,
+                   }
                 },
             )
             if len(uplink_flows) == num_ul_flows:

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_utils.py
@@ -72,6 +72,10 @@ class S1ApUtil(object):
     CM_ESM_PDN_IPV6 = 0b10
     CM_ESM_PDN_IPV4V6 = 0b11
 
+    PROT_CFG_CID_PCSCF_IPV6_ADDR_REQUEST = 0x0001
+    PROT_CFG_CID_PCSCF_IPV4_ADDR_REQUEST = 0x000C
+    PROT_CFG_CID_DNS_SERVER_IPV6_ADDR_REQUEST = 0x0003
+
     lib_name = "libtfw.so"
 
     _cond = threading.Condition()
@@ -173,12 +177,15 @@ class S1ApUtil(object):
         # Wait until callback is invoked.
         return self._msg.get(True)
 
-    def populate_pco(self, protCfgOpts_pr, pcscf_addr_type):
+    def populate_pco(
+        self, protCfgOpts_pr, pcscf_addr_type=None, dns_ipv6_addr=False
+    ):
         """
         Populates the PCO values.
         Args:
             protCfgOpts_pr: PCO structure
             pcscf_addr_type: ipv4/ipv6/ipv4v6 flag
+            dns_ipv6_addr: True/False flag
         Returns:
             None
         """
@@ -195,18 +202,37 @@ class S1ApUtil(object):
         protCfgOpts_pr.numProtId = 0
 
         # Fill Number of container IDs and Container ID
+        idx = 0
         if pcscf_addr_type == "ipv4":
-            protCfgOpts_pr.numContId = 1
-            protCfgOpts_pr.c[0].cid = 0x000C
+            protCfgOpts_pr.numContId += 1
+            protCfgOpts_pr.c[
+                idx
+            ].cid = S1ApUtil.PROT_CFG_CID_PCSCF_IPV4_ADDR_REQUEST
+            idx += 1
 
         elif pcscf_addr_type == "ipv6":
-            protCfgOpts_pr.numContId = 1
-            protCfgOpts_pr.c[0].cid = 0x0001
+            protCfgOpts_pr.numContId += 1
+            protCfgOpts_pr.c[
+                idx
+            ].cid = S1ApUtil.PROT_CFG_CID_PCSCF_IPV6_ADDR_REQUEST
+            idx += 1
 
         elif pcscf_addr_type == "ipv4v6":
-            protCfgOpts_pr.numContId = 2
-            protCfgOpts_pr.c[0].cid = 0x000C
-            protCfgOpts_pr.c[1].cid = 0x0001
+            protCfgOpts_pr.numContId += 2
+            protCfgOpts_pr.c[
+                idx
+            ].cid = S1ApUtil.PROT_CFG_CID_PCSCF_IPV4_ADDR_REQUEST
+            idx += 1
+            protCfgOpts_pr.c[
+                idx
+            ].cid = S1ApUtil.PROT_CFG_CID_PCSCF_IPV6_ADDR_REQUEST
+            idx += 1
+
+        if dns_ipv6_addr:
+            protCfgOpts_pr.numContId += 1
+            protCfgOpts_pr.c[
+                idx
+            ].cid = S1ApUtil.PROT_CFG_CID_DNS_SERVER_IPV6_ADDR_REQUEST
 
     def attach(
         self,
@@ -219,6 +245,7 @@ class S1ApUtil(object):
         eps_type=s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH,
         pdn_type=1,
         pcscf_addr_type=None,
+        dns_ipv6_addr=False,
     ):
         """
         Given a UE issue the attach request of specified type
@@ -247,8 +274,10 @@ class S1ApUtil(object):
         attach_req.pdnType_pr.pdn_type = pdn_type
 
         # Populate PCO only if pcscf_addr_type is set
-        if pcscf_addr_type:
-            self.populate_pco(attach_req.protCfgOpts_pr, pcscf_addr_type)
+        if pcscf_addr_type or dns_ipv6_addr:
+            self.populate_pco(
+                attach_req.protCfgOpts_pr, pcscf_addr_type, dns_ipv6_addr
+            )
         assert self.issue_cmd(attach_type, attach_req) == 0
 
         response = self.get_response()
@@ -331,10 +360,12 @@ class S1ApUtil(object):
         # Verify the total number of DL flows for this UE ip address
         num_dl_flows = 1
         for key, value in dl_flow_rules.items():
-            ipv4_src_addr = None
             tcp_src_port = 0
             ip_proto = 0
             ue_ip_str = str(key)
+            dst_addr = "nw_dst" if key.version == 4 else "ipv6_dst"
+            eth_typ = 2048 if key.version == 4 else 34525
+
             # Set to 1 for the default bearer
             total_num_dl_flows_to_be_verified = 1
             for item in value:
@@ -346,8 +377,8 @@ class S1ApUtil(object):
                 {
                     "table_id": self.SPGW_TABLE,
                     "match": {
-                        "nw_dst": ue_ip_str,
-                        "eth_type": 2048,
+                        dst_addr: ue_ip_str,
+                        "eth_type": eth_typ,
                         "in_port": self.LOCAL_PORT,
                     },
                 },
@@ -361,7 +392,9 @@ class S1ApUtil(object):
             for item in value:
                 for flow in item:
                     if flow["direction"] == FlowMatch.DOWNLINK:
-                        ipv4_src_addr = flow["ipv4_src"]
+                        ip_src_addr = flow["ipv4_src"] if key.version == 4 else flow["ipv6_src"]
+                        ip_src = "ipv4_src" if key.version == 4 else "ipv6_src"
+                        ip_dst = "ipv4_dst" if key.version == 4 else "ipv6_dst"
                         tcp_src_port = flow["tcp_src_port"]
                         ip_proto = flow["ip_proto"]
                         for i in range(self.MAX_NUM_RETRIES):
@@ -371,10 +404,10 @@ class S1ApUtil(object):
                                 {
                                     "table_id": self.SPGW_TABLE,
                                     "match": {
-                                        "nw_dst": ue_ip_str,
-                                        "eth_type": 2048,
+                                        dst_addr: ue_ip_str,
+                                        "eth_type": eth_typ,
                                         "in_port": self.LOCAL_PORT,
-                                        "ipv4_src": ipv4_src_addr,
+                                        ip_src: ip_src_addr,
                                         "tcp_src": tcp_src_port,
                                         "ip_proto": ip_proto,
                                     },
@@ -389,7 +422,7 @@ class S1ApUtil(object):
                             len(downlink_flows) >= num_dl_flows
                         ), "Downlink flow missing for UE"
                         assert (
-                            downlink_flows[0]["match"]["ipv4_dst"] == ue_ip_str
+                            downlink_flows[0]["match"][ip_dst] == ue_ip_str
                         )
                         actions = downlink_flows[0]["instructions"][0][
                             "actions"
@@ -941,6 +974,82 @@ class SpgwUtil(object):
         )
         self._stub.CreateBearer(req)
 
+    def create_bearer_ipv4v6(
+        self, imsi, lbi, qci_val=1, ipv4=False, ipv6=False
+    ):
+        """
+        Sends a CreateBearer Request with ipv4/ipv6/ipv4v6 packet """
+        """ filters to SPGW service """
+        print("Sending CreateBearer request to spgw service")
+        flow_match_list = []
+        if ipv4:
+            flow_match_list.append(
+                FlowDescription(
+                    match=FlowMatch(
+                        ipv4_dst="192.168.129.42/24",
+                        tcp_src=5001,
+                        ip_proto=FlowMatch.IPPROTO_TCP,
+                        direction=FlowMatch.UPLINK,
+                    ),
+                    action=FlowDescription.PERMIT,
+                )
+            )
+            flow_match_list.append(
+                FlowDescription(
+                    match=FlowMatch(
+                        ipv4_src="192.168.129.42",
+                        tcp_src=5001,
+                        ip_proto=FlowMatch.IPPROTO_TCP,
+                        direction=FlowMatch.DOWNLINK,
+                    ),
+                    action=FlowDescription.PERMIT,
+                )
+            )
+
+        if ipv6:
+            flow_match_list.append(
+                FlowDescription(
+                    match=FlowMatch(
+                        ipv6_dst="5546:222:2259::226",
+                        ip_proto=FlowMatch.IPPROTO_UDP,
+                        direction=FlowMatch.UPLINK,
+                    ),
+                    action=FlowDescription.PERMIT,
+                )
+            )
+            flow_match_list.append(
+                FlowDescription(
+                    match=FlowMatch(
+                        ip_proto=FlowMatch.IPPROTO_UDP,
+                        direction=FlowMatch.DOWNLINK,
+                    ),
+                    action=FlowDescription.PERMIT,
+                )
+            )
+
+        req = CreateBearerRequest(
+            sid=SIDUtils.to_pb(imsi),
+            link_bearer_id=lbi,
+            policy_rules=[
+                PolicyRule(
+                    qos=FlowQos(
+                        qci=qci_val,
+                        gbr_ul=10000000,
+                        gbr_dl=10000000,
+                        max_req_bw_ul=10000000,
+                        max_req_bw_dl=10000000,
+                        arp=QosArp(
+                            priority_level=1,
+                            pre_capability=1,
+                            pre_vulnerability=0,
+                        ),
+                    ),
+                    flow_list=flow_match_list,
+                )
+            ],
+        )
+        self._stub.CreateBearer(req)
+
     def delete_bearer(self, imsi, lbi, ebi):
         """
         Sends a DeleteBearer Request to SPGW service
@@ -1002,22 +1111,32 @@ class SessionManagerUtil(object):
                 tcp_src_port = 0
                 tcp_dst_port = 0
 
-            ipv4_src_addr = None
+            src_addr = None
             if flow.get("ipv4_src", None):
-                ipv4_src_addr = IPAddress(
+                src_addr = IPAddress(
                     version=IPAddress.IPV4,
                     address=flow.get("ipv4_src").encode('utf-8'))
-            ipv4_dst_addr = None
+            elif flow.get("ipv6_src", None):
+                src_addr = IPAddress(
+                    version=IPAddress.IPV6,
+                    address=flow.get("ipv6_src").encode('utf-8'))
+
+            dst_addr = None
             if flow.get("ipv4_dst", None):
-                ipv4_dst_addr = IPAddress(
+                dst_addr = IPAddress(
                     version=IPAddress.IPV4,
                     address=flow.get("ipv4_dst").encode('utf-8'))
+            elif flow.get("ipv6_dst", None):
+                dst_addr = IPAddress(
+                    version=IPAddress.IPV6,
+                    address=flow.get("ipv6_dst").encode('utf-8'))
+
 
             flow_match_list.append(
                 FlowDescription(
                     match=FlowMatch(
-                        ip_dst=ipv4_dst_addr,
-                        ip_src=ipv4_src_addr,
+                        ip_dst=dst_addr,
+                        ip_src=src_addr,
                         tcp_src=tcp_src_port,
                         tcp_dst=tcp_dst_port,
                         udp_src=udp_src_port,

--- a/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
+++ b/lte/gateway/python/integ_tests/s1aptests/s1ap_wrapper.py
@@ -478,7 +478,7 @@ class TestWrapper(object):
         print("************* Sending deactivate EPS bearer context accept\n")
 
     def sendPdnConnectivityReq(
-        self, ue_id, apn, pdn_type=1, pcscf_addr_type=None
+        self, ue_id, apn, pdn_type=1, pcscf_addr_type=None, dns_ipv6_addr=False
     ):
         req = s1ap_types.uepdnConReq_t()
         req.ue_Id = ue_id
@@ -494,9 +494,10 @@ class TestWrapper(object):
         )
         print("********* PDN type", pdn_type)
         # Populate PCO if pcscf_addr_type is set
-        if pcscf_addr_type:
-            print("********* pcscf_addr_type", pcscf_addr_type)
-            self._s1_util.populate_pco(req.protCfgOpts_pr, pcscf_addr_type)
+        if pcscf_addr_type or dns_ipv6_addr:
+            self._s1_util.populate_pco(
+                req.protCfgOpts_pr, pcscf_addr_type, dns_ipv6_addr
+            )
 
         self.s1_util.issue_cmd(s1ap_types.tfwCmd.UE_PDN_CONN_REQ, req)
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_pcscf_address.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_secondary_pdn_with_pcscf_address.py
@@ -88,7 +88,10 @@ class TestAttachDetachSecondaryPdnWithPcscfAddress(unittest.TestCase):
         for i in range(num_pdns):
             # Send PDN Connectivity Request
             self._s1ap_wrapper.sendPdnConnectivityReq(
-                ue_id, apn[i], pdn_type, pcscf_addr_type=pcscf_addr_type[i]
+                ue_id,
+                apn[i],
+                pdn_type=pdn_type,
+                pcscf_addr_type=pcscf_addr_type[i],
             )
             # Receive PDN CONN RSP/Activate default EPS bearer context request
             response = self._s1ap_wrapper.s1_util.get_response()

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_ipv6_pcscf_and_dns_addr.py
@@ -1,37 +1,38 @@
 """
 Copyright (c) 2016-present, Facebook, Inc.
 All rights reserved.
-
 This source code is licensed under the BSD-style license found in the
 LICENSE file in the root directory of this source tree. An additional grant
 of patent rights can be found in the PATENTS file in the same directory.
 """
 
 import unittest
+import time
 
 import s1ap_types
+import s1ap_wrapper
+import ipaddress
 
-from integ_tests.s1aptests import s1ap_wrapper
 
-
-class TestAttachDetachWithIpv6PcscfAndDnsAddress(unittest.TestCase):
+class TestAttachDetachWithIpv6PcscfDnsAddr(unittest.TestCase):
     def setUp(self):
         self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
 
     def tearDown(self):
         self._s1ap_wrapper.cleanup()
 
-    def test_attach_detach_with_ipv6_pcscf_and_dns_address(self):
-        """ Basic attach/detach test with IPv6 P-CSCF and DNS IPv6 address """
-        num_ues = 1
-        self._s1ap_wrapper.configUEDevice(num_ues)
+    def test_attach_detach_with_ipv6_pcscf_and_dns_addr(self):
+        """ Attach a single UE + add a secondary pdn with
+        IPv6 address and include ipv6 pcscf address and dns address req
+        + detach """
+        num_ue = 1
+
+        self._s1ap_wrapper.configUEDevice(num_ue)
         req = self._s1ap_wrapper.ue_req
-        pcscf_addr_type = "ipv6"
-        # PDN Type 1-IPv4,2-IPv6,3-IPv4v6 as per 3gpp 24.301/29.274
-        pdn_type = 1
+        ue_id = req.ue_id
 
         # APN of the secondary PDN
-        ims = {
+        ims_apn = {
             "apn_name": "ims",  # APN-name
             "qci": 5,  # qci
             "priority": 15,  # priority
@@ -40,47 +41,44 @@ class TestAttachDetachWithIpv6PcscfAndDnsAddress(unittest.TestCase):
             "mbr_ul": 200000000,  # MBR UL
             "mbr_dl": 100000000,  # MBR DL
             "pdn_type": 1,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
-            # as per 3gpp 29.272
         }
 
-        # APN list to be configured
-        apn_list = [ims]
+        apn_list = [ims_apn]
 
         self._s1ap_wrapper.configAPN(
             "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
         )
-
         print(
-            "************************* Running End to End attach for ",
-            "UE id ",
-            req.ue_id,
+            "*********************** Running End to End attach for UE id ",
+            ue_id,
         )
-        # Now actually complete the attach
-        self._s1ap_wrapper._s1_util.attach(
-            req.ue_id,
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        # Attach
+        attach = self._s1ap_wrapper.s1_util.attach(
+            ue_id,
             s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
             s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
             s1ap_types.ueAttachAccept_t,
-            pdn_type=pdn_type,
-            pcscf_addr_type=pcscf_addr_type,
-            dns_ipv6_addr=True,
         )
+        addr = attach.esmInfo.pAddr.addrInfo
+        default_ip = ipaddress.ip_address(bytes(addr[:4]))
 
         # Wait on EMM Information from MME
         self._s1ap_wrapper._s1_util.receive_emm_info()
 
-        # Send PDN Connectivity Request
-        print("***************** Sending secondary PDN request for IMS APN")
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
         apn = "ims"
-        pcscf_addr_type = "ipv6"
-        # PDN Type 1-IPv4,2-IPv6,3-IPv4v6 as per 29.274
+        # PDN Type 2 = IPv6, 3 = IPv4v6
         pdn_type = 2
-
+        # Send PDN Connectivity Request
         self._s1ap_wrapper.sendPdnConnectivityReq(
-            req.ue_id,
+            ue_id,
             apn,
             pdn_type=pdn_type,
-            pcscf_addr_type=pcscf_addr_type,
+            pcscf_addr_type="ipv6",
             dns_ipv6_addr=True,
         )
         # Receive PDN CONN RSP/Activate default EPS bearer context request
@@ -88,19 +86,59 @@ class TestAttachDetachWithIpv6PcscfAndDnsAddress(unittest.TestCase):
         self.assertEqual(
             response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
         )
+        act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+        addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
         print(
-            "************************* Sending Activate default EPS bearer "
-            "context accept for UE id ",
-            req.ue_id,
+            "************** Sending Activate default EPS bearer "
+            "context accept for APN-%s, UE id-%d" % (apn, ue_id),
+        )
+        print(
+            "*************** Added default bearer for apn-%s,"
+            " bearer id-%d, pdn type-%d"
+            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
         )
 
+        # Receive Router Advertisement message
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+        )
+        routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
         print(
-            "************************* Running UE detach for UE id ",
-            req.ue_id,
+            "************* Received Router Advertisement for APN-%s"
+            " bearer id-%d" % (apn, routerAdv.bearerId)
+        )
+        ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
+            "\x00"
+        )
+        print("********** UE IPv6 address: ", ipv6_addr)
+        sec_ip_ipv6 = ipaddress.ip_address(ipv6_addr)
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+
+        num_ul_flows = 2
+        dl_flow_rules = {
+            default_ip: [],
+            sec_ip_ipv6: [],
+        }
+
+        # Verify if flow rules are created
+        self._s1ap_wrapper.s1_util.verify_flow_rules(
+            num_ul_flows, dl_flow_rules
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        print(
+            "******************* Running UE detach (switch-off) for ",
+            "UE id ",
+            ue_id,
         )
         # Now detach the UE
         self._s1ap_wrapper.s1_util.detach(
-            req.ue_id, s1ap_types.ueDetachType_t.UE_NORMAL_DETACH.value, True,
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
         )
 
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pcscf_address.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_with_pcscf_address.py
@@ -47,7 +47,7 @@ class TestAttachDetachWithPcscfAddress(unittest.TestCase):
                 s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
                 s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
                 s1ap_types.ueAttachAccept_t,
-                pdn_type,
+                pdn_type=pdn_type,
                 pcscf_addr_type=idx,
             )
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn.py
@@ -1,0 +1,178 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+import ipaddress
+
+
+class TestIPv4v6SecondaryPdn(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_ipv4v6_secondary_pdn(self):
+        """ Attach a single UE + add 2 secondary pdns with """
+        """ IPv4v6 and IPv6 address respectively + detach """
+        num_ue = 1
+
+        self._s1ap_wrapper.configUEDevice(num_ue)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+
+        # ims and internet PDNs
+        num_pdns = 2
+        # APN of the secondary PDNs
+        ims_apn = {
+            "apn_name": "ims",  # APN-name
+            "qci": 5,  # qci
+            "priority": 15,  # priority
+            "pre_cap": 0,  # preemption-capability
+            "pre_vul": 0,  # preemption-vulnerability
+            "mbr_ul": 200000000,  # MBR UL
+            "mbr_dl": 100000000,  # MBR DL
+            "pdn_type": 2,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
+        }
+
+        internet_apn = {
+            "apn_name": "internet",  # APN-name
+            "qci": 9,  # qci
+            "priority": 15,  # priority
+            "pre_cap": 0,  # preemption-capability
+            "pre_vul": 0,  # preemption-vulnerability
+            "mbr_ul": 200000000,  # MBR UL
+            "mbr_dl": 100000000,  # MBR DL
+            "pdn_type": 1,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
+        }
+
+        apn_list = [ims_apn, internet_apn]
+
+        self._s1ap_wrapper.configAPN(
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+        )
+        print(
+            "*********************** Running End to End attach for UE id ",
+            ue_id,
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        # Attach
+        attach = self._s1ap_wrapper.s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+        addr = attach.esmInfo.pAddr.addrInfo
+        default_ip = ipaddress.ip_address(bytes(addr[:4]))
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        apn = ["ims", "internet"]
+        # PDN Type 2 = IPv6, 3 = IPv4v6
+        pdn_type = [3, 2]
+        pdn_added = 0
+        # Send PDN Connectivity Request for ims and internet apns
+        for i in range(num_pdns):
+            # Send PDN Connectivity Request
+            self._s1ap_wrapper.sendPdnConnectivityReq(
+                ue_id, apn[i], pdn_type=pdn_type[i]
+            )
+            # Receive PDN CONN RSP/Activate default EPS bearer context request
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
+            act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+            pdnType = act_def_bearer_req.m.pdnInfo.pAddr.pdnType
+            sec_ip_ipv4 = None
+            addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
+            if pdnType == 1:
+                sec_ip_ipv4 = ipaddress.ip_address(bytes(addr[:4]))
+            elif pdnType == 3:
+                sec_ip_ipv4 = ipaddress.ip_address(bytes(addr[8:12]))
+            print(
+                "************** Sending Activate default EPS bearer "
+                "context accept for APN-%s, UE id-%d" % (apn[i], ue_id),
+            )
+            print(
+                "*************** Added default bearer for apn-%s,"
+                " bearer id-%d, pdn type-%d"
+                % (
+                    apn[i],
+                    act_def_bearer_req.m.pdnInfo.epsBearerId,
+                    pdn_type[i],
+                )
+            )
+
+            # Receive Router Advertisement message
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+            )
+            routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
+            print(
+                "************* Received Router Advertisement for APN-%s"
+                " bearer id-%d" % (apn[i], routerAdv.bearerId)
+            )
+            ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
+                "\x00"
+            )
+            print("********** UE IPv6 address: ", ipv6_addr)
+            sec_ip_ipv6 = ipaddress.ip_address(ipv6_addr)
+            pdn_added += 1
+
+            print("***** Sleeping for 5 seconds")
+            time.sleep(5)
+
+            # 1-ipv4 default bearer
+            num_ul_flows = 1 + pdn_added
+            # For ipv4v6 pdn, pass default_ip, sec_ip_ipv4 and sec_ip_ipv6
+            if pdnType == 3:
+                dl_flow_rules = {
+                    default_ip: [],
+                    sec_ip_ipv4: [],
+                    sec_ip_ipv6: [],
+                }
+            # For ipv6 pdn, pass default_ip, sec_ip_ipv6
+            if pdnType == 2:
+                dl_flow_rules = {
+                    default_ip: [],
+                    sec_ip_ipv6: [],
+                }
+
+            # Verify if flow rules are created
+            self._s1ap_wrapper.s1_util.verify_flow_rules(
+                num_ul_flows, dl_flow_rules
+            )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        print(
+            "******************* Running UE detach (switch-off) for ",
+            "UE id ",
+            ue_id,
+        )
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_multi_ue.py
@@ -1,0 +1,160 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+import ipaddress
+
+
+class TestIPv4v6SecondaryPdnMultiUE(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_ipv4v6_secondary_pdn_multi_ue(self):
+        """ Attach a single UE + add a secondary pdn with
+        IPv4v6 address + detach
+        Repeat for 4 UEs"""
+        num_ues = 4
+        ue_ids = []
+        default_ip = []
+        sec_ip_ipv4 = []
+        sec_ip_ipv6 = []
+
+        # APN of the secondary PDNs
+        ims_apn = {
+            "apn_name": "ims",  # APN-name
+            "qci": 5,  # qci
+            "priority": 15,  # priority
+            "pre_cap": 0,  # preemption-capability
+            "pre_vul": 0,  # preemption-vulnerability
+            "mbr_ul": 200000000,  # MBR UL
+            "mbr_dl": 100000000,  # MBR DL
+            "pdn_type": 2,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
+        }
+
+        self._s1ap_wrapper.configUEDevice(num_ues)
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            ue_id = req.ue_id
+            apn_list = [ims_apn]
+
+            self._s1ap_wrapper.configAPN(
+                "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+            )
+            print(
+                "*********************** Running End to End attach for UE id ",
+                ue_id,
+            )
+
+            print("***** Sleeping for 5 seconds")
+            time.sleep(5)
+            # Attach
+            attach = self._s1ap_wrapper.s1_util.attach(
+                ue_id,
+                s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+                s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+                s1ap_types.ueAttachAccept_t,
+            )
+            addr = attach.esmInfo.pAddr.addrInfo
+            default_ip.append(ipaddress.ip_address(bytes(addr[:4])))
+            ue_ids.append(ue_id)
+
+            # Wait on EMM Information from MME
+            self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        self._s1ap_wrapper._ue_idx = 0
+        for i in range(num_ues):
+            req = self._s1ap_wrapper.ue_req
+            apn = "ims"
+            ue_id = req.ue_id
+
+            # PDN Type 2 = IPv6, 3 = IPv4v6
+            pdn_type = 3
+            # Send PDN Connectivity Request
+            self._s1ap_wrapper.sendPdnConnectivityReq(
+                ue_id, apn, pdn_type=pdn_type
+            )
+            # Receive PDN CONN RSP/Activate default EPS bearer context request
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+            )
+            act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+            addr = act_def_bearer_req.m.pdnInfo.pAddr.addrInfo
+            sec_ip_ipv4.append(ipaddress.ip_address(bytes(addr[8:12])))
+
+            print(
+                "********************** Sending Activate default EPS bearer "
+                "context accept for APN-%s, UE id-%d" % (apn, ue_id),
+            )
+            print(
+                "********************** Added default bearer for apn-%s,"
+                " bearer id-%d, pdn type-%d"
+                % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+            )
+
+            # Receive Router Advertisement message
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_ROUTER_ADV_IND.value
+            )
+            routerAdv = response.cast(s1ap_types.ueRouterAdv_t)
+            print(
+                "******************* Received Router Advertisement for APN-%s"
+                " and, bearer id-%d" % (apn, routerAdv.bearerId)
+            )
+
+            ipv6_addr = "".join([chr(i) for i in routerAdv.ipv6Addr]).rstrip(
+                "\x00"
+            )
+            print("******* UE IPv6 address: ", ipv6_addr)
+            sec_ip_ipv6.append(ipaddress.ip_address(ipv6_addr))
+            print("***** Sleeping for 5 seconds")
+            time.sleep(5)
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+
+        # 1-ipv4 default bearer + 1-ipv4v6(ims) bearer for 4 UEs
+        num_ul_flows = 8
+        for i in range(num_ues):
+            dl_flow_rules = {
+                default_ip[i]: [],
+                sec_ip_ipv4[i]: [],
+                sec_ip_ipv6[i]: [],
+            }
+            # Verify if flow rules are created
+            self._s1ap_wrapper.s1_util.verify_flow_rules(
+                num_ul_flows, dl_flow_rules
+            )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        for ue in ue_ids:
+            print(
+                "******************* Running UE detach (switch-off) for ",
+                "UE id ",
+                ue,
+            )
+            # Now detach the UE
+            self._s1ap_wrapper.s1_util.detach(
+                ue, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv4v6_secondary_pdn_rs_retransmit.py
@@ -1,0 +1,139 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+import ipaddress
+
+
+class TestIPv4v6SecondaryPdnRSRetransmit(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_ipv4v6_secondary_pdn_rs_retransmit(self):
+        """ Attach a single UE + add a secondary pdn with
+        IPv4v6 address + drop the RA received + restransmit RS 2 times
+        + detach """
+        num_ue = 1
+
+        self._s1ap_wrapper.configUEDevice(num_ue)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+
+        # APN of the secondary PDN
+        ims_apn = {
+            "apn_name": "ims",  # APN-name
+            "qci": 5,  # qci
+            "priority": 15,  # priority
+            "pre_cap": 0,  # preemption-capability
+            "pre_vul": 0,  # preemption-vulnerability
+            "mbr_ul": 200000000,  # MBR UL
+            "mbr_dl": 100000000,  # MBR DL
+            "pdn_type": 2,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
+        }
+
+        apn_list = [ims_apn]
+
+        self._s1ap_wrapper.configAPN(
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+        )
+        print(
+            "*********************** Running End to End attach for UE id ",
+            ue_id,
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        # Attach
+        attach = self._s1ap_wrapper.s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        addr = attach.esmInfo.pAddr.addrInfo
+        default_ip = ipaddress.ip_address(bytes(addr[:4]))
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        # Send an indication to s1ap tester to drop the RA message
+        print("*** Sending indication to drop Router Advertisement ***")
+        drop_ra = s1ap_types.UeDropRA()
+        drop_ra.ue_Id = req.ue_id
+        drop_ra.flag = 1
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SET_DROP_ROUTER_ADV, drop_ra
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        apn = "ims"
+        # PDN Type 2 = IPv6, 3 = IPv4v6
+        pdn_type = 3
+        # Send PDN Connectivity Request for ims apn
+        self._s1ap_wrapper.sendPdnConnectivityReq(
+            ue_id, apn, pdn_type=pdn_type
+        )
+        # Receive PDN CONN RSP/Activate default EPS bearer context request
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+        )
+        act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+        print(
+            "********************** Sending Activate default EPS bearer "
+            "context accept for APN-%s, UE id-%d" % (apn, ue_id),
+        )
+        print(
+            "********************** Added default bearer for apn-%s,"
+            " bearer id-%d, pdn type-%d"
+            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+        )
+
+        # Wait for RS retransmissions
+        print("***** Sleeping for 15 seconds")
+        time.sleep(15)
+
+        # ipv4v6 bearer will not be deleted
+        # as ipv4 address is allocted
+
+        # 1 ipv4 default bearer + 1 ipv4v6 bearer
+        num_ul_flows = 2
+        dl_flow_rules = {
+            default_ip: [],
+        }
+
+        # Verify if flow rules are created
+        self._s1ap_wrapper.s1_util.verify_flow_rules(
+            num_ul_flows, dl_flow_rules
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        print(
+            "******************* Running UE detach (switch-off) for ",
+            "UE id ",
+            ue_id,
+        )
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_ipv6_secondary_pdn_rs_retransmit.py
@@ -1,0 +1,153 @@
+"""
+Copyright (c) 2016-present, Facebook, Inc.
+All rights reserved.
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree. An additional grant
+of patent rights can be found in the PATENTS file in the same directory.
+"""
+
+import unittest
+import time
+
+import s1ap_types
+import s1ap_wrapper
+import ipaddress
+
+
+class TestIPv6SecondaryPdnRSRetransmit(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_ipv6_secondary_pdn_rs_retransmit(self):
+        """ Attach a single UE + add a secondary pdn with
+        IPv6 address + drop the RA received + restransmit RS 2 times
+        + detach """
+
+        num_ue = 1
+
+        self._s1ap_wrapper.configUEDevice(num_ue)
+        req = self._s1ap_wrapper.ue_req
+        ue_id = req.ue_id
+
+        # APN of the secondary PDN
+        ims_apn = {
+            "apn_name": "ims",  # APN-name
+            "qci": 5,  # qci
+            "priority": 15,  # priority
+            "pre_cap": 0,  # preemption-capability
+            "pre_vul": 0,  # preemption-vulnerability
+            "mbr_ul": 200000000,  # MBR UL
+            "mbr_dl": 100000000,  # MBR DL
+            "pdn_type": 2,  # PDN Type 0-IPv4,1-IPv6,2-IPv4v6
+        }
+
+        apn_list = [ims_apn]
+
+        self._s1ap_wrapper.configAPN(
+            "IMSI" + "".join([str(i) for i in req.imsi]), apn_list
+        )
+        print(
+            "*********************** Running End to End attach for UE id ",
+            ue_id,
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        # Attach
+        attach = self._s1ap_wrapper.s1_util.attach(
+            ue_id,
+            s1ap_types.tfwCmd.UE_END_TO_END_ATTACH_REQUEST,
+            s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND,
+            s1ap_types.ueAttachAccept_t,
+        )
+
+        addr = attach.esmInfo.pAddr.addrInfo
+        default_ip = ipaddress.ip_address(bytes(addr[:4]))
+
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        apn = "ims"
+        # PDN Type 2 = IPv6, 3 = IPv4v6
+        pdn_type = 2
+
+        # Send an indication to s1ap tester to drop the RA message
+        print("*** Sending indication to drop Router Advertisement ***")
+        drop_ra = s1ap_types.UeDropRA()
+        drop_ra.ue_Id = req.ue_id
+        drop_ra.flag = 1
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SET_DROP_ROUTER_ADV, drop_ra
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        # Send PDN Connectivity Request for ims apn
+        self._s1ap_wrapper.sendPdnConnectivityReq(
+            ue_id, apn, pdn_type=pdn_type
+        )
+        # Receive PDN CONN RSP/Activate default EPS bearer context request
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_PDN_CONN_RSP_IND.value
+        )
+        act_def_bearer_req = response.cast(s1ap_types.uePdnConRsp_t)
+
+        print(
+            "********************** Sending Activate default EPS bearer "
+            "context accept for APN-%s, UE id-%d" % (apn, ue_id),
+        )
+        print(
+            "********************** Added default bearer for apn-%s,"
+            " bearer id-%d, pdn type-%d"
+            % (apn, act_def_bearer_req.m.pdnInfo.epsBearerId, pdn_type,)
+        )
+        # Receive UE_DEACTIVATE_BER_REQ
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_DEACTIVATE_BER_REQ.value
+        )
+
+        print(
+            "******************* Received deactivate eps bearer context"
+            " request"
+        )
+        # Send DeactDedicatedBearerAccept
+        deactv_bearer_req = response.cast(s1ap_types.UeDeActvBearCtxtReq_t)
+        self._s1ap_wrapper.sendDeactDedicatedBearerAccept(
+            req.ue_id, deactv_bearer_req.bearerId
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        # 1 UL flow is created per bearer
+        num_ul_flows = 1
+        dl_flow_rules = {
+            default_ip: [],
+        }
+
+        # Verify if flow rules are created
+        self._s1ap_wrapper.s1_util.verify_flow_rules(
+            num_ul_flows, dl_flow_rules
+        )
+
+        print("***** Sleeping for 5 seconds")
+        time.sleep(5)
+        print(
+            "******************* Running UE detach (switch-off) for ",
+            "UE id ",
+            ue_id,
+        )
+        # Now detach the UE
+        self._s1ap_wrapper.s1_util.detach(
+            ue_id, s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value, False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -125,7 +125,11 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
 
             sec_apn.ambr.max_bandwidth_ul = apn.ambr.max_bandwidth_ul
             sec_apn.ambr.max_bandwidth_dl = apn.ambr.max_bandwidth_dl
-            sec_apn.pdn = (apn.pdn if apn.pdn else s6a_proxy_pb2.UpdateLocationAnswer.APNConfiguration.IPV4)
+            sec_apn.pdn = (
+                apn.pdn
+                if apn.pdn
+                else s6a_proxy_pb2.UpdateLocationAnswer.APNConfiguration.IPV4
+            )
 
         return ula
 

--- a/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
+++ b/lte/gateway/python/magma/subscriberdb/protocols/s6a_proxy_servicer.py
@@ -125,9 +125,8 @@ class S6aProxyRpcServicer(s6a_proxy_pb2_grpc.S6aProxyServicer):
 
             sec_apn.ambr.max_bandwidth_ul = apn.ambr.max_bandwidth_ul
             sec_apn.ambr.max_bandwidth_dl = apn.ambr.max_bandwidth_dl
-            sec_apn.pdn = (
-                s6a_proxy_pb2.UpdateLocationAnswer.APNConfiguration.IPV4
-            )
+            sec_apn.pdn = (apn.pdn if apn.pdn else s6a_proxy_pb2.UpdateLocationAnswer.APNConfiguration.IPV4)
+
         return ula
 
     @staticmethod


### PR DESCRIPTION
[agw][lte][new feature] ipv6 support for control plane

## Summary

This PR contains:
1.	IPv6 control plane support 
2.	Support to send DNS server IPv6 address in PCO
3.	Fix for minor bugs in test_attach_detach_secondary_pdn_with_pcscf_address.py and test_attach_detach_with_pcscf_address.py
4.	Ipv6 eth type change in GTPApplication for default bearer As this change is not yet available in master and without this change ovs rules are not created
5.	Ipv6 eth type change in GTPApplication for dedicated bearer
6.	S1 sim testcases to test the above changes


## Test Plan

1.	Verified s1ap tester sanity
2.	Verified ipv6 test cases added in this PR

Note: This PR has dependency on s1ap tester PR - https://github.com/facebookexperimental/S1APTester/pull/40
