### PR TITLE
[EventD] Cleanup RPC Servicer and separate validation logic for better clarity

### DIFF
--- a/orc8r/gateway/python/magma/eventd/event_validator.py
+++ b/orc8r/gateway/python/magma/eventd/event_validator.py
@@ -1,0 +1,90 @@
+"""
+Copyright 2020 The Magma Authors.
+
+This source code is licensed under the BSD-style license found in the
+LICENSE file in the root directory of this source tree.
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import json
+import logging
+from contextlib import closing
+from typing import Any, Dict
+import pkg_resources
+import yaml
+
+from bravado_core.spec import Spec
+from bravado_core.validate import validate_object as bravado_validate
+
+class EventValidator(object):
+    """
+    gRPC based server for EventD.
+    """
+    def __init__(self, config: Dict[str, Any]):
+        self.event_registry = config['event_registry']
+        self.event_type_to_spec = self._load_specs_from_registry()
+
+    def validate_event(self, raw_event: str, event_type: str) -> None:
+        """
+        Checks if an event is registered and validates it based on
+        a registered schema.
+        Args:
+            raw_event: The event to be validated, as a JSON-encoded string
+            event_type: The type of an event, which corresponds
+            to a generated model
+        Returns:
+            Does not return, but throws exceptions if validation fails.
+        """
+        event = json.loads(raw_event)
+
+        # Event not in registry
+        if event_type not in self.event_registry:
+            logging.debug(
+                'Event type %s not among registered event types (%s)',
+                event_type, self.event_registry)
+            raise KeyError(
+                'Event type {} not registered, '
+                'please add it to the EventD config'.format(event_type))
+
+        # swagger_spec exists because we load it up for every event_type
+        # in load_specs_from_registry()
+        swagger_spec = self.event_type_to_spec[event_type]
+
+        # Field and type checking
+        bravado_spec = Spec.from_dict(swagger_spec,
+                                      config={'validate_swagger_spec': False})
+        bravado_validate(
+            bravado_spec,
+            swagger_spec['definitions'][event_type],
+            event)
+
+
+    def _load_specs_from_registry(self) -> Dict[str, Any]:
+        """
+        Loads all swagger definitions from the files specified in the
+        event registry.
+        """
+        event_type_to_spec = {}
+        for event_type, info in self.event_registry.items():
+            module = '{}.swagger.specs'.format(info['module'])
+            filename = info['filename']
+            if not pkg_resources.resource_exists(module, filename):
+                raise LookupError(
+                    'File {} not found under {}/swagger, please ensure that '
+                    'it exists'.format(filename, info['module']))
+
+            stream = pkg_resources.resource_stream(module, filename)
+            with closing(stream) as spec_file:
+                spec = yaml.safe_load(spec_file)
+                if event_type not in spec['definitions']:
+                    raise KeyError(
+                        'Event type {} is not defined in {}, '
+                        'please add the definition and re-generate '
+                        'swagger specifications'.format(event_type, filename))
+                event_type_to_spec[event_type] = spec
+        return event_type_to_spec

--- a/orc8r/gateway/python/magma/eventd/main.py
+++ b/orc8r/gateway/python/magma/eventd/main.py
@@ -13,6 +13,7 @@ limitations under the License.
 
 from magma.common.service import MagmaService
 from .rpc_servicer import EventDRpcServicer
+from .event_validator import EventValidator
 from orc8r.protos.mconfig.mconfigs_pb2 import EventD
 
 
@@ -20,8 +21,8 @@ def main():
     """ main() for eventd """
     service = MagmaService('eventd', EventD())
 
-    eventd_servicer = EventDRpcServicer(service.config)
-    eventd_servicer.load_specs_from_registry()
+    event_validator = EventValidator(service.config)
+    eventd_servicer = EventDRpcServicer(service.config, event_validator)
     eventd_servicer.add_to_server(service.rpc_server)
 
     # Run the service loop

--- a/orc8r/gateway/python/magma/eventd/rpc_servicer.py
+++ b/orc8r/gateway/python/magma/eventd/rpc_servicer.py
@@ -16,16 +16,12 @@ import logging
 import socket
 from contextlib import closing
 from typing import Any, Dict
-
 import grpc
 import jsonschema
-import pkg_resources
-import yaml
 
-from bravado_core.spec import Spec
-from bravado_core.validate import validate_object as bravado_validate
 from magma.common.rpc_utils import return_void
 from orc8r.protos import eventd_pb2_grpc, eventd_pb2
+from .event_validator import EventValidator
 
 
 class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
@@ -33,75 +29,16 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
     gRPC based server for EventD.
     """
 
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], validator: EventValidator):
         self.fluent_bit_port = config['fluent_bit_port']
         self.tcp_timeout = config['tcp_timeout']
