### PR TITLE
[lte][agw] Fixed free mem on _esm_information_t3489_handler

### DIFF
--- a/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
+++ b/lte/gateway/c/oai/tasks/nas/esm/esm_information.c
@@ -216,7 +216,7 @@ static void _esm_information_t3489_handler(void* args, imsi64_t* imsi64) {
        * Re-start T3489 timer
        */
       bdestroy_wrapper(&esm_ebr_timer_data->msg);
-      free_wrapper((void**) esm_ebr_timer_data);
+      free_wrapper((void**) &esm_ebr_timer_data);
     }
   }
 

--- a/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_timerexpiration_max_retries.py
+++ b/lte/gateway/python/integ_tests/s1aptests/test_attach_esm_info_timerexpiration_max_retries.py
@@ -1,0 +1,152 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+
+import s1ap_types
+import time
+
+from integ_tests.s1aptests import s1ap_wrapper
+import ctypes
+
+
+class TestEsmInformationMaxRetries(unittest.TestCase):
+    def setUp(self):
+        self._s1ap_wrapper = s1ap_wrapper.TestWrapper()
+
+    def tearDown(self):
+        self._s1ap_wrapper.cleanup()
+
+    def test_esm_information_timerexpiration(self):
+        """ Testing of sending Esm Information procedure """
+        num_ues = 1
+        num_of_expires = 3
+
+        self._s1ap_wrapper.configUEDevice(num_ues)
+        print("************************* sending Attach Request for ue-id : 1")
+        attach_req = s1ap_types.ueAttachRequest_t()
+        attach_req.ue_Id = 1
+        sec_ctxt = s1ap_types.TFW_CREATE_NEW_SECURITY_CONTEXT
+        id_type = s1ap_types.TFW_MID_TYPE_IMSI
+        eps_type = s1ap_types.TFW_EPS_ATTACH_TYPE_EPS_ATTACH
+        attach_req.mIdType = id_type
+        attach_req.epsAttachType = eps_type
+        attach_req.useOldSecCtxt = sec_ctxt
+
+        # enabling ESM Information transfer flag
+        attach_req.eti.pres = 1
+        attach_req.eti.esm_info_transfer_flag = 1
+
+        print("Sending Attach Request ue-id", attach_req.ue_Id)
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ATTACH_REQUEST, attach_req
+        )
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_AUTH_REQ_IND.value
+        )
+        print("Received auth req ind ")
+
+        auth_res = s1ap_types.ueAuthResp_t()
+        auth_res.ue_Id = 1
+        sqn_recvd = s1ap_types.ueSqnRcvd_t()
+        sqn_recvd.pres = 0
+        auth_res.sqnRcvd = sqn_recvd
+        print("Sending Auth Response ue-id", auth_res.ue_Id)
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_AUTH_RESP, auth_res
+        )
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_SEC_MOD_CMD_IND.value
+        )
+        print("Received Security Mode Command ue-id", auth_res.ue_Id)
+
+        time.sleep(1)
+
+        sec_mode_complete = s1ap_types.ueSecModeComplete_t()
+        sec_mode_complete.ue_Id = 1
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_SEC_MOD_COMPLETE, sec_mode_complete
+        )
+
+        for i in range(num_of_expires):
+            # Esm Information Request indication
+            print(
+                "Received Esm Information Request ue-id", sec_mode_complete.ue_Id
+            )
+            response = self._s1ap_wrapper.s1_util.get_response()
+            self.assertEqual(
+                response.msg_type, s1ap_types.tfwCmd.UE_ESM_INFORMATION_REQ.value
+            )
+            esm_info_req = response.cast(s1ap_types.ueEsmInformationReq_t)
+
+        # Sleep for 5 seconds to trigger last max retry count timer expiry
+        time.sleep(5)
+
+        # Sending Esm Information Response
+        print(
+            "Sending Esm Information Response ue-id", sec_mode_complete.ue_Id
+        )
+        esm_info_response = s1ap_types.ueEsmInformationRsp_t()
+        esm_info_response.ue_Id = 1
+        esm_info_response.tId = esm_info_req.tId
+        esm_info_response.pdnAPN_pr.pres = 1
+        s = "magma.ipv4"
+        esm_info_response.pdnAPN_pr.len = len(s)
+        esm_info_response.pdnAPN_pr.pdn_apn = (ctypes.c_ubyte * 100)(
+            *[ctypes.c_ubyte(ord(c)) for c in s[:100]]
+        )
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ESM_INFORMATION_RSP, esm_info_response
+        )
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.INT_CTX_SETUP_IND.value
+        )
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_ATTACH_ACCEPT_IND.value
+        )
+
+        # Trigger Attach Complete
+        attach_complete = s1ap_types.ueAttachComplete_t()
+        attach_complete.ue_Id = 1
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_ATTACH_COMPLETE, attach_complete
+        )
+        # Wait on EMM Information from MME
+        self._s1ap_wrapper._s1_util.receive_emm_info()
+
+        print("*** Running UE detach ***")
+        # Now detach the UE
+        detach_req = s1ap_types.uedetachReq_t()
+        detach_req.ue_Id = 1
+        detach_req.ueDetType = (
+            s1ap_types.ueDetachType_t.UE_SWITCHOFF_DETACH.value
+        )
+        self._s1ap_wrapper._s1_util.issue_cmd(
+            s1ap_types.tfwCmd.UE_DETACH_REQUEST, detach_req
+        )
+
+        response = self._s1ap_wrapper.s1_util.get_response()
+        self.assertEqual(
+            response.msg_type, s1ap_types.tfwCmd.UE_CTX_REL_IND.value
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- On reaching max retransmission counter for T3489 (3 retries), there's a bad free on the content of the timer data, this PR fixes it.

## Test Plan

- Added s1ap integ test, before change it leads to MME crash:
```
Dec 07 20:59:12 magma-dev mme[5202]: =================================================================
Dec 07 20:59:12 magma-dev mme[5202]: ==5202==ERROR: AddressSanitizer: attempting free on address which was not malloc()-ed: 0x62200004a260 in thread T17
Dec 07 20:59:13 magma-dev mme[5202]:     #0 0x7fe25b81ba10 in free (/usr/lib/x86_64-linux-gnu/libasan.so.3+0xc1a10)
Dec 07 20:59:13 magma-dev mme[5202]:     #1 0x55f4814f75f4 in free_wrapper /home/vagrant/magma/lte/gateway/c/oai/common/dynamic_memory_check.c:47
Dec 07 20:59:13 magma-dev mme[5202]:     #2 0x55f4819e168c in _esm_information_t3489_handler /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/esm/esm_information.c:219
Dec 07 20:59:13 magma-dev mme[5202]:     #3 0x55f4818ff872 in mme_app_nas_timer_handle_signal_expiry /home/vagrant/magma/lte/gateway/c/oai/tasks/nas/util/nas_timer.c:100
Dec 07 20:59:13 magma-dev mme[5202]:     #4 0x55f4815d9896 in handle_message /home/vagrant/magma/lte/gateway/c/oai/tasks/mme_app/mme_app_main.c:235
```
- After fix:

```
Sending Attach Request ue-id 1
Received auth req ind
Sending Auth Response ue-id 1
Received Security Mode Command ue-id 1
Received Esm Information Request ue-id 1
Received Esm Information Request ue-id 1
Received Esm Information Request ue-id 1
Sending Esm Information Response ue-id 1
Building ESM Information Response for Ue
PDN_TYPE: 1
IPv4 PDN_ADDRESS:192 168 128 214

*************NbUiNbuHdlUeRadioCapMsg: Send UE cap msg SUCCESS*********
*** Running UE detach ***
Deleting Ue Context from Traffic Handler
************************* send SCTP SHUTDOWN
.
----------------------------------------------------------------------
Ran 1 test in 15.879s

OK
sleep 1
```

- sanity s1ap tests

## Additional Information

- [ ] This change is backwards-breaking