### PR TITLE
[nginx][conf] Fix nginx conf for backending to non-clientcert services

### DIFF
--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -133,7 +133,7 @@ http {
       }
       grpc_pass grpc://orc8r-$srv:9180;
       {%- else %}
-      grpc_pass grpc://$srv:$open_srvport;
+      grpc_pass grpc://{{ backend }}:$open_srvport;
       {%- endif %}
     }
   }


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR fixes an issue we have seen where the nginx conf has an issue that causes
boostrapper RPC calls not to backend properly when registry mode is set to YAML. 

## Test Plan

Ensured bootstrap works correctly.