-        self.event_registry = config['event_registry']
-        # To be initialized in load_specs_from_registry
-        self.event_type_to_spec = {}
-
-    def load_specs_from_registry(self):
-        """
-        Loads all swagger definitions from the files specified in the
-        event registry.
-        """
-        for event_type, info in self.event_registry.items():
-            module = '{}.swagger.specs'.format(info['module'])
-            filename = info['filename']
-            if not pkg_resources.resource_exists(module, filename):
-                raise LookupError(
-                    'File {} not found under {}/swagger, please ensure that '
-                    'it exists'.format(filename, info['module']))
-
-            stream = pkg_resources.resource_stream(module, filename)
-            with closing(stream) as spec_file:
-                spec = yaml.safe_load(spec_file)
-                if event_type not in spec['definitions']:
-                    raise KeyError(
-                        'Event type {} is not defined in {}, '
-                        'please add the definition and re-generate '
-                        'swagger specifications'.format(event_type, filename))
-                self.event_type_to_spec[event_type] = spec
+        self._validator = validator
 
     def add_to_server(self, server):
         """
         Add the servicer to a gRPC server
         """
         eventd_pb2_grpc.add_EventServiceServicer_to_server(self, server)
-
-    def _validate_event(self, raw_event: str, event_type: str) -> None:
-        """
-        Checks if an event is registered and validates it based on
-        a registered schema.
-        Args:
-            raw_event: The event to be validated, as a JSON-encoded string
-            event_type: The type of an event, which corresponds
-            to a generated model
-        Returns:
-            Does not return, but throws exceptions if validation fails.
-        """
-        event = json.loads(raw_event)
-
-        # Event not in registry
-        if event_type not in self.event_registry:
-            logging.debug(
-                'Event type %s not among registered event types (%s)',
-                event_type, self.event_registry)
-            raise KeyError(
-                'Event type {} not registered, '
-                'please add it to the eventd config'.format(event_type))
-
-        # swagger_spec exists because we load it up for every event_type
-        # in load_specs_from_registry()
-        swagger_spec = self.event_type_to_spec[event_type]
-
-        # Field and type checking
-        bravado_spec = Spec.from_dict(swagger_spec,
-                                      config={'validate_swagger_spec': False})
-        bravado_validate(
-            bravado_spec,
-            swagger_spec['definitions'][event_type],
-            event)
 
     @return_void
     def LogEvent(self, request: eventd_pb2.Event, context):
@@ -111,7 +48,7 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
         logging.debug("Logging event: %s", request)
 
         try:
-            self._validate_event(request.value, request.event_type)
+            self._validator.validate_event(request.value, request.event_type)
         except (KeyError, jsonschema.ValidationError) as e:
             logging.error("KeyError for log: %s. Error: %s", request, e)
             context.set_code(grpc.StatusCode.INVALID_ARGUMENT)
@@ -124,16 +61,18 @@ class EventDRpcServicer(eventd_pb2_grpc.EventServiceServicer):
                     ('localhost', self.fluent_bit_port),
                     timeout=self.tcp_timeout)) as sock:
                 logging.debug('Sending log to FluentBit')
-                sock.sendall(json.dumps({
+                value = {
                     'stream_name': request.stream_name,
                     'event_type': request.event_type,
-                    # We use event_tag as fluentd uses the "tag" field
+                    # We use event_tag as FluentD uses the "tag" field
                     'event_tag': request.tag,
                     'value': request.value
-                }).encode('utf-8'))
+                }
+                sock.sendall(json.dumps(value).encode('utf-8'))
         except socket.error as e:
             logging.error('Connection to FluentBit failed: %s', e)
-            logging.info('Fluentbit may not be configured correctly.')
+            logging.info('FluentBit (td-agent-bit) may not be enabled '
+                         'or configured correctly')
             context.set_code(grpc.StatusCode.UNAVAILABLE)
             context.set_details(
                 'Could not connect to FluentBit locally, Details: {}'

--- a/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
+++ b/orc8r/gateway/python/magma/eventd/tests/event_validation_tests.py
@@ -13,12 +13,9 @@ limitations under the License.
 
 import json
 from unittest import TestCase
-
 from jsonschema import ValidationError
 
-from magma.eventd.rpc_servicer import EventDRpcServicer
-from magma.common.service import MagmaService
-
+from magma.eventd.event_validator import EventValidator
 
 class EventValidationTests(TestCase):
 
@@ -37,78 +34,90 @@ class EventValidationTests(TestCase):
                 'null_event': test_events_location,
             },
         }
