### PR TITLE
[NMS] Fix the subscriber state and graphs to pull the right metric

### DIFF
--- a/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
+++ b/nms/app/packages/magmalte/app/state/lte/SubscriberState.js
@@ -73,8 +73,8 @@ export default async function InitSubscriberState(
   if (setSubscriberMetrics) {
     const subscriberMetrics = {};
     const queries = {
-      dailyAvg: 'avg (avg_over_time(ue_traffic[24h])) by (IMSI)',
-      currentUsage: 'sum (ue_traffic) by (IMSI)',
+      dailyAvg: 'avg (avg_over_time(ue_reported_usage[24h])) by (IMSI)',
+      currentUsage: 'sum (ue_reported_usage) by (IMSI)',
     };
 
     const requests = Object.keys(queries).map(async (queryType: string) => {

--- a/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
+++ b/nms/app/packages/magmalte/app/views/subscriber/SubscriberChart.js
@@ -72,12 +72,12 @@ async function getDatasets(props: DatasetFetchProps) {
 
   const queries = [
     {
-      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+      q: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
       color: colors.secondary.dodgerBlue,
       label: 'download',
     },
     {
-      q: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="up"}[${step}]))`,
+      q: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="up"}[${step}]))`,
       color: colors.data.flamePea,
       label: 'upload',
     },
@@ -156,7 +156,7 @@ function SubscriberDataKPI() {
           const result = await MagmaV1API.getNetworksByNetworkIdPrometheusQuery(
             {
               networkId,
-              query: `sum(increase(ue_traffic{IMSI="${subscriberId}",direction="down"}[${step}]))`,
+              query: `sum(increase(ue_reported_usage{IMSI="${subscriberId}",direction="down"}[${step}]))`,
             },
           );
           const [value, unit] = getLabelUnit(getPromValue(result));


### PR DESCRIPTION
Signed-off-by: Karthik Subraveti <ksubraveti@fb.com>

## Summary
ue_traffic metric got deprecated. Using ue_reported_usage. 
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Graphs and KPIs show as expected
![Screen Shot 2020-12-17 at 2 08 46 PM](https://user-images.githubusercontent.com/8224854/102549797-96c66a80-4071-11eb-8dc3-20aa7f9e97e3.png)
![Screen Shot 2020-12-17 at 2 08 51 PM](https://user-images.githubusercontent.com/8224854/102549805-9928c480-4071-11eb-9a61-1aa78f641a2b.png)
closes #4037 
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
