### PR TITLE
[ctraced] Add basic gateway tracing functionality using tshark

### DIFF
--- a/cwf/gateway/configs/ctraced.yml
+++ b/cwf/gateway/configs/ctraced.yml
@@ -11,3 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 log_level: INFO
+
+# Directory for temporary storage of packet captures
+trace_directory: /var/opt/magma/tmp/trace
+
+# Interface to capture on
+trace_interfaces:
+  - eth0
+
+# Options available:
+#   - tshark
+#   - tcpdump
+# tshark has more capabilities - see command_builder.py
+trace_tool: tshark

--- a/feg/gateway/configs/ctraced.yml
+++ b/feg/gateway/configs/ctraced.yml
@@ -11,3 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 log_level: INFO
+
+# Directory for temporary storage of packet captures
+trace_directory: /var/opt/magma/tmp/trace
+
+# Interface to capture on
+trace_interfaces:
+  - eth0
+
+# Options available:
+#   - tshark
+#   - tcpdump
+# tshark has more capabilities - see command_builder.py
+trace_tool: tshark

--- a/lte/gateway/configs/ctraced.yml
+++ b/lte/gateway/configs/ctraced.yml
@@ -11,3 +11,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 log_level: INFO
+
+# Directory for temporary storage of packet captures
+trace_directory: /var/opt/magma/tmp/trace
+
+# Interface to capture on
+trace_interfaces:
+  - eth0
+
+# Options available:
+#   - tshark
+#   - tcpdump
+# tshark has more capabilities - see command_builder.py
+trace_tool: tshark

