### PR TITLE
Bumping agw version to 1.4.0

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -20,8 +20,8 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
-VERSION=1.3.2 # magma version number
-SCTPD_MIN_VERSION=1.3.1 # earliest version of sctpd with which this version is compatible
+VERSION=1.4.0 # magma version number
+SCTPD_MIN_VERSION=1.4.0 # earliest version of sctpd with which this version is compatible
 
 # RelWithDebInfo or Debug
 BUILD_TYPE=Debug


### PR DESCRIPTION
Signed-off-by: Timothée Dzik <timdzik@fb.com>

Bumping agw version to 1.4.0

## Summary

Bumping agw version to 1.4.0

## Test Plan
wait for lte-agw-deploy to run and make sure it produces magma_1.4.0 package