### PR TITLE
[nms] Put Explorer tab after Grafana

### DIFF
--- a/nms/app/packages/magmalte/app/components/lte/LteMetrics.js
+++ b/nms/app/packages/magmalte/app/components/lte/LteMetrics.js
@@ -266,16 +266,16 @@ export default function () {
   } else {
     tabList = [
       {
-        icon: ExploreIcon,
-        component: {NestedRouteLink},
-        label: 'Explorer',
-        to: '/explorer',
-      },
-      {
         icon: AssessmentIcon,
         component: {NestedRouteLink},
         label: 'Grafana',
         to: '/grafana',
+      },
+      {
+        icon: ExploreIcon,
+        component: {NestedRouteLink},
+        label: 'Explorer',
+        to: '/explorer',
       },
     ];
   }
@@ -304,7 +304,7 @@ export default function () {
               component={GrafanaDashboard}
             />
             <Route path={relativePath('/explorer')} component={Explorer} />
-            <Redirect to={relativeUrl('/explorer')} />
+            <Redirect to={relativeUrl('/grafana')} />
           </>
         )}
       </Switch>


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary
People probably want to go to grafana much more often than the explorer tab. Make it the default.

## Test Plan
![image](https://user-images.githubusercontent.com/13274915/101817526-58600700-3ad7-11eb-851a-51da59cb078c.png)
