### PR TITLE
[SessionD] Only send update events for actually updated sessions

### DIFF
--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -199,4 +199,17 @@ std::string credit_validity_to_str(CreditValidity validity) {
   }
 }
 
+std::string event_trigger_to_str(EventTrigger event_trigger) {
+  switch (event_trigger) {
+    case USAGE_REPORT:
+      return "USAGE_REPORT";
+    case REVALIDATION_TIMEOUT:
+      return "REVALIDATION_TIMEOUT";
+    default:
+      std::ostringstream message;
+      message << "UNIMPLEMENTED EVENT TRIGGER: " << event_trigger;
+      return message.str();
+  }
+}
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/EnumToString.h
+++ b/lte/gateway/c/session_manager/EnumToString.h
@@ -37,4 +37,6 @@ std::string asr_result_to_str(AbortSessionResult_Code res);
 std::string wallet_state_to_str(SubscriberQuotaUpdate_Type state);
 
 std::string service_action_type_to_str(ServiceActionType action);
+
+std::string event_trigger_to_str(EventTrigger event_trigger);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.cpp
@@ -109,31 +109,31 @@ void LocalSessionManagerHandlerImpl::check_usage_for_reporting(
             static_cast<const google::protobuf::Message&>(response));
 
         // clear all the reporting flags
+        // TODO this could be done in one go with the SessionStore update below
         session_store_.set_and_save_reporting_flag(false, request, session_uc);
-
+        auto updates_by_session = UpdateRequestsBySession(request);
         if (!status.ok()) {
           MLOG(MERROR)
               << "UpdateSession request to FeG/PolicyDB failed entirely: "
               << status.error_message();
           enforcer_->handle_update_failure(
-              *session_map_ptr, UpdateRequestsBySession(request), session_uc);
+              *session_map_ptr, updates_by_session, session_uc);
           report_session_update_event_failure(
-              *session_map_ptr, session_uc, status.error_message());
-        } else {
-          enforcer_->update_session_credits_and_rules(
-              *session_map_ptr, response, session_uc);
-          report_session_update_event(*session_map_ptr, session_uc);
+              *session_map_ptr, updates_by_session, status.error_message());
+          session_store_.update_sessions(session_uc);
+          return;
         }
+        // Success!
+        enforcer_->update_session_credits_and_rules(
+            *session_map_ptr, response, session_uc);
+        report_session_update_event(*session_map_ptr, updates_by_session);
         session_store_.update_sessions(session_uc);
       });
 }
 
 bool LocalSessionManagerHandlerImpl::is_pipelined_restarted() {
   // If 0 also setup pipelined because it always waits for setup instructions
-  if (current_epoch_ == 0 || current_epoch_ != reported_epoch_) {
-    return true;
-  }
-  return false;
+  return (current_epoch_ == 0 || current_epoch_ != reported_epoch_);
 }
 
 void LocalSessionManagerHandlerImpl::handle_setup_callback(
@@ -241,7 +241,7 @@ void LocalSessionManagerHandlerImpl::CreateSession(
             failure_stream << "Received an invalid RAT type " << rat_type;
             std::string failure_msg = failure_stream.str();
             MLOG(MERROR) << failure_msg;
-            events_reporter_->session_create_failure(imsi, cfg, failure_msg);
+            events_reporter_->session_create_failure(cfg, failure_msg);
             send_local_create_session_response(
                 Status(grpc::FAILED_PRECONDITION, "Invalid RAT type"),
                 session_id, response_callback);
@@ -293,7 +293,7 @@ void LocalSessionManagerHandlerImpl::send_create_session(
                          << status.error_message();
           std::string failure_msg = failure_stream.str();
           MLOG(MERROR) << failure_msg;
-          events_reporter_->session_create_failure(imsi, cfg, failure_msg);
+          events_reporter_->session_create_failure(cfg, failure_msg);
         }
         send_local_create_session_response(status, session_id, cb);
       });
