### PR TITLE
AGW: fix coredump handler script to store core in var-core dir.

### DIFF
--- a/lte/gateway/configs/logfiles.txt
+++ b/lte/gateway/configs/logfiles.txt
@@ -1,3 +1,2 @@
 /var/log/mme.log
-/var/log/spgw.log
 /var/log/syslog


### PR DESCRIPTION
## Summary

coredump already stores zipped core dump in '/var/core/' dir.
but it could not finish execution due to a bug.
coredump handler uses 'logfiles.txt" to find log file names.
but it had 'spgw.log', which no longer exist. removing this file
fixes the issue.

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->


<!-- Enumerate changes you made and why you made them -->

## Test Plan
tested with crashing app.
 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
