### PR TITLE
[show-tech] Core dumps analysis role

### DIFF
--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -39,12 +39,9 @@ paths_to_collect:
   - "/var/log/MME.*"
   - "/var/log/enode.*"
 
-# core file paths for gdb execution
+# core file paths for gdb execution, requires core file location and binary
 core_file_age_in_days: 7
 cores_paths:
   mme:
     path: "/tmp/core-*/core-*-mme-*"
     binary: "/usr/local/bin/mme"
-  stam:
-    path: "/tmp/core-*/core-*-stam-*"
-    binary: "/usr/local/bin/stam"

--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -41,6 +41,7 @@ paths_to_collect:
   - "/var/log/enode.*"
 
 # core file paths for gdb execution, requires core file location and binary
+gdb_command: "gdb --batch --quiet -ex 'start thread apply all bt full' -ex 'quit'"
 core_file_age_in_days: 7
 cores_paths:
   mme:

--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -34,8 +34,17 @@ paths_to_collect:
   - "/var/opt/magma/configs/*"
   - "/etc/magma/configs/*"
   - "/etc/systemd/system/*"
-  - "/tmp/*core*"
   - "/usr/local/bin/mme"
   - "/var/log/syslog"
   - "/var/log/MME.*"
   - "/var/log/enode.*"
+
+# core file paths for gdb execution
+core_file_age_in_days: 7
+cores_paths:
+  mme:
+    path: "/tmp/core-*/core-*-mme-*"
+    binary: "/usr/local/bin/mme"
+  stam:
+    path: "/tmp/core-*/core-*-stam-*"
+    binary: "/usr/local/bin/stam"

--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -41,8 +41,7 @@ paths_to_collect:
   - "/var/log/enode.*"
 
 # core file paths for gdb execution, requires core file location and binary
-gdb_command: "gdb --batch --quiet -ex 'start thread apply all bt full' -ex 'quit'"
-core_file_age_in_days: 7
+core_file_age_in_days: 3
 cores_paths:
   mme:
     path: "/tmp/core-*/core-*-mme-*"

--- a/show-tech/constants.yml
+++ b/show-tech/constants.yml
@@ -27,6 +27,7 @@ debian_commands:
   - "ping google.com -I eth0 -c 5"
   - "journalctl -u magma@*"
   - "timeout 60 sudo tcpdump -i any sctp -w {{report_dir_output.stdout}}/sctp.pcap"
+  - "timeout 60 sudo tcpdump -i any port 48080 -w {{report_dir_output.stdout}}/any-48080.pcap"
 
 
 # files to collect from src to relative destination in tar.gz package

--- a/show-tech/roles/cores/files/handle_cores.py
+++ b/show-tech/roles/cores/files/handle_cores.py
@@ -11,8 +11,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import argparse
 import click
+import datetime
 import glob
 import gzip
 import logging
@@ -21,7 +21,6 @@ import os
 import shutil
 import subprocess
 import shlex
