### PR TITLE
[docs] Fix Code URL

### DIFF
--- a/docs/docusaurus/siteConfig.js
+++ b/docs/docusaurus/siteConfig.js
@@ -55,7 +55,7 @@ const siteConfig = {
     {label: ' | '},
     {href: '/', label: 'Docs'},
     {label: ' | '},
-    {href: 'https://github.org/magma', label: 'Code'},
+    {href: 'https://github.com/magma', label: 'Code'},
     {label: ' | '},
     {href: 'https://magmacore.org/community', label: 'Community'},
   ],


### PR DESCRIPTION
- Update github.org swapped to github.com

Signed-off-by: Jimmy McArthur <jimmy@tipit.net>


## Summary

The Code URL was incorrectly linking to github.org
