### PR TITLE
[lte][agw] Add condition for context not found in delete session response

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -898,9 +898,10 @@ void mme_app_handle_delete_session_rsp(
   }
 
   /*
-   * If UE is already in idle state or if response received with CONTEXT_NOT_FOUND,
-   * skip asking eNB to release UE context and just clean up locally. This can happen
-   * during implicit detach and UE initiated detach when UE sends detach req (type = switch off).
+   * If UE is already in idle state or if response received with
+   * CONTEXT_NOT_FOUND, skip asking eNB to release UE context and just clean up
+   * locally. This can happen during implicit detach and UE initiated detach
+   * when UE sends detach req (type = switch off).
    */
   if ((ECM_IDLE == ue_context_p->ecm_state) ||
       (delete_sess_resp_pP->cause.cause_value == CONTEXT_NOT_FOUND)) {

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -898,11 +898,12 @@ void mme_app_handle_delete_session_rsp(
   }
 
   /*
-   * If UE is already in idle state, skip asking eNB to release UE context and
-   * just clean up locally. This can happen during implicit detach and UE
-   * initiated detach when UE sends detach req (type = switch off)
+   * If UE is already in idle state or if response received with CONTEXT_NOT_FOUND,
+   * skip asking eNB to release UE context and just clean up locally. This can happen
+   * during implicit detach and UE initiated detach when UE sends detach req (type = switch off).
    */
-  if (ECM_IDLE == ue_context_p->ecm_state) {
+  if ((ECM_IDLE == ue_context_p->ecm_state) ||
+      (delete_sess_resp_pP->cause.cause_value == CONTEXT_NOT_FOUND)) {
     ue_context_p->ue_context_rel_cause = S1AP_IMPLICIT_CONTEXT_RELEASE;
     // Notify S1AP to release S1AP UE context locally.
     mme_app_itti_ue_context_release(

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -1183,6 +1183,7 @@ int sgw_handle_delete_session_request(
     delete_session_resp_p->trxn              = delete_session_req_pP->trxn;
     delete_session_resp_p->peer_ip.s_addr =
         delete_session_req_pP->peer_ip.s_addr;
+    delete_session_resp_p->lbi = delete_session_req_pP->lbi;
 
     message_p->ittiMsgHeader.imsi = imsi64;
     rv = send_msg_to_task(&spgw_app_task_zmq_ctx, TASK_MME, message_p);


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

When context is not found in SPGW task, session request response does not include any LBI information; instead a specific CONTEXT_NOT_FOUND cause is returned back to MME. As MME code was not considering this situation, it was leading to a crash while trying to access the session context.

## Test Plan

Sanity tests.
Also tested with a modified MME binary to trigger the case.


