### PR TITLE
[orc8r][nginx] Fix feg relay routing due to incorrectly formatted gRPC host header

### DIFF
--- a/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
+++ b/orc8r/cloud/docker/nginx/templates/nginx.conf.j2
@@ -94,11 +94,12 @@ http {
       # Helm services don't allow for underscores. Magma convention is
       # to use underscores in service names, so convert any hyphens in the
       # k8s service name.
-      if ($srv ~* "(\w+)[_](\w+)") {
-        set $srv "$1-$2";
+      set $k8s_svc $srv;
+      if ($k8s_svc ~* "(\w+)[_](\w+)") {
+        set $k8s_svc "$1-$2";
       }
-      grpc_pass grpc://orc8r-$srv.{{ backend }}:9180;
-      grpc_set_header Host $srv:9180;
+      grpc_pass grpc://orc8r-$k8s_svc.{{ backend }}:9180;
+      grpc_set_header Host $srv-orc8r-$k8s_svc.{{ backend }}:9180;
 
       {%- else %}
       grpc_pass grpc://{{ backend }}:$srvport;


### PR DESCRIPTION
Signed-off-by: Michael Germano <mgermano@fb.com>

## Summary

This PR corrects an issue we have been seeing using the newly deployed service mesh.
To properly route requests to the feg via feg_relay, we parse the gRPC host header.
Previously this was set in format `feg_service-orc8r-controller...`. The parsing logic sets the
authority to everything up to the first hyphen. This PR updates the host header to use this
format again.

## Test Plan

Updated nginx pods to ensure this fixes the issuec by using
`feg_hello_cli.py` on an agw