### PR TITLE
[feg] S8 client with basic functionality

### DIFF
--- a/feg/gateway/gtp/gtp_client.go
+++ b/feg/gateway/gtp/gtp_client.go
@@ -97,6 +97,9 @@ func (c *Client) Run(ctx context.Context) error {
 		return fmt.Errorf("nil conn object. You may need to Enable the client first")
 	}
 	go func() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
 		if err := c.ListenAndServe(ctx); err != nil {
 			glog.Errorf("error running gtp server: %s", err)
 			return

--- a/feg/gateway/services/s6a_proxy/client.go
+++ b/feg/gateway/services/s6a_proxy/client.go
@@ -22,12 +22,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/golang/glog"
-	"google.golang.org/grpc"
-
 	"magma/feg/cloud/go/protos"
 	"magma/feg/gateway/registry"
 	"magma/orc8r/lib/go/util"
+
+	"github.com/golang/glog"
+	"google.golang.org/grpc"
 )
 
 type s6aProxyClient struct {

--- a/feg/gateway/services/s8_proxy/client_api.go
+++ b/feg/gateway/services/s8_proxy/client_api.go
@@ -12,3 +12,39 @@ limitations under the License.
 */
 
 package s8_proxy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/registry"
+
+	"github.com/golang/glog"
+)
+
+type s8ProxyClient struct {
+	protos.S8ProxyClient
+}
+
+func CreateSession(req *protos.CreateSessionRequestPgw) (*protos.CreateSessionResponsePgw, error) {
+	if req == nil {
+		return nil, errors.New("Invalid CreateSessionRequestPgw")
+	}
+	cli, err := getS8ProxyClient()
+	if err != nil {
+		return nil, err
+	}
+	return cli.CreateSession(context.Background(), req)
+}
+
+func getS8ProxyClient() (*s8ProxyClient, error) {
+	conn, err := registry.GetConnection(registry.S8_PROXY)
+	if err != nil {
+		errMsg := fmt.Sprintf("S8 Proxy client initialization error: %s", err)
+		glog.Error(errMsg)
+		return nil, errors.New(errMsg)
+	}
+	return &s8ProxyClient{protos.NewS8ProxyClient(conn)}, nil
+}

--- a/feg/gateway/services/s8_proxy/servicers/config.go
+++ b/feg/gateway/services/s8_proxy/servicers/config.go
@@ -19,6 +19,6 @@ const (
 
 func GetS8ProxyConfig() *S8ProxyConfig {
 	return &S8ProxyConfig{
-		serverAddr: "127.0.0.68",
+		ServerAddr: "127.0.0.68",
 	}
 }

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy.go
@@ -31,13 +31,13 @@ type s8Proxy struct {
 }
 
 type S8ProxyConfig struct {
-	clientAddr string
-	serverAddr string
+	ClientAddr string
+	ServerAddr string
 }
 
 func NewS8Proxy(config *S8ProxyConfig) (*s8Proxy, error) {
 	// TODO: validate config
-	gtpCli, err := gtp.NewConnectedAutoClient(context.Background(), config.serverAddr, gtpv2.IFTypeS5S8SGWGTPC)
+	gtpCli, err := gtp.NewConnectedAutoClient(context.Background(), config.ServerAddr, gtpv2.IFTypeS5S8SGWGTPC)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating S8_Proxy: %s", err)
 	}
@@ -61,7 +61,7 @@ func (s *s8Proxy) CreateSession(ctx context.Context, req *protos.CreateSessionRe
 	}
 
 	// TODO: build grpc CreateSessionResponsePgw message
-	fmt.Printf("this is session response %s", csRes.String())
+	glog.V(2).Infof("This is session response %+v", csRes)
 
 	return &protos.CreateSessionResponsePgw{}, nil
 }

