### PR TITLE
[agw][mme] Make ctime call thread safe

### DIFF
--- a/lte/gateway/c/oai/common/log.c
+++ b/lte/gateway/c/oai/common/log.c
@@ -563,7 +563,8 @@ static char* log_get_readable_cur_time(time_t* cur_time) {
   // get the current local time
   *cur_time = time(NULL);
   // get the current local time in readable string format
-  return (strtok(ctime(cur_time), "\n"));
+  char buf[26];
+  return (strtok(ctime_r((const time_t*) cur_time, buf), "\n"));
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Signed-off-by: Shruti Sanadhya <ssanadhya@fb.com>

## Summary

MME service encountered seg faults due to memory corruption while calling ctime. This change replaces `ctime` with `ctime_r` 

## Test Plan

- Unable to reproduce the original memory corruption
- Sanity check with `make integ_test`