--- a/orc8r/gateway/python/magma/ctraced/command_builder.py
+++ b/orc8r/gateway/python/magma/ctraced/command_builder.py
@@ -1,0 +1,172 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class TraceBuildException(Exception):
+    pass
+
+
+class TraceBuilder(ABC):
+    """Builds commands to run call tracing.
+
+    TODO(andreilee): Support tracing for subscriber
+    TODO(andreilee): Support tracing by 3gpp protocol
+    """
+    def __init__(self):
+        super().__init__()
+
+    @abstractmethod
+    def build_trace_command(
+            self,
+            interfaces: List[str],
+            max_filesize: int,
+            output_filename: str,
+    ) -> List[str]:
+        """Builds command to start a trace. Does not execute the command.
+
+        Builds a command to start a trace using the specified arguments.
+        It is not guaranteed that the specific implementation of TraceBuilder
+        will be able to satisfy all the constraints placed by the specified
+        arguments. Check the docstring of the specific implementation for
+        additional details.
+
+        Args:
+            interfaces: Interfaces to capture the trace on. Specify "any" to
+              capture on all interfaces.
+            max_filesize: Max capture filesize specified in KiB. Capture will
+              stop after reaching the specified size. Value of -1 specifies
+              no limit.
+            output_filename: Where the output file will be saved.
+
+        Returns:
+            A command that can be run by subprocess.Popen to start the trace.
+
+            Example:
+            ["tshark", "-i", "eth0", "-a", "filesize:4000", "-w", "out.pcap"]
+
+        Raises:
+            TraceBuildException: Could not successfully build a command to
+              start a call trace with the specified arguments
+        """
+        pass
+
+
+class TSharkTraceBuilder(TraceBuilder):
+    """Builds commands to run call tracing with tshark.
+
+    This is the most feature complete TraceBuilder.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def build_trace_command(
+            self,
+            interfaces: List[str],
+            max_filesize: int,
+            output_filename: str,
+    ) -> List[str]:
+        command = ["tshark"]
+
+        # Specify interfaces
+        if "any" in interfaces:
+            command.extend(["-ni", "any"])
+        else:
+            for interface in interfaces:
+                command.extend(["-i", interface])
+
+        # Specify max filesize. tshark will terminate after it is reached.
+        if max_filesize != -1:
+            command.extend(["-a", "filesize:" + str(max_filesize)])
+
+        # Specify output file
+        command.extend(["-w", output_filename])
+
+        return command
+
+
+class TcpdumpTraceBuilder(TraceBuilder):
+    """Builds commands to run call tracing with tcpdump.
+
+    This is a less feature complete TraceBuilder, as tcpdump has less options
+    than a tool such as tshark.
+    """
+    def __init__(self):
+        super().__init__()
+
+    def build_trace_command(
+            self,
+            interfaces: List[str],
+            max_filesize: int,
+            output_filename: str,
+    ) -> List[str]:
+        """Builds command to start a trace using tcpdump. Does not execute it.
+
+        SEE PARENT CLASS FOR DETAILS.
+
+        Details here only specify argument restrictions.
+
+        Argument Restrictions:
+            interfaces: Only one interface can be specified.
+            max_filesize: Only value of -1 supported (no limit).
+            output_filename:
+
+        TODO(andreilee): Support max_filesize.
+                         Add postrotate command to stop after max filesize
+                         reached.
+        TODO(andreilee): Support multiple interfaces.
+        """
+        command = ["tcpdump"]
+
+        # Specify southbound interfaces
+        if len(interfaces) == 1:
+            command.extend(["-i", interfaces[0]])
+        elif len(interfaces) > 1:
+            raise TraceBuildException("""Cannot start trace with tcpdump with
+                                         more than one interface specified""")
+
+        # Currently unsupported.
+        # While a max filesize can be specified, tcpdump will rotate to new
+        # output files after the maximum is reached.
+        if max_filesize != -1:
+            raise TraceBuildException("""Cannot start trace with tcpdump with
+                                         max filesize""")
+
+        # Specify output file
+        command.extend(["-w", self._trace_filename])
+
+        return command
+
+
+def get_trace_builder(tool_name: str) -> TraceBuilder:
+    """Factory method for TraceBuilder.
+
+    Args:
+      tool_name: Name of tool for capturing a call trace.
+        Only options allowed are ["tshark", "tcpdump"].
+
+    Returns:
+      The TraceBuilder implementation matching the specified tool name
+
+    Raises:
+      TraceBuildException: If an unsupported tool name is specified.
+    """
+    if tool_name == "tshark":
+        return TSharkTraceBuilder()
+    elif tool_name == "tcpdump":
+        return TcpdumpTraceBuilder()
+    raise TraceBuildException("Failed to create trace builder, "
+                              "invalid tool name specified: {}"
+                              .format(tool_name))

--- a/orc8r/gateway/python/magma/ctraced/main.py
+++ b/orc8r/gateway/python/magma/ctraced/main.py
@@ -12,11 +12,18 @@ limitations under the License.
 """
 
 from magma.common.service import MagmaService
+from .rpc_servicer import CtraceDRpcServicer
+from .trace_manager import TraceManager
 from orc8r.protos.mconfig.mconfigs_pb2 import CtraceD
 
 def main():
     """ main() for ctraced """
     service = MagmaService('ctraced', CtraceD())
+
+    trace_manager = TraceManager(service.config)
+
+    ctraced_servicer = CtraceDRpcServicer(trace_manager)
+    ctraced_servicer.add_to_server(service.rpc_server)
 
     # Run the service loop
     service.run()

--- a/orc8r/gateway/python/magma/ctraced/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/ctraced/rpc_servicer.py
@@ -1,0 +1,55 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from orc8r.protos.ctraced_pb2_grpc import CallTraceServiceServicer,\
+    add_CallTraceServiceServicer_to_server
+from orc8r.protos.ctraced_pb2 import StartTraceRequest, StartTraceResponse,\
+    EndTraceRequest, EndTraceResponse
+from .trace_manager import TraceManager
+
+
+class CtraceDRpcServicer(CallTraceServiceServicer):
+    """
+    gRPC based server for CtraceD.
+    """
+
+    def __init__(self, trace_manager: TraceManager):
+        self._trace_mgr = trace_manager
+        pass
+
+    def add_to_server(self, server):
+        """
+        Add the servicer to a gRPC server
+        """
+        add_CallTraceServiceServicer_to_server(self, server)
+
+    def StartCallTrace(
+        self,
+        _request: StartTraceRequest,
+        _context,
+    ) -> StartTraceResponse:
+        success = self._trace_mgr.start_trace()
+        response = StartTraceResponse(success=success)
+        return response
+
+    def EndCallTrace(
+        self,
+        _request: EndTraceRequest,
+        _context,
+    ) -> EndTraceResponse:
+        data = self._trace_mgr.end_trace() # type: bytes
+        response = EndTraceResponse(
+            success=True,
+            trace_content=data,
+        )
+        return response

