### PR TITLE
Provided fix not to log multiple times invalid imsi and not able to fetch UE context for an invalid imsi

### DIFF
--- a/lte/gateway/c/oai/lib/itti/intertask_interface.c
+++ b/lte/gateway/c/oai/lib/itti/intertask_interface.c
@@ -269,6 +269,7 @@ static MessageDef* itti_alloc_new_message_sized(
   new_msg->ittiMsgHeader.messageId    = message_id;
   new_msg->ittiMsgHeader.originTaskId = origin_task_id;
   new_msg->ittiMsgHeader.ittiMsgSize  = size;
+  new_msg->ittiMsgHeader.imsi         = 0;
 
   return new_msg;
 }


### PR DESCRIPTION
[lte][agw]: Provided fix not to log multiple times invalid imsi and not able to fetch UE context for an invalid imsi

## Summary
Problem statement: In mme.log, there are many logs with message "No IMSI hash table for this IMSI" along with invalid imsi value.
Fix description: itti message contains 2 parts, itti header and itti message. in itti_alloc_new_message(),only itti message part is initialized to zero.
itti header contains imsi along with other information and is not initialized to zero. Since imsi was not initialized to zero, invalid imsi was getting filled and getting logged.

After initializing imsi to zero, there are no invalid messages getting logged.

## Test Plan
Executed s1ap sanity test suite
