### PR TITLE
[docker] optimization in git clone using --depth

### DIFF
--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -120,7 +120,7 @@ RUN mkdir -p /var/opt/magma/scripts
 COPY cwf/gateway/deploy/roles/cwag/files/add_uplink_bridge_flows.sh /var/opt/magma/scripts
 
 # Install OVS via Magma bionic pkg repo
-RUN git clone --single-branch --branch v2.12.0 https://github.com/openvswitch/ovs.git
+RUN git clone --depth 1 --single-branch --branch v2.12.0 https://github.com/openvswitch/ovs.git
 
 COPY cwf/gateway/deploy/roles/ovs/files/0001-Add-custom-IPDR-fields-for-IPFIX-export.patch /tmp
 COPY cwf/gateway/deploy/roles/ovs/files/0002-ovs-Handle-spaces-in-ovs-arguments.patch /tmp

--- a/lte/gateway/docker/deploy/Dockerfile
+++ b/lte/gateway/docker/deploy/Dockerfile
@@ -16,7 +16,7 @@ RUN mkdir -p ~/.ssh &&  \
     chmod 600 id_rsa
 
 ARG CACHE_DATE=2019-09-05
-RUN git clone https://github.com/facebookincubator/magma.git $MAGMA_ROOT
+RUN git clone --depth 1 https://github.com/facebookincubator/magma.git $MAGMA_ROOT
 
 RUN cp $MAGMA_ROOT/lte/gateway/docker/deploy/ssh_config /etc/ssh/ssh_config
 


### PR DESCRIPTION
## Summary

optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>