### PR TITLE
[AGW][pipelined] Fix non-NAT iface reconfiguration

### DIFF
--- a/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
+++ b/lte/gateway/python/magma/pipelined/app/uplink_bridge.py
@@ -14,6 +14,9 @@ import subprocess
 import threading
 from collections import namedtuple
 
+import netaddr
+import netifaces
+
 from magma.pipelined.app.base import MagmaController, ControllerType
 from magma.pipelined.bridge_util import BridgeTools
 from magma.pipelined.openflow import flows
@@ -271,7 +274,13 @@ class UplinkBridgeController(MagmaController):
                 self._restart_dhclient(if_name)
             else:
                 # for system port, use networking config
-                if_up_cmd = ["ifup", if_name]
+                try:
+                    self._flush_ip(if_name)
+                except subprocess.CalledProcessError as ex:
+                    self.logger.info("could not flush ip addr: %s, %s",
+                                     if_name, ex)
+
+                if_up_cmd = ["ifup", if_name, "--force"]
                 try:
                     subprocess.check_call(if_up_cmd)
                 except subprocess.CalledProcessError as ex:
@@ -282,9 +291,14 @@ class UplinkBridgeController(MagmaController):
         try:
             self._kill_dhclient(if_name)
 
-            flush_ip = ["ip", "addr", "flush",
-                        "dev", if_name]
-            subprocess.check_call(flush_ip)
+            if self._is_iface_ip_set(if_name,
+                                     self.config.sgi_management_iface_ip_addr):
+                self.logger.info("ip addr %s already set for iface %s",
+                                 self.config.sgi_management_iface_ip_addr,
+                                 if_name)
+                return
+
+            self._flush_ip(if_name)
 
             set_ip_cmd = ["ip",
                           "addr", "add",
@@ -295,6 +309,20 @@ class UplinkBridgeController(MagmaController):
             self.logger.debug("SGi ip address config: [%s]", set_ip_cmd)
         except subprocess.SubprocessError as e:
             self.logger.warning("Error while setting SGi IP: %s", e)
+
+    def _is_iface_ip_set(self, if_name, ip_addr):
+        ip_addr = netaddr.IPNetwork(ip_addr)
+        if_addrs = netifaces.ifaddresses(if_name).get(netifaces.AF_INET, [])
+
+        for addr in if_addrs:
+            addr = netaddr.IPNetwork("/".join((addr['addr'], addr['netmask'])))
+            if ip_addr == addr:
+                return True
+        return False
+
+    def _flush_ip(self, if_name):
+        flush_ip = ["ip", "addr", "flush", "dev", if_name]
+        subprocess.check_call(flush_ip)
 
     def _kill_dhclient(self, if_name):
         # Kill dhclient if running.
@@ -331,12 +359,10 @@ class UplinkBridgeController(MagmaController):
 
         if not flush:
             return
-        flush_eth_ip = ["ip", "addr", "flush", "dev", if_name]
         try:
-            subprocess.check_call(flush_eth_ip)
+            self._flush_ip(if_name)
         except subprocess.CalledProcessError as ex:
-            self.logger.info("could not flush ip addr: %s, %s",
-                             flush_eth_ip, ex)
+            self.logger.info("could not flush ip addr: %s, %s", if_name, ex)
 
         self.logger.info("SGi DHCP: port [%s] ip removed", if_name)
 


### PR DESCRIPTION
Signed-off-by: Oleksandr Berezovskyi <berezovskyi.oleksandr@gmail.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

This PR fixes IP configuration in non-NAT mode. Before this patch, deleting SGi mgmt static_ip configuration will result in no dhcp request and persisting of the static IP address. 

This patch perform deleting of old config and forced reconfiguration of the interface.

<!-- Enumerate changes you made and why you made them -->

## Test Plan

`make test`
Test on real machine

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
