### PR TITLE
[AGW][DEPLOYMENT]Remove ansible uninstall from agw_install.sh

### DIFF
--- a/lte/gateway/deploy/agw_install.sh
+++ b/lte/gateway/deploy/agw_install.sh
@@ -124,8 +124,6 @@ if [ "$MAGMA_INSTALLED" != "$SUCCESS_MESSAGE" ]; then
   if [ -f "$AGW_INSTALL_CONFIG" ]; then
     rm -rf $AGW_INSTALL_CONFIG
   fi
-  echo "Removing Ansible from the machine."
-  pip3 uninstall --yes ansible
   rm -rf /home/$MAGMA_USER/build
   echo "AGW installation is done, make sure all services above are running correctly.. rebooting"
   reboot


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

[AGW][DEPLOYMENT]Remove ansible uninstall from agw_install.sh

## Summary

Remove ansible uninstall from agw_install.sh in order to be able to run show_tech on localhost in the future

## Test Plan

`bash ~/lte/gateway/deploy/agw_install.sh `

## Additional Information

- [ ] This change is backwards-breaking

