### PR TITLE
[sessiond] new suspended state

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -15,8 +15,15 @@
 #include "ServiceAction.h"
 #include "StoredState.h"
 #include "SessionCredit.h"
+#include "DiameterCodes.h"
 
 namespace magma {
+
+enum CreditValidity {
+  VALID_CREDIT    = 0,
+  INVALID_CREDIT  = 1,
+  TRANSIENT_ERROR = 2,
+};
 
 // Used to keep track of credit grants from Gy. Some features of this type of
 // grants include:
@@ -38,13 +45,16 @@ struct ChargingGrant {
   std::time_t expiry_time;
   ServiceState service_state;
   ReAuthState reauth_state;
+  // indicates the rules have been removed from pipelined
+  bool suspended;
 
   // Default states
   ChargingGrant()
       : credit(),
         is_final_grant(false),
         service_state(SERVICE_ENABLED),
-        reauth_state(REAUTH_NOT_NEEDED) {}
+        reauth_state(REAUTH_NOT_NEEDED),
+        suspended(false) {}
 
   ChargingGrant(const StoredChargingGrant& marshaled);
 
@@ -57,7 +67,8 @@ struct ChargingGrant {
 
   // Returns true if the credit returned from the Policy component is valid and
   // good to be installed.
-  static bool is_valid_credit_response(const CreditUpdateResponse& update);
+  static CreditValidity is_valid_credit_response(
+      const CreditUpdateResponse& update);
 
   // Returns a SessionCreditUpdateCriteria that reflects the current state
   SessionCreditUpdateCriteria get_update_criteria();
@@ -92,10 +103,17 @@ struct ChargingGrant {
   ServiceActionType final_action_to_action(
       const ChargingCredit_FinalAction action) const;
 
+  ServiceActionType final_action_to_action_on_suspension(
+      const ChargingCredit_FinalAction action) const;
+
   // Set is_final_grant and final_action_info values
   void set_final_action_info(
       const magma::lte::ChargingCredit& credit,
-      SessionCreditUpdateCriteria& uc);
+      SessionCreditUpdateCriteria* uc = NULL);
+
+  bool get_suspended();
+
+  void set_suspended(bool suspended, SessionCreditUpdateCriteria* uc);
 
   // Set the object and update criteria's reauth state to new_state.
   void set_reauth_state(

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -183,4 +183,18 @@ std::string service_action_type_to_str(ServiceActionType action) {
       return "INVALID ACTION TYPE";
   }
 }
+
+std::string credit_validity_to_str(CreditValidity validity) {
+  switch (validity) {
+    case VALID_CREDIT:
+      return "VALID_CREDIT";
+    case INVALID_CREDIT:
+      return "INVALID_CREDIT";
+    case TRANSIENT_ERROR:
+      return "TRANSIENT_ERROR";
+    default:
+      return "INVALID CREDIT TYPE";
+  }
+}
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -14,6 +14,7 @@
 
 #include "StoredState.h"
 #include "ServiceAction.h"
+#include "ChargingGrant.h"
 #include <lte/protos/abort_session.pb.h>
 
 namespace magma {

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -27,6 +27,7 @@
 #include "MetricsHelpers.h"
 #include "magma_logging.h"
 #include "Utilities.h"
+#include "DiameterCodes.h"
 
 namespace {
 const char* LABEL_IMSI      = "IMSI";
@@ -1089,6 +1090,28 @@ void SessionState::set_fsm_state(
   }
 }
 
+// Suspend the service due to all the remaining credits are transient.
+// Use the rg to trigger redirection
+void SessionState::suspend_service_if_needed_for_credit(
+    CreditKey ckey, SessionStateUpdateCriteria& update_criteria) {
+  uint suspended_count = 0;
+
+  auto it = credit_map_.find(ckey);
+  if (it == credit_map_.end()) {
+    MLOG(MDEBUG) << "Could not find RG " << ckey
+                 << " Not suspending serivce for " << session_id_;
+  }
+  for (const auto& credit : credit_map_) {
+    if (credit.second->suspended) {
+      suspended_count++;
+    }
+  }
+  if (credit_map_.size() > 0 && suspended_count == credit_map_.size()) {
+    auto credit_uc = get_credit_uc(ckey, update_criteria);
+    it->second->set_service_state(SERVICE_NEEDS_SUSPENSION, *credit_uc);
+  }
+}
+
 bool SessionState::should_rule_be_active(
     const std::string& rule_id, std::time_t time) {
   auto lifetime = rule_lifetimes_[rule_id];
@@ -1183,15 +1206,21 @@ bool SessionState::receive_charging_credit(
     // new credit
     return init_charging_credit(update, session_uc);
   }
-  auto& grant    = it->second;
-  auto credit_uc = get_credit_uc(CreditKey(update), session_uc);
-  if (!ChargingGrant::is_valid_credit_response(update)) {
+  auto& grant          = it->second;
+  auto credit_uc       = get_credit_uc(CreditKey(update), session_uc);
+  auto credit_validity = ChargingGrant::is_valid_credit_response(update);
+  if (credit_validity == INVALID_CREDIT) {
     // update unsuccessful, reset credit and return
     grant->credit.mark_failure(update.result_code(), credit_uc);
     if (grant->should_deactivate_service()) {
       grant->set_service_state(SERVICE_NEEDS_DEACTIVATION, *credit_uc);
     }
     return false;
+  }
+  if (credit_validity == TRANSIENT_ERROR) {
+    // for transient errors, try to install the credit
+    // but clear the reported credit
+    grant->credit.mark_failure(update.result_code(), credit_uc);
   }
   MLOG(MINFO) << "Received a credit RG:" << key << " for " << session_id_;
   grant->receive_charging_grant(update.credit(), credit_uc);
@@ -1213,7 +1242,7 @@ bool SessionState::init_charging_credit(
     const CreditUpdateResponse& update,
     SessionStateUpdateCriteria& session_uc) {
   const uint32_t key = update.charging_key();
-  if (!ChargingGrant::is_valid_credit_response(update)) {
+  if (ChargingGrant::is_valid_credit_response(update) == INVALID_CREDIT) {
     // init failed, don't track key
     return false;
   }
@@ -1227,6 +1256,34 @@ bool SessionState::init_charging_credit(
   MLOG(MINFO) << "Initialized a new credit RG:" << key << " for "
               << session_id_;
   return true;
+}
+
+void SessionState::set_suspend_credit(
+    const CreditKey& charging_key, bool new_suspended,
+    SessionStateUpdateCriteria& update_criteria) {
+  auto it = credit_map_.find(charging_key);
+  if (it != credit_map_.end()) {
+    auto credit_uc = get_credit_uc(charging_key, update_criteria);
+    auto& grant    = it->second;
+    grant->set_suspended(new_suspended, credit_uc);
+  }
+}
+
+bool SessionState::is_credit_suspended(const CreditKey& charging_key) {
+  auto it = credit_map_.find(charging_key);
+  if (it != credit_map_.end()) {
+    auto& grant = it->second;
+    return grant->get_suspended();
+  }
+  return false;
+}
+
+void SessionState::get_rules_per_credit_key(
+    CreditKey charging_key, RulesToProcess& rulesToProcess) {
+  static_rules_.get_rule_ids_for_charging_key(
+      charging_key, rulesToProcess.static_rules);
+  dynamic_rules_.get_rule_definitions_for_charging_key(
+      charging_key, rulesToProcess.dynamic_rules);
 }
 
 uint64_t SessionState::get_charging_credit(
@@ -1323,6 +1380,7 @@ void SessionState::apply_charging_credit_update(
   charging_grant->expiry_time       = credit_uc.expiry_time;
   charging_grant->reauth_state      = credit_uc.reauth_state;
   charging_grant->service_state     = credit_uc.service_state;
+  charging_grant->suspended         = credit_uc.suspended;
 }
 
 void SessionState::set_charging_credit(
@@ -1384,6 +1442,12 @@ void SessionState::get_charging_updates(
               << key;
           break;  // no update
         }
+        if (grant->suspended && update_type == CreditUsage::QUOTA_EXHAUSTED) {
+          MLOG(MDEBUG) << "Credit " << key << " for " << session_id_
+                       << " is suspended. Not sending update to the core";
+          break;  // no update
+        }
+
         // Create Update struct
         MLOG(MDEBUG) << "Subscriber " << imsi_ << " rating group " << key
                      << " updating due to type "
@@ -1411,7 +1475,7 @@ void SessionState::get_charging_updates(
         // activate service
         action->set_ambr(config_.get_apn_ambr());
         // terminate service
-        terminate_service_action(action, action_type, key);
+        fill_service_action(action, action_type, key);
         actions_out->push_back(std::move(action));
         break;
       case RESTRICT_ACCESS: {
@@ -1427,17 +1491,17 @@ void SessionState::get_charging_updates(
         // activate service
         action->set_ambr(config_.get_apn_ambr());
         // terminate service
-        terminate_service_action(action, action_type, key);
+        fill_service_action(action, action_type, key);
         actions_out->push_back(std::move(action));
         break;
       }
       case ACTIVATE_SERVICE:
         action->set_ambr(config_.get_apn_ambr());
-        terminate_service_action(action, action_type, key);
+        fill_service_action(action, action_type, key);
         actions_out->push_back(std::move(action));
         break;
       case TERMINATE_SERVICE:
-        terminate_service_action(action, action_type, key);
+        fill_service_action(action, action_type, key);
         actions_out->push_back(std::move(action));
         break;
       default:
@@ -1449,7 +1513,7 @@ void SessionState::get_charging_updates(
   }
 }
 
-void SessionState::terminate_service_action(
+void SessionState::fill_service_action(
     std::unique_ptr<ServiceAction>& action, ServiceActionType action_type,
     const CreditKey& key) {
   MLOG(MDEBUG) << "Subscriber " << imsi_ << " rating group " << key

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -385,6 +385,12 @@ class SessionState {
   void install_scheduled_static_rule(
       const std::string& rule_id, SessionStateUpdateCriteria& update_criteria);
 
+  void set_suspend_credit(
+      const CreditKey& charging_key, bool new_suspended,
+      SessionStateUpdateCriteria& update_criteria);
+
+  bool is_credit_suspended(const CreditKey& charging_key);
+
   RuleLifetime& get_rule_lifetime(const std::string& rule_id);
 
   DynamicRuleStore& get_gy_dynamic_rules();
@@ -404,6 +410,9 @@ class SessionState {
       const std::string& rule_id, const RuleLifetime& lifetime);
 
   SessionFsmState get_state();
+
+  void get_rules_per_credit_key(
+      CreditKey charging_key, RulesToProcess& rulesToProcess);
 
   // Event Triggers
   void add_new_event_trigger(
@@ -504,6 +513,12 @@ class SessionState {
       const PolicyBearerBindingRequest& request,
       SessionStateUpdateCriteria& uc);
 
+  /**
+   * Returns true if all the credits are suspended
+   */
+  void suspend_service_if_needed_for_credit(
+      CreditKey ckey, SessionStateUpdateCriteria& update_criteria);
+
  private:
   std::string imsi_;
   std::string session_id_;
@@ -573,7 +588,7 @@ class SessionState {
       std::vector<std::unique_ptr<ServiceAction>>* actions_out,
       SessionStateUpdateCriteria& uc);
 
-  void terminate_service_action(
+  void fill_service_action(
       std::unique_ptr<ServiceAction>& action, ServiceActionType action_type,
       const CreditKey& key);
 

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -136,6 +136,7 @@ std::string serialize_stored_charging_grant(StoredChargingGrant& stored) {
   marshaled["reauth_state"]  = static_cast<int>(stored.reauth_state);
   marshaled["service_state"] = static_cast<int>(stored.service_state);
   marshaled["credit"]        = serialize_stored_session_credit(stored.credit);
+  marshaled["suspended"]     = stored.suspended;
 
   std::string serialized = folly::toJson(marshaled);
   return serialized;
@@ -158,6 +159,7 @@ StoredChargingGrant deserialize_stored_charging_grant(
       std::stoul(marshaled["expiry_time"].getString()));
   stored.credit =
       deserialize_stored_session_credit(marshaled["credit"].getString());
+  stored.suspended = marshaled["suspended"].getBool();
 
   return stored;
 }

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -91,10 +91,11 @@ enum ReAuthState {
 enum ServiceState {
   SERVICE_ENABLED            = 0,
   SERVICE_NEEDS_DEACTIVATION = 1,
-  SERVICE_DISABLED           = 2,
-  SERVICE_NEEDS_ACTIVATION   = 3,
-  SERVICE_REDIRECTED         = 4,
-  SERVICE_RESTRICTED         = 5,
+  SERVICE_NEEDS_SUSPENSION   = 2,
+  SERVICE_DISABLED           = 3,
+  SERVICE_NEEDS_ACTIVATION   = 4,
+  SERVICE_REDIRECTED         = 5,
+  SERVICE_RESTRICTED         = 6,
 };
 
 enum GrantTrackingType {
@@ -154,6 +155,7 @@ struct StoredChargingGrant {
   ReAuthState reauth_state;
   ServiceState service_state;
   std::time_t expiry_time;
+  bool suspended;
 };
 
 struct RuleLifetime {
@@ -244,6 +246,8 @@ struct SessionCreditUpdateCriteria {
 
   uint64_t time_of_first_usage;
   uint64_t time_of_last_usage;
+
+  bool suspended;
 };
 
 struct SessionStateUpdateCriteria {

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -31,6 +31,26 @@ MATCHER_P(CheckCount, count, "") {
   return arg_count == count;
 }
 
+MATCHER_P(CheckStaticRulesNames, list_static_rules, "") {
+  std::vector<std::string> static_rules = arg;
+  if (static_rules.size() != list_static_rules.size()) {
+    return false;
+  }
+  for (auto rule : list_static_rules) {
+    bool found = false;
+    for (auto rule_to_check : list_static_rules) {
+      if (rule == rule_to_check) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      return false;
+    }
+  }
+  return true;
+}
+
 MATCHER_P2(CheckUpdateRequestCount, monitorCount, chargingCount, "") {
   auto req = static_cast<const UpdateSessionRequest>(arg);
   return req.updates().size() == chargingCount &&

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -170,6 +170,32 @@ void create_credit_update_response(
   response->set_charging_key(charging_key);
 }
 
+void create_credit_update_response_with_error(
+    const std::string& imsi, const std::string session_id,
+    uint32_t charging_key, bool is_final, DiameterResultCode resultCode,
+    CreditUpdateResponse* response) {
+  response->set_success(false);
+  create_charging_credit(0, is_final, response->mutable_credit());
+  response->set_sid(imsi);
+  response->set_session_id(session_id);
+  response->set_charging_key(charging_key);
+  response->set_result_code(resultCode);
+}
+
+void create_credit_update_response_with_error(
+    const std::string& imsi, const std::string session_id,
+    uint32_t charging_key, bool is_final, DiameterResultCode resultCode,
+    ChargingCredit_FinalAction action, std::string redirect_server,
+    std::string restrict_rule, CreditUpdateResponse* response) {
+  response->set_success(false);
+  create_charging_credit(
+      0, action, redirect_server, restrict_rule, response->mutable_credit());
+  response->set_sid(imsi);
+  response->set_session_id(session_id);
+  response->set_charging_key(charging_key);
+  response->set_result_code(resultCode);
+}
+
 void create_charging_credit(
     uint64_t total_volume, uint64_t tx_volume, uint64_t rx_volume,
     bool is_final, ChargingCredit* credit) {

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.h
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.h
@@ -16,6 +16,8 @@
 #include <lte/protos/session_manager.grpc.pb.h>
 #include <lte/protos/pipelined.grpc.pb.h>
 
+#include "DiameterCodes.h"
+
 namespace magma {
 using namespace lte;
 
@@ -78,6 +80,17 @@ void create_credit_update_response(
     const std::string& imsi, const std::string session_id,
     uint32_t charging_key, uint64_t volume, bool is_final,
     CreditUpdateResponse* response);
+
+void create_credit_update_response_with_error(
+    const std::string& imsi, const std::string session_id,
+    uint32_t charging_key, bool is_final, DiameterResultCode resultCode,
+    CreditUpdateResponse* response);
+
+void create_credit_update_response_with_error(
+    const std::string& imsi, const std::string session_id,
+    uint32_t charging_key, bool is_final, DiameterResultCode resultCode,
+    ChargingCredit_FinalAction action, std::string redirect_server,
+    std::string restrict_rule, CreditUpdateResponse* response);
 
 void create_charging_credit(
     uint64_t total_volume, uint64_t tx_volume, uint64_t rx_volume,

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -29,6 +29,7 @@ class ChargingGrantTest : public ::testing::Test {
     grant.expiry_time    = time(NULL);
     grant.service_state  = SERVICE_ENABLED;
     grant.reauth_state   = REAUTH_NOT_NEEDED;
+    grant.suspended      = false;
     return grant;
   }
 

--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -29,6 +29,7 @@
 #include "SessionStore.h"
 #include "SessiondMocks.h"
 #include "magma_logging.h"
+#include "DiameterCodes.h"
 
 #define SECONDS_A_DAY 86400
 
@@ -63,7 +64,7 @@ class LocalEnforcerTest : public ::testing::Test {
 
   void initialize_lte_test_config() {
     test_cfg_.common_context =
-        build_common_context("", IP1, IPv6_1, APN1, MSISDN, TGPP_LTE);
+        build_common_context(IMSI1, IP1, IPv6_1, APN1, MSISDN, TGPP_LTE);
     QosInformationRequest qos_info;
     qos_info.set_apn_ambr_dl(32);
     qos_info.set_apn_ambr_dl(64);
@@ -258,9 +259,10 @@ TEST_F(LocalEnforcerTest, test_init_session_credit) {
       *pipelined_client,
       activate_flows_for_rules(
           testing::_, testing::_, testing::_, test_cfg_.common_context.msisdn(),
-          testing::_, CheckCount(0), CheckCount(0), testing::_))
+          testing::_, testing::_, testing::_, testing::_))
       .Times(1)
       .WillOnce(testing::Return(true));
+  ;
   local_enforcer->init_session_credit(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
@@ -518,7 +520,8 @@ TEST_F(LocalEnforcerTest, test_update_session_credits_and_rules_with_failure) {
       IMSI1, SESSION_ID_1, "1", MonitoringLevel::PCC_RULE_LEVEL, 2048,
       monitor_response);
   monitor_response->set_success(false);
-  monitor_response->set_result_code(5001);  // USER_UNKNOWN permanent failure
+  monitor_response->set_result_code(
+      DIAMETER_USER_UNKNOWN);  // USER_UNKNOWN permanent failure
 
   // expect all rules attached to this session should be removed
   EXPECT_CALL(
@@ -989,6 +992,192 @@ TEST_F(LocalEnforcerTest, test_all) {
 
   RuleRecordTable empty_table;
   local_enforcer->aggregate_records(session_map, empty_table, update);
+}
+
+TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
+  // insert key rule mapping
+  insert_static_rule(1, "", "rule1");
+
+  // insert initial session credit
+  CreateSessionResponse response;
+  auto credits = response.mutable_credits();
+  create_credit_update_response_with_error(
+      IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
+      ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
+
+  EXPECT_CALL(
+      *pipelined_client, deactivate_flows_for_rules(
+                             testing::_, testing::_, testing::_, CheckCount(1),
+                             CheckCount(0), testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+
+  auto update = SessionStore::get_default_session_update(session_map);
+
+  // receive usages from pipeline and check we still collect them but don't
+  // terminate session (this step helps to check the credit is in the suspended
+  // state
+  RuleRecordTable table;
+  auto record_list = table.mutable_records();
+  create_rule_record(
+      IMSI1, test_cfg_.common_context.ue_ipv4(), "rule1", 10, 20,
+      record_list->Add());
+  local_enforcer->aggregate_records(session_map, table, update);
+
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_RX, {{1, 10}});
+  assert_charging_credit(session_map, IMSI1, SESSION_ID_1, USED_TX, {{1, 20}});
+  EXPECT_EQ(update.size(), 1);
+  EXPECT_EQ(update[IMSI1][SESSION_ID_1].charging_credit_map.size(), 1);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1]
+                  .charging_credit_map.find(1)
+                  ->second.suspended);
+  EXPECT_EQ(
+      update[IMSI1][SESSION_ID_1]
+          .charging_credit_map.find(1)
+          ->second.service_state,
+      SERVICE_NEEDS_SUSPENSION);
+
+  // Collect updates for reporting and check Redirect action needs to be done
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto session_update =
+      local_enforcer->collect_updates(session_map, actions, update);
+  EXPECT_EQ(actions.size(), 1);
+
+  // execute actions (from collect_updates)
+  EXPECT_CALL(
+      *pipelined_client,
+      add_gy_final_action_flow(
+          IMSI1, test_cfg_.common_context.ue_ipv4(),
+          test_cfg_.common_context.ue_ipv6(), test_cfg_.common_context.msisdn(),
+          CheckCount(0), CheckCount(1)))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(session_update.updates_size(), 0);
+  EXPECT_EQ(
+      update[IMSI1][SESSION_ID_1]
+          .charging_credit_map.find(1)
+          ->second.service_state,
+      SERVICE_REDIRECTED);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1]
+                  .charging_credit_map.find(1)
+                  ->second.suspended);
+}
+
+TEST_F(LocalEnforcerTest, test_update_with_transient_error) {
+  // insert key rule mapping
+  insert_static_rule(1, "", "rule1");
+  insert_static_rule(1, "", "rule2");
+  insert_static_rule(2, "", "rule3");
+
+  // insert initial session credit
+  CreateSessionResponse response;
+  create_credit_update_response(
+      IMSI1, SESSION_ID_1, 1, 1024, response.mutable_credits()->Add());
+  create_credit_update_response(
+      IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+
+  // Add updated credit from cloud
+  auto session_uc = SessionStore::get_default_session_update(session_map);
+  UpdateSessionResponse update_response;
+  auto updates = update_response.mutable_responses();
+  create_credit_update_response_with_error(
+      IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
+      updates->Add());
+  create_credit_update_response(
+      IMSI1, SESSION_ID_1, 2, 1024, response.mutable_credits()->Add());
+  EXPECT_CALL(
+      *pipelined_client, deactivate_flows_for_rules(
+                             testing::_, testing::_, testing::_, CheckCount(2),
+                             CheckCount(0), testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+
+  local_enforcer->update_session_credits_and_rules(
+      session_map, update_response, session_uc);
+  EXPECT_FALSE(session_uc[IMSI1][SESSION_ID_1].updated_fsm_state);
+  EXPECT_TRUE(session_uc[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
+  EXPECT_EQ(
+      session_uc[IMSI1][SESSION_ID_1].charging_credit_map[1].service_state,
+      SESSION_ACTIVE);
+  EXPECT_FALSE(
+      session_uc[IMSI1][SESSION_ID_1].charging_credit_map[2].suspended);
+  EXPECT_EQ(
+      session_uc[IMSI1][SESSION_ID_1].charging_credit_map[2].service_state,
+      SESSION_ACTIVE);
+}
+
+// gy_rar
+TEST_F(LocalEnforcerTest, test_reauth_with_redirected_suspended_credit) {
+  // insert key rule mapping
+  insert_static_rule(1, "", "rule1");
+
+  // 1- INITIAL SET UP TO CREATE A REDIRECTED due to SUSPENDED CREDIT
+  // insert initial suspended and redirected credit
+  CreateSessionResponse response;
+  auto credits = response.mutable_credits();
+  create_credit_update_response_with_error(
+      IMSI1, SESSION_ID_1, 1, false, DIAMETER_CREDIT_LIMIT_REACHED,
+      ChargingCredit_FinalAction_REDIRECT, "12.7.7.4", "", credits->Add());
+  local_enforcer->init_session_credit(
+      session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
+
+  // execute redirection
+  auto update = SessionStore::get_default_session_update(session_map);
+  std::vector<std::unique_ptr<ServiceAction>> actions;
+  auto session_update =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(actions.size(), 1);
+  EXPECT_EQ(session_update.updates_size(), 0);
+  EXPECT_EQ(
+      update[IMSI1][SESSION_ID_1].charging_credit_map[1].service_state,
+      SERVICE_REDIRECTED);
+  EXPECT_TRUE(update[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
+
+  // 2- SETUP REAUTH ON A SUSPENDED CREDIT
+  // reset update and actions
+  update = SessionStore::get_default_session_update(session_map);
+  actions.clear();
+
+  ChargingReAuthRequest reauth;
+  reauth.set_sid(IMSI1);
+  reauth.set_session_id(SESSION_ID_1);
+  reauth.set_type(ChargingReAuthRequest::ENTIRE_SESSION);
+  auto result =
+      local_enforcer->init_charging_reauth(session_map, reauth, update);
+  EXPECT_EQ(result, ReAuthResult::UPDATE_INITIATED);
+
+  // check suspended credit is requested
+  auto update_req =
+      local_enforcer->collect_updates(session_map, actions, update);
+  local_enforcer->execute_actions(session_map, actions, update);
+  EXPECT_EQ(update_req.updates_size(), 1);
+  EXPECT_EQ(update_req.updates(0).sid(), IMSI1);
+  EXPECT_EQ(update_req.updates(0).usage().type(), CreditUsage::REAUTH_REQUIRED);
+
+  // 3- SUSPENSION IS CLEARED
+  // receive credit from OCS as a reauth answer
+  UpdateSessionResponse update_response;
+  auto updates = update_response.mutable_responses();
+  create_credit_update_response(IMSI1, SESSION_ID_1, 1, 4096, updates->Add());
+  std::vector<std::string> static_rules_to_activate;
+  static_rules_to_activate.push_back("rule1");
+  EXPECT_CALL(
+      *pipelined_client,
+      activate_flows_for_rules(
+          testing::_, testing::_, testing::_, test_cfg_.common_context.msisdn(),
+          testing::_, CheckStaticRulesNames(static_rules_to_activate),
+          CheckCount(0), testing::_))
+      .Times(1)
+      .WillOnce(testing::Return(true));
+  local_enforcer->update_session_credits_and_rules(
+      session_map, update_response, update);
+  EXPECT_FALSE(update[IMSI1][SESSION_ID_1].charging_credit_map[1].suspended);
 }
 
 TEST_F(LocalEnforcerTest, test_re_auth) {


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added new substatet to credits to mark them as temporary suspended.

When we receive a transient error, we will use a flag to mark a credit as supsended. Right now any transient error will trigger that, but we can narrow down to 4012 only in future PRs.

When receiving a transient error, session will be maintained active and the credit entry will not be removed. However, the rules related to that charging key will be removed from pipelined. That action can happen either during install of a brand new credit, or during an update of credit.

To activate back the credit we will need to receive an update from the core (or new credit install) with the same RG. Once new credit is received, the policies that were stored for that RG will be reinstalled. All this will happen in the same iteration where we receive the update from the core

Note that GY Reauth process now will be able to send requests for credits that are transient, allowing the user to replenish the account and be able to recover the session without terminating.


Added an extra feature to trigger redirection/restriction in case all the credits on that session are suspended. This is not 3gpp but it may work for some customers. In case this were not right, we can easily remove it by just removing the `SUSPENDED_NEEDED` action


## Test Plan

make precommit_sm
cwag integ test
3 new unit tests added to sessiond

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
