### PR TITLE
[orc8r][ctraced] Add storage interface for call tracing records

### DIFF
--- a/orc8r/cloud/go/services/ctraced/storage/storage.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+// CtracedStorage is the persistence service interface for call traces.
+// All call trace accesses from ctraced service must go through this interface.
+type CtracedStorage interface {
+
+	// StoreCallTrace
+	StoreCallTrace(networkID string, callTraceID string, data []byte) error
+
+	// GetCallTrace
+	GetCallTrace(networkID string, callTraceID string) ([]byte, error)
+}

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/storage"
+	merrors "magma/orc8r/lib/go/errors"
+
+	"github.com/pkg/errors"
+)
+
+const (
+	// CtracedTableBlobstore is the table where blobstore stores ctraced's data.
+	CtracedTableBlobstore = "ctraced_blobstore"
+
+	// CtracedBlobType is the blobstore type field for call traces
+	CtracedBlobType = "call_trace"
+)
+
+// NewCtracedBlobstore returns a ctraced storage implementation
+// backed by the provided blobstore factory.
+func NewCtracedBlobstore(factory blobstore.BlobStorageFactory) CtracedStorage {
+	return &ctracedBlobStore{factory: factory}
+}
+
+type ctracedBlobStore struct {
+	factory blobstore.BlobStorageFactory
+}
+
+// StoreCallTrace
+func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, data []byte) error {
+	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: false})
+	if err != nil {
+		return errors.Wrap(err, "failed to start transaction")
+	}
+	defer store.Rollback()
+
+	err = store.CreateOrUpdate(
+		networkID,
+		[]blobstore.Blob{
+			blobstore.Blob{Type: CtracedBlobType, Key: callTraceID, Value: data, Version: 0},
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to store call trace")
+	}
+
+	return store.Commit()
+}
+
+// GetCallTrace
+func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([]byte, error) {
+	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to start transaction")
+	}
+	defer store.Rollback()
+
+	blob, err := store.Get(
+		networkID,
+		storage.TypeAndKey{Type: CtracedBlobType, Key: callTraceID},
+	)
+	if err == merrors.ErrNotFound {
+		return nil, err
+	}
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get hostname")
+	}
+
+	return blob.Value, store.Commit()
+}

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package storage_test
+
+import (
+	"errors"
+	"testing"
+
+	"magma/orc8r/cloud/go/blobstore"
+	"magma/orc8r/cloud/go/blobstore/mocks"
+	cstorage "magma/orc8r/cloud/go/services/ctraced/storage"
+	"magma/orc8r/cloud/go/storage"
+	merrors "magma/orc8r/lib/go/errors"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+const (
+	placeholderNetworkID = "placeholder_network"
+)
+
+func TestCtracedBlobstoreStorage_GetCallTrace(t *testing.T) {
+	var blobFactMock *mocks.BlobStorageFactory
+	var blobStoreMock *mocks.TransactionalBlobStorage
+	someErr := errors.New("generic error")
+
+	ctid := "some_call_trace"
+	tk := storage.TypeAndKey{Type: cstorage.CtracedBlobType, Key: ctid}
+
+	ctData := "abcdefghijklmnopqrstuvwxyz"
+	blob := blobstore.Blob{
+		Type:  tk.Type,
+		Key:   tk.Key,
+		Value: []byte(ctData),
+	}
+
+	// Fail to start transaction
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(nil, someErr).Once()
+	store := cstorage.NewCtracedBlobstore(blobFactMock)
+
+	_, err := store.GetCallTrace(placeholderNetworkID, ctid)
+	assert.Error(t, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+
+	// store.Get fails with ErrNotFound
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
+	blobStoreMock.On("Rollback").Return(nil).Once()
+	blobStoreMock.On("Get", placeholderNetworkID, tk).Return(blobstore.Blob{}, merrors.ErrNotFound).Once()
+	store = cstorage.NewCtracedBlobstore(blobFactMock)
+
+	_, err = store.GetCallTrace(placeholderNetworkID, ctid)
+	assert.Exactly(t, merrors.ErrNotFound, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+
+	// store.Get fails with error other than ErrNotFound
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
+	blobStoreMock.On("Rollback").Return(nil).Once()
+	blobStoreMock.On("Get", placeholderNetworkID, tk).Return(blobstore.Blob{}, someErr).Once()
+	store = cstorage.NewCtracedBlobstore(blobFactMock)
+
+	_, err = store.GetCallTrace(placeholderNetworkID, ctid)
+	assert.Error(t, err)
+	assert.NotEqual(t, merrors.ErrNotFound, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+
+	// Success
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
+	blobStoreMock.On("Rollback").Return(nil).Once()
+	blobStoreMock.On("Get", placeholderNetworkID, tk).Return(blob, nil).Once()
+	blobStoreMock.On("Commit").Return(nil).Once()
+	store = cstorage.NewCtracedBlobstore(blobFactMock)
+
+	callTraceRecvd, err := store.GetCallTrace(placeholderNetworkID, ctid)
+	assert.Equal(t, ctData, string(callTraceRecvd))
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+}
+
+func TestCtracedBlobstoreStorage_StoreCallTrace(t *testing.T) {
+	var blobFactMock *mocks.BlobStorageFactory
+	var blobStoreMock *mocks.TransactionalBlobStorage
+	someErr := errors.New("generic error")
+
+	ctid := "some_call_trace"
+	tk := storage.TypeAndKey{Type: cstorage.CtracedBlobType, Key: ctid}
+
+	ctData := []byte("abcdefghijklmnopqrstuvwxyz")
+	blob := blobstore.Blob{
+		Type:  tk.Type,
+		Key:   tk.Key,
+		Value: ctData,
+	}
+
+	// Fail to start transaction
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(nil, someErr).Once()
+	store := cstorage.NewCtracedBlobstore(blobFactMock)
+
+	err := store.StoreCallTrace(placeholderNetworkID, ctid, ctData)
+	assert.Error(t, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+
+	// store.PutRecord fails
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
+	blobStoreMock.On("Rollback").Return(nil).Once()
+	blobStoreMock.On("CreateOrUpdate", placeholderNetworkID, mock.Anything, mock.Anything).
+		Return(someErr).Once()
+	store = cstorage.NewCtracedBlobstore(blobFactMock)
+
+	err = store.StoreCallTrace(placeholderNetworkID, ctid, ctData)
+	assert.Error(t, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+
+	// Success
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
+	blobStoreMock.On("Rollback").Return(nil).Once()
+	blobStoreMock.On("CreateOrUpdate", placeholderNetworkID, []blobstore.Blob{blob}).
+		Return(nil).Once()
+	blobStoreMock.On("Commit").Return(nil).Once()
+	store = cstorage.NewCtracedBlobstore(blobFactMock)
+
+	err = store.StoreCallTrace(placeholderNetworkID, ctid, ctData)
+	assert.NoError(t, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary

Adds a basic storage interface for call tracing records

## Test Plan

- Additional unit tests

## Additional Information

- [ ] This change is backwards-breaking
