### PR TITLE
[CI/CD] Switch Jenkinsfile to use libvirt and only one host

### DIFF
--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -22,31 +22,24 @@ def GIT_URL = "github.com/magma/magma"
 
 def GIT_BRANCH = "master"
 def GIT_COMMIT
+
+def OAI_GIT_URL = "https://github.com/OPENAIRINTERFACE/openair-epc-fed.git"
+def OAI_GIT_BRANCH = "master"
 // Location of the executor node
-def nodeExecutor = params.nodeExecutor
+def nodeExecutor = "libvirt"
+
 def slack_channel = "#magma-ci-bot"
 // lock mechanism
 def cn_ci_resource = params.MagmaVmDockerResources
 
-// Location of the 2nd CN executor
-def new_host_flag = false
-def new_host = ""
-def new_host_user = ""
 
 pipeline {
   agent {
-    label "OAIinteg"
+    label "libvirt"
   }
-  parameters {
-    string(name: 'MagmaVmDockerResources', defaultValue: 'lock')
-    string(name: 'Host_CN_CI_2nd_Server_Flag', defaultValue: '1')
-    string(name: 'Host_CN_CI_2nd_Server', defaultValue: 'bm_slave_1')
-  } 
   options {
-    disableConcurrentBuilds()
     timestamps()
     ansiColor('xterm')
-    lock(cn_ci_resource)
   }
 
   stages {
@@ -58,42 +51,43 @@ pipeline {
           JOB_TIMESTAMP = JOB_TIMESTAMP.trim()
 
           echo '\u2705 \u001B[32mVerify Parameters\u001B[0m'
-          if (params.Host_CN_CI_2nd_Server_Flag != null) {
-            new_host_flag = params.Host_CN_CI_2nd_Server_Flag
-            if (new_host_flag) {
-              new_host = params.Host_CN_CI_2nd_Server
-              
-              echo "1st Node   is ${NODE_NAME}"
-              echo "2nd Node   is ${new_host}"
-            } else {
-              echo "Node       is ${NODE_NAME}"
-            }
-          } else {
-            echo "Node       is ${NODE_NAME}"
-          }
         }
       }
     }
     stage ("Retrieve and Prepare Source Code") {
       steps {
         script {
-            checkout changelog: false, poll: false, scm: [$class: 'GitSCM', branches: [[name: '${sha1}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: "https://" + GIT_URL + ".git"]]]
-            GIT_COMMIT = sh returnStdout: true, script: 'git log -1 --pretty="%H"'
-            sh "git clean -x -d -e .cache -e lte/gateway/.vagrant -f > /dev/null 2>&1"
-            TEMP_COMMIT = sh returnStdout: true, script: 'git log -n1 --pretty=format:"%H"'
-            TEMP_COMMIT = TEMP_COMMIT.trim()
-
-            sh "tar -cjhf /tmp/converged_mme.tar.bz2 .git"
-            sh "mv /tmp/converged_mme.tar.bz2 ."
-            
-            copyTo2ndServer('converged_mme.tar.bz2', '.', new_host_flag, new_host_user, new_host)
-            
-            myShCmd('git checkout -f ' + TEMP_COMMIT, new_host_flag, new_host_user, new_host)
-            myShCmd('git clean -x -d -e .cache -e lte/gateway/.vagrant -f > /dev/null 2>&1', new_host_flag, new_host_user, new_host)
-            myShCmd('git status --ignored', new_host_flag, new_host_user, new_host)
-            sh "mkdir -p archives"
-            myShCmd('mkdir -p archives', new_host_flag, new_host_user, new_host)
-          
+          checkout(
+            changelog: false,
+            poll: false,
+            scm: [$class: 'GitSCM',
+                  branches: [[name: '$sha1']],
+                  doGenerateSubmoduleConfigurations: false,
+                  extensions: [],
+                  submoduleCfg: [],
+                  userRemoteConfigs: [[refspec: '+refs/pull/*:refs/remotes/origin/pr/*', url: "https://" + GIT_URL + ".git"]]]
+          )
+          sh "git clean -x -d -e .cache -e lte/gateway/.vagrant -f > /dev/null 2>&1"
+          sh("mkdir -p openair-epc-fed archives")
+          dir("openair-epc-fed") {
+            checkout(
+                changelog: false,
+                poll: false,
+                scm: [$class: 'GitSCM',
+                      branches: [[name: OAI_GIT_BRANCH]],
+                      doGenerateSubmoduleConfigurations: false,
+                      doGenerateSubmoduleConfigurations: false,
+                      extensions: [[$class: 'SubmoduleOption',
+                                    disableSubmodules: false,
+                                    parentCredentials: false,
+                                    recursiveSubmodules: true,
+                                    reference: '',
+                                    trackingSubmodules: false]],
+                      submoduleCfg: [],
+                      userRemoteConfigs: [[url: OAI_GIT_URL]]
+                ]
+            )
+          }
         }
       }
       post {
@@ -111,20 +105,30 @@ pipeline {
         stage ("Provision the AGW VM") {
           steps {
             script {
-                myShCmdWithLog('cd lte/gateway && vagrant destroy --force magma && vagrant up magma', 'archives/magma_vagrant_up.log', new_host_flag, new_host_user, new_host)
-                // Making that magma services are all down. Should be the case after wake-up
-                try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status"', new_host_flag, new_host_user, new_host)
-                } catch (Exception e) {
+              try {
+                sh('sudo virsh list --all --name')
+                sh('sudo virsh list --all --name | grep _magma | xargs --no-run-if-empty -n1 sudo virsh undefine')
+                sh('cd lte/gateway;virsh undefine gateway_magma || true; vagrant destroy --force magma')
+              }
+              catch (Exception e) {
                   echo "Fine. Let it go..."
-                }
+              }
+              sh('cd lte/gateway && vagrant up --provider libvirt magma')
+              // Check that magma services are all down. Should be the case after wake-up
+              try {
+                sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status"')
+              } catch (Exception e) {
+                echo "Fine. Let it go..."
+              }
+              sh('which zip || sudo apt-get install -y zip')
+              sh('dpkg -l apt-utils || apt-get install -y apt-utils')
             }
           }
         }
         stage ("Build Orchestrator") {
           steps {
             script {
-              echo "Not at the moment"
+              echo "Not building orc8r at the moment"
             }
           }
         }
@@ -137,43 +141,32 @@ pipeline {
             script {
                 // Manual removal of build dirs
                 try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo rm -Rf build/c build/python"', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && vagrant ssh magma -c "sudo rm -Rf build/c build/python"')
                 } catch (Exception e) {
                   echo "OK after a git clean..."
                 }
                 try {
-                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make clean"', 'archives/magma_vagrant_make_clean.log', new_host_flag, new_host_user, new_host)
+                  sh ('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make clean"')
                 } catch (Exception e) {
                   echo "OK after a git clean..."
                 }
                 // Manually creating the c build dir
                 try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma -c "mkdir -p build && mkdir -p build/c"', new_host_flag, new_host_user, new_host)
+                  sh ('cd lte/gateway && vagrant ssh magma -c "mkdir -p build/c"' )
                 } catch (Exception e) {
                   echo "It should not fail here but we still go on"
                 }
-                timeout (time: 15, unit: 'MINUTES') {
-                  // removing the magma/.cache/gateway folder with speed down build from 3 minutes to 27 minutes
-                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make run"', 'archives/magma_vagrant_make_run.log', new_host_flag, new_host_user, new_host)
+                timeout (time: 120, unit: 'MINUTES') {
+                  // removing the magma/.cache/gateway folder will slow down build from 3 minutes to 27 minutes
+                  sh('''cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make run "''')
                 }
                 sh "sleep 30"
-                // check the magma status --> non-blocking (even if OK it might fail from a bash script point of view)
+                // check magma status --> non-blocking (even if OK it might fail from a bash script point of view)
                 try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status > magma/archives/magma_status.log"', new_host_flag, new_host_user, new_host)
+                    sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* start; sudo service magma@* status"')
                 } catch (Exception e) {
                   echo "Checking magma@* status failed but still moving on!"
                 }
-            }
-          }
-          post {
-            always {
-              script {
-                try {
-                  copyFrom2ndServer('archives/magma_status.log', 'archives', new_host_flag, new_host_user, new_host)
-                } catch (Exception e) {
-                  echo "Maybe we failed before retrieving the Magma Services Status"
-                }
-              }
             }
           }
         }
@@ -182,28 +175,16 @@ pipeline {
           steps {
             script {
               // Running on xenial to have 1.72 version of cppcheck
-              myShCmd('docker run --name ci-cn-cppcheck -d ubuntu:xenial /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-cppcheck /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/cppcheck_install.log', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-cppcheck /bin/bash -c "apt-get install --yes git cppcheck bzip2" >> archives/cppcheck_install.log', new_host_flag, new_host_user, new_host)
+              sh('docker rm -f ci-cn-cppcheck || true')
+              sh('docker run --name ci-cn-cppcheck -v `pwd`:/code -d ubuntu:xenial /bin/bash -c "sleep infinity"')
+              sh('docker exec -i ci-cn-cppcheck /bin/bash -c "apt-get update && apt-get upgrade --yes" 2>&1 > archives/cppcheck_install.log')
+              sh('docker exec -i ci-cn-cppcheck /bin/bash -c "apt-get install --yes git cppcheck bzip2" 2>&1 >> archives/cppcheck_install.log')
 
-              myShCmd('docker cp /tmp/converged_mme.tar.bz2 ci-cn-cppcheck:/home', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-cppcheck /bin/bash -c "cd /home && tar -xjf converged_mme.tar.bz2"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-cppcheck /bin/bash -c "rm -f /home/converged_mme.tar.bz2"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-cppcheck /bin/bash -c "cd /home && git checkout -f ' + TEMP_COMMIT + '"', new_host_flag, new_host_user, new_host)
-
-              myShCmd('docker exec -it ci-cn-cppcheck /bin/bash -c "cd /home/lte/gateway/c/oai && cppcheck --enable=warning --force --xml --xml-version=2 -i test . 2> cppcheck.xml 1> cppcheck_build.log"', new_host_flag, new_host_user, new_host)
+              sh('docker exec -i ci-cn-cppcheck /bin/bash -c "cd /code && cppcheck -j8 --enable=warning --force --xml --xml-version=2 -i test ." 2> cppcheck.xml 1> cppcheck_build.log')
+              sh('docker rm -f ci-cn-cppcheck')
             }
           }
           post {
-            always {
-              script {
-                myShCmd('docker cp ci-cn-cppcheck:/home/lte/gateway/c/oai/cppcheck.xml archives', new_host_flag, new_host_user, new_host)
-                myShCmd('docker cp ci-cn-cppcheck:/home/lte/gateway/c/oai/cppcheck_build.log archives', new_host_flag, new_host_user, new_host)
-                copyFrom2ndServer('archives/cppcheck*.*', 'archives', new_host_flag, new_host_user, new_host)
-                // no need to keep the cppcheck container
-                myShCmd('docker rm -f ci-cn-cppcheck', new_host_flag, new_host_user, new_host)
-              }
-            }
             success {
               sh "echo 'CPPCHECK: OK' >> archives/cppcheck_install.log"
             }
@@ -215,35 +196,33 @@ pipeline {
         stage ('Code Formatting Checker') {
           steps {
             script {
-              myShCmd('docker stop ci-cn-clang-formatter || true && docker rm ci-cn-clang-formatter || true', new_host_flag, new_host_user, new_host)
-              myShCmd('docker run --name ci-cn-clang-formatter -d ubuntu:bionic /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "apt-get update && apt-get upgrade --yes" > archives/clang_format_install.log', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "apt-get install --yes git tree bzip2" >> archives/clang_format_install.log', new_host_flag, new_host_user, new_host)
+              sh('docker rm -f ci-cn-clang-formatter || true')
+              sh('docker run --name ci-cn-clang-formatter -v `pwd`:/code -d ubuntu:bionic /bin/bash -c "sleep infinity"')
+              sh('docker exec -i ci-cn-clang-formatter /bin/bash -c "apt-get update && apt-get upgrade --yes" 2>&1 > archives/clang_format_install.log')
+              sh('docker exec -i ci-cn-clang-formatter /bin/bash -c "apt-get install --yes git tree bzip2" 2>&1 >> archives/clang_format_install.log')
 
-              myShCmd('docker cp /tmp/converged_mme.tar.bz2 ci-cn-clang-formatter:/home', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf converged_mme.tar.bz2"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "rm -f /home/converged_mme.tar.bz2"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && git checkout -f ' + TEMP_COMMIT + '"', new_host_flag, new_host_user, new_host)
+              //sh('docker cp /tmp/converged_mme.tar.bz2 ci-cn-clang-formatter:/home')
+              //sh('docker exec -i ci-cn-clang-formatter /bin/bash -c "cd /home && tar -xjf converged_mme.tar.bz2"')
+              //sh('docker exec -i ci-cn-clang-formatter /bin/bash -c "rm -f /home/converged_mme.tar.bz2"')
+              //sh('docker exec -i ci-cn-clang-formatter /bin/bash -c "cd /home && git checkout -f ' + TEMP_COMMIT + '"')
 
               // We install a dedicated version (installed on our CI server).
-              myShCmd('docker cp /opt/clang-format/9.0.0/bin/clang-format ci-cn-clang-formatter:/usr/local/bin', new_host_flag, new_host_user, new_host)
-                myShCmd('docker exec -it ci-cn-clang-formatter /bin/bash -c "cd /home && ./ci-scripts/checkCodingFormattingRules.sh"', new_host_flag, new_host_user, new_host)
+              sh('docker cp /opt/clang-format/9.0.0/bin/clang-format ci-cn-clang-formatter:/usr/local/bin')
+              sh('docker exec -i ci-cn-clang-formatter /bin/bash -c "cd /code && ./ci-scripts/checkCodingFormattingRules.sh"')
             }
           }
           post {
             always {
               script {
-                myShCmd('docker cp ci-cn-clang-formatter:/home/oai_rules_result.txt .', new_host_flag, new_host_user, new_host)
+                sh('docker cp ci-cn-clang-formatter:/code/oai_rules_result.txt archives/.')
                 // May not have been generated
                 try {
-                  myShCmd('docker cp ci-cn-clang-formatter:/home/oai_rules_result_list.txt .', new_host_flag, new_host_user, new_host)
+                  sh('docker cp ci-cn-clang-formatter:/code/oai_rules_result_list.txt archives/.')
                 } catch (Exception e) {
                   echo "Failed to copy src/oai_rules_result_list.txt! It may not have been generated. That's OK!"
                 }
-                copyFrom2ndServer('archives/clang_format*.*', 'archives', new_host_flag, new_host_user, new_host)
-                copyFrom2ndServer('oai_rules*.*', '.', new_host_flag, new_host_user, new_host)
                 // no need to keep the clang-formatter container
-                myShCmd('docker rm -f ci-cn-clang-formatter', new_host_flag, new_host_user, new_host)
+                sh('docker rm -f ci-cn-clang-formatter')
               }
             }
           }
@@ -258,9 +237,15 @@ pipeline {
         stage ("Provision the Test VM") {
           steps {
             script {
-                myShCmdWithLog('cd lte/gateway && vagrant destroy --force magma_test && vagrant up magma_test', 'archives/magma_vagrant_test_up.log', new_host_flag, new_host_user, new_host)
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"', 'archives/magma_vagrant_test_make1.log', new_host_flag, new_host_user, new_host)
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"', 'archives/magma_vagrant_test_make2.log', new_host_flag, new_host_user, new_host)
+                try {
+                  sh('cd lte/gateway && virsh undefine gateway_magma_test || true; vagrant destroy --force magma_test')
+                }
+                catch (Exception e) {
+                  echo "Fine. Let it go..."
+                }
+                sh('cd lte/gateway && vagrant up --provider libvirt magma_test')
+                sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"')
+                sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"')
             }
           }
         }
@@ -268,14 +253,19 @@ pipeline {
           steps {
             script {
               sh "sleep 60"
-                myShCmdWithLog('cd lte/gateway && vagrant destroy --force magma_trfserver && vagrant up magma_trfserver', 'archives/magma_vagrant_trfserver_up.log', new_host_flag, new_host_user, new_host)
                 try {
-                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo apt update"', 'archives/magma_vagrant_trfserver_apt_get_update.log', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && virsh undefine gateway_magma_trfserver || true; vagrant destroy --force magma_trfserver')
+                } catch (Exception e) {
+                  echo "Ignoring issues cleaning up any lingering magma_trfserver"
+                }
+                sh('cd lte/gateway && vagrant up --provider libvirt magma_trfserver')
+                try {
+                  sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo apt update"')
                 } catch (Exception e) {
                   echo "Known issue with magma-custom.io public key?"
                 }
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo apt install --yes psmisc net-tools iproute"', 'archives/magma_vagrant_trfserver_killall_install.log', new_host_flag, new_host_user, new_host)
-                myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route add 192.168.128.0/24 via 192.168.129.1 dev eth2"', new_host_flag, new_host_user, new_host)
+                sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo apt install --yes psmisc net-tools iproute"')
+                sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route add 192.168.128.0/24 via 192.168.129.1 dev eth2"')
             }
           }
         }
@@ -287,10 +277,10 @@ pipeline {
           steps {
             script {
               echo "Disabling TCP checksumming on Traffic VM"
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ethtool --offload eth1 rx off tx off && sudo ethtool --offload eth2 rx off tx off"', 'archives/magma_vagrant_trfserve_disable_tcp_checksumming.log', new_host_flag, new_host_user, new_host)
+                sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ethtool --offload eth1 rx off tx off && sudo ethtool --offload eth2 rx off tx off"')
                 echo "Starting the Traffic server in foreground"
                 try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo traffic_server.py 192.168.60.144 62462 > magma/archives/magma_trfserver_run0.log 2>&1"', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo traffic_server.py 192.168.60.144 62462"')
                 } catch (Exception e) {
                   echo "Moving on!"
                 }
@@ -301,8 +291,8 @@ pipeline {
           steps {
             script {
                 echo "Disabling TCP checksumming on all VMs"
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "sudo ethtool --offload eth1 rx off tx off && sudo ethtool --offload eth2 rx off tx off"', 'archives/magma_vagrant_disable_tcp_checksumming.log', new_host_flag, new_host_user, new_host)
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "sudo ethtool --offload eth1 rx off tx off && sudo ethtool --offload eth2 rx off tx off"', 'archives/magma_vagrant_test_disable_tcp_checksumming.log', new_host_flag, new_host_user, new_host)
+                sh('cd lte/gateway && vagrant ssh magma -c "sudo ethtool --offload eth1 rx off tx off && sudo ethtool --offload eth2 rx off tx off"')
+                sh('cd lte/gateway && vagrant ssh magma_test -c "sudo ethtool --offload eth1 rx off tx off && sudo ethtool --offload eth2 rx off tx off"')
 
                 // Making sure the Traffic server is up and running
                 sh "sleep 20"
@@ -310,20 +300,22 @@ pipeline {
                 echo "Starting the integration Tests - S1AP Tester"
                 // We have removed the traffic testcases from mandatory suite.
 
+          // FIXME!!!! set 110 MINUTES instead of 30
+
                 timeout (time: 110, unit: 'MINUTES') {
-                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"')
                 }
 
                 timeout (time: 45, unit: 'SECONDS') {
                   try {
-                    myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_udp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
+                    sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_udp_data.py"')
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_dl_udp_data testcase may fail"
                   }
                 }
                 timeout (time: 45, unit: 'SECONDS') {
                   try {
-                    myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_tcp_data.py"', 'archives/magma_run_s1ap_tester.log', new_host_flag, new_host_user, new_host)
+                    sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_tcp_data.py"')
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_dl_tcp_data testcase may fail"
                   }
@@ -331,7 +323,7 @@ pipeline {
 
                 echo "Stopping the Traffic server in background"
                 try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo killall python3"', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo killall python3"')
                 } catch (Exception e) {
                   echo "Maybe Traffic server crashed"
                 }
@@ -342,24 +334,23 @@ pipeline {
               script {
                 def retrieveOAIcovFiles = true
                 try {
-                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make coverage_oai"', 'archives/magma_vagrant_make_coverage_oai.log', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make coverage_oai"')
                 } catch (Exception e) {
                   echo "Let's keep running to have some logs, but not the OAI coverage files"
                   retrieveOAIcovFiles = false
                 }
                 if (retrieveOAIcovFiles) {
                   try {
-                    myShCmd('cd lte/gateway/c/oai && zip -r -qq code_coverage.zip code_coverage/', new_host_flag, new_host_user, new_host)
-                    copyFrom2ndServer('lte/gateway/c/oai/code_coverage.zip', 'archives', new_host_flag, new_host_user, new_host)
+                    sh('cd lte/gateway/c/oai && zip -r -qq ${WORKSPACE}/archives/code_coverage.zip code_coverage/')
                   } catch (Exception e) {
                     echo "Maybe we could not generate the coverage HTML report"
                   }
                 }
-                myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"', 'archives/magma_vagrant_make_stop.log', new_host_flag, new_host_user, new_host)
+                sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"')
                 // Retrieving the sys logs and mme log for more debugging.
-                myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/syslog /home/vagrant/magma/archives/magma_dev_syslog.log"', new_host_flag, new_host_user, new_host)
-                myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/mme.log /home/vagrant/magma/archives/magma_dev_mme.log"', new_host_flag, new_host_user, new_host)
-                myShCmd('cd lte/gateway && vagrant ssh magma_test -c "sudo cp /var/log/syslog /home/vagrant/magma/archives/magma_test_syslog.log"', new_host_flag, new_host_user, new_host)
+                sh('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/syslog" > ${WORKSPACE}/archives/magma_dev_syslog.log')
+                sh('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/mme.log" > ${WORKSPACE}/archives/magma_dev_mme.log')
+                sh('cd lte/gateway && vagrant ssh magma_test -c "sudo cat /var/log/syslog" > ${WORKSPACE}/archives/magma_test_syslog.log')
               }
             }
             success {
@@ -368,7 +359,7 @@ pipeline {
             unsuccessful {
               script {
                 try {
-                  myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo killall python3"', new_host_flag, new_host_user, new_host)
+                  sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo killall python3"')
                 } catch (Exception e) {
                   echo "Why it fails to kill the traffic server?"
                 }
@@ -378,74 +369,59 @@ pipeline {
           }
         }
       }
-      post {
-        always {
-          script {
-            copyFrom2ndServer('archives/magma_trfserver_run0.log', 'archives', new_host_flag, new_host_user, new_host)
-          }
-        }
-      }
     }
 stage ("Re-Build MME-S11") {
   steps {
     script {
         // Adapt the interface and the container IP address for S11 --> SPGW-C
-        myShCmd('sed -i -f ci-scripts/adapt-mme-yaml.sed lte/gateway/configs/mme.yml', new_host_flag, new_host_user, new_host)
-        myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make clean"', 'archives/magma_vagrant_make_clean2.log', new_host_flag, new_host_user, new_host)
+        sh('sed -i -f ci-scripts/adapt-mme-yaml.sed lte/gateway/configs/mme.yml')
+        sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make clean"')
         // Re-building w/ S11 enabled
-        sh "echo 'make FEATURES=\"mme\" run' > make_mme_run.sh"
-        copyTo2ndServer('make_mme_run.sh', 'lte/gateway', new_host_flag, new_host_user, new_host)
+        sh "echo 'make FEATURES=\"mme\" run' > lte/gateway/make_mme_run.sh"
         timeout (time: 15, unit: 'MINUTES') {
           // removing the magma/.cache/gateway folder with speed down build from 3 minutes to 27 minutes
-          myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_run.sh && ./make_mme_run.sh"', 'archives/magma_vagrant_make_run2.log', new_host_flag, new_host_user, new_host)
+          sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_run.sh && sudo chown -R vagrant /home/vagrant/build && ./make_mme_run.sh"')
         }
         sh "sleep 60"
-        sh "echo 'make FEATURES=\"mme\" status' > make_mme_status.sh"
-        copyTo2ndServer('make_mme_status.sh', 'lte/gateway', new_host_flag, new_host_user, new_host)
+        sh "echo 'make FEATURES=\"mme\" status' > lte/gateway/make_mme_status.sh"
         try {
-          myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status > magma/archives/magma_status2.log"', new_host_flag, new_host_user, new_host)
+          // sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_status.sh && ./make_mme_status.sh')
+          sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status"')
         } catch (Exception e) {
           echo "Status may return an error"
         }
-    }
-  }
-  post {
-    always {
-      script {
-        try {
-          copyFrom2ndServer('archives/magma_status2.log', 'archives', new_host_flag, new_host_user, new_host)
-        } catch (Exception e) {
-          echo "Maybe we failed before retrieving the Magma Services Status"
-        }
-      }
     }
   }
 }
 stage ("Deploy SPGW-CUPS") {
   steps {
     script {
-      mySh2Cmd('git clean -ff', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('./scripts/syncComponents.sh --spgwc-branch 2020.w36 --spgwu-tiny-branch 2020.w36', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker network create --attachable --subnet 192.168.61.128/26 --ip-range 192.168.61.128/26 magma-oai-public-net', new_host_flag, new_host_user, new_host)
+      sh('cd openair-epc-fed && git clean -ff')
+      sh('cd openair-epc-fed && ./scripts/syncComponents.sh --spgwc-branch 2020.w36 --spgwu-tiny-branch 2020.w36')
+      // Build containers if they aren't present
+      sh('cd openair-epc-fed && ls -l component && docker image inspect oai-spgwc:develop > /dev/null || docker build -f component/oai-spgwc/ci-scripts/Dockerfile.ubuntu18.04 -t oai-spgwc:develop ./component/oai-spgwc')
+      sh('cd openair-epc-fed && docker image inspect oai-spgw-tiny:develop > /dev/null || docker build -f component/oai-spgwu-tiny/ci-scripts/Dockerfile.ubuntu18.04 -t oai-spgwu-tiny:develop ./component/oai-spgwu-tiny')
+      sh('docker network create --attachable --subnet 192.168.61.128/26 --ip-range 192.168.61.128/26 magma-oai-public-net')
       // We are fixing IP addresses to easy scripting
-      mySh2Cmd('docker run --privileged --name magma-oai-spgwc --network magma-oai-public-net --ip 192.168.61.130 -d oai-spgwc:develop /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker run --privileged --name magma-oai-spgwu-tiny --network magma-oai-public-net --ip 192.168.61.131 -d oai-spgwu-tiny:develop /bin/bash -c "sleep infinity"', new_host_flag, new_host_user, new_host)
+      sh('docker rm -f magma-oai-spgwc magma-oai-spgwc-tiny || true')
+      sh('docker run --privileged --name magma-oai-spgwc --network magma-oai-public-net --ip 192.168.61.130 -d oai-spgwc:develop /bin/bash -c "sleep infinity"')
+      sh('docker run --privileged --name magma-oai-spgwu-tiny --network magma-oai-public-net --ip 192.168.61.131 -d oai-spgwu-tiny:develop /bin/bash -c "sleep infinity"')
       // Configure the containers
-      mySh2Cmd('python3 component/oai-spgwc/ci-scripts/generateConfigFiles.py --kind=SPGW-C --s11c=eth0 --sxc=eth0 --from_docker_file --apn=oai.ipv4', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('python3 component/oai-spgwu-tiny/ci-scripts/generateConfigFiles.py --kind=SPGW-U --sxc_ip_addr=192.168.61.130 --sxu=eth0 --s1u=eth0 --from_docker_file', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker cp ./spgwc-cfg.sh magma-oai-spgwc:/openair-spgwc', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker exec -it magma-oai-spgwc /bin/bash -c "cd /openair-spgwc && chmod 777 spgwc-cfg.sh && ./spgwc-cfg.sh"', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker cp ./spgwu-cfg.sh magma-oai-spgwu-tiny:/openair-spgwu-tiny', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker exec -it magma-oai-spgwu-tiny /bin/bash -c "cd /openair-spgwu-tiny && chmod 777 spgwu-cfg.sh && ./spgwu-cfg.sh"', new_host_flag, new_host_user, new_host)
+      sh('cd openair-epc-fed && python3 component/oai-spgwc/ci-scripts/generateConfigFiles.py --kind=SPGW-C --s11c=eth0 --sxc=eth0 --from_docker_file --apn=oai.ipv4')
+      sh('cd openair-epc-fed && python3 component/oai-spgwu-tiny/ci-scripts/generateConfigFiles.py --kind=SPGW-U --sxc_ip_addr=192.168.61.130 --sxu=eth0 --s1u=eth0 --from_docker_file')
+      sh('cd openair-epc-fed && docker cp ./spgwc-cfg.sh magma-oai-spgwc:/openair-spgwc')
+      sh('docker exec -i magma-oai-spgwc /bin/bash -c "cd /openair-spgwc && chmod 777 spgwc-cfg.sh && ./spgwc-cfg.sh"')
+      sh('cd openair-epc-fed && docker cp ./spgwu-cfg.sh magma-oai-spgwu-tiny:/openair-spgwu-tiny')
+      sh('docker exec -i magma-oai-spgwu-tiny /bin/bash -c "cd /openair-spgwu-tiny && chmod 777 spgwu-cfg.sh && ./spgwu-cfg.sh"')
       // adapting the UE IP pool to magma test setup
-      myShCmd('docker cp ./ci-scripts/adapt-spgwc-pool-ip.sed magma-oai-spgwc:/openair-spgwc', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker exec -it magma-oai-spgwc /bin/bash -c "sed -i -f adapt-spgwc-pool-ip.sed etc/spgw_c.conf"', new_host_flag, new_host_user, new_host)
-      myShCmd('docker cp ./ci-scripts/adapt-spgwu-pool-ip.sed magma-oai-spgwu-tiny:/openair-spgwu-tiny', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker exec -it magma-oai-spgwu-tiny /bin/bash -c "sed -i -f adapt-spgwu-pool-ip.sed etc/spgw_u.conf"', new_host_flag, new_host_user, new_host)
+      sh('docker cp ./ci-scripts/adapt-spgwc-pool-ip.sed magma-oai-spgwc:/openair-spgwc')
+      sh('docker exec -i magma-oai-spgwc /bin/bash -c "sed -i -f adapt-spgwc-pool-ip.sed etc/spgw_c.conf"')
+      sh('docker cp ./ci-scripts/adapt-spgwu-pool-ip.sed magma-oai-spgwu-tiny:/openair-spgwu-tiny')
+      sh('docker exec -i magma-oai-spgwu-tiny /bin/bash -c "sed -i -f adapt-spgwu-pool-ip.sed etc/spgw_u.conf"')
 
       // Start cNFs
-      mySh2Cmd('docker exec -d magma-oai-spgwc /bin/bash -c "nohup ./bin/oai_spgwc -o -c ./etc/spgw_c.conf > spgwc_check_run.log 2>&1"', new_host_flag, new_host_user, new_host)
-      mySh2Cmd('docker exec -d magma-oai-spgwu-tiny /bin/bash -c "nohup ./bin/oai_spgwu -o -c ./etc/spgw_u.conf > spgwu_check_run.log 2>&1"', new_host_flag, new_host_user, new_host)
+      sh('docker exec -d magma-oai-spgwc /bin/bash -c "nohup ./bin/oai_spgwc -o -c ./etc/spgw_c.conf > spgwc_check_run.log 2>&1"')
+      sh('docker exec -d magma-oai-spgwu-tiny /bin/bash -c "nohup ./bin/oai_spgwu -o -c ./etc/spgw_u.conf > spgwu_check_run.log 2>&1"')
     }
   }
 }
@@ -454,33 +430,37 @@ stage ("Test-AGW1-w-S11") {
         script {
           // making sure the TRF server is up
           echo "Remove unnecessary "
-          myShCmd('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route del 192.168.128.0/24 via 192.168.129.1 dev eth2"', new_host_flag, new_host_user, new_host)
-          myShCmd('cd lte/gateway && vagrant reload magma_test ', new_host_flag, new_host_user, new_host)
+          sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo ip route del 192.168.128.0/24 via 192.168.129.1 dev eth2"')
+          sh('cd lte/gateway && vagrant reload magma_test')
           // making sure the TRF server is up
           sh "sleep 60"
           echo "Starting the integration Tests - S1AP Tester"
-          timeout (time: 10, unit: 'MINUTES') {
-            myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_emergency.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_combined_eps_imsi.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_via_guti.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_after_ue_context_release.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
-            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_no_auth_response.py"', 'archives/magma_run_s1ap_tester_s11.log', new_host_flag, new_host_user, new_host)
+          timeout (time: 20, unit: 'MINUTES') {
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py" > ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_emergency.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_combined_eps_imsi.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_via_guti.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_after_ue_context_release.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_no_auth_response.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
           }
 
+
+          // echo "Stopping the Traffic server in background"
+          // sh('cd lte/gateway && vagrant ssh magma_trfserver -c "sudo killall python3"')
+
           echo "Stopping the SPGW-CUPS"
-          mySh2Cmd('docker exec -it magma-oai-spgwc /bin/bash -c "killall --signal SIGINT oai_spgwc"', new_host_flag, new_host_user, new_host)
-          mySh2Cmd('docker exec -it magma-oai-spgwu-tiny /bin/bash -c "killall --signal SIGINT oai_spgwu"', new_host_flag, new_host_user, new_host)
+          sh('docker exec -i magma-oai-spgwc /bin/bash -c "killall --signal SIGINT oai_spgwc || echo oai_spgwc not running"')
+          sh('docker exec -i magma-oai-spgwu-tiny /bin/bash -c "killall --signal SIGINT oai_spgwu || echo oai_spgwu not running"')
           sh "sleep 10"
           try {
-            mySh2Cmd('docker exec -it magma-oai-spgwc /bin/bash -c "killall --signal SIGKILL oai_spgwc"', new_host_flag, new_host_user, new_host)
+            sh('docker exec -i magma-oai-spgwc /bin/bash -c "killall --signal SIGKILL oai_spgwc"')
           } catch (Exception e) {
             echo "oai_spgwc may already be killed"
           }
           try {
-            mySh2Cmd('docker exec -it magma-oai-spgwu-tiny /bin/bash -c "killall --signal SIGKILL oai_spgwu"', new_host_flag, new_host_user, new_host)
+            sh('docker exec -i magma-oai-spgwu-tiny /bin/bash -c "killall --signal SIGKILL oai_spgwu"')
           } catch (Exception e) {
             echo "oai_spgwu may already be killed"
           }
@@ -489,20 +469,19 @@ stage ("Test-AGW1-w-S11") {
       post {
         always {
           script {
-            myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"', 'archives/magma_vagrant_make_stop2.log', new_host_flag, new_host_user, new_host)
+            sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make stop"')
             // Retrieving the sys logs and mme log for more debugging.
-            myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/syslog /home/vagrant/magma/archives/magma_dev_syslog_s11.log"', new_host_flag, new_host_user, new_host)
+            sh('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/syslog" > ${WORKSPACE}/archives/magma_dev_syslog_s11.log')
             try {
-              myShCmd('cd lte/gateway && vagrant ssh magma -c "sudo cp /var/log/mme.log /home/vagrant/magma/archives/magma_dev_mme_s11.log"', new_host_flag, new_host_user, new_host)
-              myShCmd('docker cp magma-oai-spgwc:/openair-spgwc/spgwc_check_run.log archives', new_host_flag, new_host_user, new_host)
+              sh('cd lte/gateway && vagrant ssh magma -c "sudo cat /var/log/mme.log" > ${WORKSPACE}/archives/magma_dev_mme_s11.log')
+              sh('docker cp magma-oai-spgwc:/openair-spgwc/spgwc_check_run.log archives')
             } catch (Exception e) {
               echo "MME log may not be available"
             }
-            myShCmd('cd lte/gateway && vagrant ssh magma_test -c "sudo cp /var/log/syslog /home/vagrant/magma/archives/magma_test_syslog_s11.log"', new_host_flag, new_host_user, new_host)
+            sh('cd lte/gateway && vagrant ssh magma_test -c "sudo cat /var/log/syslog" > ${WORKSPACE}/archives/magma_test_syslog_s11.log')
             // Retrieving the container logs
-            myShCmd('docker cp magma-oai-spgwc:/openair-spgwc/spgwc_check_run.log archives', new_host_flag, new_host_user, new_host)
-            myShCmd('docker cp magma-oai-spgwu-tiny:/openair-spgwu-tiny/spgwu_check_run.log archives', new_host_flag, new_host_user, new_host)
-            copyFrom2ndServer('archives/spgw*_check_run.log', 'archives', new_host_flag, new_host_user, new_host)
+            sh('docker cp magma-oai-spgwc:/openair-spgwc/spgwc_check_run.log archives')
+            sh('docker cp magma-oai-spgwu-tiny:/openair-spgwu-tiny/spgwu_check_run.log archives')
           }
         }
         success {
@@ -511,40 +490,40 @@ stage ("Test-AGW1-w-S11") {
         unsuccessful {
           script {
             try {
-              mySh2Cmd('docker exec -it magma-oai-spgwc /bin/bash -c "killall --signal SIGKILL oai_spgwc"', new_host_flag, new_host_user, new_host)
+              sh('docker exec -i magma-oai-spgwc /bin/bash -c "killall --signal SIGKILL oai_spgwc"')
             } catch (Exception e) {
               echo "spgwc may already be stopped"
             }
             try {
-              mySh2Cmd('docker exec -it magma-oai-spgwu-tiny /bin/bash -c "killall --signal SIGKILL oai_spgwu"', new_host_flag, new_host_user, new_host)
+              sh('docker exec -i magma-oai-spgwu-tiny /bin/bash -c "killall --signal SIGKILL oai_spgwu"')
             } catch (Exception e) {
               echo "spgwu may already be stopped"
             }
             sh "echo 'AGW-VM-S1AP-TESTS: KO' >> archives/magma_run_s1ap_tester_s11.log"
           }
         }
-      
+
       }
     }
   }
   post {
     always {
       script {
-        myShCmd('git checkout -- lte/gateway/python/integ_tests/defs.mk lte/gateway/configs/mme.yml', new_host_flag, new_host_user, new_host)
+        sh('git checkout -- lte/gateway/python/integ_tests/defs.mk lte/gateway/configs/mme.yml')
 
         // Stopping the VMs and the Containers
-        myShCmdWithLog('cd lte/gateway && vagrant halt magma', 'archives/magma_vagrant_halt.log', new_host_flag, new_host_user, new_host)
-        myShCmdWithLog('cd lte/gateway && vagrant halt magma_test', 'archives/magma_test_vagrant_halt.log', new_host_flag, new_host_user, new_host)
-        myShCmdWithLog('cd lte/gateway && vagrant halt magma_trfserver', 'archives/magma_test_vagrant_halt.log', new_host_flag, new_host_user, new_host)
-        myShCmdWithLog('cd lte/gateway && vagrant global-status', 'archives/magma_vagrant_global_status.log', new_host_flag, new_host_user, new_host)
+        sh('cd lte/gateway && vagrant halt magma')
+        sh('cd lte/gateway && vagrant halt magma_test')
+        sh('cd lte/gateway && vagrant halt magma_trfserver')
+        sh('cd lte/gateway && vagrant global-status')
 
         try {
-          mySh2Cmd('docker rm -f magma-oai-spgwc magma-oai-spgwu-tiny', new_host_flag, new_host_user, new_host)
+          sh('docker rm -f magma-oai-spgwc magma-oai-spgwu-tiny')
         } catch (Exception e) {
           echo "We may not have started the CUPS containers"
         }
         try {
-          mySh2Cmd('docker network rm magma-oai-public-net', new_host_flag, new_host_user, new_host)
+          sh('docker network rm magma-oai-public-net')
         } catch (Exception e) {
           echo "We may not have created the CUPS docker network"
         }
@@ -561,7 +540,7 @@ stage ("Test-AGW1-w-S11") {
         if (fileExists('magma_logs.zip')) {
           archiveArtifacts artifacts: 'magma_logs.zip'
         }
-        myShCmd('git stash && git stash clear', new_host_flag, new_host_user, new_host)
+        sh('git stash && git stash clear')
       }
     }
     success {
@@ -580,121 +559,6 @@ stage ("Test-AGW1-w-S11") {
           sendSocialMediaMessage(slack_channel,color, message)
       }
     }
-    
-  }
-}
-
-def copyTo2ndServer(filename, destination, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-          if ("converged_mme.tar.bz2".equals(filename)) {
-            echo "ssh -i '${KEY_FILE}' ${USER}@${host} 'mkdir -p /home/${USER}/CI-Magma'"
-            sh "ssh  -i '${KEY_FILE}' ${USER}@${host} 'mkdir -p /home/${USER}/CI-Magma'"
-            sh "ssh -i '${KEY_FILE}' ${USER}@${host} 'sudo rm -Rf /home/${USER}/CI-Magma/.git'"
-          }
-          sh "scp -i '${KEY_FILE}' ${filename} ${USER}@${host}:/home/${USER}/CI-Magma/${destination}"
-          if ("converged_mme.tar.bz2".equals(filename)) {
-            sh "ssh -i '${KEY_FILE}' ${USER}@${host} 'cd /home/${USER}/CI-Magma && tar -xjf ${filename}'"
-            sh "ssh -i '${KEY_FILE}' ${USER}@${host} 'mv /home/${USER}/CI-Magma/converged_mme.tar.bz2 /tmp'"
-          }
-    }
-  }
-}
-
-def copyFrom2ndServer(filename, target, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-            sh "scp -i '${KEY_FILE}' ${USER}@${host}:/home/${USER}/CI-Magma/${filename} ${target}"
-    }
-  }
-}
-
-def myShCmd(cmd, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-          sh "ssh -i '${KEY_FILE}' -t -t ${USER}@${host} 'cd /home/${USER}/CI-Magma && ${cmd}'"
-        }
-  } else {
-    sh "${cmd}"
-  }
-}
-
-def myShCmdWithLog(cmd, logFile, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-          sh "ssh -i '${KEY_FILE}' -t -t ${USER}@${host} 'cd /home/${USER}/CI-Magma && ${cmd}' > ${logFile} 2>&1"
-    }
-  } else {
-    sh "${cmd} > ${logFile} 2>&1"
-  }
-}
-
-def myShCmdWithLogAppend(cmd, logFile, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-          sh "ssh -i '${KEY_FILE}' -t -t ${USER}@${host} 'cd /home/${USER}/CI-Magma && ${cmd}' >> ${logFile} 2>&1"
-        }
-  } else {
-    sh "${cmd} >> ${logFile} 2>&1"
-  }
-}
-
-def myShRetCmd(cmd, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-          ret = sh returnStdout: true, script: "ssh -i '${KEY_FILE}' -t -t ${USER}@${host} 'cd /home/${USER}/CI-Magma && ${cmd}'"
-        }
-  } else {
-    ret = sh returnStdout: true, script: "${cmd}"
-  }
-  ret = ret.trim()
-  return ret
-}
-
-def mySh2Cmd(cmd, flag, user, host) {
-  if (flag) {
-    withCredentials([
-      sshUserPrivateKey(
-        credentialsId: 'packet-jenkins-lab-key', 
-        keyFileVariable: 'KEY_FILE', 
-        passphraseVariable: 'PASS', 
-        usernameVariable: 'USER')]) {
-          sh "ssh -i '${KEY_FILE}' -t -t ${USER}@${host} 'mkdir -p /home/${USER}/CI-Magma-Epc-Fed'"
-          sh "ssh -i '${KEY_FILE}' -t -t ${USER}@${host} 'cd /home/${USER}/CI-Magma-Epc-Fed && ${cmd}'"
-        }
-  } else {
-    sh "mkdir -p ~/CI-Magma-Epc-Fed"
-    sh "cd ~/CI-Magma-Epc-Fed && ${cmd}"
   }
 }
 
@@ -704,3 +568,4 @@ def mySh2Cmd(cmd, flag, user, host) {
 def sendSocialMediaMessage(pipeChannel, pipeColor, pipeMessage) {
     slackSend channel: pipeChannel, color: pipeColor, message: pipeMessage
 }
+


### PR DESCRIPTION
Summary of changes:
Deploy Vagrant using libvirt instead of virtualbox (for nested virt)
Removed logic using ssh to connect to another host
Removed logic related to git clone tarball
Removed command output being saved to log files (Jenkins log shows it now)
cppcheck Docker container mounts git dir instead of using tarball
OAI opanair-epc-fed git repo is now cloned instead of depended on by external scripts
oai-spgwc and oai-spgw-tiny Docker images are built if not present on Jenkins node

This change depends on https://github.com/magma/magma/pull/3787
