### PR TITLE
[orc8r] Don't force use of python3.7 in the docker scripts.

### DIFF
--- a/orc8r/cloud/docker/build.py
+++ b/orc8r/cloud/docker/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 
 """
 Copyright 2020 The Magma Authors.

--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.7
+#!/usr/bin/env python3
 
 """
 Copyright 2020 The Magma Authors.


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Just use `/usr/env python3` so that 3.7 or better works.

## Test Plan

Run docker under Ubuntu 20.4

## Additional Information