### PR TITLE
[UESIM] Prevent nil dereference in UE sim proto conversion

### DIFF
--- a/cwf/gateway/integ_tests/multi_sessioneproxy_test.go
+++ b/cwf/gateway/integ_tests/multi_sessioneproxy_test.go
@@ -17,10 +17,10 @@ package integration
 
 import (
 	"fmt"
+	"math"
 	"sync"
 	"testing"
 	"time"
-	"math"
 
 	cwfprotos "magma/cwf/cloud/go/protos"
 	"magma/feg/cloud/go/protos"
@@ -203,8 +203,8 @@ func TestMultiSessionProxyMonitorAndUsageReportEnforcement(t *testing.T) {
 				// this wait can be remove
 				tr.WaitForEnforcementStatsToSync()
 				req := &cwfprotos.GenTrafficRequest{
-					Imsi: imsi,
-					Volume: &wrappers.StringValue{Value: "2M"},
+					Imsi:    imsi,
+					Volume:  &wrappers.StringValue{Value: "2M"},
 					Bitrate: &wrappers.StringValue{Value: "60M"},
 					Timeout: 30,
 				}
@@ -230,7 +230,7 @@ func TestMultiSessionProxyMonitorAndUsageReportEnforcement(t *testing.T) {
 				// We should not be seeing > 1024k data here
 				assert.True(t, record.BytesTx > uint64(0), fmt.Sprintf("%s did not pass any data", record.RuleId))
 				assert.NoError(t, err)
-				assert.True(t, record.BytesTx <= uint64(math.Round(2.5 * MegaBytes)+Buffer), fmt.Sprintf("policy usage: %v", record))
+				assert.True(t, record.BytesTx <= uint64(math.Round(2.5*MegaBytes)+Buffer), fmt.Sprintf("policy usage: %v", record))
 				// TODO: make sure OCS records its proper usage and it matches with what we monitored
 				//infos, err := getCreditOnOCSPerInstance(element.ocsName, imsi)
 				//fmt.Printf("\t ---> policy usage: %v\n", record)

--- a/cwf/gateway/services/uesim/servicers/uesim.go
+++ b/cwf/gateway/services/uesim/servicers/uesim.go
@@ -91,6 +91,9 @@ func (output *IperfResponse) FromBytes(b []byte) (*IperfResponse, error) {
 }
 
 func (response *IperfResponse) ToProto() *cwfprotos.GenTrafficResponse {
+	if response == nil {
+		return &cwfprotos.GenTrafficResponse{}
+	}
 	return &cwfprotos.GenTrafficResponse{
 		EndOutput: response.End.ToProto(),
 		Output:    response.RawOutput,
@@ -98,6 +101,9 @@ func (response *IperfResponse) ToProto() *cwfprotos.GenTrafficResponse {
 }
 
 func (output *TrafficOutput) ToProto() *cwfprotos.TrafficOutput {
+	if output == nil {
+		return &cwfprotos.TrafficOutput{}
+	}
 	return &cwfprotos.TrafficOutput{
 		SumSent:     output.SumSent.ToProto(),
 		SumReceived: output.SumReceived.ToProto(),
@@ -105,6 +111,9 @@ func (output *TrafficOutput) ToProto() *cwfprotos.TrafficOutput {
 }
 
 func (summary *TrafficSummary) ToProto() *cwfprotos.TrafficSummary {
+	if summary == nil {
+		return &cwfprotos.TrafficSummary{}
+	}
 	return &cwfprotos.TrafficSummary{
 		Start:         summary.Start,
 		End:           summary.End,


### PR DESCRIPTION
Signed-off-by: Marie Bremner <marwhal@fb.com>

<!--
    Tag your PR title with the components that it touches.
    E.g. "[lte][agw] Changeset" or "[orc8r][docker] ..."
-->

## Summary
Error seen: https://jenkins.magmacore.org/job/CWAG-integration-test-libvirt/151/artifact/cwf-artifacts/uesim.log
Check for nil before accessing elements.
<!-- Enumerate changes you made and why you made them -->

## Test Plan
unit tests

Reproduced the original crashing issue by uninstalling iperf3 on the trfserver, this PR fixes the crash
<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
