### PR TITLE
[lte][agw] Adding retry backoff to sctpd connection establishment

### DIFF
--- a/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp
+++ b/lte/gateway/c/oai/tasks/sctp/sctpd_downlink_client.cpp
@@ -28,6 +28,7 @@ extern "C" {
 }
 
 #include <memory.h>
+#include <unistd.h>
 
 #include <grpcpp/grpcpp.h>
 
@@ -104,6 +105,9 @@ using magma::sctpd::InitRes;
 using magma::sctpd::SendDlReq;
 using magma::sctpd::SendDlRes;
 
+// Max sleep backoff delay in microseconds
+constexpr useconds_t max_backoff_usecs = 1000000; // 1 sec
+
 std::unique_ptr<SctpdDownlinkClient> _client = nullptr;
 
 int init_sctpd_downlink_client(bool force_restart) {
@@ -121,6 +125,9 @@ int sctpd_init(sctp_init_t* init) {
   InitRes res;
   char ipv4_str[INET_ADDRSTRLEN];
   char ipv6_str[INET6_ADDRSTRLEN];
+
+  // Retry backoff delay in microseconds
+  useconds_t current_delay = 500000;
 
   req.set_use_ipv4(init->ipv4);
   req.set_use_ipv6(init->ipv6);
@@ -148,7 +155,7 @@ int sctpd_init(sctp_init_t* init) {
 
   req.set_force_restart(_client->should_force_restart);
 
-#define MAX_SCTPD_INIT_ATTEMPTS 100
+#define MAX_SCTPD_INIT_ATTEMPTS 50
   int num_inits      = 0;
   int sctpd_init_res = -1;
   while (sctpd_init_res != 0) {
@@ -158,9 +165,18 @@ int sctpd_init(sctp_init_t* init) {
     }
     ++num_inits;
     OAILOG_DEBUG(LOG_SCTP, "Sctpd Init attempt %d", num_inits);
-    auto rc        = _client->init(req, &res);
-    auto init_ok   = res.result() == InitRes::INIT_OK;
-    sctpd_init_res = (rc == 0) && init_ok ? 0 : -1;
+    auto rc      = _client->init(req, &res);
+    auto init_ok = res.result() == InitRes::INIT_OK;
+    if ((rc == 0) && init_ok) {
+      sctpd_init_res = 0;
+    } else {
+      useconds_t sleep_time = std::min(current_delay, max_backoff_usecs);
+      OAILOG_DEBUG(LOG_SCTP, "Sleeping for %d usecs", sleep_time);
+      usleep(sleep_time);
+      if (current_delay < max_backoff_usecs) {
+        current_delay += 10000; // Add 10 ms to backoff
+      }
+    }
   }
   return sctpd_init_res;
 }


### PR DESCRIPTION
Signed-off-by: Alejandro Rodriguez <alexrod@fb.com>

## Summary

- Adds retry exponential backoff implementation to sctpd connection establishment between MME and sctpd services
- Sets a maximum of sleep time to 1 sec to keep trying until reaching max retries (set to 50)

## Test Plan

- Purposely breaking connection on sctpd task on MME to test retry backoff:
```
000284 Wed Dec 16 16:11:48 2020 7F99A0A41C80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0653    - Helpers:
000285 Wed Dec 16 16:11:48 2020 7F99A0A41C80 INFO  SPGW-A tasks/sgw/pgw_config.c          :0656        Push PCO (DNS+MTU) ........: false
000286 Wed Dec 16 16:11:48 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 0 secs
000287 Wed Dec 16 16:11:48 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0167    Sctpd Init attempt 2
000288 Wed Dec 16 16:11:48 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 1 secs
000289 Wed Dec 16 16:11:49 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0167    Sctpd Init attempt 3
000290 Wed Dec 16 16:11:49 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 2 secs
000291 Wed Dec 16 16:11:51 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0167    Sctpd Init attempt 4
000292 Wed Dec 16 16:11:51 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 4 secs
000293 Wed Dec 16 16:11:55 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0167    Sctpd Init attempt 5
000294 Wed Dec 16 16:11:55 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 8 secs
000295 Wed Dec 16 16:12:03 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0167    Sctpd Init attempt 6
000296 Wed Dec 16 16:12:03 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 10 secs
000297 Wed Dec 16 16:12:13 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0167    Sctpd Init attempt 7
000298 Wed Dec 16 16:12:13 2020 7F9989780700 INFO  SCTP   tasks/sctp/sctpd_downlink_client:0175    Sleeping for 10 secs
```
- make integ_test as sanity testing

## Additional Information

- [ ] This change is backwards-breaking

