### PR TITLE
[xwfm][ci] make CI use XWF-OpenFlow AWS setup instead of building local

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -935,7 +935,7 @@ jobs:
             docker login -u ${XWF_ARTIFACTORY_USER} -p ${XWF_ARTIFACTORY_API_KEY} ${XWF_ARTIFACTORY_LINK}
             cd ${MAGMA_ROOT}/xwf/docker/
             docker-compose pull || true
-            docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py --type=analytic
+            docker-compose build --parallel && docker-compose up -d && docker exec tests pytest --log-cli-level=info code/tests.py
       - when:
           condition: <<parameters.notify_magma_ci>>
           steps: magma_slack_notify

--- a/xwf/docker/docker-compose.override.yml
+++ b/xwf/docker/docker-compose.override.yml
@@ -2,15 +2,6 @@ version: "3.7"
 # This will override the main docker compose and will make sure to fetch pinned verion of xwf with magma components
 # this file is duplicated to magma repo as override of this directory docker-compose.yml file.
 services:
-  ofproxy:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/ofproxy
-
-  ofproxy-mt:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/ofproxy
-
-  ofredirector:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/ofredirector
-
   httpserver:
     image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/httpserver
 
@@ -26,25 +17,14 @@ services:
     build:
       context: ${MAGMA_BASE}../..
       dockerfile: xwf/gateway/integ_tests/gw/Dockerfile
-    environment:
-      - CONNECTION_MODE=ssl
 
   pipelined:
     build:
       context: ${MAGMA_BASE}../../
       dockerfile: cwf/gateway/docker/python/Dockerfile
 
-  tls-termination:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/tls-termination
-
   tests:
     image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/tests
 
   xwf_client:
     image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/xwf_client
-
-  nlb:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/nlb
-
-  logrouter:
-    image: facebookconnectivity-openflow-xwfm-docker.jfrog.io/logrouter

--- a/xwf/docker/docker-compose.yml
+++ b/xwf/docker/docker-compose.yml
@@ -1,127 +1,31 @@
 version: '3.7'
 
 x-logging: &logging_anchor
-  driver: "fluentd"
+  driver: "json-file"
   options:
-    fluentd-address: "localhost:24224"
-    fluentd-async-connect: "true"
+    max-size: "100m"
+    max-file: "10"
 
 services:
