### PR TITLE
[agw][mobilityd] Clean all the mobilityd Redis keys when sctpd restarts

### DIFF
--- a/lte/gateway/python/scripts/config_stateless_agw.py
+++ b/lte/gateway/python/scripts/config_stateless_agw.py
@@ -85,7 +85,8 @@ def _clear_redis_state():
     for key_regex in [
         "*_state",
         "IMSI*",
-        "mobilityd:ip_states:IPState.RESERVED",
+        "mobilityd:assigned_ip_blocks",
+        "mobilityd:ip_states:*",
         "NO_VLAN:mobilityd_gw_info",
         "QosManager",
         "s1ap_imsi_map",


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

Some of the mobilityd Redis keys were not getting cleaned up when sctpd restarted. This change fixes that.

## Test Plan

On test VM:
- Run `make integ_test TESTS=s1aptests/test_attach_detach_with_mme_restart.py` to create the keys in Redis. Kill the test while MME is restarting, so that the keys stay in Redis on gateway VM

On gateway VM:
- Check that the keys exist
```
$ magtivate && state_cli.py keys mobility*
mobilityd:ip_states:IPState.FREE
mobilityd:systemd_status
mobilityd:assigned_ip_blocks
mobilityd:ip_states:IPState.ALLOCATED
mobilityd:ip_states:IPState.RESERVED
```
- Restart sctpd with `$ sudo service sctpd restart`
- In a separate terminal run `$ watch state_cli.py keys mobilityd*` 
- All the keys disappear as sctpd restarts and then mobilityd comes back with just 
`mobilityd:systemd_status`

and later:
```
mobilityd:ip_states:IPState.RESERVED
mobilityd:ip_states:IPState.FREE
mobilityd:systemd_status
mobilityd:assigned_ip_blocks
```