### PR TITLE
[xwfm][ci] fix dockerfile yum update

### DIFF
--- a/xwf/gateway/integ_tests/gw/Dockerfile
+++ b/xwf/gateway/integ_tests/gw/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-RUN yum update
+RUN yum update -y
 RUN yum install -y \
   git \
   sudo \


### PR DESCRIPTION
[xwfm][ci]

## Summary

We have problem with the "yum update" inside XWF docker file, it should be "yum update -y". No idea how it worked until now

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