-
 
 logging.basicConfig(format='%(levelname)s: %(message)s' ,level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -33,9 +32,18 @@ class ComponentCores(object):
         self.component_data = cores_map[component]
         self.max_age = max_age
         self.dest_dir = dest_dir
-        self.cores = glob.glob(self.component_data["path"])
+        self.all_cores = glob.glob(self.component_data["path"])
+        self.cores = self.filter_files_by_ctime()
         self.app_binary = self.component_data["binary"]
         self.core_dirs = { os.path.dirname(x) for x in self.cores }
+
+    def filter_files_by_ctime(self):
+        cores = []
+        start_time = (datetime.datetime.now() - datetime.timedelta(days=self.max_age)).timestamp()
+        for corefile in self.all_cores:
+            if os.path.getctime(corefile) > start_time:
+                cores.append(corefile)
+        return cores
 
     def get_core_files(self):
         return self.cores

--- a/show-tech/roles/cores/files/handle_cores.py
+++ b/show-tech/roles/cores/files/handle_cores.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import argparse
+import click
+import glob
+import gzip
+import logging
+import os
+import shutil
+import subprocess
+import shlex
+
+
+logging.basicConfig(format='%(levelname)s: %(message)s' ,level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+DEFAULT_CORE_MAP = {
+    "mme": {
+        "path": "/tmp/core-*/core-*-mme-*",
+        "binary": "/usr/local/bin/mme",
+    }
+}
+
+
+class ComponentCores(object):
+    def __init__(self, cores_map, component, max_age, dest_dir):
+        self.component = component
+        self.component_data = cores_map[component]
+        self.max_age = max_age
+        self.dest_dir = dest_dir
+        self.cores = glob.glob(self.component_data["path"])
+        self.app_binary = self.component_data["binary"]
+        self.core_dirs = { os.path.dirname(x) for x in self.cores }
+
+    def get_core_files(self):
+        return self.cores
+
+    def get_core_dirs(self):
+        return self.core_dirs
+
+    def process_cores(self):
+        # Copy them to destination folder
+        logger.info(f"Processing cores of component {self.component} dirs {self.get_core_dirs()}")
+        for core_dir in self.get_core_dirs():
+            dest_core_dir = os.path.join(self.dest_dir, os.path.basename(core_dir))
+            logger.info(f"Copying {core_dir} to {dest_core_dir}")
+            if os.path.exists(dest_core_dir):
+                shutil.rmtree(dest_core_dir)
+            shutil.copytree(core_dir, dest_core_dir)
+        # Uncompress them on source dir
+        for core_file in  self.get_core_files():
+            logger.debug(f"Analyzing {core_file}")
+            core = CoreFile(core_file, self.app_binary, self.dest_dir)
+            core.analyze()
+
+
+class CoreFile(object):
+    def __init__(self, core_file_name, app_binary, dest_dir):
+        self.core_file_name = core_file_name
+        self.uncompressed_core_file = core_file_name
+        self.app_binary = app_binary
+        self.dest_dir = dest_dir
+
+    def uncompress_file(self):
+        if self.is_compressed():
+            uncompressed_core_file = self.core_file_name.replace(".gz", "")
+            with gzip.open(self.core_file_name, 'rb') as f_in:
+                with open(uncompressed_core_file, 'wb') as f_out:
+                    shutil.copyfileobj(f_in, f_out)
+            self.uncompressed_core_file = uncompressed_core_file
+            os.remove(self.core_file_name)
+
+    def is_compressed(self):
+        if self.core_file_name.endswith(".gz"):
+            return True
+        return False
+
+    def analyze(self):
+        self.uncompress_file()
+        cmd = f"gdb --batch --quiet -ex 'thread apply all bt full' -ex 'quit'  {self.app_binary} {self.uncompressed_core_file}"
+        core_dest_dir = os.path.join(self.dest_dir, os.path.basename(os.path.dirname(self.uncompressed_core_file)))
+        dbg_file = os.path.join(core_dest_dir, "dbg.txt")
+        os.makedirs(core_dest_dir, exist_ok=True)
+        if os.path.isfile(dbg_file):
+            # trying to avoid duplicates of analyzing gzipped files
+            return
+        logger.info(f"dbg_file {dbg_file}")
+
+        with open(dbg_file, 'a') as fout:
+            ret = subprocess.run(
+                shlex.split(cmd),
+                check=True,
+                stdout=fout,
+                stderr=fout,
+                timeout=60
+            )
+
+
+@click.command()
+@click.option(
+    "--cores-map",
+    help="Map of core files to collect and process with binary",
+    default=DEFAULT_CORE_MAP
+)
+@click.option(
+    "--component",
+    help="Component name like mme",
+    required=True,
+)
+@click.option(
+    "--max-age",
+    help="Age of core files to process in days",
+    default=7,
+)
+@click.option(
+    "--dest-dir",
+    help="destination directory to place cores and dbg outputs in",
+    required=True,
+)
+def main(cores_map : dict, component: str, max_age: int, dest_dir: str):
+    print(f"processing cores on component {component}")
+    c = ComponentCores(cores_map, component, max_age, dest_dir)
+    c.process_cores()
+
+
+if __name__ == "__main__":
+    main()

--- a/show-tech/roles/cores/files/handle_cores.py
+++ b/show-tech/roles/cores/files/handle_cores.py
@@ -90,7 +90,7 @@ class CoreFile(object):
 
     def analyze(self):
         self.uncompress_file()
-        cmd = "gdb --batch --quiet -ex 'thread apply all bt full' -ex 'quit'  {} {}".format(self.app_binary, self.uncompressed_core_file)
+        cmd = "{{gdb_command}}  {} {}".format(self.app_binary, self.uncompressed_core_file)
         core_dest_dir = os.path.join(self.dest_dir, os.path.basename(os.path.dirname(self.uncompressed_core_file)))
         dbg_file = os.path.join(core_dest_dir, "dbg.txt")
         os.makedirs(core_dest_dir, exist_ok=True)

--- a/show-tech/roles/cores/files/handle_cores.py
+++ b/show-tech/roles/cores/files/handle_cores.py
@@ -90,7 +90,7 @@ class CoreFile(object):
 
     def analyze(self):
         self.uncompress_file()
-        cmd = "{{gdb_command}}  {} {}".format(self.app_binary, self.uncompressed_core_file)
+        cmd = "gdb --batch --quiet -ex 'start thread apply all bt full' -ex 'quit'  {} {}".format(self.app_binary, self.uncompressed_core_file)
         core_dest_dir = os.path.join(self.dest_dir, os.path.basename(os.path.dirname(self.uncompressed_core_file)))
         dbg_file = os.path.join(core_dest_dir, "dbg.txt")
         os.makedirs(core_dest_dir, exist_ok=True)

--- a/show-tech/roles/cores/files/handle_cores.py
+++ b/show-tech/roles/cores/files/handle_cores.py
@@ -45,16 +45,16 @@ class ComponentCores(object):
 
     def process_cores(self):
         # Copy them to destination folder
-        logger.debug(f"Processing cores of component {self.component} dirs {self.get_core_dirs()}")
+        logger.debug("Processing cores of component {} dirs {}".format(self.component, self.get_core_dirs()))
         for core_dir in self.get_core_dirs():
             dest_core_dir = os.path.join(self.dest_dir, os.path.basename(core_dir))
-            logger.info(f"Copying {core_dir} to {dest_core_dir}")
+            logger.info("Copying {} to {}".format(core_dir, dest_core_dir))
             if os.path.exists(dest_core_dir):
                 shutil.rmtree(dest_core_dir)
             shutil.copytree(core_dir, dest_core_dir)
         # Uncompress them on source dir
         for core_file in  self.get_core_files():
-            logger.debug(f"Analyzing {core_file}")
+            logger.debug("Analyzing {}".format(core_file))
             core = CoreFile(core_file, self.app_binary, self.dest_dir)
             core.analyze()
 
@@ -82,11 +82,11 @@ class CoreFile(object):
 
     def analyze(self):
         self.uncompress_file()
-        cmd = f"gdb --batch --quiet -ex 'thread apply all bt full' -ex 'quit'  {self.app_binary} {self.uncompressed_core_file}"
+        cmd = "gdb --batch --quiet -ex 'thread apply all bt full' -ex 'quit'  {} {}".format(self.app_binary, self.uncompressed_core_file)
         core_dest_dir = os.path.join(self.dest_dir, os.path.basename(os.path.dirname(self.uncompressed_core_file)))
         dbg_file = os.path.join(core_dest_dir, "dbg.txt")
         os.makedirs(core_dest_dir, exist_ok=True)
-        logger.info(f"component {self.app_binary} core {self.uncompressed_core_file} - dbg output file: {dbg_file}")
+        logger.info("component {} core {} - dbg output file: {}".format(self.app_binary, self.uncompressed_core_file, dbg_file))
 
         with open(dbg_file, 'a') as fout:
             ret = subprocess.run(
@@ -121,7 +121,7 @@ class CoreFile(object):
 )
 def main(cores_map : str, component: str, max_age: int, dest_dir: str):
     cores_map = json.loads(cores_map)
-    logger.info(f"processing cores on component {component}")
+    logger.info("processing cores on component {}".format(component))
     c = ComponentCores(cores_map, component, max_age, dest_dir)
     c.process_cores()
 

--- a/show-tech/roles/cores/tasks/main.yml
+++ b/show-tech/roles/cores/tasks/main.yml
@@ -20,7 +20,7 @@
 
 
 - name: handle core files
-  script: handle_cores.py --cores-map {{cores_paths}} --component {{item.key}} --max-age {{core_file_age_in_days}} --dest-dir {{report_dir_output.stdout}}
+  script: handle_cores.py --cores-map '{{cores_paths | to_json }}' --component {{item.key}} --max-age {{core_file_age_in_days}} --dest-dir {{report_dir_output.stdout}}
   register: output
   loop: "{{cores_paths | dict2items}}"
 

--- a/show-tech/roles/cores/tasks/main.yml
+++ b/show-tech/roles/cores/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+#
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+- name: install gdb package
+  apt:
+    name: "gdb"
+    state: present
+    update_cache: yes
+  when: ansible_facts['distribution'] == 'Debian' or ansible_facts['distribution'] == 'Ubuntu'
+
+
+- name: handle core files
+  script: handle_cores.py --cores-map {{cores_paths}} --component {{item.key}} --max-age {{core_file_age_in_days}} --dest-dir {{report_dir_output.stdout}}
+  register: output
+  loop: "{{cores_paths | dict2items}}"
+
+
+- name: display script output
+  debug:
+    msg: "{{ output }}"

--- a/show-tech/show-tech.yml
+++ b/show-tech/show-tech.yml
@@ -25,4 +25,5 @@
     - role: destdir
     - role: files
     - role: commands
+    - role: cores
     - role: package


### PR DESCRIPTION
<!--
    [show-tech] Core dumps analysis role
-->

## Summary

Adding capability to run gdb on agw during playbook execution

## Test Plan

Tested on agw as user root.
```
# git clone https://github.com/ayliD/magma.git -b core_dumps

# cd magma/show-tech

# ansible-playbook show-tech.yml

[....]
TASK [cores : install gdb package] *****************************************************************************************************************************************************************************************************************************************
ok: [localhost]

TASK [cores : handle core files] *******************************************************************************************************************************************************************************************************************************************

changed: [localhost] => (item={u'key': u'mme', u'value': {u'path': u'/tmp/core-*/core-*-mme-*', u'binary': u'/usr/local/bin/mme'}})

[...]
                  "INFO: component /usr/local/bin/mme core /tmp/core-1603820628-mme-14686_bundle/core-1603820628-mme-14686 - dbg output file: /tmp/magma_reports/report.magma.2020-12-01T15:26:53Z/core-1603820628-mme-14686_bundle/dbg.txt",
                    "INFO: component /usr/local/bin/mme core /tmp/core-1603825355-mme-1197_bundle/core-1603825355-mme-1197 - dbg output file: /tmp/magma_reports/report.magma.2020-12-01T15:26:53Z/core-1603825355-mme-1197_bundle/dbg.txt",
                    "INFO: component /usr/local/bin/mme core /tmp/core-1603823042-mme-25092_bundle/core-1603823042-mme-25092 - dbg output file: /tmp/magma_reports/report.magma.2020-12-01T15:26:53Z/core-1603823042-mme-25092_bundle/dbg.txt",
                    "INFO: component /usr/local/bin/mme core /tmp/core-1603823964-mme-8929_bundle/core-1603823964-mme-8929 - dbg output file: /tmp/magma_reports/report.magma.2020-12-01T15:26:53Z/core-1603823964-mme-8929_bundle/dbg.txt",
                    "INFO: component /usr/local/bin/mme core /tmp/core-1603825537-mme-4409_bundle/core-1603825537-mme-4409 - dbg output file: /tmp/magma_reports/report.magma.2020-12-01T15:26:53Z/core-1603825537-mme-4409_bundle/dbg.txt",
[...]

TASK [package : Compress directory report_dir into /tmp/magma_reports/report.<HOSTNAME>.<DATE>.tgz] ************************************************************************************************************************************************************************

changed: [localhost]

TASK [package : Recursively remove report directory /tmp/magma_reports/report.<HOSTNAME>.<DATE>] ***************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP *****************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=18   changed=11   unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```


explored the core directories on package:

```
# ls report.magma.2020-12-01T15:26:53Z/core-1603823329-mme-30152_bundle/

core-1603823329-mme-30152  dbg.txt  mme.log


# more report.magma.2020-12-01T15:26:53Z/core-1603823329-mme-30152_bundle/dbg.txt
[New LWP 5528]
[New LWP 5534]
[New LWP 5533]
[New LWP 5532]
[New LWP 5531]
[New LWP 5535]
Core was generated by `/usr/local/bin/mme -c /var/opt/magma/tmp/mme.conf -s /var/opt/magma/tmp/spgw.co'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x0000564bda97a3a1 in ?? ()
[Current thread is 1 (LWP 5528)]
Temporary breakpoint 1 at 0x67f6a0: file /home/vagrant/magma/lte/gateway/c/oai/oai_mme/oai_mme.c, line 83.
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".

Temporary breakpoint 1, main (argc=6, argv=0x7fffffffeca8) at /home/vagrant/magma/lte/gateway/c/oai/oai_mme/oai_mme.c:83
83	/home/vagrant/magma/lte/gateway/c/oai/oai_mme/oai_mme.c: No such file or directory.
A debugging session is active.

	Inferior 1 [process 11021] will be killed.

Quit anyway? (y or n) [answered Y; input not from terminal]
```

## Additional Information

- [ ] This change is backwards-breaking

