### PR TITLE
[CWF IntegTest] Attempt to stabilize flakiest tests

### DIFF
--- a/cwf/gateway/integ_tests/assertions.go
+++ b/cwf/gateway/integ_tests/assertions.go
@@ -112,6 +112,22 @@ func (tr *TestRunner) AssertPolicyEnforcementRecordIsNil(imsi string) {
 	assert.Empty(tr.t, recordsBySubID[prependIMSIPrefix(imsi)])
 }
 
+func (tr *TestRunner) AssertEventuallyAllRulesRemovedAfterDisconnect(imsi string) {
+	checkFn := func() bool {
+		fmt.Printf("Waiting until all rules are removed in enforcement stats for %s...\n", imsi)
+		records, err := tr.GetPolicyUsage()
+		if err != nil {
+			return false
+		}
+		if len(records[prependIMSIPrefix(imsi)]) == 0 {
+			return true
+		}
+		return false
+	}
+	assert.Eventually(tr.t, checkFn, 10*time.Second, 2*time.Second)
+	fmt.Println("All enforcement stats are gone!")
+}
+
 // Query assertion result from MockPCRF and assert all expectations were met.
 // Only applicable when MockDriver is used.
 func (tr *TestRunner) AssertAllGxExpectationsMetNoError() {

--- a/cwf/gateway/integ_tests/auth_test.go
+++ b/cwf/gateway/integ_tests/auth_test.go
@@ -175,8 +175,7 @@ func TestAuthenticateUplinkTraffic(t *testing.T) {
 	tr.AssertAllGxExpectationsMetNoError()
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Authenticate a UE through a first AP then switch to use a second AP
@@ -228,6 +227,5 @@ func TestAuthenticateMultipleAPsUplinkTraffic(t *testing.T) {
 
 	_, err = tr.Disconnect(imsi, CalledStationIDs[1])
 	assert.NoError(t, err)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }

--- a/cwf/gateway/integ_tests/gx_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_enforcement_test.go
@@ -114,8 +114,7 @@ func TestGxUsageReportEnforcement(t *testing.T) {
 	assert.NoError(t, setPCRFExpectations(expectations, nil))
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	// Check that enforcement stats flow is removed
-	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, "usage-enforcement-static-pass-all"), time.Minute, 2*time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 	// Assert that we saw a Terminate request
 	tr.AssertAllGxExpectationsMetNoError()
 }
@@ -171,7 +170,8 @@ func TestGxMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	tr.AuthenticateAndAssertSuccess(imsi)
 	assert.Eventually(t, tr.WaitForEnforcementStatsForRule(imsi, "static-pass-all-1", "static-pass-all-3"), time.Minute, 2*time.Second)
 
-	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "250K"}}
+	// Pass a small amount, but not enough to trigger a CCR-U
+	req := &cwfprotos.GenTrafficRequest{Imsi: imsi, Volume: &wrappers.StringValue{Value: "100K"}}
 	_, err = tr.GenULTraffic(req)
 	assert.NoError(t, err)
 
