### PR TITLE
[lte][agw] Update CPE monitoring last reported time to milliseconds

### DIFF
--- a/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/handlers/handlers_test.go
@@ -434,7 +434,8 @@ func TestListSubscribers(t *testing.T) {
 				ActiveApns: subscriberModels.ApnList{apn2, apn1},
 				Monitoring: &subscriberModels.SubscriberStatus{
 					Icmp: &subscriberModels.IcmpStatus{
-						LastReportedTime: frozenClock,
+						// LastReportedTime is calculated in milliseconds
+						LastReportedTime: frozenClock * 1000,
 						LatencyMs:        f32Ptr(12.34),
 					},
 				},
@@ -639,7 +640,8 @@ func TestGetSubscriber(t *testing.T) {
 			ActiveApns: subscriberModels.ApnList{apn2, apn1},
 			Monitoring: &subscriberModels.SubscriberStatus{
 				Icmp: &subscriberModels.IcmpStatus{
-					LastReportedTime: frozenClock,
+					// LastReportedTime is calculated in milliseconds
+					LastReportedTime: frozenClock * 1000,
 					LatencyMs:        f32Ptr(12.34),
 				},
 			},

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/conversion.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"magma/lte/cloud/go/lte"
 	policymodels "magma/lte/cloud/go/services/policydb/obsidian/models"
@@ -74,8 +73,7 @@ func (m *Subscriber) FillAugmentedFields(states state_types.StatesByID) {
 			m.State.SubscriberState = stateVal.ReportedState.(*state.ArbitraryJSON)
 		case lte.ICMPStateType:
 			reportedState := stateVal.ReportedState.(*IcmpStatus)
-			// Reported time is unix timestamp in seconds, so divide ms by 1k
-			reportedState.LastReportedTime = int64(stateVal.TimeMs / uint64(time.Second/time.Millisecond))
+			reportedState.LastReportedTime = int64(stateVal.TimeMs)
 			m.Monitoring.Icmp = reportedState
 		case lte.SPGWStateType:
 			reportedState := stateVal.ReportedState.(*state.ArbitraryJSON)

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/icmp_status_swaggergen.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/icmp_status_swaggergen.go
@@ -17,8 +17,8 @@ import (
 // swagger:model icmp_status
 type IcmpStatus struct {
 
-	// last reported time
-	LastReportedTime float32 `json:"last_reported_time,omitempty"`
+	// Timestamp of last reported status for the subscriber in ms
+	LastReportedTime int64 `json:"last_reported_time,omitempty"`
 
 	// latency ms
 	// Required: true

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/icmp_status_swaggergen.go
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/icmp_status_swaggergen.go
@@ -18,7 +18,7 @@ import (
 type IcmpStatus struct {
 
 	// last reported time
-	LastReportedTime int64 `json:"last_reported_time,omitempty"`
+	LastReportedTime float32 `json:"last_reported_time,omitempty"`
 
 	// latency ms
 	// Required: true

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
@@ -503,8 +503,9 @@ definitions:
         format: float
         example: 12.34
       last_reported_time:
-        type: number
-        format: float
+        description: Timestamp of last reported status for the subscriber in ms
+        type: integer
+        format: int64
         example: 1605747300000
 
   apn_list:

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
@@ -503,8 +503,9 @@ definitions:
         format: float
         example: 12.34
       last_reported_time:
-        type: integer
-        format: int64
+        type: number
+        format: float
+        example: 1605747300000
 
   apn_list:
     type: array

--- a/lte/gateway/configs/pipelined.yml
+++ b/lte/gateway/configs/pipelined.yml
@@ -131,7 +131,7 @@ redis_enabled: false
 magma_print_grpc_payload: false
 
 # MTR iface IP
-mtr_ip: 10.0.2.10
+mtr_ip: 10.1.0.1
 mtr_interface: mtr0
 
 ###############

--- a/lte/gateway/python/magma/monitord/cpe_monitoring.py
+++ b/lte/gateway/python/magma/monitord/cpe_monitoring.py
@@ -13,7 +13,7 @@ limitations under the License.
 import logging
 from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, NamedTuple, Optional
 import ipaddress
 
 import grpc
@@ -25,73 +25,73 @@ from magma.magmad.check.network_check.ping import PingCommandResult
 from magma.monitord.icmp_state import ICMPMonitoringResponse
 from orc8r.protos.common_pb2 import Void
 from prometheus_client import Histogram
-from magma.subscriberdb.sid import SIDUtils
 
 SUBSCRIBER_ICMP_LATENCY_MS = Histogram('subscriber_icmp_latency_ms',
-                                  'Reported latency for subscriber '
-                                  'in milliseconds',
-                                  ['imsi'],
-                                  buckets=[50, 100, 200, 500, 1000, 2000])
+                                       'Reported latency for subscriber '
+                                       'in milliseconds',
+                                       ['imsi'],
+                                       buckets=[50, 100, 200, 500, 1000, 2000])
+
+PingedTargets = NamedTuple('PingedTargets',
+                           [('ping_targets', Dict['str', IPAddress]),
+                            ('ping_addresses', List[IPAddress])])
+
 
 def _get_addr_from_subscribers(sub_ip) -> str:
-    return str(ipaddress.IPv4Address(
-        sub_ip.address.decode()) if sub_ip.version == 0 else \
-                   ipaddress.IPv6Address(sub_ip.address.decode()))
-
-class CpeMonitoringModule():
-
-  def __init__(self):
-    # TODO: Save to redis
-    self._subscriber_state = defaultdict(ICMPMonitoringResponse)
-    self.ping_addresses = []
-    self.ping_targets = {}
+    return str(ipaddress.IPv4Address(sub_ip.address)
+               if sub_ip.version == IPAddress.IPV4
+               else str(ipaddress.IPv6Address(sub_ip.address)))
 
 
-  def set_manually_configured_targets(self, configured_ping_targets: {}):
+class CpeMonitoringModule:
+    def __init__(self):
+        # TODO: Save to redis
+        self._subscriber_state = defaultdict(ICMPMonitoringResponse)
+        self.ping_addresses = []
+        self.ping_targets = {}
 
-    self.ping_targets = configured_ping_targets.copy()
-    for value in self.ping_targets.values():
-        ip = _get_addr_from_subscribers(value)
-        self.ping_addresses.append(ip)
+    def set_manually_configured_targets(self,
+                                        configured_ping_targets:
+                                        Optional[Dict] = None):
+        if configured_ping_targets:
+            self.ping_targets = configured_ping_targets.copy()
+            for value in self.ping_targets.values():
+                ip = _get_addr_from_subscribers(value)
+                self.ping_addresses.append(ip)
 
+    async def get_ping_targets(self, service_loop) -> PingedTargets:
+        """
+        Sends gRPC call to mobilityd to get all subscribers table.
 
-  async def get_ping_targets(self, service_loop) -> List[IPAddress]:
-    """
-    Sends gRPC call to mobilityd to get all subscribers table.
+        Returns: List of [Subscriber ID => IP address, APN] entries
+        """
 
-    Returns: List of [Subscriber ID => IP address, APN] entries
-    """
+        try:
+            mobilityd_chan = ServiceRegistry.get_rpc_channel('mobilityd',
+                                                             ServiceRegistry.LOCAL)
+            mobilityd_stub = MobilityServiceStub(mobilityd_chan)
+            response = await grpc_async_wrapper(
+                mobilityd_stub.GetSubscriberIPTable.future(Void(),
+                                                           10), service_loop)
+            for sub in response.entries:
+                ip = _get_addr_from_subscribers(sub.ip)
+                self.ping_addresses.append(ip)
+                self.ping_targets[sub.sid.id] = ip
+        except grpc.RpcError as err:
+            logging.error(
+                "GetSubscribers Error for %s! %s", err.code(), err.details())
+        return PingedTargets(self.ping_targets, self.ping_addresses)
 
-    try:
-        mobilityd_chan = ServiceRegistry.get_rpc_channel('mobilityd',
-                                                       ServiceRegistry.LOCAL)
-        mobilityd_stub = MobilityServiceStub(mobilityd_chan)
-        response = await grpc_async_wrapper(
-        mobilityd_stub.GetSubscriberIPTable.future(Void(),
-                                                     10),service_loop)
-        for sub in response.entries:
-            ip = _get_addr_from_subscribers(sub.ip)
-            self.ping_addresses.append(ip)
-            self.ping_targets[sub.sid.id] = ip
-    except grpc.RpcError as err:
-        logging.error(
-            "GetSubscribers Error for %s! %s", err.code(), err.details())
+    def save_ping_response(self, sid: str, ip_addr: str,
+                           ping_resp: PingCommandResult) -> None:
+        reported_time = datetime.now().timestamp()
+        self._subscriber_state[sid] = ICMPMonitoringResponse(
+            last_reported_time=float(reported_time),
+            latency_ms=ping_resp.stats.rtt_avg)
+        SUBSCRIBER_ICMP_LATENCY_MS.labels(sid).observe(ping_resp.stats.rtt_avg)
+        logging.info(
+            '{}:{} => {}ms'.format(sid, ip_addr,
+                                   self._subscriber_state[sid].latency_ms))
 
-    return self.ping_targets, self.ping_addresses
-
-
-  def save_ping_response(self, sid: str, ip_addr: str,
-                            ping_resp: PingCommandResult) -> None:
-    reported_time = datetime.now().timestamp()
-    self._subscriber_state[sid] = ICMPMonitoringResponse(
-      last_reported_time=int(reported_time),
-      latency_ms=ping_resp.stats.rtt_avg)
-    SUBSCRIBER_ICMP_LATENCY_MS.labels(sid).observe(ping_resp.stats.rtt_avg)
-    logging.info(
-      '{}:{} => {}ms'.format(sid, ip_addr,
-                             self._subscriber_state[sid].latency_ms))
-
-  def get_subscriber_state(self) -> Dict[str, ICMPMonitoringResponse]:
-      return self._subscriber_state
-
-
+    def get_subscriber_state(self) -> Dict[str, ICMPMonitoringResponse]:
+        return self._subscriber_state

--- a/lte/gateway/python/magma/monitord/icmp_monitoring.py
+++ b/lte/gateway/python/magma/monitord/icmp_monitoring.py
@@ -11,25 +11,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import asyncio
-import ipaddress
 import logging
-from typing import Dict, List
+from typing import Dict, List, Optional
 
-import grpc
-from lte.protos.mobilityd_pb2 import IPAddress, SubscriberIPTable
 from magma.common.job import Job
-from magma.common.rpc_utils import grpc_async_wrapper
-from magma.common.service_registry import ServiceRegistry
-from magma.magmad.check.network_check.ping import PingInterfaceCommandParams, ping_interface_async
+from magma.magmad.check.network_check.ping import PingInterfaceCommandParams, \
+    ping_interface_async
 from magma.magmad.check.network_check.ping import PingCommandResult
-from magma.monitord.icmp_state import ICMPMonitoringResponse
-from orc8r.protos.common_pb2 import Void
-
 
 NUM_PACKETS = 4
 DEFAULT_POLLING_INTERVAL = 60
 TIMEOUT_SECS = 10
 CHECKIN_INTERVAL = 10
+
 
 class ICMPMonitoring(Job):
     """
@@ -40,6 +34,7 @@ class ICMPMonitoring(Job):
                  mtr_interface: str):
         super().__init__(interval=CHECKIN_INTERVAL, loop=service_loop)
         self._MTR_PORT = mtr_interface
+        logging.info("Running on interface %s..." % self._MTR_PORT)
         # Matching response time output to get latency
         self._polling_interval = max(polling_interval,
                                      DEFAULT_POLLING_INTERVAL)
@@ -47,29 +42,31 @@ class ICMPMonitoring(Job):
         self._module = monitoring_module
 
     async def _ping_targets(self, hosts: List[str],
-                                targets: {}):
+                            targets: Optional[Dict] = None):
         """
         Sends a count of ICMP pings to target IP address, returns response.
         Args:
             hosts: List of ip addresses to ping
-            subscribers: List of valid subscribers to ping to
+            targets: List of valid subscribers to ping to
 
         Returns: (stdout, stderr)
         """
-        ping_params = [
-            PingInterfaceCommandParams(host, NUM_PACKETS, self._MTR_PORT,
-                                            TIMEOUT_SECS) for host in hosts]
-        ping_results = await ping_interface_async(ping_params, self._loop)
-        ping_results_list = list(ping_results)
-        for host, sub, result in zip(hosts, targets, ping_results_list):
-            self._save_ping_response(sub, host, result)
+        if targets:
+            ping_params = [
+                PingInterfaceCommandParams(host, NUM_PACKETS, self._MTR_PORT,
+                                           TIMEOUT_SECS) for host in hosts]
+            ping_results = await ping_interface_async(ping_params, self._loop)
+            ping_results_list = list(ping_results)
+            for host, sub, result in zip(hosts, targets, ping_results_list):
+                self._save_ping_response(sub, host, result)
 
     def _save_ping_response(self, target_id: str, ip_addr: str,
                             ping_resp: PingCommandResult) -> None:
         """
         Saves ping response to in-memory subscriber dict.
         Args:
-            sid: subscriber ID
+            target_id: target ID to ping
+            ip_addr: IP Address to ping
             ping_resp: response of ICMP ping command
         """
         if ping_resp.error:
@@ -79,13 +76,9 @@ class ICMPMonitoring(Job):
             self._module.save_ping_response(target_id, ip_addr, ping_resp)
 
     async def _run(self) -> None:
-        logging.info("Running on interface %s..." % self._MTR_PORT)
-        while True:
-            targets, addresses = await self._module.get_ping_targets(self._loop)
-            if len(targets) > 0:
-                await self._ping_targets(addresses, targets)
-                await asyncio.sleep(self._polling_interval, self._loop)
-            else:
-                logging.warning('No subscribers/ping targets found, retrying...')
-                await asyncio.sleep(self._polling_interval, self._loop)
-                continue
+        targets, addresses = await self._module.get_ping_targets(self._loop)
+        if len(targets) > 0:
+            await self._ping_targets(addresses, targets)
+        else:
+            logging.warning('No subscribers/ping targets found')
+        await asyncio.sleep(self._polling_interval, self._loop)

--- a/lte/gateway/python/magma/monitord/icmp_state.py
+++ b/lte/gateway/python/magma/monitord/icmp_state.py
@@ -18,7 +18,7 @@ from orc8r.protos.service303_pb2 import State
 ICMP_STATE_TYPE = "icmp_monitoring"
 
 ICMPMonitoringResponse = NamedTuple('ICMPMonitoringResponse',
-                                    [('last_reported_time', float),
+                                    [('last_reported_time', int),
                                      ('latency_ms', float)])
 
 

--- a/lte/gateway/python/magma/monitord/icmp_state.py
+++ b/lte/gateway/python/magma/monitord/icmp_state.py
@@ -18,7 +18,7 @@ from orc8r.protos.service303_pb2 import State
 ICMP_STATE_TYPE = "icmp_monitoring"
 
 ICMPMonitoringResponse = NamedTuple('ICMPMonitoringResponse',
-                                    [('last_reported_time', int),
+                                    [('last_reported_time', float),
                                      ('latency_ms', float)])
 
 

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -20,6 +20,10 @@ import logging
 from lte.protos.mobilityd_pb2 import IPAddress
 
 
+def _get_serialized_subscriber_states(cpe_monitor: CpeMonitoringModule):
+    return serialize_subscriber_states(cpe_monitor.get_subscriber_state())
+
+
 def main():
     """ main() for monitord service"""
     manual_ping_targets = {}
@@ -28,6 +32,7 @@ def main():
     # Monitoring thread loop
     mtr_interface = load_service_config("monitord")["mtr_interface"]
 
+    # Add manual IP targets from yml file
     try:
         targets = load_service_config("monitord")["ping_targets"]
         for target, data in targets.items():
@@ -51,8 +56,7 @@ def main():
 
     # Register a callback function for GetOperationalStates
     service.register_operational_states_callback(
-        lambda: serialize_subscriber_states(
-            cpe_monitor.get_subscriber_state()))
+        _get_serialized_subscriber_states(cpe_monitor))
 
     # Run the service loop
     service.run()

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -36,7 +36,7 @@ def main():
                 logging.debug('Adding {}:{}:{} to ping target'.format(target, ip.version, ip.address))
                 manual_ping_targets[target] = ip
     except KeyError:
-        logging.error("No ping targets configured")
+        logging.warning("No ping targets configured")
 
     obj = CpeMonitoringModule()
     obj.set_manually_configured_targets(manual_ping_targets)

--- a/lte/gateway/python/magma/monitord/main.py
+++ b/lte/gateway/python/magma/monitord/main.py
@@ -32,23 +32,27 @@ def main():
         targets = load_service_config("monitord")["ping_targets"]
         for target, data in targets.items():
             if "ip" in data:
-                ip = IPAddress(version=IPAddress.IPV4, address=str.encode(data["ip"]))
-                logging.debug('Adding {}:{}:{} to ping target'.format(target, ip.version, ip.address))
+                ip = IPAddress(version=IPAddress.IPV4,
+                               address=str.encode(data["ip"]))
+                logging.debug(
+                    'Adding {}:{}:{} to ping target'.format(target, ip.version,
+                                                            ip.address))
                 manual_ping_targets[target] = ip
     except KeyError:
         logging.warning("No ping targets configured")
 
-    obj = CpeMonitoringModule()
-    obj.set_manually_configured_targets(manual_ping_targets)
+    cpe_monitor = CpeMonitoringModule()
+    cpe_monitor.set_manually_configured_targets(manual_ping_targets)
 
-    icmp_monitor = ICMPMonitoring(obj, service.mconfig.polling_interval,
+    icmp_monitor = ICMPMonitoring(cpe_monitor,
+                                  service.mconfig.polling_interval,
                                   service.loop, mtr_interface)
     icmp_monitor.start()
 
     # Register a callback function for GetOperationalStates
     service.register_operational_states_callback(
         lambda: serialize_subscriber_states(
-            icmp_monitor.get_subscriber_state()))
+            cpe_monitor.get_subscriber_state()))
 
     # Run the service loop
     service.run()

--- a/lte/gateway/python/magma/monitord/tests/test_metrics.py
+++ b/lte/gateway/python/magma/monitord/tests/test_metrics.py
@@ -14,7 +14,7 @@ limitations under the License.
 import unittest
 
 from magma.common import metrics_export
-from magma.monitord.cpe_monitoring import SUBSCRIBER_ICMP_LATENCY_MS
+from magma.monitord.cpe_monitoring import subscriber_icmp_latency_ms
 
 
 class MetricTests(unittest.TestCase):
@@ -23,7 +23,7 @@ class MetricTests(unittest.TestCase):
     """
     def test_metrics_defined(self):
         """ Test that all metrics are defined in proto enum """
-        SUBSCRIBER_ICMP_LATENCY_MS.labels('IMSI00000001').observe(10.33)
+        subscriber_icmp_latency_ms.labels('IMSI00000001').observe(10.33)
 
         metrics_protos = list(metrics_export.get_metrics())
         for metrics_proto in metrics_protos:


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

- `last_reported_time` on subscriber state is updated to float, to fix NMS dependency discrepancy (Date object expects float, due to this it's showing incorrect date)
- Fixing incorrect module naming for cpe_monitoring object
- Updating pipelined.yml to `10.1.0.1` to match mtr0 iface config
- Reformatting code on monitord module

## Test Plan

- Tested locally on AGW, and local Orc8r with eNB and UE to check ICMP monitoring reaches target and reports state correctly

```
(python) vagrant@magma-dev:~/magma/lte/gateway$ sudo journalctl -fu magma@monitord
-- Logs begin at Tue 2020-12-01 07:42:04 UTC. --
Dec 01 08:54:18 magma-dev monitord[13382]: ERROR:root:GetSubscribers Error for StatusCode.UNAVAILABLE! Connect Failed
Dec 01 08:54:18 magma-dev monitord[13382]: WARNING:root:No subscribers/ping targets found
Dec 01 08:55:31 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 179.451ms
Dec 01 08:56:27 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606812931.343585, "latency_ms": 179.451}
Dec 01 08:56:45 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 127.01ms
Dec 01 08:57:27 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813005.555548, "latency_ms": 127.01}
Dec 01 08:57:58 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 244.653ms
Dec 01 08:58:27 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813078.78969, "latency_ms": 244.653}
Dec 01 08:59:12 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 172.52ms
Dec 01 08:59:27 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813152.992067, "latency_ms": 172.52}
Dec 01 09:00:27 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 249.099ms
Dec 01 09:00:27 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813227.191562, "latency_ms": 249.099}
Dec 01 09:01:27 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813227.191562, "latency_ms": 249.099}
Dec 01 09:01:41 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 152.87ms
Dec 01 09:02:28 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813301.393722, "latency_ms": 152.87}
Dec 01 09:02:54 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 239.474ms
Dec 01 09:03:28 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813374.732781, "latency_ms": 239.474}
Dec 01 09:04:08 magma-dev monitord[13382]: INFO:root:001010000000082:192.168.128.84 => 183.536ms
Dec 01 09:04:28 magma-dev monitord[13382]: INFO:root:Replicating state for 001010000000082: {"last_reported_time": 1606813448.900638, "latency_ms": 183.536}
```

## Additional Information

- [ ] This change is backwards-breaking

