### PR TITLE
[nms] handle failed api request when creating tier as errors

### DIFF
--- a/nms/app/packages/magmalte/app/components/network/UpgradeTierEditDialog.js
+++ b/nms/app/packages/magmalte/app/components/network/UpgradeTierEditDialog.js
@@ -57,7 +57,9 @@ export default function UpgradeTierEditDialog(props: Props) {
         tier,
       })
         .then(() => props.onSave(tier))
-        .catch(e => enqueueSnackbar(e.response.data.message));
+        .catch(e =>
+          enqueueSnackbar(e.response.data.message, {variant: 'error'}),
+        );
     } else {
       MagmaV1API.putNetworksByNetworkIdTiersByTierId({
         networkId: nullthrows(match.params.networkId),
@@ -65,7 +67,9 @@ export default function UpgradeTierEditDialog(props: Props) {
         tier,
       })
         .then(_resp => props.onSave(tier))
-        .catch(e => enqueueSnackbar(e.response.data.message));
+        .catch(e =>
+          enqueueSnackbar(e.response.data.message, {variant: 'error'}),
+        );
     }
   };
 


### PR DESCRIPTION
Signed-off-by: YOUSSEF EL MASMOUDI <ymasmoudi@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Creating a tier with an invalid ID (space or dash for example) will redirect the user to a blanc page and no error message.

## Test Plan

Tested locally 

<img width="1602" alt="Screenshot 2020-12-15 at 14 58 26" src="https://user-images.githubusercontent.com/8215369/102181716-16273300-3ee6-11eb-9df3-f74fdc93e2cc.png">
