### PR TITLE
[ctraced][orc8r] Add delete function to ctraced blobstore

### DIFF
--- a/orc8r/cloud/go/services/ctraced/storage/storage.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage.go
@@ -15,11 +15,16 @@ package storage
 
 // CtracedStorage is the persistence service interface for call traces.
 // All call trace accesses from ctraced service must go through this interface.
+// Call traces should be stored as .pcap files
 type CtracedStorage interface {
 
-	// StoreCallTrace
+	// StoreCallTrace stores the call trace file
 	StoreCallTrace(networkID string, callTraceID string, data []byte) error
 
-	// GetCallTrace
+	// GetCallTrace returns the call trace file
 	GetCallTrace(networkID string, callTraceID string) ([]byte, error)
+
+	// DeleteCallTrace deletes the call trace file
+	// Returns an error if the call trace does not exist
+	DeleteCallTrace(networkID string, callTraceID string) error
 }

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore.go
@@ -14,6 +14,8 @@ limitations under the License.
 package storage
 
 import (
+	"fmt"
+
 	"magma/orc8r/cloud/go/blobstore"
 	"magma/orc8r/cloud/go/storage"
 	merrors "magma/orc8r/lib/go/errors"
@@ -54,7 +56,7 @@ func (c *ctracedBlobStore) StoreCallTrace(networkID string, callTraceID string, 
 		},
 	)
 	if err != nil {
-		return errors.Wrap(err, "failed to store call trace")
+		return errors.Wrap(err, fmt.Sprintf("failed to store call trace %s", callTraceID))
 	}
 
 	return store.Commit()
@@ -76,8 +78,29 @@ func (c *ctracedBlobStore) GetCallTrace(networkID string, callTraceID string) ([
 		return nil, err
 	}
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get hostname")
+		return nil, errors.Wrap(err, fmt.Sprintf("failed to get call trace %s", callTraceID))
 	}
 
 	return blob.Value, store.Commit()
+}
+
+// DeleteCallTrace
+func (c *ctracedBlobStore) DeleteCallTrace(networkID string, callTraceID string) error {
+	store, err := c.factory.StartTransaction(&storage.TxOptions{ReadOnly: true})
+	if err != nil {
+		return errors.Wrap(err, "failed to start transaction")
+	}
+	defer store.Rollback()
+
+	err = store.Delete(
+		networkID,
+		[]storage.TypeAndKey{
+			storage.TypeAndKey{Type: CtracedBlobType, Key: callTraceID},
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("failed to delete call trace %s", callTraceID))
+	}
+
+	return store.Commit()
 }

--- a/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
+++ b/orc8r/cloud/go/services/ctraced/storage/storage_blobstore_test.go
@@ -154,3 +154,38 @@ func TestCtracedBlobstoreStorage_StoreCallTrace(t *testing.T) {
 	blobFactMock.AssertExpectations(t)
 	blobStoreMock.AssertExpectations(t)
 }
+
+func TestCtracedBlobstoreStorage_DeleteCallTrace(t *testing.T) {
+	var blobFactMock *mocks.BlobStorageFactory
+	var blobStoreMock *mocks.TransactionalBlobStorage
+	someErr := errors.New("generic error")
+
+	ctid := "some_call_trace"
+	tk := storage.TypeAndKey{Type: cstorage.CtracedBlobType, Key: ctid}
+	tkSet := []storage.TypeAndKey{tk}
+
+	// Fail to start transaction
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(nil, someErr).Once()
+	store := cstorage.NewCtracedBlobstore(blobFactMock)
+
+	err := store.DeleteCallTrace(placeholderNetworkID, ctid)
+	assert.Error(t, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+
+	// Success
+	blobFactMock = &mocks.BlobStorageFactory{}
+	blobStoreMock = &mocks.TransactionalBlobStorage{}
+	blobFactMock.On("StartTransaction", mock.Anything).Return(blobStoreMock, nil).Once()
+	blobStoreMock.On("Rollback").Return(nil).Once()
+	blobStoreMock.On("Delete", placeholderNetworkID, tkSet).Return(nil).Once()
+	blobStoreMock.On("Commit").Return(nil).Once()
+	store = cstorage.NewCtracedBlobstore(blobFactMock)
+
+	err = store.DeleteCallTrace(placeholderNetworkID, ctid)
+	assert.NoError(t, err)
+	blobFactMock.AssertExpectations(t)
+	blobStoreMock.AssertExpectations(t)
+}


### PR DESCRIPTION
Signed-off-by: Andrei Lee <andreilee@fb.com>

## Summary

Added delete function (`DeleteCallTrace`) to `ctracedBlobStore` to support delete functionality from the REST API

## Test Plan
- Unit tests have been modified to test the new `DeleteCallTrace` method implementation on `ctracedBlobStore`
- Sanity build of orc8r

## Additional Information

- [ ] This change is backwards-breaking
