### PR TITLE
[CircleCI][CWFIntegTest] Check that the test XML file exists before trying to pull the file

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -252,10 +252,11 @@ def _run_remote_cwf_integ_test(repo: str, magma_root: str):
                 print(f'Exception while running cwf integ_test\n {e}')
                 sys.exit(1)
         # Move JUnit test result to /tmp/test-results directory
-        local('mkdir cwf-tests-xml')
-        get(test_xml, 'cwf-tests-xml')
-        local('sudo mkdir -p /tmp/test-results/')
-        local('sudo mv cwf-tests-xml/* /tmp/test-results/')
+        if exists(test_xml):
+            local('mkdir cwf-tests-xml')
+            get(test_xml, 'cwf-tests-xml')
+            local('sudo mkdir -p /tmp/test-results/')
+            local('sudo mv cwf-tests-xml/* /tmp/test-results/')
         # On failure, transfer logs of key services from docker containers and
         # copy to the log directory. This will get stored as an artifact in the
         # circleCI config.

--- a/cwf/gateway/fabfile.py
+++ b/cwf/gateway/fabfile.py
@@ -355,7 +355,7 @@ def _check_docker_services(ignoreList):
             if result.return_code == 1:
                 # grep returns code 1 when empty string
                 return
-            print("Container restarting detected. Tryin one more time")
+            print("Container restarting detected. Trying one more time")
             count+=1
     # if we got here, that means all attempts failed
     print("ERROR: Test NOT started due to docker container restarting")


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I guess the circleCI test might not exist for long... but I noticed when there is a test failure due to docker container crash loop. The logs are usually super useful when the containers are crashlooping, so trying to fix that here.
This is because when no tests run, there is not `tests.xml` created. 
So the fix for this is to just check the file exists before pulling.


<!-- Enumerate changes you made and why you made them -->

## Test Plan
https://github.com/magma/magma/pull/3707
Log with crash: 
https://circle-production-customer-artifacts.s3.amazonaws.com/picard/5f0538d1af34c85ea33ada3e/5fad745c22a96377bf5749fd-0-build/artifacts/tmp/logs/sessiond.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20201112T180709Z&X-Amz-SignedHeaders=host&X-Amz-Expires=60&X-Amz-Credential=AKIAJR3Q6CR467H7Z55A%2F20201112%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=4399e8fe1514fef2bab6bc87439e3ce217ef4042785f67d8b8883981956315a1
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
