### PR TITLE
OVS: update OVS patches for latest 2.14

### DIFF
--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0001-of-match-expand-NXM_NX_TUN_FLAGS-to-include-all-tunn.patch
@@ -1,7 +1,7 @@
-From b1912129aed550273521f6fb76a25e0399a009be Mon Sep 17 00:00:00 2001
+From 68e4adb25f483eefca02b3dc1b4d2013877b8f75 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 28 Jun 2020 21:49:40 +0000
-Subject: [PATCH 01/10] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
+Subject: [PATCH 01/11] of-match: expand NXM_NX_TUN_FLAGS to include all tunnel
  flags
 
 This allows OVS flows to match tunnel key and df flags. maching on
@@ -130,10 +130,10 @@ index 48c5de9d1..a87b6777c 100644
  ])
  
 diff --git a/tests/tunnel.at b/tests/tunnel.at
-index e08fd1e04..f17d91d77 100644
+index b8ae7caa9..e104b5c8c 100644
 --- a/tests/tunnel.at
 +++ b/tests/tunnel.at
-@@ -1176,3 +1176,51 @@ Datapath actions: push_eth(src=00:00:00:00:00:00,dst=00:00:00:00:00:00),1
+@@ -1205,3 +1205,51 @@ Datapath actions: push_eth(src=00:00:00:00:00:00,dst=00:00:00:00:00:00),1
  
  OVS_VSWITCHD_STOP
  AT_CLEANUP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0002-userspace-IPFIX-Add-tunnel-type-GTP.patch
@@ -1,7 +1,7 @@
-From c9044a563d6ab0956e0c3cd73aeeb746c9b05f22 Mon Sep 17 00:00:00 2001
+From b2bf6b4bb70e7b0ac296ed0bdd3f9e5ae5ab3b72 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 24 Feb 2020 04:29:56 +0000
-Subject: [PATCH 02/10] userspace: IPFIX: Add tunnel type GTP
+Subject: [PATCH 02/11] userspace: IPFIX: Add tunnel type GTP
 
 Add support for ingress/egress tunnel type GTP
 in IPFIX.

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0003-datapath-add-vport-gtp-for-GPRS-Tunneling-Protocol.patch
@@ -1,7 +1,7 @@
-From 25741ac307902cee2c8851f38c5e26a79879430d Mon Sep 17 00:00:00 2001
+From 452d289c04c9dac1904a9fe8a10d5242fd09c655 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
-Date: Mon, 24 Feb 2020 04:45:17 +0000
-Subject: [PATCH 03/10] datapath: add vport-gtp for GPRS Tunneling Protocol
+Date: Sat, 28 Nov 2020 00:55:30 -0800
+Subject: [PATCH 03/11] datapath: add vport-gtp for GPRS Tunneling Protocol
 
 Add vport-gtp which uses gtp_create_flow_based_dev exported by the Linux GTP
 module to create a flow based net_device
@@ -34,7 +34,7 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  create mode 100644 datapath/vport-gtp.c
 
 diff --git a/acinclude.m4 b/acinclude.m4
