### PR TITLE
[CWF IntegTest] Use stateless PipelineD in CWF IntegTest

### DIFF
--- a/cwf/gateway/integ_tests/gy_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gy_enforcement_test.go
@@ -644,7 +644,7 @@ func TestGyAbortSessionRequest(t *testing.T) {
 	assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
 
 	// check if all session related info is cleaned up
-	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, "static-pass-all-ocs2"),  2*time.Minute, 5*time.Second)
+	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, "static-pass-all-ocs2"), 2*time.Minute, 5*time.Second)
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)

--- a/cwf/gateway/integ_tests/pipelined.yml
+++ b/cwf/gateway/integ_tests/pipelined.yml
@@ -126,7 +126,7 @@ monitored_ifaces: ['cwag_br0',
                   ]
 
 # Whether pipelined should cleanup flows on restarts
-clean_restart: true
+clean_restart: false
 
 # Information for cwf check quota servers
 quota_check_ip: '192.0.0.1'
@@ -138,7 +138,7 @@ li_local_iface: li_port
 li_mirror_all: false
 #li_dst_iface: eth4
 
-redis_enabled: false
+redis_enabled: true
 
 # Logs grpc payload content
 magma_print_grpc_payload: true

--- a/cwf/gateway/integ_tests/test_runner.go
+++ b/cwf/gateway/integ_tests/test_runner.go
@@ -329,6 +329,7 @@ func (tr *TestRunner) WaitForNoEnforcementStatsForRule(imsi string, ruleIDs ...s
 			return false
 		}
 		if records[prependIMSIPrefix(imsi)] == nil {
+			fmt.Printf("%s are no longer in enforcement stats!\n", imsi)
 			return true
 		}
 		for _, ruleID := range ruleIDs {


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
see title
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Ran the test on CircleCI ~5 times. Succeeded except one known issue that is unrelated to stateless PipelineD: https://github.com/magma/magma/issues/4018
https://app.circleci.com/pipelines/github/magma/magma?branch=test-cwf-stateless-pipelined
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
