### PR TITLE
[orc8r][lib] Fix initflag to not bork unit test output

### DIFF
--- a/orc8r/lib/go/initflag/initflag.go
+++ b/orc8r/lib/go/initflag/initflag.go
@@ -17,7 +17,9 @@ package initflag
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
+	"strings"
 )
 
 func init() {
@@ -26,20 +28,19 @@ func init() {
 		syslogFlag,
 		"Redirect stderr to syslog, optional syslog destination in network::address format (system default otherwise)")
 
-	// only if not already parsed
-	if !flag.Parsed() {
-		// save original settings
+	if shouldParse() {
+		// Save original settings
 		orgUsage := flag.CommandLine.Usage
 		origOut := flag.CommandLine.Output()
 		origErrorHandling := flag.CommandLine.ErrorHandling()
 
-		// set to 'silent'
+		// Set to 'silent'
 		flag.CommandLine.Init(flag.CommandLine.Name(), flag.ContinueOnError)
 		flag.CommandLine.Usage = func() {}
-		flag.CommandLine.SetOutput(devNull{})
+		flag.CommandLine.SetOutput(ioutil.Discard)
 		flag.Parse()
 
-		// restore original settings
+		// Restore original settings
 		flag.CommandLine.Init(flag.CommandLine.Name(), origErrorHandling)
 		flag.CommandLine.Usage = orgUsage
 		flag.CommandLine.SetOutput(origOut)
@@ -60,8 +61,11 @@ func init() {
 	}
 }
 
-type devNull struct{}
-
-func (devNull) Write(b []byte) (int, error) {
-	return len(b), nil
+// shouldParse returns true if initflag should parse flags.
+// This hack works around the fact that initflags breaks test tool outputs.
+func shouldParse() bool {
+	isTest := strings.HasSuffix(os.Args[0], ".test") ||
+		strings.HasSuffix(os.Args[0], "_test.go") ||
+		strings.HasSuffix(os.Args[0], "_test_go")
+	return !flag.Parsed() && !isTest
 }


### PR DESCRIPTION
## Summary

For some reason, running our unit tests in my IntelliJ under go1.13 results in "no tests were run" output. I traced the source of the issue to the initflags package. I believe it's an issue with flag parsing ordering.

I originally opened a support ticket with IntelliJ, but they pointed me to the fact that there was probably something going on weird with our stdout/stderr, which turned out to be the case.

This change resolves the issue I was experiencing, while preserving the functionality of initflags.

Before

<img width="1792" alt="Screen Shot 2020-12-20 at 8 15 06 PM" src="https://user-images.githubusercontent.com/8029544/102753981-df13b000-4331-11eb-9790-6a00e1a7e7c6.png">

After

<img width="1792" alt="Screen Shot 2020-12-20 at 8 15 34 PM" src="https://user-images.githubusercontent.com/8029544/102753970-dae79280-4331-11eb-8886-f2aa3c38fb95.png">

## Test Plan

Initflags doesn't have any tests, and I'm not 100% sure what the intended functionality is. Will sync with @emakeev.

## Additional Information

- [ ] This change is backwards-breaking