### PR TITLE
[feg] fixed transient codes not being sent

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -1,4 +1,4 @@
-// +build all gy
+// build all gy
 
 /*
  * Copyright 2020 The Magma Authors.
@@ -66,6 +66,36 @@ func ocsTestSetup(t *testing.T) (*TestRunner, *RuleManager, *cwfprotos.UEConfig)
 
 	// PCRF Setup: apply a dynamic rule that points to the static rules above
 	err = ruleManager.AddRulesToPCRF(ue.Imsi, []string{"static-pass-all-ocs1", "static-pass-all-ocs2"}, nil)
+	assert.NoError(t, err)
+	return tr, ruleManager, ues[0]
+}
+
+func ocsTestSetupSingleRule(t *testing.T) (*TestRunner, *RuleManager, *cwfprotos.UEConfig) {
+	tr := NewTestRunner(t)
+	ruleManager, err := NewRuleManager()
+	assert.NoError(t, err)
+
+	ues, err := tr.ConfigUEs(1)
+	assert.NoError(t, err)
+	setNewOCSConfig(
+		&fegprotos.OCSConfig{
+			MaxUsageOctets: &fegprotos.Octets{TotalOctets: GyMaxUsageBytes},
+			MaxUsageTime:   GyMaxUsageTime,
+			ValidityTime:   GyValidityTime,
+			UseMockDriver:  true,
+		},
+	)
+
+	ue := ues[0]
+
+	// set a pass all rule to be installed by ocs with a rating group 1
+	err = ruleManager.AddStaticPassAllToDB("static-pass-all-ocs1", "", 1, models.PolicyRuleConfigTrackingTypeONLYOCS, 10)
+	assert.NoError(t, err)
+
+	tr.WaitForPoliciesToSync()
+
+	// PCRF Setup: apply a dynamic rule that points to the static rules above
+	err = ruleManager.AddRulesToPCRF(ue.Imsi, []string{"static-pass-all-ocs1"}, nil)
 	assert.NoError(t, err)
 	return tr, ruleManager, ues[0]
 }
@@ -390,7 +420,7 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 		},
 		IsFinalCredit:       true,
 		FinalUnitIndication: &finalUnitIndication,
-		ResultCode:          2001,
+		ResultCode:          diameter.DiameterCreditLimitReached,
 	}
 
 	initRequest := protos.NewGyCCRequest(imsi, protos.CCRequestType_INITIAL)
@@ -473,7 +503,6 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 	fmt.Println("wait for flows to get deactivated")
 	time.Sleep(3 * time.Second)
 	tr.AssertAllGyExpectationsMetNoError()
-
 }
 
 func TestGyCreditUpdateCommandLevelFail(t *testing.T) {
@@ -751,21 +780,152 @@ func TestGyCreditExhaustionRestrict(t *testing.T) {
 	// Check that UE mac flow was not removed and data passed
 	tr.AssertPolicyUsage(imsi, "static-pass-all-ocs2", uint64(math.Round(1.8*MegaBytes)), 3*MegaBytes+Buffer)
 
+	// trigger disconnection
+	tr.DisconnectAndAssertSuccess(imsi)
+	fmt.Println("wait for flows to get deactivated")
+	time.Sleep(3 * time.Second)
+}
+
+// - Send a CCA-I with valid credit for a RG but with 4012 error code (transient)
+// - Assert that UE flows for that RG are deleted
+// - Generate an additional 2M traffic and assert that only Gy flows matched.
+// - Assert that Redirect flows are installed
+// - Send a Charging ReAuth request to top up quota and assert that the
+//   response is successful
+// - Assert that CCR-U was is generated
+// - Generate 2M traffic and assert that UE flows are reinstalled for RG
+//   and traffic goes through them.
+func TestGyCreditTransientErrorRestrict(t *testing.T) {
+	fmt.Println("\nRunning TestGyCreditExhaustionRestrict...")
+
+	tr, ruleManager, ue := ocsTestSetupSingleRule(t)
+	imsi := ue.GetImsi()
+	defer func() {
+		// clear hss, ocs, and pcrf
+		assert.NoError(t, clearPCRFMockDriver())
+		assert.NoError(t, clearOCSMockDriver())
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
+	provisionRestrictRules(t, tr, ruleManager)
+
+	finalUnitIndication := fegprotos.FinalUnitIndication{
+		FinalUnitAction: fegprotos.FinalUnitAction_Restrict,
+		RestrictRules:   []string{"restrict-pass-user", "restrict-deny-all"},
+	}
+	quotaGrant_Init := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 0 * MegaBytes,
+		},
+		IsFinalCredit:       true,
+		FinalUnitIndication: &finalUnitIndication,
+		ResultCode:          diameter.DiameterCreditLimitReached,
+	}
+
+	// CCR-I
+	initRequest := protos.NewGyCCRequest(imsi, protos.CCRequestType_INITIAL)
+	initAnswer := protos.NewGyCCAnswer(diam.Success).
+		SetQuotaGrant(quotaGrant_Init)
+	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	// reauth
+	expectedMSCC_forReauth := &protos.MultipleServicesCreditControl{
+		RatingGroup: 1,
+		UpdateType:  int32(gy.FORCED_REAUTHORISATION),
+	}
+	reauthRequest := protos.NewGyCCRequest(imsi, protos.CCRequestType_UPDATE).
+		SetMSCC(expectedMSCC_forReauth)
+
+	quotaGrant_Reauth := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 10 * MegaBytes,
+		},
+		IsFinalCredit:       true,
+		FinalUnitIndication: &finalUnitIndication,
+		ResultCode:          diam.Success,
+	}
+
+	reauthAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant_Reauth)
+	reauthExpectation := protos.NewGyCreditControlExpectation().Expect(reauthRequest).
+		Return(reauthAnswer)
+
+	expectations := []*protos.GyCreditControlExpectation{initExpectation, reauthExpectation}
+	assert.NoError(t, setOCSExpectations(expectations, nil))
+	tr.AuthenticateAndAssertSuccess(imsi)
+
+	// by this point we should be already redirected since credit was suspended
+
+	// Update directoryd record to include client IP
+	err := updateDirectorydRecord("IMSI"+imsi, "ipv4_addr", TrafficCltIP)
+	assert.NoError(t, err)
+
+	tr.WaitForEnforcementStatsToSync()
+
 	// Wait for service deactivation
+	time.Sleep(3 * time.Second)
+
+	// we need to generate traffic and validate it goes through restrict rule
+	req := &cwfprotos.GenTrafficRequest{
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "2M"},
+		Timeout: 20,
+	}
+	_, err = tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	tr.WaitForEnforcementStatsToSync()
+
+	// Check that UE mac flow was not removed and flow data hit restrict rule
+	tr.AssertPolicyUsage(imsi, "restrict-pass-user", uint64(math.Round(1.5*MegaBytes)), 3*MegaBytes+Buffer)
+	// check static rule is gone
+	policyUsage, err := tr.GetPolicyUsage()
+	assert.Nil(t, policyUsage["IMSI"+imsi]["static-pass-all-ocs1"], fmt.Sprintf("Policy usage record2 for imsi: %v was NOT removed", imsi))
+
+	// Send ReAuth Request to update quota
+	raa, err := sendChargingReAuthRequestEntireSession(imsi)
+	assert.NoError(t, err)
+	assert.Eventually(t, tr.WaitForChargingReAuthToProcess(raa, imsi), time.Minute, 2*time.Second)
+
+	// Check ReAuth success
+	assert.Equal(t, diam.LimitedSuccess, int(raa.ResultCode))
+
+	// Assert that a CCR-I and reauth were sent
+	tr.AssertAllGyExpectationsMetNoError()
+
+	// Wait for service activation
+	time.Sleep(3 * time.Second)
+
+	req = &cwfprotos.GenTrafficRequest{
+		Imsi:    imsi,
+		Volume:  &wrappers.StringValue{Value: "2M"},
+		Timeout: 20,
+	}
+	_, err = tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	tr.WaitForEnforcementStatsToSync()
+
+	// TODO: uncoment once we fix passing the ip to pipelined for cwf
+	// Check that UE mac flow was not removed and data passed
+	//tr.AssertPolicyUsage(imsi, "static-pass-all-ocs1", uint64(math.Round(1.5*MegaBytes)), 3*MegaBytes+Buffer)
+	//assert.Nil(t, policyUsage["IMSI"+imsi]["restrict-pass-user"], fmt.Sprintf("Policy usage restrict-pass-user for imsi: %v was NOT removed", imsi))
+
+	// trigger disconnection
+	tr.DisconnectAndAssertSuccess(imsi)
+	fmt.Println("wait for flows to get deactivated")
 	time.Sleep(3 * time.Second)
 }
 
 // - Set an expectation for a CCR-I to be sent up to OCS, to which it will
-//   respond with a quota grant of 4M.
-//   Generate traffic and assert the CCR-I is received.
+//   respond with a quota grant of 4M with two rules.
+// - Generate traffic and assert the CCR-I is received.
 // - Set an expectation for a CCR-U with >80% of data usage to be sent up to
 // 	 OCS, to which it will response with an ERROR CODE
-// - Generate traffic over 80% and under 100% to make sure sessiond triggers an update but that
-//   we don't go over 100% and cause a termination due to quota exhaustion instead of due to
-//   ERROR CODE
-// - Assert that UE flows are deleted.
-// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
-func TestGyWithErrorCode(t *testing.T) {
+// - Send an CCA-U with a 4012 code transient failure which should trigger suspend that credit
+// - Assert that UE flows for one rule are delete.
+// - Assert that UE flows for the other rule are still valid
+func TestGyWithTransientErrorCode(t *testing.T) {
 	fmt.Println("\nRunning TestGyWithErrorCode...")
 
 	tr, ruleManager, ue := ocsTestSetup(t)
@@ -790,9 +950,102 @@ func TestGyWithErrorCode(t *testing.T) {
 	initAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant)
 	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
 
+	// grant with DiameterCreditLimitReached
+	quotaGrantCreditLimitReached := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 0 * MegaBytes,
+		},
+		IsFinalCredit: false,
+		ResultCode:    diameter.DiameterCreditLimitReached,
+	}
+
 	// CCR-U  with ERROR CODE 4012 (DiameterCreditLimitReached)
 	updateRequest1 := protos.NewGyCCRequest(imsi, protos.CCRequestType_UPDATE)
-	updateAnswer1 := protos.NewGyCCAnswer(diameter.DiameterCreditLimitReached)
+	updateAnswer1 := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrantCreditLimitReached)
+	updateExpectation1 := protos.NewGyCreditControlExpectation().Expect(updateRequest1).Return(updateAnswer1)
+
+	// Load expectations into OCS
+	expectations := []*protos.GyCreditControlExpectation{initExpectation, updateExpectation1}
+	assert.NoError(t, setOCSExpectations(expectations, nil)) // We only expect one single CCR-U to be sent
+	tr.AuthenticateAndAssertSuccess(imsi)
+
+	// we need to generate over 80% but less than 100%  trigger a CCR update without triggering termination
+	req := &cwfprotos.GenTrafficRequest{
+		Imsi:   imsi,
+		Volume: &wrappers.StringValue{Value: "4.6M"},
+	}
+	_, err := tr.GenULTraffic(req)
+	assert.NoError(t, err)
+	tr.WaitForEnforcementStatsToSync()
+
+	// Wait for flow deletion due to quota exhaustion
+	tr.WaitForEnforcementStatsToSync()
+
+	// Check that one of the flows is removed but session is not terminated
+	preSuspension_recordsBySubID, err := tr.GetPolicyUsage()
+	assert.NoError(t, err)
+	preSuspensionRecord1 := preSuspension_recordsBySubID["IMSI"+imsi]["static-pass-all-ocs1"]
+	assert.NotNil(t, preSuspensionRecord1, fmt.Sprintf("Policy usage record1 for imsi: %v was removed", imsi))
+
+	// TODO: uncoment once we fix passing the ip to pipelined for cwf
+	//preSuspensionRecord2 := preSuspension_recordsBySubID["IMSI"+imsi]["static-pass-all-ocs2"]
+	//assert.Nil(t, preSuspensionRecord2, fmt.Sprintf("Policy usage record2 for imsi: %v was NOT removed", imsi))
+
+	// Assert that we saw a Terminate request
+	tr.AssertAllGyExpectationsMetNoError()
+
+	// trigger disconnection
+	tr.DisconnectAndAssertSuccess(imsi)
+	fmt.Println("wait for flows to get deactivated")
+	time.Sleep(3 * time.Second)
+}
+
+// - Set an expectation for a CCR-I to be sent up to OCS, to which it will
+//   respond with a quota grant of 4M.
+//   Generate traffic and assert the CCR-I is received.
+// - Generate traffic over 80% and under 100% not to trigger termination
+// - Send an CCA-U with a 5xxx code which should trigger termination
+// - Assert that UE flows are deleted.
+// - Expect a CCR-T, trigger a UE disconnect, and assert the CCR-T is received.
+func TestGyWithPermanetErrorCode(t *testing.T) {
+	fmt.Println("\nRunning TestGyWithErrorCode...")
+
+	tr, ruleManager, ue := ocsTestSetup(t)
+	imsi := ue.GetImsi()
+	defer func() {
+		// Clear hss, ocs, and pcrf
+		assert.NoError(t, clearOCSMockDriver())
+		assert.NoError(t, ruleManager.RemoveInstalledRules())
+		assert.NoError(t, tr.CleanUp())
+	}()
+
+	// CCR-I
+	quotaGrant := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 5 * MegaBytes,
+		},
+		IsFinalCredit: false,
+		ResultCode:    diam.Success,
+	}
+	initRequest := protos.NewGyCCRequest(imsi, protos.CCRequestType_INITIAL)
+	initAnswer := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrant)
+	initExpectation := protos.NewGyCreditControlExpectation().Expect(initRequest).Return(initAnswer)
+
+	// grant with any 5xxx error (permanent error)
+	quotaGrantCreditLimitReached := &fegprotos.QuotaGrant{
+		RatingGroup: 1,
+		GrantedServiceUnit: &fegprotos.Octets{
+			TotalOctets: 0 * MegaBytes,
+		},
+		IsFinalCredit: false,
+		ResultCode:    diameter.DiameterRatingFailed,
+	}
+
+	// CCR-U  with ERROR CODE 4012 (DiameterCreditLimitReached)
+	updateRequest1 := protos.NewGyCCRequest(imsi, protos.CCRequestType_UPDATE)
+	updateAnswer1 := protos.NewGyCCAnswer(diam.Success).SetQuotaGrant(quotaGrantCreditLimitReached)
 	updateExpectation1 := protos.NewGyCreditControlExpectation().Expect(updateRequest1).Return(updateAnswer1)
 
 	// CCR-T

--- a/cwf/gateway/integ_tests/service_wrappers.go
+++ b/cwf/gateway/integ_tests/service_wrappers.go
@@ -395,6 +395,12 @@ func getCreditOnOCSPerInstance(instanceName, imsi string) (*fegprotos.CreditInfo
 	return cli.GetCredits(context.Background(), &lteprotos.SubscriberID{Id: imsi})
 }
 
+// sendChargingReAuthRequestEntireSession triggers a RAR from OCS to Sessiond for all
+// the charging groups on a session (inclding the suspended ones)
+func sendChargingReAuthRequestEntireSession(imsi string) (*fegprotos.ChargingReAuthAnswer, error) {
+	return sendChargingReAuthRequestPerInstance(MockOCSRemote, imsi, 0)
+}
+
 // sendChargingReAuthRequest triggers a RAR from OCS to Sessiond
 // Input: ChargingReAuthTarget
 func sendChargingReAuthRequest(imsi string, ratingGroup uint32) (*fegprotos.ChargingReAuthAnswer, error) {
@@ -406,8 +412,7 @@ func sendChargingReAuthRequestPerInstance(instanceName string, imsi string, rati
 	if err != nil {
 		return nil, err
 	}
-	raa, err := cli.ReAuth(context.Background(),
-		&fegprotos.ChargingReAuthTarget{Imsi: imsi, RatingGroup: ratingGroup})
+	raa, err := cli.ReAuth(context.Background(), &fegprotos.ChargingReAuthTarget{Imsi: imsi, RatingGroup: ratingGroup})
 	return raa, err
 }
 

--- a/feg/cloud/go/services/feg/obsidian/models/validate.go
+++ b/feg/cloud/go/services/feg/obsidian/models/validate.go
@@ -107,4 +107,3 @@ func (m *SubscriptionProfile) ValidateModel() error {
 	}
 	return nil
 }
-

--- a/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
+++ b/feg/gateway/services/session_proxy/credit_control/gy/gy_client.go
@@ -183,6 +183,7 @@ func (gyClient *GyClient) DisableConnections(period time.Duration) {
 // messages received from the OCS
 func registerReAuthHandler(reAuthHandler ChargingReAuthHandler, diamClient *diameter.Client) {
 	reqHandler := func(conn diam.Conn, message *diam.Message) {
+		glog.V(2).Infof("Received Gy reauth message:\n%s\n", message)
 		rar := &ChargingReAuthRequest{}
 		if err := message.Unmarshal(rar); err != nil {
 			glog.Errorf("Received unparseable RAR over Gy %s\n%s", message, err)
@@ -192,6 +193,7 @@ func registerReAuthHandler(reAuthHandler ChargingReAuthHandler, diamClient *diam
 			raa := reAuthHandler(rar)
 			raaMsg := createReAuthAnswerMessage(message, raa)
 			raaMsg = diamClient.AddOriginAVPsToMessage(raaMsg)
+			glog.V(2).Infof("Sending (responding) Gy reauth message:\n%s\n", raaMsg)
 			_, err := raaMsg.WriteToWithRetry(conn, diamClient.Retries())
 			if err != nil {
 				glog.Errorf(

--- a/feg/gateway/services/session_proxy/servicers/credits.go
+++ b/feg/gateway/services/session_proxy/servicers/credits.go
@@ -285,7 +285,7 @@ func getSingleCreditResponseFromCCA(
 		ChargingKey: receivedCredit.RatingGroup,
 		Credit:      getSingleChargingCreditFromCCA(receivedCredit),
 		TgppCtx:     tgppCtx,
-		ResultCode:  answer.ResultCode,
+		ResultCode:  receivedCredit.ResultCode, //answer.ResultCode is returned in case of general failure
 	}
 
 	if receivedCredit.ServiceIdentifier != nil {

--- a/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
+++ b/feg/gateway/services/testcore/ocs/mock_ocs/ocs.go
@@ -283,7 +283,7 @@ func (srv *OCSDiamServer) ReAuth(
 	}
 	done := make(chan *gy.ChargingReAuthAnswer)
 	srv.mux.Handle(diam.RAA, handleRAA(done))
-	err := sendRAR(account.CurrentState, &target.RatingGroup, srv.mux.Settings())
+	err := sendRAR(account.CurrentState, target.RatingGroup, srv.mux.Settings())
 	if err != nil {
 		glog.Errorf("Error sending RaR for target IMSI=%v, RG=%v: %v", target.GetImsi(), target.GetRatingGroup(), err)
 		return nil, err
@@ -344,7 +344,7 @@ func (srv *OCSDiamServer) AbortSession(
 	}
 }
 
-func sendRAR(state *SubscriberSessionState, ratingGroup *uint32, cfg *sm.Settings) error {
+func sendRAR(state *SubscriberSessionState, ratingGroup uint32, cfg *sm.Settings) error {
 	meta, ok := smpeer.FromContext(state.Connection.Context())
 	if !ok {
 		return fmt.Errorf("peer metadata unavailable")
@@ -355,8 +355,8 @@ func sendRAR(state *SubscriberSessionState, ratingGroup *uint32, cfg *sm.Setting
 	m.NewAVP(avp.OriginRealm, avp.Mbit, 0, cfg.OriginRealm)
 	m.NewAVP(avp.DestinationRealm, avp.Mbit, 0, meta.OriginRealm)
 	m.NewAVP(avp.DestinationHost, avp.Mbit, 0, meta.OriginHost)
-	if ratingGroup != nil {
-		m.NewAVP(avp.RatingGroup, avp.Mbit, 0, datatype.Unsigned32(*ratingGroup))
+	if ratingGroup != 0 {
+		m.NewAVP(avp.RatingGroup, avp.Mbit, 0, datatype.Unsigned32(ratingGroup))
 	}
 	glog.V(2).Infof("Sending RAR to %s\n%s", state.Connection.RemoteAddr(), m)
 	_, err := m.WriteTo(state.Connection)

--- a/lte/gateway/c/session_manager/ChargingGrant.cpp
+++ b/lte/gateway/c/session_manager/ChargingGrant.cpp
@@ -80,12 +80,14 @@ CreditValidity ChargingGrant::is_valid_credit_response(
   bool gsu_all_invalid =
       !gsu.total().is_valid() && !gsu.rx().is_valid() && !gsu.tx().is_valid();
   if (gsu_all_invalid) {
-    if (update.credit().is_final()) {
+    if (update.credit().is_final() || credit_validity == TRANSIENT_ERROR) {
       // TODO @themarwhal look into this case. Before I figure it out, I will
-      // allow empty GSU credits with FUA to be on the conservative side.
+      // allow empty GSU credits with FUA or to be suspended
+      // to be on the conservative side.
       MLOG(MWARNING)
           << "GSU for RG: " << key << " " << session_id
-          << " is invalid, but accepting it as it has a final unit action";
+          << " is invalid, but accepting it as it has a final unit action or "
+             "suspended credit ";
       return credit_validity;
     }
     MLOG(MERROR) << "Credit update failed RG:" << key

--- a/lte/gateway/c/session_manager/EnumToString.cpp
+++ b/lte/gateway/c/session_manager/EnumToString.cpp
@@ -33,6 +33,8 @@ std::string service_state_to_str(ServiceState state) {
       return "SERVICE_ENABLED";
     case SERVICE_NEEDS_DEACTIVATION:
       return "SERVICE_NEEDS_DEACTIVATION";
+    case SERVICE_NEEDS_SUSPENSION:
+      return "SERVICE_NEEDS_SUSPENSION";
     case SERVICE_DISABLED:
       return "SERVICE_DISABLED";
     case SERVICE_NEEDS_ACTIVATION:

--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1293,8 +1293,7 @@ void LocalEnforcer::remove_rules_for_multiple_suspended_credit(
     SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
-      MLOG(MWARNING) << "Session " << session_id
-                     << " not found for termination";
+      MLOG(MWARNING) << "Session " << session_id << " not found for suspension";
       return;
     }
     auto& session    = **session_it;
@@ -1306,6 +1305,8 @@ void LocalEnforcer::remove_rules_for_multiple_suspended_credit(
 void LocalEnforcer::remove_rules_for_suspended_credit(
     const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
     SessionStateUpdateCriteria& session_uc) {
+  MLOG(MWARNING) << "Suspending RG " << ckey << " for "
+                 << session->get_session_id();
   // suspend this specific credit
   session->set_suspend_credit(ckey, true, session_uc);
 
@@ -1330,12 +1331,11 @@ void LocalEnforcer::add_rules_for_multiple_unsuspended_credit(
     const auto& imsi       = suspended_credit.imsi;
     const auto& session_id = suspended_credit.session_id;
     const CreditKey& ckey  = suspended_credit.cKey;
-
     SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
     auto session_it = session_store_.find_session(session_map, criteria);
     if (!session_it) {
       MLOG(MWARNING) << "Session " << session_id
-                     << " not found for termination";
+                     << " not found for un-suspension";
       return;
     }
     auto& session    = **session_it;
@@ -1347,6 +1347,8 @@ void LocalEnforcer::add_rules_for_multiple_unsuspended_credit(
 void LocalEnforcer::add_rules_for_unsuspended_credit(
     const std::unique_ptr<SessionState>& session, const CreditKey& ckey,
     SessionStateUpdateCriteria& session_uc) {
+  MLOG(MWARNING) << "Un-suspending RG " << ckey << " for "
+                 << session->get_session_id();
   // unsuspend this credit
   session->set_suspend_credit(ckey, false, session_uc);
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -1291,8 +1291,9 @@ bool SessionState::receive_charging_credit(
   if (!grant->credit.is_quota_exhausted(1) &&
       grant->service_state != SERVICE_ENABLED) {
     // if quota no longer exhausted, re-enable services as needed
-    MLOG(MINFO) << "New quota now available. Activating service RG:" << key
-                << " for " << session_id_;
+    MLOG(MINFO) << "New quota now available. Service is in state: "
+                << service_state_to_str(grant->service_state)
+                << " Activating service RG: " << key << " for " << session_id_;
     grant->set_service_state(SERVICE_NEEDS_ACTIVATION, *credit_uc);
   }
   return true;
@@ -1565,6 +1566,7 @@ void SessionState::get_charging_updates(
         action->set_ambr(config_.get_apn_ambr());
         fill_service_action(action, action_type, key);
         actions_out->push_back(std::move(action));
+        grant->set_suspended(false, credit_uc);
         break;
       case TERMINATE_SERVICE:
         fill_service_action(action, action_type, key);


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

For CCA-U, Feg was returning MSCC level result code instead of credit Result Codes. That was preventing the code to propagate properly. Cwf_integ_test had also same issue were the tests were using MSCC level result code. 

This PR fixes that and also fixes some issues found on sessiond on the result code management cycle 

We have added three new cwf integ test to check the result code management cycle.

Note two of them have a assert commented due to an issue with a rule left installed on pipelined due to ip being passed to pipelined on cwf case

## Test Plan
make precommit_sm
make precommit feg
make precommig cwf
cwf_integ_test


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
