### PR TITLE
AGW: uplink_br0: set arp ignore

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -171,6 +171,7 @@ class UplinkBridgeController(MagmaController):
         # everything else:
         self._set_sgi_ip_addr(self.config.uplink_bridge)
         self._set_sgi_gw(self.config.uplink_bridge)
+        self._set_arp_ignore('all', '1')
 
     def cleanup_on_disconnect(self, datapath):
         self._del_eth_port()
@@ -346,3 +347,7 @@ class UplinkBridgeController(MagmaController):
                              setup_dhclient, ex)
 
         self.logger.info("SGi DHCP: restart for %s done", if_name)
+
+    def _set_arp_ignore(self, if_name: str, val: str):
+        sysctl_setting = 'net.ipv4.conf.' + if_name + '.arp_ignore=' + val
+        subprocess.check_call(['sysctl', sysctl_setting])


### PR DESCRIPTION
## Summary

By setting this flag the interface would not respond for
non local IPs. without this flag, AGW can send multiple
ARP reply msg for local IP ARP requests.




Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
make test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