@@ -476,42 +476,40 @@ void LocalSessionManagerHandlerImpl::end_session(
 }
 
 void LocalSessionManagerHandlerImpl::report_session_update_event(
-    SessionMap& session_map, SessionUpdate& session_update) {
-  for (auto& it : session_map) {
-    auto imsi    = it.first;
-    auto session = it.second.begin();
-    while (session != it.second.end()) {
-      auto updates    = session_update.find(it.first)->second;
-      auto session_id = (*session)->get_session_id();
-      if (updates.find(session_id) != updates.end()) {
-        events_reporter_->session_updated(
-            imsi, session_id, (*session)->get_config());
-      }
-      ++session;
+    SessionMap& session_map, const UpdateRequestsBySession& updates) {
+  for (auto& it : updates.requests_by_id) {
+    const std::string &imsi = it.first.first, &session_id = it.first.second;
+    SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+    auto session_it = session_store_.find_session(session_map, criteria);
+    if (!session_it) {
+      MLOG(MWARNING) << "Not reporting session update event for " << session_id
+                     << " because it couldn't be found";
+      continue;
     }
+    events_reporter_->session_updated(
+        session_id, (**session_it)->get_config(), it.second);
   }
 }
 
 void LocalSessionManagerHandlerImpl::report_session_update_event_failure(
-    SessionMap& session_map, SessionUpdate& session_update,
+    SessionMap& session_map, const UpdateRequestsBySession& failed_updates,
     const std::string& failure_reason) {
-  for (auto& it : session_map) {
-    auto imsi    = it.first;
-    auto session = it.second.begin();
-    while (session != it.second.end()) {
-      auto updates    = session_update.find(it.first)->second;
-      auto session_id = (*session)->get_session_id();
-      if (updates.find(session_id) != updates.end()) {
-        std::ostringstream failure_stream;
-        failure_stream << "UpdateSession request to FeG/PolicyDB failed: "
-                       << failure_reason;
-        std::string failure_msg = failure_stream.str();
-        MLOG(MERROR) << failure_msg;
-        events_reporter_->session_update_failure(
-            imsi, session_id, (*session)->get_config(), failure_msg);
-      }
-      ++session;
+  for (auto& it : failed_updates.requests_by_id) {
+    const std::string &imsi = it.first.first, &session_id = it.first.second;
+    SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+    auto session_it = session_store_.find_session(session_map, criteria);
+    if (!session_it) {
+      MLOG(MWARNING) << "Not reporting session update failure event for "
+                     << session_id << " because it couldn't be found";
+      continue;
     }
+    std::ostringstream failure_stream;
+    failure_stream << "UpdateSession request to FeG/PolicyDB failed: "
+                   << failure_reason;
+    std::string failure_msg = failure_stream.str();
+    MLOG(MERROR) << failure_msg;
+    events_reporter_->session_update_failure(
+        session_id, (**session_it)->get_config(), it.second, failure_msg);
   }
 }
 

--- a/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
+++ b/lte/gateway/c/session_manager/LocalSessionManagerHandler.h
@@ -226,10 +226,10 @@ class LocalSessionManagerHandlerImpl : public LocalSessionManagerHandler {
       const std::uint64_t& epoch, Status status, SetupFlowsResult resp);
 
   void report_session_update_event(
-      SessionMap& session_map, SessionUpdate& session_update);
+      SessionMap& session_map, const UpdateRequestsBySession& request);
 
   void report_session_update_event_failure(
-      SessionMap& session_map, SessionUpdate& session_update,
+      SessionMap& session_map, const UpdateRequestsBySession& failed_update,
       const std::string& failure_reason);
 
   void send_local_create_session_response(

--- a/lte/gateway/c/session_manager/SessionEvents.h
+++ b/lte/gateway/c/session_manager/SessionEvents.h
@@ -35,16 +35,16 @@ class EventsReporter {
       const std::unique_ptr<SessionState>& session){};
 
   virtual void session_create_failure(
-      const std::string& imsi, const SessionConfig& session_context,
+      const SessionConfig& session_context,
       const std::string& failure_reason){};
 
   virtual void session_updated(
-      const std::string& imsi, const std::string& session_id,
-      const SessionConfig& session_context){};
+      const std::string& session_id, const SessionConfig& session_context,
+      const UpdateRequests& update_request){};
 
   virtual void session_update_failure(
-      const std::string& imsi, const std::string& session_id,
-      const SessionConfig& session_context,
+      const std::string& session_id, const SessionConfig& session_context,
+      const UpdateRequests& failed_request,
       const std::string& failure_reason){};
 
   virtual void session_terminated(
@@ -64,16 +64,15 @@ class EventsReporterImpl : public EventsReporter {
       const std::unique_ptr<SessionState>& session);
 
   void session_create_failure(
-      const std::string& imsi, const SessionConfig& session_context,
-      const std::string& failure_reason);
+      const SessionConfig& session_context, const std::string& failure_reason);
 
   void session_updated(
-      const std::string& imsi, const std::string& session_id,
-      const SessionConfig& session_context);
+      const std::string& session_id, const SessionConfig& session_context,
+      const UpdateRequests& update_request);
 
   void session_update_failure(
-      const std::string& imsi, const std::string& session_id,
-      const SessionConfig& session_context, const std::string& failure_reason);
+      const std::string& session_id, const SessionConfig& session_context,
+      const UpdateRequests& failed_request, const std::string& failure_reason);
 
   void session_terminated(
       const std::string& imsi, const std::unique_ptr<SessionState>& session);
@@ -84,6 +83,7 @@ class EventsReporterImpl : public EventsReporter {
   std::string get_spgw_ipv4(const SessionConfig& config);
   std::string get_user_location(const SessionConfig& config);
   std::string get_charging_characteristics(const SessionConfig& config);
+  folly::dynamic get_update_summary(const UpdateRequests& updates);
 
  private:
   AsyncEventdClient& eventd_client_;

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -167,8 +167,9 @@ MATCHER_P(CheckSubscriberQuotaUpdate, quota, "") {
   return update[0].update_type() == quota;
 }
 
-MATCHER_P(CheckCreateSession, imsi, "") {
+MATCHER_P2(CheckCreateSession, imsi, promise_p, "") {
   auto req = static_cast<const CreateSessionRequest*>(arg);
+  promise_p->set_value(req->session_id());
   return req->common_context().sid().id() == imsi;
 }
 

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -301,16 +301,15 @@ class MockEventsReporter : public EventsReporter {
       void(
           const std::string&, const std::string&, const SessionConfig&,
           const std::unique_ptr<SessionState>& session));
-  MOCK_METHOD3(
-      session_create_failure,
-      void(const std::string&, const SessionConfig&, const std::string&));
+  MOCK_METHOD2(
+      session_create_failure, void(const SessionConfig&, const std::string&));
   MOCK_METHOD3(
       session_updated,
-      void(const std::string&, const std::string&, const SessionConfig&));
+      void(const std::string&, const SessionConfig&, const UpdateRequests&));
   MOCK_METHOD4(
       session_update_failure, void(
-                                  const std::string&, const std::string&,
-                                  const SessionConfig&, const std::string&));
+                                  const std::string&, const SessionConfig&,
+                                  const UpdateRequests&, const std::string&));
   MOCK_METHOD2(
       session_terminated,
       void(const std::string&, const std::unique_ptr<SessionState>&));

