### PR TITLE
[orc8r documentation] Updated instructions to add orchestrator admin user

### DIFF
--- a/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/deploy_install.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/orc8r/deploy_install.md
@@ -236,7 +236,7 @@ Create the Orchestrator admin user with the `admin_operator` certificate
 created earlier
 
 ```bash
-export CNTLR_POD=$(kubectl get pod -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
+export CNTLR_POD=$(kubectl get pod -n  -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}')
 kubectl exec ${CNTLR_POD} -- envdir /var/opt/magma/envdir /var/opt/magma/bin/accessc add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem admin_operator
 ```
 


### PR DESCRIPTION
Included "-n" portion to code block in the orc8r install instructions 

Signed-off-by: Jared Mullane <jmullane@fb.com>

## Summary

Partners were copying the code block and not including the "-n" tag 

## Test Plan

Ran docs/docusaurus/create_docusaurus_website.sh to verify updates populated