@@ -213,7 +213,7 @@ func TestGxMidSessionRuleRemovalWithCCA_U(t *testing.T) {
 	tr.AssertAllGxExpectationsMetNoError()
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, "static-pass-all-ocs2"), 10*time.Second, 2*time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Set an expectation for a  CCR-I to be sent up to PCRF, to which it will
@@ -311,8 +311,7 @@ func TestGxRuleInstallTime(t *testing.T) {
 	tr.AssertAllGxExpectationsMetNoError()
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 //TestGxAbortSessionRequest
@@ -367,14 +366,7 @@ func TestGxAbortSessionRequest(t *testing.T) {
 	// processing disconnect
 	assert.Contains(t, asa.SessionId, "IMSI"+imsi)
 	assert.Equal(t, uint32(diam.LimitedSuccess), asa.ResultCode)
-	// check if all rules have been cleaned up
-	checkSessionAborted := func() bool {
-		recordsBySubID, err = tr.GetPolicyUsage()
-		assert.NoError(t, err)
-		return recordsBySubID["IMSI"+imsi][ruleKey] == nil
-	}
-	assert.Eventually(t, checkSessionAborted, 10*time.Second, 5*time.Second,
-		"request not terminated as expected")
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Set an expectation for a CCR-I to be sent up to PCRF, to which it will
@@ -448,8 +440,7 @@ func TestGxRevalidationTime(t *testing.T) {
 	assert.NoError(t, setPCRFExpectations(expectations, nil))
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	// Wait for termination to go through
-	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, "revalidation-time-static-pass-all"), 10*time.Second, 2*time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 
 	// Assert that we saw a Terminate request
 	tr.AssertAllGxExpectationsMetNoError()

--- a/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_enforcement_test.go
@@ -123,8 +123,7 @@ func TestGxUplinkTrafficQosEnforcement(t *testing.T) {
 	assert.NotNil(t, record, fmt.Sprintf("No policy usage record for imsi: %v", imsi))
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 func checkIfRuleInstalled(tr *TestRunner, ruleName string) bool {
@@ -202,7 +201,7 @@ func TestGxDownlinkTrafficQosEnforcement(t *testing.T) {
 	assert.Eventually(t, tr.WaitForEnforcementStatsForRule(imsi, ruleKey), 2*time.Minute, 2*time.Second)
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, ruleKey), 2*time.Minute, 2*time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 //TestGxQosDowngradeWithCCAUpdate
@@ -320,8 +319,7 @@ func TestGxQosDowngradeWithCCAUpdate(t *testing.T) {
 	assert.NoError(t, setPCRFExpectations(expectations, nil))
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(6 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 
 	// Assert that we saw a Terminate request
 	tr.AssertAllGxExpectationsMetNoError()
@@ -418,6 +416,5 @@ func TestGxQosDowngradeWithReAuth(t *testing.T) {
 	assert.NotNil(t, record, fmt.Sprintf("No policy usage record for imsi: %v", imsi))
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }

--- a/cwf/gateway/integ_tests/gx_qos_restart_test.go
+++ b/cwf/gateway/integ_tests/gx_qos_restart_test.go
@@ -147,8 +147,7 @@ func testQosEnforcementRestart(t *testing.T, cfgCh chan string, restartCfg strin
 	verifyEgressRate(t, tr, req, float64(uplinkBwMax))
 
 	tr.DisconnectAndAssertSuccess(imsi)
-	assert.NoError(t, err)
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 func restartPipelined(t *testing.T, tr *TestRunner) {

--- a/cwf/gateway/integ_tests/gx_reauth_test.go
+++ b/cwf/gateway/integ_tests/gx_reauth_test.go
@@ -129,8 +129,7 @@ func TestGxReAuthWithMidSessionPolicyRemoval(t *testing.T) {
 
 	// Trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Install two static rules "static-pass-all-raa1" and "static-pass-all-raa2"
@@ -154,6 +153,9 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 	imsi := ue.GetImsi()
 
 	tr.AuthenticateAndAssertSuccess(imsi)
+	// Wait for flows to be installed
+	assert.Eventually(t, tr.WaitForEnforcementStatsForRule(
+		imsi, "static-pass-all-raa1", "static-pass-all-raa2"), time.Minute, 2*time.Second)
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
@@ -196,8 +198,7 @@ func TestGxReAuthWithMidSessionPoliciesRemoval(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Install two static rules "static-pass-all-raa1" and "static-pass-all-raa2"
@@ -220,6 +221,9 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 	imsi := ue.GetImsi()
 
 	tr.AuthenticateAndAssertSuccess(imsi)
+	// Wait for flows to be installed
+	assert.Eventually(t, tr.WaitForEnforcementStatsForRule(
+		imsi, "static-pass-all-raa1", "static-pass-all-raa2"), time.Minute, 2*time.Second)
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
@@ -276,8 +280,7 @@ func TestGxReAuthWithMidSessionPolicyInstall(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Install two static rules "static-pass-all-raa1" and "static-pass-all-raa2"
@@ -301,6 +304,9 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 	imsi := ue.GetImsi()
 
 	tr.AuthenticateAndAssertSuccess(imsi)
+	// Wait for flows to be installed
+	assert.Eventually(t, tr.WaitForEnforcementStatsForRule(
+		imsi, "static-pass-all-raa1", "static-pass-all-raa2"), time.Minute, 2*time.Second)
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
@@ -364,8 +370,7 @@ func TestGxReAuthWithMidSessionPolicyInstallAndRemoval(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // - Install two static rules "static-pass-all-raa1" and "static-pass-all-raa2"
@@ -389,6 +394,9 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 	imsi := ue.GetImsi()
 
 	tr.AuthenticateAndAssertSuccess(imsi)
+	// Wait for flows to be installed
+	assert.Eventually(t, tr.WaitForEnforcementStatsForRule(
+		imsi, "static-pass-all-raa1", "static-pass-all-raa2"), time.Minute, 2*time.Second)
 
 	// Generate over 80% of the quota to trigger a CCR Update
 	req := &cwfprotos.GenTrafficRequest{
@@ -429,6 +437,5 @@ func TestGxReAuthQuotaRefill(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }

--- a/cwf/gateway/integ_tests/gy_reauth_test.go
+++ b/cwf/gateway/integ_tests/gy_reauth_test.go
@@ -114,5 +114,5 @@ func TestGyReAuth(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	assert.Eventually(t, tr.WaitForNoEnforcementStatsForRule(imsi, "static-pass-all-ocs2"), 2*time.Minute, 2*time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }

--- a/cwf/gateway/integ_tests/idle_timer_test.go
+++ b/cwf/gateway/integ_tests/idle_timer_test.go
@@ -79,8 +79,10 @@ func TestIdleTimer(t *testing.T) {
 	assert.NoError(t, setPCRFExpectations(expectations, nil))
 
 	// Wait for Session Idle Timer to kick off + Wait for Termination to go through
-	// Idle Timer = 3 + Session forced termination timeout = 3 + some buffer
-	time.Sleep(8 * time.Second)
+	// Idle Timer = 3 seconds
+	fmt.Println("Waiting 3 seconds for the idle timer to kick in...")
+	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 
 	tr.AssertAllGxExpectationsMetNoError()
 }

--- a/cwf/gateway/integ_tests/omni_rules_test.go
+++ b/cwf/gateway/integ_tests/omni_rules_test.go
@@ -144,8 +144,7 @@ func TestOmnipresentRules(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }
 
 // TODO: test disabled for now. Need to modify mconfig to enable/disable Gx
@@ -221,6 +220,5 @@ func TestGxDisabledOmnipresentRules(t *testing.T) {
 
 	// trigger disconnection
 	tr.DisconnectAndAssertSuccess(imsi)
-	fmt.Println("wait for flows to get deactivated")
-	time.Sleep(3 * time.Second)
+	tr.AssertEventuallyAllRulesRemovedAfterDisconnect(imsi)
 }

--- a/feg/gateway/services/testcore/mock_driver/mock_driver.go
+++ b/feg/gateway/services/testcore/mock_driver/mock_driver.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 
 	"magma/feg/cloud/go/protos"
+
+	"github.com/golang/glog"
 )
 
 type Expectation interface {
@@ -37,6 +39,7 @@ type MockDriver struct {
 }
 
 func NewMockDriver(expectations []Expectation, behavior protos.UnexpectedRequestBehavior, defaultAnswer interface{}) *MockDriver {
+	glog.Infof("MockDriver: Initializing a new set of Expectations: %s", expectations)
 	resultByIndex := make(map[int]*protos.ExpectationResult, len(expectations))
 	for i := range expectations {
 		resultByIndex[i] = &protos.ExpectationResult{ExpectationIndex: int32(i), ExpectationMet: false}
@@ -55,8 +58,8 @@ func NewMockDriver(expectations []Expectation, behavior protos.UnexpectedRequest
 // GetAnswerFromExpectations will use the message passed in to determine if
 // the message matches the next upcoming expectation. If it does, it will
 // return the answer specified in the expectation.
-// Otherwise, if the unexpected request behavior is set to CONTINUE_WITH_DEFAULT_ANSWER,
-// it will return the default answer.
+// On failure, if the unexpected request behavior is set to
+// CONTINUE_WITH_DEFAULT_ANSWER, it will return the default answer.
 // Otherwise, it will return nil.
 func (e *MockDriver) GetAnswerFromExpectations(message interface{}) interface{} {
 	if !e.expectationsSet {
@@ -68,6 +71,7 @@ func (e *MockDriver) GetAnswerFromExpectations(message interface{}) interface{} 
 	expectation := e.expectations[e.expectationIndex]
 	err := expectation.DoesMatch(message)
 	if err != nil {
+		glog.Errorf("MockDriver: Expectation was not met: %s, err: %s", expectation, err)
 		errByIndex := &protos.ErrorByIndex{Index: int32(e.expectationIndex), Error: err.Error()}
 		e.errorMessages = append(e.errorMessages, errByIndex)
 		return e.getAnswerForUnexpectedMessage()
@@ -91,6 +95,7 @@ func (e *MockDriver) AggregateResults() ([]*protos.ExpectationResult, []*protos.
 func (e *MockDriver) getAnswerForUnexpectedMessage() interface{} {
 	switch e.unexpectedRequestBehavior {
 	case protos.UnexpectedRequestBehavior_CONTINUE_WITH_DEFAULT_ANSWER:
+	    glog.Infof("MockDriver: Returning default answer for an unexpected request")
 		return e.defaultAnswer
 	default:
 		return nil


### PR DESCRIPTION
<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
I have a script to identify flakiest tests in the last 50 runs and here is my attempt to reduce errors. :-) 


```
In the last 50 CWAG-integration-test-libvirt builds [101-150], we had {success: 34%, failure: 36%, could-not-run-test: 30%}

Out of all the tests that failed  here is a per-test summary...
TestAuthenticateUplinkTraffic failed 9 times. Builds: [149, 148, 147, 146, 145, 142, 124, 123, 121]
TestAuthenticateMultipleAPsUplinkTraffic failed 9 times. Builds: [149, 148, 147, 146, 145, 142, 124, 123, 121]
TestGxMidSessionRuleRemovalWithCCA_U failed 2 times. Builds: [144, 140]
TestQosRestartMeterNonClean failed 2 times. Builds: [137, 102]
TestGxReAuthWithMidSessionPoliciesRemoval failed 2 times. Builds: [111, 102]
TestGyCreditExhaustionRedirect failed 1 times. Builds: [134]
TestGyCreditTransientErrorRestrict failed 1 times. Builds: [109]
TestGyWithPermanentErrorCode failed 1 times. Builds: [107]
TestGyCreditValidityTime failed 1 times. Builds: [104]
TestGyCreditExhaustionWithoutCRRU failed 1 times. Builds: [104]
TestGxReAuthWithMidSessionPolicyRemoval failed 1 times. Builds: [102]
```
* `TestGxMidSessionRuleRemovalWithCCA_U` seems to be due to CCR-U being triggered before the expectations are set, so reducing the amount of traffic passed to get around this. 

