### PR TITLE
[CI] Ignore out-of-order warning in traffic tests

### DIFF
--- a/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
+++ b/lte/gateway/python/integ_tests/s1aptests/util/traffic_util.py
@@ -564,7 +564,10 @@ class TrafficTest(object):
                     raise RuntimeError(
                         'Cached results are not iperf3.TestResult objects')
                 if result.error:
-                    raise RuntimeError(result.error)
+                    # iPerf dumps out-of-order packet information on stderr,
+                    # ignore these while verifying the test results
+                    if "OUT OF ORDER" not in result.error:
+                        raise RuntimeError(result.error)
 
     def wait(self):
         ''' Wait for this test to complete '''


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

iPerf prints out-of-order packets on stderr even though it is not an actual error. This was causing S1ap traffic tests to fail. This change fixes the traffic util to ignore the error if it includes out-of-order text.

## Test Plan

Run `make integ_test` locally multiple times and also run a job in Circle CI

