### PR TITLE
[orc8r] Fix nil pointer during Enodeb object validation

### DIFF
--- a/lte/cloud/go/services/lte/obsidian/models/validate.go
+++ b/lte/cloud/go/services/lte/obsidian/models/validate.go
@@ -329,8 +329,10 @@ func (m *Enodeb) ValidateModel() error {
 		return err
 	}
 
-	if err := m.EnodebConfig.validateEnodebConfig(); err != nil {
-		return err
+	if m.EnodebConfig != nil{
+		if err := m.EnodebConfig.validateEnodebConfig(); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #3675

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This fix implements check whether EnodebConfig exists within Enodeb object.

## Test Plan

I've deployed orc8r with this fix and the problem gone.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
