### PR TITLE
[SessionD]  Store usage updates for failed UpdateSession call and rollback credit changes

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -308,6 +308,14 @@ bool ChargingGrant::get_suspended() {
   return suspended;
 }
 
+void ChargingGrant::reset_reporting_grant(
+    SessionCreditUpdateCriteria* credit_uc) {
+  credit.reset_reporting_credit(credit_uc);
+  if (reauth_state == REAUTH_PROCESSING) {
+    set_reauth_state(REAUTH_REQUIRED, *credit_uc);
+  }
+}
+
 void ChargingGrant::log_final_action_info() const {
   std::string final_action = "";
   if (is_final_grant) {

--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -127,6 +127,9 @@ struct ChargingGrant {
   // a response from the core
   void set_reporting(bool reporting);
 
+  // Rollback reporting changes for failed updates
+  void reset_reporting_grant(SessionCreditUpdateCriteria* credit_uc);
+
   // Convert rel_time_sec, which is a delta value in seconds, into a timestamp
   // and assign it to expiry_time
   void set_expiry_time_as_timestamp(uint32_t rel_time_sec);

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -67,6 +67,13 @@ struct UpdateChargingCreditActions {
       unsuspended_credits;
 };
 
+// Used to transform the UpdateSessionRequest proto message into a per-session
+// structure
+struct UpdateRequestsBySession {
+  std::unordered_map<ImsiAndSessionID, UpdateRequests> requests_by_id;
+  UpdateRequestsBySession() {}
+  UpdateRequestsBySession(const magma::lte::UpdateSessionRequest& response);
+};
 class SessionNotFound : public std::exception {
  public:
   SessionNotFound() = default;
@@ -128,16 +135,17 @@ class LocalEnforcer {
       SessionUpdate& session_update);
 
   /**
-   * reset_updates resets all of the charging keys being updated in
-   * failed_request. This should only be called if the *entire* request fails
-   * (i.e. the entire request to the cloud timed out). Individual failures
-   * are handled when update_session_credits_and_rules is called.
+   * handle_update_failure resets all of the charging keys / monitors being
+   * updated in failed_request. This should only be called if the *entire*
+   * request fails (i.e. the entire request to the cloud timed out). Individual
+   * failures are handled when update_session_credits_and_rules is called.
    *
-   * @param failed_request - UpdateSessionRequest that couldn't be sent to the
-   *                         cloud for whatever reason
+   * @param failed_request - UpdateRequestsBySession that couldn't be sent to
+   * the cloud for whatever reason
    */
-  void reset_updates(
-      SessionMap& session_map, const UpdateSessionRequest& failed_request);
+  void handle_update_failure(
+      SessionMap& session_map, const UpdateRequestsBySession& failed_request,
+      SessionUpdate& updates);
 
   /**
    * Collect any credit keys that are either exhausted, timed out, or terminated

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -112,16 +112,19 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
         session_store_.set_and_save_reporting_flag(false, request, session_uc);
 
         if (!status.ok()) {
-          MLOG(MERROR) << "Update of size " << request.updates_size()
-                       << " to OCS failed entirely: " << status.error_message();
+          MLOG(MERROR)
+              << "UpdateSession request to FeG/PolicyDB failed entirely: "
+              << status.error_message();
+          enforcer_->handle_update_failure(
+              *session_map_ptr, UpdateRequestsBySession(request), session_uc);
           report_session_update_event_failure(
               *session_map_ptr, session_uc, status.error_message());
         } else {
           enforcer_->update_session_credits_and_rules(
               *session_map_ptr, response, session_uc);
-          session_store_.update_sessions(session_uc);
           report_session_update_event(*session_map_ptr, session_uc);
         }
+        session_store_.update_sessions(session_uc);
       });
 }
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -503,7 +503,7 @@ void LocalSessionManagerHandlerImpl::report_session_update_event_failure(
       auto session_id = (*session)->get_session_id();
       if (updates.find(session_id) != updates.end()) {
         std::ostringstream failure_stream;
-        failure_stream << "Update Session failed due to response from OCS: "
+        failure_stream << "UpdateSession request to FeG/PolicyDB failed: "
                        << failure_reason;
         std::string failure_msg = failure_stream.str();
         MLOG(MERROR) << failure_msg;

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1246,7 +1246,11 @@ RulesToProcess SessionState::get_all_final_unit_rules() {
 void SessionState::handle_update_failure(
     const UpdateRequests& failed_requests,
     SessionStateUpdateCriteria& session_uc) {
-  MLOG(MINFO) << "Rolling back changes due to a failed update " << session_id_;
+  MLOG(MDEBUG) << "Rolling back changes due to failed updates ("
+               << failed_requests.charging_requests.size()
+               << " charging requests and "
+               << failed_requests.monitor_requests.size()
+               << " monitor requests) for " << session_id_;
   for (const auto& failed_charging : failed_requests.charging_requests) {
     const auto key = failed_charging.usage().charging_key();
     if (credit_map_.find(key) == credit_map_.end()) {

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -54,6 +54,11 @@ struct RuleSetToApply {
   void combine_rule_set(const RuleSetToApply& other);
 };
 
+struct UpdateRequests {
+  std::vector<UsageMonitoringUpdateRequest> monitor_requests;
+  std::vector<CreditUsageUpdate> charging_requests;
+};
+
 // Used to transform the proto message RulesPerSubscriber into a more useful
 // structure
 struct RuleSetBySubscriber {
@@ -205,8 +210,9 @@ class SessionState {
    */
   bool can_complete_termination(SessionStateUpdateCriteria& update_criteria);
 
-  bool reset_reporting_charging_credit(
-      const CreditKey& key, SessionStateUpdateCriteria& update_criteria);
+  void handle_update_failure(
+      const UpdateRequests& failed_requests,
+      SessionStateUpdateCriteria& session_uc);
 
   /**
    * Receive the credit grant if the credit update was successful
@@ -471,9 +477,6 @@ class SessionState {
 
   void set_monitor(
       const std::string& key, Monitor monitor, SessionStateUpdateCriteria& uc);
-
-  bool reset_reporting_monitor(
-      const std::string& key, SessionStateUpdateCriteria& uc);
 
   void set_session_level_key(const std::string new_key);
 

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -167,4 +167,53 @@ MATCHER_P(CheckSubscriberQuotaUpdate, quota, "") {
   return update[0].update_type() == quota;
 }
 
+MATCHER_P(CheckCreateSession, imsi, "") {
+  auto req = static_cast<const CreateSessionRequest*>(arg);
+  return req->common_context().sid().id() == imsi;
+}
+
+MATCHER_P(CheckSingleUpdate, expected_update, "") {
+  auto request = static_cast<const UpdateSessionRequest*>(arg);
+  if (request->updates_size() != 1) {
+    return false;
+  }
+
+  auto& update = request->updates(0);
+  bool val =
+      update.usage().type() == expected_update.usage().type() &&
+      update.usage().bytes_tx() == expected_update.usage().bytes_tx() &&
+      update.usage().bytes_rx() == expected_update.usage().bytes_rx() &&
+      update.sid() == expected_update.sid() &&
+      update.usage().charging_key() == expected_update.usage().charging_key();
+  return val;
+}
+
+MATCHER_P(CheckTerminate, imsi, "") {
+  auto request = static_cast<const SessionTerminateRequest*>(arg);
+  return request->sid() == imsi;
+}
+
+MATCHER_P4(CheckActivateFlows, imsi, rule_count, ipv4, ipv6, "") {
+  auto request = static_cast<const ActivateFlowsRequest*>(arg);
+  auto res     = request->sid().id() == imsi &&
+             request->rule_ids_size() == rule_count &&
+             request->ip_addr() == ipv4 && request->ipv6_addr() == ipv6;
+  return res;
+}
+
+MATCHER_P5(
+    CheckActivateFlowsForTunnIds, imsi, ipv4, ipv6, enb_teid, agw_teid, "") {
+  auto request = static_cast<const ActivateFlowsRequest*>(arg);
+  auto res     = request->sid().id() == imsi && request->ip_addr() == ipv4 &&
+             request->ipv6_addr() == ipv6 &&
+             request->uplink_tunnel() == agw_teid &&
+             request->downlink_tunnel() == enb_teid;
+  return res;
+}
+
+MATCHER_P(CheckDeactivateFlows, imsi, "") {
+  auto request = static_cast<const DeactivateFlowsRequest*>(arg);
+  return request->sid().id() == imsi;
+}
+
 };  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -20,8 +20,10 @@
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
 
+#include "Consts.h"
 #include "SessionReporter.h"
 #include "MagmaService.h"
+#include "Matchers.h"
 #include "ProtobufCreators.h"
 #include "ServiceRegistrySingleton.h"
 #include "SessionManagerServer.h"
@@ -187,55 +189,6 @@ class SessiondTest : public ::testing::Test {
   SessionMap session_map;
 };
 
-MATCHER_P(CheckCreateSession, imsi, "") {
-  auto req = static_cast<const CreateSessionRequest*>(arg);
-  return req->common_context().sid().id() == imsi;
-}
-
-MATCHER_P(CheckSingleUpdate, expected_update, "") {
-  auto request = static_cast<const UpdateSessionRequest*>(arg);
-  if (request->updates_size() != 1) {
-    return false;
-  }
-
-  auto& update = request->updates(0);
-  bool val =
-      update.usage().type() == expected_update.usage().type() &&
-      update.usage().bytes_tx() == expected_update.usage().bytes_tx() &&
-      update.usage().bytes_rx() == expected_update.usage().bytes_rx() &&
-      update.sid() == expected_update.sid() &&
-      update.usage().charging_key() == expected_update.usage().charging_key();
-  return val;
-}
-
-MATCHER_P(CheckTerminate, imsi, "") {
-  auto request = static_cast<const SessionTerminateRequest*>(arg);
-  return request->sid() == imsi;
-}
-
-MATCHER_P4(CheckActivateFlows, imsi, rule_count, ipv4, ipv6, "") {
-  auto request = static_cast<const ActivateFlowsRequest*>(arg);
-  auto res     = request->sid().id() == imsi &&
-             request->rule_ids_size() == rule_count &&
-             request->ip_addr() == ipv4 && request->ipv6_addr() == ipv6;
-  return res;
-}
-
-MATCHER_P5(
-    CheckActivateFlowsForTunnIds, imsi, ipv4, ipv6, enb_teid, agw_teid, "") {
-  auto request = static_cast<const ActivateFlowsRequest*>(arg);
-  auto res     = request->sid().id() == imsi && request->ip_addr() == ipv4 &&
-             request->ipv6_addr() == ipv6 &&
-             request->uplink_tunnel() == agw_teid &&
-             request->downlink_tunnel() == enb_teid;
-  return res;
-}
-
-MATCHER_P(CheckDeactivateFlows, imsi, "") {
-  auto request = static_cast<const DeactivateFlowsRequest*>(arg);
-  return request->sid().id() == imsi;
-}
-
 ACTION_P2(SetEndPromise, promise_p, status) {
   promise_p->set_value();
   return status;
@@ -254,8 +207,8 @@ ACTION_P2(SetEndPromise, promise_p, status) {
  * creating session --> updating usage --> terminating session,
  * in reality, the order of those functions is not guaranteed
  * because of the following two reasons.
- * 1) All function calls to either feg or pipelined are async calls.
- * 2) ReportRuleStats() is an GRPC invoked by pipelined periodically no matter
+ * 1) All function calls to either feg or PipelineD are async calls.
+ * 2) ReportRuleStats() is an GRPC invoked by PipelineD periodically no matter
  *    if we have any alive session or not. The invoking of ReportRuleStats()
  *    is completely independent of both CreateSession() and EndSession().
  */
@@ -276,35 +229,35 @@ TEST_F(SessiondTest, end_to_end_success) {
     create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
         "rule3");
     create_credit_update_response(
-        "IMSI1", "1234", 1, 1536, create_response.mutable_credits()->Add());
+        IMSI1, SESSION_ID_1, 1, 1536, create_response.mutable_credits()->Add());
     create_credit_update_response(
-        "IMSI1", "1234", 2, 1024, create_response.mutable_credits()->Add());
+        IMSI1, SESSION_ID_1, 2, 1024, create_response.mutable_credits()->Add());
     // Expect create session with IMSI1
     EXPECT_CALL(
         *controller_mock,
-        CreateSession(testing::_, CheckCreateSession("IMSI1"), testing::_))
+        CreateSession(testing::_, CheckCreateSession(IMSI1), testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
             testing::SetArgPointee<2>(create_response),
             testing::Return(grpc::Status::OK)));
     EXPECT_CALL(
         *events_reporter,
-        session_created("IMSI1", testing::_, testing::_, testing::_))
+        session_created(IMSI1, testing::_, testing::_, testing::_))
         .Times(1);
 
