### PR TITLE
[lte][agw] fix deb package format issue after adding tshark dependency

### DIFF
--- a/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
+++ b/lte/gateway/deploy/roles/ovs_deploy/tasks/main.yml
@@ -75,6 +75,11 @@
     - 'echo "Pin: origin packages.magma.etagecom.io" >> /etc/apt/preferences.d/magma-preferences'
     - 'echo "Pin-Priority: 900" >> /etc/apt/preferences.d/magma-preferences'
 
+- name: Preconfigure wireshark (tshark) SUID property
+  become: yes
+  ignore_errors: yes
+  shell: bash -c 'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections'
+
 - name: Installing magma.
   become: yes
   apt:

--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -113,7 +113,7 @@ MAGMA_DEPS=(
     "libboost-chrono-dev" # required for folly
     "td-agent-bit >= 1.3.2" # fluent-bit
     "ntpdate" # required for eventd time synchronization
-    "python3-scapy >= 2.4.3-4",
+    "python3-scapy >= 2.4.3-4"
     "tshark" # required for call tracing
     )
 


### PR DESCRIPTION
also preconfigure SUID status of tshark package in ovs_deploy task

Signed-off-by: Ken Kahrs <kahrs@fb.com>

## Summary
bash arrays are not comma-separated
tshark by default has an interactive dialog for which a default may be configured

## Test Plan
build packages
ship to local pkgrepo
install magma from local pkgrepo onto magma_prod vm
verify packages install




## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
