### PR TITLE
[SessionD] Use IMSI+SessionID to schedule rule installs/removals

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -53,10 +53,6 @@ static SubscriberQuotaUpdate make_subscriber_quota_update(
     const std::string& imsi, const std::string& ue_mac_addr,
     const SubscriberQuotaUpdate_Type state);
 
-static bool does_session_ip_match(
-    const SessionConfig& config, const std::string& ip_addr,
-    const std::string& ipv6_addr);
-
 LocalEnforcer::LocalEnforcer(
     std::shared_ptr<SessionReporter> reporter,
     std::shared_ptr<StaticRuleStore> rule_store, SessionStore& session_store,
@@ -160,7 +156,8 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
   for (auto& it : session_map) {
     const auto& imsi = it.first;
     for (auto& session : it.second) {
-      auto& uc = session_update[it.first][session->get_session_id()];
+      const std::string session_id = session->get_session_id();
+      auto& uc                     = session_update[imsi][session_id];
       // Reschedule Revalidation Timer if it was pending before
       auto triggers   = session->get_event_triggers();
       auto trigger_it = triggers.find(REVALIDATION_TIMEOUT);
@@ -172,8 +169,6 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
       }
 
       session->sync_rules_to_time(current_time, uc);
-      const auto& ip_addr   = session->get_config().common_context.ue_ipv4();
-      const auto& ipv6_addr = session->get_config().common_context.ue_ipv6();
 
       for (std::string rule_id : session->get_static_rules()) {
         auto lifetime = session->get_rule_lifetime(rule_id);
@@ -181,17 +176,17 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
           auto rule_install =
               session->get_static_rule_install(rule_id, lifetime);
           schedule_static_rule_deactivation(
-              imsi, ip_addr, ipv6_addr, rule_install);
+              imsi, session_id, rule_id, lifetime.deactivation_time);
         }
       }
       // Schedule rule activations / deactivations
       for (std::string rule_id : session->get_scheduled_static_rules()) {
-        auto lifetime     = session->get_rule_lifetime(rule_id);
-        auto rule_install = session->get_static_rule_install(rule_id, lifetime);
-        schedule_static_rule_activation(imsi, ip_addr, ipv6_addr, rule_install);
+        auto lifetime = session->get_rule_lifetime(rule_id);
+        schedule_static_rule_activation(
+            imsi, session_id, rule_id, lifetime.activation_time);
         if (lifetime.deactivation_time > current_time) {
           schedule_static_rule_deactivation(
-              imsi, ip_addr, ipv6_addr, rule_install);
+              imsi, session_id, rule_id, lifetime.deactivation_time);
         }
       }
 
@@ -203,7 +198,7 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
           auto rule_install =
               session->get_dynamic_rule_install(rule_id, lifetime);
           schedule_dynamic_rule_deactivation(
-              imsi, ip_addr, ipv6_addr, rule_install);
+              imsi, session_id, rule_id, lifetime.deactivation_time);
         }
       }
       rule_ids.clear();
@@ -213,10 +208,10 @@ void LocalEnforcer::sync_sessions_on_restart(std::time_t current_time) {
         auto rule_install =
             session->get_dynamic_rule_install(rule_id, lifetime);
         schedule_dynamic_rule_activation(
-            imsi, ip_addr, ipv6_addr, rule_install);
+            imsi, session_id, rule_id, lifetime.deactivation_time);
         if (lifetime.deactivation_time > current_time) {
           schedule_dynamic_rule_deactivation(
-              imsi, ip_addr, ipv6_addr, rule_install);
+              imsi, session_id, rule_id, lifetime.deactivation_time);
         }
       }
       // Reschedule termination if subscriber has no quota