-    // Temporary fix for pipelined client in sessiond introduces separate calls
+    // Temporary fix for PipelineD client in SessionD introduces separate calls
     // for static and dynamic rules. So here is the call for static rules.
     EXPECT_CALL(
         *pipelined_mock,
         ActivateFlows(
-            testing::_, CheckActivateFlows("IMSI1", 3, ipv4_addrs, ipv6_addrs),
+            testing::_, CheckActivateFlows(IMSI1, 3, ipv4_addrs, ipv6_addrs),
             testing::_))
         .Times(1);
     // Here is the call for dynamic rules, which in this case should be empty.
     EXPECT_CALL(
         *pipelined_mock,
         ActivateFlows(
-            testing::_, CheckActivateFlows("IMSI1", 0, ipv4_addrs, ipv6_addrs),
+            testing::_, CheckActivateFlows(IMSI1, 0, ipv4_addrs, ipv6_addrs),
             testing::_))
         .Times(1);
 
@@ -314,19 +267,20 @@ TEST_F(SessiondTest, end_to_end_success) {
         ActivateFlows(
             testing::_,
             CheckActivateFlowsForTunnIds(
-                "IMSI1", ipv4_addrs, ipv6_addrs, enb_teid, agw_teid),
+                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid),
             testing::_))
         .Times(1);
     // 3- ReportRuleStats
     EXPECT_CALL(
-        *events_reporter, session_updated("IMSI1", testing::_, testing::_))
+        *events_reporter, session_updated(IMSI1, testing::_, testing::_))
         .Times(1);
     CreditUsageUpdate expected_update;
     create_usage_update(
-        "IMSI1", 1, 1024, 512, CreditUsage::QUOTA_EXHAUSTED, &expected_update);
+        IMSI1, 1, 1024, 512, CreditUsage::QUOTA_EXHAUSTED, &expected_update);
     UpdateSessionResponse update_response;
     create_credit_update_response(
-        "IMSI1", "1234", 1, 1024, update_response.mutable_responses()->Add());
+        IMSI1, SESSION_ID_1, 1, 1024,
+        update_response.mutable_responses()->Add());
     // Expect update with IMSI1, charging key 1
     EXPECT_CALL(
         *controller_mock,
@@ -341,20 +295,20 @@ TEST_F(SessiondTest, end_to_end_success) {
     // Expect flows to be deactivated before final update is sent out
     EXPECT_CALL(
         *pipelined_mock,
-        DeactivateFlows(testing::_, CheckDeactivateFlows("IMSI1"), testing::_))
+        DeactivateFlows(testing::_, CheckDeactivateFlows(IMSI1), testing::_))
         .Times(1);
 
     SessionTerminateResponse terminate_response;
-    terminate_response.set_sid("IMSI1");
+    terminate_response.set_sid(IMSI1);
 
     EXPECT_CALL(
         *controller_mock,
-        TerminateSession(testing::_, CheckTerminate("IMSI1"), testing::_))
+        TerminateSession(testing::_, CheckTerminate(IMSI1), testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
             testing::SetArgPointee<2>(terminate_response),
             SetEndPromise(&end_promise, Status::OK)));
