### PR TITLE
[orc8r] Reenable docusaurus publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1029,7 +1029,6 @@ workflows:
             - xwfm-test
             - cwag-deploy
 
-
   cwf_operator:
     jobs:
       - cwf-operator-precommit
@@ -1074,10 +1073,10 @@ workflows:
             - nms-yarn-test
             - nms-e2e-test
 
-#  docusaurus:
-#   jobs:
-#    - docusaurus_build_and_deploy:
-#        <<: *only_master
+  docusaurus:
+   jobs:
+    - docusaurus_build_and_deploy:
+        <<: *only_master
 
   fossa:
     jobs:


### PR DESCRIPTION
## Summary

This has been off for a couple weeks now. Some inconsistencies with our docs vs. the docusaurus site are starting to crop up (thanks @HannaFar for reporting). Reenabling to resolve.

Note: there are currently two versions of our docs site
- github pages
- magmacore, managed by netlify

The latter (not managed by us) is currently broken in a couple ways (images assets not shown, no access to master's documentation). So we're reenabling updates to the github pages site (managed by us) for now to unblock things.

## Test Plan

doing_it_live.gif

## Additional Information

- [ ] This change is backwards-breaking