### PR TITLE
[sessind] Delay rule removal when suspended credit is received at init

### DIFF
--- a/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
+++ b/lte/gateway/c/session_manager/test/test_local_enforcer.cpp
@@ -1019,6 +1019,15 @@ TEST_F(LocalEnforcerTest, test_credit_init_with_transient_error_redirect) {
   local_enforcer->init_session_credit(
       session_map, IMSI1, SESSION_ID_1, test_cfg_, response);
 
+  // Write + Read in/from SessionStore so all paramters during init are saved
+  // to the session
+  bool write_success =
+      session_store->create_sessions(IMSI1, std::move(session_map[IMSI1]));
+  EXPECT_TRUE(write_success);
+
+  evb->loopOnce();
+
+  session_map = session_store->read_sessions({IMSI1});
   auto update = SessionStore::get_default_session_update(session_map);
 
   // receive usages from pipeline and check we still collect them but don't


### PR DESCRIPTION
Signed-off-by: Oriol Batalla <obatalla@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

When we receive suspended credit on init we install it and immediately uninstall it. That causes pipelined to sometimes invert the order of the actions so the traffic never gets uninstalled.

This PR delays the command that send the removal of the rule to make sure it gets after the install.

Note this could have been done filtering out the rules and not installing them. However the rules needs to be stored in the session just in case we receive credit for that specific rule. Also we may have to potentially refactor the whole init procedure. So for now we will use this workaround of delaying the removal of the rule

## Test Plan
make precommit_sm
cwag integ test 
## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
