### PR TITLE
[agw][lte][bug fix] Bug fix for test_attach_detach_ICS_Failure.py

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ICS_Failure.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_detach_ICS_Failure.py
@@ -76,6 +76,10 @@ class TestAttachICSFailure(unittest.TestCase):
             response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
         )
 
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail
+        )
+
         # Trigger Security Mode Complete
         sec_mode_complete = s1ap_types.ueSecModeComplete_t()
         sec_mode_complete.ue_Id = req.ue_id
@@ -90,14 +94,6 @@ class TestAttachICSFailure(unittest.TestCase):
 
         print("*** Received Initial Context Setup Failure ***")
 
-        response = self._s1ap_wrapper.s1_util.get_response()
-        self.assertEqual(
-            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
-        )
-
-        self._s1ap_wrapper._s1_util.issue_cmd(
-            s1ap_types.tfwCmd.UE_SET_INIT_CTXT_SETUP_FAIL, init_ctxt_setup_fail
-        )
         # Send SCTP ABORT to MME
         sctp_abort = s1ap_types.FwSctpAbortReq_t()
         sctp_abort.cause = 0


### PR DESCRIPTION
Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>

[agw][lte][bug fix] test_attach_detach_ICS_Failure.py

## Summary
In test_attach_detach_ICS_Failure.py test case, indication to send ICS failure was sent to s1ap tester after receiving ICSR message. Due to this successful ICS response was sent from s1ap tester stack instead of ICS failure. This PR fixes the issue


## Test Plan

-Verified that ICS failure is sent instead of ICS response
-Verified s1 sim sanity

