### PR TITLE
[SessionD] Add back unit tests

### DIFF
--- a/lte/gateway/c/session_manager/test/CMakeLists.txt
+++ b/lte/gateway/c/session_manager/test/CMakeLists.txt
@@ -15,10 +15,10 @@ add_library(SESSIOND_TEST_LIB
 
 target_link_libraries(SESSIOND_TEST_LIB SESSION_MANAGER gmock_main pthread rt)
 
-foreach (session_test session_credit cloud_reporter
-    sessiond_integ 
-    session_store store_client stored_state 
-    metering_reporter charging_grant
+foreach (session_test session_credit local_enforcer cloud_reporter
+    session_manager_handler sessiond_integ session_state
+    session_store store_client stored_state proxy_responder_handler
+    metering_reporter local_enforcer_wallet_exhaust charging_grant
     usage_monitor)
   add_executable(${session_test}_test test_${session_test}.cpp)
   target_link_libraries(${session_test}_test SESSIOND_TEST_LIB)

--- a/lte/gateway/c/session_manager/test/SessiondMocks.h
+++ b/lte/gateway/c/session_manager/test/SessiondMocks.h
@@ -83,7 +83,8 @@ class MockPipelinedClient : public PipelinedClient {
     ON_CALL(*this, set_upf_session(_, _)).WillByDefault(Return(true));
     ON_CALL(*this, update_subscriber_quota_state(_))
         .WillByDefault(Return(true));
-    ON_CALL(*this, set_upf_session(_, _)).WillByDefault(Return(true));
+    ON_CALL(*this, get_next_teid()).WillByDefault(Return(0));
+    ON_CALL(*this, get_current_teid()).WillByDefault(Return(0));
   }
 
   MOCK_METHOD9(
@@ -167,6 +168,8 @@ class MockPipelinedClient : public PipelinedClient {
       bool(
           const SessionState::SessionInfo info,
           std::function<void(Status status, UPFSessionContextState)> callback));
+  MOCK_METHOD0(get_next_teid, uint32_t());
+  MOCK_METHOD0(get_current_teid, uint32_t());
 };
 
 class MockDirectorydClient : public AsyncDirectorydClient {


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Some unit tests were removed from the Makefile, so adding them back in
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
Tests are running again :) 
```
Test project /home/vagrant/build/c/session_manager
      Start  1: test_session_credit
 1/14 Test  #1: test_session_credit ..................   Passed    1.09 sec
      Start  2: test_local_enforcer
 2/14 Test  #2: test_local_enforcer ..................   Passed    2.77 sec
      Start  3: test_cloud_reporter
 3/14 Test  #3: test_cloud_reporter ..................   Passed    0.04 sec
      Start  4: test_session_manager_handler
 4/14 Test  #4: test_session_manager_handler .........   Passed    0.03 sec
      Start  5: test_sessiond_integ
 5/14 Test  #5: test_sessiond_integ ..................   Passed    0.37 sec
      Start  6: test_session_state
 6/14 Test  #6: test_session_state ...................   Passed    0.01 sec
      Start  7: test_session_store
 7/14 Test  #7: test_session_store ...................   Passed    0.01 sec
      Start  8: test_store_client
 8/14 Test  #8: test_store_client ....................   Passed    0.01 sec
      Start  9: test_stored_state
 9/14 Test  #9: test_stored_state ....................   Passed    0.01 sec
      Start 10: test_proxy_responder_handler
10/14 Test #10: test_proxy_responder_handler .........   Passed    0.02 sec
      Start 11: test_metering_reporter
11/14 Test #11: test_metering_reporter ...............   Passed    0.04 sec
      Start 12: test_local_enforcer_wallet_exhaust
12/14 Test #12: test_local_enforcer_wallet_exhaust ...   Passed    0.02 sec
      Start 13: test_charging_grant
13/14 Test #13: test_charging_grant ..................   Passed    0.03 sec
      Start 14: test_usage_monitor
14/14 Test #14: test_usage_monitor ...................   Passed    0.04 sec

100% tests passed, 0 tests failed out of 14
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