@@ -549,7 +544,7 @@ void LocalEnforcer::install_final_unit_action_flows(
   const std::string &ip_addr = config.ue_ipv4(), &ipv6_addr = config.ue_ipv6(),
                     &msisdn = config.msisdn();
   const auto fua_type       = action->get_type();
-  RuleLifetime lifetime{};
+  RuleLifetime lifetime;
 
   MLOG(MINFO) << "Installing final unit action "
               << service_action_type_to_str(fua_type) << " flows for "
@@ -682,46 +677,53 @@ static bool should_activate(
   return true;
 }
 
-// TODO pass in SessionID to uniquely identify the session
 void LocalEnforcer::schedule_static_rule_activation(
-    const std::string& imsi, const std::string& ip_addr,
-    const std::string& ipv6_addr, const StaticRuleInstall& static_rule) {
-  std::vector<std::string> static_rules{static_rule.rule_id()};
+    const std::string& imsi, const std::string& session_id,
+    const std::string& rule_id, const std::time_t activation_time) {
+  std::vector<std::string> static_rules{rule_id};
   std::vector<PolicyRule> empty_dynamic_rules;
 
-  auto delta = magma::time_difference_from_now(static_rule.activation_time());
-  MLOG(MDEBUG) << "Scheduling subscriber " << imsi << " static rule "
-               << static_rule.rule_id() << " activation in "
-               << (delta.count() / 1000) << " secs";
+  auto delta = magma::time_difference_from_now(activation_time);
+  MLOG(MDEBUG) << "Scheduling " << session_id << " static rule " << rule_id
+               << " activation in " << (delta.count() / 1000) << " secs";
   evb_->runInEventBaseThread([=] {
     evb_->timer().scheduleTimeoutFn(
         std::move([=] {
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto session_update =
               session_store_.get_default_session_update(session_map);
-          auto it = session_map.find(imsi);
-          if (it == session_map.end()) {
-            MLOG(MWARNING) << "Could not find session for IMSI " << imsi
-                           << "during installation of static rule "
-                           << static_rule.rule_id();
+          SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+          auto session_it = session_store_.find_session(session_map, criteria);
+          if (!session_it) {
+            MLOG(MWARNING) << "Could not find session  " << session_id
+                           << "during installation of static rule " << rule_id;
             return;
           }
-          for (const auto& session : it->second) {
-            const auto& config = session->get_config();
-            if (does_session_ip_match(config, ip_addr, ipv6_addr)) {
-              auto& uc = session_update[imsi][session->get_session_id()];
-              session->install_scheduled_static_rule(static_rule.rule_id(), uc);
+          auto& session = **session_it;
+          auto& uc      = session_update[imsi][session_id];
 
-              const auto ambr   = config.get_apn_ambr();
-              const auto msisdn = config.common_context.msisdn();
-              pipelined_client_->activate_flows_for_rules(
-                  imsi, ip_addr, ipv6_addr, msisdn, ambr, static_rules, {},
-                  std::bind(
-                      &LocalEnforcer::handle_activate_ue_flows_callback, this,
-                      imsi, ip_addr, ipv6_addr, msisdn, ambr, static_rules,
-                      empty_dynamic_rules, _1, _2));
-            }
+          std::time_t current_time = time(nullptr);
+          // don't install the rule if the current time is out of lifetime
+          if (session->should_rule_be_active(rule_id, current_time)) {
+            session->deactivate_scheduled_static_rule(rule_id, uc);
+            session_store_.update_sessions(session_update);
+            return;
           }
+
+          auto config          = session->get_config();
+          const auto ip_addr   = config.common_context.ue_ipv4();
+          const auto ipv6_addr = config.common_context.ue_ipv6();
+          const auto ambr      = config.get_apn_ambr();
+          const auto msisdn    = config.common_context.msisdn();
+
+          session->install_scheduled_static_rule(rule_id, uc);
+          pipelined_client_->activate_flows_for_rules(
+              imsi, ip_addr, ipv6_addr, msisdn, ambr, static_rules, {},
+              std::bind(
+                  &LocalEnforcer::handle_activate_ue_flows_callback, this, imsi,
+                  ip_addr, ipv6_addr, msisdn, ambr, static_rules,
+                  empty_dynamic_rules, _1, _2));
+
           session_store_.update_sessions(session_update);
         }),
         delta);
@@ -729,44 +731,58 @@ void LocalEnforcer::schedule_static_rule_activation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_activation(
-    const std::string& imsi, const std::string& ip_addr,
-    const std::string& ipv6_addr, const DynamicRuleInstall& dynamic_rule) {
+    const std::string& imsi, const std::string& session_id,
+    const std::string& rule_id, const std::time_t activation_time) {
   std::vector<std::string> empty_static_rules;
-  std::vector<PolicyRule> dynamic_rules{dynamic_rule.policy_rule()};
 
-  auto delta = magma::time_difference_from_now(dynamic_rule.activation_time());
-  MLOG(MDEBUG) << "Scheduling subscriber " << imsi << " dynamic rule "
-               << dynamic_rule.policy_rule().id() << " activation in "
-               << (delta.count() / 1000) << " secs";
+  auto delta = magma::time_difference_from_now(activation_time);
+  MLOG(MDEBUG) << "Scheduling " << session_id << " dynamic rule " << rule_id
+               << " activation in " << (delta.count() / 1000) << " secs";
   evb_->runInEventBaseThread([=] {
     evb_->timer().scheduleTimeoutFn(
         std::move([=] {
           auto session_map = session_store_.read_sessions(SessionRead{imsi});
           auto session_update =
               session_store_.get_default_session_update(session_map);
-          auto it = session_map.find(imsi);
-          if (it == session_map.end()) {
-            MLOG(MWARNING) << "Could not find session for IMSI " << imsi
-                           << "during installation of dynamic rule "
-                           << dynamic_rule.policy_rule().id();
+          SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+          auto session_it = session_store_.find_session(session_map, criteria);
+          if (!session_it) {
+            MLOG(MWARNING) << "Could not find session  " << session_id
+                           << "during installation of dynamic rule " << rule_id;
             return;
           }
-          for (const auto& session : it->second) {
-            const auto& config = session->get_config();
-            if (does_session_ip_match(config, ip_addr, ipv6_addr)) {
-              auto& uc = session_update[imsi][session->get_session_id()];
-              session->install_scheduled_dynamic_rule(
-                  dynamic_rule.policy_rule().id(), uc);
-              const auto ambr   = config.get_apn_ambr();
-              const auto msisdn = config.common_context.msisdn();
-              pipelined_client_->activate_flows_for_rules(
-                  imsi, ip_addr, ipv6_addr, msisdn, ambr, {}, dynamic_rules,
-                  std::bind(
-                      &LocalEnforcer::handle_activate_ue_flows_callback, this,
-                      imsi, ip_addr, ipv6_addr, msisdn, ambr,
-                      empty_static_rules, dynamic_rules, _1, _2));
-            }
+          auto& session    = **session_it;
+          auto& session_uc = session_update[imsi][session_id];
+          if (!session->is_dynamic_rule_scheduled(rule_id)) {
+            return;
           }
+          // don't install the rule if the current time is out of lifetime
+          std::time_t current_time = time(nullptr);
+          if (session->should_rule_be_active(rule_id, current_time)) {
+            session->remove_scheduled_dynamic_rule(
+                rule_id, nullptr, session_uc);
+            session_store_.update_sessions(session_update);
+            return;
+          }
+
+          auto config          = session->get_config();
+          const auto ip_addr   = config.common_context.ue_ipv4();
+          const auto ipv6_addr = config.common_context.ue_ipv6();
+          const auto ambr      = config.get_apn_ambr();
+          const auto msisdn    = config.common_context.msisdn();
+
+          session->install_scheduled_dynamic_rule(rule_id, session_uc);
+          PolicyRule policy;
+          session->get_scheduled_dynamic_rules().get_rule(rule_id, &policy);
+          std::vector<PolicyRule> dynamic_rules{policy};
+
+          pipelined_client_->activate_flows_for_rules(
+              imsi, ip_addr, ipv6_addr, msisdn, ambr, {}, dynamic_rules,
+              std::bind(
+                  &LocalEnforcer::handle_activate_ue_flows_callback, this, imsi,
+                  ip_addr, ipv6_addr, msisdn, ambr, empty_static_rules,
+                  dynamic_rules, _1, _2));
+
           session_store_.update_sessions(session_update);
         }),
         delta);
@@ -774,40 +790,39 @@ void LocalEnforcer::schedule_dynamic_rule_activation(
 }
 
 void LocalEnforcer::schedule_static_rule_deactivation(
-    const std::string& imsi, const std::string& ip_addr,
-    const std::string& ipv6_addr, const StaticRuleInstall& static_rule) {
-  std::vector<std::string> static_rules{static_rule.rule_id()};
-
-  auto delta = magma::time_difference_from_now(static_rule.deactivation_time());
-  MLOG(MDEBUG) << "Scheduling subscriber " << imsi << " static rule "
-               << static_rule.rule_id() << " deactivation in "
-               << (delta.count() / 1000) << " secs";
+    const std::string& imsi, const std::string& session_id,
+    const std::string& rule_id, const std::time_t deactivation_time) {
+  auto delta = magma::time_difference_from_now(deactivation_time);
+  MLOG(MDEBUG) << "Scheduling session " << session_id << " static rule "
+               << rule_id << " deactivation in " << (delta.count() / 1000)
+               << " secs";
   evb_->runInEventBaseThread([=] {
     evb_->timer().scheduleTimeoutFn(
         std::move([=] {
-          const auto rule_id = static_rule.rule_id();
-          auto session_map   = session_store_.read_sessions(SessionRead{imsi});
-          auto it            = session_map.find(imsi);
-          if (it == session_map.end()) {
-            MLOG(MWARNING) << "Could not find session for IMSI " << imsi
+          auto session_map = session_store_.read_sessions(SessionRead{imsi});
+          auto session_update =
+              session_store_.get_default_session_update(session_map);
+          SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+          auto session_it = session_store_.find_session(session_map, criteria);
+          if (!session_it) {
+            MLOG(MWARNING) << "Could not find session  " << session_id
                            << "during removal of static rule " << rule_id;
             return;
           }
+          auto& session = **session_it;
+          if (session->should_rule_be_active(rule_id, time(nullptr))) {
+            return;
+          }
+          auto ip_addr   = session->get_config().common_context.ue_ipv4();
+          auto ipv6_addr = session->get_config().common_context.ue_ipv6();
 
-          auto session_update =
-              session_store_.get_default_session_update(session_map);
           pipelined_client_->deactivate_flows_for_rules(
-              imsi, ip_addr, ipv6_addr, static_rules, {},
-              RequestOriginType::GX);
-          for (const auto& session : it->second) {
-            if (does_session_ip_match(
-                    session->get_config(), ip_addr, ipv6_addr)) {
-              auto& uc = session_update[imsi][session->get_session_id()];
-              if (!session->deactivate_static_rule(rule_id, uc)) {
-                MLOG(MWARNING) << "Could not find rule " << rule_id << "for "
-                               << imsi << " during static rule removal";
-              }
-            }
+              imsi, ip_addr, ipv6_addr, {rule_id}, {}, RequestOriginType::GX);
+
+          auto& session_uc = session_update[imsi][session_id];
+          if (!session->deactivate_static_rule(rule_id, session_uc)) {
+            MLOG(MWARNING) << "Could not find rule " << rule_id << "for "
+                           << session_id << " during static rule removal";
           }
           session_store_.update_sessions(session_update);
         }),
@@ -816,39 +831,38 @@ void LocalEnforcer::schedule_static_rule_deactivation(
 }
 
 void LocalEnforcer::schedule_dynamic_rule_deactivation(
-    const std::string& imsi, const std::string& ip_addr,
-    const std::string& ipv6_addr, DynamicRuleInstall& dynamic_rule) {
-  PolicyRule policy = dynamic_rule.policy_rule();
-
-  auto delta =
-      magma::time_difference_from_now(dynamic_rule.deactivation_time());
+    const std::string& imsi, const std::string& session_id,
+    const std::string& rule_id, const std::time_t deactivation_time) {
+  auto delta = magma::time_difference_from_now(deactivation_time);
   MLOG(MDEBUG) << "Scheduling subscriber " << imsi << " dynamic rule "
-               << policy.id() << " deactivation in " << (delta.count() / 1000)
+               << rule_id << " deactivation in " << (delta.count() / 1000)
                << " secs";
   evb_->runInEventBaseThread([=] {
     evb_->timer().scheduleTimeoutFn(
         std::move([=] {
-          std::vector<PolicyRule> dynamic_rules{policy};
-          auto session_map   = session_store_.read_sessions(SessionRead{imsi});
-          const auto rule_id = policy.id();
-          auto it            = session_map.find(imsi);
-          if (it == session_map.end()) {
-            MLOG(MWARNING) << "Could not find session for " << imsi
+          auto session_map = session_store_.read_sessions(SessionRead{imsi});
+          auto session_update =
+              session_store_.get_default_session_update(session_map);
+          SessionSearchCriteria criteria(imsi, IMSI_AND_SESSION_ID, session_id);
+          auto session_it = session_store_.find_session(session_map, criteria);
+          if (!session_it) {
+            MLOG(MWARNING) << "Could not find session " << session_id
                            << "during removal of dynamic rule " << rule_id;
             return;
           }
-          auto session_update =
-              session_store_.get_default_session_update(session_map);
-          pipelined_client_->deactivate_flows_for_rules(
-              imsi, ip_addr, ipv6_addr, {}, dynamic_rules,
-              RequestOriginType::GX);
-          for (const auto& session : it->second) {
-            if (does_session_ip_match(
-                    session->get_config(), ip_addr, ipv6_addr)) {
-              auto& uc = session_update[imsi][session->get_session_id()];
-              session->remove_dynamic_rule(rule_id, NULL, uc);
-            }
+          auto& session = **session_it;
+          if (session->should_rule_be_active(rule_id, time(nullptr))) {
+            return;
           }
+          auto ip_addr   = session->get_config().common_context.ue_ipv4();
+          auto ipv6_addr = session->get_config().common_context.ue_ipv6();
+
+          PolicyRule policy;
+          session->get_scheduled_dynamic_rules().get_rule(rule_id, &policy);
+          pipelined_client_->deactivate_flows_for_rules(
+              imsi, ip_addr, ipv6_addr, {}, {policy}, RequestOriginType::GX);
+          auto& uc = session_update[imsi][session_id];
+          session->remove_dynamic_rule(policy.id(), nullptr, uc);
           session_store_.update_sessions(session_update);
         }),
         delta);
@@ -1736,9 +1750,10 @@ void LocalEnforcer::process_rules_to_install(
     std::vector<DynamicRuleInstall> dynamic_rule_installs,
     RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
     SessionStateUpdateCriteria& uc) {
-  std::time_t current_time = time(NULL);
-  std::string ip_addr      = session.get_config().common_context.ue_ipv4();
-  std::string ipv6_addr    = session.get_config().common_context.ue_ipv6();
+  std::time_t current_time     = time(nullptr);
+  std::string ip_addr          = session.get_config().common_context.ue_ipv4();
+  std::string ipv6_addr        = session.get_config().common_context.ue_ipv6();
+  const std::string session_id = session.get_session_id();
   for (const auto& rule_install : static_rule_installs) {
     const auto& id = rule_install.rule_id();
     if (session.is_static_rule_installed(id)) {
@@ -1746,28 +1761,23 @@ void LocalEnforcer::process_rules_to_install(
       // Ignore them here.
       continue;
     }
-    auto activation_time =
-        TimeUtil::TimestampToSeconds(rule_install.activation_time());
-    auto deactivation_time =
-        TimeUtil::TimestampToSeconds(rule_install.deactivation_time());
-    RuleLifetime lifetime{
-        // TODO: check if we're building the time correctly
-        .activation_time   = std::time_t(activation_time),
-        .deactivation_time = std::time_t(deactivation_time),
-    };
-    if (activation_time > current_time) {
+    RuleLifetime lifetime(rule_install);
+    if (lifetime.activation_time > current_time) {
       session.schedule_static_rule(id, lifetime, uc);
-      schedule_static_rule_activation(imsi, ip_addr, ipv6_addr, rule_install);
+      schedule_static_rule_activation(
+          imsi, session_id, id, lifetime.activation_time);
     } else {
       session.activate_static_rule(id, lifetime, uc);
       rules_to_activate.static_rules.push_back(id);
     }
 
-    if (deactivation_time > current_time) {
-      schedule_static_rule_deactivation(imsi, ip_addr, ipv6_addr, rule_install);
-    } else if (deactivation_time > 0) {  // 0: never scheduled to deactivate
+    if (lifetime.deactivation_time > current_time) {
+      schedule_static_rule_deactivation(
+          imsi, session_id, id, lifetime.deactivation_time);
+    } else if (lifetime.deactivation_time > 0) {
+      // 0: never scheduled to deactivate
       if (!session.deactivate_static_rule(id, uc)) {
-        MLOG(MWARNING) << "Could not find rule " << id << "for IMSI " << imsi
+        MLOG(MWARNING) << "Could not find rule " << id << "for " << session_id
                        << " during static rule removal";
       }
       rules_to_deactivate.static_rules.push_back(id);
@@ -1775,27 +1785,21 @@ void LocalEnforcer::process_rules_to_install(
   }
 
   for (auto& rule_install : dynamic_rule_installs) {
-    auto activation_time =
-        TimeUtil::TimestampToSeconds(rule_install.activation_time());
-    auto deactivation_time =
-        TimeUtil::TimestampToSeconds(rule_install.deactivation_time());
-    RuleLifetime lifetime{
-        // TODO: check if we're building the time correctly
-        .activation_time   = std::time_t(activation_time),
-        .deactivation_time = std::time_t(deactivation_time),
-    };
-    if (activation_time > current_time) {
+    auto rule_id = rule_install.policy_rule().id();
+    RuleLifetime lifetime(rule_install);
+    if (lifetime.activation_time > current_time) {
       session.schedule_dynamic_rule(rule_install.policy_rule(), lifetime, uc);
-      schedule_dynamic_rule_activation(imsi, ip_addr, ipv6_addr, rule_install);
+      schedule_dynamic_rule_activation(
+          imsi, session_id, rule_id, lifetime.deactivation_time);
     } else {
       session.insert_dynamic_rule(rule_install.policy_rule(), lifetime, uc);
       rules_to_activate.dynamic_rules.push_back(rule_install.policy_rule());
     }
-    if (deactivation_time > current_time) {
+    if (lifetime.deactivation_time > current_time) {
       schedule_dynamic_rule_deactivation(
-          imsi, ip_addr, ipv6_addr, rule_install);
-    } else if (deactivation_time > 0) {
-      session.remove_dynamic_rule(rule_install.policy_rule().id(), NULL, uc);
+          imsi, session_id, rule_id, lifetime.deactivation_time);
+    } else if (lifetime.deactivation_time > 0) {
+      session.remove_dynamic_rule(rule_id, NULL, uc);
       rules_to_deactivate.dynamic_rules.push_back(rule_install.policy_rule());
     }
   }
@@ -2187,36 +2191,6 @@ static SubscriberQuotaUpdate make_subscriber_quota_update(
   update.set_mac_addr(ue_mac_addr);
   update.set_update_type(state);
   return update;
-}
-
-static bool does_session_ip_match(
-    const SessionConfig& config, const std::string& ip_addr,
-    const std::string& ipv6_addr) {
-  // cwag case
-  if (config.rat_specific_context.has_wlan_context()) {
-    // for cwag we do not have more than one session, so it will always match
-    return true;
-  }
-
-  auto ue_ip_addr   = config.common_context.ue_ipv4();
-  auto ue_ipv6_addr = config.common_context.ue_ipv6();
-  // Dual Stack case (ipv4 AND ipv6)
-  if (ue_ip_addr.size() != 0 && ue_ipv6_addr.size() != 0) {
-    return ue_ip_addr == ip_addr && ue_ipv6_addr == ipv6_addr;
-  }
-  // ipv4 only case
-  if (ue_ip_addr.size() != 0 && ue_ipv6_addr.size() == 0) {
-    return ue_ip_addr == ip_addr;
-  }
-  // ipv6 only case
-  if (ue_ip_addr.size() == 0 && ue_ipv6_addr.size() != 0) {
-    return ue_ipv6_addr == ipv6_addr;
-  }
-  MLOG(MWARNING) << "IP address stored does not match with request."
-                    " Stored = "
-                 << ue_ip_addr << " " << ue_ipv6_addr
-                 << " Request = " << ip_addr << " " << ipv6_addr;
-  return false;
 }
 
 UpdateRequestsBySession::UpdateRequestsBySession(

--- a/lte/gateway/c/session_manager/LocalEnforcer.h
+++ b/lte/gateway/c/session_manager/LocalEnforcer.h
@@ -435,20 +435,20 @@ class LocalEnforcer {
       const std::string& session_id, SessionUpdate& session_update);
 
   void schedule_static_rule_activation(
-      const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, const StaticRuleInstall& static_rule);
+      const std::string& imsi, const std::string& session_id,
+      const std::string& rule_id, const std::time_t activation_time);
 
   void schedule_dynamic_rule_activation(
-      const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, const DynamicRuleInstall& dynamic_rule);
+      const std::string& imsi, const std::string& session_id,
+      const std::string& rule_id, const std::time_t activation_time);
 
   void schedule_static_rule_deactivation(
-      const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, const StaticRuleInstall& static_rule);
+      const std::string& imsi, const std::string& session_id,
+      const std::string& rule_id, const std::time_t deactivation_time);
 
   void schedule_dynamic_rule_deactivation(
-      const std::string& imsi, const std::string& ip_addr,
-      const std::string& ipv6_addr, DynamicRuleInstall& dynamic_rule);
+      const std::string& imsi, const std::string& session_id,
+      const std::string& rule_id, const std::time_t deactivation_time);
 
   /**
    * Get the monitoring credits from PolicyReAuthRequest (RAR) message

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -335,16 +335,14 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
       deactivate_static_rule(rule_id, _);
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already uninstalled: " << rule_id
-                   << std::endl;
+                   << " because static rule already uninstalled: " << rule_id;
       return false;
     }
   }
   for (const auto& rule_id : uc.static_rules_to_install) {
     if (is_static_rule_installed(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already installed: " << rule_id
-                   << std::endl;
+                   << " because static rule already installed: " << rule_id;
       return false;
     }
     if (uc.new_rule_lifetimes.find(rule_id) != uc.new_rule_lifetimes.end()) {
@@ -354,16 +352,14 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
       install_scheduled_static_rule(rule_id, _);
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because rule lifetime is unspecified: " << rule_id
-                   << std::endl;
+                   << " because rule lifetime is unspecified: " << rule_id;
       return false;
     }
   }
   for (const auto& rule_id : uc.new_scheduled_static_rules) {
     if (is_static_rule_scheduled(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already scheduled: " << rule_id
-                   << std::endl;
+                   << " because static rule already scheduled: " << rule_id;
       return false;
     }
     auto lifetime = uc.new_rule_lifetimes[rule_id];
@@ -379,16 +375,14 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
       dynamic_rules_.remove_rule(rule_id, NULL);
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already uninstalled: " << rule_id
-                   << std::endl;
+                   << " because dynamic rule already uninstalled: " << rule_id;
       return false;
     }
   }
   for (const auto& rule : uc.dynamic_rules_to_install) {
     if (is_dynamic_rule_installed(rule.id())) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already installed: " << rule.id()
-                   << std::endl;
+                   << " because dynamic rule already installed: " << rule.id();
       return false;
     }
     if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
@@ -398,16 +392,14 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
       install_scheduled_dynamic_rule(rule.id(), _);
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because rule lifetime is unspecified: " << rule.id()
-                   << std::endl;
+                   << " because rule lifetime is unspecified: " << rule.id();
       return false;
     }
   }
   for (const auto& rule : uc.new_scheduled_dynamic_rules) {
     if (is_dynamic_rule_scheduled(rule.id())) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already scheduled: " << rule.id()
-                   << std::endl;
+                   << " because dynamic rule already scheduled: " << rule.id();
       return false;
     }
     auto lifetime = uc.new_rule_lifetimes[rule.id()];
@@ -419,18 +411,17 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
     if (is_gy_dynamic_rule_installed(rule.id())) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
                    << " because gy dynamic rule already installed: "
-                   << rule.id() << std::endl;
+                   << rule.id();
       return false;
     }
     if (uc.new_rule_lifetimes.find(rule.id()) != uc.new_rule_lifetimes.end()) {
       auto lifetime = uc.new_rule_lifetimes[rule.id()];
       insert_gy_dynamic_rule(rule, lifetime, _);
       MLOG(MERROR) << "Merge: " << session_id_ << " gy dynamic rule "
-                   << rule.id() << std::endl;
+                   << rule.id();
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because gy dynamic rule lifetime is not found"
-                   << std::endl;
+                   << " because gy dynamic rule lifetime is not found";
       return false;
     }
   }
@@ -440,7 +431,7 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
                    << " because gy dynamic rule already uninstalled: "
-                   << rule_id << std::endl;
+                   << rule_id;
       return false;
     }
   }
@@ -533,10 +524,7 @@ void SessionState::apply_session_static_rule_set(
     RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
     SessionStateUpdateCriteria& uc) {
   // No activation time / deactivation support yet for rule set interface
-  RuleLifetime lifetime{
-      .activation_time   = 0,
-      .deactivation_time = 0,
-  };
+  RuleLifetime lifetime;
   // Go through the rule set and install any rules not yet installed
   for (const auto& static_rule_id : static_rules) {
     if (!is_static_rule_installed(static_rule_id)) {
@@ -568,10 +556,7 @@ void SessionState::apply_session_dynamic_rule_set(
     RulesToProcess& rules_to_activate, RulesToProcess& rules_to_deactivate,
     SessionStateUpdateCriteria& uc) {
   // No activation time / deactivation support yet for rule set interface
-  RuleLifetime lifetime{
-      .activation_time   = 0,
-      .deactivation_time = 0,
-  };
+  RuleLifetime lifetime;
   for (const auto& dynamic_rule_pair : dynamic_rules) {
     if (!is_dynamic_rule_installed(dynamic_rule_pair.first)) {
       MLOG(MINFO) << "Installing dynamic rule " << dynamic_rule_pair.first
@@ -1165,7 +1150,7 @@ void SessionState::suspend_service_if_needed_for_credit(
   auto it = credit_map_.find(ckey);
   if (it == credit_map_.end()) {
     MLOG(MDEBUG) << "Could not find RG " << ckey
-                 << " Not suspending serivce for " << session_id_;
+                 << " Not suspending service for " << session_id_;
   }
   for (const auto& credit : credit_map_) {
     if (credit.second->suspended) {
@@ -1180,16 +1165,12 @@ void SessionState::suspend_service_if_needed_for_credit(
 
 bool SessionState::should_rule_be_active(
     const std::string& rule_id, std::time_t time) {
-  auto lifetime = rule_lifetimes_[rule_id];
-  bool deactivated =
-      (lifetime.deactivation_time > 0) && (lifetime.deactivation_time < time);
-  return lifetime.activation_time < time && !deactivated;
+  return rule_lifetimes_[rule_id].is_within_lifetime(time);
 }
 
 bool SessionState::should_rule_be_deactivated(
     const std::string& rule_id, std::time_t time) {
-  auto lifetime = rule_lifetimes_[rule_id];
-  return lifetime.deactivation_time > 0 && lifetime.deactivation_time < time;
+  return rule_lifetimes_[rule_id].exceeded_lifetime(time);
 }
 
 StaticRuleInstall SessionState::get_static_rule_install(

--- a/lte/gateway/c/session_manager/SessionState.h
+++ b/lte/gateway/c/session_manager/SessionState.h
@@ -532,6 +532,12 @@ class SessionState {
   void suspend_service_if_needed_for_credit(
       CreditKey ckey, SessionStateUpdateCriteria& update_criteria);
 
+  /**
+   * Returns true if the specified rule should be active at that time
+   */
+  bool should_rule_be_active(const std::string& rule_id, std::time_t time);
+  bool is_dynamic_rule_scheduled(const std::string& rule_id);
+
  private:
   std::string imsi_;
   std::string session_id_;
@@ -654,11 +660,6 @@ class SessionState {
       UsageMonitoringUpdateRequest* req);
 
   /**
-   * Returns true if the specified rule should be active at that time
-   */
-  bool should_rule_be_active(const std::string& rule_id, std::time_t time);
-
-  /**
    * Returns true if the specified rule should be deactivated by that time
    */
   bool should_rule_be_deactivated(const std::string& rule_id, std::time_t time);
@@ -687,8 +688,6 @@ class SessionState {
       SessionStateUpdateCriteria& update_criteria);
 
   bool is_static_rule_scheduled(const std::string& rule_id);
-
-  bool is_dynamic_rule_scheduled(const std::string& rule_id);
 
   /** apply static_rules which is the desired state for the session's rules **/
   void apply_session_static_rule_set(

--- a/lte/gateway/c/session_manager/StoredState.cpp
+++ b/lte/gateway/c/session_manager/StoredState.cpp
@@ -11,11 +11,15 @@
  * limitations under the License.
  */
 
+#include <google/protobuf/timestamp.pb.h>
+#include <google/protobuf/util/time_util.h>
+
 #include "StoredState.h"
 #include "CreditKey.h"
 #include "magma_logging.h"
 
 namespace magma {
+using google::protobuf::util::TimeUtil;
 
 SessionConfig::SessionConfig(const LocalCreateSessionRequest& request) {
   common_context       = request.common_context();
@@ -499,6 +503,35 @@ StoredSessionState deserialize_stored_session(std::string& serialized) {
       static_cast<uint64_t>(std::stoul(marshaled["pdp_end_time"].getString()));
 
   return stored;
+}
+
+RuleLifetime::RuleLifetime(const StaticRuleInstall& rule_install) {
+  activation_time =
+      std::time_t(TimeUtil::TimestampToSeconds(rule_install.activation_time()));
+  deactivation_time = std::time_t(
+      TimeUtil::TimestampToSeconds(rule_install.deactivation_time()));
+}
+
+RuleLifetime::RuleLifetime(const DynamicRuleInstall& rule_install) {
+  activation_time =
+      std::time_t(TimeUtil::TimestampToSeconds(rule_install.activation_time()));
+  deactivation_time = std::time_t(
+      TimeUtil::TimestampToSeconds(rule_install.deactivation_time()));
+}
+
+bool RuleLifetime::is_within_lifetime(std::time_t time) {
+  auto past_activation_time = activation_time <= time;
+  auto before_deactivation_time =
+      (deactivation_time == 0) || (time < deactivation_time);
+  return past_activation_time && before_deactivation_time;
+}
+
+bool RuleLifetime::exceeded_lifetime(std::time_t time) {
+  return deactivation_time != 0 && deactivation_time < time;
+}
+
+bool RuleLifetime::before_lifetime(std::time_t time) {
+  return time < activation_time;
 }
 
 };  // namespace magma

--- a/lte/gateway/c/session_manager/StoredState.h
+++ b/lte/gateway/c/session_manager/StoredState.h
@@ -162,6 +162,14 @@ struct StoredChargingGrant {
 struct RuleLifetime {
   std::time_t activation_time;    // Unix timestamp
   std::time_t deactivation_time;  // Unix timestamp
+  RuleLifetime() : activation_time(0), deactivation_time(0){};
+  RuleLifetime(const time_t activation, const time_t deactivation)
+      : activation_time(activation), deactivation_time(deactivation){};
+  RuleLifetime(const StaticRuleInstall& rule_install);
+  RuleLifetime(const DynamicRuleInstall& rule_install);
+  bool is_within_lifetime(std::time_t time);
+  bool exceeded_lifetime(std::time_t time);
+  bool before_lifetime(std::time_t time);
 };
 
 // QoS Management

--- a/lte/gateway/c/session_manager/Utilities.cpp
+++ b/lte/gateway/c/session_manager/Utilities.cpp
@@ -47,4 +47,12 @@ std::chrono::milliseconds time_difference_from_now(
   return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
 }
 
+std::chrono::milliseconds time_difference_from_now(
+    const std::time_t timestamp) {
+  const auto now   = time(nullptr);
+  const auto delta = std::max(timestamp - now, 0L);
+  std::chrono::seconds sec(delta);
+  return std::chrono::duration_cast<std::chrono::milliseconds>(sec);
+}
+
 }  // namespace magma

--- a/lte/gateway/c/session_manager/Utilities.h
+++ b/lte/gateway/c/session_manager/Utilities.h
@@ -20,4 +20,5 @@ std::string bytes_to_hex(const std::string& s);
 uint64_t get_time_in_sec_since_epoch();
 std::chrono::milliseconds time_difference_from_now(
     const google::protobuf::Timestamp& timestamp);
+std::chrono::milliseconds time_difference_from_now(const std::time_t timestamp);
 }  // namespace magma

--- a/lte/gateway/c/session_manager/test/SessionStateTester.h
+++ b/lte/gateway/c/session_manager/test/SessionStateTester.h
@@ -57,10 +57,7 @@ class SessionStateTest : public ::testing::Test {
       std::time_t activation_time, std::time_t deactivation_time) {
     PolicyRule rule;
     create_policy_rule(rule_id, m_key, rating_group, &rule);
-    RuleLifetime lifetime{
-        .activation_time   = activation_time,
-        .deactivation_time = deactivation_time,
-    };
+    RuleLifetime lifetime(activation_time, deactivation_time);
     switch (rule_type) {
       case STATIC:
         // insert into list of existing rules
@@ -80,10 +77,7 @@ class SessionStateTest : public ::testing::Test {
       std::time_t activation_time, std::time_t deactivation_time) {
     PolicyRule rule;
     create_policy_rule(rule_id, m_key, rating_group, &rule);
-    RuleLifetime lifetime{
-        .activation_time   = activation_time,
-        .deactivation_time = deactivation_time,
-    };
+    RuleLifetime lifetime(activation_time, deactivation_time);
     switch (rule_type) {
       case STATIC:
         // insert into list of existing rules
@@ -175,10 +169,7 @@ class SessionStateTest : public ::testing::Test {
       std::time_t activation_time, std::time_t deactivation_time) {
     PolicyRule rule;
     create_policy_rule(rule_id, m_key, rating_group, &rule);
-    RuleLifetime lifetime{
-        .activation_time   = activation_time,
-        .deactivation_time = deactivation_time,
-    };
+    RuleLifetime lifetime(activation_time, deactivation_time);
     switch (rule_type) {
       case STATIC:
         rule_store->insert_rule(rule);

--- a/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
+++ b/lte/gateway/c/session_manager/test/test_proxy_responder_handler.cpp
@@ -154,10 +154,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_policy_reauth) {
   // 2) Create bare-bones session for IMSI1
   auto uc      = get_default_update_criteria();
   auto session = get_session(rule_store);
-  RuleLifetime lifetime{
-      .activation_time   = std::time_t(0),
-      .deactivation_time = std::time_t(0),
-  };
+  RuleLifetime lifetime;
   session->activate_static_rule(rule_id, lifetime, uc);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
@@ -228,10 +225,7 @@ TEST_F(SessionProxyResponderHandlerTest, test_abort_session) {
   // 2) Create bare-bones session for IMSI1
   auto uc      = get_default_update_criteria();
   auto session = get_session(rule_store);
-  RuleLifetime lifetime{
-      .activation_time   = std::time_t(0),
-      .deactivation_time = std::time_t(0),
-  };
+  RuleLifetime lifetime;
   session->activate_static_rule(rule_id, lifetime, uc);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);

--- a/lte/gateway/c/session_manager/test/test_session_store.cpp
+++ b/lte/gateway/c/session_manager/test/test_session_store.cpp
@@ -141,10 +141,7 @@ class SessionStoreTest : public ::testing::Test {
     update_criteria.static_rules_to_install.insert(rule_id_1);
     update_criteria.dynamic_rules_to_install = std::vector<PolicyRule>{};
     update_criteria.dynamic_rules_to_install.push_back(get_dynamic_rule());
-    RuleLifetime lifetime{
-        .activation_time   = std::time_t(0),
-        .deactivation_time = std::time_t(0),
-    };
+    RuleLifetime lifetime;
     update_criteria.new_rule_lifetimes[rule_id_1]         = lifetime;
     update_criteria.new_rule_lifetimes[dynamic_rule_id_1] = lifetime;
 
@@ -232,10 +229,7 @@ TEST_F(SessionStoreTest, test_metering_reporting) {
 
   auto uc = get_default_update_criteria();
   uc.static_rules_to_install.insert("RULE_asdf");
-  RuleLifetime lifetime{
-      .activation_time   = std::time_t(0),
-      .deactivation_time = std::time_t(0),
-  };
+  RuleLifetime lifetime;
   uc.new_rule_lifetimes["RULE_asdf"] = lifetime;
 
   // Record some credit usage
@@ -304,10 +298,7 @@ TEST_F(SessionStoreTest, test_read_and_write) {
   auto session = get_session(IMSI1, SESSION_ID_1, rule_store);
 
   auto uc = get_default_update_criteria();
-  RuleLifetime lifetime{
-      .activation_time   = std::time_t(0),
-      .deactivation_time = std::time_t(0),
-  };
+  RuleLifetime lifetime;
   session->activate_static_rule(rule_id_3, lifetime, uc);
   EXPECT_EQ(session->get_session_id(), SESSION_ID_1);
   EXPECT_EQ(session->get_request_number(), 1);
@@ -522,10 +513,8 @@ TEST_F(SessionStoreTest, test_update_session_rules) {
 
   auto uc = get_default_update_criteria();
   uc.static_rules_to_install.insert("RULE_asdf");
-  RuleLifetime lifetime{
-      .activation_time   = std::time_t(0),
-      .deactivation_time = std::time_t(0),
-  };
+  RuleLifetime lifetime;
+
   uc.new_rule_lifetimes["RULE_asdf"]  = lifetime;
   session_update[IMSI1][SESSION_ID_1] = uc;
 


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
- We were previously using IMSI+ IPv4/IPv6 to identify sessions for scheduling rule installs/removals. This can be simplified by just using IMSI+SessionID to uniquely identify the session.
- Some log improvements by logging SessionID.
- Static rule activation logic adjustment: When the handler is called, check again is that the static rule's lifetime variable indicates that the rule should be active. This will avoid rule activation when 
  1. rule happened to be removed during the scheduling 
  2. The handler was delayed and exceeded the deactivation time for some reason.
- Dynamic rule activation logic adjustment. Similarly to static rules, we should always check against the SessionState (rule lifetime and the scheduled dynamic rules map) to see if the rule is still scheduled to be activated. With the previous implementation consider the following case:
  1. [Time 1] rule X is scheduled to be installed at Time 5. Rule definition is inserted into scheduled_dynamic_rule map, lifetime variable is set to {activation_time=5, deactivation_time=0}. (0 means not specified) A handler is passed into the event loop with the rule definition.
  2. [Time 2] rule X with modified rule definition is to be installed immediately. 
  3. [Time 5] rule X is now scheduled to be installed with the previous definition. :'( 
So to avoid this, we should always look up the definition from the policy map, not the one passed into the handler, and always check against the rule's lifetime. 


<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
