### PR TITLE
[lte][ha] Update ha service to use connected ue's rather than throughput

### DIFF
--- a/lte/cloud/go/services/ha/ha/main.go
+++ b/lte/cloud/go/services/ha/ha/main.go
@@ -18,14 +18,9 @@ import (
 	"magma/lte/cloud/go/protos"
 	"magma/lte/cloud/go/services/ha"
 	"magma/lte/cloud/go/services/ha/servicers"
-	"magma/orc8r/cloud/go/orc8r"
 	"magma/orc8r/cloud/go/service"
-	"magma/orc8r/cloud/go/services/metricsd"
-	"magma/orc8r/lib/go/service/config"
 
 	"github.com/golang/glog"
-	"github.com/prometheus/client_golang/api"
-	"github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 func main() {
@@ -33,25 +28,11 @@ func main() {
 	if err != nil {
 		glog.Fatalf("Error creating had service: %s", err)
 	}
-	promClient := GetPrometheusClient()
-	servicer := servicers.NewHAServicer(promClient)
+	servicer := servicers.NewHAServicer()
 	protos.RegisterHaServer(srv.GrpcServer, servicer)
 
 	err = srv.Run()
 	if err != nil {
 		glog.Fatalf("Error while running ha service and echo server: %s", err)
 	}
-}
-
-// GetPrometheusClient returns prometheus client
-func GetPrometheusClient() v1.API {
-	metricsConfig, err := config.GetServiceConfig(orc8r.ModuleName, metricsd.ServiceName)
-	if err != nil {
-		glog.Fatalf("Could not retrieve metricsd configuration needed to query ENB stats: %s", err)
-	}
-	promClient, err := api.NewClient(api.Config{Address: metricsConfig.MustGetString(metricsd.PrometheusQueryAddress)})
-	if err != nil {
-		glog.Fatalf("Error creating prometheus client: %s", promClient)
-	}
-	return v1.NewAPI(promClient)
 }

--- a/lte/cloud/go/services/ha/servicers/servicer.go
+++ b/lte/cloud/go/services/ha/servicers/servicer.go
@@ -24,11 +24,8 @@ import (
 	lte_service "magma/lte/cloud/go/services/lte"
 	lte_models "magma/lte/cloud/go/services/lte/obsidian/models"
 	"magma/orc8r/cloud/go/orc8r"
-	"magma/orc8r/cloud/go/services/analytics/query_api"
 	"magma/orc8r/cloud/go/services/configurator"
-	"magma/orc8r/cloud/go/services/metricsd/prometheus/restrictor"
 	"magma/orc8r/cloud/go/services/state/wrappers"
-	"magma/orc8r/lib/go/metrics"
 	"magma/orc8r/lib/go/protos"
 
 	"github.com/golang/glog"
@@ -41,15 +38,11 @@ const (
 	validSecsSinceStateReported = 180
 )
 
-type HAServicer struct {
-	promClient query_api.PrometheusAPI
-}
+type HAServicer struct{}
 
-// NewHAServicer creates a new service implementing the HaD proto file
-func NewHAServicer(promClient query_api.PrometheusAPI) lte_protos.HaServer {
-	return &HAServicer{
-		promClient: promClient,
-	}
+// NewHAServicer creates a new service implementing the HA proto file
+func NewHAServicer() lte_protos.HaServer {
+	return &HAServicer{}
 }
 
 // GetEnodebOffloadState fetches all primary gateways that the calling gateway
@@ -193,35 +186,12 @@ func (s *HAServicer) getOffloadStateForEnb(networkID string, primaryGwID string,
 		glog.V(2).Infof("Returning NO_OP offload state for ENB %s; Enodeb state does not have Enodeb connected or MME connected", enbSN)
 		return lte_protos.GetEnodebOffloadStateResponse_NO_OP, nil
 	}
-	isEnbServing, err := s.isEnbServingTraffic(networkID, primaryGwID, enodebState.IPAddress.String())
-	if err != nil {
-		glog.Error(err)
-	}
-	if err != nil || !isEnbServing {
+	if enodebState.UesConnected == 0 {
+		glog.V(2).Infof("Returning PRIMARY_CONNECTED offload state for ENB %s; no UEs connected", enbSN)
 		return lte_protos.GetEnodebOffloadStateResponse_PRIMARY_CONNECTED, nil
 	}
+	glog.V(2).Infof("Returning PRIMARY_CONNECTED_AND_SERVING_UES offload state for ENB %s", enbSN)
 	return lte_protos.GetEnodebOffloadStateResponse_PRIMARY_CONNECTED_AND_SERVING_UES, nil
-}
-
-func (s *HAServicer) isEnbServingTraffic(networkID string, gatewayID string, enbIP string) (bool, error) {
-	// TODO: Update metric query to use the number of users connected to an ENB
-	// once this metric exists. This will avoid the edge case issue of
-	// throughput equal to 0 while there are only users connected in IDLE mode.
-	enbDLQuery := fmt.Sprintf("gtp_port_user_plane_dl_bytes{gatewayID=\"%s\", service=\"pipelined\", ip_addr=\"%s\"}", gatewayID, enbIP)
-	networkQueryRestrictor := *restrictor.NewQueryRestrictor(restrictor.DefaultOpts).AddMatcher(metrics.NetworkLabelName, networkID)
-	query, err := networkQueryRestrictor.RestrictQuery(enbDLQuery)
-	if err != nil {
-		return false, err
-	}
-	trafficVec, err := query_api.QueryPrometheusVector(s.promClient, query)
-	if err != nil {
-		return false, err
-	}
-	trafficSample := trafficVec[0]
-	if trafficSample.Value == 0 {
-		return false, nil
-	}
-	return true, nil
 }
 
 func (s *HAServicer) getEnodebID(networkID string, hwID string, enodebSn string) (uint32, error) {

--- a/lte/cloud/go/services/ha/servicers/servicer_test.go
+++ b/lte/cloud/go/services/ha/servicers/servicer_test.go
@@ -15,7 +15,6 @@ package servicers_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -32,7 +31,6 @@ import (
 	"magma/orc8r/cloud/go/plugin"
 	"magma/orc8r/cloud/go/pluginimpl"
 	"magma/orc8r/cloud/go/serde"
-	"magma/orc8r/cloud/go/services/analytics/query_api/mocks"
 	"magma/orc8r/cloud/go/services/configurator"
 	configurator_test_init "magma/orc8r/cloud/go/services/configurator/test_init"
 	"magma/orc8r/cloud/go/services/orchestrator/obsidian/models"
@@ -43,9 +41,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
 func init() {
@@ -58,8 +54,7 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 	configurator_test_init.StartTestService(t)
 	state_test_init.StartTestService(t)
 	lte_test_init.StartTestService(t)
-	mockPromClient := &mocks.PrometheusAPI{}
-	servicer := servicers.NewHAServicer(mockPromClient)
+	servicer := servicers.NewHAServicer()
 
 	testNetworkId := "n1"
 	testGwHwId1 := "hw1"
@@ -148,15 +143,6 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 	enbState := getDefaultEnodebState(testGwId1)
 	reportEnodebState(t, testNetworkId, testGwId1, enbSn, enbState)
 
-	metric1 := model.Metric{}
-	metric1["networkID"] = "n1"
-	metric1["gatewayID"] = "g1"
-	throughputVec := model.Vector{{
-		Metric: metric1,
-		Value:  10000000,
-	}}
-	mockPromClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(throughputVec, nil, nil).Once()
-
 	// First test primary healthy
 	ctx := orc8r_protos.NewGatewayIdentity(testGwHwId2, testNetworkId, testGwId2).NewContextWithIdentity(context.Background())
 	res, err := servicer.GetEnodebOffloadState(ctx, &protos.GetEnodebOffloadStateRequest{})
@@ -167,7 +153,6 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedRes, res)
-	mockPromClient.AssertExpectations(t)
 
 	// Now simulate failed primary not checking in
 	stateTooOld := time.Now().Add(-time.Second * 600)
@@ -210,10 +195,10 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 	}
 	assert.Equal(t, expectedRes, res)
 
-	// Connected but could not query metrics
+	// Connected but no UEs connected
 	enbState.EnodebConnected = swag.Bool(true)
+	enbState.UesConnected = 0
 	reportEnodebState(t, testNetworkId, testGwId1, enbSn, enbState)
-	mockPromClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(nil, nil, fmt.Errorf("error")).Once()
 
 	res, err = servicer.GetEnodebOffloadState(ctx, &protos.GetEnodebOffloadStateRequest{})
 	assert.NoError(t, err)
@@ -223,31 +208,15 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedRes, res)
-	mockPromClient.AssertExpectations(t)
 
-	// Connected but no throughput
-	throughputVec2 := model.Vector{{
-		Metric: metric1,
-		Value:  0,
-	}}
-	mockPromClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(throughputVec2, nil, nil).Once()
-
-	res, err = servicer.GetEnodebOffloadState(ctx, &protos.GetEnodebOffloadStateRequest{})
-	assert.NoError(t, err)
-	expectedRes = &protos.GetEnodebOffloadStateResponse{
-		EnodebOffloadStates: map[uint32]protos.GetEnodebOffloadStateResponse_EnodebOffloadState{
-			138: protos.GetEnodebOffloadStateResponse_PRIMARY_CONNECTED,
-		},
-	}
-	assert.Equal(t, expectedRes, res)
-	mockPromClient.AssertExpectations(t)
+	// Back to connected with users
+	enbState.UesConnected = 10
+	reportEnodebState(t, testNetworkId, testGwId1, enbSn, enbState)
 
 	// Simulate secondary gateway updating state to ensure primary state
 	// can still be fetched
 	reportEnodebState(t, testNetworkId, testGwId2, enbSn, enbState)
 
-	// Back to connected with users
-	mockPromClient.On("Query", mock.Anything, mock.Anything, mock.Anything).Return(throughputVec, nil, nil).Once()
 	res, err = servicer.GetEnodebOffloadState(ctx, &protos.GetEnodebOffloadStateRequest{})
 	assert.NoError(t, err)
 	expectedRes = &protos.GetEnodebOffloadStateResponse{
@@ -256,7 +225,6 @@ func TestHAServicer_GetEnodebOffloadState(t *testing.T) {
 		},
 	}
 	assert.Equal(t, expectedRes, res)
-	mockPromClient.AssertExpectations(t)
 }
 
 func reportEnodebState(t *testing.T, networkID string, gatewayID string, enodebSerial string, req *lte_models.EnodebState) {
@@ -328,5 +296,6 @@ func getDefaultEnodebState(gwID string) *lte_models.EnodebState {
 		RfTxOn:             swag.Bool(true),
 		RfTxDesired:        swag.Bool(true),
 		FsmState:           swag.String("abc"),
+		UesConnected:       5,
 	}
 }

--- a/lte/cloud/go/services/lte/obsidian/models/enodeb_state_swaggergen.go
+++ b/lte/cloud/go/services/lte/obsidian/models/enodeb_state_swaggergen.go
@@ -70,6 +70,9 @@ type EnodebState struct {
 
 	// Time at which the state was reported in ms
 	TimeReported uint64 `json:"time_reported,omitempty"`
+
+	// ues connected
+	UesConnected int32 `json:"ues_connected,omitempty"`
 }
 
 // Validate validates this enodeb state

--- a/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
+++ b/lte/cloud/go/services/lte/obsidian/models/swagger.v1.yml
@@ -2336,6 +2336,9 @@ definitions:
       ip_address:
         type: string
         format: ipv4
+      ues_connected:
+        type: integer
+        format: int32
 
   aggregated_maximum_bitrate:
     type: object


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>


## Summary

This PR updates the LTE ha service to offload using the connected_ues
field in the EnodebState model rather than throughput. This corrects
an issue where UE's have connected to the primary but are 
in IDLE mode. This state is now being reported from enodebd
via https://github.com/magma/magma/pull/4115.

## Test Plan

Updated unit tests