-index 84f344da0..e712cdfd2 100644
+index 857067a88..0a6b66a04 100644
 --- a/acinclude.m4
 +++ b/acinclude.m4
 @@ -637,6 +637,8 @@ AC_DEFUN([OVS_CHECK_LINUX_COMPAT], [
@@ -60,8 +60,8 @@ index 84f344da0..e712cdfd2 100644
    OVS_GREP_IFELSE([$KSRC/include/net/sock.h], [sk_no_check_tx])
 +  OVS_GREP_IFELSE([$KSRC/include/net/sock.h], [refcount_read], [OVS_DEFINE([HAVE_SOCK_REFCNT])])
    OVS_GREP_IFELSE([$KSRC/include/linux/udp.h], [no_check6_tx])
-   OVS_GREP_IFELSE([$KSRC/include/linux/utsrelease.h], [el6],
-                   [OVS_DEFINE([HAVE_RHEL6_PER_CPU])])
+   OVS_FIND_PARAM_IFELSE([$KSRC/include/net/protocol.h],
+                         [udp_add_offload], [net],
 diff --git a/datapath/Modules.mk b/datapath/Modules.mk
 index 3c4ae366c..9d930f7a1 100644
 --- a/datapath/Modules.mk
@@ -2009,7 +2009,7 @@ index 6e4063359..2db7e1afb 100644
 +#endif /* USE_UPSTREAM_TUNNEL */
  #endif
 diff --git a/datapath/linux/compat/nf_conntrack_reasm.c b/datapath/linux/compat/nf_conntrack_reasm.c
-index ced9fba98..5d1beb4fd 100644
+index 77b4b2548..debea478c 100644
 --- a/datapath/linux/compat/nf_conntrack_reasm.c
 +++ b/datapath/linux/compat/nf_conntrack_reasm.c
 @@ -36,6 +36,7 @@
@@ -2326,10 +2326,10 @@ index 1232964bb..141a7afb4 100644
  
  ADD_NAMESPACES(at_ns0)
 diff --git a/tests/tunnel.at b/tests/tunnel.at
-index f17d91d77..e5d899ea1 100644
+index e104b5c8c..3dfd9675d 100644
 --- a/tests/tunnel.at
 +++ b/tests/tunnel.at
-@@ -1224,3 +1224,31 @@ AT_CHECK([tail -1 stdout], [0],
+@@ -1253,3 +1253,31 @@ AT_CHECK([tail -1 stdout], [0],
  ])
  OVS_VSWITCHD_STOP
  AT_CLEANUP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0004-ovs-Add-support-to-set-GTP-header-fields.patch
@@ -1,7 +1,7 @@
-From 02d660b3cbaeab7ba5375a1a4e7016d2ba68f328 Mon Sep 17 00:00:00 2001
+From 6db1c385e6febf4cca07dc566cf32ab8c820ccfb Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
-Date: Fri, 21 Aug 2020 04:54:53 +0000
-Subject: [PATCH 04/10] ovs: Add support to set GTP header fields.
+Date: Sat, 28 Nov 2020 00:58:18 -0800
+Subject: [PATCH 04/11] ovs: Add support to set GTP header fields.
 
 This allows OVS to match and set GTP header fields.
 This is useful when controller wants to send GTP
@@ -9,21 +9,21 @@ echo or end marker type msgs ovs GTP-U.
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
- datapath/flow_netlink.c                       |  54 +++++-
- datapath/linux/compat/gtp.c                   | 137 ++++++++++-----
- datapath/linux/compat/include/linux/gtp.h     |   9 +
+ datapath/flow_netlink.c                       |  54 ++++++-
+ datapath/linux/compat/gtp.c                   | 137 ++++++++++++------
+ datapath/linux/compat/include/linux/gtp.h     |   9 ++
  .../linux/compat/include/net/ip_tunnels.h     |   8 +-
  datapath/vport.c                              |   1 +
  include/openvswitch/meta-flow.h               |   6 +-
  lib/dpif-netlink.c                            |   3 +-
  lib/meta-flow.xml                             |  11 ++
- lib/netdev-native-tnl.c                       |  18 +-
- lib/odp-util.c                                | 161 +++++++++++-------
+ lib/netdev-native-tnl.c                       |  18 +--
+ lib/odp-util.c                                |  60 ++++++--
  lib/packets.h                                 |  21 ++-
  tests/odp.at                                  |   1 +
  tests/ofproto.at                              |   2 +-
- tests/tunnel.at                               |  26 +++
- 14 files changed, 331 insertions(+), 127 deletions(-)
+ tests/tunnel.at                               |  26 ++++
+ 14 files changed, 275 insertions(+), 82 deletions(-)
 
 diff --git a/datapath/flow_netlink.c b/datapath/flow_netlink.c
 index d3fd77106..f7e54cfc1 100644
@@ -456,10 +456,10 @@ index 1c5a4930a..a59c0f9bf 100644
       * OXM: NXOXM_ET_GTPU_MSGTYPE(16) since v2.13.
       */
 diff --git a/lib/dpif-netlink.c b/lib/dpif-netlink.c
-index 7da4fb54d..78de535a8 100644
+index 2f881e4fa..bb290a626 100644
 --- a/lib/dpif-netlink.c
 +++ b/lib/dpif-netlink.c
-@@ -2565,8 +2565,7 @@ parse_odp_packet(struct ofpbuf *buf, struct dpif_upcall *upcall,
+@@ -2520,8 +2520,7 @@ parse_odp_packet(struct ofpbuf *buf, struct dpif_upcall *upcall,
  {
      static const struct nl_policy ovs_packet_policy[] = {
          /* Always present. */
@@ -545,7 +545,7 @@ index 50f95e637..ea0896456 100644
      }
      ovs_mutex_unlock(&dev->mutex);
 diff --git a/lib/odp-util.c b/lib/odp-util.c
-index 5989381e9..38bca86de 100644
+index 252a91bfa..1de1d07ef 100644
 --- a/lib/odp-util.c
 +++ b/lib/odp-util.c
 @@ -764,7 +764,7 @@ format_odp_tnl_push_header(struct ds *ds, struct ovs_action_push_tnl *data)
@@ -673,128 +673,6 @@ index 5989381e9..38bca86de 100644
  }
  
  #define MASK(PTR, FIELD) PTR ? &PTR->FIELD : NULL
-@@ -3971,7 +4001,7 @@ format_odp_tun_attr(const struct nlattr *attr, const struct nlattr *mask_attr,
-         case OVS_TUNNEL_KEY_ATTR_GTPU_OPTS:
-             ds_put_cstr(ds, "gtpu(");
-             format_odp_tun_gtpu_opt(a, ma, ds, verbose);
--            ds_put_cstr(ds, ")");
-+            ds_put_cstr(ds, "),");
-             break;
-         case __OVS_TUNNEL_KEY_ATTR_MAX:
-         default:
-@@ -5180,50 +5210,6 @@ scan_vxlan_gbp(const char *s, uint32_t *key, uint32_t *mask)
-     return 0;
- }
- 
--static int
--scan_gtpu_metadata(const char *s,
--                   struct gtpu_metadata *key,
--                   struct gtpu_metadata *mask)
--{
--    const char *s_base = s;
--    uint8_t flags, flags_ma;
--    uint8_t msgtype, msgtype_ma;
--    int len;
--
--    if (!strncmp(s, "flags=", 6)) {
--        s += 6;
--        len = scan_u8(s, &flags, mask ? &flags_ma : NULL);
--        if (len == 0) {
--            return 0;
--        }
--        s += len;
--    }
--
--    if (s[0] == ',') {
--        s++;
--    }
--
--    if (!strncmp(s, "msgtype=", 8)) {
--        s += 8;
--        len = scan_u8(s, &msgtype, mask ? &msgtype_ma : NULL);
--        if (len == 0) {
--            return 0;
--        }
--        s += len;
--    }
--
--    if (!strncmp(s, ")", 1)) {
--        s += 1;
--        key->flags = flags;
--        key->msgtype = msgtype;
--        if (mask) {
--            mask->flags = flags_ma;
--            mask->msgtype = msgtype_ma;
--        }
--    }
--    return s - s_base;
--}
--
- static int
- scan_erspan_metadata(const char *s,
-                      struct erspan_metadata *key,
-@@ -5305,6 +5291,61 @@ scan_erspan_metadata(const char *s,
-     return 0;
- }
- 
-+static int
-+scan_gtpu_metadata(const char *s, struct gtpu_metadata *key, struct gtpu_metadata *mask)
-+{
-+    const char *s_base = s;
-+    struct gtpu_metadata k = {0};
-+    struct gtpu_metadata m = {0};
-+    int len;
-+
-+    if (!strncmp(s, "ver=", 4)) {
-+        s += 4;
-+        len = scan_u8(s, &k.ver, mask ? &m.ver : NULL);
-+        if (len == 0) {
-+            return 0;
-+        }
-+        s += len;
-+    }
-+
-+    if (s[0] == ',') {
-+        s++;
-+    }
-+    if (!strncmp(s, "flags=", 6)) {
-+        s += 6;
-+        len = scan_u8(s, &k.flags, mask ? &m.flags : NULL);
-+        if (len == 0) {
-+            return 0;
-+        }
-+        s += len;
-+    }
-+
-+    if (s[0] == ',') {
-+        s++;
-+    }
-+
-+    if (!strncmp(s, "msgtype=", 8)) {
-+        s += 8;
-+        len = scan_u8(s, &k.msgtype, mask ? &m.msgtype : NULL);
-+        if (len == 0) {
-+            return 0;
-+        }
-+        s += len;
-+    }
-+
-+    if (s[0] == ')') {
-+        s += 1;
-+
-+        *key = k;
-+        if (mask) {
-+            *mask = m;;
-+        }
-+
-+        return s - s_base;
-+    }
-+    return 0;
-+}
-+
- static int
- scan_geneve(const char *s, struct geneve_scan *key, struct geneve_scan *mask)
- {
 diff --git a/lib/packets.h b/lib/packets.h
 index 395bc869e..c326bf1bb 100644
 --- a/lib/packets.h
@@ -859,10 +737,10 @@ index 76a3be44d..44559374d 100644
        arbitrary mask: dp_hash tun_{id,src,dst,ipv6_{src,dst},flags,gbp_{id,flags},erspan_{idx,ver,dir,hwid},gtpu_{flags,msgtype},metadata0...metadata63} metadata pkt_mark ct_{state,mark,label,nw_{src,dst},ipv6_{src,dst},tp_{src,dst}} reg0...reg15 xreg0...xreg7 xxreg0...xxreg3 eth_{src,dst} vlan_{tci,vid} ip_{src,dst} ipv6_{src,dst,label} ip_frag arp_{spa,tpa,sha,tha} tcp_{src,dst,flags} udp_{src,dst} sctp_{src,dst} nd_{target,sll,tll} nsh_{flags,c1...c4}
        exact match or wildcard: recirc_id packet_type conj_id in_{port,port_oxm} actset_output ct_{zone,nw_proto} eth_type vlan_pcp mpls_{label,tc,bos,ttl} nw_{proto,tos} ip_dscp nw_{ecn,ttl} arp_op icmp_{type,code} icmpv6_{type,code} nd_{reserved,options_type} nsh_{mdtype,np,spi,si,ttl}
 diff --git a/tests/tunnel.at b/tests/tunnel.at
-index e5d899ea1..8f448949f 100644
+index 3dfd9675d..bf18a5e4c 100644
 --- a/tests/tunnel.at
 +++ b/tests/tunnel.at
-@@ -1252,3 +1252,29 @@ AT_CHECK([tail -1 stdout], [0],
+@@ -1281,3 +1281,29 @@ AT_CHECK([tail -1 stdout], [0],
  ])
  OVS_VSWITCHD_STOP
  AT_CLEANUP

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0005-OVS-gtp-echo-handling.patch
@@ -1,7 +1,7 @@
-From 4b30b6d91010528a43bbc571864851435b7731aa Mon Sep 17 00:00:00 2001
+From a37c40b230e3347b53548dd2c1fccbc3cb12179a Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 02:45:36 +0000
-Subject: [PATCH 05/10] OVS: gtp echo handling
+Subject: [PATCH 05/11] OVS: gtp echo handling
 
 This uses OVS BFD module to send ech msgs.
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0006-ovs-test-add-gtp-marker-test.patch
@@ -1,7 +1,7 @@
-From a53097b10391af0e92361adfa883f3dedc7dcfea Mon Sep 17 00:00:00 2001
+From 37d83995cdf39e9885a46b6c66fea3c5dc1916bd Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Mon, 29 Jun 2020 06:54:04 +0000
-Subject: [PATCH 06/10] ovs: test: add gtp marker test
+Subject: [PATCH 06/11] ovs: test: add gtp marker test
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0007-datapath-Fixes-for-4.9-kernel.patch
@@ -1,7 +1,7 @@
-From d58da2f572dff55df4d6af5c6465169297af8568 Mon Sep 17 00:00:00 2001
+From 9e4b5bb638a00ae151583f3911ab814f75910d83 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Tue, 7 Jul 2020 01:46:36 +0000
-Subject: [PATCH 07/10] datapath: Fixes for 4.9 kernel
+Subject: [PATCH 07/11] datapath: Fixes for 4.9 kernel
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0008-ovs-datapath-enable-kernel-5.6.patch
@@ -1,7 +1,7 @@
-From d0cc60411748b45dce5b3c6edb3cb471ed3a0abc Mon Sep 17 00:00:00 2001
+From 86ef7eb3bc7ef57a79cbbf57de1ff92c8248b068 Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Fri, 21 Aug 2020 05:35:16 +0000
-Subject: [PATCH 08/10] ovs: datapath enable kernel 5.6
+Subject: [PATCH 08/11] ovs: datapath enable kernel 5.6
 
 Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
 ---
@@ -9,7 +9,7 @@ Signed-off-by: Pravin B Shelar <pbshelar@fb.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/acinclude.m4 b/acinclude.m4
-index e712cdfd2..fe0419de2 100644
+index 0a6b66a04..06bbd5e3e 100644
 --- a/acinclude.m4
 +++ b/acinclude.m4
 @@ -167,10 +167,10 @@ AC_DEFUN([OVS_CHECK_LINUX], [

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0009-AGW-OVS-handle-gtp-tunnel-type.patch
@@ -1,7 +1,7 @@
-From 52fc1ed034847c5d5f725f45fe03a67571260a8e Mon Sep 17 00:00:00 2001
+From 9b26c8b68f5ceaddf9d95d34ecafdd408992606a Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Wed, 23 Sep 2020 04:01:59 +0000
-Subject: [PATCH 09/10] AGW: OVS: handle gtp tunnel type
+Subject: [PATCH 09/11] AGW: OVS: handle gtp tunnel type
 
 magma GTP implementation defines gtp as tunnel type for OVS tunnel.
 But upstream ovs it is defined as gtpu. This patch maps older name to

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0010-native-tnl-routing-tunnel-lookup-with-pkt-mark.patch
@@ -1,7 +1,7 @@
-From 5bdca1f30a3f82c5cd7e1da408bcd86401d593c0 Mon Sep 17 00:00:00 2001
+From ad09c756541947445e4fad007a208d579898691b Mon Sep 17 00:00:00 2001
 From: Pravin B Shelar <pbshelar@fb.com>
 Date: Sun, 27 Sep 2020 19:46:24 +0000
-Subject: [PATCH 10/10] native-tnl: routing: tunnel lookup with pkt-mark
+Subject: [PATCH 10/11] native-tnl: routing: tunnel lookup with pkt-mark
 
 In case of zero packet mark ignore packet mark in lookup.
 

--- a/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
+++ b/third_party/gtp_ovs/ovs-gtp-patches/2.14/0011-fixes-for-2.14.patch
@@ -1,0 +1,231 @@
+From 05b6c99274719d6c58a00f9fd5e437a9d0788f38 Mon Sep 17 00:00:00 2001
+From: Pravin B Shelar <pbshelar@fb.com>
+Date: Sat, 28 Nov 2020 23:09:50 -0800
+Subject: [PATCH 11/11] fixes for 2.14
+
+---
+ datapath/flow_netlink.c                       |  2 ++
+ datapath/linux/compat/gtp.c                   | 34 +++++++++++++------
+ .../linux/compat/include/linux/openvswitch.h  |  3 --
+ .../linux/compat/include/net/ip_tunnels.h     |  7 ++--
+ lib/odp-util.c                                | 16 +++++++++
+ manpages.mk                                   |  5 ++-
+ 6 files changed, 47 insertions(+), 20 deletions(-)
+
+diff --git a/datapath/flow_netlink.c b/datapath/flow_netlink.c
+index f7e54cfc1..a1842e1c3 100644
+--- a/datapath/flow_netlink.c
++++ b/datapath/flow_netlink.c
+@@ -41,9 +41,11 @@
+ #include <linux/icmp.h>
+ #include <linux/icmpv6.h>
+ #include <linux/rculist.h>
++#include <linux/openvswitch.h>
+ #include <net/geneve.h>
+ #include <net/ip.h>
+ #include <net/ipv6.h>
++#include <net/ip_tunnels.h>
+ #include <net/ndisc.h>
+ #include <net/mpls.h>
+ #include <net/vxlan.h>
+diff --git a/datapath/linux/compat/gtp.c b/datapath/linux/compat/gtp.c
+index 46add66dc..20ad23ecb 100644
+--- a/datapath/linux/compat/gtp.c
++++ b/datapath/linux/compat/gtp.c
+@@ -21,7 +21,6 @@
+ #include <linux/file.h>
+ #include <linux/gtp.h>
+ 
+-#include <net/dst_cache.h>
+ #include <net/dst_metadata.h>
+ #include <net/net_namespace.h>
+ #include <net/protocol.h>
+@@ -190,6 +189,15 @@ static bool gtp_check_ms(struct sk_buff *skb, struct pdp_ctx *pctx,
+ 	return false;
+ }
+ 
++static int check_header(struct sk_buff *skb, int len)
++{
++	if (unlikely(skb->len < len))
++		return -EINVAL;
++	if (unlikely(!pskb_may_pull(skb, len)))
++		return -ENOMEM;
++	return 0;
++}
++
+ static int gtp_rx(struct gtp_dev *gtp, struct sk_buff *skb,
+ 			unsigned int hdrlen, u8 gtp_version, unsigned int role,
+ 			__be64 tid, u8 flags, u8 type)
+@@ -283,6 +291,20 @@ static int gtp_rx(struct gtp_dev *gtp, struct sk_buff *skb,
+ 	 * calculate the transport header.
+ 	 */
+ 	skb_reset_network_header(skb);
++	if (!check_header(skb, sizeof(struct iphdr))) {
++		struct iphdr *iph;
++
++		iph = ip_hdr(skb);
++		if (iph->version == 4) {
++			netdev_dbg(gtp->dev, "inner pkt: ipv4");
++			skb->protocol = htons(ETH_P_IP);
++		} else if (iph->version == 6) {
++			netdev_dbg(gtp->dev, "inner pkt: ipv6");
++			skb->protocol = htons(ETH_P_IPV6);
++		} else {
++			netdev_dbg(gtp->dev, "inner pkt: control pkt");
++		}
++	}
+ 
+ 	skb->dev = gtp->dev;
+ 
+@@ -582,8 +604,6 @@ static struct rtable *gtp_get_v4_rt(struct sk_buff *skb,
+                                        struct flowi4 *fl4,
+                                        const struct ip_tunnel_info *info)
+ {
+-	bool use_cache = ip_tunnel_dst_cache_usable(skb, info);
+-	struct dst_cache *dst_cache;
+ 	struct rtable *rt = NULL;
+ 
+ 	if (!gs4)
+@@ -596,12 +616,6 @@ static struct rtable *gtp_get_v4_rt(struct sk_buff *skb,
+ 	fl4->saddr = info->key.u.ipv4.src;
+ 	fl4->flowi4_tos = RT_TOS(info->key.tos);
+ 
+-	dst_cache = (struct dst_cache *)&info->dst_cache;
+-	if (use_cache) {
+-		rt = dst_cache_get_ip4(dst_cache, &fl4->saddr);
+-		if (rt)
+-			return rt;
+-	}
+ 	rt = ip_route_output_key(dev_net(dev), fl4);
+ 	if (IS_ERR(rt)) {
+ 		netdev_dbg(dev, "no route to %pI4\n", &fl4->daddr);
+@@ -612,8 +626,6 @@ static struct rtable *gtp_get_v4_rt(struct sk_buff *skb,
+ 		ip_rt_put(rt);
+ 		return ERR_PTR(-ELOOP);
+ 	}
+-	if (use_cache)
+-		dst_cache_set_ip4(dst_cache, &rt->dst, fl4->saddr);
+ 	return rt;
+ }
+ 
+diff --git a/datapath/linux/compat/include/linux/openvswitch.h b/datapath/linux/compat/include/linux/openvswitch.h
+index 2d884312f..cc41bbea4 100644
+--- a/datapath/linux/compat/include/linux/openvswitch.h
++++ b/datapath/linux/compat/include/linux/openvswitch.h
+@@ -405,10 +405,7 @@ enum ovs_tunnel_key_attr {
+ 	OVS_TUNNEL_KEY_ATTR_IPV6_DST,		/* struct in6_addr dst IPv6 address. */
+ 	OVS_TUNNEL_KEY_ATTR_PAD,
+ 	OVS_TUNNEL_KEY_ATTR_ERSPAN_OPTS,	/* struct erspan_metadata */
+-#ifndef __KERNEL__
+-	/* Only used within userspace data path. */
+ 	OVS_TUNNEL_KEY_ATTR_GTPU_OPTS,		/* struct gtpu_metadata */
+-#endif
+ 	__OVS_TUNNEL_KEY_ATTR_MAX
+ };
+ 
+diff --git a/datapath/linux/compat/include/net/ip_tunnels.h b/datapath/linux/compat/include/net/ip_tunnels.h
+index 66bd252ea..21f3676e8 100644
+--- a/datapath/linux/compat/include/net/ip_tunnels.h
++++ b/datapath/linux/compat/include/net/ip_tunnels.h
+@@ -9,9 +9,6 @@
+  * be used. Those needs to be explicitly defined in this header file. */
+ #include_next <net/ip_tunnels.h>
+ 
+-#ifndef TUNNEL_ERSPAN_OPT
+-#define TUNNEL_ERSPAN_OPT	__cpu_to_be16(0x4000)
+-#endif
+ #define ovs_ip_tunnel_encap ip_tunnel_encap
+ 
+ #ifndef HAVE_IP_TUNNEL_INFO_OPTS_SET_FLAGS
+@@ -514,6 +511,10 @@ static inline int iptunnel_pull_offloads(struct sk_buff *skb)
+ #define skb_is_encapsulated ovs_skb_is_encapsulated
+ bool ovs_skb_is_encapsulated(struct sk_buff *skb);
+ 
++#ifndef TUNNEL_ERSPAN_OPT
++#define TUNNEL_ERSPAN_OPT	__cpu_to_be16(0x4000)
++#endif
++
+ #ifndef TUNNEL_GTPU_OPT
+ #define TUNNEL_GTPU_OPT          __cpu_to_be16(0x8000)
+ #endif
+diff --git a/lib/odp-util.c b/lib/odp-util.c
+index 1de1d07ef..c19654a03 100644
+--- a/lib/odp-util.c
++++ b/lib/odp-util.c
+@@ -5216,10 +5216,24 @@ scan_gtpu_metadata(const char *s,
+                    struct gtpu_metadata *mask)
+ {
+     const char *s_base = s;
++    uint8_t ver = 0, ver_ma = 0;
+     uint8_t flags = 0, flags_ma = 0;
+     uint8_t msgtype = 0, msgtype_ma = 0;
+     int len;
+ 
++    if (!strncmp(s, "ver=", 4)) {
++        s += 4;
++        len = scan_u8(s, &ver, mask ? &ver_ma : NULL);
++        if (len == 0) {
++            return 0;
++        }
++        s += len;
++    }
++    if (s[0] == ',') {
++        s++;
++    }
++
++
+     if (!strncmp(s, "flags=", 6)) {
+         s += 6;
+         len = scan_u8(s, &flags, mask ? &flags_ma : NULL);
+@@ -5244,9 +5258,11 @@ scan_gtpu_metadata(const char *s,
+ 
+     if (!strncmp(s, ")", 1)) {
+         s += 1;
++        key->ver = ver;
+         key->flags = flags;
+         key->msgtype = msgtype;
+         if (mask) {
++            mask->ver = ver_ma;
+             mask->flags = flags_ma;
+             mask->msgtype = msgtype_ma;
+         }
+diff --git a/manpages.mk b/manpages.mk
+index dc201484c..5f04b9c2c 100644
+--- a/manpages.mk
++++ b/manpages.mk
+@@ -104,7 +104,6 @@ utilities/bugtool/ovs-bugtool.8: \
+ utilities/bugtool/ovs-bugtool.8.in:
+ lib/ovs.tmac:
+ 
+-
+ utilities/ovs-dpctl-top.8: \
+ 	utilities/ovs-dpctl-top.8.in \
+ 	lib/ovs.tmac
+@@ -155,8 +154,6 @@ lib/common-syn.man:
+ lib/common.man:
+ lib/ovs.tmac:
+ 
+-lib/ovs.tmac:
+-
+ utilities/ovs-testcontroller.8: \
+ 	utilities/ovs-testcontroller.8.in \
+ 	lib/common.man \
+@@ -211,6 +208,7 @@ vswitchd/ovs-vswitchd.8: \
+ 	lib/coverage-unixctl.man \
+ 	lib/daemon.man \
+ 	lib/dpctl.man \
++	lib/dpdk-unixctl.man \
+ 	lib/dpif-netdev-unixctl.man \
+ 	lib/memory-unixctl.man \
+ 	lib/netdev-dpdk-unixctl.man \
+@@ -230,6 +228,7 @@ lib/common.man:
+ lib/coverage-unixctl.man:
+ lib/daemon.man:
+ lib/dpctl.man:
++lib/dpdk-unixctl.man:
+ lib/dpif-netdev-unixctl.man:
+ lib/memory-unixctl.man:
+ lib/netdev-dpdk-unixctl.man:
+-- 
+2.17.1
+


### PR DESCRIPTION
There were some changes on upstream ovs 2.14 release branch.
Last patch in series handles it.

Signed-off-by: Pravin B Shelar <pbshelar@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran OVS test suite with this patch set.
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
