### PR TITLE
[lte][ansible-galaxy] ignore errors on dev env

### DIFF
--- a/lte/gateway/deploy/roles/dev_common/tasks/main.yml
+++ b/lte/gateway/deploy/roles/dev_common/tasks/main.yml
@@ -19,6 +19,7 @@
 
 - name: Install ansible community collection
   shell: su - {{ ansible_user }} -c 'ansible-galaxy collection install community.general'
+  ignore_errors: yes
 
 - name: Set build environment variables
   lineinfile:


### PR DESCRIPTION
Signed-off-by: Ayelet Regev Dabah <ayelet.regev@gmail.com>

<!--
[lte][ansible-galaxy] ignore errors on dev env
-->

## Summary

seems like ansible downloads are being timed out more on last 1 day https://github.com/ansible/ansible/issues/73071 since this not critical to business logic on dev envs i have added ignore errors on that ansible task.

## Test Plan

<!--
Tested locally on my dev vm
-->

## Additional Information

- [ ] This change is backwards-breaking


