### PR TITLE
[agw] added restart sctpd to flushall in stateles script

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -186,6 +186,7 @@ def clear_redis_and_restart():
 def flushall_redis_and_restart():
     _flushall_redis()
     _start_magmad()
+    _restart_sctpd()
     sys.exit(0)
 
 


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

SCTPD needs to be restarted on stateless so its state is saved by MME on restart as a stateless service 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
