### PR TITLE
[CI][AGW][S1ap-tester] Remove flaky test and timer tests in sanity test suite

### DIFF
--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -54,7 +54,6 @@ s1aptests/test_attach_detach_security_algo_eea2_eia2.py \
 s1aptests/test_attach_detach_emm_status.py \
 s1aptests/test_attach_detach_enb_rlf_initial_ue_msg.py \
 s1aptests/test_attach_detach_ICS_Failure.py \
-s1aptests/test_attach_detach_ps_service_not_available.py \
 s1aptests/test_attach_missing_imsi.py \
 s1aptests/test_duplicate_attach.py \
 s1aptests/test_enb_partial_reset_con_dereg.py \
@@ -128,12 +127,14 @@ s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_mobile_reachability_timer_with_mme_restart.py \
-s1aptests/test_implicit_detach_timer_with_mme_restart.py \
-s1aptests/test_ics_timer_expiry_with_mme_restart.py \
 s1aptests/test_service_req_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
 s1aptests/test_restore_mme_config_after_sanity.py
+
+# Enable these tests once the CI job time-out has increased
+# s1aptests/test_mobile_reachability_timer_with_mme_restart.py \
+# s1aptests/test_implicit_detach_timer_with_mme_restart.py \
+# s1aptests/test_ics_timer_expiry_with_mme_restart.py \
 
 # These test cases pass without memory leaks, but needs DL-route in TRF server
 # sudo /sbin/route add -net 192.168.128.0 gw 192.168.60.142
@@ -143,6 +144,7 @@ s1aptests/test_restore_mme_config_after_sanity.py
 # s1aptests/test_attach_detach_attach_dl_tcp_data.py
 
 # TODO flaky tests we should look at
+# s1aptests/test_attach_detach_ps_service_not_available.py \
 # s1aptests/test_enb_complete_reset.py \
 # s1aptests/test_attach_detach_multi_ue_looped.py \
 


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

The CI job has been failing due to
- Flaky test `test_attach_detach_ps_service_not_available.py` @ssanadhya to fix this
- Time out while waiting for the timer tests to run. @tmdzk will fix the timeout in the fabric file and Circle CI job and re-enable these tests.

Commenting out these tests to unblock CI

## Test Plan

N/A