-    EXPECT_CALL(*events_reporter, session_terminated("IMSI1", testing::_))
+    EXPECT_CALL(*events_reporter, session_terminated(IMSI1, testing::_))
         .Times(1);
   }
 
@@ -366,7 +320,7 @@ TEST_F(SessiondTest, end_to_end_success) {
   grpc::ClientContext create_context;
   LocalCreateSessionResponse create_resp;
   LocalCreateSessionRequest request;
-  request.mutable_common_context()->mutable_sid()->set_id("IMSI1");
+  request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
   request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
   request.mutable_rat_specific_context()->mutable_lte_context()->set_bearer_id(
       5);
@@ -375,16 +329,16 @@ TEST_F(SessiondTest, end_to_end_success) {
   stub->CreateSession(&create_context, request, &create_resp);
 
   // The thread needs to be halted before proceeding to call ReportRuleStats()
-  // because the call to pipelined within CreateSession() is an async call,
-  // and the call to pipelined, ActivateFlows(), is assumed in this test
-  // to happend before the ReportRuleStats().
+  // because the call to PipelineD within CreateSession() is an async call,
+  // and the call to PipelineD, ActivateFlows(), is assumed in this test
+  // to happened before the ReportRuleStats().
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   // 2- UpdateTunnelIds
   grpc::ClientContext tun_update_context;
   UpdateTunnelIdsResponse tun_update_response;
   UpdateTunnelIdsRequest tun_update_request;
-  tun_update_request.mutable_sid()->set_id("IMSI1");
+  tun_update_request.mutable_sid()->set_id(IMSI1);
   tun_update_request.set_bearer_id(default_bearer);
   tun_update_request.set_enb_teid(enb_teid);
   tun_update_request.set_agw_teid(agw_teid);
@@ -396,10 +350,9 @@ TEST_F(SessiondTest, end_to_end_success) {
   // 3- ReportRuleStats
   RuleRecordTable table;
   auto record_list = table.mutable_records();
-  create_rule_record(
-      "IMSI1", ipv4_addrs, "rule1", 512, 512, record_list->Add());
-  create_rule_record("IMSI1", ipv6_addrs, "rule2", 512, 0, record_list->Add());
-  create_rule_record("IMSI1", ipv4_addrs, "rule3", 32, 32, record_list->Add());
+  create_rule_record(IMSI1, ipv4_addrs, "rule1", 512, 512, record_list->Add());
+  create_rule_record(IMSI1, ipv6_addrs, "rule2", 512, 0, record_list->Add());
+  create_rule_record(IMSI1, ipv4_addrs, "rule3", 32, 32, record_list->Add());
   grpc::ClientContext update_context;
   Void void_resp;
   stub->ReportRuleStats(&update_context, table, &void_resp);
@@ -414,7 +367,7 @@ TEST_F(SessiondTest, end_to_end_success) {
   LocalEndSessionResponse update_resp;
   grpc::ClientContext end_context;
   LocalEndSessionRequest end_request;
-  end_request.mutable_sid()->set_id("IMSI1");
+  end_request.mutable_sid()->set_id(IMSI1);
   stub->EndSession(&end_context, end_request, &update_resp);
 
   set_timeout(5000, &end_promise);
@@ -427,7 +380,9 @@ TEST_F(SessiondTest, end_to_end_success) {
  * 2) Report rule stats, charging key 1 goes over
  *    Expect update with charging key 1
  * 3) Cloud will respond with a timeout
- * 4) In next rule stats report, expect same update again, since last failed
+ * 4) Report rule stats for charging key 1 again
+ *    Since the last update failed, this will trigger another update
+ * 5) Expect update with usage from both (2) and (4).
  */
 TEST_F(SessiondTest, end_to_end_cloud_down) {
   std::promise<void> end_promise;
@@ -442,36 +397,41 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
     create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
         "rule3");
     create_credit_update_response(
-        "IMSI1", "1234", 1, 1025, create_response.mutable_credits()->Add());
+        IMSI1, SESSION_ID_1, 1, 1025, create_response.mutable_credits()->Add());
     create_credit_update_response(
-        "IMSI1", "1234", 2, 1024, create_response.mutable_credits()->Add());
+        IMSI1, SESSION_ID_1, 2, 1024, create_response.mutable_credits()->Add());
     // Expect create session with IMSI1
     EXPECT_CALL(
         *controller_mock,
-        CreateSession(testing::_, CheckCreateSession("IMSI1"), testing::_))
+        CreateSession(testing::_, CheckCreateSession(IMSI1), testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
             testing::SetArgPointee<2>(create_response),
             testing::Return(grpc::Status::OK)));
 
