### PR TITLE
[orc8r][ctraced] Added REST endpoint and handler for downloading traces

### DIFF
--- a/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
+++ b/orc8r/cloud/docker/controller/apidocs/v1/swagger.yml
@@ -5379,6 +5379,22 @@ paths:
       summary: Update a call trace
       tags:
       - Call Tracing
+  /networks/{network_id}/tracing/{trace_id}/download:
+    get:
+      parameters:
+      - $ref: '#/parameters/network_id'
+      - $ref: '#/parameters/trace_id'
+      responses:
+        "200":
+          description: Show tracing status
+          schema:
+            format: binary
+            type: file
+        default:
+          $ref: '#/responses/UnexpectedError'
+      summary: Get the call trace in PCAP format
+      tags:
+      - Call Tracing
   /networks/{network_id}/type:
     get:
       parameters:

--- a/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
+++ b/orc8r/cloud/go/services/ctraced/obsidian/handlers/handlers_test.go
@@ -68,6 +68,7 @@ func TestCtracedHandlersBasic(t *testing.T) {
 	getTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id", obsidian.GET).HandlerFunc
 	updateTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id", obsidian.PUT).HandlerFunc
 	deleteTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id", obsidian.DELETE).HandlerFunc
+	downloadTrace := tests.GetHandlerByPathAndMethod(t, obsidianHandlers, "/magma/v1/networks/:network_id/tracing/:trace_id/download", obsidian.GET).HandlerFunc
 
 	// Test empty response
 	tc := tests.Test{
@@ -169,6 +170,19 @@ func TestCtracedHandlersBasic(t *testing.T) {
 		Handler:        getTrace,
 		ExpectedStatus: 200,
 		ExpectedResult: testTrace,
+	}
+	tests.RunUnitTest(t, e, tc)
+
+	// Verify download of call trace
+	tc = tests.Test{
+		Method:         "GET",
+		URL:            "/magma/v1/networks/n1/tracing/CallTrace1/download",
+		Payload:        nil,
+		ParamNames:     []string{"network_id", "trace_id"},
+		ParamValues:    []string{"n1", "CallTrace1"},
+		Handler:        downloadTrace,
+		ExpectedStatus: 200,
+		ExpectedResult: tests.ByteIdentityMarshaler([]byte("abcdefghijklmnopqrstuvwxyz")),
 	}
 	tests.RunUnitTest(t, e, tc)
 

--- a/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
+++ b/orc8r/cloud/go/services/ctraced/obsidian/models/swagger.v1.yml
@@ -111,6 +111,23 @@ paths:
         default:
           $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
 
+  /networks/{network_id}/tracing/{trace_id}/download:
+    get:
+      summary: Get the call trace in PCAP format
+      tags:
+        - Call Tracing
+      parameters:
+        - $ref: './orc8r-swagger-common.yml#/parameters/network_id'
+        - $ref: '#/parameters/trace_id'
+      responses:
+        '200':
+          description: Show tracing status
+          schema:
+            type: file
+            format: binary
+        default:
+          $ref: './orc8r-swagger-common.yml#/responses/UnexpectedError'
+
 parameters:
   trace_id:
     description: Unique ID of call trace


### PR DESCRIPTION
## Summary

Added a download REST endpoint for downloading call traces at
`v1/networks/:network_id/tracing/:trace_id/download`

## Test Plan

- Modified unit tests to check new endpoint
- Manually tested new GET endpoint on swagger

## Additional Information

- [ ] This change is backwards-breaking
