### PR TITLE
[feg][cloud][nh] Switch FeG S6a Relay to Neutral Host capable service

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -30,7 +30,7 @@ services:
     proxy_type: "clientcert"
     proxy_aliases:
       s6a_proxy:
-        port: 9079
+        port: 9103
       session_proxy:
         port: 9079
       swx_proxy:


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>


## Summary

Switch FeG S6a Relay to Neutral Host capable service.
The NH s6a routing service is fully backward compatible & should work without any changed for non NH setups.

## Test Plan

unit tests & staging
## Additional Information

- [ ] This change is backwards-breaking

