### PR TITLE
Update Code URL

### DIFF
--- a/docs/docusaurus/siteConfig.js
+++ b/docs/docusaurus/siteConfig.js
@@ -55,7 +55,7 @@ const siteConfig = {
     {label: ' | '},
     {href: '/', label: 'Docs'},
     {label: ' | '},
-    {href: 'https://github.org/magma', label: 'Code'},
+    {href: 'https://github.com/magma', label: 'Code'},
     {label: ' | '},
     {href: 'https://magmacore.org/community', label: 'Community'},
   ],


### PR DESCRIPTION
- Corrects erroneous github.org URL to github.com
- 
Signed-off-by: Jimmy McArthur <jimmy@openstack.org>
