### PR TITLE
[feg][cloud][nh] Enable Neutral Host Relay on S6a proxy RPCs

### DIFF
--- a/feg/cloud/configs/service_registry.yml
+++ b/feg/cloud/configs/service_registry.yml
@@ -30,7 +30,7 @@ services:
     proxy_type: "clientcert"
     proxy_aliases:
       s6a_proxy:
-        port: 9079
+        port: 9103
       session_proxy:
         port: 9079
       swx_proxy:


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Enable Neutral Host Relay on S6a proxy RPCs

## Test Plan

test on staging with S6a & SWx proxy load, unit tests

## Additional Information

- [ ] This change is backwards-breaking