--- a/orc8r/gateway/python/magma/ctraced/trace_manager.py
+++ b/orc8r/gateway/python/magma/ctraced/trace_manager.py
@@ -1,0 +1,132 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import errno
+import logging
+import os
+import pathlib
+import subprocess
+import time
+from subprocess import SubprocessError
+from .command_builder import get_trace_builder
+
+_TRACE_FILE_NAME = "call_trace"
+_TRACE_FILE_EXT = "pcap"
+_MAX_FILESIZE = 4000  # ~ 4 MiB for a trace
+
+
+class TraceManager:
+    """
+    TraceManager is a wrapper for tshark/tcpdump specifically for starting and
+    stopping call/interface/subscriber traces.
+
+    Only a single trace can be captured at a time.
+    """
+    def __init__(self, config):
+        self._is_active = False # is call trace being captured
+        self._proc = None
+        self._trace_directory = config.get("trace_directory",
+                                           "/var/opt/magma/trace")  # type: str
+        # Specify southbound interfaces
+        self._trace_interfaces = config.get("trace_interfaces",
+                                           ["eth0"])  # type: List[str]
+
+        # Should specify absolute path of trace filename if trace is active
+        self._trace_filename = ""  # type: str
+
+        tool_name = config.get("trace_tool", "tshark")  # type: str
+        self._trace_builder = get_trace_builder(tool_name)
+
+    def start_trace(self) -> bool:
+        """Start a call trace.
+
+        Captures all packets across the eth0 interface.
+
+        Returns:
+            True if successfully started call trace
+        """
+        if self._is_active:
+            logging.error("Failed to start trace: Trace already active")
+            return False
+
+        # Example filename path:
+        #   /var/opt/magma/trace/call_trace_1607358641.pcap
+        self._trace_filename = "{0}/{1}_{2}.{3}".format(
+            self._trace_directory,
+            _TRACE_FILE_NAME,
+            int(time.time()),
+            _TRACE_FILE_EXT)
+
+        command = self._trace_builder.build_trace_command(
+            self._trace_interfaces,
+            _MAX_FILESIZE,
+            self._trace_filename)
+
+        logging.info("Starting trace with tshark, command: [%s]",
+                     ' '.join(command))
+
+        self._ensure_trace_directory_exists()
+
+        # TODO(andreilee): Handle edge case where only one instance of the
+        #                  process can be running, and may have been started
+        #                  by something external as well.
+        try:
+            self._proc = subprocess.Popen(command)
+        except SubprocessError as e:
+            logging.error("Failed to start trace: %s", str(e))
+            return False
+
+        self._is_active = True
+        logging.info("Successfully started trace with tshark")
+        return True
+
+    def end_trace(self) -> bytes:
+        """Ends call trace, if currently active.
+
+        Returns:
+            Call trace file in bytes
+        """
+        # If trace is active, then stop it
+        if self._is_active:
+            # If the process has ended, then _proc isn't None
+            self._proc.poll()
+            if self._proc.returncode is None:
+                self._proc.terminate()
+
+        # Read trace data into bytes
+        with open(self._trace_filename, "rb") as trace_file:
+            data = trace_file.read()  # type: bytes
+
+        # Ensure the tmp trace file is deleted
+        self._ensure_tmp_file_deleted()
+        self._trace_filename = ""
+
+        self._is_active = False
+
+        # Everything cleaned up, return bytes
+        return data
+
+    def _ensure_tmp_file_deleted(self):
+        """Ensure that tmp trace file is deleted.
+
+        Uses exception handling rather than a check for file existence to avoid
+        TOCTTOU bug
+        """
+        try:
+            os.remove(self._trace_filename)
+        except OSError as e:
+            if e.errno != errno.ENOENT:
+                logging.error("Error when deleting tmp trace file: %s", str(e))
+
+    def _ensure_trace_directory_exists(self) -> None:
+        pathlib.Path(self._trace_directory).mkdir(parents=True, exist_ok=True)