-        servicer = EventDRpcServicer(config)
-        servicer.load_specs_from_registry()
-        self.validate_event = servicer._validate_event
+        self.validator = EventValidator(config)
 
     def test_event_registration(self):
+        data = json.dumps({
+            'foo': 'magma',  # required
+            'bar': 123
+        })
         # Errors when event is not registered
         with self.assertRaises(Exception):
-            self.validate_event(json.dumps({'foo': 'asdf', 'bar': 123}),
-                                'non_existent_event')
+            self.validator.validate_event(data, 'non_existent_event')
 
         # Does not error when event is registered
-        self.validate_event(json.dumps({'foo': 'asdf', 'bar': 123}),
-                            'simple_event')
+        self.validator.validate_event(data, 'simple_event')
 
     def test_field_consistency(self):
         # Errors when there are missing fields (required fields)
         with self.assertRaises(ValidationError):
             # foo is missing
-            self.validate_event(json.dumps({'bar': 123}), 'simple_event')
+            data = json.dumps({
+                'bar': 123
+            })
+            self.validator.validate_event(data, 'simple_event')
 
         # Errors on excess fields (additionalProperties set to false)
         with self.assertRaises(ValidationError):
-            self.validate_event(
-                json.dumps({'extra_field': 12, 'foo': 'asdf', 'bar': 123}),
-                'simple_event')
+            data = json.dumps({
+                'extra_field': 12,
+                'foo': 'asdf',
+                'bar': 123
+            })
+            self.validator.validate_event(data,'simple_event')
 
         # Errors when there are missing AND excess fields
         with self.assertRaises(ValidationError):
+            data = json.dumps({
+                'extra_field': 12,
+                'bar': 123
+            })
             # foo is missing
-            self.validate_event(json.dumps({'extra_field': 12, 'bar': 123}),
-                                'simple_event')
+            self.validator.validate_event(data, 'simple_event')
 
         # Does not error when the fields are equivalent
-        self.validate_event(json.dumps({'foo': 'asdf', 'bar': 123}),
-                            'simple_event')
+        data = json.dumps({
+            'foo': 'magma',  # required
+            'bar': 123
+        })
+        self.validator.validate_event(data, 'simple_event')
 
         # Does not error when event has no fields
-        self.validate_event(json.dumps({}), 'null_event')
+        self.validator.validate_event(json.dumps({}), 'null_event')
 
     def test_type_checking(self):
+        data = json.dumps({
+            'an_array': ["a", "b"],
+            'an_object': {
+                "a_key": 1,
+                "b_key": 1
+            }
+        })
         # Does not error when the types match
-        self.validate_event(
-            json.dumps({
-                'an_array': ["a", "b"],
-                'an_object': {
-                    "a_key": 1,
-                    "b_key": 1
-                }
-            }),
-            'array_and_object_event')
+        self.validator.validate_event(data, 'array_and_object_event')
 
         # Errors when the type is wrong for primitive fields
         with self.assertRaises(ValidationError):
-            self.validate_event(json.dumps({'foo': 123, 'bar': 'asdf'}),
-                                'simple_event')
+            data = json.dumps({
+                'foo': 123,
+                'bar': 'asdf'
+            })
+            self.validator.validate_event(data, 'simple_event')
 
         # Errors when the type is wrong for array
         with self.assertRaises(ValidationError):
-            self.validate_event(
-                json.dumps({
-                    'an_array': [1, 2, 3],
-                    'an_object': {}
-                }),
-                'array_and_object_event')
+            data = json.dumps({
+                'an_array': [1, 2, 3],
+                'an_object': {}
+            })
+            self.validator.validate_event(data, 'array_and_object_event')
 
         # Errors when the value type is wrong for object
         with self.assertRaises(ValidationError):
-            self.validate_event(
-                json.dumps({
-                    'an_array': ["a", "b"],
-                    'an_object': {
-                        "a_key": "wrong_value"
-                    }
-                }),
-                'array_and_object_event')
+            data = json.dumps({
+                'an_array': ["a", "b"],
+                'an_object': {
+                    "a_key": "wrong_value"
+                }
+            })
+            self.validator.validate_event(data, 'array_and_object_event')


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Separate out the validation logic into its own class for better readability.
No logical changes here.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
Run S1AP tests, EventD produces events
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
