### PR TITLE
[orc8r][dev_setup] Improve dev_setup to recreate certs if any admin_operator cert is missing

### DIFF
--- a/orc8r/cloud/docker/controller/create_test_controller_certs
+++ b/orc8r/cloud/docker/controller/create_test_controller_certs
@@ -68,12 +68,12 @@ fi
 
 wait_for_db_containers
 
-if [[ -f admin_operator.pfx ]]; then
+if [[ -f admin_operator.pfx ]] && [[ -f admin_operator.pem ]] && [[ -f admin_operator.key.pem ]] ; then
   echo ""
   echo "########################"
   echo "Add existing admin certs"
   echo "########################"
-  grep -q admin_operator <(${ACCESSC} list) && exit_already_exists
+  ${ACCESSC} list | grep -q admin_operator && exit_already_exists
   ${ACCESSC} add-existing -admin -cert admin_operator.pem admin_operator
   echo "[success] test certs added"
 else


### PR DESCRIPTION
## Summary

Due to the recent dev bug where admin_operator certs were not properly being recreated, it's now clear we need to recreate admin_operator certs if *any* of the admin_operator certs are missing. This gives us additional safety against bugs + recovery after bug resolution.

This will also solve the bad state a lot of orc8r dev deployments may be in right now, mine included.

## Test Plan

- [x] delete non-pfx admin_operator certs, down+up, observe new certs, down+up, observe reusing existing certs
- [x] swagger accessible in both cases

## Additional Information

- [ ] This change is backwards-breaking