### PR TITLE
[lte][agw] Print IMEI information in mme log

### DIFF
--- a/lte/gateway/c/oai/common/conversions.h
+++ b/lte/gateway/c/oai/common/conversions.h
@@ -556,6 +556,25 @@ imsi64_t imsi_to_imsi64(const imsi_t* const imsi);
     }                                                                          \
   }
 
+#define IMEISV_MOBID_TO_STRING(iMeIsV_t_PtR, iMeIsV_sTr, MaXlEn)                 \
+  {                                                                              \
+    int l_offset = 0;                                                            \
+    int l_ret    = 0;                                                            \
+    l_ret        = snprintf(                                                     \
+        iMeIsV_sTr + l_offset, MaXlEn - l_offset, "%u%u%u%u%u%u%u%u",     \
+        (iMeIsV_t_PtR)->tac1, (iMeIsV_t_PtR)->tac2, (iMeIsV_t_PtR)->tac3, \
+        (iMeIsV_t_PtR)->tac4, (iMeIsV_t_PtR)->tac5, (iMeIsV_t_PtR)->tac6, \
+        (iMeIsV_t_PtR)->tac7, (iMeIsV_t_PtR)->tac8);                      \
+    if (l_ret > 0) {                                                             \
+      l_offset += l_ret;                                                         \
+      l_ret = snprintf(                                                          \
+          iMeIsV_sTr + l_offset, MaXlEn - l_offset, "%u%u%u%u%u%u%u%u",          \
+          (iMeIsV_t_PtR)->snr1, (iMeIsV_t_PtR)->snr2, (iMeIsV_t_PtR)->snr3,      \
+          (iMeIsV_t_PtR)->snr4, (iMeIsV_t_PtR)->snr5, (iMeIsV_t_PtR)->snr6,      \
+          (iMeIsV_t_PtR)->svn1, (iMeIsV_t_PtR)->svn2);                           \
+    }                                                                            \
+  }
+
 /*Used to convert char* IMSI/TMSI Mobile Identity to MobileIdentity(digit)
  * format*/
 #define MOBILE_ID_CHAR_TO_MOBILE_ID_IMSI_NAS(mObId_ChAr, mObId_PtR, iMsI_LeN)  \

--- a/lte/gateway/c/oai/tasks/nas/emm/msg/emm_msg.c
+++ b/lte/gateway/c/oai/tasks/nas/emm/msg/emm_msg.c
@@ -39,6 +39,8 @@
 #include "3gpp_24.301.h"
 #include "emm_msg.h"
 #include "common_defs.h"
+#include "common_ies.h"
+#include "conversions.h"
 
 /****************************************************************************/
 /****************  E X T E R N A L    D E F I N I T I O N S  ****************/
@@ -172,6 +174,13 @@ int emm_msg_decode(EMM_msg* msg, uint8_t* buffer, uint32_t len) {
     case SECURITY_MODE_COMPLETE:
       decode_result = decode_security_mode_complete(
           &msg->security_mode_complete, buffer, len);
+      // MAX_IMEISV_SIZE is defined as 15, but IMEISV is
+      // actually 16 digits. Extra char for null termination.
+      char imeisv[MAX_IMEISV_SIZE + 2];
+      IMEISV_MOBID_TO_STRING(
+          &msg->security_mode_complete.imeisv.imeisv, imeisv,
+          MAX_IMEISV_SIZE + 2);
+      OAILOG_INFO(LOG_NAS_EMM, "EMM-MSG   - IMEISV: %s", imeisv);
       break;
 
     case TRACKING_AREA_UPDATE_ACCEPT:


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

PR shows IMEISV information in the mme.log at the first time it becomes available  during attach process.

## Test Plan

Integrations tests for regression.

Check the logs in lab set up using real UE:

```
000751 Wed Dec 23 12:42:12 2020 7FD198ACB700 INFO  S1AP   tasks/s1ap/s1ap_mme_itti_messagi:0080   [1010000091010]                           Sending NAS Uplink indication to NAS_MME_APP, mme_ue_s1ap_id = (8) 
000752 Wed Dec 23 12:42:12 2020 7FD19B38F700 INFO  NAS    tasks/nas/nas_proc.c            :0309                     Received NAS UPLINK DATA IND from S1AP for ue_id = (8)
000753 Wed Dec 23 12:42:12 2020 7FD19B38F700 INFO  NAS-EM tasks/nas/emm/sap/emm_as.c      :0176                           EMMAS-SAP - Received primitive EMMAS_DATA_IND (214)
000754 Wed Dec 23 12:42:12 2020 7FD19B38F700 INFO  NAS-EM tasks/nas/emm/sap/emm_as.c      :0621                              EMMAS-SAP - Received AS data transfer indication (ue_id=0x00000008, delivered=true, length=19)
000755 Wed Dec 23 12:42:12 2020 7FD19B38F700 INFO  NAS-EM tasks/nas/emm/msg/emm_msg.c     :0181                                          EMM-MSG   - IMEISV: 8665990489906112
```

## Additional Information

- [ ] This change is backwards-breaking

