### PR TITLE
[agw][cli] Fix state_cli.py to properly parse policydb rules

### DIFF
--- a/lte/gateway/python/scripts/state_cli.py
+++ b/lte/gateway/python/scripts/state_cli.py
@@ -17,7 +17,7 @@ import json
 import jsonpickle
 import random
 import ast
-from typing import Any, Union
+from typing import Union
 
 from magma.common.redis.client import get_default_client
 from magma.common.redis.serializers import get_json_deserializer, \
@@ -30,6 +30,8 @@ from lte.protos.policydb_pb2 import PolicyRule, InstalledPolicies
 from lte.protos.oai.mme_nas_state_pb2 import MmeNasState, UeContext
 from lte.protos.oai.spgw_state_pb2 import SpgwState, S11BearerContext
 from lte.protos.oai.s1ap_state_pb2 import S1apState, UeDescription
+
+NO_DESERIAL_MSG = "No deserializer exists for type '{}'"
 
 
 def _deserialize_session_json(serialized_json_str: bytes) -> str:
@@ -85,6 +87,7 @@ class StateCLI(object):
         'rule_names': get_json_deserializer(),
         'rule_ids': get_json_deserializer(),
         'rule_versions': get_json_deserializer(),
+        'rules': get_proto_deserializer(PolicyRule),
     }
 
     STATE_PROTOS = {
@@ -130,12 +133,12 @@ class StateCLI(object):
         if redis_type == 'hash':
             deserializer = self.STATE_DESERIALIZERS.get(key_type)
             if not deserializer:
-                raise AttributeError('Key not found on redis')
+                raise AttributeError(NO_DESERIAL_MSG.format(key_type))
             self._parse_hash_type(deserializer, key)
         elif redis_type == 'set':
             deserializer = self.STATE_DESERIALIZERS.get(key_type)
             if not deserializer:
-                raise AttributeError('Key not found on redis')
+                raise AttributeError(NO_DESERIAL_MSG.format(key_type))
             self._parse_set_type(deserializer, key)
         else:
             value = self.client.get(key)


### PR DESCRIPTION
## Summary

This PR fixes two issues with state_cli.py regarding its handling of policydb:rules.

Note: policydb:rules is being stored as a [hash](https://redis.io/topics/data-types#hashes).

1. More-informative error message when we don't have a deserializer for the state type
2. Update deserializers map to allow deserializing policydb:rules

## Test Plan

Local testing -- before and after updating the deserializers map

```
# Before
(python) vagrant@magma-dev:~/magma/lte/gateway$ state_cli.py parse policydb:rules
Error: No deserializer exists for type 'rules'

# After
(python) vagrant@magma-dev:~/magma/lte/gateway$ state_cli.py parse policydb:rules
All ICMP
id: "All ICMP"
```

## Additional Information

- [ ] This change is backwards-breaking