### PR TITLE
[lte][enb][indexing] Fix enodeb state indexing incorrect gwID

### DIFF
--- a/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
+++ b/lte/cloud/go/services/lte/servicers/indexer_servicer_test.go
@@ -24,11 +24,16 @@ import (
 	"magma/lte/cloud/go/services/lte/obsidian/models"
 	lte_test_init "magma/lte/cloud/go/services/lte/test_init"
 	"magma/orc8r/cloud/go/clock"
+	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/serde"
+	"magma/orc8r/cloud/go/services/configurator"
+	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
+	models2 "magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
 	"magma/orc8r/cloud/go/services/state/indexer"
 	state_types "magma/orc8r/cloud/go/services/state/types"
+	"magma/orc8r/cloud/go/storage"
 
 	"github.com/go-openapi/swag"
 	assert "github.com/stretchr/testify/require"
@@ -43,7 +48,7 @@ func TestIndexerEnodebState(t *testing.T) {
 	)
 	assert.NoError(t, plugin.RegisterPluginForTests(t, &pluginimpl.BaseOrchestratorPlugin{}))
 	assert.NoError(t, plugin.RegisterPluginForTests(t, &lte_plugin.LteOrchestratorPlugin{}))
-
+	configurator_test_init.StartTestService(t)
 	lte_test_init.StartTestService(t)
 	idx := indexer.NewRemoteIndexer(lte_service.ServiceName, version, types...)
 
@@ -51,46 +56,90 @@ func TestIndexerEnodebState(t *testing.T) {
 	id2 := state_types.ID{Type: lte.EnodebStateType, DeviceID: "123"}
 	id3 := state_types.ID{Type: lte.MobilitydStateType, DeviceID: "555"}
 
+	networkID := "nid0"
+	gatewayID1 := "g1"
+	hwID1 := "hw1"
+	gatewayID2 := "g2"
+	hwID2 := "hw2"
+	enbSN := "123"
+
+	// Setup gw ents to be fetched during indexing
+	seedNetwork(t, networkID)
+	seedTier(t, networkID)
+	seedGateway(t, networkID, gatewayID1, hwID1)
+	seedGateway(t, networkID, gatewayID2, hwID2)
+
 	enbState1 := models.NewDefaultEnodebStatus()
 	enbState2 := models.NewDefaultEnodebStatus()
 	serializedState1 := serialize(t, enbState1)
 	enbState2.MmeConnected = swag.Bool(false)
 	serializedState2 := serialize(t, enbState2)
 	stateGw1 := state_types.SerializedStatesByID{
-		id1: {SerializedReportedState: serializedState1, ReporterID: "g1"},
+		id1: {SerializedReportedState: serializedState1, ReporterID: hwID1},
 	}
 	stateGw2 := state_types.SerializedStatesByID{
-		id2: {SerializedReportedState: serializedState2, ReporterID: "g2"},
+		id2: {SerializedReportedState: serializedState2, ReporterID: hwID2},
 	}
 
 	clock.SetAndFreezeClock(t, time.Now())
 	// Index the imsi0->sid0 state, result is sid0->imsi0 reverse mapping
-	errs, err := idx.Index("nid0", stateGw1)
+	errs, err := idx.Index(networkID, stateGw1)
 	assert.NoError(t, err)
 	assert.Empty(t, errs)
-	errs, err = idx.Index("nid0", stateGw2)
+	errs, err = idx.Index(networkID, stateGw2)
 	assert.NoError(t, err)
 	assert.Empty(t, errs)
-	gotA, err := lte_service.GetEnodebState("nid0", "g1", "123")
+	gotA, err := lte_service.GetEnodebState(networkID, gatewayID1, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState1, gotA)
-	gotB, err := lte_service.GetEnodebState("nid0", "g2", "123")
+	gotB, err := lte_service.GetEnodebState(networkID, gatewayID2, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState2, gotB)
 
 	// Correctly handle per-state errs
 	states := state_types.SerializedStatesByID{
-		id1: {SerializedReportedState: serializedState2, ReporterID: "g1"},
-		id3: {SerializedReportedState: serializedState2, ReporterID: "g3"},
+		id1: {SerializedReportedState: serializedState2, ReporterID: hwID1},
+		id3: {SerializedReportedState: serializedState2, ReporterID: "hw3"},
 	}
-	errs, err = idx.Index("nid0", states)
+	errs, err = idx.Index(networkID, states)
 	assert.NoError(t, err)
 	assert.Error(t, errs[id3])
-	gotC, err := lte_service.GetEnodebState("nid0", "g1", "123")
+	gotC, err := lte_service.GetEnodebState(networkID, gatewayID1, enbSN)
 	assert.NoError(t, err)
 	assert.Equal(t, enbState2, gotC)
 }
 
+func seedNetwork(t *testing.T, networkID string) {
+	err := configurator.CreateNetwork(configurator.Network{ID: networkID}, serdes.Network)
+	assert.NoError(t, err)
+}
+
+func seedGateway(t *testing.T, networkID string, gatewayID string, hwID string) {
+	_, err := configurator.CreateEntity(
+		networkID,
+		configurator.NetworkEntity{
+			Type:         orc8r.MagmadGatewayType,
+			Key:          gatewayID,
+			Config:       &models2.MagmadGatewayConfigs{},
+			PhysicalID:   hwID,
+			Associations: []storage.TypeAndKey{{Type: orc8r.UpgradeTierEntityType, Key: "t0"}},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+}
+
+func seedTier(t *testing.T, networkID string) {
+	// setup fixtures in backend
+	_, err := configurator.CreateEntities(
+		networkID,
+		[]configurator.NetworkEntity{
+			{Type: orc8r.UpgradeTierEntityType, Key: "t0"},
+		},
+		serdes.Entity,
+	)
+	assert.NoError(t, err)
+}
 func serialize(t *testing.T, enodebState *models.EnodebState) []byte {
 	bytes, err := serde.Serialize(enodebState, lte.EnodebStateType, serdes.State)
 	assert.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR fixes an issue with the ENB state indexing where the 
gatewayID being saved was actually the gateway's hardwareID.
When the lookup occurred, the state was not found because the
gatewayID wasn't stored as a key.

## Test Plan

Corrected unit test to use hwID are reporterID
`make precommit`

