### PR TITLE
[orc8r] Clean up github.com/facebookincubator/magma

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -16,7 +16,7 @@ name: orc8r
 version: 1.5.11
 engine: gotpl
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - or8cr

--- a/orc8r/cloud/helm/orc8r/charts/logging/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/logging/Chart.yaml
@@ -16,7 +16,7 @@ name: logging
 version: 0.1.10
 engine: gotpl
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - or8cr

--- a/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/metrics/Chart.yaml
@@ -16,7 +16,7 @@ name: metrics
 version: 1.4.21
 engine: gotpl
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - or8cr

--- a/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/nms/Chart.yaml
@@ -13,9 +13,9 @@ apiVersion: v1
 description: Magma NMS
 name: nms
 version: 0.1.7
-home: https://github.com/facebookincubator/magma
+home: https://github.com/magma/magma
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - nms

--- a/orc8r/cloud/helm/orc8r/charts/nms/README.md
+++ b/orc8r/cloud/helm/orc8r/charts/nms/README.md
@@ -20,7 +20,7 @@ This chart installs the magma NMS. The NMS is the UI for managing, configuring, 
 
 3. MySql Database created for NMS
 
-4. magmalte image ( build using Docker file https://github.com/facebookincubator/magma/blob/master/symphony/app/packages/magmalte/Dockerfile )
+4. magmalte image ( build using Docker file https://github.com/magma/magma/blob/master/nms/app/packages/magmalte/Dockerfile )
 
 
 

--- a/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/Chart.yaml
@@ -16,7 +16,7 @@ name: secrets
 version: 0.1.10
 engine: gotpl
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - or8cr

--- a/orc8r/gateway/docker/.prod_env
+++ b/orc8r/gateway/docker/.prod_env
@@ -12,7 +12,7 @@
 COMPOSE_PROJECT_NAME=magmad
 DOCKER_REGISTRY=magmad_
 IMAGE_VERSION=latest
-BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
+BUILD_CONTEXT=https://github.com/magma/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/orc8r/gateway/go/services/magmad/README.md
+++ b/orc8r/gateway/go/services/magmad/README.md
@@ -1,6 +1,6 @@
 # magmad service
 
-[![facebookincubator](https://circleci.com/gh/facebookincubator/magma.svg?style=shield)](https://circleci.com/gh/facebookincubator/magma)
+[![magma](https://circleci.com/gh/magma/magma.svg?style=shield)](https://circleci.com/gh/magma/magma)
 
 **magmad** service is a core part of [magma](https://magma.github.io/magma) gateway platform, it is required on every gateway and facilitates the following gateway functionality:
 

--- a/orc8r/tools/docker/install_gateway.sh
+++ b/orc8r/tools/docker/install_gateway.sh
@@ -65,7 +65,7 @@ fi
 rm -rf "$INSTALL_DIR"
 mkdir -p "$INSTALL_DIR"
 
-MAGMA_GITHUB_URL="https://github.com/facebookincubator/magma.git"
+MAGMA_GITHUB_URL="https://github.com/magma/magma.git"
 git -C "$INSTALL_DIR" clone "$MAGMA_GITHUB_URL"
 
 source .env


### PR DESCRIPTION
Note: Magma has moved from github.com/facebookincubator to
github.com/magma.  Clean up all of the old references in the orc8r
code.  github.com/facebookincubator/magma currently points to
github.com/magma/magma so this is primarily cosmetic.


<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Note: Magma has moved from github.com/facebookincubator to
github.com/magma.  Clean up all of the old references in the orc8r
code.  github.com/facebookincubator/magma currently points to
github.com/magma/magma so this is primarily cosmetic.

## Test Plan

Verified urls still work

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->