-  logrouter:
-    container_name: local-fluentbit
-    networks:
-      control:
-        ipv4_address: 10.0.12.217
-    ports:
-      - "24224:24224"
-    healthcheck:
-      test: ["CMD", "nc", "-vz", "localhost", "24224"]
-      interval: 30s
-      timeout: 10s
-      retries: 15
-    environment:
-      - SCRIBE_ACCESS_TOKEN=${XWF_SCUBA_ACCESS_TOKEN}
-      - SCUBA_TABLE=perfpipe_xwf_openflow_compose_logs
-      - RUN_UID=${RUN_UID:-1}
-  ofproxy:
-    container_name: ofproxy
-    privileged: true
-    networks:
-      - control
-      - server
-    environment:
-      - APPURL=${APPURL:-https://graph.expresswifi.com}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      - AWS_DEFAULT_REGION=${XWF_AWS_DEFAULT_REGION:-}
-      - AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-}
-      - DEBUG=1
-      - PORT=6653
-      - REDIRECTOR=ofredirector
-      - ACCESSTOKEN=${XWF_ACCESSTOKEN}
-      - AWSREGION=${XWF_AWS_DEFAULT_REGION:-}
-      - CPURL=${XWF_CPURL}
-      - DNSHARDTIMEOUT=60
-      - INSECURE=${INSECURE:-0}
-      - PARTNERNAME=${XWF_PARTNER_SHORT_NAME}
-      - ODS_CATEGORY_ID=${XWF_ODS_CATEGORY_ID}
-      - ODS_ACCESS_TOKEN=${XWF_ODS_ACCESS_TOKEN}
-      - ODS_PREFIX=xwf.openflow
-      - ODS_CLUSTER=${XWF_PARTNER_SHORT_NAME}.${ENV}
-      - ODS_ENTITY=ofproxy
-      - OFPRADIUS=${OFPRADIUS:-0}
-      - METERURL=${METERURL:-}
-      - AWSENDPOINT=${AWSENDPOINT:-}
-      - LOG_TYPE=production
-    logging: *logging_anchor
-    depends_on:
-      - logrouter
-  ofproxy-mt:
-    container_name: ofproxy-mt
-    privileged: true
-    networks:
-      - control
-    environment:
-      - APPURL=${APPURL:-https://graph.expresswifi.com}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      - AWS_DEFAULT_REGION=${XWF_AWS_DEFAULT_REGION:-}
-      - AWS_ACCOUNT_ID=${AWS_ACCOUNT_ID:-}
-      - DEBUG=1
-      - PORT=6653
-      - REDIRECTOR=ofredirector
-      - ACCESSTOKEN=${XWF_ACCESSTOKEN}
-      - AWSREGION=${XWF_AWS_DEFAULT_REGION:-}
-      - CPURL=${XWF_CPURL}
-      - DNSHARDTIMEOUT=60
-      - INSECURE=${INSECURE:-0}
-      - MTARCH=1
-      - AWS_ENDPOINT=http://dynamo_db:8000/
-      - PARTNERSTABLE=ofp_partners
-      - PARTNERNAME=${XWF_PARTNER_SHORT_NAME}
-      - ODS_CATEGORY_ID=${XWF_ODS_CATEGORY_ID}
-      - ODS_ACCESS_TOKEN=${XWF_ODS_ACCESS_TOKEN}
-      - ODS_PREFIX=xwf.openflow
-      - ODS_CLUSTER=${XWF_PARTNER_SHORT_NAME}.${ENV}
-      - ODS_ENTITY=ofproxy
-      - LOG_TYPE=production
-    logging: *logging_anchor
-    depends_on:
-      - logrouter
-  ofredirector:
-    container_name: ofredirector
-    privileged: true
-    networks:
-      control:
-        ipv4_address: 10.0.12.231
-    environment:
-      - PUBLICIP=10.0.12.231
-      - DEBUG=1
-      - ODS_ACCESS_TOKEN=${XWF_ODS_ACCESS_TOKEN}
-      - ODS_PREFIX=cwf.openflow
-      - ODS_CATEGORY_ID=${XWF_ODS_CATEGORY_ID}
-      - ODS_CLUSTER=${XWF_PARTNER_SHORT_NAME}.${ENV}
-      - ODS_ENTITY=ofredirector
-    logging: *logging_anchor
-    depends_on:
-      - logrouter
   httpserver:
+    image: ${XWF_REGISTRY:-facebookconnectivity-openflow-xwfm-docker.jfrog.io}/httpserver:${TAG:-latest}
     container_name: httpserver
     ports:
       - "8080:80"
     networks:
       - control
     logging: *logging_anchor
-    depends_on:
-      - logrouter
   ofpradius:
+    image: ${XWF_REGISTRY:-facebookconnectivity-openflow-xwfm-docker.jfrog.io}/ofpradius:${TAG:-latest}
     container_name: ofpradius
     environment:
       - RADIUSSERVERURL=radiusserver
       - AUTHPORT=1812
     networks:
       - control
+    logging: *logging_anchor
   radiusserver:
+    image: ${MAGMA_REGISTRY:-local}/goradius:${XWFM_TAG:-latest}
     container_name: radiusserver
     privileged: true
     environment:
@@ -138,12 +42,9 @@ services:
       - control
     ports:
       - "1812:1812/udp"
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-        max-file: "10"
+    logging: *logging_anchor
   xwfm:
+    image: ${MAGMA_REGISTRY:-local}/xwfm-integ-tests:${XWFM_TAG:-latest}
     container_name: xwfm
     privileged: true
     tty: true
@@ -157,24 +58,20 @@ services:
       - openvswitch:/var/run/openvswitch
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - CTRL_IP=${CTRL_IP:-}
       - ACCESSTOKEN=${XWF_ACCESSTOKEN}
+      - CONNECTION_MODE=ssl
     networks:
       - control
     logging: *logging_anchor
-    depends_on:
-      - ofproxy
-      - tls-termination
-      - logrouter
     cap_add:
       - ALL
   pipelined:
+    image: ${MAGMA_REGISTRY:-local}/gateway_pipelined:${XWFM_TAG:-latest}
     container_name: pipelined
     privileged: true
     network_mode: service:xwfm
     depends_on:
       - xwfm
-      - logrouter
     volumes:
       - cert:/var/opt/magma/certs
       - configs_override:/var/opt/magma/configs
@@ -192,20 +89,8 @@ services:
     logging: *logging_anchor
     cap_add:
       - ALL
-  tls-termination:
-    container_name: tls-termination
-    networks:
-      - control
-    environment:
-      - OFPROXY_ADDR=ofproxy
-      - OFPROXY_PORT=6653
-      - ACCESS_TOKEN=${XWF_ACCESSTOKEN}
-      - INSECURE=${INSECURE:-}
-    depends_on:
-      - ofproxy
-      - logrouter
-    logging: *logging_anchor
   tests:
+    image: ${XWF_REGISTRY:-facebookconnectivity-openflow-xwfm-docker.jfrog.io}/tests:${TAG:-latest}
     container_name: tests
     privileged: true
     tty: true
@@ -228,54 +113,23 @@ services:
       - CPURL=${XWF_CPURL}
       - VPCEndPointID=${XWF_VPCEndPointID}
       - BACKEND=${BACKEND:-WWW}
+      - TEST_CONFIG=${TEST_CONFIG:-xwfm}
     logging: *logging_anchor
     depends_on:
       - xwf_client
-      - ofproxy
       - xwfm
-      - tls-termination
-      - logrouter
-      - dynamo_db
   xwf_client:
+    image: ${XWF_REGISTRY:-facebookconnectivity-openflow-xwfm-docker.jfrog.io}/xwf_client:${TAG:-latest}
     container_name: xwf_client
     privileged: true
     network_mode: "none"
     dns:
       - 10.100.0.1
     logging: *logging_anchor
-    depends_on:
-      - logrouter
     cap_add:
       - NET_ADMIN
-  dynamo_db:
-    image: amazon/dynamodb-local
-    container_name: dynamo_db
-    ports:
-      - "8000:8000"
-    volumes:
-      - dynamodata:/home/dynamodblocal
-    working_dir: /home/dynamodblocal
-    command: "-jar DynamoDBLocal.jar -sharedDb -dbPath ."
-    networks:
-      - control
-    logging: *logging_anchor
-    depends_on:
-      - logrouter
-  nlb:
-    container_name: nlb
-    environment:
-      - SRCPORT=6653
-      - DSTPORT=6653
-      - FORWARD=ofproxy-mt
-      - VPCEndPointID=${XWF_VPCEndPointID}
-    networks:
-      - control
-    logging: *logging_anchor
-    depends_on:
-      - logrouter
 
 volumes:
-  dynamodata: {}
   cert:
   configs_override:
   configs_default:

--- a/xwf/gateway/integ_tests/gw/entrypoint.sh
+++ b/xwf/gateway/integ_tests/gw/entrypoint.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 
 echo "get controller ip"
-[[ -z "${CTRL_IP}" ]] && CtrlIP="$(getent hosts ofproxy | awk '{ print $1 }')" || CtrlIP="${CTRL_IP}"
+if [[ ! -z ${CTRL_IP} ]]
+then
+  CtrlIP="${CTRL_IP}"
+  echo "set ctrl to given IP ${CtrlIP}"
+elif [[ ! -z ${CTRL_HOST} ]]
+then
+  CtrlIP="$(getent hosts ${CTRL_HOST} | awk '{ print $1 }')"
+  echo "set ctrl host name ${CTRL_HOST} and IP ${CtrlIP}"
+else
+  echo "no ctrl IP or port provided, using partner ctrl and not local docker setup"
+fi
 
 echo "Running in $CONNECTION_MODE"
 CONNECTION_MODE=${CONNECTION_MODE:=tcp}
-if [ "$CONNECTION_MODE" == "ssl" ]
-then
-  CtrlIP="$(getent hosts tls-termination | awk '{ print $1 }')" || CtrlIP="${CTRL_IP}"
-fi
 
 echo "start ovs-ctl"
 /usr/share/openvswitch/scripts/ovs-ctl start --system-id=random --no-ovs-vswitchd
@@ -42,7 +48,12 @@ done
 
 echo "$result" | jq -r .configxwfm > /etc/xwfwhoami
 echo "run XWF ansible"
-ANSIBLE_CONFIG=xwf/gateway/ansible.cfg ansible-playbook -e xwf_ctrl_ip="${CtrlIP} connection_mode=$CONNECTION_MODE" \
+if [[ ! -z "${CtrlIP}" ]]
+then
+  CTLR="xwf_ctrl_ip=${CtrlIP}"
+  echo "adding option ${CTLR}"
+fi
+ANSIBLE_CONFIG=xwf/gateway/ansible.cfg ansible-playbook -e "$CTLR connection_mode=$CONNECTION_MODE" \
 xwf/gateway/deploy/xwf.yml -i "localhost," --skip-tags "install,install_docker,no_ci" -c local -v
 
 echo "run DNS server"


### PR DESCRIPTION
Signed-off-by: Aharon Novogrodski <novo@gmail.com>

[xwf][ci]

## Summary

Change the methodology we are using for tests. Instead of building all openflow dockers local, build only things that are relevant for tests

## Test Plan

Run on local "docker-compose build" and "docker-compose up -d". Then run XWF tests from tests docker

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->
