### PR TITLE
[lte][agw] preconfigure tshark setuid option

### DIFF
--- a/lte/gateway/deploy/roles/tshark_setuid_config/tasks/main.yml
+++ b/lte/gateway/deploy/roles/tshark_setuid_config/tasks/main.yml
@@ -12,15 +12,6 @@
 # limitations under the License.
 ################################################################################
 
-- name: Set up Magma prod environment on a local machine
-  hosts: prod
+- name: Preconfigure tshark (wireshark) SETUID property
   become: yes
-
-  vars:
-    preburn: false
-    full_provision: true
-
-  roles:
-    - role: stretch_snapshot
-    - role: uselocalpkgrepo
-    - role: tshark_setuid_config
+  shell: bash -c 'echo "wireshark-common wireshark-common/install-setuid boolean true" | debconf-set-selections'


### PR DESCRIPTION
to avoid a dialog appearing at install time

Signed-off-by: Ken Kahrs <kkahrs@gmail.com>

## Summary
Preconfigure the magma_prod vm with desired SETUID bit for tshark. This
would need to be applied during initial configuration of bare metal machines to
avoid manual intervention at install time.

## Test Plan
* provision magma_prod VM including tshark_setuid_config role
* install magma from repo
* verify tshark installed
* no interactive dialogs appeared

## Additional Information

- [ ] This change is backwards-breaking
