### PR TITLE
[docs] Fix gh-pages docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -880,6 +880,9 @@ jobs:
   docusaurus_build_and_deploy:
     docker:
       - image: circleci/node:8.11.1
+    environment:
+      DOCUSAURUS_URL: 'https://magma.github.io'
+      DOCUSAURUS_BASE_URL: '/magma/'
     steps:
       - checkout
       - run:

--- a/docs/docusaurus/siteConfig.js
+++ b/docs/docusaurus/siteConfig.js
@@ -26,16 +26,19 @@ const users = [
   },
 ];
 
+const url = process.env.DOCUSAURUS_URL || 'https://magmacore.org'
+const baseUrl = process.env.DOCUSAURUS_BASE_URL || '/'
+
 const siteConfig = {
   title: 'Magma Documentation', // Title for your website.
-  disableTitleTagline: true, 
+  disableTitleTagline: true,
   tagline: 'Bring more people online by enabling operators with open, flexible, and extensible network solutions',
 
   // Used for publishing and more
   projectName: 'magma',
-  organizationName: 'magma',  
-  url: 'https://magmacore.org', // Your website URL
-  baseUrl: '/', // Base URL for your project */
+  organizationName: 'magma',
+  url: url, // Your website URL
+  baseUrl: baseUrl, // Base URL for your project */
   // For github.io type URLs, you would set the url and baseUrl like:
   //   url: 'https://facebook.github.io',
   //   baseUrl: '/test-site/',


### PR DESCRIPTION
## Summary

The recent changes to mirror our Docusaurus to the magmacore site broke our github-pages site (PR #3703). We didn't realize at the time because the CircleCI publish job was temporarily turned off.

The issue is the `url` and `baseUrl` variables need to be [set a certain way for github-pages sites](https://github.com/facebook/docusaurus/issues/1029) (also see the inline docs in `docs/docusaurus/siteConfig.js`). So we just make this variable override-able via environment variable, and set that env var in the circle ci job.

## Test Plan

- [x] Manually run the job locally to ensure successful publish

![Screen Shot 2020-12-15 at 12 40 02 AM](https://user-images.githubusercontent.com/8029544/102192013-cf9eed80-3e7f-11eb-9777-cab372facd86.png)

## Additional Information

- [ ] This change is backwards-breaking