### PR TITLE
PDU Session Release support code 

### DIFF
--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -217,6 +217,11 @@ void SessionState::insert_pdr(SetGroupPDR* rule) {
   PdrList_.push_back(*rule);
 }
 
+void SessionState::set_remove_all_pdrs() {
+  for (auto& rule : PdrList_) {
+    rule.set_pdr_state(PdrState::REMOVE);
+  }
+}
 /* Remove all Pdr, FAR rules */
 void SessionState::remove_all_rules() {
   PdrList_.clear();
@@ -599,7 +604,8 @@ bool SessionState::active_monitored_rules_exist() {
 }
 
 bool SessionState::is_terminating() {
-  if (curr_state_ == SESSION_RELEASED || curr_state_ == SESSION_TERMINATED) {
+  if (curr_state_ == SESSION_RELEASED || curr_state_ == SESSION_TERMINATED ||
+      curr_state_ == RELEASE) {
     return true;
   }
   return false;

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -162,6 +162,8 @@ class SessionState {
 
   void insert_pdr(SetGroupPDR* rule);
 
+  void set_remove_all_pdrs();
+
   void insert_far(SetGroupFAR* rule);
 
   void remove_all_rules();

--- a/lte/gateway/c/session_manager/SessionStateEnforcer.h
+++ b/lte/gateway/c/session_manager/SessionStateEnforcer.h
@@ -73,8 +73,7 @@ class SessionStateEnforcer {
 
   /*Handle and update respective session upon receiving message from UPF*/
   void m5g_update_session_state_to_amf(
-      const std::string& imsi, uint32_t teid, uint32_t version,
-      SessionFsmState new_state);
+      const std::string& imsi, uint32_t teid, uint32_t version);
 
  private:
   std::vector<std::string> static_rules;


### PR DESCRIPTION
Signed-off-by: Venu Kumar Gurrapu <venukumar.g@altencalsoftlabs.com>

5g Release support changes
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


## Summary
--> PDR state support -- while releasing
--> session force_termination  proper check handling.
--> UPF response handling for creation/release case. 
-->  Added static code support for mulitple imsi range from "imsi00000000001 -imsi00000000003"
<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
[relese-log.txt](https://github.com/magma/magma/files/5581132/relese-log.txt)

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

S1ap test logs attached
[3805_PR_integ_test_Results_s1ap.txt]
(https://github.com/magma/magma/files/5601425/3805_PR_integ_test_Results_s1ap.txt)

CWAG test logs attached.g
[3805_PR_CWAG_Results.txt](https://github.com/magma/magma/files/5602612/3805_PR_CWAG_Results.txt)

