### PR TITLE
[cwf] Clean up github.com/facebookincubator/magma

### DIFF
--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -15,7 +15,7 @@ DOCKER_USERNAME=
 DOCKER_PASSWORD=
 IMAGE_VERSION=latest
 
-BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
+BUILD_CONTEXT=https://github.com/magma/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/cwf/gateway/helm/cwf-virtlet/Chart.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/Chart.yaml
@@ -13,9 +13,9 @@ apiVersion: "1.0"
 description: Magma Carrier Gateway
 name: cwf
 version: 0.1.11
-home: https://github.com/facebookincubator/magma
+home: https://github.com/magma/magma
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - cwf

--- a/cwf/gateway/helm/cwf-virtlet/README.md
+++ b/cwf/gateway/helm/cwf-virtlet/README.md
@@ -12,7 +12,7 @@ cwf:
     docker_registry: docker.io/cwf_
     tag: latest
   repo:
-    url: https://github.com/facebookincubator/magma.git
+    url: https://github.com/magma/magma.git
     branch: master
 image:
   repository: virtlet.cloud/cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
@@ -81,7 +81,7 @@ The following table list the configurable parameters of the orchestrator chart a
 | `cwf.proxy.cloud_port` | CWF proxy Cloud port. | `9443` |
 | `cwf.proxy.bootstrap_address` | CWF proxy bootstrap address. | `orc8r-bootstrap` |
 | `cwf.proxy.bootstrap_port` | CWF proxy bootstrap port. | `9444` |
-| `cwf.repo.url` | CWF magma repo url. | `https://github.com/facebookincubator/magma/` |
+| `cwf.repo.url` | CWF magma repo url. | `https://github.com/magma/magma/` |
 | `cwf.repo.branch` | CWF magma repo branch. | `master` |
 | `image.repository` | Virtlet image path | `virtlet.cloud/<image_path>` |
 | `image.pullPolicy` | Virtlet Image pullpolicy | `IfNotPresent` |

--- a/cwf/gateway/helm/cwf-virtlet/charts/secrets/Chart.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/charts/secrets/Chart.yaml
@@ -16,7 +16,7 @@ name: secrets
 version: 0.1.2
 engine: gotpl
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - cwf

--- a/cwf/gateway/helm/cwf-virtlet/values.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/values.yaml
@@ -55,7 +55,7 @@ cwf:
     port: 6380
     bind: 127.0.0.1
   repo:
-    url: https://github.com/facebookincubator/magma.git
+    url: https://github.com/magma/magma.git
     branch: master
 #  dpi:
 #    dpi_license_name: cwftest.bin

--- a/cwf/k8s/cwf_operator/deploy/crds/charts.helm.k8s.io_v1alpha1_cwf_cr.yaml
+++ b/cwf/k8s/cwf_operator/deploy/crds/charts.helm.k8s.io_v1alpha1_cwf_cr.yaml
@@ -45,7 +45,7 @@ spec:
       bootstrap_address: bootstrapper-orc8r-proxy.magma.svc.cluster.local
       bootstrap_port: 443
     repo:
-      url: https://github.com/facebookincubator/magma.git
+      url: https://github.com/magma/magma.git
       branch: master
     type: cwag
   fullnameOverride: ""


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Magma has moved from github.com/facebookincubator to
github.com/magma.  Clean up all of the old references in the cwf
code.

The github.com/facebookincubator/magma URL currently points to
github.com/magma/magma so this is primarily cosmetic.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

Double check urls
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->