### PR TITLE
[NMS] Fix APN overview page to show the actual fields rather

### DIFF
--- a/nms/app/packages/magmalte/app/e2e/__tests__/Apn-test.js
+++ b/nms/app/packages/magmalte/app/e2e/__tests__/Apn-test.js
@@ -79,6 +79,8 @@ describe('NMS Apn Add', () => {
       await page.click(apnSelector);
       await page.type(apnSelector, 'test_apn0');
 
+      // ksubraveti : TODO need to figure out why we need to add this delay
+      await page.waitFor(500);
       const saveButtonSelector = await page.$x(`//span[text()='Save']`);
       saveButtonSelector[0].click();
       await page.waitForXPath(`//span[text()='APN saved successfully']`);
@@ -115,6 +117,8 @@ describe('NMS APN Edit', () => {
       await page.click(prioSelector, {clickCount: 3});
       await page.type(prioSelector, '10');
 
+      // ksubraveti : TODO need to figure out why we need to add this delay
+      await page.waitFor(500);
       const saveButtonSelector = await page.$x(`//span[text()='Save']`);
       saveButtonSelector[0].click();
 

--- a/nms/app/packages/magmalte/app/views/traffic/ApnOverview.js
+++ b/nms/app/packages/magmalte/app/views/traffic/ApnOverview.js
@@ -108,9 +108,12 @@ const useStyles = makeStyles(theme => ({
 
 type ApnRowType = {
   apnID: string,
-  description: string,
-  qosProfile: number,
-  added: Date,
+  classID: number,
+  arpPriorityLevel: number,
+  maxReqdULBw: number,
+  maxReqDLBw: number,
+  arpPreEmptionCapability: boolean,
+  arpPreEmptionVulnerability: boolean,
 };
 
 const APN_TITLE = 'APNs';
@@ -124,11 +127,17 @@ function ApnOverview(props: WithAlert) {
   const apns = ctx.state;
   const apnRows: Array<ApnRowType> = apns
     ? Object.keys(apns).map((apn: string) => {
+        const cfg = apns[apn].apn_configuration;
         return {
           apnID: apn,
-          description: 'Test APN description',
-          qosProfile: 1,
-          added: new Date(0),
+          classID: cfg?.qos_profile.class_id ?? 0,
+          arpPriorityLevel: cfg?.qos_profile.priority_level ?? 0,
+          maxReqdULBw: cfg?.ambr.max_bandwidth_ul ?? 0,
+          maxReqDLBw: cfg?.ambr.max_bandwidth_dl ?? 0,
+          arpPreEmptionCapability:
+            cfg?.qos_profile.preemption_capability ?? false,
+          arpPreEmptionVulnerability:
+            cfg?.qos_profile.preemption_vulnerability ?? false,
         };
       })
     : [];
@@ -159,9 +168,24 @@ function ApnOverview(props: WithAlert) {
                 </Link>
               ),
             },
-            {title: 'Description', field: 'description'},
-            {title: 'Qos Profile', field: 'qosProfile', type: 'numeric'},
-            {title: 'Added', field: 'added', type: 'datetime'},
+            {title: 'Class ID', field: 'classID', type: 'numeric'},
+            {
+              title: 'Priority Level',
+              field: 'arpPriorityLevel',
+              type: 'numeric',
+            },
+            {title: 'Max Reqd UL Bw', field: 'maxReqdULBw', type: 'numeric'},
+            {title: 'Max Reqd DL Bw', field: 'maxReqDLBw', type: 'numeric'},
+            {
+              title: 'Pre-emption Capability',
+              field: 'arpPreEmptionCapability',
+              type: 'numeric',
+            },
+            {
+              title: 'Pre-emption Vulnerability',
+              field: 'arpPreEmptionVulnerability',
+              type: 'numeric',
+            },
           ]}
           handleCurrRow={(row: ApnRowType) => setCurrRow(row)}
           menuItems={[

--- a/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
+++ b/nms/app/packages/magmalte/app/views/traffic/__tests__/TrafficOverviewTest.js
@@ -57,14 +57,14 @@ const apns = {
   apn_1: {
     apn_configuration: {
       ambr: {
-        max_bandwidth_dl: 200000000,
+        max_bandwidth_dl: 100000000,
         max_bandwidth_ul: 100000000,
       },
       qos_profile: {
-        class_id: 9,
-        preemption_capability: true,
+        class_id: 6,
+        preemption_capability: false,
         preemption_vulnerability: false,
-        priority_level: 15,
+        priority_level: 10,
       },
     },
     apn_name: 'apn_1',
@@ -444,15 +444,31 @@ describe('<TrafficDashboard APNs/>', () => {
     const rowItemsApns = await getAllByRole('row');
     // first row is the header
     expect(rowItemsApns[0]).toHaveTextContent('Apn ID');
-    expect(rowItemsApns[0]).toHaveTextContent('Description');
-    expect(rowItemsApns[0]).toHaveTextContent('Qos Profile');
-    expect(rowItemsApns[0]).toHaveTextContent('Added');
+    expect(rowItemsApns[0]).toHaveTextContent('Class ID');
+    expect(rowItemsApns[0]).toHaveTextContent('Priority Level');
+    expect(rowItemsApns[0]).toHaveTextContent('Max Reqd UL Bw');
+    expect(rowItemsApns[0]).toHaveTextContent('Max Reqd DL Bw');
+    expect(rowItemsApns[0]).toHaveTextContent('Pre-emption Capability');
+    expect(rowItemsApns[0]).toHaveTextContent('Pre-emption Vulnerability');
+
+    // check first data row
     expect(rowItemsApns[1]).toHaveTextContent('apn_0');
-    expect(rowItemsApns[1]).toHaveTextContent('Test APN description');
-    expect(rowItemsApns[1]).toHaveTextContent('1');
+    expect(rowItemsApns[1]).toHaveTextContent('9');
+    expect(rowItemsApns[1]).toHaveTextContent('15');
+    expect(rowItemsApns[1]).toHaveTextContent('100000000');
+    expect(rowItemsApns[1]).toHaveTextContent('200000000');
+    expect(rowItemsApns[1]).toHaveTextContent('true');
+    expect(rowItemsApns[1]).toHaveTextContent('false');
+
+    // check second data row
     expect(rowItemsApns[2]).toHaveTextContent('apn_1');
-    expect(rowItemsApns[2]).toHaveTextContent('Test APN description');
-    expect(rowItemsApns[2]).toHaveTextContent('1');
+    expect(rowItemsApns[2]).toHaveTextContent('6');
+    expect(rowItemsApns[2]).toHaveTextContent('10');
+    expect(rowItemsApns[2]).toHaveTextContent('100000000');
+    expect(rowItemsApns[2]).toHaveTextContent('100000000');
+    expect(rowItemsApns[2]).toHaveTextContent('false');
+    expect(rowItemsApns[2]).toHaveTextContent('false');
+
     // click the actions button for apn 0
     const apnActionList = getAllByTitle('Actions');
     expect(getByTestId('actions-menu')).not.toBeVisible();


### PR DESCRIPTION
## Summary

Populate APN overview page with correct attributes. Remove dummy attributes
## Test Plan

![Screen Shot 2020-12-10 at 6 07 37 AM](https://user-images.githubusercontent.com/8224854/101785176-4bc8b800-3ab1-11eb-917a-c6d1b157ff5d.png)
![Screen Shot 2020-12-10 at 6 12 07 AM](https://user-images.githubusercontent.com/8224854/101785181-4d927b80-3ab1-11eb-8dbd-84e6893e6a1a.png)

closes #2416 

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
