### PR TITLE
[feg][cloud] Neutral Host Relay Implementation

### DIFF
--- a/feg/cloud/go/services/feg/obsidian/models/validate.go
+++ b/feg/cloud/go/services/feg/obsidian/models/validate.go
@@ -107,4 +107,3 @@ func (m *SubscriptionProfile) ValidateModel() error {
 	}
 	return nil
 }
-

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_connection.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_connection.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// gw_to_feg_relay is h2c & GRPC server serving requests from AGWs to FeG
+package gw_to_feg_relay
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/metadata"
+
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
+	"magma/orc8r/lib/go/registry"
+)
+
+// GetFegServiceConnection returns connection to FeG which serves given Gateway network (inCtx) & IMSI
+// (in effect it's a connection to the local orc8r SynRPC forwarding service)
+// GetFegServiceConnection first looks up in the existing connection cache and returns the cache connection for the
+// address if it already exists. If no connection for the address exists - GetFegServiceConnection creates a new
+// connection, caches it and returns it
+func (rtr *Router) GetFegServiceConnection(
+	inCtx context.Context,
+	imsi string,
+	service gateway_registry.GwServiceType,
+) (conn *grpc.ClientConn, ctx context.Context, cancel context.CancelFunc, err error) {
+
+	gwId, err := RetrieveGatewayIdentity(inCtx)
+	if err != nil {
+		return
+	}
+	fegHwId, err := FindServingFeGHwId(gwId.GetNetworkId(), imsi)
+	if err != nil {
+		return
+	}
+	if rtr == nil {
+		// No Router provided, use old GetGatewayConnection API and return
+		conn, ctx, err = gateway_registry.GetGatewayConnection(service, fegHwId)
+		if err != nil {
+			return
+		}
+		ctx, cancel = context.WithTimeout(ctx, registry.GrpcMaxTimeoutSec*time.Second)
+		return conn, ctx, cancel, nil
+	}
+
+	// There is a Router with connections cache, use & update it
+	var addr string
+	addr, err = gateway_registry.GetServiceAddressForGateway(fegHwId)
+	if err != nil {
+		return
+	}
+	rtr.RLock() // take read connection cache lock
+	var found bool
+	conn, found = rtr.connCache[addr]
+	rtr.RUnlock() // release read connection cache lock
+
+	if !found || conn == nil || conn.GetState() != connectivity.Ready {
+		// there is either no existing connection for the address or it's in a bad state
+		// create a new connection outside of the cache lock
+		conn, err = connectToService(addr, service)
+		if err != nil {
+			return
+		}
+		// Lock & update the connections cache
+		rtr.Lock() // take write connection cache lock
+		if len(rtr.connCache) == 0 {
+			rtr.connCache = map[string]*grpc.ClientConn{addr: conn}
+		} else {
+			connToCleanUp, ok := rtr.connCache[addr]
+			if ok && connToCleanUp != nil {
+				if connToCleanUp.GetState() == connectivity.Ready {
+					// use the old connection & close the just created connection
+					connToCleanUp, conn = conn, connToCleanUp
+				} else {
+					// use the just created connection & attempt close the old connection (ignore close failures)
+					rtr.connCache[addr] = conn
+				}
+				go connToCleanUp.Close()
+			} else {
+				// no cached connection for the address, cache the just created connection for future use
+				rtr.connCache[addr] = conn
+			}
+		}
+		rtr.Unlock() // release write connection cache lock
+	}
+	// Copy metadata from incoming context
+	md, ok := metadata.FromIncomingContext(inCtx)
+	if ok && md.Len() > 0 {
+		md = md.Copy()
+		md.Set(gateway_registry.GatewayIdHeaderKey, fegHwId) // add or overwrite if it's already set
+	} else {
+		md = metadata.New(map[string]string{gateway_registry.GatewayIdHeaderKey: fegHwId})
+	}
+	// Use inCtx to propagate caller's timeout if any
+	ctx, cancel = context.WithTimeout(inCtx, registry.GrpcMaxTimeoutSec*time.Second)
+	return conn, metadata.NewOutgoingContext(ctx, md), cancel, nil
+}
+
+func connectToService(addr string, service gateway_registry.GwServiceType) (*grpc.ClientConn, error) {
+	connCtx, connCancel := context.WithTimeout(context.Background(), registry.GrpcMaxTimeoutSec*time.Second)
+	defer connCancel()
+	bckoff := backoff.DefaultConfig
+	bckoff.MaxDelay = registry.GrpcMaxDelaySec * time.Second
+	return registry.GetClientConnection(
+		connCtx, addr,
+		grpc.WithConnectParams(
+			grpc.ConnectParams{Backoff: bckoff, MinConnectTimeout: registry.GrpcMaxTimeoutSec * time.Second}),
+		grpc.WithBlock(),
+		grpc.WithAuthority(string(service)))
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_discovery.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/feg_discovery.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// gw_to_feg_relay is h2c & GRPC server serving requests from AGWs to FeG
+package gw_to_feg_relay
+
+import (
+	"context"
+	"strings"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"magma/feg/cloud/go/feg"
+	"magma/feg/cloud/go/serdes"
+	"magma/feg/cloud/go/services/feg/obsidian/models"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/lib/go/protos"
+)
+
+// RetrieveGatewayIdentity fetches Gateway Identity from ctx, validates & returns it
+func RetrieveGatewayIdentity(inCtx context.Context) (*protos.Identity_Gateway, error) {
+	identity := protos.GetClientIdentity(inCtx)
+	if identity == nil {
+		return nil, status.Errorf(codes.PermissionDenied, "Gateway Identity Metadata is missing")
+	}
+	gwId := identity.GetGateway()
+	if gwId == nil {
+		return nil, status.Errorf(codes.PermissionDenied, "'%s' is not a Gateway", identity.String())
+	}
+	if !gwId.Registered() {
+		return nil, status.Errorf(codes.PermissionDenied, "Gateway '%s' is not registered", gwId.String())
+	}
+	return gwId, nil
+}
+
+// FindServingFeGHwId is the core of Neutral Host routing implementation, it
+// 1) fetches the request's Gateway Network configs,
+// 2) finds the serving Federation Gateway (FeG) Network,
+// 3) retrieves the FeG Network's configuration,
+// 4) if the FeG Network is a Neutral Host - FindServingFeGHwId finds the serving FeG network and the serving FeG ID
+// 5) if not Neutral Host or user PLMN ID doesn't match any configured NH route - FindServingFeGHwId finds the serving
+//    FeG ID of the serving FeG Network
+// Returns serving Federation Gateway ID or error
+func FindServingFeGHwId(agNwID, imsi string) (string, error) {
+	cfg, err := configurator.LoadNetworkConfig(agNwID, feg.FederatedNetworkType, serdes.Network)
+	if err != nil {
+		return "", status.Errorf(
+			codes.NotFound, "could not load federated network configs for access network %s: %s", agNwID, err)
+	}
+	federatedConfig, ok := cfg.(*models.FederatedNetworkConfigs)
+	if !ok || federatedConfig == nil {
+		return "", status.Errorf(codes.Internal, "invalid federated network config found for network: %s", agNwID)
+	}
+	if federatedConfig.FegNetworkID == nil || *federatedConfig.FegNetworkID == "" {
+		return "", status.Errorf(codes.Internal, "FegNetworkID is empty in network config of network: %s", agNwID)
+	}
+	fegCfg, err := configurator.LoadNetworkConfig(*federatedConfig.FegNetworkID, feg.FegNetworkType, serdes.Network)
+	if err != nil || fegCfg == nil {
+		return "", status.Errorf(
+			codes.Internal, "unable to retrieve config for federation network: %s", *federatedConfig.FegNetworkID)
+	}
+	networkFegConfigs, ok := fegCfg.(*models.NetworkFederationConfigs)
+	if !ok || networkFegConfigs == nil {
+		return "", status.Errorf(
+			codes.Internal, "invalid federation network config found for network: %s", *federatedConfig.FegNetworkID)
+	}
+	servedNetworkIDs := networkFegConfigs.ServedNetworkIds
+	for _, network := range servedNetworkIDs {
+		if agNwID == network {
+			servingFegNetwork := *federatedConfig.FegNetworkID
+			// First check if the gateway's network is served by a Neutral Host FeG network (NhRoutes are configured &
+			// IMSI is provided). If any step in finding serving NH FeG fails, try to relay the request to the
+			// servingFegNetwork's FeG (non-NH logic)
+			if len(networkFegConfigs.NhRoutes) > 0 && len(imsi) >= MinPlmnIdLen {
+				// findServingNHFeg returns serving NH FeG Hardware ID if found or an empty string
+				// given NH Routing map, calling NH network ID and user IMSI
+				nhFegHwId := findServingNHFeg(networkFegConfigs.NhRoutes, servingFegNetwork, imsi)
+				if len(nhFegHwId) > 0 {
+					// Return here only if NH FeG was successfully found
+					// in all other cases - fail back to the legacy logic and try to relay the request to the
+					// servingFegNetwork's FeG
+					glog.V(1).Infof(
+						"routing IMSI %s request to NH FeG network: %s to FeG: %s",
+						imsi, servingFegNetwork, nhFegHwId)
+					return nhFegHwId, nil
+				}
+				glog.V(1).Infof("no NH route found for IMSI: %s", imsi)
+			}
+			return getActiveFeGForNetwork(servingFegNetwork)
+		}
+	}
+	return "", status.Errorf(
+		codes.FailedPrecondition,
+		"federation network %s is not configured to serve network: %s", *federatedConfig.FegNetworkID, agNwID)
+}
+
+// findServingNHFeg returns serving NH FeG Hardware ID if found or an empty string given NH Routing map,
+// calling NH network ID and user IMSI
+func findServingNHFeg(routes models.NhRoutes, nhNetworkId, imsi string) string {
+	var (
+		servingFegNetworkId string
+		found               bool
+	)
+	sanitizedImsi := strings.TrimPrefix(strings.TrimSpace(imsi), "IMSI")
+	sanitizedLen := len(sanitizedImsi)
+	if sanitizedLen < MinPlmnIdLen {
+		glog.Errorf("invalid NH IMSI: '%s'", imsi)
+		return ""
+	}
+	if sanitizedLen >= MaxPlmnIdLen {
+		servingFegNetworkId, found = routes[sanitizedImsi[:MaxPlmnIdLen]]
+	}
+	if !found {
+		if servingFegNetworkId, found = routes[sanitizedImsi[:MinPlmnIdLen]]; !found {
+			return ""
+		}
+	}
+	// verify that serving FeG network has the NH network in it's configuration
+	fegCfg, err := configurator.LoadNetworkConfig(servingFegNetworkId, feg.FegNetworkType, serdes.Network)
+	if err != nil || fegCfg == nil {
+		glog.Errorf("unable to retrieve config for NH federation network: %s", servingFegNetworkId)
+		return ""
+	}
+	networkFegConfigs, ok := fegCfg.(*models.NetworkFederationConfigs)
+	if !ok || networkFegConfigs == nil {
+		glog.Errorf("invalid federation network config found for NH network: %s", servingFegNetworkId)
+		return ""
+	}
+	for _, network := range networkFegConfigs.ServedNhIds {
+		if nhNetworkId == network {
+			fegHwId, err := getActiveFeGForNetwork(servingFegNetworkId)
+			if err != nil {
+				glog.Errorf(
+					"failed to find active FeG in '%s' NH network for IMSI: %s: %v", servingFegNetworkId, imsi, err)
+				return ""
+			}
+			return fegHwId
+		}
+	}
+	return ""
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/gw_to_feg_relay.go
@@ -11,16 +11,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// h2c server serving requests from FeG to AG.
+// gw_to_feg_relay is h2c & GRPC server serving requests from AGWs to FeG
 package gw_to_feg_relay
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/serdes"
@@ -32,11 +37,6 @@ import (
 	"magma/orc8r/cloud/go/services/configurator"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/golang/glog"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 )
 
 const (
@@ -73,9 +73,7 @@ func (server *GatewayToFeGServer) Serve(listener net.Listener) {
 	server.H2CServer.Serve(listener, server.useDispatcherHandler)
 }
 
-func (server *GatewayToFeGServer) useDispatcherHandler(
-	responseWriter http.ResponseWriter, req *http.Request,
-) {
+func (server *GatewayToFeGServer) useDispatcherHandler(responseWriter http.ResponseWriter, req *http.Request) {
 	// check calling gateway's identity through certifier
 	gw, err := getGatewayIdentity(req.Header)
 	if err != nil || gw == nil {

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/nh_router.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/nh_router.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// gw_to_feg_relay is h2c & GRPC server serving requests from AGWs to FeG
+package gw_to_feg_relay
+
+import (
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+const (
+	// Minimal length of PLMNID
+	MinPlmnIdLen = 5
+	MaxPlmnIdLen = 6
+)
+
+// Router is a service maintaining mapping and connections from Access Gateways to FeGs
+type Router struct {
+	sync.RWMutex
+	connCache map[string]*grpc.ClientConn
+}
+
+// NewRouter returns a new instance of Gw to FeG router
+func NewRouter() *Router {
+	return &Router{connCache: map[string]*grpc.ClientConn{}}
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/hello_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/hello_relay.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/golang/glog"
+
+	"magma/feg/cloud/go/protos"
+)
+
+// should match "... @NH-FEG-FOR: IMSI123456", "... @NH-FeG-FOR IMSI123456", @nh-Feg-for Imsi 123456", etc.
+var nHTargetSuffixRe = regexp.MustCompile(`(?i)(?:\s|^)@NH-FEG-FOR:?\s*(?:IMSI:?\s*)?(\d{5,15})\s*$`)
+
+// FeG Hello implementation
+//
+// SayHello sends HelloRequest to default FeG if the greeting doesn not end with '@NH-FeG-FOR <IMSI>' (see RegEx above)
+// If the greeting ends with '@NH-FeG-FOR <IMSI>', SayHello will try to route the request to Neutral Host's FeG network
+// matching the given IMSI
+func (s *RelayRouter) SayHello(ctx context.Context, req *protos.HelloRequest) (*protos.HelloReply, error) {
+	var imsi string
+	match := nHTargetSuffixRe.FindStringSubmatch(req.GetGreeting())
+	if len(match) > 1 {
+		imsi = match[1]
+		glog.V(1).Infof("SayHello with NH IMSI '%s': %s", imsi, req.GetGreeting())
+		req.Greeting = strings.TrimSuffix(req.Greeting, match[0])
+	}
+	conn, ctx, cancel, err := s.GetFegServiceConnection(ctx, imsi, FegHello)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return protos.NewHelloClient(conn).SayHello(ctx, req)
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/relay_router.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package servicers implements individual NH routed FeG services
+package servicers
+
+import (
+	"strings"
+
+	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
+)
+
+const (
+	DiamUnableToDeliverErr = 3002
+
+	// FeG Relay Services
+	FegS6aProxy     gateway_registry.GwServiceType = "s6a_proxy"
+	FegSessionProxy gateway_registry.GwServiceType = "session_proxy"
+	FegHello        gateway_registry.GwServiceType = "feg_hello"
+	FegSwxProxy     gateway_registry.GwServiceType = "swx_proxy"
+)
+
+// RelayRouter implements generic routing logic and currently just embeds gw_to_feg_relay.Router functionality
+type RelayRouter struct {
+	gw_to_feg_relay.Router
+}
+
+// NewRelayRouter creates & returns a new RelayRouter
+func NewRelayRouter() *RelayRouter {
+	return &RelayRouter{Router: *gw_to_feg_relay.NewRouter()}
+}
+
+func getPlmnId6(imsi string) string {
+	imsi = strings.TrimPrefix(strings.TrimSpace(imsi), "IMSI")
+	if len(imsi) > gw_to_feg_relay.MaxPlmnIdLen {
+		imsi = imsi[:gw_to_feg_relay.MaxPlmnIdLen]
+	}
+	return imsi
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/s6a_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/s6a_relay.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+
+	"magma/feg/cloud/go/protos"
+)
+
+// S6AProxyServer implementation
+//
+// AuthenticationInformation sends AIR over diameter connection,
+// waits (blocks) for AIA & returns its RPC representation
+func (s *RelayRouter) AuthenticationInformation(
+	c context.Context, r *protos.AuthenticationInformationRequest) (*protos.AuthenticationInformationAnswer, error) {
+
+	client, ctx, cancel, err := s.getS6aClient(c, r.GetUserName())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	ret, err := client.AuthenticationInformation(ctx, r)
+	return ret, err
+}
+
+// UpdateLocation sends ULR (Code 316) over diameter connection,
+// waits (blocks) for ULA & returns its RPC representation
+func (s *RelayRouter) UpdateLocation(
+	ctx context.Context, r *protos.UpdateLocationRequest) (*protos.UpdateLocationAnswer, error) {
+
+	client, ctx, cancel, err := s.getS6aClient(ctx, r.GetUserName())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.UpdateLocation(ctx, r)
+}
+
+// PurgeUE sends PUR (Code 321) over diameter connection,
+// waits (blocks) for PUA & returns its RPC representation
+func (s *RelayRouter) PurgeUE(ctx context.Context, r *protos.PurgeUERequest) (*protos.PurgeUEAnswer, error) {
+
+	client, ctx, cancel, err := s.getS6aClient(ctx, r.GetUserName())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.PurgeUE(ctx, r)
+}
+
+func (s *RelayRouter) getS6aClient(
+	c context.Context, imsi string) (protos.S6AProxyClient, context.Context, context.CancelFunc, error) {
+
+	conn, ctx, cancel, err := s.GetFegServiceConnection(c, imsi, FegS6aProxy)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return protos.NewS6AProxyClient(conn), ctx, cancel, nil
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/session_proxy_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/session_proxy_relay.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+
+	"github.com/golang/glog"
+
+	"magma/lte/cloud/go/protos"
+)
+
+// SessionProxyServer implementation
+//
+// Notify OCS/PCRF of new session and return rules associated with subscriber
+// along with credits for each rule
+func (s *RelayRouter) CreateSession(
+	ctx context.Context, r *protos.CreateSessionRequest) (*protos.CreateSessionResponse, error) {
+
+	// CreateSession's SID is just IMSI with "IMSI" prefix which findServingNHFeg() should remove
+	client, ctx, cancel, err := s.getSessionProxyClient(ctx, r.GetCommonContext().GetSid().GetId())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.CreateSession(ctx, r)
+}
+
+// Updates OCS/PCRF with used credit and terminations from gateway
+func (s *RelayRouter) UpdateSession(
+	ctx context.Context, r *protos.UpdateSessionRequest) (*protos.UpdateSessionResponse, error) {
+
+	// Group requests by PLMNID
+	// Use the longest possible PLMN ID (6), in the worst case we'll fragment requests more then needed, but the routing
+	// will still be logically correct
+	reqMap := map[string]*protos.UpdateSessionRequest{}
+	for _, u := range r.GetUpdates() {
+		if u == nil {
+			continue
+		}
+		plmnid := getPlmnId6(u.GetSid())
+		req, ok := reqMap[plmnid]
+		if !ok || req == nil {
+			req = &protos.UpdateSessionRequest{Updates: []*protos.CreditUsageUpdate{u}}
+			reqMap[plmnid] = req
+		} else {
+			req.Updates = append(req.Updates, u)
+		}
+	}
+	for _, m := range r.GetUsageMonitors() {
+		if m == nil {
+			continue
+		}
+		plmnid := getPlmnId6(m.GetSid())
+		req, ok := reqMap[plmnid]
+		if !ok || req == nil {
+			req = &protos.UpdateSessionRequest{UsageMonitors: []*protos.UsageMonitoringUpdateRequest{m}}
+			reqMap[plmnid] = req
+		} else {
+			req.UsageMonitors = append(req.UsageMonitors, m)
+		}
+	}
+	resultChan := make(chan *protos.UpdateSessionResponse, len(reqMap))
+
+	// send a separate Update request for each unique PLMN ID
+	for plmnid, req := range reqMap {
+		go func(plmnid string, req *protos.UpdateSessionRequest) {
+			client, ctx, cancel, err := s.getSessionProxyClient(ctx, plmnid)
+			if err != nil {
+				glog.Errorf("failed connect to Session Proxy for PLMNID '%s': %v", plmnid, err)
+				resultChan <- genUpdateErrorResp(req)
+				return
+			}
+			defer cancel()
+			resp, err := client.UpdateSession(ctx, req)
+			if err != nil {
+				glog.Errorf("failed Session Proxy Update for PLMNID '%s': %v", plmnid, err)
+				resultChan <- genUpdateErrorResp(req)
+				return
+			}
+			resultChan <- resp
+		}(plmnid, req)
+	}
+	// Combine received responses
+	resp := &protos.UpdateSessionResponse{
+		Responses:             []*protos.CreditUpdateResponse{},
+		UsageMonitorResponses: []*protos.UsageMonitoringUpdateResponse{},
+	}
+	for i := len(reqMap); i > 0; i-- {
+		nhResp := <-resultChan
+		resp.Responses = append(resp.Responses, nhResp.GetResponses()...)
+		resp.UsageMonitorResponses = append(resp.UsageMonitorResponses, nhResp.GetUsageMonitorResponses()...)
+	}
+	// leave resultChan open, this thread is a 'reader'
+	return resp, nil
+}
+
+// Terminates session in OCS/PCRF for a subscriber
+func (s *RelayRouter) TerminateSession(
+	ctx context.Context, r *protos.SessionTerminateRequest) (*protos.SessionTerminateResponse, error) {
+
+	// TerminateSession's SID is just IMSI with "IMSI" prefix which findServingNHFeg() should remove
+	client, ctx, cancel, err := s.getSessionProxyClient(ctx, r.GetSid())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.TerminateSession(ctx, r)
+}
+
+func (s *RelayRouter) getSessionProxyClient(
+	c context.Context, imsi string) (protos.CentralSessionControllerClient, context.Context, context.CancelFunc, error) {
+
+	conn, ctx, cancel, err := s.GetFegServiceConnection(c, imsi, FegSessionProxy)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return protos.NewCentralSessionControllerClient(conn), ctx, cancel, nil
+}
+
+func genUpdateErrorResp(req *protos.UpdateSessionRequest) *protos.UpdateSessionResponse {
+	resp := &protos.UpdateSessionResponse{
+		Responses:             []*protos.CreditUpdateResponse{},
+		UsageMonitorResponses: []*protos.UsageMonitoringUpdateResponse{},
+	}
+	for _, u := range req.GetUpdates() {
+		resp.Responses = append(resp.Responses, &protos.CreditUpdateResponse{
+			Success:    false,
+			Sid:        u.GetSid(),
+			SessionId:  u.GetSessionId(),
+			ResultCode: DiamUnableToDeliverErr,
+		})
+	}
+	for _, m := range req.GetUsageMonitors() {
+		resp.UsageMonitorResponses = append(resp.UsageMonitorResponses, &protos.UsageMonitoringUpdateResponse{
+			Success:    false,
+			Sid:        m.GetSid(),
+			SessionId:  m.GetSessionId(),
+			ResultCode: DiamUnableToDeliverErr,
+		})
+	}
+	return resp
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/swx_proxy_relay.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers/swx_proxy_relay.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package servicers
+
+import (
+	"context"
+
+	"magma/feg/cloud/go/protos"
+)
+
+// SwxProxyServer implementation
+//
+// Authenticate retrieves authentication vectors from the HSS using MAR/MAA
+func (s *RelayRouter) Authenticate(
+	c context.Context, r *protos.AuthenticationRequest) (*protos.AuthenticationAnswer, error) {
+
+	client, ctx, cancel, err := s.getSwxClient(c, r.GetUserName())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.Authenticate(ctx, r)
+}
+
+// Register the AAA server serving a user to the HSS using SAR/SAA
+func (s *RelayRouter) Register(
+	ctx context.Context, r *protos.RegistrationRequest) (*protos.RegistrationAnswer, error) {
+
+	client, ctx, cancel, err := s.getSwxClient(ctx, r.GetUserName())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.Register(ctx, r)
+}
+
+// Deregister the AAA server serving a user to the HSS using SAR/SAA
+func (s *RelayRouter) Deregister(
+	ctx context.Context, r *protos.RegistrationRequest) (*protos.RegistrationAnswer, error) {
+
+	client, ctx, cancel, err := s.getSwxClient(ctx, r.GetUserName())
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
+	return client.Deregister(ctx, r)
+}
+
+func (s *RelayRouter) getSwxClient(
+	c context.Context, imsi string) (protos.SwxProxyClient, context.Context, context.CancelFunc, error) {
+
+	conn, ctx, cancel, err := s.GetFegServiceConnection(c, imsi, FegSwxProxy)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return protos.NewSwxProxyClient(conn), ctx, cancel, nil
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/relay_test.go
@@ -1,0 +1,269 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package tests
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	models2 "magma/feg/cloud/go/services/feg/obsidian/models"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/metadata"
+
+	"magma/feg/cloud/go/feg"
+	feg_protos "magma/feg/cloud/go/protos"
+	"magma/feg/cloud/go/serdes"
+	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay"
+	"magma/feg/cloud/go/services/feg_relay/gw_to_feg_relay/servicers"
+	healthTestUtils "magma/feg/cloud/go/services/health/test_utils"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/device"
+	"magma/orc8r/cloud/go/services/directoryd"
+	directoryd_test_init "magma/orc8r/cloud/go/services/directoryd/test_init"
+	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
+	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
+	service_test_utils "magma/orc8r/cloud/go/services/state/test_utils"
+	"magma/orc8r/cloud/go/storage"
+	"magma/orc8r/cloud/go/test_utils"
+	"magma/orc8r/lib/go/protos"
+	"magma/orc8r/lib/go/registry"
+)
+
+const s6aProxyService = "s6a_proxy"
+
+type testS6aProxy struct {
+	feg_protos.UnimplementedS6AProxyServer
+	resultChan chan string // Calling FeG ID string on success
+}
+
+func (tp *testS6aProxy) AuthenticationInformation(
+	ctx context.Context,
+	req *feg_protos.AuthenticationInformationRequest) (*feg_protos.AuthenticationInformationAnswer, error) {
+
+	if tp == nil {
+		return nil, fmt.Errorf("nil test S6a proxy")
+	}
+	if tp.resultChan == nil {
+		return nil, fmt.Errorf("nil test S6a proxy resultChan")
+	}
+	var targetFegId = "<MISSING METADATA>"
+	ctxMetadata, ok := metadata.FromIncomingContext(ctx)
+	if ok && ctxMetadata != nil {
+		targetFegId = "<MISSING GW ID>"
+		values, ok := ctxMetadata[gateway_registry.GatewayIdHeaderKey]
+		if !ok {
+			values, ok = ctxMetadata[strings.ToLower(gateway_registry.GatewayIdHeaderKey)]
+		}
+		if ok && len(values) > 0 {
+			targetFegId = values[0]
+		}
+	}
+	tp.resultChan <- targetFegId
+	return &feg_protos.AuthenticationInformationAnswer{}, nil
+}
+
+func TestNHRouting(t *testing.T) {
+	testHealthServicer := setupNeutralHostNetworks(t)
+
+	// test # 1: Verify, relay finds the right serving FeG for IMSI's PLMN ID
+	foundFegHwId, err := gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nhImsi)
+	assert.NoError(t, err)
+	assert.Equal(t, fegHwId, foundFegHwId)
+
+	// test #2: Verify routing of matched user PLMNID
+	//
+	// Start & register Serving FeG's test S6a Proxy Server
+	s6aProxy := &testS6aProxy{resultChan: make(chan string, 3)}
+	srv, lis := test_utils.NewTestService(t, "feg", s6aProxyService)
+	s6aAddr := lis.Addr().(*net.TCPAddr)
+	s6aHost := "localhost"
+	t.Logf("Serving FeG S6a Proxy Address: %s", s6aAddr)
+
+	feg_protos.RegisterS6AProxyServer(srv.GrpcServer, s6aProxy)
+	go srv.RunTest(lis)
+
+	// Add Serving FeG Host to directoryd
+	directoryd_test_init.StartTestService(t)
+	directoryd.MapHWIDToHostname(fegHwId, s6aHost)
+	gateway_registry.SetPort(s6aAddr.Port)
+
+	// Start S6a relay Service
+	relaySrv, relayLis := test_utils.NewTestService(t, "", s6aProxyService)
+
+	t.Logf("Relay S6a Proxy Address: %s", relayLis.Addr())
+
+	feg_protos.RegisterS6AProxyServer(relaySrv.GrpcServer, servicers.NewRelayRouter())
+	go relaySrv.RunTest(relayLis)
+
+	ctx := service_test_utils.GetContextWithCertificate(t, agwHwId)
+	connectCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	conn, err := registry.GetClientConnection(connectCtx, relayLis.Addr().String())
+	cancel()
+
+	assert.NoError(t, err)
+	s6aClient := feg_protos.NewS6AProxyClient(conn)
+	aiReq := &feg_protos.AuthenticationInformationRequest{UserName: nhImsi}
+
+	toutctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	_, err = s6aClient.AuthenticationInformation(toutctx, aiReq)
+	cancel()
+	assert.NoError(t, err)
+	select {
+	case servingFegHwId := <-s6aProxy.resultChan:
+		assert.Equal(t, fegHwId, servingFegHwId)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Neutral Host Routed S6a Proxy Call timed out")
+	}
+
+	// test #3: Verify failure of routing of unknown PLMN IDs
+	aiReq.UserName = nonNhImsi
+	toutctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	// The call for non-matching PLMN ID should end up on NH Network's FeG, but none is configured, expect an error
+	_, err = s6aClient.AuthenticationInformation(toutctx, aiReq)
+	cancel()
+	assert.Error(t, err)
+
+	// test #4: Verify serving of non-matching PLMN IDs by default NH FeG (if exist)
+	//
+	// Add a FeG to serve non-matching PLMN IDs to NH network
+	_, err = configurator.CreateEntities(
+		nhNetworkID,
+		[]configurator.NetworkEntity{
+			{
+				Type: feg.FegGatewayType, Key: nhFegId,
+			},
+			{
+				Type: orc8r.MagmadGatewayType, Key: nhFegId,
+				Name: "nh_feg_gateway", Description: "neutral host federation gateway",
+				PhysicalID:   nhFegHwId,
+				Config:       &models.MagmadGatewayConfigs{},
+				Associations: []storage.TypeAndKey{{Type: feg.FegGatewayType, Key: nhFegId}},
+			},
+			{
+				Type: orc8r.UpgradeTierEntityType, Key: "t1",
+				Associations: []storage.TypeAndKey{
+					{Type: orc8r.MagmadGatewayType, Key: nhFegId},
+				},
+			},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+	err = device.RegisterDevice(
+		nhNetworkID, orc8r.AccessGatewayRecordType, nhFegHwId,
+		&models.GatewayDevice{HardwareID: nhFegHwId, Key: &models.ChallengeKey{KeyType: "ECHO"}},
+		serdes.Device,
+	)
+	assert.NoError(t, err)
+
+	// Map NH FeG to already running test S6a proxy address
+	directoryd.MapHWIDToHostname(nhFegHwId, "localhost")
+
+	// Update Serving FeG Health status
+	healthctx := protos.NewGatewayIdentity(nhFegHwId, nhNetworkID, nhFegId).NewContextWithIdentity(context.Background())
+	req := healthTestUtils.GetHealthyRequest()
+	_, err = testHealthServicer.UpdateHealth(healthctx, req)
+	assert.NoError(t, err)
+
+	// Verify that NH FeG will be used as "catch all" for all but nhPlmnId
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, "") // no IMSI
+	assert.NoError(t, err)
+	assert.Equal(t, nhFegHwId, foundFegHwId)
+
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nhImsi) // NH IMSI
+	assert.NoError(t, err)
+	assert.Equal(t, fegHwId, foundFegHwId)
+
+	toutctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	// Now the call for non-matching PLMN ID should end up on NH Network's FeG
+	_, err = s6aClient.AuthenticationInformation(toutctx, aiReq)
+	cancel()
+	assert.NoError(t, err)
+	select {
+	case servingFegHwId := <-s6aProxy.resultChan:
+		assert.Equal(t, nhFegHwId, servingFegHwId)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Neutral Host Non Routed S6a Proxy Call timed out")
+	}
+	// Verify that matching PLMN ID routing still works
+	aiReq.UserName = nhImsi
+	toutctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	_, err = s6aClient.AuthenticationInformation(toutctx, aiReq)
+	cancel()
+	assert.NoError(t, err)
+	select {
+	case servingFegHwId := <-s6aProxy.resultChan:
+		assert.Equal(t, fegHwId, servingFegHwId)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Neutral Host Routed S6a Proxy Call timed out")
+	}
+
+	// test #5: Remove Neutral Host settings (making NH FeG network a legacy FeG Network) and verify that
+	//			legacy (non NH) relay logic works as expected (GW requests with NH IMSI are routed to NH FeG)
+	nhNet, err := configurator.LoadNetwork(nhNetworkID, true, true, serdes.Network)
+	assert.NoError(t, err)
+	assert.NotNil(t, nhNet)
+	cfg, ok := nhNet.Configs[feg.FegNetworkType]
+	assert.True(t, ok)
+	assert.NotNil(t, cfg)
+	fegCfg, ok := cfg.(*models2.NetworkFederationConfigs)
+	assert.True(t, ok)
+	assert.NotNil(t, fegCfg)
+	fegCfg.NhRoutes = nil // delete NH configuration, now FeG Network is just a regular FeG Network
+	err = configurator.UpdateNetworkConfig(nhNetworkID, feg.FegNetworkType, fegCfg, serdes.Network)
+	assert.NoError(t, err)
+
+	// Verify, relay now finds the NH local FeG for any IMSI
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nhImsi)
+	assert.NoError(t, err)
+	assert.Equal(t, nhFegHwId, foundFegHwId)
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, nonNhImsi)
+	assert.NoError(t, err)
+	assert.Equal(t, nhFegHwId, foundFegHwId)
+	foundFegHwId, err = gw_to_feg_relay.FindServingFeGHwId(federatedLteNetworkID, "") // no IMSI
+	assert.NoError(t, err)
+	assert.Equal(t, nhFegHwId, foundFegHwId)
+
+	aiReq.UserName = nhImsi
+	toutctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	// Now the call for non-matching PLMN ID should end up on NH Network's FeG
+	_, err = s6aClient.AuthenticationInformation(toutctx, aiReq)
+	cancel()
+	assert.NoError(t, err)
+	select {
+	case servingFegHwId := <-s6aProxy.resultChan:
+		assert.Equal(t, nhFegHwId, servingFegHwId)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Non Neutral Host & NH IMSI S6a Proxy Call timed out")
+	}
+
+	aiReq.UserName = nonNhImsi
+	toutctx, cancel = context.WithTimeout(ctx, 5*time.Second)
+	// Now the call for non-matching PLMN ID should end up on NH Network's FeG
+	_, err = s6aClient.AuthenticationInformation(toutctx, aiReq)
+	cancel()
+	assert.NoError(t, err)
+	select {
+	case servingFegHwId := <-s6aProxy.resultChan:
+		assert.Equal(t, nhFegHwId, servingFegHwId)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Non Neutral Host, Non NH IMSI S6a Proxy Call timed out")
+	}
+}

--- a/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/test_setup.go
+++ b/feg/cloud/go/services/feg_relay/gw_to_feg_relay/tests/test_setup.go
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package tests
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	healthTestInit "magma/feg/cloud/go/services/health/test_init"
+
+	"github.com/go-openapi/swag"
+	"github.com/stretchr/testify/assert"
+
+	"magma/feg/cloud/go/feg"
+	plugin2 "magma/feg/cloud/go/plugin"
+	"magma/feg/cloud/go/serdes"
+	models2 "magma/feg/cloud/go/services/feg/obsidian/models"
+	health_servicers "magma/feg/cloud/go/services/health/servicers"
+	healthTestUtils "magma/feg/cloud/go/services/health/test_utils"
+	"magma/lte/cloud/go/lte"
+	plugin3 "magma/lte/cloud/go/plugin"
+	models3 "magma/lte/cloud/go/services/lte/obsidian/models"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/services/configurator"
+	configuratorTestInit "magma/orc8r/cloud/go/services/configurator/test_init"
+	"magma/orc8r/cloud/go/services/device"
+	deviceTestInit "magma/orc8r/cloud/go/services/device/test_init"
+	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
+	"magma/orc8r/cloud/go/storage"
+	"magma/orc8r/lib/go/protos"
+)
+
+var (
+	nhNetworkID           = "nh"
+	servingFegNetworkID   = "serving_feg"
+	federatedLteNetworkID = "federated_lte"
+	nhImsi                = "123456000000101"
+	nhPlmnId              = nhImsi[:6]
+	agwHwId               = "lte_gw_hw_id"
+	agwId                 = "lte_gw_id"
+	fegHwId               = "feg_hw_id"
+	fegId                 = "feg_id"
+	nonNhImsi             = "654321000000102"
+	nonNhPlmnId           = nonNhImsi[:6]
+	nhFegHwId             = "nh_feg_hw_id"
+	nhFegId               = "nh_feg_id"
+
+	once sync.Once
+)
+
+func setupNeutralHostNetworks(t *testing.T) *health_servicers.TestHealthServer {
+	once.Do(func() {
+		_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+		_ = plugin.RegisterPluginForTests(t, &plugin2.FegOrchestratorPlugin{})
+		_ = plugin.RegisterPluginForTests(t, &plugin3.LteOrchestratorPlugin{})
+		configuratorTestInit.StartTestService(t)
+		deviceTestInit.StartTestService(t)
+	})
+	testHealthServicer, err := healthTestInit.StartTestService(t)
+	assert.NoError(t, err)
+
+	nhFegCfg := models2.NewDefaultNetworkFederationConfigs()
+	nhFegCfg.NhRoutes = models2.NhRoutes{nhPlmnId: servingFegNetworkID}
+	nhFegCfg.ServedNetworkIds = models2.ServedNetworkIds{federatedLteNetworkID}
+
+	servingFegCfg := models2.NewDefaultNetworkFederationConfigs()
+	servingFegCfg.ServedNhIds = models2.ServedNhIds{nhNetworkID}
+
+	lteNetCfg := models2.NewDefaultFederatedNetworkConfigs()
+	lteNetCfg.FegNetworkID = &nhNetworkID
+
+	// Neutral Host Network
+	nhNetworkConfig := configurator.Network{
+		ID:          nhNetworkID,
+		Type:        feg.FederationNetworkType,
+		Name:        "TestNeutralHost",
+		Description: "Test Neutral Host",
+		Configs: map[string]interface{}{
+			feg.FegNetworkType:          nhFegCfg,
+			orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+			orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+		},
+	}
+	// Serving FeG Network
+	servingFegNetworkCfg := configurator.Network{
+		ID:          servingFegNetworkID,
+		Type:        feg.FederationNetworkType,
+		Name:        "serving_feg_network",
+		Description: "Serving FeG Network",
+		Configs: map[string]interface{}{
+			feg.FegNetworkType:          servingFegCfg,
+			orc8r.NetworkFeaturesConfig: models.NewDefaultFeaturesConfig(),
+			orc8r.DnsdNetworkType:       models.NewDefaultDNSConfig(),
+		},
+	}
+	// Federated LTE Network
+	federatedLteNetCfg := configurator.Network{
+		ID:          federatedLteNetworkID,
+		Type:        feg.FederatedLteNetworkType,
+		Name:        "Federated_FeG_Network",
+		Description: "Federated FeG Network",
+		Configs: map[string]interface{}{
+			feg.FederatedNetworkType:      lteNetCfg,
+			lte.CellularNetworkConfigType: models3.NewDefaultTDDNetworkConfig(),
+			orc8r.NetworkFeaturesConfig:   models.NewDefaultFeaturesConfig(),
+			orc8r.DnsdNetworkType:         models.NewDefaultDNSConfig(),
+		},
+	}
+	networkConfigs := []configurator.Network{
+		nhNetworkConfig,
+		servingFegNetworkCfg,
+		federatedLteNetCfg,
+	}
+	_, err = configurator.CreateNetworks(networkConfigs, serdes.Network)
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		federatedLteNetworkID,
+		[]configurator.NetworkEntity{
+			{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+			{Type: lte.CellularEnodebEntityType, Key: "enb2"},
+			{
+				Type: lte.CellularGatewayEntityType, Key: agwId,
+				Config: &models3.GatewayCellularConfigs{
+					Epc: &models3.GatewayEpcConfigs{NatEnabled: swag.Bool(true), IPBlock: "192.168.0.0/24"},
+					Ran: &models3.GatewayRanConfigs{Pci: 260, TransmitEnabled: swag.Bool(true)},
+				},
+				Associations: []storage.TypeAndKey{
+					{Type: lte.CellularEnodebEntityType, Key: "enb1"},
+					{Type: lte.CellularEnodebEntityType, Key: "enb2"},
+				},
+			},
+			{
+				Type: orc8r.MagmadGatewayType, Key: agwId,
+				Name: "lte_gateway", Description: "federated lte gateway",
+				PhysicalID: agwHwId,
+				Config: &models.MagmadGatewayConfigs{
+					AutoupgradeEnabled:      swag.Bool(true),
+					AutoupgradePollInterval: 300,
+					CheckinInterval:         15,
+					CheckinTimeout:          5,
+				},
+				Associations: []storage.TypeAndKey{{Type: lte.CellularGatewayEntityType, Key: agwId}},
+			},
+			{
+				Type: orc8r.UpgradeTierEntityType, Key: "t1",
+				Associations: []storage.TypeAndKey{
+					{Type: orc8r.MagmadGatewayType, Key: agwId},
+				},
+			},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+	err = device.RegisterDevice(
+		federatedLteNetworkID, orc8r.AccessGatewayRecordType, agwHwId,
+		&models.GatewayDevice{HardwareID: agwHwId, Key: &models.ChallengeKey{KeyType: "ECHO"}},
+		serdes.Device,
+	)
+	assert.NoError(t, err)
+
+	_, err = configurator.CreateEntities(
+		servingFegNetworkID,
+		[]configurator.NetworkEntity{
+			{
+				Type: feg.FegGatewayType, Key: fegId,
+			},
+			{
+				Type: orc8r.MagmadGatewayType, Key: fegId,
+				Name: "feg_gateway", Description: "federation gateway",
+				PhysicalID: fegHwId,
+				Config: &models.MagmadGatewayConfigs{
+					AutoupgradeEnabled:      swag.Bool(true),
+					AutoupgradePollInterval: 300,
+					CheckinInterval:         15,
+					CheckinTimeout:          5,
+				},
+				Associations: []storage.TypeAndKey{{Type: feg.FegGatewayType, Key: fegId}},
+			},
+			{
+				Type: orc8r.UpgradeTierEntityType, Key: "t1",
+				Associations: []storage.TypeAndKey{
+					{Type: orc8r.MagmadGatewayType, Key: fegId},
+				},
+			},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+	err = device.RegisterDevice(
+		servingFegNetworkID, orc8r.AccessGatewayRecordType, fegHwId,
+		&models.GatewayDevice{HardwareID: fegHwId, Key: &models.ChallengeKey{KeyType: "ECHO"}},
+		serdes.Device,
+	)
+	assert.NoError(t, err)
+
+	actualNHNet, err := configurator.LoadNetwork(nhNetworkID, true, true, serdes.Network)
+	assert.NoError(t, err)
+	assert.Equal(t, nhNetworkConfig, actualNHNet)
+
+	actualFeGNet, err := configurator.LoadNetwork(servingFegNetworkID, true, true, serdes.Network)
+	assert.NoError(t, err)
+	assert.Equal(t, servingFegNetworkCfg, actualFeGNet)
+
+	// Update Serving FeG Health status
+	ctx := protos.NewGatewayIdentity(fegHwId, servingFegNetworkID, fegId).NewContextWithIdentity(context.Background())
+	req := healthTestUtils.GetHealthyRequest()
+	_, err = testHealthServicer.UpdateHealth(ctx, req)
+	assert.NoError(t, err)
+
+	return testHealthServicer
+}

--- a/feg/cloud/go/services/feg_relay/servicers/abort.go
+++ b/feg/cloud/go/services/feg_relay/servicers/abort.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // ServiceAbort relays the ServiceAbortRequest sent from VLR->FeG->Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/abort_session.go
+++ b/feg/cloud/go/services/feg_relay/servicers/abort_session.go
@@ -14,10 +14,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"log"
-
-	"golang.org/x/net/context"
 
 	"magma/lte/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"

--- a/feg/cloud/go/services/feg_relay/servicers/alert.go
+++ b/feg/cloud/go/services/feg_relay/servicers/alert.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // AlertReq relays the AlertRequest sent from VLR->FeG->Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/detach.go
+++ b/feg/cloud/go/services/feg_relay/servicers/detach.go
@@ -14,7 +14,7 @@ limitations under the License.
 package servicers
 
 import (
-	"golang.org/x/net/context"
+	"context"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"

--- a/feg/cloud/go/services/feg_relay/servicers/downlink.go
+++ b/feg/cloud/go/services/feg_relay/servicers/downlink.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // Downlink relays the DownlinkUnitdata sent from VLR->FeG->Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
+++ b/feg/cloud/go/services/feg_relay/servicers/feg_to_gw_relay.go
@@ -15,8 +15,13 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"strings"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
 
 	"magma/feg/cloud/go/feg"
 	"magma/feg/cloud/go/serdes"
@@ -26,11 +31,6 @@ import (
 	"magma/orc8r/cloud/go/services/directoryd"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"
 	"magma/orc8r/lib/go/protos"
-
-	"github.com/golang/glog"
-	"golang.org/x/net/context"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/metadata"
 )
 
 // FegToGwRelayServer is a server serving requests from FeG to Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/location.go
+++ b/feg/cloud/go/services/feg_relay/servicers/location.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // LocationUpdateAcc relays the LocationUpdateAccept sent from VLR->FeG->Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/paging.go
+++ b/feg/cloud/go/services/feg_relay/servicers/paging.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // PagingReq relays the PagingRequest sent from VLR->FeG->Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/release.go
+++ b/feg/cloud/go/services/feg_relay/servicers/release.go
@@ -14,10 +14,10 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"
-
-	"golang.org/x/net/context"
 )
 
 // ReleaseReq relays the ReleaseRequest sent from VLR->FeG->Access Gateway

--- a/feg/cloud/go/services/feg_relay/servicers/reset.go
+++ b/feg/cloud/go/services/feg_relay/servicers/reset.go
@@ -14,8 +14,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	"magma/feg/cloud/go/protos"
 	"magma/feg/cloud/go/services/feg_relay/utils"

--- a/feg/cloud/go/services/feg_relay/servicers/terminate_registration.go
+++ b/feg/cloud/go/services/feg_relay/servicers/terminate_registration.go
@@ -14,10 +14,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
 	"fmt"
 	"log"
-
-	"golang.org/x/net/context"
 
 	"magma/feg/cloud/go/protos"
 	"magma/orc8r/cloud/go/services/dispatcher/gateway_registry"

--- a/feg/cloud/go/services/feg_relay/servicers/vlr.go
+++ b/feg/cloud/go/services/feg_relay/servicers/vlr.go
@@ -14,8 +14,9 @@ limitations under the License.
 package servicers
 
 import (
+	"context"
+
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 
 	fegprotos "magma/feg/cloud/go/protos"
 	"magma/orc8r/lib/go/protos"

--- a/feg/gateway/services/s6a_proxy/client.go
+++ b/feg/gateway/services/s6a_proxy/client.go
@@ -17,12 +17,12 @@ limitations under the License.
 package s6a_proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/cloud/go/protos"

--- a/feg/gateway/services/s6a_proxy/gw_s6a_client_api.go
+++ b/feg/gateway/services/s6a_proxy/gw_s6a_client_api.go
@@ -14,11 +14,11 @@ limitations under the License.
 package s6a_proxy
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
 	"github.com/golang/glog"
-	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 
 	"magma/feg/cloud/go/protos"


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

## Summary

Neutral Host Relay/Router Implementation

Neutral Host is Magma concept of serving users of multiple federated MNOs
![MagmaNeutralHostSlide2](https://user-images.githubusercontent.com/2341877/100864144-73cd7100-344a-11eb-8685-6e9317da97bb.jpg)


This PR implements Neutral Host routing logic (below) and its unit tests

![MagmaNeutralHostSlide5](https://user-images.githubusercontent.com/2341877/100863980-37017a00-344a-11eb-8711-5e1fed4412cc.jpg)


## Test Plan

Added and run unit tests.

## Additional Information

- [ ] This change is backwards-breaking
