### PR TITLE
[lte][agw] Fix IPv6 unit tests

### DIFF
--- a/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
+++ b/lte/gateway/c/oai/test/openflow/test_gtp_app.cpp
@@ -626,7 +626,7 @@ TEST_F(GTPApplicationTest, TestAddTunnelIpv6) {
       *messenger, send_of_msg(
                       AllOf(
                           CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
-                          CheckEthType(0x08DD), CheckIPv6Dst(ue_ipv6),
+                          CheckEthType(0x086DD), CheckIPv6Dst(ue_ipv6),
                           CheckCommandType(of13::OFPFC_ADD)),
                       _))
       .Times(1);
@@ -634,7 +634,7 @@ TEST_F(GTPApplicationTest, TestAddTunnelIpv6) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x086DD),
               CheckIPv6Dst(ue_ipv6), CheckCommandType(of13::OFPFC_ADD)),
           _))
       .Times(1);
@@ -699,7 +699,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelIpv6) {
       *messenger, send_of_msg(
                       AllOf(
                           CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
-                          CheckEthType(0x08DD), CheckIPv6Dst(ue_ipv6),
+                          CheckEthType(0x086DD), CheckIPv6Dst(ue_ipv6),
                           CheckCommandType(of13::OFPFC_DELETE)),
                       _))
       .Times(1);
@@ -707,7 +707,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelIpv6) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x086DD),
               CheckIPv6Dst(ue_ipv6), CheckCommandType(of13::OFPFC_DELETE)),
           _))
       .Times(1);
@@ -772,7 +772,7 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlowIpv6) {
       send_of_msg(
           AllOf(
               CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
-              CheckEthType(0x08DD), CheckIPv6Dst(dl_flow.dst_ip6),
+              CheckEthType(0x086DD), CheckIPv6Dst(dl_flow.dst_ip6),
               CheckIPv6Src(dl_flow.src_ip6), CheckIPv4Proto(dl_flow.ip_proto),
               CheckTcpDstPort(dl_flow.tcp_dst_port),
               CheckTcpSrcPort(dl_flow.tcp_src_port),
@@ -783,7 +783,7 @@ TEST_F(GTPApplicationTest, TestAddTunnelDlFlowIpv6) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x086DD),
               CheckIPv6Dst(dl_flow.dst_ip6), CheckIPv6Src(dl_flow.src_ip6),
               CheckIPv4Proto(dl_flow.ip_proto),
               CheckTcpDstPort(dl_flow.tcp_dst_port),
@@ -842,7 +842,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowIpv6) {
       send_of_msg(
           AllOf(
               CheckTableId(0), CheckInPort(of13::OFPP_LOCAL),
-              CheckEthType(0x08DD), CheckIPv6Dst(dl_flow.dst_ip6),
+              CheckEthType(0x086DD), CheckIPv6Dst(dl_flow.dst_ip6),
               CheckIPv6Src(dl_flow.src_ip6), CheckIPv4Proto(dl_flow.ip_proto),
               CheckTcpDstPort(dl_flow.tcp_dst_port),
               CheckTcpSrcPort(dl_flow.tcp_src_port),
@@ -853,7 +853,7 @@ TEST_F(GTPApplicationTest, TestDeleteTunnelDlFlowIpv6) {
       *messenger,
       send_of_msg(
           AllOf(
-              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x08DD),
+              CheckTableId(0), CheckInPort(TEST_MTR_PORT), CheckEthType(0x086DD),
               CheckIPv6Dst(dl_flow.dst_ip6), CheckIPv6Src(dl_flow.src_ip6),
               CheckIPv4Proto(dl_flow.ip_proto),
               CheckTcpDstPort(dl_flow.tcp_dst_port),


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

Modified the eth field in IPv6 tests for GTP app.

## Test Plan

Run `make test_oai`

Output:
https://gist.github.com/ulaskozat/fc14ffbe562ac39e387014619b8da0c1

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
