### PR TITLE
[xwfm][ci] allow untrust connection with graph.expresswifi

### DIFF
--- a/xwf/gateway/integ_tests/gw/entrypoint.sh
+++ b/xwf/gateway/integ_tests/gw/entrypoint.sh
@@ -32,7 +32,7 @@ ret=1
 counter=0
 until [[ ${ret} -eq 0 || ${counter} -gt 10  ]]; do
     echo "performing curl"
-    result=$( curl -X POST "https://graph.expresswifi.com/openflow/configxwfm?access_token=${ACCESSTOKEN}" )
+    result=$( curl -k -X POST "https://graph.expresswifi.com/openflow/configxwfm?access_token=${ACCESSTOKEN}" )
     echo $result | grep -q  configxwfm
     ret=$?
     echo "Counter: $counter -> $ret"


### PR DESCRIPTION
Signed-off-by: Aharon Novogrodski <novo@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

in order to run our tests against www we need to support unsecured curl (in tests!)

## Test Plan

built and tests loal

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
