### PR TITLE
[helm] Use variable for release name in secrets deployment

### DIFF
--- a/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
+++ b/orc8r/cloud/deploy/terraform/orc8r-helm-aws/secrets.tf
@@ -93,7 +93,7 @@ resource "kubernetes_secret" "orc8r_configs" {
   data = {
     "metricsd.yml" = yamlencode({
       "profile" : "prometheus",
-      "prometheusQueryAddress" : format("http://%s-prometheus:9090", var.helm_deployment_name),
+      "prometheusQueryAddress" : var.thanos_enabled ? format("http://%s-thanos-query-http:10902", var.helm_deployment_name) : format("http://%s-prometheus:9090", var.helm_deployment_name),
 
       "alertmanagerApiURL" : format("http://%s-alertmanager:9093/api/v2", var.helm_deployment_name),
       "prometheusConfigServiceURL" : format("http://%s-prometheus-configurer:9100", var.helm_deployment_name),

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.1
+version: 1.5.3
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma
@@ -23,7 +23,7 @@ keywords:
 
 dependencies:
   - name: secrets
-    version: 0.1.8
+    version: 0.1.9
     repository: ""
     condition: secrets.create
   - name: metrics

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/_helpers.tpl
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/_helpers.tpl
@@ -17,3 +17,28 @@ app.kubernetes.io/managed-by: helm
 app.kubernetes.io/part-of: magma
 helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
 {{- end -}}
+
+{{- define "orchestrator-config-template" -}}
+useGRPCExporter: true
+prometheusGRPCPushAddress: "{{ .Release.Name }}-prometheus-cache:9092"
+# Comment out above line, uncomment below, and set useGRPCExporter to false
+# to switch to HTTP metric pushing (less efficient)
+# prometheusPushAddresses:
+#  - "http://{{ .Release.Name }}-prometheus-cache:9091/metrics"
+{{- end -}}
+
+{{- define "metricsd-thanos-config-template" -}}
+profile: "prometheus"
+prometheusQueryAddress: "http://{{ .Release.Name }}-thanos-query-http:10902"
+alertmanagerApiURL: "http://{{ .Release.Name }}-alertmanager:9093/api/v2"
+prometheusConfigServiceURL: "http://{{ .Release.Name }}-prometheus-configurer:9100/v1"
+alertmanagerConfigServiceURL: "http://{{ .Release.Name }}-alertmanager-configurer:9101/v1"
+{{- end -}}
+
+{{- define "metricsd-config-template" -}}
+profile: "prometheus"
+prometheusQueryAddress: "http://{{ .Release.Name }}-prometheus:9090"
+alertmanagerApiURL: "http://{{ .Release.Name }}-alertmanager:9093/api/v2"
+prometheusConfigServiceURL: "http://{{ .Release.Name }}-prometheus-configurer:9100/v1"
+alertmanagerConfigServiceURL: "http://{{ .Release.Name }}-alertmanager-configurer:9101/v1"
+{{- end -}}

--- a/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/templates/configs-orc8r.secret.yaml
@@ -21,23 +21,19 @@ metadata:
 {{ include "labels" . | indent 4 }}
 data:
 {{- if .Values.secret.configs.enabled }}
-{{ $thanos_enabled := .Values.thanos_enabled}}
+# Template the defaults (metrics, orchestrator) first, will be overriden if
+# passed in through values file
+{{ $orchestratorTemplate := include "orchestrator-config-template" .}}
+  orchestrator.yml: {{ $orchestratorTemplate | b64enc | quote }}
+{{- if .Values.thanos_enabled }}
+{{ $metricsdTemplate := include "metricsd-thanos-config-template" .}}
+  metricsd.yml: {{ $metricsdTemplate | b64enc | quote }}
+{{- else}}
+{{ $metricsdTemplate := include "metricsd-config-template" .}}
+  metricsd.yml: {{ $metricsdTemplate | b64enc | quote }}
+{{- end}}
+
 {{- range $key, $value := .Values.secret.configs.orc8r }}
-  # Set metricsd.yml explicitly if thanos is enabled
-  {{- if eq $key "metricsd.yml" }}
-    {{- if $thanos_enabled }}
-  {{ $value = `
-       profile: "prometheus"
-
-       prometheusQueryAddress: "http://{{ .Release.name }}-thanos-query-http:10902"
-
-       alertmanagerApiURL: "http://{{ .Release.name }}-alertmanager:9093/api/v2"
-       prometheusConfigServiceURL: "http://{{ .Release.name }}-prometheus-configurer:9100/v1"
-       alertmanagerConfigServiceURL: "http://{{ .Release.name }}-alertmanager-configurer:9101/v1"` }}
-
-       useSeriesCache: true
-    {{- end }}
-  {{- end }}
   {{ $key }}: {{ $value | b64enc | quote }}
 {{- end }}
 {{- end }}

--- a/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
+++ b/orc8r/cloud/helm/orc8r/charts/secrets/values.yaml
@@ -50,28 +50,9 @@ secret:
   configs:
     enabled: true
     orc8r:
-      metricsd.yml: |-
-        profile: "prometheus"
-
-        prometheusQueryAddress: "http://orc8r-prometheus:9090"
-
-        alertmanagerApiURL: "http://orc8r-alertmanager:9093/api/v2"
-        prometheusConfigServiceURL: "http://orc8r-prometheus-configurer:9100/v1"
-        alertmanagerConfigServiceURL: "http://orc8r-alertmanager-configurer:9101/v1"
-
-        useSeriesCache: true
-
       elastic.yml: |-
         elasticHost: "elasticsearch-master"
         elasticPort: 9200
-
-      orchestrator.yml: |-
-        useGRPCExporter: true
-        prometheusGRPCPushAddress: "orc8r-prometheus-cache:9092"
-        # Comment out above line, uncomment below, and set useGRPCExporter to false
-        # to switch to HTTP metric pushing (less efficient)
-        # prometheusPushAddresses:
-        #  - "http://orc8r-prometheus-cache:9091/metrics"
 
   # cwf:
   #   key: value

--- a/orc8r/cloud/helm/orc8r/values.yaml
+++ b/orc8r/cloud/helm/orc8r/values.yaml
@@ -44,6 +44,7 @@ metrics:
 # secrets sub-chart configuration.
 secrets:
   create: false
+  fullReleaseName: orc8r
 
 # Define which secrets should be mounted by pods.
 secret:


### PR DESCRIPTION
Signed-off-by: Scott8440 <scott8440@gmail.com>

## Summary

The secrets deployment was using hardcoded `orc8r` as the prefix for service names, and calls to `{{ .Release.Name }}` would use the release name of the secrets deployment, which could lead to incorrect addresses. This didn't happen because non-default deployment names are rare, but fixing it here will prevent this from being an issue. 

Introduce a variable `fullReleaseName` to the secrets chart and build the yml config files off of that.

## Test Plan
* Minikube and tf deployment on AWS
* deploy various ways and check that secrets are as expected:
  * deploy with defaults
  * deploy with non-default release name
  * deploy with/without thanos

