### PR TITLE
[orc8r][cloud][lib][docker] Fix intra cloud magic cert SN set logic

### DIFF
--- a/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
+++ b/orc8r/cloud/go/service/middleware/unary/identity_decorator.go
@@ -118,7 +118,7 @@ func SetIdentityFromContext(ctx context.Context, _ interface{}, info *grpc.Unary
 		if len(snlist) != 1 {
 			// there can be only one CSN, error out if not
 			log.Printf("Multiple CSNs found in metadata: %+v", ctxMetadata)
-			err = status.Error(codes.Unauthenticated, "Invalid SCN List")
+			err = status.Error(codes.Unauthenticated, "Multiple CSNs present")
 		} else {
 			// One CSN is found, find Identity associated with it
 			var gwIdentity *protos.Identity

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -431,7 +431,7 @@ func (r *ServiceRegistry) getGRPCDialOptions() []grpc.DialOption {
 		opts = append(opts, grpc.WithKeepaliveParams(localKeepaliveParams))
 	}
 	if r.serviceRegistryMode == K8sRegistryMode || r.serviceRegistryMode == DockerRegistryMode {
-		opts = append(opts, grpc.WithUnaryInterceptor(unary.UnaryCloudClientInterceptor))
+		opts = append(opts, grpc.WithUnaryInterceptor(unary.CloudClientInterceptor))
 	}
 	return opts
 }

--- a/orc8r/lib/go/service/middleware/unary/client_identity.go
+++ b/orc8r/lib/go/service/middleware/unary/client_identity.go
@@ -28,8 +28,21 @@ const (
 	ORC8R_CLIENT_CERT_VALUE = "7ZZXAF7CAETF241KL22B8YRR7B5UF401"
 )
 
-func UnaryCloudClientInterceptor(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-	appendedCtx := metadata.AppendToOutgoingContext(ctx, CLIENT_CERT_SN_KEY, ORC8R_CLIENT_CERT_VALUE)
-	err := invoker(appendedCtx, method, req, reply, cc, opts...)
+// CloudClientInterceptor sets Magic Certificate Value for orc8r service clients in the outgoing CTX
+// if the CTX metadata already has a client certificate SN key, CloudClientInterceptor will overwrite it with
+// the Magic Certificate Value
+func CloudClientInterceptor(
+	ctx context.Context, method string, req, reply interface{},
+	cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+
+	md, exists := metadata.FromOutgoingContext(ctx)
+	if exists {
+		md = md.Copy()
+		md.Set(CLIENT_CERT_SN_KEY, ORC8R_CLIENT_CERT_VALUE)
+	} else {
+		md = metadata.Pairs(CLIENT_CERT_SN_KEY, ORC8R_CLIENT_CERT_VALUE)
+	}
+	outgoingCtx := metadata.NewOutgoingContext(ctx, md)
+	err := invoker(outgoingCtx, method, req, reply, cc, opts...)
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary

Fix intra cloud magic cert SN set logic.

Set (overwrite) magic CSN on intra cloud service call contexts instead of appending it. It should fix multiple CSN errors on RPCs with forwarded ctx metadata.

## Test Plan

unit tests, staging later

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
