### PR TITLE
Add XWF-M variant to the CWF networks and enable XWF specific dashboards

### DIFF
--- a/cwf/cloud/go/services/cwf/obsidian/models/network_carrier_wifi_configs_swaggergen.go
+++ b/cwf/cloud/go/services/cwf/obsidian/models/network_carrier_wifi_configs_swaggergen.go
@@ -36,6 +36,9 @@ type NetworkCarrierWifiConfigs struct {
 	// eap sim
 	EapSim *models2.EapSim `json:"eap_sim,omitempty"`
 
+	// is xwfm variant
+	IsXwfmVariant bool `json:"is_xwfm_variant,omitempty"`
+
 	// li ues
 	LiUes *LiUes `json:"li_ues,omitempty"`
 

--- a/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
+++ b/cwf/cloud/go/services/cwf/obsidian/models/swagger.v1.yml
@@ -982,6 +982,10 @@ definitions:
         $ref: './feg-swagger.yml#/definitions/aaa_server'
       li_ues:
         $ref: '#/definitions/li_ues'
+      is_xwfm_variant:
+        type: boolean
+        example: false
+
   allowed_gre_peer:
     type: object
     required:

--- a/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
+++ b/nms/app/packages/fbcnms-magma-api/__generated__/MagmaAPIBindings.js
@@ -871,6 +871,7 @@ export type network_carrier_wifi_configs = {
     default_rule_id: string,
     eap_aka: eap_aka,
     eap_sim ? : eap_sim,
+    is_xwfm_variant ? : boolean,
     li_ues ? : li_ues,
     network_services: Array < "dpi" | "policy_enforcement" >
         ,

--- a/nms/app/packages/magmalte/grafana/handlers.js
+++ b/nms/app/packages/magmalte/grafana/handlers.js
@@ -25,6 +25,7 @@ import {
   CWFNetworkDBData,
   CWFSubscriberDBData,
 } from './dashboards/CWFDashboards';
+
 import {
   GatewayDBData,
   InternalDBData,
@@ -488,25 +489,29 @@ export async function syncDashboards(
     dashboardData(createDashboard(NetworkDBData(networks)).generate()),
     dashboardData(createDashboard(GatewayDBData(networks)).generate()),
     dashboardData(createDashboard(InternalDBData(networks)).generate()),
-    dashboardData(createDashboard(SubscriberDBData(networks)).generate()),
   ];
-
-  // If an org contains CWF networks, add the CWF-specific dashboards
-  if (await hasNetworkOfType(CWF, networks)) {
-    posts.push(
-      dashboardData(createDashboard(CWFNetworkDBData(networks)).generate()),
-      dashboardData(createDashboard(CWFAccessPointDBData(networks)).generate()),
-      dashboardData(createDashboard(CWFSubscriberDBData).generate()),
-      dashboardData(createDashboard(CWFGatewayDBData(networks)).generate()),
-    );
-    // Analytics Dashboard
-    posts.push(
-      dashboardData(createDashboard(AnalyticsDBData(networks)).generate()),
-    );
-  }
-  // TODO: When XWFM networks are a real thing change this to XWFM
-  if (await hasNetworkOfType(CWF, networks)) {
+  if (await hasNetworkOfXWFMType(networks)) {
     posts.push(dashboardData(createDashboard(XWFMDBData(networks)).generate()));
+  } else {
+    posts.push(
+      dashboardData(createDashboard(SubscriberDBData(networks)).generate()),
+    );
+
+    // If an org contains CWF networks, add the CWF-specific dashboards
+    if (await hasNetworkOfType(CWF, networks)) {
+      posts.push(
+        dashboardData(createDashboard(CWFNetworkDBData(networks)).generate()),
+        dashboardData(
+          createDashboard(CWFAccessPointDBData(networks)).generate(),
+        ),
+        dashboardData(createDashboard(CWFSubscriberDBData).generate()),
+        dashboardData(createDashboard(CWFGatewayDBData(networks)).generate()),
+      );
+      // Analytics Dashboard
+      posts.push(
+        dashboardData(createDashboard(AnalyticsDBData(networks)).generate()),
+      );
+    }
   }
 
   for (const post of posts) {
@@ -627,6 +632,22 @@ async function hasNetworkOfType(
     } catch (error) {
       logger.error(
         `Error retrieving network info for network while building dashboards: ${networkId}. Error: ${error}`,
+      );
+    }
+  }
+  return false;
+}
+
+async function hasNetworkOfXWFMType(networks: Array<string>): Promise<boolean> {
+  for (const networkId of networks) {
+    try {
+      const cwfNetwork = await MagmaV1API.getCwfByNetworkId({networkId});
+      return cwfNetwork.carrier_wifi?.is_xwfm_variant ?? false;
+    } catch (error) {
+      // not a real error, we are attempting to get all networks as cwf networks
+      // few of them can result in errors. These can be ignored
+      logger.error(
+        `Error attempting to retrieve ${networkId} as CWF network. Error: ${error}`,
       );
     }
   }

--- a/nms/app/packages/magmalte/server/network/routes.js
+++ b/nms/app/packages/magmalte/server/network/routes.js
@@ -149,6 +149,7 @@ router.post(
             dns: DEFAULT_DNS_CONFIG,
             federation: {feg_network_id: data.fegNetworkID},
             carrier_wifi: {
+              is_xwfm_variant: true,
               aaa_server: {
                 accounting_enabled: true,
                 create_session_on_auth: true,


### PR DESCRIPTION
to be added to NMS

Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
Added a boolean to identify xwf variants of cwf network.
Fixed NMS grafana dashboard to ensure we show XWF dashboards for XWFM networks.

## Test Plan


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
