### PR TITLE
Updated Orcr8r install with terraform pre-requisites

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.2.0/orc8r/upgrade_1_2.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/orc8r/upgrade_1_2.md
@@ -29,9 +29,8 @@ The v1.1 to v1.2 upgrade does not support Helm-only downgrades. That is,
 once you perform the Orchestrator data migrations, v1.1 deployments will lose
 access to a subset of the migrated data.
 
-Ensure that all Terraform state files (I.e. terraform.tfstate) are located
- within your working directory before proceeding. 
-
+If you are using local Terraform state (the default), ensure all Terraform state files (i.e. [`terraform.tfstate`](https://www.terraform.io/docs/state/index.html)) are located in your working directory before proceeding. This means `terraform show` should list existing state (rather than outputting `No state`).
+ 
 ## Helm 3 Upgrade
 
 Orchestrator v1.2 requires an upgrade from Helm 2 to Helm 3. Helm provides a

--- a/docs/docusaurus/versioned_docs/version-1.2.0/orc8r/upgrade_1_2.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/orc8r/upgrade_1_2.md
@@ -29,6 +29,9 @@ The v1.1 to v1.2 upgrade does not support Helm-only downgrades. That is,
 once you perform the Orchestrator data migrations, v1.1 deployments will lose
 access to a subset of the migrated data.
 
+Ensure that all Terraform state files (I.e. terraform.tfstate) are located
+ within your working directory before proceeding. 
+
 ## Helm 3 Upgrade
 
 Orchestrator v1.2 requires an upgrade from Helm 2 to Helm 3. Helm provides a

--- a/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/upgrade_1_3.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/upgrade_1_3.md
@@ -27,8 +27,7 @@ Build and publish the application containers on the head of the release branch
 by following the documentation, and package and upload version `1.4.36` of the
 orc8r Helm chart as well.
 
-Ensure that all Terraform state files (I.e. terraform.tfstate) are located
- within your working directory before proceeding. 
+If you are using local Terraform state (the default), ensure all Terraform state files (i.e. [`terraform.tfstate`](https://www.terraform.io/docs/state/index.html)) are located in your working directory before proceeding. This means `terraform show` should list existing state (rather than outputting `No state`). 
 
 ## Upgrade Terraform Modules
 

--- a/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/upgrade_1_3.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/upgrade_1_3.md
@@ -27,6 +27,9 @@ Build and publish the application containers on the head of the release branch
 by following the documentation, and package and upload version `1.4.36` of the
 orc8r Helm chart as well.
 
+Ensure that all Terraform state files (I.e. terraform.tfstate) are located
+ within your working directory before proceeding. 
+
 ## Upgrade Terraform Modules
 
 Set the `source` values for each of the Orchestrator modules in your root

--- a/docs/readmes/orc8r/upgrade_1_2.md
+++ b/docs/readmes/orc8r/upgrade_1_2.md
@@ -28,6 +28,9 @@ The v1.1 to v1.2 upgrade does not support Helm-only downgrades. That is,
 once you perform the Orchestrator data migrations, v1.1 deployments will lose
 access to a subset of the migrated data.
 
+If you are using local Terraform state (the default), ensure all Terraform state files (i.e. [`terraform.tfstate`](https://www.terraform.io/docs/state/index.html)) are located in your working directory before proceeding. This means `terraform show` should list existing state (rather than outputting `No state`).
+
+
 ## Helm 3 Upgrade
 
 Orchestrator v1.2 requires an upgrade from Helm 2 to Helm 3. Helm provides a

--- a/docs/readmes/orc8r/upgrade_1_3.md
+++ b/docs/readmes/orc8r/upgrade_1_3.md
@@ -26,6 +26,8 @@ Build and publish the application containers on the head of the release branch
 by following the documentation, and package and upload version `1.4.36` of the
 orc8r Helm chart as well.
 
+If you are using local Terraform state (the default), ensure all Terraform state files (i.e. [`terraform.tfstate`](https://www.terraform.io/docs/state/index.html)) are located in your working directory before proceeding. This means `terraform show` should list existing state (rather than outputting `No state`).
+
 ## Upgrade Terraform Modules
 
 Set the `source` values for each of the Orchestrator modules in your root

--- a/docs/readmes/orc8r/upgrade_intro.md
+++ b/docs/readmes/orc8r/upgrade_intro.md
@@ -23,3 +23,5 @@ Before every upgrade, we strongly suggest taking a DB snapshot in case you
 decide that you need to roll back your application. While the application
 components are stateless and can be upgraded or downgraded at any time, the
 data migrations that come with each release are not always reversible.
+
+If you are using local Terraform state (the default), ensure all Terraform state files (i.e. [`terraform.tfstate`](https://www.terraform.io/docs/state/index.html)) are located in your working directory before proceeding. This means `terraform show` should list existing state (rather than outputting `No state`).


### PR DESCRIPTION
>>>>>> Updated orc8r install pre-reqs to include having terraform in the working directory

Signed-off-by: Jared Mullane <jmullane@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Partners were struggling to have their Terraform state files in their working directory. Added a line to make it clear. 

## Test Plan

Ran docusaurus script to test locally. 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
