### PR TITLE
[magma][circleci] cwag_deploy and xwfm_deploy will run after code changes only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1032,6 +1032,24 @@ workflows:
           requires:
             - xwfm-test
             - cwag-deploy
+      - cwag-deploy:
+          <<: *only_master
+          name: cwag-deploy-latest
+          requires:
+            - xwfm-test
+            - cwag-precommit
+            - cwf-integ-test
+          images: 'gateway_python|gateway_pipelined'
+          tag: 'latest'
+      - xwfm-deploy:
+          <<: *only_master
+          name: xwfm-deploy-latest
+          requires:
+            - xwfm-test
+            - cwag-precommit
+            - cwf-integ-test
+          tag: 'latest'
+
 
   cwf_operator:
     jobs:
@@ -1048,15 +1066,6 @@ workflows:
     jobs:
       - xwfm-test:
           notify_magma_ci: false
-      - xwfm-deploy:
-          requires:
-            - xwfm-test
-          tag: 'hourly'
-      - cwag-deploy:
-          requires:
-            - xwfm-test
-          images: 'gateway_python|gateway_pipelined'
-          tag: 'hourly'
 
   nms:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1032,6 +1032,15 @@ workflows:
           requires:
             - xwfm-test
             - cwag-deploy
+      - xwfm-deploy:
+          requires:
+            - xwfm-test
+          tag: 'latest'
+      - cwag-deploy:
+          requires:
+            - xwfm-test
+          images: 'gateway_python|gateway_pipelined'
+          tag: 'latest'
 
   cwf_operator:
     jobs:
@@ -1048,15 +1057,6 @@ workflows:
     jobs:
       - xwfm-test:
           notify_magma_ci: false
-      - xwfm-deploy:
-          requires:
-            - xwfm-test
-          tag: 'hourly'
-      - cwag-deploy:
-          requires:
-            - xwfm-test
-          images: 'gateway_python|gateway_pipelined'
-          tag: 'hourly'
 
   nms:
     jobs:


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

<!--
    [magma][circleci] cwag_deploy and xwfm_deploy will run after code changes only
-->

## Summary

xwf team will use latest tag instead of hourly and the deployment can be done only on code changes and not based on hourly scheduling.
We will test xwf_m every hour but wont publish anything.

## Test Plan
```
$ circleci config validate ~/magma/.circleci/config.yml
Config file at /Users/ayeletrd/magma/.circleci/config.yml is valid.
```
## Additional Information

- [ ] This change is backwards-breaking


