### PR TITLE
[state] fix bug with a null pointer on _collect_states_to_replicate

### DIFF
--- a/orc8r/gateway/python/magma/state/state_replicator.py
+++ b/orc8r/gateway/python/magma/state/state_replicator.py
@@ -69,6 +69,7 @@ class StateReplicator(SDWatchdogTask):
         self._replication_iteration = 0
 
     async def _run(self):
+        logging.debug("Check state")
         if not self._has_resync_completed:
             try:
                 await self._resync()
@@ -86,6 +87,7 @@ class StateReplicator(SDWatchdogTask):
                 GARBAGE_COLLECTION_ITERATION_INTERVAL:
             await self._garbage_collector.run_garbage_collection()
             self._replication_iteration = 0
+        logging.debug("")
 
     async def _resync(self):
         states_to_sync = []
@@ -126,15 +128,21 @@ class StateReplicator(SDWatchdogTask):
         states_to_report = []
         for redis_dict in self._redis_dicts:
             for key in redis_dict:
+                redis_state = redis_dict.get(key)
                 device_id = make_scoped_device_id(key, redis_dict.state_scope)
+
                 in_mem_key = make_mem_key(device_id, redis_dict.redis_type)
+                if redis_state == None:
+                    logging.debug("Content of key %s is empty, skipping", in_mem_key)
+                    continue
+
                 redis_version = redis_dict.get_version(key)
                 self._state_keys_from_current_iteration.add(in_mem_key)
                 if in_mem_key in self._state_versions and \
                         self._state_versions[in_mem_key] == redis_version:
+                    logging.debug("key %s already read on this iteration, skipping", in_mem_key)
                     continue
 
-                redis_state = redis_dict.get(key)
                 try:
                     if redis_dict.state_format == PROTO_FORMAT:
                         state_to_serialize = MessageToDict(redis_state)
@@ -146,11 +154,14 @@ class StateReplicator(SDWatchdogTask):
                                   "replicating this state: %s",
                                   key, device_id, e)
                     continue
+
                 state_proto = State(type=redis_dict.redis_type,
                       deviceID=device_id,
                       value=serialized_json_state.encode("utf-8"),
                       version=redis_version)
 
+                logging.debug("key with version, %s contains: %s", in_mem_key,
+                              serialized_json_state)
                 states_to_report.append(state_proto)
 
         if len(states_to_report) == 0:


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Stateless adds a key related to MME with null content. That causes state service to crash. This pr ignores those keys with null values

Also added some logs that may be useful in future debugging session 

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
