### PR TITLE
[NMS] Add grafana and metrics explorer to Feg Network.

### DIFF
--- a/nms/app/packages/magmalte/app/components/feg/FEGMetrics.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGMetrics.js
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import AppContext from '@fbcnms/ui/context/AppContext';
+import Grid from '@material-ui/core/Grid';
+import LteMetrics from '../lte/LteMetrics';
+import Paper from '@material-ui/core/Paper';
+import React from 'react';
+import Text from '../../theme/design-system/Text';
+
+import {colors} from '../../theme/default';
+import {makeStyles} from '@material-ui/styles';
+import {useContext} from 'react';
+
+const useStyles = makeStyles(theme => ({
+  dashboardRoot: {
+    margin: theme.spacing(5),
+  },
+  tab: {
+    backgroundColor: colors.primary.white,
+    borderRadius: '4px 4px 0 0',
+    boxShadow: `inset 0 -2px 0 0 ${colors.primary.concrete}`,
+    '& + &': {
+      marginLeft: '4px',
+    },
+  },
+  emptyTable: {
+    backgroundColor: colors.primary.white,
+    padding: theme.spacing(4),
+    minHeight: '96px',
+  },
+  emptyTableContent: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    color: colors.primary.comet,
+  },
+}));
+
+export default function () {
+  const classes = useStyles();
+  const grafanaEnabled =
+    useContext(AppContext).isFeatureEnabled('grafana_metrics') &&
+    useContext(AppContext).user.isSuperUser;
+
+  return (
+    <>
+      {grafanaEnabled ? (
+        <LteMetrics />
+      ) : (
+        <Paper elevation={0}>
+          <Grid
+            container
+            alignItems="center"
+            justify="center"
+            className={classes.emptyTable}>
+            <Grid item xs={12} className={classes.emptyTableContent}>
+              <Text variant="body2">
+                Metrics is only enabled when grafana feature is enabled and user
+                is a superuser
+              </Text>
+            </Grid>
+          </Grid>
+        </Paper>
+      )}
+    </>
+  );
+}

--- a/nms/app/packages/magmalte/app/components/feg/FEGSections.js
+++ b/nms/app/packages/magmalte/app/components/feg/FEGSections.js
@@ -20,8 +20,10 @@ import Alarms from '@fbcnms/ui/insights/Alarms/Alarms';
 import CellWifiIcon from '@material-ui/icons/CellWifi';
 import FEGConfigure from './FEGConfigure';
 import FEGGateways from './FEGGateways';
+import FEGMetrics from './FEGMetrics';
 import React from 'react';
 import SettingsCellIcon from '@material-ui/icons/SettingsCell';
+import ShowChartIcon from '@material-ui/icons/ShowChart';
 
 export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
   const sections = [
@@ -42,6 +44,12 @@ export function getFEGSections(dashboardV2Enabled: boolean): SectionsConfigs {
       label: 'Alerts',
       icon: <AlarmIcon />,
       component: Alarms,
+    },
+    {
+      path: 'metrics',
+      label: 'Metrics',
+      icon: <ShowChartIcon />,
+      component: FEGMetrics,
     },
   ];
 

--- a/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
+++ b/nms/app/packages/magmalte/app/components/layout/__tests__/useSections-test.js
@@ -86,7 +86,7 @@ const testCases: {[string]: TestCase} = {
   },
   feg: {
     default: 'gateways',
-    sections: ['gateways', 'configure', 'alerts'],
+    sections: ['gateways', 'configure', 'alerts', 'metrics'],
   },
   carrier_wifi_network: {
     default: 'gateways',

--- a/nms/app/packages/magmalte/app/views/metrics/Explorer.js
+++ b/nms/app/packages/magmalte/app/views/metrics/Explorer.js
@@ -89,6 +89,11 @@ export default function MetricsExplorer() {
     end: startEnd.end.toISOString(),
   });
 
+  const {
+    response: tenantMetricSeriesDescription,
+    isLoading: isTenantMetricSeriesDescriptionLoading,
+  } = useMagmaAPI(MagmaV1API.getTenantsTargetsMetadata, {});
+
   useEffect(() => {
     fetch('/data/LteMetrics')
       .then(res => res.json())
@@ -109,7 +114,11 @@ export default function MetricsExplorer() {
       );
   }, [enqueueSnackbar]);
 
-  if (isLoading || isMetricSeriesLoading) {
+  if (
+    isLoading ||
+    isMetricSeriesLoading ||
+    isTenantMetricSeriesDescriptionLoading
+  ) {
     return <LoadingFiller />;
   }
 
@@ -129,12 +138,22 @@ export default function MetricsExplorer() {
     return false;
   });
 
+  const tenantMetricDescription = {};
+  tenantMetricSeriesDescription?.forEach(metricDesc => {
+    tenantMetricDescription[metricDesc.metric] = metricDesc.help;
+  });
+
   Object.keys(metricsMap).forEach(function (key) {
+    let metricDescription = tenantMetricDescription[key];
+    if (metricDescription === undefined || metricDescription === '') {
+      metricDescription = 'Description unavailable';
+    }
+
     metricsTable.push({
       MetricName: key,
       PromQL: key,
       Category: 'Category unavailable',
-      Description: 'Description unavailable',
+      Description: metricDescription,
       Service: metricsMap[key]?.['service'] ?? 'Service name unavailable',
     });
   });

--- a/nms/app/packages/magmalte/server/apicontroller/routes.js
+++ b/nms/app/packages/magmalte/server/apicontroller/routes.js
@@ -165,6 +165,14 @@ router.use(
 );
 
 router.use(
+  '/magma/v1/tenants/targets_metadata',
+  proxy(API_HOST, {
+    ...PROXY_OPTIONS,
+    filter: (req, _res) => req.method === 'GET',
+  }),
+);
+
+router.use(
   '/magma/v1/events/:networkID',
   proxy(API_HOST, {
     ...PROXY_OPTIONS,


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary

- Add grafana and metrics explorer to feg network
- Additionally pulled in the metrics description from tenants metadata api which contains the help text for
various metrics

## Test Plan
![Screen Shot 2020-12-10 at 5 49 00 AM](https://user-images.githubusercontent.com/8224854/101780443-6a2bb500-3aab-11eb-99cf-e5b5fb94059c.png)


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
