### PR TITLE
[AGW][DEPLOY] Bump agw deploy script to 1.3.1-1605904866-7933c828

### DIFF
--- a/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
+++ b/lte/gateway/deploy/roles/ovs_deploy/vars/all.yaml
@@ -13,4 +13,4 @@ private_package: "deb http://packages.magma.etagecom.io stretch-stable main"
 source_name: "packages_magma_etagecom_io"
 apt_key: "http://packages.magma.etagecom.io/pubkey.gpg"
 
-magma_version: '1.3.0-1604965249-104bbab5'
+magma_version: '1.3.1-1605904866-7933c828'


### PR DESCRIPTION
[AGW][DEPLOY] Bump agw deploy script to 1.3.1-1605904866-7933c828

## Summary

Thanks to @xjtian precious comments we didn't forget to bump deployment script. 

## Test Plan

ansible-playbook -e \"PACKAGE_LOCATION='/tmp'\" -i $DEPLOY_PATH/agw_hosts $DEPLOY_PATH/ovs_deploy.yml --skip-tags \"skipfirstinstall\"

