### PR TITLE
[CI][lte] Reintroduce pipeline logs for tests report, but remove vm up/down logs

### DIFF
--- a/ci-scripts/JenkinsFile-GitLab
+++ b/ci-scripts/JenkinsFile-GitLab
@@ -107,13 +107,14 @@ pipeline {
             script {
               try {
                 sh('sudo virsh list --all --name')
-                sh('sudo virsh list --all --name | grep _magma | xargs --no-run-if-empty -n1 sudo virsh undefine')
-                sh('cd lte/gateway;virsh undefine gateway_magma || true; vagrant destroy --force magma')
+                sh('sudo virsh list --all --name | grep _magma | xargs --no-run-if-empty -n1 sudo virsh destroy || true')
+                sh('sudo virsh list --all --name | grep _magma | xargs --no-run-if-empty -n1 sudo virsh undefine || true')
+                sh('cd lte/gateway && vagrant destroy --force magma')
               }
               catch (Exception e) {
                   echo "Fine. Let it go..."
               }
-              sh('cd lte/gateway && vagrant up --provider libvirt magma')
+              myShCmdWithLog('cd lte/gateway && vagrant up --provider libvirt magma', 'archives/magma_vagrant_up.log')
               // Check that magma services are all down. Should be the case after wake-up
               try {
                 sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status"')
@@ -146,7 +147,7 @@ pipeline {
                   echo "OK after a git clean..."
                 }
                 try {
-                  sh ('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make clean"')
+                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make clean"', 'archives/magma_vagrant_make_clean.log')
                 } catch (Exception e) {
                   echo "OK after a git clean..."
                 }
@@ -158,7 +159,7 @@ pipeline {
                 }
                 timeout (time: 120, unit: 'MINUTES') {
                   // removing the magma/.cache/gateway folder will slow down build from 3 minutes to 27 minutes
-                  sh('''cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make run "''')
+                  myShCmdWithLog('''cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make run "''', 'archives/magma_vagrant_make_run.log')
                 }
                 sh "sleep 30"
                 // check magma status --> non-blocking (even if OK it might fail from a bash script point of view)
@@ -180,7 +181,7 @@ pipeline {
               sh('docker exec -i ci-cn-cppcheck /bin/bash -c "apt-get update && apt-get upgrade --yes" 2>&1 > archives/cppcheck_install.log')
               sh('docker exec -i ci-cn-cppcheck /bin/bash -c "apt-get install --yes git cppcheck bzip2" 2>&1 >> archives/cppcheck_install.log')
 
-              sh('docker exec -i ci-cn-cppcheck /bin/bash -c "cd /code && cppcheck -j8 --enable=warning --force --xml --xml-version=2 -i test ." 2> cppcheck.xml 1> cppcheck_build.log')
+              sh('docker exec -i ci-cn-cppcheck /bin/bash -c "cd /code && cppcheck -j8 --enable=warning --force --xml --xml-version=2 -i test ." 2> cppcheck.xml 1> archives/cppcheck_build.log')
               sh('docker rm -f ci-cn-cppcheck')
             }
           }
@@ -243,9 +244,9 @@ pipeline {
                 catch (Exception e) {
                   echo "Fine. Let it go..."
                 }
-                sh('cd lte/gateway && vagrant up --provider libvirt magma_test')
-                sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"')
-                sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"')
+                myShCmdWithLog('cd lte/gateway && vagrant up --provider libvirt magma_test', 'archives/magma_vagrant_test_up.log')
+                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/ && make"', 'archives/magma_vagrant_test_make1.log')
+                myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && make"', 'archives/magma_vagrant_test_make2.log')
             }
           }
         }
