### PR TITLE
[magma][cwf] Add codeowners 4 cwf

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,6 +8,7 @@ ci-scripts/ @rdefosse @tmdzk
 orc8r/ @xjtian @mpgermano @hcgatewood @emakeev
 
 feg/ @themarwhal @mpgermano @uri200 @emakeev
+cwf/ @themarwhal @mpgermano @uri200 @emakeev
 
 openwrt/ @emakeev @uri200
 


### PR DESCRIPTION

## Summary

cwf module has no owners, as it's similar to feg - add the same owners.

## Test Plan

N/A

## Additional Information

- [ ] This change is backwards-breaking

