### PR TITLE
mobilityd: delete map entry after releasing IP.

### DIFF
--- a/lte/gateway/python/magma/mobilityd/dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/dhcp_client.py
@@ -170,6 +170,7 @@ class DHCPClient:
 
         dhcp_desc = self.dhcp_client_state[key]
         self.send_dhcp_packet(mac, dhcp_desc.vlan, DHCPState.RELEASE, dhcp_desc)
+        del self.dhcp_client_state[key]
 
     def _monitor_dhcp_state(self):
         """


### PR DESCRIPTION
delete dhcp record entry from map on DHCP ip release.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
