### PR TITLE
[lte][agw] Temporarily enable ASAN in release builds as well

### DIFF
--- a/lte/gateway/c/oai/CMakeLists.txt
+++ b/lte/gateway/c/oai/CMakeLists.txt
@@ -56,7 +56,9 @@ set(CMAKE_EXE_LINKER_FLAGS_DEBUG  "${CMAKE_EXE_LINKER_FLAGS_DEBUG} -fprofile-arc
 # Add LeakSanitizer (lsan) support to the release build of MME so that we can
 # find memory leaks in production.
 set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -fsanitize=leak -fno-omit-frame-pointer")
-set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO  "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
+# Temporary enablement of asan on release builds for better MME troubleshooting
+set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO  "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=address")
+#set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO  "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} -fsanitize=leak")
 
 ################################################################
 # Set proto directory for state proto definitions


### PR DESCRIPTION
## Summary

For testing MME off of 1.3.2 enable ASAN in release builds as well

## Test Plan

Validated that ASAN is enabled when compiled with RelWithDebInfo
Hand built debian package and verified compiler flags

## Additional Information

- [ ] This change is backwards-breaking


Signed-off-by: Amar Padmanabhan <amarpadmanabhan@fb.com>
