### PR TITLE
[agw] added missing field on agw script for stateles config

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/config_stateless_pipelined.sh
+++ b/lte/gateway/deploy/roles/magma/files/config_stateless_pipelined.sh
@@ -13,10 +13,12 @@ elif [[ $1 == "disable" ]]; then
   echo "Disabling stateless pipelined config"
   # change clean_restart setting in pipelined.yml
   sed -e '/clean_restart/ s/false/true/' -i /etc/magma/pipelined.yml
+  sed -e '/redis_enabled/ s/true/false/' -i /etc/magma/pipelined.yml
 elif [[ $1 == "enable" ]]; then
   echo "Enabling stateless pipelined config"
   # change clean_restart setting in pipelined.yml
   sed -e '/clean_restart/ s/true/false/' -i /etc/magma/pipelined.yml
+  sed -e '/redis_enabled/ s/false/true/' -i /etc/magma/pipelined.yml
 else
   echo "Invalid argument. Use one of the following"
   echo "check: Run a check whether Pipelined is stateless or not"


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Pipelned needs `redis_enabled` to be true to enable stateless. 

This PR adds that field and also changes some logic on the script to provide more visible info

## Test Plan

```
magma@agw:~/uri$ sudo config_stateless_agw.py disable
STATELESS       mme -> use_stateless
STATELESS       mobilityd -> persist_to_redis
STATELESS       pipelined -> clean_restart
STATELESS       pipelined -> redis_enabled
STATELESS       sessiond -> support_stateless
Check returning return_codes.STATELESS
Restarting sctpd
STATEFUL        mme -> use_stateless
STATEFUL        mobilityd -> persist_to_redis
STATEFUL        pipelined -> clean_restart
STATEFUL        pipelined -> redis_enabled
STATEFUL        sessiond -> support_stateless
Check returning return_codes.STATEFUL
```

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
