### PR TITLE
[SessionD] Always process rule uninstall over install

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -1651,6 +1651,14 @@ void LocalEnforcer::propagate_rule_updates_to_pipelined(
     const RulesToProcess& rules_to_deactivate, bool always_send_activate) {
   const auto ip_addr   = config.common_context.ue_ipv4();
   const auto ipv6_addr = config.common_context.ue_ipv6();
+  // deactivate_flows_for_rules() should not be called when there is no rule
+  // to deactivate, because pipelined deactivates all rules
+  // when no rule is provided as the parameter
+  if (rules_to_process_is_not_empty(rules_to_deactivate)) {
+    pipelined_client_->deactivate_flows_for_rules(
+        imsi, ip_addr, ipv6_addr, rules_to_deactivate.static_rules,
+        rules_to_deactivate.dynamic_rules, RequestOriginType::GX);
+  }
   if (always_send_activate ||
       rules_to_process_is_not_empty(rules_to_activate)) {
     const auto ambr   = config.get_apn_ambr();
@@ -1662,14 +1670,6 @@ void LocalEnforcer::propagate_rule_updates_to_pipelined(
             &LocalEnforcer::handle_activate_ue_flows_callback, this, imsi,
             ip_addr, ipv6_addr, msisdn, ambr, rules_to_activate.static_rules,
             rules_to_activate.dynamic_rules, _1, _2));
-  }
-  // deactivate_flows_for_rules() should not be called when there is no rule
-  // to deactivate, because pipelined deactivates all rules
-  // when no rule is provided as the parameter
-  if (rules_to_process_is_not_empty(rules_to_deactivate)) {
-    pipelined_client_->deactivate_flows_for_rules(
-        imsi, ip_addr, ipv6_addr, rules_to_deactivate.static_rules,
-        rules_to_deactivate.dynamic_rules, RequestOriginType::GX);
   }
 }
 

--- a/lte/gateway/c/session_manager/SessionState.cpp
+++ b/lte/gateway/c/session_manager/SessionState.cpp
@@ -327,6 +327,19 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
   }
 
   // Static rules
+  for (const auto& rule_id : uc.static_rules_to_uninstall) {
+    if (is_static_rule_installed(rule_id)) {
+      deactivate_static_rule(rule_id, _);
+    } else if (is_static_rule_scheduled(rule_id)) {
+      install_scheduled_static_rule(rule_id, _);
+      deactivate_static_rule(rule_id, _);
+    } else {
+      MLOG(MERROR) << "Failed to merge: " << session_id_
+                   << " because static rule already uninstalled: " << rule_id
+                   << std::endl;
+      return false;
+    }
+  }
   for (const auto& rule_id : uc.static_rules_to_install) {
     if (is_static_rule_installed(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
@@ -346,19 +359,6 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
       return false;
     }
   }
-  for (const auto& rule_id : uc.static_rules_to_uninstall) {
-    if (is_static_rule_installed(rule_id)) {
-      deactivate_static_rule(rule_id, _);
-    } else if (is_static_rule_scheduled(rule_id)) {
-      install_scheduled_static_rule(rule_id, _);
-      deactivate_static_rule(rule_id, _);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because static rule already uninstalled: " << rule_id
-                   << std::endl;
-      return false;
-    }
-  }
   for (const auto& rule_id : uc.new_scheduled_static_rules) {
     if (is_static_rule_scheduled(rule_id)) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
@@ -371,6 +371,19 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
   }
 
   // Dynamic rules
+  for (const auto& rule_id : uc.dynamic_rules_to_uninstall) {
+    if (is_dynamic_rule_installed(rule_id)) {
+      dynamic_rules_.remove_rule(rule_id, NULL);
+    } else if (is_dynamic_rule_scheduled(rule_id)) {
+      install_scheduled_static_rule(rule_id, _);
+      dynamic_rules_.remove_rule(rule_id, NULL);
+    } else {
+      MLOG(MERROR) << "Failed to merge: " << session_id_
+                   << " because dynamic rule already uninstalled: " << rule_id
+                   << std::endl;
+      return false;
+    }
+  }
   for (const auto& rule : uc.dynamic_rules_to_install) {
     if (is_dynamic_rule_installed(rule.id())) {
       MLOG(MERROR) << "Failed to merge: " << session_id_
@@ -386,19 +399,6 @@ bool SessionState::apply_update_criteria(SessionStateUpdateCriteria& uc) {
     } else {
       MLOG(MERROR) << "Failed to merge: " << session_id_
                    << " because rule lifetime is unspecified: " << rule.id()
-                   << std::endl;
-      return false;
-    }
-  }
-  for (const auto& rule_id : uc.dynamic_rules_to_uninstall) {
-    if (is_dynamic_rule_installed(rule_id)) {
-      dynamic_rules_.remove_rule(rule_id, NULL);
-    } else if (is_dynamic_rule_scheduled(rule_id)) {
-      install_scheduled_static_rule(rule_id, _);
-      dynamic_rules_.remove_rule(rule_id, NULL);
-    } else {
-      MLOG(MERROR) << "Failed to merge: " << session_id_
-                   << " because dynamic rule already uninstalled: " << rule_id
                    << std::endl;
       return false;
     }


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
We had a bug where a dynamic rule modification led to a merge failure. 
This should be solved by processing the update criteria in the same order we modify it. 
We should always process the rule removals, then then rule installs. 

Added a unit test to cover this case that failed with the same error before the change.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm

The new test fails with `[/home/vagrant/magma/lte/gateway/c/session_manager/SessionState.cpp:376] Failed to merge: IMSI000000000000001-SessionID because dynamic rule already installed: d-rule1` without the change.
With the code change, it passes.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
![Screen Shot 2020-12-04 at 12 56 18 PM](https://user-images.githubusercontent.com/37634144/101203369-2b6fa800-3630-11eb-917a-2b073a5fd809.png)
