### PR TITLE
[lte][agw] Extending enbConnected to enbState on s1ap_service 

### DIFF
--- a/lte/cloud/go/protos/s1ap_service.pb.go
+++ b/lte/cloud/go/protos/s1ap_service.pb.go
@@ -25,8 +25,8 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
+// enb_state_map { eNB IDs -> # UEs connected }
 type EnbStateResult struct {
-	// enb ids -> num of UEs connected
 	EnbStateMap          map[uint32]uint32 `protobuf:"bytes,1,rep,name=enb_state_map,json=enbStateMap,proto3" json:"enb_state_map,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
 	XXX_unrecognized     []byte            `json:"-"`
@@ -73,7 +73,7 @@ func init() {
 func init() { proto.RegisterFile("lte/protos/s1ap_service.proto", fileDescriptor_b760ca1045684df1) }
 
 var fileDescriptor_b760ca1045684df1 = []byte{
-	// 246 bytes of a gzipped FileDescriptorProto
+	// 249 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcd, 0x29, 0x49, 0xd5,
 	0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x2f, 0xd6, 0x2f, 0x36, 0x4c, 0x2c, 0x88, 0x2f, 0x4e, 0x2d, 0x2a,
 	0xcb, 0x4c, 0x4e, 0xd5, 0x03, 0x8b, 0x09, 0x71, 0xe6, 0x26, 0xa6, 0xe7, 0x26, 0xea, 0xe5, 0x94,
@@ -85,11 +85,11 @@ var fileDescriptor_b760ca1045684df1 = []byte{
 	0x44, 0xa4, 0xec, 0xb8, 0x04, 0xd0, 0x15, 0x08, 0x09, 0x70, 0x31, 0x67, 0xa7, 0x56, 0x4a, 0x30,
 	0x2a, 0x30, 0x6a, 0xf0, 0x06, 0x81, 0x98, 0x42, 0x22, 0x5c, 0xac, 0x65, 0x89, 0x39, 0xa5, 0xa9,
 	0x12, 0x4c, 0x60, 0x31, 0x08, 0xc7, 0x8a, 0xc9, 0x82, 0xd1, 0xc8, 0x87, 0x8b, 0x3b, 0xd8, 0x30,
-	0xb1, 0x20, 0x18, 0xe2, 0x3b, 0x21, 0x5b, 0x2e, 0x6e, 0xf7, 0xd4, 0x12, 0x98, 0x89, 0x42, 0x82,
-	0x50, 0x67, 0x81, 0xbd, 0xa8, 0x17, 0x96, 0x9f, 0x99, 0x22, 0x25, 0x89, 0xd3, 0xa5, 0x4a, 0x0c,
-	0x4e, 0xd2, 0x51, 0x92, 0x60, 0x59, 0x7d, 0x50, 0xe8, 0x25, 0xe7, 0xe4, 0x97, 0xa6, 0xe8, 0xa7,
-	0xe7, 0x43, 0x83, 0x26, 0x89, 0x0d, 0x4c, 0x1b, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0xce, 0xf1,
-	0xd5, 0x60, 0x5b, 0x01, 0x00, 0x00,
+	0xb1, 0x20, 0x18, 0xe2, 0x3b, 0x21, 0x5b, 0x2e, 0x6e, 0xf7, 0xd4, 0x12, 0x57, 0x3f, 0x27, 0xb0,
+	0x89, 0x42, 0x82, 0x50, 0x67, 0x81, 0xbd, 0xa8, 0x17, 0x96, 0x9f, 0x99, 0x22, 0x25, 0x89, 0xd3,
+	0xa5, 0x4a, 0x0c, 0x4e, 0xd2, 0x51, 0x92, 0x60, 0x59, 0x7d, 0x50, 0xe8, 0x25, 0xe7, 0xe4, 0x97,
+	0xa6, 0xe8, 0xa7, 0xe7, 0x43, 0x83, 0x26, 0x89, 0x0d, 0x4c, 0x1b, 0x03, 0x02, 0x00, 0x00, 0xff,
+	0xff, 0xba, 0x99, 0x68, 0xb2, 0x5b, 0x01, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -104,7 +104,8 @@ const _ = grpc.SupportPackageIsVersion6
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type S1ApServiceClient interface {
-	GetEnbState(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbStateResult, error)
+	// Returns state of the S1 connected eNBs
+	GetENBState(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbStateResult, error)
 }
 
 type s1ApServiceClient struct {
@@ -115,9 +116,9 @@ func NewS1ApServiceClient(cc grpc.ClientConnInterface) S1ApServiceClient {
 	return &s1ApServiceClient{cc}
 }
 
-func (c *s1ApServiceClient) GetEnbState(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbStateResult, error) {
+func (c *s1ApServiceClient) GetENBState(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbStateResult, error) {
 	out := new(EnbStateResult)
-	err := c.cc.Invoke(ctx, "/magma.lte.S1apService/GetEnbState", in, out, opts...)
+	err := c.cc.Invoke(ctx, "/magma.lte.S1apService/GetENBState", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -126,35 +127,36 @@ func (c *s1ApServiceClient) GetEnbState(ctx context.Context, in *protos.Void, op
 
 // S1ApServiceServer is the server API for S1ApService service.
 type S1ApServiceServer interface {
-	GetEnbState(context.Context, *protos.Void) (*EnbStateResult, error)
+	// Returns state of the S1 connected eNBs
+	GetENBState(context.Context, *protos.Void) (*EnbStateResult, error)
 }
 
 // UnimplementedS1ApServiceServer can be embedded to have forward compatible implementations.
 type UnimplementedS1ApServiceServer struct {
 }
 
-func (*UnimplementedS1ApServiceServer) GetEnbState(ctx context.Context, req *protos.Void) (*EnbStateResult, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetEnbState not implemented")
+func (*UnimplementedS1ApServiceServer) GetENBState(ctx context.Context, req *protos.Void) (*EnbStateResult, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetENBState not implemented")
 }
 
 func RegisterS1ApServiceServer(s *grpc.Server, srv S1ApServiceServer) {
 	s.RegisterService(&_S1ApService_serviceDesc, srv)
 }
 
-func _S1ApService_GetEnbState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _S1ApService_GetENBState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(protos.Void)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(S1ApServiceServer).GetEnbState(ctx, in)
+		return srv.(S1ApServiceServer).GetENBState(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/magma.lte.S1apService/GetEnbState",
+		FullMethod: "/magma.lte.S1apService/GetENBState",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(S1ApServiceServer).GetEnbState(ctx, req.(*protos.Void))
+		return srv.(S1ApServiceServer).GetENBState(ctx, req.(*protos.Void))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -164,8 +166,8 @@ var _S1ApService_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*S1ApServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "GetEnbState",
-			Handler:    _S1ApService_GetEnbState_Handler,
+			MethodName: "GetENBState",
+			Handler:    _S1ApService_GetENBState_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lte/cloud/go/protos/s1ap_service.pb.go
+++ b/lte/cloud/go/protos/s1ap_service.pb.go
@@ -25,66 +25,71 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.ProtoPackageIsVersion3 // please upgrade the proto package
 
-type EnbConnectedResult struct {
-	EnbIds               []uint32 `protobuf:"varint,1,rep,packed,name=enb_ids,json=enbIds,proto3" json:"enb_ids,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
+type EnbStateResult struct {
+	// enb ids -> num of UEs connected
+	EnbStateMap          map[uint32]uint32 `protobuf:"bytes,1,rep,name=enb_state_map,json=enbStateMap,proto3" json:"enb_state_map,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}          `json:"-"`
+	XXX_unrecognized     []byte            `json:"-"`
+	XXX_sizecache        int32             `json:"-"`
 }
 
-func (m *EnbConnectedResult) Reset()         { *m = EnbConnectedResult{} }
-func (m *EnbConnectedResult) String() string { return proto.CompactTextString(m) }
-func (*EnbConnectedResult) ProtoMessage()    {}
-func (*EnbConnectedResult) Descriptor() ([]byte, []int) {
+func (m *EnbStateResult) Reset()         { *m = EnbStateResult{} }
+func (m *EnbStateResult) String() string { return proto.CompactTextString(m) }
+func (*EnbStateResult) ProtoMessage()    {}
+func (*EnbStateResult) Descriptor() ([]byte, []int) {
 	return fileDescriptor_b760ca1045684df1, []int{0}
 }
 
-func (m *EnbConnectedResult) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_EnbConnectedResult.Unmarshal(m, b)
+func (m *EnbStateResult) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_EnbStateResult.Unmarshal(m, b)
 }
-func (m *EnbConnectedResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_EnbConnectedResult.Marshal(b, m, deterministic)
+func (m *EnbStateResult) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_EnbStateResult.Marshal(b, m, deterministic)
 }
-func (m *EnbConnectedResult) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_EnbConnectedResult.Merge(m, src)
+func (m *EnbStateResult) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_EnbStateResult.Merge(m, src)
 }
-func (m *EnbConnectedResult) XXX_Size() int {
-	return xxx_messageInfo_EnbConnectedResult.Size(m)
+func (m *EnbStateResult) XXX_Size() int {
+	return xxx_messageInfo_EnbStateResult.Size(m)
 }
-func (m *EnbConnectedResult) XXX_DiscardUnknown() {
-	xxx_messageInfo_EnbConnectedResult.DiscardUnknown(m)
+func (m *EnbStateResult) XXX_DiscardUnknown() {
+	xxx_messageInfo_EnbStateResult.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_EnbConnectedResult proto.InternalMessageInfo
+var xxx_messageInfo_EnbStateResult proto.InternalMessageInfo
 
-func (m *EnbConnectedResult) GetEnbIds() []uint32 {
+func (m *EnbStateResult) GetEnbStateMap() map[uint32]uint32 {
 	if m != nil {
-		return m.EnbIds
+		return m.EnbStateMap
 	}
 	return nil
 }
 
 func init() {
-	proto.RegisterType((*EnbConnectedResult)(nil), "magma.lte.EnbConnectedResult")
+	proto.RegisterType((*EnbStateResult)(nil), "magma.lte.EnbStateResult")
+	proto.RegisterMapType((map[uint32]uint32)(nil), "magma.lte.EnbStateResult.EnbStateMapEntry")
 }
 
 func init() { proto.RegisterFile("lte/protos/s1ap_service.proto", fileDescriptor_b760ca1045684df1) }
 
 var fileDescriptor_b760ca1045684df1 = []byte{
-	// 194 bytes of a gzipped FileDescriptorProto
+	// 246 bytes of a gzipped FileDescriptorProto
 	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x92, 0xcd, 0x29, 0x49, 0xd5,
 	0x2f, 0x28, 0xca, 0x2f, 0xc9, 0x2f, 0xd6, 0x2f, 0x36, 0x4c, 0x2c, 0x88, 0x2f, 0x4e, 0x2d, 0x2a,
 	0xcb, 0x4c, 0x4e, 0xd5, 0x03, 0x8b, 0x09, 0x71, 0xe6, 0x26, 0xa6, 0xe7, 0x26, 0xea, 0xe5, 0x94,
 	0xa4, 0x4a, 0x49, 0xe6, 0x17, 0x25, 0x5b, 0x14, 0xc1, 0xd4, 0x26, 0xe7, 0xe7, 0xe6, 0xe6, 0xe7,
-	0x41, 0x54, 0x29, 0xe9, 0x72, 0x09, 0xb9, 0xe6, 0x25, 0x39, 0xe7, 0xe7, 0xe5, 0xa5, 0x26, 0x97,
-	0xa4, 0xa6, 0x04, 0xa5, 0x16, 0x97, 0xe6, 0x94, 0x08, 0x89, 0x73, 0xb1, 0xa7, 0xe6, 0x25, 0xc5,
-	0x67, 0xa6, 0x14, 0x4b, 0x30, 0x2a, 0x30, 0x6b, 0xf0, 0x06, 0xb1, 0xa5, 0xe6, 0x25, 0x79, 0xa6,
-	0x14, 0x1b, 0x85, 0x70, 0x71, 0x07, 0x1b, 0x26, 0x16, 0x04, 0x43, 0x6c, 0x12, 0x72, 0xe5, 0xe2,
-	0x77, 0x4f, 0x2d, 0x41, 0x36, 0x40, 0x48, 0x50, 0x0f, 0x62, 0x2f, 0xd8, 0x4a, 0xbd, 0xb0, 0xfc,
-	0xcc, 0x14, 0x29, 0x59, 0x3d, 0xb8, 0x53, 0xf4, 0x30, 0x2d, 0x53, 0x62, 0x70, 0x92, 0x8e, 0x92,
-	0x04, 0xab, 0xd0, 0x07, 0xf9, 0x28, 0x39, 0x27, 0xbf, 0x34, 0x45, 0x3f, 0x3d, 0x1f, 0xea, 0xdc,
-	0x24, 0x36, 0x30, 0x6d, 0x0c, 0x08, 0x00, 0x00, 0xff, 0xff, 0xa0, 0x07, 0x2f, 0x5d, 0xef, 0x00,
-	0x00, 0x00,
+	0x41, 0x54, 0x29, 0x2d, 0x60, 0xe4, 0xe2, 0x73, 0xcd, 0x4b, 0x0a, 0x2e, 0x49, 0x2c, 0x49, 0x0d,
+	0x4a, 0x2d, 0x2e, 0xcd, 0x29, 0x11, 0xf2, 0xe3, 0xe2, 0x4d, 0xcd, 0x4b, 0x8a, 0x2f, 0x06, 0x09,
+	0xc5, 0xe7, 0x26, 0x16, 0x48, 0x30, 0x2a, 0x30, 0x6b, 0x70, 0x1b, 0x69, 0xe9, 0xc1, 0x0d, 0xd4,
+	0x43, 0xd5, 0x01, 0xe7, 0xfa, 0x26, 0x16, 0xb8, 0xe6, 0x95, 0x14, 0x55, 0x06, 0x71, 0xa7, 0x22,
+	0x44, 0xa4, 0xec, 0xb8, 0x04, 0xd0, 0x15, 0x08, 0x09, 0x70, 0x31, 0x67, 0xa7, 0x56, 0x4a, 0x30,
+	0x2a, 0x30, 0x6a, 0xf0, 0x06, 0x81, 0x98, 0x42, 0x22, 0x5c, 0xac, 0x65, 0x89, 0x39, 0xa5, 0xa9,
+	0x12, 0x4c, 0x60, 0x31, 0x08, 0xc7, 0x8a, 0xc9, 0x82, 0xd1, 0xc8, 0x87, 0x8b, 0x3b, 0xd8, 0x30,
+	0xb1, 0x20, 0x18, 0xe2, 0x3b, 0x21, 0x5b, 0x2e, 0x6e, 0xf7, 0xd4, 0x12, 0x98, 0x89, 0x42, 0x82,
+	0x50, 0x67, 0x81, 0xbd, 0xa8, 0x17, 0x96, 0x9f, 0x99, 0x22, 0x25, 0x89, 0xd3, 0xa5, 0x4a, 0x0c,
+	0x4e, 0xd2, 0x51, 0x92, 0x60, 0x59, 0x7d, 0x50, 0xe8, 0x25, 0xe7, 0xe4, 0x97, 0xa6, 0xe8, 0xa7,
+	0xe7, 0x43, 0x83, 0x26, 0x89, 0x0d, 0x4c, 0x1b, 0x03, 0x02, 0x00, 0x00, 0xff, 0xff, 0xce, 0xf1,
+	0xd5, 0x60, 0x5b, 0x01, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -99,7 +104,7 @@ const _ = grpc.SupportPackageIsVersion6
 //
 // For semantics around ctx use and closing/ending streaming RPCs, please refer to https://godoc.org/google.golang.org/grpc#ClientConn.NewStream.
 type S1ApServiceClient interface {
-	GetEnbConnected(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbConnectedResult, error)
+	GetEnbState(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbStateResult, error)
 }
 
 type s1ApServiceClient struct {
@@ -110,9 +115,9 @@ func NewS1ApServiceClient(cc grpc.ClientConnInterface) S1ApServiceClient {
 	return &s1ApServiceClient{cc}
 }
 
-func (c *s1ApServiceClient) GetEnbConnected(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbConnectedResult, error) {
-	out := new(EnbConnectedResult)
-	err := c.cc.Invoke(ctx, "/magma.lte.S1apService/GetEnbConnected", in, out, opts...)
+func (c *s1ApServiceClient) GetEnbState(ctx context.Context, in *protos.Void, opts ...grpc.CallOption) (*EnbStateResult, error) {
+	out := new(EnbStateResult)
+	err := c.cc.Invoke(ctx, "/magma.lte.S1apService/GetEnbState", in, out, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -121,35 +126,35 @@ func (c *s1ApServiceClient) GetEnbConnected(ctx context.Context, in *protos.Void
 
 // S1ApServiceServer is the server API for S1ApService service.
 type S1ApServiceServer interface {
-	GetEnbConnected(context.Context, *protos.Void) (*EnbConnectedResult, error)
+	GetEnbState(context.Context, *protos.Void) (*EnbStateResult, error)
 }
 
 // UnimplementedS1ApServiceServer can be embedded to have forward compatible implementations.
 type UnimplementedS1ApServiceServer struct {
 }
 
-func (*UnimplementedS1ApServiceServer) GetEnbConnected(ctx context.Context, req *protos.Void) (*EnbConnectedResult, error) {
-	return nil, status.Errorf(codes.Unimplemented, "method GetEnbConnected not implemented")
+func (*UnimplementedS1ApServiceServer) GetEnbState(ctx context.Context, req *protos.Void) (*EnbStateResult, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method GetEnbState not implemented")
 }
 
 func RegisterS1ApServiceServer(s *grpc.Server, srv S1ApServiceServer) {
 	s.RegisterService(&_S1ApService_serviceDesc, srv)
 }
 
-func _S1ApService_GetEnbConnected_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _S1ApService_GetEnbState_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(protos.Void)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(S1ApServiceServer).GetEnbConnected(ctx, in)
+		return srv.(S1ApServiceServer).GetEnbState(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: "/magma.lte.S1apService/GetEnbConnected",
+		FullMethod: "/magma.lte.S1apService/GetEnbState",
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(S1ApServiceServer).GetEnbConnected(ctx, req.(*protos.Void))
+		return srv.(S1ApServiceServer).GetEnbState(ctx, req.(*protos.Void))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -159,8 +164,8 @@ var _S1ApService_serviceDesc = grpc.ServiceDesc{
 	HandlerType: (*S1ApServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
 		{
-			MethodName: "GetEnbConnected",
-			Handler:    _S1ApService_GetEnbConnected_Handler,
+			MethodName: "GetEnbState",
+			Handler:    _S1ApService_GetEnbState_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/lte/cloud/go/services/lte/obsidian/models/defaults.go
+++ b/lte/cloud/go/services/lte/obsidian/models/defaults.go
@@ -15,6 +15,7 @@ package models
 
 import "github.com/go-openapi/swag"
 
+// Move default config function to test_models package
 func NewDefaultTDDNetworkConfig() *NetworkCellularConfigs {
 	return &NetworkCellularConfigs{
 		Ran: &NetworkRanConfigs{
@@ -41,6 +42,7 @@ func NewDefaultTDDNetworkConfig() *NetworkCellularConfigs {
 	}
 }
 
+// Move default config function to test_models package
 func NewDefaultFDDNetworkConfig() *NetworkCellularConfigs {
 	return &NetworkCellularConfigs{
 		Ran: &NetworkRanConfigs{
@@ -65,6 +67,7 @@ func NewDefaultFDDNetworkConfig() *NetworkCellularConfigs {
 	}
 }
 
+// Move default config function to test_models package
 func NewDefaultEnodebStatus() *EnodebState {
 	return &EnodebState{
 		EnodebConfigured: swag.Bool(true),

--- a/lte/cloud/go/services/lte/obsidian/models/defaults.go
+++ b/lte/cloud/go/services/lte/obsidian/models/defaults.go
@@ -79,5 +79,6 @@ func NewDefaultEnodebStatus() *EnodebState {
 		MmeConnected:     swag.Bool(true),
 		FsmState:         swag.String("TEST"),
 		IPAddress:        "192.168.0.1",
+		UesConnected:     5,
 	}
 }

--- a/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.cpp
@@ -27,7 +27,7 @@ extern "C" {
 
 using grpc::ServerContext;
 using grpc::Status;
-using magma::EnbConnectedResult;
+using magma::EnbStateResult;
 using magma::S1apService;
 
 namespace magma {
@@ -36,8 +36,8 @@ using namespace orc8r;
 
 S1apServiceImpl::S1apServiceImpl() {}
 
-Status S1apServiceImpl::GetEnbConnected(
-    ServerContext* context, const Void* request, EnbConnectedResult* response) {
+Status S1apServiceImpl::GetEnbState(
+    ServerContext* context, const Void* request, EnbStateResult* response) {
   OAILOG_DEBUG(LOG_UTIL, "Received EnbConnected GRPC request\n");
 
   // Get state from S1APStateManager
@@ -56,7 +56,8 @@ Status S1apServiceImpl::GetEnbConnected(
       ht_rc = hashtable_ts_get(
           &s1ap_state->enbs, (hash_key_t) ht_keys->keys[i], (void**) &enb_ref);
       if (ht_rc == HASH_TABLE_OK) {
-        response->add_enb_ids(enb_ref->enb_id);
+        (*response->mutable_enb_state_map())[enb_ref->enb_id] =
+            enb_ref->nb_ue_associated;
       }
     }
     FREE_HASHTABLE_KEY_ARRAY(ht_keys);

--- a/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.cpp
+++ b/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.cpp
@@ -36,9 +36,9 @@ using namespace orc8r;
 
 S1apServiceImpl::S1apServiceImpl() {}
 
-Status S1apServiceImpl::GetEnbState(
+Status S1apServiceImpl::GetENBState(
     ServerContext* context, const Void* request, EnbStateResult* response) {
-  OAILOG_DEBUG(LOG_UTIL, "Received EnbConnected GRPC request\n");
+  OAILOG_DEBUG(LOG_UTIL, "Received GetENBState GRPC request\n");
 
   // Get state from S1APStateManager
   // TODO: Get state through ITTI message from S1AP task, as it's read only

--- a/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.h
@@ -35,15 +35,16 @@ class S1apServiceImpl final : public magma::S1apService::Service {
   S1apServiceImpl();
 
   /**
-   * Returns list of S1 connected eNB ids
+   * Returns map of S1 connected eNB id as key, with num of UEs attached
+   * to each eNB as value
    * @param context grpc ServerContext
    * @param request proto request params
-   * @param response proto response EnbConnectedResult
+   * @param response proto response EnbStateResult
    * @return status response cod
    */
-  grpc::Status GetEnbConnected(
+  grpc::Status GetEnbState(
       grpc::ServerContext* context, const magma::orc8r::Void* request,
-      magma::lte::EnbConnectedResult* response) override;
+      magma::lte::EnbStateResult* response) override;
 };
 
 }  // namespace magma

--- a/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.h
+++ b/lte/gateway/c/oai/tasks/grpc_service/S1apServiceImpl.h
@@ -35,14 +35,14 @@ class S1apServiceImpl final : public magma::S1apService::Service {
   S1apServiceImpl();
 
   /**
-   * Returns map of S1 connected eNB id as key, with num of UEs attached
+   * Returns map of S1 connected eNB id as key, with num of UEs connected
    * to each eNB as value
    * @param context grpc ServerContext
    * @param request proto request params
    * @param response proto response EnbStateResult
    * @return status response cod
    */
-  grpc::Status GetEnbState(
+  grpc::Status GetENBState(
       grpc::ServerContext* context, const magma::orc8r::Void* request,
       magma::lte::EnbStateResult* response) override;
 };

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -332,9 +332,8 @@ def get_single_enb_status(
     return enb_status
 
 
-def get_operational_states(
-        enb_acs_manager: StateMachineManager, mconfig: mconfigs_pb2.EnodebD
-) -> List[State]:
+def get_operational_states(enb_acs_manager: StateMachineManager,
+                           mconfig: mconfigs_pb2.EnodebD) -> List[State]:
     """
     Returns: A list of State with EnodebStatus encoded as JSON
     """
@@ -343,7 +342,7 @@ def get_operational_states(
     enb_status_by_serial = get_all_enb_status(enb_acs_manager)
 
     # Get S1 connected eNBs
-    enb_s1_state_map = get_all_enb_state()
+    enb_statuses = get_all_enb_state()
 
     for serial_id in enb_status_by_serial:
         enb_status_dict = enb_status_by_serial[serial_id]._asdict()
@@ -352,8 +351,8 @@ def get_operational_states(
         enb_status_dict['ip_address'] = enb_acs_manager.get_ip_of_serial(
             serial_id)
 
-        # Add num of UEs connected, use cellID from enb_status handler
-        num_ue_connected = enb_s1_state_map.get(enb_status_dict['cell_id'], 0)
+        # Add num of UEs connected
+        num_ue_connected = enb_statuses.get(enb_status_dict['cell_id'], 0)
         enb_status_dict['ues_connected'] = num_ue_connected
 
         serialized = json.dumps(enb_status_dict)
@@ -366,7 +365,7 @@ def get_operational_states(
         states.append(state)
 
     # Get state for externally configured enodebs
-    s1_states = get_enb_s1_connected_states(enb_s1_state_map,
+    s1_states = get_enb_s1_connected_states(enb_statuses,
                                             configured_serial_ids,
                                             mconfig)
     states.extend(s1_states)

--- a/lte/gateway/python/magma/enodebd/enodeb_status.py
+++ b/lte/gateway/python/magma/enodebd/enodeb_status.py
@@ -28,7 +28,7 @@ from magma.enodebd.logger import EnodebdLogger as logger
 from magma.enodebd.state_machines.enb_acs import EnodebAcsStateMachine
 from magma.enodebd.state_machines.enb_acs_manager import \
     StateMachineManager
-from magma.enodebd.s1ap_client import get_all_enb_connected
+from magma.enodebd.s1ap_client import get_all_enb_state
 from magma.enodebd.device_config.configuration_util import find_enb_by_cell_id
 from orc8r.protos.service303_pb2 import State
 
@@ -356,8 +356,8 @@ def get_operational_states(
 
 def get_enb_s1_connected_states(configured_serial_ids, mconfig) -> List[State]:
     states = []
-    enb_s1_connected = get_all_enb_connected()
-    for enb_id in enb_s1_connected:
+    enb_s1_state = get_all_enb_state()
+    for enb_id in enb_s1_state:
         enb = find_enb_by_cell_id(mconfig, enb_id)
         if enb and enb.serial_num not in configured_serial_ids:
             status = EnodebStatus(enodeb_configured=False,

--- a/lte/gateway/python/magma/enodebd/s1ap_client.py
+++ b/lte/gateway/python/magma/enodebd/s1ap_client.py
@@ -25,22 +25,22 @@ DEFAULT_GRPC_TIMEOUT = 20
 
 def get_all_enb_state() -> Optional[Dict[int, int]]:
     """
-    Make RPC call to 'GetEnbstate' method of s1ap service
+    Make RPC call to 'GetENBState' method of s1ap service
     """
     try:
         chan = ServiceRegistry.get_rpc_channel(S1AP_SERVICE_NAME,
                                                ServiceRegistry.LOCAL)
     except ValueError:
         logger.error('Cant get RPC channel to %s', S1AP_SERVICE_NAME)
-        return
+        return {}
     client = S1apServiceStub(chan)
     try:
-        res = client.GetEnbState(Void(), DEFAULT_GRPC_TIMEOUT)
+        res = client.GetENBState(Void(), DEFAULT_GRPC_TIMEOUT)
         return res.enb_state_map
     except grpc.RpcError as err:
         logger.warning(
             "GetEnbState error: [%s] %s",
             err.code(),
             err.details())
-    return []
+    return {}
 

--- a/lte/gateway/python/magma/enodebd/s1ap_client.py
+++ b/lte/gateway/python/magma/enodebd/s1ap_client.py
@@ -10,7 +10,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-from typing import List, Optional
+from typing import Dict, Optional
 
 import grpc
 
@@ -23,9 +23,9 @@ S1AP_SERVICE_NAME = "s1ap_service"
 DEFAULT_GRPC_TIMEOUT = 20
 
 
-def get_all_enb_connected() -> Optional[List[int]]:
+def get_all_enb_state() -> Optional[Dict[int, int]]:
     """
-    Make RPC call to 'GetEnbConnected' method of s1ap service
+    Make RPC call to 'GetEnbstate' method of s1ap service
     """
     try:
         chan = ServiceRegistry.get_rpc_channel(S1AP_SERVICE_NAME,
@@ -35,11 +35,11 @@ def get_all_enb_connected() -> Optional[List[int]]:
         return
     client = S1apServiceStub(chan)
     try:
-        res = client.GetEnbConnected(Void(), DEFAULT_GRPC_TIMEOUT)
-        return res.enb_ids
+        res = client.GetEnbState(Void(), DEFAULT_GRPC_TIMEOUT)
+        return res.enb_state_map
     except grpc.RpcError as err:
         logger.warning(
-            "GetEnbConnected error: [%s] %s",
+            "GetEnbState error: [%s] %s",
             err.code(),
             err.details())
     return []

--- a/lte/protos/s1ap_service.proto
+++ b/lte/protos/s1ap_service.proto
@@ -19,11 +19,12 @@ package magma.lte;
 
 option go_package = "magma/lte/cloud/go/protos";
 
-message EnbStateResult {
-    // enb ids -> num of UEs connected
-    map<uint32, uint32> enb_state_map = 1;
+service S1apService {
+    // Returns state of the S1 connected eNBs
+    rpc GetENBState (magma.orc8r.Void) returns (EnbStateResult) {}
 }
 
-service S1apService {
-    rpc GetEnbState (magma.orc8r.Void) returns (EnbStateResult) {}
+// enb_state_map { eNB IDs -> # UEs connected }
+message EnbStateResult {
+    map<uint32, uint32> enb_state_map = 1;
 }

--- a/lte/protos/s1ap_service.proto
+++ b/lte/protos/s1ap_service.proto
@@ -19,10 +19,11 @@ package magma.lte;
 
 option go_package = "magma/lte/cloud/go/protos";
 
-message EnbConnectedResult {
-    repeated uint32 enb_ids = 1;
+message EnbStateResult {
+    // enb ids -> num of UEs connected
+    map<uint32, uint32> enb_state_map = 1;
 }
 
 service S1apService {
-    rpc GetEnbConnected (magma.orc8r.Void) returns (EnbConnectedResult) {}
+    rpc GetEnbState (magma.orc8r.Void) returns (EnbStateResult) {}
 }


### PR DESCRIPTION
## Summary

- This updates GetEnbConnected to GetEnbState for getting state of S1 connected enodebs with number of UEs connected to each radio
- Updates get_operational_states from enodebd to include ues_connected on the json dict
- Updates orc8r enodeb_state model struct to include new ues_connected property

## Test Plan

- Testing with local orc8r setup and gateway VM, registering unmanaged enb config on Orchestrator and running s1ap tester to simulate enb and 5 UEs connected:

```
{
  "enodeb_configured": false,
  "enodeb_connected": true,
  "fsm_state": "N/A",
  "gps_connected": false,
  "gps_latitude": "N/A",
  "gps_longitude": "N/A",
  "ip_address": "192.168.1.142",
  "mme_connected": true,
  "opstate_enabled": false,
  "ptp_connected": false,
  "reporting_gateway_id": "gw_enb",
  "rf_tx_desired": false,
  "rf_tx_on": false,
  "time_reported": 1608269570650,
  "ues_connected": 5
}
```

## Additional Information

- [ ] This change is backwards-breaking
