### PR TITLE
[tf] pass nms db name to helm chart

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/templates/orc8r-values.tpl
@@ -166,6 +166,7 @@ nms:
 
     env:
       api_host: ${api_hostname}
+      mysql_db: ${nms_db_name}
       mysql_host: ${nms_db_host}
       mysql_user: ${nms_db_user}
       grafana_address: ${user_grafana_hostname}


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I had to deploy on an account which already had an orc8r instance, so I had to use non-default values for db names. Magmalte was crashing because the value from tf is not passed down to the helm chart, meaning it was using the default nms db name. This PR just passes the value down from tf.

## Test Plan

Before: 
```
kubectl -n orc8r logs nms-magmalte-cc656ddc4-f4xj8
yarn run v1.22.4
$ nodemon scripts/server
[nodemon] 2.0.4
[nodemon] reading config ./nodemon.json
[nodemon] to restart at any time, enter `rs`
[nodemon] or send SIGHUP to 27 to restart
[nodemon] watching path(s): ../fbcnms-magma-api/**/* config/**/* scripts/**/* server/**/* grafana/**/* alerts/**/*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node -r '@fbcnms/babel-register' scripts/server.js`
[nodemon] spawning
[nodemon] child pid: 39
[nodemon] watching 38 files
2020-12-10T18:16:22.563Z [scripts/server.js] error: Unknown database 'magma'
Unhandled rejection SequelizeConnectionError: Unknown database 'magma'
    at Promise.tap.then.catch.err (/usr/src/node_modules/sequelize/lib/dialects/mysql/connection-manager.js:133:19)
    at tryCatcher (/usr/src/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/usr/src/node_modules/bluebird/js/release/promise.js:547:31)
    at Promise._settlePromise (/usr/src/node_modules/bluebird/js/release/promise.js:604:18)
    at Promise._settlePromise0 (/usr/src/node_modules/bluebird/js/release/promise.js:649:10)
    at Promise._settlePromises (/usr/src/node_modules/bluebird/js/release/promise.js:725:18)
    at _drainQueueStep (/usr/src/node_modules/bluebird/js/release/async.js:93:12)
    at _drainQueue (/usr/src/node_modules/bluebird/js/release/async.js:86:9)
    at Async._drainQueues (/usr/src/node_modules/bluebird/js/release/async.js:102:5)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/src/node_modules/bluebird/js/release/async.js:15:14)
    at runCallback (timers.js:705:18)
    at tryOnImmediate (timers.js:676:5)
    at processImmediate (timers.js:658:5)
```

After: 
```yarn run v1.22.4
$ nodemon scripts/server
[nodemon] 2.0.4
[nodemon] reading config ./nodemon.json
[nodemon] to restart at any time, enter `rs`
[nodemon] or send SIGHUP to 27 to restart
[nodemon] watching path(s): ../fbcnms-magma-api/**/* config/**/* scripts/**/* server/**/* grafana/**/* alerts/**/*
[nodemon] watching extensions: js,mjs,json
[nodemon] starting `node -r '@fbcnms/babel-register' scripts/server.js`
[nodemon] spawning
[nodemon] child pid: 39
[nodemon] watching 38 files
2020-12-10T18:26:22.565Z [scripts/runMigrations.js] info: == 20180824030303-create-user: migrating =======
2020-12-10T18:26:23.567Z [scripts/runMigrations.js] info: == 20180824030303-create-user: migrated (1.001s)

2020-12-10T18:26:24.164Z [scripts/runMigrations.js] info: == 20181009191125-add-network-ids-user: migrating =======
2020-12-10T18:26:24.609Z [scripts/runMigrations.js] info: == 20181009191125-add-network-ids-user: migrated (0.445s)

2020-12-10T18:26:24.920Z [scripts/runMigrations.js] info: == 20181129155300-create-user: migrating =======
2020-12-10T18:26:26.145Z [scripts/runMigrations.js] info: == 20181129155300-create-user: migrated (1.225s)

2020-12-10T18:26:27.147Z [scripts/runMigrations.js] info: == 20181203215100-create-user: migrating =======
2020-12-10T18:26:27.843Z [scripts/runMigrations.js] info: == 20181203215100-create-user: migrated (0.696s)

2020-12-10T18:26:29.220Z [scripts/runMigrations.js] info: == 20190105000000-create-user: migrating =======
2020-12-10T18:26:30.625Z [scripts/runMigrations.js] info: == 20190105000000-create-user: migrated (1.405s)

2020-12-10T18:26:31.528Z [scripts/runMigrations.js] info: == 20190211030303-create-organization: migrating =======
2020-12-10T18:26:33.360Z [scripts/runMigrations.js] info: == 20190211030303-create-organization: migrated (1.832s)
```
