### PR TITLE
[CwfIntegTest] Fix TestGyCreditExhaustionRedirect

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -420,7 +420,7 @@ func TestGyCreditExhaustionRedirect(t *testing.T) {
 		},
 		IsFinalCredit:       true,
 		FinalUnitIndication: &finalUnitIndication,
-		ResultCode:          diameter.DiameterCreditLimitReached,
+		ResultCode:          diameter.SuccessCode,
 	}
 
 	initRequest := protos.NewGyCCRequest(imsi, protos.CCRequestType_INITIAL)


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
A change was made recently to not ignore the credit level result code anymore, so we should make it 2001 to ensure the FUA is not activated imeediately.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran test locally 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