@@ -254,7 +255,7 @@ pipeline {
             script {
               sh "sleep 60"
                 try {
-                  sh('cd lte/gateway && virsh undefine gateway_magma_trfserver || true; vagrant destroy --force magma_trfserver')
+                  myShCmdWithLog('cd lte/gateway && virsh undefine gateway_magma_trfserver || true; vagrant destroy --force magma_trfserver', 'archives/magma_vagrant_trfserver_up.log')
                 } catch (Exception e) {
                   echo "Ignoring issues cleaning up any lingering magma_trfserver"
                 }
@@ -303,19 +304,19 @@ pipeline {
           // FIXME!!!! set 110 MINUTES instead of 30
 
                 timeout (time: 110, unit: 'MINUTES') {
-                  sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"')
+                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test"', 'archives/magma_run_s1ap_tester.log')
                 }
 
                 timeout (time: 45, unit: 'SECONDS') {
                   try {
-                    sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_udp_data.py"')
+                    myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_udp_data.py"', 'archives/magma_run_s1ap_tester.log')
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_dl_udp_data testcase may fail"
                   }
                 }
                 timeout (time: 45, unit: 'SECONDS') {
                   try {
-                    sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_tcp_data.py"')
+                    myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_dl_tcp_data.py"', 'archives/magma_run_s1ap_tester.log')
                   } catch (Exception e) {
                     echo "s1aptests/test_attach_dl_tcp_data testcase may fail"
                   }
@@ -334,7 +335,7 @@ pipeline {
               script {
                 def retrieveOAIcovFiles = true
                 try {
-                  sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make coverage_oai"')
+                  myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && make coverage_oai"', 'archives/magma_vagrant_make_coverage_oai.log')
                 } catch (Exception e) {
                   echo "Let's keep running to have some logs, but not the OAI coverage files"
                   retrieveOAIcovFiles = false
@@ -380,13 +381,13 @@ stage ("Re-Build MME-S11") {
         sh "echo 'make FEATURES=\"mme\" run' > lte/gateway/make_mme_run.sh"
         timeout (time: 15, unit: 'MINUTES') {
           // removing the magma/.cache/gateway folder with speed down build from 3 minutes to 27 minutes
-          sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_run.sh && sudo chown -R vagrant /home/vagrant/build && ./make_mme_run.sh"')
+          myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_run.sh && sudo chown -R vagrant /home/vagrant/build && ./make_mme_run.sh"', 'archives/magma_vagrant_make_run2.log')
         }
         sh "sleep 60"
         sh "echo 'make FEATURES=\"mme\" status' > lte/gateway/make_mme_status.sh"
         try {
-          // sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_status.sh && ./make_mme_status.sh')
-          sh('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status"')
+          //sh('cd lte/gateway && vagrant ssh magma -c "cd magma/lte/gateway && chmod 755 make_mme_status.sh && ./make_mme_status.sh')
+          myShCmdWithLog('cd lte/gateway && vagrant ssh magma -c "sudo service magma@* status"', 'archives/magma_status2.log')
         } catch (Exception e) {
           echo "Status may return an error"
         }
@@ -436,14 +437,14 @@ stage ("Test-AGW1-w-S11") {
           sh "sleep 60"
           echo "Starting the integration Tests - S1AP Tester"
           timeout (time: 20, unit: 'MINUTES') {
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py" > ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_emergency.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_combined_eps_imsi.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_via_guti.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_after_ue_context_release.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
-            sh('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_no_auth_response.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLog('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach.py" > ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_multi_ue.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_looped.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_emergency.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_combined_eps_imsi.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_via_guti.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_attach_detach_after_ue_context_release.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
+            myShCmdWithLogAppend('cd lte/gateway && vagrant ssh magma_test -c "cd magma/lte/gateway/python/integ_tests/ && source ~/build/python/bin/activate && make integ_test TESTS=s1aptests/test_no_auth_response.py" >> ${WORKSPACE}/archives/magma_run_s1ap_tester_s11.log', 'archives/magma_run_s1ap_tester_s11.log')
           }
 
 
@@ -562,10 +563,22 @@ stage ("Test-AGW1-w-S11") {
   }
 }
 
+def myShCmdWithLog(cmd, logFile) {
+  sh """#!/bin/bash
+        set -o pipefail
+        ${cmd} 2>&1 | tee $WORKSPACE/${logFile}
+  """
+}
+
+def myShCmdWithLogAppend(cmd, logFile) {
+  sh """#!/bin/bash
+        set -o pipefail
+        ${cmd} 2>&1 | tee -a $WORKSPACE/${logFile}
+  """
+}
 //-------------------------------------------------------------------------------
 // Abstraction function to send social media messages:
 // like on Slack or Mattermost
 def sendSocialMediaMessage(pipeChannel, pipeColor, pipeMessage) {
     slackSend channel: pipeChannel, color: pipeColor, message: pipeMessage
 }
-

--- a/ci-scripts/generateHtmlReport.py
+++ b/ci-scripts/generateHtmlReport.py
@@ -49,10 +49,8 @@ class HtmlReport():
 
     # no-S11 part
     self.buildSummaryHeader('agw1-no-s11')
-    self.vmWakeUpRow()
     self.makeRunRow('agw1-no-s11')
     self.statusCheckRow('agw1-no-s11')
-    self.vmStopCheckRow()
     self.buildSummaryFooter()
 
     self.testSummaryHeader('agw1-no-s11')
@@ -406,56 +404,6 @@ class HtmlReport():
   def buildSummaryFooter(self):
     self.file.write('  </table>\n')
     self.file.write('  <br>\n')
-
-  def vmWakeUpRow(self):
-    self.file.write('    <tr>\n')
-    self.file.write('      <td bgcolor="lightcyan" >Waking-Up Vagrant VMs</td>\n')
-    self.analyze_vagrant_up_log('magma')
-    self.analyze_vagrant_up_log('magma_test')
-    self.analyze_vagrant_up_log('magma_trfserver')
-    self.file.write('    </tr>\n')
-
-  def vmStopCheckRow(self):
-    self.file.write('    <tr>\n')
-    self.file.write('      <td bgcolor="lightcyan" >Stopping gracefully Vagrant VMs</td>\n')
-    cwd = os.getcwd()
-    logFileName = 'magma_vagrant_global_status.log'
-    if os.path.isfile(cwd + '/archives/' + logFileName):
-      magma_dev_status = ''
-      magma_test_status = ''
-      magma_trf_status = ''
-      with open(cwd + '/archives/' + logFileName, 'r') as logfile:
-        for line in logfile:
-          result = re.search('magma_test', line)
-          if result is not None:
-            result = re.search('poweroff', line)
-            if result is not None:
-              magma_test_status = 'powered-off'
-            else:
-              magma_test_status = 'unknown'
-          else:
-            result = re.search('magma_trfserver', line)
-            if result is not None:
-              result = re.search('poweroff', line)
-              if result is not None:
-                magma_trf_status = 'powered-off'
-              else:
-                magma_trf_status = 'unknown'
-            else:
-              result = re.search('magma', line)
-              if result is not None:
-                result = re.search('poweroff', line)
-                if result is not None:
-                  magma_dev_status = 'powered-off'
-                else:
-                  magma_dev_status = 'unknown'
-        logfile.close()
-      self.file.write('      <td bgcolor="LightGray"><b>' + magma_dev_status + '</b></td>\n')
-      self.file.write('      <td bgcolor="LightGray"><b>' + magma_test_status + '</b></td>\n')
-      self.file.write('      <td bgcolor="LightGray"><b>' + magma_trf_status + '</b></td>\n')
-    else:
-      self.file.write('      <td bgcolor="Red" colspan = 3 align = "center"><b><font color="white">Could not read logfile ' + logFileName + '</font></b></td>\n')
-    self.file.write('    </tr>\n')
 
   def analyze_vagrant_up_log(self, vmType):
     logFileName = vmType.lower().replace('magma','magma_vagrant') + '_up.log'


### PR DESCRIPTION
Fixes #3882

## Summary

Adds in helper commands that were lost when refactoring the pipeline to use the local host and libvirt instead of a remote host with VirtualBox.

The report no longer includes VM up and down logs because they were deemed unnecessary.
