### PR TITLE
[agw][lte] Reflect cloud streamed config for relative capacity in mme template

### DIFF
--- a/lte/gateway/configs/gateway.mconfig
+++ b/lte/gateway/configs/gateway.mconfig
@@ -14,6 +14,7 @@
       "@type": "type.googleapis.com/magma.mconfig.MME",
       "mmeCode": 1,
       "mmeGid": 1,
+      "mmeRelativeCapacity": 11,
       "logLevel": "INFO",
       "mcc": "001",
       "mnc": "01",

--- a/lte/gateway/configs/templates/mme.conf.template
+++ b/lte/gateway/configs/templates/mme.conf.template
@@ -19,7 +19,7 @@ MME :
     # When the limits will be reached, overload procedure will take place.
     MAXENB                                    = 8;                              # power of 2
     MAXUE                                     = 16;                             # power of 2
-    RELATIVE_CAPACITY                         = 10;
+    RELATIVE_CAPACITY                         = {{ mmeRelativeCapacity }};
 
     EMERGENCY_ATTACH_SUPPORTED                     = "no";
     UNAUTHENTICATED_IMSI_SUPPORTED                 = "no";


### PR DESCRIPTION
Signed-off-by: Ulas Kozat <kozat@fb.com>

## Summary

PR #3963 streams cloud API configured mme groupd id, mme code, relative mme capacity down to the AGW instance. This PR reflects the streamed down configuration for relative mme capacity in the template, as it was still hardcoded and streamed down value was not actually utilized.
 
## Test Plan
On local dev vm with no orc8r connection: 
- Change the value for relative capacity in `/etc/magma/gateway.mconfig`, restart the service, check the value in `/var/opt/magma/tmp/mme.conf` to see if the change was reflected.

On real set up with orc8r connection:
- Set value in orc8r.
- Check the value in `/var/opt/magma/tmp/mme.conf` to see if the streamed down value matches post service restart.
- Check S1 Setup Response to see if the right mme relative capacity value is sent out. E.g., for value of 1, we see this corresponding IE in pcap:

```
Item 1: id-RelativeMMECapacity
    ProtocolIE-Field
        id: id-RelativeMMECapacity (87)
        criticality: ignore (1)
        value
            RelativeMMECapacity: 1
```

## Additional Information

- [ ] This change is backwards-breaking

