### PR TITLE
[magma][lib] Default timeout for all Go GRPC client connections (local & cloud)

### DIFF
--- a/orc8r/lib/go/registry/cloud_connection.go
+++ b/orc8r/lib/go/registry/cloud_connection.go
@@ -176,6 +176,7 @@ func getDialOptions(serviceConfig *config.ConfigMap, authority string, useProxy 
 			MinConnectTimeout: grpcMaxTimeoutSec * time.Second,
 		}),
 		grpc.WithBlock(),
+		grpc.WithUnaryInterceptor(TimeoutInterceptor),
 	}
 	if useProxy {
 		opts = append(opts, grpc.WithInsecure(), grpc.WithAuthority(authority))

--- a/orc8r/lib/go/registry/interceptors.go
+++ b/orc8r/lib/go/registry/interceptors.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package registry for Magma microservices
+package registry
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"magma/orc8r/lib/go/service/middleware/unary"
+)
+
+var defaultTimeoutDuration = GrpcMaxTimeoutSec * time.Second
+
+// TimeoutInterceptor is a generic client connection interceptor which sets default timeout option for RPC if the
+// currently used CTX does not already specify it's own deadline option
+func TimeoutInterceptor(ctx context.Context, method string, req, resp interface{},
+	cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+
+	// check if given CTX already has a deadline & only add default deadline if not
+	if _, deadlineIsSet := ctx.Deadline(); !deadlineIsSet {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, defaultTimeoutDuration)
+		// cleanup timer after invoke call chain completion
+		defer cancel()
+	}
+	return invoker(ctx, method, req, resp, cc, opts...)
+}
+
+// CloudClientTimeoutInterceptor is the same as TimeoutInterceptor,
+// but - it also amends outgoing CTX with magic cloud client CSN header
+func CloudClientTimeoutInterceptor(ctx context.Context, method string, req, resp interface{},
+	cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+
+	return TimeoutInterceptor(unary.OutgoingCloudClientCtx(ctx), method, req, resp, cc, invoker, opts...)
+}

--- a/orc8r/lib/go/registry/registry.go
+++ b/orc8r/lib/go/registry/registry.go
@@ -23,7 +23,6 @@ import (
 
 	"magma/orc8r/lib/go/protos"
 	registry_client "magma/orc8r/lib/go/registry/client"
-	"magma/orc8r/lib/go/service/middleware/unary"
 
 	"github.com/golang/glog"
 	"golang.org/x/net/context"
@@ -430,9 +429,11 @@ func (r *ServiceRegistry) getGRPCDialOptions() []grpc.DialOption {
 	if *grpcKeepAlive {
 		opts = append(opts, grpc.WithKeepaliveParams(localKeepaliveParams))
 	}
+	var timeoutInterceptor = TimeoutInterceptor
 	if r.serviceRegistryMode == K8sRegistryMode || r.serviceRegistryMode == DockerRegistryMode {
-		opts = append(opts, grpc.WithUnaryInterceptor(unary.CloudClientInterceptor))
+		timeoutInterceptor = CloudClientTimeoutInterceptor
 	}
+	opts = append(opts, grpc.WithUnaryInterceptor(timeoutInterceptor))
 	return opts
 }
 

--- a/orc8r/lib/go/service/middleware/unary/client_identity.go
+++ b/orc8r/lib/go/service/middleware/unary/client_identity.go
@@ -35,6 +35,11 @@ func CloudClientInterceptor(
 	ctx context.Context, method string, req, reply interface{},
 	cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
 
+	return invoker(OutgoingCloudClientCtx(ctx), method, req, reply, cc, opts...)
+}
+
+// OutgoingCloudClientCtx amends outgoing cloud client context with magic client CSN metadata
+func OutgoingCloudClientCtx(ctx context.Context) context.Context {
 	md, exists := metadata.FromOutgoingContext(ctx)
 	if exists {
 		md = md.Copy()
@@ -42,7 +47,5 @@ func CloudClientInterceptor(
 	} else {
 		md = metadata.Pairs(CLIENT_CERT_SN_KEY, ORC8R_CLIENT_CERT_VALUE)
 	}
-	outgoingCtx := metadata.NewOutgoingContext(ctx, md)
-	err := invoker(outgoingCtx, method, req, reply, cc, opts...)
-	return err
+	return metadata.NewOutgoingContext(ctx, md)
 }


### PR DESCRIPTION
… 

Signed-off-by: Evgeniy Makeev <evgeniym@fb.com>


## Summary

Default timeout for all GRPC client connections (local & cloud).

Added Timeout Interceptor to all client connections which will amend outgoing context with timeout (deadline) if the context doesn't have it already.

## Test Plan

unit tests, staging, teravm

## Additional Information

- [ ] This change is backwards-breaking

