### PR TITLE
[lte][agw] Fix emm context initialization

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/emm_data_ctx.c
@@ -923,6 +923,7 @@ void emm_init_context(
   if (init_esm_ctxt) {
     esm_init_context(&emm_ctx->esm_ctx);
   }
+  emm_ctx->emm_procedures = NULL;
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

EMM context in MME was not initialized for `emm_procedures` that leads to segmentation fault when service request is rejected for an attached UE.

## Test Plan

s1ap integration tests

