### PR TITLE
Upgrade pip from 19.1.1 to 20.3.2

### DIFF
--- a/orc8r/gateway/python/python.mk
+++ b/orc8r/gateway/python/python.mk
@@ -28,7 +28,7 @@ install_virtualenv:
 	@echo "Initializing virtualenv with python version $(PYTHON_VERSION)"
 	virtualenv --system-site-packages --python=/usr/bin/python$(PYTHON_VERSION) $(PYTHON_BUILD)
 	. $(PYTHON_BUILD)/bin/activate;
-	$(VIRT_ENV_PIP_INSTALL) "pip>=19.1.1"
+	$(VIRT_ENV_PIP_INSTALL) "pip>=20.3.2"
 
 setupenv: $(PYTHON_BUILD)/sysdeps $(SITE_PACKAGES_DIR)/setuptools
 


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

Upgrade pip from 19.1.1 to 20.3.2

## Summary

Upgrade pip from 19.1.1 to 20.3.2

## Test Plan

`fab dev package:vcs=git`
or 
`vagrant ssh && cd magma/lte/gateway && make run`