### PR TITLE
[orc8r][ctraced] Implement basic handlers for call tracing

### DIFF
--- a/orc8r/cloud/configs/service_registry.yml
+++ b/orc8r/cloud/configs/service_registry.yml
@@ -113,7 +113,13 @@ services:
   ctraced:
     host: "localhost"
     port: 9118
+    echo_port: 10118
     proxy_type: "clientcert"
+    labels:
+      orc8r.io/obsidian_handlers: "true"
+    annotations:
+      orc8r.io/obsidian_handlers_path_prefixes: >
+        /magma/v1/networks/:network_id/tracing,
 
   tenants:
     host: "localhost"

--- a/orc8r/cloud/docker/controller/supervisord.conf
+++ b/orc8r/cloud/docker/controller/supervisord.conf
@@ -47,7 +47,7 @@ stdout_events_enabled=true
 stderr_events_enabled=true
 
 [program:ctraced]
-command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/ctraced logtostderr=true -v=0
+command=/usr/bin/envdir /var/opt/magma/envdir /var/opt/magma/bin/ctraced -run_echo_server=true logtostderr=true -v=0
 autorestart=true
 stdout_logfile=NONE
 stderr_logfile=NONE

--- a/orc8r/cloud/go/orc8r/const.go
+++ b/orc8r/cloud/go/orc8r/const.go
@@ -28,6 +28,8 @@ const (
 	UpgradeTierEntityType           = "upgrade_tier"
 	UpgradeReleaseChannelEntityType = "upgrade_release_channel"
 
+	CallTraceEntityType = "call_trace"
+
 	// ServiceHostnameEnvVar is the name of an environment variable which is
 	// required to hold the public IP of the service.
 	// In dev, this will generally be localhost.

--- a/orc8r/cloud/go/serdes/serdes.go
+++ b/orc8r/cloud/go/serdes/serdes.go
@@ -17,6 +17,7 @@ import (
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/serde"
 	directoryd_types "magma/orc8r/cloud/go/services/directoryd/types"
+	ctraced_models "magma/orc8r/cloud/go/services/ctraced/obsidian/models"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state"
 )
@@ -29,7 +30,8 @@ var (
 	// Network contains the base orc8r serdes for configurator network configs
 	Network = models.NetworkSerdes
 	// Entity contains the base orc8r serdes for configurator network entities
-	Entity = models.EntitySerdes
+	Entity = models.EntitySerdes.
+		MustMerge(ctraced_models.EntitySerdes)
 	// State contains the base orc8r serdes for the state service
 	State = serde.NewRegistry(
 		state.NewStateSerde(orc8r.GatewayStateType, &models.GatewayStatus{}),

--- a/orc8r/cloud/go/services/ctraced/ctraced/main.go
+++ b/orc8r/cloud/go/services/ctraced/ctraced/main.go
@@ -14,9 +14,11 @@ limitations under the License.
 package main
 
 import (
+	"magma/orc8r/cloud/go/obsidian"
 	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
 	"magma/orc8r/cloud/go/services/ctraced"
+	"magma/orc8r/cloud/go/services/ctraced/obsidian/handlers"
 
 	"github.com/golang/glog"
 )
@@ -27,6 +29,8 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating ctraced service: %s", err)
 	}
+
+	obsidian.AttachHandlers(srv.EchoServer, handlers.GetObsidianHandlers())
 
 	// Run service
 	err = srv.Run()

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers.go
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handlers
+
+import (
+	"net/http"
+
+	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serdes"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/ctraced/obsidian/models"
+	merrors "magma/orc8r/lib/go/errors"
+
+	"github.com/labstack/echo"
+	"github.com/pkg/errors"
+)
+
+const (
+	Tracing = "tracing"
+	// v1/networks/:network_id/tracing
+	TracingRootPath = obsidian.V1Root + obsidian.MagmaNetworksUrlPart + obsidian.UrlSep + ":" + pathParamNetworkID + obsidian.UrlSep + Tracing
+	// v1/networks/:network_id/tracing/:trace_id
+	TracingPath = TracingRootPath + obsidian.UrlSep + ":" + pathParamTraceID
+
+	pathParamTraceID   = "trace_id"
+	pathParamNetworkID = "network_id"
+)
+
+func GetObsidianHandlers() []obsidian.Handler {
+	ret := []obsidian.Handler{
+		{Path: TracingRootPath, Methods: obsidian.GET, HandlerFunc: ListCallTraces},
+		{Path: TracingRootPath, Methods: obsidian.POST, HandlerFunc: CreateCallTrace},
+		{Path: TracingPath, Methods: obsidian.GET, HandlerFunc: GetCallTrace},
+		{Path: TracingPath, Methods: obsidian.PUT, HandlerFunc: UpdateCallTrace},
+		{Path: TracingPath, Methods: obsidian.DELETE, HandlerFunc: DeleteCallTrace},
+	}
+
+	return ret
+}
+
+func ListCallTraces(c echo.Context) error {
+	networkID, nerr := obsidian.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	callTraces, err := configurator.LoadAllEntitiesOfType(
+		networkID, orc8r.CallTraceEntityType,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
+	if err != nil {
+		return obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+
+	ret := map[string]*models.CallTrace{}
+	for _, ctEnt := range callTraces {
+		ret[ctEnt.Key] = (&models.CallTrace{}).FromEntity(ctEnt)
+	}
+	return c.JSON(http.StatusOK, ret)
+}
+
+func CreateCallTrace(c echo.Context) error {
+	networkID, nerr := obsidian.GetNetworkId(c)
+	if nerr != nil {
+		return nerr
+	}
+	cfg := &models.CallTraceConfig{}
+	if err := c.Bind(cfg); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	ctr := &models.CallTrace{
+		Config: cfg,
+		State: &models.CallTraceState{
+			CallTraceAvailable: false,
+			CallTraceEnding:    false,
+		},
+	}
+
+	if err := ctr.ValidateModel(); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	createdEntity := ctr.ToEntity()
+	_, err := configurator.CreateEntity(networkID, createdEntity, serdes.Entity)
+	if err != nil {
+		return obsidian.HttpError(errors.Wrap(err, "failed to create call trace"), http.StatusInternalServerError)
+	}
+	return c.JSON(http.StatusCreated, string(cfg.TraceID))
+}
+
+func GetCallTrace(c echo.Context) error {
+	callTrace, err := getCallTrace(c)
+	if err != nil {
+		return err
+	}
+	return c.JSON(http.StatusOK, callTrace)
+}
+
+func UpdateCallTrace(c echo.Context) error {
+	networkID, callTraceID, nerr := getNetworkIDAndCallTraceID(c)
+	if nerr != nil {
+		return nerr
+	}
+	mutableCallTrace := &models.MutableCallTrace{}
+	if err := c.Bind(mutableCallTrace); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+	if err := mutableCallTrace.ValidateModel(); err != nil {
+		return obsidian.HttpError(err, http.StatusBadRequest)
+	}
+
+	callTrace, err := getCallTrace(c)
+	if err != nil {
+		return err
+	}
+
+	_, err = configurator.UpdateEntity(networkID, mutableCallTrace.ToEntityUpdateCriteria(callTraceID, *callTrace), serdes.Entity)
+	if err != nil {
+		return obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func DeleteCallTrace(c echo.Context) error {
+	networkID, callTraceID, nerr := getNetworkIDAndCallTraceID(c)
+	if nerr != nil {
+		return nerr
+	}
+
+	err := configurator.DeleteEntity(networkID, orc8r.CallTraceEntityType, callTraceID)
+	if err != nil {
+		return obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	return c.NoContent(http.StatusNoContent)
+}
+
+func getCallTrace(c echo.Context) (*models.CallTrace, error) {
+	networkID, callTraceID, nerr := getNetworkIDAndCallTraceID(c)
+	if nerr != nil {
+		return nil, nerr
+	}
+	ent, err := configurator.LoadEntity(
+		networkID, orc8r.CallTraceEntityType, callTraceID,
+		configurator.EntityLoadCriteria{LoadConfig: true},
+		serdes.Entity,
+	)
+	if err == merrors.ErrNotFound {
+		return nil, obsidian.HttpError(err, http.StatusNotFound)
+	}
+	if err != nil {
+		return nil, obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	callTrace := &models.CallTrace{}
+	err = callTrace.FromBackendModels(ent)
+	if err != nil {
+		return nil, obsidian.HttpError(err, http.StatusInternalServerError)
+	}
+	return callTrace, nil
+}
+
+func getNetworkIDAndCallTraceID(c echo.Context) (string, string, *echo.HTTPError) {
+	vals, err := obsidian.GetParamValues(c, pathParamNetworkID, pathParamTraceID)
+	if err != nil {
+		return "", "", err
+	}
+	return vals[0], vals[1], nil
+}

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package handlers_test
+
+import (
+	"magma/orc8r/cloud/go/obsidian"
+	"magma/orc8r/cloud/go/obsidian/tests"
+	"magma/orc8r/cloud/go/plugin"
+	"magma/orc8r/cloud/go/pluginimpl"
+	"magma/orc8r/cloud/go/serdes"
+	"magma/orc8r/cloud/go/services/configurator"
+	"magma/orc8r/cloud/go/services/ctraced/obsidian/handlers"
+	traceModels "magma/orc8r/cloud/go/services/ctraced/obsidian/models"
+	"testing"
+
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+
+	"github.com/go-openapi/swag"
+	"github.com/labstack/echo"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCtracedHandlersBasic(t *testing.T) {
+	_ = plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{})
+	configurator_test_init.StartTestService(t)
+	e := echo.New()
+
+	obsidianHandlers := handlers.GetObsidianHandlers()
+	err := configurator.CreateNetwork(configurator.Network{ID: "n1"}, serdes.Network)
+	assert.NoError(t, err)
+
+	listTraces := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing", obsidian.GET).HandlerFunc
+	createTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing", obsidian.POST).HandlerFunc
+	getTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id", obsidian.GET).HandlerFunc
+	updateTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id", obsidian.PUT).HandlerFunc
+	deleteTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id", obsidian.DELETE).HandlerFunc
+
+	// Test empty response
+	tc := tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/networks/n1/tracing?view=full",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        listTraces,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*traceModels.CallTrace{}),
+		ExpectedError:  "",
+	}
+	tests.RunUnitTest(t, e, tc)
+	tc.URL = "/magma/v1/networks/n1/tracing"
+	tc.ExpectedResult = tests.JSONMarshaler(map[string]*traceModels.CallTrace{})
+	tests.RunUnitTest(t, e, tc)
+
+	testTraceCfg := &traceModels.CallTraceConfig{
+		TraceID:   "CallTrace1",
+		GatewayID: "test_gateway_id",
+		Timeout:   300,
+		TraceType: traceModels.CallTraceConfigTraceTypeGATEWAY,
+	}
+	testTrace := &traceModels.CallTrace{
+		Config: testTraceCfg,
+		State: &traceModels.CallTraceState{
+			CallTraceAvailable: false,
+			CallTraceEnding:    false,
+		},
+	}
+
+	// Test create call trace
+	tc = tests.Test{
+		Method:         "POST",
+		URL:            "/magma/v1/networks/n1/tracing",
+		Payload:        testTraceCfg,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        createTrace,
+		ExpectedStatus: 201,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Check that policy rule was added
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/networks/n1/tracing?view=full",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        listTraces,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*traceModels.CallTrace{
+			"CallTrace1": testTrace,
+		}),
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test Read Rule Using URL based ID
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/networks/n1/tracing/CallTrace1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id", "trace_id"},
+		ParamValues:    []string{"n1", "CallTrace1"},
+		Handler:        getTrace,
+		ExpectedStatus: 200,
+		ExpectedResult: testTrace,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Test Update Rule Using URL based ID
+	testMutableTrace := &traceModels.MutableCallTrace{
+		RequestedEnd: swag.Bool(true),
+	}
+	tc = tests.Test{
+		Method:         "PUT",
+		URL:            "/magma/v1/networks/n1/tracing/CallTrace1",
+		Payload:        testMutableTrace,
+		ParamNames:     []string{"network_id", "trace_id"},
+		ParamValues:    []string{"n1", "CallTrace1"},
+		Handler:        updateTrace,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Verify update results
+	testTrace.State.CallTraceEnding = true
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/networks/n1/tracing/CallTrace1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id", "trace_id"},
+		ParamValues:    []string{"n1", "CallTrace1"},
+		Handler:        getTrace,
+		ExpectedStatus: 200,
+		ExpectedResult: testTrace,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Delete a rule
+	tc = tests.Test{
+		Method:         "DELETE",
+		URL:            "/magma/v1/networks/n1/tracing/CallTrace1",
+		Payload:        nil,
+		ParamNames:     []string{"network_id", "trace_id"},
+		ParamValues:    []string{"n1", "CallTrace1"},
+		Handler:        deleteTrace,
+		ExpectedStatus: 204,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Confirm delete
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/networks/n1/tracing?view=full",
+		Payload:        nil,
+		ParamNames:     []string{"network_id"},
+		ParamValues:    []string{"n1"},
+		Handler:        listTraces,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.JSONMarshaler(map[string]*traceModels.CallTrace{}),
+	}
+	tests.RunUnitTest(t, e, tc)
+	tc.URL = "/magma/v1/networks/n1/tracing"
+	tc.ExpectedResult = tests.JSONMarshaler(map[string]*traceModels.CallTrace{})
+	tests.RunUnitTest(t, e, tc)
+}

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/conversion.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/conversion.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import (
+	"fmt"
+
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+func (c *CallTrace) ToEntity() configurator.NetworkEntity {
+	ret := configurator.NetworkEntity{
+		Type:   orc8r.CallTraceEntityType,
+		Key:    c.Config.TraceID,
+		Config: c,
+	}
+	return ret
+}
+
+func (c *CallTrace) FromEntity(ent configurator.NetworkEntity) *CallTrace {
+	return ent.Config.(*CallTrace)
+}
+
+func (m *CallTrace) FromBackendModels(ent configurator.NetworkEntity) error {
+	if ent.Config == nil {
+		return fmt.Errorf("could not convert entity to CallTrace; config was nil")
+	}
+	cfg, ok := ent.Config.(*CallTrace)
+	if !ok {
+		return fmt.Errorf("could not convert entity config type %T to CallTrace", ent.Config)
+	}
+	*m = *cfg
+	return nil
+}
+
+func (c *MutableCallTrace) ToEntityUpdateCriteria(callTraceID string, callTrace CallTrace) configurator.EntityUpdateCriteria {
+	update := configurator.EntityUpdateCriteria{
+		Type:      orc8r.CallTraceEntityType,
+		Key:       callTraceID,
+		NewConfig: c.ToCallTrace(callTrace),
+	}
+	return update
+}
+
+func (c *MutableCallTrace) ToCallTrace(callTrace CallTrace) *CallTrace {
+	callTrace.State.CallTraceEnding = *c.RequestedEnd
+	return &callTrace
+}

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/serdes.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/serdes.go
@@ -1,0 +1,27 @@
+/*
+ Copyright 2020 The Magma Authors.
+
+ This source code is licensed under the BSD-style license found in the
+ LICENSE file in the root directory of this source tree.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+*/
+
+package models
+
+import (
+	"magma/orc8r/cloud/go/orc8r"
+	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+)
+
+var (
+	// EntitySerdes contains the package's configurator network entity serdes
+	EntitySerdes = serde.NewRegistry(
+		configurator.NewNetworkEntityConfigSerde(orc8r.CallTraceEntityType, &CallTrace{}),
+	)
+)

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/validate.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/validate.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Magma Authors.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import (
+	"github.com/go-openapi/strfmt"
+)
+
+func (m *CallTrace) ValidateModel() error {
+	if err := m.Validate(strfmt.Default); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *MutableCallTrace) ValidateModel() error {
+	if err := m.Validate(strfmt.Default); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

This revision adds basic API handlers for call tracing. Call trace models can be listed, and standard CRUD operations are also implemented. Update operations for call traces are only available for requesting an end to a call trace.

Not implemented in this revision is the behavior for orc8r to propagate the gRPC signals to the gateway(s) running the call traces.

## Test Plan

- Basic sanity check running all orc8r services in dev environment
- New unit tests added

## Additional Information

- [ ] This change is backwards-breaking