### PR TITLE
[teravm] one command to update and execute test

### DIFF
--- a/ci-scripts/teravm/fabfile.py
+++ b/ci-scripts/teravm/fabfile.py
@@ -45,15 +45,28 @@ fastprint("Configuration loaded\n")
 # for ssh commands.Looks like fab env.key_filename only works with authorized
 # key based ssh. A bash script can take advantage of cert-based ssh.
 
+def upgrade_to_latest_and_run_3gpp_tests(
+    setup,
+    key_filename=DEFAULT_KEY_FILENAME,
+    custom_test_file=NG40_TEST_FILES,
+    upgrade_agw="True",
+    upgrade_feg="True",
+):
+    latest_tag = _get_latest_agw_tag(setup, key_filename)
+    latest_hash = _parse_hash_from_tag(latest_tag)
+
+    return upgrade_and_run_3gpp_tests(
+        setup, latest_hash, key_filename,
+        custom_test_file, upgrade_agw, upgrade_feg)
+
 
 def upgrade_and_run_3gpp_tests(
     setup,
-    key_filename=DEFAULT_KEY_FILENAME,
     hash=None,
+    key_filename=DEFAULT_KEY_FILENAME,
     custom_test_file=NG40_TEST_FILES,
-    upgrade_cloud="True",
-    upgrade_feg="True",
     upgrade_agw="True",
+    upgrade_feg="True",
 ):
     """
     Runs upgrade and s6a and gxgy tests once. This is run in the cron job on
@@ -67,26 +80,36 @@ def upgrade_and_run_3gpp_tests(
 
     custom_test_file: a 3gpp test file to run. The default uses s6a and gxgy
     """
-    upgrade_teravm(
-        setup,
-        key_filename=key_filename,
-        hash=hash,
-        upgrade_cloud=upgrade_cloud,
-        upgrade_feg=upgrade_feg,
-        upgrade_agw=upgrade_agw,
-    )
-    fastprint("Sleeping for 30 seconds to make sure system is ready\n")
+    err = upgrade_teravm(setup, hash, key_filename,
+                         upgrade_agw, upgrade_feg)
+    if err:
+        return None
+
+    fastprint("\nSleeping for 30 seconds to make sure system is read\n\n")
     time.sleep(30)
 
     verdicts = run_3gpp_tests(setup, key_filename, custom_test_file)
     return verdicts
 
+
+def upgrade_teravm_latest(
+    setup,
+    key_filename=DEFAULT_KEY_FILENAME,
+    upgrade_agw="True",
+    upgrade_feg="True",
+):
+    latest_tag = _get_latest_agw_tag(setup, key_filename)
+    latest_hash = _parse_hash_from_tag(latest_tag)
+
+    return  upgrade_teravm(setup, latest_hash, key_filename, upgrade_agw, upgrade_feg)
+
+
 def upgrade_teravm(
     setup,
     hash=None,
     key_filename=DEFAULT_KEY_FILENAME,
-    upgrade_feg="True",
     upgrade_agw="True",
+    upgrade_feg="True",
 ):
     """
     Upgrade teravm vms feg, agw.
@@ -110,15 +133,15 @@ def upgrade_teravm(
     upgrade_feg = _prep_bool_arg(upgrade_feg)
     upgrade_agw = _prep_bool_arg(upgrade_agw)
 
-    fastprint("Hash to use: %s\n" % hash)
-
     if upgrade_agw:
-        upgrade_teravm_agw(setup, hash, key_filename)
+        err = upgrade_teravm_agw(setup, hash, key_filename)
+        if err:
+            return err
 
     if upgrade_feg:
-        upgrade_teravm_feg(setup, hash, key_filename)
-
-    return hash
+        err = upgrade_teravm_feg(setup, hash, key_filename)
+        if err:
+            return err
 
 
 def upgrade_teravm_agw(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
@@ -134,7 +157,7 @@ def upgrade_teravm_agw(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
     work instead. This can be used if the script is run manually.
     """
 
-    fastprint("Upgrade teraVM AGW to %s" % hash)
+    fastprint("\nUpgrade teraVM AGW to %s\n" % hash)
     _setup_env("magma", VM_IP_MAP[setup]["gateway"], key_filename)
     err = _set_magma_apt_repo()
     if err:
