### PR TITLE
[NMS] Fixing the health value for unmanaged eNodeBs

### DIFF
--- a/nms/app/packages/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
+++ b/nms/app/packages/magmalte/app/views/equipment/EnodebDetailSummaryStatus.js
@@ -46,24 +46,24 @@ export function EnodebStatus() {
   const enbInfo = ctx.state.enbInfo[enodebSerial];
 
   const isEnbHealthy = isEnodebHealthy(enbInfo);
+  const isEnbManaged = enbInfo.enb?.enodeb_config?.config_type === 'MANAGED';
 
   const kpiData: DataRows[] = [
     [
       {
         category: 'eNodeB Externally Managed',
-        value:
-          enbInfo.enb?.enodeb_config?.config_type === 'MANAGED'
-            ? 'False'
-            : 'True',
+        value: isEnbManaged ? 'False' : 'True',
       },
       {
         category: 'Health',
-        value: isEnbHealthy ? 'Good' : 'Bad',
-        statusCircle: true,
+        value: isEnbManaged ? (isEnbHealthy ? 'Good' : 'Bad') : 'Unavailable',
+        statusCircle: isEnbManaged,
         status: isEnbHealthy,
-        tooltip: isEnbHealthy
-          ? 'eNodeB transmit config and status match'
-          : 'mismatch in eNodeB transmit config and status',
+        tooltip: isEnbManaged
+          ? isEnbHealthy
+            ? 'eNodeB transmit config and status match'
+            : 'mismatch in eNodeB transmit config and status'
+          : 'Health information unavailable on externally managed eNodeBs',
       },
       {
         category: 'Transmit Enabled',

--- a/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebDetailMainTest.js
+++ b/nms/app/packages/magmalte/app/views/equipment/__tests__/EnodebDetailMainTest.js
@@ -225,7 +225,7 @@ describe('<Enodeb />', () => {
       'testEnodebSerial1',
     );
     expect(getByTestId('eNodeB Externally Managed')).toHaveTextContent('True');
-    expect(getByTestId('Health')).toHaveTextContent('Bad');
+    expect(getByTestId('Health')).toHaveTextContent('Unavailable');
     expect(getByTestId('Transmit Enabled')).toHaveTextContent('Disabled');
     expect(getByTestId('Gateway ID')).toHaveTextContent('testGw2');
     expect(getByTestId('Mme Connected')).toHaveTextContent('Disconnected');


### PR DESCRIPTION
## Summary

Minor change. Fix the health status for unmanaged eNodeBs

## Test Plan
<img width="1680" alt="Screen Shot 2020-12-23 at 12 07 36 PM" src="https://user-images.githubusercontent.com/8224854/103033530-76862800-4517-11eb-91e5-6e44dceed4f3.png">

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
