### PR TITLE
[lte][agw] Fix for stateless pco crash

### DIFF
--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -279,6 +279,10 @@ int sgw_handle_s11_create_session_request(
         &s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
              .saved_message,
         session_req_pP, sizeof(itti_s11_create_session_request_t));
+    copy_protocol_configuration_options(
+        &s_plus_p_gw_eps_bearer_ctxt_info_p->sgw_eps_bearer_context_information
+             .saved_message.pco,
+        &session_req_pP->pco);
 
     /*
      * Send a create bearer request to PGW and handle respond


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

The create session request message content is stored as part of the bearer context during session creation procedure. When PCO options are present, however, the copy was a shallow copy and PCO field was not copied properly. In stateless mode, during serde operations this bug surfaces due to race conditions as the original message is eventually deleted before the state was committed.

## Test Plan

Lab testing.
Integration testing.

## Additional Information

- [ ] This change is backwards-breaking

