### PR TITLE
[orc8r][nginx] Update nginx conf to backend to pods correctly

### DIFF
--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -87,13 +87,17 @@ http {
       {%- endif %}
 
       {%- if service_registry_mode == 'k8s' %}
+      # certifier is internal only service
+      if ($srv = "certifier") {
+        return 403;
+      }
       # Helm services don't allow for underscores. Magma convention is
       # to use underscores in service names, so convert any hyphens in the
       # k8s service name.
       if ($srv ~* "(\w+)[_](\w+)") {
         set $srv "$1-$2";
       }
-      grpc_pass grpc://orc8r-$srv:9180;
+      grpc_pass grpc://orc8r-$srv.{{ backend }}:9180;
       grpc_set_header Host $srv:9180;
 
       {%- else %}
@@ -131,7 +135,7 @@ http {
       if ($srv ~* "(\w+)[_](\w+)") {
         set $srv "$1-$2";
       }
-      grpc_pass grpc://orc8r-$srv:9180;
+      grpc_pass grpc://orc8r-$srv.{{ backend }}:9180;
       {%- else %}
       grpc_pass grpc://{{ backend }}:$open_srvport;
       {%- endif %}
@@ -157,7 +161,7 @@ http {
       {%- endif %}
 
       {%- if service_registry_mode == 'k8s' %}
-      proxy_pass http://orc8r-obsidian:8080;
+      proxy_pass http://orc8r-obsidian.{{ backend }}:8080;
       {%- else %}
       proxy_pass http://{{ backend }}:9081;
       {%- endif %}

--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.4
+version: 1.5.5
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/nginx.deployment.yaml
@@ -75,7 +75,7 @@ spec:
               containerPort: {{ .Values.nginx.service.port.health.targetPort }}
           env:
             - name: PROXY_BACKENDS
-              value: {{ print .Release.Name "-controller." .Release.Namespace ".svc.cluster.local" | quote }}
+              value: {{ print .Release.Namespace ".svc.cluster.local" | quote }}
             - name: CONTROLLER_HOSTNAME
               value: {{ required "nginx.spec.hostname must be provided" .Values.nginx.spec.hostname | quote }}
             - name: RESOLVER


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

This PR fixes an issue in the nginx config for service
mesh where the orc8r service name was missing the 
kube cluster backend and thus not properly backending
to the pods.

## Summary

## Test Plan
Tested live