### PR TITLE
[circleci][lte][docs] Clean up github.com/facebookincubator/magma

### DIFF
--- a/circleci/fabfile.py
+++ b/circleci/fabfile.py
@@ -62,7 +62,7 @@ def lte():
     env.stack = LTE_STACK
 
 
-def integ_test(repo: str = 'git@github.com:facebookincubator/magma.git',
+def integ_test(repo: str = 'git@github.com:magma/magma.git',
                branch: str = '', sha1: str = '', tag: str = '',
                pr_num: str = '',
                magma_root: str = '',

--- a/cwf/gateway/docker/.prod_env
+++ b/cwf/gateway/docker/.prod_env
@@ -15,7 +15,7 @@ DOCKER_USERNAME=
 DOCKER_PASSWORD=
 IMAGE_VERSION=latest
 
-BUILD_CONTEXT=https://github.com/facebookincubator/magma.git#master
+BUILD_CONTEXT=https://github.com/magma/magma.git#master
 
 ROOTCA_PATH=/var/opt/magma/certs/rootCA.pem
 CONTROL_PROXY_PATH=/etc/magma/control_proxy.yml

--- a/cwf/gateway/helm/cwf-virtlet/Chart.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/Chart.yaml
@@ -13,9 +13,9 @@ apiVersion: "1.0"
 description: Magma Carrier Gateway
 name: cwf
 version: 0.1.11
-home: https://github.com/facebookincubator/magma
+home: https://github.com/magma/magma
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - cwf

--- a/cwf/gateway/helm/cwf-virtlet/README.md
+++ b/cwf/gateway/helm/cwf-virtlet/README.md
@@ -12,7 +12,7 @@ cwf:
     docker_registry: docker.io/cwf_
     tag: latest
   repo:
-    url: https://github.com/facebookincubator/magma.git
+    url: https://github.com/magma/magma.git
     branch: master
 image:
   repository: virtlet.cloud/cloud-images.ubuntu.com/bionic/current/bionic-server-cloudimg-amd64.img
@@ -81,7 +81,7 @@ The following table list the configurable parameters of the orchestrator chart a
 | `cwf.proxy.cloud_port` | CWF proxy Cloud port. | `9443` |
 | `cwf.proxy.bootstrap_address` | CWF proxy bootstrap address. | `orc8r-bootstrap` |
 | `cwf.proxy.bootstrap_port` | CWF proxy bootstrap port. | `9444` |
-| `cwf.repo.url` | CWF magma repo url. | `https://github.com/facebookincubator/magma/` |
+| `cwf.repo.url` | CWF magma repo url. | `https://github.com/magma/magma/` |
 | `cwf.repo.branch` | CWF magma repo branch. | `master` |
 | `image.repository` | Virtlet image path | `virtlet.cloud/<image_path>` |
 | `image.pullPolicy` | Virtlet Image pullpolicy | `IfNotPresent` |

--- a/cwf/gateway/helm/cwf-virtlet/charts/secrets/Chart.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/charts/secrets/Chart.yaml
@@ -16,7 +16,7 @@ name: secrets
 version: 0.1.2
 engine: gotpl
 sources:
-  - https://github.com/facebookincubator/magma
+  - https://github.com/magma/magma
 keywords:
   - magma
   - cwf

--- a/cwf/gateway/helm/cwf-virtlet/values.yaml
+++ b/cwf/gateway/helm/cwf-virtlet/values.yaml
@@ -55,7 +55,7 @@ cwf:
     port: 6380
     bind: 127.0.0.1
   repo:
-    url: https://github.com/facebookincubator/magma.git
+    url: https://github.com/magma/magma.git
     branch: master
 #  dpi:
 #    dpi_license_name: cwftest.bin

--- a/cwf/k8s/cwf_operator/deploy/crds/charts.helm.k8s.io_v1alpha1_cwf_cr.yaml
+++ b/cwf/k8s/cwf_operator/deploy/crds/charts.helm.k8s.io_v1alpha1_cwf_cr.yaml
@@ -45,7 +45,7 @@ spec:
       bootstrap_address: bootstrapper-orc8r-proxy.magma.svc.cluster.local
       bootstrap_port: 443
     repo:
-      url: https://github.com/facebookincubator/magma.git
+      url: https://github.com/magma/magma.git
       branch: master
     type: cwag
   fullnameOverride: ""

--- a/docs/docusaurus/versioned_docs/version-1.0.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.0/lte/setup_deb.md
@@ -58,7 +58,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/facebookincubator/magma/v1.0.0/lte/gateway/deploy/agw_prepare.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.0.0/lte/gateway/deploy/agw_prepare.sh
 sh agw_prepare.sh
 ```
 
@@ -68,7 +68,7 @@ A prompt will pop up to as you if you want to stop removing linux-image-4.9.0-11
 - [AGW_DEPLOY] Build and run AGW_DEPLOY container
 
 ```bash
-git clone https://github.com/facebookincubator/magma.git ~/magma
+git clone https://github.com/magma/magma.git ~/magma
 git fetch && git fetch --tags
 git checkout v1.0.0
 

--- a/docs/docusaurus/versioned_docs/version-1.0.1/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.0.1/lte/setup_deb.md
@@ -52,7 +52,7 @@ satisfies the following requirements:
 
 ```bash
 su
-wget https://raw.githubusercontent.com/facebookincubator/magma/v1.0/lte/gateway/deploy/agw_install.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.0/lte/gateway/deploy/agw_install.sh
 bash agw_install.sh
 ```
 

--- a/docs/docusaurus/versioned_docs/version-1.1.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.1.0/lte/setup_deb.md
@@ -48,7 +48,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/facebookincubator/magma/v1.1/lte/gateway/deploy/agw_install.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.1/lte/gateway/deploy/agw_install.sh
 sh agw_install.sh
 ```
 

--- a/docs/docusaurus/versioned_docs/version-1.2.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.2.0/lte/setup_deb.md
@@ -48,7 +48,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/facebookincubator/magma/v1.2/lte/gateway/deploy/agw_install.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.2/lte/gateway/deploy/agw_install.sh
 sh agw_install.sh
 ```
 

--- a/docs/docusaurus/versioned_docs/version-1.3.0/lte/setup_deb.md
+++ b/docs/docusaurus/versioned_docs/version-1.3.0/lte/setup_deb.md
@@ -48,7 +48,7 @@ installation process to get an IP using DHCP.
 
 ```bash
 su
-wget https://raw.githubusercontent.com/facebookincubator/magma/v1.3/lte/gateway/deploy/agw_install.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.3/lte/gateway/deploy/agw_install.sh
 bash agw_install.sh
 ```
 


### PR DESCRIPTION
## Summary

Magma has moved from github.com/facebookincubator to
github.com/magma. Clean up all of the old references.

The github.com/facebookincubator/magma url currently points to
github.com/magma/magma so this is primarily cosmetic.


<!-- Enumerate changes you made and why you made them -->

## Test Plan

Double check urls
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->