--- a/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
+++ b/lte/gateway/c/session_manager/test/test_sessiond_integ.cpp
@@ -32,6 +32,7 @@
 #include "LocalEnforcer.h"
 
 #define SESSION_TERMINATION_TIMEOUT_MS 100
+#define DEFAULT_PIPELINED_EPOCH 1
 
 using grpc::Status;
 using ::testing::_;
@@ -63,7 +64,7 @@ class SessiondTest : public ::testing::Test {
 
     reporter = std::make_shared<SessionReporterImpl>(evb, test_channel);
     auto default_mconfig = get_default_mconfig();
-    monitor              = std::make_shared<LocalEnforcer>(
+    enforcer             = std::make_shared<LocalEnforcer>(
         reporter, rule_store, *session_store, pipelined_client,
         directoryd_client, events_reporter, spgw_client, nullptr,
         SESSION_TERMINATION_TIMEOUT_MS, 0, default_mconfig);
@@ -74,13 +75,13 @@ class SessiondTest : public ::testing::Test {
     session_manager = std::make_shared<LocalSessionManagerAsyncService>(
         local_service->GetNewCompletionQueue(),
         std::make_unique<LocalSessionManagerHandlerImpl>(
-            monitor, reporter.get(), directoryd_client, events_reporter,
+            enforcer, reporter.get(), directoryd_client, events_reporter,
             *session_store));
 
     proxy_responder = std::make_shared<SessionProxyResponderAsyncService>(
         local_service->GetNewCompletionQueue(),
         std::make_unique<SessionProxyResponderHandlerImpl>(
-            monitor, *session_store));
+            enforcer, *session_store));
 
     local_service->AddServiceToServer(session_manager.get());
     local_service->AddServiceToServer(proxy_responder.get());
@@ -93,18 +94,22 @@ class SessiondTest : public ::testing::Test {
     local_service->Start();
 
     std::thread([&]() {
-      std::cout << "Started cloud thread\n";
+      std::cout << "Started test_service thread\n";
       test_service->Start();
       test_service->WaitForShutdown();
     })
         .detach();
-    std::thread([&]() { pipelined_client->rpc_response_loop(); }).detach();
+    std::thread([&]() {
+      std::cout << "Started pipelined client response thread\n";
+      pipelined_client->rpc_response_loop();
+    })
+        .detach();
     std::thread([&]() { spgw_client->rpc_response_loop(); }).detach();
     std::thread([&]() {
-      std::cout << "Started monitor thread\n";
+      std::cout << "Started main event base thread\n";
       folly::EventBaseManager::get()->setEventBase(evb, 0);
-      monitor->attachEventBase(evb);
-      monitor->start();
+      enforcer->attachEventBase(evb);
+      enforcer->start();
     })
         .detach();
     std::thread([&]() {
@@ -127,8 +132,9 @@ class SessiondTest : public ::testing::Test {
   }
 
   virtual void TearDown() {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
     local_service->Stop();
-    monitor->stop();
+    enforcer->stop();
     reporter->stop();
     test_service->Stop();
     pipelined_client->stop();
@@ -162,20 +168,42 @@ class SessiondTest : public ::testing::Test {
   }
 
   // Timeout to not block test
-  void set_timeout(uint32_t ms, std::promise<void>* end_promise) {
+  void set_timeout(uint32_t ms, std::promise<void>* call_promise) {
     std::thread([&]() {
       std::this_thread::sleep_for(std::chrono::milliseconds(ms));
       EXPECT_TRUE(false);
-      end_promise->set_value();
+      call_promise->set_value();
     })
         .detach();
+  }
+
+  // This function should always be called at the beginning of the test to
+  // prevent unexpected SessionD <-> PipelineD syncing logic mid-test.
+  void send_empty_pipelined_table(
+      std::unique_ptr<LocalSessionManager::Stub>& stub) {
+    RuleRecordTable empty_table;
+    // epoch indicates the last PipelineD service start time
+    empty_table.set_epoch(DEFAULT_PIPELINED_EPOCH);
+    grpc::ClientContext context;
+    Void void_resp;
+    stub->ReportRuleStats(&context, empty_table, &void_resp);
+  }
+
+  void send_update_pipelined_table(
+      std::unique_ptr<LocalSessionManager::Stub>& stub, RuleRecordTable table) {
+    grpc::ClientContext context;
+    Void void_resp;
+    // The epoch should be consistent with the initial empty table to prevent
+    // SessionD from attempting to sync information.
+    table.set_epoch(DEFAULT_PIPELINED_EPOCH);
+    stub->ReportRuleStats(&context, table, &void_resp);
   }
 
  protected:
   folly::EventBase* evb;
   std::shared_ptr<MockCentralController> controller_mock;
   std::shared_ptr<MockPipelined> pipelined_mock;
-  std::shared_ptr<LocalEnforcer> monitor;
+  std::shared_ptr<LocalEnforcer> enforcer;
   std::shared_ptr<SessionReporterImpl> reporter;
   std::shared_ptr<LocalSessionManagerAsyncService> session_manager;
   std::shared_ptr<SessionProxyResponderAsyncService> proxy_responder;
@@ -192,6 +220,40 @@ class SessiondTest : public ::testing::Test {
 ACTION_P2(SetEndPromise, promise_p, status) {
   promise_p->set_value();
   return status;
+}
+
+ACTION_P(SetPromise, promise_p) {
+  promise_p->set_value();
+}
+
+// Take the SessionID from the request as it is generated internally
+ACTION_P2(SetCreateSessionResponse, first_quota, second_quota) {
+  auto req  = static_cast<const CreateSessionRequest*>(arg1);
+  auto res  = static_cast<CreateSessionResponse*>(arg2);
+  auto imsi = req->common_context().sid().id();
+  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule1");
+  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule2");
+  res->mutable_static_rules()->Add()->mutable_rule_id()->assign("rule3");
+  create_credit_update_response(
+      imsi, req->session_id(), 1, first_quota, res->mutable_credits()->Add());
+  create_credit_update_response(
+      imsi, req->session_id(), 2, second_quota, res->mutable_credits()->Add());
+}
+// Take the SessionID from the request as it is generated internally
+ACTION_P(SetUpdateSessionResponse, quota) {
+  auto req        = static_cast<const UpdateSessionRequest*>(arg1)->updates(0);
+  auto res        = static_cast<UpdateSessionResponse*>(arg2);
+  auto imsi       = req.common_context().sid().id();
+  auto session_id = req.session_id();
+  create_credit_update_response(
+      imsi, session_id, 1, quota, res->mutable_responses()->Add());
+}
+
+ACTION(SetSessionTerminateResponse) {
+  auto req = static_cast<const SessionTerminateRequest*>(arg1);
+  auto res = static_cast<SessionTerminateResponse*>(arg2);
+  res->set_sid(req->common_context().sid().id());
+  res->set_session_id(req->session_id());
 }
 
 /**
@@ -213,40 +275,44 @@ ACTION_P2(SetEndPromise, promise_p, status) {
  *    is completely independent of both CreateSession() and EndSession().
  */
 TEST_F(SessiondTest, end_to_end_success) {
-  std::promise<void> end_promise;
+  std::promise<void> create_promise, tunnel_promise, update_promise,
+      terminate_promise;
+  std::promise<std::string> session_id_promise;
   std::string ipv4_addrs  = "192.168.0.1";
   std::string ipv6_addrs  = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
   uint32_t default_bearer = 5;
   uint32_t enb_teid       = 10;
   uint32_t agw_teid       = 20;
+
+  auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+      "sessiond", ServiceRegistrySingleton::LOCAL);
+  auto stub = LocalSessionManager::NewStub(channel);
+
+  // Setup the SessionD/PipelineD epoch value by sending an empty record. This
+  // will prevent SessionD thinking that PipelineD has restarted mid-test.
+  send_empty_pipelined_table(stub);
+
   {
-    // 1- CreateSession
-    CreateSessionResponse create_response;
-    create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-        "rule1");
-    create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-        "rule2");
-    create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-        "rule3");
-    create_credit_update_response(
-        IMSI1, SESSION_ID_1, 1, 1536, create_response.mutable_credits()->Add());
-    create_credit_update_response(
-        IMSI1, SESSION_ID_1, 2, 1024, create_response.mutable_credits()->Add());
+    // 1- CreateSession Expectations
     // Expect create session with IMSI1
     EXPECT_CALL(
         *controller_mock,
-        CreateSession(testing::_, CheckCreateSession(IMSI1), testing::_))
+        CreateSession(
+            testing::_, CheckCreateSession(IMSI1, &session_id_promise),
+            testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
-            testing::SetArgPointee<2>(create_response),
+            SetCreateSessionResponse(1536, 1024),
             testing::Return(grpc::Status::OK)));
+
     EXPECT_CALL(
         *events_reporter,
         session_created(IMSI1, testing::_, testing::_, testing::_))
         .Times(1);
 
-    // Temporary fix for PipelineD client in SessionD introduces separate calls
-    // for static and dynamic rules. So here is the call for static rules.
+    // Temporary fix for PipelineD client in SessionD introduces separate
+    // calls for static and dynamic rules. So here is the call for static
+    // rules.
     EXPECT_CALL(
         *pipelined_mock,
         ActivateFlows(
@@ -259,64 +325,11 @@ TEST_F(SessiondTest, end_to_end_success) {
         ActivateFlows(
             testing::_, CheckActivateFlows(IMSI1, 0, ipv4_addrs, ipv6_addrs),
             testing::_))
-        .Times(1);
-
-    // 2- UpdateTunnelIds
-    EXPECT_CALL(
-        *pipelined_mock,
-        ActivateFlows(
-            testing::_,
-            CheckActivateFlowsForTunnIds(
-                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid),
-            testing::_))
-        .Times(1);
-    // 3- ReportRuleStats
-    EXPECT_CALL(
-        *events_reporter, session_updated(IMSI1, testing::_, testing::_))
-        .Times(1);
-    CreditUsageUpdate expected_update;
-    create_usage_update(
-        IMSI1, 1, 1024, 512, CreditUsage::QUOTA_EXHAUSTED, &expected_update);
-    UpdateSessionResponse update_response;
-    create_credit_update_response(
-        IMSI1, SESSION_ID_1, 1, 1024,
-        update_response.mutable_responses()->Add());
-    // Expect update with IMSI1, charging key 1
-    EXPECT_CALL(
-        *controller_mock,
-        UpdateSession(
-            testing::_, CheckSingleUpdate(expected_update), testing::_))
-        .Times(1)
         .WillOnce(testing::DoAll(
-            testing::SetArgPointee<2>(update_response),
-            testing::Return(grpc::Status::OK)));
-
-    // 4- EndSession
-    // Expect flows to be deactivated before final update is sent out
-    EXPECT_CALL(
-        *pipelined_mock,
-        DeactivateFlows(testing::_, CheckDeactivateFlows(IMSI1), testing::_))
-        .Times(1);
-
-    SessionTerminateResponse terminate_response;
-    terminate_response.set_sid(IMSI1);
-
-    EXPECT_CALL(
-        *controller_mock,
-        TerminateSession(testing::_, CheckTerminate(IMSI1), testing::_))
-        .Times(1)
-        .WillOnce(testing::DoAll(
-            testing::SetArgPointee<2>(terminate_response),
-            SetEndPromise(&end_promise, Status::OK)));
-    EXPECT_CALL(*events_reporter, session_terminated(IMSI1, testing::_))
-        .Times(1);
+            SetPromise(&create_promise), testing::Return(grpc::Status::OK)));
   }
 
-  auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-      "sessiond", ServiceRegistrySingleton::LOCAL);
-  auto stub = LocalSessionManager::NewStub(channel);
-
-  // 1- CreateSession
+  // 1- CreateSession Trigger
   grpc::ClientContext create_context;
   LocalCreateSessionResponse create_resp;
   LocalCreateSessionRequest request;
@@ -328,13 +341,30 @@ TEST_F(SessiondTest, end_to_end_success) {
   request.mutable_common_context()->set_ue_ipv6(ipv6_addrs);
   stub->CreateSession(&create_context, request, &create_resp);
 
+  // Block and wait until we process CreateSessionResponse, after which the
+  // SessionID value will be set.
+  std::string session_id = session_id_promise.get_future().get();
   // The thread needs to be halted before proceeding to call ReportRuleStats()
   // because the call to PipelineD within CreateSession() is an async call,
   // and the call to PipelineD, ActivateFlows(), is assumed in this test
   // to happened before the ReportRuleStats().
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  create_promise.get_future().get();
 
-  // 2- UpdateTunnelIds
+  {
+    // 2- UpdateTunnelIds Expectations
+    EXPECT_CALL(
+        *pipelined_mock,
+        ActivateFlows(
+            testing::_,
+            CheckActivateFlowsForTunnIds(
+                IMSI1, ipv4_addrs, ipv6_addrs, enb_teid, agw_teid),
+            testing::_))
+        .Times(1)
+        .WillOnce(testing::DoAll(
+            SetPromise(&tunnel_promise), testing::Return(grpc::Status::OK)));
+  }
+
+  // 2- UpdateTunnelIds Trigger
   grpc::ClientContext tun_update_context;
   UpdateTunnelIdsResponse tun_update_response;
   UpdateTunnelIdsRequest tun_update_request;
@@ -345,33 +375,78 @@ TEST_F(SessiondTest, end_to_end_success) {
   stub->UpdateTunnelIds(
       &tun_update_context, tun_update_request, &tun_update_response);
 
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the ActivateFlows call from UpdateTunnelIds has completed
+  tunnel_promise.get_future().get();
 
-  // 3- ReportRuleStats
+  {
+    InSequence s;
+    // 3 - PipelineD update + UpdateSession Expectations
+    CreditUsageUpdate expected_update;
+    create_usage_update(
+        IMSI1, 1, 1024, 512, CreditUsage::QUOTA_EXHAUSTED, &expected_update);
+
+    // Expect update with IMSI1, charging key 1
+    EXPECT_CALL(
+        *controller_mock,
+        UpdateSession(
+            testing::_, CheckSingleUpdate(expected_update), testing::_))
+        .Times(1)
+        .WillOnce(testing::DoAll(
+            SetUpdateSessionResponse(1024), SetPromise(&update_promise),
+            testing::Return(grpc::Status::OK)));
+
+    EXPECT_CALL(
+        *events_reporter, session_updated(session_id, testing::_, testing::_))
+        .Times(1);
+  }
+
+  // 3- ReportRuleStats Trigger
   RuleRecordTable table;
   auto record_list = table.mutable_records();
   create_rule_record(IMSI1, ipv4_addrs, "rule1", 512, 512, record_list->Add());
   create_rule_record(IMSI1, ipv6_addrs, "rule2", 512, 0, record_list->Add());
   create_rule_record(IMSI1, ipv4_addrs, "rule3", 32, 32, record_list->Add());
-  grpc::ClientContext update_context;
-  Void void_resp;
-  stub->ReportRuleStats(&update_context, table, &void_resp);
+  send_update_pipelined_table(stub, table);
 
   // The thread needs to be halted before proceeding to call EndSession()
   // because the call to FeG within ReportRuleStats() is an async call,
   // and the call to FeG, UpdateSession(), is assumed in this test
   // to happened before the EndSession().
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  // Wait until the ActivateFlows call from UpdateTunnelIds has completed
+  update_promise.get_future().get();
 
-  // 4- EndSession
-  LocalEndSessionResponse update_resp;
+  {
+    // 4- EndSession Expectations
+    // Expect flows to be deactivated before final update is sent out
+    EXPECT_CALL(
+        *pipelined_mock,
+        DeactivateFlows(testing::_, CheckDeactivateFlows(IMSI1), testing::_))
+        .Times(1);
+
+    EXPECT_CALL(*events_reporter, session_terminated(IMSI1, testing::_))
+        .Times(1);
+
+    EXPECT_CALL(
+        *controller_mock,
+        TerminateSession(testing::_, CheckTerminate(IMSI1), testing::_))
+        .Times(1)
+        .WillOnce(testing::DoAll(
+            SetSessionTerminateResponse(), SetPromise(&terminate_promise),
+            testing::Return(grpc::Status::OK)));
+  }
+
+  // 4- EndSession Trigger
+  LocalEndSessionResponse end_resp;
   grpc::ClientContext end_context;
   LocalEndSessionRequest end_request;
   end_request.mutable_sid()->set_id(IMSI1);
-  stub->EndSession(&end_context, end_request, &update_resp);
+  stub->EndSession(&end_context, end_request, &end_resp);
+  // The current logic for termination is that we wait until all rules for the
+  // session has finished reporting usage from PipelineD.
+  send_empty_pipelined_table(stub);
 
-  set_timeout(5000, &end_promise);
-  end_promise.get_future().get();
+  set_timeout(5000, &terminate_promise);
+  terminate_promise.get_future().get();
 }
 
 /**
@@ -385,30 +460,35 @@ TEST_F(SessiondTest, end_to_end_success) {
  * 5) Expect update with usage from both (2) and (4).
  */
 TEST_F(SessiondTest, end_to_end_cloud_down) {
-  std::promise<void> end_promise;
-  {
-    InSequence dummy;
+  std::promise<void> end_promise, failed_update_promise;
+  std::promise<std::string> session_id_promise;
+  auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
+      "sessiond", ServiceRegistrySingleton::LOCAL);
+  auto stub = LocalSessionManager::NewStub(channel);
+  // Setup the SessionD/PipelineD epoch value by sending an empty record. This
+  // will prevent SessionD thinking that PipelineD has restarted mid-test.
+  send_empty_pipelined_table(stub);
 
-    CreateSessionResponse create_response;
-    create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-        "rule1");
-    create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-        "rule2");
-    create_response.mutable_static_rules()->Add()->mutable_rule_id()->assign(
-        "rule3");
-    create_credit_update_response(
-        IMSI1, SESSION_ID_1, 1, 1025, create_response.mutable_credits()->Add());
-    create_credit_update_response(
-        IMSI1, SESSION_ID_1, 2, 1024, create_response.mutable_credits()->Add());
+  {
     // Expect create session with IMSI1
     EXPECT_CALL(
         *controller_mock,
-        CreateSession(testing::_, CheckCreateSession(IMSI1), testing::_))
+        CreateSession(
+            testing::_, CheckCreateSession(IMSI1, &session_id_promise),
+            testing::_))
         .Times(1)
         .WillOnce(testing::DoAll(
-            testing::SetArgPointee<2>(create_response),
+            SetCreateSessionResponse(1025, 1024),
             testing::Return(grpc::Status::OK)));
+  }
+  grpc::ClientContext create_context;
+  LocalCreateSessionResponse create_resp;
+  LocalCreateSessionRequest request;
+  request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
+  request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
+  stub->CreateSession(&create_context, request, &create_resp);
 
+  {
     CreditUsageUpdate expected_update_fail;
     create_usage_update(
         IMSI1, 1, 512, 512, CreditUsage::QUOTA_EXHAUSTED,
@@ -421,7 +501,19 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
         .Times(1)
         .WillOnce(
             testing::Return(grpc::Status(grpc::DEADLINE_EXCEEDED, "timeout")));
+  }
 
+  RuleRecordTable table1;
+  create_rule_record(IMSI1, "rule1", 0, 512, table1.mutable_records()->Add());
+  create_rule_record(IMSI1, "rule2", 512, 0, table1.mutable_records()->Add());
+  send_update_pipelined_table(stub, table1);
+
+  // Need to wait for cloud response to come back and usage monitor to reset.
+  // Unfortunately, there is no simple way to wait for response to come back
+  // then callback to be called in event base
+  std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+  {
     CreditUsageUpdate expected_update_success;
     create_usage_update(
         IMSI1, 1, 1024, 1024, CreditUsage::QUOTA_EXHAUSTED,
@@ -436,36 +528,10 @@ TEST_F(SessiondTest, end_to_end_cloud_down) {
         .WillOnce(SetEndPromise(&end_promise, Status::OK));
   }
 
-  auto channel = ServiceRegistrySingleton::Instance()->GetGrpcChannel(
-      "sessiond", ServiceRegistrySingleton::LOCAL);
-  auto stub = LocalSessionManager::NewStub(channel);
-
-  grpc::ClientContext create_context;
-  LocalCreateSessionResponse create_resp;
-  LocalCreateSessionRequest request;
-  request.mutable_common_context()->mutable_sid()->set_id(IMSI1);
-  request.mutable_common_context()->set_rat_type(RATType::TGPP_LTE);
-  stub->CreateSession(&create_context, request, &create_resp);
-
-  RuleRecordTable table1;
-  auto record_list = table1.mutable_records();
-  create_rule_record(IMSI1, "rule1", 0, 512, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 512, 0, record_list->Add());
-  grpc::ClientContext update_context1;
-  Void void_resp;
-  stub->ReportRuleStats(&update_context1, table1, &void_resp);
-
-  // Need to wait for cloud response to come back and usage monitor to reset.
-  // Unfortunately, there is no simple way to wait for response to come back
-  // then callback to be called in event base
-  std::this_thread::sleep_for(std::chrono::milliseconds(100));
-
   RuleRecordTable table2;
-  record_list = table2.mutable_records();
-  create_rule_record(IMSI1, "rule1", 512, 0, record_list->Add());
-  create_rule_record(IMSI1, "rule2", 0, 512, record_list->Add());
-  grpc::ClientContext update_context2;
-  stub->ReportRuleStats(&update_context2, table2, &void_resp);
+  create_rule_record(IMSI1, "rule1", 512, 0, table2.mutable_records()->Add());
+  create_rule_record(IMSI1, "rule2", 0, 512, table2.mutable_records()->Add());
+  send_update_pipelined_table(stub, table2);
 
   set_timeout(5000, &end_promise);
   end_promise.get_future().get();


### PR DESCRIPTION
## Summary
We have two event logs session_updated and session_update_failure to indicate the GRPC call
session_updated: indicates GRPC call to FeG/PolicyDB for session update was successful.
session_update_failure: indicates the GRPC call to FeG/PolicyDB failed entirely. If the update failed due to an OCS/PCRF error, this event log is not used.
For each update request, we send an event log for each session affected. The issue here is that the logic to decide which sessions were affected is faulty. Instead of only reporting events for the sessions involved in the update, we were sending events for all sessions in the system.

The change here is to use the original update request, indexed by IMSI+SessionID, to figure out which sessions to send events for.
The PR also includes a refactor in the integration test to appropriately assert on the update event log. I've also split up the expectations into chunks so that the test is a bit more readable. 

## Test Plan
Ran the unit tests multiple times to make sure the `test_sessiond_integ` is not, (or noticeably), flaky. (Usually can get to ~100 iterations before we hit the known `SessionReporterTest.test_single_call` flaky failure. 
```
#!/bin/bash
for run in {1..200}
do
make test_session_manager && sleep 1
if [ $? -eq 0 ]
then
  echo "Successfully ran test!"
else
  echo "$run"
  echo "FAILED"
  exit
fi
done
```
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
