### PR TITLE
[lte][agw]Bug fix for missing ue context at spgw

### DIFF
--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -951,10 +951,12 @@ void mme_app_handle_delete_session_rsp(
       OAILOG_FUNC_OUT(LOG_MME_APP);
     }
 #endif
-    hashtable_uint64_ts_remove(
+    hashtable_rc_t hash_rc = hashtable_uint64_ts_remove(
         mme_app_desc_p->mme_ue_contexts.tun11_ue_context_htbl,
         (const hash_key_t) ue_context_p->mme_teid_s11);
-    ue_context_p->mme_teid_s11 = 0;
+    if (hash_rc == HASH_TABLE_OK) {
+      ue_context_p->mme_teid_s11 = 0;
+    }
     ue_context_p->nb_active_pdn_contexts -= 1;
 
     /* In case of Ue initiated explicit IMSI Detach or Combined EPS/IMSI detach
@@ -1487,6 +1489,7 @@ static int mme_app_send_modify_bearer_request_for_active_pdns(
     itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
         &message_p->ittiMsg.s11_modify_bearer_request;
     s11_modify_bearer_request->local_teid = ue_context_p->mme_teid_s11;
+
     // Delay Value in integer multiples of 50 millisecs, or zero
     s11_modify_bearer_request->delay_dl_packet_notif_req = 0;  // TODO
 
@@ -1538,7 +1541,11 @@ void mme_app_handle_initial_context_setup_rsp(
     OAILOG_FUNC_OUT(LOG_MME_APP);
   }
 
-  // Stop Initial context setup process guard timer,if running
+  /* Stop Initial context setup process guard timer,if running.
+   * Do not process the message if timer is not running because
+   * it means that the timer has already expired
+   * and implicit detach is triggered.
+   */
   if (ue_context_p->initial_context_setup_rsp_timer.id !=
       MME_APP_TIMER_INACTIVE_ID) {
     nas_itti_timer_arg_t* timer_argP = NULL;
@@ -1557,29 +1564,29 @@ void mme_app_handle_initial_context_setup_rsp(
     ue_context_p->initial_context_setup_rsp_timer.id =
         MME_APP_TIMER_INACTIVE_ID;
     ue_context_p->time_ics_rsp_timer_started = 0;
-  }
 
-  if (mme_app_send_modify_bearer_request_for_active_pdns(
-          ue_context_p, initial_ctxt_setup_rsp_p) != RETURNok) {
-    OAILOG_ERROR_UE(
-        LOG_MME_APP, ue_context_p->emm_context._imsi64,
-        "Failed to send modify bearer request for UE id  %d \n",
-        ue_context_p->mme_ue_s1ap_id);
-    OAILOG_FUNC_OUT(LOG_MME_APP);
-  }
-  /*
-   * During Service request procedure,after initial context setup response
-   * Send ULR, when UE moved from Idle to Connected and
-   * flag location_info_confirmed_in_hss set to true during hss reset.
-   */
-  if (ue_context_p->location_info_confirmed_in_hss == true) {
-    mme_app_send_s6a_update_location_req(ue_context_p);
-  }
-  if (ue_context_p->sgs_context) {
-    ue_context_p->sgs_context->csfb_service_type = CSFB_SERVICE_NONE;
-    // Reset mt_call_in_progress flag
-    if (ue_context_p->sgs_context->mt_call_in_progress) {
-      ue_context_p->sgs_context->mt_call_in_progress = false;
+    if (mme_app_send_modify_bearer_request_for_active_pdns(
+            ue_context_p, initial_ctxt_setup_rsp_p) != RETURNok) {
+      OAILOG_ERROR_UE(
+          LOG_MME_APP, ue_context_p->emm_context._imsi64,
+          "Failed to send modify bearer request for UE id  %d \n",
+          ue_context_p->mme_ue_s1ap_id);
+      OAILOG_FUNC_OUT(LOG_MME_APP);
+    }
+    /*
+     * During Service request procedure,after initial context setup response
+     * Send ULR, when UE moved from Idle to Connected and
+     * flag location_info_confirmed_in_hss set to true during hss reset.
+     */
+    if (ue_context_p->location_info_confirmed_in_hss == true) {
+      mme_app_send_s6a_update_location_req(ue_context_p);
+    }
+    if (ue_context_p->sgs_context) {
+      ue_context_p->sgs_context->csfb_service_type = CSFB_SERVICE_NONE;
+      // Reset mt_call_in_progress flag
+      if (ue_context_p->sgs_context->mt_call_in_progress) {
+        ue_context_p->sgs_context->mt_call_in_progress = false;
+      }
     }
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);
@@ -1949,35 +1956,35 @@ void mme_app_handle_initial_context_setup_failure(
     ue_context_p->initial_context_setup_rsp_timer.id =
         MME_APP_TIMER_INACTIVE_ID;
     ue_context_p->time_implicit_detach_timer_started = 0;
-  }
-  /* *********Abort the ongoing procedure*********
-   * Check if UE is registered already that implies service request procedure is
-   * active. If so then release the S1AP context and move the UE back to idle
-   * mode. Otherwise if UE is not yet registered that implies attach procedure
-   * is active. If so,then abort the attach procedure and release the UE
-   * context.
-   */
-  ue_context_p->ue_context_rel_cause = S1AP_INITIAL_CONTEXT_SETUP_FAILED;
-  if (ue_context_p->mm_state == UE_UNREGISTERED) {
-    // Initiate Implicit Detach for the UE
-    nas_proc_implicit_detach_ue_ind(ue_context_p->mme_ue_s1ap_id);
-    increment_counter(
-        "ue_attach", 1, 2, "result", "failure", "cause",
-        "initial_context_setup_failure_rcvd");
-    increment_counter("ue_attach", 1, 1, "action", "attach_abort");
-  } else {
-    // Release S1-U bearer and move the UE to idle mode
+    /* *********Abort the ongoing procedure*********
+     * Check if UE is registered already that implies service request procedure
+     * is active. If so then release the S1AP context and move the UE back to
+     * idle mode. Otherwise if UE is not yet registered that implies attach
+     * procedure is active. If so,then abort the attach procedure and release
+     * the UE context.
+     */
+    ue_context_p->ue_context_rel_cause = S1AP_INITIAL_CONTEXT_SETUP_FAILED;
+    if (ue_context_p->mm_state == UE_UNREGISTERED) {
+      // Initiate Implicit Detach for the UE
+      nas_proc_implicit_detach_ue_ind(ue_context_p->mme_ue_s1ap_id);
+      increment_counter(
+          "ue_attach", 1, 2, "result", "failure", "cause",
+          "initial_context_setup_failure_rcvd");
+      increment_counter("ue_attach", 1, 1, "action", "attach_abort");
+    } else {
+      // Release S1-U bearer and move the UE to idle mode
 
-    for (pdn_cid_t i = 0; i < MAX_APN_PER_UE; i++) {
-      if (ue_context_p->pdn_contexts[i]) {
-        mme_app_send_s11_release_access_bearers_req(ue_context_p, i);
+      for (pdn_cid_t i = 0; i < MAX_APN_PER_UE; i++) {
+        if (ue_context_p->pdn_contexts[i]) {
+          mme_app_send_s11_release_access_bearers_req(ue_context_p, i);
+        }
       }
-    }
-    /* Handles CSFB failure */
-    if (ue_context_p->sgs_context != NULL) {
-      handle_csfb_s1ap_procedure_failure(
-          ue_context_p, "initial_context_setup_failed",
-          INTIAL_CONTEXT_SETUP_PROCEDURE_FAILED);
+      /* Handles CSFB failure */
+      if (ue_context_p->sgs_context != NULL) {
+        handle_csfb_s1ap_procedure_failure(
+            ue_context_p, "initial_context_setup_failed",
+            INTIAL_CONTEXT_SETUP_PROCEDURE_FAILED);
+      }
     }
   }
   OAILOG_FUNC_OUT(LOG_MME_APP);

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_bearer.c
@@ -1489,7 +1489,6 @@ static int mme_app_send_modify_bearer_request_for_active_pdns(
     itti_s11_modify_bearer_request_t* s11_modify_bearer_request =
         &message_p->ittiMsg.s11_modify_bearer_request;
     s11_modify_bearer_request->local_teid = ue_context_p->mme_teid_s11;
-
     // Delay Value in integer multiples of 50 millisecs, or zero
     s11_modify_bearer_request->delay_dl_packet_notif_req = 0;  // TODO
 

--- a/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
+++ b/lte/gateway/c/oai/tasks/mme_app/mme_app_context.c
@@ -588,7 +588,7 @@ void mme_ue_context_update_coll_keys(
   h_rc = hashtable_uint64_ts_remove(
       mme_ue_context_p->tun11_ue_context_htbl,
       (const hash_key_t) ue_context_p->mme_teid_s11);
-  if (INVALID_MME_UE_S1AP_ID != mme_ue_s1ap_id) {
+  if ((INVALID_MME_UE_S1AP_ID != mme_ue_s1ap_id) && (mme_teid_s11)) {
     h_rc = hashtable_uint64_ts_insert(
         mme_ue_context_p->tun11_ue_context_htbl,
         (const hash_key_t) mme_teid_s11, (uint64_t) mme_ue_s1ap_id);

--- a/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
+++ b/lte/gateway/c/oai/tasks/sgw/sgw_handlers.c
@@ -913,6 +913,8 @@ static int send_mbr_failure(
     modify_response_p->bearer_contexts_marked_for_removal.bearer_contexts[idx]
         .cause.cause_value = CONTEXT_NOT_FOUND;
   }
+  // Fill mme s11 teid received in modify bearer request
+  modify_response_p->teid = modify_bearer_pP->local_teid;
   modify_response_p->bearer_contexts_marked_for_removal.num_bearer_context += 1;
   modify_response_p->cause.cause_value = CONTEXT_NOT_FOUND;
   modify_response_p->trxn              = modify_bearer_pP->trxn;


### PR DESCRIPTION
Signed-off-by: Pruthvi Hebbani <pruthvi.hebbani@radisys.com>

[lte][agw]Bug fix for missing ue context at spgw

## Summary

Issue description:
a.	There are 2 UEs which are in the process of attach say UE1 and UE2. UE1 has sent out initial context setup request message and waiting for response. UE2 has performed GUTI attach. As part of GUTI attach, identification procedure is done and MME has sent out authentication request message to UE and waiting for authentication response.
b.	ICS timer expires for UE1 and implicit detach is triggered. MME sends delete session request message to spgw and the UE context at spgw gets deleted. In the mean time ICS response message is received from UE1. At mme, there is no check to see that the ICS timer has already expired and implicit detach has been triggered for this UE. Due to this mme sends modify bearer request message to spgw. Before spgw triggers delete session rsp message to mme (in response to delete session req sent by mme) it receives modify bearer request message. As the ue context at spgw is deleted, spgw sends modify bearer rsp with cause “CONTEXT NOT FOUND”. But this message does not contain mme s11 teid. Mme s11 teid is included only in the successful case.
c.	Mme receives modify bearer rsp message with mme s11 teid value 0 and fetches the context of UE2 instead of UE1. This is because when mme performs identification procedure for UE2 it inserts mme s11 teid into the hashtable even though the value of mme s11 teid is 0.  Mme s11 teid gets allocated during create session procedure which is not yet done for UE2
d.     Mme triggers bearer deactivation procedure for UE2 (instead of UE1) as the context at spgw is not available
e.	Since authentication procedure is not yet completed for UE2, security context is not yet available for this UE. When mme tries to build erab release command message it crashes as there is no null check on the security context. This fix is done PR #4067 

This PR has the following fixes:
1.	Do not process initial context rsp message if ICS timer is not running
2.	Include mme s11 teid in modify bearer rsp message for failure cases
3.	Insert mme s11 teid into hashlist only if it has valid value.
4.	Set ue_context_p->mme_teid_s11 to 0 only if the hash table entry is successfully removed.

## Test Plan
- Verified s1 sim sanity
