### PR TITLE
[orc8r][subscriberdb] Fix rest api access to subscriber_state

### DIFF
--- a/lte/cloud/configs/service_registry.yml
+++ b/lte/cloud/configs/service_registry.yml
@@ -24,11 +24,11 @@ services:
         /magma/v1/lte,
         /magma/v1/lte/:network_id,
       orc8r.io/stream_provider_streams: >
+        apn_rule_mappings,
         base_names,
         network_wide_rules,
         policydb,
         rating_groups,
-        apn_rule_mappings,
         subscriberdb,
 
   subscriberdb:
@@ -44,6 +44,7 @@ services:
       orc8r.io/state_indexer_version: "1"
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/lte/:network_id/msisdns,
+        /magma/v1/lte/:network_id/subscriber_state,
         /magma/v1/lte/:network_id/subscribers,
 
   policydb:

--- a/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/subscriberdb/obsidian/models/swagger.v1.yml
@@ -129,7 +129,7 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
-  /lte/{network_id}/subscriber_state/:
+  /lte/{network_id}/subscriber_state:
       get:
         summary: List subscriber state in the network
         tags:

--- a/lte/cloud/helm/lte-orc8r/values.yaml
+++ b/lte/cloud/helm/lte-orc8r/values.yaml
@@ -16,8 +16,16 @@ lte:
       orc8r.io/stream_provider: "true"
       orc8r.io/obsidian_handlers: "true"
     annotations:
-      orc8r.io/obsidian_handlers_path_prefixes: "/magma/v1/lte,/magma/v1/lte/:network_id"
-      orc8r.io/stream_provider_streams: "base_names,network_wide_rules,policydb,apn_rule_mappings,subscriberdb,rating_groups"
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/lte,
+        /magma/v1/lte/:network_id,
+      orc8r.io/stream_provider_streams: >
+        apn_rule_mappings,
+        base_names,
+        network_wide_rules,
+        policydb,
+        rating_groups,
+        subscriberdb,
 
 policydb:
   service:
@@ -39,6 +47,7 @@ subscriberdb:
       orc8r.io/state_indexer_version: "1"
       orc8r.io/obsidian_handlers_path_prefixes: >
         /magma/v1/lte/:network_id/msisdns,
+        /magma/v1/lte/:network_id/subscriber_state,
         /magma/v1/lte/:network_id/subscribers,
 
 smsd:


### PR DESCRIPTION
## Summary

The subscriber_state endpoints were functional in unit tests, but were returning 404 when deployed to staging. There were two causes here

1. Service mesh annotations: add annotation to tell obsidian where to forward the `subscriber_state` paths
2. Fix swagger endpoint for the list endpoint: should target `.../subscriber_state`, rather than `.../subscriber_state/` (note the trailing slash), since the latter always results in a 404

Both changes are addressed in this PR.

## Test Plan

- [x] Test endpoint locally

![Screen Shot 2020-12-07 at 2 58 06 PM](https://user-images.githubusercontent.com/8029544/101416351-47cd4800-38af-11eb-90ef-21945af157e6.png)

## Additional Information

- [ ] This change is backwards-breaking