### PR TITLE
[orc8r][service mesh][feg relay] Add k8s services for feg proxy aliases

### DIFF
--- a/feg/cloud/helm/feg-orc8r/Chart.yaml
+++ b/feg/cloud/helm/feg-orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator's feg module
 name: feg-orc8r
-version: 0.2.0
+version: 0.2.1
 engine: gotpl
 sources:
   - https://github.com/magma/magma

--- a/feg/cloud/helm/feg-orc8r/templates/_helpers.tpl
+++ b/feg/cloud/helm/feg-orc8r/templates/_helpers.tpl
@@ -1,0 +1,21 @@
+{{/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{/* Generate basic labels */}}
+{{- define "feg-proxy-alias-labels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/component: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: helm
+app.kubernetes.io/part-of: proxy-aliases
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/csfb.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/csfb.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "csfb.service") -}}
+{{- define "csfb.service" -}}
+metadata:
+  name: orc8r-csfb
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.csfb.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.csfb.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9079
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/feg_hello.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/feg_hello.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "feg_hello.service") -}}
+{{- define "feg_hello.service" -}}
+metadata:
+  name: orc8r-feg-hello
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.feg_hello.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.feg_hello.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9079
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/feg_relay.deployment.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/feg_relay.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/feg_relay", "-logtostderr=tr
 ports:
   - name: grpc
     containerPort: 9103
+  - name: feg
+    containerPort: 9079
 livenessProbe:
   tcpSocket:
     port: 9103

--- a/feg/cloud/helm/feg-orc8r/templates/ocs.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/ocs.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "ocs.service") -}}
+{{- define "ocs.service" -}}
+metadata:
+  name: orc8r-ocs
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.ocs.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.ocs.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9079
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/pcrf.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/pcrf.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "pcrf.service") -}}
+{{- define "pcrf.service" -}}
+metadata:
+  name: orc8r-pcrf
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.pcrf.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.pcrf.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9079
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/s6a_proxy.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/s6a_proxy.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "s6a_proxy.service") -}}
+{{- define "s6a_proxy.service" -}}
+metadata:
+  name: orc8r-s6a-proxy
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.s6a_proxy.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.s6a_proxy.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9103
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/session_proxy.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/session_proxy.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "session_proxy.service") -}}
+{{- define "session_proxy.service" -}}
+metadata:
+  name: orc8r-session-proxy
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.session_proxy.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.session_proxy.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9079
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/templates/swx_proxy.service.yaml
+++ b/feg/cloud/helm/feg-orc8r/templates/swx_proxy.service.yaml
@@ -1,0 +1,34 @@
+{{/*
+# Copyright 2020 The Magma Authors.
+
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/}}
+
+{{- include "orc8rlib.service" (list . "swx_proxy.service") -}}
+{{- define "swx_proxy.service" -}}
+metadata:
+  name: orc8r-swx-proxy
+  labels:
+{{ include "feg-proxy-alias-labels" . | indent 4 }}
+    {{- with .Values.swx_proxy.service.labels }}
+{{ toYaml . | indent 4}}
+    {{- end}}
+  {{- with .Values.swx_proxy.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4}}
+  {{- end }}
+spec:
+  selector:
+    app.kubernetes.io/component: feg-relay
+  ports:
+    - name: grpc
+      port: 9180
+      targetPort: 9103
+{{- end -}}

--- a/feg/cloud/helm/feg-orc8r/values.yaml
+++ b/feg/cloud/helm/feg-orc8r/values.yaml
@@ -93,3 +93,39 @@ health:
   service:
     labels: {}
     annotations: {}
+
+# Feg relay aliased services
+csfb:
+  service:
+    labels: {}
+    annotations: {}
+
+feg_hello:
+  service:
+    labels: {}
+    annotations: {}
+
+ocs:
+  service:
+    labels: {}
+    annotations: {}
+
+pcrf:
+  service:
+    labels: {}
+    annotations: {}
+
+s6a_proxy:
+  service:
+    labels: {}
+    annotations: {}
+
+session_proxy:
+  service:
+    labels: {}
+    annotations: {}
+
+swx_proxy:
+  service:
+    labels: {}
+    annotations: {}


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR corrects an issue we've seen when running orc8r service mesh.
Feg relay functionality depends on the "proxy_aliases" configuration to map a feg service
to a feg relay service port. Feg relay then forwards that request to the appropriate 
service.

Currently, there is no k8s service other than "feg-relay", so nginx is unable to forward
the request. Here we map these aliases to backend to the feg-relay pod at the appropriate
port (9079 or 9103). We also modify the part-of label to not be "orc8r-app" so that the
orc8r service registry service does not see these are "orc8r" services.

## Test Plan

testing live