@@ -161,7 +184,6 @@ def upgrade_teravm_agw(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
                 "Maybe the version doesn't exist. Not installing.\n".format(hash)
             )
             fastprint(err)
-    return err
 
 
 def upgrade_teravm_agw_AWS(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
@@ -175,7 +197,7 @@ def upgrade_teravm_agw_AWS(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
     the remote host. If empty file name is passed, password-based ssh will
     work instead. This can be used if the script is run manually.
     """
-    fastprint("Upgrade teraVM AGW through AWSto %s" % hash)
+    fastprint("\nUpgrade teraVM AGW through AWSto %s\n" % hash)
     _setup_env("magma", VM_IP_MAP[setup]["gateway"], key_filename)
     try:
         image = _get_gateway_image(hash)
@@ -217,7 +239,7 @@ def upgrade_teravm_feg(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
     work instead. This can be used if the script is run manually.
     """
     err = None
-    fastprint("Upgrade teraVM FEG to %s" % hash)
+    fastprint("\nUpgrade teraVM FEG to %s\n" % hash)
     _setup_env("magma", VM_IP_MAP[setup]["feg"], key_filename)
 
     with cd("/var/opt/magma/docker"), settings(abort_exception=FabricException):
@@ -247,7 +269,7 @@ def upgrade_teravm_feg(setup, hash, key_filename=DEFAULT_KEY_FILENAME):
 
 
 def run_3gpp_tests(
-    setup, key_filename=DEFAULT_KEY_FILENAME, test_files=NG40_TEST_FILES
+        setup, key_filename=DEFAULT_KEY_FILENAME, test_files=NG40_TEST_FILES
 ):
     """
     Run teravm s6a and gxgy test cases. Usage: 'fab run_3gpp_tests:' for
@@ -274,6 +296,8 @@ def run_3gpp_tests(
         fastprint("Done with file %s\n" % (test_file))
 
     verdicts = _parse_stats(test_output)
+    fastprint("Results of test:\n")
+    _prettyprint_stats(verdicts)
     return verdicts
 
 
@@ -319,6 +343,10 @@ def _parse_stats(teravm_raw_result):
                 verdicts[verdict].append(line)
     return verdicts
 
+def _prettyprint_stats(verdict):
+    for result, test_list in verdict.items():
+        for result in test_list:
+            fastprint("%s\n" %(result))
 
 def _check_disk_space(threshold=80, drive_prefix="/dev/sd"):
     over_threshold = {}
@@ -348,6 +376,28 @@ def _get_gateway_image(hash):
         raise Exception("No gateway image found with hash %s" % hash)
     else:
         return output.rsplit(" ", 1)[1]
+
+
+def _get_latest_agw_tag(setup, key_filename):
+    _setup_env("magma", VM_IP_MAP[setup]["gateway"], key_filename)
+    err = _set_magma_apt_repo()
+    if err:
+        return err
+    sudo("apt update")
+    tag = sudo(
+            "apt-cache madison magma | awk 'NR==1{{print substr ($3,1)}}'")
+    fastprint("Latest tag of AGW is %s \n" % tag)
+
+    return tag
+
+
+def _parse_hash_from_tag(tag):
+    split_tag = tag.split("-")
+    if len(split_tag) != 3:
+        fastprint("not valid tag %s\n" % split_tag)
+        return
+    fastprint("Latest hash is %s \n" % split_tag[2])
+    return split_tag[2]
 
 
 def _fetch_image(name, image):


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Added one line command to execute teravm update and run tests with
`fab upgrade_to_latest_and_run_3gpp_tests setup_2`
If error returns None 
If no error returs a dictionary of the veredicts on this form
```
{ 
	"FAIL": [
		"Verdict(gx_gy_combined_ul) = VERDICT_FAIL", 
		"Verdict(gx_gy_combined_dl) = VERDICT_FAIL", 	
		"Verdict(gx_gy_combined_03) = VERDICT_FAIL", 
		"Verdict(gx_gy_combined_04) = VERDICT_FAIL"
	],
	"PASS": [
		"Verdict(gx_gy_combined_05) = VERDICT_PASS", 
		"Verdict(gx_gy_combined_06) = VERDICT_PASS", 	
		"Verdict(gx_gy_combined_07) = VERDICT_PASS", 
		"Verdict(gx_gy_combined_08) = VERDICT_PASS"
	]
}
```

If needed, the format of this message can be changed.

## Test Plan

executed in teravm

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
