### PR TITLE
[SessionD] Migrate tests/leftover to use bundled fields

### DIFF
--- a/lte/gateway/c/session_manager/LocalEnforcer.cpp
+++ b/lte/gateway/c/session_manager/LocalEnforcer.cpp
@@ -2196,8 +2196,8 @@ static SubscriberQuotaUpdate make_subscriber_quota_update(
 UpdateRequestsBySession::UpdateRequestsBySession(
     const UpdateSessionRequest& request) {
   for (const auto& charging_request : request.updates()) {
-    const auto id =
-        ImsiAndSessionID(charging_request.sid(), charging_request.session_id());
+    const auto imsi = charging_request.common_context().sid().id();
+    const auto id   = ImsiAndSessionID(imsi, charging_request.session_id());
     requests_by_id[id].charging_requests.push_back(charging_request);
   }
   for (const auto& monitor_request : request.usage_monitors()) {

--- a/lte/gateway/c/session_manager/RestartHandler.cpp
+++ b/lte/gateway/c/session_manager/RestartHandler.cpp
@@ -143,7 +143,8 @@ bool RestartHandler::populate_sessions_to_terminate_with_retries() {
 void RestartHandler::terminate_previous_session(
     const std::string& sid, const std::string& session_id) {
   SessionTerminateRequest term_req;
-  term_req.set_sid(sid);
+  term_req.set_sid(sid);  // TODO Deprecate
+  term_req.mutable_common_context()->mutable_sid()->set_id(sid);
   term_req.set_session_id(session_id);
   std::promise<bool> termination_res;
   std::future<bool> termination_future = termination_res.get_future();

--- a/lte/gateway/c/session_manager/SessionReporter.cpp
+++ b/lte/gateway/c/session_manager/SessionReporter.cpp
@@ -41,11 +41,11 @@ SessionReporter::get_terminate_logging_cb(
     if (!status.ok()) {
       MLOG(MERROR) << "Failed to terminate session in controller for "
                       "subscriber "
-                   << request.sid() << ": " << status.error_message();
+                   << request.session_id() << ": " << status.error_message();
     } else {
       MLOG(MDEBUG) << "Termination successful in controller for "
                       "subscriber "
-                   << request.sid();
+                   << request.session_id();
     }
   };
 }

--- a/lte/gateway/c/session_manager/SessionStore.cpp
+++ b/lte/gateway/c/session_manager/SessionStore.cpp
@@ -47,7 +47,7 @@ void SessionStore::set_and_save_reporting_flag(
 
   for (const CreditUsageUpdate& credit_update :
        update_session_request.updates()) {
-    const std::string imsi       = credit_update.sid();
+    const std::string imsi       = credit_update.common_context().sid().id();
     const std::string session_id = credit_update.session_id();
     const CreditKey& ckey        = credit_update.usage().charging_key();
     const std::string mkey       = credit_update.usage().monitoring_key();

--- a/lte/gateway/c/session_manager/test/Matchers.h
+++ b/lte/gateway/c/session_manager/test/Matchers.h
@@ -80,7 +80,8 @@ MATCHER_P(CheckCoreRequest, expected_request, "") {
 
 MATCHER_P3(CheckTerminateRequestCount, imsi, monitorCount, chargingCount, "") {
   auto req = static_cast<const SessionTerminateRequest>(arg);
-  return req.sid() == imsi && req.credit_usages().size() == chargingCount &&
+  return req.common_context().sid().id() == imsi &&
+         req.credit_usages().size() == chargingCount &&
          req.monitor_usages().size() == monitorCount;
 }
 
@@ -184,14 +185,15 @@ MATCHER_P(CheckSingleUpdate, expected_update, "") {
       update.usage().type() == expected_update.usage().type() &&
       update.usage().bytes_tx() == expected_update.usage().bytes_tx() &&
       update.usage().bytes_rx() == expected_update.usage().bytes_rx() &&
-      update.sid() == expected_update.sid() &&
+      update.common_context().sid().id() ==
+          expected_update.common_context().sid().id() &&
       update.usage().charging_key() == expected_update.usage().charging_key();
   return val;
 }
 
 MATCHER_P(CheckTerminate, imsi, "") {
   auto request = static_cast<const SessionTerminateRequest*>(arg);
-  return request->sid() == imsi;
+  return request->common_context().sid().id() == imsi;
 }
 
 MATCHER_P4(CheckActivateFlows, imsi, rule_count, ipv4, ipv6, "") {

--- a/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
+++ b/lte/gateway/c/session_manager/test/ProtobufCreators.cpp
@@ -244,7 +244,7 @@ void create_usage_update(
     uint64_t bytes_tx, CreditUsage::UpdateType type,
     CreditUsageUpdate* update) {
   auto usage = update->mutable_usage();
-  update->set_sid(imsi);
+  update->mutable_common_context()->mutable_sid()->set_id(imsi);
   usage->set_charging_key(charging_key);
   usage->set_bytes_rx(bytes_rx);
   usage->set_bytes_tx(bytes_tx);


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Leftover work from https://github.com/magma/magma/pull/3725
This PR migrates SessionD reads of context info for Update and Terminate requests to be done from the common context field.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
make precommit_sm
cwf integ test
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