--- a/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
+++ b/feg/gateway/services/s8_proxy/servicers/s8_proxy_test.go
@@ -30,11 +30,8 @@ const (
 )
 
 func TestS8Proxy(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	// Create and run PGW
-	mockPgw, err := mock_pgw.NewStarted(ctx, s8proxyAddrs, pgwAddrs)
+	mockPgw, err := mock_pgw.NewStarted(nil, s8proxyAddrs, pgwAddrs)
 	if err != nil {
 		t.Fatalf("Error creating mock PGW: +%s", err)
 		return
@@ -83,6 +80,6 @@ func TestS8Proxy(t *testing.T) {
 
 func getDefaultConfig(pgwActualAddrs string) *S8ProxyConfig {
 	return &S8ProxyConfig{
-		serverAddr: pgwActualAddrs,
+		ServerAddr: pgwActualAddrs,
 	}
 }

--- a/feg/gateway/tools/s8_cli/main.go
+++ b/feg/gateway/tools/s8_cli/main.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/registry"
+	"magma/feg/gateway/services/s8_proxy/servicers"
+	"magma/feg/gateway/services/s8_proxy/servicers/mock_pgw"
+	lteprotos "magma/lte/cloud/go/protos"
+	"magma/orc8r/cloud/go/tools/commands"
+)
+
+var (
+	cmdRegistry   = new(commands.Map)
+	proxyAddr     string
+	IMSI          string = "123456789012345"
+	useMconfig    bool
+	useBuiltinCli bool
+
+	testServer     bool
+	testServerAddr string = "127.0.0.1:0"
+	pgwServerAddr  string
+)
+
+func init() {
+	// Enable logging
+	flag.Set("v", "10")             // enable the most verbose logging, can be overwritten by 'v' flag
+	flag.Set("logtostderr", "true") // enable printing to console, can be overwritten by 'logtostderr' flag
+
+	// Create Session command
+	csCmd := cmdRegistry.Add(
+		"CS",
+		"Create Session through S8 proxy", createSession)
+
+	csFlags := csCmd.Flags()
+
+	csFlags.Usage = func() {
+		fmt.Fprintf(os.Stderr,
+			"\tUsage: %s [OPTIONS] %s [%s OPTIONS] <IMSI>\n", os.Args[0], csCmd.Name(), csCmd.Name())
+		csFlags.PrintDefaults()
+	}
+
+	csFlags.BoolVar(&testServer, "test", testServer,
+		fmt.Sprintf("Start local test s8 server bound to default PGW address (%s)", testServerAddr))
+
+	csFlags.StringVar(&pgwServerAddr, "server", pgwServerAddr,
+		"PGW IP addres and port to send request with format ip:port")
+
+	csFlags.BoolVar(&useMconfig, "use_mconfig", false,
+		"Use local gateway.mconfig configuration for local proxy (if set - starts local s6a proxy)")
+
+	csFlags.BoolVar(&useBuiltinCli, "use_builtincli", true,
+		"Use local built in client instead of the running instance on the gateway")
+}
+
+func createSession(cmd *commands.Command, args []string) int {
+	f := cmd.Flags()
+
+	imsi, err := parseArgs(f)
+	if err != nil {
+		fmt.Println(err)
+		cmd.Usage()
+		return 1
+	}
+
+	conf := &servicers.S8ProxyConfig{
+		ClientAddr: "127.0.0.1:0",
+		ServerAddr: pgwServerAddr,
+	}
+
+	// start and configure a test server that will act as a PGW
+	if testServer {
+		pgwServerAddr, err = startTestServer()
+		if err != nil {
+			fmt.Println(err)
+			return 1
+		}
+		// If test server is enabled, pgwServerAddr will be overwritten
+		// and S8 config too
+		conf.ServerAddr = pgwServerAddr
+	}
+
+	var cli s8Cli
+
+	// Selection of builtIn Client or S8proxy running on the gateway
+	if useMconfig || useBuiltinCli {
+		// use builtin proxy (ignore loccal proxy)
+		if useMconfig {
+			conf = servicers.GetS8ProxyConfig()
+		}
+		fmt.Printf("Direct connection using built in S8 client: Client Config: %+v\n", *conf)
+		localProxy, err := servicers.NewS8Proxy(conf)
+		if err != nil {
+			f.Usage()
+			fmt.Printf("BuiltIn S8 Proxy initialization error: %v", err)
+			return 5
+		}
+		cli = s8BuiltIn{localProxy}
+	} else {
+		// TODO: use local proxy running on the gateway
+		proxyAddr, _ = registry.GetServiceAddress(registry.S8_PROXY)
+		cli = s8CliImpl{}
+	}
+
+	// Dummy request
+	csReq := &protos.CreateSessionRequestPgw{
+		Sid: &lteprotos.SubscriberID{
+			Id:   imsi,
+			Type: lteprotos.SubscriberID_IMSI,
+		},
+		MSISDN:               "00111",
+		MEI:                  "111",
+		MCC:                  "222",
+		MNC:                  "333",
+		RatType:              0,
+		IndicationFlag:       nil,
+		BearerId:             5,
+		UserPlaneTeid:        0,
+		S5S8Ip4UserPane:      "127.0.0.10",
+		S5S8Ip6UserPane:      "",
+		Apn:                  "internet.com",
+		SelectionMode:        "",
+		PdnType:              0,
+		PdnAddressAllocation: "",
+		ApnRestriction:       0,
+		AmbrUp:               0,
+		AmbrDown:             0,
+		Uli:                  "",
+	}
+	res, err := cli.CreateSession(csReq)
+
+	if err != nil {
+		fmt.Printf("Create Session cli command failed: %s", err)
+		return 9
+	}
+	fmt.Printf("Create Session returned:\n%s", res)
+	return 0
+}
+
+func parseArgs(f *flag.FlagSet) (string, error) {
+	if f.NArg() < 1 {
+		fmt.Printf("IMSI not provided. Using default IMSI: %s\n", IMSI)
+		return IMSI, nil
+	}
+	if f.NArg() > 1 {
+		return "", fmt.Errorf("Please provide only an IMSI argument - all other parameters should be provided with flags: %+v\n", f.Args())
+	}
+	imsi := strings.TrimSpace(f.Arg(0))
+	err := validateImsi(imsi)
+	if err != nil {
+		return "", err
+	}
+	return imsi, nil
+}
+
+func validateImsi(imsi string) error {
+	if len(imsi) < 6 || len(imsi) > 15 {
+		return fmt.Errorf("The IMSI specified must be 6 - 15 digits long\n\n")
+	}
+	_, err := strconv.ParseUint(imsi, 10, 64)
+	if err != nil {
+		return fmt.Errorf("Invalid IMSI '%s': %v\n\n", imsi, err)
+	}
+	return nil
+}
+
+func startTestServer() (string, error) {
+	// Create and run PGW
+	mockPgw, err := mock_pgw.NewStarted(nil, "", testServerAddr)
+	if err != nil {
+		return "", fmt.Errorf("Error creating test server mock PGW: +%s\n", err)
+	}
+	fmt.Printf("Running test server: mock PGW on %s\n", mockPgw.LocalAddr().String())
+	pgwServerAddr = mockPgw.LocalAddr().String()
+
+	return pgwServerAddr, nil
+}
+
+func main() {
+	flag.Parse()
+	// Init help for all commands
+	flag.Usage = func() {
+		cmd := os.Args[0]
+		fmt.Printf(
+			"\nUsage: \033[1m%s command [OPTIONS]\033[0m\n\n",
+			filepath.Base(cmd))
+		flag.PrintDefaults()
+		fmt.Println("\nCommands:")
+		cmdRegistry.Usage()
+	}
+
+	cmdName := flag.Arg(0)
+	if len(flag.Args()) < 1 || cmdName == "" || cmdName == "help" {
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	cmd := cmdRegistry.Get(cmdName)
+	if cmd == nil {
+		fmt.Println("\nInvalid Command: ", cmdName)
+		flag.Usage()
+		os.Exit(1)
+	}
+	args := os.Args[2:]
+	cmd.Flags().Parse(args)
+	os.Exit(cmd.Handle(args))
+}

--- a/feg/gateway/tools/s8_cli/s8_client.go
+++ b/feg/gateway/tools/s8_cli/s8_client.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"magma/feg/cloud/go/protos"
+	"magma/feg/gateway/services/s8_proxy"
+)
+
+type s8Cli interface {
+	CreateSession(req *protos.CreateSessionRequestPgw) (*protos.CreateSessionResponsePgw, error)
+}
+
+type s8CliImpl struct{}
+
+func (s8CliImpl) CreateSession(req *protos.CreateSessionRequestPgw) (*protos.CreateSessionResponsePgw, error) {
+	return s8_proxy.CreateSession(req)
+}
+
+type s8BuiltIn struct {
+	server protos.S8ProxyServer
+}
+
+func (s s8BuiltIn) CreateSession(req *protos.CreateSessionRequestPgw) (*protos.CreateSessionResponsePgw, error) {
+	return s.server.CreateSession(context.Background(), req)
+}


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR adds a basic client to run Create Session through S8. It uses a dummy hardcoded request.

It works using the test server. Will add automated tests once we are done with the mconfig pr.

## Test Plan

make precommit

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
