### PR TITLE
[orc8r] Fix run.py basic bug

### DIFF
--- a/orc8r/cloud/docker/run.py
+++ b/orc8r/cloud/docker/run.py
@@ -21,7 +21,6 @@ import sys
 from typing import List
 
 MODULES = [
-    'orc8r',
     'lte',
     'feg',
     'cwf',
@@ -51,6 +50,7 @@ def main() -> None:
 
     if args.clear:
         _clear_line('.env', 'COMPOSE_FILE=')
+        return
 
     files = DEPLOYMENT_TO_MODULES[args.deployment]
     if args.metrics:


### PR DESCRIPTION
## Summary

Fix two issues
- `run.py` should function as a drop-in replacement
- `run.py -c` should clear the compose file changes, and exit from there

This PR addresses both issues.

## Test Plan

Test locally

## Additional Information

- [ ] This change is backwards-breaking