-    CreditUsageUpdate expected_update;
+    CreditUsageUpdate expected_update_fail;
     create_usage_update(
-        "IMSI1", 1, 512, 512, CreditUsage::QUOTA_EXHAUSTED, &expected_update);
+        IMSI1, 1, 512, 512, CreditUsage::QUOTA_EXHAUSTED,
+        &expected_update_fail);
     // Expect update with IMSI1, charging key 1, return timeout from cloud
     EXPECT_CALL(
         *controller_mock,
         UpdateSession(
-            testing::_, CheckSingleUpdate(expected_update), testing::_))
+            testing::_, CheckSingleUpdate(expected_update_fail), testing::_))
         .Times(1)
         .WillOnce(
             testing::Return(grpc::Status(grpc::DEADLINE_EXCEEDED, "timeout")));
 
-    auto second_update = expected_update;
-    second_update.mutable_usage()->set_bytes_rx(513);
-    // expect second update that's exactly the same but with an increased rx
+    CreditUsageUpdate expected_update_success;
+    create_usage_update(
+        IMSI1, 1, 1024, 1024, CreditUsage::QUOTA_EXHAUSTED,
+        &expected_update_success);
+    // second update should contain the original usage report + new usage
+    // report since the first update failed
     EXPECT_CALL(
         *controller_mock,
-        UpdateSession(testing::_, CheckSingleUpdate(second_update), testing::_))
+        UpdateSession(
+            testing::_, CheckSingleUpdate(expected_update_success), testing::_))
         .Times(1)
         .WillOnce(SetEndPromise(&end_promise, Status::OK));
   }
