### PR TITLE
[v1.3][CI] Bump the package version for AGW to 1.3.3 and corresponding Sctpd req…

### DIFF
--- a/lte/gateway/release/build-magma.sh
+++ b/lte/gateway/release/build-magma.sh
@@ -20,8 +20,8 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 
 # Please update the version number accordingly for beta/stable builds
 # Test builds are versioned automatically by fabfile.py
-VERSION=1.3.2 # magma version number
-SCTPD_MIN_VERSION=1.3.1 # earliest version of sctpd with which this version is compatible
+VERSION=1.3.3 # magma version number
+SCTPD_MIN_VERSION=1.3.3 # earliest version of sctpd with which this version is compatible
 
 # RelWithDebInfo or Debug
 BUILD_TYPE=Debug


### PR DESCRIPTION
…uirement

Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

- Increase the package version for AGW to 1.3.3
- This version requires the latest Sctpd version 1.3.3 to be installed

## Test Plan

N/A