--- a/orc8r/gateway/python/scripts/ctraced_cli.py
+++ b/orc8r/gateway/python/scripts/ctraced_cli.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import argparse
+import textwrap
+
+from magma.common.rpc_utils import grpc_wrapper
+from orc8r.protos import common_pb2
+
+from orc8r.protos.ctraced_pb2 import StartTraceRequest, EndTraceRequest
+from orc8r.protos.ctraced_pb2_grpc import CallTraceServiceStub
+
+@grpc_wrapper
+def start_call_trace(client, args):
+    client.StartCallTrace(StartTraceRequest())
+
+
+@grpc_wrapper
+def end_call_trace(client, args):
+    res = client.EndCallTrace(common_pb2.Void())
+    print("Result of call trace: ", res)
+
+
+def create_parser():
+    """
+    Creates the argparse parser with all the arguments.
+    """
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawTextHelpFormatter,
+        description = textwrap.dedent('''\
+            Management CLI for ctraced
+            --------------------------
+            Use to start and end call traces.
+            Options are provided for the type of trace to record.
+            Only a single trace can be captured at a time.
+        '''))
+
+    # Add subcommands
+    subparsers = parser.add_subparsers(title='subcommands', dest='cmd')
+
+    # Add StartCallTrace subcommand
+    parser_start_trace = subparsers.add_parser('start_call_trace',
+                                               help='Start a call trace')
+    trace_types = list(StartTraceRequest.TraceType.DESCRIPTOR.values_by_name)
+    supported_protocols =\
+        list(StartTraceRequest.ProtocolName.DESCRIPTOR.values_by_name)
+    supported_interfaces =\
+        list(StartTraceRequest.InterfaceName.DESCRIPTOR.values_by_name)
+    parser_start_trace.add_argument('--type', type=str, choices=trace_types,
+                                    help='Trace type', required=True)
+    parser_start_trace.add_argument('--imsi', type=str, choices=trace_types,
+                                    help='Trace type')
+    parser_start_trace.add_argument('--protocol', type=str,
+                                    choices=supported_protocols)
+    parser_start_trace.add_argument('--interface', type=str,
+                                    choices=supported_interfaces)
+    parser_start_trace.set_defaults(func=start_call_trace)
+
+    # Add EndCallTrace subcommand
+    parser_end_trace = subparsers.add_parser('end_call_trace',
+                                             help='End a call trace')
+    parser_end_trace.set_defaults(func=end_call_trace)
+
+    return parser
+
+
+def main():
+    parser = create_parser()
+
+    # Parse the args
+    args = parser.parse_args()
+    if not args.cmd:
+        parser.print_usage()
+        exit(1)
+
+    # Execute the subcommand function
+    args.func(args, CallTraceServiceStub, 'ctraced')
+
+
+if __name__ == "__main__":
+    main()

