### PR TITLE
[SessionD] Allow validity timer to trigger a CCR-U even in final unit action ena…

### DIFF
--- a/lte/gateway/c/session_manager/ChargingGrant.h
+++ b/lte/gateway/c/session_manager/ChargingGrant.h
@@ -42,6 +42,7 @@ struct ChargingGrant {
   // Only valid if is_final_grant is true
   FinalActionInfo final_action_info;
   // The expiry time for the credit's validity
+  // https://tools.ietf.org/html/rfc4006#section-8.33
   std::time_t expiry_time;
   ServiceState service_state;
   ReAuthState reauth_state;
@@ -62,7 +63,7 @@ struct ChargingGrant {
   StoredChargingGrant marshal();
 
   void receive_charging_grant(
-      const magma::lte::ChargingCredit& credit,
+      const CreditUpdateResponse& update,
       SessionCreditUpdateCriteria* uc = NULL);
 
   // Returns true if the credit returned from the Policy component is valid and
@@ -134,8 +135,8 @@ struct ChargingGrant {
   // and assign it to expiry_time
   void set_expiry_time_as_timestamp(uint32_t rel_time_sec);
 
-  // Log final action related information
-  void log_final_action_info() const;
+  // Log information about the grant received
+  void log_received_grant(const CreditUpdateResponse& update);
 };
 
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/test_charging_grant.cpp
+++ b/lte/gateway/c/session_manager/test/test_charging_grant.cpp
@@ -26,7 +26,7 @@ class ChargingGrantTest : public ::testing::Test {
   ChargingGrant get_default_grant() {
     ChargingGrant grant;
     grant.is_final_grant = false;
-    grant.expiry_time    = time(NULL);
+    grant.expiry_time    = std::numeric_limits<std::time_t>::max();
     grant.service_state  = SERVICE_ENABLED;
     grant.reauth_state   = REAUTH_NOT_NEEDED;
     grant.suspended      = false;
@@ -96,7 +96,7 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
 
   grant.credit.add_used_credit(2000, 0, uc);
   EXPECT_TRUE(grant.credit.is_quota_exhausted(0.8));
-  // Credit is exhausted, we expect a quota exhaustion updat type
+  // Credit is exhausted, we expect a quota exhaustion update type
   CreditUsage::UpdateType update_type;
   EXPECT_TRUE(grant.get_update_type(&update_type));
   EXPECT_EQ(update_type, CreditUsage::QUOTA_EXHAUSTED);
@@ -125,6 +125,13 @@ TEST_F(ChargingGrantTest, test_get_update_type) {
   grant.reauth_state   = REAUTH_REQUIRED;
   EXPECT_TRUE(grant.get_update_type(&update_type));
   EXPECT_EQ(update_type, CreditUsage::REAUTH_REQUIRED);
+
+  // Set final_grant && validity timer
+  grant.is_final_grant = true;
+  grant.reauth_state   = REAUTH_NOT_NEEDED;
+  grant.expiry_time    = time(nullptr) - 50;  // 50 seconds ago
+  EXPECT_TRUE(grant.get_update_type(&update_type));
+  EXPECT_EQ(update_type, CreditUsage::VALIDITY_TIMER_EXPIRED);
 }
 
 TEST_F(ChargingGrantTest, test_should_deactivate_service) {
@@ -279,6 +286,7 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   CreditUsage::UpdateType update_type;
   EXPECT_TRUE(grant.get_update_type(&update_type));
   auto c_usage = grant.get_credit_usage(update_type, uc, false);
+  EXPECT_EQ(update_type, CreditUsage::QUOTA_EXHAUSTED);
   EXPECT_EQ(c_usage.bytes_tx(), 2000);
   EXPECT_EQ(c_usage.bytes_rx(), 0);
   EXPECT_EQ(credit.get_credit(USED_TX), 2000);
@@ -295,13 +303,9 @@ TEST_F(ChargingGrantTest, test_tolerance_quota_exhausted) {
   // we overused, so the delta is the overusage
   EXPECT_EQ(uc.bucket_deltas[ALLOWED_TOTAL], 2000);
 
-  // Trigger an update again, we expect the rest to be reported
+  // No update should be triggered as everything is reported
   uc = grant.get_update_criteria();  // reset UC
-  EXPECT_TRUE(grant.get_update_type(&update_type));
-  c_usage = grant.get_credit_usage(update_type, uc, false);
-  EXPECT_EQ(c_usage.bytes_tx(), 0);
-  EXPECT_EQ(c_usage.bytes_rx(), 0);
-  // we have used 2000 but we will report only what we were granted
+  EXPECT_FALSE(grant.get_update_type(&update_type));
   EXPECT_EQ(credit.get_credit(USED_TX), 2000);
   EXPECT_EQ(credit.get_credit(REPORTING_TX), 0);
 


### PR DESCRIPTION
…bled

Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Currently, validity timer will only trigger a CCR-U if the service is active, (not in FUA mode). 
The PR changes it so that even in FUA, a validity timer will trigger a request.
See https://tools.ietf.org/html/rfc4006#section-8.33 for spec.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
