### PR TITLE
[orc8r][ci] Publish orc8r_base image for top-level controller services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,7 @@ jobs:
             python3 build.py -a --nocache --parallel
       - tag-push-docker:
           project: orc8r
-          images: "nginx|controller"
+          images: "nginx|controller|base"
       - persist-githash-version:
           file_prefix: orc8r
       - notify-magma:


### PR DESCRIPTION
## Summary

Previously, the "in-between" service mesh still had {1 image, 1 container}, and the services in this single container were logically acting out service mesh patterns, but ultimately just calling to localhost.

Next, we want the full, top-level service mesh pattern to have one container per service. For this we'll use a new base container image, {1 image, n containers}, which we need to publish during CI.

This PR adds this base container image, `orc8r_base`, to the list of images published at the end of the `orc8r_build` step. As a result, fully-successful orc8r CI jobs on master will result in the `orc8r_base` image being published to our registry.

## Test Plan

doing-it-live.gif

## Additional Information

- [ ] This change is backwards-breaking