--- a/orc8r/gateway/python/setup.py
+++ b/orc8r/gateway/python/setup.py
@@ -42,6 +42,7 @@ setup(
     ],
     scripts=[
         'scripts/checkin_cli.py',
+        'scripts/ctraced_cli.py',
         'scripts/directoryd_cli.py',
         'scripts/generate_lighttpd_config.py',
         'scripts/generate_nghttpx_config.py',


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Note: Dependency on https://github.com/magma/magma/pull/3766

Adds basic tracing functionality to the access gateway on the ctraced service. gRPC interface is added, as well as CLI to trigger call tracing locally on the gateway. Ability to filter call traces via subscriber, protocol, and/or interface is not implemented.

## Test Plan

- Tested manually
- Checked that ctraced starts with magmad
- Checked that CLI works, also verifying the RPC interface works as well:
```
(python) vagrant@magma-dev:/var/opt/magma/tmp/trace$ ctraced_cli.py start_call_trace --type=ALL
(python) vagrant@magma-dev:/var/opt/magma/tmp/trace$ ctraced_cli.py end_call_trace
Result of end_call_trace:  success: true
trace_content: "\n\r\r\n\274\000\000\000M<+\032\001\000\000\000\377\377\377\377\377\377\377\377\002\0007\000Intel(R) Core(TM) i9-9980HK CPU @ 2.40GHz (with SSE4.2)\000\003\000\023\000Linux 4.9.0-9-amd64\000\004\000A\000Dumpcap (Wireshark) 2.6.7 (Git v2.6.7 packaged as 2.6.7-1~deb9u1)\000\000\000\000\000\000\000\274\000\000\000\001\000\000\000@\000\000\000\001\000\000\000\000\000\004\000\002\000\004\000eth0\t\000\001\000\t\000\000\000\014\000\023\000Linux 4.9.0-9-amd64\000\000\000\000\000@\000\000\000\006\000\000\000\224\000\000\000\000\000\000\000E\027H\026:=\272\033r\000\000\000r\000\000\000RT\000\0225\002\010\000\'\034\271\262\010\000E\020\000d\023\216@\000@\006\016\346\n\000\002\017\n\000\002\002\000\026\315S\033\253\360~\013\203\033\367P\030\250\220\030g\000\0009\025)\0247\363\246bE\225\006\350Lg\310\347\026\231-\"\261\024\376ev\257}\322\200\335yE\3461\274;V\216\210\215\272\203%\221S\221\352\036\027\005\301)\310#;a&\2353\274\000\000\224\000\000\000\006\000\000\000\\\000\000\000\000\000\000\000E\027H\026\366\345\275\033<\000\000\000<\000\000\000\010\000\'\034\271\262RT\000\0225\002\010\000E\000\000(d7\000\000@\006\376\210\n\000\002\002\n\000\002\017\315S\000\026\013\203\033\367\033\253\360\272P\020\377\377\226z\000\000\000\000\000\000\000\000\\\000\000\000\006\000\000\000\204\000\000\000\000\000\000\000F\027H\026)\347\305\262b\000\000\000b\000\000\000\010\000\'\034\271\262RT\000\0225\002\010\000E\000\000Td8\000\000@\006\376[\n\000\002\002\n\000\002\017\307\244\000\026\000\271\274\'AN\311\207P\030\377\377\240\267\000\000\371\325t\034\316U\203\005$\250-\3417\206\237\037\177:u\263R\237M\243 \350\242\\\255\245c<J\365\334\355\273\314=\004\214\030h\306\000\000\204\000\000\000\006\000\000\000|\000\000\000\000\000\000\000F\027H\026+}\313\262Z\000\000\000Z\000\000\000RT\000\0225\002\010\000\'\034\271\262\010\000E\020\000LU\261@\000@\006\314\332\n\000\002\017\n\000\002\002\000\026\307\244AN\311\207\000\271\274SP\030\250\220\030O\000\000lS\016){\303\264\251\324/\353\234\222\006<GNK\240k\327\206\271\327\352\342\213P*\340\3537\342]\324\367\000\000|\000\000\000\006\000\000\000\\\000\000\000\000\000\000\000F\027H\026\330$\316\262<\000\000\000<\000\000\000\010\000\'\034\271\262RT\000\0225\002\010\000E\000\000(d9\000\000@\006\376\206\n\000\002\002\n\000\002\017\307\244\000\026\000\271\274SAN\311\253P\020\377\377\010\003\000\000\000\000\000\000\000\000\\\000\000\000"
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
