### PR TITLE
[docker] use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/cwf/gateway/docker/python/Dockerfile
+++ b/cwf/gateway/docker/python/Dockerfile
@@ -81,7 +81,7 @@ RUN apt-get -y update && apt-get -y install \
     netcat \
     iputils-ping
 
-RUN python3.5 -m pip install \
+RUN python3.5 -m pip install --no-cache-dir \
     Cython \
     fire \
     envoy \
@@ -137,11 +137,11 @@ RUN make install
 
 # Install orc8r python (magma.common required for lte python)
 COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.5 -m pip install /tmp/orc8r
+RUN python3.5 -m pip install --no-cache-dir /tmp/orc8r
 
 # Install lte python
 COPY lte/gateway/python /tmp/lte
-RUN python3.5 -m pip install /tmp/lte
+RUN python3.5 -m pip install --no-cache-dir /tmp/lte
 
 # Copy the configs.
 COPY lte/gateway/configs /etc/magma

--- a/feg/gateway/docker/python/Dockerfile
+++ b/feg/gateway/docker/python/Dockerfile
@@ -111,7 +111,7 @@ RUN chmod 755 /usr/bin/docker-compose
 
 # Install python code.
 COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.5 -m pip install /tmp/orc8r
+RUN python3.5 -m pip install --no-cache-dir /tmp/orc8r
 
 # Copy the build artifacts.
 COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/

--- a/lte/gateway/docker/deploy/Dockerfile
+++ b/lte/gateway/docker/deploy/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && \
     apt-get -y install curl make virtualenv zip rsync git software-properties-common python3-pip python-dev && \
     apt-get -y upgrade openssh-server && \
     alias python=python3 && \
-    pip3 install ansible
+    pip3 install --no-cache-dir ansible
 
 RUN mkdir -p /etc/ansible && \
     mkdir -p $MAGMA_ROOT

--- a/orc8r/cloud/docker/nginx/Dockerfile
+++ b/orc8r/cloud/docker/nginx/Dockerfile
@@ -2,7 +2,7 @@ FROM nginx:1.17
 
 RUN apt-get update && \
   apt-get install -y python3-pip daemontools
-RUN pip3 install PyYAML jinja2
+RUN pip3 install --no-cache-dir PyYAML jinja2
 
 RUN mkdir -p /var/opt/magma/envdir
 COPY configs /etc/magma/configs

--- a/orc8r/gateway/docker/Dockerfile
+++ b/orc8r/gateway/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN curl -sSL https://get.docker.com/ > /tmp/get_docker.sh && \
 
 # Install python code.
 COPY orc8r/gateway/python /tmp/orc8r
-RUN python3.5 -m pip install /tmp/orc8r
+RUN python3.5 -m pip install --no-cache-dir /tmp/orc8r
 
 # Copy the build artifacts.
 COPY --from=builder /build/python/gen /usr/local/lib/python3.5/dist-packages/


### PR DESCRIPTION
## Summary

using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>