### PR TITLE
[third_party] restore subcommands to asn1c build script

### DIFF
--- a/third_party/build/bin/asn1c_build.sh
+++ b/third_party/build/bin/asn1c_build.sh
@@ -34,6 +34,8 @@ VERSION="${PKGVERSION}"-"${ITERATION}"
 
 PKGNAME=oai-asn1c
 
+if_subcommand_exec
+
 function configureopts() {
     if [ "${ARCH}" = "arm64" ]; then
         echo --build=arm-linux-gnu


### PR DESCRIPTION
needed to operate with `third_party/build/build.py`

Signed-off-by: Ken Kahrs <kkahrs@gmail.com>

## Summary

Each of the package build scripts must be able to execute the subcommands defined in `lib/utils.sh` after the appropriate variables are defined to be run successfully by `build.py`

## Test Plan
* verify `./bin/asn1c_build.sh -F` outputs a value similar to `oai-asn1c_0~20190423+c0~rf12568d6-0_amd64.deb` and exits
* verify `./bin/asn1c_build.sh` builds a package with the name output above

## Additional Information

- [ ] This change is backwards-breaking

