### PR TITLE
[dispatcher][k8s] Expose http server port on dispatcher pod

### DIFF
--- a/orc8r/cloud/helm/orc8r/Chart.yaml
+++ b/orc8r/cloud/helm/orc8r/Chart.yaml
@@ -13,7 +13,7 @@ apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for magma orchestrator
 name: orc8r
-version: 1.5.5
+version: 1.5.6
 engine: gotpl
 sources:
   - https://github.com/facebookincubator/magma

--- a/orc8r/cloud/helm/orc8r/templates/dispatcher.deployment.yaml
+++ b/orc8r/cloud/helm/orc8r/templates/dispatcher.deployment.yaml
@@ -36,6 +36,8 @@ args: ["/var/opt/magma/envdir", "/var/opt/magma/bin/dispatcher", "-logtostderr=t
 ports:
   - name: grpc
     containerPort: 9096
+  - name: http
+    containerPort: 9080
 livenessProbe:
   tcpSocket:
     port: 9096


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR should correct failing feg relay requests we have been seeing
with the recent service mesh deployment. Dispatcher has an HTTP server
port used to forward requests to the gateways. This port was not exposed
in the k8s deployment file, causing feg_relay requests to get blackholed.

## Test Plan

Will redeploy to test
