### PR TITLE
[agw] [Sctpd] [bug-fix v1.3] Re-add PartOf dependency between MME and sctpd

### DIFF
--- a/lte/gateway/deploy/roles/magma/files/systemd/sctpd.service
+++ b/lte/gateway/deploy/roles/magma/files/systemd/sctpd.service
@@ -11,6 +11,7 @@
 #
 [Unit]
 Description=Magma sctpd service
+PartOf=magma@mme.service
 Before=magma@mme.service
 
 [Service]

--- a/lte/gateway/python/integ_tests/defs.mk
+++ b/lte/gateway/python/integ_tests/defs.mk
@@ -118,18 +118,16 @@ s1aptests/test_attach_ul_tcp_data.py \
 s1aptests/test_attach_detach_rar_tcp_data.py \
 s1aptests/test_attach_detach_multiple_rar_tcp_data.py \
 s1aptests/test_attach_asr.py \
-s1aptests/test_attach_detach_with_mme_restart.py \
-s1aptests/test_attach_detach_with_mobilityd_restart.py \
-s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
 s1aptests/test_attach_detach_attach_ul_tcp_data.py \
 s1aptests/test_restore_mme_config_after_sanity.py
-#s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
+#s1aptests/test_attach_detach_with_mme_restart.py \
+s1aptests/test_attach_detach_with_mobilityd_restart.py \
+s1aptests/test_attach_detach_multiple_ip_blocks_mobilityd_restart.py \
+s1aptests/test_attach_ul_udp_data_with_mme_restart.py \
 s1aptests/test_attach_ul_udp_data_with_mobilityd_restart.py \
 s1aptests/test_attach_ul_udp_data_with_multiple_service_restart.py \
 s1aptests/test_attach_ul_udp_data_with_pipelined_restart.py \
 s1aptests/test_attach_ul_udp_data_with_sessiond_restart.py \
-s1aptests/test_attach_detach_attach_ul_tcp_data.py \
-s1aptests/test_restore_mme_config_after_sanity.py
 
 # These test cases pass without memory leaks, but needs DL-route in TRF server
 # sudo /sbin/route add -net 192.168.128.0 gw 192.168.60.142


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

After an MME crash, Sctpd goes into a crash loop while trying to acquire the socket. This change fixes the crash loop by (re-)adding the systemd dependency between Sctpd and MME service.

Note: This systemd dependency will cause Sctpd to restart even when stateless flag is set to true, hence commenting those out from the sanity test suite, while we work on a fix.

## Test Plan

As @ulaskozat identified, the issue can be reproduced by running the `test_attach_detach.py` test from test VM and then kill the MME service on gateway with `kill -9`. Sctpd loops on 
```
Dec 26 06:25:41 magma-dev sctpd[11972]: I1226 06:25:41.293893 12119 sctpd_downlink_impl.cpp:37] SctpdDownlinkImpl::Init starting
Dec 26 06:25:41 magma-dev sctpd[11972]: I1226 06:25:41.293928 12119 sctpd_downlink_impl.cpp:53] SctpdDownlinkImpl::Init creating new socket and list
Dec 26 06:25:41 magma-dev sctpd[11972]: I1226 06:25:41.293962 12119 util.cpp:58] sctp_bindx error (98): Address already in use
```

After applying this change, followed by:
- sudo systemctl daemon-reload
- sudo service magma@* stop
- sudo service magma@magmad start

Sending a `kill -9` to MME does not lead to a crash loop.

Tested sanity with S1ap tests

## Additional Information

- [x] This change is backwards-breaking
This needs an update of the Sctpd package