### PR TITLE
[nms]Fix lint  errors in GatewayDetailConfig

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
+++ b/nms/app/packages/magmalte/app/views/equipment/GatewayDetailConfigEdit.js
@@ -104,7 +104,7 @@ const DEFAULT_GATEWAY_CONFIG = {
     autoupgrade_poll_interval: 60,
     checkin_interval: 60,
     checkin_timeout: 30,
-    dynamic_services: ['eventd','td-agent-bit'],
+    dynamic_services: ['eventd', 'td-agent-bit'],
   },
   name: '',
   status: {

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/GatewayConfigTest.js
@@ -249,7 +249,7 @@ describe('<AddEditGatewayButton />', () => {
           autoupgrade_poll_interval: 60,
           checkin_interval: 60,
           checkin_timeout: 30,
-          dynamic_services: ['eventd','td-agent-bit'],
+          dynamic_services: ['eventd', 'td-agent-bit'],
         },
         status: {
           platform_info: {


### PR DESCRIPTION
Signed-off-by: Wally Rodriguez B <wallyrb@fb.com>


## Summary

Fixed lint errors in GatewayDetailConfigEdit and GatewayConfigTest

## Test Plan

yarn tests results:

```
Test Suites: 26 passed, 26 total
Tests:       87 passed, 87 total
Snapshots:   0 total
Time:        16.204 s
Ran all test suites in 2 projects.
✨  Done in 18.50s.

```
