### PR TITLE
[feg][cloud][nh] Switch SWx Proxy GW to FeG Relay to Neutral Host capable service.

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -34,7 +34,7 @@ services:
       session_proxy:
         port: 9079
       swx_proxy:
-        port: 9079
+        port: 9103
       csfb:
         port: 9079
       feg_hello:


### PR DESCRIPTION

Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

Switch SWx Proxy GW to FeG Relay to Neutral Host capable service.

## Summary

Currently NH aware FeG Relays are idle and running alone legacy generic GW to FeG Relay.
This change should switch SWx proxy GW requests to use the new NH capable relay service.

## Test Plan

unit tests; verify on staging

## Additional Information

- [ ] This change is backwards-breaking

