### PR TITLE
[NMS] Remove subscriber Overview and Config tabs for feg_lte network

### DIFF
--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberDetail.js
@@ -103,23 +103,33 @@ export default function SubscriberDetail() {
     <>
       <TopBar
         header={`Equipment/${subscriberInfo.name ?? subscriberId}`}
-        tabs={[
-          {
-            label: 'Overview',
-            to: '/overview',
-            icon: DashboardIcon,
-          },
-          {
-            label: 'Event',
-            to: '/event',
-            icon: MyLocationIcon,
-          },
-          {
-            label: 'Config',
-            to: '/config',
-            icon: SettingsIcon,
-          },
-        ]}
+        tabs={
+          !Object.keys(subscriberInfo).length
+            ? [
+                {
+                  label: 'Event',
+                  to: '/event',
+                  icon: MyLocationIcon,
+                },
+              ]
+            : [
+                {
+                  label: 'Overview',
+                  to: '/overview',
+                  icon: DashboardIcon,
+                },
+                {
+                  label: 'Event',
+                  to: '/event',
+                  icon: MyLocationIcon,
+                },
+                {
+                  label: 'Config',
+                  to: '/config',
+                  icon: SettingsIcon,
+                },
+              ]
+        }
       />
 
       <Switch>

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberOverview.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberOverview.js
@@ -309,6 +309,12 @@ function SubscriberTableRaw(props: WithAlert) {
                       ]
                     : [
                         {
+                          name: 'View JSON',
+                          handleFunc: () => {
+                            setJsonDialog(true);
+                          },
+                        },
+                        {
                           name: 'View',
                           handleFunc: () => {
                             history.push(relativeUrl('/' + currRow.imsi));


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Remove subscriber Overview and Config tabs for feg_lte networks and add JSON view for lte networks
