### PR TITLE
Added info on the AGW installation [documentation]

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.1.0/lte/upgrade.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/lte/upgrade.md
@@ -10,6 +10,9 @@ original_id: agw_110_upgrade
 You can upgrade your access gateways remotely from the NMS or SSH directly
 into them and run an `apt-get install`.
 
+The Access Gateway version needs to be equal to or less than the version
+ of your Orc8r. We recommend you update your Orc8r first. 
+
 ## NMS Autoupgrade
 
 Navigate to the "Configure" tab of the NMS and select the tab "Upgrade". Find

--- a/docs/docusaurus/versioned_docs/version-1.2.0/lte/upgrade_120.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/lte/upgrade_120.md
@@ -9,6 +9,9 @@ original_id: agw_120_upgrade
 You can upgrade your access gateways remotely from the NMS or SSH directly
 into them and run an `apt-get install`.
 
+The Access Gateway version needs to be equal to or less than the version
+ of your Orc8r. We recommend you update your Orc8r first. 
+
 ## NMS Autoupgrade
 
 If you've set up your Access Gateways in upgrade tiers already, you can upgrade

--- a/docs/docusaurus/versioned_docs/version-1.3.0/lte/upgrade_130.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/lte/upgrade_130.md
@@ -9,6 +9,9 @@ original_id: agw_130_upgrade
 You can upgrade your access gateways remotely from the NMS or SSH directly
 into them and run an `apt-get install`.
 
+The Access Gateway version needs to be equal to or less than the version
+ of your Orc8r. We recommend you update your Orc8r first.
+ 
 ## NMS Autoupgrade
 
 If you've set up your Access Gateways in upgrade tiers already, you can upgrade


### PR DESCRIPTION
Added info on what version the AGW needs to be in order to not have errors with Orc8r

Signed-off-by: Jared Mullane <jmullane@fb.com>

## Summary

Partners were experiencing issues when their AGW version would be ahead of their orc8r version (T79129904). This update should clarify those issues. 

## Test Plan

Ran the docusaurus script locally to check 


