### PR TITLE
[lte][agw] Fix SPGW state converter parsing for bstring to string data

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
+++ b/lte/gateway/c/oai/tasks/sgw/spgw_state_converter.cpp
@@ -104,14 +104,16 @@ void SpgwStateConverter::spgw_bearer_context_to_proto(
   sgw_eps_bearer_proto->set_mme_teid_s11(sgw_eps_bearer_state->mme_teid_S11);
   bstring ip_addr_bstr =
       ip_address_to_bstring(&sgw_eps_bearer_state->mme_ip_address_S11);
-  sgw_eps_bearer_proto->set_mme_ip_address_s11(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(
+      ip_addr_bstr, sgw_eps_bearer_proto->mutable_mme_ip_address_s11());
   bdestroy_wrapper(&ip_addr_bstr);
 
   sgw_eps_bearer_proto->set_sgw_teid_s11_s4(
       sgw_eps_bearer_state->s_gw_teid_S11_S4);
   ip_addr_bstr =
       ip_address_to_bstring(&sgw_eps_bearer_state->s_gw_ip_address_S11_S4);
-  sgw_eps_bearer_proto->set_sgw_ip_address_s11_s4(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(
+      ip_addr_bstr, sgw_eps_bearer_proto->mutable_sgw_ip_address_s11_s4());
   bdestroy_wrapper(&ip_addr_bstr);
 
   sgw_pdn_connection_to_proto(
@@ -219,11 +221,11 @@ void SpgwStateConverter::sgw_pdn_connection_to_proto(
   }
   bstring ip_addr_bstr =
       ip_address_to_bstring(&state_pdn->p_gw_address_in_use_cp);
-  proto_pdn->set_pgw_address_in_use_cp(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(ip_addr_bstr, proto_pdn->mutable_pgw_address_in_use_cp());
   bdestroy_wrapper(&ip_addr_bstr);
 
   ip_addr_bstr = ip_address_to_bstring(&state_pdn->p_gw_address_in_use_up);
-  proto_pdn->set_pgw_address_in_use_up(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(ip_addr_bstr, proto_pdn->mutable_pgw_address_in_use_up());
   bdestroy_wrapper(&ip_addr_bstr);
 
   proto_pdn->set_default_bearer(state_pdn->default_bearer);
@@ -310,7 +312,7 @@ void SpgwStateConverter::sgw_create_session_message_to_proto(
 
   proto->set_apn(session_request->apn, strlen(session_request->apn));
   bstring paa_addr_bstr = paa_to_bstring(&session_request->paa);
-  proto->set_paa(bdata(paa_addr_bstr));
+  BSTRING_TO_STRING(paa_addr_bstr, proto->mutable_paa());
   bdestroy_wrapper(&paa_addr_bstr);
   proto->set_peer_ip(session_request->edns_peer_ip.addr_v4.sin_addr.s_addr);
 
@@ -347,7 +349,8 @@ void SpgwStateConverter::sgw_create_session_message_to_proto(
     if (pco_protocol->contents) {
       pco_protocol_proto->set_id(pco_protocol->id);
       pco_protocol_proto->set_length(pco_protocol->length);
-      pco_protocol_proto->set_contents(bdata(pco_protocol->contents));
+      BSTRING_TO_STRING(
+          pco_protocol->contents, pco_protocol_proto->mutable_contents());
     }
   }
   for (uint32_t i = 0;
@@ -476,29 +479,33 @@ void SpgwStateConverter::sgw_eps_bearer_to_proto(
 
   bstring ip_addr_bstr =
       ip_address_to_bstring(&eps_bearer->p_gw_address_in_use_up);
-  eps_bearer_proto->set_pgw_address_in_use_up(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(
+      ip_addr_bstr, eps_bearer_proto->mutable_pgw_address_in_use_up());
   bdestroy_wrapper(&ip_addr_bstr);
   eps_bearer_proto->set_pgw_teid_s5_s8_up(eps_bearer->p_gw_teid_S5_S8_up);
 
   ip_addr_bstr = ip_address_to_bstring(&eps_bearer->s_gw_ip_address_S5_S8_up);
-  eps_bearer_proto->set_sgw_ip_address_s5_s8_up(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(
+      ip_addr_bstr, eps_bearer_proto->mutable_sgw_ip_address_s5_s8_up());
   bdestroy_wrapper(&ip_addr_bstr);
   eps_bearer_proto->set_sgw_teid_s5_s8_up(eps_bearer->s_gw_teid_S5_S8_up);
 
   ip_addr_bstr =
       ip_address_to_bstring(&eps_bearer->s_gw_ip_address_S1u_S12_S4_up);
-  eps_bearer_proto->set_sgw_ip_address_s1u_s12_s4_up(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(
+      ip_addr_bstr, eps_bearer_proto->mutable_sgw_ip_address_s1u_s12_s4_up());
   bdestroy_wrapper(&ip_addr_bstr);
   eps_bearer_proto->set_sgw_teid_s1u_s12_s4_up(
       eps_bearer->s_gw_teid_S1u_S12_S4_up);
 
   ip_addr_bstr = ip_address_to_bstring(&eps_bearer->enb_ip_address_S1u);
-  eps_bearer_proto->set_enb_ip_address_s1u(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(
+      ip_addr_bstr, eps_bearer_proto->mutable_enb_ip_address_s1u());
   bdestroy_wrapper(&ip_addr_bstr);
   eps_bearer_proto->set_enb_teid_s1u(eps_bearer->enb_teid_S1u);
 
   ip_addr_bstr = paa_to_bstring(&eps_bearer->paa);
-  eps_bearer_proto->set_paa(bdata(ip_addr_bstr));
+  BSTRING_TO_STRING(ip_addr_bstr, eps_bearer_proto->mutable_paa());
   bdestroy_wrapper(&ip_addr_bstr);
 
   eps_bearer_qos_to_proto(
@@ -571,7 +578,7 @@ void SpgwStateConverter::traffic_flow_template_to_proto(
           tft_proto->mutable_parameters_list()->add_parameters();
       param_proto->set_parameter_identifier(parameter->parameteridentifier);
       param_proto->set_length(parameter->length);
-      param_proto->set_contents(bdata(parameter->contents));
+      BSTRING_TO_STRING(parameter->contents, param_proto->mutable_contents());
     }
   }
 
@@ -841,7 +848,7 @@ void SpgwStateConverter::pcc_rule_to_proto(
     const pcc_rule_t* pcc_rule_state, PccRule* proto) {
   proto->Clear();
 
-  proto->set_name(bdata(pcc_rule_state->name));
+  BSTRING_TO_STRING(pcc_rule_state->name, proto->mutable_name());
   proto->set_is_activated(pcc_rule_state->is_activated);
   proto->set_sdf_id((unsigned int) pcc_rule_state->sdf_id);
   proto->set_precedence(pcc_rule_state->precedence);

--- a/lte/gateway/python/magma/mobilityd/ip_address_man.py
+++ b/lte/gateway/python/magma/mobilityd/ip_address_man.py
@@ -378,7 +378,7 @@ class IPAddressManager:
                 logging.error(
                     "Releasing unknown <SID, IP> pair: <%s, %s> "
                     "sid_ips_map[%s]: %s",
-                    sid, ip, sid, self._store.sid_ips_map.get(sid, ""))
+                    sid, ip, sid, self._store.sid_ips_map.get(sid))
                 raise MappingNotFoundError(
                     "(%s, %s) pair is not found", sid, str(ip))
             if not self.is_ip_in_state(ip, IPState.ALLOCATED):


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- On stateless MME, during SPGW ue state pco protocol conversion, there's a crash happening due to bad string writing for the proto, this happens on any message processed by SPGW task:

```
Dec 09 20:23:50 magma-dev mme[4388]: [INFO] Sending S6A-AUTHENTICATION_INFORMATION_REQUEST with IMSI: 001010000000082
Dec 09 20:23:50 magma-dev mme[4388]: [INFO] Received S6A-AUTHENTICATION_INFORMATION_ANSWER for IMSI: 001010000000082; Status: ; StatusCode: 2001
Dec 09 20:23:50 magma-dev mme[4388]: [DEBUG] Sending S6A-UPDATE_LOCATION_REQUEST with IMSI: 001010000000082
Dec 09 20:23:50 magma-dev mme[4388]: [INFO] Received S6A-LOCATION-UPDATE_ANSWER for IMSI: 001010000000082; Status: ; StatusCode: 2001
Dec 09 20:23:50 magma-dev mme[4388]: [INFO] sent itti S6A-LOCATION-UPDATE_ANSWER for IMSI: 001010000000082
Dec 09 20:23:50 magma-dev sudo[5643]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/ovs-vsctl --may-exist add-port gtp_br0 g_fe3ca8c0 -- set Interface g_fe3ca8c0 type=gtp options:remote_ip=192.168.60.254 options:key=flow
Dec 09 20:23:50 magma-dev sudo[5643]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 09 20:23:50 magma-dev ovs-vsctl[5644]: ovs|00001|vsctl|INFO|Called as ovs-vsctl --may-exist add-port gtp_br0 g_fe3ca8c0 -- set Interface g_fe3ca8c0 type=gtp options:remote_ip=192.168.60.254 options:key=flow
Dec 09 20:23:50 magma-dev sudo[5643]: pam_unix(sudo:session): session closed for user root
Dec 09 20:23:50 magma-dev sudo[5647]:     root : TTY=unknown ; PWD=/ ; USER=root ; COMMAND=/usr/bin/ovsdb-client dump Interface name ofport
Dec 09 20:23:50 magma-dev sudo[5647]: pam_unix(sudo:session): session opened for user root by (uid=0)
Dec 09 20:23:50 magma-dev sudo[5647]: pam_unix(sudo:session): session closed for user root
Dec 09 20:23:50 magma-dev mme[4388]: terminate called after throwing an instance of 'std::logic_error'
Dec 09 20:23:50 magma-dev mme[4388]:   what():  basic_string::_M_construct null not valid
Dec 09 20:23:50 magma-dev mme[4388]: Received SGW IP Address 0x6290002c5150
```

- There's also a mobilityd failure caused by redis serde conversion
```
Dec 09 20:27:27 magma-dev mobilityd[5728]: ERROR:grpc._server:Exception calling application: get() takes 2 positional arguments but 3 were given
Dec 09 20:27:27 magma-dev mobilityd[5728]: Traceback (most recent call last):
Dec 09 20:27:27 magma-dev mobilityd[5728]:   File "/home/vagrant/build/python/lib/python3.5/site-packages/grpc/_server.py", line 389, in _call_behavior
Dec 09 20:27:27 magma-dev mobilityd[5728]:     return behavior(argument, context), True
Dec 09 20:27:27 magma-dev mobilityd[5728]:   File "/home/vagrant/magma/orc8r/gateway/python/magma/common/rpc_utils.py", line 38, in wrapper
Dec 09 20:27:27 magma-dev mobilityd[5728]:     func(*args, **kwargs)
Dec 09 20:27:27 magma-dev mobilityd[5728]:   File "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/rpc_servicer.py", line 171, in ReleaseIPAddress
Dec 09 20:27:27 magma-dev mobilityd[5728]:     request.ip.version)
Dec 09 20:27:27 magma-dev mobilityd[5728]:   File "/home/vagrant/magma/lte/gateway/python/magma/mobilityd/ip_address_man.py", line 381, in release_ip_address
Dec 09 20:27:27 magma-dev mobilityd[5728]:     sid, ip, sid, self._store.sid_ips_map.get(sid, ""))
Dec 09 20:27:27 magma-dev mobilityd[5728]: TypeError: get() takes 2 positional arguments but 3 were given
```
- This PR fixes crashes from above

## Test Plan

- tested on UE with eNB setup, ensuring on writing of SPGW ue state is done correctly:
```
000551 Wed Dec  9 20:08:03 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_main.c    :0123    Received S11 MODIFY BEARER RESPONSE from SPGW
000552 Wed Dec  9 20:08:04 2020 7FA7EC47C700 WARNI MME-AP tasks/mme_app/mme_app_context.c :0412   [13744632839234567870]  No IMSI hashtable for this IMSI
000553 Wed Dec  9 20:08:14 2020 7FA7EC47C700 WARNI MME-AP tasks/mme_app/mme_app_context.c :0412   [13744632839234567870]  No IMSI hashtable for this IMSI
000554 Wed Dec  9 20:08:23 2020 7FA7E938F700 INFO  S1AP   tasks/s1ap/s1ap_mme_handlers.c  :0799               UE CONTEXT RELEASE REQUEST with Cause_Type = Radio Network and Cause_Value = 20
000555 Wed Dec  9 20:08:23 2020 7FA7EAC0E700 INFO  GTPv1- lib/openflow/controller/PagingAp:0116    Added paging flow rule for UE IP 192.168.128.178
000556 Wed Dec  9 20:08:23 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_itti_messa:0089   [1010000000082]      Sending UE Context Release Cmd to S1ap for (ue_id = 1)
UE Context Release Cause = (3)
000557 Wed Dec  9 20:08:23 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_context.c :1936      Received UE context release complete message for ue_id: 0x00000001
000558 Wed Dec  9 20:08:23 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_context.c :1483   [1010000000082]      UE STATE - IDLE.
000559 Wed Dec  9 20:08:24 2020 7FA7EC47C700 WARNI MME-AP tasks/mme_app/mme_app_context.c :0412   [13744632839234567870]  No IMSI hashtable for this IMSI
000560 Wed Dec  9 20:08:34 2020 7FA7EC47C700 WARNI MME-AP tasks/mme_app/mme_app_context.c :0412   [13744632839234567870]  No IMSI hashtable for this IMSI
000561 Wed Dec  9 20:08:41 2020 7FA7E938F700 INFO  S1AP   tasks/s1ap/s1ap_mme_nas_procedur:0095               Received S1AP INITIAL_UE_MESSAGE eNB_UE_S1AP_ID 0x000003
000562 Wed Dec  9 20:08:41 2020 7FA7E938F700 INFO  S1AP   tasks/s1ap/s1ap_mme_nas_procedur:0108               New Initial UE message received with eNB UE S1AP ID: 0x000003
000563 Wed Dec  9 20:08:41 2020 7FA7E938F700 INFO  S1AP   tasks/s1ap/s1ap_mme_itti_messagi:0175                  Sending Initial UE Message to MME_APP, enb_ue_s1ap_id : 0x000003
000564 Wed Dec  9 20:08:41 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_bearer.c  :0551      Received MME_APP_INITIAL_UE_MESSAGE from S1AP
000565 Wed Dec  9 20:08:41 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_bearer.c  :0717   [1010000000082]   INITIAL_UE_MESSAGE RCVD
mme_ue_s1ap_id  = 1
enb_ue_s1ap_id  = 3
000566 Wed Dec  9 20:08:41 2020 7FA7EC47C700 INFO  MME-AP tasks/mme_app/mme_app_bearer.c  :0724   [1010000000082]   Sending NAS Establishment Indication to NAS for ue_id = (1)
```


## Additional Information

- [ ] This change is backwards-breaking
