### PR TITLE
AGW: mobilityd: fix test assert for dhcp state

### DIFF
--- a/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
+++ b/lte/gateway/python/magma/mobilityd/tests/ip_alloc_dhcp_test.py
@@ -97,7 +97,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         mac1 = create_mac_from_sid(sid1)
         dhcp_state1 = dhcp_store.get(mac1.as_redis_key(None))
 
-        self.assertEqual(dhcp_state1.state_requested, DHCPState.RELEASE)
+        self.assertEqual(dhcp_state1, None)
 
         ip1_1, _ = self._dhcp_allocator.alloc_ip_address(sid1)
         threading.Event().wait(2)
@@ -139,7 +139,7 @@ class DhcpIPAllocEndToEndTest(unittest.TestCase):
         mac4 = create_mac_from_sid(sid4)
         dhcp_state = dhcp_store.get(mac4.as_redis_key(None))
 
-        self.assertEqual(dhcp_state.state_requested, DHCPState.RELEASE)
+        self.assertEqual(dhcp_state, None)
         ip4_2, _ = self._dhcp_allocator.alloc_ip_address(sid4)
         self.assertEqual(ip4, ip4_2)
 

--- a/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
+++ b/lte/gateway/python/magma/mobilityd/tests/test_dhcp_client.py
@@ -196,6 +196,8 @@ class DhcpClient(unittest.TestCase):
             LOG.debug("wait for state: %d" % x)
             with self.dhcp_wait:
                 dhcp1 = self.dhcp_store.get(mac.as_redis_key(vlan))
+                if state == DHCPState.RELEASE and dhcp1 is None:
+                    return
                 if dhcp1.state_requested == state:
                     return
             time.sleep(PKT_CAPTURE_WAIT)


### PR DESCRIPTION
Earlier commit changed the dhcp state management, I missed
test related changes from that commit.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
