### PR TITLE
Provided fix for memory leak

### DIFF
--- a/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
+++ b/lte/gateway/c/oai/tasks/s1ap/s1ap_mme_nas_procedures.c
@@ -1049,7 +1049,6 @@ void s1ap_handle_conn_est_cnf(
         (const char*) conn_est_cnf_pP->ue_radio_capability,
         conn_est_cnf_pP->ue_radio_cap_length);
     ASN_SEQUENCE_ADD(&out->protocolIEs.list, ie);
-    free_wrapper((void**) &(conn_est_cnf_pP->ue_radio_capability));
   }
 
   if (s1ap_mme_encode_pdu(&pdu, &buffer_p, &length) < 0) {


### PR DESCRIPTION
[lte][agw]: Provided fix for memory leak
## Summary
While handling service request message, mme_app sends Establishment_cnf message to s1ap; Within establishment-cnf message, ue_radio_capability was allocated memory, At s1ap task ue_radio_capability was getting freed with free_wrapper(), but it is of type bstring which needs to be freed with bdestroy_wrapper(), which is already done in fun, itti_free_msg_content(). So we should free the memory allocated for ue_radio_capability using bdestroy_wrapper()

## Test Plan
Executed s1ap sanity test suite
