### PR TITLE
[xwfm][ci] fix dockercomopse to use logrouter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -926,6 +926,7 @@ jobs:
             echo export MAGMA_ROOT=$(pwd) >> $BASH_ENV
             echo export AWS_ACCESS_KEY_ID="$(printenv XWF_AWS_ACCESS_KEY_ID)" >> $BASH_ENV
             echo export AWS_SECRET_ACCESS_KEY="$(printenv XWF_AWS_SECRET_ACCESS_KEY)" >> $BASH_ENV
+            echo export RUN_UID=$RANDOM >> $BASH_ENV
       - run:
           command: |
             env

--- a/xwf/docker/docker-compose.yml
+++ b/xwf/docker/docker-compose.yml
@@ -1,11 +1,10 @@
 version: '3.7'
 
-# Standard logging for each service
 x-logging: &logging_anchor
-  driver: "json-file"
+  driver: "fluentd"
   options:
-    max-size: "10mb"
-    max-file: "10"
+    fluentd-address: "localhost:24224"
+    fluentd-async-connect: "true"
 
 services:
   logrouter:
@@ -23,6 +22,7 @@ services:
     environment:
       - SCRIBE_ACCESS_TOKEN=${XWF_SCUBA_ACCESS_TOKEN}
       - SCUBA_TABLE=perfpipe_xwf_openflow_compose_logs
+      - RUN_UID=${RUN_UID:-1}
   ofproxy:
     container_name: ofproxy
     privileged: true
@@ -52,6 +52,7 @@ services:
       - OFPRADIUS=${OFPRADIUS:-0}
       - METERURL=${METERURL:-}
       - AWSENDPOINT=${AWSENDPOINT:-}
+      - LOG_TYPE=production
     logging: *logging_anchor
     depends_on:
       - logrouter
@@ -83,6 +84,7 @@ services:
       - ODS_PREFIX=xwf.openflow
       - ODS_CLUSTER=${XWF_PARTNER_SHORT_NAME}.${ENV}
       - ODS_ENTITY=ofproxy
+      - LOG_TYPE=production
     logging: *logging_anchor
     depends_on:
       - logrouter


### PR DESCRIPTION
[xwfm][ci]
## Summary

Make docker-compose use the XWF logrouter similar to the one in prod in order to help us debug CI issues

## Test Plan

ci + manual run of "docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py --type=analytic" and view the logs

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