@@ -483,14 +443,14 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
   grpc::ClientContext create_context;
   LocalCreateSessionResponse create_resp;
   LocalCreateSessionRequest request;
-  request.mutable_common_context()->mutable_sid()->set_id("IMSI1");
+  request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
   request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
   stub->CreateSession(&create_context, request, &create_resp);
 
   RuleRecordTable table1;
   auto record_list = table1.mutable_records();
-  create_rule_record("IMSI1", "rule1", 0, 512, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 512, 0, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 0, 512, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 512, 0, record_list->Add());
   grpc::ClientContext update_context1;
   Void void_resp;
   stub->ReportRuleStats(&update_context1, table1, &void_resp);
@@ -502,8 +462,8 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
 
   RuleRecordTable table2;
   record_list = table2.mutable_records();
-  create_rule_record("IMSI1", "rule1", 1, 512, record_list->Add());
-  create_rule_record("IMSI1", "rule2", 512, 0, record_list->Add());
+  create_rule_record(IMSI1, "rule1", 512, 0, record_list->Add());
+  create_rule_record(IMSI1, "rule2", 0, 512, record_list->Add());
   grpc::ClientContext update_context2;
   stub->ReportRuleStats(&update_context2, table2, &void_resp);
 


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
###  Bug Description
The current implementation does SessionUpdates in a bit of a peculiar way. 
1. When PipelineD reports a data usage update, SessionD reads all sessions in the system into the `SessionMap`
2. SessionD does a bunch of logic to figure out if there are any updates to be sent to the FeG / any PipelineD updates that need to be executed on.
3.
   **a**. If there are no updates, the `SessionMap` is committed into the underlying `SessionStore`. End of logic here.
   **b**. If there are updates to be sent to FeG, we do not commit the `SessionMap` into `SessionStore`, but carry it into the UpdateSession GRPC response callback. 

4.  **a**. If the `UpdateSession` call is successful, we process the response and commit the `SessionMap` into `SessionStore`. End of logic here.
     **b**. If the `UpdateSession` call fails, say due to a timeout, we log error and we do **NOT** commit the `SessionMap`

Step 4.b is problematic because this means, we discard the PipelineD usage report from step 1. So regardless of the `UpdateSession` call result, we need to commit the changes. But before we can do this, there are some things in the SessionState that we need to rollback. 
For example, if the update was due to a REAUTH, then we would have set the reauth state to `REAUTH_PROCESSING` before we sent the update. This must be reverted back to `REAUTH_REQUIRED` so we can repeat the reporting.

### Solution
Defined enforcer level and session level `handle_entire_update_failure` functions to apply rollback logic to each affected update. 
After applying rollback logic, we will always update the session store.

## Test Plan
Fixed `end_to_end_cloud_down` unit test which tests this exact scenario but incorrectly. It now tests that if one update request fails, the next one will include usage from the previous update.
`make precommit_sm`
CWF Integration Test with custom FeG failure test case: https://github.com/magma/magma/pull/3744
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
