### PR TITLE
[nms] Enabling log and event aggregation in agw by default

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -104,7 +104,7 @@ const DEFAULT_GATEWAY_CONFIG = {
     autoupgrade_poll_interval: 60,
     checkin_interval: 60,
     checkin_timeout: 30,
-    dynamic_services: [],
+    dynamic_services: ['eventd','td-agent-bit'],
   },
   name: '',
   status: {

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -249,7 +249,7 @@ describe('<AddEditGatewayButton />', () => {
           autoupgrade_poll_interval: 60,
           checkin_interval: 60,
           checkin_timeout: 30,
-          dynamic_services: [],
+          dynamic_services: ['eventd','td-agent-bit'],
         },
         status: {
           platform_info: {


### PR DESCRIPTION
[Signed-off-by:](url) Wally Rodriguez B <wallyrb@fb.com>


## Summary

Adding evend and td-agent-bit on dynamic_services, in order to have event and log aggregation by default enabled  after adding a new AGW in NMS.

## Test Plan
Tested locally(attached video)

![image](https://user-images.githubusercontent.com/37117037/101846821-a2acac80-3b06-11eb-8dc1-972171fa4c7a.png)


[nms_log_event_agg.mov.zip](https://github.com/magma/magma/files/5676401/nms_log_event_agg.mov.zip)
